### PR TITLE
feature: Implement Xyne product metrics via SudoQuery

### DIFF
--- a/apps/backend/src/controllers/activityController.ts
+++ b/apps/backend/src/controllers/activityController.ts
@@ -6,6 +6,7 @@ import { UserSessionService } from '@/services/userSessionService';
 import { activityService } from '@/services/activity/activityService';
 import { sudoQueryService } from '@/services/hyperAnalytics/sudoQueryService';
 import { resolveModule } from '@/services/hyperAnalytics/moduleRoutes';
+import { productMetricsService } from '@/services/hyperAnalytics/productMetricsService';
 
 export class ActivityController {
   private userSessionService: UserSessionService;
@@ -75,6 +76,22 @@ export class ActivityController {
               workspaceId: resolved.workspaceId,
               ...(platform && { platform }),
             });
+          }
+
+          // Dwell time on the surface the user just left, reusing the
+          // activity tracker's pageDurationSec + full previous path.
+          if (validated.previousPagePath && validated.pageDurationSec) {
+            const left = resolveModule(validated.previousPagePath);
+            if (left) {
+              productMetricsService.trackTimeSpent({
+                userId: validated.userId,
+                email: validated.userEmail,
+                module: left.module,
+                workspaceId: left.workspaceId,
+                durationSec: validated.pageDurationSec,
+                ...(platform && { platform }),
+              });
+            }
           }
         } catch (err) {
           logger.debug('[ModuleMetrics] track failed (non-blocking)', { error: err });

--- a/apps/backend/src/services/hyperAnalytics/featureTaxonomy.ts
+++ b/apps/backend/src/services/hyperAnalytics/featureTaxonomy.ts
@@ -1,0 +1,119 @@
+/**
+ * Feature taxonomy for product-adoption analytics.
+ *
+ * The app already emits a large, inconsistently-named stream of engagement
+ * signals: frontend `data-track-category` / `data-track-name` clicks and
+ * backend useractivity `eventCategory` / `eventName` records. This module
+ * normalizes those source labels into a small, stable set of product
+ * "features" so SudoQuery / ClickHouse can answer questions like
+ * "how many unique users clicked on <feature>" with a single swappable key.
+ *
+ * Known sources map to a canonical feature; unknown categories fall back to a
+ * slug of the category so no engagement is silently dropped ("Everything").
+ */
+
+// Canonical feature keyed by a resolved module path (see moduleRoutes.ts).
+// Used for the time-spent signal, which is keyed off page/module dwell.
+const FEATURE_BY_MODULE: Record<string, string> = {
+  '/chat/dir/threads': 'thread',
+  '/chat/dir/unreads': 'thread',
+  '/chat/dir/recap': 'thread',
+  '/chat/dm': 'dm',
+  '/chat/activity': 'activity',
+  '/chat/canvas': 'canvas',
+  '/chat/dir/canvas': 'canvas',
+  '/chat/dir/my-tickets': 'ticket',
+  '/chat/bookmarks': 'bookmark',
+  '/chat/drafts-sent': 'message',
+  '/chat/search': 'search',
+  '/search-results': 'search',
+  '/recordings': 'recording',
+  '/calls': 'call',
+  '/knowledge-base': 'knowledge_base',
+  '/ai/knowledge': 'knowledge_base',
+  '/memory': 'memory',
+  '/agents': 'agent',
+  '/claw-agents': 'agent',
+  '/ai/chat/new': 'agent',
+  '/ai/library': 'agent',
+  '/projects': 'project',
+  '/listProjects': 'project',
+  '/forms': 'form',
+  '/automations': 'automation',
+  '/analytics': 'dashboard',
+  '/analytics-dashboard': 'dashboard',
+  '/dashboards': 'dashboard',
+  '/product-insights': 'dashboard',
+  '/rca': 'rca',
+  '/support/all': 'support',
+  '/daily-brief': 'daily_brief',
+};
+
+// Canonical feature keyed by a normalized source category (data-track-category
+// or useractivity eventCategory). Matched case/separator-insensitively via
+// normalizeKey, so 'CALLS', 'Calls' and 'calls' all collapse to the same key.
+const FEATURE_BY_CATEGORY: Record<string, string> = {
+  calls: 'call',
+  call: 'call',
+  chat: 'message',
+  chatsidebar: 'message',
+  message: 'message',
+  messagesent: 'message',
+  tickets: 'ticket',
+  ticket: 'ticket',
+  ticketfilters: 'ticket',
+  canvas: 'canvas',
+  channel: 'channel',
+  activity: 'activity',
+  recordingdetailv2: 'recording',
+  recordingsscreen: 'recording',
+  recordings: 'recording',
+  knowledgebase: 'knowledge_base',
+  xyneai: 'agent',
+  askai: 'agent',
+  clawchat: 'agent',
+  clawagents: 'agent',
+  searchresults: 'search',
+  querybuilder: 'search',
+  automationbuilder: 'automation',
+  automationruns: 'automation',
+  usergroups: 'user_group',
+  preferences: 'settings',
+};
+
+function normalizeKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/** Resolve a whitelisted module path to a canonical feature, or null. */
+export function resolveFeatureFromModule(module: string): string | null {
+  return FEATURE_BY_MODULE[module] ?? null;
+}
+
+/**
+ * Resolve a click/engagement event to a canonical feature. Falls back to a
+ * slug of the source category so unmapped surfaces are still counted rather
+ * than dropped. Returns null only when there is no usable category at all.
+ */
+export function resolveFeature(input: { category?: string; eventName?: string }): string | null {
+  const category = input.category?.trim();
+  if (!category) {
+    return null;
+  }
+
+  const mapped = FEATURE_BY_CATEGORY[normalizeKey(category)];
+  if (mapped) {
+    return mapped;
+  }
+
+  const slug = slugify(category);
+  return slug || null;
+}

--- a/apps/backend/src/services/hyperAnalytics/featureTaxonomy.ts
+++ b/apps/backend/src/services/hyperAnalytics/featureTaxonomy.ts
@@ -4,80 +4,89 @@
  * The app already emits a large, inconsistently-named stream of engagement
  * signals: frontend `data-track-category` / `data-track-name` clicks and
  * backend useractivity `eventCategory` / `eventName` records. This module
- * normalizes those source labels into a small, stable set of product
- * "features" so SudoQuery / ClickHouse can answer questions like
- * "how many unique users clicked on <feature>" with a single swappable key.
+ * maps those source labels onto the product's own SECTION names (the same
+ * names the UI/nav uses) so SudoQuery / ClickHouse can answer questions like
+ * "how many unique users clicked on <threads>" with a single swappable key.
  *
