### PR TITLE
feat: XYNE-59220 recording summary fixes

### DIFF
--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -86,6 +86,33 @@ function sanitizeInput(input: string | null): string {
   return sanitized.length > maxLength ? sanitized.substring(0, maxLength) : sanitized;
 }
 
+/**
+ * Some legacy custom-template prompts cause the model to copy the template
+ * prompt-generation response shape and return { "systemPrompt": "..." }.
+ * Accept that response defensively, but keep ordinary Markdown untouched.
+ */
+function normalizeDetailedSummaryMarkdown(content: string): string {
+  const trimmed = content.trim();
+  const fencedJson = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i)?.[1];
+  const candidate = fencedJson ?? trimmed;
+
+  try {
+    const parsed: unknown = JSON.parse(candidate);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as Record<string, unknown>).systemPrompt === 'string'
+    ) {
+      return ((parsed as Record<string, unknown>).systemPrompt as string).trim();
+    }
+  } catch {
+    // Normal Markdown is not JSON and should pass through unchanged.
+  }
+
+  return content;
+}
+
 function renderPromptTemplate(template: string, values: Record<string, string>): string {
   const replacements = new Map(Object.entries(values));
   return template.replace(/\{([a-zA-Z0-9_]+)\}/g, (match, key: string) =>
@@ -1033,16 +1060,21 @@ export class CallDocumentService {
       RECORDING_DETAILED_SUMMARY_PROMPT,
       DEFAULT_RECORDING_SUMMARY_FIELDS,
       onDelta
-        ? accumulated => onDelta(stripRecordingSummaryMarkedItemAnnotations(accumulated))
+        ? accumulated => onDelta(
+            stripRecordingSummaryMarkedItemAnnotations(
+              normalizeDetailedSummaryMarkdown(accumulated),
+            ),
+          )
         : undefined,
     );
 
     if (!rawSummary) return null;
 
+    const normalizedSummary = normalizeDetailedSummaryMarkdown(rawSummary);
     const markedItems = citationSegments
-      ? extractMarkedItemsFromRecordingSummary(rawSummary, citationSegments)
+      ? extractMarkedItemsFromRecordingSummary(normalizedSummary, citationSegments)
       : [];
-    const summary = stripRecordingSummaryMarkedItemAnnotations(rawSummary);
+    const summary = stripRecordingSummaryMarkedItemAnnotations(normalizedSummary);
 
     return { summary, template, markedItems };
   }
@@ -1091,6 +1123,14 @@ export class CallDocumentService {
     const sanitizedCustomPrompt = customPrompt ? sanitizeInput(customPrompt) : '';
     const sanitizedFields = summaryFields?.trim() ? sanitizeInput(summaryFields) : '';
     const sanitizedSystemPrompt = systemPrompt ? sanitizeInput(systemPrompt) : '';
+    const effectiveSystemPrompt = sanitizedSystemPrompt
+      ? `${sanitizedSystemPrompt}
+
+MANDATORY OUTPUT CONTRACT:
+- Return only the completed meeting summary as Markdown.
+- Never wrap the summary in JSON or emit a systemPrompt, summary, content, or markdown property.
+- Follow the section structure, formatting, citation, and marked-item requirements in the user prompt.`
+      : '';
 
     const buildPrompt = () => {
       let prompt = renderPromptTemplate(promptTemplate, {
@@ -1109,7 +1149,7 @@ export class CallDocumentService {
       userPrompt: buildPrompt(),
       operation: 'detailed_summary_generation',
       callId,
-      ...(sanitizedSystemPrompt ? { systemPrompt: sanitizedSystemPrompt } : {}),
+      ...(effectiveSystemPrompt ? { systemPrompt: effectiveSystemPrompt } : {}),
       onDelta,
     });
 

--- a/apps/backend/src/services/recordingSummaryTemplates.ts
+++ b/apps/backend/src/services/recordingSummaryTemplates.ts
@@ -17,7 +17,8 @@ INSUFFICIENT TRANSCRIPT (check this first, before anything else below):
 FORMATTING:
 - Use Markdown headings, short paragraphs, and bullet lists. DO NOT use markdown tables anywhere.
 - Never leave a bare paragraph line as the last line of a section, directly above a \`---\` separator — Markdown turns it into a setext heading. Write such content as a bullet instead.
-- Preserve every section heading from the MARKDOWN TEMPLATE exactly, including its leading \`###\` marker and emoji.
+- Preserve every section heading from the MARKDOWN TEMPLATE exactly, including its leading \`###\` marker and emoji, except for the Decisions and Action Items headings described below.
+- Render the Decisions heading with a yellow dot (\`### 🟡 Decisions\`) and the Action Items heading with an orange dot (\`### 🟠 Action Items\`), replacing any existing emoji on those two headings. Keep the dots on the headings, not on individual bullets.
 - Never convert a template heading into plain text, bold text, or a list item.
 - Keep bullets concise; put supporting detail inline after an em dash.
 
@@ -124,10 +125,10 @@ export const DEFAULT_RECORDING_SUMMARY_FIELDS = `### 💡 Key Takeaways
 - [Main point discussed]
 - [Notable names, numbers, dates, or quotes]
 ---
-### ✅ Decisions
+### 🟡 Decisions
 - [Decision] — Owner: [Person] ([why / context])
 ---
-### 📋 Action Items
+### 🟠 Action Items
 - [Task] — @[Assignee] · Due: [Date] · Priority: [H/M/L]
 ---
 ### 🔗 Open Items & Follow-up

--- a/apps/backend/src/services/summaryTemplateAiService.ts
+++ b/apps/backend/src/services/summaryTemplateAiService.ts
@@ -35,6 +35,12 @@ const GeneratedSystemPromptResponseSchema = z.object({
   systemPrompt: z.string().trim().min(100).max(12_000),
 });
 
+const SUMMARY_MARKDOWN_OUTPUT_CONTRACT = `MANDATORY OUTPUT FORMAT:
+- Output only the completed meeting summary as Markdown.
+- Never output JSON, a JSON object, a systemPrompt property, a summary property, a content property, or a markdown property.
+- Never wrap the Markdown in a code fence.
+- Start directly with the first required level-three Markdown heading and preserve the required section order.`;
+
 function sanitize(value: string | null | undefined, maxLength: number): string {
   if (!value) return '';
   const withoutControls = [...value]
@@ -89,13 +95,18 @@ The generated system prompt will be passed to another LLM together with a meetin
 - say "Not discussed" when a required section has no supporting transcript content;
 - prohibit invented details, people, decisions, deadlines, and action items;
 - follow the user prompt's formatting and citation rules without weakening or replacing them;
+- explicitly require the downstream summary LLM to output only raw Markdown, starting with the first required level-three heading;
+- explicitly prohibit the downstream summary LLM from returning JSON, code fences, or properties named systemPrompt, summary, content, or markdown;
+- treat the JSON response shape requested below only as the transport envelope for this prompt-generation request; never copy that JSON-output requirement into the generated systemPrompt value;
 - be self-contained and reusable, without including a transcript or example summary.
 
 INPUT JSON:
 ${buildPayload(input)}
 
 Return ONLY valid JSON in this shape:
-{"systemPrompt":"the complete generated system prompt"}`,
+{"systemPrompt":"the complete generated system prompt"}
+
+The outer JSON object is required only so the application can extract the generated prompt. Inside the systemPrompt string, require the downstream meeting-summary model to return raw Markdown, never JSON.`,
     });
 
     if (!result.ok) {
@@ -121,7 +132,10 @@ Return ONLY valid JSON in this shape:
       return null;
     }
 
-    return parsed.data.systemPrompt;
+    const generatedPrompt = parsed.data.systemPrompt
+      .replace(/\s+$/, '')
+      .slice(0, 12_000 - SUMMARY_MARKDOWN_OUTPUT_CONTRACT.length - 2);
+    return `${generatedPrompt}\n\n${SUMMARY_MARKDOWN_OUTPUT_CONTRACT}`;
   }
 
   async draftMeetingContext(

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -1129,7 +1129,7 @@ Output ONLY the processed transcript, nothing else.`;
       return null;
     }
 
-    return extracted.content.substring(0, 50);
+    return extracted.content.substring(0, 60);
   }
 
   /**


### PR DESCRIPTION
https://drive.google.com/file/d/1aUA1w01zXAf8SfGPLl1BFqqZqm5o1_DE/view?usp=sharing

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
