### PR TITLE
Fix/xyne 1315 explicit personalized all tabs

### DIFF
--- a/apps/dashboard/src/components/Chat/SearchResults/SearchFilterBar.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchFilterBar.tsx
@@ -127,15 +127,18 @@ const RANK_PROFILE_OPTIONS_BY_TYPE: Partial<
   ],
   files: [
     { value: 'default_native', label: 'default_native' },
+    { value: 'personalized', label: 'personalized' },
     { value: 'default_fuzzy', label: 'default_fuzzy' },
   ],
   tickets: [
     { value: 'default_native', label: 'default_native' },
+    { value: 'personalized', label: 'personalized' },
     { value: 'default_fuzzy', label: 'default_fuzzy' },
     { value: 'semantic_ranking', label: 'semantic_ranking' },
   ],
   desk: [
     { value: 'default_native', label: 'default_native' },
+    { value: 'personalized', label: 'personalized' },
     { value: 'default_fuzzy', label: 'default_fuzzy' },
     { value: 'global_sorted', label: 'global_sorted' },
     { value: 'default_bm25', label: 'default_bm25' },

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchFilterBar.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchFilterBar.tsx
@@ -95,16 +95,10 @@ const SORT_OPTIONS = [
   { value: 'oldest' as const, label: 'Oldest' },
 ];
 
-// Hardcoded Vespa rank profiles, scoped to the schema(s) each docType resolves to.
-// Only profiles that exist in every schema the type queries are listed, because Vespa
-// rejects a rank profile that is missing from any queried schema. Selecting a single
-// type prunes the query's sources to that one schema (see searchService.ts), which is
-// what makes the chat-only and mail-only profiles below valid.
-//
-// These are the EXPLICIT picks. getRankProfileOptions() prepends a `value: ''` row
-// meaning "no explicit pick": the request layer resolves '' to the per-tab default from
-// the cmdk_search_config CAC key (see useCmdkDefaultRankProfiles), so that row is
-// labeled with the resolved default at render time — never hardcoded here.
+// Explicit rank-profile picks per docType, scoped to the schema(s) each type queries —
+// Vespa rejects a profile missing from any queried schema. getRankProfileOptions()
+// prepends a `value: ''` row ("no explicit pick"), labeled with the per-tab CAC default
+// (useCmdkDefaultRankProfiles) at render time — the default is never hardcoded here.
 type RankProfileOption = { value: string; label: string };
 const RANK_PROFILE_OPTIONS_BY_TYPE: Partial<
   Record<SearchResultsFilters['docType'], RankProfileOption[]>
@@ -154,7 +148,7 @@ function getRankProfileOptions(
   if (!explicit) return [];
   return [
     { value: '', label: resolvedDefault },
-    // The default row already covers this profile; a second row would send the same one.
+    // drop the explicit row the default row already covers
     ...explicit.filter(o => o.value !== resolvedDefault),
   ];
 }
@@ -272,8 +266,7 @@ export function SearchFilterBar({ filters, onFiltersChange }: SearchFilterBarPro
   const rankProfileOptions = getRankProfileOptions(filters.docType, resolvedDefaultRankProfile);
   const showRankProfile = rankProfileOptions.length > 0;
   const isRankActive = filters.rankProfile !== '';
-  // '' always matches the prepended default row; the fallback only covers a profile
-  // set via URL that is not in the hardcoded list — show it verbatim.
+  // fallback: a profile not in the list — show it verbatim
   const rankProfileLabel =
     rankProfileOptions.find(o => o.value === filters.rankProfile)?.label ?? filters.rankProfile;
 
@@ -799,9 +792,8 @@ export function SearchFilterBar({ filters, onFiltersChange }: SearchFilterBarPro
                   <Check
                     className={cn(
                       'size-3.5 shrink-0',
-                      // The default row also owns an explicit pick equal to the resolved
-                      // default (possible when the CAC config arrives after the pick) —
-                      // that explicit row is deduped away, and both send the same profile.
+                      // the default row also owns an explicit pick equal to the default
+                      // (its own row is deduped away; both send the same profile)
                       filters.rankProfile === opt.value ||
                         (opt.value === '' && filters.rankProfile === resolvedDefaultRankProfile)
                         ? 'opacity-100'


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
Stacked on #<first-PR-number>. Adds `personalized` as an explicit, pinnable option on the
Files, Tickets and Desk rank dropdowns (Messages and All already had it). Valid on these
schemas since XYNE-1315 added the profile to ticket/file/mail plus pass-through aliases.

Without this, those tabs could only *follow* the CAC default into `personalized` — if the
default were ever changed away from it, there'd be no way to manually select it. The
existing dedup hides the row whenever it duplicates the CAC default, so on current sandbox
config nothing visibly changes.

## Areas Touched
- [x] `apps/dashboard`

## Zero / Schema / Config / API
- [x] No changes — skip (3-line addition to a hardcoded options list)

## How did you test it?
eslint clean on the file; verified in local dev that the Files dropdown renders
`default_native ✓ / personalized / default_fuzzy` with a single checkmark.

## Checklist
- [x] Reviewed my own diff; scoped to one thing
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [x] No debug logging or commented-out code left behind