### PR TITLE
fix: collapse chat sidebar before dm paint

### DIFF
--- a/apps/dashboard/src/routes/ChatScreen/ChatScreen.tsx
+++ b/apps/dashboard/src/routes/ChatScreen/ChatScreen.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useRef, useCallback } from 'react';
+import { ReactElement, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
 import { Outlet } from 'react-router-dom';
 import ChatDirectory from '../../components/Chat/ChatDirectory/ChatDirectory';
 import ConversationPrefetcher from '../../components/Chat/ConversationPrefetcher';
@@ -73,8 +73,11 @@ const ChatScreen = ({ shouldStackThread = false }: ChatScreenProps): ReactElemen
     };
   }, [handleResizeEvent]);
 
-  // Collapse (don't unmount) the sidebar on full-screen pages — keeps rows mounted.
-  useEffect(() => {
+  // Collapse (don't unmount) the sidebar on full-screen pages before paint.
+  // Full-screen routes like /chat/dm render their own left sidebar inside the
+  // outlet, so the persistent ChatDirectory panel must not be visible even for
+  // one restored frame from the saved ResizableGroup layout.
+  useLayoutEffect(() => {
     const panel = chatSidebarPanelRef.current;
     if (!panel) return;
     if (isFullScreenPage) {
@@ -82,7 +85,7 @@ const ChatScreen = ({ shouldStackThread = false }: ChatScreenProps): ReactElemen
     } else if (panel.isCollapsed()) {
       panel.expand();
     }
-  }, [isFullScreenPage]);
+  }, [isFullScreenPage, pathnameWithoutWorkspace]);
 
   // Browser-panel webview: skip the sidebar + chrome, render only the conversation.
   if (isInPanelWebview) {


### PR DESCRIPTION
1. Problem Description:
DM routes are rendered inside ChatScreen's Outlet. On desktop, ChatScreen keeps the channel ChatDirectory panel mounted and relies on an effect to collapse it for full-screen routes. A cold/deep link to `/chat/dm...` can briefly or persistently show the restored channel sidebar beside DmsPage's own DM sidebar.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
From the reported UI screenshot/thread: user saw Channel sidebar and DM sidebar side-by-side. Verified route nesting in `apps/dashboard/src/routes/AppRoot.tsx`: `/chat` renders `ChatScreen`, child `dm` renders `DmsPage`. Verified `ChatScreen` marks `/chat/dm` as full-screen but collapsed the persistent sidebar in `useEffect` after paint.

3. Explain the solution implemented in the PR:
Change the full-screen sidebar collapse from `useEffect` to `useLayoutEffect` and include `pathnameWithoutWorkspace` in the dependency list. This ensures DM/full-screen routes collapse the persistent ChatDirectory panel before paint, preventing it from appearing beside the DM sidebar while retaining the existing keep-mounted behavior.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `git diff --check` passed.
- `pnpm --dir apps/dashboard exec eslint src/routes/ChatScreen/ChatScreen.tsx` passed with 0 errors and one pre-existing warning about missing return type on an unrelated local handler.
- `pnpm --dir apps/dashboard typecheck` could not complete in sandbox: TypeScript process hit Node heap OOM after ~100s.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A

> Reviewers need to be added manually — likely dashboard/chat reviewers.