### PR TITLE
fix: render bot-message attachments in Ask AI full page and show download-complete toast

### DIFF
--- a/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
@@ -1175,6 +1175,15 @@ function ChatMessageBubble({
             </div>
           )}
 
+          {/* Bot Message Attachments (e.g., generated PDFs from artifacts tool) */}
+          {!isUser && message.attachments && message.attachments.length > 0 && (
+            <div className='mt-2 space-y-2'>
+              {message.attachments.map((attachment, index) => (
+                <AttachmentPreview key={index} attachment={attachment} />
+              ))}
+            </div>
+          )}
+
           {inlineCitations.length > 0 && <InlineCitations citations={inlineCitations} />}
 
           {!isUser &&

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/MessageItem.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/MessageItem.tsx
@@ -50,6 +50,7 @@ import {
 } from '../utils/clawCitationUrl';
 import { CitationLink } from './CitationLink';
 import { genericInstance } from '../../../../services/clients/genericClient';
+import { showDownloadCompleteToast } from '../../../../utils/downloadToast';
 import type { Components } from 'react-markdown';
 import {
   SingleStat,
@@ -832,6 +833,7 @@ export const AttachmentPreview = ({
         link.click();
         document.body.removeChild(link);
         URL.revokeObjectURL(blobUrl);
+        showDownloadCompleteToast(displayName);
         return;
       }
 
@@ -863,6 +865,7 @@ export const AttachmentPreview = ({
       document.body.removeChild(link);
 
       URL.revokeObjectURL(blobUrl);
+      showDownloadCompleteToast(displayName);
     } catch (error) {
       logger.error(LogEvent.FRONTEND_ERROR, {
         type: 'migrated_console_error',


### PR DESCRIPTION
## Summary
Two related fixes for attachment handling in the Ask AI full-page UI and Claw agent chat UI:

1. **Bot-message attachments now render on the Ask AI full page / Claw chat.** `AIChatThread.tsx` previously only rendered attachments on user messages (`isUser` branch); the assistant/bot branch had no attachment render block, so agent-generated files (e.g. PDFs from the artifacts tool) were invisible there. The Ask AI **side pane** (`MessageItem.tsx`) already renders attachments on both user and bot messages, which is why the same file showed up there but not on the full page. Added the missing bot-attachment block using the same shared `AttachmentPreview` component (already imported), hitting the same authenticated v2 endpoint `/xyne-ai/v2/attachments/:id/download`.

2. **Download now shows a "Download complete" toast**, matching the toast shown when downloading from a chat message. The shared `AttachmentPreview.handleDownload` only emitted error toasts; it now calls the existing `showDownloadCompleteToast(displayName)` helper on success in both the base64/streaming and API-fetch branches. Because the full page, Claw chat, and side pane all reuse this one component, the toast is now consistent across all three surfaces.

## Changes
- `apps/dashboard/src/components/AIScreen/AIChatThread.tsx` — render `AttachmentPreview` for bot messages when `message.attachments` is present.
- `apps/dashboard/src/components/Chat/XyneAISidebar/components/MessageItem.tsx` — import and call `showDownloadCompleteToast` on successful download (both branches).

## PR template
1. Problem Description: Attachments could not be viewed/downloaded in the Claw agent chat UI and Ask AI full-page UI, though they worked in the Ask AI side pane. Additionally, no "Download complete" toast was shown for AI attachment downloads.
2. How the issue was identified: Traced attachment rendering across all three surfaces; the full-page `AIChatThread` had no bot-branch attachment render block, and the shared download handler never fired a success toast.
3. Solution implemented: Added the bot-attachment render block mirroring the side pane; added `showDownloadCompleteToast` calls on successful download in the shared handler.
4. Documentation: N/A
5. DB Alter Details: N/A
6. Data fix Details: N/A
7. Environment variable Changes: N/A
8. Testing: `tsc --noEmit` passes on the dashboard. Proof-of-testing screen recording + screenshots attached in the Spaces thread — shows the bot-message attachment card rendering on the Ask AI full page and the "Download complete" toast firing on download (rendered via the real `showDownloadCompleteToast` helper).
9. Services to which this change is to be deployed: dashboard (frontend).
10. Main PR link (if against a release branch): N/A