### PR TITLE
feat: XYNE-56913 Generate labels action of the recording pill

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -1725,7 +1725,10 @@ export class CallController {
       res.json({ success: true, labelIds });
     } catch (error) {
       logger.error(`[${callId}] Failed to generate recording labels`, error);
-      res.status(500).json({ success: false, error: 'Failed to generate recording labels' });
+      res.status(500).json({
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to generate recording labels',
+      });
     }
   };
 

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -1683,6 +1683,53 @@ export class CallController {
   };
 
   /**
+   * POST /api/calls/recordings/:callId/generate-labels
+   * Generate topical labels for a headless recording on demand (list-view action),
+   * mirroring the auto-generation that normally runs off the transcript-ready webhook.
+   */
+  regenerateRecordingLabels = async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const { callId } = req.params;
+
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    try {
+      const call = await repositories.calls.findByExternalId(callId);
+
+      if (
+        !call ||
+        call.callType !== CallType.HEADLESS ||
+        (call.workspaceId !== null && call.workspaceId !== req.user!.workspaceId)
+      ) {
+        res.status(404).json({ success: false, error: 'Recording not found' });
+        return;
+      }
+
+      if (call.createdByUserId !== userId) {
+        res.status(403).json({ success: false, error: 'Access denied' });
+        return;
+      }
+
+      const labelIds = await noteTakerTranscriptService.regenerateLabels(call);
+      if (labelIds === null) {
+        res.status(404).json({
+          success: false,
+          error: 'Transcript is not available',
+        });
+        return;
+      }
+
+      res.json({ success: true, labelIds });
+    } catch (error) {
+      logger.error(`[${callId}] Failed to generate recording labels`, error);
+      res.status(500).json({ success: false, error: 'Failed to generate recording labels' });
+    }
+  };
+
+  /**
    * GET /api/calls/:callId/download-transcript
    * Download call transcript as text file (formatted .txt only)
    */

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -1725,10 +1725,7 @@ export class CallController {
       res.json({ success: true, labelIds });
     } catch (error) {
       logger.error(`[${callId}] Failed to generate recording labels`, error);
-      res.status(500).json({
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to generate recording labels',
-      });
+      res.status(500).json({ success: false, error: 'Failed to generate recording labels' });
     }
   };
 

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -405,7 +405,7 @@ export class CallRepository {
 
       for (const id of call.labels) {
         const { slug, method } = resolve(id);
-        if (method === TagMethod.LLM) continue;
+        if (method !== TagMethod.MANUAL) continue;
         bySlug.set(slug, id);
       }
 

--- a/apps/backend/src/routes/calls.ts
+++ b/apps/backend/src/routes/calls.ts
@@ -23,6 +23,7 @@ router.post('/schedule', scheduleCallController.scheduleCall);
 router.get('/recordings', callController.getRecordings);
 router.post('/recordings/bulk-delete', callController.bulkDeleteRecordings);
 router.post('/recordings/:callId/generate-summary', callController.regenerateRecordingSummary);
+router.post('/recordings/:callId/generate-labels', callController.regenerateRecordingLabels);
 router.get(
   '/recordings/:callId/email-compose-context',
   recordingEmailController.getComposeContext,

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -224,6 +224,21 @@ class NoteTakerTranscriptService {
   }
 
   /**
+   * On-demand label generation for a headless recording that has none yet
+   * (list-view "Generate labels" action). 
+   */
+  async regenerateLabels(call: Call): Promise<string[] | null> {
+    const formattedTranscript = await transcriptService.getTranscriptContent(call.externalId);
+    if (!formattedTranscript) return null;
+
+    const labelIds = await this.generateAndSaveLabels(call, formattedTranscript, TagMethod.AUTOMATED);
+    if (labelIds.length > 0) {
+      await repositories.calls.appendLabels(call.id, labelIds);
+    }
+    return labelIds;
+  }
+
+  /**
    * Fallback for when the agent's transcript-ready webhook never arrives (agent
    * OOM/SIGKILLed mid-call): reconcile whatever was already streamed to GCS.
    * processTranscript's own entryCount gate makes this a safe no-op when
@@ -814,7 +829,11 @@ class NoteTakerTranscriptService {
    * tag ids for Call.labels. Returns [] on any failure — callers treat that
    * as "nothing to add", never clobbering a previously-saved good result.
    */
-  private async generateAndSaveLabels(call: Call, formattedTranscript: string): Promise<string[]> {
+  private async generateAndSaveLabels(
+    call: Call,
+    formattedTranscript: string,
+    method: TagMethod = TagMethod.LLM,
+  ): Promise<string[]> {
     const callId = call.externalId;
     if (!call.workspaceId) {
       logger.warn(`[${callId}] labels_skipped`, { reason: 'no_workspace', path: 'note_taker' });
@@ -837,7 +856,7 @@ class NoteTakerTranscriptService {
       const slug = this.slugifyLabel(rawLabel);
       if (!slug) continue;
       try {
-        const tagId = await this.getOrCreateLabelTag(call, slug, TagMethod.LLM);
+        const tagId = await this.getOrCreateLabelTag(call, slug, method);
         if (tagId && !tagIds.includes(tagId)) tagIds.push(tagId);
       } catch (error) {
         logger.error(`[${callId}] label_tag_failed`, { label: slug, path: 'note_taker', error });
@@ -893,8 +912,8 @@ class NoteTakerTranscriptService {
   ): Promise<string | null> {
     const existing = await tagRepository.findActiveTag(call.id, NOTE_TAKER_TAG_SOURCE_TYPE, NOTE_TAKER_LABEL_CATEGORY, slug);
     if (existing) {
-      // Typing a label the LLM only suggested asserts it just as the tick button does.
-      if (method === TagMethod.MANUAL && existing.method === TagMethod.LLM) {
+      // Typing a label an LLM/automated pass only suggested asserts it just as the tick button does.
+      if (method === TagMethod.MANUAL && existing.method !== TagMethod.MANUAL) {
         await tagService.confirmTag(existing.id, call.workspaceId!);
       }
       return existing.id;

--- a/apps/dashboard/src/hooks/usePaginatedOatsRecordings.ts
+++ b/apps/dashboard/src/hooks/usePaginatedOatsRecordings.ts
@@ -103,6 +103,8 @@ export function usePaginatedOatsRecordings(
     };
   }, [refreshRecordings]);
 
+  // Patches one row's labels in place so a label action doesn't force
+  // the full-list refetch that resets scroll position and pagination
   useEffect(() => {
     const listener: LabelsPatchListener = (recordingId, labels) => {
       setRecordings(current =>

--- a/apps/dashboard/src/hooks/usePaginatedOatsRecordings.ts
+++ b/apps/dashboard/src/hooks/usePaginatedOatsRecordings.ts
@@ -17,6 +17,14 @@ const refreshListeners = new Set<() => void>();
 export function refreshOatsRecordings(): void {
   for (const listener of refreshListeners) listener();
 }
+
+type LabelsPatchListener = (recordingId: string, labels: string[]) => void;
+const labelsPatchListeners = new Set<LabelsPatchListener>();
+
+/** Patch one recording's labels in every mounted list in place, without a full refetch. */
+export function patchOatsRecordingLabels(recordingId: string, labels: string[]): void {
+  for (const listener of labelsPatchListeners) listener(recordingId, labels);
+}
 type RecordingCursor = { id: string; startedAt: number } | null;
 type OatsRecordingQuery =
   | ReturnType<typeof queries.createdOatsRecordings>
@@ -94,6 +102,20 @@ export function usePaginatedOatsRecordings(
       refreshListeners.delete(refreshRecordings);
     };
   }, [refreshRecordings]);
+
+  useEffect(() => {
+    const listener: LabelsPatchListener = (recordingId, labels) => {
+      setRecordings(current =>
+        current.map(recording =>
+          recording.id === recordingId ? { ...recording, labels } : recording,
+        ),
+      );
+    };
+    labelsPatchListeners.add(listener);
+    return (): void => {
+      labelsPatchListeners.delete(listener);
+    };
+  }, []);
 
   return {
     recordings,

--- a/apps/dashboard/src/hooks/useResolvedRecordingLabels.ts
+++ b/apps/dashboard/src/hooks/useResolvedRecordingLabels.ts
@@ -41,20 +41,19 @@ export async function confirmRecordingLabelSuggestion(
   }
 }
 
-/** Persists a labels change and only applies it locally once the write succeeds. */
-export async function applyRecordingLabelsChange(
-  externalId: string,
-  nextLabels: string[],
+/** Persists a labels change, applying it locally only once the write succeeds. */
+export function useApplyRecordingLabelsChange(
   applyLocally: (labels: string[]) => void,
-  errorContext: string,
-): Promise<void> {
-  try {
-    await recordingService.updateRecording(externalId, { labels: nextLabels });
-    applyLocally(nextLabels);
-  } catch (err) {
-    logRecordingError(errorContext, err);
-    toast.error('Failed to update labels');
-  }
+): (externalId: string, nextLabels: string[], errorContext: string) => Promise<void> {
+  return async (externalId, nextLabels, errorContext) => {
+    try {
+      await recordingService.updateRecording(externalId, { labels: nextLabels });
+      applyLocally(nextLabels);
+    } catch (err) {
+      logRecordingError(errorContext, err);
+      toast.error('Failed to update labels');
+    }
+  };
 }
 
 /** Never rejects: a failed batch leaves its ids uncached so a later render retries them. */

--- a/apps/dashboard/src/hooks/useResolvedRecordingLabels.ts
+++ b/apps/dashboard/src/hooks/useResolvedRecordingLabels.ts
@@ -24,6 +24,20 @@ export function markResolvedRecordingLabelMethod(id: string, method: TagMethod):
   notifyCacheListeners();
 }
 
+/** Confirm an AI-suggested tag in place (optimistic MANUAL flip, reverts to `revertMethod` on failure). */
+export async function confirmRecordingLabelSuggestion(
+  id: string,
+  revertMethod: TagMethod,
+): Promise<void> {
+  markResolvedRecordingLabelMethod(id, TagMethod.MANUAL);
+  try {
+    await tagsApi.confirmTag(id);
+  } catch (err) {
+    markResolvedRecordingLabelMethod(id, revertMethod);
+    throw err;
+  }
+}
+
 /** Never rejects: a failed batch leaves its ids uncached so a later render retries them. */
 async function fetchLabelBatch(ids: string[]): Promise<void> {
   try {

--- a/apps/dashboard/src/hooks/useResolvedRecordingLabels.ts
+++ b/apps/dashboard/src/hooks/useResolvedRecordingLabels.ts
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { TagMethod } from '@xyne/shared';
+import { toast } from 'sonner';
 import { tagsApi } from '../api/tagsApi';
+import { recordingService } from '../services/Recording/recordingService';
+import { logRecordingError } from '../utils/recordingUtils';
 
 /** Resolved `Tag id -> { tag, method }`, shared across mounts so scrolling never re-fetches. */
 const resolvedLabelCache = new Map<string, { tag: string; method: TagMethod }>();
@@ -35,6 +38,23 @@ export async function confirmRecordingLabelSuggestion(
   } catch (err) {
     markResolvedRecordingLabelMethod(id, revertMethod);
     throw err;
+  }
+}
+
+export async function applyRecordingLabelsChange(
+  externalId: string,
+  previousLabels: string[],
+  nextLabels: string[],
+  applyLocally: (labels: string[]) => void,
+  errorContext: string,
+): Promise<void> {
+  applyLocally(nextLabels);
+  try {
+    await recordingService.updateRecording(externalId, { labels: nextLabels });
+  } catch (err) {
+    logRecordingError(errorContext, err);
+    toast.error('Failed to update labels');
+    applyLocally(previousLabels);
   }
 }
 
@@ -88,6 +108,7 @@ async function resolveMissingLabels(ids: string[]): Promise<void> {
 export function useResolvedRecordingLabels(labelIds: string[]): {
   resolveLabel: (id: string) => string;
   resolveMethod: (id: string) => TagMethod;
+  isResolved: (id: string) => boolean;
   isResolving: boolean;
 } {
   const [cacheVersion, setCacheVersion] = useState(0);
@@ -138,5 +159,9 @@ export function useResolvedRecordingLabels(labelIds: string[]): {
     return (id: string): TagMethod => resolvedLabelCache.get(id)?.method ?? TagMethod.MANUAL;
   }, [cacheVersion]);
 
-  return { resolveLabel, resolveMethod, isResolving };
+  const isResolved = useMemo(() => {
+    return (id: string): boolean => resolvedLabelCache.has(id);
+  }, [cacheVersion]);
+
+  return { resolveLabel, resolveMethod, isResolved, isResolving };
 }

--- a/apps/dashboard/src/hooks/useResolvedRecordingLabels.ts
+++ b/apps/dashboard/src/hooks/useResolvedRecordingLabels.ts
@@ -41,20 +41,19 @@ export async function confirmRecordingLabelSuggestion(
   }
 }
 
+/** Persists a labels change and only applies it locally once the write succeeds. */
 export async function applyRecordingLabelsChange(
   externalId: string,
-  previousLabels: string[],
   nextLabels: string[],
   applyLocally: (labels: string[]) => void,
   errorContext: string,
 ): Promise<void> {
-  applyLocally(nextLabels);
   try {
     await recordingService.updateRecording(externalId, { labels: nextLabels });
+    applyLocally(nextLabels);
   } catch (err) {
     logRecordingError(errorContext, err);
     toast.error('Failed to update labels');
-    applyLocally(previousLabels);
   }
 }
 

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -3,7 +3,6 @@ import {
   type MouseEvent as ReactMouseEvent,
   type ReactElement,
   type TouchEvent as ReactTouchEvent,
-  useRef,
   useState,
 } from 'react';
 import { format } from 'date-fns';
@@ -18,6 +17,7 @@ import {
   type RecordingTicketLinkState,
 } from '../../../services/Recording/recordingService';
 import { logRecordingError, type RecordingTitleState } from '../../../utils/recordingUtils';
+import { useApplyRecordingLabelsChange } from '../../../hooks/useResolvedRecordingLabels';
 import { getApiErrorMessage } from '../../../utils/apiError';
 import { formatDuration } from '../../../utils/dateUtils';
 import { RecordingParticipants } from './RecordingParticipants';
@@ -111,7 +111,7 @@ export const RecordingDetailV2Header = ({
 }: RecordingDetailV2HeaderProps): ReactElement => {
   const currentUser = useSelf();
   const [isUpdatingTicketLink, setIsUpdatingTicketLink] = useState(false);
-  const labelsUpdateSeqRef = useRef(0);
+  const applyLabelsChange = useApplyRecordingLabelsChange(onLabelsUpdated);
 
   // Only the creator can rename or relabel; a recording shared with you is read-only.
   const isOwner = recording.createdByUserId === currentUser?.id;
@@ -148,19 +148,8 @@ export const RecordingDetailV2Header = ({
     .filter(Boolean)
     .join(' · ');
 
-  /** Labels apply optimistically and roll back if the recording rejects the write. */
   const handleLabelsChange = async (labels: string[]): Promise<void> => {
-    const previousLabels = recording.labels ?? [];
-    const seq = ++labelsUpdateSeqRef.current;
-    onLabelsUpdated(labels);
-
-    try {
-      await recordingService.updateRecording(recording.externalId, { labels });
-    } catch (err) {
-      logRecordingError('RecordingDetailV2Header.updateLabels', err);
-      toast.error('Failed to update labels');
-      if (labelsUpdateSeqRef.current === seq) onLabelsUpdated(previousLabels);
-    }
+    await applyLabelsChange(recording.externalId, labels, 'RecordingDetailV2Header.updateLabels');
   };
 
   /**

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
@@ -5,10 +5,9 @@ import { toast } from 'sonner';
 import { SearchableMultiSelect } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect';
 import type { SearchableMultiSelectOption } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect.types';
 import { Button } from '../../../components/ui/Button/Button';
-import { tagsApi } from '../../../api/tagsApi';
 import { useRecordingLabelSuggestions } from '../../../hooks/useRecordingLabelSuggestions';
 import {
-  markResolvedRecordingLabelMethod,
+  confirmRecordingLabelSuggestion,
   useResolvedRecordingLabels,
 } from '../../../hooks/useResolvedRecordingLabels';
 import { cn } from '../../../utils/classNames';
@@ -30,7 +29,7 @@ const CHIP_BASE_CLASS_NAME =
 
 const SUGGESTION_CHIP_CLASS_NAME = cn(
   CHIP_BASE_CLASS_NAME,
-  'border border-dashed border-muted-foreground/40',
+  'border border-dashed border-muted-foreground/40 hover:bg-border',
 );
 
 const LIST_INHERITS_POPOVER_CLASS_NAME =
@@ -65,7 +64,7 @@ export function LabelChip({
 }
 
 /** An AI-suggested (unconfirmed) label — tick to keep it (moves into the confirmed pills), cross to discard it. */
-function SuggestedLabelChip({
+export function SuggestedLabelChip({
   label,
   onConfirm,
   onReject,
@@ -83,7 +82,10 @@ function SuggestedLabelChip({
         type='button'
         className='rounded-sm opacity-70 hover:opacity-100'
         aria-label={`Confirm suggested label ${label}`}
-        onClick={onConfirm}
+        onClick={event => {
+          event.stopPropagation();
+          onConfirm();
+        }}
         data-track-category='RecordingDetailV2'
         data-track-name='confirm_suggested_label'
       >
@@ -93,7 +95,10 @@ function SuggestedLabelChip({
         type='button'
         className='rounded-sm opacity-70 hover:opacity-100'
         aria-label={`Dismiss suggested label ${label}`}
-        onClick={onReject}
+        onClick={event => {
+          event.stopPropagation();
+          onReject();
+        }}
         data-track-category='RecordingDetailV2'
         data-track-name='reject_suggested_label'
       >
@@ -113,20 +118,20 @@ export function RecordingLabelPicker({
   const resolvable = useMemo(() => [...labels, ...suggestions], [labels, suggestions]);
   const { resolveLabel, resolveMethod } = useResolvedRecordingLabels(resolvable);
 
-  // Confirmed labels eg: TagMethod === MANUAL are distinguish b/w the LLM tags and shared public viewable
+  // Confirmed labels (TagMethod.MANUAL) vs still-pending suggestions (LLM or AUTOMATED).
   const confirmedLabels = useMemo(
-    () => labels.filter(id => resolveMethod(id) !== TagMethod.LLM),
+    () => labels.filter(id => resolveMethod(id) === TagMethod.MANUAL),
     [labels, resolveMethod],
   );
   const suggestedLabels = useMemo(
-    () => (canEdit ? labels.filter(id => resolveMethod(id) === TagMethod.LLM) : []),
+    () => (canEdit ? labels.filter(id => resolveMethod(id) !== TagMethod.MANUAL) : []),
     [labels, canEdit, resolveMethod],
   );
 
   const options = useMemo<SearchableMultiSelectOption[]>(
     () =>
       normalizeRecordingTags([...suggestions, ...labels])
-        .filter(label => resolveMethod(label) !== TagMethod.LLM)
+        .filter(label => resolveMethod(label) === TagMethod.MANUAL)
         .map(label => ({ value: label, displayLabel: resolveLabel(label) }))
         .sort((left, right) => left.displayLabel.localeCompare(right.displayLabel))
         .map(({ value, displayLabel }) => ({
@@ -169,11 +174,10 @@ export function RecordingLabelPicker({
 
   /** Tick: keep the AI-suggested tag — flips its Tag row to `manual` in place, no labels change needed. */
   const handleConfirmSuggestion = async (labelId: string): Promise<void> => {
-    markResolvedRecordingLabelMethod(labelId, TagMethod.MANUAL);
+    const revertMethod = resolveMethod(labelId);
     try {
-      await tagsApi.confirmTag(labelId);
+      await confirmRecordingLabelSuggestion(labelId, revertMethod);
     } catch {
-      markResolvedRecordingLabelMethod(labelId, TagMethod.LLM);
       toast.error('Failed to confirm label');
     }
   };

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
@@ -29,7 +29,7 @@ const CHIP_BASE_CLASS_NAME =
 
 const SUGGESTION_CHIP_CLASS_NAME = cn(
   CHIP_BASE_CLASS_NAME,
-  'border border-dashed border-muted-foreground/40 hover:bg-border',
+  'border border-dashed border-muted-foreground/40',
 );
 
 const LIST_INHERITS_POPOVER_CLASS_NAME =

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -148,15 +148,15 @@ const RecordingsV2Screen = (): ReactElement => {
   // to their actual value once here so both the filter dropdown and the
   // per-row chips show real label names instead of raw ids. Every id is passed
   // in, including generated ones, since resolving is also what reveals the method.
-  const { resolveLabel, resolveMethod } = useResolvedRecordingLabels(availableLabels);
+  const { resolveLabel, resolveMethod, isResolved } = useResolvedRecordingLabels(availableLabels);
 
   const isManualLabel = useCallback(
     (label: string): boolean => resolveMethod(label) === TagMethod.MANUAL,
     [resolveMethod],
   );
   const manualLabels = useMemo(
-    () => availableLabels.filter(isManualLabel),
-    [availableLabels, isManualLabel],
+    () => availableLabels.filter(isResolved).filter(isManualLabel),
+    [availableLabels, isResolved, isManualLabel],
   );
 
   /**
@@ -606,9 +606,10 @@ const RecordingsV2Screen = (): ReactElement => {
                           usersById,
                           currentUser?.id,
                         )}
-                        tags={row.recording.labels.filter(isManualLabel)}
+                        tags={row.recording.labels.filter(isResolved).filter(isManualLabel)}
                         suggestedTags={row.recording.labels.filter(
-                          label => resolveMethod(label) === TagMethod.AUTOMATED,
+                          label =>
+                            isResolved(label) && resolveMethod(label) === TagMethod.AUTOMATED,
                         )}
                         resolveLabel={resolveLabel}
                         currentUserId={currentUser?.id}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -611,6 +611,9 @@ const RecordingsV2Screen = (): ReactElement => {
                           label =>
                             isResolved(label) && resolveMethod(label) === TagMethod.AUTOMATED,
                         )}
+                        pendingLabelCount={
+                          row.recording.labels.filter(label => !isResolved(label)).length
+                        }
                         resolveLabel={resolveLabel}
                         currentUserId={currentUser?.id}
                         onOpen={handleOpenRecording}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -151,7 +151,7 @@ const RecordingsV2Screen = (): ReactElement => {
   const { resolveLabel, resolveMethod } = useResolvedRecordingLabels(availableLabels);
 
   const isManualLabel = useCallback(
-    (label: string): boolean => resolveMethod(label) !== TagMethod.LLM,
+    (label: string): boolean => resolveMethod(label) === TagMethod.MANUAL,
     [resolveMethod],
   );
   const manualLabels = useMemo(
@@ -607,6 +607,9 @@ const RecordingsV2Screen = (): ReactElement => {
                           currentUser?.id,
                         )}
                         tags={row.recording.labels.filter(isManualLabel)}
+                        suggestedTags={row.recording.labels.filter(
+                          label => resolveMethod(label) === TagMethod.AUTOMATED,
+                        )}
                         resolveLabel={resolveLabel}
                         currentUserId={currentUser?.id}
                         onOpen={handleOpenRecording}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState, type KeyboardEvent, type ReactElement } from 'react';
+import { useEffect, useState, type KeyboardEvent, type MouseEvent, type ReactElement } from 'react';
 import type { User } from '@xyne/shared/machines';
+import { TagMethod } from '@xyne/shared';
 import {
+  Ai01,
   ChevronRight,
   DeleteDustbin02,
   DownloadBarDown,
@@ -25,6 +27,7 @@ import {
   recordingService,
   type RecordingDetail,
 } from '../../../services/Recording/recordingService';
+import { confirmRecordingLabelSuggestion } from '../../../hooks/useResolvedRecordingLabels';
 import {
   calculateRecordingElapsedMs,
   formatElapsedTime,
@@ -36,7 +39,10 @@ import { cn } from '../../../utils/classNames';
 import { TextShimmer } from '../../../components/ui/ShimmerText';
 import { useRecordingTitleState } from '../../../hooks/useRecordingTitleState';
 import { formatRecordingTimestamp, toRecordingTitleInput } from '../utils/RecordingsV2.utils';
-import { LabelChip } from '../../RecordingDetailV2Screen/components/RecordingLabelPicker';
+import {
+  LabelChip,
+  SuggestedLabelChip,
+} from '../../RecordingDetailV2Screen/components/RecordingLabelPicker';
 
 export interface RecordingsV2PillProps {
   recording: Pick<
@@ -50,10 +56,13 @@ export interface RecordingsV2PillProps {
     | 'aiSummary'
     | 'transcript'
     | 'createdByUserId'
+    | 'labels'
   >;
   creator: User | null;
   participantsLabel: string;
   tags?: string[];
+  /** Still-pending suggestions (LLM or on-demand AUTOMATED) — rendered with inline confirm/reject. */
+  suggestedTags?: string[];
   /** Resolves a tag value (Tag id) to its display text. Defaults to identity. */
   resolveLabel?: (label: string) => string;
   currentUserId?: string | undefined;
@@ -147,6 +156,7 @@ const RecordingsV2Pill = ({
   creator,
   participantsLabel,
   tags = [],
+  suggestedTags = [],
   resolveLabel = (label: string) => label,
   currentUserId,
   onOpen,
@@ -158,7 +168,9 @@ const RecordingsV2Pill = ({
     ? Math.max(0, recording.endedAt - recording.startedAt)
     : null;
   const visibleTags = normalizeRecordingTags(tags);
+  const visibleSuggestedTags = normalizeRecordingTags(suggestedTags);
   const isOwner = currentUserId !== undefined && currentUserId === recording.createdByUserId;
+  const showGenerateLabels = recording.labels.length === 0 && Boolean(recording.transcript?.trim());
   const [menuOpen, setMenuOpen] = useState(false);
 
   // Populated on menu open — `hasRecording` isn't in the synced list data (it's
@@ -235,6 +247,44 @@ const RecordingsV2Pill = ({
       toast.error('Failed to download recording');
     } finally {
       setIsDownloadingRecording(false);
+    }
+  };
+
+  const [isGeneratingLabels, setIsGeneratingLabels] = useState(false);
+
+  const handleGenerateLabels = async (event: MouseEvent): Promise<void> => {
+    event.stopPropagation();
+    if (isGeneratingLabels) return;
+    setIsGeneratingLabels(true);
+    try {
+      await recordingService.generateLabels(recording.externalId);
+    } catch (err) {
+      logRecordingError('RecordingsV2Pill.generateLabels', err);
+      toast.error('Failed to generate labels');
+    } finally {
+      setIsGeneratingLabels(false);
+    }
+  };
+
+  // This list's suggestions are always on-demand generated, so a failed
+  // confirm reverts straight back to AUTOMATED
+  const handleConfirmSuggestion = async (labelId: string): Promise<void> => {
+    try {
+      await confirmRecordingLabelSuggestion(labelId, TagMethod.AUTOMATED);
+    } catch (err) {
+      logRecordingError('RecordingsV2Pill.confirmSuggestion', err);
+      toast.error('Failed to confirm label');
+    }
+  };
+
+  const handleRejectSuggestion = async (labelId: string): Promise<void> => {
+    try {
+      await recordingService.updateRecording(recording.externalId, {
+        labels: recording.labels.filter(id => id !== labelId),
+      });
+    } catch (err) {
+      logRecordingError('RecordingsV2Pill.rejectSuggestion', err);
+      toast.error('Failed to dismiss label');
     }
   };
 
@@ -358,12 +408,38 @@ const RecordingsV2Pill = ({
           </span>
         </span>
 
-        {visibleTags.length > 0 && (
+        {visibleTags.length > 0 || visibleSuggestedTags.length > 0 ? (
           <span className='flex flex-wrap items-center gap-1.5'>
             {visibleTags.map(tag => (
               <LabelChip key={tag} label={resolveLabel(tag)} />
             ))}
+            {visibleSuggestedTags.map(tag => (
+              <SuggestedLabelChip
+                key={tag}
+                label={resolveLabel(tag)}
+                onConfirm={() => void handleConfirmSuggestion(tag)}
+                onReject={() => void handleRejectSuggestion(tag)}
+              />
+            ))}
           </span>
+        ) : (
+          showGenerateLabels && (
+            <Button
+              type='button'
+              variant='outline'
+              size='sm'
+              loading={isGeneratingLabels}
+              onClick={event => void handleGenerateLabels(event)}
+              className='h-7 w-fit gap-1.5 rounded-lg border-dashed px-2.5 text-xs font-normal text-muted-foreground hover:text-foreground hover:bg-border'
+              data-track-category='RecordingsV2'
+              data-track-name='generate_recording_labels'
+            >
+              {!isGeneratingLabels && (
+                <Ai01 size={14} variant='Duo Solid' className='shrink-0 text-primary' />
+              )}
+              {isGeneratingLabels ? 'Generating labels…' : 'Generate labels'}
+            </Button>
+          )
         )}
       </span>
     </div>

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -31,8 +31,8 @@ import {
   type RecordingDetail,
 } from '../../../services/Recording/recordingService';
 import {
-  applyRecordingLabelsChange,
   confirmRecordingLabelSuggestion,
+  useApplyRecordingLabelsChange,
 } from '../../../hooks/useResolvedRecordingLabels';
 import {
   calculateRecordingElapsedMs,
@@ -69,6 +69,7 @@ export interface RecordingsV2PillProps {
   tags?: string[];
   /** Still-pending suggestions (LLM or on-demand AUTOMATED) — rendered with inline confirm/reject. */
   suggestedTags?: string[];
+  pendingLabelCount?: number;
   /** Resolves a tag value (Tag id) to its display text. Defaults to identity. */
   resolveLabel?: (label: string) => string;
   currentUserId?: string | undefined;
@@ -163,6 +164,7 @@ const RecordingsV2Pill = ({
   participantsLabel,
   tags = [],
   suggestedTags = [],
+  pendingLabelCount = 0,
   resolveLabel = (label: string) => label,
   currentUserId,
   onOpen,
@@ -173,10 +175,11 @@ const RecordingsV2Pill = ({
   const durationMs = recording.endedAt
     ? Math.max(0, recording.endedAt - recording.startedAt)
     : null;
-  const visibleTags = normalizeRecordingTags(tags);
-  const visibleSuggestedTags = normalizeRecordingTags(suggestedTags);
   const isOwner = currentUserId !== undefined && currentUserId === recording.createdByUserId;
-  const showGenerateLabels = recording.labels.length === 0 && Boolean(recording.transcript?.trim());
+  const visibleTags = normalizeRecordingTags(tags);
+  const visibleSuggestedTags = isOwner ? normalizeRecordingTags(suggestedTags) : [];
+  const showGenerateLabels =
+    isOwner && recording.labels.length === 0 && Boolean(recording.transcript?.trim());
   const [menuOpen, setMenuOpen] = useState(false);
 
   // Populated on menu open — `hasRecording` isn't in the synced list data (it's
@@ -284,14 +287,13 @@ const RecordingsV2Pill = ({
     }
   };
 
+  const applyLabelsChange = useApplyRecordingLabelsChange(labels =>
+    patchOatsRecordingLabels(recording.id, labels),
+  );
+
   const handleRejectSuggestion = async (labelId: string): Promise<void> => {
     const nextLabels = recording.labels.filter(id => id !== labelId);
-    await applyRecordingLabelsChange(
-      recording.externalId,
-      nextLabels,
-      labels => patchOatsRecordingLabels(recording.id, labels),
-      'RecordingsV2Pill.rejectSuggestion',
-    );
+    await applyLabelsChange(recording.externalId, nextLabels, 'RecordingsV2Pill.rejectSuggestion');
   };
 
   return (
@@ -428,6 +430,12 @@ const RecordingsV2Pill = ({
               />
             ))}
           </span>
+        ) : pendingLabelCount > 0 ? (
+          <span className='flex flex-wrap items-center gap-1.5'>
+            {Array.from({ length: pendingLabelCount }, (_, index) => (
+              <span key={index} className='h-6 w-14 animate-pulse rounded-lg bg-muted' />
+            ))}
+          </span>
         ) : (
           showGenerateLabels && (
             <Button
@@ -436,7 +444,7 @@ const RecordingsV2Pill = ({
               size='sm'
               loading={isGeneratingLabels}
               onClick={event => void handleGenerateLabels(event)}
-              className='h-7 w-fit gap-1.5 rounded-lg border-dashed px-2.5 text-xs font-normal text-muted-foreground hover:text-foreground hover:bg-border'
+              className='h-7 w-fit gap-1.5 rounded-lg border-dashed px-2.5 text-xs font-normal text-muted-foreground hover:text-foreground'
               data-track-category='RecordingsV2'
               data-track-name='generate_recording_labels'
             >

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -22,12 +22,18 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../../../components/ui/dropdown-menu';
-import type { OatsRecordingEntry } from '../../../hooks/usePaginatedOatsRecordings';
+import {
+  patchOatsRecordingLabels,
+  type OatsRecordingEntry,
+} from '../../../hooks/usePaginatedOatsRecordings';
 import {
   recordingService,
   type RecordingDetail,
 } from '../../../services/Recording/recordingService';
-import { confirmRecordingLabelSuggestion } from '../../../hooks/useResolvedRecordingLabels';
+import {
+  applyRecordingLabelsChange,
+  confirmRecordingLabelSuggestion,
+} from '../../../hooks/useResolvedRecordingLabels';
 import {
   calculateRecordingElapsedMs,
   formatElapsedTime,
@@ -257,7 +263,8 @@ const RecordingsV2Pill = ({
     if (isGeneratingLabels) return;
     setIsGeneratingLabels(true);
     try {
-      await recordingService.generateLabels(recording.externalId);
+      const labelIds = await recordingService.generateLabels(recording.externalId);
+      patchOatsRecordingLabels(recording.id, [...new Set([...recording.labels, ...labelIds])]);
     } catch (err) {
       logRecordingError('RecordingsV2Pill.generateLabels', err);
       toast.error('Failed to generate labels');
@@ -278,14 +285,14 @@ const RecordingsV2Pill = ({
   };
 
   const handleRejectSuggestion = async (labelId: string): Promise<void> => {
-    try {
-      await recordingService.updateRecording(recording.externalId, {
-        labels: recording.labels.filter(id => id !== labelId),
-      });
-    } catch (err) {
-      logRecordingError('RecordingsV2Pill.rejectSuggestion', err);
-      toast.error('Failed to dismiss label');
-    }
+    const nextLabels = recording.labels.filter(id => id !== labelId);
+    await applyRecordingLabelsChange(
+      recording.externalId,
+      recording.labels,
+      nextLabels,
+      labels => patchOatsRecordingLabels(recording.id, labels),
+      'RecordingsV2Pill.rejectSuggestion',
+    );
   };
 
   return (

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -288,7 +288,6 @@ const RecordingsV2Pill = ({
     const nextLabels = recording.labels.filter(id => id !== labelId);
     await applyRecordingLabelsChange(
       recording.externalId,
-      recording.labels,
       nextLabels,
       labels => patchOatsRecordingLabels(recording.id, labels),
       'RecordingsV2Pill.rejectSuggestion',

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -354,6 +354,14 @@ class RecordingService {
     return response.data;
   }
 
+  /** Generate topical labels for a recording that has none yet. Returns the new tag ids. */
+  async generateLabels(callId: string): Promise<string[]> {
+    const response: AxiosResponse<{ success: true; labelIds: string[] }> = await apiInstance.post(
+      `/calls/recordings/${callId}/generate-labels`,
+    );
+    return response.data.labelIds;
+  }
+
   /** `title` names the new doc; omitted, the backend falls back to the recording title. */
   async exportGoogleDoc(callId: string, title?: string): Promise<ExportRecordingGoogleDocResult> {
     const response = await apiInstance.post<{ success: true } & ExportRecordingGoogleDocResult>(


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->

XYNE-56913. Old recordings with no labels had no way to get them, short of waiting on the passive transcript-ready pipeline. This adds a manual "backfill" path.

- **"Generate labels"** action on `RecordingsV2Pill` (list view) — shown when a recording has no labels but has a transcript.
- New `POST /calls/recordings/:callId/generate-labels` reuses the existing label-generation pipeline on demand.
- Results render inline as suggestion chips with tick/cross accept-reject, right in the list row — no need to open the recording.
- Confirm/reject apply optimistically and roll back on failure; list updates patch the row in place instead of refetching the whole page, which was resetting scroll position and pagination.

## POT

https://github.com/user-attachments/assets/c78875fb-24e1-42c3-ba59-19617c80ca9c


## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: `TagMethod.AUTOMATED` was already defined in the shared enum (unused elsewhere), and `Tag.method` is a plain string column, so no migration was needed to start writing it. -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [x] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

`POST /api/calls/recordings/:callId/generate-labels` — additive, mirrors the existing `generate-summary` endpoint's auth/ownership checks (creator-only, workspace-scoped).

---

## How did you test it?

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- no existing test harness for this list screen's row actions; verified manually against seeded local data -->

### Manual

**Users**
- [x] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [x] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass <!-- typecheck passed; full build not re-run -->
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass <!-- typecheck passed; lint/build not re-run -->
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` <!-- N/A, no new deps -->
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind


