### PR TITLE
fix: add retry logic while fetching mails and attachment in desk

### DIFF
--- a/apps/backend/src/integrations/adapters/google/attachments.ts
+++ b/apps/backend/src/integrations/adapters/google/attachments.ts
@@ -17,9 +17,30 @@ import {
 import { logger } from '@/utils/logger';
 
 function base64UrlToBuffer(data: string): Buffer {
-  const base64 = data.replace(/-/g, '+').replace(/_/g, '/');
-  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
-  return Buffer.from(padded, 'base64');
+  return Buffer.from(data, 'base64url');
+}
+
+const ATTACHMENT_CONCURRENCY = 3;
+
+async function mapWithLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<PromiseSettledResult<R>[]> {
+  const results = new Array<PromiseSettledResult<R>>(items.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    while (next < items.length) {
+      const i = next++;
+      try {
+        results[i] = { status: 'fulfilled', value: await fn(items[i]!) };
+      } catch (reason) {
+        results[i] = { status: 'rejected', reason };
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
 }
 
 export async function preDownloadGmailAttachments(params: {
@@ -32,8 +53,10 @@ export async function preDownloadGmailAttachments(params: {
 
   const parts = googleService.parseEmailData(messageData).attachments ?? [];
 
-  const results = await Promise.allSettled(
-    parts.map(async (att): Promise<ExternalAttachment | null> => {
+  const results = await mapWithLimit(
+    parts,
+    ATTACHMENT_CONCURRENCY,
+    async (att): Promise<ExternalAttachment | null> => {
       // Inline part — bytes already on the payload.
       if (att.data) {
         return {
@@ -57,7 +80,7 @@ export async function preDownloadGmailAttachments(params: {
         };
       }
       return null;
-    }),
+    },
   );
 
   const attachments = results.flatMap((r, i) => {

--- a/apps/backend/src/integrations/adapters/google/attachments.ts
+++ b/apps/backend/src/integrations/adapters/google/attachments.ts
@@ -8,7 +8,7 @@
  * `downloadAttachmentsForSource` for the validate + GCS upload pipeline.
  */
 
-import { GoogleService } from '@/services/googleService';
+import { GoogleService, getHttpStatus, isRetryableGmailError } from '@/services/googleService';
 import {
   ExternalAttachmentService,
   ExternalAttachment,
@@ -83,10 +83,17 @@ export async function preDownloadGmailAttachments(params: {
     },
   );
 
+  const stillThrottled = results.find(
+    r => r.status === 'rejected' && isRetryableGmailError(r.reason),
+  );
+  if (stillThrottled?.status === 'rejected') {
+    throw stillThrottled.reason;
+  }
+
   const attachments = results.flatMap((r, i) => {
     if (r.status === 'fulfilled') return r.value ? [r.value] : [];
     logger.warn(
-      `[GoogleAttachments] fetch failed for ${parts[i]?.filename}: ${r.reason instanceof Error ? r.reason.message : 'unknown'}`,
+      `[GoogleAttachments] ${parts[i]?.filename} unavailable (status ${getHttpStatus(r.reason) ?? 'unknown'}) — ingesting without it`,
     );
     return [];
   });

--- a/apps/backend/src/services/googleService.ts
+++ b/apps/backend/src/services/googleService.ts
@@ -186,7 +186,10 @@ export class GoogleService {
       return response.data.data || null;
     } catch (error) {
       logger.error(`${TAG} Failed to fetch attachment ${attachmentId}`, error);
-      throw new Error(`Failed to fetch Gmail attachment: ${getErrorMessage(error)}`);
+      throw Object.assign(
+        new Error(`Failed to fetch Gmail attachment: ${getErrorMessage(error)}`),
+        { status: getHttpStatus(error), cause: error },
+      );
     }
   }
 
@@ -1201,7 +1204,7 @@ export function getHttpStatus(error: unknown): number | undefined {
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 const GMAIL_MAX_ATTEMPTS = 4;
 
-function isRetryableGmailError(error: unknown): boolean {
+export function isRetryableGmailError(error: unknown): boolean {
   const status = getHttpStatus(error);
   if (status !== undefined && RETRYABLE_STATUSES.has(status)) return true;
   // Some Gmail paths report the per-user concurrency cap as 403.

--- a/apps/backend/src/services/googleService.ts
+++ b/apps/backend/src/services/googleService.ts
@@ -49,6 +49,7 @@ interface WatchResult {
 export interface GmailMessageRef {
   id: string;
   threadId: string;
+  labelIds?: string[];
 }
 
 interface SetupExternalSourceParams {
@@ -152,11 +153,13 @@ export class GoogleService {
 
   async getMessageById(messageId: string): Promise<GmailMessageData | null> {
     try {
-      const response = await this.gmail.users.messages.get({
-        userId: 'me',
-        id: messageId,
-        format: 'full',
-      });
+      const response = await withGmailRetry(`messages.get ${messageId}`, () =>
+        this.gmail.users.messages.get({
+          userId: 'me',
+          id: messageId,
+          format: 'full',
+        }),
+      );
       return response.data as GmailMessageData;
     } catch (error) {
       // 404 = message was deleted/expired between Gmail publishing the event
@@ -173,15 +176,17 @@ export class GoogleService {
 
   async getAttachment(messageId: string, attachmentId: string): Promise<string | null> {
     try {
-      const response = await this.gmail.users.messages.attachments.get({
-        userId: 'me',
-        messageId,
-        id: attachmentId,
-      });
+      const response = await withGmailRetry(`attachments.get ${attachmentId}`, () =>
+        this.gmail.users.messages.attachments.get({
+          userId: 'me',
+          messageId,
+          id: attachmentId,
+        }),
+      );
       return response.data.data || null;
     } catch (error) {
       logger.error(`${TAG} Failed to fetch attachment ${attachmentId}`, error);
-      return null;
+      throw new Error(`Failed to fetch Gmail attachment: ${getErrorMessage(error)}`);
     }
   }
 
@@ -195,7 +200,8 @@ export class GoogleService {
     startHistoryId: string,
   ): Promise<{ messageIds: string[]; historyId: string | null }> {
     const { messages, historyId } = await this.listMessageRefsFromHistory(startHistoryId);
-    return { messageIds: messages.map(m => m.id), historyId };
+    const ingestable = messages.filter(m => !m.labelIds?.includes('DRAFT'));
+    return { messageIds: ingestable.map(m => m.id), historyId };
   }
 
   async listMessageRefsFromHistory(
@@ -207,17 +213,24 @@ export class GoogleService {
       let pageToken: string | undefined;
 
       do {
-        const response = await this.gmail.users.history.list({
-          userId: 'me',
-          startHistoryId,
-          historyTypes: ['messageAdded'],
-          ...(pageToken && { pageToken }),
-        });
+        const response = await withGmailRetry(`history.list ${startHistoryId}`, () =>
+          this.gmail.users.history.list({
+            userId: 'me',
+            startHistoryId,
+            historyTypes: ['messageAdded'],
+            ...(pageToken && { pageToken }),
+          }),
+        );
 
         for (const record of response.data.history || []) {
           for (const msg of record.messagesAdded || []) {
             const id = msg.message?.id;
-            if (id) messages.push({ id, threadId: msg.message?.threadId ?? id });
+            if (id)
+              messages.push({
+                id,
+                threadId: msg.message?.threadId ?? id,
+                ...(msg.message?.labelIds && { labelIds: msg.message.labelIds }),
+              });
           }
         }
 
@@ -268,12 +281,14 @@ export class GoogleService {
 
     try {
       do {
-        const response = await this.gmail.users.messages.list({
-          userId: 'me',
-          q,
-          maxResults: maxMessages === null ? 100 : Math.min(100, maxMessages - messages.length),
-          ...(pageToken && { pageToken }),
-        });
+        const response = await withGmailRetry('messages.list', () =>
+          this.gmail.users.messages.list({
+            userId: 'me',
+            q,
+            maxResults: maxMessages === null ? 100 : Math.min(100, maxMessages - messages.length),
+            ...(pageToken && { pageToken }),
+          }),
+        );
 
         for (const msg of response.data.messages || []) {
           if (msg.id) {
@@ -1176,4 +1191,34 @@ function getErrorMessage(error: unknown): string {
 
 export function getHttpStatus(error: unknown): number | undefined {
   return (error as { status?: number } | null | undefined)?.status;
+}
+
+/**
+ * Gmail rejects bursts with "Too many concurrent requests for user." — a
+ * transient signal Google asks callers to back off on, not a real failure.
+ * Without this a single burst costs a held cursor or a dropped attachment.
+ */
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const GMAIL_MAX_ATTEMPTS = 4;
+
+function isRetryableGmailError(error: unknown): boolean {
+  const status = getHttpStatus(error);
+  if (status !== undefined && RETRYABLE_STATUSES.has(status)) return true;
+  // Some Gmail paths report the per-user concurrency cap as 403.
+  return status === 403 && /rate limit|too many concurrent/i.test(getErrorMessage(error));
+}
+
+async function withGmailRetry<T>(label: string, call: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await call();
+    } catch (error) {
+      if (attempt >= GMAIL_MAX_ATTEMPTS || !isRetryableGmailError(error)) throw error;
+      const delayMs = 500 * 2 ** (attempt - 1) + Math.floor(Math.random() * 250);
+      logger.warn(
+        `${TAG} ${label} throttled — retry ${attempt}/${GMAIL_MAX_ATTEMPTS - 1} in ${delayMs}ms: ${getErrorMessage(error)}`,
+      );
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
 }


### PR DESCRIPTION
Backport of #1007 to release-20260821. Cherry-picks commit 89cd5c6 (retry logic while fetching mails and attachments in desk). Files: apps/backend/src/integrations/adapters/google/attachments.ts, apps/backend/src/services/googleService.ts.