### PR TITLE
fix: add retry logic while fetching mails and attachment in desk

### DIFF
--- a/apps/backend/src/integrations/adapters/google/attachments.ts
+++ b/apps/backend/src/integrations/adapters/google/attachments.ts
@@ -17,9 +17,30 @@ import {
 import { logger } from '@/utils/logger';
 
 function base64UrlToBuffer(data: string): Buffer {
-  const base64 = data.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
-  return Buffer.from(padded, 'base64');
+  return Buffer.from(data, 'base64url');
+}
+
+const ATTACHMENT_CONCURRENCY = 3;
+
+async function mapWithLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results = new Array<PromiseSettledResult<R>>(items.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (next < items.length) {
+      const i = next++;
+      try {
+        results[i] = { status: 'fulfilled', value: await fn(items[i]!) };
+      } catch (reason) {
+        results[i] = { status: 'rejected', reason };
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
 }
 
 export async function preDownloadGmailAttachments(params: {
@@ -32,8 +53,10 @@ export async function preDownloadGmailAttachments(params: {
 
   const parts = googleService.parseEmailData(messageData).attachments ?? [];
 
-  const results = await Promise.allSettled(
-    parts.map(async (att): Promise<ExternalAttachment | null> => {
+  const results = await mapWithLimit(
+    parts,
+    ATTACHMENT_CONCURRENCY,
+    async (att): Promise<ExternalAttachment | null> => {
       // Inline part — bytes already on the payload.
       if (att.data) {
         return {
@@ -57,7 +80,7 @@ export async function preDownloadGmailAttachments(params: {
         };
       }
       return null;
-    }),
+    },
   );
 
   const attachments = results.flatMap((r, i) => {

--- a/apps/backend/src/integrations/adapters/google/attachments.ts
+++ b/apps/backend/src/integrations/adapters/google/attachments.ts
@@ -8,7 +8,7 @@
  * `downloadAttachmentsForSource` for the validate + GCS upload pipeline.
  */
 
-import { GoogleService } from '@/services/googleService';
+import { GoogleService, getHttpStatus, isRetryableGmailError } from '@/services/googleService';
 import {
   ExternalAttachmentService,
   ExternalAttachment,
@@ -83,10 +83,17 @@ export async function preDownloadGmailAttachments(params: {
     },
   );
 
+  const stillThrottled = results.find(
+    r => r.status === 'rejected' && isRetryableGmailError(r.reason),
+  );
+  if (stillThrottled?.status === 'rejected') {
+    throw stillThrottled.reason;
+  }
+
   const attachments = results.flatMap((r, i) => {
     if (r.status === 'fulfilled') return r.value ? [r.value] : [];
     logger.warn(
-      `[GoogleAttachments] fetch failed for ${parts[i]?.filename}: ${r.reason instanceof Error ? r.reason.message : 'unknown'}`,
+      `[GoogleAttachments] ${parts[i]?.filename} unavailable (status ${getHttpStatus(r.reason) ?? 'unknown'}) — ingesting without it`,
     );
     return [];
   });

--- a/apps/backend/src/services/googleService.ts
+++ b/apps/backend/src/services/googleService.ts
@@ -186,7 +186,10 @@ export class GoogleService {
       return response.data.data || null;
     } catch (error) {
       logger.error(`${TAG} Failed to fetch attachment ${attachmentId}`, error);
-      throw new Error(`Failed to fetch Gmail attachment: ${getErrorMessage(error)}`);
+      throw Object.assign(
+        new Error(`Failed to fetch Gmail attachment: ${getErrorMessage(error)}`),
+        { status: getHttpStatus(error), cause: error },
+      );
     }
   }
 
@@ -1201,7 +1204,7 @@ export function getHttpStatus(error: unknown): number | undefined {
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 const GMAIL_MAX_ATTEMPTS = 4;
 
-function isRetryableGmailError(error: unknown): boolean {
+export function isRetryableGmailError(error: unknown): boolean {
   const status = getHttpStatus(error);
   if (status !== undefined && RETRYABLE_STATUSES.has(status)) return true;
   // Some Gmail paths report the per-user concurrency cap as 403.

--- a/apps/backend/src/services/googleService.ts
+++ b/apps/backend/src/services/googleService.ts
@@ -49,6 +49,7 @@ interface WatchResult {
 export interface GmailMessageRef {
   id: string;
   threadId: string;
+  labelIds?: string[];
 }
 
 interface SetupExternalSourceParams {
@@ -152,11 +153,13 @@ export class GoogleService {
 
   async getMessageById(messageId: string): Promise<GmailMessageData | null> {
     try {
-      const response = await this.gmail.users.messages.get({
-        userId: 'me',
-        id: messageId,
-        format: 'full',
-      });
+      const response = await withGmailRetry(`messages.get ${messageId}`, () =>
+        this.gmail.users.messages.get({
+          userId: 'me',
+          id: messageId,
+          format: 'full',
+        }),
+      );
       return response.data as GmailMessageData;
     } catch (error) {
       // 404 = message was deleted/expired between Gmail publishing the event
@@ -173,15 +176,17 @@ export class GoogleService {
 
   async getAttachment(messageId: string, attachmentId: string): Promise<string | null> {
     try {
-      const response = await this.gmail.users.messages.attachments.get({
-        userId: 'me',
-        messageId,
-        id: attachmentId,
-      });
+      const response = await withGmailRetry(`attachments.get ${attachmentId}`, () =>
+        this.gmail.users.messages.attachments.get({
+          userId: 'me',
+          messageId,
+          id: attachmentId,
+        }),
+      );
       return response.data.data || null;
     } catch (error) {
       logger.error(`${TAG} Failed to fetch attachment ${attachmentId}`, error);
-      return null;
+      throw new Error(`Failed to fetch Gmail attachment: ${getErrorMessage(error)}`);
     }
   }
 
@@ -195,7 +200,8 @@ export class GoogleService {
     startHistoryId: string,
   ): Promise<{ messageIds: string[]; historyId: string | null }> {
     const { messages, historyId } = await this.listMessageRefsFromHistory(startHistoryId);
-    return { messageIds: messages.map(m => m.id), historyId };
+    const ingestable = messages.filter(m => !m.labelIds?.includes('DRAFT'));
+    return { messageIds: ingestable.map(m => m.id), historyId };
   }
 
   async listMessageRefsFromHistory(
@@ -207,17 +213,24 @@ export class GoogleService {
       let pageToken: string | undefined;
 
       do {
-        const response = await this.gmail.users.history.list({
-          userId: 'me',
-          startHistoryId,
-          historyTypes: ['messageAdded'],
-          ...(pageToken && { pageToken }),
-        });
+        const response = await withGmailRetry(`history.list ${startHistoryId}`, () =>
+          this.gmail.users.history.list({
+            userId: 'me',
+            startHistoryId,
+            historyTypes: ['messageAdded'],
+            ...(pageToken && { pageToken }),
+          }),
+        );
 
         for (const record of response.data.history || []) {
           for (const msg of record.messagesAdded || []) {
             const id = msg.message?.id;
-            if (id) messages.push({ id, threadId: msg.message?.threadId ?? id });
+            if (id)
+              messages.push({
+                id,
+                threadId: msg.message?.threadId ?? id,
+                ...(msg.message?.labelIds && { labelIds: msg.message.labelIds }),
+              });
           }
         }
 
@@ -268,12 +281,14 @@ export class GoogleService {
 
     try {
       do {
-        const response = await this.gmail.users.messages.list({
-          userId: 'me',
-          q,
-          maxResults: maxMessages === null ? 100 : Math.min(100, maxMessages - messages.length),
-          ...(pageToken && { pageToken }),
-        });
+        const response = await withGmailRetry('messages.list', () =>
+          this.gmail.users.messages.list({
+            userId: 'me',
+            q,
+            maxResults: maxMessages === null ? 100 : Math.min(100, maxMessages - messages.length),
+            ...(pageToken && { pageToken }),
+          }),
+        );
 
         for (const msg of response.data.messages || []) {
           if (msg.id) {
@@ -1176,4 +1191,34 @@ function getErrorMessage(error: unknown): string {
 
 export function getHttpStatus(error: unknown): number | undefined {
   return (error as { status?: number } | null | undefined)?.status;
+}
+
+/**
+ * Gmail rejects bursts with "Too many concurrent requests for user." — a
+ * transient signal Google asks callers to back off on, not a real failure.
+ * Without this a single burst costs a held cursor or a dropped attachment.
+ */
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const GMAIL_MAX_ATTEMPTS = 4;
+
+function isRetryableGmailError(error: unknown): boolean {
+  const status = getHttpStatus(error);
+  if (status !== undefined && RETRYABLE_STATUSES.has(status)) return true;
+  // Some Gmail paths report the per-user concurrency cap as 403.
+  return status === 403 && /rate limit|too many concurrent/i.test(getErrorMessage(error));
+}
+
+async function withGmailRetry<T>(label: string, call: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await call();
+    } catch (error) {
+      if (attempt >= GMAIL_MAX_ATTEMPTS || !isRetryableGmailError(error)) throw error;
+      const delayMs = 500 * 2 ** (attempt - 1) + Math.floor(Math.random() * 250);
+      logger.warn(
+        `${TAG} ${label} throttled — retry ${attempt}/${GMAIL_MAX_ATTEMPTS - 1} in ${delayMs}ms: ${getErrorMessage(error)}`,
+      );
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
