### PR TITLE
fix: XYNE-58075 Custom emoji replacement breaks Slack alert HTML

### DIFF
--- a/apps/backend/src/utils/customEmojiUtils.ts
+++ b/apps/backend/src/utils/customEmojiUtils.ts
@@ -3,6 +3,29 @@ import { CustomEmojiRepository } from '@/database/repositories/customEmojiReposi
 const SHORTCODE_REGEX = /:([a-zA-Z0-9_+-]{1,50}):/g;
 
 /**
+ * Splits HTML into tags (`<…>`) and the text between them.
+ *
+ * A tag must open with a letter or `/`, the same rule browsers use, so a bare
+ * `<` in alert text (`latency < 200ms`) stays text — slack-to-html does not
+ * escape it. Anything the regex does not match is copied through untouched.
+ */
+const HTML_TAG_OR_TEXT_REGEX = /<\/?[a-zA-Z][^>]*>|[^<]+/g;
+
+/**
+ * Apply `mapText` to text content only, never to markup.
+ *
+ * `@clearfeed-ai/slack-to-html` expands a unicode emoji to
+ * `<span title=":name:">&#x…;</span>`, i.e. it leaves a copy of the shortcode
+ * inside an attribute value. Rewriting that copy would inject an `<img>` tag
+ * into the attribute and break the surrounding element.
+ */
+function replaceInTextContent(content: string, mapText: (text: string) => string): string {
+  return content.replace(HTML_TAG_OR_TEXT_REGEX, (segment) =>
+    segment.startsWith('<') ? segment : mapText(segment),
+  );
+}
+
+/**
  * Build emoji img tag with relative path.
  * Full URL is constructed at render time by the client based on current environment.
  */
@@ -14,19 +37,29 @@ function buildEmojiImgTag(name: string, emoji: { id: string }): string {
 }
 
 /**
+ * Collect shortcode names that appear in text content, ignoring markup.
+ */
+function collectShortcodeNames(content: string): string[] {
+  const names = new Set<string>();
+
+  replaceInTextContent(content, (text) => {
+    for (const match of text.matchAll(SHORTCODE_REGEX)) {
+      if (match[1]) names.add(match[1]);
+    }
+    return text;
+  });
+
+  return Array.from(names);
+}
+
+/**
  * Replace custom emoji shortcodes (e.g. :test:) with inline <img> tags
  * if the emoji exists in DB (`customEmoji` table).
  */
 export async function replaceCustomEmojiShortcodesWithImg(content: string): Promise<string> {
   if (!content) return content;
 
-  const names = Array.from(
-    new Set(
-      Array.from(content.matchAll(SHORTCODE_REGEX))
-        .map((m) => m[1])
-        .filter(Boolean),
-    ),
-  );
+  const names = collectShortcodeNames(content);
 
   if (names.length === 0) return content;
 
@@ -37,8 +70,10 @@ export async function replaceCustomEmojiShortcodesWithImg(content: string): Prom
 
   const emojiByName = new Map(emojis.map((e) => [e.name, e]));
 
-  return content.replace(SHORTCODE_REGEX, (full, name: string) => {
-    const emoji = emojiByName.get(name);
-    return emoji ? buildEmojiImgTag(name, emoji) : full;
-  });
+  return replaceInTextContent(content, (text) =>
+    text.replace(SHORTCODE_REGEX, (full, name: string) => {
+      const emoji = emojiByName.get(name);
+      return emoji ? buildEmojiImgTag(name, emoji) : full;
+    }),
+  );
 }

--- a/apps/backend/src/utils/customEmojiUtils.ts
+++ b/apps/backend/src/utils/customEmojiUtils.ts
@@ -2,14 +2,20 @@ import { CustomEmojiRepository } from '@/database/repositories/customEmojiReposi
 
 const SHORTCODE_REGEX = /:([a-zA-Z0-9_+-]{1,50}):/g;
 
+function isAsciiLetter(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
 /**
- * Splits HTML into tags (`<…>`) and the text between them.
- *
- * A tag must open with a letter or `/`, the same rule browsers use, so a bare
- * `<` in alert text (`latency < 200ms`) stays text — slack-to-html does not
- * escape it. Anything the regex does not match is copied through untouched.
+ * True when `<` at `index` opens a tag: `<` followed by a letter, or by `/`
+ * and then a letter. Same rule browsers use, so a bare `<` in alert text
+ * (`latency < 200ms`) stays text — slack-to-html does not escape it.
  */
-const HTML_TAG_OR_TEXT_REGEX = /<\/?[a-zA-Z][^>]*>|[^<]+/g;
+function isTagOpen(content: string, index: number): boolean {
+  const next = content.charAt(index + 1);
+  return isAsciiLetter(next === '/' ? content.charAt(index + 2) : next);
+}
 
 /**
  * Apply `mapText` to text content only, never to markup.
@@ -18,11 +24,44 @@ const HTML_TAG_OR_TEXT_REGEX = /<\/?[a-zA-Z][^>]*>|[^<]+/g;
  * `<span title=":name:">&#x…;</span>`, i.e. it leaves a copy of the shortcode
  * inside an attribute value. Rewriting that copy would inject an `<img>` tag
  * into the attribute and break the surrounding element.
+ *
+ * Scans with `indexOf` rather than a tag-matching regex: `<[^>]*>` backtracks
+ * quadratically on input like `<a<a<a…`, and message content is user supplied.
+ * Every character here is visited once.
  */
 function replaceInTextContent(content: string, mapText: (text: string) => string): string {
-  return content.replace(HTML_TAG_OR_TEXT_REGEX, (segment) =>
-    segment.startsWith('<') ? segment : mapText(segment),
-  );
+  let result = '';
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    const open = content.indexOf('<', cursor);
+
+    if (open === -1) {
+      result += mapText(content.slice(cursor));
+      break;
+    }
+
+    if (!isTagOpen(content, open)) {
+      // Bare `<` in text. Emit it as text and resume after it.
+      result += mapText(content.slice(cursor, open + 1));
+      cursor = open + 1;
+      continue;
+    }
+
+    const close = content.indexOf('>', open);
+
+    if (close === -1) {
+      // No `>` left anywhere, so nothing from here on can be markup.
+      result += mapText(content.slice(cursor));
+      break;
+    }
+
+    if (open > cursor) result += mapText(content.slice(cursor, open));
+    result += content.slice(open, close + 1); // markup, copied verbatim
+    cursor = close + 1;
+  }
+
+  return result;
 }
 
 /**


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
