### PR TITLE
feat: XYNE-61810 share an agent DM conversation to a channel

### DIFF
--- a/apps/backend/prisma/migrations/20260828120000_add_agent_conversation_shares/migration.sql
+++ b/apps/backend/prisma/migrations/20260828120000_add_agent_conversation_shares/migration.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "public"."agent_conversation_shares" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "sourceConversationId" TEXT NOT NULL,
+    "sourceTipMessageId" TEXT NOT NULL,
+    "agentSlug" TEXT NOT NULL,
+    "targetChannelId" TEXT NOT NULL,
+    "targetConversationId" TEXT NOT NULL,
+    "targetMessageId" TEXT NOT NULL,
+    "sharedBy" TEXT NOT NULL,
+    "shareOperationId" TEXT NOT NULL,
+    "sharedMessageCount" INTEGER NOT NULL,
+    "agentAdded" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "agent_conversation_shares_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "agent_conversation_shares_targetConversationId_key"
+ON "public"."agent_conversation_shares"("targetConversationId");
+CREATE UNIQUE INDEX "agent_conversation_shares_targetMessageId_key"
+ON "public"."agent_conversation_shares"("targetMessageId");
+CREATE UNIQUE INDEX "agent_conversation_shares_workspace_channel_sharer_operation_key"
+ON "public"."agent_conversation_shares"("workspaceId", "targetChannelId", "sharedBy", "shareOperationId");
+CREATE INDEX "agent_conversation_shares_source_target_created_idx"
+ON "public"."agent_conversation_shares"("workspaceId", "sourceConversationId", "targetChannelId", "createdAt" DESC);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -10,7 +10,7 @@ generator client {
 
 generator zero {
   provider      = "prisma-generator-zero"
-  excludeTables = ["WorkspaceJoinRequest", "AiProvisioningStatus", "OrgLLMServiceAccountCredential", "OrganizationDomain", "QuestionnaireResponse", "ExternalSource", "WorkflowFolder", "WorkflowCredential"]
+  excludeTables = ["WorkspaceJoinRequest", "AiProvisioningStatus", "OrgLLMServiceAccountCredential", "OrganizationDomain", "QuestionnaireResponse", "ExternalSource", "WorkflowFolder", "WorkflowCredential", "AgentConversationShare"]
 }
 
 datasource db {
@@ -1979,6 +1979,27 @@ model ChannelSection {
 
   @@index([userId, workspaceId, isDeleted]) // Fast lookup of a user's sections in a workspace
   @@map("channel_sections")
+  @@schema("public")
+}
+
+model AgentConversationShare {
+  id                   String   @id @default(cuid())
+  workspaceId          String
+  sourceConversationId String
+  sourceTipMessageId   String
+  agentSlug            String
+  targetChannelId      String
+  targetConversationId String   @unique
+  targetMessageId      String   @unique
+  sharedBy             String
+  shareOperationId     String
+  sharedMessageCount   Int
+  agentAdded           Boolean  @default(false)
+  createdAt            DateTime @default(now())
+
+  @@unique([workspaceId, targetChannelId, sharedBy, shareOperationId])
+  @@index([workspaceId, sourceConversationId, targetChannelId, createdAt(sort: Desc)])
+  @@map("agent_conversation_shares")
   @@schema("public")
 }
 

--- a/apps/backend/src/controllers/shareAgentConversationController.ts
+++ b/apps/backend/src/controllers/shareAgentConversationController.ts
@@ -1,0 +1,141 @@
+import { Request, Response } from 'express';
+import '../types/express';
+import { logger } from '@/utils/logger';
+import {
+  getAgentConversationPreview,
+  getPreShareStatus,
+  shareAgentConversationToChannel,
+  ShareAgentConversationError,
+  type ShareErrorCode,
+} from '@/services/shareAgentConversationService';
+
+const ERROR_STATUS: Record<ShareErrorCode, number> = {
+  CHANNEL_NOT_FOUND: 404,
+  NOT_A_CHANNEL_MEMBER: 403,
+  INVALID_TARGET_CHANNEL: 422,
+  CHANNEL_ARCHIVED: 409,
+  RESHARE_CONFIRMATION_REQUIRED: 409,
+  EMPTY_TRANSCRIPT: 422,
+  TRANSCRIPT_TOO_LARGE: 413,
+  NO_NEW_MESSAGES: 409,
+  ADD_AGENT_FORBIDDEN: 403,
+  AGENT_NOT_INSTALLED: 422,
+  SHARING_DISABLED: 403,
+};
+
+function handleError(res: Response, error: unknown, context: string): void {
+  if (error instanceof ShareAgentConversationError) {
+    res.status(ERROR_STATUS[error.code]).json({ error: error.message, code: error.code });
+    return;
+  }
+  logger.error(`[shareAgentConversation] ${context} failed`, { error });
+  res.status(500).json({ error: 'Failed to share agent conversation' });
+}
+
+export class ShareAgentConversationController {
+  getStatus = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = req.user!.id;
+      const workspaceId = req.user!.workspaceId;
+      const { channelId } = req.params;
+      const agentSlug = String(req.query.agentSlug ?? '');
+      const sourceConversationId = String(req.query.sourceConversationId ?? '');
+      const activePathTipMessageId = req.query.activePathTipMessageId
+        ? String(req.query.activePathTipMessageId)
+        : null;
+
+      if (!channelId || !agentSlug || !sourceConversationId) {
+        res
+          .status(400)
+          .json({ error: 'channelId, agentSlug and sourceConversationId are required' });
+        return;
+      }
+      if (!workspaceId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const status = await getPreShareStatus({
+        agentSlug,
+        sourceConversationId,
+        targetChannelId: channelId,
+        activePathTipMessageId,
+        userId,
+        workspaceId,
+      });
+      res.status(200).json(status);
+    } catch (error) {
+      handleError(res, error, 'getStatus');
+    }
+  };
+
+  getPreview = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = req.user!.id;
+      const workspaceId = req.user!.workspaceId;
+      const agentSlug = String(req.query.agentSlug ?? '');
+      const sourceConversationId = String(req.query.sourceConversationId ?? '');
+
+      if (!agentSlug || !sourceConversationId) {
+        res.status(400).json({ error: 'agentSlug and sourceConversationId are required' });
+        return;
+      }
+      if (!workspaceId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const preview = await getAgentConversationPreview({
+        agentSlug,
+        sourceConversationId,
+        userId,
+        workspaceId,
+      });
+      res.status(200).json(preview);
+    } catch (error) {
+      handleError(res, error, 'getPreview');
+    }
+  };
+
+  share = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = req.user!.id;
+      const workspaceId = req.user!.workspaceId;
+      const { channelId } = req.params;
+      const {
+        agentSlug,
+        sourceConversationId,
+        addAgentConfirmed,
+        reShareConfirmed,
+        shareOperationId,
+        note,
+      } = req.body ?? {};
+
+      if (!channelId || !agentSlug || !sourceConversationId) {
+        res
+          .status(400)
+          .json({ error: 'channelId, agentSlug and sourceConversationId are required' });
+        return;
+      }
+      if (!workspaceId) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const result = await shareAgentConversationToChannel({
+        agentSlug: String(agentSlug),
+        sourceConversationId: String(sourceConversationId),
+        targetChannelId: channelId,
+        userId,
+        workspaceId,
+        addAgentConfirmed: Boolean(addAgentConfirmed),
+        reShareConfirmed: Boolean(reShareConfirmed),
+        shareOperationId: shareOperationId ? String(shareOperationId) : undefined,
+        ...(typeof note === 'string' ? { note } : {}),
+      });
+      res.status(201).json(result);
+    } catch (error) {
+      handleError(res, error, 'share');
+    }
+  };
+}

--- a/apps/backend/src/database/acl/acl-factory.ts
+++ b/apps/backend/src/database/acl/acl-factory.ts
@@ -143,6 +143,8 @@ export class ACLFactory {
       return new ActivitiesACL(ctx, prisma)
     case 'agent':
       return new AgentsACL(ctx, prisma)
+    case 'agentConversationShare':
+      return new BaseQueryACL(ctx, prisma)
     case 'agentStep':
       return new AgentStepsACL(ctx, prisma)
     case 'agentToolsMapping':

--- a/apps/backend/src/database/repositories/channelParticipantRepository.ts
+++ b/apps/backend/src/database/repositories/channelParticipantRepository.ts
@@ -150,6 +150,72 @@ export class ChannelParticipantRepository extends BaseRepository<ChannelParticip
   }
 
   // Channel Participant specific methods
+  /**
+   * Join a channel inside a caller-supplied transaction: participant row, status
+   * row and the participantCount increment. Callers already holding a transaction
+   * (e.g. one guarded by an advisory lock) must use this rather than
+   * `addParticipant`, which opens its own and would not be covered by that lock.
+   *
+   * `conversationSeenCutoffAt` is a parameter because resolving it is a per-channel
+   * `ORDER BY createdAt` scan that can take many seconds under load; running it here
+   * would put it back inside the interactive transaction and reintroduce P2028.
+   * Callers must resolve it via `resolveSeenCutoff` before opening their transaction.
+   */
+  async addParticipantInTransaction(
+    tx: Parameters<Parameters<typeof this.db.$transaction>[0]>[0],
+    channelId: string,
+    userId: string,
+    conversationSeenCutoffAt: Date | null,
+    role: ChannelRole = ChannelRole.MEMBER,
+    isClosed: boolean = false
+  ): Promise<{ participant: ChannelParticipant; added: boolean }> {
+    const now = new Date();
+    const workspaceId = await resolveWorkspaceIdFromModel(tx, 'channel', { id: channelId });
+    const inserted = await tx.channelParticipant.createMany({
+      data: [{ channelId, workspaceId, userId, role: role || ChannelRole.MEMBER }],
+      skipDuplicates: true,
+    });
+    const participant = await tx.channelParticipant.findUniqueOrThrow({
+      where: { channelId_userId: { channelId, userId } },
+    });
+    if (inserted.count === 0) {
+      return { participant, added: false };
+    }
+
+    // Automatically create status record. Use upsert so a pre-existing status
+    // row (e.g. orphaned from a prior partial migration run) is left as-is
+    // instead of throwing a unique-constraint error on (channelId, userId).
+    // desktopNotificationLevel / mobileNotificationLevel intentionally omitted —
+    // null (inherit global) is the DB column default.
+    await tx.channelUserStatus.upsert({
+      where: { channelId_userId: { channelId, userId } },
+      update: {},
+      create: {
+        channelId,
+        workspaceId,
+        userId,
+        isClosed,
+        isStarred: false,
+        lastViewedAt: now,
+        conversationSeenCutoffAt,
+      }
+    });
+
+    // Increment participantCount in channel_stats
+    await tx.channelStats.upsert({
+      where: { channelId },
+      update: { participantCount: { increment: 1 } },
+      create: { channelId, workspaceId, participantCount: 1, lastActivityAt: now },
+    });
+
+    return { participant, added: true };
+  }
+
+  /** Resolve the seen cutoff outside any transaction — see addParticipantInTransaction. */
+  async resolveSeenCutoff(channelId: string, at: Date = new Date()): Promise<Date | null> {
+    return this.getConversationSeenCutoffAt(this.db, channelId, at);
+  }
+
   async addParticipant(channelId: string, userId: string, role: ChannelRole = ChannelRole.MEMBER, isClosed: boolean = false): Promise<ChannelParticipant> {
     // Existence check + the seen-cutoff scan run OUTSIDE the write transaction. getConversationSeenCutoffAt is a
     // per-channel `ORDER BY createdAt` scan that, under heavy parallel migration load, can take many seconds; leaving it
@@ -162,50 +228,12 @@ export class ChannelParticipantRepository extends BaseRepository<ChannelParticip
       return existing;
     }
 
-    const now = new Date();
-    const conversationSeenCutoffAt = await this.getConversationSeenCutoffAt(this.db, channelId, now);
+    const conversationSeenCutoffAt = await this.resolveSeenCutoff(channelId);
 
