### PR TITLE
fix: adding oauth flag and config in db

### DIFF
--- a/apps/xyne-claw-auth/backend/backfill-oauth.ts
+++ b/apps/xyne-claw-auth/backend/backfill-oauth.ts
@@ -1,0 +1,43 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const OAUTH_PROVIDERS = [
+  "google",
+  "microsoft",
+  "docusign",
+  "egnyte",
+  "miro",
+  "calendly",
+  "jotform",
+  "wix",
+  "webflow",
+  "mailerlite",
+  "attio",
+  "honeycomb",
+  "customerio"
+];
+
+async function main() {
+  console.log("Starting backfill for OAuth providers...");
+  const result = await prisma.mcpServer.updateMany({
+    where: {
+      type: {
+        in: OAUTH_PROVIDERS
+      }
+    },
+    data: {
+      isOauth: true
+    }
+  });
+  console.log(`Successfully updated ${result.count} existing MCP server rows to set isOauth=true.`);
+}
+
+main()
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260814_add_oauth_config/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260814_add_oauth_config/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "McpServer" ADD COLUMN     "isOauth" BOOLEAN NOT NULL DEFAULT false;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1423,6 +1423,8 @@ model McpServer {
   healthcheckSpec      Json?
   writeToolPolicy      Json?
   connectorMeta        Json?
+  /// Explicitly marks if this connector requires an OAuth browser flow.
+  isOauth              Boolean                   @default(false)
   /// Whether this server type can fall back to admin-managed global
   /// credentials when a user has no personal connection. Off by default —
   /// admins must opt-in per server (e.g. enable it for shared infra creds

--- a/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
@@ -52,7 +52,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
     const existing = await prisma.mcpServer.findUnique({ where: { type } });
     if (existing) return existing;
     return prisma.mcpServer.create({
-      data: { type, name: config.server.name, url: config.server.url, description: config.server.description },
+      data: { type, name: config.server.name, url: config.server.url, description: config.server.description, isOauth: true },
     });
   }
 

--- a/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
@@ -115,6 +115,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
         writeToolPolicy: config.server.writeToolPolicy as never,
         healthcheckSpec: config.server.healthcheckSpec as never,
         connectorMeta: (config.server.connectorMeta ?? { scope: "global", mode: "self-serve" }) as never,
+        isOauth: true,
       },
     });
   }

--- a/apps/xyne-claw-auth/backend/src/lib/oauth-server-types.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/oauth-server-types.ts
@@ -18,8 +18,13 @@ export function isOAuthServerType(type: string): boolean {
   return OAUTH_SERVER_TYPES.has(type);
 }
 
-/** OAuth by built-in type OR a DB-declared connectorMeta.authMethod="oauth". */
-export function isOAuthServer(type: string, connectorMeta?: unknown): boolean {
+/**
+ * OAuth by built-in type, a DB-declared connectorMeta.authMethod="oauth", or
+ * the explicit McpServer.isOauth flag (lets an admin-defined connector with
+ * no code opt in purely via the DB).
+ */
+export function isOAuthServer(type: string, connectorMeta?: unknown, isOauth?: boolean): boolean {
+  if (isOauth === true) return true;
   if (OAUTH_SERVER_TYPES.has(type)) return true;
   if (connectorMeta && typeof connectorMeta === "object") {
     const m = connectorMeta as Record<string, unknown>;

--- a/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
@@ -76,7 +76,7 @@ export async function ensureDocuSignServer() {
   const healthcheckSpec = { name: "getUserInfo", params: {} };
   return prisma.mcpServer.upsert({
     where: { type: "docusign" },
-    update: { writeToolPolicy, healthcheckSpec, transport: "http" },
+    update: { writeToolPolicy, healthcheckSpec, transport: "http", isOauth: true },
     create: {
       type: "docusign",
       name: "DocuSign",
@@ -86,6 +86,7 @@ export async function ensureDocuSignServer() {
       writeToolPolicy,
       healthcheckSpec,
       connectorMeta: { scope: "global", mode: "self-serve" },
+      isOauth: true,
     },
   });
 }

--- a/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
@@ -76,7 +76,7 @@ export async function ensureEgnyteServer() {
   const healthcheckSpec = { name: "list_filesystem_by_path", params: { path: "/" } };
   return prisma.mcpServer.upsert({
     where: { type: "egnyte" },
-    update: { writeToolPolicy: { mode: "allowlist", tools: writeTools }, healthcheckSpec, transport: "http" },
+    update: { writeToolPolicy: { mode: "allowlist", tools: writeTools }, healthcheckSpec, transport: "http", isOauth: true },
     create: {
       type: "egnyte",
       name: "Egnyte",
@@ -86,6 +86,7 @@ export async function ensureEgnyteServer() {
       writeToolPolicy: { mode: "allowlist", tools: writeTools },
       healthcheckSpec,
       connectorMeta: { scope: "global", mode: "self-serve" },
+      isOauth: true,
     },
   });
 }

--- a/apps/xyne-claw-auth/backend/src/routes/oauth-token.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/oauth-token.ts
@@ -67,8 +67,8 @@ export function getOAuthProvider(serverType: string): OAuthTokenProvider | undef
  * `isOAuthServer` alone only recognised google/microsoft, so every self-serve
  * OAuth connector was mislabelled `oauth: false` by the /servers route.
  */
-export function isOAuthConnector(serverType: string, connectorMeta?: unknown): boolean {
-  return getOAuthProvider(serverType) !== undefined || isOAuthServer(serverType, connectorMeta);
+export function isOAuthConnector(serverType: string, connectorMeta?: unknown, isOauth?: boolean): boolean {
+  return getOAuthProvider(serverType) !== undefined || isOAuthServer(serverType, connectorMeta, isOauth);
 }
 
 export const oauthTokenRouter = buildOAuthTokenRouter(ALL_OAUTH_PROVIDERS);

--- a/apps/xyne-claw-auth/backend/src/routes/servers.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/servers.ts
@@ -155,8 +155,11 @@ router.get("/", asyncHandler(async (req: Request, res: Response) => {
   const visible = servers.filter((s: any) => isVisibleToUser(parseConnectorMeta(s.connectorMeta), requesterId));
   // Decorate with `oauth` so the UI can tell OAuth connectors apart (they
   // need the browser flow, can't be pinned credential-less) without
-  // hardcoding a google/microsoft list in the frontend.
-  const decorated = visible.map((s: any) => ({ ...s, oauth: isOAuthConnector(s.type, s.connectorMeta) }));
+  // hardcoding a google/microsoft list in the frontend. isOAuthConnector is
+  // registry-derived (true for any connector with a registered
+  // OAuthTokenProvider) OR'd with the DB-declared isOauth flag, so a future
+  // admin-defined connector with no code can also opt in.
+  const decorated = visible.map((s: any) => ({ ...s, oauth: isOAuthConnector(s.type, s.connectorMeta, Boolean(s.isOauth)) }));
   ok(res, decorated);
 }));
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
