### PR TITLE
feat: scope recap Ask AI to referenced threads

### DIFF
--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/AILandingHero.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/AILandingHero.tsx
@@ -99,7 +99,7 @@ export const AILandingHero = ({ renderInput, className }: AILandingHeroProps): R
 
   const buildAskAIThreadInfo = useCallback((card: RecapCard): ThreadInfo | null => {
     const firstCitation = Object.values(card.pointCitations ?? {}).find(
-      citation => citation.conversationId || citation.messageId,
+      citation => citation.conversationId,
     );
     const conversationId =
       firstCitation?.conversationId ?? card.drilldown.conversationId ?? undefined;

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/AILandingHero.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/AILandingHero.tsx
@@ -25,6 +25,8 @@ import { cn } from '../../../../utils/classNames';
 import { Dialog } from '../../../ui/Dialog';
 import { RecapPanel } from '../../../RecapPanel';
 import type { RecapCard } from '../../../RecapPanel/RecapPanel.types';
+import { xyneAIActor, type ThreadInfo } from '../../../../machines/xyneAIMachine';
+import { XyneAIStar } from '../../../icons/xyne-ai';
 
 function getGreeting(): string {
   const hour = new Date().getHours();
@@ -93,6 +95,40 @@ export const AILandingHero = ({ renderInput, className }: AILandingHeroProps): R
       }
     },
     [isMobile, navigate],
+  );
+
+  const buildAskAIThreadInfo = useCallback((card: RecapCard): ThreadInfo | null => {
+    const firstCitation = Object.values(card.pointCitations ?? {}).find(
+      citation => citation.conversationId || citation.messageId,
+    );
+    const conversationId =
+      firstCitation?.conversationId ?? card.drilldown.conversationId ?? undefined;
+    if (!conversationId) return null;
+
+    const messageId = firstCitation?.messageId ?? card.drilldown.messageId ?? undefined;
+    return {
+      conversationId,
+      channelId: card.channelId,
+      senderName: card.channelName,
+      previewText: `${card.channelName} recap reference`,
+      ...(messageId && { messageId }),
+      isThreadMessage: true,
+    };
+  }, []);
+
+  const handleAskAIAboutRecapReference = useCallback(
+    (card: RecapCard): void => {
+      const threadInfo = buildAskAIThreadInfo(card);
+      if (!threadInfo) return;
+      setSelectedCard(null);
+      xyneAIActor.send({
+        type: 'OPEN',
+        channelId: card.channelId,
+        threadInfo,
+        startFreshChat: true,
+      });
+    },
+    [buildAskAIThreadInfo],
   );
 
   const greeting = getGreeting();
@@ -399,18 +435,32 @@ export const AILandingHero = ({ renderInput, className }: AILandingHeroProps): R
               <span className='text-xs text-muted-foreground/60'>
                 {selectedCard.messageCount} messages summarized
               </span>
-              <button
-                type='button'
-                onClick={() => {
-                  setSelectedCard(null);
-                  void navigate('/chat/dir/recap');
-                }}
-                className='text-xs text-primary transition-colors hover:underline'
-                data-track-category='AILanding'
-                data-track-name='ViewAllFromRecapPreview'
-              >
-                View all recaps
-              </button>
+              <div className='flex items-center gap-3'>
+                {buildAskAIThreadInfo(selectedCard) && (
+                  <button
+                    type='button'
+                    onClick={() => handleAskAIAboutRecapReference(selectedCard)}
+                    className='inline-flex items-center gap-1 text-xs text-primary transition-colors hover:underline'
+                    data-track-category='AILanding'
+                    data-track-name='AskAIRecapReference'
+                  >
+                    <XyneAIStar size={13} />
+                    Ask AI
+                  </button>
+                )}
+                <button
+                  type='button'
+                  onClick={() => {
+                    setSelectedCard(null);
+                    void navigate('/chat/dir/recap');
+                  }}
+                  className='text-xs text-primary transition-colors hover:underline'
+                  data-track-category='AILanding'
+                  data-track-name='ViewAllFromRecapPreview'
+                >
+                  View all recaps
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/apps/dashboard/src/components/RecapPanel/RecapPanel.tsx
+++ b/apps/dashboard/src/components/RecapPanel/RecapPanel.tsx
@@ -24,6 +24,9 @@ import { useZero } from '../../hooks/useZero';
 import { mutators } from '../../zero/mutators';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useCacConfig } from '@xyne/shared/hooks';
+import { xyneAIActor, type ThreadInfo } from '../../machines/xyneAIMachine';
+import { XyneAIStar } from '../icons/xyne-ai';
+import { Tooltip } from '../ui/Tooltip';
 
 type RecapTab = 'channel' | 'project';
 
@@ -316,6 +319,51 @@ const RecapPanel = (): ReactElement => {
     });
   };
 
