### PR TITLE
feat: Claw spotlight overlay with global shortcut

### DIFF
--- a/apps/dashboard/src/components/Claw/ClawChat/ClawMarkdown.tsx
+++ b/apps/dashboard/src/components/Claw/ClawChat/ClawMarkdown.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import type { ReactElement, ReactNode, AnchorHTMLAttributes, HTMLAttributes } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -6,6 +6,10 @@ import remarkBreaks from 'remark-breaks';
 import type { Components } from 'react-markdown';
 import type { Element } from 'hast';
 import { cn } from '../../../utils/classNames';
+import {
+  StreamingMarkdownBlocks,
+  type MarkdownBlockRenderer,
+} from '../../utils/StreamingMarkdownBlocks';
 import {
   buildClawCitationToolNumbers,
   linkifyAndGroupClawCitations,
@@ -147,13 +151,18 @@ interface ClawMarkdownProps {
   content: string;
   className?: string;
   toolInvocations?: ToolInvocation[] | undefined;
+  isStreaming?: boolean | undefined;
 }
 
 export function ClawMarkdown({
   content,
   className,
   toolInvocations,
+  isStreaming,
 }: ClawMarkdownProps): ReactElement {
+  const everStreamedRef = useRef(isStreaming === true);
+  if (isStreaming) everStreamedRef.current = true;
+
   const renderedContent = useMemo(() => {
     const toolNumbers = buildClawCitationToolNumbers(content);
     return linkifyAndGroupClawCitations(content, toolNumbers);
@@ -166,15 +175,26 @@ export function ClawMarkdown({
     [toolInvocations],
   );
 
-  return (
-    <div className={cn('claw-markdown', className)}>
+  const renderBlock = useCallback<MarkdownBlockRenderer>(
+    markdown => (
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
         urlTransform={url => url}
         components={markdownComponents}
       >
-        {renderedContent}
+        {markdown}
       </ReactMarkdown>
+    ),
+    [markdownComponents],
+  );
+
+  return (
+    <div className={cn('claw-markdown', className)}>
+      {everStreamedRef.current ? (
+        <StreamingMarkdownBlocks content={renderedContent} render={renderBlock} />
+      ) : (
+        renderBlock(renderedContent)
+      )}
     </div>
   );
 }

--- a/apps/dashboard/src/components/Claw/ClawChat/MessageBubble.tsx
+++ b/apps/dashboard/src/components/Claw/ClawChat/MessageBubble.tsx
@@ -105,7 +105,11 @@ export function MessageBubble({ message, onRetry }: MessageBubbleProps): ReactEl
               />
             )}
             <div className={cn(showActivity && 'pl-[22px]')}>
-              <ClawMarkdown content={displayText} toolInvocations={message.toolInvocations} />
+              <ClawMarkdown
+                content={displayText}
+                toolInvocations={message.toolInvocations}
+                isStreaming={message.isStreaming}
+              />
             </div>
             {message.isStreaming && rawText.trim().length > 0 && (
               <span className='inline-block h-3.5 w-1.5 animate-pulse bg-current align-middle' />

--- a/apps/dashboard/src/components/Claw/ClawOverlay.tsx
+++ b/apps/dashboard/src/components/Claw/ClawOverlay.tsx
@@ -9,7 +9,6 @@ import {
 } from 'framer-motion';
 import { cn } from '../../utils/classNames';
 import {
-  CORNER_RADII,
   DEFAULT_PANEL_HEIGHT,
   MIN_PANEL_HEIGHT,
   PANEL,
@@ -17,14 +16,21 @@ import {
   PILL,
   PILL_THINKING,
   SHADOW_GUTTER,
+  SPOTLIGHT,
+  SPOTLIGHT_REST_HEIGHT,
 } from './claw.constants';
 import { isExternalHttpHref } from './claw.utils';
 import { CLOSE_SPRING, OPEN_SPRING } from './claw.motion';
-import { useClawOverlayBridge } from './useClawOverlayBridge';
-import { ClawConversationProvider, useClawTabStatus } from './ClawConversationContext';
+import { useClawOverlayBridge, type ClawMode } from './useClawOverlayBridge';
+import {
+  ClawConversationProvider,
+  useClawConversation,
+  useClawTabStatus,
+} from './ClawConversationContext';
 import { ClawPill } from './ClawPill';
 import { ClawPeekBubble } from './ClawPeekBubble';
 import { ClawChat } from './ClawChat/ClawChat';
+import { ClawSpotlight } from './ClawSpotlight';
 import { xyneAIStreamManager } from '../../services/XyneAI';
 import './claw.css';
 
@@ -33,6 +39,38 @@ function ClawThinkingProbe({ onChange }: { onChange: (thinking: boolean) => void
   useEffect(() => {
     onChange(isStreaming);
   }, [isStreaming, onChange]);
+  return null;
+}
+
+function ClawSessionReporter(): null {
+  const { messages, isStreaming, conversationId } = useClawConversation();
+  const { hasError } = useClawTabStatus();
+  const lastSentRef = useRef('');
+
+  useEffect(() => {
+    const api = window.electronAPI?.clawOverlay;
+    if (!api?.setSessionState) return;
+
+    const lastBot = [...messages].reverse().find(message => message.type === 'bot');
+    const needsInput =
+      !isStreaming && !!lastBot?.pendingActions?.some(action => !action.resolution);
+
+    const status = isStreaming
+      ? 'running'
+      : needsInput
+        ? 'needs-input'
+        : hasError
+          ? 'error'
+          : 'idle';
+
+    const preview = status === 'running' ? null : (lastBot?.content ?? null);
+    const key = `${status}|${conversationId}|${preview ?? ''}`;
+    if (key === lastSentRef.current) return;
+    lastSentRef.current = key;
+
+    api.setSessionState({ status, conversationId: conversationId || null, preview });
+  }, [messages, isStreaming, conversationId, hasError]);
+
   return null;
 }
 
@@ -51,6 +89,12 @@ export function ClawOverlay(): React.ReactElement {
   const [panelHeight, setPanelHeight] = useState<number>(DEFAULT_PANEL_HEIGHT);
   const [isResizing, setIsResizing] = useState(false);
   const [isThinking, setIsThinking] = useState(false);
+  const [mode, setMode] = useState<ClawMode>('pill');
+  const [spotlightHeight, setSpotlightHeight] = useState<number>(SPOTLIGHT.height);
+  const [spotlightDesiredHeight, setSpotlightDesiredHeight] =
+    useState<number>(SPOTLIGHT_REST_HEIGHT);
+
+  const isSpotlight = mode === 'spotlight';
 
   const isOpenRef = useRef(isOpen);
   isOpenRef.current = isOpen;
@@ -63,6 +107,9 @@ export function ClawOverlay(): React.ReactElement {
   const pendingHeightRef = useRef<number | null>(null);
   const shellRef = useRef<HTMLDivElement>(null);
   const pointerEpochRef = useRef(0);
+  const isSpotlightRef = useRef(isSpotlight);
+  isSpotlightRef.current = isSpotlight;
+  const wasSpotlightRef = useRef(isSpotlight);
 
   useLayoutEffect(() => {
     const root = document.documentElement;
@@ -87,6 +134,41 @@ export function ClawOverlay(): React.ReactElement {
     xyneAIStreamManager.setHasClawOverlay(true);
     return () => xyneAIStreamManager.setHasClawOverlay(false);
   }, []);
+
+  useEffect(() => bridge.onMode(setMode), [bridge]);
+
+  useEffect(() => {
+    if (!isSpotlight) return;
+    const update = (): void =>
+      setSpotlightHeight(
+        Math.max(
+          SPOTLIGHT_REST_HEIGHT,
+          Math.min(SPOTLIGHT.height, window.screen.availHeight - SHADOW_GUTTER - 16),
+        ),
+      );
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, [isSpotlight]);
+
+  useEffect(() => {
+    if (!isSpotlight) return;
+    isOpenRef.current = true;
+    setIsClosing(false);
+    bridge.setExpanded(true);
+    setIsOpen(true);
+  }, [isSpotlight, bridge]);
+
+  useEffect(() => {
+    const wasSpotlight = wasSpotlightRef.current;
+    wasSpotlightRef.current = isSpotlight;
+    if (!wasSpotlight || isSpotlight) return;
+    isOpenRef.current = false;
+    setIsOpen(false);
+    setIsClosing(false);
+    setSpotlightDesiredHeight(SPOTLIGHT_REST_HEIGHT);
+    bridge.setExpanded(false);
+  }, [isSpotlight, bridge]);
 
   useEffect(() => {
     bridge.setIgnoreMouse(true);
@@ -162,7 +244,19 @@ export function ClawOverlay(): React.ReactElement {
     setIsOpen(true);
   }, [bridge]);
 
+  const handleSpotlightHeight = useCallback(
+    (height: number) => {
+      setSpotlightDesiredHeight(height);
+      bridge.setSpotlightHeight(height);
+    },
+    [bridge],
+  );
+
   const handleClose = useCallback(() => {
+    if (isSpotlightRef.current) {
+      bridge.dismissSpotlight();
+      return;
+    }
     cancelResize();
     isOpenRef.current = false;
     setIsClosing(true);
@@ -171,17 +265,20 @@ export function ClawOverlay(): React.ReactElement {
   }, [bridge, reduceMotion, cancelResize]);
 
   const handlePointerEnter = useCallback(() => {
+    if (isSpotlightRef.current) return;
     pointerEpochRef.current += 1;
     bridge.setIgnoreMouse(false);
   }, [bridge]);
 
   const handlePointerLeave = useCallback(() => {
+    if (isSpotlightRef.current) return;
     if (isResizingRef.current) return;
     pointerEpochRef.current += 1;
     bridge.setIgnoreMouse(true);
   }, [bridge]);
 
   const reconcilePassthrough = useCallback(() => {
+    if (isSpotlightRef.current) return;
     if (isResizingRef.current) return;
     const el = shellRef.current;
     if (!el) return;
@@ -265,18 +362,22 @@ export function ClawOverlay(): React.ReactElement {
     [bridge],
   );
 
-  const dims = isOpen
-    ? { width: PANEL.width, height: panelHeight }
-    : isThinking
-      ? PILL_THINKING
-      : PILL;
+  const dims = isSpotlight
+    ? { width: SPOTLIGHT.width, height: Math.min(spotlightDesiredHeight, spotlightHeight) }
+    : isOpen
+      ? { width: PANEL.width, height: panelHeight }
+      : isThinking
+        ? PILL_THINKING
+        : PILL;
   const layoutTransition: Transition = reduceMotion
     ? { duration: 0 }
-    : isResizing
+    : isSpotlight
       ? { duration: 0 }
-      : isOpen
-        ? OPEN_SPRING
-        : CLOSE_SPRING;
+      : isResizing
+        ? { duration: 0 }
+        : isOpen
+          ? OPEN_SPRING
+          : CLOSE_SPRING;
 
   const panelContentVariants: Variants = {
     hidden: { opacity: 0, y: 8 },
@@ -306,11 +407,17 @@ export function ClawOverlay(): React.ReactElement {
     <MotionConfig reducedMotion='user'>
       <ClawConversationProvider isOpen={isOpen}>
         <ClawThinkingProbe onChange={setIsThinking} />
-        <div className='pointer-events-none fixed inset-0 flex items-end justify-end pl-8 pt-8'>
-          <ClawPeekBubble isOpen={isOpen} />
+        <ClawSessionReporter />
+        <div
+          className={cn(
+            'pointer-events-none fixed inset-0 flex',
+            isSpotlight ? 'items-start justify-center p-4' : 'items-end justify-end pl-8 pt-8',
+          )}
+        >
+          {!isSpotlight && <ClawPeekBubble isOpen={isOpen} />}
           <motion.div
             ref={shellRef}
-            layout
+            layout={!isSpotlight}
             onLayoutAnimationComplete={() => {
               if (!isOpenRef.current) {
                 bridge.setExpanded(false);
@@ -325,21 +432,24 @@ export function ClawOverlay(): React.ReactElement {
             transformTemplate={(_, generatedTransform) => `${generatedTransform} translateZ(0)`}
             {...pillGestureProps}
             style={{
-              width: dims.width,
-              height: dims.height,
-              ...CORNER_RADII,
+              ...(isSpotlight ? {} : { width: dims.width, height: dims.height }),
 
-              originX: 1,
-              originY: 1,
+              originX: isSpotlight ? 0.5 : 1,
+              originY: isSpotlight ? 0 : 1,
 
               willChange: 'transform',
             }}
-            className={cn('claw-shell pointer-events-auto relative', isOpen && 'claw-shell--open')}
+            className={cn(
+              'claw-shell pointer-events-auto relative',
+              isSpotlight ? 'rounded-[14px]' : 'rounded-l-[14px] rounded-r-none',
+              isSpotlight && 'h-full w-full',
+              isOpen && 'claw-shell--open',
+            )}
             data-popover-portal-container
             data-slot='claw-overlay'
             data-testid='claw-overlay'
           >
-            {isOpen && (
+            {isOpen && !isSpotlight && (
               <div
                 role='separator'
                 aria-orientation='horizontal'
@@ -361,21 +471,31 @@ export function ClawOverlay(): React.ReactElement {
                 'shadow-[inset_0_0_0_1px_hsl(var(--border)/0.7)]',
               )}
             >
-              <ClawPill isOpen={isOpen} onOpen={handleOpen} onClose={handleClose} />
-              <AnimatePresence mode='popLayout'>
-                {isOpen && (
-                  <motion.div
-                    key='claw-panel-content'
-                    variants={panelContentVariants}
-                    initial='hidden'
-                    animate='show'
-                    exit='exit'
-                    className='flex min-h-0 flex-1 flex-col'
-                  >
-                    <ClawChat onRequestClose={handleClose} />
-                  </motion.div>
-                )}
-              </AnimatePresence>
+              {isSpotlight ? (
+                <ClawSpotlight
+                  maxHeight={spotlightHeight}
+                  onDesiredHeight={handleSpotlightHeight}
+                  onRequestClose={handleClose}
+                />
+              ) : (
+                <>
+                  <ClawPill isOpen={isOpen} onOpen={handleOpen} onClose={handleClose} />
+                  <AnimatePresence mode='popLayout'>
+                    {isOpen && (
+                      <motion.div
+                        key='claw-panel-content'
+                        variants={panelContentVariants}
+                        initial='hidden'
+                        animate='show'
+                        exit='exit'
+                        className='flex min-h-0 flex-1 flex-col'
+                      >
+                        <ClawChat onRequestClose={handleClose} />
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </>
+              )}
             </div>
           </motion.div>
         </div>

--- a/apps/dashboard/src/components/Claw/ClawSpotlight.tsx
+++ b/apps/dashboard/src/components/Claw/ClawSpotlight.tsx
@@ -1,0 +1,326 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { ReactElement } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowUp, History, Square, SquarePen, X } from 'lucide-react';
+import { cn } from '../../utils/classNames';
+import type { ConversationHistory as ConversationHistoryType } from '../Chat/XyneAISidebar/utils/XyneAITypes';
+import { AgentSelector } from '../Chat/XyneAISidebar/components/AgentSelector';
+import { ConversationHistory } from '../Chat/XyneAISidebar/components/ConversationHistory';
+import { useClawConversation } from './ClawConversationContext';
+import { useClawOverlayBridge } from './useClawOverlayBridge';
+import { MessageList } from './ClawChat/MessageList';
+import { MAX_TEXTAREA_HEIGHT_PX } from './ClawChat/clawChat.constants';
+import { contentGroupVariants } from './claw.motion';
+
+const DRAG_THRESHOLD_PX = 4;
+
+interface ClawSpotlightProps {
+  maxHeight: number;
+  onDesiredHeight: (height: number) => void;
+  onRequestClose: () => void;
+}
+
+export function ClawSpotlight({
+  maxHeight,
+  onDesiredHeight,
+  onRequestClose,
+}: ClawSpotlightProps): ReactElement {
+  const {
+    messages,
+    isStreaming,
+    conversationId,
+    selectedAgentSlug,
+    agents,
+    sessions,
+    sessionsLoading,
+    loadingSessionId,
+    submitQuery,
+    abortCurrentRequest,
+    selectAgent,
+    newChat,
+    loadConversation,
+    deleteConversation,
+    refetchSessions,
+  } = useClawConversation();
+
+  const bridge = useClawOverlayBridge();
+  const [value, setValue] = useState('');
+  const [showHistory, setShowHistory] = useState(false);
+  const [composerHeight, setComposerHeight] = useState(0);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const composerRef = useRef<HTMLDivElement>(null);
+  const dragOriginRef = useRef<{ x: number; y: number } | null>(null);
+  const draggingRef = useRef(false);
+
+  const hasThread = messages.length > 0 || showHistory;
+
+  useEffect(() => {
+    const rafId = requestAnimationFrame(() => textareaRef.current?.focus());
+    return (): void => cancelAnimationFrame(rafId);
+  }, []);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, MAX_TEXTAREA_HEIGHT_PX)}px`;
+  }, [value]);
+
+  useLayoutEffect(() => {
+    const el = composerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(entries => {
+      const next = entries[0]?.contentRect.height;
+      if (typeof next === 'number') setComposerHeight(Math.ceil(next));
+    });
+    observer.observe(el);
+    setComposerHeight(Math.ceil(el.getBoundingClientRect().height));
+    return (): void => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (hasThread) {
+      onDesiredHeight(maxHeight);
+      return;
+    }
+    if (composerHeight > 0) onDesiredHeight(composerHeight);
+  }, [hasThread, composerHeight, maxHeight, onDesiredHeight]);
+
+  useEffect(() => {
+    if (showHistory) refetchSessions();
+  }, [showHistory, refetchSessions]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return;
+      if (e.defaultPrevented) return;
+      if (showHistory) {
+        setShowHistory(false);
+        return;
+      }
+      onRequestClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return (): void => window.removeEventListener('keydown', handleKeyDown);
+  }, [showHistory, onRequestClose]);
+
+  useEffect(() => {
+    const handlePointerMove = (e: PointerEvent): void => {
+      const origin = dragOriginRef.current;
+      if (!origin || draggingRef.current) return;
+      const moved = Math.abs(e.screenX - origin.x) + Math.abs(e.screenY - origin.y);
+      if (moved <= DRAG_THRESHOLD_PX) return;
+      draggingRef.current = true;
+      bridge.dragStart();
+    };
+    const handlePointerUp = (): void => {
+      dragOriginRef.current = null;
+      if (!draggingRef.current) return;
+      draggingRef.current = false;
+      bridge.dragEnd();
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handlePointerUp);
+    return (): void => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handlePointerUp);
+    };
+  }, [bridge]);
+
+  const handleDragPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>): void => {
+    if (e.button !== 0) return;
+    const target = e.target as HTMLElement;
+    if (target.closest('button, textarea, input, a, [role="combobox"], [role="dialog"]')) return;
+    dragOriginRef.current = { x: e.screenX, y: e.screenY };
+    draggingRef.current = false;
+  }, []);
+
+  const handleSubmit = useCallback((): void => {
+    const trimmed = value.trim();
+    if (!trimmed || isStreaming) return;
+    setShowHistory(false);
+    submitQuery(trimmed);
+    setValue('');
+  }, [value, isStreaming, submitQuery]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>): void => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [handleSubmit],
+  );
+
+  const handleRetry = useCallback(() => {
+    const lastUserMessage = [...messages].reverse().find(m => m.type === 'user');
+    if (!lastUserMessage) return;
+    submitQuery(lastUserMessage.content);
+  }, [messages, submitQuery]);
+
+  const handleLoadConversation = useCallback(
+    async (conversation: ConversationHistoryType): Promise<void> => {
+      if (await loadConversation(conversation)) setShowHistory(false);
+    },
+    [loadConversation],
+  );
+
+  const handleNewChat = useCallback(() => {
+    setShowHistory(false);
+    setValue('');
+    newChat();
+    textareaRef.current?.focus();
+  }, [newChat]);
+
+  const streamingSessionIds = useMemo(
+    () => (isStreaming && conversationId ? [conversationId] : []),
+    [isStreaming, conversationId],
+  );
+
+  const canSend = value.trim().length > 0 && !isStreaming;
+
+  return (
+    <div className='flex h-full min-h-0 w-full flex-col'>
+      <AnimatePresence initial={false}>
+        {hasThread && (
+          <motion.div
+            key='claw-spotlight-thread'
+            variants={contentGroupVariants}
+            initial='hidden'
+            animate='show'
+            exit='exit'
+            className='flex min-h-0 flex-1 flex-col border-b border-border'
+          >
+            {showHistory ? (
+              <ConversationHistory
+                conversations={sessions}
+                conversationId={conversationId}
+                loadingSessionId={loadingSessionId}
+                streamingSessionIds={streamingSessionIds}
+                isLoading={sessionsLoading && sessions.length === 0}
+                onBack={() => setShowHistory(false)}
+                onClose={() => setShowHistory(false)}
+                onLoadConversation={conversation => {
+                  void handleLoadConversation(conversation);
+                }}
+                onDeleteConversation={deleteConversation}
+                selectedAgentSlug={selectedAgentSlug}
+                agents={agents}
+                onSelectAgent={selectAgent}
+                agentSelectorDisabled={isStreaming}
+              />
+            ) : (
+              <MessageList messages={messages} onRetry={handleRetry} />
+            )}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <div
+        ref={composerRef}
+        className='shrink-0'
+        onPointerDown={handleDragPointerDown}
+        data-claw-drag-region
+      >
+        <div className='flex items-start gap-2 px-4 pb-2 pt-3.5'>
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={e => setValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder='Ask Claw anything...'
+            rows={1}
+            data-track-category='CLAW_SPOTLIGHT'
+            data-track-name='COMPOSER_INPUT'
+            className={cn(
+              'max-h-32 flex-1 resize-none bg-transparent text-[15px] leading-6',
+              'text-foreground outline-none placeholder:text-muted-foreground',
+            )}
+          />
+          {isStreaming ? (
+            <button
+              type='button'
+              onClick={abortCurrentRequest}
+              aria-label='Stop generating'
+              data-track-category='CLAW_SPOTLIGHT'
+              data-track-name='STOP_GENERATION'
+              className='flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition-colors hover:bg-accent'
+            >
+              <Square className='size-3 fill-current' />
+            </button>
+          ) : (
+            <button
+              type='button'
+              onClick={handleSubmit}
+              disabled={!canSend}
+              aria-label='Send message'
+              data-track-category='CLAW_SPOTLIGHT'
+              data-track-name='SEND_MESSAGE'
+              className={cn(
+                'flex size-8 shrink-0 items-center justify-center rounded-full transition-colors',
+                canSend
+                  ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+                  : 'cursor-not-allowed bg-muted text-muted-foreground',
+              )}
+            >
+              <ArrowUp className='size-4' />
+            </button>
+          )}
+        </div>
+        <div className='flex items-center justify-between gap-2 px-3 pb-2.5'>
+          <AgentSelector
+            selectedAgentSlug={selectedAgentSlug}
+            agents={agents}
+            onSelect={selectAgent}
+            disabled={isStreaming}
+            compact
+          />
+          <div className='flex shrink-0 items-center gap-1'>
+            <button
+              type='button'
+              onClick={handleNewChat}
+              aria-label='New chat'
+              title='New chat'
+              data-track-category='CLAW_SPOTLIGHT'
+              data-track-name='NEW_CHAT'
+              className='flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+            >
+              <SquarePen className='size-4' />
+            </button>
+            <button
+              type='button'
+              onClick={() => setShowHistory(prev => !prev)}
+              aria-label='Conversation history'
+              title='Conversation history'
+              data-track-category='CLAW_SPOTLIGHT'
+              data-track-name='TOGGLE_HISTORY'
+              className={cn(
+                'flex size-7 shrink-0 items-center justify-center rounded-full transition-colors',
+                showHistory
+                  ? 'bg-accent text-foreground'
+                  : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+              )}
+            >
+              <History className='size-4' />
+            </button>
+            <button
+              type='button'
+              onClick={onRequestClose}
+              aria-label='Close Claw'
+              title='Close'
+              data-track-category='CLAW_SPOTLIGHT'
+              data-track-name='CLOSE_SPOTLIGHT'
+              className='flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+            >
+              <X className='size-4' />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Claw/claw.constants.ts
+++ b/apps/dashboard/src/components/Claw/claw.constants.ts
@@ -1,15 +1,8 @@
 export const PILL = { width: 120, height: 44 } as const;
 export const PILL_THINKING = { width: 152, height: 44 } as const;
 export const PANEL = { width: 420, height: 600 } as const;
-
-export const RADIUS = 14;
-
-export const CORNER_RADII = {
-  borderTopLeftRadius: RADIUS,
-  borderTopRightRadius: 0,
-  borderBottomRightRadius: 0,
-  borderBottomLeftRadius: RADIUS,
-} as const;
+export const SPOTLIGHT = { width: 640, height: 560 } as const;
+export const SPOTLIGHT_REST_HEIGHT = 96;
 
 export const CLAW_AGENTS_STALE_TIME_MS = 60_000;
 

--- a/apps/dashboard/src/components/Claw/useClawOverlayBridge.ts
+++ b/apps/dashboard/src/components/Claw/useClawOverlayBridge.ts
@@ -6,9 +6,16 @@ function getClawOverlayAPI(): ClawOverlayAPI {
   return window.electronAPI?.clawOverlay;
 }
 
+export type ClawMode = 'pill' | 'spotlight';
+
 export interface ClawOverlayBridge {
   setIgnoreMouse: (ignore: boolean) => void;
   setExpanded: (expanded: boolean) => void;
+  dismissSpotlight: () => void;
+  setSpotlightHeight: (height: number) => void;
+  dragStart: () => void;
+  dragEnd: () => void;
+  onMode: (cb: (mode: ClawMode) => void) => () => void;
   focus: () => void;
   blur: () => void;
   openInMain: (pathname: string) => void;
@@ -34,6 +41,28 @@ export function useClawOverlayBridge(): ClawOverlayBridge {
 
   const setExpanded = useCallback((expanded: boolean) => {
     getClawOverlayAPI()?.setExpanded(expanded);
+  }, []);
+
+  const dismissSpotlight = useCallback(() => {
+    getClawOverlayAPI()?.dismissSpotlight();
+  }, []);
+
+  const setSpotlightHeight = useCallback((height: number) => {
+    getClawOverlayAPI()?.setSpotlightHeight(height);
+  }, []);
+
+  const dragStart = useCallback(() => {
+    getClawOverlayAPI()?.dragStart();
+  }, []);
+
+  const dragEnd = useCallback(() => {
+    getClawOverlayAPI()?.dragEnd();
+  }, []);
+
+  const onMode = useCallback((cb: (mode: ClawMode) => void) => {
+    const overlay = getClawOverlayAPI();
+    if (!overlay) return () => {};
+    return overlay.onMode(cb);
   }, []);
 
   const focus = useCallback(() => {
@@ -77,6 +106,11 @@ export function useClawOverlayBridge(): ClawOverlayBridge {
     () => ({
       setIgnoreMouse,
       setExpanded,
+      dismissSpotlight,
+      setSpotlightHeight,
+      dragStart,
+      dragEnd,
+      onMode,
       focus,
       blur,
       openInMain,
@@ -88,6 +122,11 @@ export function useClawOverlayBridge(): ClawOverlayBridge {
     [
       setIgnoreMouse,
       setExpanded,
+      dismissSpotlight,
+      setSpotlightHeight,
+      dragStart,
+      dragEnd,
+      onMode,
       focus,
       blur,
       openInMain,

--- a/apps/dashboard/src/components/Settings/ClawOverlayToggle.tsx
+++ b/apps/dashboard/src/components/Settings/ClawOverlayToggle.tsx
@@ -1,21 +1,46 @@
 import type { ReactElement } from 'react';
 import { Switch } from '../ui/Switch';
 import { useClawOverlaySettings } from '../../hooks/useClawOverlaySettings';
+import { isMac } from '../../hooks/usePlatform';
+import { formatShortcut } from '../../shortcuts';
+
+function acceleratorToShortcutKeys(accelerator: string): string {
+  return accelerator.replace(/CommandOrControl|CmdOrCtrl/g, 'mod').toLowerCase();
+}
 
 export function ClawOverlayToggle(): ReactElement | null {
-  const { enabled, isSupported, setEnabled } = useClawOverlaySettings();
+  const { enabled, isSupported, shortcut, setEnabled } = useClawOverlaySettings();
 
   if (!isSupported) return null;
 
   return (
-    <div className='flex items-center justify-between gap-4 rounded-lg border border-border bg-muted/30 p-3'>
-      <div>
-        <p className='text-sm font-medium text-foreground'>Claw</p>
-        <p className='mt-0.5 text-xs text-muted-foreground'>
-          Keeps Claw docked to the edge of your screen, above other apps
-        </p>
+    <>
+      <div className='flex items-center justify-between gap-4 rounded-lg border border-border bg-muted/30 p-3'>
+        <div>
+          <p className='text-sm font-medium text-foreground'>Open Claw from anywhere</p>
+          <p className='mt-0.5 text-xs text-muted-foreground'>
+            {shortcut
+              ? 'Press this shortcut in any app to bring up the Claw composer'
+              : 'The Claw shortcut could not be registered — another app may already be using it'}
+          </p>
+        </div>
+        {shortcut ? (
+          <kbd className='shrink-0 rounded-md border border-border bg-background px-2 py-1 font-mono text-xs text-foreground'>
+            {formatShortcut(acceleratorToShortcutKeys(shortcut), isMac() === true)}
+          </kbd>
+        ) : (
+          <span className='shrink-0 text-xs font-medium text-destructive'>Unavailable</span>
+        )}
       </div>
-      <Switch id='claw-overlay' checked={enabled} onCheckedChange={setEnabled} />
-    </div>
+      <div className='flex items-center justify-between gap-4 rounded-lg border border-border bg-muted/30 p-3'>
+        <div>
+          <p className='text-sm font-medium text-foreground'>Keep Claw docked</p>
+          <p className='mt-0.5 text-xs text-muted-foreground'>
+            Also show Claw as a pill in the corner of your screen, above other apps
+          </p>
+        </div>
+        <Switch id='claw-overlay' checked={enabled} onCheckedChange={setEnabled} />
+      </div>
+    </>
   );
 }

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -7,6 +7,7 @@ import {
   Mic,
   MessageSquare,
   Zap,
+  Sparkles,
   Code2,
   Copy,
   CheckCircle2,
@@ -79,6 +80,7 @@ const NAV_ITEMS: NavItem[] = [
     desktopOnly: true,
   },
   { id: 'launch', label: 'Launch', icon: <Zap className='size-4' />, desktopOnly: true },
+  { id: 'claw', label: 'Claw', icon: <Sparkles className='size-4' />, desktopOnly: true },
   {
     id: 'toolbar',
     label: 'Toolbar',
@@ -682,6 +684,13 @@ const LaunchSection: FC<{ state: PreferencesState }> = ({ state }) => (
         onCheckedChange={state.setAiLandingDefault}
       />
     </div>
+  </div>
+);
+
+// ─── Claw ───────────────────────────────────────────────────────────────────
+const ClawSection: FC = () => (
+  <div className='space-y-4'>
+    <SectionHeader title='Claw' subtitle='How you reach Claw and where it lives' />
     <ClawOverlayToggle />
   </div>
 );
@@ -974,6 +983,7 @@ const SECTIONS: Record<PreferenceSection, FC<{ state: PreferencesState }>> = {
   calls: CallsSection,
   messaging: MessagingSection,
   launch: LaunchSection,
+  claw: ClawSection as FC<{ state: PreferencesState }>,
   toolbar: ToolbarSection,
   calendar: CalendarSection,
   password: PasswordSection as FC<{ state: PreferencesState }>,

--- a/apps/dashboard/src/components/Settings/Preferences/index.ts
+++ b/apps/dashboard/src/components/Settings/Preferences/index.ts
@@ -8,6 +8,7 @@ export type PreferenceSection =
   | 'calls'
   | 'messaging'
   | 'launch'
+  | 'claw'
   | 'toolbar'
   | 'calendar'
   | 'password'

--- a/apps/dashboard/src/hooks/useClawOverlaySettings.ts
+++ b/apps/dashboard/src/hooks/useClawOverlaySettings.ts
@@ -3,11 +3,24 @@ import { useCallback, useEffect, useState } from 'react';
 export function useClawOverlaySettings(): {
   enabled: boolean;
   isSupported: boolean;
+  shortcut: string | null;
   setEnabled: (enabled: boolean) => void;
 } {
   const api = window.electronAPI?.clawOverlay;
   const isSupported = !!api;
   const [enabled, setEnabledState] = useState(false);
+  const [shortcut, setShortcut] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!api?.getShortcut) return;
+    let cancelled = false;
+    void api.getShortcut().then(value => {
+      if (!cancelled) setShortcut(value);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [api]);
 
   useEffect(() => {
     if (!api) return;
@@ -33,5 +46,5 @@ export function useClawOverlaySettings(): {
     [api],
   );
 
-  return { enabled, isSupported, setEnabled };
+  return { enabled, isSupported, shortcut, setEnabled };
 }

--- a/apps/dashboard/src/hooks/useTheme.ts
+++ b/apps/dashboard/src/hooks/useTheme.ts
@@ -47,7 +47,11 @@ export const useTheme = (): { theme: Theme; changeTheme: (newTheme: Theme) => vo
     document.documentElement.setAttribute('data-theme', theme);
     // Persist to localStorage
     localStorage.setItem(THEME_STORAGE_KEY, theme);
-    window.electronAPI?.ipcSend?.('app:theme-changed', theme === 'midnight' ? 'dark' : 'light');
+    window.electronAPI?.ipcSend?.(
+      'app:theme-changed',
+      theme === 'midnight' ? 'dark' : 'light',
+      theme,
+    );
   }, [theme]);
 
   const changeTheme = (newTheme: Theme): void => {

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -131,6 +131,15 @@ export const shortcuts = {
     priority: 50,
     preventDefault: true,
   },
+  'claw.open': {
+    keys: 'mod+alt+c',
+    scope: 'global',
+    description: 'Open Claw from anywhere',
+    category: 'Navigation',
+    priority: 50,
+    electronOnly: true,
+    preventDefault: true,
+  },
 
   'global.openPreferences': {
     keys: 'mod+comma',

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -170,9 +170,31 @@ export interface ElectronAPI {
     setEnabled: (enabled: boolean) => void;
     onEnabledChanged: (callback: (enabled: boolean) => void) => () => void;
   };
+  clawCompletion?: {
+    onShow: (
+      callback: (payload: {
+        outcome: 'idle' | 'needs-input' | 'error';
+        preview: string | null;
+        dark: boolean;
+      }) => void,
+    ) => () => void;
+    onHide: (callback: () => void) => () => void;
+    open: () => void;
+    dismiss: () => void;
+  };
   clawOverlay?: {
     setIgnoreMouse: (ignore: boolean) => void;
     setExpanded: (expanded: boolean) => void;
+    dismissSpotlight: () => void;
+    setSpotlightHeight: (height: number) => void;
+    dragStart: () => void;
+    dragEnd: () => void;
+    setSessionState: (state: {
+      status: 'idle' | 'running' | 'needs-input' | 'error';
+      conversationId: string | null;
+      preview: string | null;
+    }) => void;
+    onMode: (callback: (mode: 'pill' | 'spotlight') => void) => () => void;
     focus: () => void;
     blur: () => void;
     openInMain: (pathname: string) => void;
@@ -186,6 +208,7 @@ export interface ElectronAPI {
       height: number;
     }) => Promise<boolean | null>;
     getEnabled: () => Promise<boolean>;
+    getShortcut: () => Promise<string | null>;
     setEnabled: (enabled: boolean) => void;
     onEnabledChanged: (callback: (enabled: boolean) => void) => () => void;
   };

--- a/apps/electron/assets/claw-completion.html
+++ b/apps/electron/assets/claw-completion.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      :root {
+        --bg: #ffffff;
+        --fg: #0c0a12;
+        --muted: #6b6577;
+        --line: rgba(12, 10, 18, 0.09);
+        --chip-bg: rgba(12, 10, 18, 0.05);
+        --btn-bg: rgba(12, 10, 18, 0.05);
+        --btn-bg-hover: rgba(12, 10, 18, 0.1);
+        --accent: #15803d;
+      }
+
+      body.dark {
+        --bg: #1c1824;
+        --fg: #eae6f1;
+        --muted: #9a93a8;
+        --line: rgba(255, 255, 255, 0.1);
+        --chip-bg: rgba(255, 255, 255, 0.07);
+        --btn-bg: rgba(255, 255, 255, 0.08);
+        --btn-bg-hover: rgba(255, 255, 255, 0.14);
+        --accent: #4ade80;
+      }
+
+      body.needs-input {
+        --accent: #b45309;
+      }
+      body.dark.needs-input {
+        --accent: #fbbf24;
+      }
+      body.error {
+        --accent: #be123c;
+      }
+      body.dark.error {
+        --accent: #fb7185;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+        overflow: hidden;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+        -webkit-font-smoothing: antialiased;
+        user-select: none;
+        cursor: default;
+      }
+
+      #card {
+        margin: 6px;
+        padding: 12px 13px 11px;
+        border-radius: 14px;
+        background: var(--bg);
+        color: var(--fg);
+        box-shadow:
+          0 0 0 0.5px var(--line),
+          0 6px 14px rgba(0, 0, 0, 0.12),
+          0 18px 34px -12px rgba(0, 0, 0, 0.22);
+        opacity: 0;
+        transform: translateY(-8px);
+        transition:
+          opacity 180ms ease-out,
+          transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+      }
+
+      body.visible #card {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      body.hiding #card {
+        opacity: 0;
+        transform: translateY(-6px);
+        transition-duration: 160ms;
+      }
+
+      #head {
+        display: flex;
+        align-items: center;
+        gap: 7px;
+      }
+
+      #dot {
+        width: 7px;
+        height: 7px;
+        border-radius: 50%;
+        background: var(--accent);
+        flex: none;
+      }
+
+      #title {
+        font-size: 13px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+
+      #preview {
+        margin-top: 5px;
+        font-size: 12px;
+        line-height: 1.42;
+        color: var(--muted);
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+
+      #actions {
+        margin-top: 10px;
+        display: flex;
+        gap: 6px;
+        justify-content: flex-end;
+      }
+
+      button {
+        font: inherit;
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--fg);
+        border: 0;
+        border-radius: 7px;
+        padding: 5px 11px;
+        background: var(--btn-bg);
+        cursor: default;
+        transition: background 120ms ease-out;
+      }
+
+      button:hover {
+        background: var(--btn-bg-hover);
+      }
+
+      button#open {
+        background: var(--chip-bg);
+        box-shadow: inset 0 0 0 1px var(--line);
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        #card {
+          transition: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="card">
+      <div id="head">
+        <span id="dot"></span>
+        <span id="title">Claw finished</span>
+      </div>
+      <div id="preview"></div>
+      <div id="actions">
+        <button type="button" id="dismiss">Dismiss</button>
+        <button type="button" id="open">Open</button>
+      </div>
+    </div>
+    <script>
+      const api = window.electronAPI && window.electronAPI.clawCompletion;
+      const titleEl = document.getElementById('title');
+      const previewEl = document.getElementById('preview');
+
+      const TITLES = {
+        idle: 'Claw finished',
+        'needs-input': 'Claw needs your input',
+        error: 'Claw hit an error',
+      };
+
+      if (api) {
+        api.onShow((payload) => {
+          document.body.classList.toggle('dark', !!payload.dark);
+          document.body.classList.remove('needs-input', 'error');
+          if (payload.outcome === 'needs-input') {
+            document.body.classList.add('needs-input');
+          } else if (payload.outcome === 'error') {
+            document.body.classList.add('error');
+          }
+          titleEl.textContent = TITLES[payload.outcome] || TITLES.idle;
+          previewEl.textContent = payload.preview || '';
+          previewEl.style.display = payload.preview ? '' : 'none';
+          requestAnimationFrame(() => document.body.classList.add('visible'));
+        });
+
+        api.onHide(() => {
+          document.body.classList.add('hiding');
+        });
+      }
+
+      document.getElementById('open').addEventListener('click', () => api && api.open());
+      document.getElementById('dismiss').addEventListener('click', () => api && api.dismiss());
+    </script>
+  </body>
+</html>

--- a/apps/electron/assets/claw-tray-badge.html
+++ b/apps/electron/assets/claw-tray-badge.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: transparent;
+        overflow: hidden;
+      }
+
+      @keyframes xn-breathe {
+        0%,
+        100% {
+          opacity: 1;
+          transform: scale(1);
+        }
+        50% {
+          opacity: 0.45;
+          transform: scale(0.78);
+        }
+      }
+
+      #badge {
+        position: absolute;
+        top: 0;
+        left: 0;
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+        height: 16px;
+        padding: 0 1px 0 0;
+      }
+
+      #glyph {
+        width: 16px;
+        height: 16px;
+        display: block;
+        flex: none;
+      }
+
+      body.dark #glyph {
+        filter: invert(1);
+      }
+
+      #dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: #14b8a6;
+        flex: none;
+        transform-origin: center;
+        animation: xn-breathe 1.6s ease-in-out infinite;
+      }
+
+      body.waiting #dot {
+        background: #f59e0b;
+        animation: none;
+        opacity: 1;
+        transform: scale(1);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="badge">
+      <img id="glyph" src="images/xyneMenubarTemplate@2x.png" alt="" />
+      <span id="dot"></span>
+    </div>
+    <script>
+      const badge = document.getElementById('badge');
+      const glyph = document.getElementById('glyph');
+
+      window.__setState = (waiting, dark) => {
+        document.body.classList.toggle('waiting', !!waiting);
+        document.body.classList.toggle('dark', !!dark);
+      };
+
+      window.__ready = async () => {
+        if (!glyph.complete) {
+          await Promise.race([
+            new Promise((resolve) => {
+              glyph.addEventListener('load', resolve, { once: true });
+              glyph.addEventListener('error', resolve, { once: true });
+            }),
+            new Promise((resolve) => setTimeout(resolve, 1500)),
+          ]);
+        }
+        return badge.getBoundingClientRect().width;
+      };
+    </script>
+  </body>
+</html>

--- a/apps/electron/src/app/main.ts
+++ b/apps/electron/src/app/main.ts
@@ -17,10 +17,20 @@ import { EnrollmentEvent } from '../services/logger/enrollment-events';
 import { startVersionChecker, stopVersionChecker } from '../services/version-checker';
 import ElectronEvent from '../services/logger/electron-events';
 import { meetingDetectorService } from '../services/meeting-detector';
-import { initTray } from '../services/tray';
+import { getTrayBounds, initTray } from '../services/tray';
 import { registerGlobalShortcuts } from '../services/global-shortcuts';
 import { initRecordingPillVisibility } from '../services/recording-controller';
-import { initClawOverlayAuthGate } from '../services/claw-overlay-window';
+import {
+  initClawOverlayAuthGate,
+  isClawSpotlightVisible,
+  openClawSpotlight,
+} from '../services/claw-overlay-window';
+import { onClawSessionCompleted } from '../services/claw-session-controller';
+import {
+  setClawCompletionAnchorProvider,
+  setClawCompletionOpenHandler,
+  showClawCompletionPanel,
+} from '../services/claw-completion-panel';
 import { registerProtocolScheme, setupCustomProtocol } from '../services/custom-protocol';
 import { initializeUIUpdater } from '../services/ui-updater';
 import { initializeTelemetry } from '../services/telemetry';
@@ -193,6 +203,13 @@ async function initializeApp(): Promise<void> {
   initRecordingPillVisibility();
 
   initClawOverlayAuthGate();
+
+  setClawCompletionAnchorProvider(getTrayBounds);
+  setClawCompletionOpenHandler(() => void openClawSpotlight());
+  onClawSessionCompleted((event) => {
+    if (isClawSpotlightVisible()) return;
+    showClawCompletionPanel(event);
+  });
 
   setupAppStateListeners();
 

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -21,6 +21,8 @@ import {
   isRecordingPillEnabled,
   setRecordingPillTheme,
 } from '../services/recording-pill-window';
+import { setClawOverlayThemeName } from '../services/claw-overlay-window';
+import { getClawSpotlightShortcut } from '../services/global-shortcuts';
 import { isTrayVisible, setTrayVisible } from '../services/tray';
 import {
   focusMainWindow,
@@ -640,8 +642,13 @@ export function setupIpcHandlers(): void {
     },
   );
 
-  ipcMain.on('app:theme-changed', (event, theme: unknown) => {
+  ipcMain.handle('claw:get-shortcut', (event) =>
+    isMainWindowSender(event) ? getClawSpotlightShortcut() : null,
+  );
+
+  ipcMain.on('app:theme-changed', (event, theme: unknown, themeName: unknown) => {
     if (!isMainWindowSender(event)) return;
+    if (typeof themeName === 'string') setClawOverlayThemeName(themeName);
     if (theme !== 'light' && theme !== 'dark') return;
     setRecordingPillTheme(theme);
   });

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -399,9 +399,45 @@ const electronAPI = {
     },
   },
 
+  clawCompletion: {
+    onShow: (
+      callback: (payload: {
+        outcome: 'idle' | 'needs-input' | 'error';
+        preview: string | null;
+        dark: boolean;
+      }) => void,
+    ) => {
+      const listener = (_event: unknown, payload: never) => callback(payload);
+      ipcRenderer.on('claw-completion:show', listener);
+      return () => ipcRenderer.removeListener('claw-completion:show', listener);
+    },
+    onHide: (callback: () => void) => {
+      const listener = () => callback();
+      ipcRenderer.on('claw-completion:hide', listener);
+      return () => ipcRenderer.removeListener('claw-completion:hide', listener);
+    },
+    open: () => ipcRenderer.send('claw-completion:open'),
+    dismiss: () => ipcRenderer.send('claw-completion:dismiss'),
+  },
+
   clawOverlay: {
     setIgnoreMouse: (ignore: boolean) => ipcRenderer.send('claw:set-ignore-mouse', ignore),
     setExpanded: (expanded: boolean) => ipcRenderer.send('claw:set-expanded', expanded),
+    dismissSpotlight: () => ipcRenderer.send('claw:dismiss-spotlight'),
+    setSpotlightHeight: (height: number) =>
+      ipcRenderer.send('claw:set-spotlight-height', height),
+    dragStart: () => ipcRenderer.send('claw:drag-start'),
+    dragEnd: () => ipcRenderer.send('claw:drag-end'),
+    setSessionState: (state: {
+      status: 'idle' | 'running' | 'needs-input' | 'error';
+      conversationId: string | null;
+      preview: string | null;
+    }) => ipcRenderer.send('claw:session-state-changed', state),
+    onMode: (callback: (mode: 'pill' | 'spotlight') => void) => {
+      const listener = (_event: unknown, mode: 'pill' | 'spotlight') => callback(mode);
+      ipcRenderer.on('claw:mode', listener);
+      return () => ipcRenderer.removeListener('claw:mode', listener);
+    },
     focus: () => ipcRenderer.send('claw:focus'),
     blur: () => ipcRenderer.send('claw:blur'),
     onVisibility: (callback: (visible: boolean) => void) => {
@@ -424,6 +460,7 @@ const electronAPI = {
     },
 
     getEnabled: (): Promise<boolean> => ipcRenderer.invoke('claw:get-enabled'),
+    getShortcut: (): Promise<string | null> => ipcRenderer.invoke('claw:get-shortcut'),
     setEnabled: (enabled: boolean) => ipcRenderer.send('claw:set-enabled', enabled),
     onEnabledChanged: (callback: (enabled: boolean) => void) => {
       const listener = (_event: unknown, enabled: boolean) => callback(enabled);

--- a/apps/electron/src/services/claw-completion-panel.ts
+++ b/apps/electron/src/services/claw-completion-panel.ts
@@ -1,0 +1,200 @@
+import { BrowserWindow, Notification, ipcMain, nativeTheme, screen } from "electron";
+import path from "path";
+import log from "electron-log/main";
+import type { ClawSessionCompletion } from "./claw-session-controller";
+
+const PANEL_WIDTH = 330;
+const PANEL_HEIGHT = 112;
+const PANEL_MARGIN = 8;
+const AUTO_DISMISS_MS = 12_000;
+const HIDE_ANIMATION_MS = 220;
+
+let panelWindow: BrowserWindow | null = null;
+let autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
+let hideTimer: ReturnType<typeof setTimeout> | null = null;
+let openHandler: (() => void) | null = null;
+let dismissHandler: ((event: Electron.IpcMainEvent) => void) | null = null;
+let openIpcHandler: ((event: Electron.IpcMainEvent) => void) | null = null;
+let anchorProvider: (() => Electron.Rectangle | null) | null = null;
+
+export function setClawCompletionAnchorProvider(
+  provider: () => Electron.Rectangle | null,
+): void {
+  anchorProvider = provider;
+}
+
+export function setClawCompletionOpenHandler(handler: () => void): void {
+  openHandler = handler;
+}
+
+function isPanelSender(event: Electron.IpcMainEvent): boolean {
+  return (
+    !!panelWindow &&
+    !panelWindow.isDestroyed() &&
+    event.sender === panelWindow.webContents &&
+    event.senderFrame === panelWindow.webContents.mainFrame
+  );
+}
+
+function computeBounds(): Electron.Rectangle {
+  const anchor = anchorProvider?.() ?? null;
+  const hasAnchor = !!anchor && anchor.width > 0 && anchor.height > 0;
+
+  const reference = hasAnchor
+    ? screen.getDisplayNearestPoint({ x: anchor.x, y: anchor.y }).workArea
+    : screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).workArea;
+
+  const x = hasAnchor
+    ? Math.round(anchor.x + anchor.width / 2 - PANEL_WIDTH / 2)
+    : reference.x + reference.width - PANEL_WIDTH - PANEL_MARGIN;
+  const y = hasAnchor
+    ? Math.round(anchor.y + anchor.height + PANEL_MARGIN)
+    : reference.y + PANEL_MARGIN;
+
+  const maxX = reference.x + Math.max(0, reference.width - PANEL_WIDTH);
+  const maxY = reference.y + Math.max(0, reference.height - PANEL_HEIGHT);
+
+  return {
+    width: PANEL_WIDTH,
+    height: PANEL_HEIGHT,
+    x: Math.round(Math.min(Math.max(x, reference.x), maxX)),
+    y: Math.round(Math.min(Math.max(y, reference.y), maxY)),
+  };
+}
+
+function clearTimers(): void {
+  if (autoDismissTimer) {
+    clearTimeout(autoDismissTimer);
+    autoDismissTimer = null;
+  }
+  if (hideTimer) {
+    clearTimeout(hideTimer);
+    hideTimer = null;
+  }
+}
+
+function destroyPanel(): void {
+  clearTimers();
+  if (openIpcHandler) {
+    ipcMain.removeListener("claw-completion:open", openIpcHandler);
+    openIpcHandler = null;
+  }
+  if (dismissHandler) {
+    ipcMain.removeListener("claw-completion:dismiss", dismissHandler);
+    dismissHandler = null;
+  }
+  if (panelWindow && !panelWindow.isDestroyed()) panelWindow.destroy();
+  panelWindow = null;
+}
+
+function hideClawCompletionPanel(): void {
+  if (!panelWindow || panelWindow.isDestroyed()) return;
+  clearTimers();
+  panelWindow.webContents.send("claw-completion:hide");
+  hideTimer = setTimeout(destroyPanel, HIDE_ANIMATION_MS);
+}
+
+function scheduleAutoDismiss(): void {
+  if (autoDismissTimer) clearTimeout(autoDismissTimer);
+  autoDismissTimer = setTimeout(hideClawCompletionPanel, AUTO_DISMISS_MS);
+}
+
+function fallbackToNotification(event: ClawSessionCompletion): void {
+  if (!Notification.isSupported()) return;
+  const title =
+    event.outcome === "needs-input"
+      ? "Claw needs your input"
+      : event.outcome === "error"
+        ? "Claw hit an error"
+        : "Claw finished";
+
+  const notification = new Notification({
+    title,
+    body: event.preview ?? "Open Xyne to see the result.",
+    silent: true,
+  });
+  notification.on("click", () => openHandler?.());
+  notification.show();
+}
+
+export function showClawCompletionPanel(event: ClawSessionCompletion): void {
+  if (process.platform !== "darwin" && process.platform !== "win32") {
+    fallbackToNotification(event);
+    return;
+  }
+
+  destroyPanel();
+
+  const bounds = computeBounds();
+
+  panelWindow = new BrowserWindow({
+    x: bounds.x,
+    y: bounds.y,
+    width: bounds.width,
+    height: bounds.height,
+    frame: false,
+    transparent: true,
+    backgroundColor: "#00000000",
+    resizable: false,
+    movable: false,
+    skipTaskbar: true,
+    hasShadow: false,
+    focusable: false,
+    fullscreenable: false,
+    show: false,
+    type: "panel",
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, "..", "preload.js"),
+    },
+  });
+
+  panelWindow.setAlwaysOnTop(true, "screen-saver");
+  panelWindow.setVisibleOnAllWorkspaces(true, {
+    visibleOnFullScreen: true,
+    skipTransformProcessType: true,
+  });
+
+  const created = panelWindow;
+
+  openIpcHandler = (ipcEvent) => {
+    if (!isPanelSender(ipcEvent)) return;
+    hideClawCompletionPanel();
+    openHandler?.();
+  };
+  ipcMain.on("claw-completion:open", openIpcHandler);
+
+  dismissHandler = (ipcEvent) => {
+    if (!isPanelSender(ipcEvent)) return;
+    hideClawCompletionPanel();
+  };
+  ipcMain.on("claw-completion:dismiss", dismissHandler);
+
+  created.webContents.once("did-finish-load", () => {
+    if (created.isDestroyed()) return;
+    created.webContents.send("claw-completion:show", {
+      outcome: event.outcome,
+      preview: event.preview,
+      dark: nativeTheme.shouldUseDarkColors,
+    });
+    created.showInactive();
+    scheduleAutoDismiss();
+  });
+
+  created.on("closed", () => {
+    if (panelWindow === created) panelWindow = null;
+  });
+
+  const panelHtml = path.join(
+    __dirname,
+    "..",
+    "..",
+    "assets",
+    "claw-completion.html",
+  );
+  created.loadFile(panelHtml).catch((error) => {
+    log.error("[ClawCompletion] Failed to load panel HTML:", error);
+    fallbackToNotification(event);
+  });
+}

--- a/apps/electron/src/services/claw-overlay-window.ts
+++ b/apps/electron/src/services/claw-overlay-window.ts
@@ -5,14 +5,34 @@ import log from "electron-log/main";
 import { config } from "../app/config";
 import { getBundledUIUrl } from "./custom-protocol";
 import { getMainWindow } from "../window/manager";
+import {
+  resetClawSessionState,
+  syncClawSessionState,
+} from "./claw-session-controller";
 
 const clawStore = new Store({ name: "claw-overlay" });
 const ENABLED_KEY = "clawOverlayEnabled";
 const PANEL_HEIGHT_KEY = "clawPanelHeight";
+const SPOTLIGHT_POSITION_KEY = "clawSpotlightPosition";
+const THEME_NAME_KEY = "clawOverlayThemeName";
+const SPOTLIGHT_REST_HEIGHT = 96;
+
+const VALID_THEME_NAMES = new Set(["classic", "summer_breeze", "midnight"]);
+
+type ClawMode = "pill" | "spotlight";
 
 let clawWindow: BrowserWindow | null = null;
 let clawRendererReady = false;
 let clawExpanded = false;
+let clawMode: ClawMode = "pill";
+let pendingSpotlightSummon = false;
+let spotlightShownAt = 0;
+let spotlightAnchor: { x: number; bottom: number } | null = null;
+let spotlightContentHeight = SPOTLIGHT_REST_HEIGHT;
+let awaitingSpotlightLayout = false;
+let spotlightRevealTimer: ReturnType<typeof setTimeout> | null = null;
+let blurDismissSuppressed = false;
+let blurSuppressTimer: ReturnType<typeof setTimeout> | null = null;
 
 let panelHeightPersistTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingPanelHeight: number | null = null;
@@ -32,6 +52,18 @@ let openInMainHandler:
 let setPanelHeightHandler:
   | ((event: Electron.IpcMainEvent, height: number) => void)
   | null = null;
+let dismissSpotlightHandler:
+  | ((event: Electron.IpcMainEvent) => void)
+  | null = null;
+let sessionStateHandler:
+  | ((event: Electron.IpcMainEvent, state: unknown) => void)
+  | null = null;
+let spotlightHeightHandler:
+  | ((event: Electron.IpcMainEvent, height: number) => void)
+  | null = null;
+let dragStartHandler: ((event: Electron.IpcMainEvent) => void) | null = null;
+let dragEndHandler: ((event: Electron.IpcMainEvent) => void) | null = null;
+let dragInterval: ReturnType<typeof setInterval> | null = null;
 
 let displayMetricsHandler:
   | ((
@@ -53,6 +85,12 @@ const PANEL = { width: 420, height: 600 };
 const DEFAULT_PANEL_HEIGHT = PANEL.height;
 const MIN_PANEL_HEIGHT = 400;
 const PANEL_TOP_MARGIN = 8;
+
+const SPOTLIGHT = { width: 640, height: 560 };
+const SPOTLIGHT_TOP_RATIO = 0.2;
+const SPOTLIGHT_BLUR_GRACE_MS = 250;
+const SPOTLIGHT_MIN_CONTENT_HEIGHT = 56;
+const SPOTLIGHT_REVEAL_TIMEOUT_MS = 400;
 
 function getWindowSize(
   contentWidth: number,
@@ -80,6 +118,141 @@ function getDockedBounds(
     width,
     height,
   };
+}
+
+function getSpotlightMaxContentHeight(workArea: Electron.Rectangle): number {
+  return Math.max(
+    SPOTLIGHT_MIN_CONTENT_HEIGHT,
+    Math.min(
+      SPOTLIGHT.height,
+      workArea.height - SHADOW_GUTTER - PANEL_TOP_MARGIN * 2,
+    ),
+  );
+}
+
+function clampBoundsToWorkArea(
+  bounds: Electron.Rectangle,
+  workArea: Electron.Rectangle,
+): Electron.Rectangle {
+  const maxX = workArea.x + Math.max(0, workArea.width - bounds.width);
+  const maxY = workArea.y + Math.max(0, workArea.height - bounds.height);
+  return {
+    width: bounds.width,
+    height: bounds.height,
+    x: Math.round(Math.min(Math.max(bounds.x, workArea.x), maxX)),
+    y: Math.round(Math.min(Math.max(bounds.y, workArea.y), maxY)),
+  };
+}
+
+function getStoredSpotlightAnchor(): { x: number; bottom: number } | null {
+  const raw = clawStore.get(SPOTLIGHT_POSITION_KEY) as
+    | { x?: unknown; bottom?: unknown }
+    | undefined;
+  if (!raw) return null;
+  const x = Number(raw.x);
+  const bottom = Number(raw.bottom);
+  if (!Number.isFinite(x) || !Number.isFinite(bottom)) return null;
+
+  const onVisibleDisplay = screen.getAllDisplays().some((display) => {
+    const area = display.workArea;
+    return (
+      x >= area.x &&
+      x < area.x + area.width &&
+      bottom > area.y &&
+      bottom <= area.y + area.height
+    );
+  });
+
+  return onVisibleDisplay ? { x, bottom } : null;
+}
+
+function startSpotlightDrag(): void {
+  if (dragInterval || !clawWindow || clawWindow.isDestroyed()) return;
+  if (clawMode !== "spotlight") return;
+
+  const cursor = screen.getCursorScreenPoint();
+  const [winX, winY] = clawWindow.getPosition();
+  const offsetX = cursor.x - winX;
+  const offsetY = cursor.y - winY;
+
+  dragInterval = setInterval(() => {
+    if (!clawWindow || clawWindow.isDestroyed() || clawMode !== "spotlight") {
+      stopSpotlightDrag();
+      return;
+    }
+    const point = screen.getCursorScreenPoint();
+    clawWindow.setPosition(point.x - offsetX, point.y - offsetY);
+  }, 16);
+}
+
+function stopSpotlightDrag(): void {
+  if (dragInterval) {
+    clearInterval(dragInterval);
+    dragInterval = null;
+  }
+  if (!clawWindow || clawWindow.isDestroyed()) return;
+  if (clawMode !== "spotlight") return;
+
+  const bounds = clawWindow.getBounds();
+  const workArea = screen.getDisplayNearestPoint({
+    x: bounds.x,
+    y: bounds.y,
+  }).workArea;
+  const clamped = clampBoundsToWorkArea(bounds, workArea);
+  if (clamped.x !== bounds.x || clamped.y !== bounds.y) {
+    clawWindow.setPosition(clamped.x, clamped.y);
+  }
+  spotlightAnchor = { x: clamped.x, bottom: clamped.y + clamped.height };
+  persistSpotlightAnchor();
+}
+
+function persistSpotlightAnchor(): void {
+  if (!spotlightAnchor) return;
+  clawStore.set(SPOTLIGHT_POSITION_KEY, spotlightAnchor);
+}
+
+function applySpotlightBounds(): void {
+  if (!clawWindow || clawWindow.isDestroyed()) return;
+
+  const workArea = spotlightAnchor
+    ? screen.getDisplayNearestPoint({
+        x: spotlightAnchor.x,
+        y: spotlightAnchor.bottom,
+      }).workArea
+    : getNearestWorkArea();
+
+  const maxContent = getSpotlightMaxContentHeight(workArea);
+  const contentHeight = Math.round(
+    Math.min(Math.max(spotlightContentHeight, SPOTLIGHT_MIN_CONTENT_HEIGHT), maxContent),
+  );
+  const { width, height } = getWindowSize(SPOTLIGHT.width, contentHeight);
+
+  if (!spotlightAnchor) {
+    const maxWindowHeight = getWindowSize(SPOTLIGHT.width, maxContent).height;
+    const x = Math.round(workArea.x + (workArea.width - width) / 2);
+    const preferredBottom =
+      workArea.y +
+      Math.round(workArea.height * SPOTLIGHT_TOP_RATIO) +
+      maxWindowHeight;
+    const bottom = Math.round(
+      Math.min(preferredBottom, workArea.y + workArea.height - PANEL_TOP_MARGIN),
+    );
+    spotlightAnchor = { x, bottom };
+  }
+
+  const bounds = clampBoundsToWorkArea(
+    {
+      x: spotlightAnchor.x,
+      y: spotlightAnchor.bottom - height,
+      width,
+      height,
+    },
+    workArea,
+  );
+
+  spotlightAnchor = { x: bounds.x, bottom: bounds.y + bounds.height };
+  applyWindowBounds(bounds);
+  applyLinuxContentShape(clawExpanded);
 }
 
 function getMaxPanelHeight(workArea: Electron.Rectangle): number {
@@ -133,6 +306,7 @@ function applyWindowBounds(bounds: Electron.Rectangle): void {
 
 function redockToCorner(): void {
   if (!clawWindow || clawWindow.isDestroyed()) return;
+  if (clawMode !== "pill") return;
   const workArea = screen.getDisplayMatching(clawWindow.getBounds()).workArea;
   const currentHeight = clawWindow.getBounds().height - SHADOW_GUTTER;
   const panelHeight = clampPanelHeight(currentHeight, workArea);
@@ -185,12 +359,22 @@ function applyIgnoreMouseEvents(ignore: boolean): void {
     return;
   }
 
-  clawWindow.setIgnoreMouseEvents(ignore, { forward: true });
+  clawWindow.setIgnoreMouseEvents(clawMode === "spotlight" ? false : ignore, {
+    forward: true,
+  });
 }
 
 function applyLinuxContentShape(expanded: boolean, liveHeight?: number): void {
   if (process.platform !== "linux" || !clawWindow || clawWindow.isDestroyed())
     return;
+  if (clawMode === "spotlight") {
+    const spotlightBounds = clawWindow.getBounds();
+    clawWindow.setShape([
+      { x: 0, y: 0, width: spotlightBounds.width, height: spotlightBounds.height },
+    ]);
+    return;
+  }
+
   const workArea = screen.getDisplayMatching(clawWindow.getBounds()).workArea;
   const panelHeight = liveHeight ?? getStoredPanelHeight(workArea);
   const content = expanded ? { width: PANEL.width, height: panelHeight } : PILL;
@@ -234,8 +418,6 @@ function registerIpcHandlers(): void {
     clawRendererReady = true;
     applyLinuxContentShape(expanded);
     if (firstReady && clawWindow && !clawWindow.isDestroyed()) {
-      clawWindow.showInactive();
-      clawWindow.webContents.send("claw:visibility", true);
       const workArea = screen.getDisplayMatching(
         clawWindow.getBounds(),
       ).workArea;
@@ -243,10 +425,55 @@ function registerIpcHandlers(): void {
         "claw:panel-height",
         getStoredPanelHeight(workArea),
       );
-      log.info("[ClawOverlay] Showing overlay");
+      clawWindow.webContents.send("claw:mode", clawMode);
+
+      if (pendingSpotlightSummon) {
+        pendingSpotlightSummon = false;
+        revealSpotlight();
+      } else if (isClawOverlayEnabled()) {
+        clawWindow.showInactive();
+        clawWindow.webContents.send("claw:visibility", true);
+        log.info("[ClawOverlay] Showing overlay");
+      }
     }
   };
   ipcMain.on("claw:set-expanded", setExpandedHandler);
+
+  dismissSpotlightHandler = (event) => {
+    if (!isClawOverlaySender(event)) return;
+    dismissClawSpotlight();
+  };
+  ipcMain.on("claw:dismiss-spotlight", dismissSpotlightHandler);
+
+  dragStartHandler = (event) => {
+    if (!isClawOverlaySender(event)) return;
+    startSpotlightDrag();
+  };
+  ipcMain.on("claw:drag-start", dragStartHandler);
+
+  sessionStateHandler = (event, state) => {
+    if (!isClawOverlaySender(event)) return;
+    if (!state || typeof state !== "object") return;
+    syncClawSessionState(state as Record<string, unknown>);
+  };
+  ipcMain.on("claw:session-state-changed", sessionStateHandler);
+
+  spotlightHeightHandler = (event, height) => {
+    if (!isClawOverlaySender(event)) return;
+    if (clawMode !== "spotlight") return;
+    const next = Number(height);
+    if (!Number.isFinite(next) || next <= 0) return;
+    spotlightContentHeight = next;
+    applySpotlightBounds();
+    finishSpotlightReveal();
+  };
+  ipcMain.on("claw:set-spotlight-height", spotlightHeightHandler);
+
+  dragEndHandler = (event) => {
+    if (!isClawOverlaySender(event)) return;
+    stopSpotlightDrag();
+  };
+  ipcMain.on("claw:drag-end", dragEndHandler);
 
   setPanelHeightHandler = (event, height) => {
     if (!isClawOverlaySender(event)) return;
@@ -330,6 +557,30 @@ function cleanupIpcHandlers(): void {
     ipcMain.removeListener("claw:set-panel-height", setPanelHeightHandler);
     setPanelHeightHandler = null;
   }
+  if (dismissSpotlightHandler) {
+    ipcMain.removeListener("claw:dismiss-spotlight", dismissSpotlightHandler);
+    dismissSpotlightHandler = null;
+  }
+  if (sessionStateHandler) {
+    ipcMain.removeListener("claw:session-state-changed", sessionStateHandler);
+    sessionStateHandler = null;
+  }
+  if (spotlightHeightHandler) {
+    ipcMain.removeListener("claw:set-spotlight-height", spotlightHeightHandler);
+    spotlightHeightHandler = null;
+  }
+  if (dragStartHandler) {
+    ipcMain.removeListener("claw:drag-start", dragStartHandler);
+    dragStartHandler = null;
+  }
+  if (dragEndHandler) {
+    ipcMain.removeListener("claw:drag-end", dragEndHandler);
+    dragEndHandler = null;
+  }
+  if (dragInterval) {
+    clearInterval(dragInterval);
+    dragInterval = null;
+  }
   ipcMain.removeHandler("claw:reconcile");
 }
 
@@ -380,7 +631,7 @@ function createClawOverlay(): BrowserWindow {
     transparent: true,
     backgroundColor: "#00000000",
     resizable: false,
-    movable: false,
+    movable: true,
     skipTaskbar: true,
     hasShadow: false,
     focusable: true,
@@ -404,12 +655,16 @@ function createClawOverlay(): BrowserWindow {
   });
   clawWindow.setMinimumSize(
     PANEL.width + SHADOW_GUTTER,
-    MIN_PANEL_HEIGHT + SHADOW_GUTTER,
+    SPOTLIGHT_MIN_CONTENT_HEIGHT + SHADOW_GUTTER,
   );
 
-  const targetUrl = config.useBundledUI
+  const baseUrl = config.useBundledUI
     ? `${getBundledUIUrl()}newWindow/claw`
     : new URL("/newWindow/claw", config.FRONTEND_URL).toString();
+  const storedTheme = getStoredThemeName();
+  const targetUrl = storedTheme
+    ? `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}theme=${encodeURIComponent(storedTheme)}`
+    : baseUrl;
   void clawWindow.loadURL(targetUrl);
 
   clawWindow.webContents.on("dom-ready", () => {
@@ -442,6 +697,7 @@ function createClawOverlay(): BrowserWindow {
     try {
       const url = new URL(details.url);
       if (url.protocol === "http:" || url.protocol === "https:") {
+        suppressSpotlightBlur();
         void shell.openExternal(details.url);
       }
     } catch (error) {
@@ -483,12 +739,20 @@ function createClawOverlay(): BrowserWindow {
     if (isSameOrigin) {
       forwardToMainWindow(parsed.pathname + parsed.search + parsed.hash);
     } else if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      suppressSpotlightBlur();
       void shell.openExternal(navUrl);
     }
   };
 
   clawWindow.webContents.on("will-navigate", guardNavigation);
   clawWindow.webContents.on("will-redirect", guardNavigation);
+
+  clawWindow.on("blur", () => {
+    if (clawMode !== "spotlight") return;
+    if (blurDismissSuppressed) return;
+    if (Date.now() - spotlightShownAt < SPOTLIGHT_BLUR_GRACE_MS) return;
+    dismissClawSpotlight();
+  });
 
   applyLinuxContentShape(false);
   applyIgnoreMouseEvents(true);
@@ -507,6 +771,8 @@ function createClawOverlay(): BrowserWindow {
     log.error(`[ClawOverlay] Renderer gone: ${details.reason}`);
     clawRendererReady = false;
     clawExpanded = false;
+    clawMode = "pill";
+    resetClawSessionState();
     applyLinuxContentShape(false);
     applyIgnoreMouseEvents(true);
     if (clawWindow && !clawWindow.isDestroyed()) {
@@ -535,9 +801,23 @@ function createClawOverlay(): BrowserWindow {
       clearTimeout(resizableLatchTimer);
       resizableLatchTimer = null;
     }
+    if (blurSuppressTimer) {
+      clearTimeout(blurSuppressTimer);
+      blurSuppressTimer = null;
+    }
+    blurDismissSuppressed = false;
+    pendingSpotlightSummon = false;
+    awaitingSpotlightLayout = false;
+    spotlightAnchor = null;
+    if (spotlightRevealTimer) {
+      clearTimeout(spotlightRevealTimer);
+      spotlightRevealTimer = null;
+    }
     clawWindow = null;
     clawRendererReady = false;
     clawExpanded = false;
+    clawMode = "pill";
+    resetClawSessionState();
   });
 
   log.info("[ClawOverlay] Window created");
@@ -550,7 +830,12 @@ export async function showClawOverlay(): Promise<void> {
     const alreadyExisted = !!clawWindow && !clawWindow.isDestroyed();
     const win = createClawOverlay();
 
-    if (alreadyExisted && clawRendererReady && !win.isVisible()) {
+    if (
+      alreadyExisted &&
+      clawRendererReady &&
+      clawMode === "pill" &&
+      !win.isVisible()
+    ) {
       win.showInactive();
       win.webContents.send("claw:visibility", true);
       log.info("[ClawOverlay] Showing overlay");
@@ -568,12 +853,142 @@ export function hideClawOverlay(): void {
   log.info("[ClawOverlay] Hiding overlay");
 }
 
+function suppressSpotlightBlur(durationMs = 1500): void {
+  blurDismissSuppressed = true;
+  if (blurSuppressTimer) clearTimeout(blurSuppressTimer);
+  blurSuppressTimer = setTimeout(() => {
+    blurSuppressTimer = null;
+    blurDismissSuppressed = false;
+  }, durationMs);
+}
+
+function finishSpotlightReveal(): void {
+  if (!awaitingSpotlightLayout) return;
+  awaitingSpotlightLayout = false;
+  if (spotlightRevealTimer) {
+    clearTimeout(spotlightRevealTimer);
+    spotlightRevealTimer = null;
+  }
+  if (!clawWindow || clawWindow.isDestroyed()) return;
+
+  spotlightShownAt = Date.now();
+  clawWindow.show();
+  clawWindow.focus();
+  clawWindow.webContents.send("claw:visibility", true);
+  log.info("[ClawOverlay] Spotlight shown");
+}
+
+function revealSpotlight(): void {
+  if (!clawWindow || clawWindow.isDestroyed()) return;
+
+  if (clawWindow.isVisible()) clawWindow.hide();
+
+  clawMode = "spotlight";
+  spotlightAnchor = getStoredSpotlightAnchor();
+  spotlightContentHeight = SPOTLIGHT_REST_HEIGHT;
+  applyIgnoreMouseEvents(false);
+  applySpotlightBounds();
+
+  clawWindow.webContents.send("claw:mode", clawMode);
+
+  awaitingSpotlightLayout = true;
+  if (spotlightRevealTimer) clearTimeout(spotlightRevealTimer);
+  spotlightRevealTimer = setTimeout(() => {
+    spotlightRevealTimer = null;
+    finishSpotlightReveal();
+  }, SPOTLIGHT_REVEAL_TIMEOUT_MS);
+}
+
+export function dismissClawSpotlight(): void {
+  if (!clawWindow || clawWindow.isDestroyed()) return;
+  if (clawMode !== "spotlight") return;
+
+  persistSpotlightAnchor();
+  awaitingSpotlightLayout = false;
+  if (spotlightRevealTimer) {
+    clearTimeout(spotlightRevealTimer);
+    spotlightRevealTimer = null;
+  }
+  clawMode = "pill";
+  clawWindow.webContents.send("claw:mode", clawMode);
+
+  if (isClawOverlayEnabled()) {
+    const workArea = screen.getDisplayMatching(clawWindow.getBounds()).workArea;
+    applyWindowBounds(
+      getDockedBounds(PANEL.width, getStoredPanelHeight(workArea), workArea),
+    );
+    applyIgnoreMouseEvents(true);
+    applyLinuxContentShape(clawExpanded);
+    clawWindow.showInactive();
+    clawWindow.webContents.send("claw:visibility", true);
+  } else {
+    clawWindow.hide();
+    clawWindow.webContents.send("claw:visibility", false);
+  }
+
+  log.info("[ClawOverlay] Spotlight dismissed");
+}
+
+export function isClawSpotlightVisible(): boolean {
+  return (
+    !!clawWindow &&
+    !clawWindow.isDestroyed() &&
+    clawMode === "spotlight" &&
+    clawWindow.isVisible()
+  );
+}
+
+async function summonSpotlight(toggle: boolean): Promise<void> {
+  try {
+    if (!(await isUserAuthenticated())) {
+      log.info("[ClawOverlay] Spotlight ignored, user not authenticated");
+      return;
+    }
+  } catch (error) {
+    log.error("[ClawOverlay] Spotlight authentication check failed", error);
+    return;
+  }
+
+  const win = createClawOverlay();
+
+  if (toggle && clawMode === "spotlight" && win.isVisible()) {
+    dismissClawSpotlight();
+    return;
+  }
+
+  if (!clawRendererReady) {
+    pendingSpotlightSummon = true;
+    return;
+  }
+
+  revealSpotlight();
+}
+
+export function toggleClawSpotlight(): Promise<void> {
+  return summonSpotlight(true);
+}
+
+export function openClawSpotlight(): Promise<void> {
+  return summonSpotlight(false);
+}
+
+export function setClawOverlayThemeName(name: string): void {
+  if (!VALID_THEME_NAMES.has(name)) return;
+  clawStore.set(THEME_NAME_KEY, name);
+}
+
+function getStoredThemeName(): string | null {
+  const raw = clawStore.get(THEME_NAME_KEY);
+  return typeof raw === "string" && VALID_THEME_NAMES.has(raw) ? raw : null;
+}
+
 export function isClawOverlayEnabled(): boolean {
   return clawStore.get(ENABLED_KEY, false) as boolean;
 }
 
 function destroyClawOverlay(): void {
   if (!clawWindow || clawWindow.isDestroyed()) return;
+  resetClawSessionState();
   clawWindow.destroy();
   clawWindow = null;
   log.info("[ClawOverlay] Destroyed");
@@ -585,8 +1000,8 @@ export function setClawOverlayEnabled(enabled: boolean): void {
 
   if (enabled) {
     void showClawOverlay();
-  } else {
-    destroyClawOverlay();
+  } else if (clawMode === "pill") {
+    hideClawOverlay();
   }
 
   for (const win of BrowserWindow.getAllWindows()) {
@@ -604,23 +1019,46 @@ async function isUserAuthenticated(): Promise<boolean> {
   return cookies.some((c) => c.name === AUTH_COOKIE_NAME && !!c.value);
 }
 
+async function ensureClawOverlayReady(): Promise<void> {
+  try {
+    if (!(await isUserAuthenticated())) return;
+    createClawOverlay();
+  } catch (error) {
+    log.error("[ClawOverlay] Failed to pre-create overlay window", error);
+  }
+}
+
 export function initClawOverlayAuthGate(): void {
   if (authGateInitialized) return;
   authGateInitialized = true;
 
   ipcMain.handle("claw:get-enabled", () => isClawOverlayEnabled());
-  ipcMain.on("claw:set-enabled", (_event, enabled: boolean) =>
-    setClawOverlayEnabled(!!enabled),
-  );
+  ipcMain.on("claw:set-enabled", (event, enabled: boolean) => {
+    const mainWindow = getMainWindow();
+    const fromMainWindow =
+      !!mainWindow &&
+      !mainWindow.isDestroyed() &&
+      event.sender === mainWindow.webContents;
+    if (!fromMainWindow && !isClawOverlaySender(event)) return;
+    setClawOverlayEnabled(!!enabled);
+  });
 
-  if (isClawOverlayEnabled()) void showClawOverlay();
+  if (isClawOverlayEnabled()) {
+    void showClawOverlay();
+  } else {
+    void ensureClawOverlayReady();
+  }
 
   session.defaultSession.cookies.on(
     "changed",
     (_event, cookie, _cause, removed) => {
       if (cookie.name !== AUTH_COOKIE_NAME) return;
       if (!removed && cookie.value) {
-        if (isClawOverlayEnabled()) void showClawOverlay();
+        if (isClawOverlayEnabled()) {
+          void showClawOverlay();
+        } else {
+          void ensureClawOverlayReady();
+        }
         return;
       }
       if (removed) {

--- a/apps/electron/src/services/claw-session-controller.ts
+++ b/apps/electron/src/services/claw-session-controller.ts
@@ -1,0 +1,125 @@
+import log from "electron-log/main";
+
+export type ClawSessionStatus = "idle" | "running" | "needs-input" | "error";
+
+export interface ClawSessionSnapshot {
+  status: ClawSessionStatus;
+  conversationId: string | null;
+  preview: string | null;
+}
+
+export interface ClawSessionCompletion {
+  outcome: Exclude<ClawSessionStatus, "running">;
+  conversationId: string | null;
+  preview: string | null;
+}
+
+const IDLE_SNAPSHOT: ClawSessionSnapshot = {
+  status: "idle",
+  conversationId: null,
+  preview: null,
+};
+
+let snapshot: ClawSessionSnapshot = IDLE_SNAPSHOT;
+
+const stateListeners = new Set<(next: ClawSessionSnapshot) => void>();
+const completionListeners = new Set<(event: ClawSessionCompletion) => void>();
+
+export function getClawSessionSnapshot(): ClawSessionSnapshot {
+  return snapshot;
+}
+
+export function onClawSessionStateChange(
+  listener: (next: ClawSessionSnapshot) => void,
+): () => void {
+  stateListeners.add(listener);
+  return () => {
+    stateListeners.delete(listener);
+  };
+}
+
+export function onClawSessionCompleted(
+  listener: (event: ClawSessionCompletion) => void,
+): () => void {
+  completionListeners.add(listener);
+  return () => {
+    completionListeners.delete(listener);
+  };
+}
+
+function emitState(): void {
+  for (const listener of stateListeners) {
+    try {
+      listener(snapshot);
+    } catch (error) {
+      log.error("[ClawSession] State listener failed", error);
+    }
+  }
+}
+
+function emitCompletion(event: ClawSessionCompletion): void {
+  for (const listener of completionListeners) {
+    try {
+      listener(event);
+    } catch (error) {
+      log.error("[ClawSession] Completion listener failed", error);
+    }
+  }
+}
+
+function normalizeStatus(value: unknown): ClawSessionStatus {
+  if (
+    value === "running" ||
+    value === "needs-input" ||
+    value === "error" ||
+    value === "idle"
+  ) {
+    return value;
+  }
+  return "idle";
+}
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.length > 160 ? `${trimmed.slice(0, 159)}…` : trimmed;
+}
+
+export function syncClawSessionState(input: {
+  status?: unknown;
+  conversationId?: unknown;
+  preview?: unknown;
+}): void {
+  const next: ClawSessionSnapshot = {
+    status: normalizeStatus(input.status),
+    conversationId: normalizeText(input.conversationId),
+    preview: normalizeText(input.preview),
+  };
+
+  const previous = snapshot;
+  if (
+    next.status === previous.status &&
+    next.conversationId === previous.conversationId &&
+    next.preview === previous.preview
+  ) {
+    return;
+  }
+
+  snapshot = next;
+  emitState();
+
+  if (previous.status === "running" && next.status !== "running") {
+    emitCompletion({
+      outcome: next.status,
+      conversationId: next.conversationId ?? previous.conversationId,
+      preview: next.preview ?? previous.preview,
+    });
+  }
+}
+
+export function resetClawSessionState(): void {
+  if (snapshot.status === "idle") return;
+  snapshot = IDLE_SNAPSHOT;
+  emitState();
+}

--- a/apps/electron/src/services/claw-tray-badge.ts
+++ b/apps/electron/src/services/claw-tray-badge.ts
@@ -1,0 +1,109 @@
+import { BrowserWindow, nativeImage, type NativeImage } from 'electron';
+import path from 'path';
+import log from 'electron-log/main';
+
+const BADGE_HEIGHT = 16;
+const BADGE_WIDTH = 25;
+const FRAME_RATE = 15;
+
+let win: BrowserWindow | null = null;
+let loaded: Promise<void> | null = null;
+let frameHandler: ((image: NativeImage) => void) | null = null;
+let lastWaiting: boolean | null = null;
+let lastDark: boolean | null = null;
+
+function createWindow(): BrowserWindow {
+  const offscreen = new BrowserWindow({
+    width: BADGE_WIDTH,
+    height: BADGE_HEIGHT,
+    show: false,
+    frame: false,
+    transparent: true,
+    backgroundColor: '#00000000',
+    webPreferences: {
+      offscreen: true,
+      nodeIntegration: false,
+      contextIsolation: true,
+      backgroundThrottling: false,
+    },
+  });
+
+  offscreen.webContents.setFrameRate(FRAME_RATE);
+
+  offscreen.webContents.on('paint', (_details, _dirty, image) => {
+    if (!frameHandler) return;
+    const size = image.getSize();
+    if (size.width === 0 || size.height === 0) return;
+
+    const scaleFactor = size.height / BADGE_HEIGHT;
+    frameHandler(
+      nativeImage.createFromBitmap(image.toBitmap(), {
+        width: size.width,
+        height: size.height,
+        scaleFactor,
+      }),
+    );
+  });
+
+  return offscreen;
+}
+
+async function ensureLoaded(): Promise<void> {
+  if (win && !win.isDestroyed() && loaded) return loaded;
+
+  win = createWindow();
+  const target = win;
+
+  loaded = new Promise<void>((resolve, reject) => {
+    target.webContents.once('did-finish-load', () => resolve());
+    target.webContents.once('did-fail-load', (_e, code, desc) =>
+      reject(new Error(`claw-tray-badge.html failed to load (${code}): ${desc}`)),
+    );
+  });
+
+  const badgeHtml = path.join(__dirname, '..', '..', 'assets', 'claw-tray-badge.html');
+  target.loadFile(badgeHtml).catch((error) => {
+    log.error('[ClawTrayBadge] Failed to load badge HTML:', error);
+  });
+
+  await loaded;
+  target.webContents.setZoomFactor(1);
+  return loaded;
+}
+
+export function startClawBadgeRenderer(onFrame: (image: NativeImage) => void): void {
+  frameHandler = onFrame;
+}
+
+export async function updateClawBadge(waiting: boolean, dark: boolean): Promise<void> {
+  try {
+    await ensureLoaded();
+    if (!win || win.isDestroyed()) return;
+
+    const wc = win.webContents;
+    await wc.executeJavaScript('window.__ready()');
+
+    if (waiting !== lastWaiting || dark !== lastDark) {
+      lastWaiting = waiting;
+      lastDark = dark;
+      await wc.executeJavaScript(`window.__setState(${waiting}, ${dark})`);
+    }
+    wc.invalidate();
+  } catch (error) {
+    log.error('[ClawTrayBadge] Failed to update badge:', error);
+  }
+}
+
+export function repaintClawBadge(): void {
+  if (!win || win.isDestroyed()) return;
+  win.webContents.invalidate();
+}
+
+export function stopClawBadgeRenderer(): void {
+  frameHandler = null;
+  lastWaiting = null;
+  lastDark = null;
+  loaded = null;
+  if (win && !win.isDestroyed()) win.destroy();
+  win = null;
+}

--- a/apps/electron/src/services/global-shortcuts.ts
+++ b/apps/electron/src/services/global-shortcuts.ts
@@ -1,10 +1,33 @@
 import { app, globalShortcut } from 'electron';
 import log from 'electron-log/main';
 import { toggleRecording } from './recording-controller';
+import { toggleClawSpotlight } from './claw-overlay-window';
 
 export const RECORDING_SHORTCUT = 'CommandOrControl+Alt+X';
 
-export function registerGlobalShortcuts(): void {
+const CLAW_SPOTLIGHT_ACCELERATORS = [
+  'CommandOrControl+Alt+C',
+  'CommandOrControl+Alt+Space',
+  'CommandOrControl+Shift+Alt+C',
+];
+
+let clawSpotlightShortcut: string | null = null;
+let cleanupRegistered = false;
+
+export function getClawSpotlightShortcut(): string | null {
+  return clawSpotlightShortcut;
+}
+
+function registerCleanupOnce(): void {
+  if (cleanupRegistered) return;
+  cleanupRegistered = true;
+
+  app.once('will-quit', () => {
+    globalShortcut.unregisterAll();
+  });
+}
+
+function registerRecordingShortcut(): void {
   if (globalShortcut.isRegistered(RECORDING_SHORTCUT)) return;
 
   const registered = globalShortcut.register(RECORDING_SHORTCUT, () => {
@@ -18,8 +41,33 @@ export function registerGlobalShortcuts(): void {
   }
 
   log.info(`[GlobalShortcuts] Registered ${RECORDING_SHORTCUT} to toggle recording`);
+}
 
-  app.once('will-quit', () => {
-    globalShortcut.unregister(RECORDING_SHORTCUT);
-  });
+function registerClawSpotlightShortcut(): void {
+  if (clawSpotlightShortcut) return;
+
+  for (const accelerator of CLAW_SPOTLIGHT_ACCELERATORS) {
+    if (globalShortcut.isRegistered(accelerator)) continue;
+
+    const registered = globalShortcut.register(accelerator, () => {
+      log.info(`[GlobalShortcuts] Claw spotlight shortcut pressed (${accelerator})`);
+      void toggleClawSpotlight();
+    });
+
+    if (registered) {
+      clawSpotlightShortcut = accelerator;
+      log.info(`[GlobalShortcuts] Registered ${accelerator} to toggle Claw spotlight`);
+      return;
+    }
+
+    log.warn(`[GlobalShortcuts] Failed to register ${accelerator}`);
+  }
+
+  log.error('[GlobalShortcuts] No Claw spotlight accelerator could be registered');
+}
+
+export function registerGlobalShortcuts(): void {
+  registerRecordingShortcut();
+  registerClawSpotlightShortcut();
+  registerCleanupOnce();
 }

--- a/apps/electron/src/services/tray.ts
+++ b/apps/electron/src/services/tray.ts
@@ -1,4 +1,4 @@
-import { Menu, Tray, nativeImage, type NativeImage } from 'electron';
+import { Menu, Tray, nativeImage, nativeTheme, type NativeImage } from 'electron';
 import path from 'path';
 import Store from 'electron-store';
 import log from 'electron-log/main';
@@ -13,8 +13,20 @@ import {
   stopRecording,
   type RecordingSnapshot,
 } from './recording-controller';
-import { RECORDING_SHORTCUT } from './global-shortcuts';
+import { RECORDING_SHORTCUT, getClawSpotlightShortcut } from './global-shortcuts';
 import { startPillRenderer, stopPillRenderer, updatePill } from './tray-pill-renderer';
+import {
+  repaintClawBadge,
+  startClawBadgeRenderer,
+  stopClawBadgeRenderer,
+  updateClawBadge,
+} from './claw-tray-badge';
+import {
+  getClawSessionSnapshot,
+  onClawSessionStateChange,
+  type ClawSessionSnapshot,
+} from './claw-session-controller';
+import { openClawSpotlight } from './claw-overlay-window';
 
 const PAUSED_TITLE = 'Paused';
 
@@ -25,6 +37,17 @@ let tray: Tray | null = null;
 let idleIcon: NativeImage | null = null;
 let timerInterval: ReturnType<typeof setInterval> | null = null;
 let unsubscribeRecordingState: (() => void) | null = null;
+let unsubscribeClawState: (() => void) | null = null;
+let lastRecording: RecordingSnapshot | null = null;
+let lastClaw: ClawSessionSnapshot | null = null;
+let clawBadgeInterval: ReturnType<typeof setInterval> | null = null;
+let themeListenerAttached = false;
+
+const CLAW_BADGE_REPAINT_MS = 120;
+
+function truncateLabel(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
 
 function formatElapsed(snapshot: RecordingSnapshot): string {
   const startTime = snapshot.startTime ?? Date.now();
@@ -49,7 +72,30 @@ async function openXyne(): Promise<void> {
   focusMainWindow();
 }
 
-function buildMenu(snapshot: RecordingSnapshot): Menu {
+function buildClawItems(claw: ClawSessionSnapshot): Electron.MenuItemConstructorOptions[] {
+  if (claw.status !== 'running' && claw.status !== 'needs-input') return [];
+
+  const items: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: claw.status === 'needs-input' ? 'Needs your input' : 'Working…',
+      enabled: false,
+    },
+  ];
+
+  if (claw.preview) {
+    items.push({ label: truncateLabel(claw.preview, 52), enabled: false });
+  }
+
+  items.push({
+    label: 'Open session',
+    click: () => void openClawSpotlight(),
+  });
+  items.push({ type: 'separator' });
+
+  return items;
+}
+
+function buildMenu(snapshot: RecordingSnapshot, claw: ClawSessionSnapshot): Menu {
   const template: Electron.MenuItemConstructorOptions[] = snapshot.active
     ? [
         {
@@ -77,9 +123,18 @@ function buildMenu(snapshot: RecordingSnapshot): Menu {
         },
       ];
 
+  const clawShortcut = getClawSpotlightShortcut();
+  const clawItems = buildClawItems(claw);
+
   return Menu.buildFromTemplate([
     ...template,
     { type: 'separator' },
+    ...clawItems,
+    {
+      label: 'Open Claw',
+      ...(clawShortcut ? { accelerator: clawShortcut, registerAccelerator: false } : {}),
+      click: () => void openClawSpotlight(),
+    },
     {
       label: 'Open Xyne',
       click: () => void openXyne(),
@@ -87,29 +142,60 @@ function buildMenu(snapshot: RecordingSnapshot): Menu {
   ]);
 }
 
-function syncTrayToState(snapshot: RecordingSnapshot): void {
+function applyTrayVisual(): void {
   if (!tray) return;
 
-  tray.setContextMenu(buildMenu(snapshot));
+  const recording = lastRecording ?? getRecordingSnapshot();
+  const claw = lastClaw ?? getClawSessionSnapshot();
+
+  tray.setContextMenu(buildMenu(recording, claw));
 
   if (timerInterval) {
     clearInterval(timerInterval);
     timerInterval = null;
   }
+  if (clawBadgeInterval) {
+    clearInterval(clawBadgeInterval);
+    clawBadgeInterval = null;
+  }
 
   if (process.platform !== 'darwin') return;
 
-  if (snapshot.active && snapshot.startTime) {
+  if (recording.active && recording.startTime) {
+    stopClawBadgeRenderer();
     startPillRenderer((image) => tray?.setImage(image));
-    void updatePill(formatLabel(snapshot), snapshot.paused);
-    if (snapshot.paused) return;
+    void updatePill(formatLabel(recording), recording.paused);
+    if (recording.paused) return;
     timerInterval = setInterval(() => {
-      void updatePill(formatLabel(snapshot), snapshot.paused);
+      void updatePill(formatLabel(recording), recording.paused);
     }, 1000);
-  } else {
-    stopPillRenderer();
-    if (idleIcon) tray.setImage(idleIcon);
+    return;
   }
+
+  stopPillRenderer();
+
+  if (claw.status === 'running' || claw.status === 'needs-input') {
+    const waiting = claw.status === 'needs-input';
+    startClawBadgeRenderer((image) => tray?.setImage(image));
+    void updateClawBadge(waiting, nativeTheme.shouldUseDarkColors);
+    if (!waiting) {
+      clawBadgeInterval = setInterval(repaintClawBadge, CLAW_BADGE_REPAINT_MS);
+    }
+    return;
+  }
+
+  stopClawBadgeRenderer();
+  if (idleIcon) tray.setImage(idleIcon);
+}
+
+function syncTrayToState(snapshot: RecordingSnapshot): void {
+  lastRecording = snapshot;
+  applyTrayVisual();
+}
+
+function syncTrayToClaw(snapshot: ClawSessionSnapshot): void {
+  lastClaw = snapshot;
+  applyTrayVisual();
 }
 
 function createTray(): void {
@@ -129,8 +215,16 @@ function createTray(): void {
   if (process.platform === 'win32') {
     tray.on('click', () => void openXyne());
   }
-  syncTrayToState(getRecordingSnapshot());
+  lastRecording = getRecordingSnapshot();
+  lastClaw = getClawSessionSnapshot();
+  applyTrayVisual();
   unsubscribeRecordingState = onRecordingStateChange(syncTrayToState);
+  unsubscribeClawState = onClawSessionStateChange(syncTrayToClaw);
+
+  if (!themeListenerAttached) {
+    themeListenerAttached = true;
+    nativeTheme.on('updated', () => applyTrayVisual());
+  }
 
   log.info('[Tray] Menu bar icon initialized');
 }
@@ -140,16 +234,32 @@ function destroyTray(): void {
     unsubscribeRecordingState();
     unsubscribeRecordingState = null;
   }
+  if (unsubscribeClawState) {
+    unsubscribeClawState();
+    unsubscribeClawState = null;
+  }
   if (timerInterval) {
     clearInterval(timerInterval);
     timerInterval = null;
   }
+  if (clawBadgeInterval) {
+    clearInterval(clawBadgeInterval);
+    clawBadgeInterval = null;
+  }
   stopPillRenderer();
+  stopClawBadgeRenderer();
   idleIcon = null;
+  lastRecording = null;
+  lastClaw = null;
   if (!tray) return;
   tray.destroy();
   tray = null;
   log.info('[Tray] Menu bar icon removed');
+}
+
+export function getTrayBounds(): Electron.Rectangle | null {
+  if (!tray || tray.isDestroyed()) return null;
+  return tray.getBounds();
 }
 
 export function isTrayVisible(): boolean {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,3 +30,6 @@ packages:
   - tools/xyne-automation-old
   - tools/deadcode-analyzer
   - tools/fcm-ota-trigger
+
+onlyBuiltDependencies:
+  - electron


### PR DESCRIPTION
Adds a spotlight mode to the Claw overlay: a centred, draggable composer summoned from anywhere with a global accelerator, sharing a single `BrowserWindow` with the existing docked pill.

## What's in here

- **Global shortcut** — `CommandOrControl+Alt+C`, with fallback accelerators if it's taken. The live binding is surfaced in Settings → Preferences → Claw.
- **Spotlight lifecycle** — reveal, dismiss, OS-level drag, and anchor persistence across summons.
- **Session state → main process** — drives a menu-bar badge while Claw is working, and a completion panel when a session finishes while the spotlight is hidden.
- **Block-wise streaming markdown** in the Claw thread, reusing the existing `StreamingMarkdownBlocks` utility.

## Proof of Testing

<!-- POT-VIDEO -->

## Review fixes folded in

This branch was reviewed adversarially before opening. Findings that were fixed:

| Sev | Where | What |
|---|---|---|
| High | `ClawSpotlight.tsx:96` | Escape dismissed the whole spotlight even when a Radix popover had already consumed it. Radix listens in capture and calls `preventDefault()` without `stopPropagation()`, so the event still reached the window listener. Now guarded on `e.defaultPrevented`. |
| Medium | `claw-overlay-window.ts:309` | `redockToCorner()` had no mode check and forced 420px docked bounds on any display change — including while the spotlight was open. Now returns early unless `clawMode === "pill"`. |
| Medium | `ClawMarkdown.tsx:162,193` | Branching on live `isStreaming` changed the element type at completion, tearing down and re-parsing the whole message. Switched to an `everStreamedRef` latch, matching `AIChatThread.tsx:1170` and `MessageItem.tsx:1839`. |
| Medium | `ClawOverlayToggle.tsx` | A second accelerator formatter rendered `Ctrl+Alt+C` where the shared `formatShortcut` renders `Ctrl Alt C`. Removed; both surfaces now agree. |
| Low | `handlers.ts:645` | `claw:get-shortcut` had no sender check while every sibling handler did. |
| Low | `claw-completion-panel.ts:34` | `isPanelSender` now also verifies `senderFrame`, matching `isClawOverlaySender`. |
| Low | `claw-overlay-window.ts:991` | `destroyClawOverlay()` now resets session state directly; the `closed` handler is skipped when a new window has already replaced the old one, which could fire a phantom "Claw finished" panel after logout→login. |
| Low | both | Dropped `export` from `hideClawCompletionPanel` and `CLAW_SPOTLIGHT_ACCELERATORS` (no external consumers); declared the missing `clawCompletion` type. |

## Verification

- `tsc --noEmit` — 0 errors in **both** `apps/dashboard` and `apps/electron`
- `eslint` — 0 errors
- `prettier --check` — clean across `apps/dashboard/src`
- gitleaks, tenant-key guard, schema-migration validation, enum guard — all pass

## Known follow-ups (deliberately not in this PR)

- `ClawSpotlight.tsx` duplicates ~70 lines of `ClawChat.tsx` / `Composer.tsx`. Wants a shared composer/thread hook rather than a patch.
- `markdownComponents` is still keyed on `toolInvocations`, so settled blocks re-render when a tool result lands. Stabilising it would restore the memo bail-out but let citation chips go stale — correctness was preferred.
- `catalog.ts:135` hardcodes `mod+alt+c` for the shortcuts modal, which can disagree with the actual binding if the fallback is used.
- `SPOTLIGHT`/`PANEL`/`PILL` constants are duplicated across the process boundary; `apps/electron` has no `@xyne/*` dependency to share them through.
- **`apps/electron` is covered by no CI gate** — `.husky/pre-commit` has no `ELECTRON_CHANGED` branch and no workflow typechecks it. Worth adding separately.
