### PR TITLE
fix: sev2 ui artifact fixes + channel level call

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -565,8 +565,10 @@ export class CallController {
       // No pre-flight validation of artifactMessageId: every artifact write is
       // scoped to the call's channel (see setSlashCommandArtifactLifecycle), so
       // an id that does not belong to this channel matches zero rows.
+      // Not gated on conversationId — an artifact's call is channel-scoped even
+      // though the artifact message itself may live inside a thread.
       const linkedArtifactMessageId =
-        typeof artifactMessageId === 'string' && conversationId ? artifactMessageId : undefined;
+        typeof artifactMessageId === 'string' ? artifactMessageId : undefined;
 
       // For headless recordings, always create a new recording session
       // For regular calls, check if there's already an active call in this channel
@@ -628,6 +630,20 @@ export class CallController {
               data: { metadata: restMeta as Prisma.InputJsonValue },
             });
             queueCallVespaFeed(existingCall.id, { source: CallVespaFeedSource.CallControllerInitiateCallClearRemovedByHostExistingRoom });
+          }
+
+          // A channel already running a call is the call this incident should
+          // use — adopt it rather than leaving the artifact card stuck pending.
+          if (linkedArtifactMessageId && existingCall.channelId) {
+            stage = 'existing_call_artifact_link';
+            const linked = await repositories.calls.linkArtifactToActiveCall({
+              callId: existingCall.id,
+              callExternalId: existingCall.externalId,
+              channelId: existingCall.channelId,
+              artifactMessageId: linkedArtifactMessageId,
+              metadata: existingCall.metadata,
+            });
+            logger.info(`[${existingCall.externalId}] artifact_link_on_existing_call | linked=${linked}, correlation_id=${correlationId}`);
           }
 
           // Room exists, generate token to join the existing call

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -242,6 +242,52 @@ export class CallRepository {
   }
 
   /**
+   * Adopt an already-running call as a slash-command artifact's call.
+   *
+   * "Start call" on an artifact card is channel-scoped, so it lands on the
+   * channel's existing call whenever one is already live instead of creating a
+   * room. Without this the card would sit in its pending state forever and the
+   * artifact would never be completed when that call ends, because completion
+   * is driven off `calls.metadata.artifactMessageId`.
+   *
+   * Refuses to steal a call that already belongs to a different artifact — the
+   * first incident to claim it keeps it.
+   */
+  async linkArtifactToActiveCall(params: {
+    callId: string;
+    callExternalId: string;
+    channelId: string;
+    artifactMessageId: string;
+    metadata: Prisma.JsonValue | null;
+  }): Promise<boolean> {
+    const { callId, callExternalId, channelId, artifactMessageId, metadata } = params;
+    const existingArtifactMessageId = getArtifactMessageId(metadata);
+    if (existingArtifactMessageId) return existingArtifactMessageId === artifactMessageId;
+
+    await DatabaseClient.getInstance().$transaction(async (tx) => {
+      await tx.call.update({
+        where: { id: callId },
+        data: {
+          metadata: {
+            ...((metadata as CallMetadata | null) ?? {}),
+            artifactMessageId,
+          } as Prisma.InputJsonValue,
+        },
+      });
+
+      await setSlashCommandArtifactLifecycle(tx, {
+        messageId: artifactMessageId,
+        channelId,
+        status: MessageArtifactStatus.ACTIVE,
+        callExternalId,
+      });
+    });
+
+    queueCallVespaFeed(callId, { source: CallVespaFeedSource.CallRepositoryUpdate });
+    return true;
+  }
+
+  /**
    * Mirror a call transition onto the slash-command artifact that started it.
    * A no-op for every other call, which is why it can sit directly on the
    * shared end-of-call paths without altering their behavior.

--- a/apps/backend/src/zero/acl/core/acl-factory.ts
+++ b/apps/backend/src/zero/acl/core/acl-factory.ts
@@ -18,6 +18,7 @@ import { ConversationParticipantsACL } from '../tables/conversation-participants
 import { ConversationsACL } from '../tables/conversations-acl';
 import { MessageAttachmentsACL } from '../tables/message-attachments-acl';
 import { MessagesACL } from '../tables/messages-acl';
+import { MessageArtifactsACL } from '../tables/message-artifacts-acl';
 import { NotificationPreferencesACL } from '../tables/notification-preferences-acl';
 import { OrgMembersACL } from '../tables/org-members-acl';
 import { OrganizationsACL } from '../tables/organizations-acl';
@@ -234,7 +235,7 @@ export class ACLFactory {
       case 'messages':
         return new MessagesACL(ctx);
       case 'message_artifacts':
-        return new BaseACL(ctx, table);
+        return new MessageArtifactsACL(ctx, table);
       case 'models':
         return new ModelsACL(ctx);
       case 'notification_preferences':

--- a/apps/backend/src/zero/acl/tables/message-artifacts-acl.ts
+++ b/apps/backend/src/zero/acl/tables/message-artifacts-acl.ts
@@ -1,0 +1,68 @@
+import type { Transaction, UpdateValue } from '@rocicorp/zero';
+import { MessageArtifactStatus, Schema } from '@xyne/shared';
+import { BaseACL } from '../core/base-acl';
+import { MutationACLError, TableSchema } from '../core/types';
+import { zql } from '../../queries';
+
+/**
+ * Artifact rows are written by the server (the message side-effect worker and
+ * the call lifecycle) for everything except one transition: the author closing
+ * their own artifact. Only that transition is opened up here.
+ *
+ * Insert and delete stay on BaseACL's deny-all — the projection is derived from
+ * message content and must never be authored by a client.
+ */
+export class MessageArtifactsACL extends BaseACL<'message_artifacts'> {
+  // Closing may only move the lifecycle forward. Everything else on the row —
+  // the projected message fields, the linked call — is server-owned.
+  private static readonly CLOSE_KEYS = ['id', 'status', 'updatedAt'];
+
+  async canUpdate(
+    args: UpdateValue<TableSchema<'message_artifacts'>>,
+    tx: Transaction<Schema>,
+  ): Promise<void> {
+    const artifact = await tx.run(zql.message_artifacts.where('id', '=', args.id).one());
+    if (!artifact) {
+      throw new MutationACLError(
+        'Message artifact update failed: artifact does not exist',
+        'message_artifacts',
+      );
+    }
+    if (artifact.workspaceId !== this.ctx.workspaceId) {
+      throw new MutationACLError(
+        'Message artifact not found in this workspace',
+        'message_artifacts',
+      );
+    }
+
+    const argsKeys = Object.keys(args);
+    if (!argsKeys.every((key) => MessageArtifactsACL.CLOSE_KEYS.includes(key))) {
+      throw new MutationACLError(
+        'Message artifact update failed: only the lifecycle status may be changed',
+        'message_artifacts',
+      );
+    }
+    if (args.status !== MessageArtifactStatus.CANCELLED) {
+      throw new MutationACLError(
+        'Message artifact update failed: only closing an artifact is allowed',
+        'message_artifacts',
+      );
+    }
+
+    const message = await tx.run(
+      zql.messages.where('messageId', '=', artifact.messageId).one(),
+    );
+    if (!message) {
+      throw new MutationACLError(
+        'Message artifact update failed: source message does not exist',
+        'message_artifacts',
+      );
+    }
+    if (message.senderId !== this.ctx.userID) {
+      throw new MutationACLError(
+        'Message artifact update failed: only the author can close this artifact',
+        'message_artifacts',
+      );
+    }
+  }
+}

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -97,6 +97,11 @@ import {
   sdlcDiscussionSchema,
 } from '@xyne/shared';
 import { THREAD_TYPE_NAMES } from '@xyne/shared';
