### PR TITLE
fix: prevent duplicate agent progress indicator rendering

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -1009,10 +1009,6 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
           </div>
         ) : (
           <>
-            <AgentProgressIndicator
-              sessionId={agentProgressConversationId ?? currentSessionId}
-              conversationId={agentProgressConversationId}
-            />
             {showOfflineBanner && (
               <div className='px-3 py-1.5 bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded text-xs text-amber-700 dark:text-amber-300 flex items-center justify-between mx-3 mb-1'>
                 <div className='flex items-center gap-1.5'>


### PR DESCRIPTION
1. Problem Description:
Agent progress status text can overlap in the thread composer when agent calls are active because ChatInput renders AgentProgressIndicator twice for the same conversation.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported from a Spaces thread screenshot showing overlapping agent-call status rows. Investigation found two AgentProgressIndicator mounts in apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx: a standalone in-flow mount above InputBox and the intended InputBox agentSlot mount.

3. Explain the solution implemented in the PR:
Remove the redundant standalone AgentProgressIndicator mount and keep the InputBox agentSlot instance, which is wired with onActiveChange so InputBox can own the shared typing/agent activity bar.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Verified only one AgentProgressIndicator mount remains in ChatInput.tsx.
- `git diff --check` passed.
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir apps/dashboard typecheck` passed.
- POT video recorded and attached in the Spaces thread.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A