### PR TITLE
feat: XYNE-55716 add brief on/off toggle, improve metrics

### DIFF
--- a/apps/dashboard/src/components/AIScreen/AISidebar.tsx
+++ b/apps/dashboard/src/components/AIScreen/AISidebar.tsx
@@ -20,6 +20,7 @@ import { usePlatform } from '../../hooks/usePlatform';
 import { useClawAdminAccessQuery } from '../../hooks/useClawAdminAccess';
 import { useClawOrgManageAccess } from '../../hooks/useClawOrganization';
 import { useAuth } from '../../hooks/useAuth';
+import { useDailyBriefEnabled } from '../../hooks/useDailyBriefEnabled';
 import { useV2SessionsList, useV2SessionInvalidator } from '../../hooks/useAskAISessionsV2';
 import { deleteV2Conversation } from '../../services/XyneAI/XyneAISessionsV2Service';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
@@ -63,6 +64,8 @@ interface AINavItem {
   trackName?: string;
   adminOnly?: boolean;
   orgManagerOnly?: boolean;
+  /** Hidden unless the user has the scheduled morning brief switched on. */
+  dailyBriefOnly?: boolean;
 }
 
 const NAV_ITEMS: AINavItem[] = [
@@ -86,6 +89,7 @@ const NAV_ITEMS: AINavItem[] = [
     to: '/ai/daily-brief/today',
     matchPath: '/ai/daily-brief',
     trackName: 'OPEN_DAILY_BRIEF',
+    dailyBriefOnly: true,
   },
 ];
 
