### PR TITLE
fix: XYNE-60936 cut recording start latency and remove pill flicker

### DIFF
--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -19,11 +19,13 @@ import { setupPresenceListeners, cleanupPresenceListeners } from '../../machines
 import { queryCacheActor, type Conversation } from '../../machines/queryCacheMachine';
 import { MEETING_DETECTION_ENABLED_KEY } from '../../constants/settings';
 import {
+  getRecordingStatus,
   sendRecordingEvent,
   stopRecordingForNavigation,
   stopRecordingForTeardown,
   useRecordingStore,
 } from '../../hooks/useRecordingStore';
+import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout';
 import { sendSosAlertEvent } from '../../stores/sosAlertStore';
 import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 
@@ -130,6 +132,12 @@ export const NotificationHandler: React.FC = () => {
   }, [activeWorkspaceId]);
   const isConnectedRef = useRef(false);
   const isElectron = typeof window !== 'undefined' && window.electronAPI !== undefined;
+
+  const goToRecordings = useCallback((): void => {
+    const workspaceId = activeWorkspaceIdRef.current;
+    if (!workspaceId) return;
+    void navigate(withWorkspacePrefix('/recordings', workspaceId));
+  }, [navigate]);
   const [suppressNativeToasts, setSuppressNativeToasts] = useState<boolean>(() =>
     reactNativeBridge.isAvailable(),
   );
