### PR TITLE
feat: add interrupt prompt pickup summary

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -3749,6 +3749,16 @@ async function redispatchQueuedMessage(msg: QueuedMessage): Promise<void> {
     ...(msg.resolveMentions ? { resolveMentions: msg.resolveMentions } : {}),
   };
   await setSession(body.sessionId, queuedContext);
+  if (msg.queueReason === "interrupt_followup") {
+    void emitAgentWorkingSignal({
+      conversationId: msg.conversationId,
+      channelId: msg.channelId,
+      agentSlug: msg.agentSlug,
+      spacesAppUserId: agentRow.spacesAppUserId ?? "",
+      appToken,
+      toolLabel: "Picked up your new message — continuing from the summary above…",
+    });
+  }
   clog.info(`[msg-queue] registered queued session context sessionId=${body.sessionId} conv=${msg.conversationId} agent=${msg.agentSlug} workspaceId=${workspaceId ?? "(none)"}`);
 }
 

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -4763,6 +4763,15 @@ async function processTask(
       const partialResult = err instanceof RunCancelledError ? err.partialText?.trim() : "";
       if (gracefulInterrupt) {
         log(`Session interrupted with reply: ${sessionId}`);
+        const interruptSummary = partialResult
+          ? `✅ Picked up your new message and I’m switching to it now.
+
+**Summary of the work so far:**
+
+${partialResult}`
+          : `✅ Picked up your new message and I’m switching to it now.
+
+**Summary of the work so far:** I had not produced a stable partial result yet.`;
         await sendCallback(callbackUrl, sessionToken, {
           sessionId,
           userId,
@@ -4770,7 +4779,7 @@ async function processTask(
           agentSlug: agentSlug ?? null,
           fastMode: fastModeForCallback,
           status: "completed",
-          result: partialResult || "I’m pausing this run here so I can continue with your new message.",
+          result: interruptSummary,
           ...(err instanceof RunCancelledError && err.toolsUsed.length > 0
             ? { toolsUsed: err.toolsUsed }
             : {}),


### PR DESCRIPTION
1. Problem Description:
After interrupt-with-reply, users can see the old run's partial output but need a deterministic indication that the agent has picked up the new prompt and is continuing from that point.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Requested in Spaces thread after the interrupt-with-reply PR was merged: user should know the agent picked up the new prompt, with a deterministic summary of current work.

3. Explain the solution implemented in the PR:
- Prefixes graceful interrupt output with a deterministic "Picked up your new message" notice.
- Labels the previous partial output as "Summary of the work so far".
- Emits an agent working/progress signal when an interrupt follow-up is redispatched, showing the agent is continuing on the new message.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `git diff --check`
- `pnpm --dir apps/xyne-claw-auth/backend exec vitest run src/lib/parseSlashCommand.test.ts`
- Attempted `pnpm --dir apps/xyne-claw exec tsc --noEmit --pretty false`; blocked by existing unrelated errors in pi-ai exports/model-speed and missing sanitize-html in shared package.

9. Services to which this change is to be deployed:
xyne-claw-auth, xyne-claw

10. Main PR link (if this PR is raised against a release branch):
N/A