### PR TITLE
fix: XYNE-59221 search performance upgrade in recordings

### DIFF
--- a/apps/dashboard/src/components/ui/UnifiedParticipantSearch/UnifiedParticipantSearch.tsx
+++ b/apps/dashboard/src/components/ui/UnifiedParticipantSearch/UnifiedParticipantSearch.tsx
@@ -1,0 +1,120 @@
+import { useMemo, type ReactElement, type ReactNode } from 'react';
+import { Hash, Users } from 'lucide-react';
+import { ChannelScopeType } from '@xyne/shared';
+import { useChannelSearch, useUserGroupSearch } from '@xyne/shared/hooks';
+import { SearchParticipants } from '../../../routes/CallHistoryScreen/SearchParticipants';
+import { useRankedActivePeople } from '../../../hooks/useRankedPeopleSearch';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+import Avatar from '../Avatar/Avatar';
+
+const DEFAULT_USER_LIMIT = 20;
+const DEFAULT_GROUP_LIMIT = 10;
+const DEFAULT_CHANNEL_LIMIT = 10;
+const EMPTY_IDS: ReadonlySet<string> = new Set();
+
+export interface UnifiedParticipantSearchProps {
+  selectedValues: string[];
+  onMultiSelect: (values: string[]) => void | Promise<void>;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  excludedUserIds?: ReadonlySet<string>;
+  excludedUserGroupIds?: ReadonlySet<string>;
+  excludedChannelIds?: ReadonlySet<string>;
+  userLimit?: number;
+  userGroupLimit?: number;
+  channelLimit?: number;
+  exclusiveSelection?: boolean;
+  helperText?: ReactNode;
+}
+
+/**
+ * Bounded, locally-backed recipient search for people, user groups, and channels.
+ *
+ * This follows the fast Forward Message picker: users are token/MFU/DM-recency
+ * ranked, while channels and groups use their shared local search hooks. Only the
+ * top results from each entity type are converted to rows and rendered.
+ */
+export function UnifiedParticipantSearch({
+  selectedValues,
+  onMultiSelect,
+  searchQuery,
+  setSearchQuery,
+  excludedUserIds = EMPTY_IDS,
+  excludedUserGroupIds = EMPTY_IDS,
+  excludedChannelIds = EMPTY_IDS,
+  userLimit = DEFAULT_USER_LIMIT,
+  userGroupLimit = DEFAULT_GROUP_LIMIT,
+  channelLimit = DEFAULT_CHANNEL_LIMIT,
+  exclusiveSelection = false,
+  helperText,
+}: UnifiedParticipantSearchProps): ReactElement {
+  // Fetch enough ranked candidates to replace excluded rows without ever mapping
+  // the complete workspace user list on each keystroke.
+  const rankedUsers = useRankedActivePeople(searchQuery.trim(), userLimit + excludedUserIds.size);
+  const userGroups = useUserGroupSearch(searchQuery, userGroupLimit + excludedUserGroupIds.size);
+  const channels = useChannelSearch(searchQuery, channelLimit + excludedChannelIds.size);
+
+  const options = useMemo(() => {
+    const userOptions = rankedUsers
+      .filter(user => !excludedUserIds.has(user.id))
+      .slice(0, userLimit)
+      .map(user => ({
+        ...user,
+        label: getUserDisplayName(user),
+        subtitle: user.email ?? '',
+        value: `user:${user.id}`,
+        icon: <Avatar userId={user.id} size='sm' showActiveStatus={false} />,
+      }));
+
+    const groupOptions = userGroups
+      .filter(group => !excludedUserGroupIds.has(group.id))
+      .slice(0, userGroupLimit)
+      .map(group => ({
+        ...group,
+        label: group.name,
+        subtitle: group.alias ? `@${group.alias} · Group` : 'Group',
+        value: `user_group:${group.id}`,
+        icon: <Users className='size-3.5 text-muted-foreground' />,
+        isDeactivated: group.isActive === false,
+      }));
+
+    const channelOptions = channels
+      .filter(
+        channel =>
+          channel.scopeType === ChannelScopeType.DEFAULT && !excludedChannelIds.has(channel.id),
+      )
+      .slice(0, channelLimit)
+      .map(channel => ({
+        ...channel,
+        label: channel.name,
+        subtitle: 'Channel',
+        value: `channel:${channel.id}`,
+        icon: <Hash className='size-3.5 text-muted-foreground' />,
+      }));
+
+    return [...userOptions, ...groupOptions, ...channelOptions];
+  }, [
+    channelLimit,
+    channels,
+    excludedChannelIds,
+    excludedUserGroupIds,
+    excludedUserIds,
+    rankedUsers,
+    userGroupLimit,
+    userGroups,
+    userLimit,
+  ]);
+
+  return (
+    <SearchParticipants
+      options={options}
+      selectedValues={selectedValues}
+      onMultiSelect={onMultiSelect}
+      searchQuery={searchQuery}
+      setSearchQuery={setSearchQuery}
+      exclusiveSelection={exclusiveSelection}
+      helperText={helperText}
+      disableClientFiltering
+    />
+  );
+}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingShareModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingShareModal.tsx
@@ -9,9 +9,9 @@ import { useUserGroupSearch, useChannelSearch } from '@xyne/shared/hooks';
 import Avatar from '../../../components/ui/Avatar/Avatar';
 import { Button } from '../../../components/ui/Button/Button';
 import { InputBox } from '../../../components/ui/InputBox';