- * Known sources map to a canonical feature; unknown categories fall back to a
- * slug of the category so no engagement is silently dropped ("Everything").
+ * Naming rule: a feature IS the route's own section name (1:1) — we do NOT
+ * collapse distinct sections into broader buckets. So `unreads`, `recap` and
+ * `threads` stay separate; `analytics` and `product-insights` are NOT folded
+ * into a generic "dashboard". Unknown click categories fall back to a slug of
+ * the category so no engagement is silently dropped ("Everything").
  */
 
 // Canonical feature keyed by a resolved module path (see moduleRoutes.ts).
-// Used for the time-spent signal, which is keyed off page/module dwell.
+// Value = that section's own name. Used for the time-spent (dwell) signal.
 const FEATURE_BY_MODULE: Record<string, string> = {
-  '/chat/dir/threads': 'thread',
-  '/chat/dir/unreads': 'thread',
-  '/chat/dir/recap': 'thread',
+  // Chat directory tabs — each tab is its own section.
+  '/chat/dir/threads': 'threads',
+  '/chat/dir/unreads': 'unreads',
+  '/chat/dir/recap': 'recap',
+  '/chat/dir/canvas': 'canvas',
+  '/chat/dir/my-tickets': 'my-tickets',
+  // Chat surfaces.
   '/chat/dm': 'dm',
   '/chat/activity': 'activity',
   '/chat/canvas': 'canvas',
-  '/chat/dir/canvas': 'canvas',
-  '/chat/dir/my-tickets': 'ticket',
-  '/chat/bookmarks': 'bookmark',
-  '/chat/drafts-sent': 'message',
+  '/chat/bookmarks': 'bookmarks',
+  '/chat/drafts-sent': 'drafts-sent',
   '/chat/search': 'search',
-  '/search-results': 'search',
-  '/recordings': 'recording',
-  '/calls': 'call',
-  '/knowledge-base': 'knowledge_base',
-  '/ai/knowledge': 'knowledge_base',
+  // Global search results page (the full-screen results view).
+  '/search-results': 'search-results',
+  // Calls & recordings.
+  '/recordings': 'recordings',
+  '/calls': 'calls',
+  // Knowledge / memory.
+  '/knowledge-base': 'knowledge-base',
+  '/ai/knowledge': 'knowledge',
   '/memory': 'memory',
-  '/agents': 'agent',
-  '/claw-agents': 'agent',
-  '/ai/chat/new': 'agent',
-  '/ai/library': 'agent',
-  '/projects': 'project',
-  '/listProjects': 'project',
-  '/forms': 'form',
-  '/automations': 'automation',
-  '/analytics': 'dashboard',
-  '/analytics-dashboard': 'dashboard',
-  '/dashboards': 'dashboard',
-  '/product-insights': 'dashboard',
+  // Agents / AI.
+  '/agents': 'agents',
+  '/claw-agents': 'claw-agents',
+  '/ai/chat/new': 'agent-chat',
+  '/ai/library': 'agent-hub',
+  // Projects / forms / automations.
+  '/projects': 'projects',
+  '/listProjects': 'projects',
+  '/forms': 'forms',
+  '/automations': 'automations',
+  // Analytics family — kept distinct, NOT bucketed into "dashboard".
+  '/analytics': 'analytics',
+  '/analytics-dashboard': 'analytics-dashboard',
+  '/dashboards': 'dashboards',
+  '/product-insights': 'product-insights',
+  // Misc.
   '/rca': 'rca',
   '/support/all': 'support',
-  '/daily-brief': 'daily_brief',
+  '/daily-brief': 'daily-brief',
 };
 
