### PR TITLE
fix: allow recording sharing without canvases (cherry-pick to release-20260821)

### DIFF
--- a/apps/backend/src/services/recordingSharingService.ts
+++ b/apps/backend/src/services/recordingSharingService.ts
@@ -662,13 +662,16 @@ export class RecordingSharingService {
     const metadata = asMetadata(recording.metadata);
     const detailedSummaryCanvasId = metadata['detailedSummaryCanvasId'];
     const notesCanvasId = metadata['notesCanvasId'];
-    if (typeof detailedSummaryCanvasId !== 'string' || detailedSummaryCanvasId.length === 0) {
-      throw new RecordingSharingError('Detailed summary canvas is not ready yet', 409);
+    const canvasIds: string[] = [];
+
+    if (typeof detailedSummaryCanvasId === 'string' && detailedSummaryCanvasId.length > 0) {
+      canvasIds.push(detailedSummaryCanvasId);
     }
-    if (typeof notesCanvasId !== 'string' || notesCanvasId.length === 0) {
-      throw new RecordingSharingError('Recording notes canvas is not ready yet', 409);
+    if (typeof notesCanvasId === 'string' && notesCanvasId.length > 0) {
+      canvasIds.push(notesCanvasId);
     }
-    return [...new Set([detailedSummaryCanvasId, notesCanvasId])];
+
+    return [...new Set(canvasIds)];
   }
 
 }


### PR DESCRIPTION
Cherry-pick of PR #1063 (commit 6768f55) onto the release-20260821 branch.

1. Problem Description:
Old recordings can have no notes canvas id (and sometimes missing canvas metadata). The recording share flow required both detailed summary and notes canvas ids before granting access, so sharing old recordings failed with HTTP 409 instead of sharing the recording.

2. How the issue was identified:
Investigated a failed recording share; the backend returned 409 because getShareCanvasIds treated missing canvas ids as blockers.

3. Solution:
getShareCanvasIds now collects and returns only canvas ids present in Call.metadata. syncCanvasAccess shares any existing notes/detailed-summary canvases, and an empty canvas list is a no-op so the NOTE_TAKER EntityAccess recording grant still succeeds for legacy recordings.

4. Documentation: N/A
5. DB Alter Details: N/A
6. Data fix Details: Existing canvas ids already backfilled separately; this PR only removes canvas presence as a blocker.
7. Environment variable Changes: N/A
8. Testing: pnpm --dir apps/backend typecheck passes; logic proven via POT covering both-present / only-summary / only-notes / none / null-metadata cases.
9. Services to deploy: backend
10. Main PR link: #1063