### PR TITLE
feat: add recording participants

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -1675,6 +1675,7 @@ export const callTable = table("calls")
     callUpdatesChannel: string().optional(),
     participantCount: number().optional(),
     participantPreviewUserIds: string().optional(),
+    recordingParticipants: string(),
     summaryTemplateId: string().optional(),
     labels: json<string[]>(),
     markedItems: json<any[]>(),

--- a/apps/backend/prisma/migrations/20260825120000_add_recording_participants_json/migration.sql
+++ b/apps/backend/prisma/migrations/20260825120000_add_recording_participants_json/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."calls" ADD COLUMN     "recordingParticipants" TEXT NOT NULL DEFAULT '[]';

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2725,6 +2725,7 @@ model Call {
   callUpdatesChannel String?   // Non-null = post call updates to this channel (Case 3); null = no broadcast
   participantCount Int?        // Denormalized total CallParticipant rows; nullable until backfilled
   participantPreviewUserIds String? // Stringified JSON: list of { userId: string , hasJoined: boolean }
+  recordingParticipants String @default("[]") // Stringified JSON: string[] of user ids this recording is about
   summaryTemplateId String?
   labels            String[]    @default([]) // Tag ids (see Tag model); no FK constraint
   markedItems       Json[]      @default([]) // Marked moments/decisions/actions surfaced during the call

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -51,6 +51,11 @@ import { canvasAuthService } from '@/services/canvasAuthService';
 import { buildCallInviteUrl } from '@/utils/urlUtils';
 import { readRecordingGoogleDocLinks } from '@/utils/recordingGoogleDocs';
 
+const RecordingParticipantsCommandSchema = z.object({
+  action: z.enum(['add', 'remove']),
+  userId: z.string().min(1).max(64),
+});
+
 const UpdateHeadlessRecordingSchema = z
   .object({
     title: z.string().trim().min(1).max(255).optional(),
@@ -1471,6 +1476,54 @@ export class CallController {
     } catch (error) {
       logger.error('Failed to fetch recording detail:', error);
       res.status(500).json({ success: false, error: 'Failed to fetch recording' });
+    }
+  };
+
+  manageRecordingParticipants = async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const { callId } = req.params;
+
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    try {
+      const input = RecordingParticipantsCommandSchema.parse(req.body);
+      const call = await repositories.calls.findByExternalId(callId);
+
+      if (
+        !call ||
+        call.callType !== CallType.HEADLESS ||
+        (call.workspaceId !== null && call.workspaceId !== req.user!.workspaceId)
+      ) {
+        res.status(404).json({ success: false, error: 'Recording not found' });
+        return;
+      }
+
+      if (call.createdByUserId !== userId) {
+        res.status(403).json({ success: false, error: 'Access denied' });
+        return;
+      }
+
+      if (input.action === 'add') {
+        const participant = await repositories.users.findById(input.userId);
+        if (
+          !participant ||
+          participant.workspaceId !== req.user!.workspaceId ||
+          participant.leftAt !== null
+        ) {
+          res.status(400).json({ success: false, error: 'User not found in this workspace' });
+          return;
+        }
+      }
+
+      await repositories.calls.updateRecordingParticipants(callId, input.action, input.userId);
+
+      res.json({ success: true });
+    } catch (error) {
+      logger.error('Failed to manage recording participants', { error, callId });
+      res.status(400).json({ success: false, error: 'Failed to update participants' });
     }
   };
 

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -18,6 +18,16 @@ import {
 
 export type { Call, CallParticipant };
 
+function parseRecordingParticipantIds(stored: string | null): string[] {
+  if (!stored) return [];
+  try {
+    const parsed: unknown = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Shape of `calls.metadata` as written by this repository.
  * `artifactMessageId` is set only for calls started from a slash-command
@@ -337,6 +347,36 @@ export class CallRepository {
       WHERE "externalId" = ${externalId}
     `;
     return rowsUpdated > 0;
+  }
+
+  async updateRecordingParticipants(
+    externalId: string,
+    action: 'add' | 'remove',
+    userId: string,
+  ): Promise<boolean> {
+    const lockKey = `call-recording-participants:${externalId}`;
+
+    return DatabaseClient.getInstance().$transaction(async (tx) => {
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`;
+
+      const call = await tx.call.findUnique({
+        where: { externalId },
+        select: { recordingParticipants: true },
+      });
+      if (!call) return false;
+
+      const current = parseRecordingParticipantIds(call.recordingParticipants);
+      const next =
+        action === 'add'
+          ? [...new Set([...current, userId])]
+          : current.filter((id) => id !== userId);
+
+      await tx.call.update({
+        where: { externalId },
+        data: { recordingParticipants: JSON.stringify(next) },
+      });
+      return true;
+    });
   }
 
   async appendLabels(callId: string, labelIds: string[]): Promise<void> {

--- a/apps/backend/src/database/repositories/noteTakerCallRepository.ts
+++ b/apps/backend/src/database/repositories/noteTakerCallRepository.ts
@@ -52,6 +52,7 @@ export class NoteTakerCallRepository {
         workspaceId,
         createdByUserId: createdBy,
         callType: CallType.HEADLESS,
+        recordingParticipants: JSON.stringify([createdBy]),
         status: CallStatus.ACTIVE,
         roomLink,
         metadata: metadata as Prisma.InputJsonValue,

--- a/apps/backend/src/routes/calls.ts
+++ b/apps/backend/src/routes/calls.ts
@@ -32,6 +32,7 @@ router.post('/recordings/:callId/export-google-doc', recordingGoogleDocControlle
 router.get('/recordings/:callId/google-doc-compose-context', recordingGoogleDocController.context);
 router.post('/recordings/:callId/sharing', recordingSharingController.manage);
 router.get('/recordings/:callId', callController.getRecordingDetail);
+router.post('/recordings/:callId/participants', callController.manageRecordingParticipants);
 router.patch('/recordings/:callId', callController.updateRecordingTitle);
 router.delete('/recordings/:callId', callController.deleteRecording);
 router.get('/summary-templates', summaryTemplateController.list);

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -4568,6 +4568,7 @@ export function createMutators(
             updatedAt: now,
             labels: [],
             markedItems: [],
+            recordingParticipants: '[]',
             xyneManaged: false,
             metadata: {
               systemMessageId,

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -2621,14 +2621,24 @@ export const queries: AnyQueryRegistry = defineQueries({
     z.object({
       limit: z.number(),
       start: z.object({ id: z.string(), startedAt: z.number() }).nullable(),
+      participantId: z.string().nullable(),
     }),
-    ({ ctx, args: { limit, start } }) => {
+    ({ ctx, args: { limit, start, participantId } }) => {
       let query = zql.calls
         .where('workspaceId', ctx.workspaceId)
         .where('callType', CallType.HEADLESS)
         .where('createdByUserId', ctx.userID)
         .orderBy('startedAt', 'desc')
         .orderBy('id', 'desc');
+
+      if (participantId) {
+        query = query.where(({ or, cmp }) =>
+          or(
+            cmp('createdByUserId', participantId),
+            cmp('recordingParticipants', 'LIKE', `%"${participantId}"%`),
+          ),
+        );
+      }
 
       if (start) {
         query = query.start({ id: start.id, startedAt: start.startedAt }, { inclusive: false });
@@ -2641,8 +2651,9 @@ export const queries: AnyQueryRegistry = defineQueries({
     z.object({
       limit: z.number(),
       start: z.object({ id: z.string(), startedAt: z.number() }).nullable(),
+      participantId: z.string().nullable(),
     }),
-    ({ ctx, args: { limit, start } }) => {
+    ({ ctx, args: { limit, start, participantId } }) => {
       let query = zql.calls
         .where('workspaceId', ctx.workspaceId)
         .where('callType', CallType.HEADLESS)
@@ -2661,6 +2672,15 @@ export const queries: AnyQueryRegistry = defineQueries({
         )
         .orderBy('startedAt', 'desc')
         .orderBy('id', 'desc');
+
+      if (participantId) {
+        query = query.where(({ or, cmp }) =>
+          or(
+            cmp('createdByUserId', participantId),
+            cmp('recordingParticipants', 'LIKE', `%"${participantId}"%`),
+          ),
+        );
+      }
 
       if (start) {
         query = query.start({ id: start.id, startedAt: start.startedAt }, { inclusive: false });

--- a/apps/dashboard/src/hooks/usePaginatedOatsRecordings.ts
+++ b/apps/dashboard/src/hooks/usePaginatedOatsRecordings.ts
@@ -22,10 +22,14 @@ type OatsRecordingQuery =
   | ReturnType<typeof queries.createdOatsRecordings>
   | ReturnType<typeof queries.sharedOatsRecordings>;
 
-const recordingQuery = (scope: OatsRecordingScope, start: RecordingCursor): OatsRecordingQuery =>
+const recordingQuery = (
+  scope: OatsRecordingScope,
+  start: RecordingCursor,
+  participantId: string | null,
+): OatsRecordingQuery =>
   scope === 'created'
-    ? queries.createdOatsRecordings({ limit: FETCH_LIMIT, start })
-    : queries.sharedOatsRecordings({ limit: FETCH_LIMIT, start });
+    ? queries.createdOatsRecordings({ limit: FETCH_LIMIT, start, participantId })
+    : queries.sharedOatsRecordings({ limit: FETCH_LIMIT, start, participantId });
 
 export interface UsePaginatedOatsRecordingsReturn {
   recordings: OatsRecordingEntry[];
@@ -39,6 +43,7 @@ export interface UsePaginatedOatsRecordingsReturn {
 
 export function usePaginatedOatsRecordings(
   scope: OatsRecordingScope,
+  participantId: string | null,
 ): UsePaginatedOatsRecordingsReturn {
   const zero = useZero();
   const [cursor, setCursor] = useState<RecordingCursor>(null);
@@ -47,13 +52,13 @@ export function usePaginatedOatsRecordings(
   const recordingsRef = useRef(recordings);
   recordingsRef.current = recordings;
 
-  const [page, details] = useCachedQuery(recordingQuery(scope, cursor));
+  const [page, details] = useCachedQuery(recordingQuery(scope, cursor, participantId));
 
   useEffect(() => {
     setCursor(null);
     setRecordings([]);
     setHasMoreRecordings(true);
-  }, [scope]);
+  }, [scope, participantId]);
 
   useEffect(() => {
     if (!page || details.type !== 'complete') return;
@@ -75,13 +80,13 @@ export function usePaginatedOatsRecordings(
   const refreshRecordings = useCallback((): void => {
     setCursor(null);
     void zero
-      .run(recordingQuery(scope, null), { type: 'complete' })
+      .run(recordingQuery(scope, null, participantId), { type: 'complete' })
       .then(result => {
         setRecordings((result ?? []) as OatsRecordingEntry[]);
         setHasMoreRecordings((result?.length ?? 0) === FETCH_LIMIT);
       })
       .catch(() => undefined);
-  }, [scope, zero]);
+  }, [scope, participantId, zero]);
 
   useEffect(() => {
     refreshListeners.add(refreshRecordings);

--- a/apps/dashboard/src/hooks/useRecordingLabelSuggestions.ts
+++ b/apps/dashboard/src/hooks/useRecordingLabelSuggestions.ts
@@ -12,7 +12,11 @@ const SUGGESTION_SAMPLE_SIZE = 100;
  */
 export function useRecordingLabelSuggestions(enabled = true): string[] {
   const [recordings] = useCachedQuery(
-    queries.createdOatsRecordings({ limit: SUGGESTION_SAMPLE_SIZE, start: null }),
+    queries.createdOatsRecordings({
+      limit: SUGGESTION_SAMPLE_SIZE,
+      start: null,
+      participantId: null,
+    }),
     { enabled },
   );
 

--- a/apps/dashboard/src/hooks/useRecordingParticipants.ts
+++ b/apps/dashboard/src/hooks/useRecordingParticipants.ts
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { toast } from 'sonner';
+import type { User } from '@xyne/shared/machines';
+import { useActiveUsers, useUsersById, useSelf, searchUsers } from './useUsers';
+import { recordingService } from '../services/Recording/recordingService';
+import type { RecordingParticipantShare } from '../services/Recording/recordingService';
+import { getRecordingParticipantIds, logRecordingError } from '../utils/recordingUtils';
+import { getApiErrorMessage } from '../utils/apiError';
+
+interface UseRecordingParticipantsArgs {
+  recordingExternalId: string;
+  createdByUserId: string | undefined;
+  recordingParticipants: string | null | undefined;
+  shares: readonly RecordingParticipantShare[] | null | undefined;
+}
+
+export interface UseRecordingParticipantsReturn {
+  self: User | undefined;
+  searchRef: React.RefObject<HTMLInputElement | null>;
+  canManage: boolean;
+  total: number;
+  participants: (User | undefined)[];
+  participantIds: string[];
+  busyIds: ReadonlySet<string>;
+  withAccess: ReadonlySet<string>;
+  accessKnown: boolean;
+  sharesLoaded: boolean;
+  withoutAccess: number;
+  changeParticipant: (action: 'add' | 'remove', userId: string) => void;
+  shareWith: (userId: string) => void;
+  query: string;
+  setQuery: Dispatch<SetStateAction<string>>;
+  trimmedQuery: string;
+  results: User[];
+  activeIndex: number;
+  onSearchKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  pickResult: (userId: string) => void;
+  highlightResult: (index: number) => void;
+}
+
+export function useRecordingParticipants({
+  recordingExternalId,
+  createdByUserId,
+  recordingParticipants,
+  shares,
+}: UseRecordingParticipantsArgs): UseRecordingParticipantsReturn {
+  const [query, setQuery] = useState('');
+  const [highlighted, setHighlighted] = useState(0);
+  const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(new Set());
+  const [pending, setPending] = useState<ReadonlyMap<string, 'add' | 'remove'>>(new Map());
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const users = useActiveUsers();
+  const usersById = useUsersById();
+  const self = useSelf();
+
+  const canManage = Boolean(self?.id && createdByUserId && self.id === createdByUserId);
+
+  const serverIds = useMemo(
+    () => getRecordingParticipantIds(createdByUserId, recordingParticipants),
+    [recordingParticipants, createdByUserId],
+  );
+
+  const participantIds = useMemo(() => {
+    if (pending.size === 0) return serverIds;
+    const ids = serverIds.filter(id => pending.get(id) !== 'remove');
+    for (const [id, change] of pending) {
+      if (change === 'add' && !ids.includes(id)) ids.push(id);
+    }
+    return ids;
+  }, [serverIds, pending]);
+
+  useEffect(() => {
+    setPending(current => {
+      const next = new Map(current);
+      for (const [id, change] of current) {
+        if (serverIds.includes(id) === (change === 'add')) next.delete(id);
+      }
+      return next.size === current.size ? current : next;
+    });
+  }, [serverIds]);
+
+  const withAccess = useMemo(() => {
+    const shared = new Set<string>();
+    for (const share of shares ?? []) {
+      if (share.userId) shared.add(share.userId);
+    }
+    if (createdByUserId) shared.add(createdByUserId);
+    return shared;
+  }, [shares, createdByUserId]);
+
+  const accessKnown = !(shares ?? []).some(
+    share => Boolean(share.userGroupId) || Boolean(share.channelId),
+  );
+  const sharesLoaded = shares !== undefined;
+
+  const participants = useMemo(
+    () => participantIds.map(id => usersById.get(id)).filter(Boolean),
+    [participantIds, usersById],
+  );
+
+  const trimmedQuery = query.trim();
+  const results = useMemo(() => {
+    if (!trimmedQuery) return [];
+    const already = new Set(participantIds);
+    return searchUsers(
+      users.filter(user => !already.has(user.id)),
+      trimmedQuery,
+      6,
+    );
+  }, [trimmedQuery, users, participantIds]);
+
+  useEffect(() => setHighlighted(0), [trimmedQuery]);
+  const activeIndex = highlighted < results.length ? highlighted : 0;
+
+  const withBusy = async (userId: string, work: () => Promise<void>): Promise<void> => {
+    setBusyIds(current => new Set(current).add(userId));
+    try {
+      await work();
+    } finally {
+      setBusyIds(current => {
+        const next = new Set(current);
+        next.delete(userId);
+        return next;
+      });
+    }
+  };
+
+  const changeParticipant = (action: 'add' | 'remove', userId: string): void => {
+    setPending(current => new Map(current).set(userId, action));
+    void withBusy(userId, async () => {
+      try {
+        await recordingService.manageRecordingParticipant(recordingExternalId, action, userId);
+      } catch (error) {
+        setPending(current => {
+          const next = new Map(current);
+          next.delete(userId);
+          return next;
+        });
+        logRecordingError('RecordingParticipants.change', error);
+        toast.error(
+          action === 'add' ? 'Could not add participant' : 'Could not remove participant',
+          {
+            description: getApiErrorMessage(error, 'Unable to update participants'),
+          },
+        );
+      }
+    });
+  };
+
+  const shareWith = (userId: string): void => {
+    void withBusy(userId, async () => {
+      try {
+        await recordingService.grantRecordingAccess(recordingExternalId, [
+          { type: 'user', id: userId },
+        ]);
+        toast.success('Recording shared');
+      } catch (error) {
+        logRecordingError('RecordingParticipants.share', error);
+        toast.error('Could not share recording', {
+          description: getApiErrorMessage(error, 'Unable to share this recording'),
+        });
+      }
+    });
+  };
+
+  const total = participantIds.length;
+  const withoutAccess = participantIds.filter(id => !withAccess.has(id)).length;
+
+  const onSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (results.length === 0) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setHighlighted((activeIndex + 1) % results.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlighted((activeIndex - 1 + results.length) % results.length);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const picked = results[activeIndex];
+      if (picked) {
+        setQuery('');
+        changeParticipant('add', picked.id);
+      }
+    }
+  };
+
+  const pickResult = (userId: string): void => {
+    setQuery('');
+    changeParticipant('add', userId);
+  };
+
+  const highlightResult = (index: number): void => setHighlighted(index);
+
+  return {
+    self,
+    searchRef,
+    canManage,
+    total,
+    participants,
+    participantIds,
+    busyIds,
+    withAccess,
+    accessKnown,
+    sharesLoaded,
+    withoutAccess,
+    changeParticipant,
+    shareWith,
+    query,
+    setQuery,
+    trimmedQuery,
+    results,
+    activeIndex,
+    onSearchKeyDown,
+    pickResult,
+    highlightResult,
+  };
+}

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
@@ -160,6 +160,7 @@ function mapVespaCallResultToCall(result: DisplaySearchResult, workspaceId: stri
     instanceDate: null,
     recordingEnabled: false,
     recordingUrl: null,
+    recordingParticipants: '[]',
     transcript: context?.hasTranscript ? 'available' : undefined,
     aiSummary: null,
     startedAt,

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -428,6 +428,8 @@ export default function RecordingDetailV2Screen(): ReactElement {
         ...prev,
         title: recordingRow.title || prev.title,
         labels: recordingRow.labels ?? prev.labels,
+        recordingParticipants: recordingRow.recordingParticipants ?? prev.recordingParticipants,
+        shares: recordingRow.shares ?? prev.shares,
         linkedTicketId,
         linkedTicketMessageId:
           typeof rawLinkedTicketMessageId === 'string' ? rawLinkedTicketMessageId : null,
@@ -458,7 +460,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
       }
       return isSameRecordingSnapshot(prev, next) ? prev : next;
     });
-  }, [recordingRow]);
+  }, [recordingRow, recording?.externalId]);
 
   useEffect(() => {
     const request = getSummaryRequest(recordingId);

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingDetailV2Header.tsx
@@ -23,6 +23,7 @@ import {
 import { logRecordingError, type RecordingTitleState } from '../../../utils/recordingUtils';
 import { getApiErrorMessage } from '../../../utils/apiError';
 import { formatDuration } from '../../../utils/dateUtils';
+import { RecordingParticipants } from './RecordingParticipants';
 import { useEditableRecordingTitle } from '../useEditableRecordingTitle';
 import { RecordingLabelPicker } from './RecordingLabelPicker';
 import { RecordingShareModal } from './RecordingShareModal';
@@ -304,6 +305,12 @@ export const RecordingDetailV2Header = ({
       {/* Actions row */}
       <div className='flex items-start gap-2'>
         <div className='flex flex-wrap items-center gap-2'>
+          <RecordingParticipants
+            recordingExternalId={recording.externalId}
+            createdByUserId={recording.createdByUserId}
+            recordingParticipants={recording.recordingParticipants}
+            shares={recording.shares}
+          />
           {!isLive && recording.detailedSummaryCanvasId && (
             <RecordingTicketLink
               linkedTicketId={recording.linkedTicketId ?? null}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingParticipants.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingParticipants.tsx
@@ -1,0 +1,253 @@
+import type { ReactElement } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { Search, Share2, Users, X } from 'lucide-react';
+import { useRecordingParticipants } from '../../../hooks/useRecordingParticipants';
+import type { RecordingParticipantShare } from '../../../services/Recording/recordingService';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+import Avatar from '../../../components/ui/Avatar/Avatar';
+import AvatarGroup from '../../../components/ui/Avatar/AvatarGroup';
+import { Popover } from '../../../components/ui/Popover/Popover';
+import { Button } from '../../../components/ui/Button/Button';
+import { cn } from '../../../utils/classNames';
+
+interface RecordingParticipantsProps {
+  recordingExternalId: string;
+  createdByUserId: string | undefined;
+  recordingParticipants: string | null | undefined;
+  shares: readonly RecordingParticipantShare[] | null | undefined;
+}
+
+export function RecordingParticipants({
+  recordingExternalId,
+  createdByUserId,
+  recordingParticipants,
+  shares,
+}: RecordingParticipantsProps): ReactElement | null {
+  const reduceMotion = useReducedMotion();
+  const {
+    self,
+    searchRef,
+    canManage,
+    total,
+    participants,
+    participantIds,
+    busyIds,
+    withAccess,
+    accessKnown,
+    sharesLoaded,
+    withoutAccess,
+    changeParticipant,
+    shareWith,
+    query,
+    setQuery,
+    trimmedQuery,
+    results,
+    activeIndex,
+    onSearchKeyDown,
+    pickResult,
+    highlightResult,
+  } = useRecordingParticipants({
+    recordingExternalId,
+    createdByUserId,
+    recordingParticipants,
+    shares,
+  });
+
+  if (total === 0) return null;
+
+  const rowMotion = reduceMotion
+    ? {}
+    : {
+        initial: { opacity: 0, y: 4, filter: 'blur(4px)' },
+        animate: { opacity: 1, y: 0, filter: 'blur(0px)' },
+        exit: {
+          opacity: 0,
+          y: -4,
+          filter: 'blur(4px)',
+          transition: { duration: 0.15, ease: 'easeIn' as const },
+        },
+        transition: { type: 'spring' as const, duration: 0.3, bounce: 0 },
+      };
+
+  const trigger = (
+    <Button
+      type='button'
+      variant='outline'
+      size='sm'
+      className='h-7 gap-1.5 rounded-lg px-2 text-xs font-normal active:scale-[0.96]'
+      aria-label={`Participants, ${total} added`}
+      data-track-category='RecordingDetailV2'
+      data-track-name='open_recording_participants'
+    >
+      <AvatarGroup userIds={participantIds.slice(0, 3)} size='xs' />
+      <span className='tabular-nums'>{total}</span>
+    </Button>
+  );
+
+  const emptyState = (
+    <div className='flex flex-col items-center gap-1 px-4 py-7 text-center'>
+      <Users className='size-4 text-muted-foreground' aria-hidden='true' />
+      <p className='text-[13px] text-muted-foreground'>No one added yet</p>
+      {canManage && (
+        <p className='text-[11px] text-muted-foreground/70'>
+          Search above to add the people this recording is about
+        </p>
+      )}
+    </div>
+  );
+
+  return (
+    <Popover
+      trigger={trigger}
+      side='bottom'
+      align='start'
+      sideOffset={6}
+      focusRef={searchRef}
+      className='w-[19rem] overflow-hidden p-0'
+      onEscapeKeyDown={event => {
+        if (!trimmedQuery) return;
+        event.preventDefault();
+        setQuery('');
+      }}
+    >
+      <div className='flex items-center justify-between gap-2 border-b border-border px-3 py-2.5'>
+        <span className='text-[13px] font-medium'>Participants</span>
+        {sharesLoaded && total > 0 && accessKnown && (
+          <span className='text-[11px] tabular-nums text-muted-foreground'>
+            {withoutAccess === 0
+              ? `all ${total} have access`
+              : `${total - withoutAccess} of ${total} have access`}
+          </span>
+        )}
+      </div>
+
+      {canManage && (
+        <div className='flex items-center gap-2 border-b border-border px-3'>
+          <Search className='size-3.5 shrink-0 text-muted-foreground' aria-hidden='true' />
+          <input
+            ref={searchRef}
+            value={query}
+            onChange={event => setQuery(event.target.value)}
+            onKeyDown={onSearchKeyDown}
+            role='combobox'
+            aria-expanded={results.length > 0}
+            aria-autocomplete='list'
+            aria-controls='recording-participant-results'
+            aria-activedescendant={results[activeIndex]?.id}
+            placeholder='Add someone by name or email'
+            className='h-9 flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground'
+            data-track-category='RecordingDetailV2'
+            data-track-name='search_recording_participants'
+          />
+        </div>
+      )}
+
+      <div
+        id='recording-participant-results'
+        role='listbox'
+        aria-label='Matching people'
+        className={cn('max-h-60 overflow-y-auto py-1', !trimmedQuery && 'hidden')}
+      >
+        {trimmedQuery && results.length === 0 && (
+          <p className='px-3 py-5 text-center text-[13px] text-muted-foreground'>
+            No one matches “{trimmedQuery}”
+          </p>
+        )}
+        {trimmedQuery &&
+          results.map((user, index) => (
+            <button
+              key={user.id}
+              id={user.id}
+              role='option'
+              aria-selected={index === activeIndex}
+              type='button'
+              disabled={busyIds.has(user.id)}
+              onMouseMove={() => highlightResult(index)}
+              onClick={() => pickResult(user.id)}
+              className={cn(
+                'flex w-full items-center gap-2.5 px-3 py-2 text-left disabled:opacity-50',
+                index === activeIndex && 'bg-muted',
+              )}
+              data-track-category='RecordingDetailV2'
+              data-track-name='add_recording_participant'
+            >
+              <Avatar userId={user.id} size='rg' showActiveStatus={false} />
+              <span className='min-w-0 flex-1'>
+                <span className='block truncate text-[13px]'>{getUserDisplayName(user)}</span>
+                <span className='block truncate text-[11px] text-muted-foreground'>
+                  {user.email}
+                </span>
+              </span>
+            </button>
+          ))}
+      </div>
+
+      {!trimmedQuery && (
+        <div className='max-h-60 overflow-y-auto py-1'>
+          {participants.length === 0 && emptyState}
+          <AnimatePresence initial={false}>
+            {participants.map(user => {
+              if (!user) return null;
+              const isSelf = user.id === self?.id;
+              const busy = busyIds.has(user.id);
+              const isOwner = user.id === createdByUserId;
+              return (
+                <motion.div
+                  key={user.id}
+                  layout={!reduceMotion}
+                  {...rowMotion}
+                  className='group flex items-center gap-2.5 px-3 py-2 hover:bg-muted/50'
+                >
+                  <Avatar userId={user.id} size='rg' showActiveStatus={false} />
+                  <div className='min-w-0 flex-1'>
+                    <div className='flex items-center gap-1.5'>
+                      <span className='truncate text-[13px]'>{getUserDisplayName(user)}</span>
+                      {isSelf && !isOwner && (
+                        <span className='shrink-0 text-[11px] text-muted-foreground'>You</span>
+                      )}
+                    </div>
+                    <span className='block truncate text-[11px] text-muted-foreground'>
+                      {isOwner ? 'Owner' : user.email}
+                    </span>
+                  </div>
+                  {canManage && !isOwner && (
+                    <div className='flex shrink-0 items-center gap-0.5'>
+                      {accessKnown && !withAccess.has(user.id) && (
+                        <Button
+                          type='button'
+                          variant='ghost'
+                          size='sm'
+                          disabled={busy}
+                          onClick={() => shareWith(user.id)}
+                          className='h-7 gap-1 px-2 text-[11px] font-normal text-muted-foreground hover:text-foreground active:scale-[0.96]'
+                          data-track-category='RecordingDetailV2'
+                          data-track-name='share_with_recording_participant'
+                        >
+                          <Share2 className='size-3' aria-hidden='true' />
+                          Share
+                        </Button>
+                      )}
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='iconSm'
+                        disabled={busy}
+                        aria-label={`Remove ${getUserDisplayName(user)}`}
+                        onClick={() => changeParticipant('remove', user.id)}
+                        className='text-muted-foreground opacity-0 hover:text-foreground focus-visible:opacity-100 active:scale-[0.96] group-hover:opacity-100'
+                        data-track-category='RecordingDetailV2'
+                        data-track-name='remove_recording_participant'
+                      >
+                        <X className='size-3.5' aria-hidden='true' />
+                      </Button>
+                    </div>
+                  )}
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
+        </div>
+      )}
+    </Popover>
+  );
+}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -42,13 +42,14 @@ import {
   filterRecordingsByLabels,
   filterRecordingsByOwnership,
   findNearestVisibleRecording,
+  formatRecordingParticipants,
   getRecordingDatePresetLabel,
   isRecordingInDatePreset,
   LIST_TAB_CLASS_NAME,
   type RecordingDatePreset,
   type RecordingOwnershipTab,
 } from './utils/RecordingsV2.utils';
-import { normalizeRecordingTags } from '../../utils/recordingUtils';
+import { getRecordingParticipantIds, normalizeRecordingTags } from '../../utils/recordingUtils';
 import { DEFAULT_RECORDING_TITLE, readRecordingCanvasIds } from '@/utils/recordingUtils';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { SummaryTemplatesModal } from '../RecordingDetailV2Screen/components/SummaryTemplatesModal';
@@ -84,7 +85,7 @@ const RecordingsV2Screen = (): ReactElement => {
     isLoading,
     error,
     refreshRecordings,
-  } = usePaginatedOatsRecordings(activeListTab);
+  } = usePaginatedOatsRecordings(activeListTab, selectedCreatorId);
   const currentUser = useSelf();
   const users = useUsers();
   const usersById = useMemo(() => new Map(users.map(user => [user.id, user])), [users]);
@@ -158,15 +159,14 @@ const RecordingsV2Screen = (): ReactElement => {
     [availableLabels, isManualLabel],
   );
 
-  /** An explicit pick in the People filter wins over the tab's shared-by picker. */
-  const selectedCreatorIds = useMemo(
-    () => (selectedCreatorId ? [selectedCreatorId] : selectedSharerIds),
-    [selectedCreatorId, selectedSharerIds],
-  );
-
+  /**
+   * The People filter is applied server-side by the recordings query, so only the
+   * tab's shared-by picker still narrows the loaded page — and an explicit pick in
+   * the People filter wins over it.
+   */
   const ownershipFilteredRecordings = useMemo(
-    () => filterRecordingsByOwnership(recordings, selectedCreatorIds),
-    [recordings, selectedCreatorIds],
+    () => filterRecordingsByOwnership(recordings, selectedCreatorId ? [] : selectedSharerIds),
+    [recordings, selectedCreatorId, selectedSharerIds],
   );
 
   const liveRecording = useMemo(() => {
@@ -244,15 +244,9 @@ const RecordingsV2Screen = (): ReactElement => {
     [activeListTab, setActiveListTab],
   );
 
-  const handleCreatorChange = useCallback(
-    (creatorId: string | null): void => {
-      setSelectedCreatorId(creatorId);
-      if (creatorId) {
-        setActiveListTab(creatorId === currentUser?.id ? 'created' : 'shared');
-      }
-    },
-    [currentUser?.id, setActiveListTab],
-  );
+  const handleCreatorChange = useCallback((creatorId: string | null): void => {
+    setSelectedCreatorId(creatorId);
+  }, []);
 
   const handleOpenRecording = useCallback(
     (recordingId: string): void => {
@@ -433,7 +427,7 @@ const RecordingsV2Screen = (): ReactElement => {
                 <RecordingDateFilter value={selectedDatePreset} onChange={setSelectedDatePreset} />
 
                 <RecordingPeopleFilter
-                  creators={availableCreators}
+                  creators={users}
                   currentUserId={currentUser?.id}
                   selectedUserId={selectedCreatorId}
                   onUserChange={handleCreatorChange}
@@ -549,7 +543,8 @@ const RecordingsV2Screen = (): ReactElement => {
               <div className='flex flex-1 flex-col items-center justify-center px-6 pb-28 text-center'>
                 <RecordingsEmptyStateIllustration />
                 <h2 className='text-base font-semibold text-foreground'>
-                  {selectedCreatorIds.length > 0 ||
+                  {selectedCreatorId !== null ||
+                  selectedSharerIds.length > 0 ||
                   selectedLabels.length > 0 ||
                   ownershipFilteredRecordings.length > 0
                     ? 'No matching recordings'
@@ -603,6 +598,14 @@ const RecordingsV2Screen = (): ReactElement => {
                       <RecordingsV2Pill
                         recording={row.recording}
                         creator={usersById.get(row.recording.createdByUserId) ?? null}
+                        participantsLabel={formatRecordingParticipants(
+                          getRecordingParticipantIds(
+                            row.recording.createdByUserId,
+                            row.recording.recordingParticipants,
+                          ),
+                          usersById,
+                          currentUser?.id,
+                        )}
                         tags={row.recording.labels.filter(isManualLabel)}
                         resolveLabel={resolveLabel}
                         currentUserId={currentUser?.id}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingPeopleFilter.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingPeopleFilter.tsx
@@ -90,7 +90,8 @@ export function RecordingPeopleFilter({
         placeholder='People'
         searchPlaceholder='Search people...'
         inputClassName={cn(
-          'h-9 rounded-xl pl-3 pr-7 text-sm font-medium shadow-sm',
+          'h-9 max-w-[9rem] rounded-xl pl-3 pr-7 text-sm font-medium shadow-sm',
+          '[&>span]:min-w-0 [&>span]:overflow-hidden [&>span]:text-ellipsis [&>span]:!whitespace-nowrap',
           selectedUserId && '!border-foreground',
         )}
         onSearchChange={setSearchValue}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -33,7 +33,6 @@ import {
   normalizeRecordingTags,
 } from '../../../utils/recordingUtils';
 import { cn } from '../../../utils/classNames';
-import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { TextShimmer } from '../../../components/ui/ShimmerText';
 import { useRecordingTitleState } from '../../../hooks/useRecordingTitleState';
 import { formatRecordingTimestamp, toRecordingTitleInput } from '../utils/RecordingsV2.utils';
@@ -53,6 +52,7 @@ export interface RecordingsV2PillProps {
     | 'createdByUserId'
   >;
   creator: User | null;
+  participantsLabel: string;
   tags?: string[];
   /** Resolves a tag value (Tag id) to its display text. Defaults to identity. */
   resolveLabel?: (label: string) => string;
@@ -145,6 +145,7 @@ export const RecordingsV2LivePill = ({
 const RecordingsV2Pill = ({
   recording,
   creator,
+  participantsLabel,
   tags = [],
   resolveLabel = (label: string) => label,
   currentUserId,
@@ -287,9 +288,7 @@ const RecordingsV2Pill = ({
               </span>
             )}
             <span className='mt-0.5 flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground'>
-              <span className='truncate'>
-                {creator ? getUserDisplayName(creator) : 'Unknown creator'}
-              </span>
+              <span className='truncate'>{participantsLabel}</span>
               <span aria-hidden='true'>·</span>
               <span className='shrink-0'>{formatRecordingTimestamp(recording.startedAt)}</span>
             </span>

--- a/apps/dashboard/src/routes/RecordingsV2Screen/utils/RecordingsV2.utils.ts
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/utils/RecordingsV2.utils.ts
@@ -12,8 +12,10 @@ import {
   subWeeks,
 } from 'date-fns';
 import { CallStatus } from '@xyne/shared';
+import type { User } from '@xyne/shared/machines';
 import type { OatsRecordingEntry } from '../../../hooks/usePaginatedOatsRecordings';
 import type { RecordingTitleInput } from '../../../utils/recordingUtils';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 export type RecordingDatePreset =
   | 'all-time'
@@ -221,6 +223,35 @@ export function filterRecordingsByOwnership(
 
   const wanted = new Set(selectedCreatorIds);
   return recordings.filter(recording => wanted.has(recording.createdByUserId));
+}
+
+/**
+ * Renders the people a recording is about: "Just you", "Alice", "Alice & you",
+ * "Alice, Bob & 2 others".
+ */
+export function formatRecordingParticipants(
+  participantIds: string[],
+  usersById: Map<string, User>,
+  currentUserId: string | undefined,
+): string {
+  const names: string[] = [];
+  let includesSelf = false;
+
+  for (const id of participantIds) {
+    if (id === currentUserId) {
+      includesSelf = true;
+      continue;
+    }
+    const user = usersById.get(id);
+    if (user) names.push(getUserDisplayName(user));
+  }
+  if (includesSelf) names.push('you');
+
+  const [first, second, ...rest] = names;
+  if (first === undefined) return 'Unknown creator';
+  if (second === undefined) return includesSelf ? 'Just you' : first;
+  if (rest.length === 0) return `${first} & ${second}`;
+  return `${first}, ${second} & ${rest.length} ${rest.length === 1 ? 'other' : 'others'}`;
 }
 
 /**

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -178,7 +178,16 @@ export interface CitationSegment {
   snippet: string;
 }
 
+export interface RecordingParticipantShare {
+  userId: string | null;
+  userGroupId: string | null;
+  channelId: string | null;
+}
+
 export interface RecordingDetail extends Recording {
+  /** Stringified JSON string[] — read it through getRecordingParticipantIds. */
+  recordingParticipants?: string | null;
+  shares?: readonly RecordingParticipantShare[] | null;
   transcript: string | null;
   identifiedTranscript: string | null;
   hasIdentifiedTranscript: boolean;
@@ -384,6 +393,14 @@ class RecordingService {
         ...(messageContent?.trim() ? { messageContent: messageContent.trim() } : {}),
       });
     return response.data;
+  }
+
+  async manageRecordingParticipant(
+    callId: string,
+    action: 'add' | 'remove',
+    userId: string,
+  ): Promise<void> {
+    await apiInstance.post(`/calls/recordings/${callId}/participants`, { action, userId });
   }
 
   async revokeRecordingAccess(

--- a/apps/dashboard/src/utils/recordingUtils.ts
+++ b/apps/dashboard/src/utils/recordingUtils.ts
@@ -178,6 +178,27 @@ export const normalizeRecordingTags = (tags: string[]): string[] => {
   return [...new Set(tags.map(tag => tag.trim()).filter(Boolean))];
 };
 
+/**
+ * Reads `calls.recordingParticipants` (stringified JSON string[]) into user ids,
+ * prepending the creator so older rows still resolve to at least one person.
+ */
+export const getRecordingParticipantIds = (
+  createdByUserId: string | undefined,
+  stored: string | null | undefined,
+): string[] => {
+  let ids: string[] = [];
+  if (stored) {
+    try {
+      const parsed: unknown = JSON.parse(stored);
+      if (Array.isArray(parsed)) ids = parsed.filter((id): id is string => typeof id === 'string');
+    } catch {
+      ids = [];
+    }
+  }
+  if (createdByUserId && !ids.includes(createdByUserId)) return [createdByUserId, ...ids];
+  return ids;
+};
+
 /** Canonical tag name, or null when the text can't make one — tags must start with a letter. */
 export const slugifyRecordingLabel = (raw: string): string | null => {
   const slug = normalizeTagName(raw);

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -2133,14 +2133,24 @@ export const queries = defineQueries({
     z.object({
       limit: z.number(),
       start: z.object({ id: z.string(), startedAt: z.number() }).nullable(),
+      participantId: z.string().nullable(),
     }),
-    ({ ctx, args: { limit, start } }) => {
+    ({ ctx, args: { limit, start, participantId } }) => {
       let query = zql.calls
         .where('workspaceId', ctx.workspaceId)
         .where('callType', CallType.HEADLESS)
         .where('createdByUserId', ctx.userID)
         .orderBy('startedAt', 'desc')
         .orderBy('id', 'desc');
+
+      if (participantId) {
+        query = query.where(({ or, cmp }) =>
+          or(
+            cmp('createdByUserId', participantId),
+            cmp('recordingParticipants', 'LIKE', `%"${participantId}"%`),
+          ),
+        );
+      }
 
       if (start) {
         query = query.start({ id: start.id, startedAt: start.startedAt }, { inclusive: false });
@@ -2153,8 +2163,9 @@ export const queries = defineQueries({
     z.object({
       limit: z.number(),
       start: z.object({ id: z.string(), startedAt: z.number() }).nullable(),
+      participantId: z.string().nullable(),
     }),
-    ({ ctx, args: { limit, start } }) => {
+    ({ ctx, args: { limit, start, participantId } }) => {
       let query = zql.calls
         .where('workspaceId', ctx.workspaceId)
         .where('callType', CallType.HEADLESS)
@@ -2173,6 +2184,15 @@ export const queries = defineQueries({
         )
         .orderBy('startedAt', 'desc')
         .orderBy('id', 'desc');
+
+      if (participantId) {
+        query = query.where(({ or, cmp }) =>
+          or(
+            cmp('createdByUserId', participantId),
+            cmp('recordingParticipants', 'LIKE', `%"${participantId}"%`),
+          ),
+        );
+      }
 
       if (start) {
         query = query.start({ id: start.id, startedAt: start.startedAt }, { inclusive: false });

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1194,6 +1194,7 @@ export const callTable = table('calls')
     callUpdatesChannel: string().optional(),
     participantCount: number().optional(),
     participantPreviewUserIds: string().optional(),
+    recordingParticipants: string(),
     summaryTemplateId: string().optional(),
     labels: json<string[]>(),
     markedItems: json<any[]>(),


### PR DESCRIPTION


https://github.com/user-attachments/assets/3f8f6353-1e2a-4158-ba7a-207ed400d87d



Relands the recording-participants feature. The original landed as #849 and was reverted in `2c7ead5d2`.

## Why

Recordings were labelled by whoever pressed record, so a workspace of recordings all read the same creator name. This stores the people a recording is *about* on the call row and surfaces them everywhere the recording is listed.

## What

- **`calls.recordingParticipants`** — `TEXT NOT NULL DEFAULT '[]'`, stringified JSON `string[]`, seeded with the creator on headless call creation.
- **`POST /api/calls/recordings/:callId/participants`** — owner-only add/remove, serialised behind a per-call advisory lock.
- **Recordings list** — the row subtitle names the participants instead of the creator: `Sara Iyer & you`, `Just you`, `admin, SDLC Assistant & 2 others`.
- **Participants popover** on the recording header — search the directory, add/remove, and see who among them can actually open the recording, with an inline **Share** for the ones who cannot.
- **People filter** narrows server-side by participant rather than by creator, so it no longer forces a tab switch and lists the whole directory.

Worth deciding separately whether `getRecordingDetail` should return both fields, so the header doesn't depend on Zero winning a race.

## Proof of testing

Side-by-side capture of the running local stack — same build, same account, same fixture, same clicks, recorded twice with only `RecordingsV2Pill.tsx` and `RecordingDetailV2Header.tsx` toggled to HEAD.

<!-- POT VIDEO: drag recording-participants-POT.mp4 onto this line -->

Every assertion inverts:

| assertion | before | after |
|---|---|---|
| `Sara Iyer & you` (list subtitle) | ✗ | ✓ |
| `Just you` | ✗ | ✓ |
| `Participants` (popover) | ✗ | ✓ |
| `1 of 2 have access` | ✗ | ✓ |
| `Owner` | ✗ | ✓ |
| `Arjun Rao` (added live) | ✗ | ✓ |
| `1 of 3 have access` | ✗ | ✓ |
| `2 of 3 have access` (after inline Share) | ✗ | ✓ |
| `Sara Iyer, Arjun Rao & 1 other` (round-trip) | ✗ | ✓ |

The race fix above was caught by this POT, not by review — the first two `after` runs failed on `1 of 2 have access`.

## Migration

```sql
ALTER TABLE "public"."calls" ADD COLUMN "recordingParticipants" TEXT NOT NULL DEFAULT '[]';
```

Additive, no backfill. On PG 11+ a constant default is metadata-only — measured at **126 ms on a 1,000,000-row table** (`atthasmissing = t`, `attmissingval = {[]}`, no rewrite), so it does not scale with row count.

## Notes for review

- Local test run was skipped at the pre-commit prompt; CI covers it.
- Requires redeployment of **backend** and **dashboard**.
