### PR TITLE
fix: preserve custom emoji as :shortcode: when copying messages

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -37,6 +37,7 @@ import { sanitizeHtmlString } from '../../../utils/sanitizer';
 import { isSlashCommandArtifactMessage } from '../SlashCommandArtifacts';
 import { cn } from '../../../utils/classNames';
 import { copyHtmlToClipboard, markdownToHtml } from '../../../utils/clipboardUtils';
+import { replaceEmojiHtmlWithShortcodes } from '../../../utils/customEmojiUtils';
 import { RenderMessageWithHTML } from '../RenderMessageWithHTML/RenderMessageWithHTML';
 import { getEmojiFontSizeClass } from '../../../utils/emojiUtils';
 import ReplyLayoutV2 from '../ReplyLayout/ReplyLayoutV2';
@@ -77,7 +78,6 @@ import { useShareableOrigin } from '../../../hooks/useShareableOrigin';
 import { SubTicketModal } from '../../Tickets/SubTicketModal/SubTicketModal';
 import { ForwardMessageForm } from '../ForwardMessageModal/ForwardMessageModal';
 import { xyneAIActor, type ThreadInfo } from '../../../machines/xyneAIMachine';
-import DOMPurify from 'dompurify';
 import { CallParticipantsSelectionModal } from '../../Call/CallParticipantsSelectionModal';
 import { AttachmentRef } from '../../../machines/attachmentViewerMachine';
 import {
@@ -713,16 +713,16 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
       // Convert markdown to HTML if needed, then normalize headings to bold paragraphs
       const copyPromise = isMarkdownContent
         ? markdownToHtml(contentToCopy)
-            .then(html => copyHtmlToClipboard(html))
+            .then(html => copyHtmlToClipboard(replaceEmojiHtmlWithShortcodes(html)))
             .catch(error => {
               logger.warn(Event.FRONTEND_ERROR, {
                 type: 'migrated_console_warn',
                 message: String('Markdown processing failed, falling back to raw content:'),
                 context: [error],
               });
-              return copyHtmlToClipboard(contentToCopy);
+              return copyHtmlToClipboard(replaceEmojiHtmlWithShortcodes(contentToCopy));
             })
-        : copyHtmlToClipboard(contentToCopy);
+        : copyHtmlToClipboard(replaceEmojiHtmlWithShortcodes(contentToCopy));
 
       copyPromise
         .then(() => {
@@ -732,25 +732,6 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
           toast.error('Could not copy message to clipboard');
         });
 
-      // Also copy plain text with emoji replacement (only if there are emoji images)
-      if (contentToCopy.includes('data-emoji="true"')) {
-        const sanitizedContent = DOMPurify.sanitize(contentToCopy);
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(sanitizedContent, 'text/html');
-
-        // Replace custom emoji <img> with :emoji_name:
-        doc.querySelectorAll('img[data-emoji="true"]').forEach(img => {
-          const alt = img.getAttribute('alt') || '';
-          img.replaceWith(document.createTextNode(alt));
-        });
-
-        const plainText = doc.body.textContent || '';
-
-        navigator.clipboard
-          .writeText(plainText)
-          .then(() => toast.success('Message copied to clipboard'))
-          .catch(() => toast.error('Could not copy message'));
-      }
     }
   };
 

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
@@ -18,6 +18,7 @@ import { ChatListItem } from '../ChatListItem/ChatListItem';
 import { DatePill } from '../DatePill';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
+import { replaceEmojiImagesWithShortcodes } from '../../../utils/customEmojiUtils';
 import { useShortcutById } from '../../../shortcuts';
 import { useAuth } from '../../../hooks/useAuth';
 import { useEditContext } from '../../../providers/EditProvider';
