### PR TITLE
fix: allow reusing channel names released by archived channels

### DIFF
--- a/apps/backend/src/controllers/channelController.ts
+++ b/apps/backend/src/controllers/channelController.ts
@@ -1421,7 +1421,7 @@ export class ChannelController {
     try {
       // projectId is accepted for backwards compatibility with older clients but
       // is no longer required or used: duplicate-channel checks are workspace-scoped.
-      const { name, projectId }: { name: string; projectId?: string } = req.body;
+      const { name, projectId, channelId }: { name: string; projectId?: string; channelId?: string } = req.body;
 
       // Validate required fields
       if (!name) {
@@ -1440,7 +1440,7 @@ export class ChannelController {
         res.status(400).json({ error: 'Missing workspaceId' });
         return;
       }
-      const isDuplicate = await this.channelRepository.checkDuplicateName(name.trim(), workspaceId);
+      const isDuplicate = await this.channelRepository.checkDuplicateName(name.trim(), workspaceId, channelId);
 
       const response: CheckDuplicateChannelResponse = {
         isDuplicate,

--- a/apps/backend/src/database/repositories/channelRepository.ts
+++ b/apps/backend/src/database/repositories/channelRepository.ts
@@ -323,9 +323,24 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
     );
   }
 
-  async checkDuplicateName(name: string, workspaceId: string): Promise<boolean> {
+  async checkDuplicateName(
+    name: string,
+    workspaceId: string,
+    excludeChannelId?: string,
+  ): Promise<boolean> {
+    // A channel name is only "taken" by an ACTIVE, DEFAULT-scope channel in the
+    // workspace. Archived channels release their name, and non-DEFAULT scopes
+    // (DM/TICKET/DOCUMENT/GROUP_DM) carry system-generated names that must not
+    // block user-facing channel names. excludeChannelId lets a channel keep its
+    // own current name during a rename pre-check.
     const existingChannel = await this.db.channel.findFirst({
-      where: { name, project: { workspaceId } }
+      where: {
+        name,
+        isArchived: false,
+        scopeType: ChannelScopeType.DEFAULT,
+        project: { workspaceId },
+        ...(excludeChannelId ? { id: { not: excludeChannelId } } : {}),
+      },
     });
     return !!existingChannel;
   }

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -1188,7 +1188,13 @@ export function createMutators(
             throw new Error('You are not a participant of this channel');
           }
 
-          const existingChannel = await tx.run(zql.channels.where('name', name).one());
+          const existingChannel = await tx.run(
+            zql.channels
+              .where('name', name)
+              .where('isArchived', false)
+              .where('scopeType', ChannelScopeType.DEFAULT)
+              .one(),
+          );
           if (existingChannel && existingChannel.id !== channelId) {
             throw new Error('A channel with this name already exists');
           }
@@ -1967,8 +1973,16 @@ export function createMutators(
           }
 
 
-          // Check for duplicate name
-          const existingChannel = await tx.run(zql.channels.where('name', name).one());
+          // Check for duplicate name — only ACTIVE, DEFAULT-scope channels own a
+          // name. Archived channels release it and non-DEFAULT scopes never
+          // block it. A channel never collides with itself (id !== channelId).
+          const existingChannel = await tx.run(
+            zql.channels
+              .where('name', name)
+              .where('isArchived', false)
+              .where('scopeType', ChannelScopeType.DEFAULT)
+              .one(),
+          );
           if (existingChannel && existingChannel.id !== channelId) {
             throw new Error('A channel with this name already exists');
           }
@@ -2220,6 +2234,25 @@ export function createMutators(
 
           if (!channel.isArchived) {
             throw new Error('Channel is not archived');
+          }
+
+          // Archived channels release their name, so another active DEFAULT
+          // channel may have claimed it in the meantime. Un-archiving into that
+          // collision would produce two active channels with the same name, so
+          // block it and ask the user to rename first.
+          if (channel.scopeType === ChannelScopeType.DEFAULT) {
+            const nameOwner = await tx.run(
+              zql.channels
+                .where('name', channel.name)
+                .where('isArchived', false)
+                .where('scopeType', ChannelScopeType.DEFAULT)
+                .one(),
+            );
+            if (nameOwner && nameOwner.id !== channelId) {
+              throw new Error(
+                `An active channel named '${channel.name}' already exists. Rename it before unarchiving this one.`,
+              );
+            }
           }
 
           await tx.mutate.channels.update({

--- a/apps/dashboard/src/components/Chat/AboutChannel/AboutChannel.tsx
+++ b/apps/dashboard/src/components/Chat/AboutChannel/AboutChannel.tsx
@@ -178,7 +178,7 @@ const AboutChannel = ({
     setIsSavingName(true);
     try {
       // Check for duplicate name before committing the optimistic mutation
-      const { isDuplicate } = await channelService.checkDuplicateChannel(trimmed);
+      const { isDuplicate } = await channelService.checkDuplicateChannel(trimmed, channel.id);
       if (isDuplicate) {
         setNameError(`A channel named "#${trimmed}" already exists`);
         setIsSavingName(false);

--- a/apps/dashboard/src/services/Chat/channelService.ts
+++ b/apps/dashboard/src/services/Chat/channelService.ts
@@ -110,10 +110,13 @@ export interface ChannelMember {
 }
 
 export class ChannelService {
-  async checkDuplicateChannel(title: string): Promise<CheckDuplicateChannelResponse> {
+  async checkDuplicateChannel(
+    title: string,
+    channelId?: string,
+  ): Promise<CheckDuplicateChannelResponse> {
     const response = await apiInstance.post<CheckDuplicateChannelResponse>(
       '/channels/check-duplicate',
-      { name: title },
+      { name: title, ...(channelId ? { channelId } : {}) },
     );
     return response.data;
   }


### PR DESCRIPTION
[POT](https://drive.google.com/file/d/19dm1IEso4B-d4izmO7MX31KVOUpzb2jk/view?usp=sharing)
## Problem
When a channel is archived it is soft-deleted (`isArchived = true`) but its row keeps its `name`. Every duplicate-name guard matched on `name` alone, so a freed name was never actually free — renaming a channel back to a previously-used name showed "Channel already exists" even though no active channel held it.

## Root cause
The channel-name uniqueness rule is enforced in four places, all matching by `name` only (ignoring `isArchived` and `scopeType`):
- `channelRepository.checkDuplicateName` (`apps/backend/src/database/repositories/channelRepository.ts`)
- `POST /channels/check-duplicate` controller (`apps/backend/src/controllers/channelController.ts`)
- Zero `renameChannel` mutator (`apps/backend/src/zero/mutators.ts`)
- Zero `promoteToChannel` mutator (same file)

## Fix
Scope the rule to **active (`isArchived: false`), `DEFAULT`-scope** channels in the workspace, applied consistently across all four sites. Also:
- `checkDuplicateName` gains an optional `excludeChannelId` so a channel never blocks its own current name; the controller threads `channelId` from the request and the frontend `checkDuplicateChannel` / `AboutChannel` rename pre-check pass `channel.id`.
- `unarchiveChannel` now refuses to unarchive a `DEFAULT` channel whose name has since been claimed by an active channel, so name reuse can't produce two active channels with the same name.

## Files changed
- `apps/backend/src/database/repositories/channelRepository.ts`
- `apps/backend/src/controllers/channelController.ts`
- `apps/backend/src/zero/mutators.ts`
- `apps/dashboard/src/services/Chat/channelService.ts`
- `apps/dashboard/src/components/Chat/AboutChannel/AboutChannel.tsx`

## Notes
No schema migration; name uniqueness remains application-enforced (the `(workspaceId, name, id)` index is non-unique). No backfill required.

## Testing
- Archive channel `dnd`, rename another channel to `dnd` → succeeds.
- Rename to a name held by an active channel → still blocked.
- Rename a channel to its own current name → no-op, not a duplicate error.
- Unarchive a channel whose name is now taken by an active channel → rejected with a clear message.