+import {
+  MessageArtifactStatus,
+  parseSlashCommandArtifactMessage,
+  withSlashCommandArtifactClosed,
+} from '@xyne/shared';
 import { isBaselineCanvasType, sdlcTrackStatusSchema } from '@xyne/shared';
 import {
   FLOW_STAGE_NAMES,
@@ -3217,6 +3222,24 @@ export function createMutators(
             throw new Error('You need to be a participant for adding a conversations');
           }
 
+          // One open artifact per thread. A thread is a single incident's workspace,
+          // so a second /sev2 inside it would fork the responders across two cards
+          // and two calls. The channel is unrestricted — that is where a genuinely
+          // separate incident belongs.
+          const outgoingArtifact = parseSlashCommandArtifactMessage(content);
+          if (outgoingArtifact) {
+            const openArtifact = await tx.run(zql.message_artifacts
+              // channelId first: it is the only selective index on this table.
+              .where('channelId', conversation.channelId)
+              .where('conversationId', conversationId)
+              .where('command', outgoingArtifact.definition.command)
+              .where('status', MessageArtifactStatus.ACTIVE)
+              .one());
+            if (openArtifact) {
+              throw new Error(`A ${outgoingArtifact.definition.badge} is already open in this thread`);
+            }
+          }
+
           const message = {
             messageId,
             conversationId,
@@ -3864,6 +3887,51 @@ export function createMutators(
 
             // Activity creation now handled by activity injection system
           }
+        },
+      ),
+      /**
+       * Close a slash-command artifact (e.g. decline a SEV2) without ever running
+       * a call. Only the message's author may do it.
+       *
+       * Two writes, both required: the artifact row moves to a terminal status so
+       * the banner and channel indicator clear for everyone, and the closed marker
+       * is baked into the message's FlowJSON so the card still renders as finished
+       * once the row has left the ACTIVE-only artifact subscription.
+       */
+      closeSlashCommandArtifact: defineMutator(
+        z.object({ messageId: z.string(), timestamp: z.number() }),
+        async ({ tx, args: { messageId, timestamp } }) => {
+          const message = await tx.run(zql.messages.where('messageId', messageId).one());
+          if (!message) {
+            throw new Error('Message not available');
+          }
+          if (message.senderId !== authData.sub) {
+            throw new Error('Only the author can close this incident');
+          }
+
+          const artifact = await tx.run(zql.message_artifacts.where('messageId', messageId).one());
+          if (artifact && artifact.status !== MessageArtifactStatus.ACTIVE) {
+            throw new Error('This incident is already closed');
+          }
+
+          const content = withSlashCommandArtifactClosed(message.content, {
+            closedAt: timestamp,
+            closedBy: authData.sub,
+          });
+          if (!content) {
+            throw new Error('Message is not a slash command artifact');
+          }
+
+          if (artifact) {
+            await tx.mutate.message_artifacts.update({
+              id: artifact.id,
+              status: MessageArtifactStatus.CANCELLED,
+              updatedAt: timestamp,
+            });
+          }
+          // Deliberately not `edited: true` — closing is a lifecycle transition,
+          // not an edit, and must not raise a "message edited" notification.
+          await tx.mutate.messages.update({ messageId, content });
         },
       ),
       updateShowInChannel: defineMutator(

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -2,6 +2,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useMemo,
   forwardRef,
   useRef,
   useImperativeHandle,
@@ -79,6 +80,7 @@ import {
   getSlashCommandArtifactBodyText,
   stripSlashCommandFromHtml,
 } from '../SlashCommandArtifacts';
+import { useSlashCommandArtifactSideEffects } from '../SlashCommandArtifactSideEffects';
 
 const CHAT_MESSAGE_SENT_EVENT = 'xyne:chat-message-sent';
 
@@ -201,6 +203,22 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
     const channelResults = useChannelSearch(channelSearchQuery, 10);
     const conversationId = conversation?.conversationId;
 
+    // A thread is one incident's workspace, so it holds at most one open artifact
+    // of a given command. The channel root is unrestricted — it has no
+    // conversation yet, so this can never match there.
+    const { bannerItems: openArtifacts } = useSlashCommandArtifactSideEffects();
+    const openArtifactCommandsInThread = useMemo(
+      () =>
+        new Set(
+          conversationId
+            ? openArtifacts
+                .filter(artifact => artifact.conversationId === conversationId)
+                .map(artifact => artifact.definition.command)
+            : [],
+        ),
+      [conversationId, openArtifacts],
+    );
+
     // Slash commands for this channel — filtered by context (thread vs chat)
     const [channelCommands, setChannelCommands] = useState<CommandItem[]>(
       SLASH_COMMAND_ARTIFACT_COMMAND_ITEMS,
@@ -244,6 +262,22 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
         .then(setGlobalShortcuts)
         .catch(() => undefined);
     }, [channelId, conversation?.conversationId]);
