### PR TITLE
fix: surface silent failures when admitting/declining call lobby requests

### DIFF
--- a/apps/dashboard/src/components/Call/CallViews/CustomLiveKitRoom.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/CustomLiveKitRoom.tsx
@@ -37,6 +37,7 @@ import { playAudio } from '../../../utils/audioPlayer';
 
 import { isParticipantScreenShareEnabled } from '../../../utils/livekitScreenShare';
 import { logger, Logger } from '../../../utils/logger';
+import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 import { CallWhiteboardSync } from '../CallWhiteboard';
 import { callService } from '../../../services/Call/callService';
 import {
@@ -276,20 +277,32 @@ export function CustomLiveKitRoom({
 
   // Lobby approval handlers
   const handleApproveLobbyRequest = useCallback(
-    (participantId: string) => {
-      if (!zero || !internalCallId) return;
-      void zero.mutate(
-        mutators.calls.approveLobbyRequest({ callId: internalCallId, participantId }),
+    async (participantId: string) => {
+      if (!zero || !internalCallId) {
+        toast.error('Call is still connecting. Please try again in a moment.');
+        return;
+      }
+      await surfaceMutationError(
+        zero.mutate(
+          mutators.calls.approveLobbyRequest({ callId: internalCallId, participantId }),
+        ),
+        'Could not admit participant. Please try again.',
       );
     },
     [zero, internalCallId],
   );
 
   const handleRejectLobbyRequest = useCallback(
-    (participantId: string) => {
-      if (!zero || !internalCallId) return;
-      void zero.mutate(
-        mutators.calls.rejectLobbyRequest({ callId: internalCallId, participantId }),
+    async (participantId: string) => {
+      if (!zero || !internalCallId) {
+        toast.error('Call is still connecting. Please try again in a moment.');
+        return;
+      }
+      await surfaceMutationError(
+        zero.mutate(
+          mutators.calls.rejectLobbyRequest({ callId: internalCallId, participantId }),
+        ),
+        'Could not decline participant. Please try again.',
       );
     },
     [zero, internalCallId],

--- a/apps/dashboard/src/components/Call/CallViews/FullCallView.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/FullCallView.tsx
@@ -88,9 +88,9 @@ interface FullCallViewProps {
   /** Optional: override current user ID */
   currentUserId?: string | null | undefined;
   /** Optional: callback when host admits a lobby participant */
-  onApproveLobbyRequest?: ((participantId: string) => void) | undefined;
+  onApproveLobbyRequest?: ((participantId: string) => void | Promise<void>) | undefined;
   /** Optional: callback when host declines a lobby participant */
-  onRejectLobbyRequest?: ((participantId: string) => void) | undefined;
+  onRejectLobbyRequest?: ((participantId: string) => void | Promise<void>) | undefined;
   /** Optional: hide invite button in sidebar */
   hideInvite?: boolean | undefined;
   /** Hide thread panel chat button (for external users) */

--- a/apps/dashboard/src/components/Call/CallViews/MiniCallView.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/MiniCallView.tsx
@@ -77,8 +77,8 @@ interface MiniCallViewProps {
     | undefined;
   isHost?: boolean | undefined;
   currentUserId?: string | null | undefined;
-  onApproveLobbyRequest?: ((participantId: string) => void) | undefined;
-  onRejectLobbyRequest?: ((participantId: string) => void) | undefined;
+  onApproveLobbyRequest?: ((participantId: string) => void | Promise<void>) | undefined;
+  onRejectLobbyRequest?: ((participantId: string) => void | Promise<void>) | undefined;
   /** Called when a new remote call chat message arrives (for unread tracking) */
   onCallChatNewMessage?: (() => void) | undefined;
   /** Identities of participants with hand raised (synced via data channel) */

--- a/apps/dashboard/src/components/Call/ParticipantsSidebar/ParticipantsSidebar.tsx
+++ b/apps/dashboard/src/components/Call/ParticipantsSidebar/ParticipantsSidebar.tsx
@@ -47,9 +47,9 @@ interface ParticipantsSidebarProps {
   /** If provided, used instead of useAuth().user?.id */
   currentUserId?: string | null | undefined;
   /** Callback when host admits an external participant */
-  onApproveLobbyRequest?: ((participantId: string) => void) | undefined;
+  onApproveLobbyRequest?: ((participantId: string) => void | Promise<void>) | undefined;
   /** Callback when host declines an external participant */
-  onRejectLobbyRequest?: ((participantId: string) => void) | undefined;
+  onRejectLobbyRequest?: ((participantId: string) => void | Promise<void>) | undefined;
   /** Hide "Add People" button and invite modal (e.g. for external users) */
   hideInvite?: boolean | undefined;
   /** Identities (userIds) of participants with hand raised */
@@ -271,11 +271,11 @@ export function ParticipantsSidebar({
   }, [participants]);
 
   const handleApprove = useCallback(
-    (participantId: string) => {
+    async (participantId: string) => {
       if (!onApproveLobbyRequest || approvingId) return;
       setApprovingId(participantId);
       try {
-        onApproveLobbyRequest(participantId);
+        await onApproveLobbyRequest(participantId);
       } finally {
         setApprovingId(null);
       }
@@ -284,11 +284,11 @@ export function ParticipantsSidebar({
   );
 
   const handleReject = useCallback(
-    (participantId: string) => {
+    async (participantId: string) => {
       if (!onRejectLobbyRequest || rejectingId) return;
       setRejectingId(participantId);
       try {
-        onRejectLobbyRequest(participantId);
+        await onRejectLobbyRequest(participantId);
       } finally {
         setRejectingId(null);
       }


### PR DESCRIPTION
## What
The call host's **Admit / Decline** buttons for lobby (external + internal) join requests appeared unresponsive — clicking did nothing and the external guest stayed stuck in the waiting lobby.

## Root cause
`handleApproveLobbyRequest` / `handleRejectLobbyRequest` in `CustomLiveKitRoom.tsx` fired `void zero.mutate(...)` fire-and-forget. Zero **resolves** `.server` (it does not reject) for application errors, so a server-side rejection from the `approveLobbyRequest` mutator (e.g. `Only the call creator can admit participants`) silently rolled back the optimistic write and the host saw nothing. The two silent early-returns (`if (!zero || !internalCallId) return;`) and a spinner that cleared in the same tick (handlers weren't awaited) made it worse.

## Changes
- Route approve/reject lobby mutations through the existing `surfaceMutationError` helper so a server rejection shows as a toast instead of a silent optimistic rollback.
- Show a toast (instead of a silent early-return) when the call isn't synced yet (`zero` / `internalCallId` missing).
- `await` the callback in the `ParticipantsSidebar` `handleApprove` / `handleReject` so the button spinner reflects real in-flight state.
- Widen the `onApproveLobbyRequest` / `onRejectLobbyRequest` prop types to `(participantId: string) => void | Promise<void>` across `ParticipantsSidebar`, `FullCallView`, `MiniCallView`.

## Not included (deliberately)
No change to authorization semantics. Admitting is still restricted to the call creator (`createdByUserId`) in the `approveLobbyRequest` / `rejectLobbyRequest` mutators. If the intended behavior is that any organizer (not only the creator) can admit guests, that's a separate product decision and a follow-up change to `useIsCallHost` + those mutators. With this fix, a non-creator now gets a clear toast explaining why, instead of a dead button.

## Validation
- `pnpm run typecheck` (dashboard) passes.
- `eslint` on the four changed files: 0 errors (only pre-existing unrelated warnings).