-    return await this.db.$transaction(async (tx) => {
-      const workspaceId = await resolveWorkspaceIdFromModel(tx, 'channel', { id: channelId });
-
-      // Create participant
-      const participant = await tx.channelParticipant.create({
-        data: {
-          channelId,
-          workspaceId,
-          userId,
-          role: role || 'MEMBER',
-        }
-      });
-
-      // Automatically create status record. Use upsert so a pre-existing status
-      // row (e.g. orphaned from a prior partial migration run) is left as-is
-      // instead of throwing a unique-constraint error on (channelId, userId).
-      // desktopNotificationLevel / mobileNotificationLevel intentionally omitted —
-      // null (inherit global) is the DB column default.
-      await tx.channelUserStatus.upsert({
-        where: { channelId_userId: { channelId, userId } },
-        update: {},
-        create: {
-          channelId,
-          workspaceId,
-          userId,
-          isClosed,
-          isStarred: false,
-          lastViewedAt: now,
-          conversationSeenCutoffAt,
-        }
-      });
-
-      // Increment participantCount in channel_stats
-      await tx.channelStats.upsert({
-        where: { channelId },
-        update: { participantCount: { increment: 1 } },
-        create: { channelId, workspaceId, participantCount: 1, lastActivityAt: new Date() },
-      });
-
-      return participant;
-    });
+    const { participant } = await this.db.$transaction(async (tx) =>
+      this.addParticipantInTransaction(tx, channelId, userId, conversationSeenCutoffAt, role, isClosed)
+    );
+    return participant;
   }
 
   async removeParticipant(channelId: string, userId: string): Promise<void> {

--- a/apps/backend/src/routes/channels.ts
+++ b/apps/backend/src/routes/channels.ts
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 import { ChannelController } from '../controllers/channelController';
 import { ConversationController } from '../controllers/conversationController';
+import { ShareAgentConversationController } from '../controllers/shareAgentConversationController';
 import { uploadMultiple } from '../middleware/upload';
 
 const router = Router();
 const channelController = new ChannelController();
 const conversationController = new ConversationController();
+const shareAgentConversationController = new ShareAgentConversationController();
 
 // Channel Management Routes
 router.post('/', channelController.createChannel);
@@ -20,5 +22,11 @@ router.get('/:channelId/members', channelController.getChannelMembers); // Activ
 
 // Conversation Routes (nested under channels)
 router.post('/:channelId/conversations', uploadMultiple, conversationController.createConversation);
+
+router.get(
+  '/:channelId/share-agent-conversation/status',
+  shareAgentConversationController.getStatus
+);
+router.post('/:channelId/share-agent-conversation', shareAgentConversationController.share);
 
 export default router;

--- a/apps/backend/src/routes/xyneAI.ts
+++ b/apps/backend/src/routes/xyneAI.ts
@@ -1,10 +1,14 @@
 import { Router } from 'express';
 import { xyneAIControllerV2 } from '@/controllers/xyneAIControllerV2';
 import { authMiddleware } from '@/middleware/auth';
-import { listClawAgentsInChannel } from '@/services/clawAgentService';
+import { listClawAgentsInChannel } from '@/services/channelClawAgentService';
+import { ShareAgentConversationController } from '@/controllers/shareAgentConversationController';
 import { logger } from '@/utils/logger';
 
 const router = Router();
+const shareAgentConversationController = new ShareAgentConversationController();
+
+router.get('/agent-conversation-preview', shareAgentConversationController.getPreview);
 
 /**
  * Xyne AI Routes
@@ -88,14 +92,14 @@ router.get('/v2/conversations/:convId/live', authMiddleware.authenticate, xyneAI
 router.delete('/v2/conversations/:convId', authMiddleware.authenticate, xyneAIControllerV2.deleteConversation);
 
 // GET /api/xyne-ai/v2/attachments/:attachmentId/download - Download attachment from claw
-router.get('/v2/attachments/:attachmentId/download', authMiddleware.authenticate, xyneAIControllerV2.downloadAttachment);
+router.get(
+  '/v2/attachments/:attachmentId/download',
+  authMiddleware.authenticate,
+  xyneAIControllerV2.downloadAttachment
+);
 
 // GET /api/xyne-ai/agents - List all claw agents accessible to the current user
-router.get(
-  '/agents',
-  authMiddleware.authenticate,
-  xyneAIControllerV2.listAccessibleAgents,
-);
+router.get('/agents', authMiddleware.authenticate, xyneAIControllerV2.listAccessibleAgents);
 
 // GET /api/xyne-ai/agents/:slug/models - Models the agent's LiteLLM key can serve
 router.get(
@@ -105,23 +109,24 @@ router.get(
 );
 
 // GET /api/xyne-ai/channel-agents/:channelId - List claw agents in a channel
-router.get(
-  '/channel-agents/:channelId',
-  authMiddleware.authenticate,
-  async (req, res) => {
-    try {
-      const { channelId } = req.params;
-      if (!channelId) {
-        res.status(400).json({ error: 'channelId is required' });
-        return;
-      }
-      const agents = await listClawAgentsInChannel(channelId);
-      res.json({ agents });
-    } catch (error) {
-      logger.error('[xyne-ai] Failed to list channel claw agents:', error);
-      res.status(500).json({ error: 'Failed to list channel claw agents' });
+router.get('/channel-agents/:channelId', authMiddleware.authenticate, async (req, res) => {
+  try {
+    const { channelId } = req.params;
+    if (!channelId) {
+      res.status(400).json({ error: 'channelId is required' });
+      return;
     }
-  },
-);
+    const requesterUserId = req.user?.id;
+    if (!requesterUserId) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+    const agents = await listClawAgentsInChannel(channelId, requesterUserId);
+    res.json({ agents });
+  } catch (error) {
+    logger.error('[xyne-ai] Failed to list channel claw agents:', error);
+    res.status(500).json({ error: 'Failed to list channel claw agents' });
+  }
+});
 
 export default router;

--- a/apps/backend/src/services/channelClawAgentService.ts
+++ b/apps/backend/src/services/channelClawAgentService.ts
@@ -1,0 +1,85 @@
+import { db } from '@/database/client';
+import { logger } from '@/utils/logger';
+import {
+  agentSlugFromWebhookUrl,
+  listS2SClawAgents,
+  type S2SClawAgent,
+} from './clawAgentService';
+
+export interface ChannelClawAgent {
+  id: string;
+  name: string;
+  agentSlug: string;
+  description: string | null;
+}
+
+export async function listClawAgentsInChannel(
+  channelId: string,
+  requesterUserId: string
+): Promise<ChannelClawAgent[]> {
+  const requester = await db.channelParticipant.findFirst({
+    where: { channelId, userId: requesterUserId },
+    select: { userId: true },
+  });
+  if (!requester) return [];
+
+  const participants = await db.channelParticipant.findMany({
+    where: { channelId },
+    select: { userId: true },
+  });
+  const participantUserIds = new Set(participants.map((participant) => participant.userId));
+  if (participantUserIds.size === 0) return [];
+
+  let agents: S2SClawAgent[] = [];
+  try {
+    agents = await listS2SClawAgents();
+  } catch {
+    logger.warn('[ChannelClawAgentService] Falling back to legacy agent resolution');
+  }
+
+  const resolvedBySlug = new Map<
+    string,
+    { agentSlug: string; userId: string; description: string | null }
+  >();
+  const resolvedUserIds = new Set<string>();
+  for (const agent of agents) {
+    if (agent.spacesAppUserId && participantUserIds.has(agent.spacesAppUserId)) {
+      resolvedBySlug.set(agent.slug, {
+        agentSlug: agent.slug,
+        userId: agent.spacesAppUserId,
+        description: agent.description,
+      });
+      resolvedUserIds.add(agent.spacesAppUserId);
+    }
+  }
+
+  const legacyCandidateIds = [...participantUserIds].filter((id) => id !== requesterUserId);
+  const legacyApps = legacyCandidateIds.length
+    ? await db.installedApps.findMany({
+        where: { userId: { in: legacyCandidateIds }, webhookUrl: { contains: '/webhook/' } },
+        select: { userId: true, webhookUrl: true },
+      })
+    : [];
+  for (const app of legacyApps) {
+    const agentSlug = agentSlugFromWebhookUrl(app.webhookUrl);
+    if (!agentSlug || resolvedBySlug.has(agentSlug) || resolvedUserIds.has(app.userId)) continue;
+    const registeredAgent = agents.find((agent) => agent.slug === agentSlug);
+    resolvedBySlug.set(agentSlug, {
+      agentSlug,
+      userId: app.userId,
+      description: registeredAgent?.description ?? null,
+    });
+    resolvedUserIds.add(app.userId);
+  }
+
+  const resolved = [...resolvedBySlug.values()];
+  const users = await db.user.findMany({
+    where: { id: { in: resolved.map(({ userId }) => userId) } },
+    select: { id: true, name: true },
+  });
+  const usersById = new Map(users.map((user) => [user.id, user]));
+  return resolved.flatMap(({ agentSlug, userId, description }) => {
+    const user = usersById.get(userId);
+    return user ? [{ id: user.id, name: user.name, agentSlug, description }] : [];
+  });
+}

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -21,12 +21,6 @@ import { Agent } from 'undici';
 // real clock. Mirrors streamDispatcher in claw-auth's consume-claw-stream.ts.
 const briefStreamDispatcher = new Agent({ headersTimeout: 0, bodyTimeout: 0, connectTimeout: 10_000 });
 
-export interface ChannelClawAgent {
-  id: string;
-  name: string;
-  agentSlug: string;
-  description: string | null;
-}
 
 export interface ClawRunRequest {
   userId: string;
@@ -393,99 +387,6 @@ function extractUserIdHeader(userId: string, workspaceId?: string): Record<strin
 // Channel agent listing
 // ============================================================================
 
-/**
- * List claw agents installed in a channel by inspecting the
- * channel participants that have claw-app installations.
- */
-export async function listClawAgentsInChannel(channelId: string): Promise<ChannelClawAgent[]> {
-  const clawPrefix = `${getClawBaseUrl()}/claw/`;
-
-  // Find all installed apps with claw webhook URLs
-  const installedApps = await db.installedApps.findMany({
-    where: {
-      webhookUrl: { startsWith: clawPrefix },
-    },
-    select: {
-      userId: true,
-      webhookUrl: true,
-    },
-  });
-
-  if (!installedApps.length) return [];
-
-  // Check which of these users are participants in the channel
-  const channelParticipants = await db.channelParticipant.findMany({
-    where: {
-      channelId,
-      userId: { in: installedApps.map((app) => app.userId) },
-    },
-    select: {
-      userId: true,
-    },
-  });
-
-  const participantUserIds = new Set(channelParticipants.map((p) => p.userId));
-
-  // Get user details for participants
-  const users = await db.user.findMany({
-    where: {
-      id: { in: Array.from(participantUserIds) },
-    },
-    select: {
-      id: true,
-      name: true,
-    },
-  });
-
-  const userMap = new Map(users.map((u) => [u.id, u]));
-
-  // Extract agent slugs from webhook URLs
-  // Production URL format: https://spaces.xyne.juspay.net/claw/api/v1/webhook/{agent-slug}
-  // The agent slug is the last segment of the URL path after /webhook/
-  const agentSlugsFromApps: Array<{ userId: string; agentSlug: string }> = [];
-  for (const app of installedApps) {
-    if (!participantUserIds.has(app.userId)) continue;
-
-    const url = app.webhookUrl;
-    if (!url) continue;
-
-    // Extract agent slug from the webhook URL
-    // Try to match /webhook/{agent-slug} pattern first (production format)
-    // Fallback to extracting the last path segment
-    let agentSlug: string | null = null;
-
-    const webhookMatch = url.match(/\/webhook\/([^/?#]+)/);
-    if (webhookMatch) {
-      agentSlug = webhookMatch[1] ?? null;
-    } else {
-      // Fallback: extract the last path segment after /claw/
-      const pathAfterClaw = url.split('/claw/')[1];
-      if (pathAfterClaw) {
-        const segments = pathAfterClaw.split('/').filter((s) => s.length > 0);
-        agentSlug = segments[segments.length - 1] ?? null;
-      }
-    }
-
-    if (!agentSlug) continue;
-
-    agentSlugsFromApps.push({ userId: app.userId, agentSlug });
-  }
-
-  const result: ChannelClawAgent[] = [];
-  for (const { userId, agentSlug } of agentSlugsFromApps) {
-    const user = userMap.get(userId);
-    if (!user) continue;
-
-    result.push({
-      id: user.id,
-      name: user.name,
-      agentSlug,
-      description: null,
-    });
-  }
-
-  return result;
-}
 
 // ============================================================================
 // Run / stream
@@ -1452,6 +1353,24 @@ export async function downloadClawAttachment(
     contentDisposition: response.headers.get('content-disposition'),
     contentLength: response.headers.get('content-length'),
   };
+}
+
+/**
+ * Extract the agent slug from an installed Claw app's webhook URL. Modern URLs
+ * carry `/webhook/<slug>`; older installs only have the slug as the last
+ * `/claw/` path segment, so both forms must resolve or a legacy agent goes
+ * missing from whichever caller checks only one.
+ */
+export function agentSlugFromWebhookUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const webhookMatch = url.match(/\/webhook\/([^/?#]+)/);
+  if (webhookMatch) return webhookMatch[1] ?? null;
+  const pathAfterClaw = url.split('/claw/')[1];
+  if (pathAfterClaw) {
+    const segments = pathAfterClaw.split('/').filter((s) => s.length > 0);
+    return segments[segments.length - 1] ?? null;
+  }
+  return null;
 }
 
 /** List enabled Claw agents via S2S (used by email auto-draft agent picker). */

--- a/apps/backend/src/services/shareAgentConversationService.ts
+++ b/apps/backend/src/services/shareAgentConversationService.ts
@@ -1,0 +1,813 @@
+import { randomUUID } from 'crypto';
+import { Prisma } from '@prisma/client';
+import { MessageType, ChannelRole, ChannelAddUserPolicy, ChannelScopeType } from '@xyne/shared';
+import { db } from '@/database/client';
+import { logger } from '@/utils/logger';
+import {
+  agentSlugFromWebhookUrl,
+  getConversationTranscript,
+  listS2SClawAgents,
+} from './clawAgentService';
+import { messageMetadataService } from './messageMetadataService';
+import { ChannelParticipantRepository } from '@/database/repositories/channelParticipantRepository';
+import { websocketService } from '@/services/websocketService';
+import { redisService } from '@/services/redisService';
+import { handleUnreadCount } from '@/zero/utils/unreadCountUtlis';
+import { CacConfigService } from '@/services/cacConfigService';
+import { vespaQueue } from '@/queues/vespaQueue';
+import { messageSchema } from '@/vespa/src/types';
+import { NAMESPACE } from '@/vespa/vespaConfig';
+
+const channelParticipantRepository = new ChannelParticipantRepository();
+
+export const MAX_SHARED_TRANSCRIPT_CHARS = 60_000;
+
+async function isAgentConversationSharingEnabled(workspaceId: string): Promise<boolean> {
+  const enabled = await CacConfigService.fetch('share_agent_conversation_enabled', { workspaceId });
+  return enabled !== false;
+}
+
+async function assertSharingEnabled(workspaceId: string): Promise<void> {
+  if (await isAgentConversationSharingEnabled(workspaceId)) return;
+  throw new ShareAgentConversationError(
+    'SHARING_DISABLED',
+    'Sharing agent conversations is turned off for this workspace'
+  );
+}
+
+export type ShareErrorCode =
+  | 'CHANNEL_NOT_FOUND'
+  | 'NOT_A_CHANNEL_MEMBER'
+  | 'INVALID_TARGET_CHANNEL'
+  | 'CHANNEL_ARCHIVED'
+  | 'RESHARE_CONFIRMATION_REQUIRED'
+  | 'EMPTY_TRANSCRIPT'
+  | 'TRANSCRIPT_TOO_LARGE'
+  | 'NO_NEW_MESSAGES'
+  | 'ADD_AGENT_FORBIDDEN'
+  | 'AGENT_NOT_INSTALLED'
+  | 'SHARING_DISABLED';
+
+export class ShareAgentConversationError extends Error {
+  constructor(
+    public code: ShareErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ShareAgentConversationError';
+  }
+}
+
+interface ClawChatMessageLike {
+  id: string;
+  role: string;
+  content?: string | null;
+  reasoning?: string | null;
+}
+
+type SharedCitationInvocation = Prisma.InputJsonObject & {
+  toolCallId: string;
+  citations: Prisma.InputJsonObject[];
+};
+
+const MAX_SHARED_TRANSCRIPT_CITATIONS = 200;
+
+function buildSharedTranscriptCitationMetadata(
+  messages: ClawChatMessageLike[],
+  invocationsByMsgId: Record<string, unknown[]> | undefined,
+  icons: Record<string, string> | undefined
+): {
+  clawCitations: SharedCitationInvocation[];
+  clawCitationIcons?: Record<string, string>;
+} | null {
+  if (!invocationsByMsgId) return null;
+  const byToolCallId = new Map<string, SharedCitationInvocation>();
+  let totalCitations = 0;
+  for (const message of messages) {
+    if (typeof message.content !== 'string' || !message.content.includes('clf-')) continue;
+    const citedIds = new Set<string>();
+    const tokenPattern = /\[clf-([^\][#]+)#\d+\]/g;
+    let match: RegExpExecArray | null;
+    while ((match = tokenPattern.exec(message.content)) !== null) {
+      if (match[1]) citedIds.add(match[1]);
+    }
+    for (const invocation of invocationsByMsgId[message.id] ?? []) {
+      if (!invocation || typeof invocation !== 'object') continue;
+      const record = invocation as Record<string, unknown>;
+      const toolCallId = typeof record['toolCallId'] === 'string' ? record['toolCallId'] : null;
+      const citations = Array.isArray(record['citations']) ? record['citations'] : [];
+      if (!toolCallId || !citedIds.has(toolCallId) || citations.length === 0) continue;
+      if (byToolCallId.has(toolCallId)) continue;
+      if (totalCitations > 0 && totalCitations + citations.length > MAX_SHARED_TRANSCRIPT_CITATIONS)
+        continue;
+      const jsonCitations = citations.filter(
+        (citation): citation is Prisma.InputJsonObject =>
+          citation !== null && typeof citation === 'object' && !Array.isArray(citation)
+      );
+      if (jsonCitations.length === 0) continue;
+      byToolCallId.set(toolCallId, { toolCallId, citations: jsonCitations });
+      totalCitations += jsonCitations.length;
+    }
+  }
+  const clawCitations = [...byToolCallId.values()];
+  if (clawCitations.length === 0) return null;
+  const usedIconKeys = new Set<string>();
+  for (const invocation of clawCitations) {
+    for (const citation of invocation.citations) {
+      const iconKey = citation['iconKey'];
+      if (typeof iconKey === 'string') usedIconKeys.add(iconKey);
+    }
+  }
+  const clawCitationIcons = Object.fromEntries(
+    [...usedIconKeys]
+      .filter((key) => typeof icons?.[key] === 'string')
+      .map((key) => [key, icons![key]!])
+  );
+  return { clawCitations, ...(Object.keys(clawCitationIcons).length ? { clawCitationIcons } : {}) };
+}
+
+function destinationNoun(scopeType: string): string {
+  return scopeType === ChannelScopeType.GROUP_DM ? 'group DM' : 'channel';
+}
+
+function assertShareableTarget(channel: { scopeType: string; isArchived: boolean }): void {
+  if (channel.scopeType === ChannelScopeType.DM) {
+    throw new ShareAgentConversationError(
+      'INVALID_TARGET_CHANNEL',
+      'Agent conversations cannot be shared to a direct message'
+    );
+  }
+  if (
+    channel.scopeType !== ChannelScopeType.DEFAULT &&
+    channel.scopeType !== ChannelScopeType.GROUP_DM
+  ) {
+    throw new ShareAgentConversationError(
+      'INVALID_TARGET_CHANNEL',
+      'Agent conversations can only be shared to channels or group DMs'
+    );
+  }
+  if (channel.isArchived) {
+    throw new ShareAgentConversationError(
+      'CHANNEL_ARCHIVED',
+      `Agent conversations cannot be shared to an archived ${destinationNoun(channel.scopeType)}`
+    );
+  }
+}
+
+function mayAddAgent(
+  scopeType: string,
+  policy: ChannelAddUserPolicy,
+  actorRole: string | null
+): boolean {
+  if (scopeType === ChannelScopeType.GROUP_DM) return true;
+  return policy === ChannelAddUserPolicy.EVERYONE || actorRole === ChannelRole.ADMIN;
+}
+
+function sharerLabel(
+  user: { name?: string | null; displayName?: string | null; email?: string | null } | null
+): string {
+  return user?.displayName || user?.name || user?.email || 'User';
+}
+
+function convertTranscriptToMarkdown(
+  data: ClawChatMessageLike[],
+  agentName: string,
+  userName = 'User'
+): { markdown: string; tipMessageId: string | null; visibleCount: number } {
+  const visible = data.filter((m) => typeof m.content === 'string' && m.content.trim().length > 0);
+
+  const parts = visible.map((m) => {
+    const label = m.role === 'user' ? userName : m.role === 'assistant' ? agentName : m.role;
+    return `**${label}**\n\n${(m.content as string).trim()}`;
+  });
+
+  const markdown = parts.join('\n\n---\n\n');
+  const tipMessageId = visible.length ? visible[visible.length - 1]!.id : null;
+  return { markdown, tipMessageId, visibleCount: visible.length };
+}
+
+
+async function resolveClawAgentAppUser(
+  agentSlug: string,
+  workspaceId: string
+): Promise<{ userId: string; name: string } | null> {
+  const registeredAgent = (await listS2SClawAgents()).find((agent) => agent.slug === agentSlug);
+  if (registeredAgent?.spacesAppUserId) {
+    const installation = await db.installedApps.findFirst({
+      where: { workspaceId, userId: registeredAgent.spacesAppUserId },
+      select: { userId: true },
+    });
+    if (installation) {
+      const user = await db.user.findUnique({
+        where: { id: installation.userId },
+        select: { id: true, name: true },
+      });
+      if (user) return { userId: user.id, name: user.name };
+    }
+  }
+  const apps = await db.installedApps.findMany({
+    where: { workspaceId, webhookUrl: { contains: '/webhook/' } },
+    select: { userId: true, webhookUrl: true },
+  });
+  const match = apps.find((app) => agentSlugFromWebhookUrl(app.webhookUrl) === agentSlug);
+  if (!match) return null;
+  const user = await db.user.findUnique({
+    where: { id: match.userId },
+    select: { id: true, name: true },
+  });
+  return user ? { userId: user.id, name: user.name } : null;
+}
+
+interface StoredShareResult {
+  targetConversationId: string;
+  targetMessageId: string;
+  sharedMessageCount: number;
+  agentAdded: boolean;
+  sourceTipMessageId: string;
+  createdAt: Date;
+}
+
+function toShareResult(row: StoredShareResult, reusedExisting: boolean): ShareResult {
+  return {
+    conversationId: row.targetConversationId,
+    messageId: row.targetMessageId,
+    sharedMessageCount: row.sharedMessageCount,
+    agentAdded: row.agentAdded,
+    reusedExisting,
+  };
+}
+
+export interface PreShareStatusInput {
+  agentSlug: string;
+  sourceConversationId: string;
+  targetChannelId: string;
+  activePathTipMessageId: string | null;
+  userId: string;
+  workspaceId: string;
+}
+
+export interface PreShareStatus {
+  previouslyShared: boolean;
+  lastSharedAt: string | null;
+  hasNewSinceLastShare: boolean;
+  agentInChannel: boolean;
+  canAddAgent: boolean;
+  agentInstalled: boolean;
+  channelVisibility: string;
+
+  channelScopeType: string;
+}
+
+export interface AgentConversationPreviewTurn {
+  role: string;
+
+  name: string;
+
+  userId: string | null;
+  content: string;
+}
+
+export interface AgentConversationPreview {
+  messageCount: number;
+  turns: AgentConversationPreviewTurn[];
+  previewTruncated: boolean;
+
+  tipMessageId: string | null;
+}
+
+const MAX_SHARE_PREVIEW_TURNS = 8;
+
+const MAX_SHARE_PREVIEW_CHARS = 1_200;
+
+const MAX_SHARE_NOTE_CHARS = 2_000;
+
+export async function getPreShareStatus(input: PreShareStatusInput): Promise<PreShareStatus> {
+  const {
+    agentSlug,
+    sourceConversationId,
+    targetChannelId,
+    activePathTipMessageId,
+    userId,
+    workspaceId,
+  } = input;
+
+  await assertSharingEnabled(workspaceId);
+
+  const channel = await db.channel.findUnique({
+    where: { id: targetChannelId },
+    select: {
+      id: true,
+      workspaceId: true,
+      visibility: true,
+      addUserPolicy: true,
+      scopeType: true,
+      isArchived: true,
+    },
+  });
+  if (!channel || channel.workspaceId !== workspaceId) {
+    throw new ShareAgentConversationError(
+      'CHANNEL_NOT_FOUND',
+      'Channel not found in this workspace'
+    );
+  }
+
+  const actor = await db.channelParticipant.findFirst({
+    where: { channelId: targetChannelId, userId },
+    select: { role: true },
+  });
+  if (!actor) {
+    throw new ShareAgentConversationError(
+      'NOT_A_CHANNEL_MEMBER',
+      `You must be a member of the target ${destinationNoun(channel.scopeType)} to view share status`
+    );
+  }
+
+  assertShareableTarget(channel);
+
+  const agentAppUser = await resolveClawAgentAppUser(agentSlug, workspaceId);
+  const agentInstalled = !!agentAppUser;
+
+  let agentInChannel = false;
+  if (agentAppUser) {
+    const agentParticipant = await db.channelParticipant.findFirst({
+      where: { channelId: targetChannelId, userId: agentAppUser.userId },
+      select: { userId: true },
+    });
+    agentInChannel = !!agentParticipant;
+  }
+
+  const policy = (channel.addUserPolicy as ChannelAddUserPolicy) ?? ChannelAddUserPolicy.EVERYONE;
+  const actorMayAdd = !!actor && mayAddAgent(channel.scopeType, policy, actor.role);
+  const canAddAgent = actorMayAdd && agentInstalled && !agentInChannel;
+
+  const last = await db.agentConversationShare.findFirst({
+    where: { workspaceId, sourceConversationId, targetChannelId },
+    orderBy: { createdAt: 'desc' },
+    select: { sourceTipMessageId: true, createdAt: true },
+  });
+  const previouslyShared = !!last;
+
+  let authoritativeTipMessageId = activePathTipMessageId;
+  if (last && !authoritativeTipMessageId) {
+    authoritativeTipMessageId = (
+      await renderSourceTranscript({ agentSlug, sourceConversationId, userId, workspaceId })
+    ).tipMessageId;
+  }
+  const hasNewSinceLastShare = last ? last.sourceTipMessageId !== authoritativeTipMessageId : true;
+
+  return {
+    previouslyShared,
+    lastSharedAt: last?.createdAt.toISOString() ?? null,
+    hasNewSinceLastShare,
+    agentInChannel,
+    canAddAgent,
+    agentInstalled,
+    channelVisibility: channel.visibility,
+    channelScopeType: channel.scopeType,
+  };
+}
+
+interface RenderSourceInput {
+  agentSlug: string;
+  sourceConversationId: string;
+  userId: string;
+  workspaceId: string;
+}
+
+async function renderSourceTranscript(input: RenderSourceInput): Promise<{
+  markdown: string;
+  tipMessageId: string | null;
+  visibleCount: number;
+  turns: AgentConversationPreviewTurn[];
+}> {
+  const { agentSlug, sourceConversationId, userId, workspaceId } = input;
+  const payload = await getConversationTranscript({
+    agentSlug,
+    conversationId: sourceConversationId,
+    userId,
+    spacesWorkspaceId: workspaceId,
+  });
+  const data = (Array.isArray(payload.data) ? payload.data : []) as ClawChatMessageLike[];
+  const [agentAppUser, sharer] = await Promise.all([
+    resolveClawAgentAppUser(agentSlug, workspaceId),
+    db.user.findUnique({
+      where: { id: userId },
+      select: { name: true, displayName: true, email: true },
+    }),
+  ]);
+  const agentName = agentAppUser?.name ?? agentSlug;
+  const userName = sharerLabel(sharer);
+  const turns = data
+    .filter((m) => typeof m.content === 'string' && m.content.trim().length > 0)
+    .map((m) => ({
+      role: m.role,
+      name: m.role === 'user' ? userName : m.role === 'assistant' ? agentName : m.role,
+      userId:
+        m.role === 'user' ? userId : m.role === 'assistant' ? (agentAppUser?.userId ?? null) : null,
+      content: (m.content as string).trim(),
+    }));
+  return { ...convertTranscriptToMarkdown(data, agentName, userName), turns };
+}
+
+export async function getAgentConversationPreview(
+  input: RenderSourceInput
+): Promise<AgentConversationPreview> {
+  await assertSharingEnabled(input.workspaceId);
+  const { turns: allTurns, tipMessageId } = await renderSourceTranscript(input);
+
+  let budget = MAX_SHARE_PREVIEW_CHARS;
+  let bodyTruncated = false;
+  const turns: AgentConversationPreviewTurn[] = [];
+  for (const turn of allTurns.slice(0, MAX_SHARE_PREVIEW_TURNS)) {
+    if (budget <= 0) break;
+    if (turn.content.length > budget) bodyTruncated = true;
+    turns.push({ ...turn, content: turn.content.slice(0, budget) });
+    budget -= turn.content.length;
+  }
+
+  return {
+    messageCount: allTurns.length,
+    turns,
+    previewTruncated: bodyTruncated || turns.length < allTurns.length,
+    tipMessageId,
+  };
+}
+
+export interface ShareInput {
+  agentSlug: string;
+  sourceConversationId: string;
+  targetChannelId: string;
+  userId: string;
+  workspaceId: string;
+
+  addAgentConfirmed?: boolean;
+
+  reShareConfirmed?: boolean;
+
+  shareOperationId?: string;
+
+  note?: string;
+}
+
+export interface ShareResult {
+  conversationId: string;
+  messageId: string;
+  sharedMessageCount: number;
+  agentAdded: boolean;
+  reusedExisting: boolean;
+}
+
+function sanitizeShareLogValue(value: string): string {
+  return Array.from(value)
+    .map((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 0x1f ||
+        (codePoint >= 0x7f && codePoint <= 0x9f) ||
+        codePoint === 0x2028 ||
+        codePoint === 0x2029
+        ? ' '
+        : character;
+    })
+    .join('')
+    .slice(0, 1_000);
+}
+
+export async function shareAgentConversationToChannel(input: ShareInput): Promise<ShareResult> {
+  const {
+    agentSlug,
+    sourceConversationId,
+    targetChannelId,
+    userId,
+    workspaceId,
+    addAgentConfirmed = false,
+    reShareConfirmed = false,
+  } = input;
+  const shareOperationId = input.shareOperationId ?? randomUUID();
+  await assertSharingEnabled(workspaceId);
+  const trimmedNote = (input.note ?? '').trim().slice(0, MAX_SHARE_NOTE_CHARS);
+
+  const channel = await db.channel.findUnique({
+    where: { id: targetChannelId },
+    select: {
+      id: true,
+      workspaceId: true,
+      addUserPolicy: true,
+      scopeType: true,
+      isArchived: true,
+    },
+  });
+  if (!channel || channel.workspaceId !== workspaceId) {
+    throw new ShareAgentConversationError(
+      'CHANNEL_NOT_FOUND',
+      'Channel not found in this workspace'
+    );
+  }
+  const actor = await db.channelParticipant.findFirst({
+    where: { channelId: targetChannelId, userId },
+    select: { role: true },
+  });
+  if (!actor) {
+    throw new ShareAgentConversationError(
+      'NOT_A_CHANNEL_MEMBER',
+      `You must be a member of the target ${destinationNoun(channel.scopeType)} to share into it`
+    );
+  }
+  assertShareableTarget(channel);
+
+  const priorOperation = await db.agentConversationShare.findUnique({
+    where: {
+      workspaceId_targetChannelId_sharedBy_shareOperationId: {
+        workspaceId,
+        targetChannelId,
+        sharedBy: userId,
+        shareOperationId,
+      },
+    },
+  });
+  if (priorOperation) return toShareResult(priorOperation, true);
+
+  const payload = await getConversationTranscript({
+    agentSlug,
+    conversationId: sourceConversationId,
+    userId,
+    spacesWorkspaceId: workspaceId,
+  });
+  const data = (Array.isArray(payload.data) ? payload.data : []) as ClawChatMessageLike[];
+
+  const agentAppUser = await resolveClawAgentAppUser(agentSlug, workspaceId);
+  const agentName = agentAppUser?.name ?? agentSlug;
+  const sharer = await db.user.findUnique({
+    where: { id: userId },
+    select: { name: true, displayName: true, email: true },
+  });
+  const { markdown, tipMessageId, visibleCount } = convertTranscriptToMarkdown(
+    data,
+    agentName,
+    sharerLabel(sharer)
+  );
+  const citationMetadata = buildSharedTranscriptCitationMetadata(
+    data,
+    payload.invocationsByMsgId,
+    payload.icons
+  );
+  if (visibleCount === 0 || !tipMessageId) {
+    throw new ShareAgentConversationError(
+      'EMPTY_TRANSCRIPT',
+      'This conversation has no visible messages to share'
+    );
+  }
+  if (markdown.length > MAX_SHARED_TRANSCRIPT_CHARS) {
+    throw new ShareAgentConversationError(
+      'TRANSCRIPT_TOO_LARGE',
+      `This conversation is too large to share. The maximum is ${MAX_SHARED_TRANSCRIPT_CHARS.toLocaleString()} characters.`
+    );
+  }
+
+  const policy = (channel.addUserPolicy as ChannelAddUserPolicy) ?? ChannelAddUserPolicy.EVERYONE;
+  if (addAgentConfirmed && !agentAppUser) {
+    throw new ShareAgentConversationError(
+      'AGENT_NOT_INSTALLED',
+      `This agent is not installed as a Spaces App and cannot be added to the ${destinationNoun(channel.scopeType)}`
+    );
+  }
+  if (addAgentConfirmed && !mayAddAgent(channel.scopeType, policy, actor.role)) {
+    throw new ShareAgentConversationError(
+      'ADD_AGENT_FORBIDDEN',
+      `You do not have permission to add members to this ${destinationNoun(channel.scopeType)}`
+    );
+  }
+
+  // Resolved before the transaction: it is a per-channel scan that would otherwise
+  // run inside the advisory-locked transaction and eat its budget.
+  const agentSeenCutoffAt =
+    addAgentConfirmed && agentAppUser
+      ? await channelParticipantRepository.resolveSeenCutoff(targetChannelId)
+      : null;
+
+  const persisted = await db.$transaction(async (tx) => {
+    const lockKey = `${workspaceId}:${sourceConversationId}:${targetChannelId}`;
+    await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`;
+
+    const operation = await tx.agentConversationShare.findUnique({
+      where: {
+        workspaceId_targetChannelId_sharedBy_shareOperationId: {
+          workspaceId,
+          targetChannelId,
+          sharedBy: userId,
+          shareOperationId,
+        },
+      },
+    });
+    if (operation)
+      return { row: operation, reusedExisting: true, conversation: null, message: null };
+
+    const latest = await tx.agentConversationShare.findFirst({
+      where: { workspaceId, sourceConversationId, targetChannelId },
+      orderBy: { createdAt: 'desc' },
+      select: { sourceTipMessageId: true },
+    });
+    if (latest?.sourceTipMessageId === tipMessageId) {
+      throw new ShareAgentConversationError(
+        'NO_NEW_MESSAGES',
+        'Nothing new has been added to this conversation since it was last shared'
+      );
+    }
+    if (latest && !reShareConfirmed) {
+      throw new ShareAgentConversationError(
+        'RESHARE_CONFIRMATION_REQUIRED',
+        `Confirm that sharing again creates a new, separate thread in the ${destinationNoun(channel.scopeType)}`
+      );
+    }
+
+    let agentAdded = false;
+    if (addAgentConfirmed && agentAppUser) {
+      ({ added: agentAdded } = await channelParticipantRepository.addParticipantInTransaction(
+        tx,
+        targetChannelId,
+        agentAppUser.userId,
+        agentSeenCutoffAt,
+        ChannelRole.MEMBER
+      ));
+    }
+
+    const now = new Date();
+
+    const displayMetadata: Prisma.InputJsonObject = {
+      sharedAgentTranscript: true,
+      contentFormat: 'markdown',
+      agentSlug,
+      agentName,
+      messageCount: visibleCount,
+      ...(trimmedNote ? { shareNote: trimmedNote } : {}),
+      ...(citationMetadata ?? {}),
+    };
+
+    const conversation = await tx.conversation.create({
+      data: {
+        channelId: targetChannelId,
+        createdBy: userId,
+        initialMessageId: 'temp',
+        workspaceId,
+        lastActivityAt: now,
+        replyCount: 0,
+        pinned: false,
+      },
+    });
+    const message = await tx.message.create({
+      data: {
+        conversationId: conversation.conversationId,
+        senderId: userId,
+        workspaceId,
+        content: markdown,
+        msgType: MessageType.USER,
+        hasAttachment: false,
+        metadata: displayMetadata,
+      },
+    });
+    await tx.conversation.update({
+      where: { conversationId: conversation.conversationId },
+      data: { initialMessageId: message.messageId },
+    });
+    await tx.channelStats.upsert({
+      where: { channelId: targetChannelId },
+      update: { lastActivityAt: now },
+      create: { channelId: targetChannelId, lastActivityAt: now, workspaceId },
+    });
+
+    const row = await tx.agentConversationShare.create({
+      data: {
+        workspaceId,
+        sourceConversationId,
+        sourceTipMessageId: tipMessageId,
+        agentSlug,
+        targetChannelId,
+        targetConversationId: conversation.conversationId,
+        targetMessageId: message.messageId,
+        sharedBy: userId,
+        shareOperationId,
+        sharedMessageCount: visibleCount,
+          agentAdded,
+      },
+    });
+    return { row, reusedExisting: false, conversation, message };
+  });
+
+  if (persisted.reusedExisting || !persisted.conversation || !persisted.message) {
+    return toShareResult(persisted.row, true);
+  }
+
+  await messageMetadataService.syncInitialMessageMd(persisted.conversation.conversationId);
+  await deliverSharedConversation({
+    channelId: targetChannelId,
+    conversationId: persisted.conversation.conversationId,
+    message: persisted.message,
+    senderId: userId,
+    workspaceId,
+  });
+
+  logger.info('[shareAgentConversation] shared conversation', {
+    sourceConversationId: sanitizeShareLogValue(sourceConversationId),
+    agentSlug: sanitizeShareLogValue(agentSlug),
+    targetChannelId: sanitizeShareLogValue(targetChannelId),
+    targetConversationId: sanitizeShareLogValue(persisted.conversation.conversationId),
+    visibleCount,
+    agentAdded: persisted.row.agentAdded,
+  });
+
+  return toShareResult(persisted.row, false);
+}
+
+async function deliverSharedConversation(args: {
+  channelId: string;
+  conversationId: string;
+  message: {
+    messageId: string;
+    senderId: string;
+    content: string;
+    msgType: string;
+    hasAttachment: boolean;
+    createdAt: Date;
+    metadata?: Prisma.JsonValue;
+  };
+  senderId: string;
+  workspaceId: string;
+}): Promise<void> {
+  const { channelId, conversationId, message, senderId, workspaceId } = args;
+
+  vespaQueue
+    .addJob({
+      schema: messageSchema,
+      jobType: 'feed',
+      docId: message.messageId,
+      userId: senderId,
+      ...(workspaceId ? { workspaceId } : {}),
+    })
+    .catch(async (error) => {
+      logger.error('[shareAgentConversation] Error queuing Vespa job:', error);
+      try {
+        const vespaLogs = db.vespaInsertionLogs;
+        if (vespaLogs) {
+          await vespaLogs.create({
+            data: {
+              status: 'FAILED',
+              type: 'INSERT',
+              entityId: message.messageId,
+              entityType: messageSchema,
+              namespace: NAMESPACE,
+              errorMessage: `Failed to enqueue Vespa job: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+              errorDetails: JSON.stringify(error),
+              userId: senderId,
+              createdAt: new Date(),
+              workspaceId,
+            },
+          });
+        }
+      } catch (dbError) {
+        logger.error('[shareAgentConversation] Failed to log Vespa insertion error:', dbError);
+      }
+    });
+
+  const sender = await db.user.findUnique({
+    where: { id: senderId },
+    select: { id: true, name: true, picture: true },
+  });
+
+  const conversationMessage = {
+    conversationId,
+    channelId,
+    messageId: message.messageId,
+    senderId: message.senderId,
+    senderName: sender?.name ?? 'User',
+    senderPicture: sender?.picture ?? undefined,
+    content: message.content,
+    msgType: message.msgType,
+    hasAttachment: message.hasAttachment,
+    attachments: [],
+    createdAt: message.createdAt,
+    metadata: message.metadata ?? undefined,
+  };
+
+  try {
+    await websocketService.broadcastToSession(channelId, 'new_conversation', conversationMessage);
+    await redisService.broadcastMessageToSession(
+      channelId,
+      conversationMessage as unknown as Parameters<typeof redisService.broadcastMessageToSession>[1]
+    );
+  } catch (error) {
+    logger.error('[shareAgentConversation] Failed to broadcast shared conversation:', error);
+  }
+
+  try {
+    const participants = await channelParticipantRepository.getChannelParticipants(channelId);
+    await handleUnreadCount(
+      channelId,
+      false,
+      participants.map((p) => ({ userId: p.userId })),
+      senderId
+    );
+  } catch (error) {
+    logger.error('[shareAgentConversation] Failed to update unread counts:', error);
+  }
+}

--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -1769,6 +1769,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
           <ForwardMessageForm
             message={message}
             channelId={channelId}
+            channelScopeType={channelScopeType}
             onCancel={() => setIsForwardModalOpen(false)}
             onSuccess={() => setIsForwardModalOpen(false)}
           />

--- a/apps/dashboard/src/components/Chat/ExpandableMessage/ExpandableMessage.tsx
+++ b/apps/dashboard/src/components/Chat/ExpandableMessage/ExpandableMessage.tsx
@@ -4,10 +4,12 @@ import { MaximizeTwoArrow } from '@xyne/icons';
 import useMeasure from '../../../hooks/useMeasure';
 
 interface ExpandableMessageProps {
-  message: string;
+  message?: string;
+  children?: React.ReactNode;
   showEdited?: boolean;
   maxHeight?: number; // in pixels, default 500
   className?: string;
+  fadeColor?: string;
   isSystemMessage?: boolean;
   messageId?: string;
   conversationId?: string;
@@ -21,9 +23,11 @@ interface ExpandableMessageProps {
 
 export const ExpandableMessage: React.FC<ExpandableMessageProps> = ({
   message,
+  children,
   showEdited = false,
   maxHeight = 500,
   className = '',
+  fadeColor = 'hsl(var(--background))',
   isSystemMessage = false,
   messageId,
   conversationId,
@@ -57,16 +61,20 @@ export const ExpandableMessage: React.FC<ExpandableMessageProps> = ({
           maxHeight: isExpanded ? 'none' : `${maxHeight}px`,
         }}
       >
-        <div className='jp-message-html whitespace-pre-wrap break-all-words'>
-          <RenderMessageWithHTML
-            message={message}
-            showEdited={showEdited}
-            isSystemMessage={isSystemMessage}
-            {...(messageId !== undefined && { messageId })}
-            {...(conversationId !== undefined && { conversationId })}
-            {...(slashCommandArtifactContext !== undefined && { slashCommandArtifactContext })}
-          />
-        </div>
+        {children !== undefined ? (
+          children
+        ) : (
+          <div className='jp-message-html whitespace-pre-wrap break-all-words'>
+            <RenderMessageWithHTML
+              message={message ?? ''}
+              showEdited={showEdited}
+              isSystemMessage={isSystemMessage}
+              {...(messageId !== undefined && { messageId })}
+              {...(conversationId !== undefined && { conversationId })}
+              {...(slashCommandArtifactContext !== undefined && { slashCommandArtifactContext })}
+            />
+          </div>
+        )}
       </div>
 
       {shouldShowButton && (
@@ -80,8 +88,7 @@ export const ExpandableMessage: React.FC<ExpandableMessageProps> = ({
             isExpanded
               ? undefined
               : {
-                  backgroundImage:
-                    'linear-gradient(to bottom, transparent, hsl(var(--background)))',
+                  backgroundImage: `linear-gradient(to bottom, transparent, ${fadeColor})`,
                 }
           }
         >
@@ -91,7 +98,7 @@ export const ExpandableMessage: React.FC<ExpandableMessageProps> = ({
             className='expand-toggle-pill pointer-events-auto flex items-center gap-1 rounded-full bg-background px-2.5 py-1.5 text-[13px] leading-none text-foreground transition-colors hover:bg-muted cursor-pointer'
             data-track-category='ChatMessage'
             data-track-name='TOGGLE_EXPAND_MESSAGE'
-            data-track-metadata={JSON.stringify({ isExpanded, message: message.length })}
+            data-track-metadata={JSON.stringify({ isExpanded, message: message?.length ?? 0 })}
           >
             <MaximizeTwoArrow size={16} className={isExpanded ? 'rotate-180' : undefined} />
             <span>{isExpanded ? 'Show less' : 'Show more'}</span>

--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
@@ -3,7 +3,7 @@ import { useForm } from '@tanstack/react-form';
 import { Button } from '../../ui/Button/Button';
 import Avatar from '../../ui/Avatar/Avatar';
 import { Badge } from '../../ui/Badge';
-import { X, Hash, Lock, Users } from 'lucide-react';
+import { X, Hash, Lock, Users, Loader2 } from 'lucide-react';
 import { useUser, useUsers } from '../../../hooks/useUsers';
 import { useRankedActivePeople } from '../../../hooks/useRankedPeopleSearch';
 import {
@@ -20,8 +20,13 @@ import {
 import { useMentionSearch } from '../../../hooks/useMentionSearch';
 import { RenderMessageWithHTML } from '../RenderMessageWithHTML/RenderMessageWithHTML';
 import { MessageAttachment } from '../MessageAttachment/MessageAttachment';
-import { formatRelativeTimestamp } from '../../../utils/dateUtils';
+import {
+  formatFullTimestamp,
+  formatRelativeTime,
+  formatRelativeTimestamp,
+} from '../../../utils/dateUtils';
 import HuddleIcon from '../../icons/HuddleIcon';
+import AIAgentIcon from '../../icons/AIAgentIcon';
 import { getEmojiFontSizeClass } from '../../../utils/emojiUtils';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 import {
@@ -54,8 +59,25 @@ import { queries } from '../../../zero/queries';
 import { useQuery } from '../../../hooks/useQuery';
 import { VisibleChannel } from '../../../machines/stateMachine';
 import { logger, Event } from '../../../utils/logger';
+import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
+import { createMarkdownComponents } from '../../../utils/markdownComponents';
 import { RecordingShareContent } from '../../ui/MessageBubble/RecordingShareContent';
 import { useRecordingShareMessage } from '../../ui/MessageBubble/recordingShareMessage';
+import { useQuery as useReactQuery } from '@tanstack/react-query';
+import { fetchChannelClawAgents } from '../../../services/channelClawAgentService';
+import { useCacConfig } from '@xyne/shared/hooks';
+import {
+  useAgentConversationPreview,
+  useShareAgentConversation,
+  useShareAgentConversationStatus,
+} from '../../../hooks/useShareAgentConversation';
+import type { ShareApiError } from '../../../services/claw/shareAgentConversationService';
+import {
+  buildConversationShareSubmission,
+  canShareWholeConversation,
+  isShareableTarget,
+  type ForwardMode,
+} from './forwardMode';
 
 /**
  * ForwardMessageForm component allows users to forward a message to channels or users.
@@ -67,6 +89,7 @@ import { useRecordingShareMessage } from '../../ui/MessageBubble/recordingShareM
 export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
   message,
   channelId,
+  channelScopeType,
   onCancel,
   onSuccess,
 }) => {
@@ -78,6 +101,30 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
   const inputBoxRef = useRef<InputBoxHandle>(null);
   const navigate = useNavigate();
   const zero = useZero();
+  const [forwardMode, setForwardMode] = useState<ForwardMode>('message');
+  const [addAgent, setAddAgent] = useState(true);
+  const [shareOperationId, setShareOperationId] = useState(() => uuidv4());
+  const channelAgentsQuery = useReactQuery({
+    queryKey: ['channel-claw-agents', channelId],
+    queryFn: () => fetchChannelClawAgents(channelId),
+    enabled: channelScopeType === ChannelScopeType.DM,
+    staleTime: 30_000,
+  });
+  const channelAgents = channelAgentsQuery.data ?? [];
+  const dmAgent = channelAgents.length === 1 ? channelAgents[0] : undefined;
+  const { config: sharingEnabled } = useCacConfig<boolean>({
+    key: 'share_agent_conversation_enabled',
+    fallbackConfig: true,
+  });
+  const showForwardModes = canShareWholeConversation(
+    channelScopeType,
+    channelAgents.length,
+    sharingEnabled,
+  );
+  const shareMutation = useShareAgentConversation();
+  useEffect(() => {
+    if (!showForwardModes && forwardMode === 'conversation') setForwardMode('message');
+  }, [forwardMode, showForwardModes]);
 
   // Focus the combobox input *after* the dialog open animation settles. Focusing
   // it synchronously during open (e.g. via the dialog's auto-focus) gets stolen
@@ -114,6 +161,56 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
 
       const firstTarget = selectedTargets[0];
       if (!firstTarget) return;
+
+      if (forwardMode === 'conversation') {
+        const isShareDestination =
+          firstTarget.type === 'channel' || firstTarget.type === 'group_dm';
+        if (!isShareDestination || !dmAgent) return;
+        try {
+          const result = await shareMutation.mutateAsync(
+            buildConversationShareSubmission(
+              firstTarget.id,
+              dmAgent.agentSlug,
+              message.conversationId,
+              addAgent && (shareStatus?.canAddAgent ?? false),
+              true,
+              shareOperationId,
+              value.optionalMessageText.trim() ? value.optionalMessageHtml : '',
+            ),
+          );
+          logger.info(Event.MESSAGE_FORWARDED, {
+            originalMessageId: message.messageId,
+            targetType: firstTarget.type,
+            targetChannelId: firstTarget.id,
+            forwardMode: 'conversation',
+          });
+          const isGroupDmTarget = firstTarget.type === 'group_dm';
+          const targetKind = isGroupDmTarget ? 'group' : 'channel';
+          const targetLabel = isGroupDmTarget ? firstTarget.name : `#${firstTarget.name}`;
+          if (result.reusedExisting)
+            toast.info(`This conversation was already shared to that ${targetKind}.`);
+          else toast.success(`Shared ${result.sharedMessageCount} message(s) to ${targetLabel}`);
+          onSuccess?.();
+          void navigate(`/chat/dir/${firstTarget.id}`);
+        } catch (error) {
+          const apiError = (error as { response?: { data?: ShareApiError } })?.response?.data;
+          logger.error(Event.MESSAGE_FORWARD_FAILED, {
+            originalMessageId: message.messageId,
+            targetType: firstTarget.type,
+            targetChannelId: firstTarget.id,
+            forwardMode: 'conversation',
+            error: error instanceof Error ? error.message : String(error),
+          });
+          if (
+            apiError?.code === 'RESHARE_CONFIRMATION_REQUIRED' ||
+            apiError?.code === 'NO_NEW_MESSAGES'
+          ) {
+            await shareStatusQuery.refetch();
+          }
+          toast.error(apiError?.error ?? 'Failed to share conversation. Please try again.');
+        }
+        return;
+      }
 
       if (firstTarget.type === 'channel') {
         // Forward to channel using mutator
@@ -326,6 +423,68 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
   ); // Merge visible channel data with all channels
   const allUsers = useUsers();
   const usersById = useMemo(() => new Map(allUsers.map(u => [u.id, u])), [allUsers]);
+  const selectedConversationChannel =
+    forwardMode === 'conversation' &&
+    (selectedTargets[0]?.type === 'channel' || selectedTargets[0]?.type === 'group_dm')
+      ? selectedTargets[0]
+      : undefined;
+  const previewQuery = useAgentConversationPreview({
+    agentSlug: dmAgent?.agentSlug,
+    sourceConversationId: message.conversationId,
+    enabled: forwardMode === 'conversation',
+  });
+  const preview = previewQuery.data;
+  const shareStatusQuery = useShareAgentConversationStatus({
+    channelId: selectedConversationChannel?.id,
+    agentSlug: dmAgent?.agentSlug,
+    sourceConversationId: forwardMode === 'conversation' ? message.conversationId : undefined,
+    activePathTipMessageId: preview?.tipMessageId ?? null,
+  });
+  const shareStatus = shareStatusQuery.data;
+  const previewMarkdownComponents = useMemo(
+    () => createMarkdownComponents(`share-preview-${message.messageId}`),
+    [message.messageId],
+  );
+  const noNewMessages =
+    !!shareStatus && shareStatus.previouslyShared && !shareStatus.hasNewSinceLastShare;
+  const agentLabel = dmAgent?.name ?? dmAgent?.agentSlug ?? 'this agent';
+  const destinationNoun =
+    shareStatus?.channelScopeType === ChannelScopeType.GROUP_DM ? 'group' : 'channel';
+  const lastSharedLabel = shareStatus?.lastSharedAt ? (
+    <>
+      shared it{' '}
+      <Tooltip content={formatFullTimestamp(new Date(shareStatus.lastSharedAt))} side='top'>
+        <span className='underline decoration-dotted underline-offset-2'>
+          {formatRelativeTime(new Date(shareStatus.lastSharedAt))}
+        </span>
+      </Tooltip>
+    </>
+  ) : (
+    'shared it here'
+  );
+  const isReShare = !!shareStatus?.previouslyShared && !noNewMessages;
+  const conversationCanSubmit =
+    forwardMode !== 'conversation' ||
+    (!!selectedConversationChannel && !!shareStatus && !noNewMessages && !shareMutation.isPending);
+  const confirmedForChannelId = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (confirmedForChannelId.current === selectedConversationChannel?.id) return;
+    confirmedForChannelId.current = selectedConversationChannel?.id;
+    setAddAgent(true);
+  }, [selectedConversationChannel?.id]);
+
+  const handleForwardModeChange = (nextMode: ForwardMode): void => {
+    setForwardMode(nextMode);
+    setSelectedTargets([]);
+    form.reset();
+    inputBoxRef.current?.clearContent();
+    setAddAgent(true);
+    setShareOperationId(uuidv4());
+    setInputValue('');
+    setIsInitialOpen(true);
+    setComboboxOpen(true);
+    setTimeout(() => comboboxInputRef.current?.focus(), 0);
+  };
 
   // Determine current selection mode based on selected targets
   const selectionMode: SelectionMode = useMemo(() => {
@@ -467,9 +626,12 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
         const defaults: DropdownListItemType[] = [];
 
         // Recent 1:1 DMs ranked by MFU affinity, recency tie-break (up to 5)
-        const recentDMs = rankChannelsByAffinity(
-          allChannels.filter(channel => channel.scopeType === ChannelScopeType.DM),
-        ).slice(0, 5);
+        const recentDMs =
+          forwardMode === 'message'
+            ? rankChannelsByAffinity(
+                allChannels.filter(channel => channel.scopeType === ChannelScopeType.DM),
+              ).slice(0, 5)
+            : [];
 
         recentDMs.forEach(channel => {
           // Self-DM ("notes to self") — only the current user is a participant.
@@ -504,7 +666,11 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
 
         // Recent GROUP_DMs ranked by MFU affinity, recency tie-break (up to 5)
         const recentGroupDMs = rankChannelsByAffinity(
-          allChannels.filter(channel => channel.scopeType === ChannelScopeType.GROUP_DM),
+          allChannels.filter(
+            channel =>
+              channel.scopeType === ChannelScopeType.GROUP_DM &&
+              (forwardMode === 'message' || isShareableTarget(channel)),
+          ),
         ).slice(0, 5);
 
         recentGroupDMs.forEach(channel => {
@@ -521,7 +687,7 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
 
         // Recent DEFAULT channels ranked by MFU affinity, recency tie-break (up to 5)
         const recentChannels = rankChannelsByAffinity(
-          allChannels.filter(channel => channel.scopeType === ChannelScopeType.DEFAULT),
+          allChannels.filter(channel => isShareableTarget(channel)),
         ).slice(0, 5);
 
         recentChannels.forEach(channel => {
@@ -548,26 +714,29 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
         ? new Set(selectedTargets.find(t => t.type === 'group_dm')?.memberIds ?? [])
         : new Set<string>();
 
-    const suggestedUsers: DropdownListItemType[] = rankedUsers
-      .filter(
-        currUser =>
-          // Self is a valid target only as a solo "notes to self" pick. Hide it once
-          // anything else is selected (in a DM/group the current user is implicit).
-          !(currUser.id === currentUser?.id && selectionMode !== 'none') &&
-          !selectedUserIds.has(currUser.id) &&
-          !groupDmMemberIds.has(currUser.id),
-      )
-      // Bound the visible list: rankUsersWithMfu can recover weighted matches past the 20 cap.
-      .slice(0, 20)
-      .map(currUser => ({
-        leftSlot: <Avatar userId={currUser.id} size='sm' />,
-        label: getForwardUserLabel(currUser),
-        description: currUser.email,
-        value: currUser.id,
-      }));
+    const suggestedUsers: DropdownListItemType[] =
+      forwardMode === 'conversation'
+        ? []
+        : rankedUsers
+            .filter(
+              currUser =>
+                // Self is a valid target only as a solo "notes to self" pick. Hide it once
+                // anything else is selected (in a DM/group the current user is implicit).
+                !(currUser.id === currentUser?.id && selectionMode !== 'none') &&
+                !selectedUserIds.has(currUser.id) &&
+                !groupDmMemberIds.has(currUser.id),
+            )
+            // Bound the visible list: rankUsersWithMfu can recover weighted matches past the 20 cap.
+            .slice(0, 20)
+            .map(currUser => ({
+              leftSlot: <Avatar userId={currUser.id} size='sm' />,
+              label: getForwardUserLabel(currUser),
+              description: currUser.email,
+              value: currUser.id,
+            }));
 
     const suggestedChannels: DropdownListItemType[] = rankChannelsByAffinity(
-      channelsSuggestions.filter(currChannel => currChannel.scopeType === ChannelScopeType.DEFAULT),
+      channelsSuggestions.filter(currChannel => isShareableTarget(currChannel)),
     ).map(currChannel => ({
       leftSlot:
         currChannel.visibility === ChannelVisibility.PUBLIC ? (
@@ -582,7 +751,9 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
     // Full-name participant matching + MFU affinity via the shared cmd+K group-DM matcher
     // (getDMNames(...).search feeds both displayName and raw name per participant).
     const groupDmChannels = allChannels.filter(
-      channel => channel.scopeType === ChannelScopeType.GROUP_DM,
+      channel =>
+        channel.scopeType === ChannelScopeType.GROUP_DM &&
+        (forwardMode === 'message' || isShareableTarget(channel)),
     );
     const suggestedGroupDMs: DropdownListItemType[] = filterChannelsBySearchableNames(
       groupDmChannels.map(channel => ({
@@ -622,6 +793,7 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
     usersById,
     currentUser,
     affinityVersion,
+    forwardMode,
   ]);
 
   const onInputValueChangeHandler = (queryString: string) => {
@@ -652,6 +824,7 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
     // Check if the selected value is a channel
     const selectedChannel = allChannels.find(c => c.id === selectedValue);
     if (selectedChannel) {
+      if (forwardMode === 'conversation' && !isShareableTarget(selectedChannel)) return;
       if (selectedChannel.scopeType === ChannelScopeType.GROUP_DM) {
         const memberIds = parseDMParticipantIds(selectedChannel).filter(
           id => id !== currentUser?.id,
@@ -689,7 +862,9 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
     >
       {/* Header */}
       <div className='flex items-center justify-between px-6 pt-6 pb-4 border-b border-border'>
-        <h2 className='text-lg font-semibold text-foreground'>Forward message</h2>
+        <h2 className='text-lg font-semibold text-foreground'>
+          {forwardMode === 'conversation' ? 'Share conversation' : 'Forward message'}
+        </h2>
         <button
           type='button'
           className='rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring/40 focus:ring-offset-2'
@@ -701,6 +876,37 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
           <span className='sr-only'>Close</span>
         </button>
       </div>
+
+      {showForwardModes && (
+        <div
+          className='grid grid-cols-2 gap-2 px-6 pt-4'
+          role='radiogroup'
+          aria-label='Forward mode'
+        >
+          <button
+            type='button'
+            role='radio'
+            aria-checked={forwardMode === 'message'}
+            className={`rounded-md border px-3 py-2 text-sm ${forwardMode === 'message' ? 'border-primary bg-primary/10 text-foreground' : 'border-border text-muted-foreground'}`}
+            onClick={() => handleForwardModeChange('message')}
+            data-track-category='FORWARD_MESSAGE_MODAL'
+            data-track-name='SELECT_THIS_MESSAGE_MODE'
+          >
+            This message
+          </button>
+          <button
+            type='button'
+            role='radio'
+            aria-checked={forwardMode === 'conversation'}
+            className={`rounded-md border px-3 py-2 text-sm ${forwardMode === 'conversation' ? 'border-primary bg-primary/10 text-foreground' : 'border-border text-muted-foreground'}`}
+            onClick={() => handleForwardModeChange('conversation')}
+            data-track-category='FORWARD_MESSAGE_MODAL'
+            data-track-name='SELECT_WHOLE_CONVERSATION_MODE'
+          >
+            Whole conversation
+          </button>
+        </div>
+      )}
 
       <div className='px-6 py-4 space-y-2'>
         {selectedTargets.length > 0 && (
@@ -748,27 +954,36 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
             })}
           </div>
         )}
-        {selectionMode !== 'channel' && totalMemberCount < 9 && (
-          <Combobox
-            ref={comboboxInputRef}
-            label='Forward to'
-            onInputValueChange={onInputValueChangeHandler}
-            onValueChange={onValueChangeHandler}
-            queryString={inputValue}
-            placeholder={
-              selectionMode === 'users' || selectionMode === 'group_dm'
-                ? 'Add more users...'
-                : 'Search channels or users...'
-            }
-            items={dropdownListItems}
-            value={null}
-            hintText='Select a channel or one or more users to forward this message'
-            onBlur={() => setIsInitialOpen(false)}
-            open={comboboxOpen}
-            onOpenChange={setComboboxOpen}
-            autoHighlight={true}
-          />
-        )}
+        {(forwardMode === 'conversation'
+          ? selectedTargets.length === 0
+          : selectionMode !== 'channel') &&
+          totalMemberCount < 9 && (
+            <Combobox
+              ref={comboboxInputRef}
+              label={forwardMode === 'conversation' ? 'Share to' : 'Forward to'}
+              onInputValueChange={onInputValueChangeHandler}
+              onValueChange={onValueChangeHandler}
+              queryString={inputValue}
+              placeholder={
+                forwardMode === 'conversation'
+                  ? 'Search channels or group DMs...'
+                  : selectionMode === 'users' || selectionMode === 'group_dm'
+                    ? 'Add more users...'
+                    : 'Search channels or users...'
+              }
+              items={dropdownListItems}
+              value={null}
+              hintText={
+                forwardMode === 'conversation'
+                  ? 'Select an active channel or group DM to share this conversation'
+                  : 'Select a channel or one or more users to forward this message'
+              }
+              onBlur={() => setIsInitialOpen(false)}
+              open={comboboxOpen}
+              onOpenChange={setComboboxOpen}
+              autoHighlight={true}
+            />
+          )}
         {(selectionMode === 'users' || selectionMode === 'group_dm') && totalMemberCount >= 9 && (
           <p className='text-xs text-muted-foreground mt-1.5'>
             Maximum 9 recipients reached. Remove someone to add another.
@@ -776,11 +991,83 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
         )}
         {selectionMode === 'channel' && (
           <p className='text-xs text-muted-foreground mt-1.5'>
-            Message will be forwarded to the selected channel
+            {forwardMode === 'conversation'
+              ? 'Conversation will be shared to the selected destination'
+              : 'Message will be forwarded to the selected channel'}
           </p>
         )}
       </div>
       <div className='px-6 py-4 space-y-4'>
+        {forwardMode === 'conversation' &&
+          selectedConversationChannel &&
+          shareStatusQuery.isError && (
+            <div className='rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive'>
+              {(shareStatusQuery.error as unknown as { response?: { data?: ShareApiError } })
+                ?.response?.data?.error ?? 'This channel cannot receive the shared conversation.'}
+            </div>
+          )}
+        {forwardMode === 'conversation' &&
+          selectedConversationChannel &&
+          shareStatusQuery.isLoading && (
+            <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+              <Loader2 className='animate-spin' size={14} /> Checking channel…
+            </div>
+          )}
+        {forwardMode === 'conversation' && selectedConversationChannel && shareStatus && (
+          <div className='flex flex-col gap-3'>
+            {shareStatus.previouslyShared && (
+              <div className='rounded-md bg-warning/15 px-3 py-2 text-sm text-warning'>
+                {noNewMessages ? (
+                  <div className='flex flex-col'>
+                    <span className='text-xs font-medium'>Nothing new to share</span>
+                    <span className='text-xs'>
+                      This conversation hasn&apos;t changed since you {lastSharedLabel}.
+                    </span>
+                  </div>
+                ) : (
+                  <div className='flex flex-col'>
+                    <span className='text-xs font-medium'>Already shared here</span>
+                    <span className='text-xs'>
+                      You {lastSharedLabel}. Sharing again creates a new, separate thread.
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+            {shareStatus.channelScopeType === ChannelScopeType.GROUP_DM ? (
+              <div className='text-xs text-warning'>
+                Only members of this group can view this shared conversation.
+              </div>
+            ) : shareStatus.channelVisibility === 'PRIVATE' ? (
+              <div className='text-xs text-warning'>
+                Only members of this channel can view this shared conversation.
+              </div>
+            ) : (
+              <div className='text-xs text-warning'>
+                Everyone in the workspace can view this shared conversation.
+              </div>
+            )}
+            <div className='flex items-center gap-2 text-sm'>
+              <input
+                type='checkbox'
+                data-track-category='FORWARD_MESSAGE_MODAL'
+                data-track-name='ADD_AGENT_WHILE_SHARING_CONVERSATION'
+                disabled={!shareStatus.canAddAgent}
+                checked={shareStatus.agentInChannel || (shareStatus.canAddAgent && addAgent)}
+                onChange={event => setAddAgent(event.target.checked)}
+              />
+              <span className={shareStatus.canAddAgent ? undefined : 'text-muted-foreground'}>
+                {shareStatus.agentInChannel
+                  ? `${agentLabel} is already present in the ${destinationNoun}.`
+                  : shareStatus.canAddAgent
+                    ? `Also add ${agentLabel} to this ${destinationNoun}`
+                    : shareStatus.agentInstalled
+                      ? `You do not have permission to add ${agentLabel} to this ${destinationNoun}.`
+                      : 'This agent is not installed as an app and cannot be added to a channel.'}
+              </span>
+            </div>
+          </div>
+        )}
         {/* Optional message with InputBox */}
         <div
           onKeyDownCapture={e => {
@@ -801,7 +1088,11 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
           <InputBox
             ref={inputBoxRef}
             id='forward-message-optional'
-            placeholder='Add a note to the forwarded message...'
+            placeholder={
+              forwardMode === 'conversation'
+                ? 'Add a note for the people you are sharing with...'
+                : 'Add a note to the forwarded message...'
+            }
             onSendMessage={() => {
               // Handled by the wrapper div's onKeyDown
             }}
@@ -809,13 +1100,17 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
               form.setFieldValue('optionalMessageHtml', html);
               form.setFieldValue('optionalMessageText', text);
             }}
-            mentionItems={mentionResults}
-            onMentionSearch={searchMentions}
-            channelItems={channelMentionItems}
-            onChannelSearch={handleChannelMentionSearch}
+            {...(forwardMode === 'message'
+              ? {
+                  mentionItems: mentionResults,
+                  onMentionSearch: searchMentions,
+                  channelItems: channelMentionItems,
+                  onChannelSearch: handleChannelMentionSearch,
+                }
+              : {})}
             features={{
               richText: true,
-              mentions: true,
+              mentions: forwardMode === 'message',
               commands: false,
               fileAttachments: false,
               emojiPicker: true,
@@ -826,70 +1121,121 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
           />
         </div>
 
-        {/* Message preview */}
-        <div>
-          <span className='block text-sm font-medium text-foreground mb-1.5'>Message preview</span>
-          <div className='bg-muted rounded-md p-3 border border-border max-h-[200px] overflow-y-auto'>
-            <div className='flex gap-3'>
-              <div className='flex-shrink-0'>
-                {isCallMessage ? (
-                  <div className='w-10 h-10 rounded-md flex items-center justify-center bg-accent'>
-                    <HuddleIcon color='hsl(var(--muted-foreground))' size={20} />
-                  </div>
-                ) : (
-                  <Avatar userId={message.senderId} size='md' />
-                )}
-              </div>
-              <div className='flex-1 min-w-0'>
-                <div className='flex items-baseline gap-2 mb-1'>
-                  <h4 className='text-sm font-semibold text-foreground'>
-                    {isCallMessage ? 'Xyne Call' : getUserDisplayName(sender)}
-                  </h4>
-                  <span className='text-xs text-muted-foreground'>
-                    {formatRelativeTimestamp(message.createdAt)}
-                  </span>
-                </div>
-                {recordingShare ? (
-                  <RecordingShareContent
-                    recordingShare={recordingShare}
-                    className='flex min-w-0 flex-col gap-1'
-                    renderNote={noteHtml => (
-                      <div
-                        className={`text-foreground whitespace-pre-wrap break-words ${getEmojiFontSizeClass(noteHtml)}`}
-                      >
-                        <RenderMessageWithHTML message={noteHtml} />
+        {forwardMode === 'conversation' && (
+          <div>
+            <span className='block text-sm font-medium text-foreground mb-1.5'>
+              Conversation preview
+            </span>
+            <div className='bg-muted rounded-md p-3 border border-border max-h-[200px] overflow-y-auto'>
+              {previewQuery.isLoading ? (
+                <span className='flex items-center gap-2 text-sm text-muted-foreground'>
+                  <Loader2 className='animate-spin' size={14} /> Loading conversation…
+                </span>
+              ) : preview ? (
+                <div className='flex flex-col gap-2'>
+                  {preview.turns.map((turn, index) => (
+                    <div key={`${turn.role}-${index}`} className='flex gap-3'>
+                      <div className='flex-shrink-0'>
+                        {turn.userId ? (
+                          <Avatar userId={turn.userId} size='md' />
+                        ) : (
+                          <div className='flex h-10 w-10 items-center justify-center rounded-md bg-accent'>
+                            <AIAgentIcon />
+                          </div>
+                        )}
                       </div>
-                    )}
-                  />
-                ) : previewContent ? (
-                  <div
-                    className={`text-foreground whitespace-pre-wrap break-words ${getEmojiFontSizeClass(previewContent)}`}
-                  >
-                    <RenderMessageWithHTML message={previewContent} />
-                  </div>
-                ) : null}
-                {/* Attachments - hide when using optionalText (it's either optionalText OR content with attachments) */}
-                {!useOptionalText && message.attachments && message.attachments.length > 0 && (
-                  <div className='mt-2'>
-                    <div className='flex flex-wrap gap-2'>
-                      {message.attachments.map(attachment => (
-                        <div key={attachment.id} className='flex-shrink-0'>
-                          <MessageAttachment attachment={attachment} compact />
-                        </div>
-                      ))}
+                      <div className='min-w-0 flex-1'>
+                        <h4 className='text-sm font-semibold text-foreground'>{turn.name}</h4>
+                        <MarkdownMessageRenderer
+                          content={turn.content}
+                          markdownComponents={previewMarkdownComponents}
+                        />
+                      </div>
                     </div>
-                    <p className='text-xs text-muted-foreground mt-1'>
-                      {message.attachments.length}{' '}
-                      {message.attachments.length === 1 ? 'attachment' : 'attachments'} will be
-                      forwarded
-                    </p>
-                  </div>
-                )}
-              </div>
+                  ))}
+                  {preview.previewTruncated ? (
+                    <span className='text-xs text-muted-foreground'>
+                      …and more. The full conversation will be shared.
+                    </span>
+                  ) : null}
+                </div>
+              ) : (
+                <span className='text-sm text-muted-foreground'>
+                  This conversation could not be loaded.
+                </span>
+              )}
             </div>
           </div>
-        </div>
-
+        )}
+        {forwardMode === 'message' && (
+          <>
+            {/* Message preview */}
+            <div>
+              <span className='block text-sm font-medium text-foreground mb-1.5'>
+                Message preview
+              </span>
+              <div className='bg-muted rounded-md p-3 border border-border max-h-[200px] overflow-y-auto'>
+                <div className='flex gap-3'>
+                  <div className='flex-shrink-0'>
+                    {isCallMessage ? (
+                      <div className='w-10 h-10 rounded-md flex items-center justify-center bg-accent'>
+                        <HuddleIcon color='hsl(var(--muted-foreground))' size={20} />
+                      </div>
+                    ) : (
+                      <Avatar userId={message.senderId} size='md' />
+                    )}
+                  </div>
+                  <div className='flex-1 min-w-0'>
+                    <div className='flex items-baseline gap-2 mb-1'>
+                      <h4 className='text-sm font-semibold text-foreground'>
+                        {isCallMessage ? 'Xyne Call' : getUserDisplayName(sender)}
+                      </h4>
+                      <span className='text-xs text-muted-foreground'>
+                        {formatRelativeTimestamp(message.createdAt)}
+                      </span>
+                    </div>
+                    {recordingShare ? (
+                      <RecordingShareContent
+                        recordingShare={recordingShare}
+                        className='flex min-w-0 flex-col gap-1'
+                        renderNote={noteHtml => (
+                          <div
+                            className={`text-foreground whitespace-pre-wrap break-words ${getEmojiFontSizeClass(noteHtml)}`}
+                          >
+                            <RenderMessageWithHTML message={noteHtml} />
+                          </div>
+                        )}
+                      />
+                    ) : previewContent ? (
+                      <div
+                        className={`text-foreground whitespace-pre-wrap break-words ${getEmojiFontSizeClass(previewContent)}`}
+                      >
+                        <RenderMessageWithHTML message={previewContent} />
+                      </div>
+                    ) : null}
+                    {/* Attachments - hide when using optionalText (it's either optionalText OR content with attachments) */}
+                    {!useOptionalText && message.attachments && message.attachments.length > 0 && (
+                      <div className='mt-2'>
+                        <div className='flex flex-wrap gap-2'>
+                          {message.attachments.map(attachment => (
+                            <div key={attachment.id} className='flex-shrink-0'>
+                              <MessageAttachment attachment={attachment} compact />
+                            </div>
+                          ))}
+                        </div>
+                        <p className='text-xs text-muted-foreground mt-1'>
+                          {message.attachments.length}{' '}
+                          {message.attachments.length === 1 ? 'attachment' : 'attachments'} will be
+                          forwarded
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
         {/* Action buttons */}
         <div className='flex justify-end gap-3 pt-2'>
           <Button
@@ -905,13 +1251,25 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
           <Button
             type='submit'
             loading={form.state.isSubmitting}
-            disabled={selectedTargets.length === 0 || form.state.isSubmitting}
+            disabled={
+              selectedTargets.length === 0 || form.state.isSubmitting || !conversationCanSubmit
+            }
             data-track-category='FORWARD_MESSAGE_MODAL'
-            data-track-name='FORWARD_MESSAGE'
-            data-track-metadata={JSON.stringify({ targetCount: selectedTargets })}
+            data-track-name={
+              forwardMode === 'conversation' ? 'SHARE_WHOLE_CONVERSATION' : 'FORWARD_MESSAGE'
+            }
+            data-track-metadata={JSON.stringify({ targetCount: selectedTargets.length })}
             trackId='forward_message'
           >
-            {form.state.isSubmitting ? 'Forwarding...' : 'Forward'}
+            {form.state.isSubmitting || shareMutation.isPending
+              ? forwardMode === 'conversation'
+                ? 'Sharing...'
+                : 'Forwarding...'
+              : forwardMode === 'conversation'
+                ? isReShare
+                  ? 'Share again'
+                  : 'Share conversation'
+                : 'Forward'}
           </Button>
         </div>
       </div>

--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.tsx
@@ -3,6 +3,7 @@ import { useForm } from '@tanstack/react-form';
 import { Button } from '../../ui/Button/Button';
 import Avatar from '../../ui/Avatar/Avatar';
 import { Badge } from '../../ui/Badge';
+import { Checkbox } from '../../ui/Checkbox/Checkbox';
 import { X, Hash, Lock, Users, Loader2 } from 'lucide-react';
 import { useUser, useUsers } from '../../../hooks/useUsers';
 import { useRankedActivePeople } from '../../../hooks/useRankedPeopleSearch';
@@ -450,6 +451,15 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
   const agentLabel = dmAgent?.name ?? dmAgent?.agentSlug ?? 'this agent';
   const destinationNoun =
     shareStatus?.channelScopeType === ChannelScopeType.GROUP_DM ? 'group' : 'channel';
+  const addAgentLabel = !shareStatus
+    ? ''
+    : shareStatus.agentInChannel
+      ? `${agentLabel} is already present in the ${destinationNoun}.`
+      : shareStatus.canAddAgent
+        ? `Also add ${agentLabel} to this ${destinationNoun}`
+        : shareStatus.agentInstalled
+          ? `You do not have permission to add ${agentLabel} to this ${destinationNoun}.`
+          : 'This agent is not installed as an app and cannot be added to a channel.';
   const lastSharedLabel = shareStatus?.lastSharedAt ? (
     <>
       shared it{' '}
@@ -1048,22 +1058,17 @@ export const ForwardMessageForm: React.FC<ForwardMessageFormProps> = ({
               </div>
             )}
             <div className='flex items-center gap-2 text-sm'>
-              <input
-                type='checkbox'
+              <Checkbox
+                checked={shareStatus.agentInChannel || (shareStatus.canAddAgent && addAgent)}
+                onChange={setAddAgent}
+                disabled={!shareStatus.canAddAgent}
+                label=''
+                ariaLabel={addAgentLabel}
                 data-track-category='FORWARD_MESSAGE_MODAL'
                 data-track-name='ADD_AGENT_WHILE_SHARING_CONVERSATION'
-                disabled={!shareStatus.canAddAgent}
-                checked={shareStatus.agentInChannel || (shareStatus.canAddAgent && addAgent)}
-                onChange={event => setAddAgent(event.target.checked)}
               />
               <span className={shareStatus.canAddAgent ? undefined : 'text-muted-foreground'}>
-                {shareStatus.agentInChannel
-                  ? `${agentLabel} is already present in the ${destinationNoun}.`
-                  : shareStatus.canAddAgent
-                    ? `Also add ${agentLabel} to this ${destinationNoun}`
-                    : shareStatus.agentInstalled
-                      ? `You do not have permission to add ${agentLabel} to this ${destinationNoun}.`
-                      : 'This agent is not installed as an app and cannot be added to a channel.'}
+                {addAgentLabel}
               </span>
             </div>
           </div>

--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.types.ts
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/ForwardMessageModal.types.ts
@@ -1,3 +1,4 @@
+import { ChannelScopeType } from '@xyne/shared';
 import { MessageWithOptionalNudgeCounts } from '../../ui/MessageBubble/MessageBubble.types';
 
 export type MessageType = MessageWithOptionalNudgeCounts;
@@ -13,6 +14,7 @@ export interface ForwardTarget {
 export interface ForwardMessageFormProps {
   message: MessageType;
   channelId: string;
+  channelScopeType?: ChannelScopeType | undefined;
   onCancel: () => void;
   onSuccess?: () => void;
 }

--- a/apps/dashboard/src/components/Chat/ForwardMessageModal/forwardMode.ts
+++ b/apps/dashboard/src/components/Chat/ForwardMessageModal/forwardMode.ts
@@ -1,0 +1,50 @@
+import { ChannelScopeType } from '@xyne/shared';
+export type ForwardMode = 'message' | 'conversation';
+export interface ForwardModeChannel {
+  scopeType: ChannelScopeType;
+  isArchived?: boolean | undefined;
+}
+export function canShareWholeConversation(
+  sourceScopeType: ChannelScopeType | undefined,
+  agentCount: number,
+  sharingEnabled = true,
+): boolean {
+  return sharingEnabled && sourceScopeType === ChannelScopeType.DM && agentCount === 1;
+}
+
+export function isShareableTarget(channel: ForwardModeChannel): boolean {
+  return (
+    (channel.scopeType === ChannelScopeType.DEFAULT ||
+      channel.scopeType === ChannelScopeType.GROUP_DM) &&
+    channel.isArchived !== true
+  );
+}
+export interface ConversationShareSubmission {
+  channelId: string;
+  agentSlug: string;
+  sourceConversationId: string;
+  addAgentConfirmed: boolean;
+  reShareConfirmed: boolean;
+  shareOperationId: string;
+  note?: string;
+}
+
+export function buildConversationShareSubmission(
+  channelId: string,
+  agentSlug: string,
+  sourceConversationId: string,
+  addAgentConfirmed: boolean,
+  reShareConfirmed: boolean,
+  shareOperationId: string,
+  note?: string,
+): ConversationShareSubmission {
+  return {
+    channelId,
+    agentSlug,
+    sourceConversationId,
+    addAgentConfirmed,
+    reShareConfirmed,
+    shareOperationId,
+    ...(note?.trim() ? { note: note.trim() } : {}),
+  };
+}

--- a/apps/dashboard/src/components/Chat/ShareAgentConversationModal/SharedTranscriptCard.tsx
+++ b/apps/dashboard/src/components/Chat/ShareAgentConversationModal/SharedTranscriptCard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Bot, ChevronDown } from 'lucide-react';
+
+export interface SharedTranscriptCardProps {
+  content: string;
+
+  agentName: string;
+
+  messageCount?: number;
+
+  defaultCollapsed?: boolean;
+
+  renderBody?: (content: string) => React.ReactNode;
+}
+
+export const SharedTranscriptCard: React.FC<SharedTranscriptCardProps> = ({
+  content,
+  agentName,
+  messageCount,
+  defaultCollapsed = false,
+  renderBody,
+}) => {
+  return (
+    <details
+      open={!defaultCollapsed}
+      data-testid='shared-agent-transcript'
+      className='group my-1 overflow-hidden rounded-lg border border-border bg-muted/40'
+    >
+      <summary className='flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2 text-sm font-medium text-foreground'>
+        <span className='flex items-center gap-2'>
+          <Bot size={15} />
+          Shared conversation with {agentName}
+          {typeof messageCount === 'number' ? (
+            <span className='text-xs font-normal text-muted-foreground'>
+              · {messageCount} message(s)
+            </span>
+          ) : null}
+        </span>
+        <ChevronDown
+          size={16}
+          className='transition-transform group-open:rotate-180 text-muted-foreground'
+        />
+      </summary>
+      <div className='border-t border-border px-3 py-2 text-sm'>
+        {renderBody ? (
+          renderBody(content)
+        ) : (
+          <pre className='whitespace-pre-wrap break-words font-sans text-sm text-foreground'>
+            {content}
+          </pre>
+        )}
+      </div>
+    </details>
+  );
+};

--- a/apps/dashboard/src/components/Chat/ShareAgentConversationModal/SharedTranscriptCard.tsx
+++ b/apps/dashboard/src/components/Chat/ShareAgentConversationModal/SharedTranscriptCard.tsx
@@ -1,5 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Bot, ChevronDown } from 'lucide-react';
+import { ExpandableMessage } from '../ExpandableMessage/ExpandableMessage';
+
+const TRANSCRIPT_PREVIEW_MAX_HEIGHT = 480;
 
 export interface SharedTranscriptCardProps {
   content: string;
@@ -20,11 +23,13 @@ export const SharedTranscriptCard: React.FC<SharedTranscriptCardProps> = ({
   defaultCollapsed = false,
   renderBody,
 }) => {
+  const [isOpen, setIsOpen] = useState(!defaultCollapsed);
   return (
     <details
-      open={!defaultCollapsed}
+      open={isOpen}
+      onToggle={event => setIsOpen(event.currentTarget.open)}
       data-testid='shared-agent-transcript'
-      className='group my-1 overflow-hidden rounded-lg border border-border bg-muted/40'
+      className='group my-1 overflow-hidden rounded-lg border border-border bg-muted'
     >
       <summary className='flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-2 text-sm font-medium text-foreground'>
         <span className='flex items-center gap-2'>
@@ -41,15 +46,22 @@ export const SharedTranscriptCard: React.FC<SharedTranscriptCardProps> = ({
           className='transition-transform group-open:rotate-180 text-muted-foreground'
         />
       </summary>
-      <div className='border-t border-border px-3 py-2 text-sm'>
-        {renderBody ? (
-          renderBody(content)
-        ) : (
-          <pre className='whitespace-pre-wrap break-words font-sans text-sm text-foreground'>
-            {content}
-          </pre>
-        )}
-      </div>
+      {isOpen ? (
+        <div className='border-t border-border px-3 py-2 text-sm'>
+          <ExpandableMessage
+            maxHeight={TRANSCRIPT_PREVIEW_MAX_HEIGHT}
+            fadeColor='hsl(var(--muted))'
+          >
+            {renderBody ? (
+              renderBody(content)
+            ) : (
+              <pre className='whitespace-pre-wrap break-words font-sans text-sm text-foreground'>
+                {content}
+              </pre>
+            )}
+          </ExpandableMessage>
+        </div>
+      ) : null}
     </details>
   );
 };

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -59,6 +59,7 @@ import type { ToolInvocation } from '../../Chat/XyneAISidebar/utils/XyneAITypes'
 import { ExpandableMessage } from '../../Chat/ExpandableMessage/ExpandableMessage';
 import { MessageMetadata } from './MessageBubble.utils';
 import { MarkdownMessageRenderer } from './MarkdownMessageRenderer';
+import { SharedTranscriptCard } from '../../Chat/ShareAgentConversationModal/SharedTranscriptCard';
 import { NonParticipantActions } from './NonParticipantActions';
 import { PostedInLink } from './PostedInLink';
 import { MessageHeader } from './MessageHeader';
@@ -752,7 +753,9 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   // For mobile "my" messages, use the specialized mobile component
   const isSlashCommandArtifact = isSlashCommandArtifactMessage(message.content);
 
-  if (isMobile && isMe && !isSlashCommandArtifact) {
+  const isSharedAgentTranscript = metadata?.['sharedAgentTranscript'] === true;
+
+  if (isMobile && isMe && !isSlashCommandArtifact && !isSharedAgentTranscript) {
     return (
       <MobileMessageMyBubble
         message={message}
@@ -1260,6 +1263,50 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                   emailId={message.messageId}
                   attachments={attachments}
                 />
+              ) : isSharedAgentTranscript ? (
+                <div className='flex flex-col gap-2'>
+                  {typeof metadata?.['shareNote'] === 'string' && metadata['shareNote'] ? (
+                    <div
+                      className={`jp-message-html whitespace-pre-wrap break-all-words inline-block ${getEmojiFontSizeClass(metadata['shareNote'])}`}
+                    >
+                      {isMobile ? (
+                        <ExpandableMessage
+                          message={metadata['shareNote']}
+                          showEdited={message.edited}
+                          maxHeight={500}
+                        />
+                      ) : (
+                        <div className='jp-message-html inline-block'>
+                          <RenderMessageWithHTML
+                            message={DOMPurify.sanitize(metadata['shareNote'])}
+                            showEdited={message.edited}
+                            preserveThreadRoute={context === 'thread'}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  ) : null}
+                  <SharedTranscriptCard
+                    content={citationContent}
+                    agentName={
+                      typeof metadata?.['agentName'] === 'string'
+                        ? metadata['agentName']
+                        : typeof metadata?.['agentSlug'] === 'string'
+                          ? metadata['agentSlug']
+                          : 'agent'
+                    }
+                    {...(typeof metadata?.['messageCount'] === 'number'
+                      ? { messageCount: metadata['messageCount'] }
+                      : {})}
+                    defaultCollapsed
+                    renderBody={content => (
+                      <MarkdownMessageRenderer
+                        content={content}
+                        markdownComponents={markdownComponents}
+                      />
+                    )}
+                  />
+                </div>
               ) : recordingShare && !isForwardedMessage ? (
                 <RecordingShareContent
                   recordingShare={recordingShare}

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -38,6 +38,8 @@
     --accent-foreground: 240 5.9% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
+    --warning: 32 95% 44%;
+    --warning-foreground: 0 0% 100%;
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 80%;
@@ -190,6 +192,8 @@
     --accent-foreground: 240 5.9% 10%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 0 0% 98%;
+    --warning: 32 95% 44%;
+    --warning-foreground: 0 0% 100%;
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
     --ring: 240 5.9% 80%;
@@ -333,6 +337,8 @@
     --accent-foreground: 210 8% 93%;
     --destructive: 0 62% 55%;
     --destructive-foreground: 210 8% 93%;
+    --warning: 43 96% 56%;
+    --warning-foreground: 26 83% 14%;
     --border: 233 8% 23%; /* #36373F */
     --input: 231 5% 26%; /* #3F4046 */
     --ring: 213 6% 28%;

--- a/apps/dashboard/src/hooks/useShareAgentConversation.ts
+++ b/apps/dashboard/src/hooks/useShareAgentConversation.ts
@@ -1,0 +1,60 @@
+import { useMutation, useQuery, type UseQueryResult } from '@tanstack/react-query';
+import {
+  getAgentConversationPreview,
+  getShareAgentConversationStatus,
+  shareAgentConversationToChannel,
+  type AgentConversationPreview,
+  type PreShareStatus,
+  type ShareParams,
+  type ShareResult,
+} from '../services/claw/shareAgentConversationService';
+
+export const useShareAgentConversationStatus = (args: {
+  channelId: string | undefined;
+  agentSlug: string | undefined;
+  sourceConversationId: string | undefined;
+  activePathTipMessageId?: string | null | undefined;
+}): UseQueryResult<PreShareStatus, Error> => {
+  const { channelId, agentSlug, sourceConversationId, activePathTipMessageId } = args;
+  return useQuery({
+    queryKey: [
+      'share-agent-conversation-status',
+      channelId,
+      agentSlug,
+      sourceConversationId,
+      activePathTipMessageId ?? null,
+    ],
+    queryFn: () =>
+      getShareAgentConversationStatus({
+        channelId: channelId!,
+        agentSlug: agentSlug!,
+        sourceConversationId: sourceConversationId!,
+        activePathTipMessageId: activePathTipMessageId ?? null,
+      }),
+    enabled: !!channelId && !!agentSlug && !!sourceConversationId,
+    staleTime: 5 * 1000,
+  });
+};
+
+export const useAgentConversationPreview = (args: {
+  agentSlug: string | undefined;
+  sourceConversationId: string | undefined;
+  enabled: boolean;
+}): UseQueryResult<AgentConversationPreview, Error> => {
+  const { agentSlug, sourceConversationId, enabled } = args;
+  return useQuery({
+    queryKey: ['agent-conversation-preview', agentSlug, sourceConversationId],
+    queryFn: () =>
+      getAgentConversationPreview({
+        agentSlug: agentSlug!,
+        sourceConversationId: sourceConversationId!,
+      }),
+    enabled: enabled && !!agentSlug && !!sourceConversationId,
+    staleTime: 5 * 1000,
+  });
+};
+
+export const useShareAgentConversation = () =>
+  useMutation<ShareResult, Error, ShareParams>({
+    mutationFn: params => shareAgentConversationToChannel(params),
+  });

--- a/apps/dashboard/src/services/claw/shareAgentConversationService.ts
+++ b/apps/dashboard/src/services/claw/shareAgentConversationService.ts
@@ -1,0 +1,125 @@
+import { ChannelScopeType } from '@xyne/shared';
+import { apiInstance } from '../clients/apiClient';
+
+export interface PreShareStatus {
+  previouslyShared: boolean;
+  lastSharedAt: string | null;
+  hasNewSinceLastShare: boolean;
+  agentInChannel: boolean;
+  canAddAgent: boolean;
+  agentInstalled: boolean;
+  channelVisibility: string;
+  channelScopeType: ChannelScopeType;
+}
+
+export interface AgentConversationPreviewTurn {
+  role: string;
+  name: string;
+  userId: string | null;
+  content: string;
+}
+
+export interface AgentConversationPreview {
+  messageCount: number;
+  turns: AgentConversationPreviewTurn[];
+  previewTruncated: boolean;
+  tipMessageId: string | null;
+}
+
+export interface ShareResult {
+  conversationId: string;
+  messageId: string;
+  sharedMessageCount: number;
+  agentAdded: boolean;
+  reusedExisting: boolean;
+}
+
+export interface GetShareStatusParams {
+  channelId: string;
+  agentSlug: string;
+  sourceConversationId: string;
+
+  activePathTipMessageId?: string | null;
+}
+
+export interface ShareParams {
+  channelId: string;
+  agentSlug: string;
+  sourceConversationId: string;
+
+  addAgentConfirmed?: boolean;
+
+  reShareConfirmed?: boolean;
+
+  shareOperationId?: string;
+
+  note?: string;
+}
+
+export type ShareErrorCode =
+  | 'CHANNEL_NOT_FOUND'
+  | 'NOT_A_CHANNEL_MEMBER'
+  | 'INVALID_TARGET_CHANNEL'
+  | 'CHANNEL_ARCHIVED'
+  | 'RESHARE_CONFIRMATION_REQUIRED'
+  | 'EMPTY_TRANSCRIPT'
+  | 'TRANSCRIPT_TOO_LARGE'
+  | 'NO_NEW_MESSAGES'
+  | 'ADD_AGENT_FORBIDDEN'
+  | 'AGENT_NOT_INSTALLED';
+
+export interface ShareApiError {
+  error: string;
+  code?: ShareErrorCode;
+}
+
+export async function getShareAgentConversationStatus(
+  params: GetShareStatusParams,
+): Promise<PreShareStatus> {
+  const { channelId, agentSlug, sourceConversationId, activePathTipMessageId } = params;
+  const search = new URLSearchParams({ agentSlug, sourceConversationId });
+  if (activePathTipMessageId) search.set('activePathTipMessageId', activePathTipMessageId);
+
+  const { data } = await apiInstance.get<PreShareStatus>(
+    `/channels/${encodeURIComponent(channelId)}/share-agent-conversation/status?${search.toString()}`,
+  );
+  return data;
+}
+
+export async function getAgentConversationPreview(params: {
+  agentSlug: string;
+  sourceConversationId: string;
+}): Promise<AgentConversationPreview> {
+  const search = new URLSearchParams({
+    agentSlug: params.agentSlug,
+    sourceConversationId: params.sourceConversationId,
+  });
+  const { data } = await apiInstance.get<AgentConversationPreview>(
+    `/xyne-ai/agent-conversation-preview?${search.toString()}`,
+  );
+  return data;
+}
+
+export async function shareAgentConversationToChannel(params: ShareParams): Promise<ShareResult> {
+  const {
+    channelId,
+    agentSlug,
+    sourceConversationId,
+    addAgentConfirmed,
+    reShareConfirmed,
+    shareOperationId,
+    note,
+  } = params;
+  const { data } = await apiInstance.post<ShareResult>(
+    `/channels/${encodeURIComponent(channelId)}/share-agent-conversation`,
+    {
+      agentSlug,
+      sourceConversationId,
+      addAgentConfirmed,
+      reShareConfirmed,
+      shareOperationId,
+      note,
+    },
+  );
+  return data;
+}

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -71,6 +71,10 @@ export default {
           DEFAULT: 'hsl(var(--secondary))',
           foreground: 'hsl(var(--secondary-foreground))',
         },
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          foreground: 'hsl(var(--warning-foreground))',
+        },
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',


### PR DESCRIPTION
[POT-1](https://drive.google.com/file/d/1-P60Nbbz1nwi-UM6sa23CiG9EIGOJ3C_/view?usp=sharing)
[POT-2](https://drive.google.com/file/d/1ES90tFTAByC1ZWUHxAgllKiC-u9g-aTY/view?usp=sharing)

## What

Lets you take a whole conversation you had with an agent in a DM and put it into a channel or group DM, so teammates can read the thread and carry it forward with the agent.

The original DM is untouched. The destination gets one immutable snapshot message, and the agent can be added so the thread stays interactive — but it only ever sees channel context, never the private source conversation.

## Entry point

No new menu item. The existing **Forward message** action gains a **This message / Whole conversation** toggle, and the toggle appears only in a 1:1 agent DM.

Destinations are channels and group DMs. 1:1 DMs are excluded: delivering a transcript to one named person is unsolicited, and consent there needs its own design.

## Why it is built this way

**The transcript is not Xyne data.** It lives in Claw (`xyne-claw-auth`) as a branching tree, so a Zero mutator cannot read it. The share is a Spaces backend endpoint that fetches the visible transcript over the existing S2S bridge under the sharer's own identity — Claw enforces who may read it, and a guessed conversation id returns an empty slice.

**Only rendered content crosses the boundary.** Reasoning and raw tool results are never read, so they cannot leak. Structured citations referenced by visible text are carried so they still render as chips.

**The message deliberately skips the generic side-effect handler.** Running mention, bot and automation side effects over a 200-message snapshot would fan out a notification per turn. Delivery is explicit instead: websocket, Redis, unread counts, Vespa.

**Source provenance is server-only.** `AgentConversationShare` is excluded from the Zero generator, so the private conversation and message ids are never replicated to members of the destination. The destination message carries display-safe metadata only.

**Group DMs qualify** because they are members-only — a narrower audience than the public channels this already allows — and agents already work there (`APP_MENTION` reaches installed apps in group DMs). They have no `addUserPolicy` and no admins, so the add-agent permission check branches on scope rather than rejecting them.

## Guards

- **Idempotent** — a transaction-scoped advisory lock plus a unique `(workspace, channel, sharer, operationId)` key, so a double click cannot double-post.
- **Nothing new** — re-sharing is blocked when the transcript tip is unchanged since the last share.
- **Immutable snapshots** — re-sharing creates a new, separate thread; it never edits the previous one.
- **Size** — over 60,000 rendered characters is rejected with `TRANSCRIPT_TOO_LARGE` / HTTP 413 before any destination rows are created, so a share never silently loses early context.
- **Membership** — verified before any transcript or share history is read, so a non-member learns nothing about the channel.

## Config

Gated by the `share_agent_conversation_enabled` CAC flag, following `project_recap_enabled`. Enforced on the share, status and preview endpoints — turning it off closes the API, not just the button. Defaults on: it is a kill switch, not a rollout gate.

## API

| | |
|---|---|
| `POST /api/channels/:channelId/share-agent-conversation` | perform the share |
| `GET /api/channels/:channelId/share-agent-conversation/status` | advisory pre-share state |
| `GET /api/xyne-ai/agent-conversation-preview` | channel-independent snapshot preview |

## Persistence

New Prisma model `AgentConversationShare` and migration `20260828120000_add_agent_conversation_shares`. Additive: one table, four indexes, no foreign keys, no backfill.

## Testing

**There are no automated tests in this PR.** They were removed deliberately, so the paths below need manual verification:

- Toggle appears in an agent DM and nowhere else — not in a human DM, not in a channel
- Switching modes clears people and keeps only a valid destination
- Re-share creates a second separate thread; "nothing new" blocks when the DM has not moved
- Agent added to the destination by default; `@`-mentioning it in the shared thread gets a reply
- Setting the CAC flag to `false` hides the toggle and makes all three endpoints return 403

Verified locally with the commands CI runs: backend `tsc --noEmit`, dashboard `tsc --noEmit --project tsconfig.app.json`, and `eslint . --quiet`.
