### PR TITLE
feat: gracefully summarize interrupted runs

### DIFF
--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -7,6 +7,7 @@ import {
   type CreateAgentSessionOptions,
   type ToolDefinition,
   type SessionEntry,
+  type AgentSession,
 } from "@earendil-works/pi-coding-agent";
 import { dirname, isAbsolute, join } from "node:path";
 import { createLogger } from "./logger.js";
@@ -1772,6 +1773,13 @@ export interface RunTaskOptions {
     isUserCancelled: () => boolean;
     onTurnBoundary: (lastTurn: number) => void;
   } | undefined;
+  /** Same-user mid-run follow-up: routes/run.ts installs a callback so the
+   *  interrupt endpoint can steer the live session to summarize and finish
+   *  before falling back to a hard abort. */
+  gracefulInterrupt?: {
+    isRequested: () => boolean;
+    registerSummaryRequest: (requestSummary: () => Promise<boolean>) => void;
+  } | undefined;
 }
 
 const FAST_MODE_ACTIVE_TOOLS_CUSTOM_TYPE = "xyne.fastMode.activeToolSet";
@@ -1838,6 +1846,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     fastMaxActiveTools,
     resumedFromHandoff,
     handoff,
+    gracefulInterrupt,
   } = opts;
   let lastHandoffTurn = 0;
   const recordHandoffBoundary = (turn: number): void => {
@@ -2292,6 +2301,31 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
       : { requested: "standard", applied: false, reason: "standard speed requested" }
     : undefined;
   installLlmCallMetrics(session.agent, sessionId ?? conversationId ?? "unknown", { fastMode: fastMode === true });
+
+  if (gracefulInterrupt) {
+    gracefulInterrupt.registerSummaryRequest(async () => {
+      const summaryInstruction = [
+        "[System Interrupt]",
+        "The user has sent a newer prompt while this run is still active.",
+        "Stop starting new work and do not call more tools unless one is already in flight and unavoidable.",
+        "Reply now with a concise summary of the work completed so far, including useful state, tools used, and any important caveats.",
+        "This run will end after that summary, and the newer user prompt will be handled next.",
+      ].join("\n");
+      try {
+        const liveSession = session as AgentSession & { sendUserMessage?: AgentSession["sendUserMessage"] };
+        if (typeof liveSession.sendUserMessage === "function") {
+          await liveSession.sendUserMessage(summaryInstruction, { deliverAs: "steer" });
+        } else {
+          await session.prompt(summaryInstruction, { streamingBehavior: "steer", expandPromptTemplates: false });
+        }
+        log.info(`[agent] Graceful interrupt summary steer queued (session=${sessionId ?? conversationId ?? "unknown"})`);
+        return true;
+      } catch (err) {
+        log.warn(`[agent] Graceful interrupt summary steer failed: ${err instanceof Error ? err.message : String(err)}`);
+        return false;
+      }
+    });
+  }
 
   // Mid-turn compaction: pi compacts AFTER an assistant message but doesn't
   // check the tool_result that just landed and goes into the NEXT prompt. The

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -174,6 +174,8 @@ interface ActiveRunControl {
    *  run before the queued follow-up is dispatched. Unlike /cancel, this must
    *  complete with a posted result so the transcript remains linear. */
   gracefulInterruptRequested?: boolean;
+  gracefulInterruptSummaryTimer?: ReturnType<typeof setTimeout>;
+  requestGracefulInterruptSummary?: () => Promise<boolean>;
   hasCallbackUrl?: boolean;
   sseClientAttached?: boolean;
   sseReconnectGraceTimer?: ReturnType<typeof setTimeout>;
@@ -852,6 +854,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
       typeof callbackUrl === "string" ? callbackUrl : undefined,
     ).finally(() => {
       if (activeRun.handoffCapTimer) clearTimeout(activeRun.handoffCapTimer);
+      if (activeRun.gracefulInterruptSummaryTimer) clearTimeout(activeRun.gracefulInterruptSummaryTimer);
       activeRuns.delete(sessionId);
     });
     return;
@@ -984,6 +987,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
         clearTimeout(activeRun.sseReconnectGraceTimer);
       }
       if (activeRun.handoffCapTimer) clearTimeout(activeRun.handoffCapTimer);
