### PR TITLE
fix: XYNE-61529 prevent desk detail back navigation loop

### DIFF
--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -2199,6 +2199,7 @@ const SupportScreen = (): ReactElement => {
         state: {
           conversationId: ticketData.conversationId,
           ticketId: ticketData.id,
+          fromDeskList: true,
         },
       });
     },
@@ -3457,7 +3458,7 @@ const SupportScreen = (): ReactElement => {
                               const back = selectedChannelId
                                 ? `${supportBase}/${selectedChannelId}`
                                 : supportBase;
-                              void navigate(back);
+                              void navigate(back, { replace: true });
                             }}
                             data-track-category='Support'
                             data-track-name='CloseTicketPanel'
@@ -3679,6 +3680,7 @@ const SupportScreen = (): ReactElement => {
                             state: {
                               conversationId: ticket.conversationId,
                               ticketId: ticket.id,
+                              fromDeskList: true,
                             },
                           });
                         }}
@@ -3700,6 +3702,7 @@ const SupportScreen = (): ReactElement => {
                             state: {
                               conversationId: ticket.conversationId,
                               ticketId: ticket.id,
+                              fromDeskList: true,
                             },
                           });
                         }}
@@ -3726,6 +3729,7 @@ const SupportScreen = (): ReactElement => {
                             state: {
                               conversationId: ticket.conversationId,
                               ticketId: ticket.id,
+                              fromDeskList: true,
                             },
                           });
                         }}