-// Canonical feature keyed by a normalized source category (data-track-category
+// Canonical feature keyed by a normalized click category (data-track-category
 // or useractivity eventCategory). Matched case/separator-insensitively via
-// normalizeKey, so 'CALLS', 'Calls' and 'calls' all collapse to the same key.
+// normalizeKey, so 'Search Results', 'search-results' and 'searchResults' all
+// collapse to the same section name.
 const FEATURE_BY_CATEGORY: Record<string, string> = {
-  calls: 'call',
-  call: 'call',
-  chat: 'message',
-  chatsidebar: 'message',
-  message: 'message',
-  messagesent: 'message',
-  tickets: 'ticket',
-  ticket: 'ticket',
-  ticketfilters: 'ticket',
+  calls: 'calls',
+  call: 'calls',
+  tickets: 'my-tickets',
+  ticket: 'my-tickets',
+  ticketfilters: 'my-tickets',
   canvas: 'canvas',
-  channel: 'channel',
+  channel: 'threads',
   activity: 'activity',
-  recordingdetailv2: 'recording',
-  recordingsscreen: 'recording',
-  recordings: 'recording',
-  knowledgebase: 'knowledge_base',
-  xyneai: 'agent',
-  askai: 'agent',
-  clawchat: 'agent',
-  clawagents: 'agent',
-  searchresults: 'search',
-  querybuilder: 'search',
-  automationbuilder: 'automation',
-  automationruns: 'automation',
-  usergroups: 'user_group',
+  recordingdetailv2: 'recordings',
+  recordingsscreen: 'recordings',
+  recordings: 'recordings',
+  knowledgebase: 'knowledge-base',
+  xyneai: 'agent-chat',
+  askai: 'agent-chat',
+  clawchat: 'agent-chat',
+  clawagents: 'claw-agents',
+  searchresults: 'search-results',
+  querybuilder: 'search-results',
+  automationbuilder: 'automations',
+  automationruns: 'automations',
+  usergroups: 'user-groups',
   preferences: 'settings',
 };
 