+
+    // Hide, don't just reject: an artifact the user cannot post here should not
+    // be offered. The send guards below still fire, because the command can also
+    // be typed inline or left over in `activeArtifactCommand`.
+    const availableCommands = useMemo(
+      () =>
+        openArtifactCommandsInThread.size === 0
+          ? channelCommands
+          : channelCommands.filter(
+              command =>
+                command.kind !== 'slash-command-artifact' ||
+                !command.slashCommandArtifactCommand ||
+                !openArtifactCommandsInThread.has(command.slashCommandArtifactCommand),
+            ),
+      [channelCommands, openArtifactCommandsInThread],
+    );
 
     const handleCommandSelect = useCallback(
       async (command: CommandItem, text?: string) => {
@@ -592,6 +626,12 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
           toast.error(`Describe the ${artifactDraft.definition.bodyNoun} before sending`);
           throw new Error(`${artifactDraft.definition.command} body is required`);
         }
+        if (artifactDraft && openArtifactCommandsInThread.has(artifactDraft.definition.command)) {
+          toast.error(`A ${artifactDraft.definition.badge} is already open in this thread`, {
+            description: 'Close it first, or declare this one in the channel instead.',
+          });
+          throw new Error(`${artifactDraft.definition.command} already open in this thread`);
+        }
 
         const bodyHtml = processMessageForSending(
           artifactDraft?.typedInline
@@ -909,6 +949,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
         twinEdit,
         channelDraftForSend,
         activeArtifactCommand,
+        openArtifactCommandsInThread,
       ],
     );
 
