### PR TITLE
feat: add Created By as group-by option and list-view column for tickets

### DIFF
--- a/apps/backend/src/controllers/kanbanTicketController.ts
+++ b/apps/backend/src/controllers/kanbanTicketController.ts
@@ -47,7 +47,7 @@ const kanbanCountsBodySchema = z.object({
     .optional(),
   groupBy: z
     .union([
-      z.enum(['none', 'assignee', 'status', 'priority']),
+      z.enum(['none', 'assignee', 'status', 'priority', 'createdBy']),
       z.object({
         type: z.literal('formField'),
         fieldId: z.string(),

--- a/apps/backend/src/services/tickets/kanbanCountsService.ts
+++ b/apps/backend/src/services/tickets/kanbanCountsService.ts
@@ -20,6 +20,7 @@ type KanbanCountTicket = {
   assignedTo: string | null;
   statusV2: string;
   priority: string;
+  createdBy: string | null;
 };
 
 type KanbanCountGroupedRow = {
@@ -28,6 +29,7 @@ type KanbanCountGroupedRow = {
   statusV2?: string;
   assignedTo: string | null;
   priority: string;
+  createdBy: string | null;
   _count: {
     _all: number;
   };
@@ -181,7 +183,7 @@ export const getFormFieldGroupKeys = (
 };
 
 const getBuiltInGroupKey = (
-  ticket: Pick<KanbanCountTicket, 'assignedTo'> & {
+  ticket: Pick<KanbanCountTicket, 'assignedTo' | 'createdBy'> & {
     statusV2?: string;
     priority?: string;
   },
@@ -189,6 +191,12 @@ const getBuiltInGroupKey = (
 ): { groupKey: string; displayName: string } => {
   if (groupBy === 'assignee') {
     const groupKey = ticket.assignedTo ?? UNASSIGNED_GROUP;
+    return { groupKey, displayName: groupKey };
+  }
+
+  if (groupBy === 'createdBy') {
+    const raw = ticket.createdBy ?? '';
+    const groupKey = raw.replace(/^user:/, '') || 'Unknown';
     return { groupKey, displayName: groupKey };
   }
 
@@ -256,8 +264,9 @@ const addAggregateRowToGroup = (
 
 const getBuiltInGroupByFields = (
   groupBy: Exclude<KanbanGroupBy, KanbanFormFieldGroup> | undefined,
-): Array<'assignedTo' | 'statusV2' | 'priority'> => {
+): Array<'assignedTo' | 'statusV2' | 'priority' | 'createdBy'> => {
   if (groupBy === 'assignee') return ['assignedTo'];
+  if (groupBy === 'createdBy') return ['createdBy'];
   if (groupBy === 'status') return ['statusV2'];
   if (groupBy === 'priority') return ['priority'];
   return [];
@@ -297,7 +306,7 @@ export const getKanbanCounts = async (
   if (!isFormFieldGroup(groupBy) && dynamicFieldIds.length === 0) {
     const groupFields = getBuiltInGroupByFields(groupBy);
     const aggregateGroupFields = [...new Set([...groupFields, countField])] as Array<
-      'assignedTo' | 'stageName' | 'statusV2' | 'priority'
+      'assignedTo' | 'stageName' | 'statusV2' | 'priority' | 'createdBy'
     >;
 
     logger.info('[KanbanCountsService] Executing aggregate counts query', {
@@ -318,6 +327,7 @@ export const getKanbanCounts = async (
       const group = getBuiltInGroupKey(
         {
           assignedTo: row.assignedTo,
+          createdBy: row.createdBy,
           statusV2: row.statusV2,
           priority: row.priority,
         },
@@ -342,7 +352,7 @@ export const getKanbanCounts = async (
     ? []
     : getBuiltInGroupByFields(groupBy);
   const fallbackFields = [...new Set(['id', countField, ...fallbackGroupFields])] as Array<
-    'id' | 'assignedTo' | 'stageName' | 'statusV2' | 'priority'
+    'id' | 'assignedTo' | 'stageName' | 'statusV2' | 'priority' | 'createdBy'
   >;
 
   const tickets = (await db.ticket.groupBy({

--- a/apps/backend/src/services/tickets/kanbanQueryBuilder.ts
+++ b/apps/backend/src/services/tickets/kanbanQueryBuilder.ts
@@ -23,7 +23,7 @@ export type KanbanFormFieldGroup = {
   fieldType: string;
 };
 
-export type KanbanGroupBy = 'none' | 'assignee' | 'status' | 'priority' | KanbanFormFieldGroup;
+export type KanbanGroupBy = 'none' | 'assignee' | 'status' | 'priority' | 'createdBy' | KanbanFormFieldGroup;
 
 export type KanbanTicketFilters = {
   priority?: TicketPriority[];

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -82,7 +82,7 @@ const kanbanTicketsPageArgsSchema = z.object({
     .nullable(),
   groupBy: z
     .union([
-      z.enum(['none', 'assignee', 'status', 'priority']),
+      z.enum(['none', 'assignee', 'status', 'priority', 'createdBy']),
       z.object({
         type: z.literal('formField'),
         fieldId: z.string(),
@@ -465,6 +465,8 @@ const applyKanbanTicketPageConditions = (
     query = query.where('statusV2', groupKey as TicketStatusV2);
   } else if (groupBy === 'priority' && groupKey) {
     query = query.where('priority', groupKey as TicketPriority);
+  } else if (groupBy === 'createdBy' && groupKey && groupKey !== 'Unknown') {
+    query = query.where('createdBy', 'IN', [groupKey, `user:${groupKey}`]);
   } else if (typeof groupBy === 'object' && groupBy.type === 'formField' && formFieldValue !== undefined) {
     query = query.whereExists('formEntityValues', (formEntityValue: any) =>
       formEntityValue

--- a/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
@@ -437,6 +437,14 @@ export const TicketTable: React.FC<TicketTableProps> = ({
       },
 
       {
+        key: 'createdBy',
+        headerName: 'Created By',
+        field: 'createdBy',
+        minWidth: 160,
+        cellRenderer: CreatedByCellRenderer,
+      },
+
+      {
         key: 'assignee',
         headerName: 'Assignee',
         field: 'assignedTo',
@@ -892,6 +900,38 @@ const AssigneeCellRenderer = (params: ICellRendererParams<Ticket>) => {
           </div>
           <span>Unassigned</span>
         </div>
+      )}
+    </div>
+  );
+};
+
+const CreatedByCellRenderer = (params: ICellRendererParams<Ticket>) => {
+  const ticket = params.data;
+  const rawCreatedBy = ticket?.createdBy;
+  const createdById = rawCreatedBy ? rawCreatedBy.replace(/^(user:|group:|userGroup:)/, '') : '';
+  const createdUser = useUser(createdById || '');
+
+  if (!ticket || !rawCreatedBy) {
+    return <span className='text-muted-foreground'>—</span>;
+  }
+
+  return (
+    <div className='flex items-center h-full'>
+      {createdUser ? (
+        <div className='flex items-center gap-2'>
+          <Tooltip content={getUserDisplayName(createdUser)}>
+            <Avatar
+              userId={createdUser.id}
+              className='rounded-full size-5 flex items-center justify-center'
+              showActiveStatus={false}
+            />
+          </Tooltip>
+          <span className='text-muted-foreground truncate text-sm'>
+            {getUserDisplayName(createdUser)}
+          </span>
+        </div>
+      ) : (
+        <span className='text-muted-foreground text-sm truncate'>{rawCreatedBy}</span>
       )}
     </div>
   );

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -294,7 +294,7 @@ interface BoardKanbanScreenProps {
   initialColumns?: string[];
 }
 
-type GroupByType = 'none' | 'assignee' | 'status' | 'priority' | FormFieldGroup;
+type GroupByType = 'none' | 'assignee' | 'status' | 'priority' | 'createdBy' | FormFieldGroup;
 
 interface FormFieldGroup {
   type: 'formField';
@@ -551,7 +551,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       return groupTicketsByFormField(tickets, criterion, formValuesByTicketId, userNamesById);
     }
 
-    // Original logic for assignee, status, priority
+    // Original logic for assignee, status, priority, createdBy
     return tickets.reduce(
       (acc, ticket) => {
         const key =
@@ -559,7 +559,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
             ? (ticket.assignedTo ?? 'Unassigned')
             : criterion === 'status'
               ? ticket.statusV2
-              : (ticket.priority ?? 'No Priority');
+              : criterion === 'createdBy'
+                ? (ticket.createdBy ?? 'Unknown')
+                : (ticket.priority ?? 'No Priority');
 
         (acc[key] ??= []).push(ticket);
         return acc;
@@ -1245,6 +1247,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         value: 'priority' as const,
         label: 'Group by: Priority',
         icon: <Vote className='h-4 w-4' />,
+      },
+      {
+        value: 'createdBy' as const,
+        label: 'Group by: Created By',
+        icon: <User className='h-4 w-4' />,
       },
     ];
 
@@ -3046,6 +3053,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       } else if (groupBy === 'priority' && groupName !== 'No Priority') {
         priority = groupName as TicketPriority;
         displayName = groupName.charAt(0).toUpperCase() + groupName.slice(1).toLowerCase();
+      } else if (groupBy === 'createdBy' && groupName !== 'Unknown') {
+        const normalizedId = groupName.replace(/^(user:|group:|userGroup:)/, '');
+        entityType = 'user';
+        entityId = normalizedId;
+        displayName = userNamesById.get(normalizedId) || displayName;
       } else if (
         isFormFieldGroup(groupBy) &&
         groupBy.fieldType === FormFieldType.USER &&
@@ -3079,11 +3091,14 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
     const isAssigneeGrouping =
       groupBy === 'assignee' ||
+      groupBy === 'createdBy' ||
       (isFormFieldGroup(groupBy) && groupBy.fieldType === FormFieldType.USER);
     if (isAssigneeGrouping) {
-      const isUnassigned = (key: string): boolean => key === 'Unassigned';
+      const isMissingGroup = (key: string): boolean =>
+        key === 'Unassigned' || key === 'Unknown';
       mapped.sort((a, b) => {
-        if (isUnassigned(a.key) !== isUnassigned(b.key)) return isUnassigned(a.key) ? 1 : -1;
+        if (isMissingGroup(a.key) !== isMissingGroup(b.key))
+          return isMissingGroup(a.key) ? 1 : -1;
         return a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' });
       });
     }
@@ -3111,7 +3126,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     if (layoutView === 'table' || layoutView === 'flow') {
       // In table mode, hide TicketCard metadata columns
       return availableColumns.filter(
-        col => !['stage', 'board', 'createdAt', 'createdBy'].includes(col.key),
+        col => !['stage', 'board', 'createdAt'].includes(col.key),
       );
     }
     if (layoutView === 'calendar') {

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanCounts.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanCounts.ts
@@ -159,6 +159,7 @@ const getGroupKeys = (
 ): string[] => {
   if (!groupBy || groupBy === 'none') return [ALL_TICKETS_GROUP];
   if (groupBy === 'assignee') return [normalizeIdentity(snapshot.assignedTo) ?? UNASSIGNED_GROUP];
+  if (groupBy === 'createdBy') return [normalizeIdentity(snapshot.createdBy) ?? 'Unknown'];
   if (groupBy === 'status') return [snapshot.statusV2 ?? ''];
   if (groupBy === 'priority') return [snapshot.priority ?? ''];
   if (typeof groupBy === 'object' && groupBy.type === 'formField') {

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -28,6 +28,7 @@ export type KanbanPageGroupBy =
   | 'assignee'
   | 'status'
   | 'priority'
+  | 'createdBy'
   | {
       type: 'formField';
       fieldId: string;
@@ -162,7 +163,7 @@ const canRepresentGroupInVespa = (
   groupKey: string | undefined,
 ): boolean => {
   if (!groupBy || groupBy === 'none') return true;
-  if (groupBy === 'assignee' || groupBy === 'status' || groupBy === 'priority') {
+  if (groupBy === 'assignee' || groupBy === 'status' || groupBy === 'priority' || groupBy === 'createdBy') {
     return true;
   }
   if (typeof groupBy !== 'object' || groupBy.type !== 'formField') return false;

--- a/apps/dashboard/src/services/ticketService.ts
+++ b/apps/dashboard/src/services/ticketService.ts
@@ -39,6 +39,7 @@ export type KanbanCountsGroupBy =
   | 'assignee'
   | 'status'
   | 'priority'
+  | 'createdBy'
   | {
       type: 'formField';
       fieldId: string;

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -82,7 +82,7 @@ const kanbanTicketsPageArgsSchema = z.object({
     .nullable(),
   groupBy: z
     .union([
-      z.enum(['none', 'assignee', 'status', 'priority']),
+      z.enum(['none', 'assignee', 'status', 'priority', 'createdBy']),
       z.object({
         type: z.literal('formField'),
         fieldId: z.string(),


### PR DESCRIPTION
- Add 'createdBy' to GroupByType and grouping options dropdown in KanbanBoardScreen
- Add CreatedByCellRenderer and column definition in TicketTable
- Handle 'createdBy' grouping in groupTickets, group header display, and sorting
- Remove 'createdBy' from table/flow column exclusion so it shows in table view
- Update KanbanCountsGroupBy, KanbanPageGroupBy, and KanbanGroupBy types
- Update getGroupKeys, canRepresentGroupInVespa for 'createdBy'
- Update backend Zod schemas in kanbanTicketController and zero/queries
- Add groupBy='createdBy' handling in Zero query (backend)
- Update kanbanCountsService: KanbanCountTicket type, getBuiltInGroupKey, getBuiltInGroupByFields, and aggregate/fallback queries to include createdBy

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
