### PR TITLE
fix: use xyne claw auth url for question tool

### DIFF
--- a/packages/xyne-claw-shared/src/tools/ask-question/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/ask-question/tools.ts
@@ -17,13 +17,34 @@ function normalizeOption(option: unknown): string | UserQuestionOption | null {
 }
 
 export const ASK_QUESTION_CONFIG_SCHEMA = {
-  CLAW_AUTH_URL: {
+  XYNE_CLAW_AUTH_URL: {
     label: "Claw Auth Service URL",
     default: "http://localhost:3003",
     required: true as const,
-    placeholder: "http://localhost:3003",
+    placeholder: "http://xyne-claw-auth.xyne-apps.svc.cluster.local:3003",
   },
 };
+
+function normalizeBaseUrl(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim().replace(/\/+$/, "") : null;
+}
+
+function errorCauseMessage(err: unknown): string | null {
+  if (!(err instanceof Error)) return null;
+  const cause = (err as Error & { cause?: unknown }).cause;
+  if (!cause) return null;
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === "object") {
+    const record = cause as Record<string, unknown>;
+    const code = typeof record["code"] === "string" ? record["code"] : undefined;
+    const syscall = typeof record["syscall"] === "string" ? record["syscall"] : undefined;
+    const address = typeof record["address"] === "string" ? record["address"] : undefined;
+    const port = typeof record["port"] === "number" || typeof record["port"] === "string" ? String(record["port"]) : undefined;
+    const hostname = typeof record["hostname"] === "string" ? record["hostname"] : undefined;
+    return [code, syscall, hostname ?? address, port].filter(Boolean).join(" ") || JSON.stringify(cause);
+  }
+  return String(cause);
+}
 
 export const askUserQuestion: ToolDefinition = {
   slug: "ask-user-question",
@@ -77,12 +98,18 @@ export const askUserQuestion: ToolDefinition = {
     if (new Set(questions.map(question => question.id)).size !== questions.length) return "Error: each question id must be unique.";
 
     const meta = context.meta ?? {};
-    const authUrl = context.config["CLAW_AUTH_URL"] ?? "http://localhost:3003";
+    const authUrl =
+      normalizeBaseUrl(context.config["XYNE_CLAW_AUTH_URL"]) ??
+      normalizeBaseUrl(process.env["XYNE_CLAW_AUTH_URL"]) ??
+      normalizeBaseUrl(context.config["CLAW_AUTH_URL"]) ??
+      normalizeBaseUrl(process.env["CLAW_AUTH_URL"]) ??
+      "http://localhost:3003";
+    const pendingQuestionsUrl = `${authUrl}/claw/api/v1/pending-questions`;
     const questionId = crypto.randomUUID();
 
     // Store question in xyne-claw-auth Redis
     try {
-      const res = await fetch(`${authUrl}/claw/api/v1/pending-questions`, {
+      const res = await fetch(pendingQuestionsUrl, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -108,7 +135,9 @@ export const askUserQuestion: ToolDefinition = {
       const data = (await res.json()) as { success: boolean; error?: string };
       if (!data.success) return `Error storing question: ${data.error ?? "unknown"}`;
     } catch (err) {
-      return `Error: ${err instanceof Error ? err.message : String(err)}`;
+      const message = err instanceof Error ? err.message : String(err);
+      const cause = errorCauseMessage(err);
+      return `Error posting question to ${pendingQuestionsUrl}: ${message}${cause ? ` (${cause})` : ""}`;
     }
 
     // Push to pendingQuestions collector so it's included in callback


### PR DESCRIPTION
1. Problem Description:
`ask-user-question` uses the `CLAW_AUTH_URL` config key while the claw deployment exports `XYNE_CLAW_AUTH_URL`. Because `CLAW_AUTH_URL` is platform-only and is not set in the claw pod, the tool falls back to `http://localhost:3003` and fails before reaching claw-auth.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Production retries returned `Error: fetch failed`; runtime logs showed the tool call completing immediately with no `pending-questions` route hit. Code inspection showed `packages/xyne-claw-shared/src/tools/ask-question/tools.ts` reading `CLAW_AUTH_URL`, while other claw-auth-calling tools use `XYNE_CLAW_AUTH_URL`.

3. Explain the solution implemented in the PR:
The ask-question tool now declares and reads `XYNE_CLAW_AUTH_URL`, normalizes trailing slashes, falls back through env and legacy `CLAW_AUTH_URL` before localhost, and returns the target URL plus fetch cause on network errors.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
Uses existing `XYNE_CLAW_AUTH_URL`; no new env var required. Keeps legacy `CLAW_AUTH_URL` fallback for compatibility.

8. Testing (how it was tested; screenshots/links):
- `pnpm --filter xyne-claw-shared typecheck`
- `git diff --check`

9. Services to which this change is to be deployed:
`xyne-claw`

10. Main PR link (if this PR is raised against a release branch):
N/A