@@ -926,6 +967,12 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
         const artifactDraft = detectSlashCommandArtifact(activeArtifactCommand, plainText);
         if (artifactDraft && !getSlashCommandArtifactBodyText(artifactDraft, plainText)) {
           toast.error(`Describe the ${artifactDraft.definition.bodyNoun} before scheduling`);
+          return;
+        }
+        if (artifactDraft && openArtifactCommandsInThread.has(artifactDraft.definition.command)) {
+          toast.error(`A ${artifactDraft.definition.badge} is already open in this thread`, {
+            description: 'Close it first, or declare this one in the channel instead.',
+          });
           return;
         }
         const bodyHtml = processMessageForSending(
@@ -994,6 +1041,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
         setRecentScheduledFor,
         allowThreadBroadcastMentions,
         activeArtifactCommand,
+        openArtifactCommandsInThread,
       ],
     );
 
@@ -1091,7 +1139,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
                   onActiveChange={setAgentActive}
                 />
               }
-              commandItems={channelCommands}
+              commandItems={availableCommands}
               onCommandSelect={handleCommandSelect}
               {...(activeArtifactCommand && {
                 slashCommandArtifactCommand: activeArtifactCommand,

--- a/apps/dashboard/src/components/Chat/SlashCommandArtifacts.tsx
+++ b/apps/dashboard/src/components/Chat/SlashCommandArtifacts.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { ChevronDown, Copy, Phone, Users } from 'lucide-react';
-import { useSelector } from '@xstate/react';
+import { Copy, Phone, Users, X } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   InvitationResponse,
@@ -11,6 +10,7 @@ import {
   parseSlashCommandArtifactMessage,
   slashCommandArtifactPropsSchema,
   type FlowComponent,
+  type SlashCommandArtifactClosed,
   type SlashCommandArtifactDefinition,
   type SlashCommandArtifactEndedCall,
 } from '@xyne/shared';
@@ -23,15 +23,11 @@ import { getUserDisplayName } from '../../utils/userDisplayName';
 import { formatTimeAmPm } from '../../utils/dateUtils';
 import { formatElapsedTime } from '../../utils/recordingUtils';
 import { Event, logger } from '../../utils/logger';
-import { roomActor } from '../../machines/roomMachine';
+import { useConfirmDialog } from '../../hooks/useConfirmDialog';
+import { useZero } from '../../hooks/useZero';
+import { mutators } from '../../zero/mutators';
 import { useFlow } from '../flowUI/FlowContext';
 import { useActiveSlashCommandArtifact } from './SlashCommandArtifactSideEffects';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '../ui/dropdown-menu';
 
 /**
  * Composer entry for a slash-command artifact. Presentation and side-effect
@@ -234,6 +230,8 @@ interface SlashCommandArtifactCardProps {
   definition: SlashCommandArtifactDefinition;
   /** Summary of the last finished call, baked into the message by the server. */
   endedCallSummary?: SlashCommandArtifactEndedCall;
+  /** Set once the author closed the artifact, baked into the message. */
+  closedSummary?: SlashCommandArtifactClosed;
   messageId?: string;
   conversationId?: string;
   channelId?: string;
@@ -246,6 +244,7 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
   children,
   definition,
   endedCallSummary,
+  closedSummary,
   messageId,
   conversationId,
   channelId,
@@ -255,24 +254,28 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
 }) => {
   const sender = useUser(senderId ?? '');
   const { user } = useAuthContext();
+  const zero = useZero();
+  const { confirm, ConfirmDialog } = useConfirmDialog();
   // Live state comes from the shared artifact subscription — no per-card query.
-  // It is ACTIVE-only, so a row here means this incident's call is current.
+  // It is ACTIVE-only, so a row here means this incident is still open.
   const activeArtifact = useActiveSlashCommandArtifact(messageId);
   // Live call details reuse the app-wide active-call subscription that already
   // backs every "X started a call" message.
   const linkedCall = useActiveCall(activeArtifact?.callExternalId ?? '');
-  const currentCallId = useSelector(roomActor, state => state.context.externalId);
-  const { initiateCall, joinCall, isInCall } = useCallJoinOrInitiate();
+  const { initiateCall, isInCall } = useCallJoinOrInitiate();
   const channelParticipation = useChannelParticipation(channelId ?? '');
   const [isCopying, setIsCopying] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
   const lastStateDiagnosticSignature = useRef<string | null>(null);
 
   const activeCallExternalId = linkedCall ? activeArtifact?.callExternalId : undefined;
   const hasActiveCall = !!activeCallExternalId;
-  // Once its call ends the artifact leaves the ACTIVE subscription, so the
-  // ended state is read from the summary the server baked into this message.
-  const endedCall = hasActiveCall ? undefined : endedCallSummary;
-  const isInArtifactCall = hasActiveCall && currentCallId === activeCallExternalId;
+  // Both terminal states are read from the message rather than the artifact row:
+  // once an incident finishes it leaves the ACTIVE-only subscription, so a live
+  // row is what makes the client-authored summaries untrustworthy, not the
+  // absence of one.
+  const endedCall = activeArtifact ? undefined : endedCallSummary;
+  const closed = activeArtifact ? undefined : closedSummary;
   const activeDuration = useCallDuration(linkedCall?.startedAt, hasActiveCall);
   const senderName = getUserDisplayName(sender) || 'Someone';
   const activeResponderCount = hasActiveCall
@@ -284,6 +287,9 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
   // in a public channel but must not start a call from it — that would relink
   // the artifact to a fresh call and orphan any call already running.
   const canActOnArtifact = !!channelParticipation;
+  // Closing is the author's call alone; the mutator and its ACL enforce the same
+  // rule server-side, this only decides whether the control is offered.
+  const isArtifactOwner = !!senderId && !!user?.id && senderId === user.id;
   const joinedCount = endedCall?.joinedCount ?? 0;
   const endedDuration = endedCall ? formatElapsedTime(endedCall.durationMs) : '';
 
@@ -304,28 +310,15 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
       artifactKey: getSlashCommandArtifactDiagnosticKey(messageId),
       channelKey: getSlashCommandArtifactDiagnosticKey(channelId),
     });
