### PR TITLE
fix(dashboard): scope Created By, Assigned To and Roles user filters …

### DIFF
--- a/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
@@ -109,7 +109,9 @@ export const TicketFiltersDropdown = ({
   projectId,
   className = '',
   availablePriorities,
-  availableUsers,
+  availableCreators,
+  availableAssignees,
+  availableRoleAssignmentUsers,
   availableBoardDetails,
   availableBoards,
   sourceChannelProjectIds,
@@ -567,7 +569,7 @@ export const TicketFiltersDropdown = ({
             includeUnassigned
             allowInvert
             channelId={channelId}
-            priorityUserIds={availableUsers}
+            availableUsers={availableAssignees || []}
             demoteDeactivated
           />
         );
@@ -585,7 +587,7 @@ export const TicketFiltersDropdown = ({
             key='role-assignments-submenu'
             selectedRoles={filters.roleAssignments || []}
             onChange={value => handleFilterChange('roleAssignments', value)}
-            availableUsers={availableUsers || []}
+            availableUsers={availableRoleAssignmentUsers || []}
           />
         );
       case 'createdBy':
@@ -594,6 +596,7 @@ export const TicketFiltersDropdown = ({
             key='created-by-submenu'
             selectedUsers={filters.createdBy || []}
             onChange={(users: string[]) => handleFilterChange('createdBy', users)}
+            availableUsers={availableCreators || []}
             label='Created by'
           />
         );
@@ -800,7 +803,7 @@ export const TicketFiltersDropdown = ({
                   includeUnassigned
                   allowInvert
                   channelId={channelId}
-                  priorityUserIds={availableUsers}
+                  availableUsers={availableAssignees || []}
                   demoteDeactivated
                 />
               </Popover.Content>

--- a/apps/dashboard/src/components/Tickets/TicketFilters/types.ts
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/types.ts
@@ -46,7 +46,9 @@ export interface TicketFiltersProps {
   projectId?: string;
   className?: string;
   availablePriorities?: TicketPriority[] | undefined;
-  availableUsers?: string[] | undefined;
+  availableCreators?: string[] | undefined;
+  availableAssignees?: string[] | undefined;
+  availableRoleAssignmentUsers?: string[] | undefined;
   availableBoards?: string[] | undefined;
   availableBoardDetails?: BoardOption[] | undefined;
   sourceChannelProjectIds?: string[] | undefined;

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -1648,16 +1648,24 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     return Object.values(TicketPriority);
   }, []);
 
-  const { availableUsers, hasPrReviewers, hasQaAssigned } = useMemo(() => {
-    const userIds = new Set<string>();
+  const {
+    availableCreators,
+    availableAssignees,
+    availableRoleAssignmentUsers,
+    hasPrReviewers,
+    hasQaAssigned,
+  } = useMemo(() => {
+    const creatorIds = new Set<string>();
+    const assigneeIds = new Set<string>();
+    const roleAssignmentUserIds = new Set<string>();
     let hasPrReviewers = false;
     let hasQaAssigned = false;
     (kanbanSourceTickets as KanbanLocalTicket[] | undefined)?.forEach(ticket => {
-      if (ticket.assignedTo) userIds.add(ticket.assignedTo);
-      userIds.add(ticket.createdBy);
+      creatorIds.add(ticket.createdBy);
+      if (ticket.assignedTo) assigneeIds.add(ticket.assignedTo);
       if (Array.isArray(ticket.assignments)) {
         ticket.assignments.forEach(assignment => {
-          if (assignment.userId) userIds.add(assignment.userId);
+          if (assignment.userId) roleAssignmentUserIds.add(assignment.userId);
           const responsibility = assignment.userResponsibility as UserResponsibility;
           if (!hasPrReviewers && responsibility === UserResponsibility.PR_REVIEWER) {
             hasPrReviewers = true;
@@ -1667,7 +1675,13 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         });
       }
     });
-    return { availableUsers: Array.from(userIds), hasPrReviewers, hasQaAssigned };
+    return {
+      availableCreators: Array.from(creatorIds),
+      availableAssignees: Array.from(assigneeIds),
+      availableRoleAssignmentUsers: Array.from(roleAssignmentUserIds),
+      hasPrReviewers,
+      hasQaAssigned,
+    };
   }, [kanbanSourceTickets]);
 
   // Get available board IDs based on view mode (only needed for my-tickets views)
@@ -3470,7 +3484,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                   : effectiveProjectId || ''
               }
               availablePriorities={availablePriorities}
-              availableUsers={availableUsers}
+              availableCreators={availableCreators}
+              availableAssignees={availableAssignees}
+              availableRoleAssignmentUsers={availableRoleAssignmentUsers}
               availableBoards={availableBoards}
               availableBoardDetails={availableBoardDetails}
               sourceChannelProjectIds={sourceChannelProjectIds}


### PR DESCRIPTION
…to the active board

- Split the single availableUsers union into availableCreators, availableAssignees and availableRoleAssignmentUsers so each filter dropdown only lists users relevant to that role.
- Stop passing the assignee set to priorityUserIds (which only reorders) and pass it to availableUsers (which scopes the list).
- Add availableUsers to the Created By submenu so it is scoped as well.
- Keep Roles submenu wired to role-assignment users only.

Bug: user filters were listing every workspace user instead of only users actually present on tickets in the selected board(s).

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