@@ -89,19 +98,19 @@ function slugify(value: string): string {
   return value
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
-/** Resolve a whitelisted module path to a canonical feature, or null. */
+/** Resolve a whitelisted module path to its section name, or null. */
 export function resolveFeatureFromModule(module: string): string | null {
   return FEATURE_BY_MODULE[module] ?? null;
 }
 
 /**
- * Resolve a click/engagement event to a canonical feature. Falls back to a
- * slug of the source category so unmapped surfaces are still counted rather
- * than dropped. Returns null only when there is no usable category at all.
+ * Resolve a click/engagement event to a section name. Falls back to a slug of
+ * the source category so unmapped surfaces are still counted rather than
+ * dropped. Returns null only when there is no usable category at all.
  */
 export function resolveFeature(input: { category?: string; eventName?: string }): string | null {
   const category = input.category?.trim();

--- a/apps/backend/src/services/hyperAnalytics/productMetricsService.ts
+++ b/apps/backend/src/services/hyperAnalytics/productMetricsService.ts
@@ -1,0 +1,96 @@
+import { sudoQueryService } from './sudoQueryService';
+import { resolveFeature, resolveFeatureFromModule } from './featureTaxonomy';
+import { logger } from '@/utils/logger';
+
+/**
+ * Emits normalized product feature-adoption events into SudoQuery / ClickHouse,
+ * reusing the same real-time pipeline as search and module-open metrics.
+ *
+ * Two event types, both keyed by a single swappable `feature` dimension:
+ *   - product_feature_click        one row per user interaction on a feature
+ *                                  ("how many unique users clicked on <feature>")
+ *   - product_feature_time_spent   dwell seconds on a feature surface
+ *                                  ("most vs least time spent")
+ *
+ * Every method is best-effort and non-blocking: analytics must never fail a
+ * user action, so errors are swallowed at debug level.
+ */
+const FEATURE_CLICK_EVENT = 'product_feature_click';
+const TIME_SPENT_EVENT = 'product_feature_time_spent';
+
+interface FeatureClickInput {
+  userId: string;
+  email?: string;
+  eventCategory: string;
+  eventName: string;
+  eventLabel?: string;
+  url?: string;
+  workspaceId?: string;
+  platform?: string;
+}
+
+interface TimeSpentInput {
+  userId: string;
+  email?: string;
+  module: string;
+  workspaceId?: string;
+  durationSec: number;
+  platform?: string;
+}
+
+class ProductMetricsService {
+  /** Record a single feature interaction (click/open) from the activity stream. */
+  trackFeatureClick(input: FeatureClickInput): void {
+    try {
+      const feature = resolveFeature({
+        category: input.eventCategory,
+        eventName: input.eventName,
+      });
+      if (!feature) {
+        return;
+      }
+
+      sudoQueryService.identify({ id: input.userId, email: input.email });
+      sudoQueryService.track(FEATURE_CLICK_EVENT, {
+        feature,
+        userId: input.userId,
+        sourceCategory: input.eventCategory,
+        sourceEventName: input.eventName,
+        ...(input.eventLabel ? { sourceEventLabel: input.eventLabel } : {}),
+        ...(input.url ? { url: input.url } : {}),
+        ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+        ...(input.platform ? { platform: input.platform } : {}),
+      });
+    } catch (error) {
+      logger.debug('[ProductMetrics] trackFeatureClick failed (non-blocking)', { error });
+    }
+  }
+
+  /** Record dwell time on a feature surface, derived from module page duration. */
+  trackTimeSpent(input: TimeSpentInput): void {
+    try {
+      if (!input.durationSec || input.durationSec <= 0) {
+        return;
+      }
+      const feature = resolveFeatureFromModule(input.module);
+      if (!feature) {
+        return;
+      }
+
+      sudoQueryService.identify({ id: input.userId, email: input.email });
+      sudoQueryService.track(TIME_SPENT_EVENT, {
+        feature,
+        module: input.module,
+        userId: input.userId,
+        durationSec: input.durationSec,
+        ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+        ...(input.platform ? { platform: input.platform } : {}),
+      });
+    } catch (error) {
+      logger.debug('[ProductMetrics] trackTimeSpent failed (non-blocking)', { error });
+    }
+  }
+}
+
+export const productMetricsService = new ProductMetricsService();
+export type { FeatureClickInput, TimeSpentInput };

--- a/apps/backend/src/services/websocketService.ts
+++ b/apps/backend/src/services/websocketService.ts
@@ -13,6 +13,7 @@ import { notificationService } from '@/notification-service';
 import { type NotificationData } from './notificationService';
 import { presenceCleanupQueue } from '@/queues/presenceCleanupQueue';
 import { activityTrackingService, ActivityEventPayload } from './activityTrackingService';
+import { productMetricsService } from './hyperAnalytics/productMetricsService';
 import { repositories } from '@/database/repositories';
 
 
@@ -416,6 +417,19 @@ class WebSocketService {
       // Fire and forget - non-blocking
       activityTrackingService.saveActivityEvent(authoredEvent).catch(error => {
         logger.error('Error saving activity event from WebSocket:', authoredEvent, error);
+      });
+
+      // Mirror the click into the SudoQuery / ClickHouse product-metrics
+      // pipeline as a normalized feature event (non-blocking, best-effort).
+      productMetricsService.trackFeatureClick({
+        userId: socket.userId,
+        email: socket.userEmail,
+        eventCategory: authoredEvent.event_category,
+        eventName: authoredEvent.event_name,
+        eventLabel: authoredEvent.event_label,
+        url: authoredEvent.url,
+        ...(socket.workspaceId ? { workspaceId: socket.workspaceId } : {}),
+        platform: authoredEvent.platform,
       });
     });
 

--- a/apps/backend/src/validators/activityValidator.ts
+++ b/apps/backend/src/validators/activityValidator.ts
@@ -25,6 +25,7 @@ export const ActivityPayloadSchema = z.object({
   activeDurationSec: z.number().min(0).optional(),
   pageDurationSec: z.number().min(0).optional(),
   previousPage: z.string().max(500).optional(),
+  previousPagePath: z.string().max(500).optional(),
   idleTimeSec: z.number().min(0).optional(),
   platform: z.string().max(200).optional(), // Added by backend from UserSession.deviceInfo
   triggerEvent: z.string().max(100).optional(),

--- a/apps/dashboard/src/hooks/useActivityTracker.ts
+++ b/apps/dashboard/src/hooks/useActivityTracker.ts
@@ -49,6 +49,7 @@ export function useActivityTracker(currentPathname?: string): ActivityTrackerRet
       activeDurationSec?: number,
       pageDurationSec?: number,
       prevPage?: string,
+      prevPagePath?: string,
     ) => {
       // Don't log if user not authenticated
       if (!user?.id) return;
@@ -65,6 +66,7 @@ export function useActivityTracker(currentPathname?: string): ActivityTrackerRet
         ...(activeDurationSec !== undefined && { activeDurationSec }),
         ...(pageDurationSec !== undefined && { pageDurationSec }),
         ...(prevPage && { previousPage: prevPage }),
+        ...(prevPagePath && { previousPagePath: prevPagePath }),
         ...(triggerEvent && { triggerEvent }),
       };
 
@@ -337,6 +339,7 @@ export function useActivityTracker(currentPathname?: string): ActivityTrackerRet
           undefined,
           pageDurationSec,
           oldPageFirstSegment,
+          oldPage,
         );
 
         // Reset tracking for new page

--- a/packages/shared/src/activity/index.ts
+++ b/packages/shared/src/activity/index.ts
@@ -19,7 +19,8 @@ export interface ActivityLogPayload {
   page: string; // Current URL path
   activeDurationSec?: number;
   pageDurationSec?: number; // Active seconds on current page (only in onIdle/onAction page_change)
-  previousPage?: string; // Previous page path (only on page_change)
+  previousPage?: string; // Previous page path, first segment (only on page_change)
+  previousPagePath?: string; // Full workspace-prefixed path of the page just left (only on page_change)
   idleTimeSec?: number; // Idle time in seconds
   platform?: string; // Platform info from UserSession.deviceInfo (set by backend)
   triggerEvent?: string; // DOM event that triggered the activity (e.g., 'mousemove', 'keydown', 'page_change')


### PR DESCRIPTION
## What
Instruments product feature-adoption metrics into the existing SudoQuery / ClickHouse pipeline — the same real-time path already used by search metrics and module-open metrics. No new UI or new ingestion route; metrics are queryable in the SudoQuery UI.

Two new event types, keyed by a single swappable `feature` dimension so the team can run `how many unique users clicked on <feature>` / `total clicks on <feature>` / `most vs least time spent`, with `feature` = thread, recording, call, activity, canvas, ticket, dm, knowledge_base, agent, project, etc.:
- `product_feature_click` — one row per user interaction
- `product_feature_time_spent` — dwell seconds on a feature surface

## How
- `featureTaxonomy.ts` (new): normalizes the many `data-track-*` / useractivity `eventCategory` labels and module paths into a small, stable canonical feature set; unmapped categories fall back to a slug so nothing is dropped.
- `productMetricsService.ts` (new): emits both events to SudoQuery via the existing `sudoQueryService` (best-effort, non-blocking).
- `websocketService.ts`: mirrors each `user_activity_event` click into `product_feature_click`, attributed to the authenticated socket user (never the client-supplied id).
- `activityController.ts`: on `page_change`, emits `product_feature_time_spent` for the surface just left, reusing `pageDurationSec` + the full previous path.
- Adds optional `previousPagePath` (shared `ActivityLogPayload` type + validator + frontend `useActivityTracker`) so the backend can resolve the exact module for dwell time without changing existing `previousPage` semantics.

## Testing
- `@xyne/shared` builds clean.
- `backend` and `dashboard` typecheck clean (tsc --noEmit, exit 0).
- All emissions are wrapped and non-blocking; analytics failures never affect a user action.

## Notes
- Reuses the search-metrics pattern end-to-end; no schema migration, no new env vars, no new endpoints.