### PR TITLE
fix: XYNE-59475 On-demand camera resolutuion selection for video zoomed and cropped issue

### DIFF
--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -19,7 +19,10 @@ import {
   Shield,
   Eye,
   EyeOff,
+  ChevronDown,
+  Check,
 } from 'lucide-react';
+import { ResolutionQualityHd, Spinner } from '@xyne/icons';
 import {
   NotificationLevel,
   MAX_NOTIFICATION_KEYWORDS,
@@ -32,6 +35,13 @@ import { Dialog } from '../../ui/Dialog/Dialog';
 import { Switch } from '../../ui/Switch';
 import { RadioGroup, Radio } from '../../ui/RadioGroup';
 import { Button } from '../../ui/Button/Button';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '../../ui/dropdown-menu';
+import { Tooltip } from '../../ui/Tooltip';
 
 import { usePlatform } from '../../../hooks/usePlatform';
 import type { Theme } from '../../../hooks/useTheme';
@@ -59,6 +69,7 @@ import {
   CALL_MEDIA_QUALITY_OPTIONS,
   type CallMediaQuality,
 } from '../../../hooks/useCallMediaQualitySettings';
+import { useMaxCameraHeight, filterQualityOptionsByMax } from '../../../hooks/useMaxCameraQuality';
 import { useVisibleNavigationItems } from '../../../hooks/useVisibleNavigationItems';
 import { useToolbarItems } from '../../../hooks/useToolbarItems';
 import { isRequiredToolbarPath } from '../../AppSidebar/navigationConfig';
@@ -115,27 +126,70 @@ const QualitySelect: FC<{
   label: string;
   value: CallMediaQuality;
   onChange: (value: CallMediaQuality) => void;
-}> = ({ id, label, value, onChange }) => (
-  <div className='flex items-center justify-between gap-4'>
-    <label htmlFor={id} className='text-sm font-medium text-foreground'>
-      {label}
-    </label>
-    <select
-      id={id}
-      value={value}
-      onChange={event => onChange(event.target.value as CallMediaQuality)}
-      className='h-8 min-w-32 rounded-md border border-border bg-background px-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring'
-      data-track-category='PREFERENCES'
-      data-track-name={id}
-    >
-      {CALL_MEDIA_QUALITY_OPTIONS.map(option => (
-        <option key={option.value} value={option.value}>
-          {option.label} - {option.description}
-        </option>
-      ))}
-    </select>
-  </div>
-);
+  options?: typeof CALL_MEDIA_QUALITY_OPTIONS;
+  disabled?: boolean;
+  action?: ReactNode;
+}> = ({
+  id,
+  label,
+  value,
+  onChange,
+  options = CALL_MEDIA_QUALITY_OPTIONS,
+  disabled = false,
+  action,
+}) => {
+  const selected = options.find(option => option.value === value) ?? options[0];
+  return (
+    <div className='flex items-center justify-between gap-4'>
+      <span id={`${id}-label`} className='text-sm font-medium text-foreground'>
+        {label}
+      </span>
+      <div className='flex items-center gap-2'>
+        {action}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild disabled={disabled}>
+            <button
+              id={id}
+              type='button'
+              disabled={disabled}
+              aria-labelledby={`${id}-label ${id}`}
+              className='flex h-8 min-w-40 items-center justify-between gap-2 rounded-md border border-border bg-background px-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-background'
+              data-track-category='PREFERENCES'
+              data-track-name={id}
+            >
+              <span className='truncate'>
+                {selected?.label}
+                {selected && (
+                  <span className='text-muted-foreground'> - {selected.description}</span>
+                )}
+              </span>
+              <ChevronDown className='size-3.5 shrink-0 text-muted-foreground' />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='end' className='min-w-40'>
+            {options.map(option => (
+              <DropdownMenuItem
+                key={option.value}
+                onClick={() => onChange(option.value)}
+                className='flex items-center justify-between gap-3'
+                data-track-category='PREFERENCES'
+                data-track-name={`${id}-${option.value}`}
+              >
+                <span>
+                  {option.label}{' '}
+                  <span className='text-muted-foreground'>- {option.description}</span>
+                </span>
+                {option.value === value && (
+                  <Check className='size-3.5 shrink-0 text-primary' aria-hidden />
+                )}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+};
 
 // ─── Appearance ─────────────────────────────────────────────────────────────
 const AppearanceSection: FC<{ state: PreferencesState }> = ({ state }) => (
@@ -469,6 +523,16 @@ const VoiceSection: FC<{ state: PreferencesState }> = ({ state }) => (
 
 const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => {
   const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const {
+    maxHeight: maxCameraHeight,
+    isDetecting,
+    detect: detectCameraQuality,
+  } = useMaxCameraHeight();
+  const videoQualityOptions = filterQualityOptionsByMax(
+    CALL_MEDIA_QUALITY_OPTIONS,
+    maxCameraHeight,
+    state.callVideoQuality,
+  );
 
   const handleDisconnectCalendar = async () => {
     setIsDisconnecting(true);
@@ -524,6 +588,30 @@ const CallsSection: FC<{ state: PreferencesState }> = ({ state }) => {
           label='Video'
           value={state.callVideoQuality}
           onChange={state.setCallVideoQuality}
+          options={videoQualityOptions}
+          disabled={maxCameraHeight === null}
+          action={
+            maxCameraHeight === null && (
+              <Tooltip content="Detect your camera's max supported resolution" side='top'>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='iconSm'
+                  disabled={isDetecting}
+                  onClick={detectCameraQuality}
+                  aria-label='Detect camera quality'
+                  data-track-category='PREFERENCES'
+                  data-track-name='DetectCameraQuality'
+                >
+                  {isDetecting ? (
+                    <Spinner className='size-3.5 animate-spin' />
+                  ) : (
+                    <ResolutionQualityHd className='size-4' />
+                  )}
+                </Button>
+              </Tooltip>
+            )
+          }
         />
         <QualitySelect
           id='call-screen-share-quality'

--- a/apps/dashboard/src/hooks/useCallMediaQualitySettings.ts
+++ b/apps/dashboard/src/hooks/useCallMediaQualitySettings.ts
@@ -30,10 +30,23 @@ export const CALL_MEDIA_QUALITY_CONFIG: Record<
   '2160p': { width: 3840, height: 2160, frameRate: 30, maxBitrate: 10_000_000 },
 };
 
-let detectedMaxCameraHeight: number | null = null;
+const DETECTED_MAX_CAMERA_HEIGHT_KEY = 'xyne:detected-camera-max-height';
+
+const readStoredMaxCameraHeight = (): number | null => {
+  if (typeof sessionStorage === 'undefined') return null;
+  const parsed = Number(sessionStorage.getItem(DETECTED_MAX_CAMERA_HEIGHT_KEY));
+  return parsed > 0 ? parsed : null;
+};
+
+let detectedMaxCameraHeight: number | null = readStoredMaxCameraHeight();
+
 export const setDetectedMaxCameraHeight = (height: number | null): void => {
   detectedMaxCameraHeight = height;
+  if (height && typeof sessionStorage !== 'undefined') {
+    sessionStorage.setItem(DETECTED_MAX_CAMERA_HEIGHT_KEY, String(height));
+  }
 };
+export const getDetectedMaxCameraHeight = (): number | null => detectedMaxCameraHeight;
 
 const getHighestCameraQuality = (): CallMediaQuality => {
   if (!detectedMaxCameraHeight) return '1080p';

--- a/apps/dashboard/src/hooks/useCallMediaQualitySettings.ts
+++ b/apps/dashboard/src/hooks/useCallMediaQualitySettings.ts
@@ -14,7 +14,7 @@ export const CALL_MEDIA_QUALITY_OPTIONS: Array<{
   label: string;
   description: string;
 }> = [
-  { value: '720p', label: '720p', description: 'Lower bandwidth' },
+  { value: '720p', label: '720p', description: 'HD' },
   { value: '1080p', label: '1080p', description: 'Full HD' },
   { value: '1440p', label: '1440p', description: '2K' },
   { value: '2160p', label: '2160p', description: '4K' },
@@ -30,8 +30,23 @@ export const CALL_MEDIA_QUALITY_CONFIG: Record<
   '2160p': { width: 3840, height: 2160, frameRate: 30, maxBitrate: 10_000_000 },
 };
 
+let detectedMaxCameraHeight: number | null = null;
+export const setDetectedMaxCameraHeight = (height: number | null): void => {
+  detectedMaxCameraHeight = height;
+};
+
+const getHighestCameraQuality = (): CallMediaQuality => {
+  if (!detectedMaxCameraHeight) return '1080p';
+  const supported = CALL_MEDIA_QUALITY_OPTIONS.filter(
+    option => CALL_MEDIA_QUALITY_CONFIG[option.value].height <= detectedMaxCameraHeight!,
+  );
+  return supported.at(-1)?.value ?? '1080p';
+};
+
 const DEFAULT_SETTINGS: CallMediaQualitySettings = {
-  videoQuality: '2160p',
+  get videoQuality() {
+    return getHighestCameraQuality();
+  },
   screenShareQuality: '2160p',
 };
 

--- a/apps/dashboard/src/hooks/useMaxCameraQuality.ts
+++ b/apps/dashboard/src/hooks/useMaxCameraQuality.ts
@@ -1,0 +1,60 @@
+import { useCallback, useState } from 'react';
+import {
+  CALL_MEDIA_QUALITY_CONFIG,
+  setDetectedMaxCameraHeight,
+  type CallMediaQuality,
+} from './useCallMediaQualitySettings';
+
+let cachedMaxHeight: number | null | undefined; // undefined = never detected
+
+async function probeMaxCameraHeight(): Promise<number | null> {
+  if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) return null;
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    const [track] = stream.getVideoTracks();
+    const maxHeight = track?.getCapabilities?.().height?.max ?? null;
+    stream.getTracks().forEach(t => t.stop());
+    return maxHeight;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Max camera capture height (px) the device can natively deliver, from
+ * `MediaStreamTrack.getCapabilities().height.max`. Detection only runs when
+ * `detect()` is called — never automatically — since it briefly activates
+ * the camera.
+ */
+export function useMaxCameraHeight(): {
+  maxHeight: number | null;
+  isDetecting: boolean;
+  detect: () => void;
+} {
+  const [maxHeight, setMaxHeight] = useState<number | null | undefined>(cachedMaxHeight);
+  const [isDetecting, setIsDetecting] = useState(false);
+
+  const detect = useCallback(() => {
+    setIsDetecting(true);
+    void probeMaxCameraHeight().then(height => {
+      cachedMaxHeight = height;
+      setDetectedMaxCameraHeight(height);
+      setMaxHeight(height);
+      setIsDetecting(false);
+    });
+  }, []);
+
+  return { maxHeight: maxHeight ?? null, isDetecting, detect };
+}
+
+export function filterQualityOptionsByMax<T extends { value: CallMediaQuality }>(
+  options: T[],
+  maxHeight: number | null,
+  currentValue: CallMediaQuality,
+): T[] {
+  if (!maxHeight) return options;
+  return options.filter(
+    option =>
+      CALL_MEDIA_QUALITY_CONFIG[option.value].height <= maxHeight || option.value === currentValue,
+  );
+}

--- a/apps/dashboard/src/hooks/useMaxCameraQuality.ts
+++ b/apps/dashboard/src/hooks/useMaxCameraQuality.ts
@@ -1,11 +1,10 @@
 import { useCallback, useState } from 'react';
 import {
   CALL_MEDIA_QUALITY_CONFIG,
+  getDetectedMaxCameraHeight,
   setDetectedMaxCameraHeight,
   type CallMediaQuality,
 } from './useCallMediaQualitySettings';
-
-let cachedMaxHeight: number | null | undefined; // undefined = never detected
 
 async function probeMaxCameraHeight(): Promise<number | null> {
   if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) return null;
@@ -31,20 +30,19 @@ export function useMaxCameraHeight(): {
   isDetecting: boolean;
   detect: () => void;
 } {
-  const [maxHeight, setMaxHeight] = useState<number | null | undefined>(cachedMaxHeight);
+  const [maxHeight, setMaxHeight] = useState<number | null>(getDetectedMaxCameraHeight());
   const [isDetecting, setIsDetecting] = useState(false);
 
   const detect = useCallback(() => {
     setIsDetecting(true);
     void probeMaxCameraHeight().then(height => {
-      cachedMaxHeight = height;
       setDetectedMaxCameraHeight(height);
       setMaxHeight(height);
       setIsDetecting(false);
     });
   }, []);
 
-  return { maxHeight: maxHeight ?? null, isDetecting, detect };
+  return { maxHeight, isDetecting, detect };
 }
 
 export function filterQualityOptionsByMax<T extends { value: CallMediaQuality }>(


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Camera video in calls appeared zoomed/cropped, even when alone. Default video capture quality requested `2160p` (true 4K) — no consumer webcam natively supports that, so the browser's `getUserMedia` crop-and-scale fallback cropped the sensor's actual field of view to force-fit the impossible resolution, which read as the camera "zooming in".

Fix: video quality now defaults to what the camera actually supports. Detection is opt-in (reading capabilities briefly activates the camera, so it's never automatic) and falls back to a safe `1080p` until detected.

[https://github.com/user-attachments/assets/4adc7de1-b3f9-43dc-9494-f809442073f8](https://github.com/user-attachments/assets/4adc7de1-b3f9-43dc-9494-f809442073f8)

### [Manuallly Tested POT](https://drive.google.com/file/d/1l3LHnsIf-Co0DllCI0CYErQLcXKW7D88/view?usp=sharing)



## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
Before/after recording of Preferences → Calls → Call media quality — same account and build, only the fix toggled between the two halves. Real captures of the running local stack, not a mock.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
