### PR TITLE
fix: allow recording sharing without canvases

### DIFF
--- a/apps/backend/src/services/recordingSharingService.ts
+++ b/apps/backend/src/services/recordingSharingService.ts
@@ -1034,13 +1034,16 @@ export class RecordingSharingService {
     const metadata = asMetadata(recording.metadata);
     const detailedSummaryCanvasId = metadata['detailedSummaryCanvasId'];
     const notesCanvasId = metadata['notesCanvasId'];
-    if (typeof detailedSummaryCanvasId !== 'string' || detailedSummaryCanvasId.length === 0) {
-      throw new RecordingSharingError('Detailed summary canvas is not ready yet', 409);
+    const canvasIds: string[] = [];
+
+    if (typeof detailedSummaryCanvasId === 'string' && detailedSummaryCanvasId.length > 0) {
+      canvasIds.push(detailedSummaryCanvasId);
     }
-    if (typeof notesCanvasId !== 'string' || notesCanvasId.length === 0) {
-      throw new RecordingSharingError('Recording notes canvas is not ready yet', 409);
+    if (typeof notesCanvasId === 'string' && notesCanvasId.length > 0) {
+      canvasIds.push(notesCanvasId);
     }
-    return [...new Set([detailedSummaryCanvasId, notesCanvasId])];
+
+    return [...new Set(canvasIds)];
   }
 
 }


### PR DESCRIPTION
1. Problem Description:
Old recordings can have no notes canvas id (and sometimes missing canvas metadata). The recording share flow required both detailed summary and notes canvas ids before granting access, so sharing old recordings failed with HTTP 409 instead of sharing the recording.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Investigated Mohan Kumar Mishra's failed recording share logs. The backend returned 409 from the recording share flow because `getShareCanvasIds` treated missing canvas ids as blockers.

3. Explain the solution implemented in the PR:
Changed `getShareCanvasIds` to collect and return only canvas ids present in `Call.metadata`. `syncCanvasAccess` now shares any existing notes/detailed-summary canvases, while an empty canvas list becomes a no-op so the NOTE_TAKER `EntityAccess` recording grant still succeeds for legacy recordings.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
Existing canvas id backfill has already been handled separately; this PR only removes canvas presence as a blocker.

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
Ran `pnpm --dir apps/backend typecheck` successfully.

9. Services to which this change is to be deployed:
backend

10. Main PR link (if this PR is raised against a release branch):
N/A