### PR TITLE
feat: XYNE-59439 Add labels , Template based summary , action buttons for calls

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -1806,6 +1806,61 @@ export class CallController {
   };
 
   /**
+   * POST /api/calls/:callId/regenerate-summary
+   * Rewrite a regular call's detailed summary with a different template.
+   * Recordings keep their own creator-only endpoint at
+   * /recordings/:callId/generate-summary; this one is open to the call's audience,
+   * matching who can already open the summary it rewrites.
+   */
+  regenerateCallSummary = async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
+    const { callId } = req.params;
+
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    try {
+      const input = RegenerateHeadlessSummarySchema.parse(req.body);
+      const call = await repositories.calls.findByExternalId(callId);
+
+      if (
+        !call ||
+        call.callType === CallType.HEADLESS ||
+        !workspaceId ||
+        call.workspaceId !== workspaceId
+      ) {
+        res.status(404).json({ success: false, error: 'Call not found' });
+        return;
+      }
+      if (!(await this.isCallAudience(call, userId))) {
+        res.status(403).json({ success: false, error: 'You do not have access to this call' });
+        return;
+      }
+
+      const result = await transcriptService.regenerateCallSummary(call, input.summaryTemplateId);
+      if (!result) {
+        res.status(404).json({
+          success: false,
+          error: 'Transcript is not available or summary generation failed',
+        });
+        return;
+      }
+
+      res.json({ success: true, ...result });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        res.status(400).json({ success: false, error: error.errors[0]?.message });
+        return;
+      }
+      logger.error(`[${callId}] Failed to regenerate call summary`, error);
+      res.status(500).json({ success: false, error: 'Failed to regenerate call summary' });
+    }
+  };
+
+  /**
    * GET /api/calls/:callId/download-transcript
    * Download call transcript as text file (formatted .txt only)
    */

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -67,6 +67,10 @@ const UpdateHeadlessRecordingSchema = z
     message: 'At least one recording field is required',
   });
 
+const UpdateCallLabelsSchema = z.object({
+  labels: z.array(z.string().trim().min(1).max(80)).max(50),
+});
+
 const RegenerateHeadlessSummarySchema = z.object({
   summaryTemplateId: z.string().trim().min(1),
   // Optional explicit model tier (e.g. the "Try the thinking model" button).
@@ -1643,6 +1647,59 @@ export class CallController {
       }
       logger.error('Failed to update recording title:', error);
       res.status(500).json({ success: false, error: 'Failed to update recording' });
+    }
+  };
+
+  /**
+   * PATCH /api/calls/:callId/labels
+   * Replace a call's labels. HEADLESS recordings keep their own endpoint
+   * (updateRecordingTitle) because they update title/markedItems/template in the
+   * same request; this one only ever touches labels.
+   */
+  updateCallLabels = async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
+    const { callId } = req.params;
+
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    try {
+      const input = UpdateCallLabelsSchema.parse(req.body);
+      const call = await repositories.calls.findByExternalId(callId);
+
+      if (
+        !call ||
+        call.callType === CallType.HEADLESS ||
+        !workspaceId ||
+        call.workspaceId !== workspaceId
+      ) {
+        res.status(404).json({ success: false, error: 'Call not found' });
+        return;
+      }
+      if (!(await this.isCallAudience(call, userId))) {
+        res.status(403).json({ success: false, error: 'You do not have access to this call' });
+        return;
+      }
+
+      // Labels arrive as a mix of already-applied Tag ids and raw text just typed
+      // in the dashboard — resolve creates a real Tag row (method=manual) for any
+      // raw text, so Call.labels only ever holds Tag ids, never bare strings.
+      const labels = await noteTakerTranscriptService.resolveLabelsToTagIds(call, input.labels);
+      await repositories.calls.update(call.id, { labels });
+
+      // Echo the resolved ids: the caller optimistically holds the raw text it
+      // typed, and the detail screen has no live query to correct it from.
+      res.json({ success: true, labels });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        res.status(400).json({ success: false, error: error.errors[0]?.message });
+        return;
+      }
+      logger.error('Failed to update call labels:', error);
+      res.status(500).json({ success: false, error: 'Failed to update labels' });
     }
   };
 

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -3089,7 +3089,10 @@ export class CallController {
       },
     });
 
+    // A call carries shares under whichever entity type it was shared as; clear both
+    // so a deleted call can never leave a live access row behind.
     await repositories.entityAccess.deleteForResource(ShareableEntityType.NOTE_TAKER, call.id);
+    await repositories.entityAccess.deleteForResource(ShareableEntityType.CALL, call.id);
 
     // Delete the call record
     await repositories.calls.delete(call.id);

--- a/apps/backend/src/controllers/recordingEmailController.ts
+++ b/apps/backend/src/controllers/recordingEmailController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { ChannelType, RecordingType } from '@xyne/shared';
+import { CallType, ChannelType, RecordingType } from '@xyne/shared';
 import z from 'zod';
 import { db } from '@/database/client';
 import { repositories } from '@/database/repositories';