@@ -342,8 +346,13 @@ export function AISidebar({
   const { user } = useAuth();
   const { isAdmin } = useClawAdminAccessQuery(user?.id);
   const { canManage: canManageOrg } = useClawOrgManageAccess();
+  const { enabled: dailyBriefEnabled } = useDailyBriefEnabled();
+  const onDailyBriefRoute = pathname.includes('/ai/daily-brief');
   const visibleNavItems = NAV_ITEMS.filter(
-    item => (!item.adminOnly || isAdmin) && (!item.orgManagerOnly || canManageOrg),
+    item =>
+      (!item.adminOnly || isAdmin) &&
+      (!item.orgManagerOnly || canManageOrg) &&
+      (!item.dailyBriefOnly || dailyBriefEnabled === true || onDailyBriefRoute),
   );
   const isNewChatActive = !routedActiveItem && !activeSessionId;
 

--- a/apps/dashboard/src/components/Settings/DailyBriefToggle.tsx
+++ b/apps/dashboard/src/components/Settings/DailyBriefToggle.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from 'react';
+import { Switch } from '../ui/Switch';
+import { cn } from '../../utils/classNames';
+import { useDailyBriefEnabled } from '../../hooks/useDailyBriefEnabled';
+
+interface DailyBriefToggleProps {
+  /** Morning Brief lives inside the Xyne AI sidebar, which "Open AI on launch" gates. */
+  available: boolean;
+}
+
+export function DailyBriefToggle({ available }: DailyBriefToggleProps): ReactElement {
+  const { enabled, loading, saving, setEnabled } = useDailyBriefEnabled();
+  const stranded = !available && enabled === true;
+
+  return (
+    <div
+      className='mt-3 border-t border-border pt-3'
+      data-track-category='DailyBrief'
+      data-track-name='daily-brief-preferences-toggle'
+    >
+      <div className='flex items-center justify-between gap-4'>
+        <div className={cn(!available && 'opacity-50')}>
+          <p className='text-sm font-medium text-foreground'>Morning brief</p>
+          <p className='mt-0.5 text-xs text-muted-foreground'>
+            {available
+              ? 'A brief of everything waiting on you, ready each morning'
+              : 'Needs “Open AI on launch” — the brief lives in the Xyne AI sidebar'}
+          </p>
+        </div>
+        <Switch
+          id='daily-brief-enabled'
+          checked={enabled === true}
+          disabled={!available || loading || saving}
+          onCheckedChange={setEnabled}
+        />
+      </div>
+      {stranded && (
+        <p className='mt-2 text-xs text-amber-600 dark:text-amber-500'>
+          Your morning brief is still being generated each day. Turn “Open AI on launch” back on to
+          switch it off.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -46,6 +46,7 @@ import { MeetingDetectionToggle } from '../MeetingDetectionToggle';
 import { MenuBarIconToggle } from '../MenuBarIconToggle';
 import { RecordingPillToggle } from '../RecordingPillToggle';
 import { ClawOverlayToggle } from '../ClawOverlayToggle';
+import { DailyBriefToggle } from '../DailyBriefToggle';
 import { UpdateAssignmentStatusModal } from '../../AppSidebar/UpdateAssignmentStatusModal';
 import { VoiceSignatureModal } from '../VoiceSignatureModal/VoiceSignatureModal';
 import HuddleIcon from '../../icons/HuddleIcon';
@@ -669,18 +670,21 @@ const MessagingSection: FC<{ state: PreferencesState }> = ({ state }) => (
 const LaunchSection: FC<{ state: PreferencesState }> = ({ state }) => (
   <div className='space-y-4'>
     <SectionHeader title='Launch' subtitle='Configure your startup experience' />
-    <div className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'>
-      <div>
-        <p className='text-sm font-medium text-foreground'>Open AI on launch</p>
-        <p className='text-xs text-muted-foreground mt-0.5'>
-          Start with the Xyne AI landing page instead of chat
-        </p>
+    <div className='p-3 rounded-lg border border-border bg-muted/30'>
+      <div className='flex items-center justify-between gap-4'>
+        <div>
+          <p className='text-sm font-medium text-foreground'>Open AI on launch</p>
+          <p className='text-xs text-muted-foreground mt-0.5'>
+            Start with the Xyne AI landing page instead of chat
+          </p>
+        </div>
+        <Switch
+          id='ai-landing-default'
+          checked={state.aiLandingDefault}
+          onCheckedChange={state.setAiLandingDefault}
+        />
       </div>
-      <Switch
-        id='ai-landing-default'
-        checked={state.aiLandingDefault}
-        onCheckedChange={state.setAiLandingDefault}
-      />
+      <DailyBriefToggle available={state.aiLandingDefault} />
     </div>
     <ClawOverlayToggle />
   </div>

--- a/apps/dashboard/src/hooks/useDailyBriefEnabled.ts
+++ b/apps/dashboard/src/hooks/useDailyBriefEnabled.ts
@@ -1,0 +1,28 @@
+import { useEffect, useSyncExternalStore } from 'react';
+import {
+  getDailyBriefEnabledState,
+  loadDailyBriefEnabled,
+  setDailyBriefEnabled,
+  subscribeDailyBriefEnabled,
+} from '../stores/dailyBriefEnabledStore';
+
+export function useDailyBriefEnabled(): {
+  /** null while the config is still loading. */
+  enabled: boolean | null;
+  loading: boolean;
+  saving: boolean;
+  setEnabled: (enabled: boolean) => void;
+} {
+  const state = useSyncExternalStore(subscribeDailyBriefEnabled, getDailyBriefEnabledState);
+
+  useEffect(() => {
+    void loadDailyBriefEnabled();
+  }, []);
+
+  return {
+    enabled: state.enabled,
+    loading: state.enabled === null,
+    saving: state.saving,
+    setEnabled: setDailyBriefEnabled,
+  };
+}

--- a/apps/dashboard/src/routes/DailyBriefScreen/BriefIntroBanner.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/BriefIntroBanner.tsx
@@ -5,9 +5,20 @@ import { cn } from '@/utils/classNames';
 interface BriefIntroBannerProps {
   onSeeMore: () => void;
   onDismiss: () => void;
+  /** Master opt-in for the scheduled brief. Undefined while the config is still loading. */
+  briefEnabled?: boolean | undefined;
+  onEnableBrief?: (() => void) | undefined;
+  enabling?: boolean | undefined;
 }
 
-export function BriefIntroBanner({ onSeeMore, onDismiss }: BriefIntroBannerProps): ReactElement {
+export function BriefIntroBanner({
+  onSeeMore,
+  onDismiss,
+  briefEnabled,
+  onEnableBrief,
+  enabling = false,
+}: BriefIntroBannerProps): ReactElement {
+  const showEnable = briefEnabled === false && onEnableBrief !== undefined;
   return (
     <div
       className={cn(
@@ -33,15 +44,34 @@ export function BriefIntroBanner({ onSeeMore, onDismiss }: BriefIntroBannerProps
         <p className='text-[16px] font-normal leading-[20px] text-foreground/80'>
           Everything that needs you, is overdue, waiting, and assigned to you summarized
         </p>
-        <button
-          type='button'
-          onClick={onSeeMore}
-          data-track-category='DailyBrief'
-          data-track-name='daily-brief-intro-see-more'
-          className='mt-1 flex h-7 items-center rounded-[8px] border border-border bg-background px-2.5 text-[14px] font-semibold leading-[20px] text-foreground shadow-sm transition-colors hover:bg-accent'
-        >
-          Learn more
-        </button>
+        {showEnable && (
+          <p className='text-[13px] leading-[18px] text-muted-foreground'>
+            You are not set up to receive this each morning yet.
+          </p>
+        )}
+        <div className='mt-1 flex items-center gap-2'>
+          {showEnable && (
+            <button
+              type='button'
+              onClick={onEnableBrief}
+              disabled={enabling}
+              data-track-category='DailyBrief'
+              data-track-name='daily-brief-intro-enable'
+              className='flex h-7 items-center rounded-[8px] bg-foreground px-2.5 text-[14px] font-semibold leading-[20px] text-background shadow-sm transition-opacity hover:opacity-90 disabled:opacity-50'
+            >
+              {enabling ? 'Turning on…' : 'Turn on morning brief'}
+            </button>
+          )}
+          <button
+            type='button'
+            onClick={onSeeMore}
+            data-track-category='DailyBrief'
+            data-track-name='daily-brief-intro-see-more'
+            className='flex h-7 items-center rounded-[8px] border border-border bg-background px-2.5 text-[14px] font-semibold leading-[20px] text-foreground shadow-sm transition-colors hover:bg-accent'
+          >
+            Learn more
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/dashboard/src/routes/DailyBriefScreen/CalendarView.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/CalendarView.tsx
@@ -1,14 +1,16 @@
 import { ReactElement, useMemo } from 'react';
 import { format } from 'date-fns';
-import { Calendar } from '../../components/ui/Calendar';
-import { ChevronBigLeft } from '@xyne/icons';
-
+import { DayPicker } from 'react-day-picker';
+import { ChevronBigLeft, ChevronBigRight } from '@xyne/icons';
 const BUCKET_FORMAT = 'yyyy-MM-dd';
 
 function parseBucket(date: string): Date | null {
   const parsed = new Date(`${date}T00:00:00`);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
+
+const NAV_BUTTON_CLASS =
+  'z-10 inline-flex size-7 items-center justify-center rounded-[8px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-40 aria-disabled:pointer-events-none aria-disabled:opacity-40';
 
 interface CalendarViewProps {
   /** Every day the user has a brief for, as YYYY-MM-DD buckets. */
@@ -43,40 +45,62 @@ export function CalendarView({
   };
 
   return (
-    <div className='flex flex-col'>
-      <div className='flex items-center gap-1 pb-1 pl-0.5 pr-2.5'>
-        <button
-          type='button'
-          onClick={onBack}
-          aria-label='Back to recent briefs'
-          data-track-category='DailyBrief'
-          data-track-name='daily-brief-calendar-back'
-          className='flex size-7 shrink-0 items-center justify-center rounded-[8px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-        >
-          <ChevronBigLeft size={14} />
-        </button>
-        <span className='text-[13px] font-medium tracking-[-0.1px] text-foreground'>
-          Select a date
-        </span>
-      </div>
+    <div className='flex flex-col gap-2'>
+      <button
+        type='button'
+        onClick={onBack}
+        aria-label='Back to recent briefs'
+        data-track-category='DailyBrief'
+        data-track-name='daily-brief-calendar-back'
+        className='self-start flex items-center rounded-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground pl-0.5 pr-1 py-0.5'
+      >
+        <ChevronBigLeft size={14} variant='Solid' />
+        <span className='text-xs font-medium tracking-[-0.1px] text-foreground'>List View</span>
+      </button>
       {availableDates.length === 0 ? (
         <div className='px-2.5 py-2 text-[13px] text-muted-foreground'>No briefs yet.</div>
       ) : (
-        <Calendar
+        <DayPicker
           mode='single'
+          navLayout='after'
+          showOutsideDays
+          weekStartsOn={0}
           {...(selectedObj && { selected: selectedObj })}
           onSelect={handleSelect}
           defaultMonth={defaultMonth}
           {...(bounds.earliest && { startMonth: bounds.earliest })}
           {...(bounds.latest && { endMonth: bounds.latest })}
           disabled={date => !dateSet.has(format(date, BUCKET_FORMAT))}
+          className='w-full'
           classNames={{
-            day: 'relative flex-1 p-0 text-center text-sm focus-within:relative focus-within:z-20',
+            months: 'flex w-full flex-col',
+            month: 'relative w-full',
+            month_caption: 'flex h-7 items-center px-2',
+            caption_label: 'text-lg font-medium tracking-[-0.1px] text-foreground',
+            nav: 'absolute top-0 right-0 px-1',
+            button_previous: `${NAV_BUTTON_CLASS}`,
+            button_next: `${NAV_BUTTON_CLASS}`,
+            month_grid: 'mt-1 w-full border-collapse',
+            weekdays: 'flex w-full',
+            weekday:
+              'flex h-7 flex-1 items-center justify-center text-[11px] font-normal text-muted-foreground',
+            week: 'flex w-full',
+            day: 'flex-1 p-0 text-center',
+            day_button:
+              'flex h-8 w-full items-center justify-center rounded-[8px] text-[13px] font-normal text-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none disabled:pointer-events-none disabled:text-muted-foreground/30',
             selected:
-              'bg-primary text-white hover:bg-primary hover:text-white focus:bg-primary focus:text-white rounded-md',
-            // root: 'relative',
+              '[&_button]:bg-primary [&_button]:text-white [&_button]:hover:bg-primary [&_button]:hover:text-white',
+            today: '[&_button]:font-semibold',
+            outside: '[&_button]:text-muted-foreground/40',
+            disabled: '[&_button]:text-muted-foreground/30',
+            hidden: 'invisible',
           }}
-          // navLayout='around'
+          components={{
+            Chevron: ({ orientation }) => {
+              const Icon = orientation === 'left' ? ChevronBigLeft : ChevronBigRight;
+              return <Icon size={18} />;
+            },
+          }}
           data-track-category='DailyBrief'
           data-track-name='daily-brief-calendar-day'
         />

--- a/apps/dashboard/src/routes/DailyBriefScreen/DailyBriefScreen.tsx
+++ b/apps/dashboard/src/routes/DailyBriefScreen/DailyBriefScreen.tsx
@@ -8,6 +8,7 @@ import { createMarkdownComponents } from '../../utils/markdownComponents';
 import { cn } from '../../utils/classNames';
 import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../utils/electronApp';
 import { useIsInPanelWebview } from '../../hooks/useIsInPanelWebview';
+import { useDailyBriefEnabled } from '../../hooks/useDailyBriefEnabled';
 import { BriefHistoryMenu, HEADER_ICON_CLASS } from './BriefHistoryMenu';
 import { BriefSettingsDialog } from './BriefSettingsDialog';
 import { BriefIntroBanner } from './BriefIntroBanner';
@@ -203,6 +204,11 @@ const DailyBriefScreen = (): ReactElement => {
   const regenerateStartedAtRef = useRef<number | null>(null);
   const isInPanelWebview = useIsInPanelWebview();
   const { introSeen, markIntroSeen } = useBriefIntroSeen();
+  const {
+    enabled: briefEnabled,
+    saving: briefEnabling,
+    setEnabled: setBriefEnabled,
+  } = useDailyBriefEnabled();
 
   const load = useCallback(async (opts?: { quiet?: boolean }) => {
     if (!mountedRef.current) return;
@@ -433,7 +439,27 @@ const DailyBriefScreen = (): ReactElement => {
       return <BriefSkeleton />;
     }
     if (!selected) {
-      return <p className={BODY_TEXT_CLASS}>No brief to show yet. Use “Generate” to create one.</p>;
+      return (
+        <div className='flex flex-col items-start gap-3'>
+          <p className={BODY_TEXT_CLASS}>
+            {briefEnabled === false
+              ? 'No brief to show yet. Turn on the morning brief to get one each day, or use “Generate” to create one now.'
+              : 'No brief to show yet. Use “Generate” to create one.'}
+          </p>
+          {briefEnabled === false && (
+            <button
+              type='button'
+              onClick={() => setBriefEnabled(true)}
+              disabled={briefEnabling}
+              data-track-category='DailyBrief'
+              data-track-name='daily-brief-empty-enable'
+              className='flex h-7 items-center rounded-[8px] bg-foreground px-2.5 text-[14px] font-semibold leading-[20px] text-background shadow-sm transition-opacity hover:opacity-90 disabled:opacity-50'
+            >
+              {briefEnabling ? 'Turning on…' : 'Turn on morning brief'}
+            </button>
+          )}
+        </div>
+      );
     }
     if (IS_DEV && showRaw) {
       return (
@@ -577,7 +603,13 @@ const DailyBriefScreen = (): ReactElement => {
       <main className='min-h-0 flex-1 overflow-y-auto px-6 pb-16'>
         <article className='mx-auto w-full max-w-[750px]'>
           {!introSeen && !isBusy && (
-            <BriefIntroBanner onSeeMore={() => setFeaturesOpen(true)} onDismiss={markIntroSeen} />
+            <BriefIntroBanner
+              onSeeMore={() => setFeaturesOpen(true)}
+              onDismiss={markIntroSeen}
+              briefEnabled={briefEnabled ?? undefined}
+              onEnableBrief={() => setBriefEnabled(true)}
+              enabling={briefEnabling}
+            />
           )}
           {hasBrief && !isBusy && (
             <h1 className='py-10 text-center font-serif text-[40px] font-semibold italic leading-[1.2] text-foreground'>

--- a/apps/dashboard/src/stores/dailyBriefEnabledStore.ts
+++ b/apps/dashboard/src/stores/dailyBriefEnabledStore.ts
@@ -1,0 +1,65 @@
+import { toast } from 'sonner';
+import { dailyBriefApi } from '../api/dailyBriefApi';
+
+export interface DailyBriefEnabledState {
+  /** null until the config has been fetched at least once. */
+  enabled: boolean | null;
+  saving: boolean;
+}
+
+let state: DailyBriefEnabledState = { enabled: null, saving: false };
+let inFlight: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function set(next: Partial<DailyBriefEnabledState>): void {
+  state = { ...state, ...next };
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function getDailyBriefEnabledState(): DailyBriefEnabledState {
+  return state;
+}
+
+export function subscribeDailyBriefEnabled(listener: () => void): () => void {
+  listeners.add(listener);
+  return (): void => {
+    listeners.delete(listener);
+  };
+}
+
+export function loadDailyBriefEnabled(force = false): Promise<void> {
+  if (inFlight) return inFlight;
+  if (state.enabled !== null && !force) return Promise.resolve();
+  inFlight = dailyBriefApi
+    .getConfig()
+    .then(config => {
+      set({ enabled: config.enabled });
+    })
+    .catch(() => {
+      set({ enabled: false });
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
+}
+
+export function setDailyBriefEnabled(next: boolean): void {
+  const previous = state.enabled;
+  set({ enabled: next, saving: true });
+  void dailyBriefApi
+    .saveConfig({ enabled: next })
+    .then(config => {
+      set({ enabled: config.enabled });
+      toast.success(next ? 'Morning brief turned on' : 'Morning brief turned off');
+    })
+    .catch(() => {
+      set({ enabled: previous });
+      toast.error('Could not update your morning brief.');
+    })
+    .finally(() => {
+      set({ saving: false });
+    });
+}

--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260820140000_daily_brief_activity/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260820140000_daily_brief_activity/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "daily_brief_activity" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "dateBucket" TEXT NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "rejectionCount" INTEGER NOT NULL DEFAULT 0,
+    "occurredAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "daily_brief_activity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "daily_brief_activity_userId_kind_dateBucket_key" ON "daily_brief_activity"("userId", "kind", "dateBucket");
+
+-- CreateIndex
+CREATE INDEX "daily_brief_activity_orgId_idx" ON "daily_brief_activity"("orgId");
+
+-- CreateIndex
+CREATE INDEX "daily_brief_activity_kind_dateBucket_idx" ON "daily_brief_activity"("kind", "dateBucket");
+
+-- AddForeignKey
+ALTER TABLE "daily_brief_activity" ADD CONSTRAINT "daily_brief_activity_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -66,6 +66,7 @@ model User {
   /// digitalTwinEnabled opt-in pattern.
   dailyBriefEnabled   Boolean   @default(false)
   dailyBriefEnabledAt DateTime?
+  dailyBriefActivity  DailyBriefActivity[]
   /// Per-user, per-agent custom instructions (injected into every agent run for
   /// this user) + feature-generated content (first consumer: Daily Brief).
   agentInstructions   UserAgentInstruction[]
@@ -652,6 +653,37 @@ model GeneratedContent {
   @@index([userId, kind, dateBucket])
   @@index([status, kind])
   @@map("generated_content")
+}
+
+/// One row per user per day per activity kind, so a distinct-user count over any
+/// date range is an exact COUNT(DISTINCT) rather than a fixed-window sketch.
+/// Upserted, so repeat activity on the same day bumps `count` instead of adding rows.
+model DailyBriefActivity {
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  orgId  String
+
+  /// "view" | "regenerate" | "switch".
+  kind       String
+  /// Calendar bucket the activity happened on (IST), matching GeneratedContent.
+  dateBucket String
+  /// How many times this user did this on this day.
+  count      Int      @default(1)
+  /// Regenerations that signal dissatisfaction — excludes retry_after_failure.
+  /// A counter rather than an origin string: the row is unique per user/kind/day,
+  /// so a single value would be last-write-wins across mixed origins.
+  rejectionCount Int  @default(0)
+  /// First occurrence on this day.
+  occurredAt DateTime @default(now())
+  /// Most recent occurrence on this day.
+  lastSeenAt DateTime @default(now())
+
+  @@unique([userId, kind, dateBucket])
+  @@index([orgId])
+  @@index([kind, dateBucket])
+  @@map("daily_brief_activity")
 }
 
 model AgentChainWorkflow {

--- a/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
+++ b/apps/xyne-claw-auth/backend/src/otel/daily-brief-metrics.ts
@@ -41,7 +41,11 @@ const switchSourceKey = (source: BriefSwitchSource): string =>
   `daily_brief:switch_users:src:${source}`;
 /** HyperLogLog per day: a windowed distinct count without one Redis member per user per day. */
 const switchDayKey = (dateBucket: string): string => `daily_brief:switch_users:day:${dateBucket}`;
-const SWITCH_DAY_TTL_SECONDS = 35 * 24 * 60 * 60;
+
+const DAY_HLL_TTL_SECONDS = 35 * 24 * 60 * 60;
+
+/** Activity kinds recorded per user per day in Postgres. Bounded set. */
+export type DailyBriefActivityKind = "view" | "regenerate" | "switch";
 
 /** Per user per day, so we know which attempt a request is. Two days is plenty. */
 const dayAttemptKey = (userId: string, dateBucket: string): string =>
@@ -112,9 +116,10 @@ export function recordDailyBriefGenerated(
   trigger: DailyBriefTrigger,
   status: "ready" | "failed",
   durationMs: number,
+  attempt = 1,
 ): void {
   try {
-    const attributes = { trigger, status };
+    const attributes = { trigger, status, attempt: attemptBucket(attempt) };
     getDailyBriefGeneratedTotal().add(1, attributes);
     getGenerationDuration().record(durationMs, attributes);
   } catch {
@@ -150,6 +155,27 @@ export function recordScheduledDeliveryDelay(dateBucket: string, generatedAt: Da
   }
 }
 
+// Daily Brief Opt-In Changes — labels: action (opted_in | opted_out)
+let _optInChanges: Counter | null = null;
+function getOptInChanges(): Counter {
+  if (!_optInChanges) {
+    _optInChanges = getMeter().createCounter("daily_brief_opt_in_changes_total", {
+      description: "Daily Brief master toggle flips, by direction",
+      unit: "1",
+    });
+  }
+  return _optInChanges;
+}
+
+/** Count one master-toggle flip. Only call when the stored value actually changed. */
+export function recordDailyBriefOptInChange(enabled: boolean): void {
+  try {
+    getOptInChanges().add(1, { action: enabled ? "opted_in" : "opted_out" });
+  } catch {
+    // metrics must never break a request
+  }
+}
+
 // Daily Brief Regeneration Attempts — labels: attempt (1 | 2 | 3 | 4+), origin
 let _regenerationAttempts: Counter | null = null;
 function getRegenerationAttempts(): Counter {
@@ -162,6 +188,11 @@ function getRegenerationAttempts(): Counter {
   return _regenerationAttempts;
 }
 
+/** Bounded attempt bucket shared by the attempts counter and the completion counter. */
+function attemptBucket(attempt: number): string {
+  return attempt >= 4 ? "4+" : String(attempt);
+}
+
 /**
  * Count one regeneration request, the user behind it, and — the useful part —
  * which attempt of the day it is and what it is replacing. Best-effort.
@@ -170,13 +201,32 @@ function getRegenerationAttempts(): Counter {
  */
 export async function recordDailyBriefRegeneration(
   userId: string,
+  orgId: string,
   dateBucket: string,
   existing: { status: string; generatedAt: Date | null } | null,
-): Promise<void> {
+): Promise<number> {
   try {
     const redis = redisService.getConnection();
     const dayKey = dayAttemptKey(userId, dateBucket);
     const attempt = await redis.incr(dayKey);
+    void finishRegenerationRecord(userId, orgId, dateBucket, existing, attempt, dayKey);
+    return attempt;
+  } catch {
+    // metrics must never break a brief run
+    return 1;
+  }
+}
+
+async function finishRegenerationRecord(
+  userId: string,
+  orgId: string,
+  dateBucket: string,
+  existing: { status: string; generatedAt: Date | null } | null,
+  attempt: number,
+  dayKey: string,
+): Promise<void> {
+  try {
+    const redis = redisService.getConnection();
     await redis.expire(dayKey, DAY_ATTEMPT_TTL_SECONDS);
 
     const origin: RegenerationOrigin =
@@ -188,10 +238,7 @@ export async function recordDailyBriefRegeneration(
             ? "replacing_scheduled_brief"
             : "first_brief_of_day";
 
-    getRegenerationAttempts().add(1, {
-      attempt: attempt >= 4 ? "4+" : String(attempt),
-      origin,
-    });
+    getRegenerationAttempts().add(1, { attempt: attemptBucket(attempt), origin });
 
     const writes = redis.multi().incr(REGEN_COUNT_KEY).sadd(REGEN_USERS_KEY, userId);
     if (origin === "replacing_scheduled_brief") writes.sadd(DEFAULT_REJECTED_USERS_KEY, userId);
@@ -199,14 +246,60 @@ export async function recordDailyBriefRegeneration(
     // run has attempt >= 2 without being dissatisfied with anything.
     if (origin === "replacing_own_regeneration") writes.sadd(REPEAT_REGEN_USERS_KEY, userId);
     await writes.exec();
+    const isRejection =
+      origin === "replacing_scheduled_brief" || origin === "replacing_own_regeneration";
+    await recordDailyBriefActivity(userId, orgId, "regenerate", dateBucket, isRejection);
   } catch {
     // metrics must never break a brief run
+  }
+}
+
+/**
+ * Upsert one row per user per day per kind. Distinct-user counts over an arbitrary
+ * date range then come from COUNT(DISTINCT "userId") in Postgres, which is exact
+ * and unbounded in lookback — a fixed-window sketch can be neither. Repeat activity
+ * on the same day bumps `count` instead of adding a row, so the table stays bounded
+ * at one row per user per day per kind however heavy the usage.
+ *
+ * @param isRejection increments `rejectionCount` alongside `count`.
+ */
+export async function recordDailyBriefActivity(
+  userId: string,
+  orgId: string,
+  kind: DailyBriefActivityKind,
+  dateBucket: string,
+  isRejection = false,
+): Promise<void> {
+  try {
+    const now = new Date();
+    const rejection = isRejection ? 1 : 0;
+    await prisma.dailyBriefActivity.upsert({
+      where: { userId_kind_dateBucket: { userId, kind, dateBucket } },
+      create: {
+        userId,
+        orgId,
+        kind,
+        dateBucket,
+        count: 1,
+        rejectionCount: rejection,
+        occurredAt: now,
+        lastSeenAt: now,
+      },
+      update: {
+        count: { increment: 1 },
+        rejectionCount: { increment: rejection },
+        lastSeenAt: now,
+      },
+    });
+  } catch {
+    // metrics must never break a request
   }
 }
 
 /** Record that a user switched to a different brief, from a given entry point. */
 export async function recordDailyBriefSwitch(
   userId: string,
+  orgId: string,
   source: BriefSwitchSource,
   dateBucket: string,
 ): Promise<void> {
@@ -220,18 +313,28 @@ export async function recordDailyBriefSwitch(
       .sadd(SWITCH_USERS_KEY, userId)
       .sadd(switchSourceKey(source), userId)
       .pfadd(dayKey, userId)
-      .expire(dayKey, SWITCH_DAY_TTL_SECONDS)
+      .expire(dayKey, DAY_HLL_TTL_SECONDS)
       .exec();
+    await recordDailyBriefActivity(userId, orgId, "switch", dateBucket);
   } catch {
     // metrics must never break a request
   }
 }
 
+/** Record that a user opened a brief. */
+export async function recordDailyBriefViewed(
+  userId: string,
+  orgId: string,
+  dateBucket: string,
+): Promise<void> {
+  await recordDailyBriefActivity(userId, orgId, "view", dateBucket);
+}
+
 /** The last `days` day-bucket keys, newest first — the union PFCOUNT reads. */
-function switchDayKeysBack(days: number): string[] {
+function dayKeysBack(key: (dateBucket: string) => string, days: number): string[] {
   const now = Date.now();
   return Array.from({ length: days }, (_, i) =>
-    switchDayKey(formatDayIST(new Date(now - i * 24 * 60 * 60 * 1000))),
+    key(formatDayIST(new Date(now - i * 24 * 60 * 60 * 1000))),
   );
 }
 
@@ -283,6 +386,15 @@ export function registerDailyBriefGauges(): void {
   const switchesSourceGauge = meter.createObservableGauge("daily_brief_switches_by_source", {
     description: "Brief switches ever served, by the control used (events, not people)",
   });
+  const enabledUsersGauge = meter.createObservableGauge("daily_brief_enabled_users_total", {
+    description: "Users who currently have the Daily Brief switched on",
+  });
+  const eligibleUsersGauge = meter.createObservableGauge("daily_brief_eligible_users_total", {
+    description: "All user accounts — the fixed denominator for the opt-in rate",
+  });
+  const deliveredTodayGauge = meter.createObservableGauge("daily_brief_delivered_today", {
+    description: "Briefs ready for today's bucket — divide by opted-in users for fan-out coverage",
+  });
 
   meter.addBatchObservableCallback(
     async (result) => {
@@ -304,6 +416,9 @@ export function registerDailyBriefGauges(): void {
           switches,
           switchesHistoryMenu,
           switchesDatePicker,
+          enabledUsers,
+          eligibleUsers,
+          deliveredToday,
         ] = await Promise.all([
           prisma.generatedContent.count({ where }),
           prisma.generatedContent.groupBy({ by: ["userId"], where }),
@@ -312,13 +427,18 @@ export function registerDailyBriefGauges(): void {
           redis.scard(DEFAULT_REJECTED_USERS_KEY).catch(() => 0),
           redis.scard(REPEAT_REGEN_USERS_KEY).catch(() => 0),
           redis.scard(SWITCH_USERS_KEY).catch(() => 0),
-          redis.pfcount(...switchDayKeysBack(7)).catch(() => 0),
-          redis.pfcount(...switchDayKeysBack(30)).catch(() => 0),
+          redis.pfcount(...dayKeysBack(switchDayKey, 7)).catch(() => 0),
+          redis.pfcount(...dayKeysBack(switchDayKey, 30)).catch(() => 0),
           redis.scard(switchSourceKey("history_menu")).catch(() => 0),
           redis.scard(switchSourceKey("date_picker")).catch(() => 0),
           redis.get(SWITCH_COUNT_KEY).catch(() => null),
           redis.get(switchSourceCountKey("history_menu")).catch(() => null),
           redis.get(switchSourceCountKey("date_picker")).catch(() => null),
+          prisma.user.count({ where: { dailyBriefEnabled: true } }),
+          prisma.user.count(),
+          prisma.generatedContent.count({
+            where: { ...where, dateBucket: formatDayIST(new Date()) },
+          }),
         ]);
         result.observe(usersGauge, users.length);
         result.observe(briefsGauge, briefs);
@@ -338,6 +458,9 @@ export function registerDailyBriefGauges(): void {
         result.observe(switchesSourceGauge, Number(switchesDatePicker ?? 0), {
           source: "date_picker",
         });
+        result.observe(enabledUsersGauge, enabledUsers);
+        result.observe(eligibleUsersGauge, eligibleUsers);
+        result.observe(deliveredTodayGauge, deliveredToday);
       } catch (err) {
         // OTel swallows a rejected callback silently — log so a broken read is visible.
         log.warn(`[otel] daily-brief gauges skipped: ${err instanceof Error ? err.message : String(err)}`);
@@ -355,6 +478,9 @@ export function registerDailyBriefGauges(): void {
       switchUsersSourceGauge,
       switchesGauge,
       switchesSourceGauge,
+      enabledUsersGauge,
+      eligibleUsersGauge,
+      deliveredTodayGauge,
     ],
   );
 }

--- a/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
@@ -17,8 +17,10 @@ import {
   type DailyBriefPayload,
 } from "../services/dailyBrief.js";
 import {
+  recordDailyBriefOptInChange,
   recordDailyBriefRegeneration,
   recordDailyBriefSwitch,
+  recordDailyBriefViewed,
   type BriefSwitchSource,
 } from "../otel/daily-brief-metrics.js";
 
@@ -80,6 +82,9 @@ router.put("/config", async (req: Request, res: Response) => {
         res.status(400).json({ success: false, error: "enabled must be a boolean" });
         return;
       }
+      const before = await prisma.user
+        .findUnique({ where: { id: userId }, select: { dailyBriefEnabled: true } })
+        .catch(() => null);
       await prisma.user.update({
         where: { id: userId },
         data: {
@@ -87,6 +92,9 @@ router.put("/config", async (req: Request, res: Response) => {
           ...(body.enabled ? { dailyBriefEnabledAt: new Date() } : {}),
         },
       });
+      if (before && before.dailyBriefEnabled !== body.enabled) {
+        recordDailyBriefOptInChange(body.enabled);
+      }
     }
 
     if (body.instructions !== undefined || body.instructionsEnabled !== undefined) {
@@ -132,6 +140,7 @@ router.put("/config", async (req: Request, res: Response) => {
 router.get("/latest", async (req: Request, res: Response) => {
   try {
     const userId = getRequesterId(req);
+    const orgId = getOrgId(req);
     if (!userId) {
       res.status(401).json({ success: false, error: "Unauthorized" });
       return;
@@ -143,6 +152,7 @@ router.get("/latest", async (req: Request, res: Response) => {
       res.json({ success: true, data: { status: "none" } });
       return;
     }
+    if (orgId) void recordDailyBriefViewed(userId, orgId, today);
     res.json({
       success: true,
       data: {
@@ -255,6 +265,7 @@ router.get("/by-date/:date", async (req: Request, res: Response) => {
 router.post("/switched", async (req: Request, res: Response) => {
   try {
     const userId = getRequesterId(req);
+    const orgId = getOrgId(req);
     if (!userId) {
       res.status(401).json({ success: false, error: "Unauthorized" });
       return;
@@ -264,7 +275,7 @@ router.post("/switched", async (req: Request, res: Response) => {
     // open the label up to arbitrary cardinality.
     const body = req.body as { source?: unknown };
     const source: BriefSwitchSource = body.source === "date_picker" ? "date_picker" : "history_menu";
-    await recordDailyBriefSwitch(userId, source, briefDateBucket());
+    if (orgId) await recordDailyBriefSwitch(userId, orgId, source, briefDateBucket());
     res.status(204).end();
   } catch (err) {
     log.error("[daily-brief] post switched", err);
@@ -279,6 +290,7 @@ router.post("/switched", async (req: Request, res: Response) => {
  */
 router.post("/regenerate", async (req: Request, res: Response) => {
   const userId = getRequesterId(req);
+  const orgId = getOrgId(req);
   if (!userId) {
     res.status(401).json({ success: false, error: "Unauthorized" });
     return;
@@ -306,12 +318,15 @@ router.post("/regenerate", async (req: Request, res: Response) => {
   const existing = await generatedContentRepository
     .findForBucket(userId, DAILY_BRIEF_KIND, dateBucket)
     .catch(() => null);
-  void recordDailyBriefRegeneration(userId, dateBucket, existing);
+  const attempt = orgId
+    ? await recordDailyBriefRegeneration(userId, orgId, dateBucket, existing)
+    : 1;
   send("start", { date: dateBucket });
   try {
     const result = await generateDailyBrief(userId, {
       signal: abort.signal,
       trigger: "regenerate",
+      attempt,
       onProgress: (label) => send("progress", { label }),
     });
     if (result) {

--- a/apps/xyne-claw-auth/backend/src/services/dailyBrief.ts
+++ b/apps/xyne-claw-auth/backend/src/services/dailyBrief.ts
@@ -127,9 +127,11 @@ export async function generateDailyBrief(
     onProgress?: (label: string) => void;
     signal?: AbortSignal;
     trigger?: DailyBriefTrigger;
+    attempt?: number;
   } = {},
 ): Promise<GenerateBriefResult | null> {
   const trigger = opts.trigger ?? "scheduled";
+  const attempt = opts.attempt ?? 1;
   const startedAt = Date.now();
   const user = await prisma.user.findUnique({
     where: { id: userId },
@@ -209,7 +211,7 @@ export async function generateDailyBrief(
         `[daily-brief] run for ${userId} finished without a dailyBrief payload (lastEvent=${streamResult.lastEventName}, error=${streamResult.errorReason ?? "none"})`,
       );
       await generatedContentRepository.markFailed(userId, DAILY_BRIEF_KIND, dateBucket);
-      recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt);
+      recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt, attempt);
       return null;
     }
 
@@ -231,13 +233,13 @@ export async function generateDailyBrief(
       generatedAt,
     });
     log.info(`[daily-brief] generated + persisted for ${userId} (session=${sessionId ?? "?"})`);
-    recordDailyBriefGenerated(trigger, "ready", Date.now() - startedAt);
+    recordDailyBriefGenerated(trigger, "ready", Date.now() - startedAt, attempt);
     if (trigger === "scheduled") recordScheduledDeliveryDelay(dateBucket, generatedAt);
     return { brief, content, sessionId };
   } catch (err) {
     log.error(`[daily-brief] generation failed for ${userId}:`, err instanceof Error ? err.message : String(err));
     await generatedContentRepository.markFailed(userId, DAILY_BRIEF_KIND, dateBucket).catch(() => {});
-    recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt);
+    recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt, attempt);
     return null;
   }
 }

--- a/docker/grafana/provisioning/dashboards/xyne-daily-brief.json
+++ b/docker/grafana/provisioning/dashboards/xyne-daily-brief.json
@@ -28,267 +28,52 @@
   "version": 15,
   "panels": [
     {
+      "type": "text",
+      "title": "Read this first",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 300,
+      "options": {
+        "mode": "markdown",
+        "content": "### Daily Brief — what this dashboard answers\n\nEvery panel here drives a decision. They are grouped by question, most urgent first: **is it working**, **are people using it**, **are the briefs good enough**, **which features earn their place**, and **how does it perform**.\n\n**Reading rules.** Titles name the statistic and the window. Panels marked *(now)* or *(all time)* are levels and ignore the time picker on purpose — their descriptions say why. Everything else re-scopes to the range you pick. Every average names its denominator. A blank panel means the answer is *undefined* for that range, not zero — where a window has no events to divide by, the line breaks rather than dropping to a misleading zero.\n\n**Start dates, honestly.** Brief *deliveries* go back to the feature's first brief (2026-07-09). Per-user *activity* — reads, regenerations, history browsing — starts **2026-08-20**. Opt-in/opt-out *events* and the subscriber gauge start when the toggle shipped (2026-08-20). Selecting a range that reaches further back shows blanks for those panels: that is missing history, not zero usage. Nothing has been back-filled or inferred.\n\n**Two data sources.** Delivery, reader and prompt panels read the application's own Postgres, so their counts are exact rather than sampled. Rate, quality and performance panels read the metrics store. One panel mixes both and says so.\n\n**Small numbers are still small.** Distributions and per-user averages need a real population before they mean anything; treat single-digit readings as directional only."
+      }
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 6
       },
-      "id": 100,
+      "id": 299,
       "panels": [],
-      "title": "Adoption & volume",
+      "title": "Is it working?",
       "type": "row"
     },
     {
-      "type": "stat",
-      "title": "Users with a brief (all time)",
-      "description": "Users who have at least one generated brief. Read from generated_content, so it is exact and independent of the time range.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 0,
-        "y": 1
-      },
-      "id": 1,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "max(daily_brief_users_total)"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Users who requested a regen (all time)",
-      "description": "Users who have requested at least one regeneration. Counted by user id in Redis when the request reaches claw-auth, so it is exact and independent of the time range.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 1
-      },
-      "id": 2,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "max(daily_brief_regen_users_total)"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Briefs generated (all time)",
-      "description": "Briefs that exist globally (one per user per day; a regeneration overwrites that day's brief rather than adding one). Read from generated_content, so it is exact and independent of the time range.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 12,
-        "y": 1
-      },
-      "id": 4,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "max(daily_brief_total)"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Regenerations (all time)",
-      "description": "Regeneration requests ever served, globally. Counted in Redis when the request reaches claw-auth, so it survives restarts and is exact regardless of the time range.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 1
-      },
-      "id": 5,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "max(daily_brief_regenerations_total)"
-        }
-      ]
-    },
-    {
       "type": "timeseries",
-      "title": "Briefs and regenerations over time",
-      "description": "Lifetime totals plotted over the selected range \u2014 the slope is how fast briefs are being produced and regenerated.",
+      "title": "Scheduled briefs delivered late (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Share of the scheduled briefs that DID arrive but arrived more than 30 minutes after the time the cron was aiming for. It exists, just not when it was needed.\n\nGOOD: flat at zero.\nBAD: any sustained level, and especially a rise that tracks subscriber growth - that is the morning fan-out queueing behind the shared model-throughput limit, so the users at the back of the queue get their brief hours late.\n\n30 minutes is used because it is a real bucket edge in the underlying histogram; a threshold that is not a bucket boundary returns a silently wrong answer.\n\nCOUNTS ONLY BRIEFS THAT SUCCEEDED. A brief that never arrived at all is not late, it is missing - see 'Generation failure rate by trigger' in the Generation reliability row below. Read the two together: a pipeline that fails almost everything and delivers one brief on time scores a perfect zero here.\n\nThe failure line that used to share this panel now lives in that row, split by trigger, because scheduled and user-triggered failures are different problems and were being averaged together.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
       },
       "gridPos": {
-        "h": 6,
+        "h": 8,
         "w": 24,
         "x": 0,
         "y": 7
       },
-      "id": 6,
+      "id": 311,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -296,21 +81,27 @@
           },
           "custom": {
             "drawStyle": "line",
-            "fillOpacity": 0,
-            "lineWidth": 1,
-            "pointSize": 5,
+            "fillOpacity": 15,
+            "lineWidth": 2,
             "showPoints": "auto",
-            "spanNulls": false
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
           },
           "mappings": [],
-          "unit": "short"
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "no scheduled runs in this range"
         },
         "overrides": []
       },
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull"
+            "lastNotNull",
+            "min",
+            "max"
           ],
           "displayMode": "list",
           "placement": "bottom",
@@ -323,978 +114,318 @@
       },
       "targets": [
         {
+          "expr": "1 - (sum(increase(daily_brief_scheduled_delivery_delay_milliseconds_bucket{le=\"1800000\"}[$__range])) / (sum(increase(daily_brief_scheduled_delivery_delay_milliseconds_count[$__range])) > 0))",
+          "legendFormat": "late (over 30 min)",
           "refId": "A",
-          "expr": "max(daily_brief_total)",
-          "legendFormat": "briefs"
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 320,
+      "panels": [],
+      "title": "Are people using it?",
+      "type": "row"
+    },
+    {
+      "type": "stat",
+      "title": "Opt-in rate: subscribers / all accounts (now)",
+      "description": "THE BIG NUMBER IS RIGHT NOW; the sparkline shows the selected range.\n\nShare of all accounts with Morning Brief switched on. Fixed denominator (everyone who could switch it on), so it stays comparable as the company grows.\n\nGOOD: rising, or high and steady.\nBAD: flat while headcount grows - the feature is not spreading, it is being carried by early adopters. A step DOWN is somebody deliberately switching it off.\n\nDeliberately not a time-average: averaging a ratio weights every scrape equally regardless of how many accounts existed at that instant, and would report ~49% for a population that was 50% and is now 0%.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 301,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 1,
+          "noValue": "no scrape data in this range",
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          },
+          "expr": "max(daily_brief_enabled_users_total) / clamp_min(max(daily_brief_eligible_users_total), 1)"
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "title": "People switching Morning Brief on and off (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Gross flow in each direction - the churn the subscriber level cannot show.\n\nTen people switching on and ten switching off leaves the level perfectly flat and reads as 'nothing is happening', when in fact the feature is replacing its entire audience.\n\nGOOD: the ON bar clearly taller than OFF.\nBAD: the two bars similar - you are acquiring and losing at the same rate, so growth is a treadmill.\nWORST: OFF taller than ON. Check the date against the failure and rejection panels below to see whether quality caused it.\n\nCounts real transitions only: re-saving the same value does not count, verified against the live route. Counts EVENTS, so somebody who leaves and returns appears in both bars - deliberately, because that is a different story from never leaving.\n\nOpt-in events are recorded from the moment the toggle shipped.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 303,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "noValue": "no toggle activity in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "xTickLabelRotation": 0,
+        "showValue": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(daily_brief_opt_in_changes_total{action=\"opted_in\"}[$__range]))",
+          "legendFormat": "switched on",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
         },
         {
+          "expr": "sum(increase(daily_brief_opt_in_changes_total{action=\"opted_out\"}[$__range]))",
+          "legendFormat": "switched off",
+          "instant": true,
           "refId": "B",
-          "expr": "max(daily_brief_regenerations_total)",
-          "legendFormat": "regenerations"
-        }
-      ]
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 13
-      },
-      "id": 104,
-      "panels": [],
-      "title": "Brief switching",
-      "type": "row"
-    },
-    {
-      "type": "stat",
-      "title": "Total brief switches (all time)",
-      "description": "Every brief switch ever served, counted server-side (Redis INCR). Events, not people \u2014 compare against \"Users who switched briefs\" to see switches-per-person.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 0,
-        "y": 14
-      },
-      "id": 24,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "expr": "max(daily_brief_switches_total)",
-          "instant": true,
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Users who switched briefs (last 30 days)",
-      "description": "Distinct users who switched to a different brief in the last 30 days, counted server-side by userId (Redis HyperLogLog, ~0.81% error). Replaces an earlier device-based count: the client metric carries a per-device localStorage id, so it counted browsers rather than people \u2014 one person on three devices read as three. A beacon can be blocked or lost on a fast page close, so treat this as a tight lower bound. See \"Brief switches by control\" for event volume.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 14
-      },
-      "id": 3,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "expr": "max(daily_brief_switch_users_window{window=\"30d\"})",
-          "instant": true,
-          "refId": "A"
-        }
-      ]
-    },
-    {
-      "type": "piechart",
-      "title": "Switches: list vs calendar (all time)",
-      "description": "Share of switch events by control, server-side. The calendar is the ONLY way to reach a brief older than the 8 most recent, so date_picker volume is the direct read on whether people want older briefs. Events, so one heavy user can dominate \u2014 read alongside panel \"Users reaching for older briefs\".",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 14
-      },
-      "id": 25,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "expr": "max by (source) (daily_brief_switches_by_source)",
-          "instant": true,
-          "refId": "A",
-          "legendFormat": "{{source}}"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "Users reaching for older briefs (all time)",
-      "description": "Distinct users who have used each control at least once. NOTE: these sets OVERLAP \u2014 someone who used both is counted in both, so the bars do not sum to the total user count and must not be drawn as a pie. date_picker here = how many people ever went past the recent window, which is the per-person version of the question.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 26,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "expr": "max by (source) (daily_brief_switch_users_by_source)",
-          "instant": true,
-          "refId": "A",
-          "legendFormat": "{{source}}"
-        }
-      ]
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 26
-      },
-      "id": 101,
-      "panels": [],
-      "title": "Regeneration behaviour & outcomes",
-      "type": "row"
-    },
-    {
-      "type": "stat",
-      "title": "Users who rejected the auto brief (all time)",
-      "description": "Users who have re-run a brief the cron produced for them \u2014 dissatisfaction with the default. Exact, lifetime.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 0,
-        "y": 27
-      },
-      "id": 7,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "max(daily_brief_default_rejected_users_total)"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Users who regenerated more than once (all time)",
-      "description": "Users who re-ran a brief they had already regenerated \u2014 the regeneration itself did not satisfy them. Exact, lifetime.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 27
-      },
-      "id": 8,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "max(daily_brief_repeat_regen_users_total)"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Rejection rate of the auto brief",
-      "description": "Share of cron-generated briefs that the user immediately re-ran. The headline quality number for the scheduled brief. Reads as blank rather than 0 when the cron has produced nothing in the window: clamp_min only rescues a denominator of zero, not a denominator that is an empty vector, so an empty panel here means 'no scheduled runs in range', not 'broken'.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 12,
-        "y": 27
-      },
-      "id": 11,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "\u2014"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum(increase(daily_brief_regeneration_attempts_total{origin=\"replacing_scheduled_brief\"}[$__range])) / clamp_min(sum(increase(daily_brief_generated_total{trigger=\"scheduled\",status=\"ready\"}[$__range])), 1)"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Regeneration success rate",
-      "description": "Share of on-demand regeneration runs that produced a brief, within the selected range. Reliability of the Regenerate button, as distinct from the quality signals above. CAVEAT: the denominator includes runs cut short by an HTTP connection close (tab close, reload, network drop, proxy timeout), which are currently recorded as 'failed', so this reads LOWER than true pipeline reliability. Treat it as a floor until 'aborted' is split out server-side.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 27
-      },
-      "id": 22,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "\u2014"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum(increase(daily_brief_generated_total{trigger=\"regenerate\",status=\"ready\"}[$__range])) / clamp_min(sum(increase(daily_brief_generated_total{trigger=\"regenerate\"}[$__range])), 1)"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "Why briefs get regenerated",
-      "description": "replacing_scheduled_brief = rejecting the cron brief \u00b7 replacing_own_regeneration = rejecting their own re-run \u00b7 retry_after_failure = the previous run errored, not a quality signal \u00b7 first_brief_of_day = no brief existed yet.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 33
-      },
-      "id": 9,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (origin) (increase(daily_brief_regeneration_attempts_total[$__range]))",
-          "legendFormat": "{{origin}}"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "Regeneration outcomes",
-      "description": "How on-demand regenerations actually ended, from the server-side completion counter. Recorded when the run finishes, unlike 'Regenerations' which is counted when the request arrives \u2014 the difference between the two is runs that started and never completed. CAVEAT: 'failed' currently absorbs runs the server aborted because the HTTP connection closed (tab close, reload, network drop, proxy timeout), so it overstates genuine pipeline failures by an unknown amount; splitting an 'aborted' status out of it is a pending server-side change. This is NOT the same event as 'Regenerations abandoned' below: that histogram fires on component unmount (an in-app route change), and the dashboard passes no AbortSignal, so navigating away inside the app does not abort the run. The two count different things and do not double-count \u2014 except on a tab close, which can trigger both.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 33
-      },
-      "id": 21,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (status) (increase(daily_brief_generated_total{trigger=\"regenerate\"}[$__range]))",
-          "legendFormat": "{{status}}"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "How far the regeneration ladder goes",
-      "description": "SURVIVAL CURVE, NOT A DISTRIBUTION. Bar N = share of the day's regenerating users who reached at least attempt N, normalised to attempt 1. A user-day that went three deep is counted in bars 1, 2 AND 3, so bar heights do NOT mean 'N users needed N regenerations' \u2014 read 'Where people stop' for that. Bars only ever descend. CAVEAT: attempts 1\u20133 count user-days (the per-user-per-day Redis key increments once per depth), but 4+ aggregates every request at depth \u22654, so the 4+ bar is a REQUEST tally in different units and can exceed 100%. The origin filter was removed deliberately: origin is computed with 'previous run failed' taking precedence over attempt depth, so one failed or connection-dropped run relabels every later attempt that day as retry_after_failure and used to delete the entire tail of this chart. Origin belongs in 'Why briefs get regenerated'.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 0,
-        "y": 39
-      },
-      "id": 10,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [],
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "auto",
-        "xTickLabelRotation": 0
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (attempt) (increase(daily_brief_regeneration_attempts_total[$__range])) / scalar(clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"1\"}[$__range])), 1))",
-          "legendFormat": "reached attempt {{attempt}}"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "Where people stop",
-      "description": "How many regenerations it actually took, derived by differencing the ladder: users who reached depth N but not N+1. This is the panel that answers 'how many regens does it take' \u2014 the ladder panel next to it cannot, because every user-day is counted at every depth it passed through. APPROXIMATE AT BUCKET 3: 'stopped at 3' subtracts the 4+ bar, which counts requests rather than user-days, so it under-reports whenever anyone is deep in the tail; all three are clamped at 0 because that subtraction can otherwise go negative (it does on the current sample data). The 4+ bar is shown separately and in different units on purpose \u2014 do not add it to the other three. A short time range can also clip a user-day's attempt 1 outside the window while its attempt 2 falls inside, which biases the first bar down. WILL CHANGE: once client-abort is split out of 'failed' server-side, fewer days will be misclassified and these buckets will shift.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 39
-      },
-      "id": 20,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "lineWidth": 1
-          },
-          "mappings": [],
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "auto",
-        "xTickLabelRotation": 0
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"1\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{attempt=\"2\"}[$__range])), 0)",
-          "legendFormat": "stopped at 1"
-        },
-        {
-          "refId": "B",
-          "instant": true,
-          "expr": "clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"2\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{attempt=\"3\"}[$__range])), 0)",
-          "legendFormat": "stopped at 2"
-        },
-        {
-          "refId": "C",
-          "instant": true,
-          "expr": "clamp_min(sum(increase(daily_brief_regeneration_attempts_total{attempt=\"3\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{attempt=\"4+\"}[$__range])), 0)",
-          "legendFormat": "stopped at 3 (approx)"
-        },
-        {
-          "refId": "D",
-          "instant": true,
-          "expr": "sum(increase(daily_brief_regeneration_attempts_total{attempt=\"4+\"}[$__range]))",
-          "legendFormat": "4+ (requests, not user-days)"
-        }
-      ]
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 45
-      },
-      "id": 102,
-      "panels": [],
-      "title": "Generation performance",
-      "type": "row"
-    },
-    {
-      "type": "stat",
-      "title": "Avg generation time",
-      "description": "Mean wall-clock time of a successful brief run. sum/count is the exact mean; the quantile panel next to it is bucket-approximated.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 0,
-        "y": 46
-      },
-      "id": 12,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "\u2014"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum(increase(daily_brief_generation_duration_milliseconds_sum{status=\"ready\"}[$__range])) / clamp_min(sum(increase(daily_brief_generation_duration_milliseconds_count{status=\"ready\"}[$__range])), 1)"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "p95 generation time",
-      "description": "95th percentile of successful runs \u2014 what the slowest users actually wait.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 8,
-        "y": 46
-      },
-      "id": 13,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "\u2014"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "histogram_quantile(0.95, sum by (le) (increase(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__range])))"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "p50 delivery delay",
-      "description": "How late the scheduled brief landed versus the cron's target time (queue wait + global LLM slot + the run). The SLO users actually feel.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 16,
-        "y": 46
-      },
-      "id": 14,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "\u2014"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "histogram_quantile(0.5, sum by (le) (increase(daily_brief_scheduled_delivery_delay_milliseconds_bucket[$__range])))"
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
         }
       ]
     },
     {
       "type": "timeseries",
-      "title": "Generation time by trigger",
-      "description": "p50 and p95 of successful runs, cron versus on-demand.",
+      "title": "Subscribers and total accounts over time",
+      "description": "FOLLOWS THE TIME PICKER. The two levels behind the opt-in rate: how many people have Morning Brief on, and how many accounts exist to switch it on.\n\nThis is the diagnostic for the rate tile. A falling rate means either the top line fell or the bottom one rose, and those need opposite responses - this panel says which happened.\n\nGOOD: both rising together.\nBAD: accounts rising while subscribers stays flat - new joiners are not finding or not wanting the feature, a discovery problem rather than a quality one.\n\nA LEVEL, so ten people joining and ten leaving draws a flat line. The panel beside it separates those.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 302,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "noValue": "no scrape data in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "max(daily_brief_enabled_users_total)",
+          "legendFormat": "subscribers",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "max(daily_brief_eligible_users_total)",
+          "legendFormat": "all accounts",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 321,
+      "panels": [],
+      "title": "Are the briefs good enough?",
+      "type": "row"
+    },
+    {
+      "type": "barchart",
+      "title": "Why people regenerate (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. What the Regenerate button is actually being used for. This is the panel that stops 'regenerations are up' being misreported as either engagement or dissatisfaction.\n\nreplacing_scheduled_brief - the morning brief was rejected. A QUALITY problem.\nreplacing_own_regeneration - their own re-run was rejected too. A WORSE quality problem.\nretry_after_failure - the previous run errored. A RELIABILITY problem; it says nothing about quality.\nfirst_brief_of_day - no brief existed yet. Not dissatisfaction at all, just normal use.\n\nGOOD: dominated by first_brief_of_day with a thin retry bar.\nBAD: a fat retry_after_failure bar - while that is wide, regeneration volume is mostly measuring outages and must not be reported as unhappiness.\n\nFiltered to the four defined origins: a fifth value from a superseded build still sits in the metrics store and would otherwise appear as a phantom bar.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 313,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "noValue": "no regenerations in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "xTickLabelRotation": 0,
+        "showValue": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum by (origin) (increase(daily_brief_regeneration_attempts_total{origin=~\"replacing_scheduled_brief|replacing_own_regeneration|retry_after_failure|first_brief_of_day\"}[$__range]))",
+          "legendFormat": "{{origin}}",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 322,
+      "panels": [],
+      "title": "Which features earn their place?",
+      "type": "row"
+    },
+    {
+      "type": "barchart",
+      "title": "People who used each way of reaching an older brief (all time)",
+      "description": "IGNORES THE TIME PICKER - these are lifetime distinct-user counts held as Redis sets, which carry no dates.\n\nThe recent list and the calendar are two different controls for the same job. The calendar is the ONLY way to reach a brief older than the handful shown in the list, so its bar is the direct read on whether anyone wants older briefs.\n\nGOOD: both bars healthy - the history feature is genuinely used.\nBAD: the calendar bar near zero over the feature's whole life - it is an expensive control nobody needs, and a clean deletion candidate.\n\nTHE SETS OVERLAP: somebody who used both is counted in both, so the bars do not sum to the reader count and must never be drawn as a pie.",
       "datasource": {
         "type": "prometheus",
         "uid": "P4169E866C3094E38"
@@ -1303,9 +434,78 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 40
       },
-      "id": 16,
+      "id": 307,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short",
+          "min": 0,
+          "decimals": 0,
+          "noValue": "nobody has browsed history yet"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "xTickLabelRotation": 0,
+        "showValue": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max by (source) (daily_brief_switch_users_by_source)",
+          "legendFormat": "{{source}}",
+          "instant": true,
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 323,
+      "panels": [],
+      "title": "Performance & patience",
+      "type": "row"
+    },
+    {
+      "type": "timeseries",
+      "title": "How long a brief takes vs how long people wait (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. All four lines are SECONDS, so they can be read against each other directly. This is the panel that says whether the wait is survivable.\n\nTHE COMPARISON THAT MATTERS: if 'half of leavers had gone by' sits BELOW 'half of briefs took', people are giving up before the brief could possibly arrive - and no amount of quality work will help, because they never see it. The fix is a progress indicator, a notification when it is ready, or a faster pipeline.\n\nGOOD: the patience lines sitting above the generation lines.\nBAD: patience below generation - every regeneration is a race the user is losing.\n\nTHE PATIENCE LINES ARE A LOWER BOUND AND CLIENT-MEASURED. They come from the browser, count devices rather than people, and are recorded when the screen unmounts - so a closed tab, the very thing being measured, may never report. They also fire on in-app navigation, and the screen sends no cancel signal, so 'left the screen' does not mean 'the run stopped'. Treat them as 'people stopped watching', not 'people cancelled'.\n\nThe browser export path is healthy, but these two lines only move when somebody actually walks away mid-regeneration - so long flat stretches are real quiet, not a broken pipe.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 316,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1315,17 +515,836 @@
             "drawStyle": "line",
             "fillOpacity": 10,
             "lineWidth": 2,
-            "showPoints": "auto"
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
           },
           "mappings": [],
-          "unit": "ms"
+          "unit": "s",
+          "min": 0,
+          "noValue": "no generation or walk-away data in this range"
         },
         "overrides": []
       },
       "options": {
         "legend": {
           "calcs": [
+            "lastNotNull",
             "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (increase(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__range]))) / 1000",
+          "legendFormat": "half of briefs took",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (increase(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__range]))) / 1000",
+          "legendFormat": "slowest 5% of briefs took",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.5, sum by (le) (increase(daily_brief_regenerate_abandoned_seconds_bucket[$__range])))",
+          "legendFormat": "half of leavers had gone by",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.9, sum by (le) (increase(daily_brief_regenerate_abandoned_seconds_bucket[$__range])))",
+          "legendFormat": "9 in 10 leavers had gone by",
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Generation time vs load, and whether failures are timeouts (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Left axis seconds, right axis briefs completed per hour.\n\nTWO QUESTIONS IN ONE CHART.\n\nCAPACITY - can this feature take more users without getting worse for the ones it has? If the slowest-5% line climbs whenever throughput climbs, the pipeline is contended and every new subscriber makes everybody else's brief later. Flat while throughput grows means there is headroom and growth is safe. Rising while throughput is FLAT is a regression in the run itself - a slower model, slower tools, more data per user - and adding capacity will not fix it.\n\nTIMEOUTS - the 'failed runs' line is how long runs took before giving up. When it pins to the top of the histogram it means failures are timeouts rather than errors, which is the mechanism behind the failure rate in 'Scheduled brief problems'. If the two rise together, the cause is duration, and the fix is making generation faster or raising the limit - not retry logic.\n\nGOOD: successful-run line flat and well below the failed-run line; throughput free to grow.\nBAD: the successful line creeping up toward the failed line - runs are approaching the ceiling and will start tipping over into failures.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 317,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "s",
+          "min": 0,
+          "noValue": "no generation runs in this range"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "briefs completed per hour"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "briefs / hour"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (increase(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__range]))) / 1000",
+          "legendFormat": "slowest 5% (successful runs)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (increase(daily_brief_generation_duration_milliseconds_bucket{status=\"failed\"}[$__range]))) / 1000",
+          "legendFormat": "slowest 5% (failed runs)",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "sum(rate(daily_brief_generated_total{status=\"ready\"}[$__range])) * 3600",
+          "legendFormat": "briefs completed per hour",
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 324,
+      "panels": [],
+      "title": "Generation reliability",
+      "type": "row"
+    },
+    {
+      "type": "timeseries",
+      "id": 325,
+      "title": "Generation failure rate by trigger (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. The share of brief generation runs that ended without producing a brief, split by who asked for the run. Both lines are BAD WHEN HIGH.\n\nTHE SPLIT IS THE POINT - these are different product problems:\nSCHEDULED - the cron ran and produced nothing. The user wakes up to an empty screen, is shown no error, and may never learn a brief was even attempted. Silent, and the worst outcome the feature has.\nUSER-TRIGGERED - somebody pressed Regenerate and watched it fail. Visible and annoying, but they know it happened and can press the button again.\n\nGOOD: both flat at zero.\nBAD: the SCHEDULED line above a few percent - each point is a morning somebody got nothing and was not told.\nALSO BAD, DIFFERENTLY: the user-triggered line high - the on-demand path is unreliable, which is more visible but more recoverable.\n\nREAD THE TWO LINES TOGETHER TO LOCATE THE FAULT. Both rising means something shared broke - the model provider, a tool, a deploy. Only one rising points at that path specifically.\n\nGaps are honest: where no run of that kind happened in a window the ratio is undefined and the line breaks rather than dropping to a fake zero.\n\nBoth counters reset when the backend restarts, and increase() extrapolates to the window edges, so treat these as close estimates rather than exact tallies - a value of 4.7 failures means about five.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 65
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "no generation runs in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(daily_brief_generated_total{trigger=\"scheduled\",status=\"failed\"}[$__range])) / (sum(increase(daily_brief_generated_total{trigger=\"scheduled\"}[$__range])) > 0)",
+          "legendFormat": "scheduled (silent - user may never know)",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "sum(increase(daily_brief_generated_total{trigger=\"regenerate\",status=\"failed\"}[$__range])) / (sum(increase(daily_brief_generated_total{trigger=\"regenerate\"}[$__range])) > 0)",
+          "legendFormat": "user-triggered (user watched it fail)",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 326,
+      "title": "Failures nobody retried (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Of the generation runs that failed, the share that were never followed by another attempt that day - so the user simply ended the day with nothing.\n\nTHIS IS THE HARM METRIC. Every other failure number counts runs; this one counts people left empty-handed. A failure that the user retried into a working brief cost them a wait. A failure nobody retried cost them the feature that day.\n\nGOOD: near zero - failures happen but people recover from them.\nBAD: high - failures are terminal. That usually means the failure was SILENT (the scheduled run failed and nobody was told) rather than that people chose to give up, so pair this with the scheduled line in the panel beside it.\n\nTHE BARS ARE THE ABSOLUTE COUNT on the right axis; the line is the share. A share off two failures is not a finding - ignore the line where the bars are short.\n\nHOW IT IS DERIVED: every retry-after-failure follows exactly one failed run, one-to-one, so failures minus retries is the number of failures with no follow-up. Recovery can only happen on the day of the failure - Regenerate always targets today's brief - so a next-day attempt is a new day's first attempt, not a recovery, and is correctly excluded.\n\nIT COUNTS RETRY ATTEMPTS, NOT RECOVERIES. A retry can itself fail, so this understates the harm: the true number of people who ended up with nothing is at least this. For whether the retries worked, see 'Attempts until a regeneration succeeds' below.\n\nNOT SPLIT BY TRIGGER, AND IT CANNOT BE. The retry counter carries no trigger label - a retry is always a user regeneration by definition - while the failure it follows may have been scheduled or user-triggered. Subtracting an unsplit number from a split one would be arithmetic nonsense, so this stays aggregate.\n\nBoth counters reset when the backend restarts, and increase() extrapolates to the window edges, so treat these as close estimates rather than exact tallies - a value of 4.7 failures means about five.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 65
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "no failures in this range"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failures never retried (count)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "max",
+                "value": null
+              },
+              {
+                "id": "custom.drawStyle",
+                "value": "bars"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 35
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "failures never retried"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "text"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "1 - (sum(increase(daily_brief_regeneration_attempts_total{origin=\"retry_after_failure\"}[$__range])) / (sum(increase(daily_brief_generated_total{status=\"failed\"}[$__range])) > 0))",
+          "legendFormat": "share of failures never retried",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "clamp_min(sum(increase(daily_brief_generated_total{status=\"failed\"}[$__range])) - sum(increase(daily_brief_regeneration_attempts_total{origin=\"retry_after_failure\"}[$__range])), 0)",
+          "legendFormat": "failures never retried (count)",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 327,
+      "title": "Attempts until a regeneration succeeds (selected range)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "description": "FOLLOWS THE TIME PICKER. Of the regenerations that ended in a working brief, how many tries into that day's sequence they were. Bar 1 is briefs that worked first time; bar 2 is briefs that needed a second go, and so on.\n\nGOOD: almost everything in bar 1 - when people re-run a brief it works immediately.\nBAD: weight in bars 2, 3 and 4+ - people are having to try repeatedly to get a brief out of the system, which is both a reliability problem and a compute bill, since every failed try is a full agent run that produced nothing.\n\nHOW THIS DIFFERS FROM 'Failures nobody retried' ABOVE: that panel measures HARM - people who gave up or were never told and ended the day with nothing. This one measures EFFORT - what it cost the people who persisted. A feature can look fine here and still be failing badly there, because everyone counted in this chart eventually succeeded.\n\nCOUNTS SUCCESSES ONLY. Failed attempts are not in these bars; they are in the two panels above. The attempt number is the position in that day's regeneration sequence, capped at '4+'.\n\nSTARTS FROM THE FIRST GENERATION AFTER THIS SHIPPED. The attempt label was added on 2026-08-24, so runs recorded before that carry no attempt and are excluded from these bars entirely. Expect the chart to be empty at first, and do not read that as 'nothing succeeds'.\n\nBoth counters reset when the backend restarts, and increase() extrapolates to the window edges, so treat these as close estimates rather than exact tallies - a value of 4.7 failures means about five.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "noValue": "no successful regenerations recorded with an attempt number yet"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "xTickLabelRotation": 0,
+        "showValue": "auto"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          },
+          "instant": true,
+          "expr": "sum by (attempt) (increase(daily_brief_generated_total{trigger=\"regenerate\",status=\"ready\",attempt!=\"\"}[$__range]))",
+          "legendFormat": "attempt {{attempt}}"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 81
+      },
+      "id": 329,
+      "panels": [],
+      "type": "row",
+      "title": "Degraded metrics (no database access)"
+    },
+    {
+      "type": "text",
+      "id": 330,
+      "title": "Why these are degraded",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### These are compromised replacements, not equals\n\nGrafana in this environment cannot reach the application database, so every metric that needed a `COUNT(DISTINCT userId)` over a chosen date range had to be rebuilt from the metrics store or dropped. The metrics store cannot count distinct people over an arbitrary range — the only way to do that would be a user id in a metric label, which is unbounded cardinality and a user roster behind an unauthenticated endpoint. So the replacements below trade away either the **time range**, the **denominator**, or both.\n\n**What each one lost:**\n\n| Panel | Compared with the database version |\n|---|---|\n| Delivery completeness | **Essentially intact.** Counts successful *scheduled runs* rather than brief-days, and lost the clamp that stopped a range predating the feature from manufacturing a shortfall. |\n| Feature reach `[lifetime]` | Was *share of readers who used each feature over your selected range*. Now **lifetime only**, and the denominator changed from *people who read a brief* to *people who were sent one* — a larger, less demanding group, so these read **lower** than the original. |\n| People who browsed brief history `[fixed 7d/30d]` | The only windowed distinct-user count that survived. Two fixed windows, and **it does not follow the time picker at all**. |\n\n**`[fixed …]` and `[lifetime]` in a title mean the time picker does nothing.** Changing the range will not change those numbers. That is the honest cost of losing the database, not a bug.\n\n### Everything that was removed\n\n**Rebuilt in degraded form** — the table above says what each gave up.\n- **Delivery completeness** → *Delivery completeness (selected range)*. Near-intact; the only one you can still trust at any range.\n- **Share of readers who used each feature** → split into *Feature reach `[lifetime]`* and *People who browsed brief history `[fixed 7d / 30d]`*.\n- **Subscribers with no brief today** → *Subscribers vs briefs delivered `[today]`*. Shows both counts instead of the difference, because subtracting two independent totals can print a false zero.\n- **Kept as-is** → *First-try acceptance of the scheduled brief*. Still per-brief-day and still follows the picker, but the denominator is briefs *delivered* rather than briefs *read* — so an unopened brief now counts as accepted.\n- **Distinct readers** → *Audience reach `[lifetime]`*. Counts people ever **sent** a brief, not people who opened one. Cumulative, so it can never fall.\n\n**Pending instrumentation** — no usable proxy exists, so these are absent rather than approximated.\n- **Custom instructions: how far people get** — how many subscribers write custom instructions and keep them on. Nothing about instructions is emitted at all.\n- **How many days each reader showed up** — whether reading is spread across the audience or carried by a handful. The only available reduction is a *mean*, which cannot tell ten light readers from two heavy ones — precisely the question the panel existed to answer, so a mean here would be worse than the absence.\n\n**Gone for good** — not recoverable without a different data path.\n- **Do custom instructions reduce regeneration?** — needs regenerations per reader split by cohort, and the per-cohort *reader* denominator cannot be rebuilt from the metrics store.\n- **Distinct readers per day** — no view metric is emitted at all, and MetricsQL can only give a rolling 24-hour window, never IST calendar days.\n- **Per-organisation breakdown** — not a panel, but it went with them. The metrics store carries no org label, so every number here is fleet-wide. Since the brief agent is configurable per org, quality numbers now average *different agents*, and one wholly-broken tenant can vanish into a healthy average."
+      }
+    },
+    {
+      "type": "stat",
+      "id": 331,
+      "title": "Delivery completeness (selected range)",
+      "description": "FOLLOWS THE TIME PICKER. Perfect delivery = every subscriber gets a brief every day, so the ideal is (subscribers x days in range). This is the share of that ideal actually delivered.\n\nGOOD: close to 100% — everyone who asked for a brief got one, most mornings.\nBAD: 60% means four mornings in ten produced nothing for the average subscriber.\n\nREBUILT WITHOUT THE DATABASE, and it survived nearly intact — this is the one degraded metric you can still trust at any range. Two differences from the original: it counts successful SCHEDULED RUNS rather than brief-days (equivalent in practice, since the cron runs once per subscriber per day), and it lost the clamp that stopped a range reaching back before the feature existed from manufacturing a shortfall — so a very wide range reads artificially low.\n\nThe subscriber count is a live reading while the numerator spans the range, so a burst of recent sign-ups drags this down for a while; those people were not subscribers for the whole range.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 96
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 1,
+          "noValue": "no scheduled deliveries in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          },
+          "expr": "sum(increase(daily_brief_generated_total{trigger=\"scheduled\",status=\"ready\"}[$__range])) / clamp_min(max(daily_brief_enabled_users_total) * ($__range_s / 86400), 1)"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 334,
+      "title": "Subscribers vs briefs delivered [today]",
+      "description": "IGNORES THE TIME PICKER — both numbers are live readings for today's date bucket.\n\nTwo counts side by side: how many people have Morning Brief switched on, and how many briefs exist for today. Compare them yourself.\n\nGOOD: the two numbers equal, once the morning fan-out has drained.\nBAD: briefs delivered clearly below subscribers — that gap is people who will open the app and find nothing, with no error shown to them or to anyone.\n\nDELIBERATELY NOT SUBTRACTED. The original panel tested per-user whether each subscriber had a brief. These are two independent totals, so a non-subscriber who still holds a brief for today would cancel out a subscriber who is missing one — a subtraction could print a confident 0 while somebody got nothing. Showing both lets you judge the gap without the panel asserting a difference it cannot support.\n\nExpect them to differ while the cron is still running; that is the fan-out in progress, not a fault. 'Delivered' above 'subscribers' is possible and means briefs exist for people who have since switched off.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 96
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "no subscribers or deliveries recorded"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "expr": "max(daily_brief_enabled_users_total)",
+          "legendFormat": "subscribers",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        },
+        {
+          "expr": "max(daily_brief_delivered_today)",
+          "legendFormat": "briefs delivered today",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 336,
+      "title": "Audience reach: people ever sent a brief [lifetime]",
+      "description": "IGNORES THE TIME PICKER — a lifetime total read from the database by the exporter. Changing the range will not change it.\n\nHow many different people have ever had a brief generated for them. The size of the audience the feature has accumulated.\n\nGOOD: growing steadily alongside subscribers.\nBAD: flat while subscribers climb — people are switching the feature on and the cron is not reaching them.\n\nTHIS COUNTS RECIPIENTS, NOT READERS. It replaces 'Distinct readers', which counted people who actually OPENED a brief in the range you picked. Nothing about reading is emitted to the metrics store, so this is the nearest available substitute and it is a materially weaker claim: a person who has been sent 200 briefs and never opened one is counted here exactly the same as a daily reader. **Do not quote this as engagement.** It also cannot fall — it is cumulative, so churn is invisible to it.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 96
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short",
+          "decimals": 0,
+          "noValue": "nobody has been sent a brief yet"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "targets": [
+        {
+          "expr": "max(daily_brief_users_total)",
+          "legendFormat": "people ever sent a brief",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          }
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 332,
+      "title": "Feature reach: share of brief recipients who ever used each feature [lifetime]",
+      "description": "IGNORES THE TIME PICKER — both sides are lifetime totals held as Redis sets, which carry no dates. Changing the range will not change these bars.\n\nOf everyone ever sent a brief, the share who have ever used each feature at least once. This is the cut decision panel: a feature sitting near zero over the product's whole life is one almost nobody has found or wanted.\n\nGOOD: a feature you invested in sitting high.\nBAD: near zero across the feature's entire lifetime — but check discoverability before deleting anything, since undiscovered and unwanted look identical here.\n\nDEGRADED FROM A BETTER METRIC. The original asked what share of people who ACTUALLY READ a brief in your selected range went on to use each feature. This version's denominator is everyone who was SENT one, which includes people who never opened it — a larger and less demanding group — so these bars read LOWER than the original did. It also cannot be scoped to a time range at all, so a feature that was popular last year and abandoned since still shows a high bar.\n\nTHE SETS OVERLAP: someone who used both is counted in both, so the bars do not sum to anything meaningful and must never be drawn as a pie.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 102
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "decimals": null,
+          "min": 0,
+          "max": 1,
+          "noValue": "nobody has been sent a brief yet"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "xTickLabelRotation": 0,
+        "showValue": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max(daily_brief_regen_users_total) / clamp_min(max(daily_brief_users_total), 1)",
+          "legendFormat": "regenerated a brief",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          },
+          "instant": true
+        },
+        {
+          "expr": "max(daily_brief_switch_users_total) / clamp_min(max(daily_brief_users_total), 1)",
+          "legendFormat": "browsed brief history",
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          },
+          "instant": true
+        }
+      ]
+    },
+    {
+      "type": "barchart",
+      "id": 333,
+      "title": "People who browsed brief history [fixed 7d / 30d]",
+      "description": "IGNORES THE TIME PICKER. These are two fixed trailing windows published by the server as pre-aggregated counts; the range you select has no effect on them.\n\nDistinct people who switched to a different brief in the trailing 7 and 30 days. The gap between the two bars is a crude retention signal: if 7d is close to 30d, the same people are browsing every week; if 7d is much smaller, most of the monthly browsers have lapsed.\n\nGOOD: both bars healthy and close together.\nBAD: 30d well above 7d — history browsing is something people did once and stopped.\n\nTHE ONLY WINDOWED DISTINCT-USER COUNT THAT SURVIVED the loss of database access, and only because the server happens to publish these two windows already. There is no equivalent for readers, regenerators, or any other group, and no way to ask for a different window without changing the server.\n\nCounted server-side by user id from a Redis HyperLogLog, so roughly 0.8% error — fine at scale, noisy at single digits.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 102
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "unit": "short",
+          "decimals": 0,
+          "min": 0,
+          "noValue": "nobody has browsed history in these windows"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "auto",
+        "xTickLabelRotation": 0,
+        "showValue": "auto"
+      },
+      "targets": [
+        {
+          "expr": "max by (window) (daily_brief_switch_users_window)",
+          "legendFormat": "{{window}}",
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
+          },
+          "instant": true
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 335,
+      "title": "First-try acceptance of the scheduled brief (selected range)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 108
+      },
+      "description": "FOLLOWS THE TIME PICKER — the only degraded metric in this group that still does, besides delivery completeness.\n\nShare of the briefs the cron delivered that their owner did NOT re-run. The headline quality number.\n\nGOOD: high, and stepping UP after a prompt or model change you shipped.\nBAD: any sustained fall — the automatic brief is getting less useful.\n\nNO TIME LIMIT IS IMPLIED: a re-run counts against the brief whether it happened five seconds or fourteen hours after delivery. Only the FIRST re-run of a given day's brief counts, and retries after a failed run are excluded via the origin label, so a bad week for reliability does not masquerade as a bad week for quality.\n\nWHAT IT REPLACES, AND WHAT CHANGED. This stands in for 'Kept as-is', which measured the share of brief-days somebody ACTUALLY OPENED and then left alone. This version's denominator is briefs DELIVERED, not briefs read — so a brief nobody ever opened counts as accepted here, where the original excluded it. That makes this read HIGHER than the original did, and it means silence is being counted as approval. Everything else is preserved: per-brief-day rather than per-person, and it re-scopes to the range you pick.\n\nBoth counters reset when the backend restarts; increase() handles that, but a range with no scheduled deliveries at all draws a gap rather than a misleading zero.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "auto",
+            "pointSize": 5,
+            "spanNulls": false,
+            "axisPlacement": "auto"
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "noValue": "no scheduled briefs delivered in this range"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "min",
             "max"
           ],
           "displayMode": "table",
@@ -1340,276 +1359,12 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "histogram_quantile(0.5, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
-          "legendFormat": "p50 {{trigger}}"
-        },
-        {
-          "refId": "B",
-          "expr": "histogram_quantile(0.95, sum by (le, trigger) (rate(daily_brief_generation_duration_milliseconds_bucket{status=\"ready\"}[$__rate_interval])))",
-          "legendFormat": "p95 {{trigger}}"
-        }
-      ]
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 59
-      },
-      "id": 103,
-      "panels": [],
-      "title": "Abandonment",
-      "type": "row"
-    },
-    {
-      "type": "stat",
-      "title": "Regenerations abandoned",
-      "description": "Times someone left the screen while a regeneration was still running. Cross with the wait buckets below to see when we lose them.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 0,
-        "y": 60
-      },
-      "id": 15,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
+          "datasource": {
+            "type": "prometheus",
+            "uid": "P4169E866C3094E38"
           },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "\u2014"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range]))"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Median patience",
-      "description": "The wait at which half of the people who walked away had already gone. Put this next to p50 generation time \u2014 if it is smaller, you are losing people before the brief can possibly arrive.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 8,
-        "y": 60
-      },
-      "id": 18,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "\u2014"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "histogram_quantile(0.5, sum by (le) (increase(daily_brief_regenerate_abandoned_seconds_bucket[$__range])))"
-        }
-      ]
-    },
-    {
-      "type": "stat",
-      "title": "Abandonment rate",
-      "description": "Share of regenerations where the user left before it finished. Client-measured, so treat it as a lower bound \u2014 a closed tab may never report.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 8,
-        "x": 16,
-        "y": 60
-      },
-      "id": 19,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "text": "\u2014"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "value"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range])) / clamp_min(sum(increase(daily_brief_regeneration_attempts_total[$__range])), 1)"
-        }
-      ]
-    },
-    {
-      "type": "barchart",
-      "title": "How long people wait before giving up",
-      "description": "Share of abandonments that had already happened by each wait threshold \u2014 read it as a cumulative curve: the bar at 60s is everyone who left within 60s. Where it crosses 50% is median patience. Compare that against p50 generation time: if patience is shorter, the pipeline is losing people mid-run.",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P4169E866C3094E38"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 66
-      },
-      "id": 17,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "custom": {
-            "fillOpacity": 85,
-            "lineWidth": 1,
-            "axisPlacement": "auto"
-          },
-          "mappings": [],
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "orientation": "horizontal",
-        "xTickLabelRotation": 0,
-        "showValue": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "instant": true,
-          "expr": "sum by (le) (increase(daily_brief_regenerate_abandoned_seconds_bucket{le!=\"+Inf\"}[$__range])) / scalar(clamp_min(sum(increase(daily_brief_regenerate_abandoned_seconds_count[$__range])), 1))",
-          "legendFormat": "within {{le}}s"
+          "legendFormat": "accepted first try",
+          "expr": "1 - (sum(increase(daily_brief_regeneration_attempts_total{origin=\"replacing_scheduled_brief\"}[$__range])) / (sum(increase(daily_brief_generated_total{trigger=\"scheduled\",status=\"ready\"}[$__range])) > 0))"
         }
       ]
     }


### PR DESCRIPTION
This is a cherry-pick of PR #873 (merged to main) onto the release-20260825 branch.

1. Problem Description: Port daily brief on/off toggle and metrics improvements to the release-20260825 line.
2. If this is a bug fix or an enhancement, how did you identify the issue?: N/A — porting merged feature to release branch.
3. Explain the solution implemented in the PR: Cherry-picked merge commit 6541256 from PR #873 (adds daily brief on/off toggle, metrics improvements, organization filter, and grafana dashboard).
4. Documentation: N/A
5. DB Alter Details (if any): Adds migration apps/xyne-claw-auth/backend/prisma/migrations/20260820140000_daily_brief_activity/migration.sql
6. Data fix Details (if any): N/A
7. Environment variable Changes (if any): N/A
8. Testing: Validated on main via PR #873.
9. Services to which this change is to be deployed: dashboard, xyne-claw-auth backend.
10. Main PR link (if this PR is raised against a release branch): https://github.com/juspay/xyne-spaces/pull/873