### PR TITLE
fix(claw): auto-retry ALL terminal transient failures, not just empty…

### DIFF
--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -4944,13 +4944,34 @@ async function processTask(
         requiresStructuredDelivery,
         stallProgress,
       );
+      // Route EVERY terminal transient failure into claw-auth's capacity-retry
+      // flow (scheduleProviderRetry — health-gated, auto-retries when the
+      // provider recovers) instead of dead-ending on a "work stopped" notice.
+      // We only reach here when isTransientProviderError(err) AND the whole
+      // provider fallback chain is exhausted — a platform availability problem
+      // (stall / 5xx / network), never a deterministic agent error or a user
+      // cancel (both handled by earlier branches). Previously only the
+      // EMPTY-completion capacity case was tagged, so stalls/timeouts — the
+      // dominant failure under load — got the terminal notice and no retry.
+      // Tagging emptyReason makes claw-auth's isCapacityFailure recognise it:
+      // interactive runs send an EMPTY result so it lands in the empty-result
+      // retry hook and the retry CARD replaces the notice; structured jobs keep
+      // their failed terminal (deliverable fails closed) and the tag routes them
+      // to the silent automation retry.
+      const transientDetail = err instanceof ProviderStallError
+        ? `model stopped responding for ${Math.round(err.idleMs / 1000)}s`
+        : (err instanceof Error ? err.message : String(err)).split(/\r?\n/, 1)[0]!.slice(0, 200);
       await sendCallback(callbackUrl, sessionToken, {
         sessionId,
         userId,
         conversationId: conversationId ?? null,
         agentSlug: agentSlug ?? null,
         fastMode: fastModeForCallback,
-        ...terminal,
+        ...(requiresStructuredDelivery
+          ? terminal
+          : { status: "completed" as const, result: "" }),
+        emptyReason: "provider_capacity" as const,
+        ...(transientDetail ? { emptyReasonDetail: transientDetail } : {}),
         ...(err instanceof ProviderStallError && err.toolsUsed.length > 0
           ? { toolsUsed: err.toolsUsed }
           : {}),

--- a/apps/xyne-claw/test/transient-terminal-autoretry.test.ts
+++ b/apps/xyne-claw/test/transient-terminal-autoretry.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const runSrc = readFileSync(resolve(here, "../src/routes/run.ts"), "utf8");
+
+// Regression pin: a TERMINAL transient failure (fallback chain fully exhausted,
+// isTransientProviderError true — stall / 5xx / network) must route into
+// claw-auth's capacity-retry flow (scheduleProviderRetry auto-retries when the
+// provider recovers) instead of dead-ending on a "work stopped" notice.
+//
+// The runtime signals this by tagging the callback emptyReason=provider_capacity
+// (which claw-auth's isCapacityFailure recognises). For interactive runs it also
+// emits an EMPTY result so it lands in claw-auth's empty-result retry hook and
+// the retry CARD replaces the notice; structured jobs keep their failed terminal.
+//
+// Before this, only the empty-completion capacity case was tagged, so stalls —
+// the dominant failure under provider saturation — never auto-retried.
+
+describe("terminal transient failure → capacity auto-retry", () => {
+  // The transient terminal branch: from `else if (isTransientProviderError(err))`
+  // up to the next `} else {`.
+  const branch = runSrc.slice(
+    runSrc.indexOf("} else if (isTransientProviderError(err)) {"),
+    runSrc.indexOf("} else {", runSrc.indexOf("} else if (isTransientProviderError(err)) {")),
+  );
+
+  it("finds exactly one transient terminal branch", () => {
+    expect(branch.length).toBeGreaterThan(0);
+    expect(runSrc.indexOf("} else if (isTransientProviderError(err)) {")).toBeGreaterThan(0);
+  });
+
+  it("tags the callback emptyReason=provider_capacity so claw-auth auto-retries", () => {
+    expect(branch).toContain('emptyReason: "provider_capacity" as const');
+  });
+
+  it("sends an EMPTY result for interactive runs (retry card replaces the notice)", () => {
+    // Interactive (!requiresStructuredDelivery) must be empty so it lands in the
+    // empty-result retry hook; structured keeps the failed `terminal`.
+    expect(branch).toContain('requiresStructuredDelivery\n          ? terminal\n          : { status: "completed" as const, result: "" }');
+  });
+
+  it("carries a human-readable detail (the stall duration / error) for the fallback notice", () => {
+    expect(branch).toContain("const transientDetail = err instanceof ProviderStallError");
+    expect(branch).toContain("model stopped responding for");
+    expect(branch).toContain("emptyReasonDetail: transientDetail");
+  });
+});


### PR DESCRIPTION
…-capacity

Under litellm saturation, the dominant failure is a STALL (first-token latency > the 120s stall watchdog → ProviderStallError), which took the transient-terminal path and produced a user-visible "⚠️ Work stopped … the model stopped responding for N seconds" notice with NO auto-retry.

Meanwhile the capacity auto-retry flow (scheduleProviderRetry — posts a card, polls provider health, re-dispatches when it recovers) only fired for the EMPTY-completion capacity case (finalProducedNothing && providerFellBack sets emptyReason=provider_capacity). Stalls / 5xx / network transients were never tagged, so they never auto-retried.

The transient terminal branch is reached ONLY when isTransientProviderError is true AND the whole provider fallback chain is exhausted — i.e. a platform availability problem, never a deterministic agent error or a user cancel (both handled by earlier branches). So EVERY callback from that branch is a legitimate auto-retry candidate.

Fix (single source-side tag; reuses the existing health-gated retry infra): tag the terminal transient callback emptyReason=provider_capacity so claw-auth's isCapacityFailure recognises it. Interactive runs send an EMPTY result so they land in the empty-result retry hook and the retry CARD replaces the notice; structured jobs keep their failed terminal (deliverable fails closed) and the tag routes them to the silent automation retry. emptyReasonDetail carries the stall duration / error for the fallback notice.

No claw-auth change needed — the empty-result (:6213), automation (:5565), and failed-status (:5231) hooks already schedule the retry on emptyReason=provider_capacity. Deterministic errors, refusals and user cancels are unaffected (they don't reach this branch).

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