@@ -27,6 +27,10 @@ const RECORDING_EMAIL_ATTACHMENT_KINDS = [
 
 type RecordingEmailAttachmentKind = (typeof RECORDING_EMAIL_ATTACHMENT_KINDS)[number];
 type RecordingCall = NonNullable<Awaited<ReturnType<typeof repositories.calls.findByExternalId>>>;
+
+/** Recordings and regular calls share these endpoints, so copy names whichever it is. */
+const subjectFor = (call: Pick<RecordingCall, 'callType'>): string =>
+  call.callType === CallType.HEADLESS ? 'recording' : 'call';
 
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const MAX_TOTAL_ATTACHMENT_BYTES = 25 * 1024 * 1024;
@@ -596,8 +600,9 @@ export class RecordingEmailController {
         ...(sender ? { channelId: sender.channelId } : { channelId: null }),
         ...(!sender
           ? {
-              unavailableReason:
-                'Connect an email account matching your Xyne account before sending recording recaps.',
+              unavailableReason: `Connect an email account matching your Xyne account before sending ${subjectFor(
+                call,
+              )} recaps.`,
             }
           : {}),
         attachments,

--- a/apps/backend/src/controllers/recordingEmailController.ts
+++ b/apps/backend/src/controllers/recordingEmailController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { CallType, ChannelType, RecordingType } from '@xyne/shared';
+import { ChannelType, RecordingType } from '@xyne/shared';
 import z from 'zod';
 import { db } from '@/database/client';
 import { repositories } from '@/database/repositories';
@@ -8,7 +8,10 @@ import type { OutgoingAttachment } from '@/integrations/core/baseMailReplySender
 import { callRecordingService } from '@/services/callRecordingService';
 import { callShareService } from '@/services/callShareService';
 import { canvasAuthService } from '@/services/canvasAuthService';
-import { convertBlockNoteToMarkdown } from '@/services/canvasService';
+import {
+  convertBlockNoteToMarkdown,
+  resolveDetailedSummaryCanvasId,
+} from '@/services/canvasService';
 import { transcriptService } from '@/services/transcriptService';
 import { normalizeStoragePath } from '@xyne/storage';
 import { extractEmailAddress } from '@/utils/email';
@@ -171,15 +174,13 @@ export class RecordingEmailController {
     }
 
     const call = await repositories.calls.findByExternalId(callId);
-    if (
-      !call ||
-      call.callType !== CallType.HEADLESS ||
-      (call.workspaceId !== null && call.workspaceId !== workspaceId)
-    ) {
+    if (!call || (call.workspaceId !== null && call.workspaceId !== workspaceId)) {
       throw new RecordingEmailError('Recording not found', 404);
     }
 
-    const canView = await callShareService.canView(call, userId, workspaceId);
+    // Recordings and regular calls both come through here; canViewCall applies
+    // whichever visibility rule the call's own type uses.
+    const canView = await callShareService.canViewCall(call, userId, workspaceId);
     if (!canView) {
       throw new RecordingEmailError('Access denied', 403);
     }
@@ -426,6 +427,8 @@ export class RecordingEmailController {
       }
     }
 
+    // Notes are a recordings-only canvas, so a regular call simply offers one
+    // attachment fewer — metadataCanvasId returns null and the descriptor drops out.
     const metadata = call.metadata;
     const [notes, detailedSummary] = await Promise.all([
       this.getCanvasDescriptor(
@@ -435,7 +438,7 @@ export class RecordingEmailController {
         'notes'
       ),
       this.getCanvasDescriptor(
-        metadataCanvasId(metadata, 'detailedSummaryCanvasId'),
+        await resolveDetailedSummaryCanvasId(call),
         workspaceId,
         userId,
         'detailed-summary'
@@ -551,7 +554,7 @@ export class RecordingEmailController {
     if (selected.has('detailed-summary')) {
       attachments.push(
         await this.buildCanvasAttachment(
-          metadataCanvasId(metadata, 'detailedSummaryCanvasId'),
+          await resolveDetailedSummaryCanvasId(call),
           workspaceId,
           userId,
           'detailed-summary'

--- a/apps/backend/src/controllers/recordingGoogleDocController.ts
+++ b/apps/backend/src/controllers/recordingGoogleDocController.ts
@@ -4,9 +4,11 @@ import { google } from 'googleapis';
 import z from 'zod';
 import { db } from '@/database/client';
 import { repositories } from '@/database/repositories';
-import { callShareService } from '@/services/callShareService';
 import { decrypt, encrypt } from '@/services/encryptionService';
-import { convertBlockNoteToMarkdown } from '@/services/canvasService';
+import {
+  convertBlockNoteToMarkdown,
+  resolveDetailedSummaryCanvasId,
+} from '@/services/canvasService';
 import { GoogleDocsApiError, googleDocsService } from '@/services/googleDocsService';
 import { readFromYSweet } from '@/utils/ysweetUtils';
 import {
@@ -106,6 +108,13 @@ async function recordCreatedGoogleDoc(
   });
 }
 
+/** Owner-only, for recordings and calls alike. */
+const canExportCall = (call: { createdByUserId: string }, userId: string): boolean =>
+  call.createdByUserId === userId;
+
+const exportDeniedMessage = (call: { callType: string }): string =>
+  `Only the ${call.callType === HEADLESS_CALL_TYPE ? 'recording' : 'call'} owner can export it`;
+
 export class RecordingGoogleDocController {
   context = async (req: Request, res: Response): Promise<void> => {
     try {
@@ -123,29 +132,18 @@ export class RecordingGoogleDocController {
       const { callId } = parsedParams.data;
 
       const call = await repositories.calls.findByExternalId(callId);
-      if (
-        !call ||
-        call.callType !== HEADLESS_CALL_TYPE ||
-        (call.workspaceId !== null && call.workspaceId !== workspaceId)
-      ) {
+      if (!call || (call.workspaceId !== null && call.workspaceId !== workspaceId)) {
         res.status(404).json({ success: false, error: 'Recording not found' });
         return;
       }
-      if (
-        call.createdByUserId !== userId ||
-        !(await callShareService.canView(call, userId, workspaceId))
-      ) {
-        res.status(403).json({ success: false, error: 'Only the recording owner can export it' });
+      if (!canExportCall(call, userId)) {
+        res.status(403).json({ success: false, error: exportDeniedMessage(call) });
         return;
       }
 
       const accessToken = await getRecordingDocAccessToken(userId);
       const canExport = !!accessToken;
-      const metadata = call.metadata as Record<string, unknown> | null;
-      const detailedSummaryCanvasId =
-        typeof metadata?.detailedSummaryCanvasId === 'string'
-          ? metadata.detailedSummaryCanvasId
-          : null;
+      const detailedSummaryCanvasId = await resolveDetailedSummaryCanvasId(call);
       const detailedSummary = await readDetailedSummary(detailedSummaryCanvasId, workspaceId).catch(
         () => null,
       );
@@ -158,7 +156,9 @@ export class RecordingGoogleDocController {
         // modal lists them so a second export is a deliberate choice, not a
         // duplicate someone makes because the earlier doc is out of sight.
         documents: readRecordingGoogleDocLinks(call.metadata),
-        unavailableReason: 'Connect Google Docs to create a document from this recording.',
+        unavailableReason: `Connect Google Docs to create a document from this ${
+          call.callType === HEADLESS_CALL_TYPE ? 'recording' : 'call'
+        }.`,
       });
     } catch (error) {
       logger.error('[RecordingGoogleDoc] Failed to prepare export context', { error });
@@ -183,20 +183,13 @@ export class RecordingGoogleDocController {
 
     try {
       const call = await repositories.calls.findByExternalId(callId);
-      if (
-        !call ||
-        call.callType !== HEADLESS_CALL_TYPE ||
-        (call.workspaceId !== null && call.workspaceId !== workspaceId)
-      ) {
+      if (!call || (call.workspaceId !== null && call.workspaceId !== workspaceId)) {
         res.status(404).json({ success: false, error: 'Recording not found' });
         return;
       }
 
-      if (
-        call.createdByUserId !== userId ||
-        !(await callShareService.canView(call, userId, workspaceId))
-      ) {
-        res.status(403).json({ success: false, error: 'Only the recording owner can export it' });
+      if (!canExportCall(call, userId)) {
+        res.status(403).json({ success: false, error: exportDeniedMessage(call) });
         return;
       }
 
@@ -209,11 +202,7 @@ export class RecordingGoogleDocController {
         return;
       }
 
-      const metadata = call.metadata as Record<string, unknown> | null;
-      const detailedSummaryCanvasId =
-        typeof metadata?.detailedSummaryCanvasId === 'string'
-          ? metadata.detailedSummaryCanvasId
-          : null;
+      const detailedSummaryCanvasId = await resolveDetailedSummaryCanvasId(call);
       const detailedSummary = await readDetailedSummary(detailedSummaryCanvasId, workspaceId).catch(
         (error) => {
           logger.warn('[RecordingGoogleDoc] Could not read detailed summary canvas', {

--- a/apps/backend/src/database/acl/tables/calls-acl.ts
+++ b/apps/backend/src/database/acl/tables/calls-acl.ts
@@ -12,13 +12,14 @@ export class CallsACL extends BaseQueryACL<
   }
 
   /**
-   * Ids of calls (headless recordings) shared with `ctx.userId` via `entity_access`
-   * (NOTE_TAKER), directly or through a userGroup/channel they belong to. `entityId`
-   * has no FK to `calls.id` (polymorphic), so this can't be expressed as a Prisma
-   * relation and is resolved as a separate lookup instead — mirrors the Zero-side
-   * `CallsACL.canSelect` `exists('shares', ...)` clause.
+   * Ids of calls shared with `ctx.userId` via `entity_access`, directly or through a
+   * userGroup/channel they belong to, split by entity type: recordings share as
+   * NOTE_TAKER and regular calls as CALL, so neither can widen the other's audience.
+   * `entityId` has no FK to `calls.id` (polymorphic), so this can't be expressed as a
+   * Prisma relation and is resolved as a separate lookup instead — mirrors the
+   * Zero-side `CallsACL.canSelect` `exists('shares', ...)` clauses.
    */
-  private async getSharedCallIds(): Promise<string[]> {
+  private async getSharedCallIds(): Promise<{ recordingIds: string[]; callIds: string[] }> {
     const [groupMappings, channelParticipations] = await Promise.all([
       this.prisma.userGroupMapping.findMany({
         where: { userId: this.ctx.userId },
@@ -35,7 +36,9 @@ export class CallsACL extends BaseQueryACL<
     const shares = await this.prisma.entityAccess.findMany({
       where: {
         workspaceId: this.ctx.workspaceId,
-        shareableEntityType: ShareableEntityType.NOTE_TAKER,
+        shareableEntityType: {
+          in: [ShareableEntityType.NOTE_TAKER, ShareableEntityType.CALL],
+        },
         entityUserAccess: { not: EntityUserAccess.REVOKED },
         OR: [
           { userId: this.ctx.userId },
@@ -43,9 +46,16 @@ export class CallsACL extends BaseQueryACL<
           ...(channelIds.length ? [{ channelId: { in: channelIds } }] : []),
         ],
       },
-      select: { entityId: true },
+      select: { entityId: true, shareableEntityType: true },
     })
-    return shares.map((s) => s.entityId)
+    return {
+      recordingIds: shares
+        .filter((s) => s.shareableEntityType === ShareableEntityType.NOTE_TAKER)
+        .map((s) => s.entityId),
+      callIds: shares
+        .filter((s) => s.shareableEntityType === ShareableEntityType.CALL)
+        .map((s) => s.entityId),
+    }
   }
 
   async getWhereClause(): Promise<Prisma.CallWhereInput> {
@@ -61,7 +71,7 @@ export class CallsACL extends BaseQueryACL<
       }
     }
 
-    const sharedCallIds = await this.getSharedCallIds()
+    const { recordingIds, callIds } = await this.getSharedCallIds()
 
     return {
       AND: [
@@ -70,8 +80,11 @@ export class CallsACL extends BaseQueryACL<
             { createdByUserId: this.ctx.userId },
             { participants: { some: { userId: this.ctx.userId } } },
             { channel: { participants: { some: { userId: this.ctx.userId } } } },
-            ...(sharedCallIds.length
-              ? [{ callType: CallType.HEADLESS, id: { in: sharedCallIds } }]
+            ...(recordingIds.length
+              ? [{ callType: CallType.HEADLESS, id: { in: recordingIds } }]
+              : []),
+            ...(callIds.length
+              ? [{ callType: { not: CallType.HEADLESS }, id: { in: callIds } }]
               : []),
             { callType: CallType.HEADLESS, visibility: CallVisibility.PUBLIC },
           ],

--- a/apps/backend/src/routes/calls.ts
+++ b/apps/backend/src/routes/calls.ts
@@ -114,8 +114,12 @@ router.get('/:callId/participants', callController.getCallParticipants);
 // Get call chat history (for recording detail page)
 router.get('/:callId/chat-history', callController.getCallChatHistory);
 
-// Update a call's labels (any workspace member; recordings use /recordings/:callId)
+// Update a call's labels (the call's audience; recordings use /recordings/:callId)
 router.patch('/:callId/labels', callController.updateCallLabels);
+
+// Regenerate a call's detailed summary with a different template (recordings use
+// /recordings/:callId/generate-summary)
+router.post('/:callId/regenerate-summary', callController.regenerateCallSummary);
 
 // Leave call endpoint
 router.post('/:callId/leave', callController.leaveCall);

--- a/apps/backend/src/routes/calls.ts
+++ b/apps/backend/src/routes/calls.ts
@@ -121,6 +121,17 @@ router.patch('/:callId/labels', callController.updateCallLabels);
 // /recordings/:callId/generate-summary)
 router.post('/:callId/regenerate-summary', callController.regenerateCallSummary);
 
+// Share a call with people, groups or channels. Same handler as the recordings
+// route above — the service picks the entity type off the call's own type.
+router.post('/:callId/sharing', recordingSharingController.manage);
+
+// Draft a follow-up email and export to Google Docs. Same handlers as the
+// /recordings routes above; both controllers branch on the call's own type.
+router.get('/:callId/email-compose-context', recordingEmailController.getComposeContext);
+router.post('/:callId/send-email', recordingEmailController.sendRecordingEmail);
+router.get('/:callId/google-doc-compose-context', recordingGoogleDocController.context);
+router.post('/:callId/export-google-doc', recordingGoogleDocController.export);
+
 // Leave call endpoint
 router.post('/:callId/leave', callController.leaveCall);
 

--- a/apps/backend/src/routes/calls.ts
+++ b/apps/backend/src/routes/calls.ts
@@ -114,6 +114,9 @@ router.get('/:callId/participants', callController.getCallParticipants);
 // Get call chat history (for recording detail page)
 router.get('/:callId/chat-history', callController.getCallChatHistory);
 
+// Update a call's labels (any workspace member; recordings use /recordings/:callId)
+router.patch('/:callId/labels', callController.updateCallLabels);
+
 // Leave call endpoint
 router.post('/:callId/leave', callController.leaveCall);
 

--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -1916,6 +1916,19 @@ A comprehensive detailed summary has been generated from this call.
   /**
    * Update call message metadata with canvas URL (generic method)
    */
+  /**
+   * Point a call's message at a newly created detailed-summary canvas. Only needed
+   * for a first generation — a rewrite edits the canvas in place, so the URL the
+   * message already carries stays correct.
+   */
+  async linkDetailedSummaryToCallMessage(
+    conversationId: string,
+    callId: string,
+    canvasUrl: string,
+  ): Promise<void> {
+    await this.updateCallMessageMetadata(conversationId, callId, 'detailedSummaryCanvasUrl', canvasUrl);
+  }
+
   private async updateCallMessageMetadata(
     conversationId: string,
     callId: string,

--- a/apps/backend/src/services/callLabelService.ts
+++ b/apps/backend/src/services/callLabelService.ts
@@ -1,0 +1,97 @@
+import type { Call } from '@prisma/client';
+import { logger } from '@/utils/logger';
+import { tagService, TagServiceError } from '@/tags/service';
+import { tagRepository } from '@/database/repositories/tagRepository';
+import { normalizeTagName, TAG_FORMAT_REGEX, TagMethod } from '@xyne/shared';
+
+// Generic Tag framework sourceType/category for call labels. No configKey is
+// used, so tagService.createTag skips the "category must be configured" check
+// entirely (see assertManualCategoryOrOverride).
+const CALL_TAG_SOURCE_TYPE = 'CALL';
+const CALL_LABEL_CATEGORY = 'topic';
+
+/** Cap on one generation run, so a verbose LLM reply can't flood Call.labels. */
+const MAX_GENERATED_LABELS = 4;
+
+/**
+ * Turns label text into Tag rows on a call. Shared by both transcript pipelines
+ * — the note-taker one for HEADLESS recordings and processCallWithSummary for
+ * regular calls — so generated and typed labels mint identical rows either way.
+ *
+ * Deliberately holds no reference to transcriptService: that service calls into
+ * here, and the note-taker service calls into both.
+ */
+class CallLabelService {
+  /** Normalize a label into the Tag framework's required format (lowercase, hyphenated). */
+  slugifyLabel(raw: string): string | null {
+    const slug = normalizeTagName(raw);
+    if (!slug) return null;
+    const safe = /^[a-z]/.test(slug) ? slug : `l-${slug}`;
+    return TAG_FORMAT_REGEX.test(safe) ? safe : null;
+  }
+
+  /**
+   * Reuse an existing label tag for this call if a prior run already created
+   * it, else create it via the generic Tag framework.
+   */
+  async getOrCreateLabelTag(call: Call, slug: string, method: TagMethod): Promise<string | null> {
+    const existing = await tagRepository.findActiveTag(call.id, CALL_TAG_SOURCE_TYPE, CALL_LABEL_CATEGORY, slug);
+    if (existing) {
+      // Typing a label an LLM/automated pass only suggested asserts it just as the tick button does.
+      if (method === TagMethod.MANUAL && existing.method !== TagMethod.MANUAL) {
+        await tagService.confirmTag(existing.id, call.workspaceId!);
+      }
+      return existing.id;
+    }
+
+    try {
+      const created = await tagService.createTag(
+        call.id,
+        CALL_TAG_SOURCE_TYPE,
+        call.workspaceId!,
+        CALL_LABEL_CATEGORY,
+        slug,
+        method,
+      );
+      return created.id;
+    } catch (error) {
+      // 409 = another run/racing worker created the same tag between the find and create above.
+      if (error instanceof TagServiceError && error.status === 409) {
+        const raced = await tagRepository.findActiveTag(call.id, CALL_TAG_SOURCE_TYPE, CALL_LABEL_CATEGORY, slug);
+        return raced?.id ?? null;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Persist LLM-generated label text as `llm` Tag rows, returning the ids for
+   * Call.labels. Returns [] on any failure — callers treat that as "nothing to
+   * add", never clobbering a previously-saved good result.
+   */
+  async persistGeneratedLabels(
+    call: Call,
+    rawLabels: string[],
+    method: TagMethod = TagMethod.LLM,
+    logPath?: string,
+  ): Promise<string[]> {
+    const callId = call.externalId;
+    const tagIds: string[] = [];
+
+    for (const rawLabel of rawLabels) {
+      if (tagIds.length >= MAX_GENERATED_LABELS) break;
+      const slug = this.slugifyLabel(rawLabel);
+      if (!slug) continue;
+      try {
+        const tagId = await this.getOrCreateLabelTag(call, slug, method);
+        if (tagId && !tagIds.includes(tagId)) tagIds.push(tagId);
+      } catch (error) {
+        logger.error(`[${callId}] label_tag_failed`, { label: slug, path: logPath, error });
+      }
+    }
+
+    return tagIds;
+  }
+}
+
+export const callLabelService = new CallLabelService();

--- a/apps/backend/src/services/callLabelService.ts
+++ b/apps/backend/src/services/callLabelService.ts
@@ -14,12 +14,8 @@ const CALL_LABEL_CATEGORY = 'topic';
 const MAX_GENERATED_LABELS = 4;
 
 /**
- * Turns label text into Tag rows on a call. Shared by both transcript pipelines
- * — the note-taker one for HEADLESS recordings and processCallWithSummary for
- * regular calls — so generated and typed labels mint identical rows either way.
- *
- * Deliberately holds no reference to transcriptService: that service calls into
- * here, and the note-taker service calls into both.
+ * Turns label text into Tag rows on a call, for both transcript pipelines.
+ * Imports nothing from transcriptService on purpose — that service calls in here.
  */
 class CallLabelService {
   /** Normalize a label into the Tag framework's required format (lowercase, hyphenated). */
@@ -30,10 +26,7 @@ class CallLabelService {
     return TAG_FORMAT_REGEX.test(safe) ? safe : null;
   }
 
-  /**
-   * Reuse an existing label tag for this call if a prior run already created
-   * it, else create it via the generic Tag framework.
-   */
+  /** Reuses this call's existing tag for `slug`, else creates one. */
   async getOrCreateLabelTag(call: Call, slug: string, method: TagMethod): Promise<string | null> {
     const existing = await tagRepository.findActiveTag(call.id, CALL_TAG_SOURCE_TYPE, CALL_LABEL_CATEGORY, slug);
     if (existing) {
@@ -64,11 +57,7 @@ class CallLabelService {
     }
   }
 
-  /**
-   * Persist LLM-generated label text as `llm` Tag rows, returning the ids for
-   * Call.labels. Returns [] on any failure — callers treat that as "nothing to
-   * add", never clobbering a previously-saved good result.
-   */
+  /** Persists generated label text as Tag rows of `method`, returning ids for Call.labels. */
   async persistGeneratedLabels(
     call: Call,
     rawLabels: string[],

--- a/apps/backend/src/services/callShareService.ts
+++ b/apps/backend/src/services/callShareService.ts
@@ -1,6 +1,7 @@
 import { type Call } from '@prisma/client';
+import { repositories } from '@/database/repositories';
 import { entityAccessService } from '@/services/entityAccessService';
-import { CallVisibility, ShareableEntityType } from '@xyne/shared';
+import { CallType, CallVisibility, ShareableEntityType } from '@xyne/shared';
 
 /**
  * Read-side check for HEADLESS call (recording) visibility. Recording sharing
@@ -14,6 +15,30 @@ export class CallShareService {
     return entityAccessService.hasActiveShare({
       workspaceId,
       shareableEntityType: ShareableEntityType.NOTE_TAKER,
+      entityId: call.id,
+      userId,
+    });
+  }
+
+  /**
+   * Read-side visibility for a call of either kind. A recording is private until
+   * shared, so it defers to canView above; a regular call is visible to its host,
+   * anyone who took part, the channel it happened in, and anyone it was shared with.
+   */
+  async canViewCall(call: Call, userId: string, workspaceId: string): Promise<boolean> {
+    if (call.workspaceId !== workspaceId) return false;
+    if (call.createdByUserId === userId) return true;
+    if (call.callType === CallType.HEADLESS) return this.canView(call, userId, workspaceId);
+    if (await repositories.calls.findParticipant(call.id, userId)) return true;
+    if (
+      call.channelId &&
+      (await repositories.channelParticipants.isParticipant(call.channelId, userId))
+    ) {
+      return true;
+    }
+    return entityAccessService.hasActiveShare({
+      workspaceId,
+      shareableEntityType: ShareableEntityType.CALL,
       entityId: call.id,
       userId,
     });

--- a/apps/backend/src/services/canvasService.ts
+++ b/apps/backend/src/services/canvasService.ts
@@ -659,3 +659,19 @@ export async function findExistingDetailedSummaryCanvas(
     return null;
   }
 }
+
+/**
+ * A call's detailed-summary canvas id. Recordings record it on their own row, and
+ * a shared call has it copied there too; otherwise fall back to finding the canvas
+ * by the call it summarizes, which is how a regular call's is normally reached.
+ */
+export async function resolveDetailedSummaryCanvasId(call: {
+  externalId: string;
+  metadata: unknown;
+}): Promise<string | null> {
+  const metadata = call.metadata as Record<string, unknown> | null;
+  const stamped = metadata?.['detailedSummaryCanvasId'];
+  if (typeof stamped === 'string' && stamped.trim()) return stamped;
+  const found = await findExistingDetailedSummaryCanvas(call.externalId);
+  return found?.canvasId ?? null;
+}

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -12,20 +12,14 @@ import { callDocumentService, numberTranscriptSegments, type CitationContext } f
 import { findExistingDetailedSummaryCanvas } from '@/services/canvasService';
 import { canvasAuthService } from '@/services/canvasAuthService';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
-import { tagService, TagServiceError } from '@/tags/service';
 import { tagRepository } from '@/database/repositories/tagRepository';
-import { normalizeTagName, TAG_FORMAT_REGEX, TagMethod, EntityUserAccess } from '@xyne/shared';
+import { callLabelService } from '@/services/callLabelService';
+import { TagMethod, EntityUserAccess } from '@xyne/shared';
 import { recordingSharingService } from '@/services/recordingSharingService';
 import {
   mergeRecordingSummaryMarkedItems,
   type RecordingSummaryMarkedItem,
 } from '@/services/recordingSummaryMarkedItems';
-
-// Generic Tag framework sourceType/category for note-taker call labels. No
-// configKey is used, so tagService.createTag skips the "category must be
-// configured" check entirely (see assertManualCategoryOrOverride).
-const NOTE_TAKER_TAG_SOURCE_TYPE = 'CALL';
-const NOTE_TAKER_LABEL_CATEGORY = 'topic';
 
 interface DetailedSummaryCanvasResult {
   canvasId: string;
@@ -138,7 +132,12 @@ class NoteTakerTranscriptService {
       // for generated decisions/actions and their transcript timestamps.
       const summaryPromise = this.generateAndSaveSummary(call, formattedTranscript, summaryModelType);
       const detailedSummaryPromise = this.generateDetailedSummaryCanvas(call, formattedTranscript, undefined, summaryModelType);
-      const labelsPromise = this.generateAndSaveLabels(call, formattedTranscript);
+      const labelsPromise = transcriptService.generateAndSaveLabels(
+        call,
+        formattedTranscript,
+        TagMethod.LLM,
+        'note_taker',
+      );
 
       const saveLabelsPromise = labelsPromise.then(async (labelIds) => {
         if (labelIds.length === 0) return labelIds;
@@ -247,7 +246,12 @@ class NoteTakerTranscriptService {
     const formattedTranscript = await transcriptService.getTranscriptContent(call.externalId);
     if (!formattedTranscript) return null;
 
-    const labelIds = await this.generateAndSaveLabels(call, formattedTranscript, TagMethod.AUTOMATED);
+    const labelIds = await transcriptService.generateAndSaveLabels(
+      call,
+      formattedTranscript,
+      TagMethod.AUTOMATED,
+      'note_taker',
+    );
     if (labelIds.length > 0) {
       await repositories.calls.appendLabels(call.id, labelIds);
     }
@@ -879,49 +883,6 @@ class NoteTakerTranscriptService {
   }
 
   /**
-   * Generate a small set of topical labels and persist each as a generic Tag
-   * row (sourceId = call.id, sourceType = 'CALL'), returning the resulting
-   * tag ids for Call.labels. Returns [] on any failure — callers treat that
-   * as "nothing to add", never clobbering a previously-saved good result.
-   */
-  private async generateAndSaveLabels(
-    call: Call,
-    formattedTranscript: string,
-    method: TagMethod = TagMethod.LLM,
-  ): Promise<string[]> {
-    const callId = call.externalId;
-    if (!call.workspaceId) {
-      logger.warn(`[${callId}] labels_skipped`, { reason: 'no_workspace', path: 'note_taker' });
-      return [];
-    }
-
-    const labels = await transcriptService.generateCallLabels(formattedTranscript, callId).catch((err) => {
-      logger.error(`[${callId}] generate_labels_threw`, {
-        path: 'note_taker',
-        error: err,
-        stack: err instanceof Error ? err.stack : undefined,
-      });
-      return [] as string[];
-    });
-    if (labels.length === 0) return [];
-
-    const tagIds: string[] = [];
-    for (const rawLabel of labels) {
-      if (tagIds.length >= 4) break;
-      const slug = this.slugifyLabel(rawLabel);
-      if (!slug) continue;
-      try {
-        const tagId = await this.getOrCreateLabelTag(call, slug, method);
-        if (tagId && !tagIds.includes(tagId)) tagIds.push(tagId);
-      } catch (error) {
-        logger.error(`[${callId}] label_tag_failed`, { label: slug, path: 'note_taker', error });
-      }
-    }
-
-    return tagIds;
-  }
-
-  /**
    * Labels arrive as a mix of Tag ids (already applied) and raw text (just typed), and
    * leave as ids only — typed text becomes a real Tag marked `manual`.
    */
@@ -937,61 +898,13 @@ class NoteTakerTranscriptService {
         ids.push(entry);
         continue;
       }
-      const slug = this.slugifyLabel(entry);
+      const slug = callLabelService.slugifyLabel(entry);
       if (!slug) continue;
-      const id = await this.getOrCreateLabelTag(call, slug, TagMethod.MANUAL);
+      const id = await callLabelService.getOrCreateLabelTag(call, slug, TagMethod.MANUAL);
       if (id) ids.push(id);
     }
 
     return [...new Set(ids)];
-  }
-
-  /** Normalize an LLM-generated label into the Tag framework's required format (lowercase, hyphenated). */
-  private slugifyLabel(raw: string): string | null {
-    const slug = normalizeTagName(raw);
-    if (!slug) return null;
-    const safe = /^[a-z]/.test(slug) ? slug : `l-${slug}`;
-    return TAG_FORMAT_REGEX.test(safe) ? safe : null;
-  }
-
-  /**
-   * Reuse an existing label tag for this call if a prior run already created
-   * it, else create it via the generic Tag framework. No configKey is passed,
-   * so tagService.createTag doesn't require a workspace-level TagsConfig for
-   * the "topic" category (see assertManualCategoryOrOverride).
-   */
-  private async getOrCreateLabelTag(
-    call: Call,
-    slug: string,
-    method: TagMethod,
-  ): Promise<string | null> {
-    const existing = await tagRepository.findActiveTag(call.id, NOTE_TAKER_TAG_SOURCE_TYPE, NOTE_TAKER_LABEL_CATEGORY, slug);
-    if (existing) {
-      // Typing a label an LLM/automated pass only suggested asserts it just as the tick button does.
-      if (method === TagMethod.MANUAL && existing.method !== TagMethod.MANUAL) {
-        await tagService.confirmTag(existing.id, call.workspaceId!);
-      }
-      return existing.id;
-    }
-
-    try {
-      const created = await tagService.createTag(
-        call.id,
-        NOTE_TAKER_TAG_SOURCE_TYPE,
-        call.workspaceId!,
-        NOTE_TAKER_LABEL_CATEGORY,
-        slug,
-        method,
-      );
-      return created.id;
-    } catch (error) {
-      // 409 = another run/racing worker created the same tag between the find and create above.
-      if (error instanceof TagServiceError && error.status === 409) {
-        const raced = await tagRepository.findActiveTag(call.id, NOTE_TAKER_TAG_SOURCE_TYPE, NOTE_TAKER_LABEL_CATEGORY, slug);
-        return raced?.id ?? null;
-      }
-      throw error;
-    }
   }
 
   // Indexing only — not a message post. Uses the Call's own denormalized

--- a/apps/backend/src/services/notificationService.ts
+++ b/apps/backend/src/services/notificationService.ts
@@ -1454,6 +1454,7 @@ class NotificationService {
     actorId: string,
     actorName: string,
     actorAction: 'recording_shared' | 'recording_access_revoked',
+    subject: string = 'recording',
   ): Promise<{ deliveredUserIds: string[] }> {
     const recipientIds = recipientUserIds.filter(id => id !== actorId);
 
@@ -1468,8 +1469,8 @@ class NotificationService {
 
     const isRevoked = actorAction === 'recording_access_revoked';
     const title = isRevoked
-      ? `${actorName} removed your access to a recording`
-      : `${actorName} shared a recording with you`;
+      ? `${actorName} removed your access to a ${subject}`
+      : `${actorName} shared a ${subject} with you`;
     const message = isRevoked
       ? `${actorName} removed your access to "${recordingTitle}"`
       : `${actorName} shared "${recordingTitle}" with you`;

--- a/apps/backend/src/services/recordingSharingNotificationService.ts
+++ b/apps/backend/src/services/recordingSharingNotificationService.ts
@@ -41,7 +41,9 @@ export class RecordingSharingNotificationService {
 
   private async publishOne(actorId: string, change: RecordingAccessActivity): Promise<void> {
     const share = await db.entityAccess.findUnique({ where: { id: change.shareId } });
-    if (!share || share.shareableEntityType !== ShareableEntityType.NOTE_TAKER) return;
+    const isRecordingShare = share?.shareableEntityType === ShareableEntityType.NOTE_TAKER;
+    const isCallShare = share?.shareableEntityType === ShareableEntityType.CALL;
+    if (!share || (!isRecordingShare && !isCallShare)) return;
 
     const isRevoked = share.entityUserAccess === EntityUserAccess.REVOKED;
     if (
@@ -75,7 +77,8 @@ export class RecordingSharingNotificationService {
 
     const actor = await repositories.users.findById(actorId);
     const actorName = actor?.name || 'Someone';
-    const recordingTitle = call.title || 'a recording';
+    const subject = isRecordingShare ? 'recording' : 'call';
+    const recordingTitle = call.title || `a ${subject}`;
 
     await Promise.all([
       activityService.createActivities(
@@ -96,6 +99,7 @@ export class RecordingSharingNotificationService {
         actorId,
         actorName,
         change.action,
+        subject,
       ),
     ]);
   }

--- a/apps/backend/src/services/recordingSharingService.ts
+++ b/apps/backend/src/services/recordingSharingService.ts
@@ -60,6 +60,8 @@ interface LoadedRecording {
   externalId: string;
   title: string | null;
   metadata: Prisma.JsonValue;
+  callType: string;
+  channelId: string | null;
   createdByUserId: string;
   startedAt: Date;
   endedAt: Date | null;
@@ -76,6 +78,16 @@ const RECORDING_SHARE_INTENT = {
   DIRECT_SHARE: 'direct_share',
   TICKET_LINK: 'ticket_link',
 } as const satisfies Record<string, RecordingShareIntent>;
+
+/**
+ * Recordings and regular calls share under separate entity types, so a recording
+ * share can never widen a call's audience or the reverse (see calls-acl.ts).
+ */
+const shareEntityTypeFor = (callType: string): string =>
+  callType === CallType.HEADLESS ? ShareableEntityType.NOTE_TAKER : ShareableEntityType.CALL;
+
+const isRecording = (call: Pick<LoadedRecording, 'callType'>): boolean =>
+  call.callType === CallType.HEADLESS;
 
 export class RecordingSharingError extends Error {
   constructor(
@@ -169,6 +181,7 @@ export class RecordingSharingService {
   ): Promise<RecordingSharingResult> {
     await this.runTransaction(async tx => {
       const recording = await this.loadManageableRecording(tx, callId, actor);
+      this.assertRecordingOnly(recording, 'Link access');
       if (recording.createdByUserId !== actor.userId) {
         throw new RecordingSharingError(
           'Only the recording creator can change link access',
@@ -184,7 +197,7 @@ export class RecordingSharingService {
           ? CanvasVisibility.PUBLIC
           : CanvasVisibility.PRIVATE;
       await tx.canvas.updateMany({
-        where: { id: { in: this.getShareCanvasIds(recording) } },
+        where: { id: { in: await this.getShareCanvasIds(tx, recording) } },
         data: { visibility: canvasVisibility },
       });
     });
@@ -221,6 +234,9 @@ export class RecordingSharingService {
     const { shares, activities } = await this.runTransaction(async tx => {
       const recording = await this.loadManageableRecording(tx, callId, actor);
       await this.validateTargets(tx, recording, actor.workspaceId, targets);
+      if (!isRecording(recording)) {
+        await this.stampCallSummaryCanvasPointer(tx, recording);
+      }
 
       const shares: Array<{ id: string; target: RecordingShareTarget; access: string }> = [];
       const activities: RecordingAccessActivity[] = [];
@@ -282,7 +298,8 @@ export class RecordingSharingService {
   ): Promise<SharePost> {
     const conversationId = randomUUID();
     const messageId = randomUUID();
-    const title = recording.title?.trim() || 'Untitled Recording';
+    const title =
+      recording.title?.trim() || (isRecording(recording) ? 'Untitled Recording' : 'Untitled Call');
     // Store the recording title as the anchor content.
     const durationMs = recording.endedAt
       ? recording.endedAt.getTime() - recording.startedAt.getTime()
@@ -293,11 +310,14 @@ export class RecordingSharingService {
       : undefined;
     const now = new Date();
     const metadata = {
-      messageSubtype: 'recording_share_post',
       callId: recording.externalId,
-      isRecordingMessage: true,
-      operation: 'recording_ended',
       durationMs,
+      ...(isRecording(recording)
+        ? { messageSubtype: 'recording_share_post', isRecordingMessage: true, operation: 'recording_ended' }
+        : // `callRowId` because the call detail route keys on `calls.id`, while every
+          // call message carries `callId` as the externalId. isCallMessage is left
+          // unset so this never renders as the live call header (see CallBubble).
+          { messageSubtype: 'call_share_post', isCallShareMessage: true, callRowId: recording.id }),
       ...(sanitizedMessageContent ? { messageContent: sanitizedMessageContent } : {}),
     };
 
@@ -467,7 +487,7 @@ export class RecordingSharingService {
       for (const target of uniqueTargets) {
         const existing = await this.findShare(
           tx,
-          recording.id,
+          recording,
           actor.workspaceId,
           target,
           RECORDING_SHARE_INTENT.DIRECT_SHARE,
@@ -521,6 +541,7 @@ export class RecordingSharingService {
   ): Promise<RecordingSharingResult> {
     const transactionResult = await this.runTransaction(async tx => {
       const recording = await this.loadManageableRecording(tx, callId, actor);
+      this.assertRecordingOnly(recording, 'Ticket linking');
       const metadata = asMetadata(recording.metadata);
       const existingTicketId = metadata['linkedTicketId'];
       const existingMessageId = metadata['linkedTicketMessageId'];
@@ -675,6 +696,7 @@ export class RecordingSharingService {
 
     await this.runTransaction(async tx => {
       const recording = await this.loadManageableRecording(tx, callId, actor);
+      this.assertRecordingOnly(recording, 'Ticket linking');
       await this.removeLinkedTicket(tx, recording, actor);
     });
 
@@ -744,7 +766,7 @@ export class RecordingSharingService {
     const target: RecordingShareTarget = { type: 'channel', id: ticket.channelId };
     const existingShare = await this.findShare(
       tx,
-      recording.id,
+      recording,
       actor.workspaceId,
       target,
       RECORDING_SHARE_INTENT.TICKET_LINK,
@@ -848,29 +870,63 @@ export class RecordingSharingService {
         title: true,
         metadata: true,
         callType: true,
+        channelId: true,
         workspaceId: true,
         createdByUserId: true,
         startedAt: true,
         endedAt: true,
       },
     });
-    if (
-      !call ||
-      call.callType !== CallType.HEADLESS ||
-      (call.workspaceId !== null && call.workspaceId !== actor.workspaceId)
-    ) {
+    if (!call || (call.workspaceId !== null && call.workspaceId !== actor.workspaceId)) {
       throw new RecordingSharingError('Recording not found', 404);
     }
-    if (call.createdByUserId !== actor.userId) {
-      const hasAccess = await this.hasActiveShare(tx, call.id, actor);
-      if (!hasAccess) {
-        throw new RecordingSharingError(
-          'Only the recording creator or people it is shared with can manage sharing',
-          403,
-        );
-      }
+    if (call.createdByUserId === actor.userId) return call;
+
+    // One rule, stated per type: whoever can already see it may pass it on.
+    // For a recording that is the creator and existing recipients; a call adds its
+    // participants and channel, which is the audience it already had.
+    const canManage =
+      (await this.hasActiveShare(tx, call, actor)) ||
+      (!isRecording(call) && (await this.isCallAudience(tx, call, actor.userId)));
+    if (!canManage) {
+      throw new RecordingSharingError(
+        isRecording(call)
+          ? 'Only the recording creator or people it is shared with can manage sharing'
+          : 'Only people in this call, or people it is shared with, can share it',
+        403,
+      );
     }
     return call;
+  }
+
+  /**
+   * Link visibility and ticket linking read and write recording-shaped state
+   * (Call.visibility, Call.metadata canvas pointers) that a regular call does not
+   * have, so they stay recordings-only rather than silently no-op'ing.
+   */
+  private assertRecordingOnly(recording: LoadedRecording, feature: string): void {
+    if (!isRecording(recording)) {
+      throw new RecordingSharingError(`${feature} is only available for recordings`, 400);
+    }
+  }
+
+  /** Anyone who took part in the call, or belongs to the channel it happened in. */
+  private async isCallAudience(
+    tx: Prisma.TransactionClient,
+    call: LoadedRecording,
+    userId: string,
+  ): Promise<boolean> {
+    const participant = await tx.callParticipant.findFirst({
+      where: { callId: call.id, userId },
+      select: { id: true },
+    });
+    if (participant) return true;
+    if (!call.channelId) return false;
+    const member = await tx.channelParticipant.findFirst({
+      where: { channelId: call.channelId, userId },
+      select: { id: true },
+    });
+    return member !== null;
   }
 
   /**
@@ -880,7 +936,7 @@ export class RecordingSharingService {
    */
   private async hasActiveShare(
     tx: Prisma.TransactionClient,
-    recordingId: string,
+    recording: Pick<LoadedRecording, 'id' | 'callType'>,
     actor: RecordingSharingActor,
   ): Promise<boolean> {
     const groupMappings = await tx.userGroupMapping.findMany({
@@ -897,8 +953,8 @@ export class RecordingSharingService {
     const share = await tx.entityAccess.findFirst({
       where: {
         workspaceId: actor.workspaceId,
-        shareableEntityType: ShareableEntityType.NOTE_TAKER,
-        entityId: recordingId,
+        shareableEntityType: shareEntityTypeFor(recording.callType),
+        entityId: recording.id,
         entityUserAccess: { not: EntityUserAccess.REVOKED },
         OR: [
           { userId: actor.userId },
@@ -937,7 +993,10 @@ export class RecordingSharingService {
     for (const target of targets) {
       if (target.type === 'user') {
         if (target.id === recording.createdByUserId) {
-          throw new RecordingSharingError('The recording owner already has access', 400);
+          throw new RecordingSharingError(
+            `The ${isRecording(recording) ? 'recording' : 'call'} owner already has access`,
+            400,
+          );
         }
         const user = await tx.user.findFirst({
           where: { id: target.id, workspaceId, leftAt: null },
@@ -962,7 +1021,7 @@ export class RecordingSharingService {
 
   private async findShare(
     tx: Prisma.TransactionClient,
-    recordingId: string,
+    recording: Pick<LoadedRecording, 'id' | 'callType'>,
     workspaceId: string,
     target: RecordingShareTarget,
     intent: RecordingShareIntent,
@@ -970,8 +1029,8 @@ export class RecordingSharingService {
     const shares = await tx.entityAccess.findMany({
       where: {
         workspaceId,
-        shareableEntityType: ShareableEntityType.NOTE_TAKER,
-        entityId: recordingId,
+        shareableEntityType: shareEntityTypeFor(recording.callType),
+        entityId: recording.id,
         ...targetWhere(target),
       },
     });
@@ -986,7 +1045,7 @@ export class RecordingSharingService {
     access: GrantableEntityUserAccess,
     intent: RecordingShareIntent,
   ): Promise<AccessChange> {
-    const existing = await this.findShare(tx, recording.id, workspaceId, target, intent);
+    const existing = await this.findShare(tx, recording, workspaceId, target, intent);
     const activated = !existing || existing.entityUserAccess === EntityUserAccess.REVOKED;
     const share = existing
       ? await tx.entityAccess.update({
@@ -1003,7 +1062,7 @@ export class RecordingSharingService {
           data: {
             id: randomUUID(),
             workspaceId,
-            shareableEntityType: ShareableEntityType.NOTE_TAKER,
+            shareableEntityType: shareEntityTypeFor(recording.callType),
             entityId: recording.id,
             entityUserAccess: access,
             metadata: { intent },
@@ -1022,7 +1081,7 @@ export class RecordingSharingService {
     target: RecordingShareTarget,
     action: 'grant' | 'revoke',
   ): Promise<void> {
-    const canvasIds = this.getShareCanvasIds(recording);
+    const canvasIds = await this.getShareCanvasIds(tx, recording);
     for (const canvasId of canvasIds) {
       const where =
         target.type === 'user'
@@ -1052,7 +1111,7 @@ export class RecordingSharingService {
         const remainingAccess = await tx.entityAccess.findFirst({
           where: {
             workspaceId,
-            shareableEntityType: ShareableEntityType.NOTE_TAKER,
+            shareableEntityType: shareEntityTypeFor(recording.callType),
             entityId: recording.id,
             entityUserAccess: { not: EntityUserAccess.REVOKED },
             ...targetWhere(target),
@@ -1065,7 +1124,51 @@ export class RecordingSharingService {
     }
   }
 
-  private getShareCanvasIds(recording: LoadedRecording): string[] {
+  /**
+   * A regular call's summary canvas is normally reached through its call message,
+   * which a recipient outside the call's channel cannot read. Copy the pointer onto
+   * the call row — the shape recordings already use — so a shared summary opens.
+   * Written here rather than when the summary is generated: sharing is a single
+   * writer, well clear of the concurrent post-call pipeline.
+   */
+  private async stampCallSummaryCanvasPointer(
+    tx: Prisma.TransactionClient,
+    recording: LoadedRecording,
+  ): Promise<void> {
+    const metadata = asMetadata(recording.metadata);
+    if (typeof metadata['detailedSummaryCanvasId'] === 'string') return;
+    const [canvasId] = await this.getShareCanvasIds(tx, recording);
+    if (!canvasId) return;
+    await tx.call.update({
+      where: { id: recording.id },
+      data: {
+        metadata: { ...metadata, detailedSummaryCanvasId: canvasId } as Prisma.InputJsonValue,
+      },
+    });
+  }
+
+  /**
+   * Canvases a share has to carry along. A recording names them on its own row; a
+   * regular call does not, so its summary canvas is found by the call it records
+   * (stamped in createOrUpdateDetailedSummaryCanvas).
+   */
+  private async getShareCanvasIds(
+    tx: Prisma.TransactionClient,
+    recording: LoadedRecording,
+  ): Promise<string[]> {
+    if (!isRecording(recording)) {
+      const canvases = await tx.canvas.findMany({
+        where: {
+          AND: [
+            { metadata: { path: ['source'], equals: 'call_detailed_summary' } },
+            { metadata: { path: ['callId'], equals: recording.externalId } },
+          ],
+        },
+        select: { id: true },
+      });
+      return canvases.map(canvas => canvas.id);
+    }
+
     const metadata = asMetadata(recording.metadata);
     const detailedSummaryCanvasId = metadata['detailedSummaryCanvasId'];
     const notesCanvasId = metadata['notesCanvasId'];

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -1,5 +1,5 @@
 import { repositories } from '@/database/repositories';
-import { getCanvasUrl } from '@/services/canvasService';
+import { getCanvasUrl, findExistingDetailedSummaryCanvas } from '@/services/canvasService';
 import { logger } from '@/utils/logger';
 import { Prisma, type Call } from '@prisma/client';
 import { config } from '@/config/env';
@@ -21,7 +21,12 @@ import { executeCallLlmWithRetry, executeStreamingLlmRequest, type SummaryModelT
 import { callRecordingService } from '@/services/callRecordingService';
 import { callLabelService } from '@/services/callLabelService';
 import { TagMethod } from '@xyne/shared';
-import { callDocumentService } from '@/services/callDocumentService';
+import {
+  callDocumentService,
+  numberTranscriptSegments,
+  type CitationContext,
+} from '@/services/callDocumentService';
+import { mergeRecordingSummaryMarkedItems } from '@/services/recordingSummaryMarkedItems';
 import { RECORDING_TITLE_PROMPT } from '@/services/recordingSummaryTemplates';
 import { acquireLock, releaseLock } from '@/utils/distributedLock';
 import { orgLLMCredentialService } from '@/services/orgLLMCredentialService';
@@ -1312,13 +1317,112 @@ Output ONLY the processed transcript, nothing else.`;
   }
 
   /**
-   * Generate a small set of topical labels and persist each as a generic Tag
-   * row (sourceId = call.id, sourceType = 'CALL'), returning the resulting tag
-   * ids for Call.labels. Returns [] on any failure — callers treat that as
-   * "nothing to add", never clobbering a previously-saved good result.
+   * Generate or rewrite a regular call's detailed summary with a given template.
    *
-   * Shared by both transcript pipelines; `logPath` tags the logs with whichever
-   * one is calling.
+   * A rewrite edits the canvas in place, so the URL already on the call message
+   * stays valid; a first generation makes a new canvas and has to stamp that URL.
+   * Recordings instead point from Call.metadata.detailedSummaryCanvasId (see
+   * regenerateSummary in the note-taker service). Null means nothing was written;
+   * the caller returns 404.
+   */
+  async regenerateCallSummary(
+    call: Call,
+    templateId: string,
+  ): Promise<{ summaryTemplateId: string; detailedSummaryCanvasId: string } | null> {
+    const callId = call.externalId;
+    const workspaceId = call.workspaceId;
+    if (!workspaceId) {
+      logger.warn(`[${callId}] regenerate_call_summary_skipped`, { reason: 'no_workspace' });
+      return null;
+    }
+
+    // A first generation needs the call message, both to hang the canvas off the
+    // conversation and to stamp the pointer the detail screen reads.
+    const existingCanvas = await findExistingDetailedSummaryCanvas(callId);
+    const callMessage = existingCanvas ? null : await repositories.messages.findHeadMessageByCallId(callId);
+    if (!existingCanvas && !callMessage) {
+      logger.warn(`[${callId}] regenerate_call_summary_skipped`, { reason: 'no_call_message' });
+      return null;
+    }
+
+    const formattedTranscript = await this.getTranscriptContent(callId);
+    if (!formattedTranscript) {
+      logger.warn(`[${callId}] regenerate_call_summary_skipped`, { reason: 'no_transcript' });
+      return null;
+    }
+
+    // Numbered segments let the LLM cite them; the map turns `[clf-n]` tokens in
+    // the reply into canvas citation chips.
+    const { numbered, segments } = numberTranscriptSegments(formattedTranscript);
+    const citationCtx: CitationContext = {
+      callId,
+      segments: new Map(segments.map(segment => [segment.n, segment])),
+    };
+
+    const generated = await callDocumentService.generateRecordingSummary(
+      numbered,
+      callId,
+      templateId,
+      undefined,
+      citationCtx.segments,
+    );
+    if (!generated) {
+      logger.error(`[${callId}] regenerate_call_summary_failed`, { reason: 'generation_failed' });
+      return null;
+    }
+
+    const xyneAutomaticBot = await unifiedBotUserService.getBotByBotId('xyne-automatic', workspaceId);
+    if (!xyneAutomaticBot) {
+      logger.error(`[${callId}] regenerate_call_summary_failed`, { reason: 'bot_not_found' });
+      return null;
+    }
+
+    const { canvasId } = await callDocumentService.createOrUpdateDetailedSummaryCanvas(
+      callId,
+      generated.summary,
+      xyneAutomaticBot.id,
+      callMessage?.conversationId ?? null,
+      call.channelId,
+      call.startedAt,
+      call.createdByUserId,
+      call.title,
+      citationCtx,
+      workspaceId,
+    );
+    if (!canvasId) {
+      logger.error(`[${callId}] regenerate_call_summary_failed`, { reason: 'canvas_update_failed' });
+      return null;
+    }
+
+    if (callMessage) {
+      await callDocumentService.linkDetailedSummaryToCallMessage(
+        callMessage.conversationId,
+        callId,
+        getCanvasUrl(canvasId),
+      );
+    }
+
+    // Re-read after the LLM round trip; merging keeps anything already ticked off.
+    const current = await repositories.calls.findByExternalId(callId);
+    const markedItems = mergeRecordingSummaryMarkedItems(
+      current?.markedItems ?? call.markedItems,
+      generated.markedItems,
+    ) as Prisma.InputJsonValue[];
+    await repositories.calls.update(call.id, {
+      summaryTemplateId: generated.template.id,
+      markedItems,
+    });
+
+    logger.info(`[${callId}] regenerate_call_summary_completed`, {
+      template_id: generated.template.id,
+    });
+    return { summaryTemplateId: generated.template.id, detailedSummaryCanvasId: canvasId };
+  }
+
+  /**
+   * Generate topical labels and persist each as a Tag row, returning ids for
+   * Call.labels. Returns [] on any failure, so a bad run never clobbers good
+   * labels. `logPath` names the calling pipeline in the logs.
    */
   async generateAndSaveLabels(
     call: Call,
@@ -1879,9 +1983,8 @@ Output ONLY the processed transcript, nothing else.`;
         logger.error(`[${callId}] generate_ticket_suggestions_threw`, { error: err, stack: err instanceof Error ? err.stack : undefined });
         return [];
       });
-      // HEADLESS recordings label themselves on the note-taker path, which owns
-      // their whole post-transcript pipeline — running here too would just spend
-      // a second LLM call to rediscover the same tags.
+      // Recordings already label themselves on the note-taker path; running here
+      // too would spend a second LLM call on the same tags.
       const labelsPromise =
         call.callType === CallType.HEADLESS
           ? Promise.resolve([] as string[])
@@ -1984,8 +2087,7 @@ Output ONLY the processed transcript, nothing else.`;
         return ticketSuggestions;
       });
 
-      // appendLabels merges rather than overwrites, so a label the user typed
-      // while the transcript was still processing survives this write.
+      // appendLabels merges, so a label typed mid-processing survives this write.
       const labelsUiPromise = labelsPromise.then(async (labelIds) => {
         if (labelIds.length === 0) return labelIds;
         try {

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -1,7 +1,7 @@
 import { repositories } from '@/database/repositories';
 import { getCanvasUrl } from '@/services/canvasService';
 import { logger } from '@/utils/logger';
-import { Prisma } from '@prisma/client';
+import { Prisma, type Call } from '@prisma/client';
 import { config } from '@/config/env';
 import { Agent, createUserMessage } from '@framework';
 import { extractAgentContent } from '@/utils/agentUtils';
@@ -19,6 +19,8 @@ import { CacConfigService } from '@/services/cacConfigService';
 import { getCallTicketSuggestionsTotal } from '@/services/otel/suggestionMetrics';
 import { executeCallLlmWithRetry, executeStreamingLlmRequest, type SummaryModelType } from './callLlmRetry';
 import { callRecordingService } from '@/services/callRecordingService';
+import { callLabelService } from '@/services/callLabelService';
+import { TagMethod } from '@xyne/shared';
 import { callDocumentService } from '@/services/callDocumentService';
 import { RECORDING_TITLE_PROMPT } from '@/services/recordingSummaryTemplates';
 import { acquireLock, releaseLock } from '@/utils/distributedLock';
@@ -1310,6 +1312,40 @@ Output ONLY the processed transcript, nothing else.`;
   }
 
   /**
+   * Generate a small set of topical labels and persist each as a generic Tag
+   * row (sourceId = call.id, sourceType = 'CALL'), returning the resulting tag
+   * ids for Call.labels. Returns [] on any failure — callers treat that as
+   * "nothing to add", never clobbering a previously-saved good result.
+   *
+   * Shared by both transcript pipelines; `logPath` tags the logs with whichever
+   * one is calling.
+   */
+  async generateAndSaveLabels(
+    call: Call,
+    formattedTranscript: string,
+    method: TagMethod = TagMethod.LLM,
+    logPath?: string,
+  ): Promise<string[]> {
+    const callId = call.externalId;
+    if (!call.workspaceId) {
+      logger.warn(`[${callId}] labels_skipped`, { reason: 'no_workspace', path: logPath });
+      return [];
+    }
+
+    const labels = await this.generateCallLabels(formattedTranscript, callId).catch((err) => {
+      logger.error(`[${callId}] generate_labels_threw`, {
+        path: logPath,
+        error: err,
+        stack: err instanceof Error ? err.stack : undefined,
+      });
+      return [] as string[];
+    });
+    if (labels.length === 0) return [];
+
+    return callLabelService.persistGeneratedLabels(call, labels, method, logPath);
+  }
+
+  /**
    * Extract the primary merchant/customer name from the transcript using the LLM.
    * Returns null if no merchant is clearly identified.
    */
@@ -1843,8 +1879,15 @@ Output ONLY the processed transcript, nothing else.`;
         logger.error(`[${callId}] generate_ticket_suggestions_threw`, { error: err, stack: err instanceof Error ? err.stack : undefined });
         return [];
       });
+      // HEADLESS recordings label themselves on the note-taker path, which owns
+      // their whole post-transcript pipeline — running here too would just spend
+      // a second LLM call to rediscover the same tags.
+      const labelsPromise =
+        call.callType === CallType.HEADLESS
+          ? Promise.resolve([] as string[])
+          : this.generateAndSaveLabels(call, formattedTranscript);
 
-      // Start all four post-call LLM operations immediately. Detailed-summary
+      // Start all five post-call LLM operations immediately. Detailed-summary
       // streaming remains unchanged; title, summary, and tickets persist their
       // own result as soon as it is ready rather than waiting on one another.
       pendingDetailedSummary = callDocumentService.generateAndPostDetailedSummary(
@@ -1941,10 +1984,24 @@ Output ONLY the processed transcript, nothing else.`;
         return ticketSuggestions;
       });
 
+      // appendLabels merges rather than overwrites, so a label the user typed
+      // while the transcript was still processing survives this write.
+      const labelsUiPromise = labelsPromise.then(async (labelIds) => {
+        if (labelIds.length === 0) return labelIds;
+        try {
+          await repositories.calls.appendLabels(call.id, labelIds);
+          logger.info(`[${callId}] call_record_updated`, { fields_updated: 'labels' });
+        } catch (error) {
+          logger.error(`[${callId}] labels_save_failed`, { error });
+        }
+        return labelIds;
+      });
+
       const [summary, title, ticketSuggestions] = await Promise.all([
         summaryUiPromise,
         titleUiPromise,
         ticketsUiPromise,
+        labelsUiPromise,
       ]);
 
       const duration = Date.now() - startTime;

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -2758,6 +2758,30 @@ export const queries: AnyQueryRegistry = defineQueries({
     },
   ),
 
+  /**
+   * A single non-HEADLESS call (+ its shares) by row id — what the detail route
+   * carries. Used both to resolve a call reached by link, with no navigation state
+   * to read it from, and to list who a call is shared with.
+   */
+  callById: defineQuery(
+    z.object({ callId: z.string() }),
+    ({ ctx, args: { callId } }) =>
+      zql.calls
+        .where('workspaceId', ctx.workspaceId)
+        .where('callType', '!=', CallType.HEADLESS)
+        .where('id', callId)
+        .related('participants', p => p.where('userId', ctx.userID))
+        .related('shares', shares =>
+          shares
+            .where('shareableEntityType', ShareableEntityType.CALL)
+            .where('entityUserAccess', '!=', EntityUserAccess.REVOKED)
+            .related('user')
+            .related('userGroup')
+            .related('channel'),
+        )
+        .one(),
+  ),
+
   // Fetches the HEADLESS recording (+ shares) by its public
   // externalId (what's in the URL / RecordingDetail.externalId) — used by
   // the Share modal and the detail screen alike.

--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -279,6 +279,9 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
 
   // Recording anchors use recording-specific actions.
   const isRecordingMessage = metadata?.['isRecordingMessage'] === true;
+  // A shared call card. Grouped with recording anchors below: both are generated
+  // cards whose deletion would orphan the entity_access row pointing at them.
+  const isSharedEntityMessage = isRecordingMessage || metadata?.['isCallShareMessage'] === true;
 
   // Both internal and external link previews are stored in link_preview_md.
   // Memoized: ChatBubble re-renders on every hover, and parsing per render
@@ -839,8 +842,8 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   // The slash command artifact wrapper is the persisted rendering contract. Keep deletion available,
   // but do not open this message in the generic editor, which would discard that wrapper.
   const canEditMessage =
-    canModifyMessage && !isSlashCommandArtifactMessage(message.content) && !isRecordingMessage;
-  const canDeleteMessage = canModifyMessage && !hasTicket && !isRecordingMessage;
+    canModifyMessage && !isSlashCommandArtifactMessage(message.content) && !isSharedEntityMessage;
+  const canDeleteMessage = canModifyMessage && !hasTicket && !isSharedEntityMessage;
 
   // Check if message has meaningful text content (not just attachments).
   // Memoized: this runs a full DOMParser parse — doing it per render meant
@@ -1051,7 +1054,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
         }),
       ...(!isMessageDeleted &&
         (isCallMessage || !isSystemMessage) &&
-        !isRecordingMessage && { onForwardMessage: handleForwardMessage }),
+        !isSharedEntityMessage && { onForwardMessage: handleForwardMessage }),
       isPinned: conversation?.pinned || false,
       ...(shouldShowSendToChannel && !isMessageDeleted && { onSendToChannel: handleSendToChannel }),
       ...(canEditMessage && { onEditMessage: handleEditMessage }),
@@ -1372,7 +1375,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
                 !isMessageDeleted && { onRemindMe: handleOpenReminderOptions })}
               {...(!isMessageDeleted &&
                 (isCallMessage || !isSystemMessage) &&
-                !isRecordingMessage && { onForwardMessage: handleForwardMessage })}
+                !isSharedEntityMessage && { onForwardMessage: handleForwardMessage })}
               {...(shouldShowSendToChannel &&
                 !isMessageDeleted && { onSendToChannel: handleSendToChannel })}
               {...(canEditMessage && { onEditMessage: handleEditMessage })}

--- a/apps/dashboard/src/components/Labels/LabelFilter.tsx
+++ b/apps/dashboard/src/components/Labels/LabelFilter.tsx
@@ -1,0 +1,123 @@
+import { useMemo, useState, type ReactElement } from 'react';
+import { ChevronDown, ChevronUp } from '@xyne/icons';
+import { SearchableMultiSelect } from '../ui/SearchableMultiSelect/SearchableMultiSelect';
+import type { SearchableMultiSelectOption } from '../ui/SearchableMultiSelect/SearchableMultiSelect.types';
+import { Button } from '../ui/Button/Button';
+import { cn } from '../../utils/classNames';
+import { getTagDotColor } from '../../utils/tagTheme';
+
+export interface LabelFilterProps {
+  labels: string[];
+  selectedLabels: string[];
+  onSelectedLabelsChange: (labels: string[]) => void;
+  /** Resolves a label value (Tag id) to its display text. Defaults to identity. */
+  resolveLabel?: ((label: string) => string) | undefined;
+  /** Analytics namespace of the host screen, e.g. 'RecordingsV2' or 'CallHistory'. */
+  trackCategory: string;
+  /** aria-label for the enabled trigger, e.g. 'Filter calls by label'. */
+  triggerAriaLabel: string;
+  /** aria-label for the disabled trigger — say why it can't be used. */
+  disabledAriaLabel: string;
+  /** Forces the disabled state even when labels exist (e.g. rows can't carry labels). */
+  isDisabled?: boolean | undefined;
+  /** Overrides the trigger's default sizing, to match whatever sits beside it. */
+  triggerClassName?: string | undefined;
+}
+
+const TRIGGER_CLASS_NAME = 'h-9 gap-1.5 rounded-xl border-border px-3 font-medium shadow-none';
+const LIST_INHERITS_POPOVER_CLASS_NAME =
+  '[[data-theme=midnight]_&_[role=listbox][aria-multiselectable]]:!bg-transparent';
+
+export function LabelFilter({
+  labels,
+  selectedLabels,
+  onSelectedLabelsChange,
+  resolveLabel = (label: string) => label,
+  trackCategory,
+  triggerAriaLabel,
+  disabledAriaLabel,
+  isDisabled = false,
+  triggerClassName = TRIGGER_CLASS_NAME,
+}: LabelFilterProps): ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Values stay Tag ids — what the selection is keyed by — while the resolved text
+  // drives both the visible label and SearchableMultiSelect's own search filtering.
+  const options = useMemo<SearchableMultiSelectOption[]>(
+    () =>
+      labels.map(label => {
+        const displayLabel = resolveLabel(label);
+        return {
+          value: label,
+          label: displayLabel,
+          icon: (
+            <span
+              className={cn('size-2 shrink-0 rounded-full', getTagDotColor(displayLabel))}
+              aria-hidden='true'
+            />
+          ),
+        };
+      }),
+    [labels, resolveLabel],
+  );
+
+  if (isDisabled || labels.length === 0) {
+    return (
+      <Button
+        type='button'
+        variant='outline'
+        disabled
+        className={triggerClassName}
+        aria-label={disabledAriaLabel}
+      >
+        Labels
+        <ChevronDown className='size-4' aria-hidden='true' />
+      </Button>
+    );
+  }
+
+  return (
+    <SearchableMultiSelect
+      options={options}
+      selectedValues={selectedLabels}
+      onSelectedValuesChange={onSelectedLabelsChange}
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      searchAriaLabel='Search labels'
+      listAriaLabel='Labels'
+      emptyMessage='No labels found'
+      trackCategory={trackCategory}
+      trackName='toggle_label_filter'
+      className={LIST_INHERITS_POPOVER_CLASS_NAME}
+      trigger={
+        <Button
+          type='button'
+          variant='outline'
+          className={cn(
+            selectedLabels.length === 0 ? 'text-muted-foreground' : '!border-foreground',
+            triggerClassName,
+          )}
+          aria-label={
+            selectedLabels.length > 0
+              ? `Labels, ${selectedLabels.length} selected`
+              : triggerAriaLabel
+          }
+          data-track-category={trackCategory}
+          data-track-name='open_label_filter'
+        >
+          Labels
+          {selectedLabels.length > 0 && (
+            <span className='flex h-4 min-w-4 items-center justify-center rounded-full bg-foreground px-1 text-xs font-semibold leading-none tabular-nums text-background'>
+              {selectedLabels.length}
+            </span>
+          )}
+          {isOpen ? (
+            <ChevronUp className='size-4 text-muted-foreground' aria-hidden='true' />
+          ) : (
+            <ChevronDown className='size-4 text-muted-foreground' aria-hidden='true' />
+          )}
+        </Button>
+      }
+    />
+  );
+}

--- a/apps/dashboard/src/components/Labels/LabelPicker.tsx
+++ b/apps/dashboard/src/components/Labels/LabelPicker.tsx
@@ -1,0 +1,268 @@
+import { useMemo, useState, type ReactElement } from 'react';
+import { CheckTickSingle, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
+import { TagMethod } from '@xyne/shared';
+import { toast } from 'sonner';
+import { SearchableMultiSelect } from '../ui/SearchableMultiSelect/SearchableMultiSelect';
+import type { SearchableMultiSelectOption } from '../ui/SearchableMultiSelect/SearchableMultiSelect.types';
+import { Button } from '../ui/Button/Button';
+import {
+  confirmRecordingLabelSuggestion,
+  useResolvedRecordingLabels,
+} from '../../hooks/useResolvedRecordingLabels';
+import { cn } from '../../utils/classNames';
+import { normalizeRecordingTags, slugifyRecordingLabel } from '../../utils/recordingUtils';
+import { getTagTheme } from '../../utils/tagTheme';
+
+export interface LabelPickerProps {
+  labels: string[];
+  canEdit: boolean;
+  /** Labels already in use elsewhere, offered in the list before anything is typed. */
+  suggestions: string[];
+  /** Analytics namespace of the host screen, e.g. 'RecordingDetailV2' or 'CallDetail'. */
+  trackCategory: string;
+  onChange: (labels: string[]) => void;
+}
+
+const LABEL_MAX_LENGTH = 40;
+/** Labels beyond this are blocked on add (existing AI suggestions past the cap aren't touched). */
+const MAX_LABELS = 10;
+
+const CHIP_BASE_CLASS_NAME =
+  'inline-flex h-6 shrink-0 items-center gap-1.5 rounded-lg pl-2 pr-1.5 text-xs font-medium whitespace-nowrap';
+
+const SUGGESTION_CHIP_CLASS_NAME = cn(
+  CHIP_BASE_CLASS_NAME,
+  'border border-dashed border-muted-foreground/40',
+);
+
+const LIST_INHERITS_POPOVER_CLASS_NAME =
+  '[[data-theme=midnight]_&_[role=listbox][aria-multiselectable]]:!bg-transparent';
+
+export function LabelChip({
+  label,
+  onRemove,
+  trackCategory,
+}: {
+  label: string;
+  onRemove?: (() => void) | undefined;
+  trackCategory?: string | undefined;
+}): ReactElement {
+  const theme = getTagTheme(label);
+  return (
+    <span className={cn(CHIP_BASE_CLASS_NAME, theme.bg, theme.text)}>
+      <span className={cn('size-1.5 shrink-0 rounded-full', theme.dot)} aria-hidden='true' />
+      <span>{label}</span>
+      {onRemove && (
+        <button
+          type='button'
+          className='rounded-sm opacity-70 hover:opacity-100'
+          aria-label={`Remove label ${label}`}
+          onClick={onRemove}
+          data-track-category={trackCategory}
+          data-track-name='remove_recording_label'
+        >
+          <MultipleCrossCancelDefault className='size-3' aria-hidden='true' />
+        </button>
+      )}
+    </span>
+  );
+}
+
+/** An AI-suggested (unconfirmed) label — tick to keep it (moves into the confirmed pills), cross to discard it. */
+export function SuggestedLabelChip({
+  label,
+  onConfirm,
+  onReject,
+  trackCategory,
+}: {
+  label: string;
+  onConfirm: () => void;
+  onReject: () => void;
+  trackCategory: string;
+}): ReactElement {
+  const theme = getTagTheme(label);
+  return (
+    <span className={cn(SUGGESTION_CHIP_CLASS_NAME, 'text-foreground')}>
+      <span className={cn('size-1.5 shrink-0 rounded-full', theme.dot)} aria-hidden='true' />
+      <span>{label}</span>
+      <button
+        type='button'
+        className='rounded-sm opacity-70 hover:opacity-100'
+        aria-label={`Confirm suggested label ${label}`}
+        onClick={event => {
+          event.stopPropagation();
+          onConfirm();
+        }}
+        data-track-category={trackCategory}
+        data-track-name='confirm_suggested_label'
+      >
+        <CheckTickSingle className='size-3' aria-hidden='true' />
+      </button>
+      <button
+        type='button'
+        className='rounded-sm opacity-70 hover:opacity-100'
+        aria-label={`Dismiss suggested label ${label}`}
+        onClick={event => {
+          event.stopPropagation();
+          onReject();
+        }}
+        data-track-category={trackCategory}
+        data-track-name='reject_suggested_label'
+      >
+        <MultipleCrossCancelDefault className='size-3' aria-hidden='true' />
+      </button>
+    </span>
+  );
+}
+
+export function LabelPicker({
+  labels,
+  canEdit,
+  suggestions,
+  trackCategory,
+  onChange,
+}: LabelPickerProps): ReactElement | null {
+  const [isOpen, setIsOpen] = useState(false);
+  const resolvable = useMemo(() => [...labels, ...suggestions], [labels, suggestions]);
+  const { resolveLabel, resolveMethod } = useResolvedRecordingLabels(resolvable);
+
+  // Confirmed labels (TagMethod.MANUAL) vs still-pending suggestions (LLM or AUTOMATED).
+  const confirmedLabels = useMemo(
+    () => labels.filter(id => resolveMethod(id) === TagMethod.MANUAL),
+    [labels, resolveMethod],
+  );
+  const suggestedLabels = useMemo(
+    () => (canEdit ? labels.filter(id => resolveMethod(id) !== TagMethod.MANUAL) : []),
+    [labels, canEdit, resolveMethod],
+  );
+
+  const options = useMemo<SearchableMultiSelectOption[]>(
+    () =>
+      normalizeRecordingTags([...suggestions, ...labels])
+        .filter(label => resolveMethod(label) === TagMethod.MANUAL)
+        .map(label => ({ value: label, displayLabel: resolveLabel(label) }))
+        .sort((left, right) => left.displayLabel.localeCompare(right.displayLabel))
+        .map(({ value, displayLabel }) => ({
+          // The value stays the stored label — an id for generated ones — so selecting
+          // writes back what the call already holds.
+          value,
+          label: displayLabel,
+          icon: (
+            <span
+              className={cn('size-2 shrink-0 rounded-full', getTagTheme(displayLabel).dot)}
+              aria-hidden='true'
+            />
+          ),
+        })),
+    [labels, suggestions, resolveLabel, resolveMethod],
+  );
+
+  const handleCreate = (label: string): void => {
+    if (confirmedLabels.length >= MAX_LABELS) {
+      toast.error(`You can add up to ${MAX_LABELS} labels`);
+      return;
+    }
+    const slug = slugifyRecordingLabel(label);
+    if (!slug) {
+      toast.error('Label needs at least one letter or number');
+      return;
+    }
+    onChange(normalizeRecordingTags([...labels, slug]));
+  };
+
+  // `options` already excludes AI-suggested labels (filtered above), so a size increase
+  // here always means a confirmed/manual label is being added.
+  const handleSelectedValuesChange = (values: string[]): void => {
+    if (values.length > labels.length && confirmedLabels.length >= MAX_LABELS) {
+      toast.error(`You can add up to ${MAX_LABELS} labels`);
+      return;
+    }
+    onChange(values);
+  };
+
+  /** Tick: keep the AI-suggested tag — flips its Tag row to `manual` in place, no labels change needed. */
+  const handleConfirmSuggestion = async (labelId: string): Promise<void> => {
+    const revertMethod = resolveMethod(labelId);
+    try {
+      await confirmRecordingLabelSuggestion(labelId, revertMethod);
+    } catch {
+      toast.error('Failed to confirm label');
+    }
+  };
+
+  /** Cross: discard the AI-suggested tag — just drop its id from the call's labels. */
+  const handleRejectSuggestion = (labelId: string): void => {
+    onChange(labels.filter(id => id !== labelId));
+  };
+
+  const suggestionPills =
+    canEdit && suggestedLabels.length > 0
+      ? suggestedLabels.map(label => (
+          <SuggestedLabelChip
+            key={label}
+            label={resolveLabel(label)}
+            onConfirm={() => void handleConfirmSuggestion(label)}
+            onReject={() => handleRejectSuggestion(label)}
+            trackCategory={trackCategory}
+          />
+        ))
+      : null;
+
+  if (!canEdit) {
+    if (labels.length === 0) return null;
+
+    // Same flat pills as the owner's view — a read-only header shouldn't look
+    // like a different screen — just no remove/add controls.
+    return (
+      <>
+        {confirmedLabels.map(label => (
+          <LabelChip key={label} label={resolveLabel(label)} />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {confirmedLabels.map(label => (
+        <LabelChip
+          key={label}
+          label={resolveLabel(label)}
+          onRemove={() => onChange(labels.filter(id => id !== label))}
+          trackCategory={trackCategory}
+        />
+      ))}
+      <SearchableMultiSelect
+        options={options}
+        selectedValues={labels}
+        onSelectedValuesChange={handleSelectedValuesChange}
+        onCreateOption={handleCreate}
+        className={LIST_INHERITS_POPOVER_CLASS_NAME}
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        searchPlaceholder='Search or create...'
+        searchMaxLength={LABEL_MAX_LENGTH}
+        searchAriaLabel='Search or create a label'
+        listAriaLabel='Labels'
+        emptyMessage='No labels yet'
+        trackCategory={trackCategory}
+        trackName='toggle_recording_label'
+        trigger={
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            className='h-6 gap-1.5 rounded-lg border-dashed border-muted-foreground/40 pl-2 pr-2.5 text-xs font-medium text-muted-foreground hover:border-foreground/30 hover:text-foreground'
+            aria-label='Add a label'
+            data-track-category={trackCategory}
+            data-track-name='open_recording_labels'
+          >
+            <PlusDefault className='size-3.5' aria-hidden='true' />
+            Label
+          </Button>
+        }
+      />
+      {suggestionPills}
+    </>
+  );
+}

--- a/apps/dashboard/src/components/Labels/LabelPicker.tsx
+++ b/apps/dashboard/src/components/Labels/LabelPicker.tsx
@@ -78,7 +78,7 @@ export function SuggestedLabelChip({
   label: string;
   onConfirm: () => void;
   onReject: () => void;
-  trackCategory: string;
+  trackCategory?: string | undefined;
 }): ReactElement {
   const theme = getTagTheme(label);
   return (

--- a/apps/dashboard/src/components/Share/EntityShareModal.tsx
+++ b/apps/dashboard/src/components/Share/EntityShareModal.tsx
@@ -1,0 +1,331 @@
+import React, { useCallback, useMemo, useRef, useState, type ReactNode } from 'react';
+import { toast } from 'sonner';
+import { Link } from 'react-router-dom';
+import { Hash, Users, X } from 'lucide-react';
+import { LinkChainSlant } from '@xyne/icons';
+import type { MentionResult } from '@xyne/shared';
+import { ChannelScopeType, ChannelVisibility } from '@xyne/shared';
+import { useUserGroupSearch, useChannelSearch } from '@xyne/shared/hooks';
+import Avatar from '../ui/Avatar/Avatar';
+import { Button } from '../ui/Button/Button';
+import { InputBox } from '../ui/InputBox';
+import { UnifiedParticipantSearch } from '../ui/UnifiedParticipantSearch/UnifiedParticipantSearch';
+import type { InputBoxHandle } from '../../hooks/useDragAndDropAreaRef';
+import { useActiveUserSearch } from '../../hooks/useUsers';
+import { useAuth } from '../../hooks/useAuth';
+import { useMentionSearch } from '../../hooks/useMentionSearch';
+import { userToMentionResult } from '../../utils/userDisplayName';
+import { getApiErrorMessage } from '../../utils/apiError';
+
+const MENTION_USER_LIMIT = 20;
+const MENTION_GROUP_LIMIT = 10;
+
+export type EntityShareTarget =
+  | { type: 'user'; id: string }
+  | { type: 'user_group'; id: string }
+  | { type: 'channel'; id: string };
+
+/**
+ * One live share, flattened by the caller so this component never touches the
+ * Zero row shapes — the recordings and calls queries return different tables.
+ */
+export interface EntityShareEntry {
+  id: string;
+  /** Who or what the entity is shared with, as shown in the access list. */
+  label: string;
+  /** Set for user shares, to render the avatar. */
+  userId: string | null;
+  target: EntityShareTarget;
+  /** The conversation the share posted into, when it posted one. */
+  post: { channelId: string; conversationId: string } | null;
+}
+
+export interface EntityShareModalProps {
+  /** Excluded from the picker — the owner already has access. */
+  ownerId: string | undefined;
+  shares: EntityShareEntry[];
+  onGrant: (targets: EntityShareTarget[], messageContent: string) => Promise<void>;
+  onRevoke: (target: EntityShareTarget) => Promise<void>;
+  /** The word the copy uses for what is being shared: 'recording' or 'call'. */
+  subject: string;
+  /** Analytics namespace of the host screen. */
+  trackCategory: string;
+  /**
+   * Heading over the share list. Defaults to the recordings wording, which is
+   * complete there — a recording starts out visible to its creator alone. A call
+   * is already visible to its participants and channel, so calls say "Shared with"
+   * rather than implying this list is everyone who can see it.
+   */
+  accessListTitle?: string;
+  /** Link-access controls and anything else specific to one entity type. */
+  generalAccess?: ReactNode;
+  onClose?: () => void;
+}
+
+/**
+ * Share and post modal shared by recordings and calls: pick people, groups or
+ * channels, add an optional note, and see or remove who already has access.
+ * Everything entity-specific — which service the grant goes to, and any extra
+ * sections — is supplied by the wrapper (RecordingShareModal, CallShareModal).
+ */
+export const EntityShareModal: React.FC<EntityShareModalProps> = ({
+  ownerId,
+  shares,
+  onGrant,
+  onRevoke,
+  subject,
+  trackCategory,
+  accessListTitle = 'People with access',
+  generalAccess,
+  onClose,
+}) => {
+  const { user: currentUser } = useAuth();
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedValues, setSelectedValues] = useState<string[]>([]);
+  const [messageContent, setMessageContent] = useState('');
+  const [sharing, setSharing] = useState(false);
+  const inputBoxRef = useRef<InputBoxHandle>(null);
+
+  const sharedUserIds = useMemo(
+    () => new Set(shares.map(share => share.userId).filter((id): id is string => Boolean(id))),
+    [shares],
+  );
+  const sharedUserGroupIds = useMemo(
+    () =>
+      new Set(
+        shares.filter(share => share.target.type === 'user_group').map(share => share.target.id),
+      ),
+    [shares],
+  );
+  const sharedChannelIds = useMemo(
+    () =>
+      new Set(
+        shares.filter(share => share.target.type === 'channel').map(share => share.target.id),
+      ),
+    [shares],
+  );
+
+  const excludedUserIds = useMemo(
+    () =>
+      new Set(
+        [ownerId, currentUser?.id, ...sharedUserIds].filter((id): id is string => Boolean(id)),
+      ),
+    [currentUser?.id, ownerId, sharedUserIds],
+  );
+
+  // Mentions inside the note resolve against the selected channel when there is
+  // one, so they match who will actually see the post.
+  const selectedChannelId = useMemo(
+    () =>
+      selectedValues.find(value => value.startsWith('channel:'))?.replace('channel:', '') ??
+      undefined,
+    [selectedValues],
+  );
+
+  const { results: channelScopedMentions, searchMentions: searchChannelScopedMentions } =
+    useMentionSearch(selectedChannelId);
+
+  const [mentionQuery, setMentionQuery] = useState('');
+  const mentionUsers = useActiveUserSearch(mentionQuery, MENTION_USER_LIMIT);
+  const mentionGroups = useUserGroupSearch(mentionQuery, MENTION_GROUP_LIMIT);
+  const workspaceMentions = useMemo<MentionResult[]>(
+    () => [
+      ...mentionUsers.map(u => userToMentionResult(u, u.id === currentUser?.id)),
+      ...mentionGroups.map(
+        (g): MentionResult => ({
+          id: g.id,
+          name: g.name,
+          type: 'group',
+          ...(g.alias && { alias: g.alias }),
+          ...(g.description && { description: g.description }),
+          memberCount: 0,
+          isDeactivated: g.isActive === false,
+        }),
+      ),
+    ],
+    [mentionUsers, mentionGroups, currentUser?.id],
+  );
+
+  const mentionResults = selectedChannelId ? channelScopedMentions : workspaceMentions;
+  const handleMentionSearch = useCallback(
+    (query: string) => {
+      if (selectedChannelId) {
+        searchChannelScopedMentions(query);
+      } else {
+        setMentionQuery(query);
+      }
+    },
+    [selectedChannelId, searchChannelScopedMentions],
+  );
+
+  const [channelMentionQuery, setChannelMentionQuery] = useState('');
+  const channelMentionResults = useChannelSearch(channelMentionQuery, 10);
+  const channelMentionItems = useMemo(
+    () =>
+      channelMentionResults
+        .filter(channel => channel.scopeType === ChannelScopeType.DEFAULT)
+        .map(channel => ({
+          id: channel.id,
+          name: channel.name,
+          isPrivate: channel.visibility === ChannelVisibility.PRIVATE,
+          ...(channel.description && { description: channel.description }),
+        })),
+    [channelMentionResults],
+  );
+
+  const handleShare = async (): Promise<void> => {
+    if (selectedValues.length === 0) return;
+
+    setSharing(true);
+    try {
+      const targets: EntityShareTarget[] = selectedValues.map(value =>
+        value.startsWith('user_group:')
+          ? { type: 'user_group', id: value.replace('user_group:', '') }
+          : value.startsWith('channel:')
+            ? { type: 'channel', id: value.replace('channel:', '') }
+            : { type: 'user', id: value.replace('user:', '') },
+      );
+      await onGrant(targets, messageContent);
+      toast.success(
+        selectedValues.length === 1
+          ? `${subject.charAt(0).toUpperCase()}${subject.slice(1)} shared`
+          : `Shared with ${selectedValues.length} recipients`,
+      );
+      setSelectedValues([]);
+      setSearchQuery('');
+      setMessageContent('');
+      onClose?.();
+    } catch (error) {
+      toast.error('Failed to share', {
+        description: getApiErrorMessage(error, `Unable to share this ${subject}`),
+      });
+    } finally {
+      setSharing(false);
+    }
+  };
+
+  return (
+    <div className='flex flex-col w-full p-5 gap-4'>
+      <div className='space-y-2'>
+        <p className='text-muted-foreground text-[13px] leading-5'>
+          Share with people, groups, or channels
+        </p>
+        <UnifiedParticipantSearch
+          selectedValues={selectedValues}
+          onMultiSelect={setSelectedValues}
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          excludedUserIds={excludedUserIds}
+          excludedUserGroupIds={sharedUserGroupIds}
+          excludedChannelIds={sharedChannelIds}
+          exclusiveSelection={false}
+        />
+      </div>
+
+      <div
+        className='space-y-1.5'
+        data-track-category={trackCategory}
+        data-track-name={`share_${subject}_message_input`}
+        onKeyDownCapture={event => {
+          if (event.key === 'Enter' && !event.shiftKey && selectedValues.length > 0) {
+            if (inputBoxRef.current?.isSuggestionOpen()) return;
+            event.preventDefault();
+            event.stopPropagation();
+            void handleShare();
+          }
+        }}
+      >
+        <label htmlFor={`share-${subject}-message`} className='text-muted-foreground text-[13px]'>
+          Add a message (optional)
+        </label>
+        <InputBox
+          ref={inputBoxRef}
+          id={`share-${subject}-message`}
+          placeholder={`Say something about this ${subject}...`}
+          onSendMessage={() => {}}
+          onContentChange={(html, _text) => {
+            setMessageContent(html);
+          }}
+          mentionItems={mentionResults}
+          onMentionSearch={handleMentionSearch}
+          channelItems={channelMentionItems}
+          onChannelSearch={setChannelMentionQuery}
+          features={{
+            richText: true,
+            mentions: true,
+            commands: false,
+            fileAttachments: false,
+            emojiPicker: true,
+          }}
+          showTypingIndicator={false}
+          disabled={sharing}
+          disableEnterToSend
+          hideSendButton
+        />
+      </div>
+
+      <div className='flex justify-end'>
+        <Button
+          size='sm'
+          onClick={() => void handleShare()}
+          disabled={selectedValues.length === 0 || sharing}
+          data-track-category={trackCategory}
+          data-track-name={`share_${subject}_confirm`}
+        >
+          {sharing ? 'Sharing...' : 'Share'}
+        </Button>
+      </div>
+
+      {shares.length > 0 && (
+        <div className='space-y-2 border-t border-border pt-3'>
+          <p className='text-muted-foreground text-[13px]'>{accessListTitle}</p>
+          <div className='space-y-3.5 max-h-60 overflow-y-auto pr-1'>
+            {shares.map(share => {
+              const icon =
+                share.target.type === 'user_group' ? (
+                  <Users className='size-4 text-muted-foreground shrink-0' />
+                ) : share.target.type === 'channel' ? (
+                  <Hash className='size-4 text-muted-foreground shrink-0' />
+                ) : (
+                  <Avatar userId={share.userId} size='sm' showActiveStatus={false} />
+                );
+
+              return (
+                <div key={share.id} className='group flex items-center justify-between gap-2'>
+                  <div className='flex items-center gap-2 min-w-0'>
+                    {icon}
+                    <span className='text-sm truncate'>{share.label}</span>
+                    {share.post && (
+                      <Link
+                        to={`/chat/dir/${share.post.channelId}/${share.post.conversationId}`}
+                        className='shrink-0 text-muted-foreground transition-colors hover:text-foreground'
+                        aria-label='Open shared conversation'
+                        data-track-category={trackCategory}
+                        data-track-name={`open_${subject}_share_conversation`}
+                      >
+                        <LinkChainSlant className='size-3.5' aria-hidden='true' />
+                      </Link>
+                    )}
+                  </div>
+                  <button
+                    type='button'
+                    onClick={() => void onRevoke(share.target)}
+                    className='shrink-0 rounded p-1 text-muted-foreground opacity-0 hover:bg-muted hover:text-foreground group-hover:opacity-100'
+                    aria-label='Remove access'
+                    data-track-category={trackCategory}
+                    data-track-name={`revoke_${subject}_share`}
+                  >
+                    <X className='size-3.5' />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {generalAccess}
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/ui/MessageBubble/CallShareBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/CallShareBubble.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Phone } from 'lucide-react';
+import { RenderMessageWithHTML } from '../../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { EntitySharePill } from './EntitySharePill';
+import { MessageMetadata } from './MessageBubble.utils';
+
+interface CallShareBubbleProps {
+  message: {
+    content: string;
+    metadata: MessageMetadata | null;
+  };
+}
+
+/**
+ * The card posted when a regular call is shared to a channel or DM
+ * (recordingSharingService.createRecordingPostMessage, `call_share_post`).
+ *
+ * The recordings counterpart is RecordingBubble, which also has to cover a live
+ * anchor; a call is only ever shared once it's over, so this is the settled card
+ * alone. Everything it renders is on the message, so no query on `calls` is needed
+ * — and the share wrote an entity_access row, so anyone who can read the message
+ * can open the call.
+ */
+export const CallShareBubble: React.FC<CallShareBubbleProps> = ({ message }) => {
+  const navigate = useNavigate();
+
+  const metadata = message.metadata;
+  const title = message.content || 'Untitled Call';
+  const durationMs = typeof metadata?.['durationMs'] === 'number' ? metadata['durationMs'] : null;
+  const noteHtml =
+    typeof metadata?.['messageContent'] === 'string' ? metadata['messageContent'] : null;
+  // The detail route keys on `calls.id`, not the externalId the rest of the
+  // metadata carries, so the share stamps it separately.
+  const callRowId = typeof metadata?.['callRowId'] === 'string' ? metadata['callRowId'] : null;
+
+  return (
+    <div className='flex w-full max-w-lg flex-col gap-1'>
+      {noteHtml && (
+        <div className='jp-message-html whitespace-pre-wrap break-words text-sm text-foreground'>
+          <RenderMessageWithHTML message={noteHtml} />
+        </div>
+      )}
+      <EntitySharePill
+        title={title}
+        durationMs={durationMs}
+        icon={<Phone size={13} strokeWidth={2.5} />}
+        ariaLabel={`Open call ${title}`}
+        onOpen={
+          callRowId
+            ? (): void => {
+                void navigate(`/calls/${callRowId}/detail`);
+              }
+            : undefined
+        }
+        trackName='OPEN_SHARED_CALL'
+      />
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/ui/MessageBubble/EntitySharePill.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/EntitySharePill.tsx
@@ -1,0 +1,66 @@
+import React, { type ReactNode } from 'react';
+import { ChevronRight } from '@xyne/icons';
+import { formatElapsedTime } from '../../../utils/recordingUtils';
+
+export interface EntitySharePillProps {
+  title: string;
+  durationMs: number | null;
+  /** Leading glyph naming what was shared. */
+  icon: ReactNode;
+  /** Screen-reader label for the whole card, e.g. 'Open recording Standup'. */
+  ariaLabel: string;
+  /** Omit to render the card inert — the viewer has no access to open it. */
+  onOpen?: (() => void) | undefined;
+  trackName?: string;
+}
+
+/**
+ * The card a shared call or recording renders as inside a channel message. One
+ * component so "a recording in a message" and "a call in a message" stay visually
+ * identical; RecordingSharePill and CallSharePill are the per-entity bindings.
+ */
+export const EntitySharePill: React.FC<EntitySharePillProps> = ({
+  title,
+  durationMs,
+  icon,
+  ariaLabel,
+  onOpen,
+  trackName = 'OPEN_SHARED_ENTITY',
+}) => (
+  <button
+    type='button'
+    onClick={event => {
+      event.stopPropagation();
+      onOpen?.();
+    }}
+    disabled={!onOpen}
+    className='group flex w-full max-w-lg items-center gap-2.5 rounded-lg border border-border bg-card px-3 py-1.5 text-left shadow-sm disabled:cursor-default'
+    aria-label={ariaLabel}
+    data-track-category='MESSAGE'
+    data-track-name={trackName}
+  >
+    <span
+      className='flex size-5 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground transition-colors'
+      aria-hidden='true'
+    >
+      {icon}
+    </span>
+
+    <span className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>{title}</span>
+
+    {durationMs !== null && (
+      <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>
+        {formatElapsedTime(durationMs)}
+      </span>
+    )}
+
+    {onOpen && (
+      <ChevronRight
+        size={16}
+        strokeWidth={2.5}
+        className='shrink-0 text-muted-foreground transition-transform'
+        aria-hidden='true'
+      />
+    )}
+  </button>
+);

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -76,6 +76,7 @@ import { StatusIndicator } from '../StatusIndicator';
 import DOMPurify from 'dompurify';
 import { CallBubble } from './CallBubble';
 import { RecordingBubble } from './RecordingBubble';
+import { CallShareBubble } from './CallShareBubble';
 import { getEmojiDisplayName, renderEmoji } from '../../../utils/customEmojiUtils';
 import { parseMarkdownWithTicketSuggestions } from '../../../utils/markdownTicketSuggestions';
 import { TicketSuggestions } from './TicketSuggestions';
@@ -613,6 +614,9 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   // picks up call-only behavior (transcript dimming, forwarding-as-call, PRD
   // buttons, etc).
   const isRecordingMessage = metadata?.['isRecordingMessage'] === true;
+  // A regular call shared into a channel (recordingSharingService). Separate from
+  // isCallMessage, which is the live call anchor in the call's own channel.
+  const isCallShareMessage = metadata?.['isCallShareMessage'] === true;
   // Only live recording anchors use the system-style sender.
   const isHeadlessRecordingAnchor =
     isRecordingMessage && metadata?.['isHeadlessRecording'] === true;
@@ -1213,7 +1217,12 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
             )}
 
           {/* ================== MESSAGE CONTENT ================== */}
-          {isRecordingMessage && metadata?.callId && !isForwardedMessage && !message.isDeleted ? (
+          {isCallShareMessage && !isForwardedMessage && !message.isDeleted ? (
+            <CallShareBubble message={{ content: message.content, metadata }} />
+          ) : isRecordingMessage &&
+            metadata?.callId &&
+            !isForwardedMessage &&
+            !message.isDeleted ? (
             <RecordingBubble
               message={{
                 messageId: message.messageId,

--- a/apps/dashboard/src/components/ui/MessageBubble/RecordingSharePill.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/RecordingSharePill.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { AudioLines } from 'lucide-react';
-import { ChevronRight } from '@xyne/icons';
-import { formatElapsedTime } from '../../../utils/recordingUtils';
+import { EntitySharePill } from './EntitySharePill';
 
 interface RecordingSharePillProps {
   title: string;
@@ -9,45 +8,18 @@ interface RecordingSharePillProps {
   onOpen?: (() => void) | undefined;
 }
 
+/** Recordings binding for {@link EntitySharePill}. */
 export const RecordingSharePill: React.FC<RecordingSharePillProps> = ({
   title,
   durationMs,
   onOpen,
 }) => (
-  <button
-    type='button'
-    onClick={event => {
-      event.stopPropagation();
-      onOpen?.();
-    }}
-    disabled={!onOpen}
-    className='group flex w-full max-w-lg items-center gap-2.5 rounded-lg border border-border bg-card px-3 py-1.5 text-left shadow-sm disabled:cursor-default'
-    aria-label={`Open recording ${title}`}
-    data-track-category='MESSAGE'
-    data-track-name='OPEN_SHARED_RECORDING'
-  >
-    <span
-      className='flex size-5 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground transition-colors'
-      aria-hidden='true'
-    >
-      <AudioLines size={14} strokeWidth={2.5} />
-    </span>
-
-    <span className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>{title}</span>
-
-    {durationMs !== null && (
-      <span className='shrink-0 font-mono text-xs tabular-nums text-muted-foreground'>
-        {formatElapsedTime(durationMs)}
-      </span>
-    )}
-
-    {onOpen && (
-      <ChevronRight
-        size={16}
-        strokeWidth={2.5}
-        className='shrink-0 text-muted-foreground transition-transform'
-        aria-hidden='true'
-      />
-    )}
-  </button>
+  <EntitySharePill
+    title={title}
+    durationMs={durationMs}
+    icon={<AudioLines size={14} strokeWidth={2.5} />}
+    ariaLabel={`Open recording ${title}`}
+    onOpen={onOpen}
+    trackName='OPEN_SHARED_RECORDING'
+  />
 );

--- a/apps/dashboard/src/hooks/useCallLabelSuggestions.ts
+++ b/apps/dashboard/src/hooks/useCallLabelSuggestions.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react';
+import { normalizeRecordingTags } from '../utils/recordingUtils';
+import { queries } from '../zero/queries';
+import { useCachedQuery } from './useCachedQuery';
+
+/** Recent calls sampled to build the suggestion list. */
+const SUGGESTION_SAMPLE_SIZE = 100;
+
+/**
+ * Label ids already applied to the user's recent calls, offered in the call
+ * detail picker before anything is typed. The recordings equivalent lives in
+ * useRecordingLabelSuggestions — the two read different slices of `calls`
+ * (HEADLESS vs. everything else), so they stay separate hooks.
+ */
+export function useCallLabelSuggestions(enabled = true): string[] {
+  const [calls] = useCachedQuery(
+    queries.userCallHistoryV2({ limit: SUGGESTION_SAMPLE_SIZE, start: null }),
+    { enabled },
+  );
+
+  return useMemo(
+    () =>
+      normalizeRecordingTags((calls ?? []).flatMap(call => call.labels)).sort((left, right) =>
+        left.localeCompare(right),
+      ),
+    [calls],
+  );
+}

--- a/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
+++ b/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
@@ -23,7 +23,12 @@ import { useAllChannels, useAllVisibleChannels } from '../../hooks/useChannels';
 import { useChannelDisplayName } from '../../hooks/useChannelDisplayName';
 import { formatCallHeldOn, formatCallLength } from './CallDetailScreen.utils';
 import { CallLabelPicker } from './CallLabelPicker';
+import { useCallSummaryRegeneration } from './useCallSummaryRegeneration';
+import { SummaryGenerationPanel } from '../RecordingDetailV2Screen/components/SummaryGenerationPill/SummaryGenerationPanel';
 import { callService } from '../../services/Call/callService';
+
+/** Past this, in-call generation is not coming on its own — offer the button instead. */
+const SUMMARY_PENDING_GRACE_MS = 60 * 60 * 1000;
 
 let _userClosedAIForCallId: string | null = null;
 
@@ -111,7 +116,16 @@ export default function CallDetailScreen(): ReactElement {
     return getCanvasIdFromUrl(meta?.['detailedSummaryCanvasUrl']);
   }, [callMessage]);
 
-  const hasDetailedSummaryTab = Boolean(detailedSummaryCanvasId);
+  // A call with a transcript but no canvas still gets the tab: within the grace
+  // window it shows the pending state, and past it the offer to generate — the
+  // same treatment the recording detail screen gives an overdue summary.
+  const hasCallTranscript = Boolean(call?.transcript?.trim());
+  const summaryEndedAtMs = call?.endedAt ? new Date(call.endedAt).getTime() : null;
+  const summaryPendingExpired =
+    !detailedSummaryCanvasId &&
+    summaryEndedAtMs !== null &&
+    Date.now() - summaryEndedAtMs > SUMMARY_PENDING_GRACE_MS;
+  const hasDetailedSummaryTab = Boolean(detailedSummaryCanvasId) || hasCallTranscript;
 
   const hasRecording = useMemo<boolean>(() => {
     if (!conversationMessages || !call?.externalId) return false;
@@ -218,8 +232,14 @@ export default function CallDetailScreen(): ReactElement {
       (call.channelId && visibleChannels.some(c => c.id === call.channelId))),
   );
 
-  // `call` comes off navigation state, so it never re-resolves from Zero. Labels
-  // are held here instead and reseeded whenever a different call is opened.
+  // Owned here, not in the pill: rewriting swaps the content pane for a panel.
+  const summaryRegeneration = useCallSummaryRegeneration(
+    call?.externalId ?? '',
+    call?.summaryTemplateId,
+  );
+
+  // `call` comes off navigation state and never re-resolves from Zero, so labels
+  // are held here and reseeded when a different call is opened.
   const [labels, setLabels] = useState<string[]>(call?.labels ?? []);
   const labelsUpdateSeqRef = useRef(0);
   useEffect(() => {
@@ -413,7 +433,9 @@ export default function CallDetailScreen(): ReactElement {
               >
                 {hasDetailedSummaryTab && (
                   <CallSummaryTemplatePicker
-                    selectedTemplateId={call.summaryTemplateId}
+                    selectedTemplateId={summaryRegeneration.appliedTemplateId}
+                    isRegenerating={summaryRegeneration.isRegenerating}
+                    onApplyTemplate={templateId => void summaryRegeneration.regenerate(templateId)}
                     isActive={activeTab === 'detailed-summary'}
                     onSelect={() => setSelectedTab('detailed-summary')}
                     className={pillClassName(activeTab === 'detailed-summary')}
@@ -458,8 +480,29 @@ export default function CallDetailScreen(): ReactElement {
                   <Loader2 className='size-4 animate-spin' />
                   Loading...
                 </div>
-              ) : activeTab === 'detailed-summary' && detailedSummaryCanvasId ? (
-                <DetailedSummaryCanvasTab canvasId={detailedSummaryCanvasId} />
+              ) : activeTab === 'detailed-summary' ? (
+                detailedSummaryCanvasId &&
+                !summaryRegeneration.isRegenerating &&
+                !summaryRegeneration.hasFailed ? (
+                  <DetailedSummaryCanvasTab
+                    key={`${detailedSummaryCanvasId}:${summaryRegeneration.canvasNonce}`}
+                    canvasId={detailedSummaryCanvasId}
+                  />
+                ) : (
+                  <SummaryGenerationPanel
+                    isAwaiting={
+                      summaryRegeneration.isRegenerating ||
+                      (!detailedSummaryCanvasId && !summaryPendingExpired)
+                    }
+                    canGenerate={hasCallTranscript}
+                    hasFailed={summaryRegeneration.hasFailed}
+                    generationRunId={summaryRegeneration.runNonce}
+                    onGenerate={summaryRegeneration.retry}
+                    onRetry={summaryRegeneration.retry}
+                    summarySubject='call'
+                    trackCategory='CallDetail'
+                  />
+                )
               ) : (
                 (() => {
                   const prd = prdEntries.find(e => e.id === activeTab);

--- a/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
+++ b/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
@@ -2,6 +2,7 @@ import { ReactElement, useState, useEffect, useRef, useCallback, useMemo } from 
 import { useSelector } from '@xstate/react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ChevronLeft, ChevronRight, Loader2, FileText } from 'lucide-react';
+import { toast } from 'sonner';
 import { recordingService } from '../../services/Recording/recordingService';
 import { AudioPlayer } from '../../components/ui/AudioPlayer/AudioPlayer';
 import { useCallPRD } from '../../hooks/useCallPRD';
@@ -21,6 +22,8 @@ import { useAuth } from '../../hooks/useAuth';
 import { useAllChannels, useAllVisibleChannels } from '../../hooks/useChannels';
 import { useChannelDisplayName } from '../../hooks/useChannelDisplayName';
 import { formatCallHeldOn, formatCallLength } from './CallDetailScreen.utils';
+import { CallLabelPicker } from './CallLabelPicker';
+import { callService } from '../../services/Call/callService';
 
 let _userClosedAIForCallId: string | null = null;
 
@@ -207,6 +210,43 @@ export default function CallDetailScreen(): ReactElement {
     };
   }, [call, isMobile, openAI]);
 
+  const canEditLabels = Boolean(
+    user?.id &&
+    call &&
+    (call.createdByUserId === user.id ||
+      call.participants?.some(p => p.userId === user.id) ||
+      (call.channelId && visibleChannels.some(c => c.id === call.channelId))),
+  );
+
+  // `call` comes off navigation state, so it never re-resolves from Zero. Labels
+  // are held here instead and reseeded whenever a different call is opened.
+  const [labels, setLabels] = useState<string[]>(call?.labels ?? []);
+  const labelsUpdateSeqRef = useRef(0);
+  useEffect(() => {
+    setLabels(call?.labels ?? []);
+    // Keyed on the call alone: re-running on the labels array would undo an
+    // optimistic edit, since navigation state keeps the pre-edit value forever.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [call?.id]);
+
+  /** Labels apply optimistically and roll back if the call rejects the write. */
+  const handleLabelsChange = async (next: string[]): Promise<void> => {
+    if (!call) return;
+    const previousLabels = labels;
+    const seq = ++labelsUpdateSeqRef.current;
+    setLabels(next);
+
+    try {
+      // Raw text typed in the picker becomes a real Tag server-side, so swap in
+      // the ids the response returns rather than keeping the optimistic strings.
+      const resolved = await callService.updateCallLabels(call.externalId, next);
+      if (labelsUpdateSeqRef.current === seq) setLabels(resolved);
+    } catch {
+      toast.error('Failed to update labels');
+      if (labelsUpdateSeqRef.current === seq) setLabels(previousLabels);
+    }
+  };
+
   const title = call?.title ?? 'Untitled Call';
   const heldOn = formatCallHeldOn(call?.startedAt);
   const callLength = formatCallLength(durationMs);
@@ -327,8 +367,17 @@ export default function CallDetailScreen(): ReactElement {
               )}
             </div>
 
-            {/* Participants */}
-            <CallParticipantsPopover call={call} currentUserId={user?.id} className='mt-3.5' />
+            {/* Participants + labels — one row, as on the recording detail header */}
+            <div className='mt-3.5 flex flex-wrap items-center gap-2'>
+              <CallParticipantsPopover call={call} currentUserId={user?.id} />
+              {(canEditLabels || labels.length > 0) && (
+                <CallLabelPicker
+                  labels={labels}
+                  canEdit={canEditLabels}
+                  onChange={next => void handleLabelsChange(next)}
+                />
+              )}
+            </div>
 
             {/* Recording */}
             {hasRecording && (

--- a/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
+++ b/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
@@ -1,7 +1,8 @@
 import { ReactElement, useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useSelector } from '@xstate/react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, Loader2, FileText } from 'lucide-react';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { ChevronLeft, ChevronRight, ChevronDown, Loader2, FileText } from 'lucide-react';
+import { Hashtag, EnvelopeDefault, File02Text } from '@xyne/icons';
 import { toast } from 'sonner';
 import { recordingService } from '../../services/Recording/recordingService';
 import { AudioPlayer } from '../../components/ui/AudioPlayer/AudioPlayer';
@@ -26,6 +27,22 @@ import { CallLabelPicker } from './CallLabelPicker';
 import { useCallSummaryRegeneration } from './useCallSummaryRegeneration';
 import { SummaryGenerationPanel } from '../RecordingDetailV2Screen/components/SummaryGenerationPill/SummaryGenerationPanel';
 import { callService } from '../../services/Call/callService';
+import { Dialog } from '../../components/ui/Dialog/Dialog';
+import { CallShareModal } from './CallShareModal';
+import { Button } from '../../components/ui/Button/Button';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '../../components/ui/dropdown-menu';
+import { PostRecordingToEmailModal } from '../RecordingDetailV2Screen/components/PostRecordingToEmailModal';
+import { GoogleDocPreviewModal } from '../RecordingDetailV2Screen/components/GoogleDocPreviewModal';
+import { useCallGoogleDocExport, useCallGoogleDocs } from './useCallGoogleDocExport';
+
+/** Matches the recording detail header's post button (POST_SPLIT_BUTTON_CLASS). */
+const POST_BUTTON_CLASS =
+  'text-background hover:bg-foreground/90 hover:text-background dark:hover:bg-foreground/90 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-background';
 
 /** Past this, in-call generation is not coming on its own — offer the button instead. */
 const SUMMARY_PENDING_GRACE_MS = 60 * 60 * 1000;
@@ -40,8 +57,20 @@ const getCanvasIdFromUrl = (url: unknown): string | null => {
 export default function CallDetailScreen(): ReactElement {
   const navigate = useNavigate();
   const location = useLocation();
-  const call = (location.state as { call: Call } | null)?.call;
+  const { callId: callIdParam } = useParams<{ callId: string }>();
   const { isMobile } = usePlatform();
+
+  // Calls Home hands the row over in navigation state. A call reached by link —
+  // from a share posted to a channel, or a pasted URL — has none, so fall back to
+  // resolving it by the id in the route.
+  const navigationCall = (location.state as { call: Call } | null)?.call;
+  const [fetchedCall, fetchedCallDetails] = useCachedQuery(
+    queries.callById({ callId: callIdParam ?? '' }),
+    { enabled: !navigationCall && Boolean(callIdParam) },
+  );
+  const call: Call | undefined = navigationCall ?? fetchedCall ?? undefined;
+  const isResolvingCall =
+    !navigationCall && Boolean(callIdParam) && fetchedCallDetails.type !== 'complete';
 
   // Hoist derived values so they're available to all hooks below
   const callConversationId =
@@ -113,8 +142,15 @@ export default function CallDetailScreen(): ReactElement {
 
   const detailedSummaryCanvasId = useMemo<string | null>(() => {
     const meta = callMessage?.metadata as Record<string, unknown> | null | undefined;
-    return getCanvasIdFromUrl(meta?.['detailedSummaryCanvasUrl']);
-  }, [callMessage]);
+    const fromMessage = getCanvasIdFromUrl(meta?.['detailedSummaryCanvasUrl']);
+    if (fromMessage) return fromMessage;
+    // A call shared out of its own channel: the recipient cannot read the call
+    // message, so the share copied the pointer onto the call row instead
+    // (recordingSharingService.stampCallSummaryCanvasPointer).
+    const callMeta = call?.metadata as Record<string, unknown> | null | undefined;
+    const stamped = callMeta?.['detailedSummaryCanvasId'];
+    return typeof stamped === 'string' && stamped.length > 0 ? stamped : null;
+  }, [callMessage, call?.metadata]);
 
   // A call with a transcript but no canvas still gets the tab: within the grace
   // window it shows the pending state, and past it the offer to generate — the
@@ -126,6 +162,23 @@ export default function CallDetailScreen(): ReactElement {
     summaryEndedAtMs !== null &&
     Date.now() - summaryEndedAtMs > SUMMARY_PENDING_GRACE_MS;
   const hasDetailedSummaryTab = Boolean(detailedSummaryCanvasId) || hasCallTranscript;
+  // aiSummaryFormat is not stored — it is sniffed from the content. Recordings do
+  // this server-side in getRecordingDetail, which never runs for a call, so apply
+  // the same test here or an HTML summary gets markdown-escaped in the email body.
+  const summaryFormat: 'markdown' | 'html' = ((): 'markdown' | 'html' => {
+    const summary = call?.aiSummary?.trim();
+    if (!summary) return 'markdown';
+    const hasHtmlTags = /<[^>]+>/i.test(summary);
+    const startsWithMarkdown = /^##?\s/.test(summary);
+    return !hasHtmlTags || startsWithMarkdown ? 'markdown' : 'html';
+  })();
+
+  // The export endpoint needs summary text, so a transcript-only call can post and
+  // email but has nothing to put in a Google Doc yet. Export is owner-only, as it
+  // is for recordings, so the item stays disabled for everyone else in the audience.
+  const isCallOwner = Boolean(user?.id && call?.createdByUserId === user.id);
+  const canExportGoogleDoc =
+    isCallOwner && Boolean(detailedSummaryCanvasId || call?.aiSummary?.trim());
 
   const hasRecording = useMemo<boolean>(() => {
     if (!conversationMessages || !call?.externalId) return false;
@@ -224,13 +277,64 @@ export default function CallDetailScreen(): ReactElement {
     };
   }, [call, isMobile, openAI]);
 
-  const canEditLabels = Boolean(
+  // The call's host, anyone who took part, or a member of the channel it happened
+  // in. Mirrors isCallAudience on the backend, which gates the same two actions.
+  const isCallAudience = Boolean(
     user?.id &&
     call &&
     (call.createdByUserId === user.id ||
       call.participants?.some(p => p.userId === user.id) ||
       (call.channelId && visibleChannels.some(c => c.id === call.channelId))),
   );
+  const [showShareModal, setShowShareModal] = useState(false);
+  const [showEmailModal, setShowEmailModal] = useState(false);
+  const [showGoogleDocModal, setShowGoogleDocModal] = useState(false);
+  const [emailModalNonce, setEmailModalNonce] = useState(0);
+  const [googleDocModalNonce, setGoogleDocModalNonce] = useState(0);
+  const callGoogleDocs = useCallGoogleDocs(call?.metadata);
+  const googleDocExport = useCallGoogleDocExport(call?.externalId ?? '', () =>
+    setShowGoogleDocModal(false),
+  );
+
+  // Connecting Google sends the browser away and back with these params. Reopen
+  // the modal it came from, remounted so it refetches what it can now do. Same
+  // param names as the recordings screen — they belong to the integration, not
+  // to whichever screen started the connection.
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const email = params.get('recordingEmailConnected') === 'true';
+    const emailError = params.get('recordingEmailError');
+    const doc = params.get('recordingGoogleDocConnected') === 'true';
+    const docError = params.get('recordingGoogleDocError');
+    if (!email && !emailError && !doc && !docError) return;
+
+    if (email || emailError) {
+      if (email) toast.success('Google email connected');
+      else toast.error(emailError as string);
+      setEmailModalNonce(nonce => nonce + 1);
+      setShowEmailModal(true);
+    }
+    if (doc || docError) {
+      if (doc) toast.success('Google Docs connected');
+      else toast.error('Google Docs connection failed. Please try again.');
+      setGoogleDocModalNonce(nonce => nonce + 1);
+      setShowGoogleDocModal(true);
+    }
+
+    for (const key of [
+      'recordingEmailConnected',
+      'recordingEmailError',
+      'recordingGoogleDocConnected',
+      'recordingGoogleDocError',
+    ]) {
+      params.delete(key);
+    }
+    const search = params.toString();
+    void navigate(
+      { pathname: location.pathname, ...(search ? { search: `?${search}` } : {}) },
+      { replace: true, state: (location.state as { call: Call } | null) ?? null },
+    );
+  }, [location.pathname, location.search, location.state, navigate]);
 
   // Owned here, not in the pill: rewriting swaps the content pane for a panel.
   const summaryRegeneration = useCallSummaryRegeneration(
@@ -274,9 +378,13 @@ export default function CallDetailScreen(): ReactElement {
   if (!call) {
     return (
       <div className='flex items-center justify-center h-full'>
-        <p className='text-sm text-muted-foreground'>
-          Call not found. Please go back and try again.
-        </p>
+        {isResolvingCall ? (
+          <Loader2 className='size-5 animate-spin text-muted-foreground' />
+        ) : (
+          <p className='text-sm text-muted-foreground'>
+            Call not found, or you do not have access to it.
+          </p>
+        )}
       </div>
     );
   }
@@ -390,10 +498,10 @@ export default function CallDetailScreen(): ReactElement {
             {/* Participants + labels — one row, as on the recording detail header */}
             <div className='mt-3.5 flex flex-wrap items-center gap-2'>
               <CallParticipantsPopover call={call} currentUserId={user?.id} />
-              {(canEditLabels || labels.length > 0) && (
+              {(isCallAudience || labels.length > 0) && (
                 <CallLabelPicker
                   labels={labels}
-                  canEdit={canEditLabels}
+                  canEdit={isCallAudience}
                   onChange={next => void handleLabelsChange(next)}
                 />
               )}
@@ -471,6 +579,80 @@ export default function CallDetailScreen(): ReactElement {
                   <ChevronRight className='size-3.5' />
                 </button>
               )}
+              {isCallAudience && hasDetailedSummaryTab && (
+                <DropdownMenu>
+                  <div className='inline-flex h-8 shrink-0 items-stretch overflow-hidden rounded-lg bg-foreground text-background shadow-sm'>
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='sm'
+                      onClick={() => setShowShareModal(true)}
+                      className={cn(POST_BUTTON_CLASS, 'text-xs font-semibold !rounded-2xl')}
+                      data-track-category='CallDetail'
+                      data-track-name='open_post_to_channel_modal'
+                    >
+                      <Hashtag className='size-3.5' />
+                      Post to channel
+                    </Button>
+                    <span className='my-1.5 w-px bg-muted-foreground/50' aria-hidden='true' />
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='iconSm'
+                        aria-label='More actions'
+                        className={POST_BUTTON_CLASS}
+                        data-track-category='CallDetail'
+                        data-track-name='open_call_share_menu'
+                      >
+                        <ChevronDown className='size-3.5' />
+                      </Button>
+                    </DropdownMenuTrigger>
+                  </div>
+                  <DropdownMenuContent
+                    align='end'
+                    sideOffset={6}
+                    className='w-60 rounded-xl p-1.5 shadow-xl'
+                  >
+                    <p className='px-2.5 pb-1 pt-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground'>
+                      Send this summary to
+                    </p>
+                    <DropdownMenuItem
+                      onSelect={() => setShowShareModal(true)}
+                      className='rounded-lg px-2.5 py-2'
+                      data-track-category='CallDetail'
+                      data-track-name='open_post_to_channel_from_menu'
+                    >
+                      <Hashtag className='size-4 text-muted-foreground' />
+                      Post to channel
+                      <span className='ml-auto rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground'>
+                        Default
+                      </span>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={() => setShowEmailModal(true)}
+                      className='rounded-lg px-2.5 py-2'
+                      data-track-category='CallDetail'
+                      data-track-name='open_post_to_email_modal'
+                    >
+                      <EnvelopeDefault className='size-4 text-muted-foreground' />
+                      Draft follow-up email
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={() => setShowGoogleDocModal(true)}
+                      disabled={googleDocExport.isExporting || !canExportGoogleDoc}
+                      className='rounded-lg px-2.5 py-2'
+                      data-track-category='CallDetail'
+                      data-track-name='export_call_google_doc'
+                    >
+                      <File02Text className='size-4 text-muted-foreground' />
+                      {googleDocExport.isExporting
+                        ? 'Creating Google Doc…'
+                        : 'Export to Google Docs'}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
 
             {/* Tab content */}
@@ -530,6 +712,75 @@ export default function CallDetailScreen(): ReactElement {
           </div>
         </div>
       </div>
+
+      {showShareModal && (
+        <Dialog
+          open={showShareModal}
+          onOpenChange={open => !open && setShowShareModal(false)}
+          title='Post to channel'
+          data-testid='post-call-to-channel-modal'
+          onOpenAutoFocus={event => event.preventDefault()}
+        >
+          <CallShareModal
+            callId={call.id}
+            externalId={call.externalId}
+            createdByUserId={call.createdByUserId}
+            onClose={() => setShowShareModal(false)}
+          />
+        </Dialog>
+      )}
+
+      {showEmailModal && (
+        <Dialog
+          open={showEmailModal}
+          onOpenChange={open => !open && setShowEmailModal(false)}
+          title='Review draft email'
+          description='Review the call recap before sending it by email.'
+          className='max-w-[1120px] overflow-hidden rounded-xl p-0'
+          testId='post-call-to-email-dialog'
+        >
+          <PostRecordingToEmailModal
+            key={emailModalNonce}
+            recording={{
+              externalId: call.externalId,
+              // `?? ''` so the modal's own "Untitled Call" fallback applies.
+              title: call.title ?? '',
+              aiSummary: call.aiSummary,
+              aiSummaryFormat: summaryFormat,
+            }}
+            onClose={() => setShowEmailModal(false)}
+            entityLabel='call'
+            isRecording={false}
+            trackCategory='CallDetail'
+          />
+        </Dialog>
+      )}
+
+      {showGoogleDocModal && (
+        <Dialog
+          open={showGoogleDocModal}
+          onOpenChange={open => !open && setShowGoogleDocModal(false)}
+          title='Preview Google Doc'
+          description='Review the call summary before creating a Google Doc.'
+          className='max-w-[720px] overflow-hidden rounded-[18px] p-0'
+          testId='call-google-doc-preview-dialog'
+        >
+          <GoogleDocPreviewModal
+            key={googleDocModalNonce}
+            recording={{
+              externalId: call.externalId,
+              title: call.title ?? '',
+              googleDocs: callGoogleDocs,
+            }}
+            onClose={() => setShowGoogleDocModal(false)}
+            onExport={googleDocExport.exportDoc}
+            isExporting={googleDocExport.isExporting}
+            entityLabel='call'
+            isRecording={false}
+            trackCategory='CallDetail'
+          />
+        </Dialog>
+      )}
     </div>
   );
 }

--- a/apps/dashboard/src/routes/CallDetailScreen/CallLabelPicker.tsx
+++ b/apps/dashboard/src/routes/CallDetailScreen/CallLabelPicker.tsx
@@ -1,0 +1,28 @@
+import { type ReactElement } from 'react';
+import { LabelPicker } from '../../components/Labels/LabelPicker';
+import { useCallLabelSuggestions } from '../../hooks/useCallLabelSuggestions';
+
+export interface CallLabelPickerProps {
+  labels: string[];
+  canEdit: boolean;
+  onChange: (labels: string[]) => void;
+}
+
+/** Calls binding for {@link LabelPicker}: call-wide suggestions and analytics namespace. */
+export function CallLabelPicker({
+  labels,
+  canEdit,
+  onChange,
+}: CallLabelPickerProps): ReactElement | null {
+  const suggestions = useCallLabelSuggestions(canEdit);
+
+  return (
+    <LabelPicker
+      labels={labels}
+      canEdit={canEdit}
+      suggestions={suggestions}
+      trackCategory='CallDetail'
+      onChange={onChange}
+    />
+  );
+}

--- a/apps/dashboard/src/routes/CallDetailScreen/CallShareModal.tsx
+++ b/apps/dashboard/src/routes/CallDetailScreen/CallShareModal.tsx
@@ -1,0 +1,100 @@
+import React, { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { EntityShareModal, type EntityShareEntry } from '../../components/Share/EntityShareModal';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { queries } from '../../zero/queries';
+import { getUserDisplayName } from '../../utils/userDisplayName';
+import { callService, type CallShareTarget } from '../../services/Call/callService';
+import { getApiErrorMessage } from '../../utils/apiError';
+import { getRecordingSharePost } from '../../utils/recordingUtils';
+
+export interface CallShareModalProps {
+  /** The call row id — what `queries.callById` and the detail route both key on. */
+  callId: string;
+  /** The call's public id, which the sharing endpoints take. */
+  externalId: string;
+  createdByUserId: string;
+  onClose?: () => void;
+}
+
+/**
+ * Calls binding for {@link EntityShareModal}. No link-access section: a regular
+ * call has no shareable link, only the explicit shares listed here.
+ */
+export const CallShareModal: React.FC<CallShareModalProps> = ({
+  callId,
+  externalId,
+  createdByUserId,
+  onClose,
+}) => {
+  // Revoking is optimistic: the row leaves the list at once, and Zero catches up.
+  const [locallyRevokedShareIds, setLocallyRevokedShareIds] = useState<Set<string>>(new Set());
+
+  const [callRow] = useCachedQuery(queries.callById({ callId }));
+
+  const shares = useMemo<EntityShareEntry[]>(
+    () =>
+      (callRow?.shares ?? [])
+        .filter(share => !locallyRevokedShareIds.has(share.id))
+        .map(share => {
+          const target: CallShareTarget = share.userGroupId
+            ? { type: 'user_group', id: share.userGroupId }
+            : share.channelId
+              ? { type: 'channel', id: share.channelId }
+              : { type: 'user', id: share.userId! };
+          const label = share.userGroupId
+            ? (share.userGroup?.name ?? share.userGroupId)
+            : share.channelId
+              ? (share.channel?.name ?? share.channelId)
+              : share.user
+                ? getUserDisplayName(share.user)
+                : (share.userId ?? '');
+          const post = getRecordingSharePost(share.metadata);
+          return {
+            id: share.id,
+            label,
+            userId: share.userId ?? null,
+            target,
+            post: post ? { channelId: post.channelId, conversationId: post.conversationId } : null,
+          };
+        }),
+    [callRow, locallyRevokedShareIds],
+  );
+
+  const handleGrant = async (targets: CallShareTarget[], messageContent: string): Promise<void> => {
+    const result = await callService.grantCallAccess(externalId, targets, messageContent);
+    if (result.shares?.length) {
+      setLocallyRevokedShareIds(current => {
+        const next = new Set(current);
+        result.shares?.forEach(share => next.delete(share.id));
+        return next;
+      });
+    }
+  };
+
+  const handleRevoke = async (target: CallShareTarget): Promise<void> => {
+    try {
+      const result = await callService.revokeCallAccess(externalId, [target]);
+      result.shares?.forEach(share => {
+        setLocallyRevokedShareIds(current => new Set(current).add(share.id));
+      });
+    } catch (error) {
+      toast.error('Failed to remove access', {
+        description: getApiErrorMessage(error, 'Unable to remove call access'),
+      });
+    }
+  };
+
+  return (
+    <EntityShareModal
+      ownerId={createdByUserId}
+      shares={shares}
+      onGrant={handleGrant}
+      onRevoke={handleRevoke}
+      subject='call'
+      trackCategory='CallDetail'
+      accessListTitle='Shared with'
+      {...(onClose && { onClose })}
+    />
+  );
+};

--- a/apps/dashboard/src/routes/CallDetailScreen/CallSummaryTemplatePicker.tsx
+++ b/apps/dashboard/src/routes/CallDetailScreen/CallSummaryTemplatePicker.tsx
@@ -1,18 +1,10 @@
 /**
- * Summary-template picker for the call detail view. The tab pill itself is the
- * trigger; the menu inside is the shared `SummaryTemplateMenu`, the same one the
- * recording detail screen hangs off its summary tab.
- *
- * Browsing, creating and editing templates all work here; **applying** one does
- * not. Regeneration goes through `POST /calls/recordings/:callId/generate-summary`,
- * which rejects anything that isn't `CallType.HEADLESS`, and writes its canvas to
- * `call.metadata.detailedSummaryCanvasId` rather than the call message metadata
- * this screen reads. Until a call-side path exists, selecting a template says so
- * instead of firing a request that would 404.
+ * Summary-template pill for the call detail view: the tab pill is the trigger, the
+ * menu inside is the shared `SummaryTemplateMenu`. The rewrite itself is owned by
+ * `useCallSummaryRegeneration` on the screen, since the content pane swaps panels
+ * for its duration — this renders only the pill half.
  */
-
 import { useState, type ReactElement } from 'react';
-import { toast } from 'sonner';
 import { ChevronBigDown } from '@xyne/icons';
 import { Popover } from '../../components/ui/Popover';
 import { Dialog } from '../../components/ui/Dialog/Dialog';
@@ -31,6 +23,8 @@ import {
   getTemplateIcon,
 } from '../RecordingDetailV2Screen/components/SummaryTemplatesModal';
 import { useSummaryTemplates } from '../../hooks/useSummaryTemplates';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { queries } from '../../zero/queries';
 import { useSelf } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
 import { cn } from '../../utils/classNames';
@@ -41,11 +35,13 @@ const DEFAULT_TEMPLATE_OPTION: SummaryTemplateOption = {
   icon: '✨',
 };
 
-const UNSUPPORTED_MESSAGE = "Summary templates aren't available for calls yet";
-
 interface CallSummaryTemplatePickerProps {
-  /** Template the call's existing summary was written with, when one is recorded. */
+  /** Template the visible summary was written with, from useCallSummaryRegeneration. */
   selectedTemplateId?: string | null;
+  /** True while a rewrite is in flight; disables Regenerate and spins its icon. */
+  isRegenerating: boolean;
+  /** Starts a rewrite with the chosen template. */
+  onApplyTemplate: (templateId: string) => void;
   /** True while the detailed summary is the visible pane. */
   isActive: boolean;
   /** Called when an inactive pill is clicked, to switch to the summary pane. */
@@ -56,6 +52,8 @@ interface CallSummaryTemplatePickerProps {
 
 export function CallSummaryTemplatePicker({
   selectedTemplateId,
+  isRegenerating,
+  onApplyTemplate,
   isActive,
   onSelect,
   className,
@@ -80,15 +78,26 @@ export function CallSummaryTemplatePicker({
       })),
   ];
 
+  // The list is only fetched once the menu opens, so on a fresh visit look up the
+  // applied template directly — otherwise the pill reads "Default summary".
+  const storedTemplateId = selectedTemplateId ?? '';
+  const [storedTemplate] = useCachedQuery(
+    queries.summaryTemplateById({ templateId: storedTemplateId }),
+    { enabled: storedTemplateId.length > 0 && storedTemplateId !== DEFAULT_TEMPLATE_OPTION.id },
+  );
+
   const selectedTemplate =
-    templateOptions.find(template => template.id === selectedTemplateId) ?? DEFAULT_TEMPLATE_OPTION;
+    templateOptions.find(template => template.id === selectedTemplateId) ??
+    (storedTemplate && storedTemplate.id === storedTemplateId
+      ? {
+          id: storedTemplate.id,
+          name: storedTemplate.name,
+          icon: getTemplateIcon(storedTemplate.name),
+        }
+      : DEFAULT_TEMPLATE_OPTION);
 
   const fullLabel = getSummaryTemplateLabel(selectedTemplate);
   const label = truncateTemplateName(fullLabel);
-
-  const notifyUnsupported = (): void => {
-    toast.info(UNSUPPORTED_MESSAGE);
-  };
 
   const trigger = (
     <button
@@ -99,9 +108,10 @@ export function CallSummaryTemplatePicker({
         if (!isActive) onSelect();
       }}
       title={fullLabel}
+      aria-busy={isRegenerating}
       data-track-category='CallDetail'
       data-track-name='open_summary_templates'
-      className={cn('max-w-[200px]', className)}
+      className={cn('max-w-[200px]', isRegenerating && 'cursor-wait', className)}
     >
       <SummaryTemplateGlyph template={selectedTemplate} size='trigger' className='shrink-0' />
       <span className='truncate'>{label}</span>
@@ -117,7 +127,7 @@ export function CallSummaryTemplatePicker({
         trigger={trigger}
         open={isActive && isMenuOpen}
         onOpenChange={open => {
-          if (!isActive) return;
+          if (!isActive || isRegenerating) return;
           if (open) setShouldLoadTemplates(true);
           setIsMenuOpen(open);
         }}
@@ -131,8 +141,9 @@ export function CallSummaryTemplatePicker({
           selectedTemplate={selectedTemplate}
           templates={templateOptions}
           isLoading={templatesLoading}
-          onSelectTemplate={notifyUnsupported}
-          onRegenerate={notifyUnsupported}
+          isRegenerating={isRegenerating}
+          onSelectTemplate={onApplyTemplate}
+          onRegenerate={() => onApplyTemplate(selectedTemplate.id)}
           onOpenTemplates={() => setTemplatesModalMode('browse')}
           onNewTemplate={() => setTemplatesModalMode('new')}
           onRequestClose={() => setIsMenuOpen(false)}
@@ -157,9 +168,9 @@ export function CallSummaryTemplatePicker({
             currentUserName={getUserDisplayName(currentUser)}
             startWithNewTemplate={templatesModalMode === 'new'}
             onClose={() => setTemplatesModalMode(null)}
-            onApply={() => {
+            onApply={template => {
               setTemplatesModalMode(null);
-              toast.info(UNSUPPORTED_MESSAGE);
+              onApplyTemplate(template.id);
             }}
           />
         </Dialog>

--- a/apps/dashboard/src/routes/CallDetailScreen/useCallGoogleDocExport.ts
+++ b/apps/dashboard/src/routes/CallDetailScreen/useCallGoogleDocExport.ts
@@ -1,0 +1,74 @@
+import { useCallback, useMemo, useState } from 'react';
+import axios from 'axios';
+import { toast } from 'sonner';
+import {
+  recordingService,
+  type RecordingGoogleDocLink,
+} from '../../services/Recording/recordingService';
+
+const isGoogleDocLink = (value: unknown): value is RecordingGoogleDocLink =>
+  !!value &&
+  typeof value === 'object' &&
+  typeof (value as RecordingGoogleDocLink).documentId === 'string' &&
+  typeof (value as RecordingGoogleDocLink).url === 'string';
+
+/**
+ * Docs already exported from this call, newest first. They live on the call row
+ * (utils/recordingGoogleDocs writes them there), so Zero keeps the list current
+ * without this screen tracking exports of its own.
+ */
+export function useCallGoogleDocs(metadata: unknown): RecordingGoogleDocLink[] {
+  return useMemo(() => {
+    const links = (metadata as Record<string, unknown> | null)?.['googleDocs'];
+    return Array.isArray(links) ? links.filter(isGoogleDocLink) : [];
+  }, [metadata]);
+}
+
+export interface CallGoogleDocExport {
+  isExporting: boolean;
+  /** Rejects so the preview modal can show why, matching the recordings contract. */
+  exportDoc: (title?: string) => Promise<void>;
+}
+
+/** Creates a Google Doc from a call's summary and opens it in a new tab. */
+export function useCallGoogleDocExport(
+  externalId: string,
+  onExported: () => void,
+): CallGoogleDocExport {
+  const [isExporting, setIsExporting] = useState(false);
+
+  const exportDoc = useCallback(
+    async (title?: string): Promise<void> => {
+      if (isExporting) return;
+
+      // Opened synchronously, or the browser treats the later navigation as a popup.
+      const documentWindow = window.open('', '_blank');
+      if (documentWindow) documentWindow.opener = null;
+
+      setIsExporting(true);
+      try {
+        const { documentUrl } = await recordingService.exportGoogleDoc(externalId, title, false);
+        if (documentWindow) {
+          documentWindow.location.assign(documentUrl);
+        } else {
+          window.open(documentUrl, '_blank', 'noopener,noreferrer');
+        }
+        toast.success('Google Doc created');
+        onExported();
+      } catch (error) {
+        documentWindow?.close();
+        toast.error('Failed to export to Google Docs', {
+          description: axios.isAxiosError<{ error?: string }>(error)
+            ? (error.response?.data?.error ?? error.message)
+            : 'Please try again.',
+        });
+        throw error;
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [externalId, isExporting, onExported],
+  );
+
+  return { isExporting, exportDoc };
+}

--- a/apps/dashboard/src/routes/CallDetailScreen/useCallSummaryRegeneration.ts
+++ b/apps/dashboard/src/routes/CallDetailScreen/useCallSummaryRegeneration.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { callService } from '../../services/Call/callService';
+
+export interface CallSummaryRegeneration {
+  /** Template the pill names — the pending one while a rewrite runs, else the applied one. */
+  appliedTemplateId: string | null;
+  isRegenerating: boolean;
+  hasFailed: boolean;
+  /** Bumped per run so SummaryGenerationPanel restarts its progress animation. */
+  runNonce: number;
+  /** Bumped on success so the canvas remounts against the rewritten document. */
+  canvasNonce: number;
+  regenerate: (templateId: string) => Promise<void>;
+  /** Re-runs the last attempted template, for the panel's Generate/Retry actions. */
+  retry: () => void;
+}
+
+/**
+ * State behind a call's summary rewrite. Lives above both consumers because the
+ * transition spans two of them: the pill and the content pane, which swaps to
+ * `SummaryGenerationPanel` while the rewrite runs.
+ */
+export function useCallSummaryRegeneration(
+  callId: string,
+  summaryTemplateId: string | null | undefined,
+): CallSummaryRegeneration {
+  const [committedTemplateId, setCommittedTemplateId] = useState<string | null>(
+    summaryTemplateId ?? null,
+  );
+  // Set on pick so the pill names the choice immediately. Clearing it reverts the
+  // pill on failure; on success the committed id has already moved.
+  const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(null);
+  const [isRegenerating, setIsRegenerating] = useState(false);
+  const [hasFailed, setHasFailed] = useState(false);
+  const [runNonce, setRunNonce] = useState(0);
+  const [canvasNonce, setCanvasNonce] = useState(0);
+  const lastTemplateIdRef = useRef<string | null>(null);
+
+  // The prop comes off navigation state and never re-resolves, so reseed on the
+  // call alone — keying on summaryTemplateId would undo each rewrite as it landed.
+  useEffect(() => {
+    setCommittedTemplateId(summaryTemplateId ?? null);
+    setPendingTemplateId(null);
+    setIsRegenerating(false);
+    setHasFailed(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [callId]);
+
+  const regenerate = useCallback(
+    async (templateId: string): Promise<void> => {
+      if (isRegenerating) return;
+      lastTemplateIdRef.current = templateId;
+      setPendingTemplateId(templateId);
+      setIsRegenerating(true);
+      setHasFailed(false);
+      setRunNonce(value => value + 1);
+      try {
+        const result = await callService.regenerateCallSummary(callId, templateId);
+        setCommittedTemplateId(result.summaryTemplateId);
+        // Canvas id is unchanged (edited in place), so force the remount.
+        setCanvasNonce(value => value + 1);
+      } catch {
+        setHasFailed(true);
+        toast.error('Failed to update summary', { description: 'Please try again.' });
+      } finally {
+        setPendingTemplateId(null);
+        setIsRegenerating(false);
+      }
+    },
+    [callId, isRegenerating],
+  );
+
+  const retry = useCallback((): void => {
+    void regenerate(lastTemplateIdRef.current ?? committedTemplateId ?? 'default');
+  }, [regenerate, committedTemplateId]);
+
+  return {
+    appliedTemplateId: pendingTemplateId ?? committedTemplateId,
+    isRegenerating,
+    hasFailed,
+    runNonce,
+    canvasNonce,
+    regenerate,
+    retry,
+  };
+}

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallCard.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallCard.tsx
@@ -15,6 +15,8 @@ import Avatar from '../../components/ui/Avatar/Avatar';
 import { AvatarStackItem } from '../../components/ui/Avatar/AvatarGroup';
 import Button from '../../components/ui/Button';
 import { formatRelativeTimestamp } from '../../utils/dateUtils';
+import { normalizeRecordingTags } from '../../utils/recordingUtils';
+import { LabelChip } from '../../components/Labels/LabelPicker';
 import {
   Call,
   getParticipantDisplayData,
@@ -53,6 +55,10 @@ interface CallHistoryItemProps {
   onViewExternalChat?: (() => void) | undefined;
   isRecentCall?: boolean;
   onDetailClick?: (() => void) | undefined;
+  /** Confirmed labels on this call, shown as chips under the meta line. */
+  labels?: string[];
+  /** Resolves a label value (Tag id) to its display text. Defaults to identity. */
+  resolveLabel?: (label: string) => string;
 }
 
 const MAX_AVATARS_TO_SHOW = 3;
@@ -67,10 +73,13 @@ export const CallCard = ({
   onViewExternalChat,
   isRecentCall = false,
   onDetailClick,
+  labels = [],
+  resolveLabel = (label: string): string => label,
 }: CallHistoryItemProps) => {
   const allChannels = useAllChannels();
   const visibleChannels = useAllVisibleChannels();
   const { isMobile } = usePlatform();
+  const visibleLabels = normalizeRecordingTags(labels);
   const channel = allChannels.find(c => c.id === call.channelId);
   const isChannelCall = channel?.scopeType === ChannelScopeType.DEFAULT;
 
@@ -303,6 +312,13 @@ export const CallCard = ({
                 )}
                 <span className={cn('text-xs', iconColorClass)}>•</span>
                 <span className={cn('text-xs', iconColorClass)}>{statusText}</span>
+              </div>
+            )}
+            {visibleLabels.length > 0 && (
+              <div className='flex flex-wrap items-center gap-1.5 pt-1'>
+                {visibleLabels.map(label => (
+                  <LabelChip key={label} label={resolveLabel(label)} />
+                ))}
               </div>
             )}
           </div>

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallHistoryScreen.tsx
@@ -29,6 +29,7 @@ import {
   ChannelScopeType,
   InvitationResponse,
   MeetingStatus,
+  TagMethod,
 } from '@xyne/shared';
 import { logger, Event } from '../../utils/logger';
 import { dataLoadDuration, safeRecordMetric } from '../../services/otel';
@@ -58,6 +59,9 @@ import {
   RecentCallFilter,
   FILTER_LABELS,
 } from './callHistoryItem.utils';
+import { CallLabelFilter } from './CallLabelFilter';
+import { useResolvedRecordingLabels } from '../../hooks/useResolvedRecordingLabels';
+import { normalizeRecordingTags } from '../../utils/recordingUtils';
 import { CallExternalChatDialog } from '../../components/Call/CallExternalChatDialog/CallExternalChatDialog';
 import { ParticipantsModal } from './ParticipantsModal';
 import CalendarWeekView from './CalendarWeekView';
@@ -254,6 +258,7 @@ const CallHistoryScreen = (): ReactElement => {
     return d;
   });
   const [recentCallFilter, setRecentCallFilter] = useState<RecentCallFilter>('all');
+  const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
   const [upcomingDay, setUpcomingDay] = useState<Date>(() => {
     const d = new Date();
     d.setHours(0, 0, 0, 0);
@@ -811,6 +816,33 @@ const CallHistoryScreen = (): ReactElement => {
     call => !isExternalCalendarEvent(call),
   );
 
+  // Options come off the Zero-backed list rather than the current view, so the
+  // dropdown doesn't shrink as you narrow the results.
+  const availableCallLabels = useMemo(
+    () => normalizeRecordingTags((calls ?? []).flatMap(call => call.labels)),
+    [calls],
+  );
+  // call.labels stores Tag ids (no FK), not display text — resolve them once so
+  // the dropdown shows real names. Every id is passed in, including generated
+  // ones, since resolving is also what reveals the method.
+  const { resolveLabel: resolveCallLabel, resolveMethod: resolveCallLabelMethod } =
+    useResolvedRecordingLabels(availableCallLabels);
+  const isManualCallLabel = useCallback(
+    (label: string): boolean => resolveCallLabelMethod(label) !== TagMethod.LLM,
+    [resolveCallLabelMethod],
+  );
+  const manualCallLabels = useMemo(
+    () =>
+      availableCallLabels
+        .filter(isManualCallLabel)
+        .sort((left, right) => resolveCallLabel(left).localeCompare(resolveCallLabel(right))),
+    [availableCallLabels, isManualCallLabel, resolveCallLabel],
+  );
+  // Search results are Vespa rows, built with `labels: []` (mapVespaCallResultToCall),
+  // so a selection would wrongly empty the list. Disable the control and skip it
+  // rather than silently filtering everything away.
+  const isLabelFilterDisabled = hasCallSearch;
+
   const filteredMissedCalls = (
     hasCallSearch
       ? filteredRecentCalls?.filter(call => isMissedCallForUser(call, user?.id))
@@ -846,6 +878,10 @@ const CallHistoryScreen = (): ReactElement => {
       default:
         filtered = base;
     }
+    if (selectedLabels.length > 0 && !hasCallSearch) {
+      const wanted = new Set(selectedLabels);
+      filtered = filtered.filter(call => (call.labels ?? []).some(label => wanted.has(label)));
+    }
     if (hasCallSearch) {
       return filtered;
     }
@@ -856,7 +892,14 @@ const CallHistoryScreen = (): ReactElement => {
       const bTop = b.status === CallStatus.ACTIVE || isScheduledCallJoinable(b) ? 0 : 1;
       return aTop - bTop;
     });
-  }, [filteredRecentCallsNoGcal, filteredMissedCalls, hasCallSearch, recentCallFilter, user?.id]);
+  }, [
+    filteredRecentCallsNoGcal,
+    filteredMissedCalls,
+    hasCallSearch,
+    recentCallFilter,
+    selectedLabels,
+    user?.id,
+  ]);
 
   if (queryDetails.type === 'error') {
     return (
@@ -1230,28 +1273,37 @@ const CallHistoryScreen = (): ReactElement => {
                 <span className='text-xs font-semibold tracking-widest text-muted-foreground uppercase'>
                   Recents
                 </span>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button className='flex items-center gap-1 px-2.5 py-1 text-sm font-medium text-foreground border border-border rounded-lg hover:bg-accent transition-colors focus:outline-none'>
-                      {FILTER_LABELS[recentCallFilter]}
-                      <ChevronDown className='size-3' />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align='end' className='rounded-xl w-44'>
-                    {(Object.keys(FILTER_LABELS) as RecentCallFilter[]).map(f => (
-                      <DropdownMenuItem
-                        key={f}
-                        className={cn(
-                          'text-sm rounded-lg cursor-pointer',
-                          recentCallFilter === f && 'font-medium',
-                        )}
-                        onSelect={() => setRecentCallFilter(f)}
-                      >
-                        {FILTER_LABELS[f]}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <div className='flex items-center gap-2'>
+                  <CallLabelFilter
+                    labels={manualCallLabels}
+                    selectedLabels={selectedLabels}
+                    onSelectedLabelsChange={setSelectedLabels}
+                    resolveLabel={resolveCallLabel}
+                    isDisabled={isLabelFilterDisabled}
+                  />
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button className='flex items-center gap-1 px-2.5 py-1 text-sm font-medium text-foreground border border-border rounded-lg hover:bg-accent transition-colors focus:outline-none'>
+                        {FILTER_LABELS[recentCallFilter]}
+                        <ChevronDown className='size-3' />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align='end' className='rounded-xl w-44'>
+                      {(Object.keys(FILTER_LABELS) as RecentCallFilter[]).map(f => (
+                        <DropdownMenuItem
+                          key={f}
+                          className={cn(
+                            'text-sm rounded-lg cursor-pointer',
+                            recentCallFilter === f && 'font-medium',
+                          )}
+                          onSelect={() => setRecentCallFilter(f)}
+                        >
+                          {FILTER_LABELS[f]}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
               </div>
 
               {displayRecentCalls.length === 0 ? (
@@ -1302,6 +1354,8 @@ const CallHistoryScreen = (): ReactElement => {
                               : undefined
                           }
                           isRecentCall
+                          labels={call.labels.filter(isManualCallLabel)}
+                          resolveLabel={resolveCallLabel}
                           onDetailClick={() => {
                             void navigate(`${call.id}/detail`, { state: { call } });
                           }}

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallLabelFilter.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallLabelFilter.tsx
@@ -1,0 +1,43 @@
+import { type ReactElement } from 'react';
+import { LabelFilter } from '../../components/Labels/LabelFilter';
+
+interface CallLabelFilterProps {
+  labels: string[];
+  selectedLabels: string[];
+  onSelectedLabelsChange: (labels: string[]) => void;
+  /** Resolves a label value (Tag id) to its display text. Defaults to identity. */
+  resolveLabel?: (label: string) => string;
+  /** Search rows carry no labels, so the filter is turned off while a search is active. */
+  isDisabled?: boolean;
+}
+
+/** Sized to sit level with the Recents dropdown beside it. */
+const TRIGGER_CLASS_NAME =
+  'h-7 gap-1 rounded-lg border-border px-2.5 text-sm font-medium shadow-none';
+
+/** Calls binding for {@link LabelFilter}: calls copy, analytics namespace and trigger sizing. */
+export function CallLabelFilter({
+  labels,
+  selectedLabels,
+  onSelectedLabelsChange,
+  resolveLabel,
+  isDisabled = false,
+}: CallLabelFilterProps): ReactElement {
+  return (
+    <LabelFilter
+      labels={labels}
+      selectedLabels={selectedLabels}
+      onSelectedLabelsChange={onSelectedLabelsChange}
+      resolveLabel={resolveLabel}
+      isDisabled={isDisabled}
+      triggerClassName={TRIGGER_CLASS_NAME}
+      trackCategory='CallHistory'
+      triggerAriaLabel='Filter calls by label'
+      disabledAriaLabel={
+        isDisabled
+          ? 'Label filter unavailable while searching'
+          : 'Label filter unavailable because no calls are labelled'
+      }
+    />
+  );
+}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/GoogleDocPreviewModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/GoogleDocPreviewModal.tsx
@@ -44,14 +44,24 @@ function formatDocTimestamp(createdAt: string, style: 'date' | 'relative'): stri
 
 const LABEL_CLASS = 'text-[11px] font-semibold uppercase tracking-[0.4px] text-muted-foreground';
 
-const CONNECT_PROMPT = 'Connect Google Docs to create a document from this recording.';
+const connectPrompt = (entityLabel: string): string =>
+  `Connect Google Docs to create a document from this ${entityLabel}.`;
+
+/** Only the fields this preview reads — a call has no full RecordingDetail. */
+export type GoogleDocSource = Pick<RecordingDetail, 'externalId' | 'title' | 'googleDocs'>;
 
 interface GoogleDocPreviewModalProps {
-  recording: RecordingDetail;
+  recording: GoogleDocSource;
   onClose: () => void;
   /** Creates the doc; `title` names it. Rejects so this modal can surface the reason. */
   onExport: (title?: string) => Promise<void>;
   isExporting: boolean;
+  /** The word the copy uses for the source: 'recording' or 'call'. */
+  entityLabel?: string;
+  /** False routes the request to the regular-call endpoints. */
+  isRecording?: boolean;
+  /** Analytics namespace of the host screen. */
+  trackCategory?: string;
 }
 
 export function GoogleDocPreviewModal({
@@ -59,17 +69,22 @@ export function GoogleDocPreviewModal({
   onClose,
   onExport,
   isExporting,
+  entityLabel = 'recording',
+  isRecording = true,
+  trackCategory = 'RecordingDetailV2',
 }: GoogleDocPreviewModalProps): ReactElement {
   const [context, setContext] = useState<RecordingGoogleDocComposeContext | null>(null);
   const [contextError, setContextError] = useState<string | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
-  const [title, setTitle] = useState(() => recording.title?.trim() || 'Untitled Recording');
+  const [title, setTitle] = useState(
+    () => recording.title?.trim() || (isRecording ? 'Untitled Recording' : 'Untitled Call'),
+  );
   const [earlierOpen, setEarlierOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     void recordingService
-      .getGoogleDocComposeContext(recording.externalId)
+      .getGoogleDocComposeContext(recording.externalId, isRecording)
       .then(next => !cancelled && setContext(next))
       .catch(error => {
         if (cancelled) return;
@@ -81,14 +96,18 @@ export function GoogleDocPreviewModal({
     return (): void => {
       cancelled = true;
     };
-  }, [recording.externalId]);
+  }, [recording.externalId, isRecording]);
 
   const connectGoogleDoc = async (): Promise<void> => {
     setIsConnecting(true);
     try {
       const currentPath = `${window.location.pathname}${window.location.search}`;
       const returnPath =
-        currentPath.startsWith('/') && !currentPath.startsWith('//') ? currentPath : '/recordings';
+        currentPath.startsWith('/') && !currentPath.startsWith('//')
+          ? currentPath
+          : isRecording
+            ? '/recordings'
+            : '/calls';
       const isElectron = typeof window.electronAPI?.openExternal === 'function';
       const authUrl = await recordingService.connectGoogleDoc(
         returnPath,
@@ -163,7 +182,7 @@ export function GoogleDocPreviewModal({
             Export to Google Doc
           </h2>
           <p className='mt-0.5 text-[12.5px] text-muted-foreground'>
-            Review the recording summary before creating the document.
+            Review the {entityLabel} summary before creating the document.
           </p>
         </div>
         <button
@@ -172,7 +191,7 @@ export function GoogleDocPreviewModal({
           disabled={isExporting || isConnecting}
           className='inline-flex size-[30px] shrink-0 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50'
           aria-label='Close Google Docs preview'
-          data-track-category='RecordingDetailV2'
+          data-track-category={trackCategory}
           data-track-name='close_google_doc_preview'
         >
           <X className='size-[15px]' aria-hidden='true' />
@@ -209,7 +228,7 @@ export function GoogleDocPreviewModal({
               title='Copy link'
               aria-label='Copy document link'
               className='inline-flex size-[30px] shrink-0 items-center justify-center rounded-lg border border-border bg-background text-muted-foreground hover:border-muted-foreground/60 hover:text-foreground'
-              data-track-category='RecordingDetailV2'
+              data-track-category={trackCategory}
               data-track-name='copy_recording_google_doc_link'
             >
               <LinkIcon className='size-[15px]' aria-hidden='true' />
@@ -220,7 +239,7 @@ export function GoogleDocPreviewModal({
               rel='noopener noreferrer'
               onClick={event => openDoc(event, latestDoc.url)}
               className='inline-flex shrink-0 items-center gap-[7px] rounded-[9px] bg-foreground px-3 py-2 text-[12.5px] font-semibold text-background hover:opacity-90'
-              data-track-category='RecordingDetailV2'
+              data-track-category={trackCategory}
               data-track-name='open_recording_google_doc'
             >
               Open doc
@@ -236,7 +255,7 @@ export function GoogleDocPreviewModal({
               onClick={() => setEarlierOpen(open => !open)}
               className={`flex items-center gap-1.5 pb-2 ${LABEL_CLASS} hover:text-foreground`}
               aria-expanded={earlierOpen}
-              data-track-category='RecordingDetailV2'
+              data-track-category={trackCategory}
               data-track-name='toggle_earlier_google_doc_exports'
             >
               <ChevronDown
@@ -266,7 +285,7 @@ export function GoogleDocPreviewModal({
                       rel='noopener noreferrer'
                       onClick={event => openDoc(event, doc.url)}
                       className='inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-foreground hover:bg-muted'
-                      data-track-category='RecordingDetailV2'
+                      data-track-category={trackCategory}
                       data-track-name='open_recording_google_doc'
                     >
                       Open
@@ -306,14 +325,14 @@ export function GoogleDocPreviewModal({
           <>
             <p className='flex min-w-0 flex-1 items-start gap-2 text-[11.5px] text-amber-700 dark:text-amber-200'>
               <LockKeyhole className='mt-px size-3.5 shrink-0' aria-hidden='true' />
-              <span>{context?.unavailableReason ?? CONNECT_PROMPT}</span>
+              <span>{context?.unavailableReason ?? connectPrompt(entityLabel)}</span>
             </p>
             <Button
               className='bg-foreground text-background hover:bg-foreground/90'
               onClick={() => void connectGoogleDoc()}
               disabled={isConnecting}
               loading={isConnecting}
-              data-track-category='RecordingDetailV2'
+              data-track-category={trackCategory}
               data-track-name='recording_google_doc_connect_calendar'
             >
               Connect Google Docs
@@ -339,7 +358,7 @@ export function GoogleDocPreviewModal({
               onClick={() => void createGoogleDoc()}
               disabled={!context?.canExport || !!contextError || isTitleEmpty}
               loading={isExporting}
-              data-track-category='RecordingDetailV2'
+              data-track-category={trackCategory}
               data-track-name='create_recording_google_doc'
             >
               {latestDoc ? (

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToEmailModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/PostRecordingToEmailModal.tsx
@@ -44,9 +44,24 @@ import {
 } from '../../../services/Recording/recordingEmailService';
 import type { RecordingDetail } from '../../../services/Recording/recordingService';
 
+/** Only the fields the draft is built from — a call has no full RecordingDetail. */
+export type EmailDraftSource = Pick<
+  RecordingDetail,
+  'externalId' | 'title' | 'aiSummary' | 'aiSummaryFormat'
+>;
+
 export interface PostRecordingToEmailModalProps {
-  recording: RecordingDetail;
+  recording: EmailDraftSource;
   onClose: () => void;
+  /**
+   * The word the copy uses for what is being sent: 'recording' or 'call'. Not
+   * `subject` — that name already belongs to the email's own subject line.
+   */
+  entityLabel?: string;
+  /** False routes the request to the regular-call endpoints. */
+  isRecording?: boolean;
+  /** Analytics namespace of the host screen. */
+  trackCategory?: string;
 }
 
 interface RecipientLineProps {
@@ -57,6 +72,7 @@ interface RecipientLineProps {
   contactPool: RecipientSuggestion[];
   users: ReturnType<typeof useUsers>;
   actions?: ReactNode;
+  trackCategory: string;
 }
 
 const escapeHtml = (value: string): string =>
@@ -80,15 +96,18 @@ const attachmentIcon = (kind: RecordingEmailAttachmentKind): ReactElement => {
   }
 };
 
-const summaryHtmlForEmail = async (recording: RecordingDetail): Promise<string> => {
+const summaryHtmlForEmail = async (recording: EmailDraftSource): Promise<string> => {
   const rawSummary = recording.aiSummary?.replace(/\[clf-\d+\]/gi, '').trim();
   if (!rawSummary) return '';
   if (recording.aiSummaryFormat === 'html') return DOMPurify.sanitize(rawSummary);
   return markdownToHtml(rawSummary);
 };
 
-const buildInitialEmailBody = async (recording: RecordingDetail): Promise<string> => {
-  const title = escapeHtml(recording.title?.trim() || 'this recording');
+const buildInitialEmailBody = async (
+  recording: EmailDraftSource,
+  entityLabel: string,
+): Promise<string> => {
+  const title = escapeHtml(recording.title?.trim() || `this ${entityLabel}`);
   const summary = await summaryHtmlForEmail(recording);
   const summarySection = summary
     ? summary
@@ -109,6 +128,7 @@ const RecipientLine = ({
   contactPool,
   users,
   actions,
+  trackCategory,
 }: RecipientLineProps): ReactElement => {
   const rowRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -153,7 +173,7 @@ const RecipientLine = ({
         tabIndex={0}
         className='relative flex min-h-8 flex-wrap items-center gap-1.5 rounded-md py-0.5 focus-within:outline-none focus-within:ring-2 focus-within:ring-ring/70'
         onClick={() => inputRef.current?.focus()}
-        data-track-category='RecordingDetailV2'
+        data-track-category={trackCategory}
         data-track-name={`recording_email_${field}_recipients_focus`}
         onKeyDown={event => {
           if (
@@ -188,7 +208,7 @@ const RecipientLine = ({
           onKeyDown={handleKeyDown}
           className='min-w-[126px] flex-1 bg-transparent py-1 text-sm text-foreground outline-none placeholder:text-muted-foreground'
           aria-label={`${label} recipients`}
-          data-track-category='RecordingDetailV2'
+          data-track-category={trackCategory}
           data-track-name={`recording_email_${field}_input`}
         />
         <RecipientSuggestionsDropdown
@@ -208,6 +228,9 @@ const RecipientLine = ({
 export const PostRecordingToEmailModal = ({
   recording,
   onClose,
+  entityLabel = 'recording',
+  isRecording = true,
+  trackCategory = 'RecordingDetailV2',
 }: PostRecordingToEmailModalProps): ReactElement => {
   const users = useUsers();
   const [context, setContext] = useState<RecordingEmailComposeContext | null>(null);
@@ -216,7 +239,7 @@ export const PostRecordingToEmailModal = ({
   const [ccEmails, setCcEmails] = useState<string[]>([]);
   const [showCc, setShowCc] = useState(false);
   const [subject, setSubject] = useState(
-    `Recap: ${recording.title?.trim() || 'Untitled Recording'}`,
+    `Recap: ${recording.title?.trim() || (isRecording ? 'Untitled Recording' : 'Untitled Call')}`,
   );
   const [body, setBody] = useState('');
   const [selectedAttachments, setSelectedAttachments] = useState<RecordingEmailAttachmentKind[]>(
@@ -244,7 +267,7 @@ export const PostRecordingToEmailModal = ({
     setContext(null);
     setContextError(null);
     void recordingEmailService
-      .getComposeContext(recording.externalId)
+      .getComposeContext(recording.externalId, isRecording)
       .then(next => {
         if (cancelled) return;
         setContext(next);
@@ -263,12 +286,12 @@ export const PostRecordingToEmailModal = ({
     return (): void => {
       cancelled = true;
     };
-  }, [recording.externalId]);
+  }, [recording.externalId, isRecording]);
 
   useEffect(() => {
     if (initializedBodyRef.current) return;
     let cancelled = false;
-    void buildInitialEmailBody(recording).then(nextBody => {
+    void buildInitialEmailBody(recording, entityLabel).then(nextBody => {
       if (cancelled) return;
       initializedBodyRef.current = true;
       setBody(nextBody);
@@ -276,7 +299,7 @@ export const PostRecordingToEmailModal = ({
     return (): void => {
       cancelled = true;
     };
-  }, [recording]);
+  }, [recording, entityLabel]);
 
   const selectedAttachmentDetails = useMemo(
     () =>
@@ -312,13 +335,17 @@ export const PostRecordingToEmailModal = ({
     if (!canSend) return;
     setIsSending(true);
     try {
-      await recordingEmailService.send(recording.externalId, {
-        to: toEmails,
-        cc: ccEmails,
-        subject: subject.trim(),
-        body,
-        attachments: selectedAttachments,
-      });
+      await recordingEmailService.send(
+        recording.externalId,
+        {
+          to: toEmails,
+          cc: ccEmails,
+          subject: subject.trim(),
+          body,
+          attachments: selectedAttachments,
+        },
+        isRecording,
+      );
       toast.success('Email sent');
       onClose();
     } catch (error) {
@@ -376,7 +403,7 @@ export const PostRecordingToEmailModal = ({
           <div className='min-w-0'>
             <h2 className='text-lg font-semibold leading-6 text-foreground'>Review draft email</h2>
             <p className='mt-0.5 text-sm text-muted-foreground'>
-              Recipients and text are pre-filled from this recording. Review before sending.
+              Recipients and text are pre-filled from this {entityLabel}. Review before sending.
             </p>
           </div>
         </div>
@@ -387,7 +414,7 @@ export const PostRecordingToEmailModal = ({
             disabled={isSending}
             className='-mr-1 inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50'
             aria-label='Close email draft'
-            data-track-category='RecordingDetailV2'
+            data-track-category={trackCategory}
             data-track-name='close_recording_email_draft'
           >
             <X className='size-5' aria-hidden='true' />
@@ -424,13 +451,14 @@ export const PostRecordingToEmailModal = ({
           onEmailsChange={setToEmails}
           contactPool={contactPool}
           users={users}
+          trackCategory={trackCategory}
           actions={
             !showCc ? (
               <button
                 type='button'
                 onClick={() => setShowCc(true)}
                 className='rounded px-1 py-0.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground'
-                data-track-category='RecordingDetailV2'
+                data-track-category={trackCategory}
                 data-track-name='recording_email_open_cc'
               >
                 Cc
@@ -446,6 +474,7 @@ export const PostRecordingToEmailModal = ({
             onEmailsChange={setCcEmails}
             contactPool={contactPool}
             users={users}
+            trackCategory={trackCategory}
             actions={
               <button
                 type='button'
@@ -455,7 +484,7 @@ export const PostRecordingToEmailModal = ({
                 }}
                 className='inline-flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
                 aria-label='Remove Cc field'
-                data-track-category='RecordingDetailV2'
+                data-track-category={trackCategory}
                 data-track-name='recording_email_remove_cc'
               >
                 <X className='size-3.5' aria-hidden='true' />
@@ -473,7 +502,7 @@ export const PostRecordingToEmailModal = ({
             className='min-w-0 bg-transparent py-1 text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground'
             placeholder='Add a subject'
             aria-label='Email subject'
-            data-track-category='RecordingDetailV2'
+            data-track-category={trackCategory}
             data-track-name='recording_email_subject_input'
           />
         </label>
@@ -489,7 +518,7 @@ export const PostRecordingToEmailModal = ({
                 onClick={() => void handleConnectGoogle()}
                 disabled={isConnectingGoogle || isSending}
                 loading={isConnectingGoogle}
-                data-track-category='RecordingDetailV2'
+                data-track-category={trackCategory}
                 data-track-name='recording_email_connect_google'
               >
                 Connect Google email
@@ -572,7 +601,7 @@ export const PostRecordingToEmailModal = ({
                     className='inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
                     aria-label={`Remove ${attachment.label}`}
                     disabled={isSending}
-                    data-track-category='RecordingDetailV2'
+                    data-track-category={trackCategory}
                     data-track-name='recording_email_remove_attachment'
                   >
                     <X className='size-3.5' aria-hidden='true' />
@@ -599,7 +628,7 @@ export const PostRecordingToEmailModal = ({
             onClick={() => void handleSend()}
             disabled={!canSend}
             className='min-w-[164px] gap-2'
-            data-track-category='RecordingDetailV2'
+            data-track-category={trackCategory}
             data-track-name='send_recording_email'
           >
             {isSending ? <Loader2 className='size-4 animate-spin' /> : <Send className='size-4' />}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingLabelPicker.tsx
@@ -1,18 +1,8 @@
-import { useMemo, useState, type ReactElement } from 'react';
-import { CheckTickSingle, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
-import { TagMethod } from '@xyne/shared';
-import { toast } from 'sonner';
-import { SearchableMultiSelect } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect';
-import type { SearchableMultiSelectOption } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect.types';
-import { Button } from '../../../components/ui/Button/Button';
+import { type ReactElement } from 'react';
+import { LabelPicker } from '../../../components/Labels/LabelPicker';
 import { useRecordingLabelSuggestions } from '../../../hooks/useRecordingLabelSuggestions';
-import {
-  confirmRecordingLabelSuggestion,
-  useResolvedRecordingLabels,
-} from '../../../hooks/useResolvedRecordingLabels';
-import { cn } from '../../../utils/classNames';
-import { normalizeRecordingTags, slugifyRecordingLabel } from '../../../utils/recordingUtils';
-import { getTagTheme } from '../../../utils/tagTheme';
+
+export { LabelChip, SuggestedLabelChip } from '../../../components/Labels/LabelPicker';
 
 export interface RecordingLabelPickerProps {
   labels: string[];
@@ -20,239 +10,21 @@ export interface RecordingLabelPickerProps {
   onChange: (labels: string[]) => void;
 }
 
-const LABEL_MAX_LENGTH = 40;
-/** Labels beyond this are blocked on add (existing AI suggestions past the cap aren't touched). */
-const MAX_LABELS = 10;
-
-const CHIP_BASE_CLASS_NAME =
-  'inline-flex h-6 shrink-0 items-center gap-1.5 rounded-lg pl-2 pr-1.5 text-xs font-medium whitespace-nowrap';
-
-const SUGGESTION_CHIP_CLASS_NAME = cn(
-  CHIP_BASE_CLASS_NAME,
-  'border border-dashed border-muted-foreground/40',
-);
-
-const LIST_INHERITS_POPOVER_CLASS_NAME =
-  '[[data-theme=midnight]_&_[role=listbox][aria-multiselectable]]:!bg-transparent';
-
-export function LabelChip({
-  label,
-  onRemove,
-}: {
-  label: string;
-  onRemove?: () => void;
-}): ReactElement {
-  const theme = getTagTheme(label);
-  return (
-    <span className={cn(CHIP_BASE_CLASS_NAME, theme.bg, theme.text)}>
-      <span className={cn('size-1.5 shrink-0 rounded-full', theme.dot)} aria-hidden='true' />
-      <span>{label}</span>
-      {onRemove && (
-        <button
-          type='button'
-          className='rounded-sm opacity-70 hover:opacity-100'
-          aria-label={`Remove label ${label}`}
-          onClick={onRemove}
-          data-track-category='RecordingDetailV2'
-          data-track-name='remove_recording_label'
-        >
-          <MultipleCrossCancelDefault className='size-3' aria-hidden='true' />
-        </button>
-      )}
-    </span>
-  );
-}
-
-/** An AI-suggested (unconfirmed) label — tick to keep it (moves into the confirmed pills), cross to discard it. */
-export function SuggestedLabelChip({
-  label,
-  onConfirm,
-  onReject,
-}: {
-  label: string;
-  onConfirm: () => void;
-  onReject: () => void;
-}): ReactElement {
-  const theme = getTagTheme(label);
-  return (
-    <span className={cn(SUGGESTION_CHIP_CLASS_NAME, 'text-foreground')}>
-      <span className={cn('size-1.5 shrink-0 rounded-full', theme.dot)} aria-hidden='true' />
-      <span>{label}</span>
-      <button
-        type='button'
-        className='rounded-sm opacity-70 hover:opacity-100'
-        aria-label={`Confirm suggested label ${label}`}
-        onClick={event => {
-          event.stopPropagation();
-          onConfirm();
-        }}
-        data-track-category='RecordingDetailV2'
-        data-track-name='confirm_suggested_label'
-      >
-        <CheckTickSingle className='size-3' aria-hidden='true' />
-      </button>
-      <button
-        type='button'
-        className='rounded-sm opacity-70 hover:opacity-100'
-        aria-label={`Dismiss suggested label ${label}`}
-        onClick={event => {
-          event.stopPropagation();
-          onReject();
-        }}
-        data-track-category='RecordingDetailV2'
-        data-track-name='reject_suggested_label'
-      >
-        <MultipleCrossCancelDefault className='size-3' aria-hidden='true' />
-      </button>
-    </span>
-  );
-}
-
+/** Recordings binding for {@link LabelPicker}: recording-wide suggestions and analytics namespace. */
 export function RecordingLabelPicker({
   labels,
   canEdit,
   onChange,
 }: RecordingLabelPickerProps): ReactElement | null {
-  const [isOpen, setIsOpen] = useState(false);
   const suggestions = useRecordingLabelSuggestions(canEdit);
-  const resolvable = useMemo(() => [...labels, ...suggestions], [labels, suggestions]);
-  const { resolveLabel, resolveMethod } = useResolvedRecordingLabels(resolvable);
-
-  // Confirmed labels (TagMethod.MANUAL) vs still-pending suggestions (LLM or AUTOMATED).
-  const confirmedLabels = useMemo(
-    () => labels.filter(id => resolveMethod(id) === TagMethod.MANUAL),
-    [labels, resolveMethod],
-  );
-  const suggestedLabels = useMemo(
-    () => (canEdit ? labels.filter(id => resolveMethod(id) !== TagMethod.MANUAL) : []),
-    [labels, canEdit, resolveMethod],
-  );
-
-  const options = useMemo<SearchableMultiSelectOption[]>(
-    () =>
-      normalizeRecordingTags([...suggestions, ...labels])
-        .filter(label => resolveMethod(label) === TagMethod.MANUAL)
-        .map(label => ({ value: label, displayLabel: resolveLabel(label) }))
-        .sort((left, right) => left.displayLabel.localeCompare(right.displayLabel))
-        .map(({ value, displayLabel }) => ({
-          // The value stays the stored label — an id for generated ones — so selecting
-          // writes back what the recording already holds.
-          value,
-          label: displayLabel,
-          icon: (
-            <span
-              className={cn('size-2 shrink-0 rounded-full', getTagTheme(displayLabel).dot)}
-              aria-hidden='true'
-            />
-          ),
-        })),
-    [labels, suggestions, resolveLabel, resolveMethod],
-  );
-
-  const handleCreate = (label: string): void => {
-    if (confirmedLabels.length >= MAX_LABELS) {
-      toast.error(`You can add up to ${MAX_LABELS} labels`);
-      return;
-    }
-    const slug = slugifyRecordingLabel(label);
-    if (!slug) {
-      toast.error('Label needs at least one letter or number');
-      return;
-    }
-    onChange(normalizeRecordingTags([...labels, slug]));
-  };
-
-  // `options` already excludes AI-suggested labels (filtered above), so a size increase
-  // here always means a confirmed/manual label is being added.
-  const handleSelectedValuesChange = (values: string[]): void => {
-    if (values.length > labels.length && confirmedLabels.length >= MAX_LABELS) {
-      toast.error(`You can add up to ${MAX_LABELS} labels`);
-      return;
-    }
-    onChange(values);
-  };
-
-  /** Tick: keep the AI-suggested tag — flips its Tag row to `manual` in place, no labels change needed. */
-  const handleConfirmSuggestion = async (labelId: string): Promise<void> => {
-    const revertMethod = resolveMethod(labelId);
-    try {
-      await confirmRecordingLabelSuggestion(labelId, revertMethod);
-    } catch {
-      toast.error('Failed to confirm label');
-    }
-  };
-
-  /** Cross: discard the AI-suggested tag — just drop its id from the recording's labels. */
-  const handleRejectSuggestion = (labelId: string): void => {
-    onChange(labels.filter(id => id !== labelId));
-  };
-
-  const suggestionPills =
-    canEdit && suggestedLabels.length > 0
-      ? suggestedLabels.map(label => (
-          <SuggestedLabelChip
-            key={label}
-            label={resolveLabel(label)}
-            onConfirm={() => void handleConfirmSuggestion(label)}
-            onReject={() => handleRejectSuggestion(label)}
-          />
-        ))
-      : null;
-
-  if (!canEdit) {
-    if (labels.length === 0) return null;
-
-    // Same flat pills as the owner's view — a shared recording's header shouldn't
-    // look like a different screen — just no remove/add controls.
-    return (
-      <>
-        {confirmedLabels.map(label => (
-          <LabelChip key={label} label={resolveLabel(label)} />
-        ))}
-      </>
-    );
-  }
 
   return (
-    <>
-      {confirmedLabels.map(label => (
-        <LabelChip
-          key={label}
-          label={resolveLabel(label)}
-          onRemove={() => onChange(labels.filter(id => id !== label))}
-        />
-      ))}
-      <SearchableMultiSelect
-        options={options}
-        selectedValues={labels}
-        onSelectedValuesChange={handleSelectedValuesChange}
-        onCreateOption={handleCreate}
-        className={LIST_INHERITS_POPOVER_CLASS_NAME}
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        searchPlaceholder='Search or create...'
-        searchMaxLength={LABEL_MAX_LENGTH}
-        searchAriaLabel='Search or create a label'
-        listAriaLabel='Labels'
-        emptyMessage='No labels yet'
-        trackCategory='RecordingDetailV2'
-        trackName='toggle_recording_label'
-        trigger={
-          <Button
-            type='button'
-            variant='outline'
-            size='sm'
-            className='h-6 gap-1.5 rounded-lg border-dashed border-muted-foreground/40 pl-2 pr-2.5 text-xs font-medium text-muted-foreground hover:border-foreground/30 hover:text-foreground'
-            aria-label='Add a label'
-            data-track-category='RecordingDetailV2'
-            data-track-name='open_recording_labels'
-          >
-            <PlusDefault className='size-3.5' aria-hidden='true' />
-            Label
-          </Button>
-        }
-      />
-      {suggestionPills}
-    </>
+    <LabelPicker
+      labels={labels}
+      canEdit={canEdit}
+      suggestions={suggestions}
+      trackCategory='RecordingDetailV2'
+      onChange={onChange}
+    />
   );
 }

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingShareModal.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingShareModal.tsx
@@ -1,24 +1,17 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import { Link } from 'react-router-dom';
-import { Globe, Hash, Link2, Lock, Users, X } from 'lucide-react';
-import { LinkChainSlant } from '@xyne/icons';
-import type { MentionResult } from '@xyne/shared';
-import { CallVisibility, ChannelScopeType, ChannelVisibility } from '@xyne/shared';
-import { useUserGroupSearch, useChannelSearch } from '@xyne/shared/hooks';
-import Avatar from '../../../components/ui/Avatar/Avatar';
-import { Button } from '../../../components/ui/Button/Button';
+import { Globe, Link2, Lock } from 'lucide-react';
+import { CallVisibility } from '@xyne/shared';
 import { Switch } from '../../../components/ui/Switch';
-import { InputBox } from '../../../components/ui/InputBox';
-import { UnifiedParticipantSearch } from '../../../components/ui/UnifiedParticipantSearch/UnifiedParticipantSearch';
-import type { InputBoxHandle } from '../../../hooks/useDragAndDropAreaRef';
-import { useActiveUserSearch } from '../../../hooks/useUsers';
+import {
+  EntityShareModal,
+  type EntityShareEntry,
+} from '../../../components/Share/EntityShareModal';
 import { useAuth } from '../../../hooks/useAuth';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useShareableOrigin } from '../../../hooks/useShareableOrigin';
-import { useMentionSearch } from '../../../hooks/useMentionSearch';
 import { queries } from '../../../zero/queries';
-import { getUserDisplayName, userToMentionResult } from '../../../utils/userDisplayName';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 import {
   recordingService,
   type RecordingDetail,
@@ -32,16 +25,17 @@ import {
   logRecordingError,
 } from '../../../utils/recordingUtils';
 
-const MENTION_USER_LIMIT = 20;
-const MENTION_GROUP_LIMIT = 10;
-
 export interface RecordingShareModalProps {
   recording: Pick<RecordingDetail, 'externalId' | 'createdByUserId'>;
   onClose?: () => void;
   onTicketLinkUpdated?: (ticketLink: RecordingTicketLinkState) => void;
 }
 
-/** Unified recording share and post modal. */
+/**
+ * Recordings binding for {@link EntityShareModal}: the recordings share endpoints,
+ * plus the link-access section, which only recordings have (a regular call is not
+ * reachable by link — see calls-acl).
+ */
 export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
   recording,
   onClose,
@@ -51,13 +45,8 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
   const shareableOrigin = useShareableOrigin();
   const isCreator = currentUser?.id === recording.createdByUserId;
 
-  const [searchQuery, setSearchQuery] = useState('');
-  const [selectedValues, setSelectedValues] = useState<string[]>([]);
-  const [messageContent, setMessageContent] = useState('');
-  const [sharing, setSharing] = useState(false);
   const [locallyRevokedShareIds, setLocallyRevokedShareIds] = useState<Set<string>>(new Set());
   const [visibilityOverride, setVisibilityOverride] = useState<CallVisibility | null>(null);
-  const inputBoxRef = useRef<InputBoxHandle>(null);
 
   const [recordingRow] = useCachedQuery(
     queries.oatsRecordingByExternalId({ callId: recording.externalId }),
@@ -65,111 +54,43 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
   const visibility = visibilityOverride ?? recordingRow?.visibility ?? CallVisibility.PRIVATE;
   const isPublic = visibility === CallVisibility.PUBLIC;
 
-  const shares = useMemo(
+  const shares = useMemo<EntityShareEntry[]>(
     () =>
-      (recordingRow?.shares ?? []).filter(
-        share =>
-          !locallyRevokedShareIds.has(share.id) && !isRecordingTicketLinkShare(share.metadata),
-      ),
+      (recordingRow?.shares ?? [])
+        .filter(
+          share =>
+            !locallyRevokedShareIds.has(share.id) && !isRecordingTicketLinkShare(share.metadata),
+        )
+        .map(share => {
+          const target: RecordingShareTarget = share.userGroupId
+            ? { type: 'user_group', id: share.userGroupId }
+            : share.channelId
+              ? { type: 'channel', id: share.channelId }
+              : { type: 'user', id: share.userId! };
+          const label = share.userGroupId
+            ? (share.userGroup?.name ?? share.userGroupId)
+            : share.channelId
+              ? (share.channel?.name ?? share.channelId)
+              : share.user
+                ? getUserDisplayName(share.user)
+                : (share.userId ?? '');
+          const post = getRecordingSharePost(share.metadata);
+          return {
+            id: share.id,
+            label,
+            userId: share.userId ?? null,
+            target,
+            post: post ? { channelId: post.channelId, conversationId: post.conversationId } : null,
+          };
+        }),
     [locallyRevokedShareIds, recordingRow],
   );
 
-  const sharedUserIds = useMemo(
-    () => new Set(shares.map(share => share.userId).filter((id): id is string => Boolean(id))),
-    [shares],
-  );
-  const sharedUserGroupIds = useMemo(
-    () => new Set(shares.map(share => share.userGroupId).filter((id): id is string => Boolean(id))),
-    [shares],
-  );
-  const sharedChannelIds = useMemo(
-    () => new Set(shares.map(share => share.channelId).filter((id): id is string => Boolean(id))),
-    [shares],
-  );
-
-  const excludedUserIds = useMemo(
-    () =>
-      new Set(
-        [recording.createdByUserId, currentUser?.id, ...sharedUserIds].filter((id): id is string =>
-          Boolean(id),
-        ),
-      ),
-    [currentUser?.id, recording.createdByUserId, sharedUserIds],
-  );
-
-  // Configure the share message composer.
-  const selectedChannelId = useMemo(
-    () =>
-      selectedValues.find(value => value.startsWith('channel:'))?.replace('channel:', '') ??
-      undefined,
-    [selectedValues],
-  );
-
-  const { results: channelScopedMentions, searchMentions: searchChannelScopedMentions } =
-    useMentionSearch(selectedChannelId);
-
-  // Search workspace mentions when no channel is selected.
-  const [mentionQuery, setMentionQuery] = useState('');
-  const mentionUsers = useActiveUserSearch(mentionQuery, MENTION_USER_LIMIT);
-  const mentionGroups = useUserGroupSearch(mentionQuery, MENTION_GROUP_LIMIT);
-  const workspaceMentions = useMemo<MentionResult[]>(
-    () => [
-      ...mentionUsers.map(u => userToMentionResult(u, u.id === currentUser?.id)),
-      ...mentionGroups.map(
-        (g): MentionResult => ({
-          id: g.id,
-          name: g.name,
-          type: 'group',
-          ...(g.alias && { alias: g.alias }),
-          ...(g.description && { description: g.description }),
-          memberCount: 0,
-          isDeactivated: g.isActive === false,
-        }),
-      ),
-    ],
-    [mentionUsers, mentionGroups, currentUser?.id],
-  );
-
-  const mentionResults = selectedChannelId ? channelScopedMentions : workspaceMentions;
-  const handleMentionSearch = useCallback(
-    (query: string) => {
-      if (selectedChannelId) {
-        searchChannelScopedMentions(query);
-      } else {
-        setMentionQuery(query);
-      }
-    },
-    [selectedChannelId, searchChannelScopedMentions],
-  );
-
-  // Search channel mentions.
-  const [channelMentionQuery, setChannelMentionQuery] = useState('');
-  const channelMentionResults = useChannelSearch(channelMentionQuery, 10);
-  const channelMentionItems = useMemo(
-    () =>
-      channelMentionResults
-        .filter(channel => channel.scopeType === ChannelScopeType.DEFAULT)
-        .map(channel => ({
-          id: channel.id,
-          name: channel.name,
-          isPrivate: channel.visibility === ChannelVisibility.PRIVATE,
-          ...(channel.description && { description: channel.description }),
-        })),
-    [channelMentionResults],
-  );
-
-  const handleShare = async (): Promise<void> => {
-    if (selectedValues.length === 0) return;
-
-    setSharing(true);
+  const handleGrant = async (
+    targets: RecordingShareTarget[],
+    messageContent: string,
+  ): Promise<void> => {
     try {
-      const targets: RecordingShareTarget[] = selectedValues.map(value =>
-        value.startsWith('user_group:')
-          ? { type: 'user_group', id: value.replace('user_group:', '') }
-          : value.startsWith('channel:')
-            ? { type: 'channel', id: value.replace('channel:', '') }
-            : { type: 'user', id: value.replace('user:', '') },
-      );
       const result = await recordingService.grantRecordingAccess(
         recording.externalId,
         targets,
@@ -183,22 +104,30 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
           return next;
         });
       }
-      toast.success(
-        selectedValues.length === 1
-          ? 'Recording shared'
-          : `Shared with ${selectedValues.length} recipients`,
-      );
-      setSelectedValues([]);
-      setSearchQuery('');
-      setMessageContent('');
-      onClose?.();
     } catch (error) {
       logRecordingError('RecordingShareModal.share', error);
-      toast.error('Failed to share', {
-        description: getApiErrorMessage(error, 'Unable to share this recording'),
+      throw error;
+    }
+  };
+
+  const handleRevoke = async (target: RecordingShareTarget): Promise<void> => {
+    try {
+      const result = await recordingService.revokeRecordingAccess(recording.externalId, [target]);
+      if (result.shares?.length) {
+        setLocallyRevokedShareIds(current => {
+          const next = new Set(current);
+          result.shares?.forEach(share => next.add(share.id));
+          return next;
+        });
+      }
+      if (result.linkedTicketId === null) {
+        onTicketLinkUpdated?.({ linkedTicketId: null, linkedTicketMessageId: null });
+      }
+    } catch (error) {
+      logRecordingError('RecordingShareModal.revoke', error);
+      toast.error('Failed to remove access', {
+        description: getApiErrorMessage(error, 'Unable to remove recording access'),
       });
-    } finally {
-      setSharing(false);
     }
   };
 
@@ -231,216 +160,63 @@ export const RecordingShareModal: React.FC<RecordingShareModalProps> = ({
     }
   };
 
-  const handleAccessChange = async (
-    target: { targetUserId: string } | { targetUserGroupId: string } | { targetChannelId: string },
-  ): Promise<void> => {
-    const apiTarget: RecordingShareTarget =
-      'targetUserId' in target
-        ? { type: 'user', id: target.targetUserId }
-        : 'targetUserGroupId' in target
-          ? { type: 'user_group', id: target.targetUserGroupId }
-          : { type: 'channel', id: target.targetChannelId };
-    try {
-      const result = await recordingService.revokeRecordingAccess(recording.externalId, [
-        apiTarget,
-      ]);
-      if (result.shares?.length) {
-        setLocallyRevokedShareIds(current => {
-          const next = new Set(current);
-          result.shares?.forEach(share => next.add(share.id));
-          return next;
-        });
-      }
-      if (result.linkedTicketId === null) {
-        onTicketLinkUpdated?.({ linkedTicketId: null, linkedTicketMessageId: null });
-      }
-    } catch (error) {
-      logRecordingError('RecordingShareModal.revoke', error);
-      toast.error('Failed to remove access', {
-        description: getApiErrorMessage(error, 'Unable to remove recording access'),
-      });
-    }
-  };
-
-  return (
-    <div className='flex flex-col w-full p-5 gap-4'>
-      <div className='space-y-2'>
-        <p className='text-muted-foreground text-[13px] leading-5'>
-          Share with people, groups, or channels
-        </p>
-        <UnifiedParticipantSearch
-          selectedValues={selectedValues}
-          onMultiSelect={setSelectedValues}
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
-          excludedUserIds={excludedUserIds}
-          excludedUserGroupIds={sharedUserGroupIds}
-          excludedChannelIds={sharedChannelIds}
-          exclusiveSelection={false}
-        />
-      </div>
-
-      <div
-        className='space-y-1.5'
-        data-track-category='RecordingDetailV2'
-        data-track-name='share_recording_message_input'
-        onKeyDownCapture={event => {
-          if (event.key === 'Enter' && !event.shiftKey && selectedValues.length > 0) {
-            if (inputBoxRef.current?.isSuggestionOpen()) return;
-            event.preventDefault();
-            event.stopPropagation();
-            void handleShare();
-          }
-        }}
-      >
-        <label htmlFor='share-recording-message' className='text-muted-foreground text-[13px]'>
-          Add a message (optional)
-        </label>
-        <InputBox
-          ref={inputBoxRef}
-          id='share-recording-message'
-          placeholder='Say something about this recording...'
-          onSendMessage={() => {}}
-          onContentChange={(html, _text) => {
-            setMessageContent(html);
-          }}
-          mentionItems={mentionResults}
-          onMentionSearch={handleMentionSearch}
-          channelItems={channelMentionItems}
-          onChannelSearch={setChannelMentionQuery}
-          features={{
-            richText: true,
-            mentions: true,
-            commands: false,
-            fileAttachments: false,
-            emojiPicker: true,
-          }}
-          showTypingIndicator={false}
-          disabled={sharing}
-          disableEnterToSend
-          hideSendButton
-        />
-      </div>
-
-      <div className='flex justify-end'>
-        <Button
-          size='sm'
-          onClick={() => void handleShare()}
-          disabled={selectedValues.length === 0 || sharing}
-          data-track-category='RecordingDetailV2'
-          data-track-name='share_recording_confirm'
-        >
-          {sharing ? 'Sharing...' : 'Share'}
-        </Button>
-      </div>
-
-      {shares.length > 0 && (
-        <div className='space-y-2 border-t border-border pt-3'>
-          <p className='text-muted-foreground text-[13px]'>People with access</p>
-          <div className='space-y-3.5 max-h-60 overflow-y-auto pr-1'>
-            {shares.map(share => {
-              const target = share.userGroupId
-                ? { targetUserGroupId: share.userGroupId }
-                : share.channelId
-                  ? { targetChannelId: share.channelId }
-                  : { targetUserId: share.userId! };
-              const label = share.userGroupId
-                ? (share.userGroup?.name ?? share.userGroupId)
-                : share.channelId
-                  ? `${share.channel?.name ?? share.channelId}`
-                  : share.user
-                    ? getUserDisplayName(share.user)
-                    : share.userId;
-              const icon = share.userGroupId ? (
-                <Users className='size-4 text-muted-foreground shrink-0' />
-              ) : share.channelId ? (
-                <Hash className='size-4 text-muted-foreground shrink-0' />
-              ) : (
-                <Avatar userId={share.userId ?? null} size='sm' showActiveStatus={false} />
-              );
-              // Link to the posted conversation.
-              const post = getRecordingSharePost(share.metadata);
-
-              return (
-                <div key={share.id} className='group flex items-center justify-between gap-2'>
-                  <div className='flex items-center gap-2 min-w-0'>
-                    {icon}
-                    <span className='text-sm truncate'>{label}</span>
-                    {post && (
-                      <Link
-                        to={`/chat/dir/${post.channelId}/${post.conversationId}`}
-                        className='shrink-0 text-muted-foreground transition-colors hover:text-foreground'
-                        aria-label='Open shared conversation'
-                        data-track-category='RecordingDetailV2'
-                        data-track-name='open_recording_share_conversation'
-                      >
-                        <LinkChainSlant className='size-3.5' aria-hidden='true' />
-                      </Link>
-                    )}
-                  </div>
-                  <button
-                    type='button'
-                    onClick={() => void handleAccessChange(target)}
-                    className='shrink-0 rounded p-1 text-muted-foreground opacity-0 hover:bg-muted hover:text-foreground group-hover:opacity-100'
-                    aria-label='Remove access'
-                    data-track-category='RecordingDetailV2'
-                    data-track-name='revoke_recording_share'
-                  >
-                    <X className='size-3.5' />
-                  </button>
-                </div>
-              );
-            })}
+  const generalAccess = (
+    <div className='space-y-2 border-t border-border pt-3'>
+      <p className='text-muted-foreground text-[13px]'>General access</p>
+      <div className='flex items-center gap-3 rounded-lg border border-border bg-muted/40 px-3 py-2.5'>
+        <span className='w-9 h-9 rounded-full bg-background border border-border grid place-items-center shrink-0 text-muted-foreground'>
+          {isPublic ? <Globe className='w-4 h-4' /> : <Lock className='w-4 h-4' />}
+        </span>
+        <div className='min-w-0 flex-1'>
+          <div className='text-sm font-medium'>
+            {isPublic ? 'Anyone with the link' : 'Restricted'}
+          </div>
+          <div className='text-xs text-muted-foreground mt-0.5'>
+            {isPublic
+              ? 'Anyone in the workspace with the link can view'
+              : 'Only people with access can open'}
           </div>
         </div>
-      )}
-
-      <div className='space-y-2 border-t border-border pt-3'>
-        <p className='text-muted-foreground text-[13px]'>General access</p>
-        <div className='flex items-center gap-3 rounded-lg border border-border bg-muted/40 px-3 py-2.5'>
-          <span className='w-9 h-9 rounded-full bg-background border border-border grid place-items-center shrink-0 text-muted-foreground'>
-            {isPublic ? <Globe className='w-4 h-4' /> : <Lock className='w-4 h-4' />}
-          </span>
-          <div className='min-w-0 flex-1'>
-            <div className='text-sm font-medium'>
-              {isPublic ? 'Anyone with the link' : 'Restricted'}
-            </div>
-            <div className='text-xs text-muted-foreground mt-0.5'>
-              {isPublic
-                ? 'Anyone in the workspace with the link can view'
-                : 'Only people with access can open'}
-            </div>
-          </div>
-          {isCreator && (
-            <Switch
-              checked={isPublic}
-              onCheckedChange={checked =>
-                void handleVisibilityChange(
-                  checked ? CallVisibility.PUBLIC : CallVisibility.PRIVATE,
-                )
-              }
-              aria-label='Anyone with the link'
-              id='recording-visibility-toggle'
-            />
-          )}
-        </div>
-        {isPublic && (
-          <div className='flex justify-end'>
-            <button
-              type='button'
-              onClick={() => void handleCopyLink()}
-              className='inline-flex items-center gap-2 text-sm font-medium text-foreground rounded-md px-2.5 py-1.5 -mr-2.5 transition-colors hover:bg-accent hover:text-primary'
-              data-testid='recording-copy-link-button'
-              data-track-category='RecordingDetailV2'
-              data-track-name='copy_recording_link'
-            >
-              <Link2 className='w-4 h-4' />
-              Copy link
-            </button>
-          </div>
+        {isCreator && (
+          <Switch
+            checked={isPublic}
+            onCheckedChange={checked =>
+              void handleVisibilityChange(checked ? CallVisibility.PUBLIC : CallVisibility.PRIVATE)
+            }
+            aria-label='Anyone with the link'
+            id='recording-visibility-toggle'
+          />
         )}
       </div>
+      {isPublic && (
+        <div className='flex justify-end'>
+          <button
+            type='button'
+            onClick={() => void handleCopyLink()}
+            className='inline-flex items-center gap-2 text-sm font-medium text-foreground rounded-md px-2.5 py-1.5 -mr-2.5 transition-colors hover:bg-accent hover:text-primary'
+            data-testid='recording-copy-link-button'
+            data-track-category='RecordingDetailV2'
+            data-track-name='copy_recording_link'
+          >
+            <Link2 className='w-4 h-4' />
+            Copy link
+          </button>
+        </div>
+      )}
     </div>
+  );
+
+  return (
+    <EntityShareModal
+      ownerId={recording.createdByUserId}
+      shares={shares}
+      onGrant={handleGrant}
+      onRevoke={handleRevoke}
+      subject='recording'
+      trackCategory='RecordingDetailV2'
+      generalAccess={generalAccess}
+      {...(onClose && { onClose })}
+    />
   );
 };
 

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryGenerationPill/SummaryGenerationPanel.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/SummaryGenerationPill/SummaryGenerationPanel.tsx
@@ -25,6 +25,10 @@ export interface SummaryGenerationPanelProps {
   initialProgress?: number;
   initialStageIndex?: number;
   onProgressPause?: (progress: number, stageIndex: number) => void;
+  /** The word the copy uses for what is being summarized: 'recording' or 'call'. */
+  summarySubject?: string;
+  /** Analytics namespace of the host screen. */
+  trackCategory?: string;
 }
 
 /** A status line shown while Scribe works, swapped in once `atMs` has elapsed. */
@@ -74,6 +78,8 @@ export const SummaryGenerationPanel = ({
   initialProgress = 0,
   initialStageIndex = 0,
   onProgressPause,
+  summarySubject = 'recording',
+  trackCategory = 'RecordingDetailV2',
 }: SummaryGenerationPanelProps): ReactElement => {
   // —— State and hooks ———
   const shouldReduceMotion = useReducedMotion() ?? false;
@@ -160,7 +166,7 @@ export const SummaryGenerationPanel = ({
               <div className='min-w-0 flex-1'>
                 <p className='font-semibold text-foreground'>Something went wrong</p>
                 <p className='mt-1 text-pretty text-sm text-muted-foreground'>
-                  Scribe couldn&rsquo;t generate a summary for this recording. Your notes and
+                  Scribe couldn&rsquo;t generate a summary for this {summarySubject}. Your notes and
                   transcript are untouched.
                 </p>
                 <div className='mt-3 flex flex-wrap items-center gap-2.5'>
@@ -170,7 +176,7 @@ export const SummaryGenerationPanel = ({
                     onClick={onRetry}
                     disabled={!canGenerate}
                     className='shrink-0 gap-1.5 bg-foreground py-2 px-3 text-sm rounded-xl font-medium text-background transition-opacity duration-150 hover:bg-foreground hover:opacity-90'
-                    data-track-category='RecordingDetailV2'
+                    data-track-category={trackCategory}
                     data-track-name='retry_summary'
                   >
                     <XyneAIStar size={12} />
@@ -183,7 +189,7 @@ export const SummaryGenerationPanel = ({
                       variant='outline'
                       onClick={onReadTranscript}
                       className='shrink-0 rounded-xl border-border bg-background px-3 py-2 text-sm font-semibold text-foreground shadow-none transition-[border-color,color] duration-150 hover:bg-background hover:text-foreground'
-                      data-track-category='RecordingDetailV2'
+                      data-track-category={trackCategory}
                       data-track-name='read_transcript_after_summary_failure'
                     >
                       Read the transcript
@@ -210,12 +216,12 @@ export const SummaryGenerationPanel = ({
                 </span>
                 <div className='min-w-0'>
                   <p className='text-sm font-medium text-foreground'>
-                    This recording hasn&rsquo;t been summarized yet
+                    This {summarySubject} hasn&rsquo;t been summarized yet
                   </p>
                   <p className='mt-1 text-sm text-muted-foreground'>
                     {canGenerate
                       ? 'Transcript ready. Scribe takes up to 2 minutes to write the recap, decisions and action items — often less.'
-                      : 'A summary needs a transcript. This recording doesn’t have one yet.'}
+                      : `A summary needs a transcript. This ${summarySubject} doesn’t have one yet.`}
                   </p>
                 </div>
               </div>
@@ -225,7 +231,7 @@ export const SummaryGenerationPanel = ({
                 onClick={onGenerate}
                 disabled={!canGenerate}
                 className='h-8 shrink-0 gap-2 rounded-xl px-3 text-xs font-medium bg-foreground text-background hover:bg-foreground/80 hover:text-background disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed'
-                data-track-category='RecordingDetailV2'
+                data-track-category={trackCategory}
                 data-track-name='generate_summary'
               >
                 <XyneAIStar size={12} />

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingLabelFilter.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingLabelFilter.tsx
@@ -1,10 +1,5 @@
-import { useMemo, useState, type ReactElement } from 'react';
-import { ChevronDown, ChevronUp } from '@xyne/icons';
-import { SearchableMultiSelect } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect';
-import type { SearchableMultiSelectOption } from '../../../components/ui/SearchableMultiSelect/SearchableMultiSelect.types';
-import { Button } from '../../../components/ui/Button/Button';
-import { cn } from '../../../utils/classNames';
-import { getTagDotColor } from '../../../utils/tagTheme';
+import { type ReactElement } from 'react';
+import { LabelFilter } from '../../../components/Labels/LabelFilter';
 
 interface RecordingLabelFilterProps {
   labels: string[];
@@ -14,95 +9,22 @@ interface RecordingLabelFilterProps {
   resolveLabel?: (label: string) => string;
 }
 
-const TRIGGER_CLASS_NAME = 'h-9 gap-1.5 rounded-xl border-border px-3 font-medium shadow-none';
-const LIST_INHERITS_POPOVER_CLASS_NAME =
-  '[[data-theme=midnight]_&_[role=listbox][aria-multiselectable]]:!bg-transparent';
-
+/** Recordings binding for {@link LabelFilter}: recordings copy and analytics namespace. */
 export function RecordingLabelFilter({
   labels,
   selectedLabels,
   onSelectedLabelsChange,
-  resolveLabel = (label: string) => label,
+  resolveLabel,
 }: RecordingLabelFilterProps): ReactElement {
-  const [isOpen, setIsOpen] = useState(false);
-
-  // Values stay Tag ids — what the selection is keyed by — while the resolved text
-  // drives both the visible label and SearchableMultiSelect's own search filtering.
-  const options = useMemo<SearchableMultiSelectOption[]>(
-    () =>
-      labels.map(label => {
-        const displayLabel = resolveLabel(label);
-        return {
-          value: label,
-          label: displayLabel,
-          icon: (
-            <span
-              className={cn('size-2 shrink-0 rounded-full', getTagDotColor(displayLabel))}
-              aria-hidden='true'
-            />
-          ),
-        };
-      }),
-    [labels, resolveLabel],
-  );
-
-  if (labels.length === 0) {
-    return (
-      <Button
-        type='button'
-        variant='outline'
-        disabled
-        className={TRIGGER_CLASS_NAME}
-        aria-label='Label filter unavailable because no recordings are labelled'
-      >
-        Labels
-        <ChevronDown className='size-4' aria-hidden='true' />
-      </Button>
-    );
-  }
-
   return (
-    <SearchableMultiSelect
-      options={options}
-      selectedValues={selectedLabels}
-      onSelectedValuesChange={onSelectedLabelsChange}
-      isOpen={isOpen}
-      onOpenChange={setIsOpen}
-      searchAriaLabel='Search labels'
-      listAriaLabel='Labels'
-      emptyMessage='No labels found'
+    <LabelFilter
+      labels={labels}
+      selectedLabels={selectedLabels}
+      onSelectedLabelsChange={onSelectedLabelsChange}
+      resolveLabel={resolveLabel}
       trackCategory='RecordingsV2'
-      trackName='toggle_label_filter'
-      className={LIST_INHERITS_POPOVER_CLASS_NAME}
-      trigger={
-        <Button
-          type='button'
-          variant='outline'
-          className={cn(
-            selectedLabels.length === 0 ? 'text-muted-foreground' : '!border-foreground',
-            TRIGGER_CLASS_NAME,
-          )}
-          aria-label={
-            selectedLabels.length > 0
-              ? `Labels, ${selectedLabels.length} selected`
-              : 'Filter recordings by label'
-          }
-          data-track-category='RecordingsV2'
-          data-track-name='open_label_filter'
-        >
-          Labels
-          {selectedLabels.length > 0 && (
-            <span className='flex h-4 min-w-4 items-center justify-center rounded-full bg-foreground px-1 text-xs font-semibold leading-none tabular-nums text-background'>
-              {selectedLabels.length}
-            </span>
-          )}
-          {isOpen ? (
-            <ChevronUp className='size-4 text-muted-foreground' aria-hidden='true' />
-          ) : (
-            <ChevronDown className='size-4 text-muted-foreground' aria-hidden='true' />
-          )}
-        </Button>
-      }
+      triggerAriaLabel='Filter recordings by label'
+      disabledAriaLabel='Label filter unavailable because no recordings are labelled'
     />
   );
 }

--- a/apps/dashboard/src/services/Call/callService.ts
+++ b/apps/dashboard/src/services/Call/callService.ts
@@ -180,6 +180,18 @@ function isApiErrorResponse(data: unknown): data is ApiErrorResponse {
 // ============================================================================
 
 export class CallService {
+  /**
+   * Replace a call's labels. Returns the resolved Tag ids — raw text typed in the
+   * picker becomes a real Tag server-side, so the response is what to store.
+   */
+  async updateCallLabels(callId: string, labels: string[]): Promise<string[]> {
+    const response = await apiInstance.patch<{ success: true; labels: string[] }>(
+      `/calls/${callId}/labels`,
+      { labels },
+    );
+    return response.data.labels;
+  }
+
   async updateMeetingStatus(callId: string, data: UpdateRsvpRequest): Promise<void> {
     try {
       await apiInstance.post(`/calls/${callId}/rsvp`, data);

--- a/apps/dashboard/src/services/Call/callService.ts
+++ b/apps/dashboard/src/services/Call/callService.ts
@@ -192,6 +192,22 @@ export class CallService {
     return response.data.labels;
   }
 
+  /** Rewrites the call's detailed summary with `summaryTemplateId`, reusing the same canvas. */
+  async regenerateCallSummary(
+    callId: string,
+    summaryTemplateId: string,
+  ): Promise<{ summaryTemplateId: string; detailedSummaryCanvasId: string }> {
+    const response = await apiInstance.post<{
+      success: true;
+      summaryTemplateId: string;
+      detailedSummaryCanvasId: string;
+    }>(`/calls/${callId}/regenerate-summary`, { summaryTemplateId });
+    return {
+      summaryTemplateId: response.data.summaryTemplateId,
+      detailedSummaryCanvasId: response.data.detailedSummaryCanvasId,
+    };
+  }
+
   async updateMeetingStatus(callId: string, data: UpdateRsvpRequest): Promise<void> {
     try {
       await apiInstance.post(`/calls/${callId}/rsvp`, data);

--- a/apps/dashboard/src/services/Call/callService.ts
+++ b/apps/dashboard/src/services/Call/callService.ts
@@ -179,6 +179,16 @@ function isApiErrorResponse(data: unknown): data is ApiErrorResponse {
 // SERVICE CLASS
 // ============================================================================
 
+export type CallShareTarget =
+  | { type: 'user'; id: string }
+  | { type: 'user_group'; id: string }
+  | { type: 'channel'; id: string };
+
+export interface CallSharingResult {
+  action: 'grant' | 'revoke';
+  shares?: Array<{ id: string; target: CallShareTarget; access: string }>;
+}
+
 export class CallService {
   /**
    * Replace a call's labels. Returns the resolved Tag ids — raw text typed in the
@@ -206,6 +216,35 @@ export class CallService {
       summaryTemplateId: response.data.summaryTemplateId,
       detailedSummaryCanvasId: response.data.detailedSummaryCanvasId,
     };
+  }
+
+  /**
+   * Share a call with people, groups or channels, optionally with a note. Each
+   * target also gets a card posted into the channel (or a DM, for a user target).
+   */
+  async grantCallAccess(
+    callId: string,
+    targets: CallShareTarget[],
+    messageContent?: string,
+  ): Promise<CallSharingResult> {
+    const response = await apiInstance.post<{ success: true } & CallSharingResult>(
+      `/calls/${callId}/sharing`,
+      {
+        action: 'grant',
+        targets,
+        ...(messageContent?.trim() ? { messageContent: messageContent.trim() } : {}),
+      },
+    );
+    return response.data;
+  }
+
+  /** Removes a target's access and deletes the card the share posted for it. */
+  async revokeCallAccess(callId: string, targets: CallShareTarget[]): Promise<CallSharingResult> {
+    const response = await apiInstance.post<{ success: true } & CallSharingResult>(
+      `/calls/${callId}/sharing`,
+      { action: 'revoke', targets },
+    );
+    return response.data;
   }
 
   async updateMeetingStatus(callId: string, data: UpdateRsvpRequest): Promise<void> {

--- a/apps/dashboard/src/services/Recording/recordingEmailService.ts
+++ b/apps/dashboard/src/services/Recording/recordingEmailService.ts
@@ -1,4 +1,5 @@
 import { apiInstance } from '../clients/apiClient';
+import { callScopedPath } from './recordingService';
 
 export const RECORDING_EMAIL_ATTACHMENT_KINDS = [
   'transcript',
@@ -47,16 +48,23 @@ interface GoogleRecordingEmailConnectionResponse {
 }
 
 class RecordingEmailService {
-  async getComposeContext(callId: string): Promise<RecordingEmailComposeContext> {
+  async getComposeContext(
+    callId: string,
+    isRecording = true,
+  ): Promise<RecordingEmailComposeContext> {
     const response = await apiInstance.get<RecordingEmailComposeContext>(
-      `/calls/recordings/${callId}/email-compose-context`,
+      `/calls/${callScopedPath(callId, isRecording)}/email-compose-context`,
     );
     return response.data;
   }
 
-  async send(callId: string, input: SendRecordingEmailInput): Promise<SendRecordingEmailResponse> {
+  async send(
+    callId: string,
+    input: SendRecordingEmailInput,
+    isRecording = true,
+  ): Promise<SendRecordingEmailResponse> {
     const response = await apiInstance.post<SendRecordingEmailResponse>(
-      `/calls/recordings/${callId}/send-email`,
+      `/calls/${callScopedPath(callId, isRecording)}/send-email`,
       input,
     );
     return response.data;

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -268,6 +268,13 @@ interface RecordingDetailResponse {
   recording: RecordingDetail;
 }
 
+/**
+ * Recordings and regular calls share these handlers but sit on different routes:
+ * `/calls/recordings/:id/...` and `/calls/:id/...`.
+ */
+export const callScopedPath = (callId: string, isRecording: boolean): string =>
+  isRecording ? `recordings/${callId}` : callId;
+
 class RecordingService {
   /**
    * Start a headless recording session
@@ -372,17 +379,24 @@ class RecordingService {
   }
 
   /** `title` names the new doc; omitted, the backend falls back to the recording title. */
-  async exportGoogleDoc(callId: string, title?: string): Promise<ExportRecordingGoogleDocResult> {
+  async exportGoogleDoc(
+    callId: string,
+    title?: string,
+    isRecording = true,
+  ): Promise<ExportRecordingGoogleDocResult> {
     const response = await apiInstance.post<{ success: true } & ExportRecordingGoogleDocResult>(
-      `/calls/recordings/${callId}/export-google-doc`,
+      `/calls/${callScopedPath(callId, isRecording)}/export-google-doc`,
       title ? { title } : {},
     );
     return response.data;
   }
 
-  async getGoogleDocComposeContext(callId: string): Promise<RecordingGoogleDocComposeContext> {
+  async getGoogleDocComposeContext(
+    callId: string,
+    isRecording = true,
+  ): Promise<RecordingGoogleDocComposeContext> {
     const response = await apiInstance.get<{ success: true } & RecordingGoogleDocComposeContext>(
-      `/calls/recordings/${callId}/google-doc-compose-context`,
+      `/calls/${callScopedPath(callId, isRecording)}/google-doc-compose-context`,
     );
     return response.data;
   }

--- a/packages/shared/src/zero/acl/tables/calls-acl.ts
+++ b/packages/shared/src/zero/acl/tables/calls-acl.ts
@@ -4,6 +4,31 @@ import { CallType, CallVisibility, EntityUserAccess, ShareableEntityType } from 
 import { BaseQueryACL } from '../core/base-acl';
 import { guestChannelAccessWhere, isGuestContext } from '../core/guest-acl-utils';
 
+/**
+ * A live `entity_access` row of `entityType` reaching the viewer directly or through
+ * a group/channel they belong to. Recordings and regular calls each have their own
+ * entity type, so neither can widen the other's audience.
+ *
+ * A module function rather than a private method: query-acl-factory casts between
+ * table ACLs structurally, and a private member would make CallsACL nominal.
+ */
+const shareIsActiveForViewer = <TReturn>(
+  share: Query<'entity_access', Schema, TReturn>,
+  ctx: Context,
+  entityType: ShareableEntityType,
+): Query<'entity_access', Schema, TReturn> =>
+  share
+    .where('workspaceId', ctx.workspaceId)
+    .where('shareableEntityType', entityType)
+    .where('entityUserAccess', '!=', EntityUserAccess.REVOKED)
+    .where(({ or, cmp, exists }) =>
+      or(
+        cmp('userId', ctx.userID),
+        exists('userGroupMemberships', m => m.where('userId', ctx.userID)),
+        exists('channelMembers', m => m.where('userId', ctx.userID)),
+      ),
+    );
+
 export class CallsACL extends BaseQueryACL<'calls'> {
   constructor(ctx: Context) {
     super(ctx, 'calls');
@@ -17,17 +42,13 @@ export class CallsACL extends BaseQueryACL<'calls'> {
           and(
             cmp('callType', CallType.HEADLESS),
             exists('shares', share =>
-              share
-                .where('workspaceId', this.ctx.workspaceId)
-                .where('shareableEntityType', ShareableEntityType.NOTE_TAKER)
-                .where('entityUserAccess', '!=', EntityUserAccess.REVOKED)
-                .where(({ or: shareOr, cmp: shareCmp, exists: shareExists }) =>
-                  shareOr(
-                    shareCmp('userId', this.ctx.userID),
-                    shareExists('userGroupMemberships', m => m.where('userId', this.ctx.userID)),
-                    shareExists('channelMembers', m => m.where('userId', this.ctx.userID)),
-                  ),
-                ),
+              shareIsActiveForViewer(share, this.ctx, ShareableEntityType.NOTE_TAKER),
+            ),
+          ),
+          and(
+            cmp('callType', '!=', CallType.HEADLESS),
+            exists('shares', share =>
+              shareIsActiveForViewer(share, this.ctx, ShareableEntityType.CALL),
             ),
           ),
           and(
@@ -51,17 +72,13 @@ export class CallsACL extends BaseQueryACL<'calls'> {
         and(
           cmp('callType', CallType.HEADLESS),
           exists('shares', share =>
-            share
-              .where('workspaceId', this.ctx.workspaceId)
-              .where('shareableEntityType', ShareableEntityType.NOTE_TAKER)
-              .where('entityUserAccess', '!=', EntityUserAccess.REVOKED)
-              .where(({ or: shareOr, cmp: shareCmp, exists: shareExists }) =>
-                shareOr(
-                  shareCmp('userId', this.ctx.userID),
-                  shareExists('userGroupMemberships', m => m.where('userId', this.ctx.userID)),
-                  shareExists('channelMembers', m => m.where('userId', this.ctx.userID)),
-                ),
-              ),
+            shareIsActiveForViewer(share, this.ctx, ShareableEntityType.NOTE_TAKER),
+          ),
+        ),
+        and(
+          cmp('callType', '!=', CallType.HEADLESS),
+          exists('shares', share =>
+            shareIsActiveForViewer(share, this.ctx, ShareableEntityType.CALL),
           ),
         ),
         and(

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -2196,6 +2196,30 @@ export const queries = defineQueries({
     },
   ),
 
+  /**
+   * A single non-HEADLESS call (+ its shares) by row id — what the detail route
+   * carries. Used both to resolve a call reached by link, with no navigation state
+   * to read it from, and to list who a call is shared with.
+   */
+  callById: defineQuery(
+    z.object({ callId: z.string() }),
+    ({ ctx, args: { callId } }) =>
+      zql.calls
+        .where('workspaceId', ctx.workspaceId)
+        .where('callType', '!=', CallType.HEADLESS)
+        .where('id', callId)
+        .related('participants', p => p.where('userId', ctx.userID))
+        .related('shares', shares =>
+          shares
+            .where('shareableEntityType', ShareableEntityType.CALL)
+            .where('entityUserAccess', '!=', EntityUserAccess.REVOKED)
+            .related('user')
+            .related('userGroup')
+            .related('channel'),
+        )
+        .one(),
+  ),
+
   // Fetches the HEADLESS recording (+ shares) by its public
   // externalId (what's in the URL / RecordingDetail.externalId) — used by
   // the Share modal and the detail screen alike.

--- a/packages/shared/src/zero/types.ts
+++ b/packages/shared/src/zero/types.ts
@@ -1171,6 +1171,7 @@ export enum WorkflowMappingEntityType {
 export const ShareableEntityType = {
   NOTE_TAKER: 'NOTE_TAKER',
   SUMMARY_TEMPLATE: 'SUMMARY_TEMPLATE',
+  CALL: 'CALL',
 } as const;
 
 export type ShareableEntityType = typeof ShareableEntityType[keyof typeof ShareableEntityType];


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
updated POT : https://drive.google.com/file/d/1axL8US0fZZrnwuia4BzxvZZ-KMVN8Ah8/view?usp=sharing


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
