### PR TITLE
fix: enable xlsx reads for kb files

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
@@ -20,6 +20,7 @@ import { fetchAccessibleKb, indexKbTree, type KbCollectionNode } from "../lib/sp
 import { spacesFetchBuffer, search as spacesVespaSearch } from "./servers/xyne-spaces-client.js";
 import { getSpacesAuthForUser } from "../lib/spaces-db.js";
 import { createLogger } from "../logger.js";
+import { extractXlsxText, isXlsxFile } from "./kb-xlsx.js";
 
 /**
  * Debug sidecar — the YQL spaces actually emitted to Vespa for this call.
@@ -38,6 +39,7 @@ export interface VespaDebugBlock {
 }
 
 const log = createLogger("kb-handlers");
+
 
 export interface KbHandlerResult {
   content: string;
@@ -252,7 +254,7 @@ async function resolveKbContext(
     // retained in the DB by agents.ts (so flipping back to COLLECTIONS
     // restores the picker's previous selection) but dropped from the
     // runtime context. The accessibility layer is the only gate in USER mode.
-    grants: scope === "USER" ? [] : agent.collections.map(c => ({ collectionId: c.collectionId, fileId: c.fileId })),
+    grants: scope === "USER" ? [] : agent.collections.map((c: { collectionId: string; fileId: string | null }) => ({ collectionId: c.collectionId, fileId: c.fileId })),
     accessibleTree: tree,
     accessibleCollectionIds: collections,
     accessibleFileIds: files,
@@ -1008,6 +1010,12 @@ export async function handleKbReadFile(args: {
     const citeToken = `[clf-__TOOL_CALL_ID__#0]`;
 
     if (isLikelyBinary) {
+      if (isXlsxFile(contentType, fileMeta.name)) {
+        const body = await extractXlsxText(buffer, fileMeta.name);
+        const header = `## ${fileMeta.name} ${citeToken}\n\n_collection: ${fileMeta.collectionName}_\n\n---\n\n`;
+        return { content: header + body, citations: [citation] };
+      }
+
       return {
         content:
           `File \`${fileMeta.name}\` ${citeToken} is a binary type (PDF / image / office doc). ` +

--- a/apps/xyne-claw-auth/backend/src/mcp/kb-xlsx-extraction.test.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/kb-xlsx-extraction.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import ExcelJS from "exceljs";
+
+import { extractXlsxText, isXlsxFile } from "./kb-xlsx.js";
+
+describe("KB XLSX extraction", () => {
+  it("detects modern Excel workbooks from content type or filename", () => {
+    expect(isXlsxFile("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "report.bin")).toBe(true);
+    expect(isXlsxFile("application/octet-stream", "Holiday List - 2026.xlsx")).toBe(true);
+    expect(isXlsxFile("application/vnd.ms-excel", "legacy.xls")).toBe(false);
+    expect(isXlsxFile("application/pdf", "report.pdf")).toBe(false);
+  });
+
+  it("extracts sheet names, row numbers, cell coordinates and values", async () => {
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet("Holidays");
+    sheet.addRow(["Date", "Holiday", "Region"]);
+    sheet.addRow([new Date("2026-10-02T00:00:00.000Z"), "Gandhi Jayanti", "IN"]);
+    sheet.addRow([new Date("2026-11-08T00:00:00.000Z"), "Diwali", "IN"]);
+
+    const buffer = Buffer.from(await workbook.xlsx.writeBuffer());
+    const text = await extractXlsxText(buffer, "Holiday List - 2026.xlsx");
+
+    expect(text).toContain("## Holiday List - 2026.xlsx");
+    expect(text).toContain("### Sheet: Holidays");
+    expect(text).toContain("Row 1: A1: Date | B1: Holiday | C1: Region");
+    expect(text).toContain("B2: Gandhi Jayanti");
+    expect(text).toContain("B3: Diwali");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/mcp/kb-xlsx.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/kb-xlsx.ts
@@ -1,0 +1,65 @@
+import ExcelJS from "exceljs";
+
+const XLSX_CONTENT_TYPES = new Set([
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel.sheet.macroenabled.12",
+]);
+
+export function isXlsxFile(contentType: string, fileName: string): boolean {
+  const normalizedContentType = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  const normalizedFileName = fileName.toLowerCase();
+  return (
+    XLSX_CONTENT_TYPES.has(normalizedContentType) ||
+    normalizedFileName.endsWith(".xlsx") ||
+    normalizedFileName.endsWith(".xlsm")
+  );
+}
+
+function stringifyCellValue(value: ExcelJS.CellValue): string {
+  if (value === null || value === undefined) return "";
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (typeof value === "object") {
+    if ("text" in value && typeof value.text === "string") return value.text;
+    if ("richText" in value && Array.isArray(value.richText)) {
+      return value.richText.map((part) => part.text ?? "").join("");
+    }
+    if ("formula" in value) {
+      const result = "result" in value ? stringifyCellValue(value.result as ExcelJS.CellValue) : "";
+      return result ? `${result} (formula: =${value.formula})` : `=${value.formula}`;
+    }
+    if ("hyperlink" in value) {
+      const text = "text" in value && typeof value.text === "string" ? value.text : "";
+      return text && text !== value.hyperlink ? `${text} (${value.hyperlink})` : String(value.hyperlink);
+    }
+    if ("error" in value) return String(value.error);
+  }
+  return String(value);
+}
+
+export async function extractXlsxText(buffer: Buffer, fileName: string): Promise<string> {
+  const workbook = new ExcelJS.Workbook();
+  await workbook.xlsx.load(buffer as unknown as ArrayBuffer);
+
+  const lines: string[] = [`## ${fileName}`, "", "_Extracted from Excel workbook._"];
+  workbook.worksheets.forEach((worksheet) => {
+    lines.push("", `### Sheet: ${worksheet.name}`);
+    let nonEmptyRows = 0;
+    worksheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+      const cells: string[] = [];
+      row.eachCell({ includeEmpty: false }, (cell, colNumber) => {
+        const value = stringifyCellValue(cell.value).trim();
+        if (!value) return;
+        const address = `${worksheet.getColumn(colNumber).letter}${rowNumber}`;
+        cells.push(`${address}: ${value.replace(/\r?\n/g, " ")}`);
+      });
+      if (cells.length > 0) {
+        nonEmptyRows++;
+        lines.push(`Row ${rowNumber}: ${cells.join(" | ")}`);
+      }
+    });
+    if (nonEmptyRows === 0) lines.push("_Empty sheet._");
+  });
+
+  const text = lines.join("\n");
+  return text.length > 100_000 ? `${text.slice(0, 100_000)}\n\n…(truncated to 100k characters)` : text;
+}


### PR DESCRIPTION
1. Problem Description:
Ask AI / KB read-file currently treats `.xlsx` Knowledge Base files as binary and returns "Plain text extraction isn't available in v1", so users cannot read spreadsheet rows such as holiday dates from KB files.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in Spaces thread: Ask AI was unable to read `Holiday List - 2026.xlsx`. Code inspection showed `apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts` downloads KB files directly and only decodes textual MIME types; binary Office docs return the v1 unsupported message.

3. Explain the solution implemented in the PR:
Added a focused XLSX extraction helper in `apps/xyne-claw-auth/backend/src/mcp/kb-xlsx.ts` using the existing `exceljs` dependency. `kb-read-file` now detects `.xlsx` / `.xlsm` by content type or filename and returns Markdown-like text with workbook name, sheet names, row numbers, cell coordinates, and values instead of the binary unsupported message.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `git diff --check`
- `pnpm --dir apps/xyne-claw-auth/backend test src/mcp/kb-xlsx-extraction.test.ts` (2 tests passed)
- `pnpm --dir apps/xyne-claw-auth/backend exec tsc --noEmit` was attempted; it still fails on existing generated Prisma/client typing errors outside this change. No new errors were reported for `kb-handlers`, `kb-xlsx`, or the XLSX test files.

9. Services to which this change is to be deployed:
xyne-claw-auth

10. Main PR link (if this PR is raised against a release branch):
N/A