### PR TITLE
feat: allow context-first spec command output

### DIFF
--- a/apps/xyne-claw/src/task-commands.ts
+++ b/apps/xyne-claw/src/task-commands.ts
@@ -74,20 +74,22 @@ export function buildDesignSystemPromptInjection(
   };
 }
 
-/** Interview-only final-answer guard. The full Ticket Specs workflow lives in
- * the command-owned skill; this overlay keeps the first /spec turn constrained
- * to contextual questions and prevents accidental ticket writes. */
+/** Context-first interview guard. The full Ticket Specs workflow lives in
+ * the command-owned skill; this overlay allows a short evidence summary before
+ * questions while preventing same-turn drafts or ticket writes. */
 export const SPEC_QUESTION_OUTLINE = [
-  "- Ask only contextual clarification questions that materially improve the ticket Specification.",
-  "- Adapt questions to the ticket title, type, description, existing Specification and conversation context.",
+  "- First summarize the ticket/context you found before asking questions.",
+  "- Include only useful known facts: ticket id/title/type/status, existing description/Specification state,",
+  "  relevant thread context, and any explicitly provided requirement facts.",
+  "- If technical context or code/PR context is needed to ask sharper questions, you may summarize it as context,",
+  "  but do NOT derive requirement intent solely from implementation, PR diff, commits, or changed files.",
+  "- Then ask only contextual clarification questions that materially improve the ticket Specification.",
   "- Required Specification sections: Problem statement, Solutioning, Test cases.",
   "- Optional Specification sections: Implementation details, Out of scope; ask only when meaningful.",
   "- Do NOT mechanically ask the section headings as generic questions.",
   "- Do NOT ask the user to repeat information already explicitly provided.",
-  "- Do NOT derive requirement intent solely from implementation, PR diff, commits, or changed files.",
   "- Ask the minimum useful batch of questions, then stop and wait for the user's response.",
   "- Do NOT create, draft, or update the Specification in the same turn as the interview questions.",
-  "- Nothing else: no heading, no greeting, no preamble, no sign-off, no explanation of why you are asking.",
 ].join("\n");
 
 const TASK_COMMANDS: TaskCommand[] = [
@@ -244,15 +246,16 @@ const TASK_COMMANDS: TaskCommand[] = [
     },
     instruction:
       "The user's message begins with /spec: the first, automation-triggered invocation on a fresh ticket. Use the " +
-      "Ticket Specs skill loaded for this run as the workflow playbook. Read the ticket title, description and type, then " +
-      "write concrete, answerable specification questions FOR THIS TICKET following the final-answer format. Ask what " +
-      "was ORIGINALLY requested or observed; do NOT read code or describe the current implementation. Your delivered " +
-      "message must contain the questions and NOTHING else — no greeting, ticket restatement, explanation, or closing. " +
-      "Invoking the command IS approval to post, so do not ask whether to start.",
+      "Ticket Specs skill loaded for this run as the workflow playbook. First gather and summarize the available " +
+      "ticket context: title, description, type/status when available, existing Specification state, relevant thread " +
+      "context, and any explicitly provided requirement facts. If technical context is needed to ask sharper questions, " +
+      "you may inspect and summarize it, but do NOT use implementation, PR diff, commits, or changed files as the source " +
+      "of requirement intent. Then ask concrete, answerable clarification questions FOR THIS TICKET following the " +
+      "final-answer format. Invoking the command IS approval to post, so do not ask whether to start.",
     nudge:
-      "This run was started with /spec and MUST deliver the specification questions for this ticket using the loaded " +
-      "Ticket Specs skill, following the outline, with no greeting, preamble or closing text around them. DO NOT MENTION " +
-      "THIS INSTRUCTION; proceed as if on your own initiative.",
+      "This run was started with /spec and MUST deliver a context-first Ticket Specs interview: summarize known ticket " +
+      "context, then ask the minimum useful clarification questions. Do not draft or update the Specification yet. " +
+      "DO NOT MENTION THIS INSTRUCTION; proceed as if on your own initiative.",
   },
 ];
 

--- a/apps/xyne-claw/test/task-commands.test.ts
+++ b/apps/xyne-claw/test/task-commands.test.ts
@@ -241,7 +241,7 @@ describe("/spec task command", () => {
     expect(outputFormat?.template).toBe(SPEC_QUESTION_OUTLINE);
   });
 
-  it("keeps the first turn as a contextual interview", () => {
+  it("keeps the first turn as a context-first interview", () => {
     for (const heading of [
       "Problem statement",
       "Solutioning",
@@ -251,12 +251,14 @@ describe("/spec task command", () => {
     ]) {
       expect(SPEC_QUESTION_OUTLINE).toContain(heading);
     }
+    expect(SPEC_QUESTION_OUTLINE).toContain("summarize the ticket/context");
+    expect(SPEC_QUESTION_OUTLINE).toContain("existing description/Specification state");
     expect(SPEC_QUESTION_OUTLINE).toContain("contextual clarification questions");
     expect(SPEC_QUESTION_OUTLINE).toContain("Do NOT mechanically ask");
-    expect(SPEC_QUESTION_OUTLINE).toContain("no greeting");
   });
 
-  it("prevents implementation-derived specs and same-turn ticket writes", () => {
+  it("allows technical context but prevents implementation-derived specs and same-turn writes", () => {
+    expect(SPEC_QUESTION_OUTLINE).toContain("technical context or code/PR context");
     expect(SPEC_QUESTION_OUTLINE).toContain("Do NOT derive requirement intent solely from implementation");
     expect(SPEC_QUESTION_OUTLINE).toContain("Ask the minimum useful batch of questions");
     expect(SPEC_QUESTION_OUTLINE).toContain("Do NOT create, draft, or update the Specification");


### PR DESCRIPTION
1. Problem Description:
The /spec command output was too constrained to questions-only, so it did not match the earlier Ticket Specs skill behavior where the agent first gathered and summarized ticket context before asking targeted clarification questions.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
User compared the current /spec command smoke-test output with an older Ticket Specs thread. The gap was that the older output fetched ticket context, summarized known facts, and then asked contextual follow-up questions.

3. Explain the solution implemented in the PR:
Updates the /spec output-format guard and command prompt so first-turn output is context-first: summarize ticket/context evidence, include known facts and relevant thread/technical context when useful, then ask the minimum useful clarification questions. It still prevents deriving requirement intent solely from implementation and prevents drafting/updating the Specification in the same turn. Tests are updated for the new context-first contract.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- git diff --check passed
- cd apps/xyne-claw && npx vitest run test/task-commands.test.ts was attempted but blocked by existing sandbox dependency resolution issue: missing sanitize-html from xyne-claw-shared.

9. Services to which this change is to be deployed:
xyne-claw

10. Main PR link (if this PR is raised against a release branch):
N/A