### PR TITLE
feat: XYNE-55716 add brief on/off toggle, improve metrics (xyne-claw* specific changes)

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260820140000_daily_brief_activity/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260820140000_daily_brief_activity/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "daily_brief_activity" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "dateBucket" TEXT NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "rejectionCount" INTEGER NOT NULL DEFAULT 0,
+    "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "daily_brief_activity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "daily_brief_activity_userId_kind_dateBucket_key" ON "daily_brief_activity"("userId", "kind", "dateBucket");
+
+-- CreateIndex
+CREATE INDEX "daily_brief_activity_orgId_idx" ON "daily_brief_activity"("orgId");
+
+-- CreateIndex
+CREATE INDEX "daily_brief_activity_kind_dateBucket_idx" ON "daily_brief_activity"("kind", "dateBucket");
+
+-- AddForeignKey
+ALTER TABLE "daily_brief_activity" ADD CONSTRAINT "daily_brief_activity_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -66,6 +66,7 @@ model User {
   /// digitalTwinEnabled opt-in pattern.
   dailyBriefEnabled   Boolean   @default(false)
   dailyBriefEnabledAt DateTime?
+  dailyBriefActivity  DailyBriefActivity[]
   /// Per-user, per-agent custom instructions (injected into every agent run for
   /// this user) + feature-generated content (first consumer: Daily Brief).
   agentInstructions   UserAgentInstruction[]
