### PR TITLE
feat: XYNE-56903 Add channel-scoped Automations section to SDLC hub

### DIFF
--- a/apps/dashboard/src/components/Automation/AutomationApprovalsList/AutomationApprovalsList.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationApprovalsList/AutomationApprovalsList.tsx
@@ -22,6 +22,9 @@ import { useIsAutomationsAdmin } from '../useIsAutomationsAdmin';
 export interface AutomationApprovalsListProps {
   /** When provided, only proposals passing this predicate are shown. */
   filterPredicate?: (automation: Automation) => boolean;
+  /** Embedded hosts must supply both, or the defaults navigate away to /automations. */
+  onOpenProposal?: (automation: Automation) => void;
+  onBack?: () => void;
 }
 
 /**
@@ -31,6 +34,8 @@ export interface AutomationApprovalsListProps {
  */
 export function AutomationApprovalsList({
   filterPredicate,
+  onOpenProposal,
+  onBack,
 }: AutomationApprovalsListProps = {}): React.ReactElement {
   const navigate = useNavigate();
   const me = useSelf();
@@ -88,7 +93,7 @@ export function AutomationApprovalsList({
         <div className='flex items-start gap-3'>
           <button
             type='button'
-            onClick={() => void navigate('/automations')}
+            onClick={() => (onBack ? onBack() : void navigate('/automations'))}
             aria-label='Back to automations'
             data-track-category='automation-approvals'
             data-track-name='back-to-list'
@@ -138,7 +143,11 @@ export function AutomationApprovalsList({
                     setRejectingId(item.id);
                     setRejectNote('');
                   }}
-                  onOpen={() => void navigate(`/automations/${item.id}?from=approvals`)}
+                  onOpen={() =>
+                    onOpenProposal
+                      ? onOpenProposal(item)
+                      : void navigate(`/automations/${item.id}?from=approvals`)
+                  }
                 />
               ))}
             </ul>

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.tsx
@@ -66,6 +66,7 @@ import {
   moveStep,
 } from './AutomationBuilder.utils';
 import type { AutomationBuilderProps } from './AutomationBuilder.types';
+import { resolveSchema } from './SchemaForm/SchemaForm.utils';
 import type { StepSchema } from '../Automation.types';
 
 const MAX_AUTOMATION_NAME_LENGTH = 80;
