### PR TITLE
feature: XYNE-17198 add seperate key for thread tagging and entity ex…

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -80,6 +80,9 @@ VESPA_BACKFILL_FILE_QUEUE_NAME=vespa-backfill-file
 # content's createdAt is older than this many days (historical/migration writes). Default 365.
 VESPA_BACKFILL_AGE_DAYS=365
 ENABLE_MESSAGE_CLASSIFICATION=false
+# Dedicated LiteLLM service account key for thread-type classification. When set it is
+# used instead of the org's provisioned key (which would otherwise shadow it).
+THREAD_TYPE_CLASSIFICATION_LITELLM_API_KEY=
 ENABLE_VESPA_FILE_WORKER=false
 
 # Google OAuth Configuration

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -205,7 +205,7 @@ const envSchema = Joi.object({
   LITELLM_BASE_URL: Joi.string().default(''),
   LITELLM_API_KEY: Joi.string().allow('').default(''),
   ENABLE_ENTITY_EXTRACTION: Joi.boolean().default(true),
-  ENTITY_EXTRACTION_MODEL: Joi.string().default('glm-private'),
+  ENTITY_EXTRACTION_MODEL: Joi.string().default('open-fast'),
   ENTITY_EXTRACTION_CONCURRENCY: Joi.number().default(2),
   // How long a thread's job sits delayed before it runs. This is the debounce
   // window: every message on the thread inside it collapses into one job, so a
@@ -231,6 +231,8 @@ const envSchema = Joi.object({
   IMAGE_GENERATION_ENDPOINT: Joi.string().default(''),
   IMAGE_GENERATION_MODEL: Joi.string().default(''),
   ACTIVITY_CLASSIFICATION_LITELLM_API_KEY: Joi.string().allow('').default(''),
+  // Dedicated LiteLLM key for thread-type classification; falls back to the org's when unset.
+  THREAD_TYPE_CLASSIFICATION_LITELLM_API_KEY: Joi.string().allow('').default(''),
   // LiteLLM config specifically for call features (transcript summary, PRD, detailed summary)
   CALL_LITELLM_API_KEY: Joi.string().allow('').default(''),
   CALL_LITELLM_MODEL: Joi.string().default(''),
@@ -242,6 +244,8 @@ const envSchema = Joi.object({
   WORKING_HOUR_END: Joi.number().default(19),
   ENABLE_NOTIFICATION_WORKER: Joi.boolean().default(false),
   ENABLE_MESSAGE_CLASSIFICATION: Joi.boolean().default(false),
+  // What the dedicated classification key serves.
+  MESSAGE_CLASSIFIER_MODEL: Joi.string().default('open-fast'),
   ENABLE_TICKET_CLEANUP_WORKER: Joi.boolean().default(false),
   ENABLE_WORKER_SCHEDULER: Joi.boolean().default(true),
   ENABLE_RECAP_SCHEDULER: Joi.boolean().default(true),
@@ -779,6 +783,7 @@ export const config = {
     baseUrl: envVars.LITELLM_BASE_URL,
     apiKey: envVars.LITELLM_API_KEY,
     askAiApiKey: envVars.ASK_AI_LITELLM_API_KEY || envVars.LITELLM_API_KEY,
+    threadTypeClassificationApiKey: envVars.THREAD_TYPE_CLASSIFICATION_LITELLM_API_KEY,
     imageGenerationEndpoint: envVars.IMAGE_GENERATION_ENDPOINT,
     imageGenerationModel: envVars.IMAGE_GENERATION_MODEL,
     documentOutlineEnabled: envVars.DOCUMENT_OUTLINE_ENABLED,
@@ -882,6 +887,9 @@ export const config = {
   ticketCleanupWorkerEnabled: envVars.ENABLE_TICKET_CLEANUP_WORKER,
   notificationWorkerEnabled: envVars.ENABLE_NOTIFICATION_WORKER,
   messageClassificationEnabled: envVars.ENABLE_MESSAGE_CLASSIFICATION,
+  messageClassification: {
+    model: envVars.MESSAGE_CLASSIFIER_MODEL,
+  },
   runWorkerInBackend: envVars.RUN_WORKER_IN_BACKEND,
   recapScheduler: {
     enabled: envVars.ENABLE_RECAP_SCHEDULER,

--- a/apps/backend/src/services/entityExtraction/entityLlmClient.ts
+++ b/apps/backend/src/services/entityExtraction/entityLlmClient.ts
@@ -36,7 +36,9 @@ async function callLiteLLM(messages: Array<{ role: string; content: string }>): 
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${config.litellm.apiKey}`,
+        // The same dedicated key thread-type classification runs on: one service account
+        // for the classification workers, so their limits are not the gateway's shared ones.
+        Authorization: `Bearer ${config.litellm.threadTypeClassificationApiKey || config.litellm.apiKey}`,
       },
       body: JSON.stringify({
         model: config.entityExtraction.model,

--- a/apps/backend/src/services/messageClassification/index.ts
+++ b/apps/backend/src/services/messageClassification/index.ts
@@ -6,6 +6,7 @@ import {
   THREAD_TYPES,
   OrgLLMServiceAccountPurpose,
 } from '@xyne/shared';
+import { config } from '@/config/env';
 import { db } from '@/database/client';
 import { logger } from '@/utils/logger';
 import { logLLMCallStart, logLLMError, logLLMSuccess } from '@/agents/agentLogger';
@@ -149,7 +150,7 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
   });
   const rootIsBot = rootMessage?.msgType === 'BOT';
 
-  const modelName = process.env['MESSAGE_CLASSIFIER_MODEL'] ?? 'gpt-4o-mini';
+  const modelName = config.messageClassification.model;
   const { acts, threadTypes } = await classifyThread(
     {
       thread_messages: threadMessages,
@@ -382,21 +383,33 @@ const coerce = (raw: string | null | undefined, valid: Set<string>): string | nu
   return valid.has(normalized) ? normalized : null;
 };
 
+/**
+ * The key minted for this classifier alone, so its rate limit and spend are its own. Env
+ * rather than an org service-account row: one key for the worker, nothing to provision.
+ */
+const dedicatedCredential = (): OrgLLMCredential | null => {
+  const { threadTypeClassificationApiKey: apiKey, baseUrl } = config.litellm;
+  if (!apiKey || !baseUrl) return null;
+  return { apiKey, baseUrl, defaultModel: null, purpose: OrgLLMServiceAccountPurpose.DEFAULT };
+};
+
 async function classifyThread(
   input: ClassifierInput,
   projectId: string | null,
   workspaceId: string,
   modelName: string,
 ): Promise<Classification> {
-  const credential = projectId
-    ? await orgLLMCredentialService.getCredentialByProjectId(
-        projectId,
-        OrgLLMServiceAccountPurpose.DEFAULT,
-      )
-    : await orgLLMCredentialService.getCredentialByWorkspaceId(
-        workspaceId,
-        OrgLLMServiceAccountPurpose.DEFAULT,
-      );
+  const credential =
+    dedicatedCredential() ??
+    (projectId
+      ? await orgLLMCredentialService.getCredentialByProjectId(
+          projectId,
+          OrgLLMServiceAccountPurpose.DEFAULT,
+        )
+      : await orgLLMCredentialService.getCredentialByWorkspaceId(
+          workspaceId,
+          OrgLLMServiceAccountPurpose.DEFAULT,
+        ));
   if (!credential) {
     throw new Error('LiteLLM credentials are not configured for this organization');
   }


### PR DESCRIPTION
…traction

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
