### PR TITLE
feat: gate agent approval cards to the intended approver

### DIFF
--- a/apps/dashboard/src/components/flowUI/FlowScreenManager.tsx
+++ b/apps/dashboard/src/components/flowUI/FlowScreenManager.tsx
@@ -5,6 +5,9 @@ import { FlowRenderer } from './FlowRenderer';
 import type { FlowDefinition, AppActionResponse, FlowState } from '@xyne/shared';
 import { toast } from 'sonner';
 import type { FlowMessageContext } from './FlowContext';
+import { useAuthContextValues } from '../../hooks/useAuth';
+import { isApprovalHiddenFromViewer } from './approvalVisibility';
+import { RestrictedApprovalPlaceholder } from './RestrictedApprovalPlaceholder';
 
 interface FlowScreenManagerProps {
   /** Initial screen — rendered inline inside the message bubble */
@@ -36,6 +39,15 @@ export const FlowScreenManager: React.FC<FlowScreenManagerProps> = ({
   messageContext,
 }) => {
   const [screenStack, setScreenStack] = useState<FlowDefinition[]>([flow]);
+
+  // Visibility gate: some approval cards (HITL write, skill-update, clone,
+  // mcp-configure) are addressed to a SINGLE user — the server rejects any
+  // other clicker with a 403. Hide the actionable card from everyone except
+  // that intended approver so the rest of the thread isn't shown buttons they
+  // cannot use. Fails open: if the intended user can't be determined, or this
+  // isn't an approval card, the flow renders unchanged.
+  const { userID } = useAuthContextValues();
+  const hiddenFromViewer = isApprovalHiddenFromViewer(flow, userID);
 
   // Live re-sync of the inline (base) screen when the agent UPDATES this
   // message's flow in place — e.g. a plan/todo card advancing
@@ -141,6 +153,10 @@ export const FlowScreenManager: React.FC<FlowScreenManagerProps> = ({
       return [...prev.slice(0, -1), { ...last, state: cleanState }];
     });
   }, []);