+    // Deliberately channel-scoped: no conversationId, no targetUserIds. An
+    // incident belongs to the whole channel, so every member is invited and sees
+    // "Join" on the channel's live-call message rather than "Request to join",
+    // and the call's system message lands in the channel instead of the thread
+    // the artifact happens to live in.
     initiateCall({
       channelId,
-      // Targeting only the initiator starts a normal call without ringing the channel.
-      targetUserIds: [user.id],
-      ...(conversationId && { conversationId }),
       ...(messageId && { artifactMessageId: messageId }),
     });
-  };
-
-  const handlePrimaryCallAction = (): void => {
-    if (activeCallExternalId) {
-      if (!isInArtifactCall) {
-        logger.info(Event.SLASH_COMMAND_ARTIFACT_ACTION, {
-          action: 'join_call_from_card',
-          artifactKey: getSlashCommandArtifactDiagnosticKey(messageId),
-          callKey: getSlashCommandArtifactDiagnosticKey(activeCallExternalId),
-        });
-        joinCall({ callId: activeCallExternalId });
-      }
-      return;
-    }
-    startNewCall();
   };
 
   const handleCopyCallLink = async (): Promise<void> => {
@@ -353,7 +346,52 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
     }
   };
 
-  const resolvedState = hasActiveCall ? 'active' : endedCall ? 'completed' : 'pending';
+  const handleCloseArtifact = async (): Promise<void> => {
+    if (!messageId || !isArtifactOwner || isClosing) return;
+    const confirmed = await confirm({
+      title: `Close this ${definition.bodyNoun}?`,
+      description:
+        `The ${definition.badge} alert stops showing for everyone in the channel and no ` +
+        'call can be started from it. This cannot be undone.',
+      confirmLabel: `Close ${definition.bodyNoun}`,
+      variant: 'destructive',
+    });
+    if (!confirmed) return;
+
+    setIsClosing(true);
+    try {
+      const result = zero.mutate(
+        mutators.messages.closeSlashCommandArtifact({ messageId, timestamp: Date.now() }),
+      );
+      await result.server;
+      logger.info(Event.SLASH_COMMAND_ARTIFACT_ACTION, {
+        action: 'close_artifact',
+        artifactKey: getSlashCommandArtifactDiagnosticKey(messageId),
+        channelKey: getSlashCommandArtifactDiagnosticKey(channelId),
+      });
+    } catch (error) {
+      logger.warn(Event.SLASH_COMMAND_ARTIFACT_INVARIANT_FAILED, {
+        reason: 'close_artifact_failed',
+        artifactKey: getSlashCommandArtifactDiagnosticKey(messageId),
+        error: error instanceof Error ? error.message : String(error),
+      });
+      toast.error(`Could not close this ${definition.bodyNoun}`);
+    } finally {
+      setIsClosing(false);
+    }
+  };
+
+  const resolvedState = hasActiveCall
+    ? 'active'
+    : closed
+      ? 'closed'
+      : endedCall
+        ? 'completed'
+        : 'pending';
+  // The author can stand an incident down only while nothing is running: during
+  // a call the call itself is the thing to end, and once it has ended or been
+  // closed the artifact is already finished.
+  const canCloseArtifact = isArtifactOwner && resolvedState === 'pending';
   const artifactKey = getSlashCommandArtifactDiagnosticKey(messageId);
   const trackingMetadata = JSON.stringify({
     slashCommandArtifactCommand: definition.command,
@@ -404,12 +442,37 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
               : `${joinedCount} joined the call`}
           </span>
         )}
