### PR TITLE
feat: XYNE re-fire APP_MENTION when a mentioned agent is added via suggestion box

### DIFF
--- a/apps/backend/src/zero/side-effects/tables/channel-participants-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/channel-participants-handler.ts
@@ -3,8 +3,24 @@ import type { SideEffectJobConfig, ChannelParticipantPreviousValue } from '../ty
 import { db } from '@/database/client';
 import { notificationService } from '@/services/notificationService';
 import { logger } from '@/utils/logger';
-import { ChannelScopeType } from '@xyne/shared';
+import { ChannelScopeType, UserType, MessageType } from '@xyne/shared';
 import { refreshCanvasPermissionsForChannel } from '@/services/canvasPermissionSync';
+import { extractAllUsersForNotification } from '@/utils/mentionUtils';
+import { extractPlainTextFromHtml } from '@/utils/contentUtils';
+import { handleEventSubscriptionsForUsers } from '@/apps/core/eventSubscriptionUtils';
+import { AppEventType, type AppMentionEventPayload, type BaseAppEvent } from '@/apps/types';
+import { MessageAttachmentRepository } from '@/database/repositories/messageAttachmentRepository';
+
+const messageAttachmentRepository = new MessageAttachmentRepository();
+
+/**
+ * How far back to look for the message that triggered a suggestion-box add.
+ * The add happens right after the mention, so a tight window is enough and it
+ * prevents replaying a stale mention if the same app is re-added much later.
+ */
+const PENDING_MENTION_LOOKBACK_MS = 10 * 60 * 1000;
+/** Cap on how many recent messages we scan for a pending mention. */
+const PENDING_MENTION_SCAN_LIMIT = 20;
 
 export class ChannelParticipantsSideEffectHandler extends BaseSideEffectHandler {
 
@@ -85,8 +101,140 @@ export class ChannelParticipantsSideEffectHandler extends BaseSideEffectHandler 
 
       logger.info(`[ChannelParticipantsHandler] Notification sent for user ${userId} added to channel ${channelId} by ${adderName}`);
 
+      // Slice 1: if the just-added user is an installed APP that was @mentioned in a
+      // recent message it wasn't yet a member of, replay that mention as an APP_MENTION
+      // so the agent triggers automatically — the user should not have to re-tag it after
+      // adding it from the suggestion box. Humans already got the participant-added
+      // notification above, so this replay is APP-only. Fire-and-forget: a failure here
+      // must never break the add/notify path.
+      await this.replayPendingMentionForAddedApp(
+        channelId,
+        userId,
+        channel?.name ?? channelId,
+        channel?.scopeType as ChannelScopeType | undefined,
+      ).catch(err =>
+        logger.error(`[ChannelParticipantsHandler] pending-mention replay failed for user ${userId} in channel ${channelId}: ${err}`));
+
     } catch (error) {
       logger.error(`[ChannelParticipantsHandler] Failed to process onInsert for entity ${job.entityId}:`, error);
+    }
+  }
+
+  /**
+   * Re-fire the APP_MENTION event for an app that was @mentioned before it was a
+   * channel member. On message create, mentions are only delivered to current
+   * participants (messages-handler filters on channelParticipantIds), so a mention of
+   * a non-member app is dropped. When that app is subsequently added — e.g. via the
+   * compose-box "add to channel" suggestion — this replays the single most recent
+   * triggering mention so the agent runs without the sender re-tagging it.
+   *
+   * Safety properties:
+   * - APP users only. Humans are never auto-triggered (they get the participant-added
+   *   notification instead).
+   * - Bounded lookback + scan cap, so a much-later re-add can't resurrect a stale mention.
+   * - Delivery reuses handleEventSubscriptionsForUsers, which no-ops for an app without a
+   *   valid webhook and never delivers to the sender — so this can't self-trigger.
+   * - onInsert only fires on a real participant insert (the mutator skips already-present
+   *   members), so this won't double-fire against the original create-time delivery.
+   */
+  private async replayPendingMentionForAddedApp(
+    channelId: string,
+    addedUserId: string,
+    channelName: string,
+    scopeType: ChannelScopeType | undefined,
+  ): Promise<void> {
+    // DMs / group DMs have their own APP_MENTION delivery path; only the regular
+    // channel add flow needs this replay.
+    if (scopeType === ChannelScopeType.DM || scopeType === ChannelScopeType.GROUP_DM) {
+      return;
+    }
+
+    const addedUser = await db.user.findUnique({
+      where: { id: addedUserId },
+      select: { userType: true },
+    });
+    if (addedUser?.userType !== UserType.APP) {
+      return; // only agents auto-trigger on add
+    }
+
+    const workspaceId = this.ctx.workspaceId;
+    const since = new Date(Date.now() - PENDING_MENTION_LOOKBACK_MS);
+
+    const recentMessages = await db.message.findMany({
+      where: {
+        conversation: { is: { channelId } },
+        isDeleted: false,
+        msgType: { not: MessageType.SYSTEM },
+        createdAt: { gte: since },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: PENDING_MENTION_SCAN_LIMIT,
+      select: {
+        messageId: true,
+        conversationId: true,
+        content: true,
+        senderId: true,
+        createdAt: true,
+        hasAttachment: true,
+      },
+    });
+
+    for (const msg of recentMessages) {
+      if (msg.senderId === addedUserId) continue; // never trigger on the app's own message
+      const content = msg.content ?? '';
+      if (!content) continue;
+
+      const mentioned = await extractAllUsersForNotification(content, workspaceId);
+      const isDirectlyMentioned = mentioned.some(
+        u => u.userId === addedUserId && (u.mentionSource === 'direct' || u.mentionSource === 'group'),
+      );
+      if (!isDirectlyMentioned) continue;
+
+      // Found the message that triggered the add → replay APP_MENTION for this app only.
+      const sender = await db.user.findUnique({
+        where: { id: msg.senderId },
+        select: { name: true, displayName: true, orgMemberId: true },
+      });
+      const senderName = sender?.displayName || sender?.name || 'Someone';
+      const attachments = msg.hasAttachment
+        ? await messageAttachmentRepository.findByMessageId(msg.messageId)
+        : [];
+
+      const payload: AppMentionEventPayload = {
+        workspaceId,
+        ...(sender?.orgMemberId ? { orgMemberId: sender.orgMemberId } : {}),
+        conversationId: msg.conversationId,
+        messageId: msg.messageId,
+        content,
+        cleanContent: extractPlainTextFromHtml(content).replace(/\s+/g, ' ').trim(),
+        createdAt: msg.createdAt,
+        userId: msg.senderId,
+        senderName,
+        channelId,
+        channelName,
+        ...(attachments.length > 0 && {
+          attachments: attachments.map(att => ({
+            attachmentId: att.id,
+            fileName: att.originalFilename,
+            fileSize: att.size,
+            mimeType: att.mimetype,
+            fileUrl: att.url,
+          })),
+        }),
+      };
+
+      const event: BaseAppEvent = {
+        eventType: AppEventType.APP_MENTION,
+        payload,
+        timestamp: new Date().toISOString(),
+      };
+
+      await handleEventSubscriptionsForUsers(event, [addedUserId]);
+
+      logger.info(
+        `[ChannelParticipantsHandler] Replayed APP_MENTION for app ${addedUserId} on message ${msg.messageId} after add to channel ${channelId}`,
+      );
+      return; // only the most recent triggering mention is replayed
     }
   }
 }


