### PR TITLE
fix: DM thread does not open from the New Message composer

### DIFF
--- a/apps/dashboard/src/hooks/useRouteContext.ts
+++ b/apps/dashboard/src/hooks/useRouteContext.ts
@@ -4,8 +4,10 @@ export type BaseRoute =
   | '/chat/dm'
   | '/chat/dir'
   | '/chat/bookmarks'
-  | '/chat/canvas'
+  | '/chat/drafts-sent'
   | '/chat/activity';
+
+const CHANNEL_ROUTE_SEGMENTS = ['dm', 'bookmarks', 'drafts-sent', 'activity'];
 
 /**
  * Hook to detect the current route context and build a context-aware navigation URL
@@ -22,7 +24,11 @@ export const useRouteContext = (): {
   const routeSegment =
     chatIndex !== -1 && chatIndex + 1 < pathSegments.length ? pathSegments[chatIndex + 1] : 'dir';
 
-  const baseRoute = `/chat/${routeSegment}` as BaseRoute;
+  const baseRoute = (
+    routeSegment && CHANNEL_ROUTE_SEGMENTS.includes(routeSegment)
+      ? `/chat/${routeSegment}`
+      : '/chat/dir'
+  ) as BaseRoute;
 
   const buildChannelRoute = (channelId: string, params?: Record<string, string>): string => {
     const route = `${baseRoute}/${channelId}`;


### PR DESCRIPTION
POT - 

https://github.com/user-attachments/assets/33dcf99e-dfdf-4062-9e9c-ade36f08f305



## Problem

Open a DM through **New Message** (`Cmd+N`, or the Inbox sidebar button), type a person, click them — the existing conversation renders inline. Click the thread on any message and you get a blank page: **Unknown Channel**, *No conversations in this channel yet*, *No thread messages*.

Opening the same DM from the sidebar and clicking the same thread works fine.

## Root cause

Every chat link is built as `` `${baseRoute}/${channelId}/${conversationId}` ``. `useRouteContext` produced `baseRoute` by taking whatever segment followed `/chat/` and casting it:

```ts
const baseRoute = `/chat/${routeSegment}` as BaseRoute;
```

The New Message composer lives at **`/chat/search?mode=dm`** (`AppRoot.tsx` `global.composeMessage`, `ChatDirectory.tsx`) → `Search` → `ComposeDmPanel`, which embeds a real `ChatListV2` when an existing DM is found. So `baseRoute` became `'/chat/search'` — a prefix with no `:channelId/:conversationId` children.

`/chat/search/<channelId>/<conversationId>` therefore matched nothing, fell through to the `chat/*` catch-all, and `DirectoryRedirect` rewrote it to `/chat/dir/search/<channelId>/<conversationId>`. That shifts every param one position right:

| param | got | should be |
| --- | --- | --- |
| `channelId` | `"search"` | the DM channel id |
| `conversationId` | the **channel** id | the conversation id |
| `ticketId` | the **conversation** id | — |

Hence "Unknown Channel" (the `useChannelDisplayName` fallback) and a thread panel querying a conversation id that doesn't exist.

The `as BaseRoute` cast is what hid it: `'/chat/search'` isn't in the union, but a cast asserts instead of checking.

## Fix

Only echo the current section back when its route subtree actually mounts the channel children; otherwise fall back to `/chat/dir`, which always does — extending the fallback the hook already applied when no segment was present.

The `BaseRoute` union was also wrong in both directions, so it now matches the router: dropped `'/chat/canvas'` (that subtree has only `:canvasId`, so the hook could never legitimately return it) and added `'/chat/drafts-sent'` (it spreads `sharedChatRoutes`, so the hook does return it).

> **Note on `drafts-sent`:** the whitelist entry is inert today. `DraftsAndSentPage` renders no `<Outlet />`, so the `sharedChatRoutes` spread under `drafts-sent` is dead config, and `DraftsPanel`/`SentPanel` hardcode `/chat/dir/...` rather than using `baseRoute`. It is whitelisted so the hook mirrors the router config — if an `<Outlet />` is ever added there, links will correctly stay in-section instead of silently redirecting out. Behaviour under `drafts-sent` is byte-identical before and after this change either way.

One file, +8/-2. Nothing outside the file imports `BaseRoute`, and no code compares against `'/chat/canvas'`.

## Blast radius

This is one fix for the whole class — `ChatListV3`/`V4` build thread URLs identically, and profile / mention / group / pin / ticket links under the composer were broken the same way.

## Testing

Recorded before/after against the local stack with Playwright — same build, same account, same DM, same click sequence, only the fix toggled. Captured nav trails:

**Before**
```
/chat/search?mode=dm
  -> /chat/search/cmt86vvdq.../cmt86vxgv...       (no route matches)
  -> /chat/dir/search/cmt86vvdq.../cmt86vxgv...   (DirectoryRedirect rewrite)
Unknown Channel: true | No thread messages: true | No conversations in this channel yet: true
```

**After**
```
/chat/search?mode=dm
  -> /chat/dir/cmt86vvdq.../cmt86vxgv...          (matches ChatView + ThreadMessages)
Unknown Channel: false | No thread messages: false | No conversations in this channel yet: false
```

Route matching also verified directly against react-router's `matchRoutes` for `/chat/{search,dir,dm,drafts-sent}/...`.

`tsc --noEmit` and `eslint` clean on the changed file.

POT video attached below.