+        {canCloseArtifact && (
+          <button
+            type='button'
+            onClick={event => {
+              event.preventDefault();
+              event.stopPropagation();
+              void handleCloseArtifact();
+            }}
+            disabled={isClosing}
+            className='-mr-1 ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+            aria-label={`Close this ${definition.bodyNoun}`}
+            title={`Close this ${definition.bodyNoun}`}
+            data-prevent-thread
+            data-track-category='SLASH_COMMAND_ARTIFACT'
+            data-track-name='CLOSE_ARTIFACT'
+            data-track-metadata={trackingMetadata}
+          >
+            <X className='size-4' />
+          </button>
+        )}
       </div>
 
       <div className='px-4 py-3 text-sm leading-6 text-foreground'>{children}</div>
 
       <div className='flex flex-wrap items-center gap-2 px-4 pb-4'>
-        {endedCall ? (
+        {resolvedState === 'closed' ? (
+          <div className='inline-flex h-10 items-center gap-2 rounded-lg bg-muted px-3 text-sm font-medium text-muted-foreground'>
+            <X className='size-4' />
+            <span>Closed by {senderName}</span>
+          </div>
+        ) : resolvedState === 'completed' ? (
           <>
             <div className='inline-flex h-10 items-center gap-2 rounded-lg bg-muted px-3 text-sm font-medium text-muted-foreground'>
               <Phone className='size-4' />
@@ -435,64 +498,59 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
               Start a new call
             </button>
           </>
-        ) : (
-          <div className='inline-flex overflow-hidden rounded-lg bg-foreground text-background'>
+        ) : resolvedState === 'active' ? (
+          <>
+            {/* Informational only. Joining happens on the channel's live-call
+                message, which the channel-scoped call above puts in front of
+                every member. */}
+            <div
+              className='inline-flex h-10 items-center gap-2 rounded-lg bg-muted px-3 text-sm font-medium text-muted-foreground'
+              aria-live='polite'
+            >
+              <span className='size-2.5 animate-pulse rounded-full bg-orange-500 motion-reduce:animate-none' />
+              <Phone className='size-4' />
+              <span>Call live{activeDuration ? ` · ${activeDuration}` : ''}</span>
+            </div>
             <button
               type='button'
               onClick={event => {
                 event.preventDefault();
                 event.stopPropagation();
-                handlePrimaryCallAction();
+                void handleCopyCallLink();
               }}
-              disabled={!canActOnArtifact || (!hasActiveCall && isInCall)}
-              className='inline-flex h-10 items-center gap-2 px-4 text-sm font-semibold transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60'
-              aria-label={hasActiveCall && !isInArtifactCall ? 'Join call' : undefined}
+              disabled={!linkedCall?.roomLink || isCopying}
+              className='inline-flex h-10 items-center gap-2 rounded-lg border border-border bg-background px-4 text-sm font-semibold hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60'
               data-prevent-thread
               data-track-category='SLASH_COMMAND_ARTIFACT'
-              data-track-name={hasActiveCall ? 'JOIN_CALL' : 'START_CALL'}
+              data-track-name='COPY_CALL_LINK'
               data-track-metadata={trackingMetadata}
             >
-              {hasActiveCall && (
-                <span className='size-2.5 animate-pulse rounded-full bg-orange-500' />
-              )}
-              <Phone className='size-4' />
-              {hasActiveCall ? activeDuration || 'Join call' : 'Start call'}
+              <Copy className='size-4' />
+              Copy link
             </button>
-
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <button
-                  type='button'
-                  onClick={event => event.stopPropagation()}
-                  className='flex h-10 w-10 items-center justify-center border-l border-background/20 hover:bg-background/10'
-                  aria-label='Call options'
-                  data-prevent-thread
-                  data-track-category='SLASH_COMMAND_ARTIFACT'
-                  data-track-name='OPEN_CALL_OPTIONS'
-                  data-track-metadata={trackingMetadata}
-                >
-                  <ChevronDown className='size-4' />
-                </button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align='start' side='bottom'>
-                <DropdownMenuItem
-                  disabled={!activeCallExternalId || isCopying}
-                  onClick={event => {
-                    event.stopPropagation();
-                    void handleCopyCallLink();
-                  }}
-                  data-track-category='SLASH_COMMAND_ARTIFACT'
-                  data-track-name='COPY_CALL_LINK'
-                  data-track-metadata={trackingMetadata}
-                >
-                  <Copy className='size-4' />
-                  Copy call link
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          </>
+        ) : (
+          <button
+            type='button'
+            onClick={event => {
+              event.preventDefault();
+              event.stopPropagation();
+              startNewCall();
+            }}
+            disabled={!canActOnArtifact || isInCall}
+            className='inline-flex h-10 items-center gap-2 rounded-lg bg-foreground px-4 text-sm font-semibold text-background transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60'
+            data-prevent-thread
+            data-track-category='SLASH_COMMAND_ARTIFACT'
+            data-track-name='START_CALL'
+            data-track-metadata={trackingMetadata}
+          >
+            <Phone className='size-4' />
+            Start call
+          </button>
         )}
       </div>
+
+      <ConfirmDialog />
     </section>
   );
 };
