### PR TITLE
fix: XYNE-56934 use shared date picker for status expiry

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/UpdateStatusModal.tsx
+++ b/apps/dashboard/src/components/AppSidebar/UpdateStatusModal.tsx
@@ -6,6 +6,7 @@ import { Check, ChevronDown, SmilePlus, X } from 'lucide-react';
 import { Dialog } from '../ui/Dialog/Dialog';
 import { Button } from '../ui/Button/Button';
 import Input from '../ui/Input/Input';
+import { DatePicker } from '../ui/DatePicker/DatePicker';
 import { useZero } from '../../hooks/useZero';
 import { mutators } from '../../zero/mutators';
 import { DEFAULT_STATUS_EMOJI, EXPIRY_OPTIONS, calculateExpiryTime } from '../../utils/statusUtils';
@@ -25,6 +26,12 @@ const STATUS_SUGGESTIONS = [
 ];
 
 const RECENT_STATUSES_KEY = 'xyne_recent_statuses';
+
+const getStartOfToday = (): Date => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+};
 
 interface RecentStatus {
   emoji: string;
@@ -507,18 +514,15 @@ export const UpdateStatusModal: React.FC<UpdateStatusModalProps> = ({
             {/* Custom Date/Time Picker */}
             {showDatePicker && (
               <div className='flex items-center gap-2'>
-                <div className='px-3 py-2 border border-input rounded-lg flex-1 bg-background'>
-                  <Input
-                    type='date'
-                    value={customDate ? customDate.toISOString().split('T')[0] : ''}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      const date = e.target.value ? new Date(e.target.value) : undefined;
-                      setCustomDate(date);
-                    }}
-                    min={new Date().toISOString().split('T')[0]}
-                    className='w-full border-none p-0 focus:ring-0'
-                  />
-                </div>
+                <DatePicker
+                  selectedDate={customDate ?? null}
+                  onSelect={date => setCustomDate(date ?? undefined)}
+                  minDate={getStartOfToday()}
+                  showClearButton={false}
+                  placeholder='Select date'
+                  inputClassName='h-9 flex-1 w-full'
+                  contentClassName='z-[100]'
+                />
 
                 <div className='px-3 py-2 border border-input rounded-lg bg-background'>
                   <Input

--- a/apps/dashboard/src/components/Settings/Views/SetStatusView.tsx
+++ b/apps/dashboard/src/components/Settings/Views/SetStatusView.tsx
@@ -5,6 +5,7 @@ import EmojiPicker, { EmojiStyle, Theme } from 'emoji-picker-react';
 import { Check, ChevronDown, ChevronLeft, SmilePlus, X } from 'lucide-react';
 import { Button } from '../../ui/Button/Button';
 import Input from '../../ui/Input/Input';
+import { DatePicker } from '../../ui/DatePicker/DatePicker';
 import { useZero } from '../../../hooks/useZero';
 import { mutators } from '../../../zero/mutators';
 import {
@@ -30,6 +31,12 @@ const STATUS_SUGGESTIONS = [
 ];
 
 const RECENT_STATUSES_KEY = 'xyne_recent_statuses';
+
+const getStartOfToday = (): Date => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+};
 
 interface RecentStatus {
   emoji: string;
@@ -531,18 +538,15 @@ export const StatusEditView: React.FC<StatusEditViewProps> = ({ setView, initial
       {/* Custom Date/Time Picker */}
       {showDatePicker && (
         <div className='flex items-center gap-2'>
-          <div className='px-3 py-2 border border-input rounded-lg flex-1 bg-background'>
-            <Input
-              type='date'
-              value={customDate ? customDate.toISOString().split('T')[0] : ''}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                const date = e.target.value ? new Date(e.target.value) : undefined;
-                setCustomDate(date);
-              }}
-              min={new Date().toISOString().split('T')[0]}
-              className='w-full border-none p-0 focus:ring-0'
-            />
-          </div>
+          <DatePicker
+            selectedDate={customDate ?? null}
+            onSelect={date => setCustomDate(date ?? undefined)}
+            minDate={getStartOfToday()}
+            showClearButton={false}
+            placeholder='Select date'
+            inputClassName='h-9 flex-1 w-full'
+            contentClassName='z-[100]'
+          />
 
           <div className='px-3 py-2 border border-input rounded-lg bg-background'>
             <Input


### PR DESCRIPTION
1. Problem Description:
The Set status custom “Remove status after” flow used the browser-native HTML date input, which caused inconsistent UI in dark mode and kept date parsing tied to native date string handling.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Ticket XYNE-56934 requested replacing the native status expiry date input with the shared Spaces DatePicker.

3. Explain the solution implemented in the PR:
Replaced the native date inputs in apps/dashboard/src/components/AppSidebar/UpdateStatusModal.tsx and apps/dashboard/src/components/Settings/Views/SetStatusView.tsx with the shared DatePicker component. Preserved the existing native time input and customDate + customTime expiry calculation. Added start-of-today minDate handling, showClearButton={false}, and a raised DatePicker popover z-index for modal stacking.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- git diff --check: passed
- ESLint on changed files: passed
- grep confirmed no native type='date' / type="date" remains in the two changed status files
- grep confirmed DatePicker is used in both changed status files
- Full dashboard typecheck was attempted with increased heap, but fails on unrelated existing RecordingShareModal.tsx metadata type errors.
- Dashboard POT was captured from the sandbox:

![Dashboard POT for XYNE-56934 shared DatePicker status expiry](https://github.com/user-attachments/assets/89ae2900-4877-4c15-b550-263ded41d1b0)

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A