### PR TITLE
feat: waveform identity and in-place transcript modal for recordings

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
+++ b/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react';
+import { createElement, type ComponentType, type ReactElement } from 'react';
 import {
   GraphTrendLine,
   Settings01,
@@ -14,7 +14,6 @@ import {
   ClipboardDefault,
   Piechart01,
   FileText,
-  MicOn,
   CalendarTimer,
   Globe,
   UserShield,
@@ -32,6 +31,7 @@ import {
   RocketShip,
   type PikaIconProps,
 } from '@xyne/icons';
+import { AudioLines } from 'lucide-react';
 
 import { PATH_TO_RESOURCE } from './utils/resourceMapping';
 import { isElectronApp } from '../../utils/electronApp';
@@ -40,6 +40,12 @@ import { AccessType } from '@xyne/shared';
 
 /** A themeable pika-icon component (accepts size, color, variant, strokeWidth, className). */
 export type PikaIcon = ComponentType<PikaIconProps>;
+
+// Matches the waveform the Xyne Scribe list uses. lucide has no Solid/Stroke
+// pair, so `variant` is dropped here rather than passed through to the <svg>.
+const AudioWaveIcon = ({ variant: _variant, ...props }: PikaIconProps): ReactElement =>
+  createElement(AudioLines, props);
+
 export const RAIL_SHORTCUT_LIMIT = 9;
 export const railShortcutsAvailable = (): boolean => isElectronApp();
 
@@ -65,7 +71,7 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
   { path: '/chat/dm', label: 'DMs', icon: ChatDefault },
   { path: '/chat/activity', label: 'Activity', icon: NotificationBellOn },
   { path: '/calls', label: 'Calls', icon: PhoneDefault },
-  { path: '/recordings', label: 'Recordings', icon: MicOn },
+  { path: '/recordings', label: 'Recordings', icon: AudioWaveIcon },
   { path: '/projects', label: 'Tickets', icon: TicketToken },
   { path: '/sdlc', label: 'SDLC', icon: Atom },
   { path: '/support', label: 'Support', icon: Troubleshoot },

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPillRow.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPillRow.tsx
@@ -16,12 +16,12 @@ import {
   Globe,
   Hashtag,
   LockClose,
-  MicOn,
   MultipleCrossCancelDefault,
   Notebook,
   PhoneDefault,
   TicketToken,
 } from '@xyne/icons';
+import { AudioLines } from 'lucide-react';
 import { motion } from 'framer-motion';
 import Avatar from '../../../ui/Avatar/Avatar';
 import useMeasure from '../../../../hooks/useMeasure';
@@ -693,7 +693,7 @@ export const ContextPillRow = ({
           {pillContent(
             <>
               <div className='flex-shrink-0'>
-                <MicOn className={CONTEXT_PILL_ICON_CLASS} />
+                <AudioLines className={CONTEXT_PILL_ICON_CLASS} />
               </div>
               <span className={`${CONTEXT_PILL_LABEL_CLASS} max-w-[120px] truncate`}>
                 {recording.title}
@@ -702,7 +702,9 @@ export const ContextPillRow = ({
             onRecordingClick && (recording.externalId || recording.channelId)
               ? {
                   onClick: (): void => onRecordingClick(recording),
-                  ariaLabel: `Open recording ${recording.title}`,
+                  ariaLabel: recording.externalId
+                    ? `Open transcript for ${recording.title}`
+                    : `Open recording ${recording.title}`,
                   trackName: 'CLICK_RECORDING_CONTEXT_PILL',
                   trackMetadata: JSON.stringify({ recordingId: recording.id }),
                 }

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/RecordingTranscriptModal.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/RecordingTranscriptModal.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import { Dialog } from '../../../ui/Dialog';
+import { TranscriptSidePanel } from '../../TranscriptCitationModal/TranscriptSidePanel';
+import { fetchTranscriptCached } from '../../TranscriptCitationModal/transcriptCache';
+
+export interface RecordingTranscriptModalProps {
+  /** Recording's externalId — the call the transcript belongs to. `null` keeps the modal closed. */
+  callId: string | null;
+  onClose: () => void;
+}
+
+/**
+ * The transcript behind an attached recording pill, shown centred over the
+ * composer so the half-written question stays put. Reuses the citation panel's
+ * body (copy / download / search) rather than a second transcript reader.
+ */
+export const RecordingTranscriptModal = ({
+  callId,
+  onClose,
+}: RecordingTranscriptModalProps): ReactElement => {
+  // Radix focuses the first tabbable child on open, which is the panel's Copy
+  // button — and a focused tooltip trigger keeps its tooltip up. Park focus on
+  // the container instead so the dialog still traps it without that side effect.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [transcript, setTranscript] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!callId) return;
+
+    let cancelled = false;
+    setTranscript('');
+    setError(null);
+    setIsLoading(true);
+
+    fetchTranscriptCached(callId)
+      .then(data => {
+        if (!cancelled) setTranscript(data ?? '');
+      })
+      .catch(() => {
+        if (!cancelled) setError('Could not load the transcript for this recording.');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return (): void => {
+      cancelled = true;
+    };
+  }, [callId]);
+
+  return (
+    <Dialog
+      open={callId !== null}
+      onOpenChange={open => {
+        if (!open) onClose();
+      }}
+      title='Transcript'
+      description='Transcript of the attached recording'
+      className='h-[80vh] max-w-2xl overflow-hidden rounded-2xl p-0'
+      mobileVariant='dialog'
+      testId='recording-transcript-modal'
+      focusRef={containerRef}
+    >
+      <div ref={containerRef} tabIndex={-1} className='h-full outline-none'>
+        <TranscriptSidePanel
+          transcript={transcript}
+          isLoading={isLoading}
+          error={error}
+          onClose={onClose}
+          className='border-l-0 shadow-none'
+        />
+      </div>
+    </Dialog>
+  );
+};

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
@@ -40,6 +40,7 @@ import type { VoiceInputHandle } from '../../../ui/InputBox/VoiceInput';
 import { StopIcon } from './StopIcon';
 import { AgentSelector } from './AgentSelector';
 import { ContextPillRow } from './ContextPillRow';
+import { RecordingTranscriptModal } from './RecordingTranscriptModal';
 import { CONTEXT_PICKER_TOGGLE_ATTR } from './ContextPicker';
 import { ModelThinkingSelector } from '../../../AIScreen/ModelThinkingSelector';
 import type { ClawAgentModel } from '../../../../services/clawAgentModelsService';
@@ -621,6 +622,8 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
 
     // Browser context state
     const [browserContext, setBrowserContext] = useState<BrowserContext | null>(null);
+    // Recording pill → its transcript, read in place over the composer.
+    const [transcriptCallId, setTranscriptCallId] = useState<string | null>(null);
 
     // Update activeThreadInfo when threadInfo prop changes
     useEffect(() => {
@@ -831,12 +834,12 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
       if (isMobile) xyneAIActor.send({ type: 'CLOSE' });
     };
 
-    // Recordings have a real linkable detail route; fall back to the shared
-    // conversation when the search result didn't carry the recording id.
+    // The transcript is what the pill actually attached, so show it in a modal
+    // rather than routing away from the half-written question. Falls back to the
+    // shared conversation when the search result didn't carry the recording id.
     const handleRecordingContextClick = (recording: SelectedRecording): void => {
       if (recording.externalId) {
-        void navigate(`/recordings/${recording.externalId}`);
-        if (isMobile) xyneAIActor.send({ type: 'CLOSE' });
+        setTranscriptCallId(recording.externalId);
         return;
       }
       handleTranscriptContextClick(recording);
@@ -1715,6 +1718,11 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
           onRecordingClick={handleRecordingContextClick}
           activities={selectedActivities}
           {...(onActivitiesChange && { onActivitiesChange })}
+        />
+
+        <RecordingTranscriptModal
+          callId={transcriptCallId}
+          onClose={() => setTranscriptCallId(null)}
         />
 
         {/* MentionSelector for "@" trigger in editor (user mentions) */}

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -3991,24 +3991,29 @@ img.inline-emoji,
    and role="option" on its rows ([cmdk-item]) via cmdk. Those already use design
    tokens (bg-background list, text-foreground/-muted-foreground rows, its own
    cmdk-active-row selection), so this hardcoded dark must not override them.
-   Mirrors the [role="option"]:not([cmdk-item]) exclusion below. */
-[data-theme="midnight"] [role="listbox"]:not([cmdk-list]) {
+   Mirrors the [role="option"]:not([cmdk-item]) exclusion below.
+
+   [data-theme-tokens] is the general opt-out: any listbox already built on the
+   design tokens marks itself with it and keeps its own surface, hover and
+   selected colours instead of these hardcoded ones. */
+[data-theme="midnight"] [role="listbox"]:not([cmdk-list]):not([data-theme-tokens]) {
   background-color: #1a1a1a !important;
   border-color: #374151 !important;
 }
 
-[data-theme="midnight"] [role="option"]:not([cmdk-item]) {
+[data-theme="midnight"] [role="option"]:not([cmdk-item]):not([data-theme-tokens]) {
   color: #d1d5db !important;
 }
 
-[data-theme="midnight"] [role="option"]:not([cmdk-item]):hover {
+[data-theme="midnight"] [role="option"]:not([cmdk-item]):not([data-theme-tokens]):hover {
   background-color: #2a2d30 !important;
 }
 
 /* Select/combobox dropdown options. Excludes cmd+K rows ([cmdk-item]) so they keep the
    documented gray-resting / blue-navigated two-tier above — otherwise this !important blue
    overrides the resting gray and resting vs. navigated become indistinguishable in midnight. */
-[data-theme="midnight"] [role="option"][aria-selected="true"]:not([cmdk-item]) {
+[data-theme="midnight"]
+  [role="option"][aria-selected="true"]:not([cmdk-item]):not([data-theme-tokens]) {
   background-color: rgba(37, 99, 235, 0.2) !important;
   color: #60a5fa !important;
 }

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -2,7 +2,7 @@ import { type ReactElement, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
 import { toast } from 'sonner';
-import { MinimizeLineArrow, Share02, Spinner, UturnLeft } from '@xyne/icons';
+import { MinimizeLineArrow, Share02, Spinner } from '@xyne/icons';
 import { Button } from '../../../components/ui/Button/Button';
 import { Dialog } from '../../../components/ui/Dialog';
 import { Tooltip } from '../../../components/ui/Tooltip';
@@ -214,7 +214,6 @@ export const RecordingDetailV2Header = ({
               data-track-category='RecordingDetailV2'
               data-track-name='breadcrumb_recordings'
             >
-              <UturnLeft className='size-3.5' variant='Stroke' aria-hidden='true' />
               Recordings
             </button>
           </li>

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingAskAIModal.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingAskAIModal.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
 import type { User } from '@xyne/shared/machines';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
-import { AlertTriangle, MicOn, MultipleCrossCancelDefault, SearchBig } from '@xyne/icons';
+import { AlertTriangle, MultipleCrossCancelDefault, SearchBig } from '@xyne/icons';
+import { AudioLines } from 'lucide-react';
 import { Button } from '../../../components/ui/Button/Button';
 import { Checkbox } from '../../../components/ui/Checkbox/Checkbox';
 import { Dialog } from '../../../components/ui/Dialog';
@@ -269,7 +270,12 @@ const RecordingAskAIModal = ({
               No recordings match that search.
             </p>
           ) : (
-            <ul className='flex flex-col' role='listbox' aria-multiselectable='true'>
+            <ul
+              className='flex flex-col'
+              role='listbox'
+              aria-multiselectable='true'
+              data-theme-tokens
+            >
               {rows.map(row =>
                 row.type === 'group' ? (
                   <li
@@ -335,7 +341,7 @@ const RecordingAskAIModal = ({
             type='button'
             onClick={handleConfirm}
             disabled={selectedCount === 0}
-            className='h-8 shrink-0 gap-2.5 rounded-lg px-5 text-xs font-semibold bg-foreground hover:bg-foreground/80 transition-opacity duration-300'
+            className='h-8 shrink-0 gap-2.5 rounded-lg px-5 text-xs font-semibold bg-foreground text-background hover:bg-foreground/80 transition-opacity duration-300'
             data-track-category='RecordingsV2'
             data-track-name='send_recordings_to_ask_ai'
             data-track-metadata={JSON.stringify({ recordingCount: selectedCount })}
@@ -378,6 +384,7 @@ const RecordingOption = ({
       role='option'
       aria-selected={checked}
       aria-disabled={blocked}
+      data-theme-tokens
       onClick={() => onToggle(recording.id)}
       onKeyDown={event => {
         if (event.key !== 'Enter') return;
@@ -397,7 +404,7 @@ const RecordingOption = ({
       </span>
 
       <span className='flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground'>
-        <MicOn size={15} strokeWidth={2} variant='Contrast' />
+        <AudioLines size={15} strokeWidth={2.2} />
       </span>
 
       <span className='min-w-0 flex-1'>


### PR DESCRIPTION
POT - 

https://github.com/user-attachments/assets/2e8020e9-1553-46e9-b57c-664eb5603c33



## What this does

Four fixes to the recordings surfaces, all in the dashboard.

### 1. Ask AI recording pills open the transcript in place

Clicking a recording pill in the Ask AI composer used to `navigate('/recordings/:id')`, taking a half-written question with it. It now opens the transcript in a centred modal over the composer.

The modal reuses `TranscriptSidePanel` — the same body the canvas-citation flow uses — so copy / download / in-transcript search come for free. Pills with no `externalId` still fall back to the shared conversation as before.

Focus is parked on the panel container rather than left to Radix's default: Radix auto-focuses the first tabbable child, which is the Copy button, and a focused tooltip trigger keeps its tooltip open for as long as it holds focus.

**New file:** `components/Chat/XyneAISidebar/components/RecordingTranscriptModal.tsx`

### 2. One waveform for a recording, everywhere

A recording read as a microphone in three places and as a waveform in the Xyne Scribe list. It is now lucide `AudioLines` in all of them:

- the Ask AI context pill row
- the "Choose context" modal rows
- the sidebar rail

The rail types its icons as `PikaIcon` and every render site passes a Solid/Stroke `variant`, which lucide has no pair for — a three-line adapter drops `variant` instead of leaking it onto the `<svg>`. Side effect worth knowing: the rail icon no longer switches to a solid fill when active, so active state reads from the background/colour alone, same as the Scribe screen.

### 3. Dark mode on the "Choose context" modal

Two separate problems, both real:

**The list was painted off-token.** Legacy `[data-theme="midnight"]` rules hard-override `[role="listbox"]` and `[role="option"]` with hardcoded colour — `#1a1a1a` for the list surface, `#2a2d30` on hover, and `rgba(37,99,235,.2)` + `#60a5fa` text for `aria-selected="true"`, i.e. every selected recording turned blue. Sampling the reported screenshot confirmed the list slab at `#1a1a1a` against a `#242628` popover.

Added a `:not([data-theme-tokens])` opt-out to those four rules, mirroring the existing `[cmdk-list]` / `[cmdk-item]` exclusions, and marked this list with it. The rows keep `bg-popover` / `bg-accent` in both themes. The exclusion only narrows the existing selectors, so no other surface changes.

**"Ask this recording" was white on white.** The button is `variant='default'` (`bg-primary text-primary-foreground`) with the background locally overridden to `bg-foreground`, but the text colour was not overridden with it. In light mode `--foreground` is near-black and white text reads fine; in dark mode `--foreground` is `#e0e3ea`, giving white on near-white. Now `text-background`, which is correct in both themes. Verified `twMerge` drops the stale `text-primary-foreground` rather than leaving both classes to fight.

### 4. Breadcrumb back icon removed

The `UturnLeft` glyph is gone from the recording detail header. "Recordings" is still the click target.

## Files

| File | |
| --- | --- |
| `RecordingTranscriptModal.tsx` | new — transcript modal |
| `XyneAIInputBox.tsx` | pill click → modal instead of route |
| `ContextPillRow.tsx` | waveform icon + accurate aria-label |
| `RecordingAskAIModal.tsx` | waveform icon, dark-mode opt-out, button contrast |
| `navigationConfig.ts` | sidebar rail icon + variant-dropping adapter |
| `global.css` | `[data-theme-tokens]` opt-out on the midnight listbox rules |
| `RecordingDetailV2Header.tsx` | breadcrumb back icon removed |

## Checks

`tsc --noEmit`, `eslint --quiet`, `prettier --check`, gitleaks staged scan, tenant-key guard, schema-migration validation and the enum guard all pass. The pre-commit hook's own checks were run individually because the hook needs a TTY.

## Not done here

Recording rows in the AI **context picker** (`ContextPicker.tsx`) and in **search results** (`SearchResultItem.tsx`, `ChannelCommandMenu.tsx`) still use `MicOn`. The unchecked `Checkbox` is `bg-card` (`#22232A`, slightly blue against the neutral popover) — that is the app-wide component, so it was left alone.