@@ -512,6 +570,7 @@ export const SlashCommandArtifactNode: React.FC<{
     <SlashCommandArtifactCard
       definition={definition}
       {...(props.endedCall && { endedCallSummary: props.endedCall })}
+      {...(props.closed && { closedSummary: props.closed })}
       messageId={messageId}
       conversationId={conversationId}
       {...(messageContext?.channelId && { channelId: messageContext.channelId })}

--- a/packages/shared/src/utils/slashCommandArtifact.ts
+++ b/packages/shared/src/utils/slashCommandArtifact.ts
@@ -2,6 +2,7 @@ import type { FlowComponent, FlowDefinition } from "../types/flowUI";
 import {
   flowDefinitionSchema,
   slashCommandArtifactPropsSchema,
+  type SlashCommandArtifactClosed,
   type SlashCommandArtifactEndedCall,
   type SlashCommandArtifactProps,
 } from "../validation/flowSchema";
@@ -275,16 +276,15 @@ export const getSlashCommandArtifactPreviewText = (
 };
 
 /**
- * Bake the summary of a finished call into the artifact's FlowJSON.
+ * Merge extra props into the artifact component of a FlowJSON message.
  *
- * Called once when a linked call ends — the same pattern the standard call
- * system message uses. Returns null when the content is not a recognised
- * artifact, so the caller can skip the write entirely rather than rewriting a
- * message it does not understand.
+ * Returns null when the content is not a recognised artifact, so the caller can
+ * skip the write entirely rather than rewriting a message it does not
+ * understand.
  */
-export const withSlashCommandArtifactEndedCall = (
+const withSlashCommandArtifactProps = (
   content: string,
-  endedCall: SlashCommandArtifactEndedCall,
+  props: Partial<SlashCommandArtifactProps>,
 ): string | null => {
   const parsed = parseSlashCommandArtifactMessage(content);
   if (!parsed) return null;
@@ -292,7 +292,7 @@ export const withSlashCommandArtifactEndedCall = (
   const patchComponents = (components: FlowComponent[]): FlowComponent[] =>
     components.map((component) => {
       if (component.type === "slash_command_artifact") {
-        return { ...component, props: { ...component.props, endedCall } };
+        return { ...component, props: { ...component.props, ...props } };
       }
       return component.children
         ? { ...component, children: patchComponents(component.children) }
@@ -304,3 +304,26 @@ export const withSlashCommandArtifactEndedCall = (
     components: patchComponents(parsed.flow.components),
   });
 };
+
+/**
+ * Bake the summary of a finished call into the artifact's FlowJSON.
+ *
+ * Called once when a linked call ends — the same pattern the standard call
+ * system message uses.
+ */
+export const withSlashCommandArtifactEndedCall = (
+  content: string,
+  endedCall: SlashCommandArtifactEndedCall,
+): string | null => withSlashCommandArtifactProps(content, { endedCall });
+
+/**
+ * Bake the "closed by its author" marker into the artifact's FlowJSON.
+ *
+ * The artifact row moves to a terminal status at the same time, which removes
+ * it from the ACTIVE-only subscription — this marker is what tells the card it
+ * was closed rather than never started.
+ */
+export const withSlashCommandArtifactClosed = (
+  content: string,
+  closed: SlashCommandArtifactClosed,
+): string | null => withSlashCommandArtifactProps(content, { closed });

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -802,6 +802,11 @@ export const slashCommandArtifactEndedCallSchema = z.object({
   joinedCount: z.number().int().nonnegative(),
 });
 
+export const slashCommandArtifactClosedSchema = z.object({
+  closedAt: z.number().int().nonnegative(),
+  closedBy: z.string(),
+});
+
 export const slashCommandArtifactPropsSchema = z.object({
   command: z.string().regex(/^[a-z0-9][a-z0-9_-]*$/),
   /**
@@ -816,10 +821,23 @@ export const slashCommandArtifactPropsSchema = z.object({
    * claims a call ended.
    */
   endedCall: slashCommandArtifactEndedCallSchema.optional(),
+  /**
+   * Written once when the message's author closes the artifact without ever
+   * running — or after having run — a call. Same reasoning as `endedCall`: a
+   * closed artifact drops out of the ACTIVE-only artifact subscription, so the
+   * card would otherwise fall back to looking brand new.
+   *
+   * Only trusted when no live artifact row contradicts it.
+   */
+  closed: slashCommandArtifactClosedSchema.optional(),
 });
 
 export type SlashCommandArtifactEndedCall = z.infer<
   typeof slashCommandArtifactEndedCallSchema
+>;
+
+export type SlashCommandArtifactClosed = z.infer<
+  typeof slashCommandArtifactClosedSchema
 >;
 
 export const slashCommandArtifactComponentSchema = baseComponentSchema.extend({

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -65,6 +65,7 @@ import {
   CollectionRole,
   VCSProviderType,
   ReleaseTrackingMode,
+  MessageArtifactStatus,
 } from './schema.js';
 import { FlowPlanSchema, serializeFlowPlan, validateFlowPlan } from '../board-types/index.js';
 import { createForwardedMessageXml, parseForwardedMessageXml } from '../forwardedMessage.js';
@@ -184,6 +185,10 @@ import {
   updateInitialMessageMdReaction,
 } from './messageMetadata.js';
 import { updateTicketMdFromZero } from '../utils/ticketMetadata.js';
+import {
+  parseSlashCommandArtifactMessage,
+  withSlashCommandArtifactClosed,
+} from '../utils/slashCommandArtifact.js';
 import { stringFromFormValue } from '../tickets/utils.js';
 
 async function getConversationSeenCutoffAt(
@@ -2254,6 +2259,28 @@ export const mutators = defineMutators({
           throw new Error("Channel doesn't exists");
         }
 
+        // One open artifact per thread. A thread is a single incident's workspace,
+        // so a second /sev2 inside it would fork the responders across two cards
+        // and two calls. The channel is unrestricted — that is where a genuinely
+        // separate incident belongs.
+        const outgoingArtifact = parseSlashCommandArtifactMessage(content);
+        if (outgoingArtifact) {
+          const openArtifact = await tx.run(
+            zql.message_artifacts
+              // channelId first: it is the only selective index on this table.
+              .where('channelId', conversation.channelId)
+              .where('conversationId', conversationId)
+              .where('command', outgoingArtifact.definition.command)
+              .where('status', MessageArtifactStatus.ACTIVE)
+              .one(),
+          );
+          if (openArtifact) {
+            throw new Error(
+              `A ${outgoingArtifact.definition.badge} is already open in this thread`,
+            );
+          }
+        }
+
         let hasAttachments = false;
         if (attachmentIds !== undefined) {
           // Explicit list from a pending-message-aware caller: transfer only
@@ -2479,6 +2506,57 @@ export const mutators = defineMutators({
             await updateInitialMessageMdField(tx, { messageId }, { content, edited: true });
           }
         }
+      },
+    ),
+    /**
+     * Close a slash-command artifact (e.g. decline a SEV2) without ever running
+     * a call. Only the message's author may do it.
+     *
+     * Two writes, both required: the artifact row moves to a terminal status so
+     * the banner and channel indicator clear for everyone, and the closed marker
+     * is baked into the message's FlowJSON so the card still renders as finished
+     * once the row has left the ACTIVE-only artifact subscription.
+     */
+    closeSlashCommandArtifact: defineMutator(
+      z.object({ messageId: z.string(), timestamp: z.number() }),
+      async ({ tx, ctx, args: { messageId, timestamp } }) => {
+        const message = await resolveMessage(tx, messageId);
+        if (!message) {
+          throw new Error('Message not available');
+        }
+        if (message.senderId !== ctx.userID) {
+          throw new Error('Only the author can close this incident');
+        }
+        if (!parseSlashCommandArtifactMessage(message.content)) {
+          throw new Error('Message is not a slash command artifact');
+        }
+
+        const artifact = await tx.run(
+          zql.message_artifacts.where('messageId', messageId).one(),
+        );
+        if (artifact && artifact.status !== MessageArtifactStatus.ACTIVE) {
+          throw new Error('This incident is already closed');
+        }
+
+        const content = withSlashCommandArtifactClosed(message.content, {
+          closedAt: timestamp,
+          closedBy: ctx.userID,
+        });
+        if (!content) {
+          throw new Error('Message is not a slash command artifact');
+        }
+
+        if (artifact) {
+          await tx.mutate.message_artifacts.update({
+            id: artifact.id,
+            status: MessageArtifactStatus.CANCELLED,
+            updatedAt: timestamp,
+          });
+        }
+        // Deliberately not `edited: true` — closing is a lifecycle transition,
+        // not an edit, and must not raise a "message edited" notification.
+        await tx.mutate.messages.update({ messageId, content });
+        await updateInitialMessageMdField(tx, { messageId }, { content });
       },
     ),
     updateShowInChannel: defineMutator(


### PR DESCRIPTION
POT https://drive.google.com/file/d/1UbMAVq0VQUp4xdFxOz2fxe7ERjoi6_pg/view?usp=sharing

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
