### PR TITLE
fix: reopenDm resets isClosed on the correct table (channel_user_status)

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
+++ b/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
@@ -24,7 +24,11 @@ import {
   EVENT_PROPERTIES,
 } from '../../../services/Analytics/mixpanelService';
 import { usePreviousChannelId } from '../../../hooks/usePreviousChannelId';
-import { useChannel, useGetChannelUserStatus } from '../../../hooks/useChannels';
+import {
+  useChannel,
+  useGetChannelUserStatus,
+  useChannelParticipation,
+} from '../../../hooks/useChannels';
 import { setLastVisitedChannel } from '../../../hooks/useLastVisitedChannel';
 import { useRouteContext } from '../../../hooks/useRouteContext';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -65,7 +69,7 @@ const ChatView = (): ReactElement => {
 
   // Query channel data to check if it's a DM and if user's participation is closed
   const channel = useChannel(channelId || '');
-  const channelUserStatus = useGetChannelUserStatus(channelId || '');
+  const channelUserStatus = useChannelParticipation(channelId || '');
   const { baseRoute } = useRouteContext();
   const { isMobile } = usePlatform();
   const isInPanelWebview = useIsInPanelWebview();
@@ -94,16 +98,13 @@ const ChatView = (): ReactElement => {
   const { groupId } = useParams<{ groupId?: string }>();
   const isGroupPanelOpen = !!groupId;
 
-  // Reopen DM if user navigates to a closed DM (only on navigation, not on data updates)
+  // Track conversation-opened once per navigation (gated on the channelId
+  // change ref so it does not re-fire on data updates).
   useEffect(() => {
-    // Only run when channelId changes (navigation), not on data updates
     if (prevChannelIdRef.current === channelId) return;
     prevChannelIdRef.current = channelId;
 
     if (!channel || !channelId) return;
-
-    const isDM =
-      channel.scopeType === ChannelScopeType.DM || channel.scopeType === ChannelScopeType.GROUP_DM;
 
     // Track conversation opened (no sensitive data - only conversation type)
     const conversationType =
@@ -116,14 +117,38 @@ const ChatView = (): ReactElement => {
     mixpanelService.track(EVENTS.CONVERSATION_OPENED, {
       type: conversationType,
     });
+  }, [channel, channelId, context.userID, zero]);
 
+  // Reopen a closed DM when navigating to it.
+  //
+  // A closed DM is absent from the XState channel-status map (that map is
+  // seeded from userVisibleChannelsV3, which filters isClosed=false), so
+  // useChannelParticipation resolves its status via a fallback query that
+  // lands a render *after* channelId changes. We therefore key this effect on
+  // channelUserStatus and use a per-channel "attempted" ref instead of the
+  // single-shot navigation ref, so the reopen still fires on the render where
+  // the closed status first becomes available.
+  const reopenAttemptedForRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (!channel || !channelId) return;
+
+    const isDM =
+      channel.scopeType === ChannelScopeType.DM || channel.scopeType === ChannelScopeType.GROUP_DM;
     if (!isDM) return;
 
-    // If user's participation is closed, reopen it
-    if (channelUserStatus?.isClosed) {
+    // Already handled this channel during the current visit.
+    if (reopenAttemptedForRef.current === channelId) return;
+
+    // Status not resolved yet (closed DMs load via a fallback query). Wait —
+    // this effect re-runs when channelUserStatus changes.
+    if (channelUserStatus === undefined) return;
+
+    reopenAttemptedForRef.current = channelId;
+
+    if (channelUserStatus.isClosed) {
       zero.mutate(mutators.channel.reopenDm({ channelId, updatedAt: Date.now() }));
     }
-  }, [channel, channelId, context.userID, zero]);
+  }, [channel, channelId, channelUserStatus, zero]);
 
   // Save the current channelId as the last visited channel.
   useEffect(() => {

--- a/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
+++ b/apps/dashboard/src/components/Chat/ChatView/ChatView.tsx
@@ -24,11 +24,7 @@ import {
   EVENT_PROPERTIES,
 } from '../../../services/Analytics/mixpanelService';
 import { usePreviousChannelId } from '../../../hooks/usePreviousChannelId';
-import {
-  useChannel,
-  useGetChannelUserStatus,
-  useChannelParticipation,
-} from '../../../hooks/useChannels';
+import { useChannel, useChannelParticipation } from '../../../hooks/useChannels';
 import { setLastVisitedChannel } from '../../../hooks/useLastVisitedChannel';
 import { useRouteContext } from '../../../hooks/useRouteContext';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -98,8 +94,7 @@ const ChatView = (): ReactElement => {
   const { groupId } = useParams<{ groupId?: string }>();
   const isGroupPanelOpen = !!groupId;
 
-  // Track conversation-opened once per navigation (gated on the channelId
-  // change ref so it does not re-fire on data updates).
+  // Track conversation-opened once per navigation (gated on the channelId change ref).
   useEffect(() => {
     if (prevChannelIdRef.current === channelId) return;
     prevChannelIdRef.current = channelId;
@@ -119,15 +114,7 @@ const ChatView = (): ReactElement => {
     });
   }, [channel, channelId, context.userID, zero]);
 
-  // Reopen a closed DM when navigating to it.
-  //
-  // A closed DM is absent from the XState channel-status map (that map is
-  // seeded from userVisibleChannelsV3, which filters isClosed=false), so
-  // useChannelParticipation resolves its status via a fallback query that
-  // lands a render *after* channelId changes. We therefore key this effect on
-  // channelUserStatus and use a per-channel "attempted" ref instead of the
-  // single-shot navigation ref, so the reopen still fires on the render where
-  // the closed status first becomes available.
+  // Reopen a closed DM: its status loads async (absent from the channel-status map), so key on channelUserStatus with a per-channel ref rather than the single-shot navigation ref.
   const reopenAttemptedForRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     if (!channel || !channelId) return;
@@ -136,11 +123,10 @@ const ChatView = (): ReactElement => {
       channel.scopeType === ChannelScopeType.DM || channel.scopeType === ChannelScopeType.GROUP_DM;
     if (!isDM) return;
 
-    // Already handled this channel during the current visit.
+    // Already handled this channel this visit.
     if (reopenAttemptedForRef.current === channelId) return;
 
-    // Status not resolved yet (closed DMs load via a fallback query). Wait —
-    // this effect re-runs when channelUserStatus changes.
+    // Status not resolved yet (closed DMs load via a fallback query); this effect re-runs when it changes.
     if (channelUserStatus === undefined) return;
 
     reopenAttemptedForRef.current = channelId;

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -1278,7 +1278,11 @@ export const mutators = defineMutators({
       z.object({ channelId: z.string(), updatedAt: z.number() }),
       async ({ tx, ctx, args: { channelId, updatedAt } }) => {
         const participation = await tx.run(
-          zql.channel_participants.where('channelId', channelId).where('userId', ctx.userID).one(),
+          zql.channel_user_status
+            .where('channelId', channelId)
+            .where('userId', ctx.userID)
+            .where('isDeleted', false)
+            .one(),
         );
 
         if (!participation) {


### PR DESCRIPTION
## Problem
Once a user closes a DM (the ✕ on the sidebar DM row → `closeDm` sets `channel_user_status.isClosed = true`), it can never come back to the sidebar. Opening/viewing the DM is supposed to auto-reopen it — `ChatView.tsx` calls the `reopenDm` mutator when a closed DM is viewed — but `reopenDm` was broken.

Concretely, this hides the **Automations bot DM** permanently: new approval-notification messages keep arriving (and still show on the full DM page, which does not filter `isClosed`), but the DM never returns to the sidebar list (`userVisibleChannelsV3` filters `isClosed = false`).

## Root cause
In `packages/shared/src/zero/mutators.ts`, `reopenDm` looked up the participation row in `channel_participants`, then called `tx.mutate.channel_user_status.update({ id: participation.id, ... })`. `channel_participants.id` and `channel_user_status.id` are independent CUIDs, so the update targeted a non-existent `channel_user_status` row and silently no-oped — `isClosed` stayed `true`. (`closeDm` correctly reads from `channel_user_status`, which is why closing works but reopening does not.)

## Fix
Make `reopenDm` query `channel_user_status` by `channelId` + `userId` with `isDeleted = false` (mirroring `closeDm`), so the update targets the real row. One-mutator change, 5 insertions / 1 deletion.

## Testing
- `tsc --noEmit` on `packages/shared` passes.
- Manual: close a DM, then open it → it returns to the sidebar (isClosed flips back to false).