@@ -594,20 +602,28 @@ export const NotificationHandler: React.FC = () => {
     // Sync stored preference to main process on startup
     meetingDetector.setEnabled(localStorage.getItem(MEETING_DETECTION_ENABLED_KEY) !== 'false');
     const cleanup = meetingDetector.onStartRecordingFromMeeting(() => {
-      sendRecordingEvent({ type: 'requestAutoStart' });
+      goToRecordings();
+      const status = getRecordingStatus();
+      if (status === 'idle' || status === 'error') {
+        sendRecordingEvent({ type: 'clearTranscripts' });
+        sendRecordingEvent({ type: 'startRecording', defaultLayout: getRecordingDefaultLayout() });
+      } else {
+        sendRecordingEvent({ type: 'requestAutoStart' });
+      }
     });
     window.electronAPI?.ipcSend?.('recording:renderer-ready');
     return cleanup;
-  }, [isElectron]);
+  }, [isElectron, goToRecordings]);
 
   // Handle stop signal from the floating recording pill's Stop button
   useEffect(() => {
     const meetingDetector = window.electronAPI?.meetingDetector;
     if (!isElectron || !meetingDetector) return;
     return meetingDetector.onStopRecordingFromMeeting(() => {
+      goToRecordings();
       sendRecordingEvent({ type: 'requestStop' });
     });
-  }, [isElectron]);
+  }, [isElectron, goToRecordings]);
 
   useEffect(() => {
     if (!isElectron || !window.electronAPI?.onRecordingSystemSuspend) return;

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -147,13 +147,16 @@ export const recordingStore = createStore({
     requestAutoStart: (
       context,
       event: { conversationId?: string; channelId?: string } = {},
-    ): RecordingState => ({
-      ...context,
-      pendingAutoStart: true,
-      autoStartRequestedAt: Date.now(),
-      pendingConversationId: event.conversationId ?? null,
-      pendingChannelId: event.channelId ?? null,
-    }),
+    ): RecordingState => {
+      if (context.status === 'starting') return context;
+      return {
+        ...context,
+        pendingAutoStart: true,
+        autoStartRequestedAt: Date.now(),
+        pendingConversationId: event.conversationId ?? null,
+        pendingChannelId: event.channelId ?? null,
+      };
+    },
 
     clearAutoStart: (context): RecordingState => ({
       ...context,

--- a/apps/electron/assets/recording-pill.html
+++ b/apps/electron/assets/recording-pill.html
@@ -68,8 +68,8 @@
       transition:
         width 0.24s var(--ease-out),
         border-radius 0.24s var(--ease-out),
-        opacity 0.2s ease,
-        transform 0.2s ease;
+        opacity 0.12s ease,
+        transform 0.12s ease;
     }
 
     .card.dragging { cursor: grabbing; }
@@ -142,6 +142,26 @@
     #rowResume { display: none; }
     .card.paused #rowTimer { display: none; }
     .card.paused #rowResume { display: flex; }
+
+    #rowStarting { display: none; }
+    .card.starting #rowTimer,
+    .card.starting #rowResume { display: none; }
+    .card.starting #rowStarting { display: flex; }
+
+    .spinner {
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      border: 2px solid var(--card-border);
+      border-top-color: var(--green);
+      animation: spin 0.7s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    .starting-label {
+      color: var(--green);
+      font-weight: 600;
+    }
 
     .resume-label {
       color: var(--amber);
@@ -238,6 +258,11 @@
       <span class="label timer" id="timer">0s</span>
     </div>
 
+    <div class="row" id="rowStarting">
+      <span class="icon-slot"><span class="spinner"></span></span>
+      <span class="label starting-label">Starting</span>
+    </div>
+
     <button class="row" id="rowResume" title="Resume recording">
       <span class="icon-slot"><span class="resume-icon"></span></span>
       <span class="label resume-label">Resume</span>
@@ -261,7 +286,7 @@
   <script>
     const card = document.getElementById('card');
     const timerEl = document.getElementById('timer');
-    let state = { startTime: null, paused: false, pauseStartedAt: null, accumulatedPausedMs: 0 };
+    let state = { starting: false, startTime: null, paused: false, pauseStartedAt: null, accumulatedPausedMs: 0 };
     let timerInterval = null;
     let collapseTimer = null;
 
@@ -283,22 +308,27 @@
     }
 
     function applyState(next) {
+      const starting = !!(next && next.starting);
       state = {
-        startTime: (next && next.startTime) || Date.now(),
+        starting,
+        startTime: (next && next.startTime) || (starting ? null : Date.now()),
         paused: !!(next && next.paused),
         pauseStartedAt: (next && next.pauseStartedAt) || null,
         accumulatedPausedMs: (next && next.accumulatedPausedMs) || 0,
       };
-      card.classList.toggle('paused', state.paused);
-      renderTimer();
+      card.classList.toggle('starting', starting);
+      card.classList.toggle('paused', state.paused && !starting);
       if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
+      if (starting) return;
+      renderTimer();
       if (!state.paused) timerInterval = setInterval(renderTimer, 1000);
     }
 
     function stopTimer() {
       if (timerInterval) { clearInterval(timerInterval); timerInterval = null; }
-      state = { startTime: null, paused: false, pauseStartedAt: null, accumulatedPausedMs: 0 };
+      state = { starting: false, startTime: null, paused: false, pauseStartedAt: null, accumulatedPausedMs: 0 };
       card.classList.remove('paused');
+      card.classList.remove('starting');
     }
 
     const DRAG_THRESHOLD = 4;

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -24,6 +24,7 @@ import {
 import { isTrayVisible, setTrayVisible } from '../services/tray';
 import {
   focusMainWindow,
+  isRecordingInProgress,
   markRendererReady,
   resumeRecordingFromOutside,
   setCallActive,
@@ -569,9 +570,10 @@ export function setupIpcHandlers(): void {
   ipcMain.on('meeting-popup:start-recording', () => {
     Logger.info(ElectronEvent.MEETING_POPUP_START_RECORDING, {}, 'MeetingDetector');
     const mainWindow = getMainWindow();
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      // Navigate and auto-start recording without stealing focus from the meeting
-      mainWindow.webContents.send('navigate-to', '/recordings');
+    if (mainWindow && !mainWindow.isDestroyed() && !isRecordingInProgress()) {
+      // Auto-start recording without stealing focus from the meeting. The
+      // renderer navigates itself — main has no workspace id, and the router is
+      // /:workspaceId/recordings.
       mainWindow.webContents.send('meeting:start-recording');
     }
     // Delay close so the popup can show the recording-started state for 3 seconds
@@ -631,12 +633,14 @@ export function setupIpcHandlers(): void {
     ) => {
       if (!isMainWindowSender(event)) return;
       markRendererReady();
-      setRecordingStarting(!!state?.starting);
+      // Applied before clearing `starting`: the reverse order briefly leaves
+      // both flags false, which flickers the pill off and back on every start.
       syncRecordingState(!!state?.active, state?.startTime, {
         paused: !!state?.paused,
         pauseStartedAt: state?.pauseStartedAt ?? null,
         accumulatedPausedMs: state?.accumulatedPausedMs ?? 0,
       });
+      setRecordingStarting(!!state?.starting);
     },
   );
 

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -7,6 +7,7 @@ import {
   isPillWindow,
   isRecordingPillEnabled,
   persistRecordingPillEnabled,
+  prewarmRecordingPill,
 } from './recording-pill-window';
 
 export type RecordingTrigger = 'tray' | 'shortcut' | 'pill';
@@ -141,13 +142,12 @@ function clearFocusRequested(): void {
   focusRequestTimer = null;
 }
 
-export function focusMainWindow(pathname?: string): BrowserWindow | null {
+export function focusMainWindow(): BrowserWindow | null {
   const mainWindow = getMainWindow();
   if (!mainWindow || mainWindow.isDestroyed()) return null;
   markFocusRequested();
   mainWindow.show();
   mainWindow.focus();
-  if (pathname) mainWindow.webContents.send('navigate-to', pathname);
   return mainWindow;
 }
 
@@ -175,9 +175,14 @@ function cancelPendingPillSync(): void {
 
 function syncPillVisibility(): void {
   cancelPendingPillSync();
-  if (active && isRecordingPillEnabled() && (minimized || !isMainWindowFocused())) {
+  const wantsPill =
+    (active || startingRecording) &&
+    isRecordingPillEnabled() &&
+    (minimized || !isMainWindowFocused());
+  if (wantsPill) {
     showRecordingPill({
-      startTime: startTime ?? Date.now(),
+      starting: !active,
+      startTime: active ? (startTime ?? Date.now()) : null,
       paused,
       pauseStartedAt,
       accumulatedPausedMs,
@@ -197,6 +202,7 @@ function scheduleSyncPillVisibility(): void {
 
 export function setRecordingPillEnabled(enabled: boolean): void {
   persistRecordingPillEnabled(enabled);
+  if (enabled) prewarmRecordingPill();
   syncPillVisibility();
   log.info(`[RecordingController] Recording pill ${enabled ? 'enabled' : 'disabled'}`);
 }
@@ -212,6 +218,8 @@ export function setOverlayMinimized(next: boolean): void {
 }
 
 export function initRecordingPillVisibility(): void {
+  if (isRecordingPillEnabled()) prewarmRecordingPill();
+
   const handleWindowFocus = (_event: Electron.Event, window: BrowserWindow): void => {
     if (isPillWindow(window)) return;
     if (window === getMainWindow()) clearFocusRequested();
@@ -262,7 +270,9 @@ function markExternalStartPending(): void {
 }
 
 export async function startRecordingFromOutside(trigger: RecordingTrigger): Promise<void> {
-  if (active) return;
+  if (active || startingRecording) return;
+
+  setRecordingStarting(true);
 
   let mainWindow = getMainWindow();
   let createdMainWindow = false;
@@ -274,12 +284,16 @@ export async function startRecordingFromOutside(trigger: RecordingTrigger): Prom
       createdMainWindow = true;
     } catch (error) {
       log.error(`[RecordingController] Failed to create window for ${trigger} start:`, error);
+      setRecordingStarting(false);
       return;
     }
   }
 
   mainWindow = getMainWindow();
-  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    setRecordingStarting(false);
+    return;
+  }
 
   if (
     !rendererReady &&
@@ -289,18 +303,28 @@ export async function startRecordingFromOutside(trigger: RecordingTrigger): Prom
   }
 
   mainWindow = getMainWindow();
-  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    setRecordingStarting(false);
+    return;
+  }
 
   log.info(`[RecordingController] Start requested from ${trigger}`);
   markExternalStartPending();
-  mainWindow.webContents.send('navigate-to', '/recordings');
+
+  if (!rendererReady) {
+    log.warn(`[RecordingController] Renderer not ready for ${trigger} start`);
+    setRecordingStarting(false);
+  }
+
+  if (!isRecordingPillEnabled()) focusMainWindow();
   mainWindow.webContents.send('meeting:start-recording');
 }
 
 export function stopRecording(trigger: RecordingTrigger): void {
   minimized = false;
   cancelPendingPillSync();
-  focusMainWindow('/recordings')?.webContents.send('meeting:stop-recording');
+  setRecordingStarting(false);
+  focusMainWindow()?.webContents.send('meeting:stop-recording');
   hideRecordingPill();
   log.info(`[RecordingController] Stop requested from ${trigger}`);
 }
@@ -360,7 +384,9 @@ export function setRecordingStarting(next: boolean): void {
     clearTimeout(startingRecordingExpiry);
     startingRecordingExpiry = null;
   }
+  const changed = startingRecording !== next;
   startingRecording = next;
+  if (changed) syncPillVisibility();
   if (!next) return;
 
   // The renderer is the only thing that clears this, and a hung start never
@@ -369,6 +395,7 @@ export function setRecordingStarting(next: boolean): void {
   startingRecordingExpiry = setTimeout(() => {
     startingRecordingExpiry = null;
     startingRecording = false;
+    syncPillVisibility();
     log.warn('[RecordingController] Recording start was not confirmed by the renderer');
   }, STARTING_RECORDING_TIMEOUT_MS);
 }

--- a/apps/electron/src/services/recording-pill-window.ts
+++ b/apps/electron/src/services/recording-pill-window.ts
@@ -26,7 +26,8 @@ let currentTheme: RecordingPillTheme = 'light';
 export type RecordingPillTheme = 'light' | 'dark';
 
 export interface RecordingPillState {
-  startTime: number;
+  starting: boolean;
+  startTime: number | null;
   paused: boolean;
   pauseStartedAt: number | null;
   accumulatedPausedMs: number;
@@ -191,18 +192,33 @@ export function showRecordingPill(state: RecordingPillState): void {
   currentState = state;
   pillRequested = true;
 
-  if (pillWindow && !pillWindow.isDestroyed()) {
-    pillWindow.webContents.send('recording-pill:theme-changed', currentTheme);
-    pillWindow.webContents.send('recording-pill:show', currentState);
-    if (!pillWindow.isVisible() || wasHiding) {
-      applyIgnoreMouseEvents(true);
-    }
-    if (!pillWindow.isVisible()) {
-      pillWindow.showInactive();
-    }
+  if (!pillWindow || pillWindow.isDestroyed()) {
+    createPillWindow();
     return;
   }
 
+  if (pillWindow.webContents.isLoading()) return;
+
+  pillWindow.webContents.send('recording-pill:theme-changed', currentTheme);
+  pillWindow.webContents.send('recording-pill:show', currentState);
+  if (!pillWindow.isVisible() || wasHiding) {
+    applyIgnoreMouseEvents(true);
+  }
+  if (!pillWindow.isVisible()) {
+    pillWindow.showInactive();
+  }
+}
+
+/**
+ * Builds the pill window ahead of the first recording so a start never pays
+ * window construction + loadFile on the critical path.
+ */
+export function prewarmRecordingPill(): void {
+  if (pillWindow && !pillWindow.isDestroyed()) return;
+  createPillWindow();
+}
+
+function createPillWindow(): void {
   const pos = getInitialPosition();
 
   pillWindow = new BrowserWindow({
@@ -219,6 +235,7 @@ export function showRecordingPill(state: RecordingPillState): void {
     focusable: true,
     fullscreenable: false,
     show: false,
+    paintWhenInitiallyHidden: true,
     type: 'panel',
     webPreferences: {
       nodeIntegration: false,
@@ -324,7 +341,7 @@ export function showRecordingPill(state: RecordingPillState): void {
     }
   });
 
-  log.info('[RecordingPill] Showing recording pill');
+  log.info('[RecordingPill] Pill window created');
 }
 
 export function hideRecordingPill(): void {


### PR DESCRIPTION
## Type of Change

- [x] Enhancement

## Description

Recording start felt slow and the floating pill flickered on every start. Two causes:

1. The pill's `BrowserWindow` was constructed and `loadFile`'d lazily on the first start, so window construction sat on the critical path of the very first recording.
2. `starting` and `active` were applied in an order that briefly left both flags false, which tore the pill down and rebuilt it mid-start.

This prewarms the pill window and gives the pill a real "Starting" state so the user gets feedback the moment they hit start, instead of after the recording goes active.

- Prewarm the pill window on `initRecordingPillVisibility()` and when the pill is enabled, with `paintWhenInitiallyHidden` so it is composited before it is ever shown. `showRecordingPill` now bails while `webContents.isLoading()` rather than racing the load.
- Show the pill while `startingRecording` is set — new spinner + "Starting" row in `recording-pill.html`, driven by a `starting` flag on `RecordingPillState`. `setRecordingStarting` now re-syncs pill visibility when the flag actually changes (including on the hung-start timeout).
- In the `recording:state` IPC handler, apply `syncRecordingState` **before** `setRecordingStarting`; the reverse order is what produced the flicker.
- Drop the redundant `navigate-to` IPC from main. Main has no workspace id and the router is `/:workspaceId/recordings`, so the renderer navigates itself via `withWorkspacePrefix`. `focusMainWindow` loses its `pathname` param (no caller passed one after this change), and `NoteTakerOverlayHost` now prefixes its post-stop redirect too.
- Re-entrancy guards: `requestAutoStart` is a no-op while `status === 'starting'`, `startRecordingFromOutside` returns early if `active || startingRecording`, and `meeting-popup:start-recording` checks `isRecordingInProgress()`.
- Pill opacity/transform transitions cut from 0.2s to 0.12s.

## Areas Touched

- [x] `apps/dashboard`
- [x] `apps/electron`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Manually in the Electron desktop app: start a recording from the tray, the shortcut, and the meeting popup; confirmed the pill appears immediately with the "Starting" spinner, transitions to the timer without flickering off, and that the renderer lands on the workspace-prefixed `/recordings` route each time. Also exercised pause/resume, stop from the pill, and stop from the app, plus a rapid double-trigger to confirm the re-entrancy guards hold.

### Automated

- [x] Not covered by tests <!-- no existing coverage for the pill window / recording controller; behaviour is Electron-window and timing dependent -->

### Manual

**Users**
- [x] Single user

**Login**
- [x] Google

**Run mode**
- [x] Electron desktop

**Surface & data**
- [x] Electron desktop
- [x] Narrow viewport, dark + light theme
- [x] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] No debug logging or commented-out code left behind