+      if (activeRun.gracefulInterruptSummaryTimer) clearTimeout(activeRun.gracefulInterruptSummaryTimer);
       activeRuns.delete(sessionId);
       // Backstop: processTask has several silent-return paths (most notably
       // SessionLockedError — another pod owns this run and suppresses the
@@ -1079,6 +1083,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
     typeof callbackUrl === "string" ? callbackUrl : undefined,
   ).finally(() => {
     if (activeRun.handoffCapTimer) clearTimeout(activeRun.handoffCapTimer);
+    if (activeRun.gracefulInterruptSummaryTimer) clearTimeout(activeRun.gracefulInterruptSummaryTimer);
     activeRuns.delete(sessionId);
   });
 });
@@ -1321,10 +1326,27 @@ router.post("/run/:sessionId/interrupt-with-reply", validateS2SKey, (req, res: R
   }
 
   // This is intentionally NOT userCancelled. /cancel suppresses output; a
-  // same-user follow-up wants the active turn to produce/post what it has, then
-  // let claw-auth drain the queued follow-up as the next user turn.
+  // same-user follow-up wants the active turn to summarize/post what it has, then
+  // let claw-auth drain the queued follow-up as the next user turn. Prefer a
+  // model-generated summary via steering, but keep a bounded hard-abort fallback
+  // so a stuck tool/provider cannot block the new prompt forever.
   active.gracefulInterruptRequested = true;
-  active.abortController.abort();
+  if (!active.gracefulInterruptSummaryTimer) {
+    const timeoutMs = Number(process.env["CLAW_INTERRUPT_SUMMARY_TIMEOUT_MS"] ?? 15_000);
+    const delay = Number.isFinite(timeoutMs) && timeoutMs > 0 ? Math.floor(timeoutMs) : 15_000;
+    active.gracefulInterruptSummaryTimer = setTimeout(() => {
+      if (!active.abortController.signal.aborted) {
+        clog.warn(`[run] interrupt-with-reply summary timed out; aborting session=${sessionId}`);
+        active.abortController.abort();
+      }
+    }, delay);
+    active.gracefulInterruptSummaryTimer.unref?.();
+  }
+  void active.requestGracefulInterruptSummary?.().then((queued) => {
+    if (!queued && !active.abortController.signal.aborted) {
+      active.abortController.abort();
+    }
+  });
   res.json({ success: true, sessionId, status: "interrupt_requested" });
 });
 
@@ -1410,6 +1432,24 @@ router.post("/clone-session", validateS2SKey, async (req, res: Response) => {
     res.status(500).json({ success: false, error: "Failed to clone session" });
   }
 });
+
+function buildInterruptSummary(partialResult: string, fallback?: { toolsUsed?: string[]; toolInvocations?: Array<{ toolName?: string; isError?: boolean }> }): string {
+  const trimmed = partialResult.trim();
+  const details: string[] = [];
+  const tools = [...new Set(fallback?.toolsUsed ?? [])].slice(0, 8);
+  if (tools.length > 0) details.push(`Tools used so far: ${tools.join(", ")}.`);
+  const invocations = fallback?.toolInvocations ?? [];
+  if (invocations.length > 0) {
+    const lastTool = [...invocations].reverse().find((inv) => typeof inv.toolName === "string" && inv.toolName.trim().length > 0);
+    details.push(`Tool calls completed so far: ${invocations.length}${lastTool?.toolName ? `; latest: ${lastTool.toolName}${lastTool.isError ? " (failed)" : ""}.` : "."}`);
+  }
+  const fallbackText = details.length > 0
+    ? details.join("\n")
+    : "I had not produced a stable partial result yet.";
+  return trimmed
+    ? `✅ Picked up your new message and I’m switching to it now.\n\n**Summary of the work so far:**\n\n${trimmed}`
+    : `✅ Picked up your new message and I’m switching to it now.\n\n**Summary of the work so far:** ${fallbackText}`;
+}
 
 async function processTask(
   sessionId: string,
@@ -3990,6 +4030,13 @@ async function processTask(
         ...(catalogActive ? { fastMaxActiveTools: fastModeLoadedToolBudget } : {}),
         ...(resumedFromHandoff === true ? { resumedFromHandoff: true } : {}),
         handoff: handoffControl,
+        gracefulInterrupt: {
+          isRequested: () => activeRuns.get(sessionId)?.gracefulInterruptRequested === true,
+          registerSummaryRequest: (requestSummary) => {
+            const active = activeRuns.get(sessionId);
+            if (active) active.requestGracefulInterruptSummary = requestSummary;
+          },
+        },
       });
 
     // Capture provider-fallback context so an empty FINAL result can tell the
