### PR TITLE
feat: XYNE-56934 add subagent artifact handoff

### DIFF
--- a/apps/xyne-claw/src/mcp.ts
+++ b/apps/xyne-claw/src/mcp.ts
@@ -6,6 +6,7 @@ import { promoteIfOversized } from "./tool-output.js";
 import { writeAttachmentToContext } from "./attachment-write.js";
 import { readFile, realpath } from "node:fs/promises";
 import { resolve as resolvePath, isAbsolute, sep } from "node:path";
+import crypto from "node:crypto";
 
 import { createLogger } from "./logger.js";
 const log = createLogger("mcp");
@@ -17,7 +18,7 @@ const log = createLogger("mcp");
  * (multi-sheet markdown / unpdf), text gets utf-8 decoded, images and
  * unknown binaries are written as-is. Returns null if no marker is found.
  */
-async function persistSpacesAttachmentIfMarker(
+export async function persistSpacesAttachmentIfMarker(
   workspaceDir: string,
   content: string,
 ): Promise<string | null> {
@@ -35,7 +36,12 @@ async function persistSpacesAttachmentIfMarker(
       mimeType,
       buf,
     );
-    return `Saved attachment to \`${relPath}\` (${kind}, ${byteSize} bytes). Use the read tool to view it.`;
+    const sha256 = crypto.createHash("sha256").update(buf).digest("hex");
+    return [
+      `Saved attachment to \`${relPath}\` (${kind}, ${byteSize} bytes). Use the read tool to view it.`,
+      `Workspace file marker: {{file:${relPath}}}`,
+      `Attachment metadata: ${JSON.stringify({ fileName, mimeType, sha256 })}`,
+    ].join("\n");
   } catch (err) {
     return `Failed to persist attachment ${fileName}: ${err instanceof Error ? err.message : String(err)}`;
   }
@@ -139,7 +145,7 @@ export interface McpToolGroup {
 // Allowlist source: the CLAW_FILE_INPUT_FORWARDING_SERVERS env var (comma-
 // separated serverTypes). Mirrors claw-auth's FILE_FORWARDING_SERVERS pattern.
 const FILE_INPUT_FORWARDING_SERVERS = new Set<string>(
-  (process.env["CLAW_FILE_INPUT_FORWARDING_SERVERS"] ?? "")
+  (process.env["CLAW_FILE_INPUT_FORWARDING_SERVERS"] ?? "github")
     .split(",")
     .map((x) => x.trim())
     .filter(Boolean),

--- a/apps/xyne-claw/src/subagent-tools.ts
+++ b/apps/xyne-claw/src/subagent-tools.ts
@@ -57,6 +57,67 @@ const log = createLogger("subagent-tools");
  */
 const SUBAGENT_CACHE_TTL_MS = 30 * 60 * 1000;
 
+export interface SubagentArtifact {
+  relPath: string;
+  marker: string;
+  fileName: string;
+  mimeType: string;
+  sha256: string;
+}
+
+function encodeArtifactPart(value: string): string {
+  return encodeURIComponent(value).replace(/%20/g, "+");
+}
+
+export function parseSubagentArtifact(toolName: string, resultText: string): SubagentArtifact | null {
+  if (!toolName.endsWith("__spaces-fetch-attachment") && toolName !== "spaces-fetch-attachment") return null;
+
+  const markerMatch = /^Workspace file marker:\s*(\{\{file:([^}]+)\}\})\s*$/m.exec(resultText);
+  const metadataMatch = /^Attachment metadata:\s*(\{.*\})\s*$/m.exec(resultText);
+  if (!markerMatch || !metadataMatch) return null;
+
+  try {
+    const metadata = JSON.parse(metadataMatch[1]!) as Record<string, unknown>;
+    const fileName = typeof metadata["fileName"] === "string" ? metadata["fileName"] : null;
+    const mimeType = typeof metadata["mimeType"] === "string" ? metadata["mimeType"] : null;
+    const sha256 = typeof metadata["sha256"] === "string" ? metadata["sha256"] : null;
+    if (!fileName || !mimeType || !sha256 || !/^[a-f0-9]{64}$/i.test(sha256)) return null;
+    return {
+      marker: markerMatch[1]!,
+      relPath: markerMatch[2]!,
+      fileName,
+      mimeType,
+      sha256,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function renderSubagentArtifacts(artifacts: SubagentArtifact[]): string {
+  if (artifacts.length === 0) return "";
+  const seen = new Set<string>();
+  const lines: string[] = [];
+  for (const artifact of artifacts) {
+    const key = `${artifact.sha256}:${artifact.relPath}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const artifactId = artifact.sha256.slice(0, 16);
+    const machineMarker = `[SUBAGENT_ARTIFACT:spaces:${artifactId}:${encodeArtifactPart(artifact.fileName)}:${encodeArtifactPart(artifact.mimeType)}]`;
+    lines.push(
+      `- ${machineMarker} path=\`${artifact.relPath}\` marker=\`${artifact.marker}\` fileName=\`${artifact.fileName}\` mimeType=\`${artifact.mimeType}\` sha256=\`${artifact.sha256}\``,
+    );
+  }
+  if (lines.length === 0) return "";
+  return [
+    "",
+    "---",
+    "**Subagent artifacts available to parent**",
+    "These files were fetched by the child tool and written into the parent workspace `.context/` directory. For MCP tools that accept file input, pass the `marker` value so bytes are forwarded out-of-band instead of through model context.",
+    ...lines,
+  ].join("\n");
+}
+
 /**
  * Per-call timeout for stdio MCPs spawned from xyne-claw (deepwiki, context7,
  * playwright). The `@modelcontextprotocol/sdk` runs an internal timer
@@ -642,6 +703,12 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
       // verbatim to the returned text (below) so the parent always has the exact
       // [clf-…#n] tokens to cite, independent of how the inner LLM summarized.
       const citedToolOutputs: string[] = [];
+      // Child `spaces-fetch-attachment` calls persist files into the parent workspace.
+      // Capture their deterministic file markers here and append them to the wrapper
+      // result so the parent can pass `{{file:.context/...}}` to a later MCP tool
+      // (for example GitHub `upload-pr-attachment`) without routing base64 through
+      // either LLM.
+      const subagentArtifacts: SubagentArtifact[] = [];
       let turnStartedAt: number | null = null;
       let firstDeltaAt: number | null = null;
       let turnStreamChars = 0;
@@ -994,6 +1061,10 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
               if (resStr && /\[clf-[^#\s[\]]+#\d+\]/i.test(resStr)) {
                 citedToolOutputs.push(resStr);
               }
+              const artifact = parseSubagentArtifact(event.toolName, resStr);
+              if (artifact) {
+                subagentArtifacts.push(artifact);
+              }
             } catch { /* ignore non-serializable results */ }
 
             // Tier 2: stream nested child invocation up to the parent's progressUrl
@@ -1219,6 +1290,12 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
           // unusual but possible. Keep the original fallback wording so callers
           // that special-case "(No findings)" don't regress.
           text = "(No findings)";
+        }
+
+        const artifactAppendix = renderSubagentArtifacts(subagentArtifacts);
+        if (artifactAppendix) {
+          text += artifactAppendix;
+          log.info(`[${def.name}] Appended ${subagentArtifacts.length} subagent artifact marker(s) to parent-visible result`);
         }
 
         // Citation-token safety net: surface any `[clf-…#n]` token from the raw

--- a/apps/xyne-claw/test/subagent-artifact-handoff.test.ts
+++ b/apps/xyne-claw/test/subagent-artifact-handoff.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+import { persistSpacesAttachmentIfMarker } from "../src/mcp.js";
+import { parseSubagentArtifact, renderSubagentArtifacts } from "../src/subagent-tools.js";
+
+describe("spaces attachment persistence", () => {
+  it("writes a spaces-fetch-attachment marker to .context and returns a forwardable file marker", async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), "claw-artifact-"));
+    const bytes = Buffer.from("png bytes");
+    const result = await persistSpacesAttachmentIfMarker(
+      workspace,
+      `[SPACES_ATTACHMENT:shot.png:image/png]\n${bytes.toString("base64")}`,
+    );
+
+    expect(result).toContain("Saved attachment to `.context/shot.png` (image, 9 bytes)");
+    expect(result).toContain("Workspace file marker: {{file:.context/shot.png}}");
+    expect(result).toContain(`"sha256":"${crypto.createHash("sha256").update(bytes).digest("hex")}"`);
+    expect(existsSync(path.join(workspace, ".context", "shot.png"))).toBe(true);
+    expect(readFileSync(path.join(workspace, ".context", "shot.png"))).toEqual(bytes);
+  });
+
+  it("ignores ordinary tool output", async () => {
+    const workspace = mkdtempSync(path.join(tmpdir(), "claw-artifact-"));
+    await expect(persistSpacesAttachmentIfMarker(workspace, "hello")).resolves.toBeNull();
+  });
+});
+
+describe("subagent artifact appendix", () => {
+  it("extracts deterministic artifact metadata from a child spaces-fetch-attachment result", () => {
+    const sha = "a".repeat(64);
+    const artifact = parseSubagentArtifact(
+      "Xyne_Spaces__spaces-fetch-attachment",
+      [
+        "Saved attachment to `.context/shot.png` (image, 9 bytes). Use the read tool to view it.",
+        "Workspace file marker: {{file:.context/shot.png}}",
+        `Attachment metadata: ${JSON.stringify({ fileName: "shot.png", mimeType: "image/png", sha256: sha })}`,
+      ].join("\n"),
+    );
+
+    expect(artifact).toEqual({
+      relPath: ".context/shot.png",
+      marker: "{{file:.context/shot.png}}",
+      fileName: "shot.png",
+      mimeType: "image/png",
+      sha256: sha,
+    });
+  });
+
+  it("renders a parent-visible machine marker and file-forwarding marker", () => {
+    const sha = "b".repeat(64);
+    const text = renderSubagentArtifacts([
+      {
+        relPath: ".context/a b.png",
+        marker: "{{file:.context/a b.png}}",
+        fileName: "a b.png",
+        mimeType: "image/png",
+        sha256: sha,
+      },
+    ]);
+
+    expect(text).toContain("[SUBAGENT_ARTIFACT:spaces:bbbbbbbbbbbbbbbb:a+b.png:image%2Fpng]");
+    expect(text).toContain("marker=`{{file:.context/a b.png}}`");
+    expect(text).toContain(`sha256=\`${sha}\``);
+  });
+});


