### PR TITLE
feat: XYNE-58071 Added desk insights pannel cron job sheduler

### DIFF
--- a/apps/backend/prisma/migrations/20260824073557_add_desk_report_preferences/migration.sql
+++ b/apps/backend/prisma/migrations/20260824073557_add_desk_report_preferences/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: add desk-report scheduling preferences to email_channel_preferences
+ALTER TABLE "public"."email_channel_preferences"
+  ADD COLUMN "deskReportEnabled" BOOLEAN DEFAULT false,
+  ADD COLUMN "deskReportAgentSlug" TEXT,
+  ADD COLUMN "deskReportRangeDays" INTEGER DEFAULT 1;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2213,7 +2213,7 @@ model EmailChannelPreference {
   frtStageNames          String?  // JSON-serialised string[] of stage names whose first entry stops the FRT clock
   appWebhookDeliveryEnabled Boolean @default(true) // APP desks only: off means replies are stored without ever calling the app webhook
   deskReportEnabled      Boolean? @default(false) // Gates the scheduled desk-report cron + sidebar panel
-  deskReportAgentSlug    String?  // null = the desk owner/admin hasn't picked one yet — no default agent, generation is skipped until one is set
+  deskReportAgentSlug    String?
   deskReportRangeDays    Int?     @default(1) // 1 = "Last 1 day", 7 = "Last 1 week"
   @@index([ownerUserId])
   @@index([assigneeUserGroupId])

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2212,6 +2212,9 @@ model EmailChannelPreference {
   metricsEnabled         Boolean? // Gates the desk metrics dashboard
   frtStageNames          String?  // JSON-serialised string[] of stage names whose first entry stops the FRT clock
   appWebhookDeliveryEnabled Boolean @default(true) // APP desks only: off means replies are stored without ever calling the app webhook
+  deskReportEnabled      Boolean? @default(false) // Gates the scheduled desk-report cron + sidebar panel
+  deskReportAgentSlug    String?  // null = the desk owner/admin hasn't picked one yet — no default agent, generation is skipped until one is set
+  deskReportRangeDays    Int?     @default(1) // 1 = "Last 1 day", 7 = "Last 1 week"
   @@index([ownerUserId])
   @@index([assigneeUserGroupId])
   @@index([boardId])

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -591,7 +591,7 @@ export class App {
       sdlcArtifactVersionsInternalRoutes
     );
     this.app.post(
-      '/api/internal/desk-report/callback/:channelId',
+      '/api/internal/desk-report/callback/:channelId/:attachmentId',
       validateS2SKey,
       handleDeskReportCallback,
     );

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -123,6 +123,7 @@ import priorityClassificationRoutes from '@/routes/priorityClassificationRoutes'
 import deskMetricsRoutes from '@/routes/deskMetricsRoutes';
 import deskMetricsAggregateRoutes from '@/routes/deskMetricsAggregateRoutes';
 import deskMetricsClawRoutes from '@/routes/deskMetricsClawRoutes';
+import deskReportPanelRoutes from '@/routes/deskReportPanelRoutes';
 import aiRetriggerRoutes from '@/routes/aiRetriggerRoutes';
 import testAuthRoutes from '@/routes/testAuth';
 import customInstructionRoutes from '@/routes/customInstruction';
@@ -136,6 +137,7 @@ import { handleClawCallback } from '@/automations/routes/claw-callback.handler';
 import sdlcWikiInternalRoutes from '@/routes/sdlcWikiInternal';
 import sdlcArtifactVersionsInternalRoutes from '@/routes/sdlcArtifactVersionsInternal';
 import { handleAutoDraftCallback } from '@/controllers/autodraftCallback.handler';
+import { handleDeskReportCallback } from '@/controllers/deskReportCallback.handler';
 import automationWebhookRoutes from '@/automations/routes/webhook-trigger.handler';
 import activityLogRoutes from '@/routes/activityLog';
 import userActivityRoutes from '@/routes/userActivity';
@@ -362,6 +364,7 @@ export class App {
     this.app.use('/api/channels/:channelId/metrics', authMiddleware.authenticate, deskMetricsRoutes);
     this.app.use('/api/desk-metrics/claw', authenticateUserOrApp, deskMetricsClawRoutes);
     this.app.use('/api/desk-metrics', authMiddleware.authenticate, deskMetricsAggregateRoutes);
+    this.app.use('/api/desk-report', authMiddleware.authenticate, deskReportPanelRoutes);
     this.app.use('/api/channels/:channelId/ai-retrigger', authMiddleware.authenticate, aiRetriggerRoutes);
 
     // Meet callback route (API key auth - called by SAM service)
@@ -586,6 +589,11 @@ export class App {
       '/api/internal/sdlc/artifact-versions',
       validateS2SKey,
       sdlcArtifactVersionsInternalRoutes
+    );
+    this.app.post(
+      '/api/internal/desk-report/callback/:channelId',
+      validateS2SKey,
+      handleDeskReportCallback,
     );
 
     // Internal canvas read/update (S2S-only, used by MCP tools)

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -261,6 +261,10 @@ const envSchema = Joi.object({
   RECAP_GENERATION_CRON: Joi.string().default('15 0 * * *'), //5:45 IST daily
   RECAP_CLEANUP_CRON: Joi.string().default('30 23 * * *'), //5:00 IST daily
   RECAP_RETENTION_DAYS: Joi.number().default(30),
+  ENABLE_DESK_REPORT_SCHEDULER: Joi.boolean().default(true),
+  DESK_REPORT_GENERATION_CRON: Joi.string().default('30 22 * * *'), //4:00 IST daily
+  DESK_REPORT_CLEANUP_CRON: Joi.string().default('30 21 * * *'), //3:00 IST daily
+  DESK_REPORT_RETENTION_DAYS: Joi.number().default(3),
   RECENT_VISITED_LOOKBACK_DAYS: Joi.number().integer().min(1).default(7),
   ACTIVITY_CLASSIFICATION_MAX_RETRIES: Joi.number().default(2),
   TICKET_DESC_CLEAN_MODEL: Joi.string().default(''),
@@ -922,6 +926,12 @@ export const config = {
     generationCron: envVars.RECAP_GENERATION_CRON,
     cleanupCron: envVars.RECAP_CLEANUP_CRON,
     retentionDays: envVars.RECAP_RETENTION_DAYS,
+  },
+  deskReportScheduler: {
+    enabled: envVars.ENABLE_DESK_REPORT_SCHEDULER,
+    generationCron: envVars.DESK_REPORT_GENERATION_CRON,
+    cleanupCron: envVars.DESK_REPORT_CLEANUP_CRON,
+    retentionDays: envVars.DESK_REPORT_RETENTION_DAYS,
   },
   otel: {
     metricsEnabled: envVars.ENABLE_OTEL_METRICS,

--- a/apps/backend/src/controllers/deskReportCallback.handler.ts
+++ b/apps/backend/src/controllers/deskReportCallback.handler.ts
@@ -1,0 +1,149 @@
+/**
+ * Terminal callback for a Claw agent run triggered by
+ * deskReportGenerationService. Mirrors autodraftCallback.handler.ts's shape,
+ * but decodes the `[ATTACHMENT:<name>:<mime>]\n<base64>` marker
+ * `create-desk-report` emits instead of treating the result as plain text,
+ * and persists into MessageAttachment (entityType=DESK_REPORT).
+ */
+import type { Request, Response } from 'express';
+import { logger } from '@/utils/logger';
+import { db } from '@/database/client';
+import { runAsServiceActor } from '@/database/tenant/context';
+import { uploadFiles } from '@/services/fileUploadService';
+import { AttachmentEntityType } from '@xyne/shared';
+
+// Matches the same marker create-desk-report emits and custom-tools.ts parses
+// on the claw side: `[ATTACHMENT:<fileName>:<mimeType>]\n<base64>`.
+const ATTACHMENT_RE = /\[ATTACHMENT:([^:\]]+):([^\]]+)\]\n([A-Za-z0-9+/=]+)/;
+
+interface RawAttachment {
+  fileName?: string;
+  filename?: string;
+  mimeType?: string;
+  mimetype?: string;
+  data?: string;
+}
+
+function extractHtmlAttachment(
+  payload: Record<string, unknown>,
+): { fileName: string; mimeType: string; data: string } | null {
+  // Prefer a structured attachments array if the callback carries one
+  // (the shape the S2S `/run` terminal callback uses — see
+  // agent-attachment.service.ts's `resultAttachments`).
+  const arrays = [payload['attachments'], payload['resultAttachments']];
+  for (const arr of arrays) {
+    if (!Array.isArray(arr)) continue;
+    for (const raw of arr as RawAttachment[]) {
+      const mimeType = raw.mimeType ?? raw.mimetype ?? '';
+      if (!mimeType.includes('html')) continue;
+      const fileName = raw.fileName ?? raw.filename ?? 'desk-report.html';
+      if (raw.data) return { fileName, mimeType, data: raw.data };
+    }
+  }
+
+  // Fall back to scanning the plain-text result for the inline marker —
+  // this is the format the tool actually returns from its own `execute()`.
+  const result = payload['result'];
+  if (typeof result === 'string') {
+    const match = ATTACHMENT_RE.exec(result);
+    if (match) {
+      const [, fileName, mimeType, data] = match;
+      if (fileName && mimeType && data) return { fileName, mimeType, data };
+    }
+  }
+  return null;
+}
+
+export async function handleDeskReportCallback(
+  req: Request<{ channelId: string }>,
+  res: Response,
+): Promise<void> {
+  const { channelId } = req.params;
+  const payload = (req.body ?? {}) as Record<string, unknown>;
+  const sessionId = typeof payload['sessionId'] === 'string' ? payload['sessionId'] : undefined;
+  const status = typeof payload['status'] === 'string' ? payload['status'] : undefined;
+
+  logger.info('[DeskReport] callback received', { channelId, sessionId, status });
+
+  try {
+    const channel = await db.channel.findUnique({ where: { id: channelId }, select: { workspaceId: true } });
+    if (!channel?.workspaceId) {
+      logger.error('[DeskReport] callback: channel not found — cannot scope write', { channelId, sessionId });
+      throw new Error(`Desk report callback: channel ${channelId} not found or has no workspaceId`);
+    }
+    const workspaceId = channel.workspaceId;
+    const runScoped = <T>(fn: () => Promise<T>): Promise<T> =>
+      runAsServiceActor('desk-report-callback', workspaceId, fn);
+
+    // Only ever matches a row still 'pending' — a stale/duplicated webhook
+    // delivery arriving after the row already settled must never be able to
+    // flip an already-completed (or failed) report with a different run's result.
+    const recent = await runScoped(() =>
+      db.messageAttachment.findMany({
+        where: { entityType: AttachmentEntityType.DESK_REPORT, entityId: channelId, isDeleted: false },
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+      }),
+    );
+    const pending = recent.find((row) => {
+      const rowMetadata = (row.metadata as Record<string, unknown> | null) ?? {};
+      return rowMetadata['status'] === 'pending';
+    });
+    if (!pending) {
+      logger.warn('[DeskReport] callback: no pending row found for channel — dropping', { channelId, sessionId });
+      res.json({ success: true, persisted: false });
+      return;
+    }
+    const metadata = (pending.metadata as Record<string, unknown> | null) ?? {};
+
+    const errorMessage = typeof payload['error'] === 'string' ? payload['error'] : undefined;
+    const attachment = status === 'error' || errorMessage ? null : extractHtmlAttachment(payload);
+
+    if (!attachment) {
+      logger.warn('[DeskReport] callback: no report produced — marking failed', {
+        channelId,
+        sessionId,
+        status,
+        error: errorMessage,
+      });
+      await runScoped(() =>
+        db.messageAttachment.update({
+          where: { id: pending.id },
+          data: { metadata: { ...metadata, status: 'failed', error: errorMessage ?? 'No report produced' } },
+        }),
+      );
+      res.json({ success: true, persisted: false });
+      return;
+    }
+
+    const buffer = Buffer.from(attachment.data, 'base64');
+    const [uploaded] = await uploadFiles([
+      {
+        originalname: attachment.fileName,
+        mimetype: attachment.mimeType || 'text/html',
+        size: buffer.byteLength,
+        buffer,
+      } as Express.Multer.File,
+    ]);
+    if (!uploaded) throw new Error('Desk report upload produced no result');
+
+    await runScoped(() =>
+      db.messageAttachment.update({
+        where: { id: pending.id },
+        data: {
+          originalFilename: uploaded.originalName,
+          size: uploaded.fileSize,
+          mimetype: uploaded.mimeType,
+          url: uploaded.fileUrl,
+          metadata: { ...metadata, status: 'completed', generatedAt: new Date().toISOString() },
+        },
+      }),
+    );
+
+    logger.info('[DeskReport] callback: report persisted', { channelId, sessionId, url: uploaded.fileUrl });
+    res.json({ success: true, persisted: true });
+  } catch (err) {
+    logger.error('[DeskReport] callback failed', { channelId, sessionId, error: err });
+    res.status(500).json({ success: false, error: 'failed to persist desk report' });
+  }
+}

--- a/apps/backend/src/controllers/deskReportCallback.handler.ts
+++ b/apps/backend/src/controllers/deskReportCallback.handler.ts
@@ -108,26 +108,6 @@ export async function handleDeskReportCallback(
     }
     const metadata = (pending.metadata as Record<string, unknown> | null) ?? {};
 
-    // Reject a definite sessionId mismatch — a stray result must not bind to
-    // a different dispatched run. A callback that omits sessionId entirely
-    // still goes through, just logged, since some shapes may not echo it.
-    const pendingSessionId = typeof metadata['sessionId'] === 'string' ? metadata['sessionId'] : undefined;
-    if (sessionId && pendingSessionId && sessionId !== pendingSessionId) {
-      logger.warn('[DeskReport] callback: sessionId mismatch — dropping', {
-        channelId,
-        receivedSessionId: sessionId,
-        pendingSessionId,
-      });
-      res.json({ success: true, persisted: false });
-      return;
-    }
-    if (!sessionId) {
-      logger.warn('[DeskReport] callback: no sessionId in payload — accepting without cross-check', {
-        channelId,
-        pendingSessionId,
-      });
-    }
-
     const errorMessage = typeof payload['error'] === 'string' ? payload['error'] : undefined;
     const attachment = status === 'error' || errorMessage ? null : extractHtmlAttachment(payload);
 

--- a/apps/backend/src/controllers/deskReportCallback.handler.ts
+++ b/apps/backend/src/controllers/deskReportCallback.handler.ts
@@ -3,7 +3,7 @@ import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { runAsServiceActor } from '@/database/tenant/context';
 import { uploadFiles } from '@/services/fileUploadService';
-import { AttachmentEntityType } from '@xyne/shared';
+import { AttachmentEntityType, AttachmentUploadStatus } from '@xyne/shared';
 
 const ATTACHMENT_MARKER_PREFIX = '[ATTACHMENT:';
 const ATTACHMENT_HEADER_END = ']\n';
@@ -97,7 +97,7 @@ export async function handleDeskReportCallback(
           entityType: AttachmentEntityType.DESK_REPORT,
           entityId: channelId,
           isDeleted: false,
-          uploadStatus: 'pending',
+          uploadStatus: AttachmentUploadStatus.PENDING,
         },
       }),
     );
@@ -142,7 +142,7 @@ export async function handleDeskReportCallback(
         db.messageAttachment.update({
           where: { id: pending.id },
           data: {
-            uploadStatus: 'failed',
+            uploadStatus: AttachmentUploadStatus.FAILED,
             metadata: { ...metadata, error: errorMessage ?? 'No report produced' },
           },
         }),
@@ -170,7 +170,7 @@ export async function handleDeskReportCallback(
           size: uploaded.fileSize,
           mimetype: uploaded.mimeType,
           url: uploaded.fileUrl,
-          uploadStatus: 'completed',
+          uploadStatus: AttachmentUploadStatus.COMPLETED,
           metadata: { ...metadata, generatedAt: new Date().toISOString() },
         },
       }),

