### PR TITLE
feat: add forward thread

### DIFF
--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -64,6 +64,7 @@ import {
   FormFieldType,
   MessageAttachment,
   createForwardedMessageXml,
+  createForwardedThreadXml,
   parseForwardedMessageXml,
   type BoardMetadata,
   SavedConfigContextType,
@@ -2776,6 +2777,128 @@ export function createMutators(
           });
         },
       ),
+      forwardThread: defineMutator(
+        z.object({
+          sourceConversationId: z.string(),
+          targetChannelId: z.string(),
+          optionalMessage: z.string().max(10000, 'Optional message too long').optional(),
+          conversationId: z.string(),
+          messageId: z.string(),
+          timestamp: z.number(),
+        }),
+        async ({
+          tx,
+          args: {
+            sourceConversationId,
+            targetChannelId,
+            optionalMessage,
+            conversationId,
+            messageId,
+            timestamp,
+          },
+        }) => {
+          const sourceConversation = await tx.run(
+            zql.conversations.where('conversationId', sourceConversationId).one(),
+          );
+          if (!sourceConversation) throw new Error('Source thread not found');
+
+          const originParticipation = await tx.run(
+            zql.channel_participants
+              .where('channelId', sourceConversation.channelId)
+              .where('userId', authData.sub)
+              .one(),
+          );
+          if (!originParticipation) {
+            throw new Error('You are not a participant of the source thread channel');
+          }
+
+          const targetChannel = await tx.run(zql.channels.where('id', targetChannelId).one());
+          if (!targetChannel) throw new Error('Target channel not found');
+
+          const targetParticipation = await tx.run(
+            zql.channel_participants
+              .where('channelId', targetChannelId)
+              .where('userId', authData.sub)
+              .one(),
+          );
+          if (!targetParticipation) {
+            throw new Error('You are not a participant of the target channel');
+          }
+
+          const sourceMessages = await tx.run(
+            zql.messages
+              .where('conversationId', sourceConversationId)
+              .where(({ or, cmp }) =>
+                or(cmp('visibleTo', 'IS', null), cmp('visibleTo', '=', authData.sub)),
+              )
+              .orderBy('createdAt', 'asc')
+              .related('attachments'),
+          );
+          if (sourceMessages.length === 0) throw new Error('Source thread has no visible messages');
+
+          const previewSourceMessages = sourceMessages.slice(0, 8);
+          const senderIds = Array.from(new Set(previewSourceMessages.map(m => m.senderId)));
+          const senders = await Promise.all(
+            senderIds.map(async senderId => tx.run(zql.users.where('id', senderId).one())),
+          );
+          const senderById = new Map(senders.filter(Boolean).map(sender => [sender!.id, sender!]));
+          const rootMessage = sourceMessages.find(m => m.messageId === sourceConversation.initialMessageId) ?? sourceMessages[0]!;
+          const rootSender = senderById.get(rootMessage.senderId) ?? await tx.run(zql.users.where('id', rootMessage.senderId).one());
+          const attachmentCount = sourceMessages.reduce((sum, msg) => sum + (msg.attachments?.length ?? 0), 0);
+
+          const xmlContent = createForwardedThreadXml({
+            originalConversationId: sourceConversation.conversationId,
+            originalChannelId: sourceConversation.channelId,
+            originalInitialMessageId: sourceConversation.initialMessageId,
+            originalCreatedAt: rootMessage.createdAt as number,
+            originalSenderId: rootMessage.senderId,
+            originalSenderName: rootSender?.name || 'Unknown User',
+            optionalText: optionalMessage || null,
+            previewMessages: previewSourceMessages.map(msg => ({
+              messageId: msg.messageId,
+              senderId: msg.senderId,
+              senderName: senderById.get(msg.senderId)?.name || 'Unknown User',
+              createdAt: msg.createdAt as number,
+              content: msg.isDeleted ? 'This message was deleted' : msg.content,
+              attachmentCount: msg.attachments?.length ?? 0,
+            })),
+            totalMessageCount: sourceMessages.length,
+            replyCount: Math.max(0, sourceMessages.length - 1),
+            attachmentCount,
+          });
+
+          const now = timestamp;
+          await tx.mutate.conversations.insert({
+            conversationId,
+            channelId: targetChannelId,
+            workspaceId: authData.workspaceId,
+            createdBy: authData.sub,
+            initialMessageId: messageId,
+            lastActivityAt: now,
+            replyCount: 0,
+            pinned: false,
+            metadata: {},
+            createdAt: now,
+          });
+
+          await tx.mutate.messages.insert({
+            messageId,
+            conversationId,
+            workspaceId: authData.workspaceId,
+            senderId: authData.sub,
+            content: xmlContent,
+            msgType: MessageType.FORWARDED,
+            hasAttachment: false,
+            edited: false,
+            isDeleted: false,
+            isSent: true,
+            showInChannel: false,
+            createdAt: now,
+            metadata: {},
+          });
+        },
+      ),
+
       forwardMessage: defineMutator(
         z.object({
           targetChannelId: z.string(),

--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardThreadModal.tsx
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardThreadModal.tsx
@@ -1,0 +1,292 @@
+import React, { useMemo, useRef, useState } from 'react';
+import { useForm } from '@tanstack/react-form';
+import { Hash, Lock, Users, X } from 'lucide-react';
+import { v4 as uuidv4 } from 'uuid';
+import { toast } from 'sonner';
+import { ChannelScopeType, ChannelVisibility } from '@xyne/shared';
+import Avatar from '../../ui/Avatar/Avatar';
+import { Badge } from '../../ui/Badge';
+import { Button } from '../../ui/Button/Button';
+import { Combobox } from '../../ui/Combobox/Combobox';
+import { DropdownListItemType } from '../../ui/Combobox/Combobox.types';
+import { InputBox } from '../../ui/InputBox';
+import type { InputBoxHandle } from '../../../hooks/useDragAndDropAreaRef';
+import { useAllChannels, useChannelSearch } from '../../../hooks/useChannels';
+import { useUsers } from '../../../hooks/useUsers';
+import { useSelf } from '../../../hooks/useUsers';
+import { useZero } from '../../../hooks/useZero';
+import { mutators } from '../../../zero/mutators';
+import { channelService } from '../../../services/Chat/channelService';
+import { useNavigate } from 'react-router-dom';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+import { parseDMParticipantIds } from '../ChatDirectory/ChatDirectory.utils';
+import { ForwardTarget, SelectionMode } from './ForwardMessageModal.types';
+import { RenderMessageWithHTML } from '../RenderMessageWithHTML/RenderMessageWithHTML';
+import { formatRelativeTimestamp } from '../../../utils/dateUtils';
+
+type ThreadMessage = {
+  messageId: string;
+  senderId: string;
+  content: string;
+  createdAt: number;
+  attachments?: readonly unknown[];
+};
+
+interface ForwardThreadFormProps {
+  conversationId: string;
+  channelId: string;
+  messages: readonly ThreadMessage[];
+  onCancel: () => void;
+  onSuccess?: () => void;
+}
+
+export const ForwardThreadForm: React.FC<ForwardThreadFormProps> = ({
+  conversationId,
+  messages,
+  onCancel,
+  onSuccess,
+}) => {
+  const zero = useZero();
+  const navigate = useNavigate();
+  const currentUser = useSelf();
+  const allUsers = useUsers();
+  const allChannels = useAllChannels();
+  const inputBoxRef = useRef<InputBoxHandle>(null);
+  const [selectedTargets, setSelectedTargets] = useState<ForwardTarget[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [comboboxOpen, setComboboxOpen] = useState(true);
+  const channelsSuggestions = useChannelSearch(inputValue.trim(), 8);
+
+  const form = useForm({
+    defaultValues: { optionalMessageHtml: '', optionalMessageText: '' },
+    onSubmit: async ({ value }) => {
+      const firstTarget = selectedTargets[0];
+      if (!firstTarget) return;
+
+      let targetChannelId = firstTarget.id;
+      if (firstTarget.type !== 'channel') {
+        const userIds =
+          firstTarget.type === 'group_dm'
+            ? [
+                ...(firstTarget.memberIds ?? []),
+                ...selectedTargets.filter(t => t.type === 'user').map(t => t.id),
+              ]
+            : selectedTargets.map(t => t.id);
+        const dm = await channelService.createDm({ participantIds: userIds });
+        targetChannelId = dm.id;
+      }
+
+      const destinationConversationId = uuidv4();
+      const destinationMessageId = uuidv4();
+      zero.mutate(
+        mutators.conversations.forwardThread({
+          sourceConversationId: conversationId,
+          targetChannelId,
+          optionalMessage: value.optionalMessageText.trim()
+            ? value.optionalMessageHtml
+            : undefined,
+          conversationId: destinationConversationId,
+          messageId: destinationMessageId,
+          timestamp: Date.now(),
+        }),
+      );
+
+      toast.success('Thread forwarded');
+      onSuccess?.();
+      void navigate(`/chat/dir/${targetChannelId}`);
+    },
+  });
+
+  const selectedUserIds = useMemo(
+    () => new Set(selectedTargets.filter(t => t.type === 'user').map(t => t.id)),
+    [selectedTargets],
+  );
+  const selectionMode: SelectionMode = useMemo(() => {
+    if (selectedTargets.length === 0) return 'none';
+    const first = selectedTargets[0];
+    if (first?.type === 'channel') return 'channel';
+    if (first?.type === 'group_dm') return 'group_dm';
+    return 'users';
+  }, [selectedTargets]);
+
+  const dropdownListItems: DropdownListItemType[] = useMemo(() => {
+    const query = inputValue.trim().toLowerCase();
+    const users = allUsers
+      .filter(user => {
+        if (selectedUserIds.has(user.id)) return false;
+        if (user.id === currentUser?.id && selectionMode !== 'none') return false;
+        const label = `${user.name ?? ''} ${user.displayName ?? ''} ${user.email ?? ''}`.toLowerCase();
+        return !query || label.includes(query);
+      })
+      .slice(0, 8)
+      .map(user => ({
+        leftSlot: <Avatar userId={user.id} size='sm' />,
+        label: user.id === currentUser?.id ? `${getUserDisplayName(user)} (You)` : getUserDisplayName(user),
+        description: user.email,
+        value: user.id,
+      }));
+
+    const channels = channelsSuggestions
+      .filter(channel => channel.scopeType === ChannelScopeType.DEFAULT)
+      .slice(0, 8)
+      .map(channel => ({
+        leftSlot:
+          channel.visibility === ChannelVisibility.PUBLIC ? (
+            <Hash className='w-3.5 h-3.5 text-muted-foreground' />
+          ) : (
+            <Lock className='w-3.5 h-3.5 text-muted-foreground' />
+          ),
+        label: channel.name,
+        value: channel.id,
+      }));
+
+    const groupDms = allChannels
+      .filter(channel => channel.scopeType === ChannelScopeType.GROUP_DM)
+      .filter(channel => !query || channel.name.toLowerCase().includes(query))
+      .slice(0, 5)
+      .map(channel => ({
+        leftSlot: <Users className='w-3.5 h-3.5 text-muted-foreground' />,
+        label: 'Group DM',
+        value: channel.id,
+      }));
+
+    if (selectionMode === 'channel') return channels;
+    if (selectionMode === 'users' || selectionMode === 'group_dm') return users;
+    return [...users, ...groupDms, ...channels];
+  }, [allChannels, allUsers, channelsSuggestions, currentUser?.id, inputValue, selectedUserIds, selectionMode]);
+
+  const handleValueChange = (selectedValue: string | null) => {
+    if (!selectedValue) return;
+    const selectedUser = allUsers.find(user => user.id === selectedValue);
+    if (selectedUser) {
+      setSelectedTargets(prev => [
+        ...prev,
+        { type: 'user', id: selectedUser.id, name: getUserDisplayName(selectedUser) },
+      ]);
+      setInputValue('');
+      return;
+    }
+
+    const selectedChannel = allChannels.find(channel => channel.id === selectedValue);
+    if (!selectedChannel) return;
+    if (selectedChannel.scopeType === ChannelScopeType.GROUP_DM) {
+      setSelectedTargets([
+        {
+          type: 'group_dm',
+          id: selectedChannel.id,
+          name: 'Group DM',
+          memberIds: parseDMParticipantIds(selectedChannel).filter(id => id !== currentUser?.id),
+        },
+      ]);
+    } else {
+      setSelectedTargets([{ type: 'channel', id: selectedChannel.id, name: selectedChannel.name }]);
+    }
+    setInputValue('');
+  };
+
+  const rootMessage = messages[0];
+  const previewMessages = messages.slice(0, 4);
+  const attachmentCount = messages.reduce((sum, msg) => sum + (msg.attachments?.length ?? 0), 0);
+
+  return (
+    <form
+      data-testid='forward-thread-form'
+      onSubmit={event => {
+        event.preventDefault();
+        void form.handleSubmit();
+      }}
+    >
+      <div className='flex items-center justify-between px-6 pt-6 pb-4 border-b border-border'>
+        <h2 className='text-lg font-semibold text-foreground'>Forward thread</h2>
+        <button type='button' onClick={onCancel} className='rounded-sm opacity-70 hover:opacity-100'>
+          <X className='h-4 w-4' />
+        </button>
+      </div>
+
+      <div className='px-6 py-4 space-y-4'>
+        {selectedTargets.length > 0 && (
+          <div className='flex flex-wrap gap-2'>
+            {selectedTargets.map(target => (
+              <Badge key={target.id} variant='primary' className='flex items-center gap-1.5 pr-1'>
+                <span className='text-xs'>{target.name}</span>
+                <button
+                  type='button'
+                  onClick={() => setSelectedTargets(prev => prev.filter(t => t.id !== target.id))}
+                  aria-label={`Remove ${target.name}`}
+                >
+                  <X className='h-3 w-3' />
+                </button>
+              </Badge>
+            ))}
+          </div>
+        )}
+
+        <Combobox
+          label='Forward to'
+          onInputValueChange={setInputValue}
+          onValueChange={handleValueChange}
+          queryString={inputValue}
+          placeholder={selectionMode === 'none' ? 'Search channels or users...' : 'Add more users...'}
+          items={dropdownListItems}
+          value={null}
+          hintText='Select a channel or one or more users to forward this thread'
+          open={comboboxOpen}
+          onOpenChange={setComboboxOpen}
+          autoHighlight
+        />
+
+        <div>
+          <label className='block text-sm font-medium text-foreground mb-1.5'>Add a message (optional)</label>
+          <InputBox
+            ref={inputBoxRef}
+            id='forward-thread-optional'
+            placeholder='Add a note to the forwarded thread...'
+            onSendMessage={() => {}}
+            onContentChange={(html: string, text: string) => {
+              form.setFieldValue('optionalMessageHtml', html);
+              form.setFieldValue('optionalMessageText', text);
+            }}
+            features={{ richText: true, mentions: false, commands: false, fileAttachments: false, emojiPicker: true }}
+            showTypingIndicator={false}
+            hideSendButton
+          />
+        </div>
+
+        <div>
+          <span className='block text-sm font-medium text-foreground mb-1.5'>Thread preview</span>
+          <div className='bg-muted rounded-md p-3 border border-border max-h-[220px] overflow-y-auto space-y-2'>
+            <p className='text-xs text-muted-foreground'>
+              {messages.length} {messages.length === 1 ? 'message' : 'messages'}
+              {attachmentCount > 0 ? ` · ${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'}` : ''}
+            </p>
+            {previewMessages.map(msg => (
+              <div key={msg.messageId} className='border-l-2 border-border pl-2'>
+                <div className='flex items-center gap-2 mb-0.5'>
+                  <Avatar userId={msg.senderId} size='sm' />
+                  <span className='text-xs text-muted-foreground'>{formatRelativeTimestamp(msg.createdAt)}</span>
+                </div>
+                {msg.content && <RenderMessageWithHTML message={msg.content} />}
+              </div>
+            ))}
+            {rootMessage && messages.length > previewMessages.length && (
+              <p className='text-xs text-muted-foreground'>
+                +{messages.length - previewMessages.length} more replies will be linked from the original thread
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className='flex justify-end gap-3 pt-2'>
+          <Button variant='secondary' type='button' onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type='submit' disabled={selectedTargets.length === 0 || form.state.isSubmitting}>
+            {form.state.isSubmitting ? 'Forwarding...' : 'Forward'}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default ForwardThreadForm;

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -14,7 +14,7 @@ import { useChannel, useChannelParticipation } from '../../hooks/useChannels';
 import { useRouteContext } from '../../hooks/useRouteContext';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useIsInPanelWebview } from '../../hooks/useIsInPanelWebview';
-import { X, FileText, ClipboardCheck, Hash, Tag as TagIcon, ChevronRight } from 'lucide-react';
+import { X, FileText, ClipboardCheck, Hash, Tag as TagIcon, ChevronRight, Forward } from 'lucide-react';
 import {
   ArrowLeft,
   ArrowTurnDownRight,
@@ -99,6 +99,8 @@ import { ThreadRecordingButton } from '../Call/ThreadRecordingButton/ThreadRecor
 import { sendRecordingEvent, useRecordingStore } from '../../hooks/useRecordingStore';
 import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout';
 import { ConversationTabContext } from './ConversationTabContext';
+import { Dialog } from '../ui/Dialog/Dialog';
+import { ForwardThreadForm } from './ForwardMessageModal/ForwardThreadModal';
 
 type TabType = 'thread' | 'details' | 'files' | 'rca';
 type UnderTicketTabType = 'replies' | 'rca';
@@ -309,6 +311,7 @@ export const ThreadMessages = ({
     isThreadParticipant,
   );
   const [isScheduleCallModalOpen, setIsScheduleCallModalOpen] = useState(false);
+  const [isForwardThreadModalOpen, setIsForwardThreadModalOpen] = useState(false);
   const channel = useChannel(derivedChannelId);
   const { displayName: channelDisplayName } = useChannelDisplayName(channel, currentUser?.id ?? '');
   const isDmThread =
@@ -1333,6 +1336,20 @@ export const ThreadMessages = ({
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>
                   )}
+                  {derivedConversationId && !channel?.isArchived && messages.length > 0 && (
+                    <DropdownMenuItem
+                      className='gap-2'
+                      onClick={() => setIsForwardThreadModalOpen(true)}
+                      data-track-category='THREAD_PANEL'
+                      data-track-name='FORWARD_THREAD'
+                      data-track-metadata={JSON.stringify({
+                        conversationId: derivedConversationId,
+                      })}
+                    >
+                      <Forward size={16} className='shrink-0' />
+                      <span className='flex-1'>Forward thread</span>
+                    </DropdownMenuItem>
+                  )}
                   {!isMobile && !channel?.isArchived && (
                     <DropdownMenuItem
                       className='gap-2'
@@ -1702,6 +1719,20 @@ export const ThreadMessages = ({
                           </DropdownMenuSubContent>
                         </DropdownMenuSub>
                       )}
+                      {derivedConversationId && !channel?.isArchived && messages.length > 0 && (
+                        <DropdownMenuItem
+                          className='gap-2'
+                          onClick={() => setIsForwardThreadModalOpen(true)}
+                          data-track-category='THREAD_PANEL'
+                          data-track-name='FORWARD_THREAD'
+                          data-track-metadata={JSON.stringify({
+                            conversationId: derivedConversationId,
+                          })}
+                        >
+                          <Forward size={16} className='shrink-0' />
+                          <span className='flex-1'>Forward thread</span>
+                        </DropdownMenuItem>
+                      )}
                       {!isMobile && !channel?.isArchived && (
                         <DropdownMenuItem
                           className='gap-2'
@@ -1823,6 +1854,22 @@ export const ThreadMessages = ({
             onContextItemToggle={handleContextItemToggle}
             onContextSelectionConfirm={handleContextConfirm}
           />
+        )}
+
+        {isForwardThreadModalOpen && derivedConversationId && (
+          <Dialog
+            open={isForwardThreadModalOpen}
+            onOpenChange={setIsForwardThreadModalOpen}
+            onOpenAutoFocus={event => event.preventDefault()}
+          >
+            <ForwardThreadForm
+              conversationId={derivedConversationId}
+              channelId={derivedChannelId}
+              messages={messages}
+              onCancel={() => setIsForwardThreadModalOpen(false)}
+              onSuccess={() => setIsForwardThreadModalOpen(false)}
+            />
+          </Dialog>
         )}
 
         {/* Schedule Call Modal */}

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -9,6 +9,8 @@ import {
   parsePreviewMd,
   parseForwardedMessageXml,
   isForwardedMessageXml,
+  parseForwardedThreadXml,
+  isForwardedThreadXml,
   parseReactionsMd,
   ReactionsData,
   parseTicketMd,
@@ -545,6 +547,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   const isSystemMessage = message.msgType === MessageType.SYSTEM;
   const isBotMessage = message.msgType === MessageType.BOT;
   const isForwardedMessage = message.msgType === MessageType.FORWARDED;
+  const isForwardedThread = isForwardedMessage && isForwardedThreadXml(message.content);
   const metadata = message.metadata as MessageMetadata | null;
   const previewResult = parsePreviewMd(message.link_preview_md);
 
@@ -555,6 +558,13 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
     }
     return null;
   }, [isForwardedMessage, message.content]);
+
+  const forwardedThreadData = useMemo(() => {
+    if (isForwardedThread) {
+      return parseForwardedThreadXml(message.content);
+    }
+    return null;
+  }, [isForwardedThread, message.content]);
 
   // Query the original conversation only when this is a forwarded desk-ticket
   // message with empty content (email body lives in the email table, not in
@@ -581,7 +591,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
     return forwardedMessageData.content;
   }, [forwardedMessageData, forwardedOriginalConversation]);
   const recordingShare = useRecordingShareMessage(
-    isForwardedMessage ? resolvedForwardedContent : message.content,
+    forwardedMessageData ? resolvedForwardedContent : message.content,
   );
 
   const systemMessageStyles: React.CSSProperties = {
@@ -1324,6 +1334,83 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                     />
                   )}
                 </>
+              ) : forwardedThreadData ? (
+                <div className='space-y-2'>
+                  {forwardedThreadData.optionalText && (
+                    <div
+                      className={`jp-message-html whitespace-pre-wrap break-all-words inline-block ${getEmojiFontSizeClass(forwardedThreadData.optionalText)}`}
+                    >
+                      {isMobile ? (
+                        <ExpandableMessage
+                          message={forwardedThreadData.optionalText}
+                          showEdited={false}
+                          maxHeight={500}
+                        />
+                      ) : (
+                        <RenderMessageWithHTML
+                          message={DOMPurify.sanitize(forwardedThreadData.optionalText)}
+                          showEdited={false}
+                          preserveThreadRoute={context === 'thread'}
+                        />
+                      )}
+                    </div>
+                  )}
+                  <div className='border-l-4 border-l-muted-foreground/30 pl-3 py-2 bg-muted/30 rounded-r-md space-y-2'>
+                    <div className='flex items-center gap-2 text-xs text-muted-foreground'>
+                      <span className='font-medium text-foreground'>Forwarded thread</span>
+                      <span>·</span>
+                      <span>
+                        {forwardedThreadData.totalMessageCount} messages
+                        {forwardedThreadData.attachmentCount > 0
+                          ? ` · ${forwardedThreadData.attachmentCount} attachment${forwardedThreadData.attachmentCount === 1 ? '' : 's'}`
+                          : ''}
+                      </span>
+                    </div>
+                    <div className='space-y-2'>
+                      {forwardedThreadData.previewMessages.map(previewMessage => (
+                        <div key={previewMessage.messageId} className='border-l border-border pl-2'>
+                          <div className='flex items-center gap-2 mb-1 text-xs'>
+                            <span className='font-medium text-foreground'>
+                              {previewMessage.senderName}
+                            </span>
+                            <span className='text-muted-foreground visual-regression-hide'>
+                              {formatRelativeTimestamp(previewMessage.createdAt)}
+                            </span>
+                            {previewMessage.attachmentCount > 0 && (
+                              <span className='text-muted-foreground'>
+                                {previewMessage.attachmentCount} attachment
+                                {previewMessage.attachmentCount === 1 ? '' : 's'}
+                              </span>
+                            )}
+                          </div>
+                          {previewMessage.content && (
+                            <div className='jp-message-html text-muted-foreground'>
+                              <RenderMessageWithHTML
+                                message={previewMessage.content}
+                                showEdited={false}
+                                preserveThreadRoute={context === 'thread'}
+                              />
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                    {forwardedThreadData.totalMessageCount >
+                      forwardedThreadData.previewMessages.length && (
+                      <p className='text-xs text-muted-foreground'>
+                        +{forwardedThreadData.totalMessageCount - forwardedThreadData.previewMessages.length}{' '}
+                        more messages in the original thread
+                      </p>
+                    )}
+                    {forwardedThreadData.originalChannelId && (
+                      <PostedInLink
+                        originalChannelId={forwardedThreadData.originalChannelId}
+                        originalConversationId={forwardedThreadData.originalConversationId}
+                        originalMessageId={forwardedThreadData.originalInitialMessageId}
+                      />
+                    )}
+                  </div>
+                </div>
               ) : isForwardedMessage && forwardedMessageData ? (
                 // Forwarded message display (parsed from XML)
                 <div className='flex flex-col gap-2'>

--- a/packages/shared/src/forwardedMessage.ts
+++ b/packages/shared/src/forwardedMessage.ts
@@ -23,6 +23,34 @@ export interface ForwardedMessageData {
 }
 
 /**
+ * A bounded snapshot of a thread forwarded as a single message/card.
+ * The source of truth remains the original conversation; previewMessages is
+ * intentionally capped by the backend to avoid copying large/private threads.
+ */
+export interface ForwardedThreadPreviewMessage {
+  messageId: string;
+  senderId: string;
+  senderName: string;
+  createdAt: number;
+  content: string;
+  attachmentCount: number;
+}
+
+export interface ForwardedThreadData {
+  originalConversationId: string;
+  originalChannelId: string | null;
+  originalInitialMessageId: string;
+  originalCreatedAt: number;
+  originalSenderId: string;
+  originalSenderName: string;
+  optionalText: string | null;
+  previewMessages: ForwardedThreadPreviewMessage[];
+  totalMessageCount: number;
+  replyCount: number;
+  attachmentCount: number;
+}
+
+/**
  * XML Parser instance configured for forwarded messages
  */
 const xmlParser = new XMLParser({
@@ -141,5 +169,102 @@ export function parseForwardedMessageXml(xml: string): ForwardedMessageData | nu
 export function isForwardedMessageXml(content: string): boolean {
   if (!content) return false;
   const trimmed = content.trim();
-  return trimmed.startsWith('<ForwardedMessage>') && trimmed.endsWith('</ForwardedMessage>');
+  return (
+    trimmed.startsWith('<ForwardedMessage>') && trimmed.endsWith('</ForwardedMessage>')
+  );
+}
+
+/** Creates XML for a forwarded thread card. */
+export function createForwardedThreadXml(data: ForwardedThreadData): string {
+  const xmlObject = {
+    ForwardedThread: {
+      OriginalConversationId: data.originalConversationId,
+      OriginalChannelId: data.originalChannelId ?? '',
+      OriginalInitialMessageId: data.originalInitialMessageId,
+      OriginalCreatedAt: data.originalCreatedAt,
+      OriginalSenderId: data.originalSenderId,
+      OriginalSenderName: data.originalSenderName,
+      OptionalText: data.optionalText ?? '',
+      TotalMessageCount: data.totalMessageCount,
+      ReplyCount: data.replyCount,
+      AttachmentCount: data.attachmentCount,
+      PreviewMessagesJson: JSON.stringify(data.previewMessages),
+    },
+  };
+
+  return xmlBuilder.build(xmlObject);
+}
+
+/** Parses forwarded-thread XML. */
+export function parseForwardedThreadXml(xml: string): ForwardedThreadData | null {
+  if (!isForwardedThreadXml(xml)) return null;
+
+  try {
+    const parsed = xmlParser.parse(xml);
+    const forwardedThread = parsed?.ForwardedThread;
+    if (!forwardedThread) return null;
+
+    const originalConversationId = String(forwardedThread.OriginalConversationId || '');
+    const originalInitialMessageId = String(
+      forwardedThread.OriginalInitialMessageId || '',
+    );
+    const originalSenderId = String(forwardedThread.OriginalSenderId || '');
+    if (!originalConversationId || !originalInitialMessageId || !originalSenderId) {
+      return null;
+    }
+
+    let previewMessages: ForwardedThreadPreviewMessage[] = [];
+    try {
+      const rawPreview = String(forwardedThread.PreviewMessagesJson || '[]');
+      const parsedPreview = JSON.parse(rawPreview);
+      if (Array.isArray(parsedPreview)) {
+        previewMessages = parsedPreview
+          .filter(
+            (item): item is ForwardedThreadPreviewMessage =>
+              item &&
+              typeof item.messageId === 'string' &&
+              typeof item.senderId === 'string' &&
+              typeof item.senderName === 'string' &&
+              typeof item.createdAt === 'number' &&
+              typeof item.content === 'string' &&
+              typeof item.attachmentCount === 'number',
+          )
+          .slice(0, 8);
+      }
+    } catch {
+      previewMessages = [];
+    }
+
+    const originalChannelId = String(forwardedThread.OriginalChannelId || '');
+    const optionalText = String(forwardedThread.OptionalText || '');
+    const originalSenderName = String(forwardedThread.OriginalSenderName || '');
+
+    return {
+      originalConversationId,
+      originalChannelId: originalChannelId || null,
+      originalInitialMessageId,
+      originalCreatedAt:
+        parseInt(String(forwardedThread.OriginalCreatedAt || '0'), 10) || 0,
+      originalSenderId,
+      originalSenderName: originalSenderName || 'Unknown User',
+      optionalText: optionalText || null,
+      previewMessages,
+      totalMessageCount:
+        parseInt(String(forwardedThread.TotalMessageCount || '0'), 10) ||
+        previewMessages.length,
+      replyCount:
+        parseInt(String(forwardedThread.ReplyCount || '0'), 10) ||
+        Math.max(0, previewMessages.length - 1),
+      attachmentCount: parseInt(String(forwardedThread.AttachmentCount || '0'), 10) || 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Checks if a string is forwarded-thread XML. */
+export function isForwardedThreadXml(content: string): boolean {
+  if (!content) return false;
+  const trimmed = content.trim();
+  return trimmed.startsWith('<ForwardedThread>') && trimmed.endsWith('</ForwardedThread>');
 }

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -67,7 +67,7 @@ import {
   ReleaseTrackingMode,
 } from './schema.js';
 import { FlowPlanSchema, serializeFlowPlan, validateFlowPlan } from '../board-types/index.js';
-import { createForwardedMessageXml, parseForwardedMessageXml } from '../forwardedMessage.js';
+import { createForwardedMessageXml, createForwardedThreadXml, parseForwardedMessageXml } from '../forwardedMessage.js';
 import { getNudgeActionBehavior } from '../nudges.js';
 import {
   parseTicketMd,
@@ -1817,6 +1817,138 @@ export const mutators = defineMutators({
         await updateInitialMessageMdField(tx, { messageId }, { content, edited: true });
       },
     ),
+    forwardThread: defineMutator(
+      z.object({
+        sourceConversationId: z.string(),
+        targetChannelId: z.string(),
+        optionalMessage: z.string().max(10000, 'Optional message too long').optional(),
+        conversationId: z.string(),
+        messageId: z.string(),
+        timestamp: z.number(),
+      }),
+      async ({
+        tx,
+        ctx,
+        args: {
+          sourceConversationId,
+          targetChannelId,
+          optionalMessage,
+          conversationId,
+          messageId,
+          timestamp,
+        },
+      }) => {
+        const sourceConversation = await tx.run(
+          zql.conversations.where('conversationId', sourceConversationId).one(),
+        );
+        if (!sourceConversation) throw new Error('Source thread not found');
+
+        const originParticipation = await tx.run(
+          zql.channel_participants
+            .where('channelId', sourceConversation.channelId)
+            .where('userId', ctx.userID)
+            .one(),
+        );
+        if (!originParticipation) {
+          throw new Error('You are not a participant of the source thread channel');
+        }
+
+        const targetChannel = await tx.run(zql.channels.where('id', targetChannelId).one());
+        if (!targetChannel) throw new Error('Target channel not found');
+
+        const targetParticipation = await tx.run(
+          zql.channel_participants
+            .where('channelId', targetChannelId)
+            .where('userId', ctx.userID)
+            .one(),
+        );
+        if (!targetParticipation) {
+          throw new Error('You are not a participant of the target channel');
+        }
+
+        const sourceMessages = await tx.run(
+          zql.messages
+            .where('conversationId', sourceConversationId)
+            .where(({ or, cmp }) =>
+              or(cmp('visibleTo', 'IS', null), cmp('visibleTo', '=', ctx.userID)),
+            )
+            .orderBy('createdAt', 'asc')
+            .related('attachments'),
+        );
+        if (sourceMessages.length === 0) throw new Error('Source thread has no visible messages');
+
+        const previewSourceMessages = sourceMessages.slice(0, 8);
+        const senderIds = Array.from(new Set(previewSourceMessages.map(m => m.senderId)));
+        const senders = await Promise.all(
+          senderIds.map(async senderId => tx.run(zql.users.where('id', senderId).one())),
+        );
+        const senderById = new Map(senders.filter(Boolean).map(sender => [sender!.id, sender!]));
+        const rootMessage = sourceMessages.find(m => m.messageId === sourceConversation.initialMessageId) ?? sourceMessages[0]!;
+        const rootSender = senderById.get(rootMessage.senderId) ?? await tx.run(zql.users.where('id', rootMessage.senderId).one());
+        const attachmentCount = sourceMessages.reduce((sum, msg) => sum + (msg.attachments?.length ?? 0), 0);
+
+        const xmlContent = createForwardedThreadXml({
+          originalConversationId: sourceConversation.conversationId,
+          originalChannelId: sourceConversation.channelId,
+          originalInitialMessageId: sourceConversation.initialMessageId,
+          originalCreatedAt: rootMessage.createdAt,
+          originalSenderId: rootMessage.senderId,
+          originalSenderName: rootSender?.name || 'Unknown User',
+          optionalText: optionalMessage || null,
+          previewMessages: previewSourceMessages.map(msg => ({
+            messageId: msg.messageId,
+            senderId: msg.senderId,
+            senderName: senderById.get(msg.senderId)?.name || 'Unknown User',
+            createdAt: msg.createdAt,
+            content: msg.isDeleted ? 'This message was deleted' : msg.content,
+            attachmentCount: msg.attachments?.length ?? 0,
+          })),
+          totalMessageCount: sourceMessages.length,
+          replyCount: Math.max(0, sourceMessages.length - 1),
+          attachmentCount,
+        });
+
+        await tx.mutate.conversations.insert({
+          conversationId,
+          channelId: targetChannelId,
+          workspaceId: ctx.workspaceId,
+          createdBy: ctx.userID,
+          initialMessageId: messageId,
+          lastActivityAt: timestamp,
+          replyCount: 0,
+          pinned: false,
+          metadata: {},
+          createdAt: timestamp,
+          initial_message_md: buildInitialMessageMd({
+            messageId,
+            conversationId,
+            workspaceId: ctx.workspaceId,
+            senderId: ctx.userID,
+            content: xmlContent,
+            msgType: MessageType.FORWARDED,
+            hasAttachment: false,
+            createdAt: timestamp,
+          }),
+        });
+
+        await tx.mutate.messages.insert({
+          messageId,
+          conversationId,
+          workspaceId: ctx.workspaceId,
+          senderId: ctx.userID,
+          content: xmlContent,
+          msgType: MessageType.FORWARDED,
+          hasAttachment: false,
+          edited: false,
+          isDeleted: false,
+          isSent: true,
+          showInChannel: false,
+          createdAt: timestamp,
+          metadata: {},
+        });
+      },
+    ),
+
     togglePin: defineMutator(
       z.object({ conversationId: z.string() }),
       async ({ tx, args: { conversationId } }) => {


### PR DESCRIPTION
1. Problem Description:
Spaces users can forward individual messages, but they cannot forward an entire thread when the useful context is the full discussion.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Requested from a Spaces thread after reviewing the existing forward-message implementation and planning the forward-thread flow.

3. Explain the solution implemented in the PR:
Adds a thread-scoped Forward thread action in the thread panel More menu. The new forward-thread modal reuses the target-picker UX to forward to channels, DMs, or group DMs. The backend adds a Zero forwardThread mutator that validates source/target participation, builds a bounded server-derived thread preview, and writes one forwarded-thread card/message in the destination. Message rendering now recognizes forwarded-thread XML and shows a bounded preview with a link back to the original thread.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- pnpm --filter @xyne/shared build
- NODE_OPTIONS=--max-old-space-size=4096 pnpm run typecheck (apps/dashboard)
- NODE_OPTIONS=--max-old-space-size=4096 pnpm run typecheck (apps/backend)
- git diff --check

9. Services to which this change is to be deployed:
backend, dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A