+import { UnifiedParticipantSearch } from '../../../components/ui/UnifiedParticipantSearch/UnifiedParticipantSearch';
 import type { InputBoxHandle } from '../../../hooks/useDragAndDropAreaRef';
-import { SearchParticipants } from '../../CallHistoryScreen/SearchParticipants';
-import { useActiveUsers, useActiveUserSearch } from '../../../hooks/useUsers';
+import { useActiveUserSearch } from '../../../hooks/useUsers';
 import { useAuth } from '../../../hooks/useAuth';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useMentionSearch } from '../../../hooks/useMentionSearch';
@@ -46,7 +46,6 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
   onTicketLinkUpdated,
 }) => {
   const { user: currentUser } = useAuth();
-  const activeUsers = useActiveUsers();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedValues, setSelectedValues] = useState<string[]>([]);
@@ -54,9 +53,6 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
   const [sharing, setSharing] = useState(false);
   const [locallyRevokedShareIds, setLocallyRevokedShareIds] = useState<Set<string>>(new Set());
   const inputBoxRef = useRef<InputBoxHandle>(null);
-
-  const userGroups = useUserGroupSearch(searchQuery, 10);
-  const channels = useChannelSearch(searchQuery, 10);
 
   const [recordingRow] = useCachedQuery(
     queries.oatsRecordingByExternalId({ callId: recording.externalId }),
@@ -83,51 +79,15 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
     [shares],
   );
 
