### PR TITLE
fix: apply Ask AI sidebar custom instructions in v2 claw flow

### DIFF
--- a/apps/backend/src/controllers/xyneAIControllerV2.ts
+++ b/apps/backend/src/controllers/xyneAIControllerV2.ts
@@ -465,6 +465,16 @@ export class XyneAIControllerV2 {
         select: { id: true, name: true, email: true },
       });
 
+      // Load the user's Ask AI custom instructions (set via the sidebar
+      // Settings modal). These are stored on userPreference but were never
+      // forwarded to the claw agent — surface them through the ClawRunRequest
+      // so the agent actually honours them.
+      const userPreference = await db.userPreference.findUnique({
+        where: { userId },
+        select: { askai_custom_instruction: true },
+      });
+      const customInstructions = userPreference?.askai_custom_instruction ?? null;
+
       // Track metrics: context channels count
       getAskAIContextChannels().record(effectiveChannelIds.length);
 
@@ -526,6 +536,7 @@ export class XyneAIControllerV2 {
         const runReq: ClawRunRequest = {
           userId,
           spacesWorkspaceId: req.user?.workspaceId,
+          customInstructions,
           userName: user?.name || 'Unknown',
           userEmail: user?.email || '',
           query,

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -110,6 +110,11 @@ export interface ClawRunRequest {
    *  /run/stream, which merges it over the agent's modelSettings for this run.
    *  Absent = agent default. */
   thinkingLevel?: 'off' | 'minimal' | 'low' | 'medium' | 'high';
+  /** User's Ask AI "Custom Instructions" (userPreference.askai_custom_instruction),
+   *  set via the Xyne AI sidebar Settings modal. Loaded per-run in the v2
+   *  controller and surfaced to the agent through additionalInstructions.
+   *  Empty/null = user has none. */
+  customInstructions?: string | null;
 }
 
 export interface ClawRunStreamResult {
@@ -508,6 +513,15 @@ function normalizeAttachmentsForRun(
 // "## Additional Instructions" heading and duplicate that block.
 function buildAdditionalInstructions(req: ClawRunRequest): string | undefined {
   const parts: string[] = [];
+
+  const customInstructions = req.customInstructions?.trim();
+  if (customInstructions) {
+    parts.push(
+      `The user has configured the following custom instructions for Ask AI. ` +
+        `Follow them for behaviour, style, and tone unless they conflict with a safety, ` +
+        `grounding, or tool-usage rule:\n\n${customInstructions}`
+    );
+  }
 
   if (req.researchContext) {
     parts.push(


### PR DESCRIPTION
## Problem
Custom instructions set in the Xyne AI sidebar (Settings → Custom Instructions) are saved to `userPreference.askai_custom_instruction` and correctly echoed back to the settings UI, but the AI completely ignores them. The active Ask AI **v2** path (`XyneAIControllerV2` → `clawAgentService` → xyne-claw) never reads that column, so the saved instruction is orphaned. The `{{custom_instructions}}` slot in the in-repo fallback prompt is only used by the legacy v1 agent and is never populated either.

## Root cause
`askai_custom_instruction` is only ever **written** (controller + user init). Across the whole backend it is never read into any prompt that reaches the running agent. The v2 `ClawRunRequest` had no field to carry it.

## Fix
- `xyneAIControllerV2.ts`: load `userPreference.askai_custom_instruction` per run (right after the user fetch) and forward it on `ClawRunRequest.customInstructions`.
- `clawAgentService.ts`: add optional `customInstructions` to `ClawRunRequest`, and prepend it in `buildAdditionalInstructions()` so it reaches the agent through claw-auth's existing `additionalInstructions` prompt mechanism. It is wrapped with guidance so it shapes behaviour/tone but does not override safety, grounding, or tool-usage rules.

## Scope / risk
Two files, additive only. No schema change, no migration. If a user has no custom instruction the value is null and nothing is added to the prompt (existing behaviour preserved).

## Testing notes
Full backend `tsc` could not finish in the dev sandbox (unrelated prebake drift), but the changes reuse existing type-safe patterns (`db.userPreference.findUnique({ select: { askai_custom_instruction: true } })` already exists in `customInstructionController`) and the new interface field is optional. Manual validation: set a custom instruction in the sidebar, send an Ask AI v2 message, confirm the agent honours it; clear it and confirm no additional-instructions block is emitted.