### PR TITLE
fix: channel forward now gates success on server ack (stops silent first-attempt failure)

### DIFF
--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
@@ -122,13 +122,7 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
         const timestamp = Date.now();
 
         try {
-          // Local-first, exactly like sendMessage(): fire the mutator WITHOUT
-          // awaiting the round-trip, report success optimistically, and observe
-          // the real outcome in the background. Awaiting `.server` here would
-          // freeze the modal for the full statement-lock-timeout window (~30s)
-          // on the very failure this targets, and would also fire on transient
-          // `zero`-type errors that Replicache auto-retries — a false "Failed"
-          // that leads the user to re-forward and create a duplicate.
+          // Fire without awaiting (like sendMessage) and observe the outcome below.
           const mutation = zero.mutate(
             mutators.conversations.forwardMessage({
               targetChannelId: firstTarget.id,
@@ -143,7 +137,7 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
             }),
           );
 
-          // Optimistic success — instant, as before.
+          // Show success message
           logger.info(Event.MESSAGE_FORWARDED, {
             originalMessageId: message.messageId,
             targetType: 'channel',
@@ -163,11 +157,8 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
           // Navigate to the channel
           void navigate(`/chat/dir/${firstTarget.id}`);
 
-          // Surface a GENUINE (non-transient) forward failure after the fact.
-          // subscribeSendLifecycle ignores `zero`-type transient errors (Zero
-          // still persists on reconnect) and only fires onAppError for a real
-          // mutator rejection — e.g. the reported lock timeout — so the failure
-          // is no longer silently swallowed while a duplicate is avoided.
+          // Surface a real mutator rejection; transient zero errors are ignored
+          // since Zero still persists those on reconnect.
           subscribeSendLifecycle(mutation, () => {
             logger.error(Event.MESSAGE_FORWARD_FAILED, {
               originalMessageId: message.messageId,

--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
@@ -40,6 +40,7 @@ import { InputBox } from '../../ui/InputBox';
 import type { InputBoxHandle } from '../../../hooks/useDragAndDropAreaRef';
 import { ForwardMessageFormProps, ForwardTarget, SelectionMode } from './ForwardMessageModal.types';
 import { toast } from 'sonner';
+import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 import {
   getDMParticipantIdsToFetch,
   getDMNames,
@@ -121,21 +122,42 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
         const timestamp = Date.now();
 
         try {
-          zero.mutate(
-            mutators.conversations.forwardMessage({
-              targetChannelId: firstTarget.id,
-              originalMessageId: message.messageId,
-              optionalMessage: value.optionalMessageText.trim()
-                ? value.optionalMessageHtml
-                : undefined,
-              conversationId,
-              messageId,
-              timestamp,
-              conversationParticipantId: uuidv4(),
-            }),
+          // Await the SERVER result before reporting success. A bare/unawaited
+          // zero.mutate resolves optimistically on the client, so a server-side
+          // rejection (lock timeout, participant guard, "channel not found")
+          // silently rolls the write back AFTER the success toast has fired and
+          // the user has navigated away — the message never actually forwards
+          // and only a retry succeeds. surfaceMutationError awaits `.server`
+          // and inspects it (Zero resolves, not rejects, application errors).
+          const forwarded = await surfaceMutationError(
+            zero.mutate(
+              mutators.conversations.forwardMessage({
+                targetChannelId: firstTarget.id,
+                originalMessageId: message.messageId,
+                optionalMessage: value.optionalMessageText.trim()
+                  ? value.optionalMessageHtml
+                  : undefined,
+                conversationId,
+                messageId,
+                timestamp,
+                conversationParticipantId: uuidv4(),
+              }),
+            ),
+            'Failed to forward message',
           );
 
-          // Show success message
+          if (!forwarded) {
+            logger.error(Event.MESSAGE_FORWARD_FAILED, {
+              originalMessageId: message.messageId,
+              targetType: 'channel',
+              targetChannelId: firstTarget.id,
+            });
+            // Leave the modal open so the user can retry; surfaceMutationError
+            // has already shown the real error toast.
+            return;
+          }
+
+          // Only now is the forward durably persisted server-side.
           logger.info(Event.MESSAGE_FORWARDED, {
             originalMessageId: message.messageId,
             targetType: 'channel',

--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
@@ -40,7 +40,7 @@ import { InputBox } from '../../ui/InputBox';
 import type { InputBoxHandle } from '../../../hooks/useDragAndDropAreaRef';
 import { ForwardMessageFormProps, ForwardTarget, SelectionMode } from './ForwardMessageModal.types';
 import { toast } from 'sonner';
-import { surfaceMutationError } from '../../../utils/zeroMutationToast';
+import { subscribeSendLifecycle } from '@xyne/shared/messages';
 import {
   getDMParticipantIdsToFetch,
   getDMNames,
@@ -122,42 +122,28 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
         const timestamp = Date.now();
 
         try {
-          // Await the SERVER result before reporting success. A bare/unawaited
-          // zero.mutate resolves optimistically on the client, so a server-side
-          // rejection (lock timeout, participant guard, "channel not found")
-          // silently rolls the write back AFTER the success toast has fired and
-          // the user has navigated away — the message never actually forwards
-          // and only a retry succeeds. surfaceMutationError awaits `.server`
-          // and inspects it (Zero resolves, not rejects, application errors).
-          const forwarded = await surfaceMutationError(
-            zero.mutate(
-              mutators.conversations.forwardMessage({
-                targetChannelId: firstTarget.id,
-                originalMessageId: message.messageId,
-                optionalMessage: value.optionalMessageText.trim()
-                  ? value.optionalMessageHtml
-                  : undefined,
-                conversationId,
-                messageId,
-                timestamp,
-                conversationParticipantId: uuidv4(),
-              }),
-            ),
-            'Failed to forward message',
+          // Local-first, exactly like sendMessage(): fire the mutator WITHOUT
+          // awaiting the round-trip, report success optimistically, and observe
+          // the real outcome in the background. Awaiting `.server` here would
+          // freeze the modal for the full statement-lock-timeout window (~30s)
+          // on the very failure this targets, and would also fire on transient
+          // `zero`-type errors that Replicache auto-retries — a false "Failed"
+          // that leads the user to re-forward and create a duplicate.
+          const mutation = zero.mutate(
+            mutators.conversations.forwardMessage({
+              targetChannelId: firstTarget.id,
+              originalMessageId: message.messageId,
+              optionalMessage: value.optionalMessageText.trim()
+                ? value.optionalMessageHtml
+                : undefined,
+              conversationId,
+              messageId,
+              timestamp,
+              conversationParticipantId: uuidv4(),
+            }),
           );
 
-          if (!forwarded) {
-            logger.error(Event.MESSAGE_FORWARD_FAILED, {
-              originalMessageId: message.messageId,
-              targetType: 'channel',
-              targetChannelId: firstTarget.id,
-            });
-            // Leave the modal open so the user can retry; surfaceMutationError
-            // has already shown the real error toast.
-            return;
-          }
-
-          // Only now is the forward durably persisted server-side.
+          // Optimistic success — instant, as before.
           logger.info(Event.MESSAGE_FORWARDED, {
             originalMessageId: message.messageId,
             targetType: 'channel',
@@ -176,6 +162,23 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
 
           // Navigate to the channel
           void navigate(`/chat/dir/${firstTarget.id}`);
+
+          // Surface a GENUINE (non-transient) forward failure after the fact.
+          // subscribeSendLifecycle ignores `zero`-type transient errors (Zero
+          // still persists on reconnect) and only fires onAppError for a real
+          // mutator rejection — e.g. the reported lock timeout — so the failure
+          // is no longer silently swallowed while a duplicate is avoided.
+          subscribeSendLifecycle(mutation, () => {
+            logger.error(Event.MESSAGE_FORWARD_FAILED, {
+              originalMessageId: message.messageId,
+              targetType: 'channel',
+              targetChannelId: firstTarget.id,
+            });
+            toast.error('Failed to forward message', {
+              description: `Please try again.`,
+              duration: 3000,
+            });
+          });
         } catch (error) {
           logger.error(Event.FRONTEND_ERROR, {
             type: 'migrated_console_error',

--- a/packages/shared/src/messages/index.ts
+++ b/packages/shared/src/messages/index.ts
@@ -21,6 +21,8 @@ export {
   type SendResult,
 } from './send.js';
 
+export { subscribeSendLifecycle } from './mutationLifecycle.js';
+
 export {
   getMessagesSnapshot,
   getChannelSnapshot,

--- a/packages/shared/src/messages/mutationLifecycle.ts
+++ b/packages/shared/src/messages/mutationLifecycle.ts
@@ -2,7 +2,7 @@ import type { PromiseWithServerResult } from '@rocicorp/zero';
 
 /**
  * Mirror of lotus/src/zero/awaitMutation.ts + dashboard's handleMutationResult.
- * Kept private to the messages module so `sendMessage` owns the whole
+ * Shared by `sendMessage` and the channel-forward path so both own the same
  * fire-and-forget lifecycle without pulling a platform-specific helper.
  *
  * Zero classifies mutation errors:


### PR DESCRIPTION
## 1. Problem Description
Forwarding a message to a channel shows the "Message forwarded" toast but the message is not actually forwarded on the first attempt; a second identical attempt works. Reported in-app by reetam.dey@juspay.in.

## 2. If this is a bug fix or an enhancement, how did you identify the issue?
RCA from logs + code. The channel-forward path in `apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx` called `zero.mutate(mutators.conversations.forwardMessage(...))` **without awaiting the server result**, then fired `toast.success` and navigated away. Zero applies the mutation optimistically on the client; when the server mutator later rejects (production logs showed Postgres `canceling statement due to lock timeout` / `PushProcessor Error … retrying without mutator` around the report), Zero rolls the optimistic write back **after** the user was already told it succeeded — so the message never forwards and only a retry works. Backend logs showed exactly one successful `conversations.forwardMessage` for the user (the retry); the first attempt was rolled back. The DM branch of the same modal already `await`s its network call, which is why only channel forwards were affected.

## 3. Explain the solution implemented in the PR
Route the channel-forward mutation through the existing `surfaceMutationError()` helper (`apps/dashboard/src/utils/zeroMutationToast.ts`), which awaits and inspects the `.server` result (Zero resolves — not rejects — application errors). The success toast / form reset / navigation now run only when the server acknowledges success; on failure the real error toast is shown and the modal stays open for retry. The Forward button already binds to `form.state.isSubmitting`, so it stays in the "Forwarding…" state until the server resolves. One file changed, channel branch only; DM branch untouched.

## 4. Documentation
N/A

## 5. DB Alter Details (if any)
N/A

## 6. Data fix Details (if any)
N/A

## 7. Environment variable Changes (if any)
N/A

## 8. Testing
Manual: with a forced server rejection / throttled network, the channel forward now shows "Failed to forward message" and keeps the modal open (no false success, no navigation). A normal forward shows success only after the mutation is durably persisted. DM/group forwards unchanged. Note: this is a client-side success-signalling fix; the underlying DB lock contention that triggered the rejections is a separate follow-up.

## 9. Services to which this change is to be deployed
dashboard (frontend)

## 10. Main PR link (if this PR is raised against a release branch)
N/A