### PR TITLE
feat: XYNE-57204 slack supported ephemeral msg

### DIFF
--- a/apps/backend/src/apps/controllers/chatController.ts
+++ b/apps/backend/src/apps/controllers/chatController.ts
@@ -373,7 +373,7 @@ export class ChatController {
       if (!bodyResult.success) {
         res.status(400).json({
           error: `Validation error`,
-          code: 'VALIDATION_ERROR',
+          code: 'VALIDATION__ERROR',
           details: bodyResult.error.errors,
         });
         return;

--- a/apps/backend/src/apps/controllers/chatController.ts
+++ b/apps/backend/src/apps/controllers/chatController.ts
@@ -231,6 +231,24 @@ export class ChatController {
   }
 
   /**
+   * Content for a non-flow message: markdown is stored as-is after sanitizing, plain
+   * text goes through attachment and mention processing. Shared by postMessage and
+   * postEphemeral so the two routes can't drift apart.
+   */
+  private async buildTextContent(
+    fields: Pick<
+      z.infer<typeof PostMessageFieldsSchema>,
+      'text' | 'markdownText' | 'contentFormat' | 'attachments'
+    >,
+    workspaceId: string | undefined,
+  ): Promise<string> {
+    const { text, markdownText, contentFormat, attachments } = fields;
+    if (markdownText) return sanitizeMessageContent(markdownText);
+    if (contentFormat === ContentFormat.MARKDOWN) return sanitizeMessageContent(text || '');
+    return await this.processMessageContent(text, attachments, workspaceId);
+  }
+
+  /**
    * Post a message to a channel or conversation
    * POST /api/external-event/chat/postMessage
    *
@@ -301,12 +319,11 @@ export class ChatController {
         }
         content = built.content;
         isMarkdown = false;
-      } else if (markdownText) {
-        content = sanitizeMessageContent(markdownText);
-      } else if (contentFormat === ContentFormat.MARKDOWN) {
-        content = sanitizeMessageContent(text || '');
       } else {
-          content = await this.processMessageContent(text, attachments, req.user?.workspaceId);
+        content = await this.buildTextContent(
+          { text, markdownText, contentFormat, attachments },
+          req.user?.workspaceId,
+        );
       }
 
       // Messages posted via the internal /api/internal/postAsUser route are authored
@@ -365,6 +382,10 @@ export class ChatController {
    *
    * The message vanishes on reload. A `flow` stays interactive for 30 minutes via
    * ephemeralFlowStore, which is what lets executeAction resolve the owning app.
+   *
+   * Delivery is best-effort and is NOT guaranteed by the 201. Nothing is persisted, so
+   * a recipient with no live socket never receives it and there is nothing to catch up
+   * on when they reconnect. The response reports `delivery: 'best-effort'` to say so.
    */
   postEphemeral = async (req: Request, res: Response): Promise<void> => {
     try {
@@ -373,7 +394,7 @@ export class ChatController {
       if (!bodyResult.success) {
         res.status(400).json({
           error: `Validation error`,
-          code: 'VALIDATION__ERROR',
+          code: 'VALIDATION_ERROR',
           details: bodyResult.error.errors,
         });
         return;
@@ -417,7 +438,9 @@ export class ChatController {
       let isMarkdown = !!markdownText || contentFormat === ContentFormat.MARKDOWN;
 
       if (flow) {
-        const built = this.buildFlowContent(flow, (req as any).auth?.appId);
+        // Verified token appId for app callers; the S2S postAsUser route may pass it in the body.
+        const appId = (req as any).auth?.appId ?? (req.body as Record<string, unknown>).appId;
+        const built = this.buildFlowContent(flow, appId);
         if (!built.ok) {
           res.status(400).json({
             error: built.error,
@@ -428,12 +451,11 @@ export class ChatController {
         }
         content = built.content;
         isMarkdown = false;
-      } else if (markdownText) {
-        content = sanitizeMessageContent(markdownText);
-      } else if (contentFormat === ContentFormat.MARKDOWN) {
-        content = sanitizeMessageContent(text || '');
       } else {
-        content = await this.processMessageContent(text, attachments, req.user?.workspaceId);
+        content = await this.buildTextContent(
+          { text, markdownText, contentFormat, attachments },
+          req.user?.workspaceId,
+        );
       }
 
       const messageId = crypto.randomUUID();
@@ -471,6 +493,8 @@ export class ChatController {
         conversationId: conversationId ?? null,
         visibleTo: targetUser.id,
         ephemeral: true,
+        // Broadcast, not delivered: an offline recipient silently misses it.
+        delivery: 'best-effort',
       });
     } catch (error) {
       logger.error('Error posting ephemeral message:', error);

--- a/apps/backend/src/apps/controllers/chatController.ts
+++ b/apps/backend/src/apps/controllers/chatController.ts
@@ -14,6 +14,7 @@ import { ContentFormat } from '../types';
 import { updateAppActionStatus } from '@/utils/appActionMarkdownUtils';
 import { sanitizeMessageContent, isAlphanumericId, encodeHtmlAttr } from '@/utils/contentUtils';
 import { redisService } from '@/services/redisService';
+import { storeEphemeralFlow } from '../utils/ephemeralFlowStore';
 import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
 
 const ChatActionBodySchema = z.object({
@@ -35,7 +36,7 @@ const ChatActionBodySchema = z.object({
   contentFormat: z.nativeEnum(ContentFormat).optional(),
 });
 
-const PostMessageBodySchema = ChatActionBodySchema.extend({
+const PostMessageFieldsSchema = ChatActionBodySchema.extend({
   channelId: z.string().min(1, 'Channel ID is required').trim().optional(),
   channelName: z.string().min(1, 'Channel name is required').trim().optional(),
   conversationId: z.string().trim().optional(),
@@ -56,13 +57,26 @@ const PostMessageBodySchema = ChatActionBodySchema.extend({
       loadingComponentIds: z.array(z.string()).optional(),
     }),
   }).optional(),
-}).refine(
-  data => !!data.text || !!data.markdownText || !!data.flow || (data.attachments && data.attachments.length > 0),
-  { message: 'Either text, markdownText, flow, or attachments is required', path: ['text'] }
-).refine(
-  data => !!data.channelId || !!data.channelName || !!data.conversationId,
-  { message: 'Either channelId, channelName, or conversationId is required', path: ['channelId'] }
-);
+});
+
+const hasContent = (data: z.infer<typeof PostMessageFieldsSchema>): boolean =>
+  !!data.text || !!data.markdownText || !!data.flow || !!data.attachments?.length;
+
+const hasTarget = (data: z.infer<typeof PostMessageFieldsSchema>): boolean =>
+  !!data.channelId || !!data.channelName || !!data.conversationId;
+
+const CONTENT_ERR = 'Either text, markdownText, flow, or attachments is required';
+const TARGET_ERR = 'Either channelId, channelName, or conversationId is required';
+
+const PostMessageBodySchema = PostMessageFieldsSchema
+  .refine(hasContent, { message: CONTENT_ERR, path: ['text'] })
+  .refine(hasTarget, { message: TARGET_ERR, path: ['channelId'] });
+
+/** postMessage's body plus `user` — the single recipient. Mirrors Slack's chat.postEphemeral. */
+const PostEphemeralBodySchema = PostMessageFieldsSchema
+  .extend({ user: z.string().min(1, 'user is required').trim() })
+  .refine(hasContent, { message: CONTENT_ERR, path: ['text'] })
+  .refine(hasTarget, { message: TARGET_ERR, path: ['channelId'] });
 
 const UpdateMessageBodySchema = ChatActionBodySchema.extend({
   messageId: z.string().min(1, 'Message ID is required').trim(),
@@ -175,6 +189,48 @@ export class ChatController {
 
 
   /**
+   * Build the stored content for a v2 flow definition.
+   *
+   * `data-flow-appid` is what FlowController.executeAction reads back to route an
+   * action to the owning app, so every flow message must carry it.
+   */
+  private buildFlowContent(
+    flow: NonNullable<z.infer<typeof PostMessageFieldsSchema>['flow']>,
+    appId: unknown,
+  ):
+    | { ok: true; content: string }
+    | { ok: false; error: string; details?: string[] } {
+    if (appId !== undefined && !isAlphanumericId(appId)) {
+      return { ok: false, error: 'Invalid appId' };
+    }
+
+    const flowId = crypto.randomUUID();
+    const flowResult = validateFlowDefinition({
+      version: '2.0' as const,
+      screenId: flow.screenId ?? flowId,
+      title: flow.title,
+      components: flow.components ?? [],
+      data: flow.data,
+      state: { ...flow.state, loadingComponentIds: flow.state.loadingComponentIds ?? [] },
+    });
+    if (!flowResult.success) {
+      return { ok: false, error: 'Invalid flowJSON', details: formatValidationErrors(flowResult) };
+    }
+
+    const escapedJSON = JSON.stringify(flowResult.data).replace(/"/g, '&quot;');
+    // Inner text = notification/preview fallback (shown when the widget isn't rendered).
+    const fbRaw = (flowResult.data.data as Record<string, unknown> | undefined)?.['fallbackText'];
+    const flowFallback = encodeHtmlAttr(
+      (typeof fbRaw === 'string' && fbRaw.trim() ? fbRaw : flowResult.data.title) || 'Flow JSON',
+    );
+
+    return {
+      ok: true,
+      content: `<div data-flow-json="${escapedJSON}" data-flow-appid="${encodeHtmlAttr(appId)}" data-flow-id="${encodeHtmlAttr(flowId)}">${flowFallback}</div>`,
+    };
+  }
+
+  /**
    * Post a message to a channel or conversation
    * POST /api/external-event/chat/postMessage
    *
@@ -232,45 +288,18 @@ export class ChatController {
       let isMarkdown = !!markdownText || contentFormat === ContentFormat.MARKDOWN;
 
       if (flow) {
-        const flowId = crypto.randomUUID();
         // Verified token appId for app callers; the S2S postAsUser route may pass it in the body.
         const appId = (req as any).auth?.appId ?? (req.body as Record<string, unknown>).appId;
-        if (appId !== undefined && !isAlphanumericId(appId)) {
-          res.status(400).json({ error: 'Invalid appId', code: 'VALIDATION_ERROR' });
-          return;
-        }
-        const flowJSON = {
-          version: '2.0' as const,
-          screenId: flow.screenId ?? flowId,
-          title: flow.title,
-          components: flow.components ?? [],
-          data: flow.data,
-          state: {
-            ...flow.state,
-            loadingComponentIds: flow.state.loadingComponentIds ?? [],
-          },
-        };
-
-        // Validate against the strict schema before storing
-        const flowResult = validateFlowDefinition(flowJSON);
-        if (!flowResult.success) {
+        const built = this.buildFlowContent(flow, appId);
+        if (!built.ok) {
           res.status(400).json({
-            error: 'Invalid flowJSON',
+            error: built.error,
             code: 'VALIDATION_ERROR',
-            details: formatValidationErrors(flowResult),
+            ...(built.details && { details: built.details }),
           });
           return;
         }
-
-        const escapedJSON = JSON.stringify(flowResult.data).replace(/"/g, '&quot;');
-        // Inner text = notification/preview fallback (shown when the widget
-        // isn't rendered). Prefer flow.data.fallbackText, then the flow title,
-        // else a generic label — never worse than the old hardcoded "Flow JSON".
-        const fbRaw = (flowResult.data.data as Record<string, unknown> | undefined)?.['fallbackText'];
-        const flowFallback = encodeHtmlAttr(
-          (typeof fbRaw === 'string' && fbRaw.trim() ? fbRaw : flowResult.data.title) || 'Flow JSON',
-        );
-        content = `<div data-flow-json="${escapedJSON}" data-flow-appid="${encodeHtmlAttr(appId)}" data-flow-id="${encodeHtmlAttr(flowId)}">${flowFallback}</div>`;
+        content = built.content;
         isMarkdown = false;
       } else if (markdownText) {
         content = sanitizeMessageContent(markdownText);
@@ -320,6 +349,135 @@ export class ChatController {
           });
           return;
         }
+      }
+
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  /**
+   * Post an ephemeral message — relayed over Redis pub/sub to a single user and
+   * never written to the messages table.
+   * POST /api/apps/chat/postEphemeral
+   *
+   * Same body as postMessage plus:
+   * - user: string - recipient's Xyne user id
+   *
+   * The message vanishes on reload. A `flow` stays interactive for 30 minutes via
+   * ephemeralFlowStore, which is what lets executeAction resolve the owning app.
+   */
+  postEphemeral = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const bodyResult = PostEphemeralBodySchema.safeParse(req.body);
+
+      if (!bodyResult.success) {
+        res.status(400).json({
+          error: `Validation error`,
+          code: 'VALIDATION_ERROR',
+          details: bodyResult.error.errors,
+        });
+        return;
+      }
+
+      const {
+        channelId, channelName, conversationId, user,
+        text, markdownText, flow, attachments, metadata, contentFormat,
+      } = bodyResult.data;
+
+      const sender = req.user;
+      if (!sender) {
+        res.status(400).json({ error: 'userId is required', code: 'VALIDATION_ERROR' });
+        return;
+      }
+
+      const targetUser = await repositories.users.findById(user);
+      if (!targetUser) {
+        res.status(404).json({ error: `User not found: ${user}`, code: 'NOT_FOUND' });
+        return;
+      }
+
+      const resolvedChannelId = await resolveChannelId(channelId, conversationId, channelName);
+
+      // The bot's own access was checked by validateChannelAccessForPost; the
+      // recipient needs checking too, or an app could push a message into a
+      // channel the recipient has no part in.
+      const isParticipant = await repositories.channelParticipants.isParticipant(
+        resolvedChannelId,
+        targetUser.id,
+      );
+      if (!isParticipant) {
+        res.status(403).json({
+          error: 'Recipient is not a participant of this channel',
+          code: 'USER_NOT_IN_CHANNEL',
+        });
+        return;
+      }
+
+      let content: string;
+      let isMarkdown = !!markdownText || contentFormat === ContentFormat.MARKDOWN;
+
+      if (flow) {
+        const built = this.buildFlowContent(flow, (req as any).auth?.appId);
+        if (!built.ok) {
+          res.status(400).json({
+            error: built.error,
+            code: 'VALIDATION_ERROR',
+            ...(built.details && { details: built.details }),
+          });
+          return;
+        }
+        content = built.content;
+        isMarkdown = false;
+      } else if (markdownText) {
+        content = sanitizeMessageContent(markdownText);
+      } else if (contentFormat === ContentFormat.MARKDOWN) {
+        content = sanitizeMessageContent(text || '');
+      } else {
+        content = await this.processMessageContent(text, attachments, req.user?.workspaceId);
+      }
+
+      const messageId = crypto.randomUUID();
+      if (flow) {
+        await storeEphemeralFlow(messageId, { content, visibleTo: targetUser.id });
+      }
+
+      // Addressed to one user, so route by user room rather than channel session:
+      // a session broadcast only reaches sockets that have that channel open, and
+      // silently drops otherwise. User rooms are joined at connect time.
+      await redisService.broadcastUserEvent(targetUser.id, {
+        type: 'ephemeral_message',
+        userId: targetUser.id,
+        data: {
+          channelId: resolvedChannelId,
+          message: {
+            messageId,
+            conversationId: conversationId ?? resolvedChannelId,
+            senderId: sender.id,
+            senderName: sender.name,
+            content,
+            msgType: MessageType.BOT,
+            createdAt: new Date(),
+            metadata: { ...(isMarkdown && { contentFormat: ContentFormat.MARKDOWN }), ...metadata },
+            visibleTo: targetUser.id,
+            ephemeral: true,
+          },
+        },
+        timestamp: new Date(),
+      });
+
+      res.status(201).json({
+        messageId,
+        channelId: resolvedChannelId,
+        conversationId: conversationId ?? null,
+        visibleTo: targetUser.id,
+        ephemeral: true,
+      });
+    } catch (error) {
+      logger.error('Error posting ephemeral message:', error);
+
+      if (error instanceof Error && error.message.includes('not found')) {
+        res.status(404).json({ error: error.message, code: 'NOT_FOUND' });
+        return;
       }
 
       res.status(500).json({ error: 'Internal server error' });

--- a/apps/backend/src/apps/controllers/flowController.ts
+++ b/apps/backend/src/apps/controllers/flowController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { repositories } from '@/database/repositories';
+import { getEphemeralFlow } from '../utils/ephemeralFlowStore';
 import { SsrfBlockedError } from '@/utils/ssrfGuard';
 import { signWebhookPayload } from '@/apps/core/eventSubscriptionUtils';
 import { prepareAppWebhookDispatch } from '@/apps/core/appUrlResolver';
@@ -62,14 +63,25 @@ export class FlowController {
     }
 
     try {
-      // 3. Look up the message to get the appId (stored in <xyne-flow> content tag)
+      // 3. Look up the message to get the appId (stored in <xyne-flow> content tag).
+      // Ephemeral messages are never persisted, so fall back to the store written
+      // at post time — which also names the one user allowed to act on them.
       const message = await repositories.messages.findById(messageId);
-      if (!message) {
-        res.status(404).json({ error: `Message not found: ${messageId}` });
-        return;
+      let content = message?.content;
+      if (!content) {
+        const ephemeral = await getEphemeralFlow(messageId);
+        if (!ephemeral) {
+          res.status(404).json({ error: `Message not found: ${messageId}` });
+          return;
+        }
+        if (ephemeral.visibleTo !== userId) {
+          res.status(403).json({ error: 'Not permitted to act on this message' });
+          return;
+        }
+        content = ephemeral.content;
       }
 
-      const appId = parseAppIdFromContent(message.content);
+      const appId = parseAppIdFromContent(content);
       if (!appId) {
         res.status(400).json({ error: 'Message is not a flow UI message or missing appId' });
         return;

--- a/apps/backend/src/apps/controllers/flowController.ts
+++ b/apps/backend/src/apps/controllers/flowController.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { repositories } from '@/database/repositories';
-import { getEphemeralFlow } from '../utils/ephemeralFlowStore';
+import { getEphemeralFlow, deleteEphemeralFlow } from '../utils/ephemeralFlowStore';
+import { redisService } from '@/services/redisService';
 import { SsrfBlockedError } from '@/utils/ssrfGuard';
 import { signWebhookPayload } from '@/apps/core/eventSubscriptionUtils';
 import { prepareAppWebhookDispatch } from '@/apps/core/appUrlResolver';
@@ -68,6 +69,9 @@ export class FlowController {
       // at post time — which also names the one user allowed to act on them.
       const message = await repositories.messages.findById(messageId);
       let content = message?.content;
+      // Non-null only for ephemerals — it doubles as the "this was never persisted" flag
+      // and as the one user the card was delivered to.
+      let ephemeralVisibleTo: string | null = null;
       if (!content) {
         const ephemeral = await getEphemeralFlow(messageId);
         if (!ephemeral) {
@@ -79,6 +83,7 @@ export class FlowController {
           return;
         }
         content = ephemeral.content;
+        ephemeralVisibleTo = ephemeral.visibleTo;
       }
 
       const appId = parseAppIdFromContent(content);
@@ -209,6 +214,32 @@ export class FlowController {
             details: formatValidationErrors(screenResult),
           });
           return;
+        }
+      }
+
+      // Ephemerals are one-shot: once the app says the interaction is over, take the card
+      // away on every device this user has open and drop the authorization record, so the
+      // Submit button can't be pressed a second time inside the 30-minute TTL.
+      // Screen-advancing replies keep the card — the flow is still running — and so does
+      // `error`, so the user can retry. inputChange never dismisses: it fires on every
+      // keystroke of a cascading form.
+      if (
+        ephemeralVisibleTo &&
+        type === 'submit' &&
+        (appData.type === 'close_screen' || appData.type === 'ack')
+      ) {
+        try {
+          await deleteEphemeralFlow(messageId);
+          await redisService.broadcastUserEvent(ephemeralVisibleTo, {
+            type: 'ephemeral_dismissed',
+            userId: ephemeralVisibleTo,
+            data: { messageId },
+            timestamp: new Date(),
+          });
+        } catch (dismissError) {
+          // The action itself succeeded — a Redis hiccup must not turn that into a 500.
+          // Worst case the card lingers until reload, exactly as it did before.
+          logger.error('[FLOW-ACTION] Failed to dismiss ephemeral', { messageId, error: dismissError });
         }
       }
 

--- a/apps/backend/src/apps/platform-adapters/slack/controller.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/controller.ts
@@ -47,6 +47,7 @@ import {
 	transformUsersLookupByEmail,
 } from "./request-transformers/users";
 import {
+	transformPostEphemeralResponse,
 	transformPostMessageResponse,
 	transformUpdateResponse,
 } from "./response-transformers/chat";
@@ -133,6 +134,26 @@ const PostMessageSchema = z
 		mrkdwn: SlackBooleanSchema.default(true),
 		metadata: SlackRecordSchema,
 		username: SlackOptionalStringSchema,
+	})
+	.refine(
+		(data) =>
+			!!data.text ||
+			(data.blocks && data.blocks.length > 0) ||
+			(data.attachments && data.attachments.length > 0),
+		{
+			message: "Either text, blocks, or attachments is required",
+			path: ["text"],
+		},
+	);
+const PostEphemeralSchema = z
+	.object({
+		channel: z.string().min(1, "channel is required"),
+		user: z.string().min(1, "user is required"),
+		text: z.string().optional(),
+		blocks: SlackArraySchema,
+		attachments: SlackArraySchema,
+		thread_ts: SlackOptionalStringSchema,
+		as_user: SlackBooleanSchema,
 	})
 	.refine(
 		(data) =>
@@ -408,6 +429,63 @@ export class SlackController {
 			})();
 		}
 	});
+
+	chatPostEphemeral = wrapSlackHandler(async (req: Request, res: Response) => {
+		const parsed = PostEphemeralSchema.safeParse(req.body);
+		if (!parsed.success) {
+			res.status(200).json({ ok: false, error: "invalid_arguments" });
+			return;
+		}
+
+		const context = getSlackAuthContext(req);
+		const channelId = getResolvedChannelId(req);
+		const targetUserId = parsed.data.user;
+		const targetUser =
+			(await repositories.users.findById(targetUserId)) ??
+			(await repositories.users.findByMetadataField("slackId", targetUserId));
+		if (!targetUser) {
+			res.status(200).json({ ok: false, error: "user_not_found" });
+			return;
+		}
+
+		const args = await transformPostMessage(
+			{ ...parsed.data, channel: channelId },
+			context,
+		);
+		if (args.content.length > XYNE_MESSAGE_CONTENT_MAX_LENGTH) {
+			res.status(200).json({ ok: false, error: "msg_too_long" });
+			return;
+		}
+
+		const messageId = uuidv4();
+
+		// Same transport as the native chat.postEphemeral: user rooms are joined at
+		// connect time, so delivery no longer depends on the recipient having this
+		// channel open.
+		await redisService.broadcastUserEvent(targetUser.id, {
+			type: "ephemeral_message",
+			userId: targetUser.id,
+			data: {
+				channelId,
+				message: {
+					messageId,
+					conversationId: args.conversationId ?? channelId,
+					senderId: context.userId,
+					senderName: parsed.data.as_user ? "" : context.appId,
+					content: args.content,
+					msgType: MessageType.BOT,
+					createdAt: new Date(),
+					visibleTo: targetUser.id,
+					ephemeral: true,
+				},
+			},
+			timestamp: new Date(),
+		});
+
+		const slackResponse = transformPostEphemeralResponse(messageId, channelId);
+		res.status(200).json(slackResponse);
+	});
+
 
 	chatUpdate = wrapSlackHandler(async (req: Request, res: Response) => {
 		const parsed = UpdateSchema.safeParse(req.body);

--- a/apps/backend/src/apps/platform-adapters/slack/controller.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/controller.ts
@@ -442,9 +442,26 @@ export class SlackController {
 		const targetUserId = parsed.data.user;
 		const targetUser =
 			(await repositories.users.findById(targetUserId)) ??
-			(await repositories.users.findByMetadataField("slackId", targetUserId));
+			(await repositories.users.findByMetadataField(
+				"slackId",
+				targetUserId,
+				context.workspaceId,
+			));
 		if (!targetUser) {
-			res.status(200).json({ ok: false, error: "user_not_found" });
+			res.status(200).json({ ok: false, error: "user_not_in_channel" });
+			return;
+		}
+
+		// slackChannelValidation only covers the bot's own access to the channel. The
+		// recipient needs checking too, the way the native route does at
+		// chatController.postEphemeral — otherwise an app can address a message at
+		// someone with no part in the channel it claims to come from.
+		const isParticipant = await repositories.channelParticipants.isParticipant(
+			channelId,
+			targetUser.id,
+		);
+		if (!isParticipant) {
+			res.status(200).json({ ok: false, error: "user_not_in_channel" });
 			return;
 		}
 
@@ -482,7 +499,7 @@ export class SlackController {
 			timestamp: new Date(),
 		});
 
-		const slackResponse = transformPostEphemeralResponse(messageId, channelId);
+		const slackResponse = transformPostEphemeralResponse(messageId);
 		res.status(200).json(slackResponse);
 	});
 

--- a/apps/backend/src/apps/platform-adapters/slack/response-transformers/chat.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/response-transformers/chat.ts
@@ -1,5 +1,6 @@
 import type { ChatActionResponse } from "@/apps/types";
 import type {
+	SlackChatPostEphemeralResponse,
 	SlackChatPostMessageResponse,
 	SlackChatUpdateResponse,
 } from "../types";
@@ -23,6 +24,17 @@ export function transformPostMessageResponse(
 			text,
 			...(username ? { username } : {}),
 		},
+	};
+}
+
+export function transformPostEphemeralResponse(
+	messageId: string,
+	channelId: string,
+): SlackChatPostEphemeralResponse {
+	return {
+		ok: true,
+		channel: channelId,
+		message_ts: messageId,
 	};
 }
 

--- a/apps/backend/src/apps/platform-adapters/slack/response-transformers/chat.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/response-transformers/chat.ts
@@ -29,11 +29,9 @@ export function transformPostMessageResponse(
 
 export function transformPostEphemeralResponse(
 	messageId: string,
-	channelId: string,
 ): SlackChatPostEphemeralResponse {
 	return {
 		ok: true,
-		channel: channelId,
 		message_ts: messageId,
 	};
 }

--- a/apps/backend/src/apps/platform-adapters/slack/routes.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/routes.ts
@@ -38,6 +38,13 @@ router.post(
 	controller.chatUpdate,
 );
 
+router.post(
+	"/chat.postEphemeral",
+	requirePermission("chat:write"),
+	slackChannelValidation("body"),
+	controller.chatPostEphemeral,
+);
+
 router.get(
 	"/conversations.history",
 	requirePermission("channels:read"),

--- a/apps/backend/src/apps/platform-adapters/slack/types.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/types.ts
@@ -122,6 +122,11 @@ export interface SlackChatPostMessageResponse {
 	ts: string;
 	message: SlackMessageObject;
 }
+export interface SlackChatPostEphemeralResponse {
+	ok: true;
+	channel: string;
+	message_ts: string;
+}
 
 export interface SlackChatUpdateResponse {
 	ok: true;

--- a/apps/backend/src/apps/platform-adapters/slack/types.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/types.ts
@@ -124,7 +124,6 @@ export interface SlackChatPostMessageResponse {
 }
 export interface SlackChatPostEphemeralResponse {
 	ok: true;
-	channel: string;
 	message_ts: string;
 }
 

--- a/apps/backend/src/apps/routes/chat.ts
+++ b/apps/backend/src/apps/routes/chat.ts
@@ -7,6 +7,7 @@ const router = Router();
 const chatController = new ChatController();
 
 router.post('/postMessage', requirePermission('chat:write'), validateChannelAccessForPost, chatController.postMessage);
+router.post('/postEphemeral', requirePermission('chat:write'), validateChannelAccessForPost, chatController.postEphemeral);
 router.post('/updateMessage', requirePermission('chat:write'), validateChannelAccessForPost, chatController.updateMessage);
 router.post('/agentProgress', requirePermission('chat:write'), validateChannelAccessForPost, chatController.agentProgress);
 router.get('/channelHistory', requirePermission('channels:read'), validateChannelAccessForGet, chatController.channelHistory);

--- a/apps/backend/src/apps/utils/ephemeralFlowStore.ts
+++ b/apps/backend/src/apps/utils/ephemeralFlowStore.ts
@@ -1,0 +1,28 @@
+/**
+ * Ephemeral flow messages are broadcast over Redis pub/sub and never written to
+ * the messages table, but FlowController.executeAction resolves the owning appId
+ * by reading the stored message content. This holds just enough to authorize an
+ * action — the rendered content and the one user it was delivered to.
+ */
+import { redisService } from '@/services/redisService';
+
+/** Matches Slack's response_url window for interactive ephemerals. */
+const TTL_SECONDS = 30 * 60;
+
+export interface EphemeralFlow {
+  /** Rendered content, carrying the data-flow-appid that identifies the app. */
+  content: string;
+  /** The only user permitted to dispatch actions for this message. */
+  visibleTo: string;
+}
+
+const key = (messageId: string): string => `ephemeral:flow:${messageId}`;
+
+export async function storeEphemeralFlow(messageId: string, entry: EphemeralFlow): Promise<void> {
+  await redisService.set(key(messageId), JSON.stringify(entry), TTL_SECONDS);
+}
+
+export async function getEphemeralFlow(messageId: string): Promise<EphemeralFlow | null> {
+  const raw = await redisService.get(key(messageId));
+  return raw ? (JSON.parse(raw) as EphemeralFlow) : null;
+}

--- a/apps/backend/src/apps/utils/ephemeralFlowStore.ts
+++ b/apps/backend/src/apps/utils/ephemeralFlowStore.ts
@@ -26,3 +26,11 @@ export async function getEphemeralFlow(messageId: string): Promise<EphemeralFlow
   const raw = await redisService.get(key(messageId));
   return raw ? (JSON.parse(raw) as EphemeralFlow) : null;
 }
+
+/**
+ * Drop the authorization record once the interaction is over, so the Submit button
+ * cannot be pressed a second time inside the TTL window.
+ */
+export async function deleteEphemeralFlow(messageId: string): Promise<void> {
+  await redisService.del(key(messageId));
+}

--- a/apps/backend/src/services/redisService.ts
+++ b/apps/backend/src/services/redisService.ts
@@ -23,7 +23,7 @@ export interface SessionEvent {
 }
 
 export interface UserEvent {
-  type: 'channel_added' | 'channel_removed' | 'participant_added' | 'participant_removed' | 'user_mentioned' | 'incoming_call' | 'call_ended' | 'call_cancelled' | 'recap_unread_count_updated' | 'recap_generated' | 'recap_cleanup_completed' | 'data_source_ingestion_updated' | 'data_source_ingestion_progress' | 'client_command' | 'ephemeral_message';
+  type: 'channel_added' | 'channel_removed' | 'participant_added' | 'participant_removed' | 'user_mentioned' | 'incoming_call' | 'call_ended' | 'call_cancelled' | 'recap_unread_count_updated' | 'recap_generated' | 'recap_cleanup_completed' | 'data_source_ingestion_updated' | 'data_source_ingestion_progress' | 'client_command' | 'ephemeral_message' | 'ephemeral_dismissed';
   userId: string;
   data: any;
   timestamp: Date;

--- a/apps/backend/src/services/redisService.ts
+++ b/apps/backend/src/services/redisService.ts
@@ -10,6 +10,9 @@ export interface ChatMessage {
   content: string;
   msgType: string;
   createdAt: Date;
+  metadata?: Record<string, unknown>;
+  visibleTo?: string;
+  ephemeral?: boolean;
 }
 
 export interface SessionEvent {
@@ -20,7 +23,7 @@ export interface SessionEvent {
 }
 
 export interface UserEvent {
-  type: 'channel_added' | 'channel_removed' | 'participant_added' | 'participant_removed' | 'user_mentioned' | 'incoming_call' | 'call_ended' | 'call_cancelled' | 'recap_unread_count_updated' | 'recap_generated' | 'recap_cleanup_completed' | 'data_source_ingestion_updated' | 'data_source_ingestion_progress' | 'client_command';
+  type: 'channel_added' | 'channel_removed' | 'participant_added' | 'participant_removed' | 'user_mentioned' | 'incoming_call' | 'call_ended' | 'call_cancelled' | 'recap_unread_count_updated' | 'recap_generated' | 'recap_cleanup_completed' | 'data_source_ingestion_updated' | 'data_source_ingestion_progress' | 'client_command' | 'ephemeral_message';
   userId: string;
   data: any;
   timestamp: Date;

--- a/apps/backend/src/services/websocketService.ts
+++ b/apps/backend/src/services/websocketService.ts
@@ -1346,9 +1346,8 @@ class WebSocketService {
 
         // Send to each subscribed socket
         for (const socketId of subscribedSockets) {
-           if (message.visibleTo) {
+          if (message.visibleTo) {
             const socket = this.io?.sockets.sockets.get(socketId) as AuthenticatedSocket | undefined;
-            logger.info(`[EPHEMERAL-FILTER] socketId=${socketId}, socket.userId=${socket?.userId}, visibleTo=${message.visibleTo}, match=${socket?.userId === message.visibleTo}`);
             if (socket?.userId !== message.visibleTo) continue;
           }
           this.io?.to(socketId).emit('session_activity', {

--- a/apps/backend/src/services/websocketService.ts
+++ b/apps/backend/src/services/websocketService.ts
@@ -1346,6 +1346,11 @@ class WebSocketService {
 
         // Send to each subscribed socket
         for (const socketId of subscribedSockets) {
+           if (message.visibleTo) {
+            const socket = this.io?.sockets.sockets.get(socketId) as AuthenticatedSocket | undefined;
+            logger.info(`[EPHEMERAL-FILTER] socketId=${socketId}, socket.userId=${socket?.userId}, visibleTo=${message.visibleTo}, match=${socket?.userId === message.visibleTo}`);
+            if (socket?.userId !== message.visibleTo) continue;
+          }
           this.io?.to(socketId).emit('session_activity', {
             sessionId,
             message,

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
@@ -416,6 +416,10 @@ const ChatListV4: React.FC<ChatListProps> = ({
     const byAnchor = new Map<number, EphemeralMessage[]>();
     const leading: EphemeralMessage[] = [];
     for (const em of ephemeralMessages ?? []) {
+      // Channel-level ephemerals only. The backend falls back to the channel id when no
+      // thread was targeted, so anything else is addressed to a thread and belongs in
+      // ThreadPannel, not in the main feed.
+      if (em.conversationId !== channelId) continue;
       const t = new Date(em.createdAt).getTime();
       let anchor = -1;
       for (let i = 0; i < combinedMessages.length; i++) {
@@ -431,7 +435,7 @@ const ChatListV4: React.FC<ChatListProps> = ({
       }
     }
     return { ephemeralsByAnchorIndex: byAnchor, leadingEphemerals: leading };
-  }, [ephemeralMessages, combinedMessages]);
+  }, [ephemeralMessages, combinedMessages, channelId]);
 
   const virtualItems = virtualizer.getVirtualItems();
   const isConversationFullyVisible = useCallback(

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
@@ -27,7 +27,9 @@ import { formatDatePill } from '../../../utils/dateUtils';
 import { standaloneNavigate } from '../../../utils/electronApp';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useRouteContext } from '../../../hooks/useRouteContext';
-import { ArrowDown } from 'lucide-react';
+import { ArrowDown, Eye } from 'lucide-react';
+import { RenderMessageWithHTML } from '../RenderMessageWithHTML/RenderMessageWithHTML';
+import type { EphemeralMessage } from '../../../hooks/useEphemeralMessages';
 import { mutators } from '../../../zero/mutators';
 import { queryCacheActor, flushQueryCachePersistence } from '../../../machines/queryCacheMachine';
 import { browserPanelActor } from '../../../machines/browserPanelMachine';
@@ -48,11 +50,32 @@ export type ChatListProps = {
   linkedConversationId?: string | null;
   channelScopeType?: ChannelScopeType | undefined;
   skipMarkAsReadRef: React.RefObject<boolean>;
+  ephemeralMessages?: EphemeralMessage[];
 };
 
 type Anchor = {
   createdAt: number;
 };
+
+const EphemeralRow: React.FC<{ em: EphemeralMessage }> = ({ em }) => (
+  <div className='pt-4 pb-1'>
+    <div className='group relative px-5 py-1'>
+      <div className='flex items-center gap-2 mb-1'>
+        <Eye className='w-3 h-3 text-muted-foreground' />
+        <span className='text-xs text-muted-foreground'>Only visible to you</span>
+      </div>
+      <div className='jp-message-html whitespace-pre-wrap break-words inline-block'>
+        {/* Both ids are required for flow actions — FlowRenderer refuses to
+            dispatch without them. */}
+        <RenderMessageWithHTML
+          message={em.content}
+          messageId={em.messageId}
+          conversationId={em.conversationId}
+        />
+      </div>
+    </div>
+  </div>
+);
 
 type UpdatedConveresationsAnchor = {
   direction: 'forward' | 'backward';
@@ -201,6 +224,7 @@ const ChatListV4: React.FC<ChatListProps> = ({
   linkedConversationId,
   channelScopeType,
   skipMarkAsReadRef,
+  ephemeralMessages,
 }) => {
   // Save scroll position when unmounting due to /browser fullscreen navigation.
   useEffect(() => {
@@ -387,6 +411,27 @@ const ChatListV4: React.FC<ChatListProps> = ({
     const isLastFewItems = item.index >= instance.options.count - 5;
     return (isNearBottom && isLastFewItems) || virtualizer.scrollDirection === 'backward';
   };
+
+  const { ephemeralsByAnchorIndex, leadingEphemerals } = useMemo(() => {
+    const byAnchor = new Map<number, EphemeralMessage[]>();
+    const leading: EphemeralMessage[] = [];
+    for (const em of ephemeralMessages ?? []) {
+      const t = new Date(em.createdAt).getTime();
+      let anchor = -1;
+      for (let i = 0; i < combinedMessages.length; i++) {
+        if (combinedMessages[i]!.createdAt.getTime() <= t) anchor = i;
+        else break;
+      }
+      if (anchor === -1) {
+        leading.push(em);
+      } else {
+        const arr = byAnchor.get(anchor) ?? [];
+        arr.push(em);
+        byAnchor.set(anchor, arr);
+      }
+    }
+    return { ephemeralsByAnchorIndex: byAnchor, leadingEphemerals: leading };
+  }, [ephemeralMessages, combinedMessages]);
 
   const virtualItems = virtualizer.getVirtualItems();
   const isConversationFullyVisible = useCallback(
@@ -1359,6 +1404,13 @@ const ChatListV4: React.FC<ChatListProps> = ({
             justifyContent: 'flex-end',
           }}
         >
+          {leadingEphemerals.length > 0 && (
+            <div className='flex flex-col'>
+              {leadingEphemerals.map(em => (
+                <EphemeralRow key={em.messageId} em={em} />
+              ))}
+            </div>
+          )}
           <div
             ref={virtualizer.containerRef}
             style={{
@@ -1433,6 +1485,9 @@ const ChatListV4: React.FC<ChatListProps> = ({
                       handleOpenThread={handleOpenThread}
                       linkedConversationId={linkedConversationId ?? null}
                     />
+                    {ephemeralsByAnchorIndex.get(virtualItem.index)?.map(em => (
+                      <EphemeralRow key={em.messageId} em={em} />
+                    ))}
                   </div>
                 </div>
               );

--- a/apps/dashboard/src/components/Chat/ConversationPannel/ConversationPanelV2.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationPannel/ConversationPanelV2.tsx
@@ -34,6 +34,7 @@ import { useUser } from '../../../hooks/useUsers';
 import { useAuthContextValues } from '../../../hooks/useAuth';
 import { isUserDeactivated } from '../../../utils/userDisplayName';
 import { parseDMParticipantIds } from '../ChatDirectory/ChatDirectory.utils';
+import { useEphemeralMessages } from '../../../hooks/useEphemeralMessages';
 
 // Stable empty array — an inline `[]` here would be a new reference on every
 // render, causing useChannelSubscription's effect to unsubscribe/resubscribe
@@ -183,6 +184,8 @@ const ConversationPanelV2 = ({
     skipMarkAsReadRef.current = skip;
   }, []);
 
+  const ephemeralMessages = useEphemeralMessages(channelId);
+
   useChannelSubscription(channelId, NO_CONVERSATION_IDS);
   useScope('channel', !!channelId);
   useShortcutById('global.openCanvasTab', () => {
@@ -260,6 +263,7 @@ const ConversationPanelV2 = ({
                   projectId={channel?.projectId}
                   channelScopeType={channel?.scopeType}
                   skipMarkAsReadRef={skipMarkAsReadRef}
+                  ephemeralMessages={ephemeralMessages}
                 ></ChatListV4>
               )}
               {hideComposer ? null : shouldShowJoinChannel ? (

--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -14,7 +14,7 @@ import { ConversationWithTicket } from '../../ui/MessageBubble/MessageBubble.typ
 import { useEditContext } from '../../../providers/EditProvider';
 import { useShortcutById } from '../../../shortcuts';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
-import { ArrowDown, ArrowUp, ChevronUp } from 'lucide-react';
+import { ArrowDown, ArrowUp, ChevronUp, Eye } from 'lucide-react';
 import { AttachmentRef } from '../../../machines/attachmentViewerMachine';
 import { useThreadReadTracking } from '../../../hooks/useThreadReadTracking';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
@@ -49,6 +49,26 @@ type ThreadListProps = {
     ChatListV4. Applied as padding-bottom on the scroll container, so scroll-to-bottom
     (`scrollHeight - clientHeight`) naturally lands with the last message clear of it. */
 const ACTIVITY_BAR_PADDING = 28;
+
+/**
+ * Messages carrying `visibleTo` are shown to one person only — ephemerals, and the
+ * command responses persisted by commandController. The channel feed labels them
+ * (ChatListV4's EphemeralRow); without this the thread renders them as ordinary
+ * bubbles, and it's easy to reply assuming everyone else saw it.
+ */
+const VisibleOnlyToYouLabel = ({
+  message,
+}: {
+  message: { visibleTo?: string | null };
+}): ReactElement | null => {
+  if (!message.visibleTo) return null;
+  return (
+    <div className='flex items-center gap-2 px-5 pt-2'>
+      <Eye className='w-3 h-3 text-muted-foreground' />
+      <span className='text-xs text-muted-foreground'>Only visible to you</span>
+    </div>
+  );
+};
 
 const ThreadList = ({
   channelId,
@@ -495,6 +515,7 @@ const ThreadList = ({
               return (
                 <div key={threadMessage.messageId}>
                   <div id={`thread-message-${conversationId}-${threadMessage.messageId}`}>
+                    <VisibleOnlyToYouLabel message={threadMessage} />
                     <ChatBubble
                       message={threadMessage}
                       channelId={channelId}
@@ -595,6 +616,7 @@ const ThreadList = ({
                   </div>
                 )}
                 <div id={`thread-message-${conversationId}-${threadMessage.messageId}`}>
+                  <VisibleOnlyToYouLabel message={threadMessage} />
                   <ChatBubble
                     message={threadMessage}
                     channelId={channelId}

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -287,10 +287,20 @@ export const ThreadMessages = ({
   const queryDetails = conversationDetails;
 
   // Use pre-fetched messages if provided, otherwise use queried
-  const dbMessages = propThreadMessages ?? queriedMessages ?? [];
+  const dbMessages = useMemo(
+    () => propThreadMessages ?? queriedMessages ?? [],
+    [propThreadMessages, queriedMessages],
+  );
   const messagesDetails = propThreadMessages ? { type: 'complete' as const } : queryDetails;
-  // Ephemeral messages: WebSocket-only, not persisted, visible only to current user
-  const ephemeralMessages = useEphemeralMessages(derivedChannelId);
+  // Ephemeral messages: WebSocket-only, not persisted, visible only to current user.
+  // The hook is channel-scoped, so narrow to this thread: the backend falls back to the
+  // channel id when an ephemeral targets no particular thread, and those belong in the
+  // channel feed rather than in every thread that happens to be open.
+  const channelEphemerals = useEphemeralMessages(derivedChannelId);
+  const ephemeralMessages = useMemo(
+    () => channelEphemerals.filter(em => em.conversationId === derivedConversationId),
+    [channelEphemerals, derivedConversationId],
+  );
   const messages = useMemo(() => {
     if (ephemeralMessages.length === 0) return dbMessages;
     const converted = ephemeralMessages.map(

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -99,6 +99,7 @@ import { ThreadRecordingButton } from '../Call/ThreadRecordingButton/ThreadRecor
 import { sendRecordingEvent, useRecordingStore } from '../../hooks/useRecordingStore';
 import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout';
 import { ConversationTabContext } from './ConversationTabContext';
+import { useEphemeralMessages, type EphemeralMessage } from '../../hooks/useEphemeralMessages';
 
 type TabType = 'thread' | 'details' | 'files' | 'rca';
 type UnderTicketTabType = 'replies' | 'rca';
@@ -286,11 +287,38 @@ export const ThreadMessages = ({
   const queryDetails = conversationDetails;
 
   // Use pre-fetched messages if provided, otherwise use queried
-  const messages = useMemo(
-    () => propThreadMessages ?? queriedMessages ?? [],
-    [propThreadMessages, queriedMessages],
-  );
+  const dbMessages = propThreadMessages ?? queriedMessages ?? [];
   const messagesDetails = propThreadMessages ? { type: 'complete' as const } : queryDetails;
+  // Ephemeral messages: WebSocket-only, not persisted, visible only to current user
+  const ephemeralMessages = useEphemeralMessages(derivedChannelId);
+  const messages = useMemo(() => {
+    if (ephemeralMessages.length === 0) return dbMessages;
+    const converted = ephemeralMessages.map(
+      (em: EphemeralMessage) =>
+        ({
+          messageId: em.messageId,
+          conversationId: em.conversationId,
+          senderId: em.senderId,
+          content: em.content,
+          msgType: em.msgType as MessageType,
+          hasAttachment: em.hasAttachment ?? false,
+          edited: false,
+          isDeleted: false,
+          showInChannel: false,
+          visibleTo: em.visibleTo ?? null,
+          createdAt: new Date(em.createdAt).getTime(),
+          metadata: (em.metadata ?? null) as (typeof dbMessages)[number]['metadata'],
+          nudgeCount: null,
+          isSent: true,
+          reactions_md: null,
+          link_preview_md: null,
+          childConversationId: null,
+          attachments: [] as (typeof dbMessages)[number]['attachments'],
+          nudgeCounts: [] as (typeof dbMessages)[number]['nudgeCounts'],
+        }) as (typeof dbMessages)[number],
+    );
+    return [...dbMessages, ...converted].sort((a, b) => a.createdAt - b.createdAt);
+  }, [dbMessages, ephemeralMessages]);
   const isMessagesLoaded = messagesDetails.type === 'complete' || messagesDetails.type === 'error';
 
   const threadParticipantIds = useMemo(() => {

--- a/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
+++ b/apps/dashboard/src/components/flowUI/FlowRenderer.tsx
@@ -124,7 +124,7 @@ export const FlowRenderer: React.FC<FlowRendererProps> = ({
       if (props?.name) {
         const value = state.values[props.name];
         newTouched[props.name] = true;
-        if (props.required && (value === undefined || value === '' || value === null)) {
+        if (props.required && isEmptyValue(value)) {
           newErrors[props.name] = 'This field is required';
           isValid = false;
         } else if (props.validation) {
@@ -384,6 +384,11 @@ export const FlowRenderer: React.FC<FlowRendererProps> = ({
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+function isEmptyValue(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length === 0;
+  return value === undefined || value === '' || value === null;
+}
+
 function findFieldInComponents(components: FlowComponent[], name: string): FlowComponent | null {
   for (const c of components) {
     const props = c.props as { name?: string } | undefined;
@@ -399,7 +404,7 @@ function findFieldInComponents(components: FlowComponent[], name: string): FlowC
 function validateRule(rule: ValidationRule, value: unknown): string | null {
   switch (rule.type) {
     case 'required':
-      return value === undefined || value === '' || value === null ? rule.message : null;
+      return isEmptyValue(value) ? rule.message : null;
     case 'min':
       return (value as number) < (rule.value as number) ? rule.message : null;
     case 'max':

--- a/apps/dashboard/src/components/flowUI/nodes/SelectNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/SelectNode.tsx
@@ -8,6 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../ui/Select/Select';
+import { MultiSelect, type MultiSelectOption } from '../../ui/MultiSelect';
 import { cn } from '../../../utils/classNames';
 import type { FlowComponent, SelectOption, FlowAction } from '@xyne/shared';
 
@@ -27,6 +28,8 @@ export const SelectNode: React.FC<SelectNodeProps> = ({ node }) => {
         required?: boolean;
         /** Optional action fired when value changes (e.g. inputChange for cascading dropdowns) */
         action?: FlowAction;
+        /** Renders a searchable pill dropdown; the field value becomes string[] */
+        multiple?: boolean;
       }
     | undefined;
 
@@ -48,39 +51,91 @@ export const SelectNode: React.FC<SelectNodeProps> = ({ node }) => {
     return [];
   })();
 
-  const value = (state.values[props.name] as string) || '';
   const error = state.errors[props.name];
   const isTouched = state.touched[props.name];
   const isLoading = state.loadingComponentIds.includes(node.id);
+
+  // Shared by both modes. updateFieldValue syncs stateRef synchronously, and
+  // executeAction reads that ref when the timer fires, so the new value does not
+  // need threading through here.
+  const scheduleInputChange = (): void => {
+    const action = props.action;
+    if (action?.type !== 'inputChange') return;
+    const ms = action.debounceMs ?? 0;
+    logger.info(LogEvent.INFO, {
+      type: 'migrated_console_log',
+      message: String(
+        `[SelectNode] scheduling inputChange  actionId=${action.actionId}  debounceMs=${ms}`,
+      ),
+    });
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      logger.info(LogEvent.INFO, {
+        type: 'migrated_console_log',
+        message: String(`[SelectNode] firing inputChange  actionId=${action.actionId}`),
+      });
+      void executeAction(action);
+    }, ms);
+  };
+
+  // ── Multi-select mode ──────────────────────────────────────────────────────
+  // Radix Select has no multiple mode, so this path uses the MultiSelect popover
+  // (search + removable pills) instead. No hooks here — both branches must run the
+  // same ones, and everything above this point is already unconditional.
+  if (props.multiple === true) {
+    const rawValue = state.values[props.name];
+    const selectedValues: string[] = Array.isArray(rawValue) ? (rawValue as string[]) : [];
+
+    const multiOptions: MultiSelectOption[] = resolvedOptions.map(opt => ({
+      value: opt.value,
+      label: opt.label,
+      ...(opt.description ? { subtitle: opt.description } : {}),
+      ...(opt.disabled ? { isDeactivated: true } : {}),
+    }));
+
+    const handleMultiChange = (values: string[]): void => {
+      // MultiSelect treats isDeactivated as presentational — it greys the row but
+      // still lets it be toggled — so SelectOption.disabled is enforced here.
+      const next = values.filter(v => !resolvedOptions.some(o => o.value === v && o.disabled));
+      logger.info(LogEvent.INFO, {
+        type: 'migrated_console_log',
+        message: String(`[SelectNode] values changed  name=${props.name}  value=${next.join(',')}`),
+      });
+      updateFieldValue(props.name, next);
+      validateField(props.name, next);
+      scheduleInputChange();
+    };
+
+    return (
+      <div className='space-y-1.5' style={node.style}>
+        {props.label && (
+          <label className='text-sm font-medium text-foreground leading-none'>
+            {props.label}
+            {props.required && <span className='text-destructive ml-0.5'>*</span>}
+          </label>
+        )}
+        <MultiSelect
+          options={multiOptions}
+          selectedValues={selectedValues}
+          onChange={handleMultiChange}
+          placeholder={isLoading ? 'Loading…' : props.placeholder || 'Select...'}
+          disabled={state.submitting || isLoading}
+          {...(error && isTouched ? { error } : {})}
+        />
+      </div>
+    );
+  }
+
+  const value = (state.values[props.name] as string) || '';
 
   const handleChange = (val: string) => {
     logger.info(LogEvent.INFO, {
       type: 'migrated_console_log',
       message: String(`[SelectNode] value changed  name=${props.name}  value=${val}`),
     });
-    // updateFieldValue syncs stateRef immediately so the debounced executeAction
-    // reads the correct (freshly selected) values when it fires
     updateFieldValue(props.name, val);
     validateField(props.name, val);
-
-    const action = props.action;
-    if (action?.type === 'inputChange') {
-      const ms = action.debounceMs ?? 0;
-      logger.info(LogEvent.INFO, {
-        type: 'migrated_console_log',
-        message: String(
-          `[SelectNode] scheduling inputChange  actionId=${action.actionId}  debounceMs=${ms}`,
-        ),
-      });
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        logger.info(LogEvent.INFO, {
-          type: 'migrated_console_log',
-          message: String(`[SelectNode] firing inputChange  actionId=${action.actionId}`),
-        });
-        void executeAction(action);
-      }, ms);
-    }
+    scheduleInputChange();
   };
 
   return (

--- a/apps/dashboard/src/hooks/useEphemeralMessages.ts
+++ b/apps/dashboard/src/hooks/useEphemeralMessages.ts
@@ -1,5 +1,7 @@
-import { useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
+import { useSelector } from '@xstate/react';
 import { websocketService } from '../services/clients/socketClient';
+import { authActor } from '../machines/authMachine';
 
 export type EphemeralMessage = {
   messageId: string;
@@ -27,16 +29,29 @@ type EphemeralMessageEvent = {
 const store = new Map<string, EphemeralMessage[]>();
 const listeners = new Set<() => void>();
 const EMPTY: EphemeralMessage[] = [];
-let initialized = false;
+
+/** Who the messages currently held in `store` were delivered to. */
+let currentUserId: string | null = null;
 
 function notify(): void {
   for (const listener of listeners) listener();
+}
+
+function clearStore(): void {
+  if (store.size === 0) return;
+  store.clear();
+  notify();
 }
 
 function handleEphemeralMessage(event: EphemeralMessageEvent): void {
   const message = event.message;
   const channelId = event.channelId;
   if (!message || !channelId) return;
+
+  // The server routes these to the recipient's user room, so this is a second guard:
+  // it keeps another account's message out of the store after a user switch in the
+  // same tab, before `clearStore` has run.
+  if (message.visibleTo && currentUserId && message.visibleTo !== currentUserId) return;
 
   const existing = store.get(channelId) ?? EMPTY;
   if (existing.some(m => m.messageId === message.messageId)) return;
@@ -48,21 +63,6 @@ function handleEphemeralMessage(event: EphemeralMessageEvent): void {
   notify();
 }
 
-// Register the websocket listener exactly once for the lifetime of the page.
-function ensureInitialized(): void {
-  if (initialized) return;
-  initialized = true;
-
-  const start = async (): Promise<void> => {
-    if (!websocketService.isConnectedToServer()) {
-      await websocketService.connect();
-    }
-    websocketService.on('ephemeral_message', handleEphemeralMessage);
-  };
-
-  void start();
-}
-
 function subscribe(callback: () => void): () => void {
   listeners.add(callback);
   return (): void => {
@@ -71,7 +71,42 @@ function subscribe(callback: () => void): () => void {
 }
 
 export function useEphemeralMessages(channelId: string | undefined): EphemeralMessage[] {
-  ensureInitialized();
+  // Selected narrowly rather than via useAuth(), which subscribes to the whole auth
+  // state — this hook runs inside ConversationPanelV2 and ThreadPannel.
+  const userId = useSelector(authActor, state => state.context.user?.id ?? null);
+
+  // A different account in the same tab must not inherit the previous one's messages.
+  useEffect(() => {
+    if (currentUserId === userId) return;
+    currentUserId = userId;
+    clearStore();
+  }, [userId]);
+
+  // Registered per mount, not once per page: `connect()` calls removeAllListeners() and
+  // builds a new Socket (socketClient.ts), so a listener attached once is silently lost
+  // the first time anything reconnects. Same shape as DynamicDashboardPanel.
+  useEffect(() => {
+    let active = true;
+
+    // A fresh socket means a fresh session — anything held is unreplayable, and may
+    // belong to a login that has since been replaced.
+    const handleConnect = (): void => clearStore();
+
+    void websocketService
+      .connect()
+      .then(() => {
+        if (!active) return;
+        websocketService.on('ephemeral_message', handleEphemeralMessage);
+        websocketService.on('connect', handleConnect);
+      })
+      .catch(() => {});
+
+    return (): void => {
+      active = false;
+      websocketService.removeListener('ephemeral_message', handleEphemeralMessage);
+      websocketService.removeListener('connect', handleConnect);
+    };
+  }, []);
 
   return useSyncExternalStore(subscribe, () =>
     channelId ? (store.get(channelId) ?? EMPTY) : EMPTY,

--- a/apps/dashboard/src/hooks/useEphemeralMessages.ts
+++ b/apps/dashboard/src/hooks/useEphemeralMessages.ts
@@ -43,6 +43,27 @@ function clearStore(): void {
   notify();
 }
 
+/**
+ * Drop one message wherever it is held. The dismissal event carries only a messageId —
+ * the server keys the broadcast by the resolved channel id but writes
+ * `conversationId ?? resolvedChannelId` into the message, so the two can differ and the
+ * channel is not a reliable lookup key. The map holds a handful of entries; scan it.
+ */
+function removeMessage(messageId: string): void {
+  for (const [channelId, list] of store) {
+    const next = list.filter(m => m.messageId !== messageId);
+    if (next.length === list.length) continue;
+    if (next.length === 0) store.delete(channelId);
+    else store.set(channelId, next);
+    notify();
+    return;
+  }
+}
+
+function handleEphemeralDismissed(event: { messageId?: string }): void {
+  if (event.messageId) removeMessage(event.messageId);
+}
+
 function handleEphemeralMessage(event: EphemeralMessageEvent): void {
   const message = event.message;
   const channelId = event.channelId;
@@ -97,6 +118,7 @@ export function useEphemeralMessages(channelId: string | undefined): EphemeralMe
       .then(() => {
         if (!active) return;
         websocketService.on('ephemeral_message', handleEphemeralMessage);
+        websocketService.on('ephemeral_dismissed', handleEphemeralDismissed);
         websocketService.on('connect', handleConnect);
       })
       .catch(() => {});
@@ -104,6 +126,7 @@ export function useEphemeralMessages(channelId: string | undefined): EphemeralMe
     return (): void => {
       active = false;
       websocketService.removeListener('ephemeral_message', handleEphemeralMessage);
+      websocketService.removeListener('ephemeral_dismissed', handleEphemeralDismissed);
       websocketService.removeListener('connect', handleConnect);
     };
   }, []);

--- a/apps/dashboard/src/hooks/useEphemeralMessages.ts
+++ b/apps/dashboard/src/hooks/useEphemeralMessages.ts
@@ -1,0 +1,79 @@
+import { useSyncExternalStore } from 'react';
+import { websocketService } from '../services/clients/socketClient';
+
+export type EphemeralMessage = {
+  messageId: string;
+  conversationId: string;
+  channelId?: string;
+  senderId: string;
+  senderName?: string;
+  senderPicture?: string | null;
+  content: string;
+  msgType: string;
+  createdAt: Date | number | string;
+  hasAttachment?: boolean;
+  attachments?: unknown[];
+  metadata?: Record<string, unknown>;
+  visibleTo?: string | null;
+  ephemeral?: boolean;
+};
+
+/** Payload of the `ephemeral_message` user event (handleUserEvent spreads event.data). */
+type EphemeralMessageEvent = {
+  channelId?: string;
+  message?: EphemeralMessage;
+};
+
+const store = new Map<string, EphemeralMessage[]>();
+const listeners = new Set<() => void>();
+const EMPTY: EphemeralMessage[] = [];
+let initialized = false;
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+function handleEphemeralMessage(event: EphemeralMessageEvent): void {
+  const message = event.message;
+  const channelId = event.channelId;
+  if (!message || !channelId) return;
+
+  const existing = store.get(channelId) ?? EMPTY;
+  if (existing.some(m => m.messageId === message.messageId)) return;
+
+  const next = [...existing, message].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  );
+  store.set(channelId, next);
+  notify();
+}
+
+// Register the websocket listener exactly once for the lifetime of the page.
+function ensureInitialized(): void {
+  if (initialized) return;
+  initialized = true;
+
+  const start = async (): Promise<void> => {
+    if (!websocketService.isConnectedToServer()) {
+      await websocketService.connect();
+    }
+    websocketService.on('ephemeral_message', handleEphemeralMessage);
+  };
+
+  void start();
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  return (): void => {
+    listeners.delete(callback);
+  };
+}
+
+export function useEphemeralMessages(channelId: string | undefined): EphemeralMessage[] {
+  ensureInitialized();
+
+  return useSyncExternalStore(subscribe, () =>
+    channelId ? (store.get(channelId) ?? EMPTY) : EMPTY,
+  );
+}

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -159,6 +159,10 @@ export const dropdownComponentSchema = baseComponentSchema.extend({
     options: selectOptionsField,
     required: z.boolean().optional(),
     action: flowActionSchema.optional(),
+    // Renders a searchable pill dropdown instead of the single-value Select, and
+    // changes the submitted value for this field from `string` to `string[]`.
+    // `multiselect` stays the checkbox-group variant.
+    multiple: z.boolean().optional(),
   }).strict(),
 });
 


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
