### PR TITLE
fix: pin thread message composer to the bottom regardless of content length

### DIFF
--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -428,7 +428,7 @@ const ThreadList = ({
   // Render with date separators for ticket threads
   if (isTicketThread && messagesWithSeparators) {
     return (
-      <div ref={hoverToolbarContainerRef} className='relative min-h-0 max-h-full bg-background'>
+      <div ref={hoverToolbarContainerRef} className='relative flex-1 min-h-0 bg-background'>
         {/* ONE shared hover-actions toolbar for the thread (zero-render hover). */}
         <MessageHoverToolbar containerRef={hoverToolbarContainerRef} />
         <div
@@ -437,7 +437,7 @@ const ThreadList = ({
           className='h-full overflow-auto no-scrollbar pt-4'
           style={{ paddingBottom: ACTIVITY_BAR_PADDING }}
         >
-          <div ref={scrollContentRef}>
+          <div ref={scrollContentRef} className='flex min-h-full flex-col justify-end'>
             {messagesWithSeparators.map((item, index) => {
               if (item.type === 'date-separator') {
                 return <DatePill key={`date-separator-${index}`} dateText={item.dateText} />;
@@ -557,7 +557,7 @@ const ThreadList = ({
 
   // Default render without date separators
   return (
-    <div ref={hoverToolbarContainerRef} className='relative min-h-0 max-h-full bg-background'>
+    <div ref={hoverToolbarContainerRef} className='relative flex-1 min-h-0 bg-background'>
       {/* ONE shared hover-actions toolbar for the thread (zero-render hover). */}
       <MessageHoverToolbar containerRef={hoverToolbarContainerRef} />
       <div
@@ -566,7 +566,7 @@ const ThreadList = ({
         className='h-full overflow-auto no-scrollbar pt-4'
         style={{ paddingBottom: ACTIVITY_BAR_PADDING }}
       >
-        <div ref={scrollContentRef}>
+        <div ref={scrollContentRef} className='flex min-h-full flex-col justify-end'>
           {visibleMessages.map((threadMessage, index) => {
             const showAvatar =
               enableCollapsing ||


### PR DESCRIPTION
## Summary
The message composer sat at a different vertical position in a thread vs the main channel when the thread had little content. In a short thread the composer floated up directly beneath the last message instead of resting at the bottom of the panel.

Root cause: the thread message list (`apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx`) sized itself to its content — its root had `min-h-0 max-h-full` with no `flex-1` — so it did not fill the panel and the composer (a `shrink-0` sibling) rode up under the content. The main channel list (`ChatListV4.tsx`) already fills its container (`flex-1`) and bottom-anchors short content (`justifyContent: flex-end`, introduced in PR #7486 / XYNE-13222), so the two surfaces diverged.

Fix (both `ThreadList` render branches):
- Root container: `relative min-h-0 max-h-full` → `relative flex-1 min-h-0` so the list fills the panel and the composer is pinned to the bottom.
- Inner content wrapper: added `flex min-h-full flex-col justify-end` so short threads bottom-anchor their messages just above the composer, matching the channel.

CSS-only change; no logic, data, or schema changes.

## Checklist
1. Problem Description: Message composer appeared at different positions in main channel vs thread when content was short; in short threads it floated up under the last message instead of staying at the bottom.
2. If this is a bug fix or an enhancement, how did you identify the issue?: Reported in-app; traced to ThreadList not filling its container (no flex-1) while ChatListV4 does, and the flex-end bottom-anchor added in PR #7486 was never applied to ThreadList.
3. Explain the solution implemented in the PR: Made ThreadList fill the panel (flex-1) and bottom-anchor short content (min-h-full + justify-end) in both render branches, mirroring ChatListV4.
4. Documentation: N/A
5. DB Alter Details (if any): N/A
6. Data fix Details (if any): N/A
7. Environment variable Changes (if any): N/A
8. Testing: Manual — verify a short thread (1–2 replies) shows the composer at the bottom of the panel, matching the main channel; verify a long/overflowing thread still scrolls normally and stays pinned to latest.
9. Services to which this change is to be deployed: dashboard (frontend)
10. Main PR link (if this PR is raised against a release branch): N/A