--- a/apps/backend/src/controllers/deskReportCallback.handler.ts
+++ b/apps/backend/src/controllers/deskReportCallback.handler.ts
@@ -68,15 +68,15 @@ function extractHtmlAttachment(
 }
 
 export async function handleDeskReportCallback(
-  req: Request<{ channelId: string }>,
+  req: Request<{ channelId: string; attachmentId: string }>,
   res: Response,
 ): Promise<void> {
-  const { channelId } = req.params;
+  const { channelId, attachmentId } = req.params;
   const payload = (req.body ?? {}) as Record<string, unknown>;
   const sessionId = typeof payload['sessionId'] === 'string' ? payload['sessionId'] : undefined;
   const status = typeof payload['status'] === 'string' ? payload['status'] : undefined;
 
-  logger.info('[DeskReport] callback received', { channelId, sessionId, status });
+  logger.info('[DeskReport] callback received', { channelId, attachmentId, sessionId, status });
 
   try {
     const channel = await db.channel.findUnique({ where: { id: channelId }, select: { workspaceId: true } });
@@ -88,12 +88,11 @@ export async function handleDeskReportCallback(
     const runScoped = <T>(fn: () => Promise<T>): Promise<T> =>
       runAsServiceActor('desk-report-callback', workspaceId, fn);
 
-    // Only ever matches a row still 'pending' — a stale/duplicated webhook
-    // delivery arriving after the row already settled must never flip an
-    // already-completed (or failed) report.
+    // Matched by the exact row id embedded in the callback URL at dispatch time
     const pending = await runScoped(() =>
       db.messageAttachment.findFirst({
         where: {
+          id: attachmentId,
           entityType: AttachmentEntityType.DESK_REPORT,
           entityId: channelId,
           isDeleted: false,
@@ -102,7 +101,7 @@ export async function handleDeskReportCallback(
       }),
     );
     if (!pending) {
-      logger.warn('[DeskReport] callback: no pending row found for channel — dropping', { channelId, sessionId });
+      logger.warn('[DeskReport] callback: no matching pending row — dropping', { channelId, attachmentId, sessionId });
       res.json({ success: true, persisted: false });
       return;
     }

--- a/apps/backend/src/controllers/deskReportCallback.handler.ts
+++ b/apps/backend/src/controllers/deskReportCallback.handler.ts
@@ -1,10 +1,3 @@
-/**
- * Terminal callback for a Claw agent run triggered by
- * deskReportGenerationService. Mirrors autodraftCallback.handler.ts's shape,
- * but decodes the `[ATTACHMENT:<name>:<mime>]\n<base64>` marker
- * `create-desk-report` emits instead of treating the result as plain text,
- * and persists into MessageAttachment (entityType=DESK_REPORT).
- */
 import type { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
@@ -12,9 +5,32 @@ import { runAsServiceActor } from '@/database/tenant/context';
 import { uploadFiles } from '@/services/fileUploadService';
 import { AttachmentEntityType } from '@xyne/shared';
 
-// Matches the same marker create-desk-report emits and custom-tools.ts parses
-// on the claw side: `[ATTACHMENT:<fileName>:<mimeType>]\n<base64>`.
-const ATTACHMENT_RE = /\[ATTACHMENT:([^:\]]+):([^\]]+)\]\n([A-Za-z0-9+/=]+)/;
+const ATTACHMENT_MARKER_PREFIX = '[ATTACHMENT:';
+const ATTACHMENT_HEADER_END = ']\n';
+
+function parseAttachmentMarker(
+  text: string,
+): { fileName: string; mimeType: string; data: string } | null {
+  const start = text.indexOf(ATTACHMENT_MARKER_PREFIX);
+  if (start === -1) return null;
+  const headerStart = start + ATTACHMENT_MARKER_PREFIX.length;
+  const headerEnd = text.indexOf(ATTACHMENT_HEADER_END, headerStart);
+  if (headerEnd === -1) return null;
+
+  const header = text.slice(headerStart, headerEnd);
+  const sep = header.indexOf(':');
+  if (sep === -1) return null;
+
+  const fileName = header.slice(0, sep);
+  const mimeType = header.slice(sep + 1);
+
+  const dataStart = headerEnd + ATTACHMENT_HEADER_END.length;
+  const dataEnd = text.indexOf('\n', dataStart);
+  const data = (dataEnd === -1 ? text.slice(dataStart) : text.slice(dataStart, dataEnd)).trim();
+  if (!fileName || !mimeType || !data) return null;
+
+  return { fileName, mimeType, data };
+}
 
 interface RawAttachment {
   fileName?: string;
@@ -45,11 +61,8 @@ function extractHtmlAttachment(
   // this is the format the tool actually returns from its own `execute()`.
   const result = payload['result'];
   if (typeof result === 'string') {
-    const match = ATTACHMENT_RE.exec(result);
-    if (match) {
-      const [, fileName, mimeType, data] = match;
-      if (fileName && mimeType && data) return { fileName, mimeType, data };
-    }
+    const parsed = parseAttachmentMarker(result);
+    if (parsed) return parsed;
   }
   return null;
 }
@@ -76,25 +89,44 @@ export async function handleDeskReportCallback(
       runAsServiceActor('desk-report-callback', workspaceId, fn);
 
     // Only ever matches a row still 'pending' — a stale/duplicated webhook
-    // delivery arriving after the row already settled must never be able to
-    // flip an already-completed (or failed) report with a different run's result.
-    const recent = await runScoped(() =>
-      db.messageAttachment.findMany({
-        where: { entityType: AttachmentEntityType.DESK_REPORT, entityId: channelId, isDeleted: false },
-        orderBy: { createdAt: 'desc' },
-        take: 5,
+    // delivery arriving after the row already settled must never flip an
+    // already-completed (or failed) report.
+    const pending = await runScoped(() =>
+      db.messageAttachment.findFirst({
+        where: {
+          entityType: AttachmentEntityType.DESK_REPORT,
+          entityId: channelId,
+          isDeleted: false,
+          uploadStatus: 'pending',
+        },
       }),
     );
-    const pending = recent.find((row) => {
-      const rowMetadata = (row.metadata as Record<string, unknown> | null) ?? {};
-      return rowMetadata['status'] === 'pending';
-    });
     if (!pending) {
       logger.warn('[DeskReport] callback: no pending row found for channel — dropping', { channelId, sessionId });
       res.json({ success: true, persisted: false });
       return;
     }
     const metadata = (pending.metadata as Record<string, unknown> | null) ?? {};
+
+    // Reject a definite sessionId mismatch — a stray result must not bind to
+    // a different dispatched run. A callback that omits sessionId entirely
+    // still goes through, just logged, since some shapes may not echo it.
+    const pendingSessionId = typeof metadata['sessionId'] === 'string' ? metadata['sessionId'] : undefined;
+    if (sessionId && pendingSessionId && sessionId !== pendingSessionId) {
+      logger.warn('[DeskReport] callback: sessionId mismatch — dropping', {
+        channelId,
+        receivedSessionId: sessionId,
+        pendingSessionId,
+      });
+      res.json({ success: true, persisted: false });
+      return;
+    }
+    if (!sessionId) {
+      logger.warn('[DeskReport] callback: no sessionId in payload — accepting without cross-check', {
+        channelId,
+        pendingSessionId,
+      });
+    }
 
     const errorMessage = typeof payload['error'] === 'string' ? payload['error'] : undefined;
     const attachment = status === 'error' || errorMessage ? null : extractHtmlAttachment(payload);
@@ -109,7 +141,10 @@ export async function handleDeskReportCallback(
       await runScoped(() =>
         db.messageAttachment.update({
           where: { id: pending.id },
-          data: { metadata: { ...metadata, status: 'failed', error: errorMessage ?? 'No report produced' } },
+          data: {
+            uploadStatus: 'failed',
+            metadata: { ...metadata, error: errorMessage ?? 'No report produced' },
+          },
         }),
       );
       res.json({ success: true, persisted: false });
@@ -135,7 +170,8 @@ export async function handleDeskReportCallback(
           size: uploaded.fileSize,
           mimetype: uploaded.mimeType,
           url: uploaded.fileUrl,
-          metadata: { ...metadata, status: 'completed', generatedAt: new Date().toISOString() },
+          uploadStatus: 'completed',
+          metadata: { ...metadata, generatedAt: new Date().toISOString() },
         },
       }),
     );

--- a/apps/backend/src/controllers/deskReportPanelController.ts
+++ b/apps/backend/src/controllers/deskReportPanelController.ts
@@ -1,0 +1,247 @@
+/**
+ * Read-side for the Desk Report sidebar panel — "give me the latest generated
+ * report for THIS desk". Every query is filtered by entityId=channelId, which
+ * is what guarantees a desk can never see another desk's report (see the
+ * Phase 2 plan's isolation requirement).
+ */
+import type { Request, Response } from 'express';
+import { logger } from '@/utils/logger';
+import { db } from '@/database/client';
+import { assertChannelMembership } from '@/utils/channelMembership';
+import { AttachmentEntityType, ChannelRole } from '@xyne/shared';
+import { deskReportGenerationService } from '@/services/deskReportGenerationService';
+import { storageService } from '@/services/storage/index';
+import { normalizeStoragePath } from '@xyne/storage';
+import { config } from '@/config/env';
+import { ChannelParticipantRepository } from '@/database/repositories/channelParticipantRepository';
+
+const channelParticipantRepo = new ChannelParticipantRepository();
+
+/**
+ * "Can this user manage Desk Report for this desk" — same rule as
+ * EmailChannelPreferencesACL.canUpdate: the desk owner, or a channel-level
+ * admin, never an org-wide role. Shared by getLatest (button visibility)
+ * and generateNow (actual enforcement).
+ */
+async function canManageDeskReport(
+  channelId: string,
+  userId: string | undefined,
+  ownerUserId: string | null | undefined,
+): Promise<boolean> {
+  if (!userId) return false;
+  if (ownerUserId && ownerUserId === userId) return true;
+  const participant = await channelParticipantRepo.findParticipant(channelId, userId);
+  return participant?.role === ChannelRole.ADMIN;
+}
+
+export class DeskReportPanelController {
+  /** GET /api/desk-report/:channelId/latest */
+  getLatest = async (req: Request, res: Response): Promise<void> => {
+    const channelId = req.params['channelId'];
+    if (!channelId) {
+      res.status(400).json({ success: false, error: 'channelId is required' });
+      return;
+    }
+
+    const access = await assertChannelMembership(req, channelId);
+    if (!access.ok) {
+      res.status(access.status).json({ success: false, error: access.error });
+      return;
+    }
+
+    try {
+      // Computed server-side and returned as `canGenerate` so the panel's
+      // button visibility can never drift from what generateNow enforces.
+      const ownerUserId = (
+        await db.emailChannelPreference.findUnique({ where: { channelId }, select: { ownerUserId: true } })
+      )?.ownerUserId;
+      const canGenerate = await canManageDeskReport(channelId, req.user?.id, ownerUserId);
+
+      // Pull recent rows, not just the newest — a regeneration writes a
+      // fresh 'pending' row that would otherwise blank out the report the
+      // user is looking at. We report the latest COMPLETED report plus a
+      // `generating` flag, so the previous report never disappears mid-run.
+      const recent = await db.messageAttachment.findMany({
+        where: {
+          entityType: AttachmentEntityType.DESK_REPORT,
+          entityId: channelId,
+          isDeleted: false,
+        },
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+      });
+
+      if (recent.length === 0) {
+        res.json({ success: true, data: null, canGenerate });
+        return;
+      }
+
+      const statusOf = (row: (typeof recent)[number]): string => {
+        const metadata = (row.metadata as Record<string, unknown> | null) ?? {};
+        return typeof metadata['status'] === 'string' ? metadata['status'] : 'completed';
+      };
+
+      const newest = recent[0];
+      const completed = recent.find((row) => statusOf(row) === 'completed') ?? null;
+      const generating = statusOf(newest) === 'pending';
+
+      if (!completed) {
+        // Never had a completed report — surface the newest row's own state
+        // (pending/failed) as before.
+        const metadata = (newest.metadata as Record<string, unknown> | null) ?? {};
+        res.json({
+          success: true,
+          data: {
+            status: statusOf(newest),
+            url: null,
+            generatedAt: (metadata['generatedAt'] as string | undefined) ?? newest.createdAt.toISOString(),
+            rangeDays: (metadata['rangeDays'] as number | undefined) ?? 1,
+            agentSlug: (metadata['agentSlug'] as string | undefined) ?? null,
+            error: (metadata['error'] as string | undefined) ?? null,
+            generating,
+          },
+          canGenerate,
+        });
+        return;
+      }
+
+      const metadata = (completed.metadata as Record<string, unknown> | null) ?? {};
+      // Only surface an error if the newest attempt failed AND it's not the
+      // one already represented by `completed` — i.e. a regeneration attempt
+      // failed after this report was generated.
+      const newestFailed = statusOf(newest) === 'failed' && newest.id !== completed.id;
+      const newestMetadata = newestFailed ? ((newest.metadata as Record<string, unknown> | null) ?? {}) : null;
+
+      res.json({
+        success: true,
+        data: {
+          status: 'completed',
+          // `latest.url` is a raw storage path, not a fetchable web URL —
+          // point the client at our own streaming route instead.
+          url: `/desk-report/${encodeURIComponent(channelId)}/view`,
+          generatedAt: (metadata['generatedAt'] as string | undefined) ?? completed.createdAt.toISOString(),
+          rangeDays: (metadata['rangeDays'] as number | undefined) ?? 1,
+          agentSlug: (metadata['agentSlug'] as string | undefined) ?? null,
+          error: newestFailed ? ((newestMetadata?.['error'] as string | undefined) ?? 'Generation failed') : null,
+          generating,
+        },
+        canGenerate,
+      });
+    } catch (err) {
+      logger.error('[DeskReportPanel] getLatest failed', { channelId, error: err });
+      res.status(500).json({ success: false, error: 'Failed to fetch desk report' });
+    }
+  };
+
+  /**
+   * GET /api/desk-report/:channelId/view — streams the latest completed
+   * report's HTML. Add `?download=1` to force a save-as instead of inline
+   * render. The report is our own server-generated, sanitized HTML (not a
+   * user upload), so unlike the generic attachment-download route it's safe
+   * to serve as inline text/html for the sidebar iframe.
+   */
+  serveReport = async (req: Request, res: Response): Promise<void> => {
+    const channelId = req.params['channelId'];
+    if (!channelId) {
+      res.status(400).send('channelId is required');
+      return;
+    }
+
+    const access = await assertChannelMembership(req, channelId);
+    if (!access.ok) {
+      res.status(access.status).send(access.error);
+      return;
+    }
+
+    try {
+      // Must match getLatest's fallback — serve the latest COMPLETED row,
+      // not just the newest, since a regeneration may still be pending.
+      const recent = await db.messageAttachment.findMany({
+        where: { entityType: AttachmentEntityType.DESK_REPORT, entityId: channelId, isDeleted: false },
+        orderBy: { createdAt: 'desc' },
+        take: 5,
+      });
+      const latest = recent.find((row) => {
+        const metadata = (row.metadata as Record<string, unknown> | null) ?? {};
+        return metadata['status'] === 'completed';
+      });
+      if (!latest || !latest.url) {
+        res.status(404).send('No completed desk report for this channel');
+        return;
+      }
+
+      const filePath = normalizeStoragePath(latest.url);
+      if (!filePath) {
+        res.status(404).send('Report file not found');
+        return;
+      }
+      const buffer = await storageService.getFileBuffer(filePath);
+
+      const download = req.query['download'] === '1';
+      const filename = encodeURIComponent(latest.originalFilename || 'desk-report.html');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.setHeader('Content-Disposition', `${download ? 'attachment' : 'inline'}; filename="${filename}"`);
+      res.setHeader('Cache-Control', 'private, max-age=60');
+      if (!download) {
+        // helmet's default X-Frame-Options/CSP would otherwise block this
+        // route's whole purpose — embedding in the dashboard's iframe.
+        res.removeHeader('X-Frame-Options');
+        res.setHeader('Content-Security-Policy', `frame-ancestors 'self' ${config.frontendUrl}`);
+      }
+      res.send(buffer);
+    } catch (err) {
+      logger.error('[DeskReportPanel] serveReport failed', { channelId, error: err });
+      res.status(500).send('Failed to load desk report');
+    }
+  };
+
+  /** POST /api/desk-report/:channelId/generate — manual "generate now" trigger. */
+  generateNow = async (req: Request, res: Response): Promise<void> => {
+    const channelId = req.params['channelId'];
+    if (!channelId) {
+      res.status(400).json({ success: false, error: 'channelId is required' });
+      return;
+    }
+
+    const access = await assertChannelMembership(req, channelId);
+    if (!access.ok) {
+      res.status(access.status).json({ success: false, error: access.error });
+      return;
+    }
+
+    try {
+      const pref = await db.emailChannelPreference.findUnique({
+        where: { channelId },
+        select: {
+          channelId: true,
+          ownerUserId: true,
+          workspaceId: true,
+          deskReportEnabled: true,
+          deskReportAgentSlug: true,
+          deskReportRangeDays: true,
+        },
+      });
+
+      if (!(await canManageDeskReport(channelId, req.user?.id, pref?.ownerUserId))) {
+        res
+          .status(403)
+          .json({ success: false, error: 'Only the desk owner or a channel admin can generate a report for this desk' });
+        return;
+      }
+
+      if (!pref?.deskReportEnabled) {
+        res.status(400).json({ success: false, error: 'Desk report is not enabled for this desk' });
+        return;
+      }
+
+      const result = await deskReportGenerationService.generateReportForChannel(pref);
+      res.json({ success: result.success, error: result.error });
+    } catch (err) {
+      logger.error('[DeskReportPanel] generateNow failed', { channelId, error: err });
+      res.status(500).json({ success: false, error: 'Failed to trigger desk report' });
+    }
+  };
+}
+
+export const deskReportPanelController = new DeskReportPanelController();

--- a/apps/backend/src/controllers/deskReportPanelController.ts
+++ b/apps/backend/src/controllers/deskReportPanelController.ts
@@ -2,7 +2,7 @@ import type { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { assertChannelMembership } from '@/utils/channelMembership';
-import { AttachmentEntityType, ChannelRole } from '@xyne/shared';
+import { AttachmentEntityType, AttachmentUploadStatus, ChannelRole } from '@xyne/shared';
 import { deskReportGenerationService, STUCK_PENDING_HOURS } from '@/services/deskReportGenerationService';
 import { storageService } from '@/services/storage/index';
 import { normalizeStoragePath } from '@xyne/storage';
@@ -10,6 +10,13 @@ import { config } from '@/config/env';
 import { ChannelParticipantRepository } from '@/database/repositories/channelParticipantRepository';
 
 const channelParticipantRepo = new ChannelParticipantRepository();
+
+/** Maps the DB's uppercase enum to the lowercase status shape the frontend expects. */
+function toClientStatus(uploadStatus: string | null): 'pending' | 'completed' | 'failed' {
+  if (uploadStatus === AttachmentUploadStatus.COMPLETED) return 'completed';
+  if (uploadStatus === AttachmentUploadStatus.FAILED) return 'failed';
+  return 'pending';
+}
 
 async function canManageDeskReport(
   channelId: string,
@@ -57,7 +64,7 @@ export class DeskReportPanelController {
             entityType: AttachmentEntityType.DESK_REPORT,
             entityId: channelId,
             isDeleted: false,
-            uploadStatus: 'completed',
+            uploadStatus: AttachmentUploadStatus.COMPLETED,
           },
           orderBy: { createdAt: 'desc' },
         }),
@@ -71,8 +78,8 @@ export class DeskReportPanelController {
       // A 'pending' row older than this is a crashed/dropped run, not still
       // generating — don't show "Generating…" forever.
       const stuckCutoff = new Date(Date.now() - STUCK_PENDING_HOURS * 60 * 60 * 1000);
-      const isStuckPending = newest.uploadStatus === 'pending' && newest.createdAt < stuckCutoff;
-      const generating = newest.uploadStatus === 'pending' && !isStuckPending;
+      const isStuckPending = newest.uploadStatus === AttachmentUploadStatus.PENDING && newest.createdAt < stuckCutoff;
+      const generating = newest.uploadStatus === AttachmentUploadStatus.PENDING && !isStuckPending;
 
       if (!completed) {
         // Never had a completed report — surface the newest row's own state
@@ -81,7 +88,7 @@ export class DeskReportPanelController {
         res.json({
           success: true,
           data: {
-            status: isStuckPending ? 'failed' : (newest.uploadStatus ?? 'completed'),
+            status: isStuckPending ? 'failed' : toClientStatus(newest.uploadStatus),
             url: null,
             generatedAt: (metadata['generatedAt'] as string | undefined) ?? newest.createdAt.toISOString(),
             rangeDays: (metadata['rangeDays'] as number | undefined) ?? 1,
@@ -98,7 +105,7 @@ export class DeskReportPanelController {
       // Only surface an error if the newest attempt failed (or timed out) AND
       // it's not the one already represented by `completed` — i.e. a
       // regeneration attempt failed after this report was generated.
-      const newestFailed = (newest.uploadStatus === 'failed' || isStuckPending) && newest.id !== completed.id;
+      const newestFailed = (newest.uploadStatus === AttachmentUploadStatus.FAILED || isStuckPending) && newest.id !== completed.id;
       const newestMetadata = newestFailed ? ((newest.metadata as Record<string, unknown> | null) ?? {}) : null;
 
       res.json({
@@ -151,7 +158,7 @@ export class DeskReportPanelController {
           entityType: AttachmentEntityType.DESK_REPORT,
           entityId: channelId,
           isDeleted: false,
-          uploadStatus: 'completed',
+          uploadStatus: AttachmentUploadStatus.COMPLETED,
         },
         orderBy: { createdAt: 'desc' },
       });

--- a/apps/backend/src/controllers/deskReportPanelController.ts
+++ b/apps/backend/src/controllers/deskReportPanelController.ts
@@ -1,15 +1,9 @@
-/**
- * Read-side for the Desk Report sidebar panel — "give me the latest generated
- * report for THIS desk". Every query is filtered by entityId=channelId, which
- * is what guarantees a desk can never see another desk's report (see the
- * Phase 2 plan's isolation requirement).
- */
 import type { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { assertChannelMembership } from '@/utils/channelMembership';
 import { AttachmentEntityType, ChannelRole } from '@xyne/shared';
-import { deskReportGenerationService } from '@/services/deskReportGenerationService';
+import { deskReportGenerationService, STUCK_PENDING_HOURS } from '@/services/deskReportGenerationService';
 import { storageService } from '@/services/storage/index';
 import { normalizeStoragePath } from '@xyne/storage';
 import { config } from '@/config/env';
@@ -17,12 +11,6 @@ import { ChannelParticipantRepository } from '@/database/repositories/channelPar
 
 const channelParticipantRepo = new ChannelParticipantRepository();
 
-/**
- * "Can this user manage Desk Report for this desk" — same rule as
- * EmailChannelPreferencesACL.canUpdate: the desk owner, or a channel-level
- * admin, never an org-wide role. Shared by getLatest (button visibility)
- * and generateNow (actual enforcement).
- */
 async function canManageDeskReport(
   channelId: string,
   userId: string | undefined,
@@ -57,33 +45,34 @@ export class DeskReportPanelController {
       )?.ownerUserId;
       const canGenerate = await canManageDeskReport(channelId, req.user?.id, ownerUserId);
 
-      // Pull recent rows, not just the newest — a regeneration writes a
-      // fresh 'pending' row that would otherwise blank out the report the
-      // user is looking at. We report the latest COMPLETED report plus a
-      // `generating` flag, so the previous report never disappears mid-run.
-      const recent = await db.messageAttachment.findMany({
-        where: {
-          entityType: AttachmentEntityType.DESK_REPORT,
-          entityId: channelId,
-          isDeleted: false,
-        },
-        orderBy: { createdAt: 'desc' },
-        take: 5,
-      });
+      // Query the latest completed report and the newest row directly via
+      // uploadStatus — no fixed-window scan to push a completed report out of view.
+      const [newest, completed] = await Promise.all([
+        db.messageAttachment.findFirst({
+          where: { entityType: AttachmentEntityType.DESK_REPORT, entityId: channelId, isDeleted: false },
+          orderBy: { createdAt: 'desc' },
+        }),
+        db.messageAttachment.findFirst({
+          where: {
+            entityType: AttachmentEntityType.DESK_REPORT,
+            entityId: channelId,
+            isDeleted: false,
+            uploadStatus: 'completed',
+          },
+          orderBy: { createdAt: 'desc' },
+        }),
+      ]);
 
-      if (recent.length === 0) {
+      if (!newest) {
         res.json({ success: true, data: null, canGenerate });
         return;
       }
 
-      const statusOf = (row: (typeof recent)[number]): string => {
-        const metadata = (row.metadata as Record<string, unknown> | null) ?? {};
-        return typeof metadata['status'] === 'string' ? metadata['status'] : 'completed';
-      };
-
-      const newest = recent[0];
-      const completed = recent.find((row) => statusOf(row) === 'completed') ?? null;
-      const generating = statusOf(newest) === 'pending';
+      // A 'pending' row older than this is a crashed/dropped run, not still
+      // generating — don't show "Generating…" forever.
+      const stuckCutoff = new Date(Date.now() - STUCK_PENDING_HOURS * 60 * 60 * 1000);
+      const isStuckPending = newest.uploadStatus === 'pending' && newest.createdAt < stuckCutoff;
+      const generating = newest.uploadStatus === 'pending' && !isStuckPending;
 
       if (!completed) {
         // Never had a completed report — surface the newest row's own state
@@ -92,12 +81,12 @@ export class DeskReportPanelController {
         res.json({
           success: true,
           data: {
-            status: statusOf(newest),
+            status: isStuckPending ? 'failed' : (newest.uploadStatus ?? 'completed'),
             url: null,
             generatedAt: (metadata['generatedAt'] as string | undefined) ?? newest.createdAt.toISOString(),
             rangeDays: (metadata['rangeDays'] as number | undefined) ?? 1,
             agentSlug: (metadata['agentSlug'] as string | undefined) ?? null,
-            error: (metadata['error'] as string | undefined) ?? null,
+            error: isStuckPending ? 'Generation timed out' : ((metadata['error'] as string | undefined) ?? null),
             generating,
           },
           canGenerate,
@@ -106,10 +95,10 @@ export class DeskReportPanelController {
       }
 
       const metadata = (completed.metadata as Record<string, unknown> | null) ?? {};
-      // Only surface an error if the newest attempt failed AND it's not the
-      // one already represented by `completed` — i.e. a regeneration attempt
-      // failed after this report was generated.
-      const newestFailed = statusOf(newest) === 'failed' && newest.id !== completed.id;
+      // Only surface an error if the newest attempt failed (or timed out) AND
+      // it's not the one already represented by `completed` — i.e. a
+      // regeneration attempt failed after this report was generated.
+      const newestFailed = (newest.uploadStatus === 'failed' || isStuckPending) && newest.id !== completed.id;
       const newestMetadata = newestFailed ? ((newest.metadata as Record<string, unknown> | null) ?? {}) : null;
 
       res.json({
@@ -122,7 +111,11 @@ export class DeskReportPanelController {
           generatedAt: (metadata['generatedAt'] as string | undefined) ?? completed.createdAt.toISOString(),
           rangeDays: (metadata['rangeDays'] as number | undefined) ?? 1,
           agentSlug: (metadata['agentSlug'] as string | undefined) ?? null,
-          error: newestFailed ? ((newestMetadata?.['error'] as string | undefined) ?? 'Generation failed') : null,
+          error: newestFailed
+            ? isStuckPending
+              ? 'Generation timed out'
+              : ((newestMetadata?.['error'] as string | undefined) ?? 'Generation failed')
+            : null,
           generating,
         },
         canGenerate,
@@ -134,11 +127,7 @@ export class DeskReportPanelController {
   };
 
   /**
-   * GET /api/desk-report/:channelId/view — streams the latest completed
-   * report's HTML. Add `?download=1` to force a save-as instead of inline
-   * render. The report is our own server-generated, sanitized HTML (not a
-   * user upload), so unlike the generic attachment-download route it's safe
-   * to serve as inline text/html for the sidebar iframe.
+   * GET /api/desk-report/:channelId/view — streams the latest completed report's HTML.
    */
   serveReport = async (req: Request, res: Response): Promise<void> => {
     const channelId = req.params['channelId'];
@@ -154,16 +143,17 @@ export class DeskReportPanelController {
     }
 
     try {
-      // Must match getLatest's fallback — serve the latest COMPLETED row,
-      // not just the newest, since a regeneration may still be pending.
-      const recent = await db.messageAttachment.findMany({
-        where: { entityType: AttachmentEntityType.DESK_REPORT, entityId: channelId, isDeleted: false },
+      // Must match getLatest — serve the latest COMPLETED row directly via
+      // uploadStatus, not just the newest, since a regeneration may still be
+      // pending.
+      const latest = await db.messageAttachment.findFirst({
+        where: {
+          entityType: AttachmentEntityType.DESK_REPORT,
+          entityId: channelId,
+          isDeleted: false,
+          uploadStatus: 'completed',
+        },
         orderBy: { createdAt: 'desc' },
-        take: 5,
-      });
-      const latest = recent.find((row) => {
-        const metadata = (row.metadata as Record<string, unknown> | null) ?? {};
-        return metadata['status'] === 'completed';
       });
       if (!latest || !latest.url) {
         res.status(404).send('No completed desk report for this channel');
@@ -187,7 +177,21 @@ export class DeskReportPanelController {
         // helmet's default X-Frame-Options/CSP would otherwise block this
         // route's whole purpose — embedding in the dashboard's iframe.
         res.removeHeader('X-Frame-Options');
-        res.setHeader('Content-Security-Policy', `frame-ancestors 'self' ${config.frontendUrl}`);
+        res.setHeader(
+          'Content-Security-Policy',
+          [
+            'sandbox allow-scripts',
+            "default-src 'none'",
+            "script-src 'unsafe-inline'",
+            "style-src 'unsafe-inline'",
+            'img-src data: https:',
+            "connect-src 'none'",
+            "frame-src 'none'",
+            "form-action 'none'",
+            "base-uri 'none'",
+            `frame-ancestors 'self' ${config.frontendUrl}`,
+          ].join('; '),
+        );
       }
       res.send(buffer);
     } catch (err) {

--- a/apps/backend/src/database/repositories/messageAttachmentRepository.ts
+++ b/apps/backend/src/database/repositories/messageAttachmentRepository.ts
@@ -19,6 +19,7 @@ export interface CreateMessageAttachmentInput {
   workspaceId: string;
   metadata?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   createdAt?: Date;
+  uploadStatus?: string;
 }
 
 export class MessageAttachmentRepository {
@@ -42,6 +43,7 @@ export class MessageAttachmentRepository {
         conversationId: data.conversationId,
         workspaceId: data.workspaceId,
         metadata: data.metadata || {},
+        ...(data.uploadStatus && { uploadStatus: data.uploadStatus }),
         ...(data.createdAt && { createdAt: data.createdAt })
       }
     });

--- a/apps/backend/src/routes/deskReportPanelRoutes.ts
+++ b/apps/backend/src/routes/deskReportPanelRoutes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { deskReportPanelController } from '@/controllers/deskReportPanelController';
+
+const router = Router();
+
+router.get('/:channelId/latest', deskReportPanelController.getLatest);
+router.get('/:channelId/view', deskReportPanelController.serveReport);
+// Manual "generate now" is desk-owner/channel-admin only — see
+// generateNow's own check for why this isn't org-level requireAdminOrOwner.
+router.post('/:channelId/generate', deskReportPanelController.generateNow);
+
+export default router;

--- a/apps/backend/src/services/deskReportGenerationService.ts
+++ b/apps/backend/src/services/deskReportGenerationService.ts
@@ -5,7 +5,7 @@ import { config } from '@/config/env';
 import { runClawAgent, listS2SClawAgents } from '@/services/clawAgentService';
 import { MessageAttachmentRepository } from '@/database/repositories/messageAttachmentRepository';
 import { storageService } from '@/services/storage';
-import { AttachmentEntityType } from '@xyne/shared';
+import { AttachmentEntityType, AttachmentUploadStatus } from '@xyne/shared';
 
 const DESK_REPORT_ENTITY_TYPE = AttachmentEntityType.DESK_REPORT;
 // A run with no callback (crash, dropped webhook) is reaped as failed past this age.
@@ -89,7 +89,7 @@ export class DeskReportGenerationService {
 
     // Refuse a second run while one's in flight. Plain check-then-write.
     const existingPending = await db.messageAttachment.findFirst({
-      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false, uploadStatus: 'pending' },
+      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false, uploadStatus: AttachmentUploadStatus.PENDING },
       orderBy: { createdAt: 'desc' },
     });
     if (existingPending) {
@@ -141,7 +141,7 @@ export class DeskReportGenerationService {
         storageProvider: config.fileStorage.provider,
         conversationId: null,
         workspaceId,
-        uploadStatus: 'failed',
+        uploadStatus: AttachmentUploadStatus.FAILED,
         metadata: { rangeDays, agentSlug, triggeredBy: 'cron', error: dispatchBlockedMessage },
       });
       return { channelId, success: false, error: dispatchBlockedMessage };
@@ -164,7 +164,7 @@ export class DeskReportGenerationService {
       storageProvider: config.fileStorage.provider,
       conversationId: null,
       workspaceId,
-      uploadStatus: 'pending',
+      uploadStatus: AttachmentUploadStatus.PENDING,
       metadata: {
         rangeDays,
         agentSlug: resolvedAgentSlug,
@@ -194,7 +194,7 @@ export class DeskReportGenerationService {
         channelId,
         agentSlug: resolvedAgentSlug,
       });
-      await this.markLatestPending(channelId, 'failed', 'Agent not installed for this workspace');
+      await this.markLatestPending(channelId, AttachmentUploadStatus.FAILED, 'Agent not installed for this workspace');
       return { channelId, success: false, error: 'Agent not installed for this workspace' };
     }
 
@@ -203,9 +203,9 @@ export class DeskReportGenerationService {
   }
 
   /** Flip the most recent pending row for a channel to failed, e.g. on dispatch failure. */
-  private async markLatestPending(channelId: string, status: 'failed', errorMessage?: string): Promise<void> {
+  private async markLatestPending(channelId: string, status: AttachmentUploadStatus.FAILED, errorMessage?: string): Promise<void> {
     const pending = await db.messageAttachment.findFirst({
-      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false, uploadStatus: 'pending' },
+      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false, uploadStatus: AttachmentUploadStatus.PENDING },
       orderBy: { createdAt: 'desc' },
     });
     if (!pending) return;
@@ -228,7 +228,7 @@ export class DeskReportGenerationService {
         entityType: DESK_REPORT_ENTITY_TYPE,
         entityId: channelId,
         isDeleted: false,
-        uploadStatus: 'pending',
+        uploadStatus: AttachmentUploadStatus.PENDING,
         createdAt: { lt: stuckCutoff },
       },
     });
@@ -236,7 +236,7 @@ export class DeskReportGenerationService {
       const metadata = (row.metadata as Record<string, unknown> | null) ?? {};
       await db.messageAttachment.update({
         where: { id: row.id },
-        data: { uploadStatus: 'failed', metadata: { ...metadata, error: 'Generation timed out' } },
+        data: { uploadStatus: AttachmentUploadStatus.FAILED, metadata: { ...metadata, error: 'Generation timed out' } },
       });
     }
   }
@@ -250,10 +250,10 @@ export class DeskReportGenerationService {
       where: {
         entityType: DESK_REPORT_ENTITY_TYPE,
         isDeleted: false,
-        uploadStatus: 'pending',
+        uploadStatus: AttachmentUploadStatus.PENDING,
         createdAt: { lt: stuckCutoff },
       },
-      data: { uploadStatus: 'failed' },
+      data: { uploadStatus: AttachmentUploadStatus.FAILED },
     });
 
     const rows = await db.messageAttachment.findMany({
@@ -265,7 +265,7 @@ export class DeskReportGenerationService {
     // Group by channel so we can always spare each channel's newest completed row.
     const latestCompletedIdByChannel = new Map<string, string>();
     for (const row of rows) {
-      if (row.uploadStatus !== 'completed') continue;
+      if (row.uploadStatus !== AttachmentUploadStatus.COMPLETED) continue;
       if (!latestCompletedIdByChannel.has(row.entityId)) {
         latestCompletedIdByChannel.set(row.entityId, row.id); // rows are newest-first
       }

--- a/apps/backend/src/services/deskReportGenerationService.ts
+++ b/apps/backend/src/services/deskReportGenerationService.ts
@@ -10,6 +10,7 @@ import { AttachmentEntityType, AttachmentUploadStatus } from '@xyne/shared';
 const DESK_REPORT_ENTITY_TYPE = AttachmentEntityType.DESK_REPORT;
 // A run with no callback (crash, dropped webhook) is reaped as failed past this age.
 export const STUCK_PENDING_HOURS = 3;
+export const DEFAULT_DESK_REPORT_AGENT_SLUG = 'desk-report-generator';
 
 const messageAttachmentRepo = new MessageAttachmentRepository();
 
@@ -76,7 +77,7 @@ export class DeskReportGenerationService {
     deskReportRangeDays: number | null;
   }): Promise<DeskReportGenerationResult> {
     const { channelId, workspaceId } = pref;
-    const agentSlug = pref.deskReportAgentSlug?.trim() || null;
+    const agentSlug = pref.deskReportAgentSlug?.trim() || DEFAULT_DESK_REPORT_AGENT_SLUG;
     const rangeDays = pref.deskReportRangeDays && pref.deskReportRangeDays > 0 ? pref.deskReportRangeDays : 1;
 
     if (!pref.ownerUserId) {
@@ -109,12 +110,8 @@ export class DeskReportGenerationService {
     const channel = await db.channel.findUnique({ where: { id: channelId }, select: { name: true } });
     const channelName = channel?.name ?? channelId;
 
-    // Two reasons dispatch can be blocked, both surfaced as a 'failed' row:
-    // no agent picked, or a picked agent no longer exists.
     let dispatchBlockedMessage: string | null = null;
-    if (!agentSlug) {
-      dispatchBlockedMessage = 'No agent selected for Desk Report. Pick an agent in Desk Settings → Agent before this desk\'s report can be generated.';
-    } else {
+    {
       let agentExists: boolean;
       try {
         const agents = await listS2SClawAgents();
@@ -124,7 +121,9 @@ export class DeskReportGenerationService {
         agentExists = true; // fail open on a transient lookup error — let the dispatch attempt itself decide
       }
       if (!agentExists) {
-        dispatchBlockedMessage = `Agent "${agentSlug}" isn't configured in this workspace. Pick a different agent for Desk Report in Desk Settings → Agent.`;
+        dispatchBlockedMessage = pref.deskReportAgentSlug?.trim()
+          ? `Agent "${agentSlug}" isn't configured in this workspace. Pick a different agent for Desk Report in Desk Settings → Agent.`
+          : `The default Desk Report agent isn't installed in this workspace yet. Ask an admin to install it, or pick a different agent in Desk Settings → Agent.`;
       }
     }
     if (dispatchBlockedMessage) {

--- a/apps/backend/src/services/deskReportGenerationService.ts
+++ b/apps/backend/src/services/deskReportGenerationService.ts
@@ -2,10 +2,13 @@ import { randomUUID } from 'crypto';
 import { db } from '@/database/client';
 import { logger } from '@/utils/logger';
 import { config } from '@/config/env';
-import { runClawAgent, listS2SClawAgents } from '@/services/clawAgentService';
+import { runClawAgent } from '@/services/clawAgentService';
 import { MessageAttachmentRepository } from '@/database/repositories/messageAttachmentRepository';
 import { storageService } from '@/services/storage';
+import { runAsServiceActor } from '@/database/tenant/context';
 import { AttachmentEntityType, AttachmentUploadStatus } from '@xyne/shared';
+
+const DESK_REPORT_SCHEDULER_ACTOR_ID = 'desk-report-scheduler';
 
 const DESK_REPORT_ENTITY_TYPE = AttachmentEntityType.DESK_REPORT;
 // A run with no callback (crash, dropped webhook) is reaped as failed past this age.
@@ -46,7 +49,9 @@ export class DeskReportGenerationService {
     const results: DeskReportGenerationResult[] = [];
     for (const pref of preferences) {
       try {
-        const result = await this.generateReportForChannel(pref);
+        const result = await runAsServiceActor(DESK_REPORT_SCHEDULER_ACTOR_ID, pref.workspaceId, () =>
+          this.generateReportForChannel(pref),
+        );
         results.push(result);
       } catch (error) {
         logger.error(`[DeskReport] Unexpected error for channel ${pref.channelId}:`, error);
@@ -109,49 +114,14 @@ export class DeskReportGenerationService {
 
     const channel = await db.channel.findUnique({ where: { id: channelId }, select: { name: true } });
     const channelName = channel?.name ?? channelId;
-
-    let dispatchBlockedMessage: string | null = null;
-    {
-      let agentExists: boolean;
-      try {
-        const agents = await listS2SClawAgents();
-        agentExists = agents.some((a) => a.slug === agentSlug);
-      } catch (err) {
-        logger.error(`[DeskReport] failed to check agent existence for ${agentSlug}:`, err);
-        agentExists = true; // fail open on a transient lookup error — let the dispatch attempt itself decide
-      }
-      if (!agentExists) {
-        dispatchBlockedMessage = pref.deskReportAgentSlug?.trim()
-          ? `Agent "${agentSlug}" isn't configured in this workspace. Pick a different agent for Desk Report in Desk Settings → Agent.`
-          : `The default Desk Report agent isn't installed in this workspace yet. Ask an admin to install it, or pick a different agent in Desk Settings → Agent.`;
-      }
-    }
-    if (dispatchBlockedMessage) {
-      logger.warn(`[DeskReport] channel ${channelId}: cannot dispatch — ${dispatchBlockedMessage}`, { channelId, agentSlug });
-      await messageAttachmentRepo.create({
-        entityId: channelId,
-        entityType: DESK_REPORT_ENTITY_TYPE,
-        originalFilename: `${channelName}-desk-report.html`,
-        size: 0,
-        mimetype: 'text/html',
-        url: '',
-        uploadedByUserId: owner.id,
-        createdBy: owner.id,
-        storageProvider: config.fileStorage.provider,
-        conversationId: null,
-        workspaceId,
-        uploadStatus: AttachmentUploadStatus.FAILED,
-        metadata: { rangeDays, agentSlug, triggeredBy: 'cron', error: dispatchBlockedMessage },
-      });
-      return { channelId, success: false, error: dispatchBlockedMessage };
-    }
-    // Reached only when agentSlug was picked AND confirmed to exist above.
-    const resolvedAgentSlug = agentSlug as string;
+    const resolvedAgentSlug = agentSlug;
 
     // Write a pending placeholder first so the sidebar panel can show
-    // "Generating…" while the agent run is in flight.
+    // "Generating…" while the agent run is in flight. The callback URL below
+    // embeds this row's own id so a stale/delayed callback can only ever
+    // complete THIS run's row, never a different pending row for the same channel.
     const sessionId = randomUUID();
-    await messageAttachmentRepo.create({
+    const pending = await messageAttachmentRepo.create({
       entityId: channelId,
       entityType: DESK_REPORT_ENTITY_TYPE,
       originalFilename: `${channelName}-desk-report.html`,
@@ -175,7 +145,7 @@ export class DeskReportGenerationService {
 
     const rangeLabel = rangeDays === 1 ? 'the last 1 day' : `the last ${rangeDays} days`;
     const task = `Generate a desk html report for ${channelName} for ${rangeLabel}.`;
-    const callbackUrl = `${config.backendUrl.replace(/\/$/, '')}/api/internal/desk-report/callback/${encodeURIComponent(channelId)}`;
+    const callbackUrl = `${config.backendUrl.replace(/\/$/, '')}/api/internal/desk-report/callback/${encodeURIComponent(channelId)}/${encodeURIComponent(pending.id)}`;
 
     const { dispatched } = await runClawAgent({
       agentSlug: resolvedAgentSlug,
@@ -189,29 +159,29 @@ export class DeskReportGenerationService {
     });
 
     if (!dispatched) {
+      const errorMessage = pref.deskReportAgentSlug?.trim()
+        ? `Agent "${resolvedAgentSlug}" isn't configured in this workspace. Pick a different agent for Desk Report in Desk Settings → Agent.`
+        : `The default Desk Report agent isn't installed in this workspace yet. Ask an admin to install it, or pick a different agent in Desk Settings → Agent.`;
       logger.warn('[DeskReport] no installed-app webhook for agent — marking failed', {
         channelId,
         agentSlug: resolvedAgentSlug,
       });
-      await this.markLatestPending(channelId, AttachmentUploadStatus.FAILED, 'Agent not installed for this workspace');
-      return { channelId, success: false, error: 'Agent not installed for this workspace' };
+      await this.markPendingFailed(pending.id, errorMessage);
+      return { channelId, success: false, error: errorMessage };
     }
 
     logger.info(`[DeskReport] dispatched report generation for channel ${channelId} (agent=${resolvedAgentSlug})`);
     return { channelId, success: true };
   }
 
-  /** Flip the most recent pending row for a channel to failed, e.g. on dispatch failure. */
-  private async markLatestPending(channelId: string, status: AttachmentUploadStatus.FAILED, errorMessage?: string): Promise<void> {
-    const pending = await db.messageAttachment.findFirst({
-      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false, uploadStatus: AttachmentUploadStatus.PENDING },
-      orderBy: { createdAt: 'desc' },
-    });
+  /** Flip a specific pending row to failed by id, e.g. on dispatch failure. */
+  private async markPendingFailed(id: string, errorMessage?: string): Promise<void> {
+    const pending = await db.messageAttachment.findUnique({ where: { id } });
     if (!pending) return;
     const metadata = (pending.metadata as Record<string, unknown> | null) ?? {};
     await db.messageAttachment.update({
-      where: { id: pending.id },
-      data: { uploadStatus: status, metadata: { ...metadata, error: errorMessage ?? 'Generation failed' } },
+      where: { id },
+      data: { uploadStatus: AttachmentUploadStatus.FAILED, metadata: { ...metadata, error: errorMessage ?? 'Generation failed' } },
     });
   }
 

--- a/apps/backend/src/services/deskReportGenerationService.ts
+++ b/apps/backend/src/services/deskReportGenerationService.ts
@@ -9,7 +9,7 @@ import { AttachmentEntityType, AttachmentUploadStatus } from '@xyne/shared';
 
 const DESK_REPORT_ENTITY_TYPE = AttachmentEntityType.DESK_REPORT;
 // A run with no callback (crash, dropped webhook) is reaped as failed past this age.
-export const STUCK_PENDING_HOURS = 2;
+export const STUCK_PENDING_HOURS = 3;
 
 const messageAttachmentRepo = new MessageAttachmentRepository();
 

--- a/apps/backend/src/services/deskReportGenerationService.ts
+++ b/apps/backend/src/services/deskReportGenerationService.ts
@@ -1,0 +1,301 @@
+/**
+ * Desk Report scheduled generation — mirrors recapGenerationService.ts's
+ * shape (sweep enabled channels, per-channel try/catch), but triggers a
+ * Claw agent run per desk since the report comes from the `create-desk-report`
+ * tool, not something computed in-process.
+ *
+ * Persistence reuses the generic MessageAttachment table
+ * (entityType='DESK_REPORT', entityId=channelId). A 'pending' row is written
+ * before dispatch so the panel can show "Generating…"; the callback route
+ * (deskReportCallback.handler.ts) flips it to 'completed'/'failed'.
+ */
+import { randomUUID } from 'crypto';
+import { db } from '@/database/client';
+import { logger } from '@/utils/logger';
+import { config } from '@/config/env';
+import { runClawAgent, listS2SClawAgents } from '@/services/clawAgentService';
+import { MessageAttachmentRepository } from '@/database/repositories/messageAttachmentRepository';
+import { storageService } from '@/services/storage';
+import { AttachmentEntityType } from '@xyne/shared';
+
+const DESK_REPORT_ENTITY_TYPE = AttachmentEntityType.DESK_REPORT;
+// A run that never gets a callback (crashed agent, dropped webhook) would
+// otherwise leave a 'pending' row stuck forever, showing "Generating…" in the
+// panel indefinitely. Anything past this age is reaped as failed.
+const STUCK_PENDING_HOURS = 2;
+
+const messageAttachmentRepo = new MessageAttachmentRepository();
+
+export interface DeskReportGenerationResult {
+  channelId: string;
+  success: boolean;
+  error?: string;
+}
+
+export class DeskReportGenerationService {
+  /**
+   * Sweep every channel with deskReportEnabled=true and trigger a fresh
+   * report for each. Per-channel failures are isolated — one bad desk never
+   * blocks the rest, same resilience pattern as recap's channel loop.
+   */
+  async generateReportsForEnabledDesks(): Promise<{
+    total: number;
+    dispatched: number;
+    failed: number;
+    results: DeskReportGenerationResult[];
+  }> {
+    const preferences = await db.emailChannelPreference.findMany({
+      where: { deskReportEnabled: true },
+      select: {
+        channelId: true,
+        ownerUserId: true,
+        workspaceId: true,
+        deskReportAgentSlug: true,
+        deskReportRangeDays: true,
+      },
+    });
+
+    logger.info(`[DeskReport] Starting scheduled generation for ${preferences.length} desk(s)`);
+
+    const results: DeskReportGenerationResult[] = [];
+    for (const pref of preferences) {
+      try {
+        const result = await this.generateReportForChannel(pref);
+        results.push(result);
+      } catch (error) {
+        logger.error(`[DeskReport] Unexpected error for channel ${pref.channelId}:`, error);
+        results.push({
+          channelId: pref.channelId,
+          success: false,
+          error: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    }
+
+    const dispatched = results.filter((r) => r.success).length;
+    const failed = results.filter((r) => !r.success).length;
+    logger.info(`[DeskReport] Scheduled generation done: ${dispatched} dispatched, ${failed} failed`);
+
+    return { total: preferences.length, dispatched, failed, results };
+  }
+
+  /**
+   * Trigger one desk's report. This is also the entry point for a manual
+   * "generate now" trigger — always scoped to a single channelId, so a
+   * caller can never accidentally regenerate another desk's report.
+   */
+  async generateReportForChannel(pref: {
+    channelId: string;
+    ownerUserId: string | null;
+    workspaceId: string;
+    deskReportAgentSlug: string | null;
+    deskReportRangeDays: number | null;
+  }): Promise<DeskReportGenerationResult> {
+    const { channelId, workspaceId } = pref;
+    const agentSlug = pref.deskReportAgentSlug?.trim() || null;
+    const rangeDays = pref.deskReportRangeDays && pref.deskReportRangeDays > 0 ? pref.deskReportRangeDays : 1;
+
+    if (!pref.ownerUserId) {
+      logger.warn(`[DeskReport] channel ${channelId} has deskReportEnabled but no ownerUserId — skipping`);
+      return { channelId, success: false, error: 'No desk owner configured' };
+    }
+
+    // Refuse a second run while one is already in flight for this channel —
+    // otherwise a manual click during an active cron run races two pending
+    // rows and whichever callback lands last can flip an already-completed
+    // report to failed. Stale rows past STUCK_PENDING_HOURS don't count as
+    // "in flight" so a crashed run can't block generations for hours.
+    const existingPending = await db.messageAttachment.findFirst({
+      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (existingPending) {
+      const existingMetadata = (existingPending.metadata as Record<string, unknown> | null) ?? {};
+      const stuckCutoff = new Date(Date.now() - STUCK_PENDING_HOURS * 60 * 60 * 1000);
+      if (existingMetadata['status'] === 'pending' && existingPending.createdAt > stuckCutoff) {
+        logger.info(`[DeskReport] channel ${channelId} already has a report generating — skipping`);
+        return { channelId, success: false, error: 'A report is already generating for this desk' };
+      }
+    }
+
+    const owner = await db.user.findUnique({
+      where: { id: pref.ownerUserId },
+      select: { id: true, name: true },
+    });
+    if (!owner) {
+      logger.warn(`[DeskReport] channel ${channelId} owner ${pref.ownerUserId} not found — skipping`);
+      return { channelId, success: false, error: 'Desk owner not found' };
+    }
+
+    const channel = await db.channel.findUnique({ where: { id: channelId }, select: { name: true } });
+    const channelName = channel?.name ?? channelId;
+
+    // Two distinct reasons a report can't be dispatched, both surfaced the
+    // same way (a 'failed' row with an actionable message): nothing picked
+    // yet, or something was picked but no longer exists (deleted/renamed
+    // since). Only the second case needs an actual lookup.
+    let dispatchBlockedMessage: string | null = null;
+    if (!agentSlug) {
+      dispatchBlockedMessage = 'No agent selected for Desk Report. Pick an agent in Desk Settings → Agent before this desk\'s report can be generated.';
+    } else {
+      let agentExists: boolean;
+      try {
+        const agents = await listS2SClawAgents();
+        agentExists = agents.some((a) => a.slug === agentSlug);
+      } catch (err) {
+        logger.error(`[DeskReport] failed to check agent existence for ${agentSlug}:`, err);
+        agentExists = true; // fail open on a transient lookup error — let the dispatch attempt itself decide
+      }
+      if (!agentExists) {
+        dispatchBlockedMessage = `Agent "${agentSlug}" isn't configured in this workspace. Pick a different agent for Desk Report in Desk Settings → Agent.`;
+      }
+    }
+    if (dispatchBlockedMessage) {
+      logger.warn(`[DeskReport] channel ${channelId}: cannot dispatch — ${dispatchBlockedMessage}`, { channelId, agentSlug });
+      await messageAttachmentRepo.create({
+        entityId: channelId,
+        entityType: DESK_REPORT_ENTITY_TYPE,
+        originalFilename: `${channelName}-desk-report.html`,
+        size: 0,
+        mimetype: 'text/html',
+        url: '',
+        uploadedByUserId: owner.id,
+        createdBy: owner.id,
+        storageProvider: config.fileStorage.provider,
+        conversationId: null,
+        workspaceId,
+        metadata: { status: 'failed', rangeDays, agentSlug, triggeredBy: 'cron', error: dispatchBlockedMessage },
+      });
+      return { channelId, success: false, error: dispatchBlockedMessage };
+    }
+    // Reached only when agentSlug was picked AND confirmed to exist above.
+    const resolvedAgentSlug = agentSlug as string;
+
+    // Write a pending placeholder first so the sidebar panel can show
+    // "Generating…" while the agent run is in flight.
+    const sessionId = randomUUID();
+    await messageAttachmentRepo.create({
+      entityId: channelId,
+      entityType: DESK_REPORT_ENTITY_TYPE,
+      originalFilename: `${channelName}-desk-report.html`,
+      size: 0,
+      mimetype: 'text/html',
+      url: '',
+      uploadedByUserId: owner.id,
+      createdBy: owner.id,
+      storageProvider: config.fileStorage.provider,
+      conversationId: null,
+      workspaceId,
+      metadata: {
+        status: 'pending',
+        rangeDays,
+        agentSlug: resolvedAgentSlug,
+        triggeredBy: 'cron',
+        sessionId,
+        generatedAt: new Date().toISOString(),
+      },
+    });
+
+    const rangeLabel = rangeDays === 1 ? 'the last 1 day' : `the last ${rangeDays} days`;
+    const task = `Generate a desk html report for ${channelName} for ${rangeLabel}.`;
+    const callbackUrl = `${config.backendUrl.replace(/\/$/, '')}/api/internal/desk-report/callback/${encodeURIComponent(channelId)}`;
+
+    const { dispatched } = await runClawAgent({
+      agentSlug: resolvedAgentSlug,
+      task,
+      userId: owner.id,
+      userName: owner.name || 'Desk Owner',
+      conversationId: `desk-report-${channelId}-${sessionId}`,
+      channelId,
+      workspaceId,
+      resultForwardUrl: callbackUrl,
+    });
+
+    if (!dispatched) {
+      logger.warn('[DeskReport] no installed-app webhook for agent — marking failed', {
+        channelId,
+        agentSlug: resolvedAgentSlug,
+      });
+      await this.markLatestPending(channelId, 'failed', 'Agent not installed for this workspace');
+      return { channelId, success: false, error: 'Agent not installed for this workspace' };
+    }
+
+    logger.info(`[DeskReport] dispatched report generation for channel ${channelId} (agent=${resolvedAgentSlug})`);
+    return { channelId, success: true };
+  }
+
+  /** Flip the most recent pending row for a channel to failed, e.g. on dispatch failure. */
+  private async markLatestPending(channelId: string, status: 'failed', errorMessage?: string): Promise<void> {
+    const pending = await db.messageAttachment.findFirst({
+      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (!pending) return;
+    const metadata = (pending.metadata as Record<string, unknown> | null) ?? {};
+    if (metadata['status'] !== 'pending') return;
+    await db.messageAttachment.update({
+      where: { id: pending.id },
+      data: { metadata: { ...metadata, status, error: errorMessage ?? 'Generation failed' } },
+    });
+  }
+
+  /**
+   * Nightly cleanup — mirrors recap's cleanup job, but a desk's newest
+   * COMPLETED report is never deleted regardless of age, so cleanup can't
+   * regress a desk to "No report generated yet". Everything else past
+   * retentionDays (or STUCK_PENDING_HOURS for stuck 'pending' rows) is
+   * removed, storage file included.
+   */
+  async cleanupOldReports(retentionDays: number): Promise<{ deletedRows: number; deletedFiles: number }> {
+    const cutoff = new Date();
+    cutoff.setUTCDate(cutoff.getUTCDate() - retentionDays);
+
+    const pendingCutoff = new Date();
+    pendingCutoff.setUTCHours(pendingCutoff.getUTCHours() - STUCK_PENDING_HOURS);
+
+    const rows = await db.messageAttachment.findMany({
+      where: { entityType: DESK_REPORT_ENTITY_TYPE, isDeleted: false },
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, entityId: true, url: true, createdAt: true, metadata: true },
+    });
+
+    // Group by channel so we can always spare each channel's newest completed row.
+    const latestCompletedIdByChannel = new Map<string, string>();
+    for (const row of rows) {
+      const status = (row.metadata as Record<string, unknown> | null)?.['status'];
+      if (status !== 'completed') continue;
+      if (!latestCompletedIdByChannel.has(row.entityId)) {
+        latestCompletedIdByChannel.set(row.entityId, row.id); // rows are newest-first
+      }
+    }
+
+    const toDelete = rows.filter((row) => {
+      if (row.id === latestCompletedIdByChannel.get(row.entityId)) return false; // spare the newest per channel
+      const status = (row.metadata as Record<string, unknown> | null)?.['status'];
+      if (status === 'pending') return row.createdAt < pendingCutoff;
+      return row.createdAt < cutoff;
+    });
+
+    let deletedFiles = 0;
+    for (const row of toDelete) {
+      if (!row.url) continue;
+      try {
+        await storageService.deleteFile(row.url);
+        deletedFiles++;
+      } catch (err) {
+        logger.warn(`[DeskReport] cleanup: failed to delete storage file for ${row.id}:`, err);
+      }
+    }
+
+    if (toDelete.length > 0) {
+      await db.messageAttachment.deleteMany({ where: { id: { in: toDelete.map((r) => r.id) } } });
+    }
+
+    logger.info(
+      `[DeskReport] cleanup: deleted ${toDelete.length} row(s), ${deletedFiles} storage file(s) (retention=${retentionDays}d)`,
+    );
+    return { deletedRows: toDelete.length, deletedFiles };
+  }
+}
+
+export const deskReportGenerationService = new DeskReportGenerationService();

--- a/apps/backend/src/services/deskReportGenerationService.ts
+++ b/apps/backend/src/services/deskReportGenerationService.ts
@@ -1,14 +1,3 @@
-/**
- * Desk Report scheduled generation — mirrors recapGenerationService.ts's
- * shape (sweep enabled channels, per-channel try/catch), but triggers a
- * Claw agent run per desk since the report comes from the `create-desk-report`
- * tool, not something computed in-process.
- *
- * Persistence reuses the generic MessageAttachment table
- * (entityType='DESK_REPORT', entityId=channelId). A 'pending' row is written
- * before dispatch so the panel can show "Generating…"; the callback route
- * (deskReportCallback.handler.ts) flips it to 'completed'/'failed'.
- */
 import { randomUUID } from 'crypto';
 import { db } from '@/database/client';
 import { logger } from '@/utils/logger';
@@ -19,10 +8,8 @@ import { storageService } from '@/services/storage';
 import { AttachmentEntityType } from '@xyne/shared';
 
 const DESK_REPORT_ENTITY_TYPE = AttachmentEntityType.DESK_REPORT;
-// A run that never gets a callback (crashed agent, dropped webhook) would
-// otherwise leave a 'pending' row stuck forever, showing "Generating…" in the
-// panel indefinitely. Anything past this age is reaped as failed.
-const STUCK_PENDING_HOURS = 2;
+// A run with no callback (crash, dropped webhook) is reaped as failed past this age.
+export const STUCK_PENDING_HOURS = 2;
 
 const messageAttachmentRepo = new MessageAttachmentRepository();
 
@@ -34,9 +21,7 @@ export interface DeskReportGenerationResult {
 
 export class DeskReportGenerationService {
   /**
-   * Sweep every channel with deskReportEnabled=true and trigger a fresh
-   * report for each. Per-channel failures are isolated — one bad desk never
-   * blocks the rest, same resilience pattern as recap's channel loop.
+   * Sweep every channel with deskReportEnabled=true and trigger a fresh report for each.
    */
   async generateReportsForEnabledDesks(): Promise<{
     total: number;
@@ -81,8 +66,7 @@ export class DeskReportGenerationService {
 
   /**
    * Trigger one desk's report. This is also the entry point for a manual
-   * "generate now" trigger — always scoped to a single channelId, so a
-   * caller can never accidentally regenerate another desk's report.
+   * "generate now" trigger — always scoped to a single channelId.
    */
   async generateReportForChannel(pref: {
     channelId: string;
@@ -100,22 +84,17 @@ export class DeskReportGenerationService {
       return { channelId, success: false, error: 'No desk owner configured' };
     }
 
-    // Refuse a second run while one is already in flight for this channel —
-    // otherwise a manual click during an active cron run races two pending
-    // rows and whichever callback lands last can flip an already-completed
-    // report to failed. Stale rows past STUCK_PENDING_HOURS don't count as
-    // "in flight" so a crashed run can't block generations for hours.
+    // Reap anything past STUCK_PENDING_HOURS before checking if one's in flight.
+    await this.reapStuckPending(channelId);
+
+    // Refuse a second run while one's in flight. Plain check-then-write.
     const existingPending = await db.messageAttachment.findFirst({
-      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false },
+      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false, uploadStatus: 'pending' },
       orderBy: { createdAt: 'desc' },
     });
     if (existingPending) {
-      const existingMetadata = (existingPending.metadata as Record<string, unknown> | null) ?? {};
-      const stuckCutoff = new Date(Date.now() - STUCK_PENDING_HOURS * 60 * 60 * 1000);
-      if (existingMetadata['status'] === 'pending' && existingPending.createdAt > stuckCutoff) {
-        logger.info(`[DeskReport] channel ${channelId} already has a report generating — skipping`);
-        return { channelId, success: false, error: 'A report is already generating for this desk' };
-      }
+      logger.info(`[DeskReport] channel ${channelId} already has a report generating — skipping`);
+      return { channelId, success: false, error: 'A report is already generating for this desk' };
     }
 
     const owner = await db.user.findUnique({
@@ -130,10 +109,8 @@ export class DeskReportGenerationService {
     const channel = await db.channel.findUnique({ where: { id: channelId }, select: { name: true } });
     const channelName = channel?.name ?? channelId;
 
-    // Two distinct reasons a report can't be dispatched, both surfaced the
-    // same way (a 'failed' row with an actionable message): nothing picked
-    // yet, or something was picked but no longer exists (deleted/renamed
-    // since). Only the second case needs an actual lookup.
+    // Two reasons dispatch can be blocked, both surfaced as a 'failed' row:
+    // no agent picked, or a picked agent no longer exists.
     let dispatchBlockedMessage: string | null = null;
     if (!agentSlug) {
       dispatchBlockedMessage = 'No agent selected for Desk Report. Pick an agent in Desk Settings → Agent before this desk\'s report can be generated.';
@@ -164,7 +141,8 @@ export class DeskReportGenerationService {
         storageProvider: config.fileStorage.provider,
         conversationId: null,
         workspaceId,
-        metadata: { status: 'failed', rangeDays, agentSlug, triggeredBy: 'cron', error: dispatchBlockedMessage },
+        uploadStatus: 'failed',
+        metadata: { rangeDays, agentSlug, triggeredBy: 'cron', error: dispatchBlockedMessage },
       });
       return { channelId, success: false, error: dispatchBlockedMessage };
     }
@@ -186,8 +164,8 @@ export class DeskReportGenerationService {
       storageProvider: config.fileStorage.provider,
       conversationId: null,
       workspaceId,
+      uploadStatus: 'pending',
       metadata: {
-        status: 'pending',
         rangeDays,
         agentSlug: resolvedAgentSlug,
         triggeredBy: 'cron',
@@ -227,43 +205,67 @@ export class DeskReportGenerationService {
   /** Flip the most recent pending row for a channel to failed, e.g. on dispatch failure. */
   private async markLatestPending(channelId: string, status: 'failed', errorMessage?: string): Promise<void> {
     const pending = await db.messageAttachment.findFirst({
-      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false },
+      where: { entityType: DESK_REPORT_ENTITY_TYPE, entityId: channelId, isDeleted: false, uploadStatus: 'pending' },
       orderBy: { createdAt: 'desc' },
     });
     if (!pending) return;
     const metadata = (pending.metadata as Record<string, unknown> | null) ?? {};
-    if (metadata['status'] !== 'pending') return;
     await db.messageAttachment.update({
       where: { id: pending.id },
-      data: { metadata: { ...metadata, status, error: errorMessage ?? 'Generation failed' } },
+      data: { uploadStatus: status, metadata: { ...metadata, error: errorMessage ?? 'Generation failed' } },
     });
   }
 
   /**
-   * Nightly cleanup — mirrors recap's cleanup job, but a desk's newest
-   * COMPLETED report is never deleted regardless of age, so cleanup can't
-   * regress a desk to "No report generated yet". Everything else past
-   * retentionDays (or STUCK_PENDING_HOURS for stuck 'pending' rows) is
-   * removed, storage file included.
+   * Flip this channel's pending row(s) to 'failed' if they've been pending
+   * longer than STUCK_PENDING_HOURS (crashed agent, dropped webhook) — so a
+   * dropped run doesn't just sit there and block a fresh dispatch.
    */
+  private async reapStuckPending(channelId: string): Promise<void> {
+    const stuckCutoff = new Date(Date.now() - STUCK_PENDING_HOURS * 60 * 60 * 1000);
+    const stuck = await db.messageAttachment.findMany({
+      where: {
+        entityType: DESK_REPORT_ENTITY_TYPE,
+        entityId: channelId,
+        isDeleted: false,
+        uploadStatus: 'pending',
+        createdAt: { lt: stuckCutoff },
+      },
+    });
+    for (const row of stuck) {
+      const metadata = (row.metadata as Record<string, unknown> | null) ?? {};
+      await db.messageAttachment.update({
+        where: { id: row.id },
+        data: { uploadStatus: 'failed', metadata: { ...metadata, error: 'Generation timed out' } },
+      });
+    }
+  }
+
   async cleanupOldReports(retentionDays: number): Promise<{ deletedRows: number; deletedFiles: number }> {
     const cutoff = new Date();
     cutoff.setUTCDate(cutoff.getUTCDate() - retentionDays);
 
-    const pendingCutoff = new Date();
-    pendingCutoff.setUTCHours(pendingCutoff.getUTCHours() - STUCK_PENDING_HOURS);
+    const stuckCutoff = new Date(Date.now() - STUCK_PENDING_HOURS * 60 * 60 * 1000);
+    await db.messageAttachment.updateMany({
+      where: {
+        entityType: DESK_REPORT_ENTITY_TYPE,
+        isDeleted: false,
+        uploadStatus: 'pending',
+        createdAt: { lt: stuckCutoff },
+      },
+      data: { uploadStatus: 'failed' },
+    });
 
     const rows = await db.messageAttachment.findMany({
       where: { entityType: DESK_REPORT_ENTITY_TYPE, isDeleted: false },
       orderBy: { createdAt: 'desc' },
-      select: { id: true, entityId: true, url: true, createdAt: true, metadata: true },
+      select: { id: true, entityId: true, url: true, createdAt: true, uploadStatus: true },
     });
 
     // Group by channel so we can always spare each channel's newest completed row.
     const latestCompletedIdByChannel = new Map<string, string>();
     for (const row of rows) {
-      const status = (row.metadata as Record<string, unknown> | null)?.['status'];
-      if (status !== 'completed') continue;
+      if (row.uploadStatus !== 'completed') continue;
       if (!latestCompletedIdByChannel.has(row.entityId)) {
         latestCompletedIdByChannel.set(row.entityId, row.id); // rows are newest-first
       }
@@ -271,8 +273,6 @@ export class DeskReportGenerationService {
 
     const toDelete = rows.filter((row) => {
       if (row.id === latestCompletedIdByChannel.get(row.entityId)) return false; // spare the newest per channel
-      const status = (row.metadata as Record<string, unknown> | null)?.['status'];
-      if (status === 'pending') return row.createdAt < pendingCutoff;
       return row.createdAt < cutoff;
     });
 

--- a/apps/backend/src/workers/deskReportWorker.ts
+++ b/apps/backend/src/workers/deskReportWorker.ts
@@ -1,0 +1,39 @@
+import type Bull from 'bull';
+import { logger } from '@/utils/logger';
+import { deskReportGenerationService } from '@/services/deskReportGenerationService';
+
+/**
+ * Desk Report generation worker — mirrors recapWorker.ts's single
+ * processGenerationJob entry point. Sweeps every desk with deskReportEnabled
+ * and dispatches (does not wait on) a Claw agent run per desk; each run
+ * reports back asynchronously via deskReportCallback.handler.ts.
+ */
+export class DeskReportWorker {
+  async processGenerationJob(job: Bull.Job): Promise<{ total: number; dispatched: number; failed: number }> {
+    logger.info(`[DESK_REPORT_WORKER] Processing generation job ${job.id || 'manual'}...`);
+    try {
+      const result = await deskReportGenerationService.generateReportsForEnabledDesks();
+      if (result.failed > 0) {
+        const failedChannels = result.results.filter((r) => !r.success);
+        logger.error('[DESK_REPORT_WORKER] Failed channels:', failedChannels);
+      }
+      return { total: result.total, dispatched: result.dispatched, failed: result.failed };
+    } catch (error) {
+      logger.error('[DESK_REPORT_WORKER] Generation job failed:', error);
+      throw error;
+    }
+  }
+
+  async processCleanupJob(job: Bull.Job<{ retentionDays?: number }>): Promise<{ deletedRows: number; deletedFiles: number }> {
+    logger.info(`[DESK_REPORT_WORKER] Processing cleanup job ${job.id || 'manual'}...`);
+    try {
+      const retentionDays = job.data?.retentionDays || 30;
+      return await deskReportGenerationService.cleanupOldReports(retentionDays);
+    } catch (error) {
+      logger.error('[DESK_REPORT_WORKER] Cleanup job failed:', error);
+      throw error;
+    }
+  }
+}
+
+export const deskReportWorker = new DeskReportWorker();

--- a/apps/backend/src/workers/deskReportWorker.ts
+++ b/apps/backend/src/workers/deskReportWorker.ts
@@ -1,11 +1,11 @@
 import type Bull from 'bull';
 import { logger } from '@/utils/logger';
+import { config } from '@/config/env';
 import { deskReportGenerationService } from '@/services/deskReportGenerationService';
 
 /**
- * Desk Report generation worker — mirrors recapWorker.ts's single
- * processGenerationJob entry point. Sweeps every desk with deskReportEnabled
- * and dispatches (does not wait on) a Claw agent run per desk; each run
+ * Desk Report generation worker — \Sweeps every
+ * deskReportEnabled desk and dispatches a Claw agent run per desk; each
  * reports back asynchronously via deskReportCallback.handler.ts.
  */
 export class DeskReportWorker {
@@ -27,7 +27,7 @@ export class DeskReportWorker {
   async processCleanupJob(job: Bull.Job<{ retentionDays?: number }>): Promise<{ deletedRows: number; deletedFiles: number }> {
     logger.info(`[DESK_REPORT_WORKER] Processing cleanup job ${job.id || 'manual'}...`);
     try {
-      const retentionDays = job.data?.retentionDays || 30;
+      const retentionDays = job.data?.retentionDays || config.deskReportScheduler.retentionDays;
       return await deskReportGenerationService.cleanupOldReports(retentionDays);
     } catch (error) {
       logger.error('[DESK_REPORT_WORKER] Cleanup job failed:', error);

--- a/apps/backend/src/workers/index.ts
+++ b/apps/backend/src/workers/index.ts
@@ -6,6 +6,7 @@ import { config } from '@/config/env';
 import { runReclusteringFlow } from '@/services/productInsightsPipeline';
 import { db } from '@/database/client';
 import { recapWorker } from './recapWorker';
+import { deskReportWorker } from './deskReportWorker';
 
 /**
  * Worker Scheduler
@@ -18,6 +19,8 @@ export class WorkerScheduler {
     private productInsightsQueue: Bull.Queue | null = null;
     private recapGenerationQueue: Bull.Queue | null = null;
     private recapCleanupQueue: Bull.Queue | null = null;
+    private deskReportGenerationQueue: Bull.Queue | null = null;
+    private deskReportCleanupQueue: Bull.Queue | null = null;
 
     /**
      * Start all workers
@@ -226,6 +229,136 @@ export class WorkerScheduler {
             logger.info('[WORKER_SCHEDULER] Recap scheduler is disabled (ENABLE_RECAP_SCHEDULER=false)');
         }
 
+        // Initialize Desk Report Generation Queue
+        if (config.deskReportScheduler.enabled) {
+            this.deskReportGenerationQueue = new Bull('desk-report-generation', {
+                redis: { ...redisService.getRedisConfig(), lazyConnect: false },
+                defaultJobOptions: {
+                    removeOnComplete: true,
+                    removeOnFail: false,
+                    attempts: 3,
+                    backoff: {
+                        type: 'exponential',
+                        delay: 5000,
+                    },
+                },
+                settings: {
+                    stalledInterval: 30 * 60 * 1000, // 30 minutes - dispatch loop over many desks
+                    maxStalledCount: 1,
+                },
+            });
+
+            this.deskReportGenerationQueue.process(async (job) => {
+                logger.info(`[WORKER_SCHEDULER] Processing desk report generation job ${job.id}...`);
+                try {
+                    await deskReportWorker.processGenerationJob(job);
+                    logger.info(`[WORKER_SCHEDULER] Desk report generation job ${job.id} completed successfully`);
+                } catch (error) {
+                    logger.error(`[WORKER_SCHEDULER] Desk report generation job ${job.id} failed:`, error);
+                    throw error;
+                }
+            });
+
+            // Remove existing repeatable job(s) to allow CRON updates
+            try {
+                const existingRepeatable = await this.deskReportGenerationQueue.getRepeatableJobs();
+                for (const job of existingRepeatable) {
+                    if (job.id !== 'desk-report-generation-repeatable') continue;
+                    await this.deskReportGenerationQueue.removeRepeatableByKey(job.key);
+                    logger.info(`[WORKER_SCHEDULER] Removed existing desk report generation repeatable job (cron: ${job.cron})`);
+                }
+            } catch (error) {
+                logger.debug('[WORKER_SCHEDULER] No existing desk report generation repeatable job to remove', error);
+            }
+
+            const deskReportCron = config.deskReportScheduler.generationCron;
+            logger.info(`[WORKER_SCHEDULER] Scheduling desk report generation with cron: "${deskReportCron}"`);
+
+            try {
+                await this.deskReportGenerationQueue.add(
+                    {},
+                    {
+                        repeat: { cron: deskReportCron },
+                        jobId: 'desk-report-generation-repeatable',
+                        attempts: 3,
+                        backoff: {
+                            type: 'exponential',
+                            delay: 5000,
+                        },
+                        removeOnComplete: true,
+                    }
+                );
+                logger.info(`[WORKER_SCHEDULER] Desk report generation scheduled via Bull (${deskReportCron})`);
+            } catch (cronError) {
+                logger.error(`[WORKER_SCHEDULER] Failed to schedule desk report generation with cron "${deskReportCron}":`, cronError);
+                logger.warn(`[WORKER_SCHEDULER] Desk report generation will not be automatically scheduled. Manual triggers will still work.`);
+            }
+            // Initialize Desk Report Cleanup Queue
+            this.deskReportCleanupQueue = new Bull('desk-report-cleanup', {
+                redis: { ...redisService.getRedisConfig(), lazyConnect: false },
+                defaultJobOptions: {
+                    removeOnComplete: true,
+                    removeOnFail: false,
+                    attempts: 3,
+                    backoff: {
+                        type: 'exponential',
+                        delay: 5000,
+                    },
+                },
+                settings: {
+                    stalledInterval: 10 * 60 * 1000,
+                    maxStalledCount: 1,
+                },
+            });
+
+            this.deskReportCleanupQueue.process(async (job) => {
+                logger.info(`[WORKER_SCHEDULER] Processing desk report cleanup job ${job.id}...`);
+                try {
+                    await deskReportWorker.processCleanupJob(job);
+                    logger.info(`[WORKER_SCHEDULER] Desk report cleanup job ${job.id} completed successfully`);
+                } catch (error) {
+                    logger.error(`[WORKER_SCHEDULER] Desk report cleanup job ${job.id} failed:`, error);
+                    throw error;
+                }
+            });
+
+            try {
+                const existingCleanupRepeatable = await this.deskReportCleanupQueue.getRepeatableJobs();
+                for (const job of existingCleanupRepeatable) {
+                    if (job.id !== 'desk-report-cleanup-repeatable') continue;
+                    await this.deskReportCleanupQueue.removeRepeatableByKey(job.key);
+                    logger.info(`[WORKER_SCHEDULER] Removed existing desk report cleanup repeatable job (cron: ${job.cron})`);
+                }
+            } catch (error) {
+                logger.debug('[WORKER_SCHEDULER] No existing desk report cleanup repeatable job to remove', error);
+            }
+
+            const deskReportCleanupCron = config.deskReportScheduler.cleanupCron;
+            logger.info(`[WORKER_SCHEDULER] Scheduling desk report cleanup with cron: "${deskReportCleanupCron}"`);
+
+            try {
+                await this.deskReportCleanupQueue.add(
+                    { retentionDays: config.deskReportScheduler.retentionDays },
+                    {
+                        repeat: { cron: deskReportCleanupCron },
+                        jobId: 'desk-report-cleanup-repeatable',
+                        attempts: 3,
+                        backoff: {
+                            type: 'exponential',
+                            delay: 5000,
+                        },
+                        removeOnComplete: true,
+                    }
+                );
+                logger.info(`[WORKER_SCHEDULER] Desk report cleanup scheduled via Bull (${deskReportCleanupCron})`);
+            } catch (cronError) {
+                logger.error(`[WORKER_SCHEDULER] Failed to schedule desk report cleanup with cron "${deskReportCleanupCron}":`, cronError);
+                logger.warn(`[WORKER_SCHEDULER] Desk report cleanup will not be automatically scheduled. Manual triggers will still work.`);
+            }
+        } else {
+            logger.info('[WORKER_SCHEDULER] Desk report scheduler is disabled (ENABLE_DESK_REPORT_SCHEDULER=false)');
+        }
+
         this.isRunning = true;
         logger.info('[WORKER_SCHEDULER] All workers started');
     }
@@ -260,6 +393,16 @@ export class WorkerScheduler {
         if (this.recapCleanupQueue) {
             await this.recapCleanupQueue.close();
             this.recapCleanupQueue = null;
+        }
+
+        if (this.deskReportGenerationQueue) {
+            await this.deskReportGenerationQueue.close();
+            this.deskReportGenerationQueue = null;
+        }
+
+        if (this.deskReportCleanupQueue) {
+            await this.deskReportCleanupQueue.close();
+            this.deskReportCleanupQueue = null;
         }
 
         this.isRunning = false;

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -15179,6 +15179,9 @@ export function createMutators(
           metricsEnabled: z.boolean().optional(),
           frtStageNames: z.string().optional().nullable(),
           appWebhookDeliveryEnabled: z.boolean().optional(),
+          deskReportEnabled: z.boolean().optional(),
+          deskReportAgentSlug: z.string().optional().nullable(),
+          deskReportRangeDays: z.number().optional(),
         }),
         async ({
           tx,
@@ -15195,6 +15198,9 @@ export function createMutators(
             metricsEnabled,
             frtStageNames,
             appWebhookDeliveryEnabled,
+            deskReportEnabled,
+            deskReportAgentSlug,
+            deskReportRangeDays,
           },
         }) => {
           const existing = await tx.run(
@@ -15214,6 +15220,9 @@ export function createMutators(
               ...(metricsEnabled !== undefined ? { metricsEnabled } : {}),
               ...(frtStageNames !== undefined ? { frtStageNames } : {}),
               ...(appWebhookDeliveryEnabled !== undefined ? { appWebhookDeliveryEnabled } : {}),
+              ...(deskReportEnabled !== undefined ? { deskReportEnabled } : {}),
+              ...(deskReportAgentSlug !== undefined ? { deskReportAgentSlug } : {}),
+              ...(deskReportRangeDays !== undefined ? { deskReportRangeDays } : {}),
             });
           } else {
             const channel = await tx.run(zql.channels.where('id', channelId).one());
@@ -15241,6 +15250,9 @@ export function createMutators(
               metricsEnabled: metricsEnabled ?? false,
               frtStageNames: frtStageNames ?? null,
               appWebhookDeliveryEnabled: appWebhookDeliveryEnabled ?? true,
+              deskReportEnabled: deskReportEnabled ?? false,
+              deskReportAgentSlug: deskReportAgentSlug ?? null,
+              deskReportRangeDays: deskReportRangeDays ?? 1,
             });
           }
         },

--- a/apps/dashboard/src/components/xyne-desk/DeskReport/DeskReportPanel.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskReport/DeskReportPanel.tsx
@@ -1,0 +1,282 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { X, Download, RefreshCw, FileText } from 'lucide-react';
+import { toast } from 'sonner';
+import { Dialog } from '../../ui/Dialog/Dialog';
+import { cn } from '../../../utils/classNames';
+import { apiInstance, BASE_URL } from '../../../services/clients/apiClient';
+import { showDownloadCompleteToast } from '../../../utils/downloadToast';
+
+export interface DeskReportPanelProps {
+  open: boolean;
+  onClose: () => void;
+  channelId: string;
+  channelName?: string;
+}
+
+interface LatestDeskReport {
+  status: 'pending' | 'completed' | 'failed';
+  url: string | null;
+  generatedAt: string;
+  rangeDays: number;
+  agentSlug: string | null;
+  error: string | null;
+  // True while a newer regeneration (cron or manual) is in flight. The
+  // previous completed report (if any) stays in `url`/`status` untouched —
+  // this is purely an "in progress" banner, never a state that hides it.
+  generating: boolean;
+}
+
+interface LatestDeskReportResponse {
+  success: boolean;
+  data: LatestDeskReport | null;
+  // Whether the current user may trigger "Generate now" — computed
+  // server-side (canManageDeskReport), not re-derived from an org role here.
+  canGenerate: boolean;
+}
+
+/**
+ * Sidebar panel for the scheduled desk report — sibling to
+ * DeskMetricsDashboard, same Dialog shell. Every fetch is scoped by
+ * channelId (enforced again server-side), so it never shows another desk's report.
+ */
+export const DeskReportPanel: React.FC<DeskReportPanelProps> = ({
+  open,
+  onClose,
+  channelId,
+  channelName,
+}) => {
+  const [report, setReport] = useState<LatestDeskReport | null>(null);
+  // Defaults to false (hide the button) until the first fetch resolves — the
+  // server is the only source of truth for this, no client-side guess.
+  const [canGenerate, setCanGenerate] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Only show the full-panel spinner on the very first load. Once a report
+  // is on screen, subsequent refreshes (polling, "generate now") update
+  // `report` in place so the previous report never disappears mid-fetch.
+  const fetchLatest = useCallback(
+    async (opts?: { silent?: boolean }): Promise<void> => {
+      if (!opts?.silent) setLoading(true);
+      setLoadError(null);
+      try {
+        const res = await apiInstance.get<LatestDeskReportResponse>(
+          `/desk-report/${encodeURIComponent(channelId)}/latest`,
+        );
+        setReport(res.data.data);
+        setCanGenerate(res.data.canGenerate);
+      } catch {
+        if (!opts?.silent) setLoadError('Failed to load the desk report.');
+      } finally {
+        if (!opts?.silent) setLoading(false);
+      }
+    },
+    [channelId],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    void fetchLatest();
+  }, [open, fetchLatest]);
+
+  // While a generation is in flight (cron-triggered or manual), poll quietly
+  // in the background so the "Generating…" banner clears on its own the
+  // moment the new report lands — the currently-shown report is never
+  // touched while this is running.
+  useEffect(() => {
+    if (!open || !report?.generating) return;
+    const interval = setInterval((): void => {
+      void fetchLatest({ silent: true });
+    }, 5000);
+    return (): void => clearInterval(interval);
+  }, [open, report?.generating, fetchLatest]);
+
+  const handleGenerateNow = useCallback(async () => {
+    setSubmitting(true);
+    try {
+      const res = await apiInstance.post<{ success: boolean; error?: string }>(
+        `/desk-report/${encodeURIComponent(channelId)}/generate`,
+      );
+      if (res.data.success) {
+        toast.success('Generating desk report…', {
+          description:
+            'This can take a few minutes — the current report stays visible until it’s ready.',
+        });
+      } else {
+        // e.g. a generation is already in flight for this desk — not an
+        // error the user needs to retry, just a no-op they should know about.
+        toast.info(res.data.error ?? 'Could not start desk report generation');
+      }
+      // Silent: the previous report (if any) should stay on screen; only the
+      // `generating` banner should appear, not a loading state that hides it.
+      await fetchLatest({ silent: true });
+    } catch {
+      toast.error('Failed to start desk report generation');
+    } finally {
+      setSubmitting(false);
+    }
+  }, [channelId, fetchLatest]);
+
+  const handleDownload = useCallback(async () => {
+    if (!report?.url) return;
+    setDownloading(true);
+    try {
+      const res = await apiInstance.get(`${report.url}?download=1`, { responseType: 'blob' });
+      const filename = `${channelName ?? 'desk'}-report.html`;
+      const blobUrl = URL.createObjectURL(res.data as Blob);
+      const a = document.createElement('a');
+      a.href = blobUrl;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(blobUrl);
+      showDownloadCompleteToast(filename);
+    } catch {
+      toast.error('Failed to download desk report');
+    } finally {
+      setDownloading(false);
+    }
+  }, [report?.url, channelName]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+      title='Desk Report'
+      className={cn(
+        'left-auto right-0 top-0 bottom-0 h-screen w-[85vw] max-h-none max-w-none translate-x-0 translate-y-0 rounded-l-[16px] rounded-r-none bg-transparent shadow-none',
+        'data-[state=open]:!zoom-in-100 data-[state=open]:!slide-in-from-top-[0%] data-[state=open]:!slide-in-from-right-full',
+        'data-[state=closed]:!zoom-out-100 data-[state=closed]:!slide-out-to-top-[0%] data-[state=closed]:!slide-out-to-right-full',
+      )}
+    >
+      <div className='relative h-full w-full'>
+        <button
+          type='button'
+          onClick={onClose}
+          className='absolute right-6 top-4 z-20 flex h-8 w-8 items-center justify-center rounded-[10px] border border-desk-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground dark:border-border'
+          aria-label='Close desk report'
+          data-track-category='DeskReport'
+          data-track-name='CloseButton'
+        >
+          <X size={16} />
+        </button>
+        <div className='isolate flex h-full w-full flex-col overflow-hidden rounded-l-[16px] border border-desk-border bg-popover shadow-2xl dark:border-border'>
+          <div className='flex shrink-0 items-center justify-between gap-3 border-b border-desk-border px-6 py-4 dark:border-border'>
+            <div className='min-w-0'>
+              <div className='flex items-center gap-2'>
+                <FileText size={16} className='text-desk-muted' />
+                <h2 className='truncate text-[15px] font-semibold text-foreground'>
+                  Desk Report{channelName ? ` — ${channelName}` : ''}
+                </h2>
+              </div>
+              {report && report.status === 'completed' && (
+                <p className='mt-0.5 flex items-center gap-1.5 text-xs text-desk-muted'>
+                  <span>
+                    Generated {new Date(report.generatedAt).toLocaleString()} · last{' '}
+                    {report.rangeDays === 1 ? '1 day' : `${report.rangeDays} days`}
+                  </span>
+                  {report.generating && (
+                    <span className='flex items-center gap-1 text-desk-accent'>
+                      <RefreshCw size={11} className='animate-spin' />
+                      Generating new report…
+                    </span>
+                  )}
+                </p>
+              )}
+            </div>
+            <div className='flex shrink-0 items-center gap-2 pr-12'>
+              {report?.status === 'completed' && report.url && (
+                <button
+                  type='button'
+                  onClick={() => void handleDownload()}
+                  disabled={downloading}
+                  className='flex items-center gap-1.5 rounded-[8px] border border-border px-3 py-1.5 text-sm text-foreground hover:bg-accent disabled:opacity-60'
+                  data-track-category='DeskReport'
+                  data-track-name='DownloadReport'
+                >
+                  <Download size={14} />
+                  {downloading ? 'Downloading…' : 'Download'}
+                </button>
+              )}
+              {canGenerate && (
+                <button
+                  type='button'
+                  onClick={() => void handleGenerateNow()}
+                  disabled={submitting || report?.generating}
+                  className='flex items-center gap-1.5 rounded-[8px] bg-desk-accent px-3 py-1.5 text-sm font-medium text-white disabled:opacity-60'
+                  data-track-category='DeskReport'
+                  data-track-name='GenerateNow'
+                >
+                  <RefreshCw
+                    size={14}
+                    className={submitting || report?.generating ? 'animate-spin' : ''}
+                  />
+                  {submitting || report?.generating ? 'Generating…' : 'Generate now'}
+                </button>
+              )}
+            </div>
+          </div>
+
+          <div className='min-h-0 flex-1'>
+            {loading ? (
+              <div className='flex h-full items-center justify-center text-sm text-desk-muted'>
+                Loading report…
+              </div>
+            ) : loadError ? (
+              <div className='flex h-full flex-col items-center justify-center gap-2 text-center'>
+                <p className='text-sm text-desk-muted'>{loadError}</p>
+              </div>
+            ) : !report ? (
+              <div className='flex h-full flex-col items-center justify-center gap-3 text-center px-6'>
+                <FileText size={28} className='text-desk-muted/70' />
+                <p className='text-sm font-medium text-foreground'>
+                  No report generated yet for this desk
+                </p>
+                <p className='max-w-sm text-xs text-desk-muted'>
+                  {canGenerate
+                    ? 'Enable Desk Report in Desk Settings → Agent to schedule this automatically, or generate one now.'
+                    : 'Ask a desk owner or admin to enable Desk Report in Desk Settings, or generate one.'}
+                </p>
+              </div>
+            ) : report.status === 'pending' ? (
+              // No completed report exists yet at all — nothing to keep
+              // showing, so this is the only case that's a full spinner.
+              <div className='flex h-full flex-col items-center justify-center gap-2 text-center'>
+                <RefreshCw size={22} className='animate-spin text-desk-muted' />
+                <p className='text-sm text-desk-muted'>Generating the desk report…</p>
+              </div>
+            ) : report.status === 'failed' ? (
+              <div className='flex h-full flex-col items-center justify-center gap-2 text-center px-6'>
+                <p className='text-sm font-medium text-foreground'>Report generation failed</p>
+                {report.error && <p className='max-w-sm text-xs text-desk-muted'>{report.error}</p>}
+              </div>
+            ) : (
+              // A completed report exists — keep it visible even if a newer
+              // generation is running or the newest attempt failed; the
+              // header banner / error strip carries that state instead of
+              // replacing the report.
+              <div className='flex h-full flex-col'>
+                {report.error && (
+                  <p className='shrink-0 border-b border-desk-border bg-destructive/5 px-6 py-2 text-xs text-destructive dark:border-border'>
+                    Last regeneration attempt failed: {report.error}
+                  </p>
+                )}
+                <iframe
+                  title='Desk report'
+                  src={report.url ? `${BASE_URL}${report.url}` : undefined}
+                  sandbox='allow-scripts'
+                  className='h-full w-full flex-1 border-0'
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+};

--- a/apps/dashboard/src/components/xyne-desk/DeskReport/DeskReportPanel.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskReport/DeskReportPanel.tsx
@@ -20,24 +20,20 @@ interface LatestDeskReport {
   rangeDays: number;
   agentSlug: string | null;
   error: string | null;
-  // True while a newer regeneration (cron or manual) is in flight. The
-  // previous completed report (if any) stays in `url`/`status` untouched —
-  // this is purely an "in progress" banner, never a state that hides it.
+  // True while a regeneration is in flight — purely a banner, never hides
+  // the previous completed report.
   generating: boolean;
 }
 
 interface LatestDeskReportResponse {
   success: boolean;
   data: LatestDeskReport | null;
-  // Whether the current user may trigger "Generate now" — computed
-  // server-side (canManageDeskReport), not re-derived from an org role here.
+  // Computed server-side (canManageDeskReport) — not re-derived here.
   canGenerate: boolean;
 }
 
 /**
- * Sidebar panel for the scheduled desk report — sibling to
- * DeskMetricsDashboard, same Dialog shell. Every fetch is scoped by
- * channelId (enforced again server-side), so it never shows another desk's report.
+ * Sidebar panel for the scheduled desk report
  */
 export const DeskReportPanel: React.FC<DeskReportPanelProps> = ({
   open,
@@ -46,17 +42,13 @@ export const DeskReportPanel: React.FC<DeskReportPanelProps> = ({
   channelName,
 }) => {
   const [report, setReport] = useState<LatestDeskReport | null>(null);
-  // Defaults to false (hide the button) until the first fetch resolves — the
-  // server is the only source of truth for this, no client-side guess.
   const [canGenerate, setCanGenerate] = useState(false);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
 
-  // Only show the full-panel spinner on the very first load. Once a report
-  // is on screen, subsequent refreshes (polling, "generate now") update
-  // `report` in place so the previous report never disappears mid-fetch.
+  // Full-panel spinner only on first load — later refreshes update in place.
   const fetchLatest = useCallback(
     async (opts?: { silent?: boolean }): Promise<void> => {
       if (!opts?.silent) setLoading(true);
@@ -81,10 +73,7 @@ export const DeskReportPanel: React.FC<DeskReportPanelProps> = ({
     void fetchLatest();
   }, [open, fetchLatest]);
 
-  // While a generation is in flight (cron-triggered or manual), poll quietly
-  // in the background so the "Generating…" banner clears on its own the
-  // moment the new report lands — the currently-shown report is never
-  // touched while this is running.
+  // Poll quietly while generating so the banner clears on its own.
   useEffect(() => {
     if (!open || !report?.generating) return;
     const interval = setInterval((): void => {
@@ -105,12 +94,10 @@ export const DeskReportPanel: React.FC<DeskReportPanelProps> = ({
             'This can take a few minutes — the current report stays visible until it’s ready.',
         });
       } else {
-        // e.g. a generation is already in flight for this desk — not an
-        // error the user needs to retry, just a no-op they should know about.
+        // e.g. already generating — a no-op to know about, not an error to retry.
         toast.info(res.data.error ?? 'Could not start desk report generation');
       }
-      // Silent: the previous report (if any) should stay on screen; only the
-      // `generating` banner should appear, not a loading state that hides it.
+      // Silent: keep the previous report visible, no loading state.
       await fetchLatest({ silent: true });
     } catch {
       toast.error('Failed to start desk report generation');
@@ -244,8 +231,7 @@ export const DeskReportPanel: React.FC<DeskReportPanelProps> = ({
                 </p>
               </div>
             ) : report.status === 'pending' ? (
-              // No completed report exists yet at all — nothing to keep
-              // showing, so this is the only case that's a full spinner.
+              // No completed report yet — the only case that's a full spinner.
               <div className='flex h-full flex-col items-center justify-center gap-2 text-center'>
                 <RefreshCw size={22} className='animate-spin text-desk-muted' />
                 <p className='text-sm text-desk-muted'>Generating the desk report…</p>
@@ -256,10 +242,8 @@ export const DeskReportPanel: React.FC<DeskReportPanelProps> = ({
                 {report.error && <p className='max-w-sm text-xs text-desk-muted'>{report.error}</p>}
               </div>
             ) : (
-              // A completed report exists — keep it visible even if a newer
-              // generation is running or the newest attempt failed; the
-              // header banner / error strip carries that state instead of
-              // replacing the report.
+              // Keep the completed report visible even mid-regeneration or
+              // after a failed retry — the banner/error strip carries that.
               <div className='flex h-full flex-col'>
                 {report.error && (
                   <p className='shrink-0 border-b border-desk-border bg-destructive/5 px-6 py-2 text-xs text-destructive dark:border-border'>

--- a/apps/dashboard/src/components/xyne-desk/DeskReport/index.ts
+++ b/apps/dashboard/src/components/xyne-desk/DeskReport/index.ts
@@ -1,0 +1,2 @@
+export { DeskReportPanel } from './DeskReportPanel';
+export type { DeskReportPanelProps } from './DeskReportPanel';

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/AutoDraftAgentPicker.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/AutoDraftAgentPicker.tsx
@@ -20,6 +20,9 @@ export interface AutoDraftAgentPickerProps {
   clawAgents: ChannelClawAgent[];
   disabled?: boolean;
   compact?: boolean;
+  defaultLabel?: string;
+  /** Helper text under the picker when no Claw agents are on this channel yet. */
+  emptyStateHelperText?: string;
 }
 
 /**
@@ -31,6 +34,8 @@ export const AutoDraftAgentPicker: React.FC<AutoDraftAgentPickerProps> = ({
   clawAgents,
   disabled = false,
   compact = false,
+  defaultLabel = 'Xyne AI',
+  emptyStateHelperText = 'Add a Claw agent to this channel to use it for drafts. Until then, the built-in Xyne AI is used.',
 }) => {
   const [showAddAgent, setShowAddAgent] = useState(false);
 
@@ -52,14 +57,14 @@ export const AutoDraftAgentPicker: React.FC<AutoDraftAgentPickerProps> = ({
         data-track-category='DeskSettings'
         data-track-name='SelectAutoDraftAgent'
       >
-        <SelectValue placeholder='Default (Xyne AI)' />
+        <SelectValue placeholder={`Default (${defaultLabel})`} />
       </SelectTrigger>
       <SelectContent className='rounded-[10px]'>
         <SelectItem value={DEFAULT_AGENT_OPTION} className='rounded-[8px]'>
           <span className='flex items-center gap-2'>
             <Sparkles size={14} className='text-desk-accent' />
             <span>
-              Default <span className='text-desk-helper'>(Xyne AI)</span>
+              Default <span className='text-desk-helper'>({defaultLabel})</span>
             </span>
           </span>
         </SelectItem>
@@ -114,7 +119,7 @@ export const AutoDraftAgentPicker: React.FC<AutoDraftAgentPickerProps> = ({
       <p className='text-desk-helper'>
         {clawAgents.length > 0
           ? 'Choose which agent writes the draft. Claw agents added to this channel appear here.'
-          : 'Add a Claw agent to this channel to use it for drafts. Until then, the built-in Xyne AI is used.'}
+          : emptyStateHelperText}
         {value && !clawAgents.some(a => a.slug === value) && (
           <span className='block text-amber-600 dark:text-amber-500 mt-1'>
             The selected agent is no longer in this channel — drafts fall back to the default until

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/DeskSettings.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/DeskSettings.tsx
@@ -42,11 +42,17 @@ export const DESK_SETTINGS_TABS: { id: TabId; label: string; icon: React.Element
   { id: 'metrics', label: 'Metrics', icon: BarChart3 },
 ];
 
-export type AIFeaturesSubTabId = 'ai-draft' | 'knowledge' | 'attribution' | 'ai-sync';
+export type AIFeaturesSubTabId =
+  | 'ai-draft'
+  | 'knowledge'
+  | 'desk-report'
+  | 'attribution'
+  | 'ai-sync';
 
 export const AI_FEATURES_SUB_TABS: { id: AIFeaturesSubTabId; label: string }[] = [
   { id: 'ai-draft', label: 'AI Draft' },
   { id: 'knowledge', label: 'Knowledge' },
+  { id: 'desk-report', label: 'Desk Report' },
   { id: 'attribution', label: 'Attribution' },
   { id: 'ai-sync', label: 'AI Sync' },
 ];

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AIFeaturesTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AIFeaturesTab.tsx
@@ -203,8 +203,8 @@ export const AIFeaturesTab: React.FC<AIFeaturesTabProps> = ({ channelId, form, s
                 content={
                   <div className='flex max-w-[260px] flex-col gap-1'>
                     <span>
-                      Add a Claw agent to this channel and pick it as the report agent — the report
-                      won&apos;t generate until one is selected, there&apos;s no built-in default.
+                      Uses the built-in Desk Report Generator agent by default — pick a different
+                      Claw agent here if you want another one to generate the report instead.
                     </span>
                   </div>
                 }
@@ -232,8 +232,8 @@ export const AIFeaturesTab: React.FC<AIFeaturesTabProps> = ({ channelId, form, s
                 onChange={setDeskReportAgentSlug}
                 clawAgents={clawAgents}
                 disabled={!canManage}
-                defaultLabel='None'
-                emptyStateHelperText="Add a Claw agent to this channel and pick it as the report agent. There's no built-in default — the report won't generate until one is selected."
+                defaultLabel='Report Generator'
+                emptyStateHelperText='Uses the built-in Report Generator agent. Add a Claw agent to this channel to use a different one instead.'
               />
             )}
             <Switch

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AIFeaturesTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AIFeaturesTab.tsx
@@ -204,7 +204,7 @@ export const AIFeaturesTab: React.FC<AIFeaturesTabProps> = ({ channelId, form, s
                   <div className='flex max-w-[260px] flex-col gap-1'>
                     <span>
                       Add a Claw agent to this channel and pick it as the report agent — the report
-                      won`t generate until one is selected, there`s no built-in default.
+                      won&apos;t generate until one is selected, there&apos;s no built-in default.
                     </span>
                   </div>
                 }

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AIFeaturesTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AIFeaturesTab.tsx
@@ -31,6 +31,12 @@ export const AIFeaturesTab: React.FC<AIFeaturesTabProps> = ({ channelId, form, s
     setAutoAIDraft,
     autoDraftAgentSlug,
     setAutoDraftAgentSlug,
+    deskReportEnabled,
+    setDeskReportEnabled,
+    deskReportAgentSlug,
+    setDeskReportAgentSlug,
+    deskReportRangeDays,
+    setDeskReportRangeDays,
     classificationEnabledDraft,
     classificationEnabledSaved,
     setClassificationEnabled,
@@ -181,6 +187,102 @@ export const AIFeaturesTab: React.FC<AIFeaturesTabProps> = ({ channelId, form, s
             autoDraftAgentSlug={autoDraftAgentSlug}
             clawAgents={clawAgents}
           />
+        )}
+      </div>
+    );
+  }
+
+  if (section === 'desk-report') {
+    return (
+      <div className='flex flex-col gap-[20px]'>
+        <div className='flex shrink-0 flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6'>
+          <div className='min-w-0 flex-1'>
+            <div className='flex items-center gap-1.5'>
+              <div className='text-desk-label text-[15px] font-semibold'>Desk report</div>
+              <Tooltip
+                content={
+                  <div className='flex max-w-[260px] flex-col gap-1'>
+                    <span>
+                      Add a Claw agent to this channel and pick it as the report agent — the report
+                      won`t generate until one is selected, there`s no built-in default.
+                    </span>
+                  </div>
+                }
+              >
+                <button
+                  type='button'
+                  className='text-desk-muted hover:text-foreground'
+                  aria-label='About the desk report'
+                >
+                  <CircleHelp size={14} />
+                </button>
+              </Tooltip>
+            </div>
+            <div className='text-desk-helper w-full max-w-[400px]'>
+              Get a detailed desk insights report every day — ticket volume, recurring issues,
+              priority mix, and workload — viewable right in the desk report panel or downloaded as
+              a file.
+            </div>
+          </div>
+          <div className='flex shrink-0 items-center gap-3'>
+            {deskReportEnabled && (
+              <AutoDraftAgentPicker
+                compact
+                value={deskReportAgentSlug}
+                onChange={setDeskReportAgentSlug}
+                clawAgents={clawAgents}
+                disabled={!canManage}
+                defaultLabel='None'
+                emptyStateHelperText="Add a Claw agent to this channel and pick it as the report agent. There's no built-in default — the report won't generate until one is selected."
+              />
+            )}
+            <Switch
+              variant='desk'
+              checked={deskReportEnabled}
+              onCheckedChange={setDeskReportEnabled}
+              disabled={!canManage}
+            />
+          </div>
+        </div>
+
+        {deskReportEnabled && (
+          <div className='flex flex-col gap-1.5'>
+            <div className='text-desk-label text-sm'>Report window</div>
+            <div className='flex items-center gap-2'>
+              <button
+                type='button'
+                onClick={() => setDeskReportRangeDays(1)}
+                disabled={!canManage}
+                className={
+                  deskReportRangeDays === 1
+                    ? 'rounded-[8px] bg-desk-accent px-3 py-1.5 text-sm font-medium text-white'
+                    : 'rounded-[8px] border border-border px-3 py-1.5 text-sm text-desk-muted hover:bg-accent/50'
+                }
+                data-track-category='DeskSettings'
+                data-track-name='SelectDeskReportRangeLastDay'
+              >
+                Last 1 day
+              </button>
+              <button
+                type='button'
+                onClick={() => setDeskReportRangeDays(7)}
+                disabled={!canManage}
+                className={
+                  deskReportRangeDays === 7
+                    ? 'rounded-[8px] bg-desk-accent px-3 py-1.5 text-sm font-medium text-white'
+                    : 'rounded-[8px] border border-border px-3 py-1.5 text-sm text-desk-muted hover:bg-accent/50'
+                }
+                data-track-category='DeskSettings'
+                data-track-name='SelectDeskReportRangeLastWeek'
+              >
+                Last 1 week
+              </button>
+            </div>
+            <p className='text-desk-helper'>
+              How much history the report covers each time it regenerates. Defaults to the last 1
+              day.
+            </p>
+          </div>
         )}
       </div>
     );

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/useDeskSettingsForm.ts
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/useDeskSettingsForm.ts
@@ -333,13 +333,6 @@ export function useDeskSettingsForm(
       toast.error('Incomplete classification config', { description: classificationConfigError });
       return;
     }
-    if (pref.draft.deskReportEnabled && !pref.draft.deskReportAgentSlug) {
-      toast.error('Select an agent for Desk Report', {
-        description:
-          'Pick an agent before saving, e.g. "Desk Report Generator" — or create one if it\'s not available yet.',
-      });
-      return;
-    }
     setSaving(true);
     try {
       const d = pref.draft;

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/useDeskSettingsForm.ts
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/useDeskSettingsForm.ts
@@ -201,6 +201,9 @@ export function useDeskSettingsForm(
     metricsEnabled: emailChannelPreference?.metricsEnabled ?? false,
     frtStageNames: emailChannelPreference?.frtStageNames ?? '[]',
     appWebhookDeliveryEnabled: emailChannelPreference?.appWebhookDeliveryEnabled ?? true,
+    deskReportEnabled: emailChannelPreference?.deskReportEnabled ?? false,
+    deskReportAgentSlug: emailChannelPreference?.deskReportAgentSlug ?? null,
+    deskReportRangeDays: emailChannelPreference?.deskReportRangeDays ?? 1,
   });
   const cls = useDraft({
     enabled: classificationConfig?.enabled ?? false,
@@ -230,6 +233,9 @@ export function useDeskSettingsForm(
   const metricsEnabled = pref.draft.metricsEnabled;
   const frtStageNames = parseFrtStageNames(pref.draft.frtStageNames);
   const appWebhookDeliveryEnabled = pref.draft.appWebhookDeliveryEnabled;
+  const deskReportEnabled = pref.draft.deskReportEnabled;
+  const deskReportAgentSlug = pref.draft.deskReportAgentSlug;
+  const deskReportRangeDays = pref.draft.deskReportRangeDays;
   const boardId = emailChannelPreference?.boardId ?? null;
   const classificationEnabledDraft = cls.draft.enabled;
   const classificationEnabledSaved = classificationConfig?.enabled ?? false;
@@ -267,6 +273,13 @@ export function useDeskSettingsForm(
     if (!canManage) return;
     pref.setField('appWebhookDeliveryEnabled', checked);
   };
+  const setDeskReportEnabled = (checked: boolean) => {
+    if (!canManage) return;
+    pref.setField('deskReportEnabled', checked);
+  };
+  const setDeskReportAgentSlug = (slug: string | null) =>
+    pref.setField('deskReportAgentSlug', slug);
+  const setDeskReportRangeDays = (days: number) => pref.setField('deskReportRangeDays', days);
   const setFrtStageNames = (updater: string[] | ((prev: string[]) => string[])) => {
     if (!canManage) return;
     pref.setField('frtStageNames', prevStr => {
@@ -320,6 +333,13 @@ export function useDeskSettingsForm(
       toast.error('Incomplete classification config', { description: classificationConfigError });
       return;
     }
+    if (pref.draft.deskReportEnabled && !pref.draft.deskReportAgentSlug) {
+      toast.error('Select an agent for Desk Report', {
+        description:
+          'Pick an agent before saving, e.g. "Desk Report Generator" — or create one if it\'s not available yet.',
+      });
+      return;
+    }
     setSaving(true);
     try {
       const d = pref.draft;
@@ -352,6 +372,15 @@ export function useDeskSettingsForm(
       if (d.frtStageNames !== s.frtStageNames) {
         const names = parseFrtStageNames(d.frtStageNames);
         patch.frtStageNames = names.length > 0 ? JSON.stringify(names) : null;
+      }
+      if (d.deskReportEnabled !== s.deskReportEnabled) {
+        patch.deskReportEnabled = d.deskReportEnabled;
+      }
+      if (d.deskReportAgentSlug !== s.deskReportAgentSlug) {
+        patch.deskReportAgentSlug = d.deskReportAgentSlug;
+      }
+      if (d.deskReportRangeDays !== s.deskReportRangeDays) {
+        patch.deskReportRangeDays = d.deskReportRangeDays;
       }
 
       if (cls.dirty) {
@@ -464,6 +493,12 @@ export function useDeskSettingsForm(
     setFrtStageNames,
     appWebhookDeliveryEnabled,
     setAppWebhookDeliveryEnabled,
+    deskReportEnabled,
+    setDeskReportEnabled,
+    deskReportAgentSlug,
+    setDeskReportAgentSlug,
+    deskReportRangeDays,
+    setDeskReportRangeDays,
     boardId,
     clawAgents,
     classificationEnabledDraft,

--- a/apps/dashboard/src/hooks/useDeskChannelPreferenceAutoSave.ts
+++ b/apps/dashboard/src/hooks/useDeskChannelPreferenceAutoSave.ts
@@ -16,6 +16,9 @@ export type ChannelPreferencePatch = {
   metricsEnabled?: boolean;
   frtStageNames?: string | null;
   appWebhookDeliveryEnabled?: boolean;
+  deskReportEnabled?: boolean;
+  deskReportAgentSlug?: string | null;
+  deskReportRangeDays?: number;
 };
 
 /**

--- a/apps/dashboard/src/hooks/useEmailChannelPreference.ts
+++ b/apps/dashboard/src/hooks/useEmailChannelPreference.ts
@@ -37,6 +37,9 @@ export function useUpdateEmailChannelPreference() {
       metricsEnabled,
       frtStageNames,
       appWebhookDeliveryEnabled,
+      deskReportEnabled,
+      deskReportAgentSlug,
+      deskReportRangeDays,
     }: {
       channelId: string;
       ownerUserId?: string;
@@ -50,6 +53,9 @@ export function useUpdateEmailChannelPreference() {
       metricsEnabled?: boolean;
       frtStageNames?: string | null;
       appWebhookDeliveryEnabled?: boolean;
+      deskReportEnabled?: boolean;
+      deskReportAgentSlug?: string | null;
+      deskReportRangeDays?: number;
     }): Promise<void> => {
       zero.mutate(
         mutators.emailChannelPreference.upsert({
@@ -67,6 +73,11 @@ export function useUpdateEmailChannelPreference() {
           ...(metricsEnabled !== undefined ? { metricsEnabled } : {}),
           ...(frtStageNames !== undefined ? { frtStageNames } : {}),
           ...(appWebhookDeliveryEnabled !== undefined ? { appWebhookDeliveryEnabled } : {}),
+          ...(deskReportEnabled !== undefined ? { deskReportEnabled } : {}),
+          ...(deskReportAgentSlug !== undefined
+            ? { deskReportAgentSlug: deskReportAgentSlug || null }
+            : {}),
+          ...(deskReportRangeDays !== undefined ? { deskReportRangeDays } : {}),
         }),
       );
       return Promise.resolve();

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -44,6 +44,7 @@ import {
   BarChart4Icon,
   CalendarDays,
   BarChart3,
+  FileText,
   Circle,
   UserPlus,
   Info as InfoIcon,
@@ -196,6 +197,7 @@ import { attachmentViewerActor, type AttachmentRef } from '../../machines/attach
 import { DeskSettings } from '../../components/xyne-desk/DeskSettings';
 import { DeskMetricsDashboard } from '../../components/xyne-desk/DeskMetrics';
 import { AutoLabelWizard } from '../../components/xyne-desk/AutoLabelWizard/AutoLabelWizard';
+import { DeskReportPanel } from '../../components/xyne-desk/DeskReport';
 import {
   useChannelIntegrationInfo,
   clearChannelConnectedEmailCache,
@@ -1159,6 +1161,7 @@ const SupportScreen = (): ReactElement => {
       searchParams.get('settings') === 'open' || searchParams.get('openSettings') === 'signatures',
   );
   const [isMetricsOpen, setIsMetricsOpen] = useState(() => searchParams.get('metrics') === 'open');
+  const [isReportOpen, setIsReportOpen] = useState(() => searchParams.get('report') === 'open');
   const [showCreateChannelModal, setShowCreateChannelModal] = useState(false);
   const [showDeskIntegrationsModal, setShowDeskIntegrationsModal] = useState(
     () =>
@@ -1426,6 +1429,10 @@ const SupportScreen = (): ReactElement => {
 
   useEffect(() => {
     setIsMetricsOpen(searchParams.get('metrics') === 'open');
+  }, [searchParams]);
+
+  useEffect(() => {
+    setIsReportOpen(searchParams.get('report') === 'open');
   }, [searchParams]);
 
   useEffect(() => {
@@ -2749,6 +2756,35 @@ const SupportScreen = (): ReactElement => {
                             </button>
                           </Tooltip>
                         )}
+                      {isSelectedChannelJoined &&
+                        selectedChannelId !== ALL_CHANNELS_ID &&
+                        channelPreference?.deskReportEnabled && (
+                          <Tooltip content='Desk report' side='bottom'>
+                            <button
+                              onClick={() => {
+                                const base = selectedChannelId
+                                  ? `${supportBase}/${selectedChannelId}`
+                                  : supportBase;
+                                if (isReportOpen) {
+                                  void navigate(base, { replace: true });
+                                } else {
+                                  void navigate(`${base}?report=open`);
+                                }
+                              }}
+                              className={cn(
+                                'p-1.5 rounded transition-colors',
+                                isReportOpen
+                                  ? 'bg-muted text-foreground'
+                                  : 'text-muted-foreground hover:text-foreground hover:bg-accent',
+                              )}
+                              data-track-category='Support'
+                              data-track-name='OpenDeskReport'
+                              data-track-metadata={JSON.stringify({ channelId: selectedChannelId })}
+                            >
+                              <FileText size={16} />
+                            </button>
+                          </Tooltip>
+                        )}
                       {isSelectedChannelJoined && (
                         <button
                           onClick={() => {
@@ -3388,6 +3424,19 @@ const SupportScreen = (): ReactElement => {
                   availableDesks={metricsSelectableDesks}
                   customFieldDefinitions={deskDynamicFields}
                   availableStages={availableStages}
+                />
+              )}
+              {isReportOpen && selectedChannelId && selectedChannelId !== ALL_CHANNELS_ID && (
+                <DeskReportPanel
+                  open
+                  onClose={() => {
+                    const base = selectedChannelId
+                      ? `${supportBase}/${selectedChannelId}`
+                      : supportBase;
+                    void navigate(base, { replace: true });
+                  }}
+                  channelId={selectedChannelId}
+                  channelName={selectedChannelName ?? undefined}
                 />
               )}
               <div className='h-full flex-1 min-h-0 overflow-y-auto no-scrollbar'>

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -9652,6 +9652,9 @@ export const mutators = defineMutators({
         metricsEnabled: z.boolean().optional(),
         frtStageNames: z.string().optional().nullable(),
         appWebhookDeliveryEnabled: z.boolean().optional(),
+        deskReportEnabled: z.boolean().optional(),
+        deskReportAgentSlug: z.string().optional().nullable(),
+        deskReportRangeDays: z.number().optional(),
       }),
       async ({
         tx,
@@ -9669,6 +9672,9 @@ export const mutators = defineMutators({
           metricsEnabled,
           frtStageNames,
           appWebhookDeliveryEnabled,
+          deskReportEnabled,
+          deskReportAgentSlug,
+          deskReportRangeDays,
         },
       }) => {
         const existing = await tx.run(
@@ -9688,6 +9694,9 @@ export const mutators = defineMutators({
             ...(metricsEnabled !== undefined ? { metricsEnabled } : {}),
             ...(frtStageNames !== undefined ? { frtStageNames } : {}),
             ...(appWebhookDeliveryEnabled !== undefined ? { appWebhookDeliveryEnabled } : {}),
+            ...(deskReportEnabled !== undefined ? { deskReportEnabled } : {}),
+            ...(deskReportAgentSlug !== undefined ? { deskReportAgentSlug } : {}),
+            ...(deskReportRangeDays !== undefined ? { deskReportRangeDays } : {}),
           });
         } else {
           const channel = await tx.run(zql.channels.where('id', channelId).one());
@@ -9714,6 +9723,9 @@ export const mutators = defineMutators({
             metricsEnabled: metricsEnabled ?? false,
             frtStageNames: frtStageNames ?? null,
             appWebhookDeliveryEnabled: appWebhookDeliveryEnabled ?? true,
+            deskReportEnabled: deskReportEnabled ?? false,
+            deskReportAgentSlug: deskReportAgentSlug ?? null,
+            deskReportRangeDays: deskReportRangeDays ?? 1,
           });
         }
       },

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1653,6 +1653,9 @@ export const emailChannelPreferenceTable = table('email_channel_preferences')
     metricsEnabled: boolean().optional(),
     frtStageNames: string().optional(),
     appWebhookDeliveryEnabled: boolean().optional(),
+    deskReportEnabled: boolean().optional(),
+    deskReportAgentSlug: string().optional(),
+    deskReportRangeDays: number().optional(),
   })
   .primaryKey('channelId');
 

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -118,8 +118,6 @@ export enum AttachmentEntityType {
   COLLECTION = 'COLLECTION',
   FORM_ENTITY_VALUE = 'FORM_ENTITY_VALUE',
   WORKFLOW_STEPS = 'WORKFLOW_STEPS',
-  // Generated desk-report HTML files — entityId is the channelId, not a
-  // message/ticket id. See deskReportGenerationService.ts.
   DESK_REPORT = 'DESK_REPORT',
 }
 

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -118,6 +118,9 @@ export enum AttachmentEntityType {
   COLLECTION = 'COLLECTION',
   FORM_ENTITY_VALUE = 'FORM_ENTITY_VALUE',
   WORKFLOW_STEPS = 'WORKFLOW_STEPS',
+  // Generated desk-report HTML files — entityId is the channelId, not a
+  // message/ticket id. See deskReportGenerationService.ts.
+  DESK_REPORT = 'DESK_REPORT',
 }
 
 // @ts-ignore TS1294


### PR DESCRIPTION
Migration-Changes:
  - added new column fro desk report

Environment-Changes:
  - ENABLE_DESK_REPORT_SCHEDULER: Toggle automated desk report schedules
  - DESK_REPORT_GENERATION_CRON: Cron schedule for generating reports
  - DESK_REPORT_CLEANUP_CRON: Cron schedule for report cleanup
  - DESK_REPORT_RETENTION_DAYS: Days to keep generated reports

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## POT


https://github.com/user-attachments/assets/411b4c3b-48e1-424f-9dd5-de694af024fb



## Description
Introduces scheduled and on-demand generation, automated retention pruning, and dedicated UI components for desk reports.

---

## Technical Details

* **Scheduled & On-Demand Generation:**
  * **Cron Trigger:** Generates each desk's report automatically based on configurable per-desk parameters (enable toggle, agent selection, and time range: 1 day or 1 week).
  * **Manual Trigger:** Provides a "Generate Now" action that mirrors the automated cron execution logic.

* **Retention & Storage:**
  * **Pruning Cron:** Removes historical reports exceeding a configurable retention window, while guaranteeing the preservation of each desk's latest report.
  * **Data Architecture:** Reuses the existing `attachments` table for report payload storage, requiring only supplementary settings columns rather than new table schemas.

* **User Interface & Security:**
  * **Management UI:** Adds a Desk Settings tab for report configuration and a dedicated sidebar panel for viewing and downloading recent reports.
  * **Route Hardening:** Enforces a strict Content Security Policy (CSP) on the report-viewing route to block network requests and cookie access from rendered report content.


## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [x] Adds/modifies a **mutator**
- [x] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [x] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [x] No `Date.now()` / `uuid()` generated inside a mutator
- [x] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [x] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [x] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [x] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [x] Clients regenerated (`db:generate`, `db:common:generate`)
- [x] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [x] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [x] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [x] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
