### PR TITLE
Feature/spaces desk metrics release25

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -122,6 +122,7 @@ import deskTagsConfigRoutes from '@/routes/deskTagsConfig';
 import priorityClassificationRoutes from '@/routes/priorityClassificationRoutes';
 import deskMetricsRoutes from '@/routes/deskMetricsRoutes';
 import deskMetricsAggregateRoutes from '@/routes/deskMetricsAggregateRoutes';
+import deskMetricsClawRoutes from '@/routes/deskMetricsClawRoutes';
 import aiRetriggerRoutes from '@/routes/aiRetriggerRoutes';
 import testAuthRoutes from '@/routes/testAuth';
 import customInstructionRoutes from '@/routes/customInstruction';
@@ -359,6 +360,7 @@ export class App {
     this.app.use('/api/channels/:channelId/tags-config', authMiddleware.authenticate, deskTagsConfigRoutes);
     this.app.use('/api/channels/:channelId/priority-classification', authMiddleware.authenticate, priorityClassificationRoutes);
     this.app.use('/api/channels/:channelId/metrics', authMiddleware.authenticate, deskMetricsRoutes);
+    this.app.use('/api/desk-metrics/claw', authenticateUserOrApp, deskMetricsClawRoutes);
     this.app.use('/api/desk-metrics', authMiddleware.authenticate, deskMetricsAggregateRoutes);
     this.app.use('/api/channels/:channelId/ai-retrigger', authMiddleware.authenticate, aiRetriggerRoutes);
 

--- a/apps/backend/src/controllers/deskMetricsController.ts
+++ b/apps/backend/src/controllers/deskMetricsController.ts
@@ -22,6 +22,7 @@ import {
 } from '../services/deskMetricsAggregator.js';
 import { logger } from '../utils/logger.js';
 import {
+  DEFAULT_DESK_METRIC_KEYS,
   DESK_METRIC_KEYS,
   DESK_METRICS_MAX_AGGREGATE_DESKS,
   TicketPriority,
@@ -332,8 +333,10 @@ export class DeskMetricsController {
         return;
       }
 
-      const metrics: DeskMetricKey[] = body.metrics ?? [...DESK_METRIC_KEYS];
       const includeTickets = body.includeTickets ?? 0;
+      const metricsDefaulted = body.metrics === undefined;
+      const metrics: DeskMetricKey[] = body.metrics ?? [...DEFAULT_DESK_METRIC_KEYS];
+      if (includeTickets > 0 && !metrics.includes('tickets')) metrics.push('tickets');
       const wanted = new Set(metrics);
       const filters = {
         assigneeIds: body.assigneeIds ?? [],
@@ -351,6 +354,7 @@ export class DeskMetricsController {
       const desks: DeskMetricsDeskSummary[] = [];
       const skipped: DeskMetricsSkippedDesk[] = [];
       let anyDeskTruncated = false;
+      let desksWithoutFrtStages = 0;
 
       // Sequential, matching getAggregateMetrics — bounds peak DB connections.
       for (const channelId of channelIds) {
@@ -373,10 +377,12 @@ export class DeskMetricsController {
           }
 
           const channel = await this.channelRepo.findById(channelId);
+          const frtStageNames = this.parseFrtStageNames(preference);
+          if (frtStageNames.length === 0) desksWithoutFrtStages += 1;
           const partial = await deskMetricsRepository.queryMetrics({
             channelId,
             timeRange,
-            frtStageNames: this.parseFrtStageNames(preference),
+            frtStageNames,
             metrics,
             includeTickets,
             ...(body.customFieldBreakdown
@@ -405,12 +411,15 @@ export class DeskMetricsController {
       }
 
       if (contributions.length === 0) {
-        const status = skipped.some(desk => desk.reason === 'error') ? 500 : 403;
+        const hasError = skipped.some(desk => desk.reason === 'error');
+        const hasForbidden = skipped.some(desk => desk.reason === 'forbidden');
+        const status = hasError ? 500 : hasForbidden ? 403 : 404;
         res.status(status).json({
-          error:
-            status === 500
-              ? 'Failed to compute desk metrics'
-              : 'None of the selected desks have metrics available',
+          error: hasError
+            ? 'Failed to compute desk metrics'
+            : hasForbidden
+              ? 'You are not a member of the requested desk(s)'
+              : 'No such desk. Check the channelId, or list the available desks first.',
           skipped,
         });
         return;
@@ -447,8 +456,10 @@ export class DeskMetricsController {
           wanted,
           contributions.length,
           result.ticketsTruncated === true,
-          desks.filter(d => !d.metricsEnabled).length,
+          desksWithoutFrtStages,
           result.customFieldBreakdown ?? [],
+          result.tickets !== undefined,
+          metricsDefaulted,
         ),
       };
 
@@ -472,13 +483,15 @@ export class DeskMetricsController {
     wanted: Set<DeskMetricKey>,
     deskCount: number,
     ticketsTruncated: boolean,
-    unconfiguredDeskCount: number,
+    desksWithoutFrtStages: number,
     customFieldBreakdown: DeskMetricsCustomFieldBreakdown[],
+    ticketsReturned: boolean,
+    metricsDefaulted: boolean,
   ): string[] {
     const notes: string[] = [];
 
-    const cohortKeys = ['frt', 'rt', 'counts', 'priority', 'agents', 'tags', 'tickets'].filter(k =>
-      wanted.has(k as DeskMetricKey),
+    const cohortKeys = ['frt', 'rt', 'counts', 'priority', 'agents', 'tags', 'tickets'].filter(
+      k => wanted.has(k as DeskMetricKey) && (k !== 'tickets' || ticketsReturned),
     );
     if (cohortKeys.length > 0) {
       notes.push(
@@ -506,6 +519,15 @@ export class DeskMetricsController {
         'rt.avgSeconds is creation to the LAST resolution event (so a reopened-then-reclosed ticket ' +
           'measures to the final close). Tickets still open are excluded entirely, so a low average ' +
           'over a small resolvedTickets count is survivorship bias, not good performance.',
+      );
+    }
+    if (wanted.has('trend')) {
+      notes.push(
+        'trend.opened and trend.closed are NOT counted the same way. opened counts tickets CREATED ' +
+          'in that bucket; closed counts every ticket resolved in it whatever its age, including ' +
+          'ones opened long before the range. On a backlog-clearing day closed can far exceed ' +
+          'opened. Never divide one by the other for a resolution rate, a percentage, or a backlog ' +
+          'trajectory — read them as two independent series.',
       );
     }
     if (wanted.has('agents')) {
@@ -537,6 +559,24 @@ export class DeskMetricsController {
           '"not classified", never as a real category.',
       );
     }
+    if (metricsDefaulted) {
+      const omitted = DESK_METRIC_KEYS.filter(k => !wanted.has(k));
+      notes.push(
+        `No \`metrics\` were requested, so this is the default set (${[...wanted].join(', ')}). ` +
+          `NOT computed: ${omitted.join(', ')} — they are available, just ask for them by name. ` +
+          'Do not tell the user this desk has no tag, category, agent or custom-field data on the ' +
+          'strength of this response.',
+      );
+    }
+    const truncatedFields = customFieldBreakdown.filter(b => b.truncated).map(b => b.field);
+    if (truncatedFields.length > 0) {
+      notes.push(
+        `customFieldBreakdown for ${truncatedFields.join(', ')} was TRUNCATED to the top values by ` +
+          'ticket count — the field has more distinct values than were returned, so this is not a ' +
+          'complete distribution and the counts shown do not add up to the cohort. A field like ' +
+          'this (an id or free text) is usually not worth breaking down at all.',
+      );
+    }
     const multiValueFields = customFieldBreakdown.filter(b => b.multiValue).map(b => b.field);
     if (multiValueFields.length > 0) {
       notes.push(
@@ -545,11 +585,13 @@ export class DeskMetricsController {
           'to the ticket total. Read them as "tickets mentioning X", never as a split of the whole.',
       );
     }
-    if (unconfiguredDeskCount > 0) {
+    if (desksWithoutFrtStages > 0 && wanted.has('frt')) {
       notes.push(
-        `${unconfiguredDeskCount} desk(s) here never enabled the metrics dashboard, so their ` +
-          'first-response stop stages are probably unset. That makes frt null (unknown) rather ' +
-          'than zero — report it as not configured, never as "no responses".',
+        `${desksWithoutFrtStages} desk(s) here have no configured first-response stop stages, so ` +
+          'for them frt falls back to the time of the first OUTBOUND EMAIL. That is a real ' +
+          'measurement, not a missing one — report the number, and mention only that the desk has ' +
+          'not chosen its own stop condition. Do not call it unconfigured and do not omit the desk ' +
+          'from a comparison.',
       );
     }
     return notes;

--- a/apps/backend/src/controllers/deskMetricsController.ts
+++ b/apps/backend/src/controllers/deskMetricsController.ts
@@ -15,6 +15,7 @@ import { assertChannelMembership } from '@/utils/channelMembership';
 import {
   aggregateDeskMetrics,
   fillDeskMetrics,
+  mergeAiCategorySlices,
   mergeCustomFieldSlices,
   prunePerDesk,
   type DeskMetricsContribution,
@@ -63,6 +64,8 @@ const queryBodySchema = z
     priorities: z.array(z.nativeEnum(TicketPriority)).optional(),
     userGroupIds: z.array(z.string().min(1)).optional(),
     tagValues: z.array(z.string().min(1)).optional(),
+    aiCategories: z.array(z.string().min(1)).optional(),
+    aiSubCategories: z.array(z.string().min(1)).optional(),
     customFieldFilter: z
       .object({
         keys: z.array(z.string().min(1)).min(1),
@@ -338,6 +341,8 @@ export class DeskMetricsController {
         priorities: body.priorities ?? [],
         userGroupIds: body.userGroupIds ?? [],
         tagValues: body.tagValues ?? [],
+        aiCategories: body.aiCategories ?? [],
+        aiSubCategories: body.aiSubCategories ?? [],
         ...(body.customFieldFilter ? { customFieldFilter: body.customFieldFilter } : {}),
       };
 
@@ -427,6 +432,7 @@ export class DeskMetricsController {
         result.tagBreakdown = merged.tagBreakdown;
       }
       Object.assign(result, mergeCustomFieldSlices(partials));
+      Object.assign(result, mergeAiCategorySlices(partials));
       if (wanted.has('tickets') && includeTickets > 0) {
         result.tickets = merged.tickets.slice(0, includeTickets);
         result.ticketsTruncated = anyDeskTruncated || merged.tickets.length > includeTickets;
@@ -522,6 +528,14 @@ export class DeskMetricsController {
     );
     if (ticketsTruncated) {
       notes.push('Ticket rows were truncated by includeTickets — this is not the full cohort.');
+    }
+    if (wanted.has('aiCategories')) {
+      notes.push(
+        'aiCategoryCounts / aiSubCategoryCounts bucket tickets the classifier never labelled under ' +
+          '"Unclassified" instead of dropping them, so the counts sum to the cohort. A desk with AI ' +
+          'classification switched off therefore reads as entirely Unclassified — report that as ' +
+          '"not classified", never as a real category.',
+      );
     }
     const multiValueFields = customFieldBreakdown.filter(b => b.multiValue).map(b => b.field);
     if (multiValueFields.length > 0) {

--- a/apps/backend/src/controllers/deskMetricsController.ts
+++ b/apps/backend/src/controllers/deskMetricsController.ts
@@ -6,18 +6,31 @@
  */
 
 import { Request, Response } from 'express';
+import { z } from 'zod';
 import { deskMetricsRepository } from '../database/repositories/deskMetricsRepository.js';
 import { EmailChannelPreferenceRepository } from '../database/repositories/emailChannelPreferenceRepository.js';
 import { ChannelRepository } from '../database/repositories/channelRepository.js';
 import { assertChannelMembership } from '@/utils/channelMembership';
 import {
   aggregateDeskMetrics,
+  fillDeskMetrics,
+  mergeCustomFieldSlices,
   type DeskMetricsContribution,
 } from '../services/deskMetricsAggregator.js';
 import { logger } from '../utils/logger.js';
-import { DESK_METRICS_MAX_AGGREGATE_DESKS, TicketPriority } from '@xyne/shared';
+import {
+  DESK_METRIC_KEYS,
+  DESK_METRICS_MAX_AGGREGATE_DESKS,
+  TicketPriority,
+} from '@xyne/shared';
 import type {
+  DeskMetricKey,
   DeskMetricsAggregateResponse,
+  DeskMetricsCustomFieldBreakdown,
+  DeskMetricsDeskListResponse,
+  DeskMetricsDeskSummary,
+  DeskMetricsPartial,
+  DeskMetricsQueryResponse,
   DeskMetricsResponse,
   DeskMetricsSkippedDesk,
 } from '@xyne/shared';
@@ -28,6 +41,41 @@ const MAX_CUSTOM_RANGE_DAYS = 90;
 // +1 day of slack: the UI sends whole days (00:00 → 23:59:59.999), so a
 // 90-day selection spans a hair under 90 * DAY_MS + the trailing day.
 const MAX_CUSTOM_RANGE_MS = (MAX_CUSTOM_RANGE_DAYS + 1) * DAY_MS;
+
+/** Cap on cohort rows the agent surface will return in one call. */
+const MAX_TICKET_ROWS = 50;
+
+/** Each requested field is a GROUP BY over the cohort's form values. */
+const MAX_BREAKDOWN_FIELDS = 5;
+
+const queryBodySchema = z
+  .object({
+    channelIds: z.array(z.string().min(1)).min(1).max(DESK_METRICS_MAX_AGGREGATE_DESKS),
+    timeRange: z.string().min(1).optional(),
+    lastDays: z.number().int().positive().max(MAX_CUSTOM_RANGE_DAYS).optional(),
+    metrics: z.array(z.enum(DESK_METRIC_KEYS)).min(1).optional(),
+    includeTickets: z.number().int().nonnegative().max(MAX_TICKET_ROWS).optional(),
+    customFieldBreakdown: z.array(z.string().min(1)).max(MAX_BREAKDOWN_FIELDS).optional(),
+    assigneeIds: z.array(z.string().min(1)).optional(),
+    stageNames: z.array(z.string().min(1)).optional(),
+    priorities: z.array(z.nativeEnum(TicketPriority)).optional(),
+    userGroupIds: z.array(z.string().min(1)).optional(),
+    tagValues: z.array(z.string().min(1)).optional(),
+    customFieldFilter: z
+      .object({
+        keys: z.array(z.string().min(1)).min(1),
+        perKeyFilters: z
+          .record(
+            z.object({
+              values: z.array(z.string()).optional(),
+              textTerms: z.array(z.string().min(1)).optional(),
+            }),
+          )
+          .optional(),
+      })
+      .optional(),
+  })
+  .strict();
 
 type CustomFieldFilterArg = {
   keys: string[];
@@ -173,19 +221,10 @@ export class DeskMetricsController {
       customFieldFilter?: CustomFieldFilterArg;
     },
   ): Promise<DeskMetricsResponse> {
-    const frtStageNames: string[] = (() => {
-      try {
-        const parsed: unknown = JSON.parse(preference.frtStageNames ?? '[]');
-        return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === 'string') : [];
-      } catch {
-        return [];
-      }
-    })();
-
     return deskMetricsRepository.getMetrics({
       channelId,
       timeRange: query.timeRange,
-      frtStageNames,
+      frtStageNames: this.parseFrtStageNames(preference),
       assigneeIds: query.assigneeIds,
       stageNames: query.stageNames,
       priorities: query.priorities,
@@ -224,6 +263,276 @@ export class DeskMetricsController {
       res.status(500).json({ error: 'Failed to compute desk metrics' });
     }
   };
+
+  /**
+   * GET /desk-metrics/desks
+   */
+  listDesks = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = req.user?.id;
+      const workspaceId = req.user?.workspaceId;
+      if (!userId || !workspaceId) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+
+      const desks = await deskMetricsRepository.listAccessibleDesks(workspaceId, userId);
+      res.json({ desks } satisfies DeskMetricsDeskListResponse);
+    } catch (error) {
+      logger.error('[DeskMetrics] Failed to list desks', { error });
+      res.status(500).json({ error: 'Failed to list desks' });
+    }
+  };
+
+  /**
+   * POST /desk-metrics/claw/query
+   */
+  queryMetrics = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = queryBodySchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        res.status(400).json({
+          error: `Invalid request: ${parsed.error.issues
+            .map(i => `${i.path.join('.') || 'body'}: ${i.message}`)
+            .slice(0, 3)
+            .join('; ')}`,
+        });
+        return;
+      }
+      const body = parsed.data;
+
+      if (body.timeRange && body.lastDays !== undefined) {
+        res.status(400).json({ error: 'Provide either timeRange or lastDays, not both.' });
+        return;
+      }
+
+      const channelIds = [...new Set(body.channelIds)];
+      const now = Date.now();
+      const timeRange =
+        body.timeRange ?? `${now - (body.lastDays ?? 7) * DAY_MS}_${now}`;
+      const rangeParts = timeRange.split('_');
+      const fromMs = Number(rangeParts[0]);
+      const toMs = Number(rangeParts[1]);
+      if (
+        rangeParts.length !== 2 ||
+        !Number.isFinite(fromMs) ||
+        !Number.isFinite(toMs) ||
+        fromMs > toMs
+      ) {
+        res.status(400).json({ error: 'Invalid timeRange. Use startMs_endMs' });
+        return;
+      }
+      if (toMs - fromMs > MAX_CUSTOM_RANGE_MS) {
+        res.status(400).json({ error: `Time range cannot exceed ${MAX_CUSTOM_RANGE_DAYS} days` });
+        return;
+      }
+
+      const metrics: DeskMetricKey[] = body.metrics ?? [...DESK_METRIC_KEYS];
+      const includeTickets = body.includeTickets ?? 0;
+      const wanted = new Set(metrics);
+      const filters = {
+        assigneeIds: body.assigneeIds ?? [],
+        stageNames: body.stageNames ?? [],
+        priorities: body.priorities ?? [],
+        userGroupIds: body.userGroupIds ?? [],
+        tagValues: body.tagValues ?? [],
+        ...(body.customFieldFilter ? { customFieldFilter: body.customFieldFilter } : {}),
+      };
+
+      const contributions: DeskMetricsContribution[] = [];
+      const partials: DeskMetricsPartial[] = [];
+      const desks: DeskMetricsDeskSummary[] = [];
+      const skipped: DeskMetricsSkippedDesk[] = [];
+      let anyDeskTruncated = false;
+
+      // Sequential, matching getAggregateMetrics — bounds peak DB connections.
+      for (const channelId of channelIds) {
+        try {
+          const access = await this.assertChannelAccess(req, channelId);
+          if (!access.ok) {
+            skipped.push({ channelId, reason: access.status === 404 ? 'not_found' : 'forbidden' });
+            continue;
+          }
+
+          const preference = await this.preferenceRepo.findByChannelId(channelId);
+          if (!preference) {
+            skipped.push({ channelId, reason: 'not_found' });
+            continue;
+          }
+
+          const channel = await this.channelRepo.findById(channelId);
+          const partial = await deskMetricsRepository.queryMetrics({
+            channelId,
+            timeRange,
+            frtStageNames: this.parseFrtStageNames(preference),
+            metrics,
+            includeTickets,
+            ...(body.customFieldBreakdown
+              ? { customFieldBreakdown: body.customFieldBreakdown }
+              : {}),
+            ...filters,
+          });
+          partials.push(partial);
+
+          if (partial.ticketsTruncated) anyDeskTruncated = true;
+          desks.push({
+            channelId,
+            channelName: channel?.name ?? null,
+            deskType: preference.deskType,
+            metricsEnabled: preference.metricsEnabled === true,
+          });
+          contributions.push({
+            channelId,
+            channelName: channel?.name ?? null,
+            metrics: fillDeskMetrics(partial),
+          });
+        } catch (error) {
+          logger.error('[DeskMetrics] Query: desk failed, skipping', { channelId, error });
+          skipped.push({ channelId, reason: 'error' });
+        }
+      }
+
+      if (contributions.length === 0) {
+        const status = skipped.some(desk => desk.reason === 'error') ? 500 : 403;
+        res.status(status).json({
+          error:
+            status === 500
+              ? 'Failed to compute desk metrics'
+              : 'None of the selected desks have metrics available',
+          skipped,
+        });
+        return;
+      }
+
+      // Aggregate even for a single desk so the merge path is exercised
+      // identically; the zero-filled slices are stripped right after.
+      const merged = aggregateDeskMetrics(contributions);
+      const result: DeskMetricsPartial = { range: merged.range };
+      if (wanted.has('frt')) result.frt = merged.frt;
+      if (wanted.has('rt')) result.rt = merged.rt;
+      if (wanted.has('csat')) result.csat = merged.csat;
+      if (wanted.has('counts')) result.counts = merged.counts;
+      if (wanted.has('priority')) result.priority = merged.priority;
+      if (wanted.has('trend')) result.trend = merged.trend;
+      if (wanted.has('agents')) result.agents = merged.agents;
+      if (wanted.has('tags')) {
+        result.tagCategories = merged.tagCategories;
+        result.tagBreakdown = merged.tagBreakdown;
+      }
+      Object.assign(result, mergeCustomFieldSlices(partials));
+      if (wanted.has('tickets') && includeTickets > 0) {
+        result.tickets = merged.tickets.slice(0, includeTickets);
+        result.ticketsTruncated = anyDeskTruncated || merged.tickets.length > includeTickets;
+      }
+
+      const response: DeskMetricsQueryResponse = {
+        ...result,
+        desks,
+        skipped,
+        ...(contributions.length > 1 ? { perDesk: merged.perDesk } : {}),
+        notes: this.buildNotes(
+          wanted,
+          contributions.length,
+          result.ticketsTruncated === true,
+          desks.filter(d => !d.metricsEnabled).length,
+          result.customFieldBreakdown ?? [],
+        ),
+      };
+
+      res.json(response);
+    } catch (error) {
+      logger.error('[DeskMetrics] Failed to run metrics query', { error });
+      res.status(500).json({ error: 'Failed to compute desk metrics' });
+    }
+  };
+
+  private parseFrtStageNames(preference: { frtStageNames?: string | null }): string[] {
+    try {
+      const parsed: unknown = JSON.parse(preference.frtStageNames ?? '[]');
+      return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === 'string') : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private buildNotes(
+    wanted: Set<DeskMetricKey>,
+    deskCount: number,
+    ticketsTruncated: boolean,
+    unconfiguredDeskCount: number,
+    customFieldBreakdown: DeskMetricsCustomFieldBreakdown[],
+  ): string[] {
+    const notes: string[] = [];
+
+    const cohortKeys = ['frt', 'rt', 'counts', 'priority', 'agents', 'tags', 'tickets'].filter(k =>
+      wanted.has(k as DeskMetricKey),
+    );
+    if (cohortKeys.length > 0) {
+      notes.push(
+        `Cohort-scoped (${cohortKeys.join(', ')}): these describe tickets CREATED inside the range, ` +
+          'not activity that happened inside it. A ticket created before the range is excluded even ' +
+          'if it was answered or resolved during it.',
+      );
+    }
+    if (wanted.has('csat') || wanted.has('counts')) {
+      notes.push(
+        'Activity-scoped (csat, counts.emailRepliesInRange): these count events that happened inside ' +
+          'the range regardless of when their ticket was created — deliberately different from the ' +
+          'cohort-scoped metrics above.',
+      );
+    }
+    if (wanted.has('frt')) {
+      notes.push(
+        'frt.avgSeconds is creation to first response, where "response" is the first outbound email ' +
+          'and/or first entry into the stages this desk configured as its FRT stop. respondedTickets ' +
+          'is how many cohort tickets have one at all.',
+      );
+    }
+    if (wanted.has('rt')) {
+      notes.push(
+        'rt.avgSeconds is creation to the LAST resolution event (so a reopened-then-reclosed ticket ' +
+          'measures to the final close). Tickets still open are excluded entirely, so a low average ' +
+          'over a small resolvedTickets count is survivorship bias, not good performance.',
+      );
+    }
+    if (wanted.has('agents')) {
+      notes.push(
+        'agents[] attributes ticket metrics to the CURRENT assignee, not whoever handled the ticket ' +
+          'at the time; emailReplies is attributed to the actual sender. assigneeId null is the ' +
+          'Unassigned bucket.',
+      );
+    }
+    if (deskCount > 1) {
+      notes.push(
+        `Merged across ${deskCount} desks. Averages are weighted by their denominators (FRT by ` +
+          'respondedTickets, RT by resolvedTickets, CSAT by scoredResponses) — do not re-average ' +
+          'the perDesk rows yourself. See perDesk for the split.',
+      );
+    }
+    notes.push(
+      'Data is forward-only: it derives from ticket activity records that only exist since desk ' +
+        'metrics was deployed. Ranges reaching further back report partial data, not zero activity.',
+    );
+    if (ticketsTruncated) {
+      notes.push('Ticket rows were truncated by includeTickets — this is not the full cohort.');
+    }
+    const multiValueFields = customFieldBreakdown.filter(b => b.multiValue).map(b => b.field);
+    if (multiValueFields.length > 0) {
+      notes.push(
+        `customFieldBreakdown for ${multiValueFields.join(', ')} is MULTI-VALUE: a ticket can carry ` +
+          'several values and is counted once under each, so those counts deliberately do not sum ' +
+          'to the ticket total. Read them as "tickets mentioning X", never as a split of the whole.',
+      );
+    }
+    if (unconfiguredDeskCount > 0) {
+      notes.push(
+        `${unconfiguredDeskCount} desk(s) here never enabled the metrics dashboard, so their ` +
+          'first-response stop stages are probably unset. That makes frt null (unknown) rather ' +
+          'than zero — report it as not configured, never as "no responses".',
+      );
+    }
+    return notes;
+  }
 
   getAggregateMetrics = async (req: Request, res: Response): Promise<void> => {
     const rawIds = getStringQueryParam(req, 'channelIds') ?? '';

--- a/apps/backend/src/controllers/deskMetricsController.ts
+++ b/apps/backend/src/controllers/deskMetricsController.ts
@@ -1,8 +1,9 @@
 /**
  * Desk Metrics Controller
  * Hardcoded per-desk-channel metrics (FRT, RT, CSAT, counts, priority,
- * activity), computed from ticket_activities. Gated on the per-desk
- * metricsEnabled preference so desks that never opted in cost nothing.
+ * activity), computed from ticket_activities. The dashboard endpoints are
+ * gated on the per-desk metricsEnabled preference so desks that never opted in
+ * cost nothing; the agent-facing query endpoint is not (see queryMetrics).
  */
 
 import { Request, Response } from 'express';
@@ -15,6 +16,7 @@ import {
   aggregateDeskMetrics,
   fillDeskMetrics,
   mergeCustomFieldSlices,
+  prunePerDesk,
   type DeskMetricsContribution,
 } from '../services/deskMetricsAggregator.js';
 import { logger } from '../utils/logger.js';
@@ -354,6 +356,11 @@ export class DeskMetricsController {
             continue;
           }
 
+          // Deliberately no metricsEnabled gate here — that flag gates the
+          // dashboard tab, not access to the numbers, and membership above is
+          // the real boundary. Consequence: this path never emits the
+          // 'metrics_disabled' skip reason; unconfigured desks are computed and
+          // called out in `notes` instead. The dashboard endpoints still gate.
           const preference = await this.preferenceRepo.findByChannelId(channelId);
           if (!preference) {
             skipped.push({ channelId, reason: 'not_found' });
@@ -429,7 +436,7 @@ export class DeskMetricsController {
         ...result,
         desks,
         skipped,
-        ...(contributions.length > 1 ? { perDesk: merged.perDesk } : {}),
+        ...(contributions.length > 1 ? { perDesk: prunePerDesk(merged.perDesk, wanted) } : {}),
         notes: this.buildNotes(
           wanted,
           contributions.length,

--- a/apps/backend/src/database/repositories/deskMetricsRepository.ts
+++ b/apps/backend/src/database/repositories/deskMetricsRepository.ts
@@ -34,6 +34,7 @@ import { logger } from '@/utils/logger';
  */
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const MAX_BREAKDOWN_VALUES_PER_FIELD = 25;
 
 const activeTicketFilter = (assigneeIds: string[] = []): Prisma.Sql => {
   const assigneeCondition =
@@ -726,12 +727,20 @@ export class DeskMetricsRepository {
         WITH ${cohortCte},
         ${this.dedupedFieldValuesCte()},
         ${this.expandedFieldValuesCte()}
-        SELECT field_name, bool_or(multi_value) AS multi_value, value,
-               COUNT(DISTINCT ticket_id)::int AS tickets
-        FROM expanded_cf
-        WHERE field_name IN (${Prisma.join(fields)})
-          AND value IS NOT NULL AND value <> ''
-        GROUP BY field_name, value
+        SELECT field_name, multi_value, value, tickets
+        FROM (
+          SELECT field_name, bool_or(multi_value) AS multi_value, value,
+                 COUNT(DISTINCT ticket_id)::int AS tickets,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY field_name
+                   ORDER BY COUNT(DISTINCT ticket_id) DESC, value ASC
+                 ) AS rn
+          FROM expanded_cf
+          WHERE field_name IN (${Prisma.join(fields)})
+            AND value IS NOT NULL AND value <> ''
+          GROUP BY field_name, value
+        ) ranked
+        WHERE rn <= ${MAX_BREAKDOWN_VALUES_PER_FIELD + 1}
         ORDER BY field_name ASC, tickets DESC, value ASC
       `
     );
@@ -747,7 +756,15 @@ export class DeskMetricsRepository {
       entry.values.push({ value: r.value, tickets: r.tickets });
       byField.set(r.field_name, entry);
     }
-    return [...byField.values()];
+    return [...byField.values()].map(entry =>
+      entry.values.length > MAX_BREAKDOWN_VALUES_PER_FIELD
+        ? {
+            ...entry,
+            values: entry.values.slice(0, MAX_BREAKDOWN_VALUES_PER_FIELD),
+            truncated: true,
+          }
+        : entry,
+    );
   }
 
   private async resolvedStageNamesForChannel(channelId: string): Promise<string[]> {

--- a/apps/backend/src/database/repositories/deskMetricsRepository.ts
+++ b/apps/backend/src/database/repositories/deskMetricsRepository.ts
@@ -1,7 +1,12 @@
 import { Prisma } from '@prisma/client';
 import { DatabaseClient, readReplicaDb } from '../client';
 import {
+  DeskMetricKey,
   DeskMetricsAgentRow,
+  DeskMetricsCustomFieldBreakdown,
+  DeskMetricsCustomFieldSummary,
+  DeskMetricsDeskSummary,
+  DeskMetricsPartial,
   DeskMetricsResponse,
   DeskMetricsTicketRow,
   TicketPriority,
@@ -42,6 +47,37 @@ const activeTicketFilter = (assigneeIds: string[] = []): Prisma.Sql => {
   )`;
 };
 
+/** Everything both entry points need to describe one metrics run. */
+export interface DeskMetricsQueryParams {
+  channelId: string;
+  timeRange?: string;
+  frtStageNames: string[];
+  assigneeIds: string[];
+  stageNames: string[];
+  priorities: TicketPriority[];
+  userGroupIds: string[];
+  tagValues: string[];
+  customFieldFilter?: {
+    keys: string[];
+    perKeyFilters?: Record<string, { values?: string[]; textTerms?: string[] }>;
+  };
+}
+
+/** Compiled SQL fragments for one run, produced once by buildContext. */
+interface MetricsContext {
+  db: ReturnType<DeskMetricsRepository['getDbInstance']>;
+  channelId: string;
+  gte: Date;
+  lte: Date;
+  assigneeIds: string[];
+  cohortCte: Prisma.Sql;
+  frtStop: Prisma.Sql;
+  resolvedAtSql: Prisma.Sql;
+  resolvedPredicate: Prisma.Sql;
+  reopenedSql: Prisma.Sql;
+  ticketScopeExists: Prisma.Sql;
+}
+
 export class DeskMetricsRepository {
   private getDbInstance() {
     const replica = readReplicaDb;
@@ -70,20 +106,7 @@ export class DeskMetricsRepository {
     return { gte: new Date(now.getTime() - 7 * DAY_MS), lte: now };
   }
 
-  async getMetrics(params: {
-    channelId: string;
-    timeRange?: string;
-    frtStageNames: string[];
-    assigneeIds: string[];
-    stageNames: string[];
-    priorities: TicketPriority[];
-    userGroupIds: string[];
-    tagValues: string[];
-    customFieldFilter?: {
-      keys: string[];
-      perKeyFilters?: Record<string, { values?: string[]; textTerms?: string[] }>;
-    };
-  }): Promise<DeskMetricsResponse> {
+  private async buildContext(params: DeskMetricsQueryParams): Promise<MetricsContext> {
     const {
       channelId,
       frtStageNames,
@@ -270,7 +293,41 @@ export class DeskMetricsRepository {
           ${ticketScopeExists}
       )`;
 
-    const frtStop = frtStopSql();
+
+    return {
+      db,
+      channelId,
+      gte,
+      lte,
+      assigneeIds,
+      cohortCte,
+      frtStop: frtStopSql(),
+      resolvedAtSql,
+      resolvedPredicate,
+      reopenedSql,
+      ticketScopeExists,
+    };
+  }
+
+  /**
+   * Dashboard payload — every metric, every cohort ticket row.
+   */
+  async getMetrics(params: DeskMetricsQueryParams): Promise<DeskMetricsResponse> {
+    const ctx = await this.buildContext(params);
+    const {
+      db,
+      channelId,
+      gte,
+      lte,
+      assigneeIds,
+      cohortCte,
+      frtStop,
+      resolvedAtSql,
+      resolvedPredicate,
+      reopenedSql,
+      ticketScopeExists,
+    } = ctx;
+
     const [
       aggregates,
       tickets,
@@ -323,6 +380,305 @@ export class DeskMetricsRepository {
       tickets,
       agents,
     };
+  }
+
+  /**
+   * Agent-facing run: computes only the requested metrics and only as many
+   * ticket rows as were asked for. Everything else is identical to getMetrics
+   */
+  async queryMetrics(
+    params: DeskMetricsQueryParams & {
+      metrics: DeskMetricKey[];
+      includeTickets?: number;
+      customFieldBreakdown?: string[];
+    }
+  ): Promise<DeskMetricsPartial> {
+    const ctx = await this.buildContext(params);
+    const {
+      db,
+      channelId,
+      gte,
+      lte,
+      assigneeIds,
+      cohortCte,
+      frtStop,
+      resolvedAtSql,
+      resolvedPredicate,
+      reopenedSql,
+      ticketScopeExists,
+    } = ctx;
+
+    const wanted = new Set(params.metrics);
+    const needsAggregate = wanted.has('frt') || wanted.has('rt') || wanted.has('counts');
+    const needsCounts = wanted.has('counts');
+    // Fetch one extra row so the caller can tell a full page from a truncated one.
+    const ticketLimit =
+      wanted.has('tickets') && params.includeTickets && params.includeTickets > 0
+        ? params.includeTickets
+        : null;
+    // A named breakdown implies the field work even if 'customFields' wasn't asked for.
+    const breakdownFields = params.customFieldBreakdown ?? [];
+
+    const [
+      aggregates,
+      tickets,
+      emailRepliesInRange,
+      stageCounts,
+      priority,
+      csat,
+      trend,
+      agents,
+      tagCategories,
+      tagBreakdown,
+      customFields,
+      customFieldBreakdown,
+    ] = await Promise.all([
+      needsAggregate ? this.frtRtAggregates(db, cohortCte, frtStop, resolvedAtSql) : null,
+      ticketLimit ? this.ticketRows(db, cohortCte, frtStop, resolvedAtSql, ticketLimit + 1) : null,
+      needsCounts ? this.emailRepliesCount(db, channelId, gte, lte, ticketScopeExists) : null,
+      needsCounts ? this.stageCounts(db, cohortCte) : null,
+      wanted.has('priority') ? this.priorityBreakdown(db, cohortCte) : null,
+      wanted.has('csat') ? this.csatStats(db, channelId, gte, lte, ticketScopeExists) : null,
+      wanted.has('trend')
+        ? this.trendByDay(db, channelId, gte, lte, resolvedPredicate, ticketScopeExists)
+        : null,
+      wanted.has('agents')
+        ? this.agentPerformance(
+            db,
+            cohortCte,
+            frtStop,
+            resolvedAtSql,
+            reopenedSql,
+            channelId,
+            gte,
+            lte,
+            assigneeIds,
+            ticketScopeExists
+          )
+        : null,
+      wanted.has('tags') ? this.tagCategoryBreakdown(db, cohortCte) : null,
+      wanted.has('tags') ? this.tagBreakdown(db, cohortCte) : null,
+      wanted.has('customFields') ? this.customFieldSummary(db, cohortCte) : null,
+      breakdownFields.length > 0 ? this.customFieldBreakdown(db, cohortCte, breakdownFields) : null,
+    ]);
+
+    const result: DeskMetricsPartial = {
+      range: { from: gte.toISOString(), to: lte.toISOString() },
+    };
+
+    if (aggregates) {
+      if (wanted.has('frt')) {
+        result.frt = { avgSeconds: aggregates.avgFrt, respondedTickets: aggregates.responded };
+      }
+      if (wanted.has('rt')) {
+        result.rt = { avgSeconds: aggregates.avgRt, resolvedTickets: aggregates.resolved };
+      }
+      if (wanted.has('counts')) {
+        result.counts = {
+          openedInRange: aggregates.opened,
+          emailRepliesInRange: emailRepliesInRange ?? 0,
+          stageCounts: stageCounts ?? [],
+        };
+      }
+    }
+    if (csat) result.csat = csat;
+    if (priority) result.priority = priority;
+    if (trend) result.trend = trend;
+    if (agents) result.agents = agents;
+    if (tagCategories) result.tagCategories = tagCategories;
+    if (tagBreakdown) result.tagBreakdown = tagBreakdown;
+    if (customFields) result.customFields = customFields;
+    if (customFieldBreakdown) result.customFieldBreakdown = customFieldBreakdown;
+    if (tickets && ticketLimit) {
+      result.ticketsTruncated = tickets.length > ticketLimit;
+      result.tickets = tickets.slice(0, ticketLimit);
+    }
+
+    return result;
+  }
+
+
+  /**
+   * Every desk in the caller's workspace that the caller participates in.
+   */
+  async listAccessibleDesks(
+    workspaceId: string,
+    userId: string
+  ): Promise<DeskMetricsDeskSummary[]> {
+    const db = this.getDbInstance();
+
+    const preferences = await db.emailChannelPreference.findMany({
+      where: { workspaceId },
+      select: { channelId: true, deskType: true, metricsEnabled: true },
+    });
+    if (preferences.length === 0) return [];
+
+    const channelIds = preferences.map(p => p.channelId);
+    // Membership is the same gate the per-desk endpoints apply, checked in bulk
+    // here so listing 50 desks is one query rather than 50.
+    const memberships = await db.channelParticipant.findMany({
+      where: { userId, channelId: { in: channelIds } },
+      select: { channelId: true },
+    });
+    const allowed = new Set(memberships.map(m => m.channelId));
+    if (allowed.size === 0) return [];
+
+    const channels = await db.channel.findMany({
+      where: { id: { in: [...allowed] }, workspaceId },
+      select: { id: true, name: true },
+    });
+    const nameById = new Map(channels.map(c => [c.id, c.name]));
+
+    return preferences
+      .filter(p => allowed.has(p.channelId) && nameById.has(p.channelId))
+      .map(p => ({
+        channelId: p.channelId,
+        channelName: nameById.get(p.channelId) ?? null,
+        deskType: p.deskType,
+        metricsEnabled: p.metricsEnabled === true,
+      }))
+      .sort((a, b) => (a.channelName ?? '').localeCompare(b.channelName ?? ''));
+  }
+
+  /**
+   * Text form of a custom field value.
+   */
+  private customFieldValueSql(): Prisma.Sql {
+    return Prisma.sql`(
+      CASE WHEN jsonb_typeof(fev."actualFieldValue") = 'array'
+        THEN (
+          SELECT string_agg(av.value, ', ' ORDER BY av.ord)
+          FROM jsonb_array_elements_text(fev."actualFieldValue")
+            WITH ORDINALITY AS av(value, ord)
+        )
+        ELSE COALESCE(fev."actualFieldValue"#>>'{}', NULLIF(fev."fieldValue", ''))
+      END
+    )`;
+  }
+
+  /**
+   * One row per (ticket, field), newest wins. form_entity_values is unique on
+   * (entityId, entityType, fieldId, contextId, version), so a ticket can carry
+   * several rows for the same field across stage context and version — without
+   * this dedup a breakdown would double-count them.
+   */
+  private dedupedFieldValuesCte(): Prisma.Sql {
+    return Prisma.sql`
+      deduped_cf AS (
+        SELECT DISTINCT ON (fev."entityId", COALESCE(gf."fieldName", ff."fieldName"))
+          fev."entityId" AS ticket_id,
+          COALESCE(gf."fieldName", ff."fieldName") AS field_name,
+          fev."actualFieldValue" AS raw_value,
+          ${this.customFieldValueSql()} AS field_value
+        FROM "public"."form_entity_values" fev
+        LEFT JOIN "public"."global_fields" gf ON gf.id = fev."fieldId"
+        LEFT JOIN "public"."form_fields" ff ON ff.id = fev."fieldId"
+        WHERE fev."entityId" IN (SELECT "ticketId" FROM cohort)
+          AND fev."entityType" = 'TICKET'
+        ORDER BY fev."entityId", COALESCE(gf."fieldName", ff."fieldName"),
+                 fev."updatedAt" DESC, fev.id DESC
+      )`;
+  }
+
+  /**
+   * deduped_cf with array fields expanded element-by-element, so "Issues"
+   * yields Cab/Auto/Other rather than one row per literal combination. Shared
+   * by discovery and breakdown so their value counts can never disagree.
+   */
+  private expandedFieldValuesCte(): Prisma.Sql {
+    return Prisma.sql`
+      expanded_cf AS (
+        SELECT
+          d.ticket_id,
+          d.field_name,
+          jsonb_typeof(d.raw_value) = 'array' AS multi_value,
+          CASE WHEN jsonb_typeof(d.raw_value) = 'array' THEN el.value ELSE d.field_value END
+            AS value
+        FROM deduped_cf d
+        -- Coerce non-arrays to '[]' so the set-returning function is never
+        -- handed a scalar; the LEFT JOIN then yields one NULL row and the CASE
+        -- above falls back to the plain value.
+        LEFT JOIN LATERAL jsonb_array_elements_text(
+          CASE WHEN jsonb_typeof(d.raw_value) = 'array' THEN d.raw_value ELSE '[]'::jsonb END
+        ) AS el(value) ON true
+      )`;
+  }
+
+  /** Which custom fields the cohort's tickets actually carry. */
+  private async customFieldSummary(
+    db: ReturnType<DeskMetricsRepository['getDbInstance']>,
+    cohortCte: Prisma.Sql
+  ): Promise<DeskMetricsCustomFieldSummary[]> {
+    const rows = await db.$queryRaw<
+      Array<{
+        field_name: string;
+        multi_value: boolean;
+        tickets_with_value: number;
+        distinct_values: number;
+      }>
+    >(
+      Prisma.sql`
+        WITH ${cohortCte},
+        ${this.dedupedFieldValuesCte()},
+        ${this.expandedFieldValuesCte()}
+        SELECT
+          field_name,
+          bool_or(multi_value) AS multi_value,
+          COUNT(DISTINCT ticket_id) FILTER (WHERE value IS NOT NULL AND value <> '')::int
+            AS tickets_with_value,
+          COUNT(DISTINCT value)::int AS distinct_values
+        FROM expanded_cf
+        WHERE field_name IS NOT NULL
+        GROUP BY field_name
+        ORDER BY tickets_with_value DESC, field_name ASC
+      `
+    );
+    return rows.map((r): DeskMetricsCustomFieldSummary => ({
+      field: r.field_name,
+      multiValue: r.multi_value,
+      ticketsWithValue: r.tickets_with_value,
+      distinctValues: r.distinct_values,
+    }));
+  }
+
+  /**
+   * Value distribution for the named custom fields.
+   */
+  private async customFieldBreakdown(
+    db: ReturnType<DeskMetricsRepository['getDbInstance']>,
+    cohortCte: Prisma.Sql,
+    fields: string[]
+  ): Promise<DeskMetricsCustomFieldBreakdown[]> {
+    if (fields.length === 0) return [];
+    const rows = await db.$queryRaw<
+      Array<{ field_name: string; multi_value: boolean; value: string; tickets: number }>
+    >(
+      Prisma.sql`
+        WITH ${cohortCte},
+        ${this.dedupedFieldValuesCte()},
+        ${this.expandedFieldValuesCte()}
+        SELECT field_name, bool_or(multi_value) AS multi_value, value,
+               COUNT(DISTINCT ticket_id)::int AS tickets
+        FROM expanded_cf
+        WHERE field_name IN (${Prisma.join(fields)})
+          AND value IS NOT NULL AND value <> ''
+        GROUP BY field_name, value
+        ORDER BY field_name ASC, tickets DESC, value ASC
+      `
+    );
+
+    const byField = new Map<string, DeskMetricsCustomFieldBreakdown>();
+    for (const r of rows) {
+      const entry: DeskMetricsCustomFieldBreakdown = byField.get(r.field_name) ?? {
+        field: r.field_name,
+        multiValue: r.multi_value,
+        values: [],
+      };
+      entry.multiValue = entry.multiValue || r.multi_value;
+      entry.values.push({ value: r.value, tickets: r.tickets });
+      byField.set(r.field_name, entry);
+    }
+    return [...byField.values()];
   }
 
   private async resolvedStageNamesForChannel(channelId: string): Promise<string[]> {
@@ -403,8 +759,12 @@ export class DeskMetricsRepository {
     db: ReturnType<DeskMetricsRepository['getDbInstance']>,
     cohortCte: Prisma.Sql,
     frtStopSql: Prisma.Sql,
-    resolvedAtSql: Prisma.Sql
+    resolvedAtSql: Prisma.Sql,
+    limit?: number
   ): Promise<DeskMetricsTicketRow[]> {
+    // The dashboard takes every cohort row; the agent surface caps it, because
+    // each row carries custom fields and tags and would swamp a context window.
+    const limitSql = limit ? Prisma.sql` LIMIT ${limit}` : Prisma.sql``;
     const rows = await db.$queryRaw<
       Array<{
         ticket_id: string;
@@ -429,7 +789,7 @@ export class DeskMetricsRepository {
           SELECT DISTINCT ON (fev."entityId", COALESCE(gf."fieldName", ff."fieldName"))
             fev."entityId" AS ticket_id,
             COALESCE(gf."fieldName", ff."fieldName") AS field_name,
-            COALESCE(fev."actualFieldValue"#>>'{}', NULLIF(fev."fieldValue", '')) AS field_value
+            ${this.customFieldValueSql()} AS field_value
           FROM "public"."form_entity_values" fev
           LEFT JOIN "public"."global_fields" gf ON gf.id = fev."fieldId"
           LEFT JOIN "public"."form_fields" ff ON ff.id = fev."fieldId"
@@ -485,7 +845,7 @@ export class DeskMetricsRepository {
         LEFT JOIN "public"."users" u ON u.id = t."assignedTo"
         LEFT JOIN form_vals fv ON fv.ticket_id = c."ticketId"
         LEFT JOIN ticket_tags_agg tta ON tta.ticket_id = c."ticketId"
-        ORDER BY c.created_at DESC
+        ORDER BY c.created_at DESC${limitSql}
       `
     );
     return rows.map((r) => {

--- a/apps/backend/src/database/repositories/deskMetricsRepository.ts
+++ b/apps/backend/src/database/repositories/deskMetricsRepository.ts
@@ -3,6 +3,8 @@ import { DatabaseClient, readReplicaDb } from '../client';
 import {
   DeskMetricKey,
   DeskMetricsAgentRow,
+  DeskMetricsAiCategoryCount,
+  DeskMetricsAiSubCategoryCount,
   DeskMetricsCustomFieldBreakdown,
   DeskMetricsCustomFieldSummary,
   DeskMetricsDeskSummary,
@@ -11,6 +13,7 @@ import {
   DeskMetricsTicketRow,
   TicketPriority,
   TicketStatusV2,
+  UNCLASSIFIED_AI_CATEGORY,
 } from '@xyne/shared';
 import { logger } from '@/utils/logger';
 
@@ -57,6 +60,8 @@ export interface DeskMetricsQueryParams {
   priorities: TicketPriority[];
   userGroupIds: string[];
   tagValues: string[];
+  aiCategories?: string[];
+  aiSubCategories?: string[];
   customFieldFilter?: {
     keys: string[];
     perKeyFilters?: Record<string, { values?: string[]; textTerms?: string[] }>;
@@ -117,6 +122,8 @@ export class DeskMetricsRepository {
       tagValues,
       customFieldFilter,
     } = params;
+    const aiCategories = params.aiCategories ?? [];
+    const aiSubCategories = params.aiSubCategories ?? [];
     const db = this.getDbInstance();
     const { gte, lte } = this.resolveRange(params.timeRange);
 
@@ -267,6 +274,16 @@ export class DeskMetricsRepository {
     if (userGroupIds.length > 0) {
       ticketAttributeConditions.push(
         Prisma.sql`filter_ticket."userGroupId" IN (${Prisma.join(userGroupIds)})`
+      );
+    }
+    if (aiCategories.length > 0) {
+      ticketAttributeConditions.push(
+        Prisma.sql`filter_ticket."aiCategory" IN (${Prisma.join(aiCategories)})`
+      );
+    }
+    if (aiSubCategories.length > 0) {
+      ticketAttributeConditions.push(
+        Prisma.sql`filter_ticket."aiSubCategory" IN (${Prisma.join(aiSubCategories)})`
       );
     }
     const ticketAttributeExists =
@@ -432,6 +449,8 @@ export class DeskMetricsRepository {
       tagBreakdown,
       customFields,
       customFieldBreakdown,
+      aiCategoryCountRows,
+      aiSubCategoryCountRows,
     ] = await Promise.all([
       needsAggregate ? this.frtRtAggregates(db, cohortCte, frtStop, resolvedAtSql) : null,
       ticketLimit ? this.ticketRows(db, cohortCte, frtStop, resolvedAtSql, ticketLimit + 1) : null,
@@ -460,6 +479,8 @@ export class DeskMetricsRepository {
       wanted.has('tags') ? this.tagBreakdown(db, cohortCte) : null,
       wanted.has('customFields') ? this.customFieldSummary(db, cohortCte) : null,
       breakdownFields.length > 0 ? this.customFieldBreakdown(db, cohortCte, breakdownFields) : null,
+      wanted.has('aiCategories') ? this.aiCategoryCounts(db, cohortCte) : null,
+      wanted.has('aiCategories') ? this.aiSubCategoryCounts(db, cohortCte) : null,
     ]);
 
     const result: DeskMetricsPartial = {
@@ -489,6 +510,8 @@ export class DeskMetricsRepository {
     if (tagBreakdown) result.tagBreakdown = tagBreakdown;
     if (customFields) result.customFields = customFields;
     if (customFieldBreakdown) result.customFieldBreakdown = customFieldBreakdown;
+    if (aiCategoryCountRows) result.aiCategoryCounts = aiCategoryCountRows;
+    if (aiSubCategoryCountRows) result.aiSubCategoryCounts = aiSubCategoryCountRows;
     if (tickets && ticketLimit) {
       result.ticketsTruncated = tickets.length > ticketLimit;
       result.tickets = tickets.slice(0, ticketLimit);
@@ -538,6 +561,52 @@ export class DeskMetricsRepository {
         metricsEnabled: p.metricsEnabled === true,
       }))
       .sort((a, b) => (a.channelName ?? '').localeCompare(b.channelName ?? ''));
+  }
+
+  /**
+   * Ticket counts per AI category over the cohort.
+   */
+  private async aiCategoryCounts(
+    db: ReturnType<DeskMetricsRepository['getDbInstance']>,
+    cohortCte: Prisma.Sql
+  ): Promise<DeskMetricsAiCategoryCount[]> {
+    const rows = await db.$queryRaw<Array<{ ai_category: string; count: number }>>(
+      Prisma.sql`
+        WITH ${cohortCte}
+        SELECT COALESCE(t."aiCategory", ${UNCLASSIFIED_AI_CATEGORY}) AS ai_category,
+               COUNT(*)::int AS count
+        FROM cohort c
+        JOIN "public"."tickets" t ON t.id = c."ticketId"
+        GROUP BY 1
+        ORDER BY count DESC, ai_category ASC
+      `
+    );
+    return rows.map(r => ({ aiCategory: r.ai_category, count: r.count }));
+  }
+
+  private async aiSubCategoryCounts(
+    db: ReturnType<DeskMetricsRepository['getDbInstance']>,
+    cohortCte: Prisma.Sql
+  ): Promise<DeskMetricsAiSubCategoryCount[]> {
+    const rows = await db.$queryRaw<
+      Array<{ ai_category: string; ai_sub_category: string; count: number }>
+    >(
+      Prisma.sql`
+        WITH ${cohortCte}
+        SELECT COALESCE(t."aiCategory", ${UNCLASSIFIED_AI_CATEGORY}) AS ai_category,
+               COALESCE(t."aiSubCategory", ${UNCLASSIFIED_AI_CATEGORY}) AS ai_sub_category,
+               COUNT(*)::int AS count
+        FROM cohort c
+        JOIN "public"."tickets" t ON t.id = c."ticketId"
+        GROUP BY 1, 2
+        ORDER BY count DESC, ai_category ASC, ai_sub_category ASC
+      `
+    );
+    return rows.map(r => ({
+      aiCategory: r.ai_category,
+      aiSubCategory: r.ai_sub_category,
+      count: r.count,
+    }));
   }
 
   /**

--- a/apps/backend/src/routes/deskMetricsAggregateRoutes.ts
+++ b/apps/backend/src/routes/deskMetricsAggregateRoutes.ts
@@ -4,5 +4,6 @@ import { deskMetricsController } from '../controllers/deskMetricsController.js';
 const router = Router();
 
 router.get('/aggregate', deskMetricsController.getAggregateMetrics);
+router.get('/desks', deskMetricsController.listDesks);
 
 export default router;

--- a/apps/backend/src/routes/deskMetricsClawRoutes.ts
+++ b/apps/backend/src/routes/deskMetricsClawRoutes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { deskMetricsController } from '../controllers/deskMetricsController.js';
+
+/**
+ * Agent-facing desk metrics, called by the spaces-desk-metrics MCP tool rather
+ * than the browser. Mounted behind authenticateUserOrApp in app.ts, ahead of
+ * the dashboard's /api/desk-metrics mount so app tokens are not rejected by
+ * the user-only middleware there.
+ */
+const router = Router();
+
+router.get('/desks', deskMetricsController.listDesks);
+router.post('/query', deskMetricsController.queryMetrics);
+
+export default router;

--- a/apps/backend/src/services/deskMetricsAggregator.ts
+++ b/apps/backend/src/services/deskMetricsAggregator.ts
@@ -1,6 +1,8 @@
 import type {
   DeskMetricKey,
   DeskMetricsAgentRow,
+  DeskMetricsAiCategoryCount,
+  DeskMetricsAiSubCategoryCount,
   DeskMetricsCustomFieldBreakdown,
   DeskMetricsCustomFieldSummary,
   DeskMetricsPartial,
@@ -254,6 +256,64 @@ export const mergeCustomFieldSlices = (
                 .sort((a, b) => b.tickets - a.tickets || a.value.localeCompare(b.value)),
             }))
             .sort((a, b) => a.field.localeCompare(b.field)),
+        }
+      : {}),
+  };
+};
+
+/**
+ * Merge the AI-classification slices across desks.
+ */
+export const mergeAiCategorySlices = (
+  partials: DeskMetricsPartial[],
+): {
+  aiCategoryCounts?: DeskMetricsAiCategoryCount[];
+  aiSubCategoryCounts?: DeskMetricsAiSubCategoryCount[];
+} => {
+  const categories = new Map<string, number>();
+  const subCategories = new Map<string, { cat: string; sub: string; count: number }>();
+  let sawCategories = false;
+  let sawSub = false;
+
+  for (const p of partials) {
+    if (p.aiCategoryCounts) {
+      sawCategories = true;
+      for (const r of p.aiCategoryCounts) {
+        categories.set(r.aiCategory, (categories.get(r.aiCategory) ?? 0) + r.count);
+      }
+    }
+    if (p.aiSubCategoryCounts) {
+      sawSub = true;
+      for (const r of p.aiSubCategoryCounts) {
+        const key = `${r.aiCategory}::${r.aiSubCategory}`;
+        const existing = subCategories.get(key);
+        subCategories.set(key, {
+          cat: r.aiCategory,
+          sub: r.aiSubCategory,
+          count: (existing?.count ?? 0) + r.count,
+        });
+      }
+    }
+  }
+
+  return {
+    ...(sawCategories
+      ? {
+          aiCategoryCounts: [...categories.entries()]
+            .map(([aiCategory, count]) => ({ aiCategory, count }))
+            .sort((a, b) => b.count - a.count || a.aiCategory.localeCompare(b.aiCategory)),
+        }
+      : {}),
+    ...(sawSub
+      ? {
+          aiSubCategoryCounts: [...subCategories.values()]
+            .map(v => ({ aiCategory: v.cat, aiSubCategory: v.sub, count: v.count }))
+            .sort(
+              (a, b) =>
+                b.count - a.count ||
+                a.aiCategory.localeCompare(b.aiCategory) ||
+                a.aiSubCategory.localeCompare(b.aiSubCategory),
+            ),
         }
       : {}),
   };

--- a/apps/backend/src/services/deskMetricsAggregator.ts
+++ b/apps/backend/src/services/deskMetricsAggregator.ts
@@ -1,5 +1,8 @@
 import type {
   DeskMetricsAgentRow,
+  DeskMetricsCustomFieldBreakdown,
+  DeskMetricsCustomFieldSummary,
+  DeskMetricsPartial,
   DeskMetricsResponse,
   DeskMetricsTicketRow,
 } from '@xyne/shared';
@@ -175,6 +178,83 @@ const mergeTickets = (contributions: DeskMetricsContribution[]): DeskMetricsTick
   contributions
     .flatMap(({ metrics }) => metrics.tickets)
     .sort((a, b) => b.createdAt - a.createdAt);
+
+export const fillDeskMetrics = (partial: DeskMetricsPartial): DeskMetricsResponse => ({
+  range: partial.range,
+  frt: partial.frt ?? { avgSeconds: null, respondedTickets: 0 },
+  rt: partial.rt ?? { avgSeconds: null, resolvedTickets: 0 },
+  csat: partial.csat ?? { avgScore: null, scoredResponses: 0, good: 0, bad: 0 },
+  counts: partial.counts ?? { openedInRange: 0, emailRepliesInRange: 0, stageCounts: [] },
+  priority: partial.priority ?? [],
+  trend: partial.trend ?? [],
+  tagCategories: partial.tagCategories ?? [],
+  tagBreakdown: partial.tagBreakdown ?? [],
+  tickets: partial.tickets ?? [],
+  agents: partial.agents ?? [],
+});
+
+
+export const mergeCustomFieldSlices = (
+  partials: DeskMetricsPartial[],
+): {
+  customFields?: DeskMetricsCustomFieldSummary[];
+  customFieldBreakdown?: DeskMetricsCustomFieldBreakdown[];
+} => {
+  const summaries = new Map<string, DeskMetricsCustomFieldSummary>();
+  let sawSummary = false;
+  for (const p of partials) {
+    if (!p.customFields) continue;
+    sawSummary = true;
+    for (const f of p.customFields) {
+      const existing = summaries.get(f.field);
+      if (!existing) {
+        summaries.set(f.field, { ...f });
+        continue;
+      }
+      existing.multiValue = existing.multiValue || f.multiValue;
+      existing.ticketsWithValue += f.ticketsWithValue;
+      existing.distinctValues = Math.max(existing.distinctValues, f.distinctValues);
+    }
+  }
+
+  const breakdowns = new Map<string, { multiValue: boolean; values: Map<string, number> }>();
+  let sawBreakdown = false;
+  for (const p of partials) {
+    if (!p.customFieldBreakdown) continue;
+    sawBreakdown = true;
+    for (const b of p.customFieldBreakdown) {
+      const entry = breakdowns.get(b.field) ?? { multiValue: false, values: new Map() };
+      entry.multiValue = entry.multiValue || b.multiValue;
+      for (const v of b.values) {
+        entry.values.set(v.value, (entry.values.get(v.value) ?? 0) + v.tickets);
+      }
+      breakdowns.set(b.field, entry);
+    }
+  }
+
+  return {
+    ...(sawSummary
+      ? {
+          customFields: [...summaries.values()].sort(
+            (a, b) => b.ticketsWithValue - a.ticketsWithValue || a.field.localeCompare(b.field),
+          ),
+        }
+      : {}),
+    ...(sawBreakdown
+      ? {
+          customFieldBreakdown: [...breakdowns.entries()]
+            .map(([field, e]) => ({
+              field,
+              multiValue: e.multiValue,
+              values: [...e.values.entries()]
+                .map(([value, tickets]) => ({ value, tickets }))
+                .sort((a, b) => b.tickets - a.tickets || a.value.localeCompare(b.value)),
+            }))
+            .sort((a, b) => a.field.localeCompare(b.field)),
+        }
+      : {}),
+  };
+};
 
 export const aggregateDeskMetrics = (
   contributions: DeskMetricsContribution[],

--- a/apps/backend/src/services/deskMetricsAggregator.ts
+++ b/apps/backend/src/services/deskMetricsAggregator.ts
@@ -1,8 +1,11 @@
 import type {
+  DeskMetricKey,
   DeskMetricsAgentRow,
   DeskMetricsCustomFieldBreakdown,
   DeskMetricsCustomFieldSummary,
   DeskMetricsPartial,
+  DeskMetricsPerDeskRow,
+  DeskMetricsQueryPerDeskRow,
   DeskMetricsResponse,
   DeskMetricsTicketRow,
 } from '@xyne/shared';
@@ -255,6 +258,32 @@ export const mergeCustomFieldSlices = (
       : {}),
   };
 };
+
+/**
+ * Drop per-desk fields whose metric was never requested. fillDeskMetrics
+ * zero-fills those slices so aggregateDeskMetrics can run, and without this
+ * the placeholders reach the caller as real measurements.
+ */
+export const prunePerDesk = (
+  rows: DeskMetricsPerDeskRow[],
+  wanted: Set<DeskMetricKey>,
+): DeskMetricsQueryPerDeskRow[] =>
+  rows.map(row => ({
+    channelId: row.channelId,
+    channelName: row.channelName,
+    ...(wanted.has('frt')
+      ? { avgFrtSeconds: row.avgFrtSeconds, respondedTickets: row.respondedTickets }
+      : {}),
+    ...(wanted.has('rt')
+      ? { avgRtSeconds: row.avgRtSeconds, resolvedTickets: row.resolvedTickets }
+      : {}),
+    ...(wanted.has('csat')
+      ? { csatAvgScore: row.csatAvgScore, csatGood: row.csatGood, csatBad: row.csatBad }
+      : {}),
+    ...(wanted.has('counts')
+      ? { openedInRange: row.openedInRange, emailRepliesInRange: row.emailRepliesInRange }
+      : {}),
+  }));
 
 export const aggregateDeskMetrics = (
   contributions: DeskMetricsContribution[],

--- a/packages/shared/src/types/deskMetrics.ts
+++ b/packages/shared/src/types/deskMetrics.ts
@@ -118,6 +118,7 @@ export const DESK_METRIC_KEYS = [
   'tickets',
 ] as const;
 export type DeskMetricKey = (typeof DESK_METRIC_KEYS)[number];
+export const DEFAULT_DESK_METRIC_KEYS: DeskMetricKey[] = ['frt', 'rt', 'csat', 'counts'];
 
 /** A metrics run with only the requested slices populated. */
 export interface DeskMetricsPartial {
@@ -165,6 +166,7 @@ export interface DeskMetricsCustomFieldBreakdown {
   field: string;
   multiValue: boolean;
   values: Array<{ value: string; tickets: number }>;
+  truncated?: boolean;
 }
 
 /** One desk the caller can read metrics for. */

--- a/packages/shared/src/types/deskMetrics.ts
+++ b/packages/shared/src/types/deskMetrics.ts
@@ -163,9 +163,27 @@ export interface DeskMetricsDeskListResponse {
   desks: DeskMetricsDeskSummary[];
 }
 
+/**
+ * Per-desk row on the agent-facing query response. Metric fields are optional:
+ * absent means "not requested", which a hard zero cannot express.
+ */
+export interface DeskMetricsQueryPerDeskRow {
+  channelId: string;
+  channelName: string | null;
+  avgFrtSeconds?: number | null;
+  respondedTickets?: number;
+  avgRtSeconds?: number | null;
+  resolvedTickets?: number;
+  csatAvgScore?: number | null;
+  csatGood?: number;
+  csatBad?: number;
+  openedInRange?: number;
+  emailRepliesInRange?: number;
+}
+
 export interface DeskMetricsQueryResponse extends DeskMetricsPartial {
   desks: DeskMetricsDeskSummary[];
   skipped: DeskMetricsSkippedDesk[];
-  perDesk?: DeskMetricsPerDeskRow[];
+  perDesk?: DeskMetricsQueryPerDeskRow[];
   notes: string[];
 }

--- a/packages/shared/src/types/deskMetrics.ts
+++ b/packages/shared/src/types/deskMetrics.ts
@@ -113,6 +113,7 @@ export const DESK_METRIC_KEYS = [
   'trend',
   'agents',
   'tags',
+  'aiCategories',
   'customFields',
   'tickets',
 ] as const;
@@ -132,10 +133,25 @@ export interface DeskMetricsPartial {
   tagBreakdown?: DeskMetricsResponse['tagBreakdown'];
   customFields?: DeskMetricsCustomFieldSummary[];
   customFieldBreakdown?: DeskMetricsCustomFieldBreakdown[];
+  aiCategoryCounts?: DeskMetricsAiCategoryCount[];
+  aiSubCategoryCounts?: DeskMetricsAiSubCategoryCount[];
   tickets?: DeskMetricsTicketRow[];
   ticketsTruncated?: boolean;
 }
 
+
+export interface DeskMetricsAiCategoryCount {
+  aiCategory: string;
+  count: number;
+}
+
+export interface DeskMetricsAiSubCategoryCount {
+  aiCategory: string;
+  aiSubCategory: string;
+  count: number;
+}
+
+export const UNCLASSIFIED_AI_CATEGORY = 'Unclassified';
 
 export interface DeskMetricsCustomFieldSummary {
   field: string;

--- a/packages/shared/src/types/deskMetrics.ts
+++ b/packages/shared/src/types/deskMetrics.ts
@@ -102,3 +102,70 @@ export interface DeskMetricsAggregateResponse extends DeskMetricsResponse {
 }
 
 export const DESK_METRICS_MAX_AGGREGATE_DESKS = 20;
+// Agent-facing API — GET /api/desk-metrics/desks and
+// POST /api/desk-metrics/claw/query, behind the spaces-desk-metrics MCP tool.
+export const DESK_METRIC_KEYS = [
+  'frt',
+  'rt',
+  'csat',
+  'counts',
+  'priority',
+  'trend',
+  'agents',
+  'tags',
+  'customFields',
+  'tickets',
+] as const;
+export type DeskMetricKey = (typeof DESK_METRIC_KEYS)[number];
+
+/** A metrics run with only the requested slices populated. */
+export interface DeskMetricsPartial {
+  range: { from: string; to: string };
+  frt?: DeskMetricsResponse['frt'];
+  rt?: DeskMetricsResponse['rt'];
+  csat?: DeskMetricsResponse['csat'];
+  counts?: DeskMetricsResponse['counts'];
+  priority?: DeskMetricsResponse['priority'];
+  trend?: DeskMetricsResponse['trend'];
+  agents?: DeskMetricsAgentRow[];
+  tagCategories?: DeskMetricsResponse['tagCategories'];
+  tagBreakdown?: DeskMetricsResponse['tagBreakdown'];
+  customFields?: DeskMetricsCustomFieldSummary[];
+  customFieldBreakdown?: DeskMetricsCustomFieldBreakdown[];
+  tickets?: DeskMetricsTicketRow[];
+  ticketsTruncated?: boolean;
+}
+
+
+export interface DeskMetricsCustomFieldSummary {
+  field: string;
+  multiValue: boolean;
+  ticketsWithValue: number;
+  distinctValues: number;
+}
+
+/** Value distribution for one custom field across the cohort. */
+export interface DeskMetricsCustomFieldBreakdown {
+  field: string;
+  multiValue: boolean;
+  values: Array<{ value: string; tickets: number }>;
+}
+
+/** One desk the caller can read metrics for. */
+export interface DeskMetricsDeskSummary {
+  channelId: string;
+  channelName: string | null;
+  deskType: string;
+  metricsEnabled: boolean;
+}
+
+export interface DeskMetricsDeskListResponse {
+  desks: DeskMetricsDeskSummary[];
+}
+
+export interface DeskMetricsQueryResponse extends DeskMetricsPartial {
+  desks: DeskMetricsDeskSummary[];
+  skipped: DeskMetricsSkippedDesk[];
+  perDesk?: DeskMetricsPerDeskRow[];
+  notes: string[];
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