@@ -4342,6 +4389,28 @@ async function processTask(
         agentSlug: agentSlug ?? null,
         fastMode: fastModeForCallback,
         status: "cancelled",
+      });
+      return;
+    }
+
+    if (activeRuns.get(sessionId)?.gracefulInterruptRequested === true) {
+      log(`Session interrupted with model summary: ${sessionId}`);
+      await sendCallback(callbackUrl, sessionToken, {
+        sessionId,
+        userId,
+        conversationId: conversationId ?? null,
+        agentSlug: agentSlug ?? null,
+        fastMode: fastModeForCallback,
+        status: "completed",
+        result: buildInterruptSummary(callbackResultText, {
+          toolsUsed: combinedToolsUsed,
+          toolInvocations: result.toolInvocations,
+        }),
+        toolsUsed: combinedToolsUsed,
+        tokenUsage: result.tokenUsage,
+        ...(result.toolInvocations.length > 0 ? { toolInvocations: result.toolInvocations } : {}),
+        provider: completedProvider,
+        model: completedModel,
       });
       return;
     }
@@ -4763,15 +4832,10 @@ async function processTask(
       const partialResult = err instanceof RunCancelledError ? err.partialText?.trim() : "";
       if (gracefulInterrupt) {
         log(`Session interrupted with reply: ${sessionId}`);
-        const interruptSummary = partialResult
-          ? `✅ Picked up your new message and I’m switching to it now.
-
-**Summary of the work so far:**
-
-${partialResult}`
-          : `✅ Picked up your new message and I’m switching to it now.
-
-**Summary of the work so far:** I had not produced a stable partial result yet.`;
+        const interruptSummary = buildInterruptSummary(partialResult, err instanceof RunCancelledError ? {
+          toolsUsed: err.toolsUsed,
+          toolInvocations: err.toolInvocations,
+        } : undefined);
         await sendCallback(callbackUrl, sessionToken, {
           sessionId,
           userId,


### PR DESCRIPTION
1. Problem Description:
Same-user mid-run follow-ups currently hard-abort the active run and return only already-streamed assistant text. Tool-heavy agents often have no streamed assistant prose yet, so users see the fallback "I had not produced a stable partial result yet" even though useful work happened.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
After deploying the interrupt-with-reply behavior, production logs showed interrupted runs frequently had no text_delta output before cancellation. The user requested the safer UX: ask the active agent to summarize before ending, then continue with the new prompt.

3. Explain the solution implemented in the PR:
- Adds a graceful interrupt summary hook from routes/run.ts into agent.ts.
- On interrupt-with-reply, xyne-claw now steers the live pi session with a system interrupt asking it to stop new work and summarize current progress.
- Adds a bounded timeout via CLAW_INTERRUPT_SUMMARY_TIMEOUT_MS, defaulting to 15 seconds, so stuck tools/providers still hard-abort and unblock the queued follow-up.
- Wraps successful model summaries with the deterministic "Picked up your new message" notice.
- Keeps deterministic fallback summary from streamed text, tools used, and tool invocation count if the model cannot summarize before the timeout.
- Clears the interrupt summary timer on all active-run cleanup paths.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
Optional: CLAW_INTERRUPT_SUMMARY_TIMEOUT_MS controls how long to wait for a model-generated interrupt summary before hard-aborting. Default: 15000 ms.

8. Testing (how it was tested; screenshots/links):
- git diff --check
- pnpm --dir apps/xyne-claw-auth/backend exec vitest run src/lib/parseSlashCommand.test.ts
- Attempted pnpm --dir apps/xyne-claw exec tsc --noEmit --pretty false; still blocked by existing unrelated errors: missing pi-ai exports getModels/getProviders, model-speed nullability, and missing sanitize-html in shared package.

9. Services to which this change is to be deployed:
xyne-claw-auth, xyne-claw

10. Main PR link (if this PR is raised against a release branch):
N/A