### PR TITLE
fix: enable xlsx reads for kb files

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/kb-handlers.ts
@@ -21,6 +21,7 @@ import { fetchAccessibleKb, indexKbTree, type KbCollectionNode } from "../lib/sp
 import { spacesFetchBuffer, search as spacesVespaSearch } from "./servers/xyne-spaces-client.js";
 import { getSpacesAuthForUser } from "../lib/spaces-db.js";
 import { createLogger } from "../logger.js";
+import { extractXlsxText, isXlsxFile } from "./kb-xlsx.js";
 
 /**
  * Debug sidecar — the YQL spaces actually emitted to Vespa for this call.
@@ -39,6 +40,7 @@ export interface VespaDebugBlock {
 }
 
 const log = createLogger("kb-handlers");
+
 
 export interface KbHandlerResult {
   content: string;
@@ -253,7 +255,7 @@ async function resolveKbContext(
     // retained in the DB by agents.ts (so flipping back to COLLECTIONS
     // restores the picker's previous selection) but dropped from the
     // runtime context. The accessibility layer is the only gate in USER mode.
-    grants: scope === "USER" ? [] : agent.collections.map(c => ({ collectionId: c.collectionId, fileId: c.fileId })),
+    grants: scope === "USER" ? [] : agent.collections.map((c: { collectionId: string; fileId: string | null }) => ({ collectionId: c.collectionId, fileId: c.fileId })),
     accessibleTree: tree,
     accessibleCollectionIds: collections,
     accessibleFileIds: files,
@@ -1009,6 +1011,12 @@ export async function handleKbReadFile(args: {
     const citeToken = `[clf-__TOOL_CALL_ID__#0]`;
 
     if (isLikelyBinary) {
+      if (isXlsxFile(contentType, fileMeta.name)) {
+        const body = await extractXlsxText(buffer, fileMeta.name);
+        const header = `## ${fileMeta.name} ${citeToken}\n\n_collection: ${fileMeta.collectionName}_\n\n---\n\n`;
+        return { content: header + body, citations: [citation] };
+      }
+
       return {
         content:
           `File \`${fileMeta.name}\` ${citeToken} is a binary type (PDF / image / office doc). ` +

--- a/apps/xyne-claw-auth/backend/src/mcp/kb-xlsx.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/kb-xlsx.ts
@@ -1,0 +1,65 @@
+import ExcelJS from "exceljs";
+
+const XLSX_CONTENT_TYPES = new Set([
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel.sheet.macroenabled.12",
+]);
+
+export function isXlsxFile(contentType: string, fileName: string): boolean {
+  const normalizedContentType = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  const normalizedFileName = fileName.toLowerCase();
+  return (
+    XLSX_CONTENT_TYPES.has(normalizedContentType) ||
+    normalizedFileName.endsWith(".xlsx") ||
+    normalizedFileName.endsWith(".xlsm")
+  );
+}
+
+function stringifyCellValue(value: ExcelJS.CellValue): string {
+  if (value === null || value === undefined) return "";
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (typeof value === "object") {
+    if ("text" in value && typeof value.text === "string") return value.text;
+    if ("richText" in value && Array.isArray(value.richText)) {
+      return value.richText.map((part) => part.text ?? "").join("");
+    }
+    if ("formula" in value) {
+      const result = "result" in value ? stringifyCellValue(value.result as ExcelJS.CellValue) : "";
+      return result ? `${result} (formula: =${value.formula})` : `=${value.formula}`;
+    }
+    if ("hyperlink" in value) {
+      const text = "text" in value && typeof value.text === "string" ? value.text : "";
+      return text && text !== value.hyperlink ? `${text} (${value.hyperlink})` : String(value.hyperlink);
+    }
+    if ("error" in value) return String(value.error);
+  }
+  return String(value);
+}
+
+export async function extractXlsxText(buffer: Buffer, fileName: string): Promise<string> {
+  const workbook = new ExcelJS.Workbook();
+  await workbook.xlsx.load(buffer as unknown as ArrayBuffer);
+
+  const lines: string[] = [`## ${fileName}`, "", "_Extracted from Excel workbook._"];
+  workbook.worksheets.forEach((worksheet) => {
+    lines.push("", `### Sheet: ${worksheet.name}`);
+    let nonEmptyRows = 0;
+    worksheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+      const cells: string[] = [];
+      row.eachCell({ includeEmpty: false }, (cell, colNumber) => {
+        const value = stringifyCellValue(cell.value).trim();
+        if (!value) return;
+        const address = `${worksheet.getColumn(colNumber).letter}${rowNumber}`;
+        cells.push(`${address}: ${value.replace(/\r?\n/g, " ")}`);
+      });
+      if (cells.length > 0) {
+        nonEmptyRows++;
+        lines.push(`Row ${rowNumber}: ${cells.join(" | ")}`);
+      }
+    });
+    if (nonEmptyRows === 0) lines.push("_Empty sheet._");
+  });
+
+  const text = lines.join("\n");
+  return text.length > 100_000 ? `${text.slice(0, 100_000)}\n\n…(truncated to 100k characters)` : text;
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