@@ -158,6 +159,9 @@ export function AutomationBuilder({
   onAfterApprovalDecision,
   onBack,
   onShowRuns,
+  scopeDefaults,
+  onFork,
+  onOpenAutomation,
 }: AutomationBuilderProps): React.ReactElement {
   const [name, setName] = useState(automation?.name ?? initialName ?? '');
   const [description, setDescription] = useState(
@@ -507,10 +511,13 @@ export function AutomationBuilder({
   });
 
   const handleProposeChangeNavigate = useCallback((): void => {
-    if (automation?.id) {
-      void navigate(`../new?fork=${automation.id}`, { relative: 'path' });
+    if (!automation?.id) return;
+    if (onFork) {
+      onFork(automation.id, 'fork');
+      return;
     }
-  }, [automation?.id, navigate]);
+    void navigate(`../new?fork=${automation.id}`, { relative: 'path' });
+  }, [automation?.id, navigate, onFork]);
 
   // Approve / Reject — only used in approval-review mode, when an admin
   // opens a PENDING_APPROVAL proposal from the inbox. The actual auth check
@@ -753,6 +760,37 @@ export function AutomationBuilder({
   const operators = operatorsQuery.data ?? [];
   const triggerSchema = triggerSchemaQuery.data ?? null;
 
+  const triggerScope = useMemo((): Record<string, string[]> => {
+    if (!scopeDefaults || !triggerSchema?.configSchema) return {};
+    // zodToJsonSchema({ name: 'config' }) puts the object behind a $ref.
+    const declared = resolveSchema(triggerSchema.configSchema).properties ?? {};
+    return Object.fromEntries(Object.entries(scopeDefaults).filter(([key]) => key in declared));
+  }, [scopeDefaults, triggerSchema]);
+
+  // Only new automations (including forks) — seeding a saved one would silently
+  // rescope it. Ref guard: react-query's refetch identity would otherwise re-seed
+  // a value the user cleared.
+  const seededForTypeRef = useRef<string | null>(null);
+  useEffect(() => {
+    const type = triggerSchema?.type;
+    if (!type || automation || seededForTypeRef.current === type) return;
+    const seed = Object.entries(triggerScope);
+    if (seed.length === 0) return;
+    seededForTypeRef.current = type;
+    setConfig(prev => {
+      if (prev.trigger.type !== type) return prev; // stale fetch, type changed
+      const next = { ...prev.trigger.config };
+      let changed = false;
+      for (const [key, value] of seed) {
+        if (next[key] === undefined) {
+          next[key] = value;
+          changed = true;
+        }
+      }
+      return changed ? { ...prev, trigger: { ...prev.trigger, config: next } } : prev;
+    });
+  }, [triggerScope, triggerSchema?.type, automation]);
+
   const [formFieldNameMap, setFormFieldNameMap] = useState<Map<string, string>>(new Map());
 
   const handleFormFieldNamesResolved = useCallback((map: Map<string, string>) => {
@@ -815,7 +853,8 @@ export function AutomationBuilder({
                     return;
                   }
                   if (forkSourceAutomationId) {
-                    void navigate(`../${forkSourceAutomationId}`, { relative: 'path' });
+                    if (onOpenAutomation) onOpenAutomation(forkSourceAutomationId);
+                    else void navigate(`../${forkSourceAutomationId}`, { relative: 'path' });
                     return;
                   }
                   onBack();
@@ -855,7 +894,11 @@ export function AutomationBuilder({
                 <Button
                   variant='outline'
                   size='sm'
-                  onClick={() => void navigate(`/automations/new?fork=${savedId}&clone=1`)}
+                  onClick={() =>
+                    onFork
+                      ? onFork(savedId, 'clone')
+                      : void navigate(`/automations/new?fork=${savedId}&clone=1`)
+                  }
                   data-track-category='automation-builder'
                   data-track-name='header-clone'
                 >
@@ -1087,6 +1130,7 @@ export function AutomationBuilder({
               view='condition'
               trigger={config.trigger}
               catalog={triggerCatalog}
+              lockedValues={triggerScope}
               schema={triggerSchema}
               schemaLoading={triggerSchemaQuery.isLoading && !!config.trigger.type}
               onChangeType={handleTriggerTypeChange}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.types.ts
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.types.ts
@@ -3,6 +3,8 @@ import type { Automation, AutomationConfig, ValidationResult } from '../Automati
 export interface AutomationBuilderProps {
   automation: Automation | null;
   initialConfig?: AutomationConfig;
+  /** Seeded + pinned per trigger-type pick. Not `initialConfig` — picking a type resets config. */
+  scopeDefaults?: Record<string, string[]>;
   initialName?: string;
   initialDescription?: string;
   forkFromSeriesId?: string;
@@ -12,4 +14,7 @@ export interface AutomationBuilderProps {
   onAfterApprovalDecision?: () => void;
   onBack: () => void;
   onShowRuns?: (automationId: string) => void;
+  /** Embedded hosts must supply both, or the defaults navigate away to /automations. */
+  onFork?: (automationId: string, mode: 'fork' | 'clone') => void;
+  onOpenAutomation?: (automationId: string) => void;
 }

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/EntityField.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/EntityField.tsx
@@ -491,6 +491,7 @@ interface MultiEntityFieldProps {
   kind: EntityKind;
   value: string[];
   onChange: (next: string[]) => void;
+  lockedValues?: string[];
   placeholder?: string;
 }
 
@@ -499,6 +500,7 @@ export function MultiEntityField({
   value,
   onChange,
   placeholder,
+  lockedValues,
 }: MultiEntityFieldProps): React.ReactElement {
   if (kind === EntityKind.USER) {
     return (
@@ -520,6 +522,7 @@ export function MultiEntityField({
         value={value}
         onChange={onChange}
         placeholder={placeholder ?? 'Pick channels'}
+        {...(lockedValues ? { lockedValues } : {})}
       />
     );
   }
@@ -592,7 +595,12 @@ function MultiUserGroups({ value, onChange, placeholder }: MultiFieldProps): Rea
   );
 }
 
-function MultiChannels({ value, onChange, placeholder }: MultiFieldProps): React.ReactElement {
+function MultiChannels({
+  value,
+  onChange,
+  placeholder,
+  lockedValues,
+}: MultiFieldProps & { lockedValues?: string[] }): React.ReactElement {
   const [search, setSearch] = useState('');
   const channels = useAllChannels();
   const options: SelectorOption[] = useMemo(() => {
@@ -627,6 +635,7 @@ function MultiChannels({ value, onChange, placeholder }: MultiFieldProps): React
       options={options}
       selectedValues={value}
       onMultiSelect={onChange}
+      {...(lockedValues ? { lockedValues } : {})}
       placeholder={placeholder}
       searchPlaceholder='Search channels…'
       onSearchChange={setSearch}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.tsx
@@ -47,11 +47,13 @@ export function SchemaForm(props: SchemaFormProps): React.ReactElement {
       issues={props.issues ?? null}
       pathPrefix={props.pathPrefix}
       variableSources={props.variableSources ?? []}
+      lockedValues={props.lockedValues ?? {}}
     />
   );
 }
 
 interface ObjectFieldsProps {
+  lockedValues?: Record<string, string[]>;
   schema: JsonSchema;
   value: Record<string, unknown>;
   onChange: (next: Record<string, unknown>) => void;
@@ -88,6 +90,7 @@ function ObjectFields({
   issues,
   pathPrefix,
   variableSources,
+  lockedValues,
 }: ObjectFieldsProps): React.ReactElement {
   const properties = schema.properties ?? {};
   const required = new Set(schema.required ?? []);
@@ -131,6 +134,9 @@ function ObjectFields({
             issues={issues}
             pathPrefix={pathPrefix}
             variableSources={variableSources}
+            {...(lockedValues?.[effectiveFieldKey]
+              ? { lockedValues: lockedValues[effectiveFieldKey] }
+              : {})}
           />
         );
       })}
@@ -140,6 +146,7 @@ function ObjectFields({
 
 interface FieldProps {
   fieldKey: string;
+  lockedValues?: string[];
   displayLabel?: string | undefined;
   schema: JsonSchema;
   required: boolean;
@@ -152,6 +159,7 @@ interface FieldProps {
 
 function Field({
   fieldKey,
+  lockedValues,
   displayLabel,
   schema,
   required,
@@ -400,6 +408,7 @@ function Field({
             kind={entityArrayKind}
             value={arrayValue}
             onChange={next => onChange(next)}
+            {...(lockedValues ? { lockedValues } : {})}
             placeholder={`Pick ${entityKindLabel(entityArrayKind)}s`}
           />
           {hasError && <FieldError message={errorMessage} />}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.types.ts
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.types.ts
@@ -8,4 +8,6 @@ export interface SchemaFormProps {
   issues?: ValidationIssue[] | null;
   pathPrefix: string;
   variableSources?: VariablePickerSource[];
+  /** Per-field values the host pins: rendered without an × and undeletable. */
+  lockedValues?: Record<string, string[]>;
 }

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/TriggerCard/TriggerCard.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/TriggerCard/TriggerCard.tsx
@@ -101,6 +101,7 @@ export function TriggerCard({
   catalog,
   schema,
   schemaLoading,
+  lockedValues,
   onChangeType,
   onConfigChange,
   issues,
@@ -162,6 +163,7 @@ export function TriggerCard({
               onChange={onConfigChange}
               issues={issues ?? null}
               pathPrefix='trigger.config.'
+              {...(lockedValues ? { lockedValues } : {})}
             />
             <TicketUpdatedFormFieldsSection
               boardIds={(trigger.config?.['boardIds'] as string[] | undefined) ?? []}
@@ -185,6 +187,7 @@ export function TriggerCard({
             onChange={onConfigChange}
             issues={issues ?? null}
             pathPrefix='trigger.config.'
+            {...(lockedValues ? { lockedValues } : {})}
           />
         )}
       </div>

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/TriggerCard/TriggerCard.types.ts
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/TriggerCard/TriggerCard.types.ts
@@ -9,6 +9,7 @@ export interface TriggerCardProps {
   trigger: AutomationConfig['trigger'];
   catalog: TriggerCatalogItem[];
   schema: TriggerSchema | null;
+  lockedValues?: Record<string, string[]>;
   schemaLoading?: boolean;
   onChangeType: (type: string) => void;
   onConfigChange: (config: Record<string, unknown>) => void;

--- a/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
@@ -1,6 +1,14 @@
 import { useMemo, useState } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { ArrowLeft, CheckCircle2, Hourglass, Loader2, MinusCircle, XCircle } from 'lucide-react';
+import {
+  ArrowLeft,
+  Ban,
+  CheckCircle2,
+  Hourglass,
+  Loader2,
+  MinusCircle,
+  XCircle,
+} from 'lucide-react';
 import { cn } from '../../../../utils/classNames';
 import {
   Select,
@@ -243,7 +251,10 @@ function RunRow({
           <Hourglass className='size-4 text-purple-600' />
         ) : run.status === 'SKIPPED' ? (
           <MinusCircle className='size-4 text-muted-foreground' />
+        ) : run.status === 'CANCELLED' ? (
+          <Ban className='size-4 text-muted-foreground' />
         ) : (
+          // PENDING / SCHEDULED / RUNNING — the only statuses still in flight.
           <Loader2 className='size-4 animate-spin text-blue-600' />
         )}
       </div>

--- a/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.tsx
@@ -63,6 +63,8 @@ export function AutomationsList({
   onOpen,
   onShowRuns,
   filterPredicate,
+  onFork,
+  onShowApprovals,
 }: AutomationsListProps): React.ReactElement {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<ListCategory>('all');
@@ -157,12 +159,20 @@ export function AutomationsList({
   });
 
   const handleClone = (item: Automation): void => {
+    if (onFork) {
+      onFork(item, 'clone');
+      return;
+    }
     void navigate(`/automations/new?fork=${item.id}&clone=1`);
   };
 
   const handleEdit = (item: Automation): void => {
     if (item.status === AutomationStatusValues.DRAFT) {
       onOpen(item);
+      return;
+    }
+    if (onFork) {
+      onFork(item, 'fork');
       return;
     }
     void navigate(`/automations/new?fork=${item.id}`);
@@ -222,12 +232,19 @@ export function AutomationsList({
           </div>
           {/* Approvals inbox is readable by anyone — non-admins see the
               queue but the Approve / Reject buttons stay admin-gated. */}
-          <Link to='/automations/approvals'>
-            <Button variant='outline' className='font-semibold'>
+          {onShowApprovals ? (
+            <Button variant='outline' className='font-semibold' onClick={onShowApprovals}>
               <Check className='size-4' />
               Approvals
             </Button>
-          </Link>
+          ) : (
+            <Link to='/automations/approvals'>
+              <Button variant='outline' className='font-semibold'>
+                <Check className='size-4' />
+                Approvals
+              </Button>
+            </Link>
+          )}
           <Button onClick={onCreate} className='font-semibold'>
             <Plus className='size-4' />
             New automation

--- a/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.types.ts
+++ b/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.types.ts
@@ -6,4 +6,7 @@ export interface AutomationsListProps {
   onShowRuns?: (automation: Automation) => void;
   /** When provided, only automations passing this predicate are shown (and counted). */
   filterPredicate?: (automation: Automation) => boolean;
+  /** Embedded hosts must supply both, or the defaults navigate away to /automations/*. */
+  onFork?: (automation: Automation, mode: 'fork' | 'clone') => void;
+  onShowApprovals?: () => void;
 }

--- a/apps/dashboard/src/components/ui/EntitySelector/EntityMultiSelector.tsx
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntityMultiSelector.tsx
@@ -7,6 +7,8 @@ import { EntitySelectorProps } from './EntitySelector.types';
 interface EntityMultiSelectorProps extends EntitySelectorProps {
   selectedValues: string[]; // Controlled selected tags
   onMultiSelect: (tags: string[]) => void;
+  /** Values that are pinned: they cannot be deselected, and render without an × . */
+  lockedValues?: string[];
   allowCreate?: boolean;
   onCreateOption?: (value: string) => void;
   showSearch?: boolean;
@@ -18,6 +20,7 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
   options,
   selectedValues,
   onMultiSelect,
+  lockedValues,
   placeholder,
   searchPlaceholder,
   isLoading = false,
@@ -64,8 +67,15 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
   /**
    * Handle selecting an option
    */
+  const isLocked = (value: string): boolean => (lockedValues ?? []).includes(value);
+  const keepLocked = (next: string[]): string[] => [
+    ...next,
+    ...(lockedValues ?? []).filter(v => selectedValues.includes(v) && !next.includes(v)),
+  ];
+
   const toggleValue = (value: string) => {
     if (selectedValues.includes(value)) {
+      if (isLocked(value)) return;
       onMultiSelect(selectedValues.filter(v => v !== value));
     } else {
       onMultiSelect([...selectedValues, value]);
@@ -73,6 +83,7 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
   };
 
   const removeValue = (value: string) => {
+    if (isLocked(value)) return;
     onMultiSelect(selectedValues.filter(v => v !== value));
   };
 
@@ -181,16 +192,18 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
             <span className='max-w-32 text-xs font-medium text-foreground truncate'>
               {opt.label}
             </span>
-            <button
-              type='button'
-              onClick={e => {
-                e.stopPropagation();
-                removeValue(opt.value);
-              }}
-              className='text-muted-foreground hover:text-muted-foreground'
-            >
-              <X className='size-2.5' strokeWidth={2.5} />
-            </button>
+            {!isLocked(opt.value) && (
+              <button
+                type='button'
+                onClick={e => {
+                  e.stopPropagation();
+                  removeValue(opt.value);
+                }}
+                className='text-muted-foreground hover:text-muted-foreground'
+              >
+                <X className='size-2.5' strokeWidth={2.5} />
+              </button>
+            )}
           </span>
         ))}
       <Popover.Root open={isOpen} onOpenChange={setIsOpen} modal={false}>
@@ -211,7 +224,7 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
                 type='button'
                 onClick={e => {
                   e.stopPropagation();
-                  onMultiSelect([]);
+                  onMultiSelect(keepLocked([]));
                 }}
                 className='text-muted-foreground hover:text-muted-foreground'
               >

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcAutomationsSection.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcAutomationsSection.tsx
@@ -1,0 +1,223 @@
+import { ReactElement, ReactNode, useCallback, useMemo } from 'react';
+import { Loader2 } from 'lucide-react';
+import { AutomationsList } from '../../components/Automation/AutomationsList/AutomationsList';
+import { AutomationBuilder } from '../../components/Automation/AutomationBuilder/AutomationBuilder';
+import { AutomationApprovalsList } from '../../components/Automation/AutomationApprovalsList/AutomationApprovalsList';
+import { RunHistory } from '../../components/Automation/AutomationRuns/RunHistory/RunHistory';
+import { RunDetail } from '../../components/Automation/AutomationRuns/RunDetail/RunDetail';
+import {
+  isAutomationWorkflow,
+  workflowToAutomation,
+} from '../../components/Automation/automation.adapter';
+import {
+  AutomationStatusValues,
+  type Automation,
+} from '../../components/Automation/Automation.types';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { useAuthContextValues } from '../../hooks/useAuth';
+import { queries } from '../../zero/queries';
+
+export function sdlcAutomationScopesToChannel(automation: Automation, channelId: string): boolean {
+  const cfg = automation.config?.trigger?.config;
+  const channelIds = Array.isArray(cfg?.['channelIds']) ? (cfg['channelIds'] as string[]) : [];
+  return channelIds.length === 0 || channelIds.includes(channelId);
+}
+
+/** `all` backs deep links (may be filtered out of the list); `activeCount` is the rail badge. */
+export function useSdlcChannelAutomations(channelId: string | null): {
+  all: Automation[];
+  activeCount: number;
+  isLoading: boolean;
+} {
+  const { workspaceId } = useAuthContextValues();
+  const [rows, rowsMeta] = useCachedQuery(queries.automationsList({ workspaceId }));
+
+  const all = useMemo(
+    () => (rows ?? []).filter(isAutomationWorkflow).map(workflowToAutomation),
+    [rows],
+  );
+  const activeCount = useMemo(
+    () =>
+      channelId === null
+        ? 0
+        : all.filter(
+            a =>
+              a.status === AutomationStatusValues.ACTIVE &&
+              sdlcAutomationScopesToChannel(a, channelId),
+          ).length,
+    [all, channelId],
+  );
+
+  return { all, activeCount, isLoading: !rows || rowsMeta?.type !== 'complete' };
+}
+
+/** Omitted keys keep their current value; `null`/`false` clear them. */
+export interface SdlcAutomationsNav {
+  automation?: string | null;
+  fork?: string | null;
+  clone?: boolean;
+  runs?: boolean;
+  run?: string | null;
+  approvals?: boolean;
+}
+
+export interface SdlcAutomationsSectionProps {
+  channelId: string | null;
+  automationId: string | null;
+  forkFromId: string | null;
+  isClone: boolean;
+  showRuns: boolean;
+  runId: string | null;
+  showApprovals: boolean;
+  onNavigate: (next: SdlcAutomationsNav) => void;
+}
+
+function Centered({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <div className='flex h-full min-h-[24rem] w-full items-center justify-center px-6 text-center text-sm text-muted-foreground'>
+      {children}
+    </div>
+  );
+}
+
+export function SdlcAutomationsSection({
+  channelId,
+  automationId,
+  forkFromId,
+  isClone,
+  showRuns,
+  runId,
+  showApprovals,
+  onNavigate,
+}: SdlcAutomationsSectionProps): ReactElement {
+  const { all, isLoading } = useSdlcChannelAutomations(channelId);
+
+  const filterPredicate = useCallback(
+    (automation: Automation) =>
+      channelId !== null && sdlcAutomationScopesToChannel(automation, channelId),
+    [channelId],
+  );
+
+  // Stable identity — the builder's seeding effect depends on it.
+  const scopeDefaults = useMemo(
+    () => (channelId ? { channelIds: [channelId] } : undefined),
+    [channelId],
+  );
+
+  const backToApprovals = useCallback(
+    () => onNavigate({ automation: null, fork: null, clone: false, approvals: true }),
+    [onNavigate],
+  );
+
+  const backToList = useCallback(
+    () =>
+      onNavigate({
+        automation: null,
+        fork: null,
+        clone: false,
+        runs: false,
+        run: null,
+        approvals: false,
+      }),
+    [onNavigate],
+  );
+
+  const isNew = automationId === 'new';
+  const current = isNew ? null : (all.find(a => a.id === automationId) ?? null);
+  const forkSource = forkFromId ? (all.find(a => a.id === forkFromId) ?? null) : null;
+
+  if (!channelId) {
+    return (
+      <Centered>
+        This repository has no linked channel yet, so there are no automations to scope to it.
+      </Centered>
+    );
+  }
+
+  // AutomationBuilder reads initialConfig in useState initialisers only, and the
+  // key does not change when rows land — so the fork source must be resolved first.
+  if (isLoading && (forkFromId || (automationId && !isNew))) {
+    return (
+      <Centered>
+        <Loader2 className='mr-2 size-4 animate-spin' />
+        Loading automations…
+      </Centered>
+    );
+  }
+
+  if (automationId && runId) {
+    return <RunDetail runId={runId} onBack={() => onNavigate({ run: null, runs: true })} />;
+  }
+
+  if (automationId && showRuns && current) {
+    return (
+      <RunHistory
+        automationId={current.id}
+        onBack={() => onNavigate({ runs: false, run: null })}
+        onOpenRun={run => onNavigate({ run: run.id, runs: false })}
+      />
+    );
+  }
+
+  if (automationId) {
+    if (!isNew && !current) {
+      return <Centered>Automation not found.</Centered>;
+    }
+
+    return (
+      <AutomationBuilder
+        key={isNew ? `new-${forkFromId ?? 'fresh'}` : (automationId ?? '')}
+        automation={current}
+        approvalReviewMode={showApprovals}
+        {...(scopeDefaults ? { scopeDefaults } : {})}
+        {...(isNew
+          ? forkSource
+            ? {
+                initialConfig: forkSource.config,
+                initialName: isClone ? `${forkSource.name.slice(0, 72)} - Clone` : forkSource.name,
+                ...(forkSource.description ? { initialDescription: forkSource.description } : {}),
+                // Clones start an independent lineage — forks stay pinned to the source.
+                ...(isClone
+                  ? {}
+                  : {
+                      forkFromSeriesId: forkSource.automationSeriesId ?? forkSource.id,
+                      forkSourceAutomationId: forkSource.id,
+                    }),
+              }
+            : {}
+          : {})}
+        onBack={showApprovals ? backToApprovals : backToList}
+        onAfterApprovalDecision={backToApprovals}
+        onSaved={result => {
+          if (isNew) onNavigate({ automation: result.automation.id, fork: null, clone: false });
+        }}
+        onShowRuns={id => onNavigate({ automation: id, runs: true })}
+        onFork={(id, mode) => onNavigate({ automation: 'new', fork: id, clone: mode === 'clone' })}
+        onOpenAutomation={id => onNavigate({ automation: id, fork: null, clone: false })}
+      />
+    );
+  }
+
+  if (showApprovals) {
+    return (
+      <AutomationApprovalsList
+        filterPredicate={filterPredicate}
+        onBack={backToList}
+        onOpenProposal={automation => onNavigate({ automation: automation.id })}
+      />
+    );
+  }
+
+  return (
+    <AutomationsList
+      filterPredicate={filterPredicate}
+      onCreate={() => onNavigate({ automation: 'new' })}
+      onOpen={automation => onNavigate({ automation: automation.id })}
+      onShowRuns={automation => onNavigate({ automation: automation.id, runs: true })}
+      onFork={(automation, mode) =>
+        onNavigate({ automation: 'new', fork: automation.id, clone: mode === 'clone' })
+      }
+      onShowApprovals={() => onNavigate({ approvals: true })}
+    />
+  );
+}

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -36,6 +36,7 @@ import {
   Trash2,
   Users,
   X,
+  Zap,
 } from 'lucide-react';
 import { isFramedSdlcSurface, requestSdlcFrameReset } from './useSdlcFrameBridge';
 import { toast } from 'sonner';
@@ -87,6 +88,11 @@ import {
   type SdlcWikiStartInput,
 } from './SdlcWikiSection';
 import { SdlcDebuggerPanel } from './SdlcDebuggerPanel';
+import {
+  SdlcAutomationsSection,
+  useSdlcChannelAutomations,
+  type SdlcAutomationsNav,
+} from './SdlcAutomationsSection';
 import { SdlcActivityPreview } from './SdlcActivityPreview';
 import {
   discussionConversationIds as discussionIdsForOwner,
@@ -121,7 +127,15 @@ import {
   type RepoKnowledgeControl,
 } from './repoKnowledgePolicy';
 
-type Section = 'overview' | 'wiki' | 'baseline' | 'prds' | 'tech-docs' | 'tracks' | 'tickets';
+type Section =
+  | 'overview'
+  | 'wiki'
+  | 'baseline'
+  | 'prds'
+  | 'tech-docs'
+  | 'tracks'
+  | 'tickets'
+  | 'automations';
 type ArtifactKind = 'PRD' | 'TECH_DOC';
 
 const StableCanvasScreen = memo(CanvasScreen);
@@ -141,6 +155,7 @@ const SECTIONS: Array<{ id: Section; label: string; icon: typeof Boxes }> = [
   { id: 'prds', label: 'PRDs', icon: ScrollText },
   { id: 'tech-docs', label: 'Tech Docs', icon: Network },
   { id: 'tickets', label: 'Tickets', icon: CircleDot },
+  { id: 'automations', label: 'Automations', icon: Zap },
 ];
 
 const BASELINE_LABELS: Record<string, string> = {
@@ -489,6 +504,15 @@ export default function SdlcScreen(): ReactElement {
     [selectedCanvasRelatedConversations],
   );
   const selectedTicketId = routeSearchParams.get('ticket');
+
+  const selectedAutomationId = routeSearchParams.get('automation');
+  const automationForkFromId = routeSearchParams.get('fork');
+  const automationIsClone = routeSearchParams.get('clone') === '1';
+  const automationShowRuns = routeSearchParams.get('runs') === '1';
+  const selectedAutomationRunId = routeSearchParams.get('run');
+  const automationShowApprovals = routeSearchParams.get('approvals') === '1';
+  const repoChannelId = repo && !(repo instanceof Error) ? (repo.channelId ?? null) : null;
+  const { activeCount: activeAutomationCount } = useSdlcChannelAutomations(repoChannelId);
   const chatLayout = sdlcChatLayout({
     chatParam: routeSearchParams.get('chat'),
     discussionParam: routeSearchParams.get('discussion'),
@@ -805,6 +829,40 @@ export default function SdlcScreen(): ReactElement {
       void navigate(`${pathname}${search}`);
     },
     [location.search, navigate, ownerHasConversations],
+  );
+
+  const navigateAutomations = useCallback(
+    (next: SdlcAutomationsNav): void => {
+      if (!repoId) return;
+      const keep = <T,>(patch: T | undefined, current: T): T =>
+        patch === undefined ? current : patch;
+      const automation = keep(next.automation, selectedAutomationId);
+      const fork = keep(next.fork, automationForkFromId);
+      const clone = keep(next.clone, automationIsClone);
+      const runs = keep(next.runs, automationShowRuns);
+      const run = keep(next.run, selectedAutomationRunId);
+      const approvals = keep(next.approvals, automationShowApprovals);
+
+      const params = new URLSearchParams();
+      if (automation) params.set('automation', automation);
+      if (fork) params.set('fork', fork);
+      if (clone) params.set('clone', '1');
+      if (runs) params.set('runs', '1');
+      if (run) params.set('run', run);
+      if (approvals) params.set('approvals', '1');
+      const query = params.toString();
+      navigateWithinSdlc(`/sdlc/${repoId}/automations`, query ? `?${query}` : '');
+    },
+    [
+      automationForkFromId,
+      automationIsClone,
+      automationShowApprovals,
+      automationShowRuns,
+      navigateWithinSdlc,
+      repoId,
+      selectedAutomationId,
+      selectedAutomationRunId,
+    ],
   );
 
   const openCanvas = (canvasId: string): void => {
@@ -1697,7 +1755,9 @@ export default function SdlcScreen(): ReactElement {
                               ? tickets.length
                               : item.id === 'tracks'
                                 ? tracks.filter(track => track.status === 'ACTIVE').length
-                                : ''}
+                                : item.id === 'automations'
+                                  ? activeAutomationCount
+                                  : ''}
                   </span>
                 </button>
               </div>
@@ -2289,6 +2349,20 @@ export default function SdlcScreen(): ReactElement {
                 {section === 'tickets' && repo.channelId && (
                   <div className='h-[calc(100vh-8rem)] min-h-[36rem]'>
                     <KanbanBoardScreen channelId={repo.channelId} />
+                  </div>
+                )}
+                {section === 'automations' && (
+                  <div className='h-[calc(100vh-8rem)] min-h-[36rem]'>
+                    <SdlcAutomationsSection
+                      channelId={repo.channelId ?? null}
+                      automationId={selectedAutomationId}
+                      forkFromId={automationForkFromId}
+                      isClone={automationIsClone}
+                      showRuns={automationShowRuns}
+                      runId={selectedAutomationRunId}
+                      showApprovals={automationShowApprovals}
+                      onNavigate={navigateAutomations}
+                    />
                   </div>
                 )}
               </div>


### PR DESCRIPTION
## What

Adds an **Automations** section to the SDLC hub (`/sdlc/:repoId/automations`), showing the automations that fire in that repo's channel.

Step 1 of moving SDLC's hardcoded flows onto the automations engine. This step adds **no engine capability** — it is a view. No migration, no backend change, no new step or trigger.

## Scoping

There is no new storage. An automation "belongs" to a repo when its **trigger's own `channelIds` filter** matches `repo.channelId`, matched client-side via the `filterPredicate` prop that already exists on `AutomationsList`. This is the same approach the Desk settings tab uses.

Consequences, both deliberate:
- Same rows as `/automations` — anything created there shows here and vice versa.
- An automation with an *empty* channel filter appears in every repo's panel, because it genuinely does fire there.

List / builder / run history / run detail / approvals are driven by search params (`?automation`, `?fork`, `?clone`, `?runs`, `?run`, `?approvals`), matching the `?canvas` / `?track` / `?ticket` convention already in `SdlcScreen`. The rail badge counts **ACTIVE only**, like the Tracks badge.

## Why this touches shared components

12 of the 14 files are shared. Embedding surfaced two things that were broken but unreachable before:

**1. Hardcoded absolute navigation.** `AutomationsList`, `AutomationApprovalsList` and `AutomationBuilder` navigated to literal `/automations/...` paths. Mounted inside the SDLC hub — especially the framed `/sdlc-app` lane — those ejected the user out of the hub. Most visibly *Start proposal*, where `navigate('../new?fork=…', {relative:'path'})` resolved to `/sdlc/:repoId/new`, not a valid `Section`, so `SdlcScreen` silently fell back to Overview.

Six call sites now take optional callbacks that **default to the previous behaviour**, so `/automations` and the Desk tab are behaviourally unchanged:

| Component | Props |
| --- | --- |
| `AutomationsList` | `onFork`, `onShowApprovals` |
| `AutomationApprovalsList` | `onOpenProposal`, `onBack` |
| `AutomationBuilder` | `onFork`, `onOpenAutomation` |

**2. Channel pre-fill + pinning.** New automations created in the panel default to the repo's channel via `AutomationBuilder`'s new `scopeDefaults`, and that value is pinned in the trigger's condition form via `lockedValues` threaded down to `EntityMultiSelector` (which gained a per-value lock guarding all five of its removal paths).

Seeding is skipped for **saved** automations, so opening an existing workspace-wide automation from this panel cannot silently rescope it.

Two implementation notes for reviewers:
- `GET /automations/schema/triggers/:type` serialises with `zodToJsonSchema(schema, {name:'config'})`, so `configSchema.properties` is always `undefined` — reads must go through `resolveSchema()`.
- Seeding is guarded to once per trigger-type pick; react-query hands back a new object identity on refetch, which would otherwise resurrect a value the user cleared.

## Also

`RunHistory` rendered `CANCELLED` runs with an infinite spinner — the status→icon ternary handled 4 of the 8 `AutomationRunStatus` values and everything else fell through to `<Loader2 animate-spin>`.

## Not in scope

Repo Knowledge is **not** yet an automation — the pipeline shape (single step vs. step-per-document vs. the design note's `GROUP` + `FOR_EACH` block) is still undecided. Desk's identical navigation bug is left alone; it's now three props away from fixable.

## Testing

`tsc --noEmit` clean, `eslint` 0 errors, full pre-commit suite passed. Exercised manually in the SDLC hub: section + badge, list filtering, create with pre-filled channel, Start proposal, clone, run history.

Not covered by automated tests — the dashboard has no test runner.

## Pre-existing bugs found, not fixed here

1. No `add_sdlc_resource` migration — the SDLC nav item is gated on a `resources` row that nothing creates, so it is invisible on any database not hand-patched.
2. Variable arity is never validated. The picker offers array-valued variables (e.g. `trigger.mentionedUserIds`) for slots that require a single id; the config saves fine and fails only at run time as `userIds.0: Invalid input`.
3. `useSeedSoleVariable` tracks "already settled" in refs, which reset on every mount — so clearing an auto-bound variable never sticks across a reload.