@@ -652,6 +653,37 @@ model GeneratedContent {
   @@index([userId, kind, dateBucket])
   @@index([status, kind])
   @@map("generated_content")
+}
+
+/// One row per user per day per activity kind, so a distinct-user count over any
+/// date range is an exact COUNT(DISTINCT) rather than a fixed-window sketch.
+/// Upserted, so repeat activity on the same day bumps `count` instead of adding rows.
+model DailyBriefActivity {
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  orgId  String
+
+  /// "view" | "regenerate" | "switch".
+  kind       String
+  /// Calendar bucket the activity happened on (IST), matching GeneratedContent.
+  dateBucket String
+  /// How many times this user did this on this day.
+  count      Int      @default(1)
+  /// Regenerations that signal dissatisfaction — excludes retry_after_failure.
+  /// A counter rather than an origin string: the row is unique per user/kind/day,
+  /// so a single value would be last-write-wins across mixed origins.
+  rejectionCount Int  @default(0)
+  /// First occurrence on this day.
+  occurredAt DateTime @default(now())
+  /// Most recent occurrence on this day.
+  lastSeenAt DateTime @default(now())
+
+  @@unique([userId, kind, dateBucket])
+  @@index([orgId])
+  @@index([kind, dateBucket])
+  @@map("daily_brief_activity")
 }
 
 model AgentChainWorkflow {

--- a/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
+++ b/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
@@ -42,7 +42,11 @@ const switchSourceKey = (source: BriefSwitchSource): string =>
   `daily_brief:switch_users:src:${source}`;
 /** HyperLogLog per day: a windowed distinct count without one Redis member per user per day. */
 const switchDayKey = (dateBucket: string): string => `daily_brief:switch_users:day:${dateBucket}`;
-const SWITCH_DAY_TTL_SECONDS = 35 * 24 * 60 * 60;
+
+const DAY_HLL_TTL_SECONDS = 35 * 24 * 60 * 60;
+
+/** Activity kinds recorded per user per day in Postgres. Bounded set. */
+export type DailyBriefActivityKind = "view" | "regenerate" | "switch";
 
 /** Per user per day, so we know which attempt a request is. Two days is plenty. */
 const dayAttemptKey = (userId: string, dateBucket: string): string =>
@@ -113,9 +117,10 @@ export function recordDailyBriefGenerated(
   trigger: DailyBriefTrigger,
   status: "ready" | "failed",
   durationMs: number,
+  attempt = 1,
 ): void {
   try {
-    const attributes = { trigger, status };
+    const attributes = { trigger, status, attempt: attemptBucket(attempt) };
     getDailyBriefGeneratedTotal().add(1, attributes);
     getGenerationDuration().record(durationMs, attributes);
   } catch {
@@ -151,6 +156,27 @@ export function recordScheduledDeliveryDelay(dateBucket: string, generatedAt: Da
   }
 }
 
+// Daily Brief Opt-In Changes — labels: action (opted_in | opted_out)
+let _optInChanges: Counter | null = null;
+function getOptInChanges(): Counter {
+  if (!_optInChanges) {
+    _optInChanges = getMeter().createCounter("daily_brief_opt_in_changes_total", {
+      description: "Daily Brief master toggle flips, by direction",
+      unit: "1",
+    });
+  }
+  return _optInChanges;
+}
+
+/** Count one master-toggle flip. Only call when the stored value actually changed. */
+export function recordDailyBriefOptInChange(enabled: boolean): void {
+  try {
+    getOptInChanges().add(1, { action: enabled ? "opted_in" : "opted_out" });
+  } catch {
+    // metrics must never break a request
+  }
+}
+
 // Daily Brief Regeneration Attempts — labels: attempt (1 | 2 | 3 | 4+), origin
 let _regenerationAttempts: Counter | null = null;
 function getRegenerationAttempts(): Counter {
@@ -163,6 +189,11 @@ function getRegenerationAttempts(): Counter {
   return _regenerationAttempts;
 }
 
+/** Bounded attempt bucket shared by the attempts counter and the completion counter. */
+function attemptBucket(attempt: number): string {
+  return attempt >= 4 ? "4+" : String(attempt);
+}
+
 /**
  * Count one regeneration request, the user behind it, and — the useful part —
  * which attempt of the day it is and what it is replacing. Best-effort.
@@ -171,13 +202,32 @@ function getRegenerationAttempts(): Counter {
  */
 export async function recordDailyBriefRegeneration(
   userId: string,
+  orgId: string,
   dateBucket: string,
   existing: { status: string; generatedAt: Date | null } | null,
-): Promise<void> {
+): Promise<number> {
   try {
     const redis = redisService.getConnection();
     const dayKey = dayAttemptKey(userId, dateBucket);
     const attempt = await redis.incr(dayKey);
+    void finishRegenerationRecord(userId, orgId, dateBucket, existing, attempt, dayKey);
+    return attempt;
+  } catch {
+    // metrics must never break a brief run
+    return 1;
+  }
+}
+
+async function finishRegenerationRecord(
+  userId: string,
+  orgId: string,
+  dateBucket: string,
+  existing: { status: string; generatedAt: Date | null } | null,
+  attempt: number,
+  dayKey: string,
+): Promise<void> {
+  try {
+    const redis = redisService.getConnection();
     await redis.expire(dayKey, DAY_ATTEMPT_TTL_SECONDS);
 
     const origin: RegenerationOrigin =
@@ -189,10 +239,7 @@ export async function recordDailyBriefRegeneration(
             ? "replacing_scheduled_brief"
             : "first_brief_of_day";
 
-    getRegenerationAttempts().add(1, {
-      attempt: attempt >= 4 ? "4+" : String(attempt),
-      origin,
-    });
+    getRegenerationAttempts().add(1, { attempt: attemptBucket(attempt), origin });
 
     const writes = redis.multi().incr(REGEN_COUNT_KEY).sadd(REGEN_USERS_KEY, userId);
     if (origin === "replacing_scheduled_brief") writes.sadd(DEFAULT_REJECTED_USERS_KEY, userId);
@@ -200,14 +247,60 @@ export async function recordDailyBriefRegeneration(
     // run has attempt >= 2 without being dissatisfied with anything.
     if (origin === "replacing_own_regeneration") writes.sadd(REPEAT_REGEN_USERS_KEY, userId);
     await writes.exec();
+    const isRejection =
+      origin === "replacing_scheduled_brief" || origin === "replacing_own_regeneration";
+    await recordDailyBriefActivity(userId, orgId, "regenerate", dateBucket, isRejection);
   } catch {
     // metrics must never break a brief run
+  }
+}
+
+/**
+ * Upsert one row per user per day per kind. Distinct-user counts over an arbitrary
+ * date range then come from COUNT(DISTINCT "userId") in Postgres, which is exact
+ * and unbounded in lookback — a fixed-window sketch can be neither. Repeat activity
+ * on the same day bumps `count` instead of adding a row, so the table stays bounded
+ * at one row per user per day per kind however heavy the usage.
+ *
+ * @param isRejection increments `rejectionCount` alongside `count`.
+ */
+export async function recordDailyBriefActivity(
+  userId: string,
+  orgId: string,
+  kind: DailyBriefActivityKind,
+  dateBucket: string,
+  isRejection = false,
+): Promise<void> {
+  try {
+    const now = new Date();
+    const rejection = isRejection ? 1 : 0;
+    await prisma.dailyBriefActivity.upsert({
+      where: { userId_kind_dateBucket: { userId, kind, dateBucket } },
+      create: {
+        userId,
+        orgId,
+        kind,
+        dateBucket,
+        count: 1,
+        rejectionCount: rejection,
+        occurredAt: now,
+        lastSeenAt: now,
+      },
+      update: {
+        count: { increment: 1 },
+        rejectionCount: { increment: rejection },
+        lastSeenAt: now,
+      },
+    });
+  } catch {
+    // metrics must never break a request
   }
 }
 
 /** Record that a user switched to a different brief, from a given entry point. */
 export async function recordDailyBriefSwitch(
   userId: string,
+  orgId: string,
   source: BriefSwitchSource,
   dateBucket: string,
 ): Promise<void> {
@@ -221,18 +314,28 @@ export async function recordDailyBriefSwitch(
       .sadd(SWITCH_USERS_KEY, userId)
       .sadd(switchSourceKey(source), userId)
       .pfadd(dayKey, userId)
-      .expire(dayKey, SWITCH_DAY_TTL_SECONDS)
+      .expire(dayKey, DAY_HLL_TTL_SECONDS)
       .exec();
+    await recordDailyBriefActivity(userId, orgId, "switch", dateBucket);
   } catch {
     // metrics must never break a request
   }
 }
 
+/** Record that a user opened a brief. */
+export async function recordDailyBriefViewed(
+  userId: string,
+  orgId: string,
+  dateBucket: string,
+): Promise<void> {
+  await recordDailyBriefActivity(userId, orgId, "view", dateBucket);
+}
+
 /** The last `days` day-bucket keys, newest first — the union PFCOUNT reads. */
-function switchDayKeysBack(days: number): string[] {
+function dayKeysBack(key: (dateBucket: string) => string, days: number): string[] {
   const now = Date.now();
   return Array.from({ length: days }, (_, i) =>
-    switchDayKey(formatDayIST(new Date(now - i * 24 * 60 * 60 * 1000))),
+    key(formatDayIST(new Date(now - i * 24 * 60 * 60 * 1000))),
   );
 }
 
@@ -284,6 +387,15 @@ export function registerDailyBriefGauges(): void {
   const switchesSourceGauge = meter.createObservableGauge("daily_brief_switches_by_source", {
     description: "Brief switches ever served, by the control used (events, not people)",
   });
+  const enabledUsersGauge = meter.createObservableGauge("daily_brief_enabled_users_total", {
+    description: "Users who currently have the Daily Brief switched on",
+  });
+  const eligibleUsersGauge = meter.createObservableGauge("daily_brief_eligible_users_total", {
+    description: "All user accounts — the fixed denominator for the opt-in rate",
+  });
+  const deliveredTodayGauge = meter.createObservableGauge("daily_brief_delivered_today", {
+    description: "Briefs ready for today's bucket — divide by opted-in users for fan-out coverage",
+  });
 
   meter.addBatchObservableCallback(
     async (result) => {
@@ -305,6 +417,9 @@ export function registerDailyBriefGauges(): void {
           switches,
           switchesHistoryMenu,
           switchesDatePicker,
+          enabledUsers,
+          eligibleUsers,
+          deliveredToday,
         ] = await Promise.all([
           prisma.generatedContent.count({ where }),
           prisma.generatedContent.groupBy({ by: ["userId"], where }),
@@ -313,13 +428,18 @@ export function registerDailyBriefGauges(): void {
           redis.scard(DEFAULT_REJECTED_USERS_KEY).catch(() => 0),
           redis.scard(REPEAT_REGEN_USERS_KEY).catch(() => 0),
           redis.scard(SWITCH_USERS_KEY).catch(() => 0),
-          redis.pfcount(...switchDayKeysBack(7)).catch(() => 0),
-          redis.pfcount(...switchDayKeysBack(30)).catch(() => 0),
+          redis.pfcount(...dayKeysBack(switchDayKey, 7)).catch(() => 0),
+          redis.pfcount(...dayKeysBack(switchDayKey, 30)).catch(() => 0),
           redis.scard(switchSourceKey("history_menu")).catch(() => 0),
           redis.scard(switchSourceKey("date_picker")).catch(() => 0),
           redis.get(SWITCH_COUNT_KEY).catch(() => null),
           redis.get(switchSourceCountKey("history_menu")).catch(() => null),
           redis.get(switchSourceCountKey("date_picker")).catch(() => null),
+          prisma.user.count({ where: { dailyBriefEnabled: true } }),
+          prisma.user.count(),
+          prisma.generatedContent.count({
+            where: { ...where, dateBucket: formatDayIST(new Date()) },
+          }),
         ]);
         result.observe(usersGauge, users.length);
         result.observe(briefsGauge, briefs);
@@ -339,6 +459,9 @@ export function registerDailyBriefGauges(): void {
         result.observe(switchesSourceGauge, Number(switchesDatePicker ?? 0), {
           source: "date_picker",
         });
+        result.observe(enabledUsersGauge, enabledUsers);
+        result.observe(eligibleUsersGauge, eligibleUsers);
+        result.observe(deliveredTodayGauge, deliveredToday);
       } catch (err) {
         // OTel swallows a rejected callback silently — log so a broken read is visible.
         log.warn(`[otel] daily-brief gauges skipped: ${errMsg(err)}`);
@@ -356,6 +479,9 @@ export function registerDailyBriefGauges(): void {
       switchUsersSourceGauge,
       switchesGauge,
       switchesSourceGauge,
+      enabledUsersGauge,
+      eligibleUsersGauge,
+      deliveredTodayGauge,
     ],
   );
 }

--- a/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
@@ -18,8 +18,10 @@ import {
   type DailyBriefPayload,
 } from "../services/dailyBrief.js";
 import {
+  recordDailyBriefOptInChange,
   recordDailyBriefRegeneration,
   recordDailyBriefSwitch,
+  recordDailyBriefViewed,
   type BriefSwitchSource,
 } from "../otel/daily-brief-metrics.js";
 
@@ -64,6 +66,9 @@ router.put("/config", asyncHandler(async (req: Request, res: Response) => {
     if (typeof body.enabled !== "boolean") {
       throw badRequest("enabled must be a boolean");
     }
+    const before = await prisma.user
+      .findUnique({ where: { id: userId }, select: { dailyBriefEnabled: true } })
+      .catch(() => null);
     await prisma.user.update({
       where: { id: userId },
       data: {
@@ -71,6 +76,9 @@ router.put("/config", asyncHandler(async (req: Request, res: Response) => {
         ...(body.enabled ? { dailyBriefEnabledAt: new Date() } : {}),
       },
     });
+    if (before && before.dailyBriefEnabled !== body.enabled) {
+      recordDailyBriefOptInChange(body.enabled);
+    }
   }
 
   if (body.instructions !== undefined || body.instructionsEnabled !== undefined) {
@@ -107,6 +115,7 @@ router.put("/config", asyncHandler(async (req: Request, res: Response) => {
 /** GET /latest — today's stored brief (falls back to the most recent one). */
 router.get("/latest", asyncHandler(async (req: Request, res: Response) => {
   const userId = requireRequester(req);
+  const orgId = getOrgId(req);
   const today = briefDateBucket();
   const todays = await generatedContentRepository.findForBucket(userId, DAILY_BRIEF_KIND, today);
   const row = todays ?? (await generatedContentRepository.findLatest(userId, DAILY_BRIEF_KIND));
@@ -114,6 +123,7 @@ router.get("/latest", asyncHandler(async (req: Request, res: Response) => {
     ok(res, { status: "none" });
     return;
   }
+  if (orgId) void recordDailyBriefViewed(userId, orgId, today);
   ok(res, {
     status: row.status,
     date: row.dateBucket,
@@ -180,6 +190,7 @@ router.get("/by-date/:date", asyncHandler(async (req: Request, res: Response) =>
 router.post("/switched", async (req: Request, res: Response) => {
   try {
     const userId = getRequesterId(req);
+    const orgId = getOrgId(req);
     if (!userId) {
       res.status(401).json({ success: false, error: "Unauthorized" });
       return;
@@ -189,7 +200,7 @@ router.post("/switched", async (req: Request, res: Response) => {
     // open the label up to arbitrary cardinality.
     const body = req.body as { source?: unknown };
     const source: BriefSwitchSource = body.source === "date_picker" ? "date_picker" : "history_menu";
-    await recordDailyBriefSwitch(userId, source, briefDateBucket());
+    if (orgId) await recordDailyBriefSwitch(userId, orgId, source, briefDateBucket());
     res.status(204).end();
   } catch (err) {
     log.error("[daily-brief] post switched", err);
@@ -204,6 +215,7 @@ router.post("/switched", async (req: Request, res: Response) => {
  */
 router.post("/regenerate", async (req: Request, res: Response) => {
   const userId = getRequesterId(req);
+  const orgId = getOrgId(req);
   if (!userId) {
     res.status(401).json({ success: false, error: "Unauthorized" });
     return;
@@ -231,12 +243,15 @@ router.post("/regenerate", async (req: Request, res: Response) => {
   const existing = await generatedContentRepository
     .findForBucket(userId, DAILY_BRIEF_KIND, dateBucket)
     .catch(() => null);
-  void recordDailyBriefRegeneration(userId, dateBucket, existing);
+  const attempt = orgId
+    ? await recordDailyBriefRegeneration(userId, orgId, dateBucket, existing)
+    : 1;
   send("start", { date: dateBucket });
   try {
     const result = await generateDailyBrief(userId, {
       signal: abort.signal,
       trigger: "regenerate",
+      attempt,
       onProgress: (label) => send("progress", { label }),
     });
     if (result) {

--- a/apps/xyne-claw-auth/backend/src/services/dailyBrief.ts
+++ b/apps/xyne-claw-auth/backend/src/services/dailyBrief.ts
@@ -128,9 +128,11 @@ export async function generateDailyBrief(
     onProgress?: (label: string) => void;
     signal?: AbortSignal;
     trigger?: DailyBriefTrigger;
+    attempt?: number;
   } = {},
 ): Promise<GenerateBriefResult | null> {
   const trigger = opts.trigger ?? "scheduled";
+  const attempt = opts.attempt ?? 1;
   const startedAt = Date.now();
   const user = await prisma.user.findUnique({
     where: { id: userId },
@@ -210,7 +212,7 @@ export async function generateDailyBrief(
         `[daily-brief] run for ${userId} finished without a dailyBrief payload (lastEvent=${streamResult.lastEventName}, error=${streamResult.errorReason ?? "none"})`,
       );
       await generatedContentRepository.markFailed(userId, DAILY_BRIEF_KIND, dateBucket);
-      recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt);
+      recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt, attempt);
       return null;
     }
 
@@ -232,13 +234,13 @@ export async function generateDailyBrief(
       generatedAt,
     });
     log.info(`[daily-brief] generated + persisted for ${userId} (session=${sessionId ?? "?"})`);
-    recordDailyBriefGenerated(trigger, "ready", Date.now() - startedAt);
+    recordDailyBriefGenerated(trigger, "ready", Date.now() - startedAt, attempt);
     if (trigger === "scheduled") recordScheduledDeliveryDelay(dateBucket, generatedAt);
     return { brief, content, sessionId };
   } catch (err) {
     log.error(`[daily-brief] generation failed for ${userId}:`, errMsg(err));
     await generatedContentRepository.markFailed(userId, DAILY_BRIEF_KIND, dateBucket).catch(() => {});
-    recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt);
+    recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt, attempt);
     return null;
   }
 }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

`xyne-claw-auth` specific changes for https://github.com/juspay/xyne-spaces/pull/873. Dashboard and Grafana changes stay in that PR; this is the backend half only.

**What it adds**

- **`daily_brief_activity`** — one upserted row per `(userId, kind, dateBucket)` for `view` / `regenerate` / `switch`, so repeat activity on a day bumps a counter instead of adding rows (bounded at ≤3 rows/user/day). Carries non-nullable `orgId` with an index, matching `GeneratedContent` and `UserAgentInstruction`.
- **`rejectionCount`** on that table — incremented only for `replacing_scheduled_brief` and `replacing_own_regeneration`, so an acceptance metric can distinguish a genuine rejection from a retry after a failed run. A counter rather than an `origin` string because the row is unique per user/kind/day and a single value would be last-write-wins across mixed origins.
- **Opt-in / opt-out counter** on `PUT /config`, recording only real transitions — a no-op write that sets `enabled` to its current value does not count.
- **`attempt` label** on the generation counter, making "how many tries before a brief succeeds" answerable. `recordDailyBriefRegeneration` was split so only the Redis `INCR` is awaited and returned; the multi-exec and the Prisma upsert stay fire-and-forget, keeping the SSE stream's critical path to one round-trip.

**Note on the port:** `deploy-xyneclaw` has an `asyncHandler` / `badRequest()` error convention that `main` does not, so `daily-brief.ts` could not be cherry-picked directly. The five changes there were re-applied by hand in this branch's style; the other four files applied unchanged.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [x] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [x] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

**Rollout notes:** `daily_brief_activity` is a new, additive table — nothing existing reads it, so deployed code is unaffected and it starts empty. `rejectionCount` ships inside the `CREATE TABLE` rather than as a follow-up `ALTER`, so there is one migration and no historical rows defaulting to a value that would read as "never rejected".

⚠️ `prisma migrate deploy` returns **P3005** on databases provisioned with `db push` and never baselined. Run `prisma migrate resolve --applied 20260820140000_daily_brief_activity` there first, or continue with `db push`.

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind

