### PR TITLE
feat(migration): self-serve Slack DM, group DM & channel migration (backport of #896 to release-20260825)

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -82,6 +82,15 @@ const envSchema = Joi.object({
   // Google Cloud Storage Configuration (Workload Identity)
   GCS_PROJECT_ID: Joi.string().allow('').default(''),
   GCS_BUCKET_NAME: Joi.string().allow('').default(''),
+  MIGRATION_GCS_BUCKET: Joi.string().allow('').default(''),
+  MIGRATION_ENC_KEYS: Joi.string().allow('').default('{}'),
+  MIGRATION_ENC_ACTIVE: Joi.string().allow('').default(''),
+  RUN_SLACK_MIGRATION_WORKERS: Joi.boolean().default(false),
+  MIGRATION_SLACK_PAGE_DELAY_MS: Joi.number().default(1000),      // pause between paged Slack calls during collection
+  MIGRATION_SLACK_FILE_TIMEOUT_MS: Joi.number().default(200000),  // per-attachment download timeout
+  MIGRATION_SLACK_REQUEST_TIMEOUT_MS: Joi.number().default(30000),// per Slack API request timeout (aborts hung pages)
+  MIGRATION_SLACK_STALL_LIMIT_MS: Joi.number().default(600000),   // no forward progress despite a live heartbeat ⇒ wedged (10 min)
+  MIGRATION_INGEST_MESSAGE_DELAY_MS: Joi.number().default(2),     // pause between messages at ingest (~500 msg/s cap)
   GCS_BUNDLE_BUCKET_NAME: Joi.string().allow('').default(''),
   GCS_CANVAS_BUCKET_NAME: Joi.string().allow('').default(''),
   GCS_DOCS_BUCKET_NAME: Joi.string().allow('').default(''),
@@ -614,9 +623,22 @@ export const config = {
     publicKey: envVars.LANGFUSE_PUBLIC_KEY,
     secretKey: envVars.LANGFUSE_SECRET_KEY,
   },
+  migrationEncryption: {
+    keys: envVars.MIGRATION_ENC_KEYS,
+    activeKeyId: envVars.MIGRATION_ENC_ACTIVE,
+  },
+  runSlackMigrationWorkers: envVars.RUN_SLACK_MIGRATION_WORKERS,
+  slackMigration: {
+    pageDelayMs: envVars.MIGRATION_SLACK_PAGE_DELAY_MS,
+    fileTimeoutMs: envVars.MIGRATION_SLACK_FILE_TIMEOUT_MS,
+    requestTimeoutMs: envVars.MIGRATION_SLACK_REQUEST_TIMEOUT_MS,
+    stallLimitMs: envVars.MIGRATION_SLACK_STALL_LIMIT_MS,
+    ingestMessageDelayMs: envVars.MIGRATION_INGEST_MESSAGE_DELAY_MS,
+  },
   gcs: {
     projectId: envVars.GCS_PROJECT_ID,
     bucketName: envVars.GCS_BUCKET_NAME,
+    migrationBucketName: envVars.MIGRATION_GCS_BUCKET,
     bundleBucketName: envVars.GCS_BUNDLE_BUCKET_NAME,
     canvasBucketName: envVars.GCS_CANVAS_BUCKET_NAME,
     docsBucketName: envVars.GCS_DOCS_BUCKET_NAME,

--- a/apps/backend/src/database/repositories/channelRepository.ts
+++ b/apps/backend/src/database/repositories/channelRepository.ts
@@ -234,6 +234,16 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
     });
   }
 
+  // Set lastActivityAt explicitly so a migrated DM lands at its real position, not the `now` placeholder.
+  async setLastActivity(channelId: string, at: Date): Promise<void> {
+    const workspaceId = await this.getWorkspaceId(channelId);
+    await this.db.channelStats.upsert({
+      where: { channelId },
+      update: { lastActivityAt: at },
+      create: { channelId, workspaceId, lastActivityAt: at },
+    });
+  }
+
   async incrementUnreadForAllMembers(channelId: string, increment: number): Promise<void> {
     if (increment <= 0) return;
     await this.db.channelUserStatus.updateMany({

--- a/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackOfflineReference.ts
+++ b/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackOfflineReference.ts
@@ -1,0 +1,22 @@
+import { AsyncLocalStorage } from 'async_hooks';
+
+/**
+ * Per-operation offline snapshot of Slack reference data (users, usergroups, channels)
+ * captured during migration collection. When present, fetchers resolve from it instead
+ * of calling Slack, so ingestion runs with zero Slack API calls. Values match fetcher
+ * return shapes; a miss returns null (no Slack fallback — ingestion must stay offline).
+ */
+export interface SlackOfflineReference {
+  users: Map<string, unknown>;    // SlackUserInfo shape
+  groups: Map<string, unknown>;   // SlackGroupInfo shape
+  channels: Map<string, { id: string; name: string; isPrivate: boolean }>;
+  /** Migration only: find-or-create a Xyne user by email so a not-yet-present mentioned person is created and linked. */
+  createUser?: (email: string, name: string, isDeactivated: boolean) => Promise<string | undefined>;
+}
+
+const store = new AsyncLocalStorage<SlackOfflineReference>();
+
+export const runWithSlackOfflineReference = <T>(ref: SlackOfflineReference, fn: () => Promise<T>): Promise<T> =>
+  store.run(ref, fn);
+
+export const slackOfflineReference = (): SlackOfflineReference | undefined => store.getStore();

--- a/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackUserResolver.ts
+++ b/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackUserResolver.ts
@@ -7,6 +7,7 @@ import { config } from '../../../../config/env';
 
 import { logger } from '../../../../utils/logger';
 import { getAllBotTokens } from '../../../../migration/slack/slackMigrationBotConfig';
+import { slackOfflineReference } from './slackOfflineReference';
 import { WebClient } from '@slack/web-api';
 
 /**
@@ -161,6 +162,8 @@ export async function fetchSlackUserInfo(
   slackUserId: string,
   botOauthToken: string
 ): Promise<SlackUserInfo | null> {
+  const offline = slackOfflineReference();
+  if (offline) return (offline.users.get(slackUserId) as SlackUserInfo) ?? null;
   const tokens = buildTokenFallbackList(botOauthToken);
   let bestResult: SlackUserInfo | null = null;
 
@@ -222,6 +225,8 @@ async function fetchSlackChannelInfo(
   channelId: string,
   botOauthToken: string
 ): Promise<{ id: string; name: string; isPrivate: boolean } | null> {
+  const offline = slackOfflineReference();
+  if (offline) return offline.channels.get(channelId) ?? null;
   const tokens = buildTokenFallbackList(botOauthToken);
 
   for (let i = 0; i < tokens.length; i++) {
@@ -273,6 +278,8 @@ async function requestSlackGroupInfo(slackGroupId: string, botOauthToken: string
  * first token that resolves the group with members; otherwise the best result.
  */
 async function fetchSlackGroupInfo(slackGroupId: string, botOauthToken: string): Promise<SlackGroupInfo | null> {
+  const offline = slackOfflineReference();
+  if (offline) return (offline.groups.get(slackGroupId) as SlackGroupInfo) ?? null;
   const tokens = buildTokenFallbackList(botOauthToken);
   let bestResult: SlackGroupInfo | null = null;
 
@@ -309,11 +316,26 @@ async function resolveApiUser(
     undefined;
 
   if (!slackUser?.profile?.email) {
+    // Offline migration: an author with no email (deactivated / external / missing scope) still has
+    // a name in the dump — create a best-effort placeholder so the message keeps its sender instead
+    // of being silently dropped. The live path (no offline ref) is unchanged.
+    const offline = slackOfflineReference();
+    if (offline?.createUser) {
+      const name = displayName || `Slack user ${slackUserId}`;
+      const dbUserId = await offline.createUser(`slack-${slackUserId}@migrated.invalid`, name, !!slackUser?.deleted);
+      if (dbUserId) return { dbUserId, displayName: name };
+    }
     return { displayName };
   }
   const userRepo = new UserRepository();
   const user = await userRepo.findByEmail(slackUser.profile.email, workspaceId);
-  return { dbUserId: user?.id, displayName };
+  if (user) return { dbUserId: user.id, displayName };
+  const offline = slackOfflineReference();
+  if (offline?.createUser) {
+    const dbUserId = await offline.createUser(slackUser.profile.email, displayName || slackUser.profile.email, !!slackUser.deleted);
+    return { dbUserId, displayName };
+  }
+  return { displayName };
 }
 
 /**

--- a/apps/backend/src/middleware/rateLimiters.ts
+++ b/apps/backend/src/middleware/rateLimiters.ts
@@ -30,6 +30,20 @@ export const aiTitleLimiter: RateLimitRequestHandler = rateLimit({
   legacyHeaders: false,
 });
 
+/** Per-user limiter for the self-serve Slack migration API (~2 req/s/user): above polling, blocks refresh/script spam. */
+export const slackMigrationLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 120,
+  keyGenerator: (req): string => req.user?.id ?? ipKeyGenerator(req.ip ?? 'unknown'),
+  message: {
+    success: false,
+    error: 'Too many migration requests. Please slow down and try again shortly.',
+    timestamp: new Date().toISOString(),
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 /**
  * Rate limiter for webhook endpoints
  * Applied to: /api/webhooks/* and external source sync routes

--- a/apps/backend/src/migration/index.ts
+++ b/apps/backend/src/migration/index.ts
@@ -5,7 +5,9 @@
 
 import express, { Router, Request, Response } from 'express';
 import { workspaceScopedRoute } from '@/database/tenant/context';
+import { authV2Middleware } from '@/middleware/authV2Middleware';
 import slackRoutes from './slack';
+import selfServeSlackRoutes from './self-serve';
 import jiraRoutes from './jira';
 import confluenceRoutes from './confluence';
 import whatsappRoutes from './whatsapp';
@@ -30,6 +32,9 @@ router.use(express.urlencoded({ extended: true, limit: '50mb', verify: rawBodyCa
 
 // Route to Slack migration
 router.use('/slack', workspaceScopedRoute, slackRoutes);
+
+// Self-serve Slack migration dashboard API (auth-gated, tenant-scoped) — migration pod at /migrate/api/migration/slack-migration/*.
+router.use('/slack-migration', authV2Middleware.authenticate, workspaceScopedRoute, selfServeSlackRoutes);
 
 // Route to Jira migration
 router.use('/jira', workspaceScopedRoute, jiraRoutes);

--- a/apps/backend/src/migration/scripts/ingestConversationSlack.ts
+++ b/apps/backend/src/migration/scripts/ingestConversationSlack.ts
@@ -42,6 +42,9 @@ export interface IngestConversationSlackInput {
    * Leave false/undefined for the regular channel flow (unchanged behaviour).
    */
   skipChannelMigratedUpdate?: boolean;
+  /** Pause (ms) between messages to cap DB/Vespa-queue rate (self-serve migration); 0/undefined = unpaced. */
+  interMessageDelayMs?: number;
+  onProgress?: () => void;
 }
 
 export interface IngestConversationSlackResult {
@@ -303,7 +306,7 @@ export const findOrCreateApp = async (
 export async function ingestConversationSlack(
   input: IngestConversationSlackInput
 ): Promise<IngestConversationSlackResult> {
-  const { slackMessages, externalSourceName, channelId, onlyReplies = false, workspaceId, userToken, botToken: inputBotToken, skipChannelMigratedUpdate = false } = input;
+  const { slackMessages, externalSourceName, channelId, onlyReplies = false, workspaceId, userToken, botToken: inputBotToken, skipChannelMigratedUpdate = false, interMessageDelayMs = 0, onProgress } = input;
 
   logger.info('[IngestSlack] Starting ingestion', {
     externalSourceName,
@@ -360,12 +363,15 @@ export async function ingestConversationSlack(
       }
 
       try {
-        const externalAttachments: ExternalAttachment[] = slackFiles.map((file) => ({
-          fileName: file.name,
-          fileUrl: file.url_private,
-          mimeType: file.mimetype,
-          size: file.size,
-        }));
+        const externalAttachments: ExternalAttachment[] = slackFiles
+          // Keep if prefetched (self-serve offline) or it has a url_private to fetch. Gating on
+          // userToken dropped attachments for callers without one; download failures skip downstream.
+          .filter((file) => file.prefetchedStoragePath || file.url_private)
+          .map((file) =>
+            file.prefetchedStoragePath
+              ? { fileName: file.name, mimeType: file.mimetype, size: file.size, storageSourcePath: file.prefetchedStoragePath, storageSourceEncrypted: true }
+              : { fileName: file.name, fileUrl: file.url_private, mimeType: file.mimetype, size: file.size },
+          );
         return await new ExternalAttachmentService().downloadAttachmentsForSource(
           externalSourceName,
           externalAttachments,
@@ -451,6 +457,13 @@ export async function ingestConversationSlack(
       // Download attachments (continues on failure)
       const downloadedAttachments = await downloadAttachments(slackFiles);
 
+      // If a message had files but none migrated and there's no text, use file name(s) as
+      // placeholder so the message isn't dropped.
+      let effectiveContent = content;
+      if ((!effectiveContent || !effectiveContent.trim()) && downloadedAttachments.length === 0 && (slackFiles?.length ?? 0) > 0) {
+        effectiveContent = slackFiles!.map((f) => `📎 ${f.name}`).join(' ');
+      }
+
       // Find or create conversation
       const existingConversationId = await findConversationByThread(externalThreadId);
       const isNewConversation = !existingConversationId;
@@ -464,7 +477,7 @@ export async function ingestConversationSlack(
         const result = await conversationService.createConversationWithMessage({
           channelId,
           userId: resolvedUserId,
-          content,
+          content: effectiveContent,
           msgType: MessageType.USER,
           uploadedFiles: downloadedAttachments,
           isBot: false,
@@ -483,7 +496,7 @@ export async function ingestConversationSlack(
         const result = await conversationService.addMessageToConversation({
           conversationId,
           userId: resolvedUserId,
-          content,
+          content: effectiveContent,
           msgType: MessageType.USER,
           uploadedFiles: downloadedAttachments,
           replyBroadcast: replyBroadcast ?? false,
@@ -513,7 +526,9 @@ export async function ingestConversationSlack(
     };
 
     // Process all messages
+    let ingestProgress = 0;
     for (const slackMessage of slackMessages) {
+      if (++ingestProgress % 200 === 0) onProgress?.();
       try {
         // Skip main message ingestion if onlyReplies is true
         if (!onlyReplies) {
@@ -607,6 +622,8 @@ export async function ingestConversationSlack(
         });
         // Continue with next message
       }
+      // Pace DB writes / Vespa-queue jobs when the caller asks (self-serve migration).
+      if (interMessageDelayMs > 0) await new Promise((r) => setTimeout(r, interMessageDelayMs));
     }
 
     logger.info('[IngestSlack] Ingestion completed', {

--- a/apps/backend/src/migration/self-serve/engine.ts
+++ b/apps/backend/src/migration/self-serve/engine.ts
@@ -1,0 +1,551 @@
+import { PassThrough } from 'stream';
+import readline from 'readline';
+import fetch from 'node-fetch';
+import { WebClient, LogLevel } from '@slack/web-api';
+import { ChannelRole } from '@xyne/shared';
+import { logger } from '@/utils/logger';
+import { config } from '@/config/env';
+import { decrypt } from '@/services/encryptionService';
+import { getStorageService } from '@/services/storage';
+import { runAsServiceActor } from '@/database/tenant/context';
+import { UserRepository } from '@/database/repositories/users';
+import { ChannelRepository } from '@/database/repositories/channelRepository';
+import { ChannelParticipantRepository } from '@/database/repositories/channelParticipantRepository';
+import { channelService } from '@/services/channelService';
+import {
+  findOrCreateUser,
+  findOrCreateApp,
+  ingestConversationSlack,
+} from '@/migration/scripts/ingestConversationSlack';
+import {
+  transformMessage,
+  collectRawFiles,
+  fetchPinnedMessageTimestamps,
+  isHumanMessage,
+  type UserInfoCache,
+} from '@/migration/slack/utils/extractConversation';
+import type { SlackMessage } from '@/migration/slack/utils/extractConversation';
+import { postMessage } from '@/migration/slack/utils/postMessage';
+import { getBotConfigByWorkspaceId } from '@/migration/slack/slackMigrationBotConfig';
+import { runWithSlackOfflineReference, type SlackOfflineReference } from '@/integrations/adapters/slack-webhook-tickets/utils/slackOfflineReference';
+import { encryptStream, decryptStream, encryptBuffer, decryptBuffer } from './migrationCrypto';
+import { ChannelInput, MigrationJob, MigrationType } from './types';
+
+const PAGE = 200;
+// Timing knobs (validated in config/env.ts): pageDelayMs (throttle paged Slack calls),
+// fileTimeoutMs (per-attachment), requestTimeoutMs (per Slack request), ingestMessageDelayMs (per-message DB/Vespa upper bound).
+const PAGE_DELAY_MS = config.slackMigration.pageDelayMs;
+const FILE_TIMEOUT_MS = config.slackMigration.fileTimeoutMs;
+const REQUEST_TIMEOUT_MS = config.slackMigration.requestTimeoutMs;
+const INGEST_MESSAGE_DELAY_MS = config.slackMigration.ingestMessageDelayMs;
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Route the Slack SDK's own diagnostics (esp. rate-limit "A rate limit was exceeded … retry in N seconds")
+// into our logs, so a stalled collection can be attributed to throttling vs. a genuinely hung request.
+const sdkLogger = {
+  debug: () => undefined,
+  info: (...m: unknown[]) => logger.info(`[SlackMigration:sdk] ${m.map(String).join(' ')}`),
+  warn: (...m: unknown[]) => logger.warn(`[SlackMigration:sdk] ${m.map(String).join(' ')}`),
+  error: (...m: unknown[]) => logger.error(`[SlackMigration:sdk] ${m.map(String).join(' ')}`),
+  setLevel: () => undefined,
+  getLevel: () => LogLevel.INFO,
+  setName: () => undefined,
+};
+// Per-request timeout so a hung page aborts (SDK retries) instead of wedging collection.
+const slackClient = (token: string) => new WebClient(token, { timeout: REQUEST_TIMEOUT_MS, logger: sdkLogger });
+
+// Time a Slack call and warn (with method + context) when it runs long, so a stall points at the exact culprit.
+async function timed<T>(label: string, ctx: Record<string, unknown>, fn: () => Promise<T>): Promise<T> {
+  const start = Date.now();
+  try {
+    const out = await fn();
+    const ms = Date.now() - start;
+    if (ms >= 5000) logger.warn(`[SlackMigration] slow ${label}`, { ms, ...ctx });
+    return out;
+  } catch (e) {
+    logger.warn(`[SlackMigration] ${label} errored`, { ms: Date.now() - start, ...ctx, error: e instanceof Error ? e.message : String(e) });
+    throw e;
+  }
+}
+
+/** Slack-hosted file we can fetch with the user token; external/tombstoned/deleted have no bytes and stay metadata-only. */
+const isDownloadableSlackFile = (f: any): boolean =>
+  !!f?.id &&
+  typeof f?.url_private === 'string' &&
+  !f.is_external &&
+  !f.external_type &&
+  f.mode !== 'external' &&
+  f.mode !== 'tombstone' &&
+  !f.file_deleted;
+
+const paths = {
+  manifest: (p: string) => `${p}/manifest.json`,
+  users: (p: string) => `${p}/users.json`,
+  conversation: (p: string, id: string) => `${p}/conversations/${id}.jsonl`,
+  pins: (p: string, id: string) => `${p}/pins/${id}.json`,
+  usergroups: (p: string) => `${p}/usergroups.json`,
+  channels: (p: string) => `${p}/channels.json`,
+  file: (p: string, fileId: string) => `${p}/files/${fileId}`,
+};
+
+export interface CollectedConversation { id: string; isMpim: boolean; members: string[]; }
+
+export interface DirUser { id: string; email?: string; real_name?: string; display_name?: string; is_bot?: boolean; deleted?: boolean; bot_id?: string; }
+
+/** Errors meaning "token can no longer read this conversation" (deactivated/left) — skipped so one dead conversation
+ *  doesn't fail the migration. Everything else (rate limit, network, auth) propagates and keeps the job resumable. */
+const SKIPPABLE_CONVERSATION_ERRORS = new Set(['channel_not_found', 'not_in_channel']);
+const slackErrorCode = (err: unknown): string | undefined => {
+  const e = err as { data?: { error?: string }; message?: string };
+  return e?.data?.error ?? e?.message?.replace(/^An API error occurred:\s*/, '');
+};
+const isSkippableConversationError = (err: unknown): boolean =>
+  SKIPPABLE_CONVERSATION_ERRORS.has(slackErrorCode(err) ?? '');
+
+/** Newest message time in a batch (Slack ts → Date), to place a new DM channel at its real spot. */
+const newestMessageDate = (messages: SlackMessage[]): Date | undefined => {
+  let maxTs = 0;
+  for (const m of messages) {
+    const t = parseFloat(m.externalId);
+    if (t > maxTs) maxTs = t;
+  }
+  return maxTs > 0 ? new Date(maxTs * 1000) : undefined;
+};
+
+/** Convert a YYYY-MM-DD start date to a Slack `oldest` ts (epoch seconds) for conversations.history. */
+const oldestFromStartDate = (startDate?: string): string | undefined => {
+  if (!startDate) return undefined;
+  const ms = Date.parse(startDate);
+  return Number.isNaN(ms) ? undefined : String(Math.floor(ms / 1000));
+};
+
+/**
+ * Self-serve pipeline engine: collection streams Slack → GCS (never buffered), loading reuses
+ * `transformMessage` + `ingestConversationSlack`. TODO: for full identity fidelity share code with
+ * the validated `ingestDumpLocal` loader — see PRD §5.11.
+ */
+export class SlackMigrationEngine {
+  /** Dedicated migration bucket isolated from app data; no fallback (fail loudly if unset).
+   *  Lazy so API-only pods that never run a job don't trip it. */
+  private get storage() {
+    const bucket = config.gcs.migrationBucketName;
+    if (!bucket) {
+      throw new Error('MIGRATION_GCS_BUCKET is not configured — self-serve migration requires a dedicated bucket');
+    }
+    return getStorageService(bucket);
+  }
+
+  async collectDirectory(token: string, gcsPrefix: string): Promise<Record<string, DirUser>> {
+    const client = slackClient(token);
+    const users: Record<string, DirUser> = {};
+    let cursor: string | undefined;
+    do {
+      const r = await client.users.list({ limit: 1000, cursor }); // large page → fewer requests, gentler on Tier-2 rate limit
+      for (const u of r.members ?? []) {
+        const p = (u as { profile?: { email?: string; real_name?: string; display_name?: string; bot_id?: string } }).profile ?? {};
+        users[(u as { id: string }).id] = {
+          id: (u as { id: string }).id, email: p.email, real_name: p.real_name,
+          display_name: p.display_name, is_bot: (u as { is_bot?: boolean }).is_bot ?? false,
+          deleted: (u as { deleted?: boolean }).deleted ?? false, bot_id: p.bot_id,
+        };
+      }
+      cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
+      if (cursor && PAGE_DELAY_MS > 0) await sleep(PAGE_DELAY_MS);
+    } while (cursor);
+    await this.writeJson(paths.users(gcsPrefix), users);
+    return users;
+  }
+
+  async listConversations(token: string, type: MigrationType, channel?: ChannelInput): Promise<CollectedConversation[]> {
+    if (type === MigrationType.CHANNEL) {
+      if (!channel) return [];
+      // Real Slack membership → synced as Xyne participants at ingest.
+      const members = await this.fetchChannelMembers(token, channel.slackChannelId);
+      return [{ id: channel.slackChannelId, isMpim: false, members }];
+    }
+    const client = slackClient(token);
+    const out: CollectedConversation[] = [];
+    let cursor: string | undefined;
+    do {
+      const r = await client.conversations.list({ types: 'im,mpim', limit: 1000, cursor });
+      for (const c of r.channels ?? []) {
+        const cc = c as { id: string; is_mpim?: boolean; user?: string };
+        // im carries the other user in `.user`; mpim (group DM) needs members fetched, else the loader drops it.
+        const members = cc.is_mpim ? await this.fetchChannelMembers(token, cc.id) : (cc.user ? [cc.user] : []);
+        out.push({ id: cc.id, isMpim: !!cc.is_mpim, members });
+      }
+      cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
+      if (cursor && PAGE_DELAY_MS > 0) await sleep(PAGE_DELAY_MS);
+    } while (cursor);
+    return out;
+  }
+
+  /** All member Slack user ids of a channel (paginated). */
+  private async fetchChannelMembers(token: string, channelId: string): Promise<string[]> {
+    const client = slackClient(token);
+    const members: string[] = [];
+    let cursor: string | undefined;
+    try {
+      do {
+        const r = await client.conversations.members({ channel: channelId, limit: 1000, cursor });
+        members.push(...(r.members ?? []));
+        cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
+        if (cursor && PAGE_DELAY_MS > 0) await sleep(PAGE_DELAY_MS);
+      } while (cursor);
+    } catch (e) {
+      logger.warn('[SlackMigration] conversations.members failed — channel participants may be incomplete', {
+        channelId, error: e instanceof Error ? e.message : String(e),
+      });
+    }
+    return members;
+  }
+
+  async collectConversation(token: string, conv: CollectedConversation, gcsPrefix: string, startDate?: string, onProgress?: (p: { messages: number; newestTs: number; oldestTs: number }) => Promise<void>): Promise<{ messages: number; outcome: 'ok' | 'truncated' | 'skipped'; reason?: string }> {
+    const client = slackClient(token);
+    const oldest = oldestFromStartDate(startDate);
+    const pinned = await fetchPinnedMessageTimestamps(client, conv.id).catch(() => new Set<string>());
+    const stream = new PassThrough();
+    const done = this.storage.uploadStreamToPath(encryptStream(stream), {
+      path: paths.conversation(gcsPrefix, conv.id), contentType: 'application/octet-stream',
+    });
+    let count = 0;
+    let outcome: 'ok' | 'truncated' | 'skipped' = 'ok';
+    let reason: string | undefined;
+    // history pages newest → oldest: newestTs fixes after page 1, oldestTs marches toward window start — drives the progress bar.
+    let newestTs = 0;
+    let oldestTs = Infinity;
+    let cursor: string | undefined;
+    let page = 0;
+    logger.debug('[SlackMigration] collecting conversation', { convId: conv.id, isMpim: conv.isMpim, members: conv.members.length });
+    try {
+      do {
+        const r = await timed('conversations.history', { convId: conv.id, page: page + 1, cursor: !!cursor }, () =>
+          client.conversations.history({ channel: conv.id, limit: PAGE, cursor, inclusive: true, oldest }));
+        page += 1;
+        logger.debug('[SlackMigration] history page', { convId: conv.id, page, messages: (r.messages ?? []).length, running: count });
+        for (const m of r.messages ?? []) {
+          await this.prefetchFiles(token, m, gcsPrefix);
+          if (((m as { reply_count?: number }).reply_count ?? 0) > 0 && (m as { ts?: string }).ts) {
+            const replies = await this.fetchReplies(token, conv.id, (m as { ts: string }).ts, gcsPrefix);
+            if (replies.length) (m as { _replies?: unknown[] })._replies = replies;
+          }
+          const ts = parseFloat((m as { ts?: string }).ts ?? '0');
+          if (ts > newestTs) newestTs = ts;
+          if (ts > 0 && ts < oldestTs) oldestTs = ts;
+          stream.write(`${JSON.stringify(m)}\n`);
+          count += 1;
+        }
+        if (onProgress) await onProgress({ messages: count, newestTs, oldestTs: oldestTs === Infinity ? 0 : oldestTs }); // live per-page progress
+        cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
+        if (cursor && PAGE_DELAY_MS > 0) await sleep(PAGE_DELAY_MS);
+      } while (cursor);
+    } catch (err) {
+      if (!isSkippableConversationError(err)) throw err;
+      const code = slackErrorCode(err);
+      if (code === 'channel_not_found') {
+        outcome = 'skipped';
+        reason = 'Channel not found on Slack (deleted or inaccessible).';
+      } else {
+        // not_in_channel: mid-collection ⇒ truncated (keep what we have); before any page ⇒ skipped.
+        outcome = count > 0 ? 'truncated' : 'skipped';
+        reason = count > 0
+          ? `Lost access after ~${count} messages (bot removed from the channel).`
+          : 'Bot is not in the channel.';
+      }
+      logger.warn('[SlackMigration] conversation not fully collected', { conversationId: conv.id, error: code, outcome });
+    } finally {
+      stream.end();
+    }
+    await done;
+    await this.writeJson(paths.pins(gcsPrefix, conv.id), [...pinned]);
+    return { messages: count, outcome, reason };
+  }
+
+  /** Reference dumps so ingestion resolves users/groups/channels offline (no Slack). */
+  async collectUsergroups(token: string, gcsPrefix: string): Promise<void> {
+    const groups: Record<string, unknown> = {};
+    try {
+      const r = await slackClient(token).usergroups.list({ include_users: true });
+      for (const g of r.usergroups ?? []) groups[(g as { id: string }).id] = g;
+    } catch (e) {
+      logger.warn('[SlackMigration] usergroups.list failed — mentions of usergroups will be unresolved', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+    await this.writeJson(paths.usergroups(gcsPrefix), groups);
+  }
+
+  async collectChannels(token: string, gcsPrefix: string): Promise<void> {
+    const client = slackClient(token);
+    const channels: Record<string, { id: string; name: string; isPrivate: boolean }> = {};
+    let cursor: string | undefined;
+    try {
+      do {
+        const r = await client.conversations.list({ types: 'public_channel,private_channel', limit: 1000, cursor, exclude_archived: false });
+        for (const c of r.channels ?? []) {
+          const cc = c as { id: string; name?: string; is_private?: boolean };
+          channels[cc.id] = { id: cc.id, name: cc.name || cc.id, isPrivate: !!cc.is_private };
+        }
+        cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
+        if (cursor && PAGE_DELAY_MS > 0) await sleep(PAGE_DELAY_MS);
+      } while (cursor);
+    } catch (e) {
+      logger.warn('[SlackMigration] conversations.list (channels) failed — channel mentions may be unresolved', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+    await this.writeJson(paths.channels(gcsPrefix), channels);
+  }
+
+  /** Stream every Slack-hosted file on a message (top-level or reply) → storage. */
+  private async prefetchFiles(token: string, m: unknown, gcsPrefix: string): Promise<void> {
+    for (const f of collectRawFiles(m)) {
+      if (!isDownloadableSlackFile(f)) continue;
+      const uri = await this.streamFileToGcs(token, f, gcsPrefix);
+      if (uri) f.prefetchedStoragePath = uri;
+    }
+  }
+
+  /** Fetch all replies of a thread (excluding the parent) and prefetch their files. */
+  private async fetchReplies(token: string, channelId: string, ts: string, gcsPrefix: string): Promise<unknown[]> {
+    const client = slackClient(token);
+    const replies: unknown[] = [];
+    let cursor: string | undefined;
+    do {
+      const r = await timed('conversations.replies', { channelId, ts }, () =>
+        client.conversations.replies({ channel: channelId, ts, limit: PAGE, cursor }));
+      for (const m of r.messages ?? []) {
+        if ((m as { ts?: string }).ts === ts) continue; // conversations.replies includes the parent first
+        await this.prefetchFiles(token, m, gcsPrefix);
+        replies.push(m);
+      }
+      cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
+      if (cursor && PAGE_DELAY_MS > 0) await sleep(PAGE_DELAY_MS);
+    } while (cursor);
+    return replies;
+  }
+
+  /** Stream one Slack-hosted file straight to storage (never buffered); returns its storage path. */
+  private async streamFileToGcs(token: string, file: { id: string; url_private: string; url_private_download?: string; mimetype?: string }, gcsPrefix: string): Promise<string | undefined> {
+    const dest = paths.file(gcsPrefix, file.id);
+    const url = file.url_private_download || file.url_private;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FILE_TIMEOUT_MS);
+    const startedAt = Date.now();
+    try {
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}`, 'User-Agent': 'Xyne-Spaces-Backend/1.0' },
+        signal: controller.signal,
+      });
+      if (!res.ok || !res.body) {
+        // Skip rather than fail the conversation — a 403 (missing files:read) or dead file shouldn't abort the migration.
+        logger.warn('[SlackMigration] attachment download failed — skipping', {
+          id: file.id, status: res.status, statusText: res.statusText,
+        });
+        return undefined;
+      }
+      const body = res.body as NodeJS.ReadableStream;
+      // node-fetch emits the abort/socket error on the body stream out-of-band; without a listener it becomes an
+      // uncaught exception that can crash the pod. Handle it here so a slow/aborted download is contained, not fatal.
+      body.on('error', (err: unknown) => logger.warn('[SlackMigration] attachment stream aborted — skipping', {
+        id: file.id, error: err instanceof Error ? err.message : String(err),
+      }));
+      await this.storage.uploadStreamToPath(encryptStream(body), {
+        path: dest,
+        contentType: 'application/octet-stream',
+      });
+      const ms = Date.now() - startedAt;
+      if (ms >= 5000) logger.warn('[SlackMigration] slow attachment download', { id: file.id, ms });
+      // Full gs://bucket/key URI so ingestion reads the migration bucket, not the default attachment storage.
+      return this.storage.buildStorageUri(dest);
+    } catch (e) {
+      logger.warn('[SlackMigration] attachment download errored — skipping', {
+        id: file.id, error: e instanceof Error ? e.message : String(e),
+      });
+      return undefined;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Build the offline Slack reference (users/groups/channels) from the collected dumps. */
+  async buildOfflineReference(gcsPrefix: string): Promise<SlackOfflineReference> {
+    const [usersRec, groupsRec, channelsRec] = await Promise.all([
+      this.readJson<Record<string, DirUser>>(paths.users(gcsPrefix)).catch(() => ({} as Record<string, DirUser>)),
+      this.readJson<Record<string, unknown>>(paths.usergroups(gcsPrefix)).catch(() => ({} as Record<string, unknown>)),
+      this.readJson<Record<string, { id: string; name: string; isPrivate: boolean }>>(paths.channels(gcsPrefix)).catch(() => ({} as Record<string, { id: string; name: string; isPrivate: boolean }>)),
+    ]);
+    return {
+      users: new Map(Object.entries(usersRec).map(([id, u]) => [id, {
+        id, is_bot: u.is_bot, deleted: u.deleted,
+        profile: { email: u.email, real_name: u.real_name, display_name: u.display_name, bot_id: u.bot_id },
+      }])),
+      groups: new Map(Object.entries(groupsRec)),
+      channels: new Map(Object.entries(channelsRec)),
+    };
+  }
+
+  async loadConversation(job: MigrationJob, conv: CollectedConversation, ref: SlackOfflineReference, onProgress?: () => void): Promise<{ ingested: number; failed: number }> {
+    return runAsServiceActor('slack-migration', job.workspaceId, async () => {
+      const userRepo = new UserRepository();
+      const channelRepo = new ChannelRepository();
+      const participantRepo = new ChannelParticipantRepository();
+      const cache: UserInfoCache = new Map();
+      const provCache = new Map<string, { id: string; isDeactivated: boolean }>();
+
+      const resolve = async (slackId: string): Promise<string | undefined> => {
+        const u = ref.users.get(slackId) as { profile?: { email?: string; real_name?: string; display_name?: string }; is_bot?: boolean; deleted?: boolean } | undefined;
+        const email = u?.profile?.email;
+        if (!email || u?.is_bot) return undefined;
+        const name = u?.profile?.display_name || u?.profile?.real_name || email;
+        const id = await findOrCreateUser(email, name, !!u?.deleted, userRepo, provCache, job.workspaceId);
+        if (id) cache.set(slackId, { userId: id, userEmail: email, userName: name, isBot: false });
+        return id ?? undefined;
+      };
+
+      // Let the offline resolver create a mentioned user from their dumped email, so the mention
+      // links to a real Xyne user even if they never posted / aren't a member.
+      ref.createUser = async (email, name, isDeactivated) => {
+        try { return await findOrCreateUser(email, name, isDeactivated, userRepo, provCache, job.workspaceId); }
+        catch { return undefined; }
+      };
+
+      const isChannel = job.type === MigrationType.CHANNEL;
+      // Self-DM ("notes to self") has only the owner as member — no "other" side, so otherIds resolution would wrongly drop it.
+      const isSelfDm = !isChannel && conv.members.length > 0 && conv.members.every((m) => m === job.ownerSlackId);
+
+      // DM: resolve both sides up front (bail if we can't). Channel: ingests into the pre-selected Xyne channel (resolved after empty check).
+      let dmOwnerId: string | undefined;
+      const dmOtherIds: string[] = [];
+      if (isChannel) {
+        if (!job.channelInput?.xyneChannelId) return { ingested: 0, failed: 0 };
+      } else {
+        dmOwnerId = job.ownerSlackId ? await resolve(job.ownerSlackId) : undefined;
+        if (!dmOwnerId) return { ingested: 0, failed: 0 };
+        if (!isSelfDm) {
+          for (const m of conv.members) if (m !== job.ownerSlackId) { const id = await resolve(m); if (id) dmOtherIds.push(id); }
+          if (dmOtherIds.length === 0) return { ingested: 0, failed: 0 };
+        }
+      }
+
+      const pinnedTs = new Set(await this.readJson<string[]>(paths.pins(job.gcsPrefix, conv.id)).catch(() => []));
+
+      // Transform with the offline reference active so mentions, author lookups and usergroup import all resolve from the dumps, never Slack.
+      const stream = await this.storage.createReadStream(paths.conversation(job.gcsPrefix, conv.id));
+      const rl = readline.createInterface({ input: decryptStream(stream), crlfDelay: Infinity });
+      const messages: SlackMessage[] = await runWithSlackOfflineReference(ref, async () => {
+        const out: SlackMessage[] = [];
+        for await (const line of rl) {
+          if (!line.trim()) continue;
+          let raw: unknown;
+          try { raw = JSON.parse(line); } catch { continue; }
+          // Drop Slack system messages ("X joined the channel", topic changes) and env-ignored bots,
+          // matching the existing /sync flow (isHumanMessage); real bot content is still kept.
+          if (!isHumanMessage(raw, 'channel', [], true)) continue;
+          out.push(await transformMessage(raw as never, (raw as { _replies?: never[] })._replies, cache, true, true, true, pinnedTs, job.workspaceId, ''));
+        }
+        return out;
+      });
+      if (messages.length === 0) return { ingested: 0, failed: 0 };
+
+      // Channel → the requester's chosen Xyne channel. DM → find/create it (only now we know it has messages, so an empty DM never pins to the top).
+      const channelId = isChannel
+        ? job.channelInput!.xyneChannelId
+        : isSelfDm
+          ? await channelService.ensureSelfDmExists(dmOwnerId!, job.workspaceId) // canonical self-DM (same as login)
+          : await channelRepo.findOrCreateDMChannel(dmOwnerId!, dmOtherIds, participantRepo, job.workspaceId);
+
+      if (isChannel) {
+        // Slack channel creator → Xyne ADMIN (matches /sync). First, because the member loop's
+        // default-role addParticipant returns existing participants unchanged, so the creator stays ADMIN.
+        if (job.slackChannelCreator) {
+          const creatorId = await resolve(job.slackChannelCreator);
+          if (creatorId) await participantRepo.addParticipant(channelId, creatorId, ChannelRole.ADMIN).catch(() => undefined);
+        }
+        // Sync real Slack members (captured at collection) as participants — humans via the user dump, bots as app users. All offline.
+        const botCache: UserInfoCache = new Map();
+        for (const slackId of conv.members) {
+          const u = ref.users.get(slackId) as { is_bot?: boolean; profile?: { real_name?: string; display_name?: string; bot_id?: string } } | undefined;
+          let participantId: string | undefined;
+          if (u?.is_bot && u.profile?.bot_id) {
+            const botName = u.profile.display_name || u.profile.real_name || 'bot';
+            participantId = await findOrCreateApp(botName, u.profile.bot_id, botCache, slackId, job.workspaceId).catch(() => undefined);
+          } else {
+            participantId = await resolve(slackId);
+          }
+          if (participantId) await participantRepo.addParticipant(channelId, participantId).catch(() => undefined);
+        }
+      } else {
+        // Place the new DM at its real last-message time so it never jumps to the top.
+        const newest = newestMessageDate(messages);
+        if (newest) await channelRepo.setLastActivity(channelId, newest);
+      }
+
+      const ingestResult = await ingestConversationSlack({
+        slackMessages: messages,
+        externalSourceName: `${isChannel ? 'channelMigration' : 'dmMigration'}-${channelId}`,
+        channelId,
+        workspaceId: job.workspaceId,
+        botToken: 'slack-migration-offline',
+        interMessageDelayMs: INGEST_MESSAGE_DELAY_MS,
+        onProgress,
+      });
+      await channelRepo.recalculateLastActivityFromMessages(channelId);
+      return { ingested: messages.length, failed: ingestResult.errorDetails?.length ?? 0 };
+    });
+  }
+
+  /** Opt-in: post a "migrated to Xyne Spaces" notice back into Slack via the central bot token
+   *  (the per-job token is already dropped by ingest time). */
+  async announceMigration(job: MigrationJob): Promise<void> {
+    if (job.type !== MigrationType.CHANNEL || !job.channelInput?.announceInSlack) return;
+    const wsConfig = getBotConfigByWorkspaceId(job.workspaceId);
+    if (!wsConfig.notificationsEnabled) return;
+    const link = `<https://spaces.xyne.juspay.net/${job.workspaceId}/chat/dir/${job.channelInput.xyneChannelId}|Xyne Spaces>`;
+    let text = `<!channel> This Channel has been migrated to ${link}. Please move your conversations there only this channel will be soon archived.`;
+    if (wsConfig.migrationFinalMessage) text += `\n${wsConfig.migrationFinalMessage}`;
+    await postMessage({
+      channelId: job.channelInput.slackChannelId,
+      text,
+      botToken: wsConfig.slackBotToken,
+    });
+  }
+
+  async deletePrefix(prefix: string): Promise<void> {
+    // StorageService has no prefix-delete; enumerate and delete each object.
+    const files = await this.storage.listFiles(prefix);
+    for (const f of files) {
+      await this.storage.deleteFile(f.name).catch((e: unknown) =>
+        logger.warn('[SlackMigration] failed to delete object during cleanup', {
+          name: f.name, error: e instanceof Error ? e.message : String(e),
+        }),
+      );
+    }
+  }
+
+  decryptToken(job: MigrationJob): string {
+    if (!job.encryptedToken) throw new Error('migration token missing');
+    return decrypt(job.encryptedToken);
+  }
+
+  writeManifest(gcsPrefix: string, conversations: CollectedConversation[]): Promise<void> {
+    return this.writeJson(paths.manifest(gcsPrefix), conversations);
+  }
+
+  readManifest(gcsPrefix: string): Promise<CollectedConversation[]> {
+    return this.readJson<CollectedConversation[]>(paths.manifest(gcsPrefix));
+  }
+
+  private async writeJson(path: string, data: unknown): Promise<void> {
+    const encrypted = encryptBuffer(Buffer.from(JSON.stringify(data)));
+    await this.storage.uploadFileV2(encrypted, { path, contentType: 'application/octet-stream' });
+  }
+
+  private async readJson<T>(path: string): Promise<T> {
+    const stream = await this.storage.createReadStream(path);
+    const chunks: Buffer[] = [];
+    for await (const c of stream as AsyncIterable<Buffer>) chunks.push(Buffer.from(c));
+    const plain = decryptBuffer(Buffer.concat(chunks));
+    return JSON.parse(plain.toString('utf8')) as T;
+  }
+}

--- a/apps/backend/src/migration/self-serve/index.ts
+++ b/apps/backend/src/migration/self-serve/index.ts
@@ -1,0 +1,46 @@
+import { Router } from 'express';
+import { config } from '@/config/env';
+import { logger } from '@/utils/logger';
+import { getStorageService } from '@/services/storage';
+import { MigrationStore } from './store';
+import { MigrationQueues } from './queues';
+import { SlackMigrationEngine } from './engine';
+import { SlackMigrationService } from './service';
+import { MigrationWorkers } from './workers';
+import { buildRouter } from './routes';
+
+/**
+ * Composition root for self-serve Slack migration, mounted at
+ * /migrate/api/migration/slack-migration/*. Queues run one-at-a-time (§5.4).
+ * Workers are opt-in via RUN_SLACK_MIGRATION_WORKERS on the single migration pod;
+ * other pods serve the API only.
+ */
+const store = new MigrationStore();
+const queues = new MigrationQueues();
+const engine = new SlackMigrationEngine();
+const service = new SlackMigrationService(store, queues, engine);
+
+if (config.runSlackMigrationWorkers) {
+  // Ensure the migration bucket exists before workers run (idempotent; auto-creates in fake-gcs).
+  if (config.gcs.migrationBucketName) {
+    void getStorageService(config.gcs.migrationBucketName)
+      .ensureBucketExists()
+      .catch((e: unknown) =>
+        logger.error('[SlackMigration] failed to ensure migration bucket exists', {
+          bucket: config.gcs.migrationBucketName, error: e instanceof Error ? e.message : String(e),
+        }),
+      );
+  } else {
+    logger.warn('[SlackMigration] MIGRATION_GCS_BUCKET is not set — migration jobs will fail until it is configured');
+  }
+  // Ingestion starts paused: approvals only stage jobs until SLACK-MIGRATION-INGEST starts it.
+  void queues.pauseIngestionOnFirstInit().catch((e: unknown) =>
+    logger.error('[SlackMigration] failed to initialise ingestion queue paused', {
+      error: e instanceof Error ? e.message : String(e),
+    }),
+  );
+  new MigrationWorkers(queues, store, engine).register();
+}
+
+const router: Router = buildRouter(service);
+export default router;

--- a/apps/backend/src/migration/self-serve/migrationCrypto.ts
+++ b/apps/backend/src/migration/self-serve/migrationCrypto.ts
@@ -1,0 +1,190 @@
+/**
+ * Envelope encryption for migration-bucket objects: per-object DEK encrypts bytes
+ * (AES-256-GCM), wrapped by the active KEK (id stored per object) so rotation re-wraps
+ * DEKs, not data. Keep old KEKs in MIGRATION_ENC_KEYS for reads; MIGRATION_ENC_ACTIVE = new one.
+ *
+ * Layout: ["XME1"|ver|keyIdLen|keyId|wrapIv(12)|wrapTag(16)|wrappedDek(32)|dataIv(12)][ciphertext][tag(16)]
+ */
+import { Transform, Readable } from 'stream';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { config } from '@/config/env';
+
+const MAGIC = Buffer.from('XME1');
+const VERSION = 1;
+const IV_LEN = 12;
+const TAG_LEN = 16;
+const DEK_LEN = 32;
+const WRAPPED_DEK_LEN = 32;
+
+// ── Key store (parsed once from env) ────────────────────────────────────────
+let cachedStore: Map<string, Buffer> | null = null;
+
+function keyStore(): Map<string, Buffer> {
+  if (cachedStore) return cachedStore;
+  let parsed: Record<string, string>;
+  try {
+    parsed = JSON.parse(config.migrationEncryption.keys || '{}');
+  } catch {
+    throw new Error('MIGRATION_ENC_KEYS is not valid JSON (expected {"k1":"<64-hex>", ...})');
+  }
+  const store = new Map<string, Buffer>();
+  for (const [id, hex] of Object.entries(parsed)) {
+    const key = Buffer.from(hex, 'hex');
+    if (key.length !== DEK_LEN) {
+      throw new Error(`MIGRATION_ENC_KEYS["${id}"] must be 32 bytes (64 hex chars), got ${key.length}`);
+    }
+    store.set(id, key);
+  }
+  cachedStore = store;
+  return store;
+}
+
+function activeKek(): { keyId: string; kek: Buffer } {
+  const keyId = config.migrationEncryption.activeKeyId;
+  if (!keyId) throw new Error('MIGRATION_ENC_ACTIVE is not set — migration encryption requires an active key');
+  const kek = keyStore().get(keyId);
+  if (!kek) throw new Error(`MIGRATION_ENC_ACTIVE="${keyId}" is not present in MIGRATION_ENC_KEYS`);
+  return { keyId, kek };
+}
+
+function lookupKek(keyId: string): Buffer {
+  const kek = keyStore().get(keyId);
+  if (!kek) throw new Error(`migration crypto: KEK "${keyId}" not in MIGRATION_ENC_KEYS (retired but still referenced?)`);
+  return kek;
+}
+
+/** True once a valid active key is configured — lets callers fail fast at submit time. */
+export function isMigrationEncryptionConfigured(): boolean {
+  try { activeKek(); return true; } catch { return false; }
+}
+
+// ── Header codec ────────────────────────────────────────────────────────────
+/** Fresh DEK + IVs, wrapped by the active KEK → the header that precedes the ciphertext. */
+function seal(): { header: Buffer; dek: Buffer; dataIv: Buffer } {
+  const { keyId, kek } = activeKek();
+  const dek = randomBytes(DEK_LEN);
+  const wrapIv = randomBytes(IV_LEN);
+  const dataIv = randomBytes(IV_LEN);
+
+  const wrap = createCipheriv('aes-256-gcm', kek, wrapIv);
+  const wrappedDek = Buffer.concat([wrap.update(dek), wrap.final()]);
+  const wrapTag = wrap.getAuthTag();
+
+  const idBuf = Buffer.from(keyId, 'utf8');
+  if (idBuf.length > 255) throw new Error('migration crypto: keyId too long');
+  const header = Buffer.concat([
+    MAGIC, Buffer.from([VERSION, idBuf.length]), idBuf, wrapIv, wrapTag, wrappedDek, dataIv,
+  ]);
+  return { header, dek, dataIv };
+}
+
+/** Parse a header buffer and unwrap the DEK using the referenced KEK. */
+function open(buf: Buffer): { dek: Buffer; dataIv: Buffer; headerLen: number } {
+  if (buf.length < 6 || !buf.subarray(0, 4).equals(MAGIC)) {
+    throw new Error('migration crypto: bad magic (object not encrypted with this scheme?)');
+  }
+  if (buf[4] !== VERSION) throw new Error(`migration crypto: unsupported version ${buf[4]}`);
+  const keyIdLen = buf[5];
+  const headerLen = 6 + keyIdLen + IV_LEN + TAG_LEN + WRAPPED_DEK_LEN + IV_LEN;
+  if (buf.length < headerLen) throw new Error('migration crypto: truncated header');
+
+  let o = 6;
+  const keyId = buf.subarray(o, o + keyIdLen).toString('utf8'); o += keyIdLen;
+  const wrapIv = buf.subarray(o, o + IV_LEN); o += IV_LEN;
+  const wrapTag = buf.subarray(o, o + TAG_LEN); o += TAG_LEN;
+  const wrappedDek = buf.subarray(o, o + WRAPPED_DEK_LEN); o += WRAPPED_DEK_LEN;
+  const dataIv = buf.subarray(o, o + IV_LEN); o += IV_LEN;
+
+  const unwrap = createDecipheriv('aes-256-gcm', lookupKek(keyId), wrapIv);
+  unwrap.setAuthTag(wrapTag);
+  const dek = Buffer.concat([unwrap.update(wrappedDek), unwrap.final()]);
+  return { dek, dataIv, headerLen };
+}
+
+// ── Streaming ───────────────────────────────────────────────────────────────
+/** Prepends the header, AES-256-GCM-encrypts the body, appends the tag last. */
+class EncryptTransform extends Transform {
+  private wroteHeader = false;
+  constructor(private readonly header: Buffer, private readonly cipher: ReturnType<typeof createCipheriv>) { super(); }
+  private ensureHeader(): void { if (!this.wroteHeader) { this.push(this.header); this.wroteHeader = true; } }
+  _transform(chunk: Buffer, _enc: BufferEncoding, cb: (e?: Error | null) => void): void {
+    this.ensureHeader();
+    this.push(this.cipher.update(chunk));
+    cb();
+  }
+  _flush(cb: (e?: Error | null) => void): void {
+    this.ensureHeader();
+    this.push(this.cipher.final());
+    this.push((this.cipher as ReturnType<typeof createCipheriv> & { getAuthTag(): Buffer }).getAuthTag());
+    cb();
+  }
+}
+
+/** Reads the header, then decrypts — holding back a 16-byte tail so the trailing GCM tag applies at the end. */
+class DecryptTransform extends Transform {
+  private buf = Buffer.alloc(0);
+  private decipher: ReturnType<typeof createDecipheriv> | null = null;
+  _transform(chunk: Buffer, _enc: BufferEncoding, cb: (e?: Error | null) => void): void {
+    this.buf = Buffer.concat([this.buf, chunk]);
+    try {
+      if (!this.decipher) {
+        if (this.buf.length < 6) return cb();
+        const keyIdLen = this.buf[5];
+        const headerLen = 6 + keyIdLen + IV_LEN + TAG_LEN + WRAPPED_DEK_LEN + IV_LEN;
+        if (this.buf.length < headerLen) return cb();
+        const { dek, dataIv } = open(this.buf.subarray(0, headerLen));
+        this.decipher = createDecipheriv('aes-256-gcm', dek, dataIv);
+        this.buf = this.buf.subarray(headerLen);
+      }
+      // everything but the trailing TAG_LEN bytes is ciphertext we can decrypt now
+      if (this.buf.length > TAG_LEN) {
+        const body = this.buf.subarray(0, this.buf.length - TAG_LEN);
+        this.buf = this.buf.subarray(this.buf.length - TAG_LEN);
+        this.push(this.decipher.update(body));
+      }
+      cb();
+    } catch (e) { cb(e as Error); }
+  }
+  _flush(cb: (e?: Error | null) => void): void {
+    if (!this.decipher) return cb(new Error('migration crypto: object too small / missing header'));
+    if (this.buf.length !== TAG_LEN) return cb(new Error('migration crypto: missing auth tag'));
+    try {
+      (this.decipher as ReturnType<typeof createDecipheriv> & { setAuthTag(t: Buffer): void }).setAuthTag(this.buf);
+      this.push(this.decipher.final()); // throws on tamper / wrong key
+      cb();
+    } catch (e) { cb(e as Error); }
+  }
+}
+
+/** Encrypt a stream: plaintext → [header][ciphertext][tag]. Bounded memory. */
+export function encryptStream(plaintext: NodeJS.ReadableStream): Readable {
+  const { header, dek, dataIv } = seal();
+  const t = new EncryptTransform(header, createCipheriv('aes-256-gcm', dek, dataIv));
+  plaintext.on('error', (e) => t.destroy(e as Error));
+  return plaintext.pipe(t);
+}
+
+/** Decrypt a stream produced by encryptStream/encryptBuffer. Bounded memory. */
+export function decryptStream(ciphertext: NodeJS.ReadableStream): Readable {
+  const t = new DecryptTransform();
+  ciphertext.on('error', (e) => t.destroy(e as Error));
+  return ciphertext.pipe(t);
+}
+
+// ── Buffers (small JSON blobs) ──────────────────────────────────────────────
+export function encryptBuffer(plain: Buffer): Buffer {
+  const { header, dek, dataIv } = seal();
+  const c = createCipheriv('aes-256-gcm', dek, dataIv);
+  const body = Buffer.concat([c.update(plain), c.final()]);
+  return Buffer.concat([header, body, c.getAuthTag()]);
+}
+
+export function decryptBuffer(enc: Buffer): Buffer {
+  const { dek, dataIv, headerLen } = open(enc);
+  const tag = enc.subarray(enc.length - TAG_LEN);
+  const body = enc.subarray(headerLen, enc.length - TAG_LEN);
+  const d = createDecipheriv('aes-256-gcm', dek, dataIv);
+  d.setAuthTag(tag);
+  return Buffer.concat([d.update(body), d.final()]);
+}
+

--- a/apps/backend/src/migration/self-serve/queues.ts
+++ b/apps/backend/src/migration/self-serve/queues.ts
@@ -1,0 +1,76 @@
+import Bull from 'bull';
+import { getBaseRedisOptions } from '@/services/redisFactory';
+import { QueueName } from './types';
+
+interface JobRef { migrationId: string; }
+
+/** Two serial (concurrency 1) queues — one-at-a-time for accountability (§5.4). Resume position: `lifo`=front (admin-stopped), normal add=end (failure). */
+export class MigrationQueues {
+  private readonly queues = new Map<QueueName, Bull.Queue<JobRef>>();
+
+  constructor() {
+    for (const name of [QueueName.COLLECTION, QueueName.INGESTION]) {
+      this.queues.set(
+        name,
+        new Bull<JobRef>(name, {
+          redis: { ...getBaseRedisOptions('bullmq'), lazyConnect: false },
+          defaultJobOptions: { attempts: 1, removeOnComplete: true, removeOnFail: true },
+          settings: { lockDuration: 5 * 60_000, stalledInterval: 30_000, maxStalledCount: 1 },
+        }),
+      );
+    }
+  }
+
+  async enqueue(name: QueueName, migrationId: string, position: 'front' | 'end'): Promise<Bull.Job<JobRef>> {
+    const q = this.queue(name);
+    await this.evict(q, migrationId);
+    return q.add(
+      { migrationId },
+      { jobId: migrationId, ...(position === 'front' ? { lifo: true } : {}) },
+    );
+  }
+
+  async removeJob(name: QueueName, migrationId: string): Promise<void> {
+    await this.evict(this.queue(name), migrationId);
+  }
+
+  async hasJob(name: QueueName, migrationId: string): Promise<boolean> {
+    return (await this.queue(name).getJob(migrationId)) != null;
+  }
+
+  /** Bull's view of a job: 'active' | 'waiting' | 'delayed' | 'completed' | 'failed' | 'stuck', or null if absent. */
+  async jobState(name: QueueName, migrationId: string): Promise<string | null> {
+    const job = await this.queue(name).getJob(migrationId);
+    return job ? job.getState() : null;
+  }
+
+  private async evict(q: Bull.Queue<JobRef>, migrationId: string): Promise<void> {
+    const existing = await q.getJob(migrationId);
+    if (!existing) return;
+    await existing.remove().catch(async () => {
+      await existing.moveToFailed({ message: 'superseded' }, true).catch(() => undefined);
+      await existing.remove().catch(() => undefined);
+    });
+  }
+
+  process(name: QueueName, handler: (migrationId: string) => Promise<void>): void {
+    this.queue(name).process(1, (job) => handler(job.data.migrationId));
+  }
+
+  pause(name: QueueName): Promise<void> { return this.queue(name).pause(); }
+  resume(name: QueueName): Promise<void> { return this.queue(name).resume(); }
+  isPaused(name: QueueName): Promise<boolean> { return this.queue(name).isPaused(); }
+
+  /** On first-ever init, pause ingestion so approved jobs only stage until someone with SLACK-MIGRATION-INGEST starts it. NX marker keeps restarts from re-pausing in-progress ingestion. */
+  async pauseIngestionOnFirstInit(): Promise<void> {
+    const q = this.queue(QueueName.INGESTION);
+    const firstInit = await q.client.set('slackmig:ingestion:initialized', '1', 'NX');
+    if (firstInit) await q.pause();
+  }
+
+  private queue(name: QueueName): Bull.Queue<JobRef> {
+    const q = this.queues.get(name);
+    if (!q) throw new Error(`queue ${name} not initialized`);
+    return q;
+  }
+}

--- a/apps/backend/src/migration/self-serve/routes.ts
+++ b/apps/backend/src/migration/self-serve/routes.ts
@@ -1,0 +1,90 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import { slackMigrationLimiter } from '@/middleware/rateLimiters';
+import { Actor, HttpError, SlackMigrationService } from './service';
+import { QueueName } from './types';
+
+const ok = (data: unknown) => ({ success: true, data });
+const fail = (code: string, message: string) => ({ success: false, error: { code, message } });
+
+interface AuthedUser { id: string; workspaceId: string; name?: string; email?: string; role?: string; orgRole?: string; }
+
+const actorOf = (req: Request): Actor => {
+  const u = (req as Request & { user?: AuthedUser }).user;
+  if (!u) throw new HttpError(401, 'UNAUTHORIZED', 'Authentication required');
+  return { userId: u.id, workspaceId: u.workspaceId, name: u.name, email: u.email };
+};
+
+const requireAdmin = (service: SlackMigrationService) =>
+  (req: Request, _res: Response, next: NextFunction): void => {
+    const u = (req as Request & { user?: AuthedUser }).user;
+    if (!u) return next(new HttpError(401, 'UNAUTHORIZED', 'Authentication required'));
+    if (u.role === 'ADMIN' || u.role === 'OWNER' || u.orgRole === 'OWNER' || u.orgRole === 'ADMIN') return next();
+    // Fall back to the TICKET-MIGRATION resource — its admins manage Slack migrations too.
+    service.hasMigrationAdminResource(u.id)
+      .then((ok) => (ok ? next() : next(new HttpError(403, 'FORBIDDEN', 'Admin access required'))))
+      .catch(() => next(new HttpError(403, 'FORBIDDEN', 'Admin access required')));
+  };
+
+const wrap = (fn: (req: Request, res: Response) => Promise<void>) =>
+  (req: Request, res: Response, next: NextFunction): void => { fn(req, res).catch(next); };
+
+export function buildRouter(service: SlackMigrationService): Router {
+  const router = Router();
+  const admin = requireAdmin(service);
+  router.use(slackMigrationLimiter); // per-user throttle — this feature runs on one pod
+
+
+  // ── Member ────────────────────────────────────────────────────────────────
+  router.post('/dm', wrap(async (req, res) => {
+    res.status(202).json(ok(await service.submitDm(actorOf(req), req.body?.token)));
+  }));
+  router.post('/channel', wrap(async (req, res) => {
+    res.status(202).json(ok(await service.submitChannel(actorOf(req), {
+      slackChannelId: req.body?.slackChannelId,
+      xyneChannelId: req.body?.xyneChannelId,
+      startDate: req.body?.startDate,
+      announceInSlack: !!req.body?.announceInSlack,
+    })));
+  }));
+  router.get('/mine', wrap(async (req, res) => { res.json(ok(await service.getMineList(actorOf(req)))); }));
+  // Owner self-service: the submitter can resume/delete their OWN jobs (service asserts ownership) — no admin needed.
+  router.post('/mine/:id/resume', wrap(async (req, res) => { res.json(ok(await service.resume(req.params.id, actorOf(req), true))); }));
+  router.delete('/mine/:id', wrap(async (req, res) => { await service.remove(req.params.id, actorOf(req), true); res.json(ok({ deleted: true })); }));
+
+  // ── Jobs (admin-gated: list + act on every migration in the workspace) ──────
+  router.get('/migration-jobs', admin, wrap(async (req, res) => {
+    res.json(ok(await service.listForAdmin(actorOf(req))));
+  }));
+  router.get('/migration-jobs/export', admin, wrap(async (req, res) => { res.json(ok(await service.listForAdmin(actorOf(req), 1000))); }));
+
+  // ── Ingestion control — gated by SLACK-MIGRATION-INGEST, not the admin role.
+  //    `approve` only stages jobs; these start/stop the worker.
+  router.get('/ingestion', wrap(async (req, res) => {
+    res.json(ok(await service.ingestionStatus(actorOf(req).userId)));
+  }));
+  router.post('/ingestion/start', wrap(async (req, res) => {
+    res.json(ok(await service.startIngestion(actorOf(req).userId)));
+  }));
+  router.post('/ingestion/stop', wrap(async (req, res) => {
+    res.json(ok(await service.stopIngestion(actorOf(req).userId)));
+  }));
+
+  router.post('/migration-jobs/:id/approve', admin, wrap(async (req, res) => { res.json(ok(await service.approve(req.params.id, actorOf(req)))); }));
+  router.post('/migration-jobs/:id/stop', admin, wrap(async (req, res) => { res.json(ok(await service.stop(req.params.id, actorOf(req)))); }));
+  router.post('/migration-jobs/:id/resume', admin, wrap(async (req, res) => { res.json(ok(await service.resume(req.params.id, actorOf(req)))); }));
+  router.delete('/migration-jobs/:id', admin, wrap(async (req, res) => { await service.remove(req.params.id, actorOf(req)); res.json(ok({ deleted: true })); }));
+  router.post('/queues/:queue/pause', admin, wrap(async (req, res) => {
+    await service.pauseQueue(req.params.queue as QueueName); res.json(ok({ paused: req.params.queue }));
+  }));
+  router.post('/queues/:queue/resume', admin, wrap(async (req, res) => {
+    await service.resumeQueue(req.params.queue as QueueName); res.json(ok({ resumed: req.params.queue }));
+  }));
+
+  // Scoped error handler → consistent envelope
+  router.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    if (err instanceof HttpError) return res.status(err.statusCode).json(fail(err.code, err.message));
+    return res.status(500).json(fail('INTERNAL_ERROR', 'Something went wrong'));
+  });
+
+  return router;
+}

--- a/apps/backend/src/migration/self-serve/service.ts
+++ b/apps/backend/src/migration/self-serve/service.ts
@@ -1,0 +1,317 @@
+import { randomUUID } from 'crypto';
+import { WebClient } from '@slack/web-api';
+import { AccessType } from '@xyne/shared';
+import { encrypt } from '@/services/encryptionService';
+import { repositories } from '@/database/repositories';
+import { ChannelRepository } from '@/database/repositories/channelRepository';
+import { isMigrationEncryptionConfigured } from './migrationCrypto';
+import { config } from '@/config/env';
+import { getWorkspaceIdByTeamId } from '@/migration/slack/slackMigrationBotConfig';
+import { SlackMigrationEngine } from './engine';
+import { MigrationStore } from './store';
+import { MigrationQueues } from './queues';
+import {
+  ChannelInput,
+  MigrationJob,
+  MigrationJobView,
+  MigrationStatus,
+  MigrationType,
+  QueueName,
+  toView,
+} from './types';
+
+export interface Actor { userId: string; workspaceId: string; name?: string; email?: string; }
+
+export class HttpError extends Error {
+  constructor(readonly statusCode: number, readonly code: string, message: string) {
+    super(message);
+  }
+}
+
+// Env separation comes from the dedicated MIGRATION_GCS_BUCKET, not the key.
+const gcsPrefix = (id: string) => `slack-migration/${id}`;
+
+export class SlackMigrationService {
+  constructor(
+    private readonly store: MigrationStore,
+    private readonly queues: MigrationQueues,
+    private readonly engine: SlackMigrationEngine,
+  ) {}
+
+  async submitDm(actor: Actor, tokenInput: string): Promise<MigrationJobView> {
+    this.assertEncryptionReady();
+    const token = tokenInput?.trim();
+    if (!token?.startsWith('xox')) throw new HttpError(400, 'VALIDATION_ERROR', 'A valid Slack user token is required');
+
+    const slack = new WebClient(token);
+    const auth = await slack.auth.test().catch(() => null);
+    if (!auth?.team_id || !auth?.user_id) throw new HttpError(400, 'VALIDATION_ERROR', 'Slack rejected the token (auth.test failed)');
+
+    // Identity check: token's Slack email must match the signed-in Xyne email — blocks migrating someone else's DMs with a borrowed token.
+    const info = await slack.users.info({ user: auth.user_id as string }).catch(() => null);
+    const slackEmail = (info?.user as { profile?: { email?: string } } | undefined)?.profile?.email?.trim().toLowerCase();
+    const xyneEmail = actor.email?.trim().toLowerCase();
+    if (!slackEmail) {
+      throw new HttpError(422, 'EMAIL_UNAVAILABLE', 'Could not read the Slack account email from this token (it may be missing the users:read.email scope).');
+    }
+    if (!xyneEmail || slackEmail !== xyneEmail) {
+      throw new HttpError(403, 'EMAIL_MISMATCH', `This Slack token belongs to ${slackEmail}, which does not match your Xyne account${xyneEmail ? ` (${xyneEmail})` : ''}. Submit a token for your own Slack account.`);
+    }
+
+    const workspaceId = getWorkspaceIdByTeamId(auth.team_id as string);
+    if (!workspaceId) {
+      throw new HttpError(422, 'UNMAPPED_WORKSPACE', `No Xyne workspace is mapped to Slack team ${auth.team_id}`);
+    }
+    // Token's workspace must match the actor's, else owner and target workspace diverge.
+    if (actor.workspaceId !== workspaceId) {
+      throw new HttpError(403, 'WORKSPACE_MISMATCH', "This token belongs to a different workspace than the one you're in. Submit it from that workspace's dashboard.");
+    }
+    if (await this.store.hasDmMigration(workspaceId, actor.userId)) {
+      throw new HttpError(409, 'CONFLICT', 'You already have a DM migration. An admin must delete it before you can submit again.');
+    }
+
+    const job = this.build(MigrationType.DM, actor, workspaceId, auth.team_id as string, {
+      ownerSlackId: auth.user_id as string,
+      encryptedToken: encrypt(token),
+    });
+    return this.persistAndQueue(job);
+  }
+
+  async submitChannel(actor: Actor, input: ChannelInput): Promise<MigrationJobView> {
+    this.assertEncryptionReady();
+    if (!input.slackChannelId || !input.xyneChannelId) {
+      throw new HttpError(400, 'VALIDATION_ERROR', 'slackChannelId and xyneChannelId are required');
+    }
+    if (await this.store.hasChannelMigration(actor.workspaceId, input.slackChannelId)) {
+      throw new HttpError(409, 'CONFLICT', 'A migration for this channel is already in progress. You can request it again once it completes.');
+    }
+    const token = config.slackBotToken;
+    if (!token) throw new HttpError(400, 'VALIDATION_ERROR', 'Central Slack workspace token is not configured');
+    const slack = new WebClient(token);
+    const auth = await slack.auth.test().catch(() => null);
+    if (!auth?.team_id) throw new HttpError(400, 'VALIDATION_ERROR', 'Central token auth.test failed');
+
+    // Resolve readable names up front — this also validates both channels exist.
+    const info = await slack.conversations.info({ channel: input.slackChannelId }).catch(() => null);
+    const ch = info?.channel as { name?: string; creator?: string; created?: number; is_member?: boolean } | undefined;
+    const slackChannelName = ch?.name;
+    if (!slackChannelName) {
+      throw new HttpError(422, 'CHANNEL_NOT_FOUND', `Slack channel ${input.slackChannelId} not found, or the migration bot isn't in it.`);
+    }
+    if (!ch?.is_member) {
+      throw new HttpError(422, 'BOT_NOT_IN_CHANNEL', `The Xyne Spaces bot isn't in #${slackChannelName}. In Slack, open the channel and run "/invite @Xyne Spaces", then submit again.`);
+    }
+    // Fail CLOSED: the requester must be a verified member of the Slack channel. If we can't
+    // resolve their Slack id or the member list, reject — never skip the check.
+    if (!actor.email) throw new HttpError(403, 'IDENTITY_UNVERIFIED', 'Cannot verify your Slack identity — sign in again.');
+    let submitterSlackId: string | undefined;
+    try {
+      const r = await slack.users.lookupByEmail({ email: actor.email });
+      submitterSlackId = (r.user as { id?: string } | undefined)?.id;
+    } catch {
+      throw new HttpError(403, 'IDENTITY_UNVERIFIED', 'Could not verify your Slack account (the migration bot may be missing the users:read.email scope). Ask an admin to grant it.');
+    }
+    if (!submitterSlackId) throw new HttpError(403, 'NOT_A_CHANNEL_MEMBER', `No Slack account matches ${actor.email}.`);
+    let members: string[];
+    try {
+      members = await this.channelMemberIds(slack, input.slackChannelId);
+    } catch {
+      throw new HttpError(502, 'MEMBERSHIP_CHECK_FAILED', `Couldn't verify who's in #${slackChannelName} — please try again.`);
+    }
+    if (!members.includes(submitterSlackId)) {
+      throw new HttpError(403, 'NOT_A_CHANNEL_MEMBER', `You're not a member of #${slackChannelName}. Join it in Slack, then request the migration.`);
+    }
+    const xyneChannel = await new ChannelRepository().findById(input.xyneChannelId);
+    if (!xyneChannel || xyneChannel.workspaceId !== actor.workspaceId) {
+      throw new HttpError(422, 'CHANNEL_NOT_FOUND', `No Xyne channel found for id ${input.xyneChannelId} in this workspace.`);
+    }
+    // Must be a member of the DESTINATION Xyne channel — not just the workspace — or anyone
+    // could dump a private Slack channel into a channel they don't belong to.
+    if (!(await repositories.channelParticipants.isParticipant(input.xyneChannelId, actor.userId))) {
+      throw new HttpError(403, 'NOT_A_CHANNEL_MEMBER', `You must be a member of the destination Xyne channel "${xyneChannel.name}" to migrate into it.`);
+    }
+
+    const job = this.build(MigrationType.CHANNEL, actor, actor.workspaceId, auth.team_id as string, {
+      encryptedToken: encrypt(token),
+      channelInput: input,
+      slackChannelName,
+      xyneChannelName: xyneChannel.name,
+      slackChannelCreator: ch?.creator,
+      slackChannelCreated: ch?.created,
+    });
+    return this.persistAndQueue(job);
+  }
+
+  /** All member Slack ids of a channel (paginated) — used to confirm the requester is in it. */
+  private async channelMemberIds(slack: WebClient, channelId: string): Promise<string[]> {
+    const members: string[] = [];
+    let cursor: string | undefined;
+    do {
+      const r = await slack.conversations.members({ channel: channelId, limit: 1000, cursor });
+      members.push(...(r.members ?? []));
+      cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
+    } while (cursor);
+    return members;
+  }
+
+  async approve(id: string, actor: Actor): Promise<MigrationJobView> {
+    const job = await this.mustGet(id, actor);
+    if (job.status !== MigrationStatus.AWAITING_APPROVAL) {
+      throw new HttpError(409, 'INVALID_STATE', `Only a migration awaiting approval can be approved (current: ${job.status})`);
+    }
+    const updated = await this.store.update(id, { currentQueue: QueueName.INGESTION });
+    await this.queues.enqueue(QueueName.INGESTION, id, 'end');
+    return toView(updated);
+  }
+
+  async stop(id: string, actor: Actor): Promise<MigrationJobView> {
+    const job = await this.mustGet(id, actor);
+    if (job.status === MigrationStatus.QUEUED) {
+      await this.queues.removeJob(job.currentQueue, id).catch(() => undefined);
+      return toView(await this.store.update(id, { status: MigrationStatus.STOPPED, stopReason: 'admin' }));
+    }
+    if (![MigrationStatus.COLLECTING, MigrationStatus.INGESTING].includes(job.status)) {
+      throw new HttpError(409, 'INVALID_STATE', `Only a running migration can be stopped (current: ${job.status})`);
+    }
+    // Record reason (not identity) so the submitter sees a deliberate admin stop, not a failure.
+    return toView(await this.store.update(id, { stopRequested: true, stopReason: 'admin' }));
+  }
+
+  async resume(id: string, actor: Actor, requireOwner = false): Promise<MigrationJobView> {
+    const job = await this.mustGet(id, actor);
+    if (requireOwner) this.assertOwner(job, actor);
+    if (![MigrationStatus.STOPPED, MigrationStatus.FAILED].includes(job.status)) {
+      throw new HttpError(409, 'INVALID_STATE', `Only a stopped or failed migration can be resumed (current: ${job.status})`);
+    }
+    // Admin-stopped ⇒ front (resumes next); failed/pod-killed ⇒ end (don't block others). §5.9
+    const position = job.status === MigrationStatus.STOPPED ? 'front' : 'end';
+    const updated = await this.store.update(id, { status: MigrationStatus.QUEUED, stopRequested: false, stopReason: undefined });
+    await this.queues.enqueue(job.currentQueue, id, position);
+    return toView(updated);
+  }
+
+  async remove(id: string, actor: Actor, requireOwner = false): Promise<void> {
+    const job = await this.mustGet(id, actor);
+    if (requireOwner) this.assertOwner(job, actor);
+    if ([MigrationStatus.COLLECTING, MigrationStatus.INGESTING].includes(job.status)) {
+      throw new HttpError(409, 'INVALID_STATE', 'Stop the migration before deleting it.');
+    }
+    if (job.status !== MigrationStatus.COMPLETED) {
+      await this.engine.deletePrefix(job.gcsPrefix); // completed jobs already deleted their data
+    }
+    await this.queues.removeJob(QueueName.COLLECTION, id).catch(() => undefined);
+    await this.queues.removeJob(QueueName.INGESTION, id).catch(() => undefined);
+    await this.store.delete(id);
+  }
+
+  async listForAdmin(actor: Actor, limit = 500): Promise<MigrationJobView[]> {
+    // Scope to the caller's workspace — slackmig:index is global, so filter after fetch.
+    return (await this.store.list(limit, 0)).filter((j) => j.workspaceId === actor.workspaceId).map(toView);
+  }
+
+  async getMineList(actor: Actor): Promise<MigrationJobView[]> {
+    return (await this.store.list(500, 0)).filter((j) => j.submittedByUserId === actor.userId).map(toView);
+  }
+
+  // Generic queue controls are COLLECTION-only; ingestion must use the gated
+  // start/stop so blanket-admin endpoints can't bypass SLACK-MIGRATION-INGEST.
+  pauseQueue(name: QueueName): Promise<void> {
+    this.assertControllableQueue(name);
+    return this.queues.pause(name);
+  }
+  resumeQueue(name: QueueName): Promise<void> {
+    this.assertControllableQueue(name);
+    return this.queues.resume(name);
+  }
+  // Only the collection queue is controllable here (ingestion is gated separately). An unknown name
+  // (the route casts `req.params.queue as QueueName` unvalidated) must be a clean 400, not a raw 500.
+  private assertControllableQueue(name: QueueName): void {
+    if (name === QueueName.INGESTION) throw new HttpError(403, 'FORBIDDEN', 'Use the gated Start/Stop Ingestion control for the ingestion queue.');
+    if (name !== QueueName.COLLECTION) throw new HttpError(400, 'VALIDATION_ERROR', `Unknown queue "${name}".`);
+  }
+
+  // ── Ingestion control (gated by the SLACK-MIGRATION-INGEST resource) ─────────
+  // `approve` only stages onto the paused ingestion queue; starting/stopping it
+  // requires the SLACK-MIGRATION-INGEST grant — the admin role is not enough.
+
+  /** True if the user holds the ingestion permission (drives the UI + guards start/stop). */
+  async canIngest(userId: string): Promise<boolean> {
+    const resource = await repositories.resources.findByName('SLACK-MIGRATION-INGEST');
+    if (!resource) return false;
+    return repositories.resourceAccess.hasAccess(userId, resource.id, AccessType.ADMIN);
+  }
+
+  /** TICKET-MIGRATION admins manage Slack migrations too — this gates the admin panel alongside the workspace role. */
+  async hasMigrationAdminResource(userId: string): Promise<boolean> {
+    const resource = await repositories.resources.findByName('TICKET-MIGRATION');
+    if (!resource) return false;
+    return repositories.resourceAccess.hasAccess(userId, resource.id, AccessType.ADMIN);
+  }
+
+  private async assertCanIngest(userId: string): Promise<void> {
+    if (!(await this.canIngest(userId))) {
+      throw new HttpError(403, 'FORBIDDEN', 'You do not have permission to start or stop migration ingestion.');
+    }
+  }
+
+  /** canIngest + whether the ingestion queue is currently running (not paused). */
+  async ingestionStatus(userId: string): Promise<{ canIngest: boolean; running: boolean }> {
+    const [canIngest, paused] = await Promise.all([
+      this.canIngest(userId),
+      this.queues.isPaused(QueueName.INGESTION),
+    ]);
+    return { canIngest, running: !paused };
+  }
+
+  async startIngestion(userId: string): Promise<{ running: boolean }> {
+    await this.assertCanIngest(userId);
+    await this.queues.resume(QueueName.INGESTION);
+    return { running: true };
+  }
+
+  async stopIngestion(userId: string): Promise<{ running: boolean }> {
+    await this.assertCanIngest(userId);
+    await this.queues.pause(QueueName.INGESTION);
+    return { running: false };
+  }
+
+  private assertEncryptionReady(): void {
+    if (!isMigrationEncryptionConfigured()) {
+      throw new HttpError(500, 'CONFIG_ERROR', 'Migration encryption is not configured (set MIGRATION_ENC_KEYS and MIGRATION_ENC_ACTIVE).');
+    }
+  }
+
+  private build(type: MigrationType, actor: Actor, workspaceId: string, teamId: string, extra: Partial<MigrationJob>): MigrationJob {
+    const id = randomUUID();
+    const now = Date.now();
+    return {
+      id, type, status: MigrationStatus.SUBMITTED, currentQueue: QueueName.COLLECTION,
+      workspaceId, submittedByUserId: actor.userId, submittedByName: actor.name, teamId,
+      gcsPrefix: gcsPrefix(id),
+      checkpoint: { totalConversations: 0, collectedConversationIds: [], ingestedConversationIds: [] },
+      stats: { conversations: 0, messages: 0 },
+      stopRequested: false, heartbeatAt: now, createdAt: now, updatedAt: now,
+      ...extra,
+    };
+  }
+
+  private async persistAndQueue(job: MigrationJob): Promise<MigrationJobView> {
+    await this.store.create(job);
+    await this.queues.enqueue(QueueName.COLLECTION, job.id, 'end');
+    return toView(job);
+  }
+
+  private async mustGet(id: string, actor: Actor): Promise<MigrationJob> {
+    const job = await this.store.findById(id);
+    // 404 (not 403) for another workspace's job — don't leak that the id exists.
+    if (!job || job.workspaceId !== actor.workspaceId) throw new HttpError(404, 'NOT_FOUND', 'Migration not found');
+    return job;
+  }
+
+  /** For member (non-admin) actions: the caller must be the person who submitted the job. */
+  private assertOwner(job: MigrationJob, actor: Actor): void {
+    if (job.submittedByUserId !== actor.userId) {
+      throw new HttpError(403, 'FORBIDDEN', 'You can only manage your own migration.');
+    }
+  }
+}

--- a/apps/backend/src/migration/self-serve/store.ts
+++ b/apps/backend/src/migration/self-serve/store.ts
@@ -1,0 +1,249 @@
+import { createRedisClient } from '@/services/redisFactory';
+import { Checkpoint, MigrationIssue, MigrationJob, MigrationStatus, MigrationType } from './types';
+
+const TTL_SECONDS = 60 * 60 * 24 * 182; // ~6 months
+const KEY = (id: string) => `slackmig:job:${id}`;
+const INDEX = 'slackmig:index';
+const DM_LOCK = (workspaceId: string, userId: string) => `slackmig:dmlock:${workspaceId}:${userId}`;
+const CHANNEL_LOCK = (workspaceId: string, slackChannelId: string) => `slackmig:chanlock:${workspaceId}:${slackChannelId}`;
+const channelKeyOf = (job: MigrationJob): string | undefined =>
+  job.type === MigrationType.CHANNEL ? job.channelInput?.slackChannelId : undefined;
+
+const emptyCheckpoint = (): Checkpoint => ({ totalConversations: 0, collectedConversationIds: [], ingestedConversationIds: [] });
+
+/**
+ * Map a MigrationJob-shaped patch onto Redis HASH fields.
+ *  - `stats` is flattened to two numeric fields so counts move via atomic HINCRBY, never a read-modify-write of a blob.
+ *  - nested objects are stored as JSON in a single field; `stopRequested` as '0'/'1'.
+ *  - an explicit `undefined` in the patch means "clear this field" → HDEL (e.g. dropping the token at the approval gate).
+ */
+function encodePatch(patch: Partial<MigrationJob>): { set: Record<string, string>; del: string[] } {
+  const set: Record<string, string> = {};
+  const del: string[] = [];
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) {
+      if (k === 'stats') del.push('statsConversations', 'statsMessages');
+      else del.push(k);
+      continue;
+    }
+    switch (k) {
+      case 'stats': {
+        const s = v as MigrationJob['stats'];
+        set.statsConversations = String(s.conversations);
+        set.statsMessages = String(s.messages);
+        break;
+      }
+      case 'stopRequested':
+        set.stopRequested = v ? '1' : '0';
+        break;
+      case 'checkpoint':
+      case 'channelInput':
+      case 'channelProgress':
+      case 'issues':
+        set[k] = JSON.stringify(v);
+        break;
+      default:
+        set[k] = String(v);
+    }
+  }
+  return { set, del };
+}
+
+/**
+ * Source of truth for a migration: a Redis HASH (6-month TTL). Bull jobs carry only the id; bulk data lives in GCS.
+ *
+ * Why a HASH and not a JSON blob: the heartbeat ticker fires every 15s in parallel with the worker's own writes.
+ * With a whole-record read-modify-write, a stale heartbeat snapshot would clobber freshly-written stats/checkpoint/issues.
+ * Per-field writes make each mutation touch only what it owns — heartbeat writes `heartbeatAt`, counts move via HINCRBY —
+ * so no write can lose another's data.
+ */
+export class MigrationStore {
+  // createRedisClient attaches an 'error' listener — a bare `new Redis(...)` would let an
+  // 'error' event go unhandled and crash the whole backend if Redis is briefly unreachable.
+  private readonly redis = createRedisClient('slack-migration-store');
+
+  async create(job: MigrationJob): Promise<void> {
+    await this.persist(job);
+    await this.redis.zadd(INDEX, job.createdAt, job.id);
+    if (job.type === MigrationType.DM) {
+      await this.redis.set(DM_LOCK(job.workspaceId, job.submittedByUserId), job.id, 'EX', TTL_SECONDS);
+    }
+    const chan = channelKeyOf(job);
+    if (chan) await this.redis.set(CHANNEL_LOCK(job.workspaceId, chan), job.id, 'EX', TTL_SECONDS);
+  }
+
+  async findById(id: string): Promise<MigrationJob | null> {
+    const h = await this.redis.hgetall(KEY(id));
+    if (!h || Object.keys(h).length === 0) return null;
+    return decode(h);
+  }
+
+  async update(id: string, patch: Partial<MigrationJob>): Promise<MigrationJob> {
+    // HSET on a missing key would resurrect a deleted job as a partial record — guard first.
+    if ((await this.redis.exists(KEY(id))) !== 1) throw new Error(`migration ${id} not found`);
+    const { set, del } = encodePatch({ ...patch, updatedAt: Date.now() });
+    const pipe = this.redis.pipeline();
+    if (Object.keys(set).length) pipe.hset(KEY(id), set);
+    if (del.length) pipe.hdel(KEY(id), ...del);
+    pipe.expire(KEY(id), TTL_SECONDS);
+    await pipe.exec();
+    const next = await this.mustGet(id);
+    // Channels are re-migratable: release the per-channel lock once ingestion completes.
+    const chan = channelKeyOf(next);
+    if (chan && patch.status === MigrationStatus.COMPLETED) {
+      await this.redis.del(CHANNEL_LOCK(next.workspaceId, chan));
+    }
+    return next;
+  }
+
+  /** Liveness only — writes the single `heartbeatAt` field so it can never clobber a concurrent stats/checkpoint write. */
+  async heartbeat(id: string): Promise<void> {
+    const now = String(Date.now());
+    await this.redis.hset(KEY(id), 'heartbeatAt', now, 'updatedAt', now);
+    await this.redis.expire(KEY(id), TTL_SECONDS);
+  }
+
+  /** Forward-progress signal for the stall watchdog: a page actually advanced (distinct from mere liveness/heartbeat). */
+  async markProgress(id: string): Promise<void> {
+    const now = String(Date.now());
+    await this.redis.hset(KEY(id), 'progressAt', now, 'heartbeatAt', now);
+    await this.redis.expire(KEY(id), TTL_SECONDS);
+  }
+
+  async addCollected(id: string, conversationId: string, messages: number): Promise<void> {
+    const cp = await this.readCheckpoint(id);
+    cp.collectedConversationIds.push(conversationId);
+    const now = String(Date.now());
+    const pipe = this.redis.pipeline();
+    pipe.hset(KEY(id), 'checkpoint', JSON.stringify(cp), 'progressAt', now, 'heartbeatAt', now, 'updatedAt', now);
+    pipe.hincrby(KEY(id), 'statsConversations', 1);
+    if (messages) pipe.hincrby(KEY(id), 'statsMessages', messages);
+    pipe.expire(KEY(id), TTL_SECONDS);
+    await pipe.exec();
+  }
+
+  async setChannelProgress(id: string, p: { messages: number; start: number; end: number; through: number }): Promise<void> {
+    // Channel message count is live/authoritative (a single conversation), so set it absolute rather than incrementing.
+    const now = String(Date.now());
+    await this.redis.hset(
+      KEY(id),
+      'statsMessages', String(p.messages),
+      'channelProgress', JSON.stringify({ start: p.start, end: p.end, through: p.through }),
+      'progressAt', now,
+      'heartbeatAt', now,
+      'updatedAt', now,
+    );
+    await this.redis.expire(KEY(id), TTL_SECONDS);
+  }
+
+  async addIngested(id: string, conversationId: string): Promise<void> {
+    const cp = await this.readCheckpoint(id);
+    cp.ingestedConversationIds.push(conversationId);
+    const now = String(Date.now());
+    await this.redis.hset(KEY(id), 'checkpoint', JSON.stringify(cp), 'progressAt', now, 'heartbeatAt', now, 'updatedAt', now);
+    await this.redis.expire(KEY(id), TTL_SECONDS);
+  }
+
+  /** Record a conversation that couldn't be fully collected/ingested so the UI can show it. */
+  async addIssue(id: string, issue: MigrationIssue): Promise<void> {
+    const raw = await this.redis.hget(KEY(id), 'issues');
+    const issues: MigrationIssue[] = raw ? (JSON.parse(raw) as MigrationIssue[]) : [];
+    issues.push(issue);
+    const now = String(Date.now());
+    await this.redis.hset(KEY(id), 'issues', JSON.stringify(issues), 'heartbeatAt', now, 'updatedAt', now);
+    await this.redis.expire(KEY(id), TTL_SECONDS);
+  }
+
+  async isStopRequested(id: string): Promise<boolean> {
+    return (await this.redis.hget(KEY(id), 'stopRequested')) === '1';
+  }
+
+  async list(limit: number, offset: number): Promise<MigrationJob[]> {
+    const ids = await this.redis.zrevrange(INDEX, offset, offset + limit - 1);
+    if (ids.length === 0) return [];
+    const pipe = this.redis.pipeline();
+    for (const id of ids) pipe.hgetall(KEY(id));
+    const res = await pipe.exec();
+    if (!res) return [];
+    const out: MigrationJob[] = [];
+    for (const [, h] of res) {
+      const hash = h as Record<string, string> | null;
+      if (hash && Object.keys(hash).length > 0) out.push(decode(hash));
+    }
+    return out;
+  }
+
+  async delete(id: string): Promise<void> {
+    const job = await this.findById(id);
+    await this.redis.del(KEY(id));
+    await this.redis.zrem(INDEX, id);
+    if (job?.type === MigrationType.DM) await this.redis.del(DM_LOCK(job.workspaceId, job.submittedByUserId));
+    if (job) { const chan = channelKeyOf(job); if (chan) await this.redis.del(CHANNEL_LOCK(job.workspaceId, chan)); }
+  }
+
+  /** Enforces "DMs are one-time per person" (§5.6). */
+  async hasDmMigration(workspaceId: string, userId: string): Promise<boolean> {
+    return (await this.redis.exists(DM_LOCK(workspaceId, userId))) === 1;
+  }
+
+  /** One in-flight migration per channel; released on completion so it can be re-run. */
+  async hasChannelMigration(workspaceId: string, slackChannelId: string): Promise<boolean> {
+    return (await this.redis.exists(CHANNEL_LOCK(workspaceId, slackChannelId))) === 1;
+  }
+
+  private async mustGet(id: string): Promise<MigrationJob> {
+    const job = await this.findById(id);
+    if (!job) throw new Error(`migration ${id} not found`);
+    return job;
+  }
+
+  /** Read just the checkpoint field for an append; the single worker owns these arrays, so a tight RMW here is race-free. */
+  private async readCheckpoint(id: string): Promise<Checkpoint> {
+    const raw = await this.redis.hget(KEY(id), 'checkpoint');
+    return raw ? (JSON.parse(raw) as Checkpoint) : emptyCheckpoint();
+  }
+
+  private async persist(job: MigrationJob): Promise<void> {
+    const { set } = encodePatch(job);
+    await this.redis.hset(KEY(job.id), set);
+    await this.redis.expire(KEY(job.id), TTL_SECONDS);
+  }
+}
+
+/** Reconstruct a MigrationJob from its HASH, coercing numbers/booleans and parsing JSON sub-fields. */
+function decode(h: Record<string, string>): MigrationJob {
+  const req = (k: string): string => h[k] ?? '';
+  const opt = (k: string): string | undefined => h[k];
+  const numReq = (k: string): number => Number(h[k] ?? 0);
+  const numOpt = (k: string): number | undefined => (h[k] !== undefined ? Number(h[k]) : undefined);
+  return {
+    id: req('id'),
+    type: req('type') as MigrationType,
+    status: req('status') as MigrationStatus,
+    currentQueue: req('currentQueue') as MigrationJob['currentQueue'],
+    workspaceId: req('workspaceId'),
+    submittedByUserId: req('submittedByUserId'),
+    submittedByName: opt('submittedByName'),
+    teamId: req('teamId'),
+    ownerSlackId: opt('ownerSlackId'),
+    gcsPrefix: req('gcsPrefix'),
+    encryptedToken: opt('encryptedToken'),
+    channelInput: h.channelInput ? (JSON.parse(h.channelInput) as MigrationJob['channelInput']) : undefined,
+    slackChannelName: opt('slackChannelName'),
+    xyneChannelName: opt('xyneChannelName'),
+    slackChannelCreator: opt('slackChannelCreator'),
+    slackChannelCreated: numOpt('slackChannelCreated'),
+    channelProgress: h.channelProgress ? (JSON.parse(h.channelProgress) as MigrationJob['channelProgress']) : undefined,
+    checkpoint: h.checkpoint ? (JSON.parse(h.checkpoint) as Checkpoint) : emptyCheckpoint(),
+    stats: { conversations: numReq('statsConversations'), messages: numReq('statsMessages') },
+    stopRequested: h.stopRequested === '1',
+    stopReason: opt('stopReason') as MigrationJob['stopReason'],
+    heartbeatAt: numReq('heartbeatAt'),
+    progressAt: numOpt('progressAt'),
+    createdAt: numReq('createdAt'),
+    updatedAt: numReq('updatedAt'),
+    completedAt: numOpt('completedAt'),
+    error: opt('error'),
+    issues: h.issues ? (JSON.parse(h.issues) as MigrationIssue[]) : undefined,
+  };
+}

--- a/apps/backend/src/migration/self-serve/types.ts
+++ b/apps/backend/src/migration/self-serve/types.ts
@@ -1,0 +1,126 @@
+export enum MigrationType {
+  DM = 'DM',            // DMs + group DMs — token-based, per person, one-time
+  CHANNEL = 'CHANNEL',  // channels — form-based, central token, re-migratable
+}
+
+export enum MigrationStatus {
+  SUBMITTED = 'SUBMITTED',
+  QUEUED = 'QUEUED',
+  COLLECTING = 'COLLECTING',
+  AWAITING_APPROVAL = 'AWAITING_APPROVAL',
+  INGESTING = 'INGESTING',
+  STOPPED = 'STOPPED',
+  FAILED = 'FAILED',
+  COMPLETED = 'COMPLETED',
+}
+
+export enum QueueName {
+  COLLECTION = 'slack-migration-collection',
+  INGESTION = 'slack-migration-ingestion',
+}
+
+export interface Checkpoint {
+  totalConversations: number;
+  collectedConversationIds: string[];
+  ingestedConversationIds: string[];
+}
+
+export interface ChannelInput {
+  slackChannelId: string;
+  xyneChannelId: string;
+  startDate?: string;
+  announceInSlack?: boolean;
+}
+
+/** A conversation that couldn't be fully collected — surfaced so a partial migration isn't shown as complete. */
+export interface MigrationIssue {
+  conversationId: string;
+  kind: 'skipped' | 'truncated' | 'ingest-error';
+  reason: string;
+}
+
+export interface MigrationJob {
+  id: string;
+  type: MigrationType;
+  status: MigrationStatus;
+  currentQueue: QueueName;
+  workspaceId: string;
+  submittedByUserId: string;
+  submittedByName?: string;
+  teamId: string;
+  ownerSlackId?: string;
+  gcsPrefix: string;
+  encryptedToken?: string;       // DM: cleared once collection completes; never logged/exported
+  channelInput?: ChannelInput;
+  slackChannelName?: string;
+  xyneChannelName?: string;
+  slackChannelCreator?: string; // Slack channel creator's user id → Xyne channel ADMIN
+  slackChannelCreated?: number; // creation unix ts (secs) — lower bound for collection progress
+  channelProgress?: { start: number; end: number; through: number }; // epoch secs: window [start,end] + oldest collected
+  checkpoint: Checkpoint;
+  stats: { conversations: number; messages: number };
+  stopRequested: boolean;
+  stopReason?: 'admin' | 'system';
+  heartbeatAt: number;          // liveness: bumped by the heartbeat ticker AND every write
+  progressAt?: number;          // forward progress: bumped only when a page/conversation actually advances — drives the stall watchdog
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  error?: string;
+  issues?: MigrationIssue[]; // conversations that couldn't be fully collected (Slack-side)
+}
+
+/** Public projection — never carries the token. */
+export interface MigrationJobView {
+  id: string;
+  type: MigrationType;
+  status: MigrationStatus;
+  phase: 'collect' | 'ingest';
+  stopRequested: boolean;
+  stopReason?: 'admin' | 'system';
+  submittedByUserId: string;
+  submittedByName?: string;
+  stats: { conversations: number; messages: number };
+  progress: { total: number; collected: number; ingested: number };
+  channel?: { slackId: string; xyneId: string; slackName?: string; xyneName?: string; startDate?: string; announceInSlack?: boolean; windowStart?: number; windowEnd?: number; collectedThrough?: number };
+  issues?: MigrationIssue[];
+  heartbeatAt: number;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  error?: string;
+}
+
+export const toView = (j: MigrationJob): MigrationJobView => ({
+  id: j.id,
+  type: j.type,
+  status: j.status,
+  phase: j.currentQueue === QueueName.INGESTION ? 'ingest' : 'collect',
+  stopRequested: j.stopRequested,
+  stopReason: j.stopReason,
+  submittedByUserId: j.submittedByUserId,
+  submittedByName: j.submittedByName,
+  stats: j.stats,
+  progress: {
+    total: j.checkpoint.totalConversations,
+    collected: j.checkpoint.collectedConversationIds.length,
+    ingested: j.checkpoint.ingestedConversationIds.length,
+  },
+  channel: j.type === MigrationType.CHANNEL && j.channelInput ? {
+    slackId: j.channelInput.slackChannelId,
+    xyneId: j.channelInput.xyneChannelId,
+    slackName: j.slackChannelName,
+    xyneName: j.xyneChannelName,
+    startDate: j.channelInput.startDate,
+    announceInSlack: j.channelInput.announceInSlack,
+    windowStart: j.channelProgress?.start,
+    windowEnd: j.channelProgress?.end,
+    collectedThrough: j.channelProgress?.through,
+  } : undefined,
+  heartbeatAt: j.heartbeatAt,
+  createdAt: j.createdAt,
+  updatedAt: j.updatedAt,
+  completedAt: j.completedAt,
+  error: j.error,
+  issues: j.issues,
+});

--- a/apps/backend/src/migration/self-serve/workers.ts
+++ b/apps/backend/src/migration/self-serve/workers.ts
@@ -1,0 +1,208 @@
+import { config } from '@/config/env';
+import { logger } from '@/utils/logger';
+import { MigrationStore } from './store';
+import { MigrationQueues } from './queues';
+import { SlackMigrationEngine } from './engine';
+import { MigrationJob, MigrationStatus, MigrationType, QueueName } from './types';
+
+const HEARTBEAT_MS = 15_000;
+const RECONCILE_EVERY_MS = 60_000;
+const RECLAIM_STALE_MS = 90_000; // several missed heartbeats ⇒ the pod that owned the job is gone
+const STALL_LIMIT_MS = config.slackMigration.stallLimitMs; // live heartbeat but no forward progress ⇒ worker wedged
+
+/** Bull processors for the two queues, each with lifecycle + heartbeat + cooperative stop. */
+export class MigrationWorkers {
+  constructor(
+    private readonly queues: MigrationQueues,
+    private readonly store: MigrationStore,
+    private readonly engine: SlackMigrationEngine,
+  ) {}
+
+  register(): void {
+    this.queues.process(QueueName.COLLECTION, (id) => this.guard(id, (j) => this.collect(j)));
+    this.queues.process(QueueName.INGESTION, (id) => this.guard(id, (j) => this.ingest(j)));
+    logger.info('[SlackMigration] workers registered (collection + ingestion processors active)');
+    // Recover jobs orphaned by a pod kill (stuck COLLECTING/INGESTING, stale heartbeat). Store is the source of truth, not Bull.
+    const timer = setInterval(() => void this.reconcile().catch(() => undefined), RECONCILE_EVERY_MS);
+    timer.unref?.();
+    void this.reconcile().catch(() => undefined);
+  }
+
+  /** Recover running jobs that a live worker can no longer make progress on: pod died (stale heartbeat) → re-enqueue;
+   *  or wedged/looping (fresh heartbeat, no progress) → fail resumably. */
+  private async reconcile(): Promise<void> {
+    const now = Date.now();
+    for (const job of await this.store.list(1000, 0)) {
+      // Queued/submitted jobs live in Bull, not here — but recover one whose Bull entry was lost (e.g. a crash
+      // between the store write and enqueue) so it can't sit stranded forever. Only re-enqueue if genuinely absent.
+      if (job.status === MigrationStatus.QUEUED || job.status === MigrationStatus.SUBMITTED) {
+        if (now - job.updatedAt >= RECLAIM_STALE_MS && !(await this.queues.hasJob(job.currentQueue, job.id))) {
+          logger.warn('[SlackMigration] re-enqueuing stranded job (no queue entry)', { id: job.id, status: job.status });
+          await this.queues.enqueue(job.currentQueue, job.id, 'end').catch(() => undefined);
+        }
+        continue;
+      }
+      const running = job.status === MigrationStatus.COLLECTING || job.status === MigrationStatus.INGESTING;
+      if (!running) continue;
+      // Status says running — but is a worker actually processing it? If Bull has it sitting in the wait/delayed
+      // queue (bumped back by a restart/stall, or a resume jumped ahead), the "Collecting/Ingesting" status is
+      // stale. Show it as QUEUED so two jobs never both look like they're running.
+      const bstate = await this.queues.jobState(job.currentQueue, job.id);
+      if (bstate && bstate !== 'active') {
+        await this.store.update(job.id, { status: MigrationStatus.QUEUED }).catch(() => undefined);
+        continue;
+      }
+      if (now - (job.heartbeatAt ?? 0) < RECLAIM_STALE_MS) {
+        // A live worker still owns it — but is it actually progressing? A fresh heartbeat with no forward progress
+        // means the worker is wedged on an unresponsive upstream (e.g. a socket killed by a laptop sleep) or stuck
+        // retrying. We can't preempt the locked Bull job, so surface it as FAILED (resumable) rather than let it
+        // masquerade as "running" forever. Threshold is generous so normal Slack rate-limit backoffs don't trip it.
+        const lastProgress = job.progressAt ?? job.createdAt;
+        if (now - lastProgress >= STALL_LIMIT_MS) {
+          const minutes = Math.round((now - lastProgress) / 60_000);
+          logger.error('[SlackMigration] migration stalled — live heartbeat but no progress; marking failed (resumable)', {
+            id: job.id, status: job.status, stalledForMin: minutes,
+          });
+          await this.store.update(job.id, {
+            status: MigrationStatus.FAILED,
+            error: `Stalled: no progress for ~${minutes} min (worker likely wedged on an unresponsive Slack connection). Resume to retry from the last checkpoint.`,
+          }).catch(() => undefined);
+        }
+        continue;
+      }
+      // Heartbeat is stale ⇒ the owning pod is gone.
+      if (job.stopRequested) {
+        // Owning pod died before honoring the stop — finalize to STOPPED (resumable) instead of leaving it hung.
+        logger.warn('[SlackMigration] finalizing stop for orphaned migration after restart', { id: job.id, status: job.status });
+        await this.store.update(job.id, { status: MigrationStatus.STOPPED });
+        continue;
+      }
+      logger.warn('[SlackMigration] reclaiming orphaned migration after restart', {
+        id: job.id, status: job.status, queue: job.currentQueue,
+      });
+      await this.store.update(job.id, { status: MigrationStatus.QUEUED }).catch(() => undefined); // waiting to resume, not running
+      await this.queues.enqueue(job.currentQueue, job.id, 'end');
+    }
+  }
+
+  private async collect(job: MigrationJob): Promise<void> {
+    // Idempotency: a duplicate/stale delivery must not reprocess past collection (re-collecting after the token was dropped fails it).
+    if ([MigrationStatus.AWAITING_APPROVAL, MigrationStatus.INGESTING, MigrationStatus.COMPLETED].includes(job.status)) return;
+    const token = this.engine.decryptToken(job);
+    await this.store.update(job.id, { status: MigrationStatus.COLLECTING });
+    logger.info('[SlackMigration] collection started', { id: job.id, type: job.type });
+
+    const directory = await this.engine.collectDirectory(token, job.gcsPrefix);
+    await this.store.markProgress(job.id).catch(() => undefined);
+    await this.engine.collectUsergroups(token, job.gcsPrefix);
+    await this.engine.collectChannels(token, job.gcsPrefix);
+    const conversations = await this.engine.listConversations(token, job.type, job.channelInput);
+    await this.engine.writeManifest(job.gcsPrefix, conversations);
+    await this.store.markProgress(job.id).catch(() => undefined);
+    await this.store.update(job.id, { checkpoint: { ...job.checkpoint, totalConversations: conversations.length } });
+    logger.info('[SlackMigration] collection plan ready', { id: job.id, users: Object.keys(directory).length, conversations: conversations.length });
+
+    const done = new Set(job.checkpoint.collectedConversationIds);
+    const PROGRESS_EVERY = 25;
+    let collected = 0, messages = 0, skipped = 0, truncated = 0;
+    // A channel is a single conversation (conversation bar meaningless) and Slack gives no message total, so report progress
+    // through the date window [start, newest message], where start = chosen startDate or the channel's creation ts.
+    const isChannel = job.type === MigrationType.CHANNEL;
+    const windowStart = job.channelInput?.startDate
+      ? Math.floor(Date.parse(job.channelInput.startDate) / 1000)
+      : (job.slackChannelCreated ?? 0);
+    for (const [index, conv] of conversations.entries()) {
+      if (await this.store.isStopRequested(job.id)) {
+        logger.info('[SlackMigration] stop requested — halting at next conversation', { id: job.id, queue: job.currentQueue });
+        return void this.store.update(job.id, { status: MigrationStatus.STOPPED });
+      }
+      if (done.has(conv.id)) continue;
+      const result = await this.engine.collectConversation(
+        token, conv, job.gcsPrefix, job.channelInput?.startDate,
+        isChannel
+          ? (p) => this.store.setChannelProgress(job.id, { messages: p.messages, start: windowStart, end: p.newestTs, through: p.oldestTs })
+          : () => this.store.markProgress(job.id), // DMs: per-page progress signal so the stall watchdog isn't tripped mid-conversation
+      );
+      if (result.outcome === 'skipped') {
+        // Inaccessible on Slack — don't migrate it. A channel job is a single conversation, so fail
+        // the whole job; a DM job records the skip and keeps going with the rest.
+        if (isChannel) throw new Error(result.reason ?? 'Channel is inaccessible on Slack.');
+        skipped += 1;
+        await this.store.addIssue(job.id, { conversationId: conv.id, kind: 'skipped', reason: result.reason ?? 'Inaccessible on Slack.' });
+        continue;
+      }
+      await this.store.addCollected(job.id, conv.id, isChannel ? 0 : result.messages); // channel count already live via setChannelProgress
+      collected += 1;
+      messages += result.messages;
+      if (result.outcome === 'truncated') {
+        truncated += 1;
+        await this.store.addIssue(job.id, { conversationId: conv.id, kind: 'truncated', reason: result.reason ?? 'Partial — lost Slack access mid-collection.' });
+      }
+      if (conversations.length > PROGRESS_EVERY && (index + 1) % PROGRESS_EVERY === 0) {
+        logger.info('[SlackMigration] collection progress', { id: job.id, done: index + 1, total: conversations.length, messages });
+      }
+    }
+
+    // Collection done → approval gate; drop the token immediately (§5.7).
+    await this.store.update(job.id, { status: MigrationStatus.AWAITING_APPROVAL, encryptedToken: undefined });
+    logger.info('[SlackMigration] collection complete → awaiting approval', {
+      id: job.id, conversations: conversations.length, collected, messages, skipped, truncated,
+    });
+  }
+
+  private async ingest(job: MigrationJob): Promise<void> {
+    // Idempotency: never re-ingest a completed job (its GCS data is already deleted).
+    if ([MigrationStatus.SUBMITTED, MigrationStatus.COLLECTING, MigrationStatus.COMPLETED].includes(job.status)) return;
+    await this.store.update(job.id, { status: MigrationStatus.INGESTING });
+    let conversations;
+    try {
+      conversations = await this.engine.readManifest(job.gcsPrefix);
+    } catch {
+      await this.store.update(job.id, { status: MigrationStatus.COMPLETED, completedAt: Date.now() });
+      logger.warn('[SlackMigration] ingest manifest missing — finalizing as complete', { id: job.id });
+      return;
+    }
+    logger.info('[SlackMigration] ingestion started', { id: job.id, total: conversations.length });
+    // Build the offline reference once per job so ingestion resolves users/usergroups/channels from the dumps, never Slack.
+    const ref = await this.engine.buildOfflineReference(job.gcsPrefix);
+    const done = new Set(job.checkpoint.ingestedConversationIds);
+
+    for (const conv of conversations) {
+      if (await this.store.isStopRequested(job.id)) {
+        logger.info('[SlackMigration] stop requested — halting at next conversation', { id: job.id, queue: job.currentQueue });
+        return void this.store.update(job.id, { status: MigrationStatus.STOPPED });
+      }
+      if (done.has(conv.id)) continue;
+      const loaded = await this.engine.loadConversation(job, conv, ref, () => void this.store.markProgress(job.id).catch(() => undefined));
+      if (loaded.failed > 0) {
+        await this.store.addIssue(job.id, { conversationId: conv.id, kind: 'ingest-error', reason: `${loaded.failed} message(s) couldn't be migrated (unresolved sender or attachment).` });
+      } else {
+        await this.store.addIngested(job.id, conv.id);
+      }
+    }
+
+    await this.store.update(job.id, { status: MigrationStatus.COMPLETED, completedAt: Date.now() });
+    await this.engine.announceMigration(job).catch((err) => logger.warn('[SlackMigration] announce failed (non-fatal)', { id: job.id, error: err instanceof Error ? err.message : String(err) }));
+    await this.engine.deletePrefix(job.gcsPrefix).catch(() => undefined);
+    logger.info('[SlackMigration] ingestion complete', { id: job.id, total: conversations.length });
+  }
+
+  /** Loads the record, runs a heartbeat ticker, and centralizes failure marking. */
+  private async guard(id: string, work: (job: MigrationJob) => Promise<void>): Promise<void> {
+    const job = await this.store.findById(id);
+    if (!job) return;
+    logger.info('[SlackMigration] worker picked up job', { id, queue: job.currentQueue, status: job.status });
+    await this.store.markProgress(id).catch(() => undefined); // fresh stall window on pickup — don't inherit a prior attempt's stale progressAt
+    const heartbeat = setInterval(() => void this.store.heartbeat(id).catch(() => undefined), HEARTBEAT_MS);
+    heartbeat.unref?.();
+    try {
+      await work(job);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await this.store.update(id, { status: MigrationStatus.FAILED, error: message }).catch(() => undefined);
+      logger.error('[SlackMigration] job failed', { id, message });
+    } finally {
+      clearInterval(heartbeat);
+    }
+  }
+}

--- a/apps/backend/src/migration/slack/utils/extractConversation.ts
+++ b/apps/backend/src/migration/slack/utils/extractConversation.ts
@@ -38,6 +38,7 @@ export interface SlackFile {
   mimetype: string;
   url_private: string;
   size: number;
+  prefetchedStoragePath?: string;
 }
 
 export interface SlackReply {
@@ -305,7 +306,7 @@ async function processBatch<T>(
  * @param allowedBots - Array of bot names (case-insensitive) to include (default: [])
  * @param includeBotMessages - When allowedBots is empty, include all (non-ignored) bot messages (default: false)
  */
-function isHumanMessage(
+export function isHumanMessage(
   message: any,
   context: 'channel' | 'thread' = 'channel',
   allowedBots: string[] = [],
@@ -344,7 +345,7 @@ function isHumanMessage(
  * plus files nested inside `msg.attachments[]` (forwarded/shared messages).
  * De-duplicated by Slack file id so a file referenced in both places is kept once.
  */
-function collectRawFiles(msg: any): any[] {
+export function collectRawFiles(msg: any): any[] {
   const out: any[] = [];
   const seen = new Set<string>();
   const push = (f: any) => {
@@ -380,6 +381,8 @@ function transformFiles(msg: any, includeAttachments: boolean): SlackFile[] | un
       mimetype: f.mimetype,
       url_private: f.url_private,
       size: f.size,
+      // Preserve the collector's storage annotation so ingestion can attach offline.
+      ...(f.prefetchedStoragePath ? { prefetchedStoragePath: f.prefetchedStoragePath as string } : {}),
     }));
 
   return validFiles.length ? validFiles : undefined;
@@ -985,7 +988,7 @@ export async function transformReply(
 /**
  * Transform raw Slack message to SlackMessage
  */
-async function transformMessage(
+export async function transformMessage(
   rawMessage: any,
   threadReplies: any[] | undefined,
   cache: UserInfoCache,

--- a/apps/backend/src/services/externalAttachmentService.ts
+++ b/apps/backend/src/services/externalAttachmentService.ts
@@ -1,4 +1,5 @@
-import { storageService } from './storage/index';
+import { storageService, getStorageService } from './storage/index';
+import { decryptStream } from '../migration/self-serve/migrationCrypto';
 import { logger } from '../utils/logger';
 import { ExternalSourceRepository } from '../database/repositories/externalSourceRepository';
 import { decrypt } from './encryptionService';
@@ -17,6 +18,13 @@ export interface ExternalAttachment {
   fileUrl?: string;
   /** Pre-fetched bytes — when provided, the URL fetch is skipped. */
   buffer?: Buffer;
+  /**
+   * Path to bytes already in OUR storage (self-serve migration collection). Streamed straight
+   * to the final location — no fetch/token, bounded memory. Takes precedence over `fileUrl`/`buffer`.
+   */
+  storageSourcePath?: string;
+  /** True when `storageSourcePath` bytes are envelope-encrypted (migration bucket) — decrypt while streaming. */
+  storageSourceEncrypted?: boolean;
   mimeType?: string;
   size?: number;
   /** MIME Content-ID (no angle brackets) for inline images referenced from the HTML body. */
@@ -113,6 +121,12 @@ class DefaultAuthHandler implements AuthHandler {
       'User-Agent': 'Xyne-Spaces-Backend/1.0'
     };
   }
+}
+
+/** Split a `gs://`/`s3://` URI into bucket+key; a bare key (no scheme) returns `{ key }` (default bucket). */
+function parseStorageUri(uri: string): { bucket?: string; key: string } {
+  const m = /^[a-z0-9]+:\/\/([^/]+)\/(.+)$/i.exec(uri);
+  return m ? { bucket: m[1], key: m[2] } : { key: uri };
 }
 
 export class ExternalAttachmentService {
@@ -230,6 +244,39 @@ export class ExternalAttachmentService {
     } = options;
 
     const { fileName, fileUrl, mimeType: expectedMimeType, size: expectedSize } = attachment;
+
+    // Bytes already in our storage (self-serve migration): stream straight to the final
+    // location — no fetch/token, never lands whole in the pod's heap.
+    if (attachment.storageSourcePath) {
+      const finalMimeType = expectedMimeType || 'application/octet-stream';
+      const fileExtension = path.extname(fileName) || this.getExtensionFromMimeType(finalMimeType);
+      const baseName = path.basename(fileName, path.extname(fileName));
+      const uniqueFileName = `${baseName}-${uuidv4().substring(0, 8)}${fileExtension}`;
+      // Read from the source bucket (gs://bucket/key from the collector); write final to default bucket.
+      const { bucket, key } = parseStorageUri(attachment.storageSourcePath);
+      const sourceStore = bucket ? getStorageService(bucket) : storageService;
+      const raw = await sourceStore.createReadStream(key);
+      const source = attachment.storageSourceEncrypted ? decryptStream(raw) : raw;
+      const gcsResult = await storageService.uploadStream(source, {
+        filename: uniqueFileName,
+        contentType: finalMimeType,
+        metadata: {
+          originalName: fileName,
+          migratedFrom: attachment.storageSourcePath,
+          downloadedAt: new Date().toISOString(),
+        },
+        scopeType,
+        scopeId,
+      });
+      return {
+        originalName: fileName,
+        fileName: gcsResult.filename,
+        fileSize: gcsResult.size,
+        mimeType: finalMimeType,
+        fileUrl: gcsResult.path,
+        metadata: { gcsPath: gcsResult.path, storageSourcePath: attachment.storageSourcePath },
+      };
+    }
 
     let buffer: Buffer;
     let responseMimeType: string | undefined;

--- a/apps/dashboard/.env.example
+++ b/apps/dashboard/.env.example
@@ -52,6 +52,8 @@ VITE_ELECTRON_BACKEND_URL=
 VITE_ELECTRON_ZERO_BACKEND_URL=
 VITE_SHAREABLE_ORIGIN=
 
+# Slack app install page — where a user gets their own User OAuth token for DM migration
+VITE_SLACK_APP_INSTALL_URL=
 # --- SDLC fast lane ---------------------------------------------------------
 # Set only in the SDLC bundle's build; empty here keeps the main bundle unchanged.
 # Real values live in .env.sdlc. See docs/sdlc-fast-lane.md.

--- a/apps/dashboard/src/api/slackMigrationApi.ts
+++ b/apps/dashboard/src/api/slackMigrationApi.ts
@@ -1,0 +1,128 @@
+import { apiInstance } from '../services/clients/apiClient';
+import { API_BASE_URL } from '../config';
+
+// Served by the migration pod at /migrate/api/migration/slack-migration/*.
+const BASE = API_BASE_URL.replace(/\/api\/?$/, '/migrate/api/migration/slack-migration');
+
+export type MigrationType = 'DM' | 'CHANNEL';
+export type MigrationStatus =
+  | 'SUBMITTED'
+  | 'QUEUED'
+  | 'COLLECTING'
+  | 'AWAITING_APPROVAL'
+  | 'INGESTING'
+  | 'STOPPED'
+  | 'FAILED'
+  | 'COMPLETED';
+
+export interface MigrationJobView {
+  id: string;
+  type: MigrationType;
+  status: MigrationStatus;
+  phase: 'collect' | 'ingest';
+  stopRequested: boolean;
+  stopReason?: 'admin' | 'system';
+  submittedByUserId: string;
+  submittedByName?: string;
+  stats: { conversations: number; messages: number };
+  progress: { total: number; collected: number; ingested: number };
+  channel?: {
+    slackId: string;
+    xyneId: string;
+    slackName?: string;
+    xyneName?: string;
+    startDate?: string;
+    announceInSlack?: boolean;
+    windowStart?: number;
+    windowEnd?: number;
+    collectedThrough?: number;
+  };
+  heartbeatAt: number;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  error?: string;
+  issues?: {
+    conversationId: string;
+    kind: 'skipped' | 'truncated' | 'ingest-error';
+    reason: string;
+  }[];
+}
+
+interface Envelope<T> {
+  success: boolean;
+  data: T;
+  error?: { code: string; message: string };
+}
+
+const unwrap = <T>(payload: Envelope<T>): T => {
+  if (!payload.success) throw new Error(payload.error?.message ?? 'Request failed');
+  return payload.data;
+};
+
+export const slackMigrationApi = {
+  submitDm: async (token: string): Promise<MigrationJobView> =>
+    unwrap((await apiInstance.post<Envelope<MigrationJobView>>(`${BASE}/dm`, { token })).data),
+
+  submitChannel: async (input: {
+    slackChannelId: string;
+    xyneChannelId: string;
+    startDate?: string;
+    announceInSlack?: boolean;
+  }): Promise<MigrationJobView> =>
+    unwrap((await apiInstance.post<Envelope<MigrationJobView>>(`${BASE}/channel`, input)).data),
+
+  listMine: async (): Promise<MigrationJobView[]> =>
+    unwrap((await apiInstance.get<Envelope<MigrationJobView[]>>(`${BASE}/mine`)).data),
+
+  listAdmin: async (): Promise<MigrationJobView[]> =>
+    unwrap((await apiInstance.get<Envelope<MigrationJobView[]>>(`${BASE}/migration-jobs`)).data),
+
+  approve: async (id: string): Promise<MigrationJobView> =>
+    unwrap(
+      (await apiInstance.post<Envelope<MigrationJobView>>(`${BASE}/migration-jobs/${id}/approve`))
+        .data,
+    ),
+
+  stop: async (id: string): Promise<MigrationJobView> =>
+    unwrap(
+      (await apiInstance.post<Envelope<MigrationJobView>>(`${BASE}/migration-jobs/${id}/stop`))
+        .data,
+    ),
+
+  resume: async (id: string): Promise<MigrationJobView> =>
+    unwrap(
+      (await apiInstance.post<Envelope<MigrationJobView>>(`${BASE}/migration-jobs/${id}/resume`))
+        .data,
+    ),
+
+  remove: async (id: string): Promise<void> => {
+    await apiInstance.delete(`${BASE}/migration-jobs/${id}`);
+  },
+
+  // Owner self-service (own jobs only).
+  resumeMine: async (id: string): Promise<MigrationJobView> =>
+    unwrap((await apiInstance.post<Envelope<MigrationJobView>>(`${BASE}/mine/${id}/resume`)).data),
+
+  removeMine: async (id: string): Promise<void> => {
+    await apiInstance.delete(`${BASE}/mine/${id}`);
+  },
+
+  // Ingestion control, gated by SLACK-MIGRATION-INGEST.
+  ingestionStatus: async (): Promise<{ canIngest: boolean; running: boolean }> =>
+    unwrap(
+      (
+        await apiInstance.get<Envelope<{ canIngest: boolean; running: boolean }>>(
+          `${BASE}/ingestion`,
+        )
+      ).data,
+    ),
+  startIngestion: async (): Promise<{ running: boolean }> =>
+    unwrap(
+      (await apiInstance.post<Envelope<{ running: boolean }>>(`${BASE}/ingestion/start`)).data,
+    ),
+  stopIngestion: async (): Promise<{ running: boolean }> =>
+    unwrap((await apiInstance.post<Envelope<{ running: boolean }>>(`${BASE}/ingestion/stop`)).data),
+
+  exportUrl: `${BASE}/migration-jobs/export`,
+};

--- a/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
+++ b/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
@@ -102,6 +102,7 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
     icon: ChatChatting,
     iconSize: 18,
   },
+  { path: '/slack-migration', label: 'Slack Migration', icon: SwapArrowHorizontal, iconSize: 18 },
   { path: '/team-intelligence', label: 'Team Intelligence', icon: Atom },
   { path: '/claw-agents', label: 'Claw Agents', icon: Bot },
 ];

--- a/apps/dashboard/src/config.ts
+++ b/apps/dashboard/src/config.ts
@@ -101,6 +101,10 @@ export const ENABLE_SUMMARY_ACTION_BUTTON: boolean =
 export const DEFAULT_WORKSPACE_ID: string =
   (import.meta.env['VITE_DEFAULT_WORKSPACE_ID'] as string) ?? '';
 
+// Slack app install page (user's own OAuth token for DM migration). Workspace-specific, so env-only;
+// set VITE_SLACK_APP_INSTALL_URL in .env.local — the UI hides the link when unset.
+export const SLACK_APP_INSTALL_URL: string =
+  (import.meta.env['VITE_SLACK_APP_INSTALL_URL'] as string) || '';
 // Deployment lane. The same source builds a second 'sdlc' bundle served at
 // '/sdlc-app/' with its own backend and zero-cache. Inert when VITE_XYNE_SURFACE
 // is unset. See docs/sdlc-fast-lane.md.

--- a/apps/dashboard/src/pages/SlackMigration.tsx
+++ b/apps/dashboard/src/pages/SlackMigration.tsx
@@ -1,0 +1,1129 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  MessageSquare,
+  Hash,
+  Play,
+  Square,
+  Trash2,
+  RotateCcw,
+  Check,
+  TriangleAlert,
+  Clock,
+  ShieldCheck,
+  Info,
+  CloudOff,
+  ExternalLink,
+  KeyRound,
+  ListChecks,
+  Megaphone,
+} from 'lucide-react';
+import { MigrationJobView, MigrationStatus, slackMigrationApi } from '../api/slackMigrationApi';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
+import { Checkbox } from '../components/ui/Checkbox/Checkbox';
+import { DatePicker } from '../components/ui/DatePicker/DatePicker';
+import AppNavigator from '../components/AppNavigator/AppNavigator';
+import { SLACK_APP_INSTALL_URL } from '../config';
+import { cn } from '../utils/classNames';
+
+// Adaptive polling: fast when a job runs, relaxed when idle, paused when hidden,
+// and backed off when the pod is down so a restart isn't hammered by every dashboard.
+const POLL_ACTIVE_MS = 4000;
+const POLL_IDLE_MS = 15000;
+const POLL_HIDDEN_MS = 10000;
+const POLL_DOWN_MS = 5000;
+const POLL_MAX_MS = 60000;
+
+/** No response (network error) or 5xx means the migration pod is down/starting: treat
+ *  as "unreachable" and keep polling. 4xx means the pod is up (auth etc.). */
+const isServiceDown = (e: unknown): boolean => {
+  const status = (e as { response?: { status?: number } })?.response?.status;
+  return status === undefined || status >= 500;
+};
+const STALE_MS = 45_000; // no heartbeat this long while running ⇒ stalled
+
+const ADMIN_NOTES = [
+  'Approve only stages a job onto the ingestion queue — nothing ingests until ingestion is started.',
+  'Start ingestion is restricted to authorized users — not every admin can run it.',
+  'Processing is serial: one job at a time per queue.',
+  'Stop is graceful (stops at the next conversation) and leaves the job resumable.',
+  'A stopped or failed job can be resumed; it never re-fetches or re-ingests what is already done.',
+  'Delete is destructive: it removes the job and its collected data. Deleting a completed DM lets that person submit again.',
+  'If a job fails, resume it — or delete it and have the submitter re-submit. Members can do this for their own jobs too.',
+];
+
+// ── status vocabulary ───────────────────────────────────────────────────────
+type Tone = 'muted' | 'blue' | 'amber' | 'violet' | 'orange' | 'red' | 'green';
+
+const STATUS: Record<MigrationStatus, { label: string; tone: Tone }> = {
+  SUBMITTED: { label: 'Queued', tone: 'muted' },
+  QUEUED: { label: 'Queued', tone: 'muted' },
+  COLLECTING: { label: 'Collecting', tone: 'blue' },
+  AWAITING_APPROVAL: { label: 'Awaiting approval', tone: 'amber' },
+  INGESTING: { label: 'Ingesting', tone: 'violet' },
+  STOPPED: { label: 'Stopped', tone: 'orange' },
+  FAILED: { label: 'Failed', tone: 'red' },
+  COMPLETED: { label: 'Completed', tone: 'green' },
+};
+
+const TONE: Record<Tone, { pill: string; dot: string; bar: string; ring: string }> = {
+  muted: {
+    pill: 'bg-muted text-muted-foreground',
+    dot: 'bg-muted-foreground',
+    bar: 'bg-muted-foreground',
+    ring: 'ring-border',
+  },
+  blue: {
+    pill: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+    dot: 'bg-blue-500',
+    bar: 'bg-blue-500',
+    ring: 'ring-blue-500',
+  },
+  amber: {
+    pill: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+    dot: 'bg-amber-500',
+    bar: 'bg-amber-500',
+    ring: 'ring-amber-500',
+  },
+  violet: {
+    pill: 'bg-violet-500/10 text-violet-600 dark:text-violet-400',
+    dot: 'bg-violet-500',
+    bar: 'bg-violet-500',
+    ring: 'ring-violet-500',
+  },
+  orange: {
+    pill: 'bg-orange-500/10 text-orange-600 dark:text-orange-400',
+    dot: 'bg-orange-500',
+    bar: 'bg-orange-500',
+    ring: 'ring-orange-500',
+  },
+  red: {
+    pill: 'bg-destructive/10 text-destructive',
+    dot: 'bg-destructive',
+    bar: 'bg-destructive',
+    ring: 'ring-destructive',
+  },
+  green: {
+    pill: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+    dot: 'bg-emerald-500',
+    bar: 'bg-emerald-500',
+    ring: 'ring-emerald-500',
+  },
+};
+
+const isStalled = (j: MigrationJobView): boolean =>
+  (j.status === 'COLLECTING' || j.status === 'INGESTING') && Date.now() - j.heartbeatAt > STALE_MS;
+
+const ago = (ts: number): string => {
+  const s = Math.max(0, Math.round((Date.now() - ts) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+};
+
+// Pipeline stages; position derived from status (and phase when stopped/failed).
+const STAGES = ['Collect', 'Approve', 'Ingest', 'Done'] as const;
+const activeStage = (j: MigrationJobView): number => {
+  switch (j.status) {
+    case 'SUBMITTED':
+    case 'COLLECTING':
+      return 0;
+    case 'QUEUED':
+      return j.phase === 'ingest' ? 2 : 0; // queued to (re)run in its current phase
+    case 'AWAITING_APPROVAL':
+      return j.phase === 'ingest' ? 2 : 1; // approved ⇒ ingest gate
+    case 'INGESTING':
+      return 2;
+    case 'COMPLETED':
+      return 3;
+    case 'STOPPED':
+    case 'FAILED':
+      return j.phase === 'ingest' ? 2 : 0;
+    default:
+      return 0;
+  }
+};
+
+// ── small pieces ─────────────────────────────────────────────────────────────
+function StatusPill({ job }: { job: MigrationJobView }): React.JSX.Element {
+  const running = job.status === 'COLLECTING' || job.status === 'INGESTING';
+  const stopping = running && job.stopRequested;
+  const stalled = running && !stopping && isStalled(job);
+  const approvedQueued = job.status === 'AWAITING_APPROVAL' && job.phase === 'ingest';
+  const desc = stopping
+    ? { label: 'Stopping at next conversation…', tone: 'orange' as Tone }
+    : stalled
+      ? { label: 'Stalled · recovering', tone: 'amber' as Tone }
+      : approvedQueued
+        ? { label: 'Approved · waiting to ingest', tone: 'violet' as Tone }
+        : STATUS[job.status];
+  const t = TONE[desc.tone];
+  const live = running && !stalled; // pulse while collecting/ingesting
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium',
+        t.pill,
+      )}
+    >
+      <span
+        className={cn(
+          'size-1.5 rounded-full',
+          t.dot,
+          live && 'animate-pulse motion-reduce:animate-none',
+        )}
+      />
+      {desc.label}
+    </span>
+  );
+}
+
+function Stepper({ job }: { job: MigrationJobView }): React.JSX.Element {
+  const idx = activeStage(job);
+  const failed = job.status === 'FAILED';
+  const stopped = job.status === 'STOPPED';
+  const stalled = isStalled(job);
+  const activeTone: Tone = failed
+    ? 'red'
+    : stopped
+      ? 'orange'
+      : stalled
+        ? 'amber'
+        : STATUS[job.status].tone;
+
+  return (
+    <div className='flex items-center'>
+      {STAGES.map((stage, i) => {
+        const done = i < idx || job.status === 'COMPLETED';
+        const active = i === idx && job.status !== 'COMPLETED';
+        const t = TONE[done ? 'green' : active ? activeTone : 'muted'];
+        return (
+          <div key={stage} className='flex flex-1 items-center last:flex-none'>
+            <div className='flex flex-col items-center gap-1'>
+              <span
+                className={cn(
+                  'flex size-5 items-center justify-center rounded-full text-[10px] font-semibold',
+                  done && 'bg-emerald-500 text-white',
+                  active && cn(t.pill, 'ring-2', t.ring, 'ring-offset-1 ring-offset-background'),
+                  !done && !active && 'bg-muted text-muted-foreground',
+                )}
+              >
+                {done ? (
+                  <Check className='size-3' />
+                ) : active && (failed || stopped) ? (
+                  <TriangleAlert className='size-3' />
+                ) : (
+                  i + 1
+                )}
+              </span>
+              <span
+                className={cn(
+                  'text-[10px] leading-none',
+                  active ? 'text-foreground font-medium' : 'text-muted-foreground',
+                )}
+              >
+                {stage}
+              </span>
+            </div>
+            {i < STAGES.length - 1 && (
+              <div
+                className={cn(
+                  'mx-1.5 h-px flex-1',
+                  i < idx || job.status === 'COMPLETED' ? 'bg-emerald-500' : 'bg-border',
+                )}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function PhaseProgress({ job }: { job: MigrationJobView }): React.JSX.Element | null {
+  const { total, collected, ingested } = job.progress;
+  if (total === 0 && job.status === 'SUBMITTED') return null;
+  const ingestPhase = job.phase === 'ingest' && job.status !== 'AWAITING_APPROVAL';
+  const tone = TONE[job.status === 'COMPLETED' ? 'green' : ingestPhase ? 'violet' : 'blue'];
+
+  // Slack gives no channel message total, but every message has a ts, so show progress
+  // through the date window with collectedThrough (oldest reached) as position.
+  if (job.channel) {
+    const active = job.status === 'COLLECTING' || job.status === 'INGESTING';
+    const complete = job.status === 'COMPLETED';
+    const { windowStart, windowEnd, collectedThrough } = job.channel;
+    const pct =
+      job.status === 'COLLECTING' &&
+      windowStart &&
+      windowEnd &&
+      collectedThrough &&
+      windowEnd > windowStart
+        ? Math.min(
+            100,
+            Math.max(
+              0,
+              Math.round(((windowEnd - collectedThrough) / (windowEnd - windowStart)) * 100),
+            ),
+          )
+        : null;
+    const throughLabel = collectedThrough
+      ? new Date(collectedThrough * 1000).toLocaleDateString(undefined, {
+          year: 'numeric',
+          month: 'short',
+        })
+      : null;
+    return (
+      <div>
+        <div className='mb-1 flex items-center justify-between text-xs text-muted-foreground'>
+          <span>
+            {job.stats.messages.toLocaleString()} messages{ingestPhase ? '' : ' collected'}
+          </span>
+          {pct !== null ? (
+            <span className='tabular-nums'>
+              back to {throughLabel} · {pct}%
+            </span>
+          ) : (
+            active && (
+              <span className='text-muted-foreground/70'>
+                {ingestPhase ? 'ingesting…' : 'collecting…'}
+              </span>
+            )
+          )}
+        </div>
+        <div className='h-1.5 overflow-hidden rounded-full bg-muted'>
+          {complete ? (
+            <div className={cn('h-full w-full rounded-full', TONE.green.bar)} />
+          ) : pct !== null ? (
+            <div
+              className={cn('h-full rounded-full transition-[width] duration-500', tone.bar)}
+              style={{ width: `${pct}%` }}
+            />
+          ) : active ? (
+            <div className={cn('h-full w-1/3 rounded-full animate-pulse', tone.bar)} />
+          ) : (
+            <div className='h-full w-0' />
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // DM: many conversations → a real percentage.
+  const done = ingestPhase ? ingested : collected;
+  const verb = ingestPhase ? 'ingested' : 'collected';
+  const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
+  return (
+    <div>
+      <div className='mb-1 flex items-center justify-between text-xs text-muted-foreground'>
+        <span>
+          {done.toLocaleString()} / {total.toLocaleString()} conversations {verb}
+        </span>
+        <span className='tabular-nums'>{pct}%</span>
+      </div>
+      <div className='h-1.5 overflow-hidden rounded-full bg-muted'>
+        <div
+          className={cn('h-full rounded-full transition-[width] duration-500', tone.bar)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function JobCard({
+  job,
+  actions,
+}: {
+  job: MigrationJobView;
+  actions?: React.ReactNode;
+}): React.JSX.Element {
+  const isDm = job.type === 'DM';
+  return (
+    <div className='rounded-xl border border-border bg-card p-4 shadow-xs'>
+      <div className='flex items-start justify-between gap-3'>
+        <div className='flex items-center gap-2.5'>
+          <span
+            className={cn(
+              'flex size-8 items-center justify-center rounded-lg',
+              isDm
+                ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400'
+                : 'bg-violet-500/10 text-violet-600 dark:text-violet-400',
+            )}
+          >
+            {isDm ? <MessageSquare className='size-4' /> : <Hash className='size-4' />}
+          </span>
+          <div className='leading-tight'>
+            <div className='text-sm font-medium text-foreground'>
+              {isDm ? (
+                'Direct messages'
+              ) : job.channel ? (
+                <>
+                  #{job.channel.slackName ?? job.channel.slackId}{' '}
+                  <span className='text-muted-foreground'>→</span>{' '}
+                  {job.channel.xyneName ?? job.channel.xyneId}
+                </>
+              ) : (
+                'Channel'
+              )}
+            </div>
+            <div className='text-xs text-muted-foreground'>
+              {job.submittedByName ? `${job.submittedByName} · ` : ''}submitted {ago(job.createdAt)}
+              {job.channel?.startDate ? ` · from ${job.channel.startDate}` : ''}
+            </div>
+            {job.channel?.announceInSlack && (
+              <span className='mt-1.5 inline-flex items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground'>
+                <Megaphone className='size-3' />
+                {job.status === 'COMPLETED'
+                  ? 'Notice posted in Slack'
+                  : 'Posts a Slack notice when done'}
+              </span>
+            )}
+          </div>
+        </div>
+        <StatusPill job={job} />
+      </div>
+
+      <div className='mt-4'>
+        <Stepper job={job} />
+      </div>
+
+      <div className='mt-4'>
+        <PhaseProgress job={job} />
+      </div>
+
+      {job.status === 'FAILED' && job.error && (
+        <div className='mt-3 flex items-start gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-xs text-destructive'>
+          <TriangleAlert className='mt-0.5 size-3.5 shrink-0' />
+          <span className='break-words'>{job.error}</span>
+        </div>
+      )}
+
+      {job.stopReason && (job.status === 'STOPPED' || job.stopRequested) && (
+        <div className='mt-3 flex items-start gap-2 rounded-lg bg-orange-500/10 px-3 py-2 text-xs text-orange-600 dark:text-orange-400'>
+          <Info className='mt-0.5 size-3.5 shrink-0' />
+          <span className='break-words'>
+            {job.stopReason === 'system'
+              ? 'Stopped after a system restart — an admin can resume it.'
+              : 'An admin stopped this migration — not a failure. An admin can resume it.'}
+          </span>
+        </div>
+      )}
+
+      {job.issues && job.issues.length > 0 && (
+        <div className='mt-3 flex items-start gap-2 rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400'>
+          <TriangleAlert className='mt-0.5 size-3.5 shrink-0' />
+          <span className='break-words'>
+            {job.issues.length} conversation{job.issues.length > 1 ? 's' : ''} not fully migrated —{' '}
+            {job.issues[0]?.reason}
+            {job.issues.length > 1 ? ` (+${job.issues.length - 1} more)` : ''}
+          </span>
+        </div>
+      )}
+
+      <div className='mt-4 flex items-center justify-between border-t border-border pt-3'>
+        <div className='flex items-center gap-4 text-xs text-muted-foreground'>
+          <span>
+            <span className='font-medium text-foreground tabular-nums'>
+              {job.stats.messages.toLocaleString()}
+            </span>{' '}
+            messages
+          </span>
+          <span className='inline-flex items-center gap-1'>
+            <Clock className='size-3' />
+            updated {ago(job.updatedAt)}
+          </span>
+        </div>
+        {actions && <div className='flex items-center gap-1.5'>{actions}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Ordered sequence: the numbers are meaningful steps, not decoration.
+function Steps({ items }: { items: React.ReactNode[] }): React.JSX.Element {
+  return (
+    <ol className='space-y-2.5'>
+      {items.map((item, i) => (
+        <li key={i} className='flex gap-2.5 text-sm leading-relaxed text-muted-foreground'>
+          <span className='mt-px flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-semibold tabular-nums text-foreground'>
+            {i + 1}
+          </span>
+          <span>{item}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function Checklist({ items }: { items: React.ReactNode[] }): React.JSX.Element {
+  return (
+    <ul className='space-y-2.5'>
+      {items.map((item, i) => (
+        <li key={i} className='flex gap-2.5 text-sm leading-relaxed text-muted-foreground'>
+          <Check className='mt-0.5 size-4 shrink-0 text-emerald-500' />
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function RailCard({
+  title,
+  icon,
+  children,
+}: {
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}): React.JSX.Element {
+  return (
+    <div className='rounded-xl border border-border bg-card p-4 shadow-xs'>
+      <h3 className='mb-3 flex items-center gap-2 text-sm font-semibold text-foreground'>
+        <span className='text-muted-foreground'>{icon}</span>
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+// Token steps on the DM tab, channel prerequisites on the Channel tab.
+function GuideRail({
+  tab,
+  isAdmin,
+}: {
+  tab: 'dm' | 'channel';
+  isAdmin: boolean;
+}): React.JSX.Element {
+  return (
+    <div className='space-y-4'>
+      {tab === 'dm' ? (
+        <RailCard title='Get your Slack token' icon={<KeyRound className='size-4' />}>
+          <Steps
+            items={[
+              SLACK_APP_INSTALL_URL ? (
+                <>
+                  Open the{' '}
+                  <a
+                    href={SLACK_APP_INSTALL_URL}
+                    target='_blank'
+                    rel='noreferrer'
+                    className='inline-flex items-center gap-0.5 font-medium text-primary hover:underline'
+                  >
+                    Slack app install page
+                    <ExternalLink className='size-3' />
+                  </a>
+                  .
+                </>
+              ) : (
+                <>
+                  Open your workspace’s{' '}
+                  <span className='font-medium text-foreground'>Slack app install page</span> — ask
+                  an admin for the link if you don’t have it.
+                </>
+              ),
+              <>
+                Can’t open it? You need to be a{' '}
+                <span className='font-medium text-foreground'>collaborator</span> on the app first —
+                ask a workspace admin to add you, then reopen the link.
+              </>,
+              <>
+                Click <span className='font-medium text-foreground'>Install</span> or{' '}
+                <span className='font-medium text-foreground'>Re-install</span> to your workspace —
+                you’ll get the token.
+              </>,
+              <>
+                Copy your <span className='font-medium text-foreground'>User OAuth token</span>{' '}
+                (starts with <code className='rounded bg-muted px-1 py-0.5 text-xs'>xoxp-</code>)
+                and paste it into the form.
+              </>,
+            ]}
+          />
+          <ul className='mt-4 space-y-2 border-t border-border pt-3.5 text-sm leading-relaxed text-muted-foreground'>
+            <li>Used once to fetch your data, then dropped — never stored, shown, or exported.</li>
+            <li>Must be your own account: the token’s email has to match your Xyne email.</li>
+            <li>One-time per person; an admin deletes your job to let you redo it.</li>
+          </ul>
+        </RailCard>
+      ) : (
+        <RailCard title='Before you migrate a channel' icon={<ListChecks className='size-4' />}>
+          <Checklist
+            items={[
+              <>
+                Add the <span className='font-medium text-foreground'>Xyne Spaces bot</span> to the
+                channel — in Slack, run{' '}
+                <code className='rounded bg-muted px-1 py-0.5 text-xs'>/invite @Xyne Spaces</code>.
+                A channel the bot isn’t in is rejected.
+              </>,
+              <>
+                You must be a <span className='font-medium text-foreground'>member</span> of{' '}
+                <span className='font-medium text-foreground'>both</span> the Slack channel and the
+                destination Xyne channel.
+              </>,
+              <>One migration per channel at a time — request again once it completes.</>,
+            ]}
+          />
+        </RailCard>
+      )}
+      {isAdmin && (
+        <RailCard title='For admins' icon={<ShieldCheck className='size-4' />}>
+          <ul className='space-y-2 text-sm leading-relaxed text-muted-foreground'>
+            {ADMIN_NOTES.map(n => (
+              <li key={n} className='flex gap-2.5'>
+                <span className='mt-[7px] size-1 shrink-0 rounded-full bg-muted-foreground/50' />
+                {n}
+              </li>
+            ))}
+          </ul>
+        </RailCard>
+      )}
+    </div>
+  );
+}
+
+const inputCls =
+  'h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm text-foreground shadow-xs placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[2px] focus-visible:ring-ring/10 outline-none';
+
+// ── page ─────────────────────────────────────────────────────────────────────
+export default function SlackMigration(): React.JSX.Element {
+  const [mine, setMine] = useState<MigrationJobView[]>([]);
+  const [all, setAll] = useState<MigrationJobView[] | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [ingest, setIngest] = useState<{ canIngest: boolean; running: boolean } | null>(null);
+  const [tab, setTab] = useState<'dm' | 'channel'>('dm');
+  const [token, setToken] = useState('');
+  const [channel, setChannel] = useState({
+    slackChannelId: '',
+    xyneChannelId: '',
+    startDate: '',
+    announceInSlack: false,
+  });
+  const [error, setError] = useState<string | null>(null);
+  const [unreachable, setUnreachable] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async (): Promise<boolean> => {
+    try {
+      setMine(await slackMigrationApi.listMine());
+      try {
+        const adminJobs = await slackMigrationApi.listAdmin();
+        setIsAdmin(true);
+        setAll(adminJobs);
+        setIngest(await slackMigrationApi.ingestionStatus());
+      } catch (e) {
+        // Only a real 403 means "not an admin"; a transient 5xx/network blip must not hide the panel.
+        if ((e as { response?: { status?: number } })?.response?.status === 403) {
+          setIsAdmin(false);
+          setAll(null);
+        }
+      }
+      setUnreachable(false); // a successful poll clears the banner
+      setError(null);
+      return true;
+    } catch (e) {
+      const down = isServiceDown(e);
+      setUnreachable(down);
+      if (!down) setError(e instanceof Error ? e.message : String(e));
+      return false;
+    }
+  }, []);
+
+  // Mirror "is a job running?" into a ref so the poll loop reads it without re-subscribing.
+  const hasActive = useMemo(
+    () =>
+      [...(mine ?? []), ...(all ?? [])].some(
+        j => j.status === 'COLLECTING' || j.status === 'INGESTING',
+      ),
+    [mine, all],
+  );
+  const hasActiveRef = useRef(hasActive);
+  hasActiveRef.current = hasActive;
+
+  useEffect(() => {
+    let stopped = false;
+    let fails = 0;
+    let timer: ReturnType<typeof setTimeout>;
+    const loop = async () => {
+      if (stopped) return;
+      if (document.hidden) {
+        timer = setTimeout(() => void loop(), POLL_HIDDEN_MS);
+        return;
+      } // skip background tabs
+      const ok = await refresh();
+      if (stopped) return;
+      fails = ok ? 0 : fails + 1;
+      const next = ok
+        ? hasActiveRef.current
+          ? POLL_ACTIVE_MS
+          : POLL_IDLE_MS
+        : Math.min(POLL_DOWN_MS * 2 ** Math.min(fails - 1, 4), POLL_MAX_MS); // backoff when down
+      timer = setTimeout(() => void loop(), next);
+    };
+    void loop();
+    const onVisible = () => {
+      if (!document.hidden) {
+        clearTimeout(timer);
+        void loop();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      stopped = true;
+      clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [refresh]);
+
+  const run = useCallback(
+    async (fn: () => Promise<unknown>): Promise<boolean> => {
+      setBusy(true);
+      setError(null);
+      try {
+        await fn();
+        await refresh();
+        return true;
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+        return false;
+      } finally {
+        setBusy(false);
+      }
+    },
+    [refresh],
+  );
+
+  const activeDm = useMemo(() => mine.find(m => m.type === 'DM'), [mine]);
+
+  return (
+    <div className='flex h-full w-full flex-col'>
+      {/* Shared app navigator (back/forward + search). */}
+      <div className='h-[52px] w-full shrink-0'>
+        <AppNavigator />
+      </div>
+      <div className='min-h-0 flex-1 overflow-y-auto border-t border-sidebar-border-muted'>
+        <div className='mx-auto max-w-6xl px-4 py-8 sm:px-6'>
+          <div className='lg:grid lg:grid-cols-[19rem_minmax(0,1fr)] lg:gap-10'>
+            {/* LEFT — sticky rail: title + guide */}
+            <aside className='mb-8 lg:mb-0 lg:sticky lg:top-8 lg:self-start'>
+              <header className='mb-5'>
+                <h1 className='text-2xl font-semibold tracking-tight text-foreground'>
+                  Slack migration
+                </h1>
+                <p className='mt-1.5 text-sm leading-relaxed text-muted-foreground'>
+                  Bring your Slack direct messages, group DMs, and channels into Xyne Spaces.
+                </p>
+              </header>
+              <GuideRail tab={tab} isAdmin={isAdmin} />
+            </aside>
+
+            {/* RIGHT — actions */}
+            <div className='min-w-0 space-y-8'>
+              {unreachable && (
+                <div className='flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3.5 py-2.5 text-sm text-amber-600 dark:text-amber-400'>
+                  <CloudOff className='mt-0.5 size-4 shrink-0' />
+                  <span className='break-words'>
+                    The migration service is unreachable — the pod may be starting up or briefly
+                    down. This page keeps retrying; new submissions are paused until it’s back.
+                  </span>
+                </div>
+              )}
+
+              {error && !unreachable && (
+                <div className='flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3.5 py-2.5 text-sm text-destructive'>
+                  <TriangleAlert className='mt-0.5 size-4 shrink-0' />
+                  <span className='break-words'>{error}</span>
+                </div>
+              )}
+
+              {/* Start a migration */}
+              <div className='rounded-xl border border-border bg-card p-4 shadow-xs sm:p-5'>
+                <div className='mb-4 inline-flex rounded-lg bg-muted p-0.5'>
+                  {(['dm', 'channel'] as const).map(k => (
+                    <button
+                      key={k}
+                      onClick={() => setTab(k)}
+                      data-track-category='SLACK_MIGRATION'
+                      data-track-name={`TAB_${k.toUpperCase()}`}
+                      className={cn(
+                        'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                        tab === k
+                          ? 'bg-background text-foreground shadow-xs'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      {k === 'dm' ? 'Direct messages' : 'Channel'}
+                    </button>
+                  ))}
+                </div>
+
+                {tab === 'dm' ? (
+                  activeDm ? (
+                    <p className='text-sm leading-relaxed text-muted-foreground'>
+                      {activeDm.status === 'COMPLETED'
+                        ? 'Your DMs have already been migrated.'
+                        : activeDm.status === 'STOPPED'
+                          ? 'Your DM migration was stopped.'
+                          : activeDm.status === 'FAILED'
+                            ? 'Your DM migration failed.'
+                            : 'Your DM migration is already in progress.'}{' '}
+                      DM migration is one-time per person — an admin must delete it before you can
+                      start again.
+                    </p>
+                  ) : (
+                    <div>
+                      <label
+                        htmlFor='mig-token'
+                        className='mb-1.5 block text-sm font-medium text-foreground'
+                      >
+                        Your Slack user token
+                      </label>
+                      <div className='flex flex-col gap-2 sm:flex-row'>
+                        <Input
+                          id='mig-token'
+                          type='password'
+                          placeholder='xoxp-…'
+                          value={token}
+                          onChange={e => setToken(e.target.value)}
+                          className='flex-1 font-mono'
+                        />
+                        <Button
+                          disabled={busy || unreachable || !token.trim()}
+                          loading={busy}
+                          onClick={() =>
+                            void run(() => slackMigrationApi.submitDm(token.trim())).then(ok => {
+                              if (ok) setToken('');
+                            })
+                          }
+                        >
+                          Migrate my DMs
+                        </Button>
+                      </div>
+                      <p className='mt-2 text-xs text-muted-foreground'>
+                        Used once to fetch your DMs, then dropped. Steps to get your token are on
+                        the left.
+                      </p>
+                    </div>
+                  )
+                ) : (
+                  <div className='space-y-4'>
+                    <div className='grid gap-3 sm:grid-cols-2'>
+                      <div>
+                        <label
+                          htmlFor='mig-slack-channel'
+                          className='mb-1.5 block text-sm font-medium text-foreground'
+                        >
+                          Slack channel ID
+                        </label>
+                        <Input
+                          id='mig-slack-channel'
+                          placeholder='C0…'
+                          value={channel.slackChannelId}
+                          onChange={e => setChannel({ ...channel, slackChannelId: e.target.value })}
+                          className='font-mono'
+                        />
+                      </div>
+                      <div>
+                        <label
+                          htmlFor='mig-xyne-channel'
+                          className='mb-1.5 block text-sm font-medium text-foreground'
+                        >
+                          Xyne channel ID
+                        </label>
+                        <Input
+                          id='mig-xyne-channel'
+                          placeholder='Destination channel'
+                          value={channel.xyneChannelId}
+                          onChange={e => setChannel({ ...channel, xyneChannelId: e.target.value })}
+                          className='font-mono'
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <span className='mb-1.5 block text-sm font-medium text-foreground'>
+                        Start date{' '}
+                        <span className='font-normal text-muted-foreground'>· optional</span>
+                      </span>
+                      <DatePicker
+                        selectedDate={channel.startDate ? new Date(channel.startDate) : null}
+                        onSelect={d =>
+                          setChannel({
+                            ...channel,
+                            startDate: d ? d.toISOString().slice(0, 10) : '',
+                          })
+                        }
+                        placeholder='From the beginning'
+                        maxDate={new Date()}
+                        showClearButton
+                        inputClassName={inputCls}
+                      />
+                    </div>
+                    <Checkbox
+                      checked={channel.announceInSlack}
+                      onChange={c => setChannel({ ...channel, announceInSlack: c })}
+                      label='Post a “Migrated to Xyne Spaces” notice in the Slack channel when it’s done'
+                      size='md'
+                    />
+                    <div className='flex flex-wrap items-center justify-between gap-2 border-t border-border pt-3.5'>
+                      <p className='text-xs text-muted-foreground'>
+                        Add the Xyne Spaces bot to the channel first — checklist on the left.
+                      </p>
+                      <Button
+                        disabled={
+                          busy ||
+                          unreachable ||
+                          !channel.slackChannelId.trim() ||
+                          !channel.xyneChannelId.trim()
+                        }
+                        loading={busy}
+                        onClick={() =>
+                          void run(() => slackMigrationApi.submitChannel(channel)).then(ok => {
+                            if (ok)
+                              setChannel({
+                                slackChannelId: '',
+                                xyneChannelId: '',
+                                startDate: '',
+                                announceInSlack: false,
+                              });
+                          })
+                        }
+                      >
+                        Request channel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {mine.length > 0 && (
+                <section className='space-y-3'>
+                  <h2 className='text-sm font-semibold text-foreground'>Your migrations</h2>
+                  <p className='text-xs text-muted-foreground'>
+                    If a migration fails, delete it and submit again. You can resume or delete your
+                    own jobs here — or ask an admin to do it for you.
+                  </p>
+                  {mine.map(job => (
+                    <JobCard
+                      key={job.id}
+                      job={job}
+                      actions={<OwnerActions job={job} busy={busy} run={run} />}
+                    />
+                  ))}
+                </section>
+              )}
+
+              {/* Admin control panel */}
+              {isAdmin && all && (
+                <section className='space-y-4'>
+                  <div className='flex items-center justify-between'>
+                    <h2 className='text-sm font-semibold text-foreground'>Admin control panel</h2>
+                    <a
+                      href={slackMigrationApi.exportUrl}
+                      target='_blank'
+                      rel='noreferrer'
+                      className='text-xs font-medium text-primary hover:underline'
+                    >
+                      Export history
+                    </a>
+                  </div>
+                  {ingest && <IngestionControl status={ingest} busy={busy} run={run} />}
+                  {all.length === 0 ? (
+                    <p className='rounded-xl border border-dashed border-border py-8 text-center text-sm text-muted-foreground'>
+                      No migrations yet.
+                    </p>
+                  ) : (
+                    <div className='space-y-3'>
+                      {all.map(job => (
+                        <JobCard
+                          key={job.id}
+                          job={job}
+                          actions={<AdminActions job={job} busy={busy} run={run} />}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </section>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IngestionControl({
+  status,
+  busy,
+  run,
+}: {
+  status: { canIngest: boolean; running: boolean };
+  busy: boolean;
+  run: (fn: () => Promise<unknown>) => Promise<boolean>;
+}): React.JSX.Element {
+  const t = TONE[status.running ? 'green' : 'orange'];
+  return (
+    <div className='flex flex-wrap items-center gap-3 rounded-xl border border-border bg-card p-4 shadow-xs'>
+      <span className={cn('flex size-8 items-center justify-center rounded-lg', t.pill)}>
+        {status.running ? <Play className='size-4' /> : <Square className='size-4' />}
+      </span>
+      <div className='leading-tight'>
+        <div className='text-sm font-medium text-foreground'>
+          Ingestion {status.running ? 'running' : 'paused'}
+        </div>
+        <div className='text-xs text-muted-foreground'>
+          {status.running
+            ? 'The queue is on — approved jobs process one at a time, in order.'
+            : 'The queue is off — approved jobs stage here and wait until you start.'}
+        </div>
+      </div>
+      <div className='ml-auto'>
+        {status.canIngest ? (
+          status.running ? (
+            <Button
+              variant='outline'
+              size='sm'
+              disabled={busy}
+              onClick={() => void run(() => slackMigrationApi.stopIngestion())}
+            >
+              <Square className='size-3.5' />
+              Stop ingestion
+            </Button>
+          ) : (
+            <Button
+              size='sm'
+              disabled={busy}
+              onClick={() => void run(() => slackMigrationApi.startIngestion())}
+            >
+              <Play className='size-3.5' />
+              Start ingestion
+            </Button>
+          )
+        ) : (
+          <span className='text-xs text-muted-foreground'>
+            You don’t have permission to start or stop ingestion.
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Actions the submitter gets on their OWN jobs: resume a stopped/failed one, or delete it (when not running).
+function OwnerActions({
+  job,
+  busy,
+  run,
+}: {
+  job: MigrationJobView;
+  busy: boolean;
+  run: (fn: () => Promise<unknown>) => Promise<boolean>;
+}): React.JSX.Element {
+  const [pending, setPending] = useState<string | null>(null);
+  const act = (key: string, fn: () => Promise<unknown>): void => {
+    setPending(key);
+    void run(fn).finally(() => setPending(null));
+  };
+  const canResume = job.status === 'STOPPED' || job.status === 'FAILED';
+  const canDelete = job.status !== 'COLLECTING' && job.status !== 'INGESTING';
+  return (
+    <>
+      {canResume && (
+        <Button
+          variant='outline'
+          size='sm'
+          disabled={busy}
+          loading={pending === 'resume'}
+          onClick={() => act('resume', () => slackMigrationApi.resumeMine(job.id))}
+        >
+          <RotateCcw className='size-3.5' />
+          Resume
+        </Button>
+      )}
+      {canDelete && (
+        <Button
+          variant='ghost'
+          size='sm'
+          disabled={busy}
+          loading={pending === 'remove'}
+          onClick={() => act('remove', () => slackMigrationApi.removeMine(job.id))}
+          className='text-destructive hover:text-destructive'
+        >
+          <Trash2 className='size-3.5' />
+        </Button>
+      )}
+    </>
+  );
+}
+
+function AdminActions({
+  job,
+  busy,
+  run,
+}: {
+  job: MigrationJobView;
+  busy: boolean;
+  run: (fn: () => Promise<unknown>) => Promise<boolean>;
+}): React.JSX.Element {
+  const [pending, setPending] = useState<string | null>(null);
+  const act = (key: string, fn: () => Promise<unknown>): void => {
+    setPending(key);
+    void run(fn).finally(() => setPending(null));
+  };
+  const canApprove = job.status === 'AWAITING_APPROVAL' && job.phase === 'collect';
+  const canStop =
+    job.status === 'COLLECTING' || job.status === 'INGESTING' || job.status === 'QUEUED';
+  const canResume = job.status === 'STOPPED' || job.status === 'FAILED';
+  return (
+    <>
+      {canApprove && (
+        <Button
+          size='sm'
+          disabled={busy}
+          loading={pending === 'approve'}
+          onClick={() => act('approve', () => slackMigrationApi.approve(job.id))}
+        >
+          <Check className='size-3.5' />
+          Approve
+        </Button>
+      )}
+      {canStop && (
+        <Button
+          variant='outline'
+          size='sm'
+          disabled={busy}
+          loading={pending === 'stop'}
+          onClick={() => act('stop', () => slackMigrationApi.stop(job.id))}
+        >
+          <Square className='size-3.5' />
+          Stop
+        </Button>
+      )}
+      {canResume && (
+        <Button
+          variant='outline'
+          size='sm'
+          disabled={busy}
+          loading={pending === 'resume'}
+          onClick={() => act('resume', () => slackMigrationApi.resume(job.id))}
+        >
+          <RotateCcw className='size-3.5' />
+          Resume
+        </Button>
+      )}
+      <Button
+        variant='ghost'
+        size='sm'
+        disabled={busy}
+        loading={pending === 'remove'}
+        onClick={() => act('remove', () => slackMigrationApi.remove(job.id))}
+        className='text-destructive hover:text-destructive'
+      >
+        <Trash2 className='size-3.5' />
+      </Button>
+    </>
+  );
+}

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -3,6 +3,7 @@ import SplashScreen from './SplashScreen/SplashScreen';
 import ProtectedRoute from '../components/Auth/ProtectedRoute';
 import { useActivityTracker } from '../hooks/useActivityTracker';
 import HomeScreen from './HomeScreen';
+import SlackMigration from '../pages/SlackMigration';
 import AuthScreen from './AuthScreen/AuthScreen';
 import CommunityWorkspaceSelectionRoute from './AuthScreen/CommunityWorkspaceSelectionRoute';
 import WorkspaceSelectionScreen from './WorkspaceSelectionScreen';
@@ -1047,6 +1048,10 @@ export const router = createBrowserRouter(
                 {
                   index: true,
                   element: <HomeScreen />,
+                },
+                {
+                  path: 'slack-migration',
+                  element: <SlackMigration />,
                 },
                 {
                   path: 'ai',


### PR DESCRIPTION
# Self-serve Slack migration — backport to `release-20260825`

> Backport of #896 (squash-merged into `main`, commit `61858b6`) onto the `release-20260825` release branch. Content is identical to #896; applied via 3-way merge with no conflicts. The **Environment variables** section below is expanded and corrected vs. the original (notably it now includes `MIGRATION_SLACK_STALL_LIMIT_MS`, which was missing from #896's env table).

Bring Slack **DMs, group DMs, and channels** into Xyne Spaces from a dashboard page.
Two-phase pipeline: **collect** (Slack → GCS, streamed + encrypted) → admin **approve** → **ingest** (GCS → DB, fully offline). Redis-backed jobs on serial Bull queues.

## What's included
- Backend `migration/self-serve/*`: job store, two serial queues, collection/ingest engine, workers, REST API, envelope encryption, and an offline Slack reference (no Slack calls at ingest).
- Dashboard page: token/channel submit, live progress (DM %, channel date-window %), admin approve/stop/resume/delete + ingestion gate.
- Channel submit now **rejects** if the bot isn't in the channel or the requester isn't a member (prevents "migrated but empty" channels). Group DMs now migrate (mpim members are fetched).

## Folder structure
```
apps/backend/src/migration/self-serve/
  index.ts            composition root (store/queues/engine/workers/routes)
  types.ts            job + view models
  store.ts            Redis job store (record + index + per-person/channel locks)
  queues.ts           two serial Bull queues (jobId = migrationId, idempotent)
  workers.ts          collect / ingest processors + reconcile
  engine.ts           Slack → GCS collection (streamed) + offline ingest
  service.ts          submit / approve / stop / resume / delete + validation
  routes.ts           REST API (member routes + admin-gated)
  migrationCrypto.ts  envelope encrypt/decrypt (stream + buffer)
apps/backend/src/integrations/.../utils/slackOfflineReference.ts   offline resolver
apps/dashboard/src/
  pages/SlackMigration.tsx     the page
  api/slackMigrationApi.ts     client
  config.ts · routes/AppRoot.tsx · components/AppSidebar/navigationConfig.ts   wiring
```

## Attachments
Streamed Slack → encrypt → GCS (`uploadStreamToPath(encryptStream(res.body))`) — never buffered whole in the pod (bounded memory, any file size). Dumps + attachments are AES-encrypted at rest.

## Rates (defaults)
| Stage | Env knob | Default | Ceiling |
|---|---|---|---|
| Fetch (collect) | `MIGRATION_SLACK_PAGE_DELAY_MS` | 1000 ms/page (200 msgs/page) | ~200 msg/s |
| Ingest | `MIGRATION_INGEST_MESSAGE_DELAY_MS` | 2 ms/msg | ~500 msg/s |
| Slack request timeout | `MIGRATION_SLACK_REQUEST_TIMEOUT_MS` | 30000 ms | — |
| Attachment timeout | `MIGRATION_SLACK_FILE_TIMEOUT_MS` | 200000 ms | — |
| Stall detection | `MIGRATION_SLACK_STALL_LIMIT_MS` | 600000 ms | — |

## Environment variables to add

### Backend — required
| Var | Purpose |
|---|---|
| `RUN_SLACK_MIGRATION_WORKERS=true` | Enable workers on the **single** migration pod only (API pods leave it unset/false). |
| `MIGRATION_GCS_BUCKET` | Dedicated GCS bucket for dumps + attachments. |
| `MIGRATION_ENC_KEYS` | JSON map `{"k1":"<64 hex chars>"}`, each value a 32-byte KEK (hex, **not** base64). Envelope encryption. |
| `MIGRATION_ENC_ACTIVE` | Which keyId encrypts new writes (e.g. `k1`). |
| `SLACK_BOT_TOKEN` | Central bot token (channel migrations). *(already present in env schema; required for this feature)* |
| `MIGRATION_SLACK_BOT_CONFIGS` | Per-workspace bot config (team→workspace map, notice text). *(already present in env schema; required for this feature)* |
| Redis (`REDIS_*`) | Existing. Also seed the `SLACK-MIGRATION-INGEST` ACL resource to gate ingestion (SQL below). |

### Backend — optional (tunable; defaults shown)
| Var | Default |
|---|---|
| `MIGRATION_SLACK_PAGE_DELAY_MS` | `1000` |
| `MIGRATION_SLACK_REQUEST_TIMEOUT_MS` | `30000` |
| `MIGRATION_SLACK_FILE_TIMEOUT_MS` | `200000` |
| `MIGRATION_SLACK_STALL_LIMIT_MS` | `600000` — no forward progress despite a live heartbeat ⇒ treated as wedged (**new; was missing from #896's table**) |
| `MIGRATION_INGEST_MESSAGE_DELAY_MS` | `2` |

### Dashboard
| Var | Purpose |
|---|---|
| `VITE_SLACK_APP_INSTALL_URL` | Slack app install page where a user gets their own User OAuth token for DM migration. The UI hides the link when unset. Also added to `apps/dashboard/.env.example`. |

## Generating the encryption key
Each value in `MIGRATION_ENC_KEYS` is a **32-byte KEK, hex-encoded** (64 hex chars — the code does `Buffer.from(hex,'hex')` and rejects any other length with *"must be 32 bytes (64 hex chars)"*). It is **hex, not base64**.

```python
import secrets, json
kid = "k1"
print("MIGRATION_ENC_KEYS=" + json.dumps({kid: secrets.token_hex(32)}))  # 32 bytes → 64 hex chars
print("MIGRATION_ENC_ACTIVE=" + kid)
```
Or without Python: `openssl rand -hex 32`, then set `MIGRATION_ENC_KEYS={"k1":"<that hex>"}` and `MIGRATION_ENC_ACTIVE=k1`.

**Rotation:** add a new key to the map, point `MIGRATION_ENC_ACTIVE` at it, and keep the old keys so existing objects still decrypt (every object records the keyId it was sealed with).

## DB seed — ACL resource to gate ingestion
```sql
INSERT INTO resources (id, name, description, "createdAt", "updatedAt")
VALUES (gen_random_uuid()::text, 'SLACK-MIGRATION-INGEST',
        'Authorizes starting/stopping Slack migration ingestion', now(), now())
ON CONFLICT (name) DO NOTHING;

INSERT INTO resource_access (id, "workspaceId", "userId", "resourceId", "accessType", "createdAt", "updatedAt")
SELECT gen_random_uuid()::text, u."workspaceId", u.id, r.id, 'ADMIN', now(), now()
FROM users u
JOIN resources r ON r.name = 'SLACK-MIGRATION-INGEST'
WHERE u.email = 'user@gmail.com'
  AND u."workspaceId" = 'cmt8fhtb6001h79ursb350oen'   -- ← scope to the specific workspace
ON CONFLICT ("userId", "resourceId", "accessType") DO NOTHING;
```
