### PR TITLE
feat: add claw interrupt-with-reply queue controls

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/message-queue.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/message-queue.ts
@@ -144,6 +144,14 @@ export interface QueuedMessage {
   sessionContext?: Record<string, unknown>;
   /** Defaults to "conversation" on drain when absent (legacy-safe). */
   responseMode?: "conversation" | "approval";
+  /** Why this message is waiting. Used to distinguish explicit `/queue <msg>`
+   *  from a normal busy-thread enqueue and from a same-user interrupt follow-up. */
+  queueReason?: "busy" | "explicit_queue" | "interrupt_followup";
+  /** Requested handling mode for the active run when this message was queued. */
+  interruptMode?: "queue_only" | "interrupt_with_reply";
+  /** Suppress the normal "queued" notice when another control path already
+   *  posts a better acknowledgement. */
+  suppressQueuedNotice?: boolean;
   /** epoch ms when enqueued */
   ts: number;
 }

--- a/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parseSlashCommand } from "./parseSlashCommand.js";
+
+describe("parseSlashCommand queue commands", () => {
+  it("parses bare /queue as queue inspection", () => {
+    expect(parseSlashCommand("/queue")).toEqual({ kind: "queueShow" });
+  });
+
+  it("parses /queue clear before /queue <message>", () => {
+    expect(parseSlashCommand("/queue clear")).toEqual({ kind: "queueClear" });
+  });
+
+  it("parses /queue <message> as an explicit queue-only message", () => {
+    expect(parseSlashCommand("/queue run this after the current task")).toEqual({
+      kind: "queueAdd",
+      message: "run this after the current task",
+    });
+  });
+
+  it("strips a leading agent mention before parsing /queue <message>", () => {
+    expect(parseSlashCommand("@Xyne Doctor /queue follow up later")).toEqual({
+      kind: "queueAdd",
+      message: "follow up later",
+    });
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/parseSlashCommand.ts
@@ -27,6 +27,9 @@ export type SlashCommand =
   // `/queue` — show the messages currently waiting behind the active run for
   // this conversation (the mid-run message queue). Read-only; short-circuits.
   | { kind: "queueShow" }
+  // `/queue <message>` — append a message behind the active run without
+  // interrupting it. Short-circuits after enqueueing.
+  | { kind: "queueAdd"; message: string }
   // `/queue clear` — drop the messages waiting behind the active run (does NOT
   // stop the current run — that's `/stop`). Short-circuits.
   | { kind: "queueClear" }
@@ -114,6 +117,13 @@ function parseFromSlash(trimmed: string): SlashCommand | null {
   // `/queue` — exact match only; show the mid-run message queue for this thread.
   if (lower === "/queue") {
     return { kind: "queueShow" };
+  }
+  // `/queue <message>` — explicit opt-out from same-user interrupt-with-reply.
+  // It appends the message behind the active run and does not touch that run.
+  if (lower.startsWith("/queue ")) {
+    const message = trimmed.slice("/queue ".length).trim();
+    if (message.length === 0) return { kind: "queueShow" };
+    return { kind: "queueAdd", message: message.slice(0, 20_000) };
   }
   // `/compact` or `/compact <instructions>`.
   if (lower === "/compact") {

--- a/apps/xyne-claw-auth/backend/src/routes/run.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run.ts
@@ -2002,46 +2002,63 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
   }
 });
 
+async function forwardRunControl(
+  action: "cancel" | "interrupt-with-reply",
+  req: Request<{ sessionId: string }>,
+  res: Response,
+): Promise<void> {
+  const { sessionId } = req.params;
+  if (!sessionId || typeof sessionId !== "string") {
+    res.status(400).json({ success: false, error: "sessionId is required" });
+    return;
+  }
+
+  const callerUserId = req.headers["x-user-id"];
+  if (typeof callerUserId !== "string" || !callerUserId.trim()) {
+    res.status(400).json({ success: false, error: "x-user-id is required" });
+    return;
+  }
+
+  try {
+    const clawRes = await fetch(`${CONFIG.xyneClawUrl}/run/${encodeURIComponent(sessionId)}/${action}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+        "x-user-id": callerUserId,
+      },
+    });
+
+    const body = (await clawRes.json().catch(() => null)) as Record<string, unknown> | null;
+    if (!clawRes.ok) {
+      res
+        .status(clawRes.status)
+        .json(body ?? { success: false, error: `${action} failed: HTTP ${clawRes.status}` });
+      return;
+    }
+
+    res.json(body ?? { success: true, sessionId });
+  } catch (err) {
+    log.error(`[run] Error forwarding ${action} to xyne-claw:`, err);
+    res.status(502).json({ success: false, error: "Failed to reach agent service" });
+  }
+}
+
+// ── POST /run/:sessionId/interrupt-with-reply — ask active run to post a partial reply, then drain queued follow-up ──
+router.post(
+  "/run/:sessionId/interrupt-with-reply",
+  requireRunCaller,
+  async (req: Request<{ sessionId: string }>, res: Response) => {
+    await forwardRunControl("interrupt-with-reply", req, res);
+  },
+);
+
 // ── POST /run/:sessionId/cancel — proxy cancel to xyne-claw ──
 router.post(
   "/run/:sessionId/cancel",
   requireRunCaller,
   async (req: Request<{ sessionId: string }>, res: Response) => {
-    const { sessionId } = req.params;
-    if (!sessionId || typeof sessionId !== "string") {
-      res.status(400).json({ success: false, error: "sessionId is required" });
-      return;
-    }
-
-    const callerUserId = req.headers["x-user-id"];
-    if (typeof callerUserId !== "string" || !callerUserId.trim()) {
-      res.status(400).json({ success: false, error: "x-user-id is required" });
-      return;
-    }
-
-    try {
-      const clawRes = await fetch(`${CONFIG.xyneClawUrl}/run/${encodeURIComponent(sessionId)}/cancel`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
-          "x-user-id": callerUserId,
-        },
-      });
-
-      const body = (await clawRes.json().catch(() => null)) as Record<string, unknown> | null;
-      if (!clawRes.ok) {
-        res
-          .status(clawRes.status)
-          .json(body ?? { success: false, error: `Cancel failed: HTTP ${clawRes.status}` });
-        return;
-      }
-
-      res.json(body ?? { success: true, sessionId });
-    } catch (err) {
-      log.error("[run] Error forwarding cancel to xyne-claw:", err);
-      res.status(502).json({ success: false, error: "Failed to reach agent service" });
-    }
+    await forwardRunControl("cancel", req, res);
   },
 );
 

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -2076,7 +2076,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         "- `/stop` (or `/goal clear`) — stop the current run, drop queued messages, and clear any active goal",
         "- `/clear` — wipe this thread's context and start fresh",
         "- `/compact [focus]` — summarize & shrink the context, then continue",
-        "- `/queue` — show messages waiting behind the current run · `/queue clear` — drop them",
+        "- `/queue` — show messages waiting behind the current run · `/queue <message>` — run it after the current run without interrupting · `/queue clear` — drop waiting messages",
         "- `/upgrade [task]` — use the premium model for this conversation",
         "- `/fast [task]` / `/fast off` — fast mode: the agent calls tools directly instead of delegating to subagents (quicker for short asks; use normal mode for deep investigations)",
         "- `/help` — show this list",
@@ -2226,6 +2226,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
   // Not a short-circuit: it dispatches a normal turn with compactBeforeRun set,
   // so the agent compacts the resumed session and replies with a summary.
   const compactBeforeRun = slash?.kind === "compact";
+  const explicitQueueOnly = slash?.kind === "queueAdd";
 
   // Only goal commands reach the goal relooper; stop/clear/compact are handled
   // here (goalClear was short-circuited above into the full /stop path).
@@ -2247,6 +2248,11 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       log.warn("Failed to post /goal control reply", { error: err instanceof Error ? err.message : String(err) });
     });
     return;
+  } else if (slash?.kind === "queueAdd") {
+    // `/queue <message>` is an explicit opt-out from same-user interrupt-with-reply.
+    // If a run is active the slot gate below will enqueue it without touching the
+    // active run; if nothing is active we just run the message now.
+    task = slash.message;
   } else if (compactBeforeRun) {
     // The run resumes the session, forces a compaction, and answers this task —
     // a short summary for the user while the context shrinks.
@@ -2341,6 +2347,13 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
     const slot = await tryAcquireSlot(payload.conversationId, runAgentSlug);
     slotToken = slot;
     if (!slot) {
+      const activeRun = await agentRunRepository.findRunningByConversation(payload.conversationId).catch(() => null);
+      const sameUserActiveRun =
+        !explicitQueueOnly &&
+        activeRun?.agentSlug === runAgentSlug &&
+        activeRun.userId === targetUserId
+          ? activeRun
+          : null;
       const queuedMsg: QueuedMessage = {
         eventId: (payload as { messageId?: string }).messageId ?? traceId,
         conversationId: payload.conversationId,
@@ -2352,16 +2365,45 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
         orgId: agent.orgId,
         task,
         eventType,
+        queueReason: sameUserActiveRun ? "interrupt_followup" : explicitQueueOnly ? "explicit_queue" : "busy",
+        interruptMode: sameUserActiveRun ? "interrupt_with_reply" : "queue_only",
         ts: Date.now(),
       };
       const enq = await enqueueMessage(queuedMsg);
-      const notice = enq.enqueued
-        ? `🕒 I’m still working on your previous message — this one is queued (position ${enq.position}). I’ll get to it as soon as I’m done.`
-        : enq.deduped
-          ? `🕒 Already queued — I’ll get to it as soon as I’m done with the current one.`
-          : enq.full
-            ? `⚠️ I’m still working and this thread’s queue is full (${QUEUE_CAP}). Please resend once I’ve caught up.`
-            : `⚠️ I’m still working on your previous message and couldn’t queue this one. Please resend in a moment.`;
+      let interruptRequested = false;
+      if (enq.enqueued && sameUserActiveRun) {
+        try {
+          const interruptRes = await fetch(
+            `${CONFIG.internalUrl}/claw/api/v1/internal/run/${encodeURIComponent(sameUserActiveRun.sessionId)}/interrupt-with-reply`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+                "x-user-id": targetUserId,
+              },
+            },
+          );
+          interruptRequested = interruptRes.ok;
+          if (!interruptRes.ok) {
+            const body = await interruptRes.text().catch(() => "");
+            log.warn(`[msg-queue] interrupt-with-reply rejected session=${sameUserActiveRun.sessionId} status=${interruptRes.status} body=${body.slice(0, 200)}`);
+          }
+        } catch (err) {
+          log.warn("Failed to request interrupt-with-reply", { error: err instanceof Error ? err.message : String(err) });
+        }
+      }
+      const notice = sameUserActiveRun && interruptRequested
+        ? `⏸️ I’ll wrap up my current reply first, then continue with your new message.`
+        : enq.enqueued
+          ? explicitQueueOnly
+            ? `🕒 Queued after the current run (position ${enq.position}).`
+            : `🕒 I’m still working on your previous message — this one is queued (position ${enq.position}). I’ll get to it as soon as I’m done.`
+          : enq.deduped
+            ? `🕒 Already queued — I’ll get to it as soon as I’m done with the current one.`
+            : enq.full
+              ? `⚠️ I’m still working and this thread’s queue is full (${QUEUE_CAP}). Please resend once I’ve caught up.`
+              : `⚠️ I’m still working on your previous message and couldn’t queue this one. Please resend in a moment.`;
       await spacesAppFetch("/chat/postMessage", {
         channelId: payload.channelId,
         conversationId: payload.conversationId,
@@ -2371,7 +2413,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       }, agent.appToken).catch((err) => {
         log.warn("Failed to post queue notice", { error: err instanceof Error ? err.message : String(err) });
       });
-      log.info(`[msg-queue] conv ${payload.conversationId} busy — queued eventId=${queuedMsg.eventId} (enqueued=${enq.enqueued} pos=${enq.position} deduped=${enq.deduped} full=${enq.full})`);
+      log.info(`[msg-queue] conv ${payload.conversationId} busy — queued eventId=${queuedMsg.eventId} reason=${queuedMsg.queueReason} interruptRequested=${interruptRequested} (enqueued=${enq.enqueued} pos=${enq.position} deduped=${enq.deduped} full=${enq.full})`);
       return;
     }
   }

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -168,6 +168,10 @@ interface ActiveRunControl {
    *  respond-to-user termination (which also aborts the controller). Lets the
    *  catch block honor a user stop instead of posting a just-generated answer. */
   userCancelled?: boolean;
+  /** Same-user follow-up requested an early, user-visible reply for the current
+   *  run before the queued follow-up is dispatched. Unlike /cancel, this must
+   *  complete with a posted result so the transcript remains linear. */
+  gracefulInterruptRequested?: boolean;
   hasCallbackUrl?: boolean;
   sseClientAttached?: boolean;
   sseReconnectGraceTimer?: ReturnType<typeof setTimeout>;
@@ -1287,6 +1291,39 @@ router.get("/run/:sessionId/alive", validateS2SKey, (req, res: Response) => {
     return;
   }
   res.json({ success: true, sessionId, alive: activeRuns.has(sessionId) });
+});
+
+router.post("/run/:sessionId/interrupt-with-reply", validateS2SKey, (req, res: Response) => {
+  const { sessionId } = req.params as { sessionId?: string };
+  if (!sessionId) {
+    res.status(400).json({ success: false, error: "sessionId is required" });
+    return;
+  }
+
+  const active = activeRuns.get(sessionId);
+  if (!active) {
+    res.json({ success: true, sessionId, status: "not_running" });
+    return;
+  }
+
+  const callerUserId = req.headers["x-user-id"];
+  if (
+    typeof callerUserId !== "string" ||
+    !callerUserId ||
+    callerUserId !== active.userId
+  ) {
+    res
+      .status(403)
+      .json({ success: false, error: "Not authorized to interrupt this run" });
+    return;
+  }
+
+  // This is intentionally NOT userCancelled. /cancel suppresses output; a
+  // same-user follow-up wants the active turn to produce/post what it has, then
+  // let claw-auth drain the queued follow-up as the next user turn.
+  active.gracefulInterruptRequested = true;
+  active.abortController.abort();
+  res.json({ success: true, sessionId, status: "interrupt_requested" });
 });
 
 router.post("/run/:sessionId/cancel", validateS2SKey, (req, res: Response) => {
@@ -4695,6 +4732,32 @@ async function processTask(
         model: callbackModel,
       });
     } else if (err instanceof RunCancelledError || abortSignal?.aborted) {
+      const gracefulInterrupt = activeRuns.get(sessionId)?.gracefulInterruptRequested === true;
+      const partialResult = err instanceof RunCancelledError ? err.partialText?.trim() : "";
+      if (gracefulInterrupt) {
+        log(`Session interrupted with reply: ${sessionId}`);
+        await sendCallback(callbackUrl, sessionToken, {
+          sessionId,
+          userId,
+          conversationId: conversationId ?? null,
+          agentSlug: agentSlug ?? null,
+          fastMode: fastModeForCallback,
+          status: "completed",
+          result: partialResult || "I’m pausing this run here so I can continue with your new message.",
+          ...(err instanceof RunCancelledError && err.toolsUsed.length > 0
+            ? { toolsUsed: err.toolsUsed }
+            : {}),
+          ...(err instanceof RunCancelledError && err.toolInvocations.length > 0
+            ? { toolInvocations: err.toolInvocations }
+            : {}),
+          ...(err instanceof RunCancelledError
+            ? { tokenUsage: err.tokenUsage }
+            : {}),
+          provider: callbackProvider,
+          model: callbackModel,
+        });
+        return;
+      }
       log(`Session cancelled: ${sessionId}`);
       await sendCallback(callbackUrl, sessionToken, {
         sessionId,


### PR DESCRIPTION
1. Problem Description:
Claw Spaces thread messages currently serialize behind an active run. Users must manually /stop when they want the active run to finish early and continue with a new instruction, and there is no explicit `/queue <message>` opt-out for queue-only behavior.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Requested in Spaces thread: same-user follow-up should force the previous run to reply/finish early, then insert the new instruction after it so context remains linear. If the user does not want an early reply, they should be able to use `/queue <message>`.

3. Explain the solution implemented in the PR:
- Adds `/queue <message>` parsing and tests.
- Marks queued messages with queueReason/interruptMode metadata.
- When a same-user message arrives while the same agent/conversation is busy, queues it as an interrupt follow up and requests `/interrupt-with-reply` on the active run.
- Adds claw-auth proxy route for `/run/:sessionId/interrupt-with-reply`.
- Adds xyne-claw runtime endpoint that differs from `/cancel`: it aborts the active run but reports a completed partial reply so webhook result posting and queue drain preserve transcript order.
- Keeps `/stop` behavior unchanged.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `git diff --check`
- `pnpm --dir apps/xyne-claw-auth/backend exec vitest run src/lib/parseSlashCommand.test.ts`
- Attempted `pnpm --dir apps/xyne-claw-auth/backend exec tsc --noEmit --pretty false`; blocked by existing Prisma/client and unrelated repo type errors.
- Attempted `pnpm --dir apps/xyne-claw exec tsc --noEmit --pretty false`; blocked by existing missing `sanitize-html` type/module errors in shared package.

9. Services to which this change is to be deployed:
xyne-claw-auth, xyne-claw

10. Main PR link (if this PR is raised against a release branch):
N/A