@@ -339,6 +340,24 @@ const ChatListV4: React.FC<ChatListProps> = ({
   // Container for the shared hover toolbar overlay (Slack pattern): one
   // toolbar for the whole list, positioned over the hovered row.
   const hoverToolbarContainerRef = useRef<HTMLDivElement>(null);
+
+  // Native copy (Cmd/Ctrl+C on a text selection) drops custom-emoji <img>
+  // elements from the plain-text clipboard flavor. Rewrite the selection so
+  // each emoji is copied as its :shortcode:. No-op when the selection has no
+  // custom emoji, so ordinary copy behaviour is unchanged.
+  const handleMessageCopy = useCallback((event: React.ClipboardEvent<HTMLDivElement>): void => {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+
+    const holder = document.createElement('div');
+    holder.appendChild(selection.getRangeAt(0).cloneContents());
+    if (!holder.querySelector('img[data-emoji="true"]')) return;
+
+    replaceEmojiImagesWithShortcodes(holder);
+    event.clipboardData.setData('text/plain', holder.textContent || '');
+    event.clipboardData.setData('text/html', holder.innerHTML);
+    event.preventDefault();
+  }, []);
   const shouldUseCutoffQuery =
     channelParticipation?.conversationSeenCutoffAt !== null && isMember && !linkedConversationId;
 
@@ -1326,6 +1345,7 @@ const ChatListV4: React.FC<ChatListProps> = ({
   return (
     <div
       ref={hoverToolbarContainerRef}
+      onCopy={handleMessageCopy}
       data-component='ChatListV11'
       data-testid='chat-message-list'
       className='flex-1 relative no-scrollbar min-h-0'

--- a/apps/dashboard/src/utils/customEmojiUtils.tsx
+++ b/apps/dashboard/src/utils/customEmojiUtils.tsx
@@ -100,10 +100,47 @@ const renderEmoji = (
   return <span className={`${unicodeSizeClass} leading-none`}>{emojiName}</span>;
 };
 
+
+/**
+ * Convert a single custom-emoji <img> element to its :shortcode: text.
+ * Tolerates alt/title stored as either the bare name ("party") or ":party:".
+ */
+const emojiImageToShortcode = (img: Element): string => {
+  const raw = img.getAttribute('alt') || img.getAttribute('title') || '';
+  const name = raw.replace(/^:+|:+$/g, '').trim();
+  return name ? `:${name}:` : '';
+};
+
+/**
+ * In-place: replace every custom-emoji <img data-emoji="true"> inside `root`
+ * with a :shortcode: text node. Used by the native copy handler so a text
+ * selection containing custom emoji serializes to :name: instead of dropping
+ * the image entirely.
+ */
+const replaceEmojiImagesWithShortcodes = (root: ParentNode): void => {
+  root.querySelectorAll('img[data-emoji="true"]').forEach(img => {
+    img.replaceWith(document.createTextNode(emojiImageToShortcode(img)));
+  });
+};
+
+/**
+ * Return a copy of `html` with every custom-emoji <img> replaced by :shortcode:.
+ * Used by the "Copy message" action so BOTH the text/html and text/plain
+ * clipboard flavors carry the shortcode in a single clipboard write.
+ */
+const replaceEmojiHtmlWithShortcodes = (html: string): string => {
+  if (!html || !html.includes('data-emoji="true"')) return html;
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  replaceEmojiImagesWithShortcodes(doc.body);
+  return doc.body.innerHTML;
+};
+
 export {
   getEmojiDisplayName,
   parseCustomEmoji,
   isCustomEmoji,
   renderEmoji,
   convertCustomEmojiUrls,
+  replaceEmojiImagesWithShortcodes,
+  replaceEmojiHtmlWithShortcodes,
 };


### PR DESCRIPTION
## Problem Description
Copying a message that contains a custom emoji did not preserve the emoji. Native Cmd/Ctrl+C over a selection dropped the custom-emoji `<img data-emoji="true">` from the plain-text clipboard flavor, so pasting elsewhere lost the emoji (Chromium at best leaves a bare word like `party`, which no longer renders as the emoji). The "Copy message" action also raced two sequential clipboard writes (`copyHtmlToClipboard` followed by a separate `navigator.clipboard.writeText`), which is non-deterministic.

## How the issue was identified
Custom emojis render as `<img data-emoji="true" data-emoji-id="…" alt="name" src="/api/emojis/{id}/stream">`, not text. Native copy serialises only text nodes into `text/plain`, and `copyHtmlToClipboard` derives its plain text from HTML — both drop the emoji `<img>`. The correct on-wire representation is the `:shortcode:`, which the composer re-renders back into the custom emoji.

## Solution implemented
- `apps/dashboard/src/utils/customEmojiUtils.tsx`: add `replaceEmojiImagesWithShortcodes(root)` (DOM, in-place) and `replaceEmojiHtmlWithShortcodes(html)` (string) helpers that turn each `img[data-emoji="true"]` into its `:name:` shortcode (tolerating alt stored as `party` or `:party:`).
- `apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx`: add an `onCopy` handler on the message-list container that rewrites the current selection to `:shortcode:` and sets BOTH `text/plain` and `text/html` in a single clipboard write. No-op (ordinary copy) when the selection contains no custom emoji.
- `apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx`: route `handleCopyMessage` through `replaceEmojiHtmlWithShortcodes` inside the single `copyHtmlToClipboard` write, remove the racing second `writeText`, and drop the now-unused `DOMPurify` import.

## Documentation
N/A

## DB Alter Details
N/A

## Data fix Details
N/A

## Environment variable Changes
N/A

## Testing
- `tsc --noEmit` on `apps/dashboard`: passes clean (0 errors).
- Recorded before/after proof driving the shipped helper: selecting the message and pressing Ctrl+C then pasting yields — before: `Great work team party — ship it!` (bare word) — after: `Great work team :party: — ship it!` (re-usable shortcode).

## Services to which this change is to be deployed
Spaces dashboard (frontend only)

## Main PR link (if raised against a release branch)
N/A