### PR DESCRIPTION
1. Problem Description:
Spaces subagents can fetch attachments, but the parent agent only receives natural-language output. That breaks follow-up flows such as taking a POT attachment fetched by the Spaces subagent and uploading it to a GitHub PR attachment tool, because raw file bytes should not be routed through the model context.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Identified while trying to attach dashboard POT from Spaces to GitHub PR #992. GitHub upload-pr-attachment requires base64 bytes, while Spaces subagent only surfaced attachment metadata/IDs to the parent.

3. Explain the solution implemented in the PR:
- spaces-fetch-attachment persistence now returns a workspace file marker `{{file:.context/...}}` plus JSON metadata with fileName, mimeType, and sha256.
- Subagent execution captures child spaces-fetch-attachment results and appends a deterministic `[SUBAGENT_ARTIFACT:spaces:...]` appendix to the parent-visible result.
- The appendix includes the existing file-forwarding marker so a parent can pass it directly to GitHub `upload-pr-attachment`; bytes are forwarded out-of-band by the MCP wrapper.
- GitHub is enabled by default for workspace file forwarding.
- Added focused tests for attachment persistence, artifact parsing/rendering, and existing MCP file-forwarding behavior.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
`CLAW_FILE_INPUT_FORWARDING_SERVERS` still overrides the allowlist; default now includes `github` so GitHub PR attachment upload can consume `{{file:...}}` markers without extra env setup.

8. Testing (how it was tested; screenshots/links):
- `git diff --check`
- `PATH=/nix/store/fpksy87c7p8b0bp2s7qlxmn0mnrh392k-nodejs-22.21.1/bin:$PATH pnpm --dir apps/xyne-claw exec vitest run test/subagent-artifact-handoff.test.ts test/mcp-file-forwarding.test.ts --pool=forks --no-file-parallelism` — 12 tests passed
- `PATH=/nix/store/fpksy87c7p8b0bp2s7qlxmn0mnrh392k-nodejs-22.21.1/bin:$PATH pnpm --filter xyne-claw typecheck` — passed

9. Services to which this change is to be deployed:
xyne-claw

10. Main PR link (if this PR is raised against a release branch):
N/A