-  // Combine users, groups, and channels.
-  const options = useMemo(() => {
-    const userOptions = activeUsers
-      .filter(
-        u =>
-          u.id !== recording.createdByUserId &&
-          u.id !== currentUser?.id &&
-          !sharedUserIds.has(u.id),
-      )
-      .map(u => ({
-        label: getUserDisplayName(u),
-        subtitle: u.email ?? '',
-        value: `user:${u.id}`,
-        icon: <Avatar userId={u.id} size='sm' showActiveStatus={false} />,
-      }));
-
-    const groupOptions = userGroups
-      .filter(group => !sharedUserGroupIds.has(group.id))
-      .map(group => ({
-        label: group.name,
-        subtitle: 'Group',
-        value: `user_group:${group.id}`,
-        icon: <Users className='size-3.5 text-muted-foreground' />,
-      }));
-
-    const channelOptions = channels
-      .filter(channel => !sharedChannelIds.has(channel.id))
-      .map(channel => ({
-        label: channel.name,
-        subtitle: 'Channel',
-        value: `channel:${channel.id}`,
-        icon: <Hash className='size-3.5 text-muted-foreground' />,
-      }));
-
-    return [...userOptions, ...groupOptions, ...channelOptions];
-  }, [
-    activeUsers,
-    userGroups,
-    channels,
-    sharedUserIds,
-    sharedUserGroupIds,
-    sharedChannelIds,
-    recording.createdByUserId,
-    currentUser?.id,
-  ]);
+  const excludedUserIds = useMemo(
+    () =>
+      new Set(
+        [recording.createdByUserId, currentUser?.id, ...sharedUserIds].filter((id): id is string =>
+          Boolean(id),
+        ),
+      ),
+    [currentUser?.id, recording.createdByUserId, sharedUserIds],
+  );
 
   // Configure the share message composer.
   const selectedChannelId = useMemo(
@@ -271,12 +231,14 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
         <p className='text-muted-foreground text-[13px] leading-5'>
           Share with people, groups, or channels
         </p>
-        <SearchParticipants
-          options={options}
+        <UnifiedParticipantSearch
           selectedValues={selectedValues}
           onMultiSelect={setSelectedValues}
           searchQuery={searchQuery}
           setSearchQuery={setSearchQuery}
+          excludedUserIds={excludedUserIds}
+          excludedUserGroupIds={sharedUserGroupIds}
+          excludedChannelIds={sharedChannelIds}
           exclusiveSelection={false}
         />
       </div>

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryTemplateShareModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryTemplateShareModal.tsx
@@ -9,11 +9,10 @@ import {
   UserTwo,
 } from '@xyne/icons';
 import { toast } from 'sonner';
-import { useChannelSearch, useUserGroupSearch } from '@xyne/shared/hooks';
 import Avatar from '../../../components/ui/Avatar/Avatar';
 import { Button } from '../../../components/ui/Button/Button';
+import { UnifiedParticipantSearch } from '../../../components/ui/UnifiedParticipantSearch/UnifiedParticipantSearch';
 import { useAuth } from '../../../hooks/useAuth';
-import { useActiveUsers } from '../../../hooks/useUsers';
 import {
   recordingService,
   type SummaryTemplate,
@@ -24,7 +23,6 @@ import {
 } from '../../../services/Recording/recordingService';
 import { getApiErrorMessage } from '../../../utils/apiError';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
-import { SearchParticipants } from '../../CallHistoryScreen/SearchParticipants';
 
 interface SummaryTemplateShareModalProps {
   template: SummaryTemplate;
@@ -45,7 +43,6 @@ export function SummaryTemplateShareModal({
   onSharesChange,
 }: SummaryTemplateShareModalProps): ReactElement {
   const { user: currentUser } = useAuth();
-  const activeUsers = useActiveUsers();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedValues, setSelectedValues] = useState<string[]>([]);
   const [shares, setShares] = useState<SummaryTemplateShare[]>([]);
@@ -57,8 +54,6 @@ export function SummaryTemplateShareModal({
   const [publicationAction, setPublicationAction] =
     useState<SummaryTemplatePublicationAction | null>(null);
   const [showAdmins, setShowAdmins] = useState(true);
-  const userGroups = useUserGroupSearch(searchQuery, 10);
-  const channels = useChannelSearch(searchQuery, 10);
   const isOwner = currentUser?.id === template.createdBy && template.canEdit;
 
   useEffect(() => {
@@ -106,41 +101,10 @@ export function SummaryTemplateShareModal({
     [shares],
   );
 
-  const options = useMemo(() => {
-    const userOptions = activeUsers
-      .filter(user => user.id !== template.createdBy && !sharedUserIds.has(user.id))
-      .map(user => ({
-        label: getUserDisplayName(user),
-        subtitle: user.email ?? '',
-        value: `user:${user.id}`,
-        icon: <Avatar userId={user.id} size='sm' showActiveStatus={false} />,
-      }));
-    const groupOptions = userGroups
-      .filter(group => !sharedUserGroupIds.has(group.id))
-      .map(group => ({
-        label: group.name,
-        subtitle: 'Group',
-        value: `user_group:${group.id}`,
-        icon: <UserTwo className='size-3.5 text-muted-foreground' />,
-      }));
-    const channelOptions = channels
-      .filter(channel => !sharedChannelIds.has(channel.id))
-      .map(channel => ({
-        label: channel.name,
-        subtitle: 'Channel',
-        value: `channel:${channel.id}`,
-        icon: <Hashtag className='size-3.5 text-muted-foreground' />,
-      }));
-    return [...userOptions, ...groupOptions, ...channelOptions];
-  }, [
-    activeUsers,
-    channels,
-    sharedChannelIds,
-    sharedUserGroupIds,
-    sharedUserIds,
-    template.createdBy,
-    userGroups,
-  ]);
+  const excludedUserIds = useMemo(
+    () => new Set([template.createdBy, ...sharedUserIds]),
+    [sharedUserIds, template.createdBy],
+  );
 
   const toTarget = (value: string): SummaryTemplateShareTarget =>
     value.startsWith('user_group:')
@@ -236,12 +200,14 @@ export function SummaryTemplateShareModal({
 
       {isOwner && (
         <>
-          <SearchParticipants
-            options={options}
+          <UnifiedParticipantSearch
             selectedValues={selectedValues}
             onMultiSelect={setSelectedValues}
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
+            excludedUserIds={excludedUserIds}
+            excludedUserGroupIds={sharedUserGroupIds}
+            excludedChannelIds={sharedChannelIds}
             exclusiveSelection={false}
           />
           {selectedValues.length > 0 && (


### PR DESCRIPTION
https://drive.google.com/file/d/1aUA1w01zXAf8SfGPLl1BFqqZqm5o1_DE/view?usp=sharing

Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