### PR DESCRIPTION
## 1. Problem Description
When a user @mentions an agent (APP user) that is NOT yet a member of the channel and then adds it from the compose-box suggestion box, the agent is never triggered. On message create, mentions are only delivered to current channel participants (messages-handler filters mentions on `channelParticipantIds`), so a mention of a non-member app is silently dropped. Adding the app afterwards only inserted the participant row and posted a system message — it never revisited the message that mentioned the app. The user had to re-tag the agent to get a run.

## 2. If this is a bug fix or an enhancement, how did you identify the issue?
Traced the mention→trigger flow: `apps/backend/src/zero/side-effects/tables/messages-handler.ts` derives `appUserIds` from channel participants only and filters mentioned users to `channelParticipantIds`, so non-member apps never reach `mentionedAppUsersIds`/APP_MENTION dispatch. The add path (`channel-participants-handler.onInsert`) had no mention replay.

## 3. Explain the solution implemented in the PR
This is Slice 1 of a two-slice plan (Slice 2 = re-process mentions on message edit, tracked separately).

In `apps/backend/src/zero/side-effects/tables/channel-participants-handler.ts` `onInsert`, after the existing participant-added notification, I added `replayPendingMentionForAddedApp`:
- Runs only when the just-added user is an APP (`userType === APP`). Humans already receive the participant-added notification and are never auto-triggered.
- Skips DM/GROUP_DM (they have their own APP_MENTION path).
- Scans at most the last 20 non-deleted, non-SYSTEM messages in the channel within a 10-minute lookback window for the most recent message that directly (or via group) @mentions the added app.
- On a hit, replays exactly that one message as an `APP_MENTION` via `handleEventSubscriptionsForUsers` — the same delivery primitive the create path uses — building an identical `AppMentionEventPayload` (workspaceId + orgMemberId stamped, attachments mapped the same way).

Safety properties: bounded lookback + scan cap prevents resurrecting a stale mention on a later re-add; `handleEventSubscriptionsForUsers` no-ops for an app without a valid webhook and never delivers to the sender; onInsert only fires on a real participant insert (the mutator skips already-present members), so it can't double-fire against the original create-time delivery. Auto-add ACL is unchanged — this rides on whatever add the sender was already permitted to make.

## 4. Documentation (link to docs created/updated for this change)
N/A

## 5. DB Alter Details (if any)
N/A — no schema change.

## 6. Data fix Details (if any)
N/A

## 7. Environment variable Changes (if any)
N/A

## 8. Testing (how it was tested; screenshots/links)
Type-check clean (`tsc --noEmit`) for the backend. NOTE: not yet exercised end-to-end in a running backend — reviewers should validate: (a) mention a non-member agent, add it via suggestion box → exactly one agent run; (b) add a non-member human → participant-added notification only, no trigger; (c) app with no webhook → no-op; (d) re-add the same app minutes later with no fresh mention → no trigger (lookback window).

## 9. Services to which this change is to be deployed
backend (Zero side-effect worker).

## 10. Main PR link (if this PR is raised against a release branch)
N/A — raised against `main`.