+
+  if (hiddenFromViewer) {
+    return <RestrictedApprovalPlaceholder />;
+  }
 
   return (
     <>

--- a/apps/dashboard/src/components/flowUI/RestrictedApprovalPlaceholder.tsx
+++ b/apps/dashboard/src/components/flowUI/RestrictedApprovalPlaceholder.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Lock } from 'lucide-react';
+
+/**
+ * Shown in place of an approval card that is addressed to another member of the
+ * thread. It reveals no action details (tool, params, diff) — only that a
+ * pending approval exists and is not actionable by the current viewer.
+ */
+export const RestrictedApprovalPlaceholder: React.FC = () => {
+  return (
+    <div className='my-2 flex items-center gap-2 rounded-[10px] border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground'>
+      <Lock className='size-3.5 shrink-0' aria-hidden='true' />
+      <span>Approval requested — only the assigned reviewer can action this.</span>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/approvalVisibility.ts
+++ b/apps/dashboard/src/components/flowUI/approvalVisibility.ts
@@ -1,0 +1,64 @@
+import type { FlowDefinition } from '@xyne/shared';
+
+/**
+ * Visibility gating for agent-proposed approval cards.
+ *
+ * Some flow cards are *addressed to exactly one person*: a HITL write approval
+ * (KB upload, ticket/memory create, etc.), a skill-update approval, an
+ * agent-clone approval, or an MCP-configure request. The server already
+ * ENFORCES this — claw-auth's flow-action handler rejects any clicker whose id
+ * is not the intended user with a 403 ("Unauthorized"). But the card itself is
+ * posted as an ordinary channel message, so every member of the thread *sees*
+ * the actionable buttons even though only one of them can use them.
+ *
+ * This map lets the client hide the actionable card from everyone except the
+ * intended approver. It is a UI de-clutter / least-astonishment measure layered
+ * on top of the server authorization — it is NOT itself the security boundary
+ * (the message still syncs to every client; the real gate is the 403).
+ *
+ * The field that names the single allowed user DIFFERS per card type, so it is
+ * mapped explicitly. Only ACTIONABLE approval cards are listed here — result /
+ * status cards (e.g. a successful write result) carry no gated actionType and
+ * therefore stay visible to the whole thread.
+ */
+const RESTRICTED_FLOW_INTENDED_USER_FIELD: Record<string, string> = {
+  // HITL write approval — and the failed-write "Retry" card, which reuses
+  // actionType 'write' + userId. Both are actionable only by `userId`.
+  write: 'userId',
+  // update-skill approval (DM'd to the skill owner).
+  'skill-update': 'approverUserId',
+  // agent clone request (addressed to the source agent's owner).
+  'clone-approval': 'ownerUserId',
+  // MCP account/config request (addressed to the invoking user).
+  'mcp-configure': 'userId',
+};
+
+/**
+ * If `flow` is an approval card addressed to a single user, return that user's
+ * id; otherwise return null (the card is not visibility-restricted).
+ */
+export function intendedApproverId(flow: FlowDefinition): string | null {
+  const data = (flow?.data ?? {}) as Record<string, unknown>;
+  const actionType = typeof data.actionType === 'string' ? data.actionType : undefined;
+  if (!actionType) return null;
+  const field = RESTRICTED_FLOW_INTENDED_USER_FIELD[actionType];
+  if (!field) return null;
+  const uid = data[field];
+  return typeof uid === 'string' && uid.length > 0 ? uid : null;
+}
+
+/**
+ * True when this flow card is an approval addressed to someone OTHER than the
+ * current viewer, so the actionable card should be hidden from them.
+ * Fails OPEN: if we cannot determine the intended user, the card renders
+ * normally (unchanged behavior).
+ */
+export function isApprovalHiddenFromViewer(
+  flow: FlowDefinition,
+  currentUserId: string | null | undefined,
+): boolean {
+  const intended = intendedApproverId(flow);
+  if (!intended) return false;
+  if (!currentUserId) return false;
+  return intended !== currentUserId;
+}


### PR DESCRIPTION
## What
Agent-proposed approval cards (HITL write approvals — KB upload, ticket/memory create, etc. — plus skill-update, clone-approval, and mcp-configure) are posted into the thread as ordinary channel messages. Because Spaces messages are channel-scoped, every member of the thread sees the Approve/Decline buttons, even though only ONE user can actually act on them.

The server already enforces this: claw-auth's flow-action handler rejects any clicker who is not the intended user with a 403 ("Unauthorized"). This PR closes the matching **visibility** gap on the client — the actionable card is now hidden from everyone except the intended approver.

## How
- `apps/dashboard/src/components/flowUI/approvalVisibility.ts` — maps each restricted approval `actionType` to the field that names the single allowed user (`write`→`userId`, `skill-update`→`approverUserId`, `clone-approval`→`ownerUserId`, `mcp-configure`→`userId`) and exposes `isApprovalHiddenFromViewer(flow, currentUserId)`.
- `apps/dashboard/src/components/flowUI/FlowScreenManager.tsx` — reads the current user via `useAuthContextValues()` and short-circuits to a placeholder when the card is addressed to someone else.
- `apps/dashboard/src/components/flowUI/RestrictedApprovalPlaceholder.tsx` — a compact muted "Approval requested — only the assigned reviewer can action this." note that reveals no tool/params/diff.

## Scope & safety
- **Fails open**: if the intended user can't be determined (or it isn't an approval card), the flow renders unchanged.
- **Result/status cards stay visible to all** — a successful write-result card carries no gated `actionType`; only actionable approval/retry cards (which carry `actionType: 'write'` + `userId`) are gated.
- This is a UI de-clutter layered on top of the existing server-side authorization, **not** a new security boundary — the message still syncs to every client; the real gate remains the server 403.

## Test plan
- As a non-approver in a thread where an agent proposes a write/skill-update: see the muted placeholder, not the buttons.
- As the intended approver: see and use the Approve/Decline card as before.
- After approval: the success result remains visible to the whole thread.