### PR TITLE
fix: XYNE-1315 rank profile dropdown reflects the CAC default per tab

### DIFF
--- a/apps/dashboard/src/components/Chat/SearchResults/SearchFilterBar.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchFilterBar.tsx
@@ -796,7 +796,13 @@ export function SearchFilterBar({ filters, onFiltersChange }: SearchFilterBarPro
                   <Check
                     className={cn(
                       'size-3.5 shrink-0',
-                      filters.rankProfile === opt.value ? 'opacity-100' : 'opacity-0',
+                      // The default row also owns an explicit pick equal to the resolved
+                      // default (possible when the CAC config arrives after the pick) —
+                      // that explicit row is deduped away, and both send the same profile.
+                      filters.rankProfile === opt.value ||
+                        (opt.value === '' && filters.rankProfile === resolvedDefaultRankProfile)
+                        ? 'opacity-100'
+                        : 'opacity-0',
                     )}
                   />
                   {opt.label}

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchFilterBar.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchFilterBar.tsx
@@ -96,22 +96,27 @@ const SORT_OPTIONS = [
 ];
 
 // Hardcoded Vespa rank profiles, scoped to the schema(s) each docType resolves to.
-// '' means "send nothing" => backend default (default_native). Only profiles that exist
-// in every schema the type queries are listed, because Vespa rejects a rank profile that
-// is missing from any queried schema. Selecting a single type prunes the query's sources
-// to that one schema (see searchService.ts), which is what makes the chat-only and
-// mail-only profiles below valid.
+// Only profiles that exist in every schema the type queries are listed, because Vespa
+// rejects a rank profile that is missing from any queried schema. Selecting a single
+// type prunes the query's sources to that one schema (see searchService.ts), which is
+// what makes the chat-only and mail-only profiles below valid.
+//
+// These are the EXPLICIT picks. getRankProfileOptions() prepends a `value: ''` row
+// meaning "no explicit pick": the request layer resolves '' to the per-tab default from
+// the cmdk_search_config CAC key (see useCmdkDefaultRankProfiles), so that row is
+// labeled with the resolved default at render time — never hardcoded here.
 type RankProfileOption = { value: string; label: string };
 const RANK_PROFILE_OPTIONS_BY_TYPE: Partial<
   Record<SearchResultsFilters['docType'], RankProfileOption[]>
 > = {
   all: [
     { value: 'default_native', label: 'default_native' },
+    { value: 'personalized', label: 'personalized' },
     { value: 'default_fuzzy', label: 'default_fuzzy' },
     { value: 'unified', label: 'unified' },
   ],
   messages: [
-    { value: '', label: 'default_native' },
+    { value: 'default_native', label: 'default_native' },
     { value: 'personalized', label: 'personalized' },
     { value: 'default_random', label: 'default_random' },
     { value: 'default_fuzzy', label: 'default_fuzzy' },
@@ -121,16 +126,16 @@ const RANK_PROFILE_OPTIONS_BY_TYPE: Partial<
     })),
   ],
   files: [
-    { value: '', label: 'default_native' },
+    { value: 'default_native', label: 'default_native' },
     { value: 'default_fuzzy', label: 'default_fuzzy' },
   ],
   tickets: [
-    { value: '', label: 'default_native' },
+    { value: 'default_native', label: 'default_native' },
     { value: 'default_fuzzy', label: 'default_fuzzy' },
     { value: 'semantic_ranking', label: 'semantic_ranking' },
   ],
   desk: [
-    { value: '', label: 'default_native' },
+    { value: 'default_native', label: 'default_native' },
     { value: 'default_fuzzy', label: 'default_fuzzy' },
     { value: 'global_sorted', label: 'global_sorted' },
     { value: 'default_bm25', label: 'default_bm25' },
@@ -138,8 +143,17 @@ const RANK_PROFILE_OPTIONS_BY_TYPE: Partial<
   ],
 };
 
-function getRankProfileOptions(docType: SearchResultsFilters['docType']): RankProfileOption[] {
-  return RANK_PROFILE_OPTIONS_BY_TYPE[docType] ?? [];
+function getRankProfileOptions(
+  docType: SearchResultsFilters['docType'],
+  resolvedDefault: string,
+): RankProfileOption[] {
+  const explicit = RANK_PROFILE_OPTIONS_BY_TYPE[docType];
+  if (!explicit) return [];
+  return [
+    { value: '', label: resolvedDefault },
+    // The default row already covers this profile; a second row would send the same one.
+    ...explicit.filter(o => o.value !== resolvedDefault),
+  ];
 }
 
 function useListKeyNav(
@@ -251,12 +265,14 @@ export function SearchFilterBar({ filters, onFiltersChange }: SearchFilterBarPro
   const isAssigneeActive = filters.assigneeIds.length > 0;
   const isSortActive = filters.sortBy !== 'relevance';
 
-  const rankProfileOptions = getRankProfileOptions(filters.docType);
+  const resolvedDefaultRankProfile = defaultRankProfileFor(cmdkTabKeyForDocType(filters.docType));
+  const rankProfileOptions = getRankProfileOptions(filters.docType, resolvedDefaultRankProfile);
   const showRankProfile = rankProfileOptions.length > 0;
   const isRankActive = filters.rankProfile !== '';
+  // '' always matches the prepended default row; the fallback only covers a profile
+  // set via URL that is not in the hardcoded list — show it verbatim.
   const rankProfileLabel =
-    rankProfileOptions.find(o => o.value === filters.rankProfile)?.label ??
-    defaultRankProfileFor(cmdkTabKeyForDocType(filters.docType));
+    rankProfileOptions.find(o => o.value === filters.rankProfile)?.label ?? filters.rankProfile;
 
   const showFromIn = filters.docType !== 'channels' && filters.docType !== 'people';
   const showAssignee = filters.docType === 'tickets' || filters.docType === 'all';


### PR DESCRIPTION
https://github.com/user-attachments/assets/4000b83a-d4aa-41d5-a000-ef36e73ef402


## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-1315 follow-up. The rank-profile dropdown in the full-page search was built from a hardcoded table that assumed the default profile is `default_native`. Since XYNE-1315 the per-tab default comes from the `cmdk_search_config` CAC key at runtime, so on deployments where it resolves to `personalized` the UI lied: the Messages tab chip showed `default_native` while the wire request sent `rankProfile=personalized`, and the ALL tab's dropdown had no row for the active default at all (chip said `personalized`, list didn't contain it).

Fix (`apps/dashboard/src/components/Chat/SearchResults/SearchFilterBar.tsx` only):
- The options table now holds only explicit profiles; `getRankProfileOptions()` prepends a `value: ''` row labeled with the **resolved CAC default** for that tab, so chip, checkmark, and wire always agree — on every tab with a Rank dropdown (All, Messages, Files, Tickets, Desk).
- An explicit row equal to the resolved default is deduped (no double `personalized`).
- ALL gains `personalized` as an explicit option (valid across schemas via the XYNE-1315 aliases).
- Nothing hardcodes `personalized` — a deployment without the CAC key still resolves to `default_native`.

Request behavior is unchanged: `''` already resolved to the CAC default in `useSearchMetrics`.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section** (reads the existing `cmdk_search_config` CAC key; no new keys)

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?

Scripted Playwright run against local dev (recording below), with the CAC endpoint serving the enterprise value (`personalized` per tab) and then no key at all. Asserted:
- ALL tab: chip `Rank: personalized`, dropdown top row `personalized` ✓ + `default_native`/`default_fuzzy`/`unified` each listed once, wire request `rankProfile=personalized`