+  const buildAskAIThreadInfo = useCallback(
+    (
+      card: RecapCard,
+      pointCitations: Record<string, { conversationId?: string; messageId?: string }> | undefined,
+      drilldown?: { conversationId: string | null; messageId: string | null },
+    ): ThreadInfo | null => {
+      const firstCitation = Object.values(pointCitations ?? {}).find(
+        citation => citation.conversationId || citation.messageId,
+      );
+      const conversationId =
+        firstCitation?.conversationId ?? drilldown?.conversationId ?? undefined;
+      if (!conversationId) return null;
+
+      const messageId = firstCitation?.messageId ?? drilldown?.messageId ?? undefined;
+      return {
+        conversationId,
+        channelId: card.channelId,
+        senderName: card.channelName,
+        previewText: `${card.channelName} recap reference`,
+        ...(messageId && { messageId }),
+        isThreadMessage: true,
+      };
+    },
+    [],
+  );
+
+  const handleAskAIAboutRecapReference = useCallback(
+    (
+      card: RecapCard,
+      pointCitations: Record<string, { conversationId?: string; messageId?: string }> | undefined,
+      drilldown?: { conversationId: string | null; messageId: string | null },
+    ): void => {
+      const threadInfo = buildAskAIThreadInfo(card, pointCitations, drilldown);
+      if (!threadInfo) return;
+
+      xyneAIActor.send({
+        type: 'OPEN',
+        channelId: card.channelId,
+        threadInfo,
+        startFreshChat: true,
+      });
+    },
+    [buildAskAIThreadInfo],
+  );
+
   // Render recap cards content (left/center panel)
   const renderRecapCards = (): ReactElement => {
     // Show loading spinner when fetching historical data
@@ -478,34 +526,52 @@ const RecapPanel = (): ReactElement => {
           </div>
 
           {/* Card footer */}
-          <div className='flex items-center justify-between pt-4 border-t border-border'>
+          <div className='flex items-center justify-between gap-3 pt-4 border-t border-border'>
             <span className={`text-muted-foreground ${isMobile ? 'text-xs' : 'text-sm'}`}>
               {displayMessageCount} {isMobile ? 'messages' : 'messages summarized'}
             </span>
-            {!isHistoricalView && (
-              <button
-                onClick={() => void handleToggleRead(card.channelId, isRead)}
-                className={`flex items-center gap-1.5 text-xs font-medium transition-colors px-2.5 py-1 rounded-md border ${
-                  isRead
-                    ? 'border-blue-500/30 text-blue-600 hover:bg-blue-500/10'
-                    : 'border-green-500/30 text-green-600 hover:bg-green-500/10'
-                }`}
-                data-track-category='RECAP_PANEL'
-                data-track-name={isRead ? 'MARK_AS_UNREAD' : 'MARK_AS_READ'}
-              >
-                {isRead ? (
-                  <>
-                    <MailOpen size={13} />
-                    <span>Mark as unread</span>
-                  </>
-                ) : (
-                  <>
-                    <CheckCircle size={13} />
-                    <span>Mark as read</span>
-                  </>
-                )}
-              </button>
-            )}
+            <div className='flex items-center gap-2'>
+              {buildAskAIThreadInfo(card, displayPointCitations, displayDrilldown) && (
+                <Tooltip content='Ask AI about the referenced thread'>
+                  <button
+                    type='button'
+                    onClick={() =>
+                      handleAskAIAboutRecapReference(card, displayPointCitations, displayDrilldown)
+                    }
+                    className='flex items-center gap-1.5 text-xs font-medium transition-colors px-2.5 py-1 rounded-md border border-blue-500/30 text-blue-600 hover:bg-blue-500/10'
+                    data-track-category='RECAP_PANEL'
+                    data-track-name='ASK_AI_RECAP_REFERENCE'
+                  >
+                    <XyneAIStar size={13} />
+                    <span>Ask AI</span>
+                  </button>
+                </Tooltip>
+              )}
+              {!isHistoricalView && (
+                <button
+                  onClick={() => void handleToggleRead(card.channelId, isRead)}
+                  className={`flex items-center gap-1.5 text-xs font-medium transition-colors px-2.5 py-1 rounded-md border ${
+                    isRead
+                      ? 'border-blue-500/30 text-blue-600 hover:bg-blue-500/10'
+                      : 'border-green-500/30 text-green-600 hover:bg-green-500/10'
+                  }`}
+                  data-track-category='RECAP_PANEL'
+                  data-track-name={isRead ? 'MARK_AS_UNREAD' : 'MARK_AS_READ'}
+                >
+                  {isRead ? (
+                    <>
+                      <MailOpen size={13} />
+                      <span>Mark as unread</span>
+                    </>
+                  ) : (
+                    <>
+                      <CheckCircle size={13} />
+                      <span>Mark as read</span>
+                    </>
+                  )}
+                </button>
+              )}
+            </div>
           </div>
         </div>
       );

--- a/apps/dashboard/src/components/RecapPanel/RecapPanel.tsx
+++ b/apps/dashboard/src/components/RecapPanel/RecapPanel.tsx
@@ -326,7 +326,7 @@ const RecapPanel = (): ReactElement => {
       drilldown?: { conversationId: string | null; messageId: string | null },
     ): ThreadInfo | null => {
       const firstCitation = Object.values(pointCitations ?? {}).find(
-        citation => citation.conversationId || citation.messageId,
+        citation => citation.conversationId,
       );
       const conversationId =
         firstCitation?.conversationId ?? drilldown?.conversationId ?? undefined;


### PR DESCRIPTION
1. Problem Description:
Recap surfaces show referenced source threads, but users could only open the cited thread manually. The requested Ask AI entry point should open the assistant scoped to the referenced thread rather than the whole channel recap.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Requested in Spaces thread: add Ask AI in recap and scope referenced threads.

3. Explain the solution implemented in the PR:
- Adds Ask AI actions to the full Recap panel and the AI landing recap preview.
- Builds ThreadInfo from the recap citation/drilldown conversationId and messageId.
- Opens Xyne AI with channelId + threadInfo + startFreshChat so Claw receives threadConversationId and resolves the attached Spaces thread.
- Hides the button when a recap card has no thread reference to scope.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir apps/dashboard typecheck
- pnpm --dir apps/dashboard exec eslint src/components/RecapPanel/RecapPanel.tsx src/components/Chat/XyneAISidebar/components/AILandingHero.tsx (passes with one pre-existing naming-convention warning around dangerouslySetInnerHTML __html in RecapPanel)
- pnpm --dir apps/dashboard exec prettier --write src/components/RecapPanel/RecapPanel.tsx src/components/Chat/XyneAISidebar/components/AILandingHero.tsx

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A