@@ -4090,6 +4094,7 @@ export const SupportTicketDetail = ({
     conversationId?: string | null;
     ticketId?: string | null;
     returnToUrl?: string | null;
+    fromDeskList?: boolean;
   };
   // List navigation supplies stable IDs in router state; direct URL loads and
   // new-tab openings fall back to the :ticketId path parameter below.
@@ -4386,15 +4391,27 @@ export const SupportTicketDetail = ({
     // inbox they never visited. Only same-origin paths are honoured — reject
     // absolute URLs and the "//host" / "/\host" protocol-relative forms so
     // router state can't drive an off-site redirect.
+    if (routerState?.fromDeskList) {
+      void navigate(-1);
+      return;
+    }
     const returnToUrl = routerState?.returnToUrl;
     if (returnToUrl && /^\/(?![/\\])/.test(returnToUrl)) {
-      void navigate(returnToUrl);
+      void navigate(returnToUrl, { replace: true });
       return;
     }
     const base = navBasePath ?? supportBase;
     const back = channelIdParam ? `${base}/${channelIdParam}` : base;
-    void navigate(back);
-  }, [channelIdParam, navBasePath, navigate, onBack, routerState?.returnToUrl, supportBase]);
+    void navigate(back, { replace: true });
+  }, [
+    channelIdParam,
+    navBasePath,
+    navigate,
+    onBack,
+    routerState?.fromDeskList,
+    routerState?.returnToUrl,
+    supportBase,
+  ]);
 
   const navigateAdjacent = async (dir: 'forward' | 'backward'): Promise<void> => {
     const windowTarget = dir === 'forward' ? windowNext : windowPrev;

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -566,9 +566,6 @@ const SupportScreen = (): ReactElement => {
   }>();
   const supportBase = workspaceId ? `/${workspaceId}/support` : '/support';
   const navigate = useNavigate();
-  // Stamped by the desk list when it pushes a ticket: the list is the entry directly
-  // behind the detail, so closing the detail pops instead of stacking a second list.
-  const detailRouterState = useLocation().state as { fromDeskList?: boolean } | null;
   // Gate the Tickets shortcut the same way the main rail gates '/projects'.
   const canAccessProjects = useHasResourceAccess('PROJECTS');
   const [searchParams, setSearchParams] = useSearchParams();
@@ -1895,7 +1892,11 @@ const SupportScreen = (): ReactElement => {
         setShowMergeDialog(false);
         if (parentTicket) {
           void navigate(`${supportBase}/${parentTicket.channelId}/${parentTicket.xyneId}`, {
-            state: { conversationId: parentTicket.conversationId, ticketId: parentTicket.id },
+            state: {
+              conversationId: parentTicket.conversationId,
+              ticketId: parentTicket.id,
+              fromDeskList: true,
+            },
           });
         }
       } catch (error: unknown) {
@@ -3458,14 +3459,10 @@ const SupportScreen = (): ReactElement => {
                             size='sm'
                             variant='ghost'
                             onClick={() => {
-                              if (detailRouterState?.fromDeskList) {
-                                void navigate(-1);
-                                return;
-                              }
                               const back = selectedChannelId
                                 ? `${supportBase}/${selectedChannelId}`
                                 : supportBase;
-                              void navigate(back, { replace: true });
+                              void navigate(back);
                             }}
                             data-track-category='Support'
                             data-track-name='CloseTicketPanel'
@@ -3574,7 +3571,7 @@ const SupportScreen = (): ReactElement => {
                   availableStages={availableStages}
                   onTicketClick={ticket => {
                     void navigate(`${supportBase}/${ticket.channelId}/${ticket.xyneId}`, {
-                      state: { ticketId: ticket.ticketId },
+                      state: { ticketId: ticket.ticketId, fromDeskList: true },
                     });
                   }}
                 />
@@ -4412,20 +4409,11 @@ export const SupportTicketDetail = ({
       onBack();
       return;
     }
-    // The desk list is the entry directly behind us, so pop it — navigating to the
-    // list instead would leave the ticket sitting one Back away.
-    if (routerState?.fromDeskList) {
+    // Both markers are stamped by the opener (desk list, Kanban, My Tickets) as it pushes
+    // this entry, so its page is one Back away — pop it rather than stacking a second copy.
+    // returnToUrl is only a signal now; we never navigate to it, so it needs no URL check.
+    if (routerState?.fromDeskList || routerState?.returnToUrl) {
       void navigate(-1);
-      return;
-    }
-    // Ticket boards (Kanban, My Tickets) hand us the URL they came from, so
-    // "back" returns to that board instead of dumping the user in the channel
-    // inbox they never visited. Only same-origin paths are honoured — reject
-    // absolute URLs and the "//host" / "/\host" protocol-relative forms so
-    // router state can't drive an off-site redirect.
-    const returnToUrl = routerState?.returnToUrl;
-    if (returnToUrl && /^\/(?![/\\])/.test(returnToUrl)) {
-      void navigate(returnToUrl, { replace: true });
       return;
     }
     const base = navBasePath ?? supportBase;
@@ -5658,6 +5646,10 @@ const EmailThreadItem = ({
 }): ReactElement => {
   const { channelId: channelIdParam } = useParams<{ channelId?: string }>();
   const navigate = useNavigate();
+  const emailRouterState = useLocation().state as {
+    fromDeskList?: boolean;
+    returnToUrl?: string | null;
+  } | null;
   const { name: fromName, email: fromEmail } = parseFromField(email.from || '');
   const toList = email.to || [];
   const ccList = email.cc || [];
@@ -5696,11 +5688,17 @@ const EmailThreadItem = ({
         });
 
         if (channelIdParam) {
+          // In-place swap like the ticket-level unmerge — the opener stays directly behind.
           void navigate(`/support/${channelIdParam}/${response.data.newTicket.xyneId}`, {
+            replace: true,
             state: {
               conversationId: response.data.newTicket.conversationId,
               title: email.subject,
               ticketId: response.data.newTicket.ticketId,
+              ...(emailRouterState?.fromDeskList ? { fromDeskList: true } : {}),
+              ...(emailRouterState?.returnToUrl
+                ? { returnToUrl: emailRouterState.returnToUrl }
+                : {}),
             },
           });
         }

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -566,6 +566,9 @@ const SupportScreen = (): ReactElement => {
   }>();
   const supportBase = workspaceId ? `/${workspaceId}/support` : '/support';
   const navigate = useNavigate();
+  // Stamped by the desk list when it pushes a ticket: the list is the entry directly
+  // behind the detail, so closing the detail pops instead of stacking a second list.
+  const detailRouterState = useLocation().state as { fromDeskList?: boolean } | null;
   // Gate the Tickets shortcut the same way the main rail gates '/projects'.
   const canAccessProjects = useHasResourceAccess('PROJECTS');
   const [searchParams, setSearchParams] = useSearchParams();
@@ -3455,6 +3458,10 @@ const SupportScreen = (): ReactElement => {
                             size='sm'
                             variant='ghost'
                             onClick={() => {
+                              if (detailRouterState?.fromDeskList) {
+                                void navigate(-1);
+                                return;
+                              }
                               const back = selectedChannelId
                                 ? `${supportBase}/${selectedChannelId}`
                                 : supportBase;
@@ -4167,7 +4174,14 @@ export const SupportTicketDetail = ({
             : undefined,
         });
         if (sourceTicketXyneId && channelIdParam) {
-          void navigate(`${navBasePath ?? supportBase}/${channelIdParam}/${sourceTicketXyneId}`);
+          // Same in-place swap as prev/next — the opener stays directly behind us.
+          void navigate(`${navBasePath ?? supportBase}/${channelIdParam}/${sourceTicketXyneId}`, {
+            replace: true,
+            state: {
+              ...(routerState?.fromDeskList ? { fromDeskList: true } : {}),
+              ...(routerState?.returnToUrl ? { returnToUrl: routerState.returnToUrl } : {}),
+            },
+          });
         }
       } catch (err) {
         toast.error('Unmerge Failed', {
@@ -4176,7 +4190,14 @@ export const SupportTicketDetail = ({
         });
       }
     },
-    [channelIdParam, navigate, navBasePath, supportBase],
+    [
+      channelIdParam,
+      navigate,
+      navBasePath,
+      routerState?.fromDeskList,
+      routerState?.returnToUrl,
+      supportBase,
+    ],
   );
 
   const [allEmails] = useCachedQuery(
@@ -4327,10 +4348,15 @@ export const SupportTicketDetail = ({
     if (!t.xyneId) return;
     const nextChannelId = t.channelId || channelIdParam;
     if (!nextChannelId) return;
+    // Swap the ticket in place: pushing would bury the opener under the ticket chain
+    // and leave the back arrow one entry short of it.
     void navigate(`${navBasePath ?? supportBase}/${nextChannelId}/${t.xyneId}`, {
+      replace: true,
       state: {
         conversationId: t.conversationId,
         ticketId: t.id,
+        ...(routerState?.fromDeskList ? { fromDeskList: true } : {}),
+        ...(routerState?.returnToUrl ? { returnToUrl: routerState.returnToUrl } : {}),
       },
     });
   };
@@ -4386,15 +4412,17 @@ export const SupportTicketDetail = ({
       onBack();
       return;
     }
+    // The desk list is the entry directly behind us, so pop it — navigating to the
+    // list instead would leave the ticket sitting one Back away.
+    if (routerState?.fromDeskList) {
+      void navigate(-1);
+      return;
+    }
     // Ticket boards (Kanban, My Tickets) hand us the URL they came from, so
     // "back" returns to that board instead of dumping the user in the channel
     // inbox they never visited. Only same-origin paths are honoured — reject
     // absolute URLs and the "//host" / "/\host" protocol-relative forms so
     // router state can't drive an off-site redirect.
-    if (routerState?.fromDeskList) {
-      void navigate(-1);
-      return;
-    }
     const returnToUrl = routerState?.returnToUrl;
     if (returnToUrl && /^\/(?![/\\])/.test(returnToUrl)) {
       void navigate(returnToUrl, { replace: true });


### PR DESCRIPTION
Desk's ticket back arrow pushed a new history entry instead of popping, so browser Back landed on the ticket again and the two bounced forever — it now pops when the desk list opened the ticket, and replaces otherwise.