### PR TITLE
Feature/xyne ai

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260825120000_add_agent_awakening/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260825120000_add_agent_awakening/migration.sql
@@ -1,0 +1,64 @@
+-- CreateTable
+CREATE TABLE "agent_awakening_state" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "nextDueAt" TIMESTAMP(3) NOT NULL,
+    "lastTickAt" TIMESTAMP(3),
+    "watermarkAt" TIMESTAMP(3) NOT NULL,
+    "watermarkMessageId" TEXT,
+    "consecutiveFailures" INTEGER NOT NULL DEFAULT 0,
+    "consecutiveSkips" INTEGER NOT NULL DEFAULT 0,
+    "lastError" TEXT,
+    "reflexNextCheckAt" TIMESTAMP(3),
+    "reflexWatermarkAt" TIMESTAMP(3),
+    "reflexLastRunAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "agent_awakening_state_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "agent_awakening_runs" (
+    "id" TEXT NOT NULL,
+    "agentId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "windowStartMs" BIGINT NOT NULL,
+    "windowEndMs" BIGINT NOT NULL,
+    "outcome" TEXT NOT NULL,
+    "skipReason" TEXT,
+    "eventCount" INTEGER NOT NULL DEFAULT 0,
+    "signals" JSONB,
+    "sessionId" TEXT,
+    "idempotencyKey" TEXT NOT NULL,
+    "artifactUri" TEXT,
+    "injectionsUsed" INTEGER NOT NULL DEFAULT 0,
+    "startedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "agent_awakening_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "agent_awakening_state_agentId_key" ON "agent_awakening_state"("agentId");
+
+-- CreateIndex
+CREATE INDEX "agent_awakening_state_enabled_nextDueAt_idx" ON "agent_awakening_state"("enabled", "nextDueAt");
+
+-- CreateIndex
+CREATE INDEX "agent_awakening_state_enabled_reflexNextCheckAt_idx" ON "agent_awakening_state"("enabled", "reflexNextCheckAt");
+
+-- CreateIndex
+CREATE INDEX "agent_awakening_state_orgId_idx" ON "agent_awakening_state"("orgId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "agent_awakening_runs_idempotencyKey_key" ON "agent_awakening_runs"("idempotencyKey");
+
+-- CreateIndex
+CREATE INDEX "agent_awakening_runs_agentId_windowStartMs_idx" ON "agent_awakening_runs"("agentId", "windowStartMs");
+
+-- CreateIndex
+CREATE INDEX "agent_awakening_runs_orgId_startedAt_idx" ON "agent_awakening_runs"("orgId", "startedAt");

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -64,7 +64,7 @@ model User {
   /// cron enqueues a brief-generation job for this user; when false the cron
   /// simply skips them (no per-user scheduler to tear down). Mirrors the
   /// digitalTwinEnabled opt-in pattern.
-  dailyBriefEnabled   Boolean   @default(false)
+  dailyBriefEnabled   Boolean                @default(false)
   dailyBriefEnabledAt DateTime?
   /// Per-user, per-agent custom instructions (injected into every agent run for
   /// this user) + feature-generated content (first consumer: Daily Brief).
@@ -179,31 +179,31 @@ model TwinBehaviorSignal {
 /// `learnedAt` so the twin's memory learns what got accepted vs edited vs
 /// declined vs ignored — the feedback loop, moved OFF the immediate accept path.
 model TwinResponseFeedback {
-  id               String   @id @default(cuid())
-  userId           String
-  conversationId   String
-  channelId        String?
-  channelName      String?
+  id              String    @id @default(cuid())
+  userId          String
+  conversationId  String
+  channelId       String?
+  channelName     String?
   /// The inbound message that triggered the twin (dedup + link key).
-  sourceMessageId  String?
+  sourceMessageId String?
   /// The incoming message text the twin was responding to.
-  incomingTask     String?
+  incomingTask    String?
   /// The twin's proposed delivery. "react" | "reply" | "react_and_reply".
-  deliveryAction   String   @default("reply")
-  deliveryEmoji    String?
+  deliveryAction  String    @default("reply")
+  deliveryEmoji   String?
   /// "origin_thread" | "origin_channel" | "channel" | "thread".
-  destinationKind  String?
+  destinationKind String?
   /// The twin's proposed reply text (the draft shown for approval).
-  draftMessage     String?
+  draftMessage    String?
   /// What the user actually approved (may be edited); null on decline/ignore.
-  finalMessage     String?
+  finalMessage    String?
   /// "pending" | "accepted" | "accepted_edited" | "declined" | "ignored".
-  status           String   @default("pending")
-  proposedAt       DateTime @default(now())
-  decidedAt        DateTime?
+  status          String    @default("pending")
+  proposedAt      DateTime  @default(now())
+  decidedAt       DateTime?
   /// Set once the daily learning loop has consumed this row.
-  learnedAt        DateTime?
-  createdAt        DateTime @default(now())
+  learnedAt       DateTime?
+  createdAt       DateTime  @default(now())
 
   @@unique([userId, sourceMessageId])
   @@index([userId, status])
@@ -238,18 +238,18 @@ enum SurfaceStatus {
 }
 
 model Organization {
-  id          String    @id @default(cuid())
-  name        String    @unique
-  description String?
-  createdBy   String
-  status      OrgStatus @default(ACTIVE)
-  metadata    Json?
+  id                  String    @id @default(cuid())
+  name                String    @unique
+  description         String?
+  createdBy           String
+  status              OrgStatus @default(ACTIVE)
+  metadata            Json?
   /// Which agent (by slug) executes this org's Daily Brief. NULL ⇒ fall back to
   /// the deployment default (CONFIG.dailyBriefAgentSlug / env, default "ask-ai").
   /// Changed at runtime via the daily-brief settings API (org-admin only).
   dailyBriefAgentSlug String?
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
 
   members             OrgMember[]
   users               User[]
@@ -319,39 +319,39 @@ model UserSurfaceIdentity {
 }
 
 model SurfaceAgent {
-  id               String   @id @default(cuid())
-  agentId          String
-  agent            Agent    @relation(fields: [agentId], references: [id], onDelete: Cascade)
-  surfaceId        String
-  surface          Surface  @relation(fields: [surfaceId], references: [id], onDelete: Restrict)
-  surfaceTenantId  String   @default("")
-  surfaceChannelId String?
+  id                        String                @id @default(cuid())
+  agentId                   String
+  agent                     Agent                 @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  surfaceId                 String
+  surface                   Surface               @relation(fields: [surfaceId], references: [id], onDelete: Restrict)
+  surfaceTenantId           String                @default("")
+  surfaceChannelId          String?
   /// The surface-side application identity (Slack app id, Teams bot id).
   /// Events arrive tagged with this; unique per surface so the reverse
   /// lookup (app -> agent) is guaranteed single-owner.
-  externalAppId    String?
+  externalAppId             String?
   /// Non-secret OAuth client identifier of the surface app.
-  clientId         String?
+  clientId                  String?
   /// AES-GCM `ciphertext:iv:authTag` — never stored plaintext.
-  encryptedClientSecret String? @db.Text
-  signingSecret    String?  @db.Text
+  encryptedClientSecret     String?               @db.Text
+  signingSecret             String?               @db.Text
   /// Slash-command name bound to this agent (e.g. "/euler-doctor").
-  commandName      String?
+  commandName               String?
   /// ConnectedSurface row whose bot token answers this agent's slash
   /// commands (the umbrella app's team connection). Read at dispatch time.
   commandConnectedSurfaceId String?
   /// Registration lifecycle: "created" (app minted) | "installed".
-  status           String?
+  status                    String?
   /// sha256 of the manifest template last pushed to the surface app —
   /// compared against the current template to detect drift.
-  manifestHash     String?
-  manifestSyncedAt DateTime?
+  manifestHash              String?
+  manifestSyncedAt          DateTime?
   /// Surface-idiosyncratic residue ONLY (validated by the surface's schema);
   /// anything the core queries must be a real column above.
-  config           Json?
-  installs         SurfaceAgentInstall[]
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  config                    Json?
+  installs                  SurfaceAgentInstall[]
+  createdAt                 DateTime              @default(now())
+  updatedAt                 DateTime              @updatedAt
 
   @@unique([agentId, surfaceId, surfaceTenantId])
   @@unique([surfaceId, externalAppId])
@@ -1123,7 +1123,7 @@ model ChatAttachment {
   metadata         Json?
   createdAt        DateTime @default(now())
 
-  chatMessage ChatMessage? @relation(fields: [chatMessageId], references: [id], onDelete: Cascade)
+  chatMessage  ChatMessage?          @relation(fields: [chatMessageId], references: [id], onDelete: Cascade)
   designShares DesignArtifactShare[]
 
   @@index([chatMessageId])
@@ -1136,8 +1136,8 @@ model ChatAttachment {
 /// verification; its encrypted copy exists so
 /// the owner can reopen the Share dialog without rotating a live link.
 model DesignArtifactShare {
-  id              String   @id @default(cuid())
-  tokenHash       String   @unique
+  id              String    @id @default(cuid())
+  tokenHash       String    @unique
   tokenCiphertext String
   tokenIv         String
   tokenAuthTag    String
@@ -1148,10 +1148,10 @@ model DesignArtifactShare {
   title           String
   expiresAt       DateTime?
   revokedAt       DateTime?
-  viewCount       Int      @default(0)
+  viewCount       Int       @default(0)
   lastViewedAt    DateTime?
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
 
   attachment ChatAttachment @relation(fields: [attachmentId], references: [id], onDelete: Cascade)
 
@@ -1848,43 +1848,43 @@ model ActiveGoal {
 }
 
 model ExperimentRun {
-  id                String              @id @default(cuid())
-  conversationId    String
-  channelId         String
-  agentSlug         String
-  userId            String
-  orgId             String
-  focus             String?
+  id                 String              @id @default(cuid())
+  conversationId     String
+  channelId          String
+  agentSlug          String
+  userId             String
+  orgId              String
+  focus              String?
   /// Per-experiment LLM pin, forwarded as providerOverride on every epoch
   /// dispatch. NULL = the agent's normal provider resolution.
-  provider          String?
-  modelId           String?
+  provider           String?
+  modelId            String?
   /// "experiment" (default proof-reward loop) or "understanding" (coverage-gated:
   /// end-experiment stays locked until the open-conjecture frontier is exhausted).
   /// Persisted per-run so EVERY epoch dispatch forwards it, not just the first.
-  kind              String              @default("experiment")
-  status            String              @default("running") /// running | finishing | done | aborted
-  epoch             Int                 @default(1)
-  deadlineAt        DateTime
-  currentHypothesis String?             @db.Text
-  currentSessionId  String?
-  lastEpochEndedAt  DateTime?
-  sandboxNote       String?
+  kind               String              @default("experiment")
+  status             String              @default("running") /// running | finishing | done | aborted
+  epoch              Int                 @default(1)
+  deadlineAt         DateTime
+  currentHypothesis  String?             @db.Text
+  currentSessionId   String?
+  lastEpochEndedAt   DateTime?
+  sandboxNote        String?
   /// Basenames of files the agent actually delivered to the thread via
   /// sandbox-deliver-files. A finding may only be marked `proved` if its
   /// proofArtifactPath resolves to one of these — proof left behind in a
   /// sandbox dies with the sandbox and is worthless to a human reader.
-  deliveredArtifacts String[]           @default([])
+  deliveredArtifacts String[]            @default([])
   /// Sessions of in-flight CHECKER runs. Checkers deliberately never claim
   /// currentSessionId (that would make the epoch handoff chain off their
   /// completion), which also meant `/experiment stop` could not reach them —
   /// a stopped run kept emitting checker output into the thread.
-  checkerSessionIds  String[]           @default([])
-  finalReport       String?             @db.Text
-  createdAt         DateTime            @default(now())
-  updatedAt         DateTime            @updatedAt
-  findings          ExperimentFinding[]
-  reviews           ExperimentReview[]
+  checkerSessionIds  String[]            @default([])
+  finalReport        String?             @db.Text
+  createdAt          DateTime            @default(now())
+  updatedAt          DateTime            @updatedAt
+  findings           ExperimentFinding[]
+  reviews            ExperimentReview[]
 
   @@index([conversationId, status])
   @@map("experiment_runs")
@@ -1892,17 +1892,17 @@ model ExperimentRun {
 
 // workspace-check:ignore — tenant scope inherited via experimentId -> ExperimentRun.orgId (FK, onDelete: Cascade); never queried cross-tenant.
 model ExperimentFinding {
-  id                String        @id @default(cuid())
+  id                String             @id @default(cuid())
   experimentId      String
-  experiment        ExperimentRun @relation(fields: [experimentId], references: [id], onDelete: Cascade)
+  experiment        ExperimentRun      @relation(fields: [experimentId], references: [id], onDelete: Cascade)
   epoch             Int
   status            String /// conjecture | proved | refuted
   title             String
-  hypothesis        String        @db.Text
-  note              String?       @db.Text
+  hypothesis        String             @db.Text
+  note              String?            @db.Text
   proofArtifactPath String?
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
+  createdAt         DateTime           @default(now())
+  updatedAt         DateTime           @updatedAt
   reviews           ExperimentReview[]
 
   @@index([experimentId])
@@ -2199,37 +2199,37 @@ model SearchEvalQuery {
 /// creation time (fixed there, not chosen per run) — kept denormalized here so
 /// each run's historical display is accurate even if read long after.
 model SearchEvalRun {
-  id             String             @id @default(cuid())
-  sheetId        String
-  sheet          SearchEvalSheet    @relation(fields: [sheetId], references: [id], onDelete: Cascade)
-  queryType      String[] /// entity types searched; empty = all types
-  rankProfile    String? /// null = let the backend auto-pick (default_native for scored text)
+  id                String             @id @default(cuid())
+  sheetId           String
+  sheet             SearchEvalSheet    @relation(fields: [sheetId], references: [id], onDelete: Cascade)
+  queryType         String[] /// entity types searched; empty = all types
+  rankProfile       String? /// null = let the backend auto-pick (default_native for scored text)
   /// Overrides for the active rank profile's `input.query(<name>)` params —
   /// only meaningful when rankProfile is a real per-schema "tunable" profile
   /// (see TUNABLE_INPUTS_BY_AREA in SearchEvalsPageV3.tsx / the tunable
   /// rank-profile inputs {} block per Vespa schema); null otherwise.
   rankProfileInputs Json?
-  permissionMode String /// "with" | "without" — copied from the sheet at run creation
-  asOfTimestamp  DateTime?
-  status         String             @default("running") /// "running" | "completed" | "failed"
-  createdBy      String?
-  orgId          String
-  startedAt      DateTime           @default(now())
-  completedAt    DateTime?
+  permissionMode    String /// "with" | "without" — copied from the sheet at run creation
+  asOfTimestamp     DateTime?
+  status            String             @default("running") /// "running" | "completed" | "failed"
+  createdBy         String?
+  orgId             String
+  startedAt         DateTime           @default(now())
+  completedAt       DateTime?
   /// Top1/Top3/Top10 count+% and Mean Reciprocal Rank — written by the worker
   /// alongside completedAt when the run finishes (null while "running", or for
   /// runs from before this existed — the API falls back to live computation
   /// from `results` in that case). `completedAt` is the "with timestamp" this
   /// was asked to be stored with.
-  queriesScored  Int?
-  top1Count      Int?
-  top1Pct        Float?
-  top3Count      Int?
-  top3Pct        Float?
-  top10Count     Int?
-  top10Pct       Float?
-  mrr            Float?
-  results        SearchEvalResult[]
+  queriesScored     Int?
+  top1Count         Int?
+  top1Pct           Float?
+  top3Count         Int?
+  top3Pct           Float?
+  top10Count        Int?
+  top10Pct          Float?
+  mrr               Float?
+  results           SearchEvalResult[]
 
   @@index([sheetId, startedAt])
   @@index([orgId])
@@ -2358,4 +2358,113 @@ model EntityExtractionRun {
   @@index([workspaceId, channelId, status])
   @@index([workspaceId, status])
   @@map("entity_extraction_runs")
+}
+
+/// Scheduler state for an awakened agent — an agent that wakes on its own
+/// (periodic heartbeat, or a reflex fired by accumulated events) instead of
+/// waiting for a human to trigger it.
+///
+/// This table holds ONLY what the tick loop must index-scan. Every tunable
+/// knob lives in `agents.config.awakening` (JSON) instead, so the existing
+/// PUT /agents/:slug write path, its ACL and its audit diff keep working
+/// unchanged. The split matters: Postgres cannot index-scan JSON, and the
+/// claim query below runs every tick for every org.
+///
+/// `watermarkAt` is the exactly-once seam. It advances only after a window is
+/// successfully sealed, never rewinds (see awakening/cursor.ts), and is the
+/// sole source of truth for "what has this agent already seen".
+model AgentAwakeningState {
+  id      String @id @default(cuid())
+  agentId String @unique
+  orgId   String
+
+  enabled    Boolean   @default(false)
+  /// Wall-clock the tick loop compares against. Claimed with FOR UPDATE SKIP
+  /// LOCKED so N pods can run the same tick without double-firing an agent.
+  nextDueAt  DateTime
+  lastTickAt DateTime?
+
+  /// Exclusive upper bound of the last sealed window. The next window is
+  /// (watermarkAt, now - replicaSafetyMs].
+  watermarkAt        DateTime
+  /// Tie-breaker for events sharing watermarkAt to the millisecond.
+  watermarkMessageId String?
+
+  /// Backoff state. A failed window increments this and pushes nextDueAt out
+  /// exponentially; the first success resets it. This is the whole circuit
+  /// breaker — no separate state machine.
+  consecutiveFailures Int     @default(0)
+  consecutiveSkips    Int     @default(0)
+  lastError           String? @db.Text
+
+  /// Reflex cadence, tracked separately from the heartbeat.
+  ///
+  /// A reflex checks far more often than a heartbeat (a cheap COUNT, not a
+  /// window collect) and fires only once enough events have piled up. It keeps
+  /// its OWN watermark on purpose: the two wake kinds are meant to see the same
+  /// events for different reasons — the reflex reacts fast and shallow, the
+  /// heartbeat later synthesises the whole period AND reads what the reflexes
+  /// already did (requirement 7). Sharing one watermark would let a reflex
+  /// consume events the heartbeat then never sees.
+  reflexNextCheckAt  DateTime?
+  reflexWatermarkAt  DateTime?
+  /// Last time a reflex actually dispatched — enforces the minimum gap between
+  /// reflex runs so a busy channel cannot fire one every check.
+  reflexLastRunAt    DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  /// The only hot query: the per-tick claim scan.
+  @@index([enabled, nextDueAt])
+  /// The reflex claim scan — same shape, different cadence.
+  @@index([enabled, reflexNextCheckAt])
+  @@index([orgId])
+  @@map("agent_awakening_state")
+}
+
+/// One row per wake attempt, whether or not it dispatched a run.
+///
+/// Serves three jobs at once: the idempotency guard (`idempotencyKey`), the
+/// admin health view (outcome/skipReason/signals), and requirement 7 — a
+/// heartbeat reads the reflex runs whose window OVERLAPS its own so it does
+/// not redo work that already happened. Overlap, not containment: a reflex
+/// that started before the window and ran into it consumed events this
+/// heartbeat is about to see.
+model AgentAwakeningRun {
+  id      String @id @default(cuid())
+  agentId String
+  orgId   String
+
+  /// "heartbeat" | "reflex". Plain String — Postgres enums are frozen
+  /// repo-wide (scripts/validate-no-new-enums.sh).
+  kind String
+
+  /// Window bounds as epoch millis. BigInt so a JS Date round-trip cannot
+  /// silently lose precision on the overlap query.
+  windowStartMs BigInt
+  windowEndMs   BigInt
+
+  /// "ran" | "skipped" | "failed" | "shadow"
+  outcome    String
+  /// Populated when outcome = "skipped": which gate rule fired.
+  skipReason String?
+
+  eventCount Int   @default(0)
+  /// Denormalized signal counts the gate decided on — what an operator needs
+  /// to answer "why did/didn't it wake" without re-deriving the window.
+  signals    Json?
+
+  sessionId      String?
+  idempotencyKey String  @unique
+  artifactUri    String?
+  injectionsUsed Int     @default(0)
+
+  startedAt   DateTime  @default(now())
+  completedAt DateTime?
+
+  /// Requirement 7: overlap lookup for a heartbeat reading prior reflexes.
+  @@index([agentId, windowStartMs])
+  @@index([orgId, startedAt])
+  @@map("agent_awakening_runs")
 }

--- a/apps/xyne-claw-auth/backend/scripts/awakening-dry-run.ts
+++ b/apps/xyne-claw-auth/backend/scripts/awakening-dry-run.ts
@@ -1,0 +1,122 @@
+/**
+ * End-to-end dry run of the awakening window pipeline against real data,
+ * WITHOUT dispatching a run.
+ *
+ * Exercises the genuine code path — channel resolution, the windowed Spaces
+ * pull, signal extraction, the triage gate and the renderer — then prints the
+ * artifact the agent would have received and the gate's verdict.
+ *
+ * This is the loop to use when tuning gate rules or the artifact layout: it
+ * costs one set of Spaces queries and zero LLM tokens.
+ *
+ * Usage:
+ *   pnpm --filter xyne-claw-auth exec tsx --env-file=.env \
+ *     scripts/awakening-dry-run.ts <agent-slug> [windowMinutes]
+ */
+
+import { prisma } from "../src/db.js";
+import { redisService } from "../src/redis.js";
+import { resolveAwakeningConfig, AWAKENING_DEFAULTS, type AwakeningConfig } from "../src/awakening/config.js";
+import { resolveAwakeningChannels } from "../src/awakening/channel-resolver.js";
+import { collectWindow } from "../src/awakening/collector.js";
+import { computeSignals } from "../src/awakening/signals.js";
+import { evaluateGate } from "../src/awakening/gate.js";
+import { renderWindow } from "../src/awakening/render.js";
+import { loadOverlappingRuns, markCoverage } from "../src/awakening/prior-runs.js";
+import { resolveAgentIdentity } from "../src/awakening/dispatch.js";
+import { resolveWorkspaceId } from "../src/awakening/workspace.js";
+import type { AwakeningWindow } from "../src/awakening/types.js";
+
+const slug = process.argv[2];
+const windowMinutes = Number(process.argv[3] ?? 30);
+
+if (!slug) {
+  console.error("usage: awakening-dry-run.ts <agent-slug> [windowMinutes]");
+  process.exit(2);
+}
+
+async function main(): Promise<void> {
+  const agent = await prisma.agent.findFirst({
+    where: { slug },
+    select: {
+      id: true, slug: true, orgId: true, config: true,
+      spacesAppId: true, spacesAppUserId: true, spacesAppToken: true,
+    },
+  });
+  if (!agent) throw new Error(`no agent with slug "${slug}"`);
+
+  // Fall back to permissive defaults so a dry run works on an agent that has
+  // never had awakening enabled — the point is to preview what it WOULD see.
+  const stored = resolveAwakeningConfig(agent.config);
+  const config: AwakeningConfig = stored.enabled
+    ? stored
+    : { ...AWAKENING_DEFAULTS, ...stored, enabled: true };
+
+  const workspaceId = await resolveWorkspaceId(agent.orgId, config.workspaceId);
+  const identity = resolveAgentIdentity(agent, workspaceId);
+
+  const endMs = Date.now() - config.cursor.replicaSafetyMs;
+  const startMs = endMs - windowMinutes * 60_000;
+
+  console.log(`agent=${agent.slug} workspace=${workspaceId} bot=${identity.spacesAppUserId}`);
+  console.log(`window=${new Date(startMs).toISOString()} -> ${new Date(endMs).toISOString()}\n`);
+
+  const resolved = await resolveAwakeningChannels(agent.id, config.channels, identity, config.periodMs);
+  console.log(`channels resolved: ${resolved.channels.length}${resolved.truncated ? " (truncated)" : ""}`);
+  for (const c of resolved.channels) console.log(`  - ${c.name} (${c.id})`);
+  if (resolved.channels.length === 0) {
+    console.log("\nno channels matched — the agent would skip with reason=no_channels");
+    return;
+  }
+
+  const collected = await collectWindow(resolved.channels, startMs, endMs, identity, config);
+  // Requirement 7: what did earlier awakened runs in this window already do?
+  const priorRuns = await loadOverlappingRuns(agent.id, startMs, endMs);
+  markCoverage(collected.events, priorRuns);
+  const signals = computeSignals(collected.events);
+  const gate = evaluateGate({ signals, config, consecutiveSkips: 0 });
+
+  console.log(`\ncollected ${collected.events.length} event(s)${collected.truncated ? " (TRUNCATED)" : ""}`);
+  if (priorRuns.length > 0) {
+    const uncovered = collected.events.filter((e) => !e.covered).length;
+    console.log(
+      `prior runs overlapping this window: ${priorRuns.length} (${priorRuns.filter((p) => p.covers).length} acted) — ${uncovered} event(s) not already handled`,
+    );
+  }
+  console.log(`gate: ${gate.decision.toUpperCase()} (rule=${gate.rule})\n`);
+  console.log(JSON.stringify(signals, null, 2));
+
+  const window: AwakeningWindow = {
+    agentId: agent.id,
+    agentSlug: agent.slug,
+    orgId: agent.orgId,
+    kind: "heartbeat",
+    startMs,
+    endMs,
+    channels: resolved.channels.filter((c) => collected.activeChannels.has(c.id)),
+    silentChannels: resolved.channels.filter((c) => !collected.activeChannels.has(c.id)),
+    events: collected.events,
+    signals,
+    truncated: collected.truncated,
+    gap: null,
+    priorRuns,
+    config,
+  };
+
+  const rendered = renderWindow(window);
+  for (const file of rendered.files) {
+    console.log(`\n${"=".repeat(72)}\n${file.path}\n${"=".repeat(72)}`);
+    console.log(file.content);
+  }
+}
+
+main()
+  .catch((err) => {
+    console.error(`\ndry run failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    // Both clients hold the event loop open; without this the script never exits.
+    await prisma.$disconnect().catch(() => {});
+    await redisService.disconnect().catch(() => {});
+  });

--- a/apps/xyne-claw-auth/backend/scripts/awakening-injection-watch.ts
+++ b/apps/xyne-claw-auth/backend/scripts/awakening-injection-watch.ts
@@ -1,0 +1,111 @@
+/**
+ * Live watch for the injection path — answers "is a live update actually
+ * reaching my running agent, and if not, which step dropped it?"
+ *
+ * Injection has five sequential preconditions and failing any one of them looks
+ * identical from the channel (the agent just never mentions your new message).
+ * This prints each one as it happens, so the first line that never appears is
+ * the answer.
+ *
+ * Usage:
+ *   pnpm exec tsx --env-file=.env scripts/awakening-injection-watch.ts [agent-slug]
+ *
+ * Then post messages in a watched channel while a reflex run is in flight.
+ * Ctrl-C to stop.
+ */
+
+import { prisma } from "../src/db.js";
+import { redisService } from "../src/redis.js";
+import { readAgentLock } from "../src/awakening/lock.js";
+import { readInjectionStats } from "../src/awakening/inbox.js";
+import { resolveAwakeningConfig } from "../src/awakening/config.js";
+import { TICK_INTERVAL_MS } from "../src/queue/awakening-queue.js";
+
+const slug = process.argv[2] ?? "ask-ai";
+const POLL_MS = 1000;
+
+function stamp(): string {
+  return new Date().toISOString().slice(11, 19);
+}
+
+function say(icon: string, msg: string): void {
+  console.log(`${stamp()}  ${icon} ${msg}`);
+}
+
+async function main(): Promise<void> {
+  const agent = await prisma.agent.findFirst({ where: { slug }, select: { id: true, slug: true, config: true } });
+  if (!agent) {
+    console.error(`No agent "${slug}"`);
+    process.exit(1);
+  }
+
+  const cfg = resolveAwakeningConfig(agent.config);
+  const effectiveCheckMs = Math.max(cfg.reflex.checkIntervalMs, TICK_INTERVAL_MS);
+
+  console.log(`\nAgent: ${agent.slug} (${agent.id})`);
+  console.log(`  injectEnabled ......... ${cfg.reflex.injectEnabled}`);
+  console.log(`  injectThreshold ....... ${cfg.reflex.injectThreshold} new event(s)`);
+  console.log(`  maxInjectionsPerSession ${cfg.reflex.maxInjectionsPerSession}`);
+  console.log(`  injectMinIntervalMs ... ${cfg.reflex.injectMinIntervalMs}`);
+  console.log(`  replicaSafetyMs ....... ${cfg.cursor.replicaSafetyMs}`);
+  console.log(`  checkIntervalMs ....... ${cfg.reflex.checkIntervalMs}`);
+  console.log(`  AWAKENING_TICK_MS ..... ${TICK_INTERVAL_MS}`);
+
+  if (cfg.reflex.checkIntervalMs < TICK_INTERVAL_MS) {
+    console.log(
+      `\n  ! checkIntervalMs (${cfg.reflex.checkIntervalMs}ms) is below the tick interval ` +
+      `(${TICK_INTERVAL_MS}ms).\n` +
+      `    Reflex checks are CLAIMED by the tick, so the effective cadence is ` +
+      `${effectiveCheckMs}ms.\n` +
+      `    Set AWAKENING_TICK_MS=${cfg.reflex.checkIntervalMs} to honour it.`,
+    );
+  }
+
+  console.log(
+    `\n  → A run must stay alive ~${Math.round((cfg.cursor.replicaSafetyMs + effectiveCheckMs) / 1000)}s ` +
+    `past your message for an injection to be possible.\n`,
+  );
+  console.log("Watching. Post messages in a watched channel while a run is in flight.\n");
+
+  const redis = redisService.getConnection();
+  let lastSession: string | null = null;
+  let lastDepth = -1;
+  let lastUsed = -1;
+
+  for (;;) {
+    const holder = await readAgentLock(agent.id).catch(() => null);
+    const session = holder?.sessionId ?? null;
+
+    if (session !== lastSession) {
+      if (session) say("▶", `run STARTED  session=${session} kind=${holder?.kind}`);
+      else if (lastSession) say("■", `run ENDED    session=${lastSession}`);
+      lastSession = session;
+      lastDepth = -1;
+      lastUsed = -1;
+    }
+
+    if (session) {
+      const depth = await redis.llen(`claw:awk:inbox:${session}`).catch(() => -1);
+      const stats = await readInjectionStats(session).catch(() => ({ used: 0, lastAtMs: 0 }));
+
+      if (lastUsed >= 0 && stats.used > lastUsed) {
+        say("↓", `QUEUED batch #${stats.used} — claw-auth decided to inject`);
+      }
+      if (lastDepth > 0 && depth === 0) {
+        say("↑", `DRAINED — the claw pod pulled it; the model sees it at its next turn boundary`);
+      }
+      if (depth > 0 && depth !== lastDepth) {
+        say("·", `inbox depth=${depth} (waiting for the run to hit a tool call)`);
+      }
+      lastDepth = depth;
+      lastUsed = stats.used;
+    }
+
+    await new Promise((r) => setTimeout(r, POLL_MS));
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/channel-resolver.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/channel-resolver.ts
@@ -1,0 +1,128 @@
+/**
+ * Turns an agent's channel RULES into the concrete set of Spaces channels a
+ * wake will read, with a short-TTL cache in front.
+ *
+ * Resolved on every wake, never once at config time: channels get created,
+ * renamed, archived, and the bot gets added to and removed from them. A
+ * snapshot taken at save time rots silently, and a backbone must not depend
+ * on one. The cache key includes a hash of the rules, so editing them
+ * invalidates instantly with no explicit bust.
+ *
+ * Rule semantics live in channel-rules.ts; this module owns only the I/O.
+ */
+
+import { redisService } from "../redis.js";
+import { boundedInteract } from "./spaces-read.js";
+import { hashChannelRules, type AwakeningChannelRules } from "./config.js";
+import { applyChannelRules, type ChannelRuleResult } from "./channel-rules.js";
+import type { AgentSpacesIdentity, ResolvedChannel } from "./types.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-channels");
+
+const CACHE_TTL_MAX_MS = 15 * 60_000;
+const MEMBERSHIP_PAGE = 1000;
+
+interface CachedResolution extends ChannelRuleResult {
+  resolvedAtMs: number;
+}
+
+function cacheKey(agentId: string, rules: AwakeningChannelRules): string {
+  return `claw:awk:chan:${agentId}:${hashChannelRules(rules)}`;
+}
+
+/**
+ * The bot's channel memberships, as full rows.
+ *
+ * No `select` on either query: the Spaces query AST (QueryASTSchema in
+ * apps/backend/src/services/pythonQuery/validator.ts) defines only
+ * model/operation/where/orderBy/take/skip, so a `select` is silently stripped
+ * and the row comes back whole. Projecting here would be a lie about what the
+ * wire actually carries.
+ */
+async function fetchMemberships(identity: AgentSpacesIdentity): Promise<ResolvedChannel[]> {
+  const auth = { token: identity.appToken, workspaceId: identity.workspaceId };
+
+  const participants = await boundedInteract<Array<{ channelId: string }>>(
+    {
+      model: "channelParticipant",
+      operation: "findMany",
+      where: { userId: { equals: identity.spacesAppUserId } },
+      take: MEMBERSHIP_PAGE,
+    },
+    auth,
+  );
+
+  const ids = [...new Set(participants.map((p) => p.channelId).filter(Boolean))];
+  if (ids.length === 0) return [];
+
+  const channels = await boundedInteract<Array<{ id: string; name: string; lastActivityAt: string }>>(
+    {
+      model: "channel",
+      operation: "findMany",
+      where: {
+        id: { in: ids },
+        isArchived: { equals: false },
+        scopeType: { equals: "DEFAULT" },
+      },
+      orderBy: [{ lastActivityAt: "desc" }],
+      take: MEMBERSHIP_PAGE,
+    },
+    auth,
+  );
+
+  return channels.map((c) => ({
+    id: c.id,
+    name: c.name ?? "",
+    lastActivityAt: new Date(c.lastActivityAt).getTime() || 0,
+  }));
+}
+
+/**
+ * Resolve the watched channel set.
+ *
+ * Stale-ok on failure: if Spaces is unreachable we return the last cached
+ * value even past its TTL, because a stale channel list is enormously better
+ * than a skipped wake. Only a cold cache plus a failed fetch throws — and the
+ * caller must then NOT advance the watermark.
+ */
+export async function resolveAwakeningChannels(
+  agentId: string,
+  rules: AwakeningChannelRules,
+  identity: AgentSpacesIdentity,
+  periodMs: number,
+): Promise<ChannelRuleResult & { stale: boolean }> {
+  const redis = redisService.getConnection();
+  const key = cacheKey(agentId, rules);
+  const freshnessMs = Math.min(periodMs, CACHE_TTL_MAX_MS);
+
+  const cached = await redis.get(key).catch(() => null);
+  let parsed: CachedResolution | null = null;
+  if (cached) {
+    try {
+      parsed = JSON.parse(cached) as CachedResolution;
+    } catch {
+      parsed = null;
+    }
+  }
+  if (parsed && Date.now() - parsed.resolvedAtMs < freshnessMs) {
+    return { channels: parsed.channels, truncated: parsed.truncated, stale: false };
+  }
+
+  try {
+    const resolved = applyChannelRules(await fetchMemberships(identity), rules);
+    const payload: CachedResolution = { ...resolved, resolvedAtMs: Date.now() };
+    // TTL is generous relative to the freshness check above so the value
+    // survives as a stale fallback well past the point we stop trusting it.
+    await redis.set(key, JSON.stringify(payload), "PX", freshnessMs * 4).catch(() => undefined);
+    return { ...resolved, stale: false };
+  } catch (err) {
+    if (parsed) {
+      log.warn(
+        `[awakening] channel resolution failed for agent=${agentId}; serving stale set of ${parsed.channels.length}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return { channels: parsed.channels, truncated: parsed.truncated, stale: true };
+    }
+    throw err;
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/channel-rules.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/channel-rules.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { applyChannelRules } from "./channel-rules.js";
+import type { ResolvedChannel } from "./types.js";
+
+const ch = (id: string, name: string, lastActivityAt = 0): ResolvedChannel => ({ id, name, lastActivityAt });
+
+const memberships = [
+  ch("ch_1", "eng-payments", 500),
+  ch("ch_2", "eng-platform", 400),
+  ch("ch_3", "ops-oncall", 300),
+  ch("ch_4", "random-watercooler", 200),
+  ch("ch_5", "eng-payments-archive", 100),
+];
+
+const rules = (over: Partial<Parameters<typeof applyChannelRules>[1]> = {}) => ({
+  include: [],
+  includePattern: [],
+  exclude: [],
+  excludePattern: [],
+  maxChannels: 25,
+  ...over,
+});
+
+describe("applyChannelRules", () => {
+  it("with no include rule, watches every channel the bot is a member of", () => {
+    const out = applyChannelRules(memberships, rules());
+    expect(out.channels).toHaveLength(5);
+    expect(out.truncated).toBe(false);
+  });
+
+  it("matches explicit ids", () => {
+    const out = applyChannelRules(memberships, rules({ include: ["ch_1", "ch_3"] }));
+    expect(out.channels.map((c) => c.id)).toEqual(["ch_1", "ch_3"]);
+  });
+
+  it("matches a name regex, case-insensitively", () => {
+    const out = applyChannelRules(memberships, rules({ includePattern: ["^ENG-"] }));
+    expect(out.channels.map((c) => c.name)).toEqual(["eng-payments", "eng-platform", "eng-payments-archive"]);
+  });
+
+  it("unions ids and patterns", () => {
+    const out = applyChannelRules(memberships, rules({ include: ["ch_4"], includePattern: ["^ops-"] }));
+    expect(out.channels.map((c) => c.id).sort()).toEqual(["ch_3", "ch_4"]);
+  });
+
+  it("applies exclude after include — exclusion always wins", () => {
+    const out = applyChannelRules(
+      memberships,
+      rules({ includePattern: ["^eng-"], excludePattern: ["-archive$"] }),
+    );
+    expect(out.channels.map((c) => c.name)).toEqual(["eng-payments", "eng-platform"]);
+  });
+
+  it("excludes by explicit id even when a pattern matched it", () => {
+    const out = applyChannelRules(memberships, rules({ includePattern: ["^eng-"], exclude: ["ch_2"] }));
+    expect(out.channels.map((c) => c.id)).toEqual(["ch_1", "ch_5"]);
+  });
+
+  it("can only ever narrow to actual memberships — a catch-all cannot reach a channel the bot is not in", () => {
+    const out = applyChannelRules([ch("ch_1", "only-one")], rules({ includePattern: [".*"] }));
+    expect(out.channels.map((c) => c.id)).toEqual(["ch_1"]);
+  });
+
+  it("caps at maxChannels, dropping the LEAST recently active", () => {
+    const out = applyChannelRules(memberships, rules({ maxChannels: 2 }));
+    expect(out.truncated).toBe(true);
+    expect(out.channels.map((c) => c.id)).toEqual(["ch_1", "ch_2"]);
+  });
+
+  it("returns nothing when nothing matches, rather than falling back to everything", () => {
+    const out = applyChannelRules(memberships, rules({ includePattern: ["^nope-"] }));
+    expect(out.channels).toEqual([]);
+  });
+
+  it("ignores an uncompilable pattern instead of throwing", () => {
+    expect(() => applyChannelRules(memberships, rules({ includePattern: ["([a-z"] }))).not.toThrow();
+  });
+
+  it("handles empty memberships", () => {
+    expect(applyChannelRules([], rules({ includePattern: [".*"] })).channels).toEqual([]);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/channel-rules.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/channel-rules.ts
@@ -1,0 +1,77 @@
+/**
+ * The pure part of channel resolution: applying an agent's include/exclude
+ * rules to the set of channels its bot is actually a member of.
+ *
+ * Split from channel-resolver.ts (which owns the Redis cache and the Spaces
+ * queries) so the rule semantics — the part with all the edge cases — can be
+ * tested without a database, a cache or an env file.
+ *
+ * The membership list passed in is the ACL gate. Rules can only ever narrow
+ * it, so a catch-all pattern like ".*" widens to exactly what the bot can
+ * already read and never to a channel nobody added it to.
+ */
+
+import type { AwakeningChannelRules } from "./config.js";
+import type { ResolvedChannel } from "./types.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-channel-rules");
+
+/** Wall-clock budget for regex matching, so a pathological pattern cannot stall the tick. */
+const MATCH_BUDGET_MS = 50;
+
+function compile(patterns: string[]): RegExp[] {
+  const out: RegExp[] = [];
+  for (const src of patterns) {
+    try {
+      out.push(new RegExp(src, "i"));
+    } catch {
+      log.warn(`[awakening] dropping uncompilable channel pattern: ${src.slice(0, 80)}`);
+    }
+  }
+  return out;
+}
+
+export interface ChannelRuleResult {
+  channels: ResolvedChannel[];
+  /** True when maxChannels cut the set short. Surfaced to the agent in the artifact. */
+  truncated: boolean;
+}
+
+export function applyChannelRules(
+  memberships: ResolvedChannel[],
+  rules: AwakeningChannelRules,
+): ChannelRuleResult {
+  const includeIds = new Set(rules.include);
+  const includePatterns = compile(rules.includePattern);
+  const excludeIds = new Set(rules.exclude);
+  const excludePatterns = compile(rules.excludePattern);
+  const deadline = Date.now() + MATCH_BUDGET_MS;
+  let budgetExhausted = false;
+
+  const matches = (name: string, patterns: RegExp[]): boolean => {
+    if (patterns.length === 0 || budgetExhausted) return false;
+    if (Date.now() > deadline) {
+      budgetExhausted = true;
+      log.warn("[awakening] channel pattern matching exceeded its budget; remaining patterns skipped");
+      return false;
+    }
+    return patterns.some((re) => re.test(name));
+  };
+
+  // No include rule at all means "every channel the bot is in" — the useful
+  // default for an agent that was simply added to the channels it should watch.
+  const hasIncludeRule = includeIds.size > 0 || includePatterns.length > 0;
+
+  const selected = memberships.filter((c) => {
+    if (excludeIds.has(c.id)) return false;
+    if (matches(c.name, excludePatterns)) return false;
+    if (!hasIncludeRule) return true;
+    return includeIds.has(c.id) || matches(c.name, includePatterns);
+  });
+
+  // Sorted by recency so the cap deterministically drops the least active.
+  selected.sort((a, b) => b.lastActivityAt - a.lastActivityAt);
+  const truncated = selected.length > rules.maxChannels;
+  return { channels: selected.slice(0, rules.maxChannels), truncated };
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/collector.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/collector.ts
@@ -1,0 +1,252 @@
+/**
+ * Collects everything that happened in the watched channels during a window.
+ *
+ * Two-stage by necessity: Message has no channelId column (only conversationId),
+ * so we first find the threads a channel touched in the window, then page their
+ * messages. Both stages are index-served —
+ *   conversations: @@index([channelId, lastActivityAt])
+ *   messages:      @@index([conversationId, createdAt, messageId])
+ *
+ * Stage 1 is prefiltered by `lastActivityAt >= windowStart - overlap` rather
+ * than by message time. A thread whose last activity predates the window
+ * cannot contain a message inside it, so this is a safe and very large cut.
+ *
+ * Every read is bounded (see spaces-read.ts) and the whole collection is capped
+ * at config.limits.maxEvents. Hitting the cap sets `truncated`, which the
+ * renderer surfaces to the agent — a silent cut would read as "quiet window".
+ */
+
+import { boundedInteract, pageBounded, SPACES_MAX_TAKE } from "./spaces-read.js";
+import { messageToText, threadTitleFrom } from "./message-text.js";
+import type { AgentSpacesIdentity, ResolvedChannel, WindowEvent } from "./types.js";
+import type { AwakeningConfig } from "./config.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-collector");
+
+const MESSAGE_PAGE = 500;
+const CONVERSATION_PAGE = 500;
+
+interface RawConversation {
+  conversationId: string;
+  channelId: string;
+  initialMessageId: string;
+  initial_message_md: string | null;
+  createdAt: string;
+}
+
+interface RawMessage {
+  messageId: string;
+  conversationId: string;
+  senderId: string;
+  content: string;
+  msgType: string;
+  edited: boolean;
+  createdAt: string;
+}
+
+interface RawUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+}
+
+/** Words that mark a message as needing someone to do something. */
+const ACTION_PATTERNS: Array<{ signal: string; re: RegExp }> = [
+  { signal: "urgent", re: /\b(urgent|asap|immediately|right away)\b/i },
+  { signal: "blocked", re: /\b(blocked|blocker|stuck|can'?t proceed)\b/i },
+  { signal: "escalation", re: /\b(p0|p1|sev1|sev-1|escalat\w*|outage|incident)\b/i },
+  { signal: "request", re: /\b(can someone|could someone|who can|please (?:help|review|check|look))\b/i },
+];
+
+function detectActionSignals(text: string): string[] {
+  return ACTION_PATTERNS.filter((p) => p.re.test(text)).map((p) => p.signal);
+}
+
+function isQuestion(text: string): boolean {
+  return /\?\s*$/.test(text.trim()) || /^(who|what|when|where|why|how|is|are|can|should|does|did)\b/i.test(text.trim());
+}
+
+/**
+ * Spaces renders a mention as the user id inside the message body. Matching on
+ * the raw id is deliberate: display names change, ids do not.
+ */
+function mentionsUser(text: string, userId: string): boolean {
+  return userId.length > 0 && text.includes(userId);
+}
+
+function titleOf(conv: RawConversation | undefined): string {
+  return threadTitleFrom(conv?.initial_message_md);
+}
+
+/**
+ * Resolve display names for the senders in a window.
+ *
+ * A separate query because the Spaces query AST supports neither `select` nor
+ * `include` — QueryASTSchema drops both, so a relation select is silently a
+ * no-op and every row comes back whole. Names matter: an artifact full of raw
+ * cuids is unreadable, and the agent cannot address anyone by name.
+ *
+ * Best-effort. If the lookup fails the window still renders, just with ids.
+ */
+async function resolveSenderNames(
+  messages: RawMessage[],
+  auth: { token: string; workspaceId: string },
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+  const ids = [...new Set(messages.map((m) => m.senderId).filter(Boolean))];
+  if (ids.length === 0) return names;
+
+  try {
+    const users = await boundedInteract<RawUser[]>(
+      {
+        model: "user",
+        operation: "findMany",
+        where: { id: { in: ids } },
+        take: Math.min(ids.length, SPACES_MAX_TAKE),
+      },
+      auth,
+    );
+    for (const u of users) {
+      const label = u.name?.trim() || u.email?.trim();
+      if (u.id && label) names.set(u.id, label);
+    }
+  } catch (err) {
+    log.warn(`[awakening] sender name lookup failed; falling back to ids: ${err instanceof Error ? err.message : err}`);
+  }
+  return names;
+}
+
+export interface CollectResult {
+  events: WindowEvent[];
+  truncated: boolean;
+  activeChannels: Set<string>;
+}
+
+/**
+ * Pull the window's messages for the given channels.
+ * Returns events in chronological order with `L` left at 0 — the renderer
+ * assigns line numbers once the final ordering is fixed.
+ */
+export async function collectWindow(
+  channels: ResolvedChannel[],
+  startMs: number,
+  endMs: number,
+  identity: AgentSpacesIdentity,
+  config: AwakeningConfig,
+): Promise<CollectResult> {
+  const auth = { token: identity.appToken, workspaceId: identity.workspaceId };
+  const activeChannels = new Set<string>();
+  if (channels.length === 0) return { events: [], truncated: false, activeChannels };
+
+  const channelNameById = new Map(channels.map((c) => [c.id, c.name]));
+  const overlapStart = new Date(startMs - config.cursor.overlapMs).toISOString();
+
+  const conversations = await boundedInteract<RawConversation[]>(
+    {
+      model: "conversation",
+      operation: "findMany",
+      where: {
+        channelId: { in: channels.map((c) => c.id) },
+        lastActivityAt: { gte: overlapStart },
+      },
+      orderBy: [{ lastActivityAt: "desc" }],
+      take: Math.min(config.limits.maxActiveThreads, CONVERSATION_PAGE),
+    },
+    auth,
+  );
+
+  if (conversations.length === 0) return { events: [], truncated: false, activeChannels };
+
+  const convById = new Map(conversations.map((c) => [c.conversationId, c]));
+  const messages = await pageBounded<RawMessage>(
+    {
+      model: "message",
+      operation: "findMany",
+      where: {
+        conversationId: { in: conversations.map((c) => c.conversationId) },
+        createdAt: { gt: new Date(startMs).toISOString(), lte: new Date(endMs).toISOString() },
+        isDeleted: { equals: false },
+      },
+      orderBy: [{ createdAt: "asc" }, { messageId: "asc" }],
+    },
+    auth,
+    config.limits.maxEvents + 1,
+    MESSAGE_PAGE,
+    // Keyset resume: strictly after (createdAt, messageId) of the last row.
+    (last) => ({
+      OR: [
+        { createdAt: { gt: last.createdAt } },
+        { AND: [{ createdAt: { equals: last.createdAt } }, { messageId: { gt: last.messageId } }] },
+      ],
+    }),
+  );
+
+  const senderNames = await resolveSenderNames(messages, auth);
+  const truncated = messages.length > config.limits.maxEvents;
+  const capped = truncated ? messages.slice(0, config.limits.maxEvents) : messages;
+  if (truncated) {
+    log.warn(
+      `[awakening] window truncated at maxEvents=${config.limits.maxEvents} for agent=${identity.spacesAppUserId}`,
+    );
+  }
+
+  const events: WindowEvent[] = capped.map((m) => {
+    const conv = convById.get(m.conversationId);
+    const channelId = conv?.channelId ?? "";
+    // Two forms of the body: the stored HTML, and readable text. Signals and
+    // the artifact use the text; the mention check stays on the RAW html
+    // because that is where a mention's user id lives as a span attribute —
+    // and it still matches after conversion, which preserves the id.
+    const rawContent = (m.content ?? "").trim();
+    const text = messageToText(rawContent);
+    const isMe = m.senderId === identity.spacesAppUserId;
+    if (channelId) activeChannels.add(channelId);
+
+    return {
+      L: 0,
+      kind: "message",
+      at: new Date(m.createdAt).toISOString(),
+      atMs: new Date(m.createdAt).getTime(),
+      id: m.messageId,
+      ch: channelId,
+      chName: channelNameById.get(channelId) ?? "",
+      cv: m.conversationId,
+      cvTitle: titleOf(conv),
+      sender: senderNames.get(m.senderId) ?? m.senderId,
+      senderId: m.senderId,
+      isHuman: m.msgType === "USER" && !isMe,
+      isMe,
+      root: conv?.initialMessageId === m.messageId,
+      mentionsMe: mentionsUser(rawContent, identity.spacesAppUserId),
+      unanswered: false,
+      covered: false,
+      coveredBy: null,
+      question: isQuestion(text),
+      actionSignals: detectActionSignals(text),
+      edited: Boolean(m.edited),
+      chars: text.length,
+      text,
+    };
+  });
+
+  markUnanswered(events);
+  return { events, truncated, activeChannels };
+}
+
+/**
+ * Mark the last event of each thread as unanswered when it is a human message
+ * — i.e. somebody said something and nobody (human or agent) followed up
+ * inside this window. This is the single most load-bearing signal for deciding
+ * whether an agent has anything useful to do.
+ */
+export function markUnanswered(events: WindowEvent[]): void {
+  const lastByThread = new Map<string, WindowEvent>();
+  for (const e of events) {
+    const prev = lastByThread.get(e.cv);
+    if (!prev || e.atMs >= prev.atMs) lastByThread.set(e.cv, e);
+  }
+  for (const last of lastByThread.values()) {
+    if (last.isHuman) last.unanswered = true;
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/config.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/config.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { resolveAwakeningConfig, hashChannelRules, participatesIn, AWAKENING_DEFAULTS } from "./config.js";
+
+describe("resolveAwakeningConfig — never throws, always in bounds", () => {
+  it("returns defaults for missing / non-object config", () => {
+    expect(resolveAwakeningConfig(undefined)).toEqual(AWAKENING_DEFAULTS);
+    expect(resolveAwakeningConfig(null)).toEqual(AWAKENING_DEFAULTS);
+    expect(resolveAwakeningConfig({})).toEqual(AWAKENING_DEFAULTS);
+    expect(resolveAwakeningConfig({ awakening: "nope" })).toEqual(AWAKENING_DEFAULTS);
+    expect(resolveAwakeningConfig({ awakening: [] })).toEqual(AWAKENING_DEFAULTS);
+  });
+
+  it("defaults to safe values: disabled, shadow on, reply-only", () => {
+    expect(AWAKENING_DEFAULTS.enabled).toBe(false);
+    expect(AWAKENING_DEFAULTS.shadow).toBe(true);
+    expect(AWAKENING_DEFAULTS.writePolicy).toBe("reply");
+  });
+
+  it("clamps an out-of-range period rather than throwing", () => {
+    expect(resolveAwakeningConfig({ awakening: { periodMs: 1 } }).periodMs).toBe(5 * 60_000);
+    expect(resolveAwakeningConfig({ awakening: { periodMs: 999 * 60 * 60_000 } }).periodMs).toBe(24 * 60 * 60_000);
+    expect(resolveAwakeningConfig({ awakening: { periodMs: "30m" } }).periodMs).toBe(AWAKENING_DEFAULTS.periodMs);
+    expect(resolveAwakeningConfig({ awakening: { periodMs: NaN } }).periodMs).toBe(AWAKENING_DEFAULTS.periodMs);
+  });
+
+  it("drops uncompilable channel patterns instead of failing the whole read", () => {
+    const cfg = resolveAwakeningConfig({
+      awakening: { channels: { includePattern: ["^eng-", "([a-z]+", "ops$"] } },
+    });
+    expect(cfg.channels.includePattern).toEqual(["^eng-", "ops$"]);
+  });
+
+  it("drops oversized patterns and caps pattern count", () => {
+    const long = "a".repeat(201);
+    expect(resolveAwakeningConfig({ awakening: { channels: { includePattern: [long] } } }).channels.includePattern).toEqual([]);
+    const many = Array.from({ length: 30 }, (_, i) => `p${i}`);
+    expect(resolveAwakeningConfig({ awakening: { channels: { includePattern: many } } }).channels.includePattern).toHaveLength(10);
+  });
+
+  it("de-duplicates and trims channel id lists, ignoring non-strings", () => {
+    const cfg = resolveAwakeningConfig({
+      awakening: { channels: { include: [" ch_1 ", "ch_1", "", 42, "ch_2"] } },
+    });
+    expect(cfg.channels.include).toEqual(["ch_1", "ch_2"]);
+  });
+
+  it("falls back on an unknown kind or writePolicy", () => {
+    expect(resolveAwakeningConfig({ awakening: { kind: "sideways" } }).kind).toBe("heartbeat");
+    expect(resolveAwakeningConfig({ awakening: { writePolicy: "destroy" } }).writePolicy).toBe("reply");
+  });
+
+  it("keeps a valid full config intact", () => {
+    const cfg = resolveAwakeningConfig({
+      awakening: {
+        enabled: true,
+        kind: "both",
+        periodMs: 900_000,
+        shadow: false,
+        writePolicy: "act",
+        workspaceId: " ws_1 ",
+        channels: { include: ["ch_a"], includePattern: ["^eng"], maxChannels: 10 },
+        gate: { minHumanEvents: 3, forceRunEveryNSkips: 5 },
+        limits: { maxEvents: 200, maxActiveThreads: 50, maxRunsPerHour: 6 },
+        cursor: { replicaSafetyMs: 10_000, overlapMs: 60_000, maxCatchupWindows: 2 },
+      },
+    });
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.kind).toBe("both");
+    expect(cfg.workspaceId).toBe("ws_1");
+    expect(cfg.gate.minHumanEvents).toBe(3);
+    expect(cfg.limits.maxRunsPerHour).toBe(6);
+    expect(cfg.cursor.overlapMs).toBe(60_000);
+  });
+});
+
+describe("hashChannelRules", () => {
+  it("is order-insensitive so a reordered list does not bust the cache", () => {
+    const a = { include: ["b", "a"], includePattern: [], exclude: [], excludePattern: [], maxChannels: 25 };
+    const b = { include: ["a", "b"], includePattern: [], exclude: [], excludePattern: [], maxChannels: 25 };
+    expect(hashChannelRules(a)).toBe(hashChannelRules(b));
+  });
+
+  it("changes when any rule changes", () => {
+    const base = { include: ["a"], includePattern: [], exclude: [], excludePattern: [], maxChannels: 25 };
+    expect(hashChannelRules(base)).not.toBe(hashChannelRules({ ...base, include: ["a", "c"] }));
+    expect(hashChannelRules(base)).not.toBe(hashChannelRules({ ...base, maxChannels: 10 }));
+    expect(hashChannelRules(base)).not.toBe(hashChannelRules({ ...base, excludePattern: ["x"] }));
+  });
+});
+
+describe("participatesIn", () => {
+  it("routes each kind correctly", () => {
+    const cfg = (kind: "heartbeat" | "reflex" | "both") => ({ ...AWAKENING_DEFAULTS, kind });
+    expect(participatesIn(cfg("heartbeat"), "heartbeat")).toBe(true);
+    expect(participatesIn(cfg("heartbeat"), "reflex")).toBe(false);
+    expect(participatesIn(cfg("reflex"), "heartbeat")).toBe(false);
+    expect(participatesIn(cfg("both"), "heartbeat")).toBe(true);
+    expect(participatesIn(cfg("both"), "reflex")).toBe(true);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/config.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/config.ts
@@ -1,0 +1,334 @@
+/**
+ * The `agents.config.awakening` block — every knob that governs an awakened
+ * agent, plus its default and its clamp.
+ *
+ * Config lives in the agent's JSON config rather than in dedicated columns so
+ * the existing PUT /agents/:slug path, its ACL and its audit diff keep working
+ * untouched. Scheduling STATE (nextDueAt, watermark, failure counters) lives
+ * in agent_awakening_state instead, because the tick loop has to index-scan it
+ * and Postgres cannot index JSON.
+ *
+ * Every read goes through resolveAwakeningConfig(), which clamps as it reads.
+ * A value that was valid when written but is out of bounds today (a lowered
+ * ceiling, a hand-edited row, a rolled-back deploy) degrades to the nearest
+ * legal value instead of throwing on the wake path. The API-layer validator in
+ * lib/agent-config-validation.ts rejects bad input at write time; this module
+ * is the runtime backstop that keeps the tick loop from ever crashing on
+ * malformed config.
+ */
+
+/** Which wake kinds an agent participates in. */
+export const AWAKENING_KINDS = ["heartbeat", "reflex", "both"] as const;
+export type AwakeningKind = (typeof AWAKENING_KINDS)[number];
+
+/**
+ * What the agent is permitted to DO once awake.
+ *   observe — reason and write memory; no outbound Spaces writes at all.
+ *   reply   — may reply inside existing threads it was given.
+ *   act     — may also start new threads and post to a channel.
+ * Enforced at runtime in xyne-claw, not just by tool-set assembly: the app
+ * identity's post tool is ungated by design, so assembly alone is not a bound.
+ */
+export const WRITE_POLICIES = ["observe", "reply", "act"] as const;
+export type WritePolicy = (typeof WRITE_POLICIES)[number];
+
+export interface AwakeningChannelRules {
+  /** Explicit Spaces channel ids. Always intersected with the bot's memberships. */
+  include: string[];
+  /** Case-insensitive regex sources matched against Channel.name. */
+  includePattern: string[];
+  exclude: string[];
+  excludePattern: string[];
+  /** Hard cap after resolution; least-recently-active channels drop first. */
+  maxChannels: number;
+}
+
+export interface AwakeningConfig {
+  enabled: boolean;
+  kind: AwakeningKind;
+  /**
+   * Which Spaces workspace to read and act in. Optional: an org with exactly
+   * one linked workspace resolves automatically. Required when the org has
+   * several — guessing between tenants must never happen silently.
+   */
+  workspaceId?: string;
+  /** Heartbeat period. The floor exists so a typo cannot make an agent wake every second. */
+  periodMs: number;
+  channels: AwakeningChannelRules;
+  writePolicy: WritePolicy;
+  /**
+   * Shadow mode: run the agent and record what it WOULD have done, but strip
+   * every outbound write tool. The safe first rollout for any agent.
+   */
+  shadow: boolean;
+  /**
+   * Free-text guidance the agent owner writes for awakened runs — tone, what
+   * is worth reacting to, what to leave alone. Appended to the operating
+   * contract as its own labelled block.
+   *
+   * Deliberately advisory: it shapes JUDGEMENT, never mechanics. The contract's
+   * delivery rules and the Bounds below it are appended AFTER this block and
+   * are not overridable from config, so a careless instruction cannot make a
+   * run mute, make it answer its own messages, or bypass the write policy.
+   */
+  instructions: string;
+  gate: {
+    /** Below this many human events the window is not worth a run. */
+    minHumanEvents: number;
+    /** Wake regardless of the gate every Nth consecutive skip (0 = never). */
+    forceRunEveryNSkips: number;
+  };
+  limits: {
+    maxEvents: number;
+    maxActiveThreads: number;
+    maxRunsPerHour: number;
+  };
+  /**
+   * Reflex: the fast, shallow wake driven by how many events have piled up
+   * rather than by the clock. Checked cheaply (a COUNT) far more often than a
+   * heartbeat, and fires only once `threshold` events have accumulated.
+   */
+  reflex: {
+    /** How often the accumulated-event count is checked. */
+    checkIntervalMs: number;
+    /** Events since the reflex watermark that trigger a wake. */
+    threshold: number;
+    /** Floor on the gap between two reflex runs, whatever the event rate. */
+    minIntervalMs: number;
+    /**
+     * Live injection: while a reflex run is in flight, keep collecting. Once
+     * `injectThreshold` NEW events have arrived, hand them to the running
+     * session so it can adapt mid-task instead of finishing on stale input.
+     */
+    injectEnabled: boolean;
+    injectThreshold: number;
+    /** Hard cap on injections per session — a run must still converge. */
+    maxInjectionsPerSession: number;
+    /** Floor on the gap between two injections into the same session. */
+    injectMinIntervalMs: number;
+  };
+  cursor: {
+    /**
+     * How far behind "now" a window closes. Spaces reads hit a read replica;
+     * sealing right up to now() would miss rows that had not replicated yet,
+     * and the watermark would step past them forever.
+     */
+    replicaSafetyMs: number;
+    /** Re-scan band below the watermark, de-duplicated against a seen-set. */
+    overlapMs: number;
+    /** Cap on catch-up windows after an outage before the gap guard jumps forward. */
+    maxCatchupWindows: number;
+  };
+}
+
+export const AWAKENING_BOUNDS = {
+  periodMs: { min: 5 * 60_000, max: 24 * 60 * 60_000, default: 30 * 60_000 },
+  maxChannels: { min: 1, max: 100, default: 25 },
+  minHumanEvents: { min: 0, max: 1_000, default: 1 },
+  forceRunEveryNSkips: { min: 0, max: 100, default: 0 },
+  maxEvents: { min: 10, max: 5_000, default: 1_500 },
+  maxActiveThreads: { min: 5, max: 1_000, default: 400 },
+  maxRunsPerHour: { min: 1, max: 60, default: 4 },
+  replicaSafetyMs: { min: 0, max: 300_000, default: 30_000 },
+  overlapMs: { min: 0, max: 900_000, default: 120_000 },
+  maxCatchupWindows: { min: 1, max: 50, default: 4 },
+  reflexCheckIntervalMs: { min: 15_000, max: 3_600_000, default: 60_000 },
+  reflexThreshold: { min: 1, max: 1_000, default: 25 },
+  reflexMinIntervalMs: { min: 0, max: 24 * 60 * 60_000, default: 300_000 },
+  injectThreshold: { min: 1, max: 1_000, default: 10 },
+  maxInjectionsPerSession: { min: 0, max: 20, default: 3 },
+  injectMinIntervalMs: { min: 0, max: 3_600_000, default: 60_000 },
+  /** Cap on owner-written run guidance — long enough for real direction,
+   *  short enough that it cannot crowd out the window itself. */
+  instructionsLength: { max: 4_000 },
+  /** Guards against a pathological or hostile channel-name pattern. */
+  patternLength: { max: 200 },
+  patternCount: { max: 10 },
+} as const;
+
+export const AWAKENING_DEFAULTS: AwakeningConfig = {
+  enabled: false,
+  kind: "heartbeat",
+  periodMs: AWAKENING_BOUNDS.periodMs.default,
+  channels: {
+    include: [],
+    includePattern: [],
+    exclude: [],
+    excludePattern: [],
+    maxChannels: AWAKENING_BOUNDS.maxChannels.default,
+  },
+  writePolicy: "reply",
+  shadow: true,
+  instructions: "",
+  gate: {
+    minHumanEvents: AWAKENING_BOUNDS.minHumanEvents.default,
+    forceRunEveryNSkips: AWAKENING_BOUNDS.forceRunEveryNSkips.default,
+  },
+  limits: {
+    maxEvents: AWAKENING_BOUNDS.maxEvents.default,
+    maxActiveThreads: AWAKENING_BOUNDS.maxActiveThreads.default,
+    maxRunsPerHour: AWAKENING_BOUNDS.maxRunsPerHour.default,
+  },
+  reflex: {
+    checkIntervalMs: AWAKENING_BOUNDS.reflexCheckIntervalMs.default,
+    threshold: AWAKENING_BOUNDS.reflexThreshold.default,
+    minIntervalMs: AWAKENING_BOUNDS.reflexMinIntervalMs.default,
+    injectEnabled: true,
+    injectThreshold: AWAKENING_BOUNDS.injectThreshold.default,
+    maxInjectionsPerSession: AWAKENING_BOUNDS.maxInjectionsPerSession.default,
+    injectMinIntervalMs: AWAKENING_BOUNDS.injectMinIntervalMs.default,
+  },
+  cursor: {
+    replicaSafetyMs: AWAKENING_BOUNDS.replicaSafetyMs.default,
+    overlapMs: AWAKENING_BOUNDS.overlapMs.default,
+    maxCatchupWindows: AWAKENING_BOUNDS.maxCatchupWindows.default,
+  },
+};
+
+type Bound = { min: number; max: number; default: number };
+
+function clampNumber(raw: unknown, bound: Bound): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return bound.default;
+  return Math.min(bound.max, Math.max(bound.min, Math.floor(raw)));
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+/** Non-empty trimmed strings only, de-duplicated, capped at `max` entries. */
+function stringList(raw: unknown, max: number): string[] {
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (!trimmed || out.includes(trimmed)) continue;
+    out.push(trimmed);
+    if (out.length >= max) break;
+  }
+  return out;
+}
+
+/**
+ * Regex sources that survive `new RegExp(src, "i")`. An invalid or oversized
+ * pattern is dropped rather than thrown: a bad pattern must never be able to
+ * take the tick loop down, and channel resolution simply matches less.
+ */
+function patternList(raw: unknown): string[] {
+  const candidates = stringList(raw, AWAKENING_BOUNDS.patternCount.max);
+  return candidates.filter((src) => {
+    if (src.length > AWAKENING_BOUNDS.patternLength.max) return false;
+    try {
+      new RegExp(src, "i");
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function oneOf<T extends string>(raw: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof raw === "string" && (allowed as readonly string[]).includes(raw) ? (raw as T) : fallback;
+}
+
+/**
+ * Owner-written free text. Trimmed, truncated to the bound and stripped of
+ * control characters — never rejected, because resolveAwakeningConfig must not
+ * be able to throw on a stored config (a bad string would otherwise disable an
+ * agent that was previously working).
+ */
+function boundedText(raw: unknown, max: number): string {
+  if (typeof raw !== "string") return "";
+  // eslint-disable-next-line no-control-regex
+  return raw.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g, "").trim().slice(0, max);
+}
+
+function bool(raw: unknown, fallback: boolean): boolean {
+  return typeof raw === "boolean" ? raw : fallback;
+}
+
+/**
+ * Read `agent.config.awakening` into a fully-populated, in-bounds config.
+ * Never throws — a missing, malformed or hostile block yields defaults.
+ */
+export function resolveAwakeningConfig(agentConfig: unknown): AwakeningConfig {
+  const raw = isPlainObject(agentConfig) ? agentConfig["awakening"] : undefined;
+  if (!isPlainObject(raw)) return { ...AWAKENING_DEFAULTS };
+
+  const channels = isPlainObject(raw["channels"]) ? raw["channels"] : {};
+  const gate = isPlainObject(raw["gate"]) ? raw["gate"] : {};
+  const limits = isPlainObject(raw["limits"]) ? raw["limits"] : {};
+  const cursor = isPlainObject(raw["cursor"]) ? raw["cursor"] : {};
+  const reflex = isPlainObject(raw["reflex"]) ? raw["reflex"] : {};
+  const idCap = AWAKENING_BOUNDS.maxChannels.max;
+
+  return {
+    enabled: bool(raw["enabled"], AWAKENING_DEFAULTS.enabled),
+    kind: oneOf(raw["kind"], AWAKENING_KINDS, AWAKENING_DEFAULTS.kind),
+    ...(typeof raw["workspaceId"] === "string" && raw["workspaceId"].trim()
+      ? { workspaceId: raw["workspaceId"].trim() }
+      : {}),
+    periodMs: clampNumber(raw["periodMs"], AWAKENING_BOUNDS.periodMs),
+    channels: {
+      include: stringList(channels["include"], idCap),
+      includePattern: patternList(channels["includePattern"]),
+      exclude: stringList(channels["exclude"], idCap),
+      excludePattern: patternList(channels["excludePattern"]),
+      maxChannels: clampNumber(channels["maxChannels"], AWAKENING_BOUNDS.maxChannels),
+    },
+    writePolicy: oneOf(raw["writePolicy"], WRITE_POLICIES, AWAKENING_DEFAULTS.writePolicy),
+    shadow: bool(raw["shadow"], AWAKENING_DEFAULTS.shadow),
+    instructions: boundedText(raw["instructions"], AWAKENING_BOUNDS.instructionsLength.max),
+    gate: {
+      minHumanEvents: clampNumber(gate["minHumanEvents"], AWAKENING_BOUNDS.minHumanEvents),
+      forceRunEveryNSkips: clampNumber(gate["forceRunEveryNSkips"], AWAKENING_BOUNDS.forceRunEveryNSkips),
+    },
+    limits: {
+      maxEvents: clampNumber(limits["maxEvents"], AWAKENING_BOUNDS.maxEvents),
+      maxActiveThreads: clampNumber(limits["maxActiveThreads"], AWAKENING_BOUNDS.maxActiveThreads),
+      maxRunsPerHour: clampNumber(limits["maxRunsPerHour"], AWAKENING_BOUNDS.maxRunsPerHour),
+    },
+    reflex: {
+      checkIntervalMs: clampNumber(reflex["checkIntervalMs"], AWAKENING_BOUNDS.reflexCheckIntervalMs),
+      threshold: clampNumber(reflex["threshold"], AWAKENING_BOUNDS.reflexThreshold),
+      minIntervalMs: clampNumber(reflex["minIntervalMs"], AWAKENING_BOUNDS.reflexMinIntervalMs),
+      injectEnabled: bool(reflex["injectEnabled"], AWAKENING_DEFAULTS.reflex.injectEnabled),
+      injectThreshold: clampNumber(reflex["injectThreshold"], AWAKENING_BOUNDS.injectThreshold),
+      maxInjectionsPerSession: clampNumber(
+        reflex["maxInjectionsPerSession"],
+        AWAKENING_BOUNDS.maxInjectionsPerSession,
+      ),
+      injectMinIntervalMs: clampNumber(reflex["injectMinIntervalMs"], AWAKENING_BOUNDS.injectMinIntervalMs),
+    },
+    cursor: {
+      replicaSafetyMs: clampNumber(cursor["replicaSafetyMs"], AWAKENING_BOUNDS.replicaSafetyMs),
+      overlapMs: clampNumber(cursor["overlapMs"], AWAKENING_BOUNDS.overlapMs),
+      maxCatchupWindows: clampNumber(cursor["maxCatchupWindows"], AWAKENING_BOUNDS.maxCatchupWindows),
+    },
+  };
+}
+
+/**
+ * Stable fingerprint of the channel rules. Used as part of the resolved-channel
+ * cache key so editing the rules invalidates the cache with no explicit bust.
+ */
+export function hashChannelRules(rules: AwakeningChannelRules): string {
+  const canonical = JSON.stringify([
+    [...rules.include].sort(),
+    [...rules.includePattern].sort(),
+    [...rules.exclude].sort(),
+    [...rules.excludePattern].sort(),
+    rules.maxChannels,
+  ]);
+  let hash = 5381;
+  for (let i = 0; i < canonical.length; i++) {
+    hash = ((hash << 5) + hash + canonical.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/** True when the agent's config makes it eligible for the given wake kind. */
+export function participatesIn(config: AwakeningConfig, kind: "heartbeat" | "reflex"): boolean {
+  return config.kind === "both" || config.kind === kind;
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/config.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/config.ts
@@ -140,7 +140,7 @@ export const AWAKENING_BOUNDS = {
   injectMinIntervalMs: { min: 0, max: 3_600_000, default: 60_000 },
   /** Cap on owner-written run guidance — long enough for real direction,
    *  short enough that it cannot crowd out the window itself. */
-  instructionsLength: { max: 4_000 },
+  instructionsLength: { max: 10_000 },
   /** Guards against a pathological or hostile channel-name pattern. */
   patternLength: { max: 200 },
   patternCount: { max: 10 },

--- a/apps/xyne-claw-auth/backend/src/awakening/contract.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/contract.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { buildOperatingContract } from "./contract.js";
+import { AWAKENING_DEFAULTS, type AwakeningConfig } from "./config.js";
+import type { AwakeningWindow } from "./types.js";
+
+const win = (config: Partial<AwakeningConfig>): AwakeningWindow => ({
+  agentId: "a", agentSlug: "ops", orgId: "o", kind: "reflex",
+  startMs: 0, endMs: 1000, channels: [], silentChannels: [], events: [],
+  signals: {
+    eventCount: 0, humanEventCount: 0, botEventCount: 0, selfEventCount: 0,
+    distinctSenders: 0, distinctThreads: 0, newThreads: 0, unansweredThreads: 0,
+    mentionsOfMe: 0, questions: 0, actionSignals: 0, channelsWithActivity: 0,
+  },
+  truncated: false, gap: null, priorRuns: [],
+  config: { ...AWAKENING_DEFAULTS, ...config },
+});
+
+/**
+ * The contract exists because an agent read a window, identified an unanswered
+ * mention aimed at it, wrote an excellent reply — and posted nothing, because
+ * in every other kind of run the platform delivers the final answer for it.
+ */
+describe("buildOperatingContract", () => {
+  it("always states that the final answer is not delivered", () => {
+    for (const cfg of [{ shadow: true }, { shadow: false, writePolicy: "reply" as const }, { shadow: false, writePolicy: "act" as const }]) {
+      expect(buildOperatingContract(win(cfg))).toContain("NOT delivered");
+    }
+  });
+
+  it("names the tool and both id parameters when the run can write", () => {
+    const c = buildOperatingContract(win({ shadow: false, writePolicy: "act" }));
+    expect(c).toContain("send-message");
+    expect(c).toContain("channelId");
+    expect(c).toContain("conversationId");
+    expect(c).toContain("reply here →");
+  });
+
+  it("tells a reply-policy run it may not start threads or mutate tickets", () => {
+    const c = buildOperatingContract(win({ shadow: false, writePolicy: "reply" }));
+    expect(c).toMatch(/INSIDE existing threads only/);
+    expect(c).toMatch(/Do not start new threads/);
+  });
+
+  it("permits new threads under the act policy", () => {
+    expect(buildOperatingContract(win({ shadow: false, writePolicy: "act" }))).toMatch(/start new threads/);
+  });
+
+  it("tells a shadow run to describe what it would have posted, and offers no tool", () => {
+    const c = buildOperatingContract(win({ shadow: true, writePolicy: "act" }));
+    expect(c).toContain("NO message-sending tool");
+    expect(c).toMatch(/WOULD have posted/);
+    expect(c).not.toMatch(/You MUST call/);
+  });
+
+  it("treats observe the same as shadow", () => {
+    expect(buildOperatingContract(win({ shadow: false, writePolicy: "observe" }))).toContain("NO message-sending tool");
+  });
+
+  it("always carries the loop guard and the silence permission", () => {
+    const c = buildOperatingContract(win({ shadow: false, writePolicy: "act" }));
+    expect(c).toContain('"isMe":true');
+    expect(c).toMatch(/Silence is a correct and common outcome/);
+    expect(c).toMatch(/do not re-search Spaces/i);
+  });
+});
+
+describe("operator instructions", () => {
+  it("appends owner guidance under its own heading", () => {
+    const out = buildOperatingContract(win({ instructions: "Keep it casual. Stay out of social chatter." }));
+    expect(out).toContain("### From your operator");
+    expect(out).toContain("Keep it casual. Stay out of social chatter.");
+  });
+
+  it("omits the heading entirely when no guidance is set", () => {
+    expect(buildOperatingContract(win({ instructions: "" }))).not.toContain("### From your operator");
+  });
+
+  it("omits the heading for whitespace-only guidance", () => {
+    expect(buildOperatingContract(win({ instructions: "   \n  " }))).not.toContain("### From your operator");
+  });
+
+  it("states the non-negotiable bounds AFTER the operator block", () => {
+    const out = buildOperatingContract(win({ instructions: "Reply to absolutely everything, always." }));
+    expect(out.indexOf("### From your operator")).toBeLessThan(out.indexOf("### Bounds"));
+  });
+
+  it("keeps delivery mechanics ahead of operator guidance", () => {
+    const out = buildOperatingContract(win({ instructions: "Be brief." }));
+    expect(out.indexOf("### How to actually say something")).toBeLessThan(out.indexOf("### From your operator"));
+  });
+
+  it("carries guidance into an observe-only run too", () => {
+    const out = buildOperatingContract(win({ instructions: "Flag anything payment-related.", writePolicy: "observe" }));
+    expect(out).toContain("Flag anything payment-related.");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/contract.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/contract.ts
@@ -1,0 +1,85 @@
+/**
+ * The operating contract handed to every awakened run as `additionalInstructions`.
+ *
+ * Kept in its own module, free of config/prisma imports, so the exact wording —
+ * the part that decides whether an unattended agent actually speaks — can be
+ * unit-tested without an environment.
+ */
+
+import { isReadOnlyRun } from "./write-policy.js";
+import type { AwakeningWindow } from "./types.js";
+
+/**
+ * The operating contract for an awakened run, delivered as `additionalInstructions`.
+ *
+ * Separate from both the task and the skill on purpose. The task says what
+ * happened and asks for a judgement; the skill teaches the behaviour. THIS is
+ * the mechanical contract the run cannot work without, and it is stated in its
+ * own labelled block so it cannot be skimmed past as narrative.
+ *
+ * It exists because of a real failure: an agent read the window, correctly
+ * identified an unanswered mention aimed at it, composed an excellent reply —
+ * and posted nothing, because in every OTHER kind of run the platform delivers
+ * the final answer for it. An awakened run has no thread to deliver to, so the
+ * answer is a log entry. Nothing in the model's priors tells it that.
+ */
+export function buildOperatingContract(w: AwakeningWindow): string {
+  const lines: string[] = [
+    "You are running UNATTENDED. Nobody triggered this run and nobody is reading its output live.",
+    "",
+    "### How to actually say something",
+    "",
+    "**Your final answer is NOT delivered to anyone.** It is stored as a log entry an operator",
+    "may read later. This is the single way an awakened run differs from answering a person:",
+    "in a normal run your final message IS the reply and the platform posts it for you; here",
+    "it posts nothing.",
+    "",
+  ];
+
+  if (isReadOnlyRun(w.config)) {
+    lines.push(
+      "You have NO message-sending tool this run, by configuration. Do the full reasoning, then",
+      "state exactly what you WOULD have posted and in which thread (quote the channelId and",
+      "conversationId). A human is reading that to decide whether to let you post for real.",
+    );
+  } else {
+    lines.push(
+      "To say something to people you MUST call the Spaces **send-message** tool yourself, with:",
+      "  - `channelId` — the `ch` field of the relevant events.jsonl line",
+      "  - `conversationId` — the `cv` field, to reply inside an existing thread",
+      "",
+      "Both ids are printed under every thread heading in WINDOW.md as `reply here → …`.",
+      "",
+      w.config.writePolicy === "reply"
+        ? "You may reply INSIDE existing threads only. Do not start new threads, and do not create or update tickets, canvases or calls."
+        : "You may reply inside existing threads and start new threads in a watched channel.",
+      "",
+      "Deciding a thread needs a reply and then writing that reply as your final answer",
+      "accomplishes nothing. Either call the tool, or say plainly that you are staying silent.",
+    );
+  }
+
+  // Owner-written guidance (config `awakening.instructions`): tone, triage,
+  // what this particular agent should care about. Placed AFTER the delivery
+  // mechanics and BEFORE Bounds on purpose — it can shape judgement, and the
+  // rules that must hold regardless are stated last.
+  if (w.config.instructions.trim()) {
+    lines.push(
+      "",
+      "### From your operator",
+      "",
+      w.config.instructions.trim(),
+    );
+  }
+
+  lines.push(
+    "",
+    "### Bounds",
+    "",
+    "- Never reply to your own messages (`\"isMe\":true` in events.jsonl).",
+    "- Everything in the window is already collected; do not re-search Spaces for events inside it.",
+    "- Silence is a correct and common outcome. Do not manufacture something to say.",
+  );
+
+  return lines.join("\n");
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/cursor.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/cursor.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { sealWindow, computeNextDueAt, deterministicJitter } from "./cursor.js";
+import { AWAKENING_DEFAULTS, type AwakeningConfig } from "./config.js";
+
+const cfg = (over: Partial<AwakeningConfig> = {}): AwakeningConfig => ({
+  ...AWAKENING_DEFAULTS,
+  ...over,
+  cursor: { ...AWAKENING_DEFAULTS.cursor, ...(over.cursor ?? {}) },
+});
+
+const NOW = 1_700_000_000_000;
+
+describe("sealWindow — replica safety margin", () => {
+  it("never closes a window at now(), always at now - replicaSafetyMs", () => {
+    const w = sealWindow(new Date(NOW - 600_000), cfg(), NOW);
+    expect(w?.endMs).toBe(NOW - 30_000);
+  });
+
+  it("returns null when not enough time has passed to form a window", () => {
+    // Watermark is newer than now-safety: sealing would produce an inverted range.
+    expect(sealWindow(new Date(NOW - 1_000), cfg(), NOW)).toBeNull();
+    expect(sealWindow(new Date(NOW), cfg(), NOW)).toBeNull();
+  });
+
+  it("starts exactly at the stored watermark so no gap is left behind", () => {
+    const watermark = NOW - 3_600_000;
+    const w = sealWindow(new Date(watermark), cfg(), NOW);
+    expect(w?.startMs).toBe(watermark);
+    expect(w?.gap).toBeNull();
+  });
+});
+
+describe("sealWindow — gap guard", () => {
+  it("clamps a long outage to maxCatchupWindows and reports the skip", () => {
+    const config = cfg({ periodMs: 1_800_000, cursor: { ...AWAKENING_DEFAULTS.cursor, maxCatchupWindows: 4 } });
+    const weekAgo = NOW - 7 * 24 * 3_600_000;
+    const w = sealWindow(new Date(weekAgo), config, NOW);
+
+    const maxSpan = 1_800_000 * 4;
+    expect(w).not.toBeNull();
+    expect(w!.endMs - w!.startMs).toBe(maxSpan);
+    expect(w!.gap).not.toBeNull();
+    // Everything between the old watermark and the new start is reported as skipped.
+    expect(w!.gap!.skippedMs).toBe(w!.startMs - weekAgo);
+  });
+
+  it("does not report a gap when the backlog fits inside the allowance", () => {
+    const config = cfg({ periodMs: 1_800_000 });
+    const w = sealWindow(new Date(NOW - 3_600_000), config, NOW);
+    expect(w!.gap).toBeNull();
+  });
+});
+
+describe("computeNextDueAt", () => {
+  it("is deterministic for the same agent — a beat must not wander across restarts", () => {
+    const a = computeNextDueAt("agent_abc", cfg(), 0, NOW);
+    const b = computeNextDueAt("agent_abc", cfg(), 0, NOW);
+    expect(a.getTime()).toBe(b.getTime());
+  });
+
+  it("spreads different agents so a fleet does not stampede one tick", () => {
+    const times = new Set(
+      Array.from({ length: 50 }, (_, i) => computeNextDueAt(`agent_${i}`, cfg(), 0, NOW).getTime()),
+    );
+    expect(times.size).toBeGreaterThan(25);
+  });
+
+  it("backs off exponentially on repeated failure and caps the factor", () => {
+    const period = AWAKENING_DEFAULTS.periodMs;
+    const at = (fails: number) => computeNextDueAt("agent_x", cfg(), fails, NOW).getTime() - NOW;
+    expect(at(1)).toBeGreaterThanOrEqual(period * 2);
+    expect(at(2)).toBeGreaterThanOrEqual(period * 4);
+    // Capped at 8x so a recovered agent rejoins its beat promptly.
+    expect(at(20)).toBeLessThan(period * 8 + period);
+  });
+
+  it("uses no backoff on a healthy agent", () => {
+    const delta = computeNextDueAt("agent_y", cfg(), 0, NOW).getTime() - NOW;
+    expect(delta).toBeGreaterThanOrEqual(AWAKENING_DEFAULTS.periodMs);
+    expect(delta).toBeLessThan(AWAKENING_DEFAULTS.periodMs * 1.11);
+  });
+});
+
+describe("deterministicJitter", () => {
+  it("stays inside the requested range and handles a zero range", () => {
+    for (let i = 0; i < 200; i++) {
+      const j = deterministicJitter(`agent_${i}`, 1000);
+      expect(j).toBeGreaterThanOrEqual(0);
+      expect(j).toBeLessThan(1000);
+    }
+    expect(deterministicJitter("agent", 0)).toBe(0);
+    expect(deterministicJitter("agent", -5)).toBe(0);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/cursor.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/cursor.ts
@@ -1,0 +1,107 @@
+/**
+ * Watermark management — the exactly-once seam of the whole pipeline.
+ *
+ * Three invariants, each protecting against a specific way this breaks:
+ *
+ *  1. A window never closes at now(). Spaces reads hit a read replica, so rows
+ *     written moments ago may not have replicated. Sealing at
+ *     `now - replicaSafetyMs` and stepping the watermark to that same instant
+ *     is what stops the cursor from stepping over unreplicated rows forever.
+ *
+ *  2. The watermark NEVER rewinds. It advances with a compare-and-set that
+ *     only moves it forward, so two pods racing on the same agent can at worst
+ *     both do the same work — never un-see events.
+ *
+ *  3. A failed window does NOT advance it. Skips do (the window was genuinely
+ *     empty or boring, and re-reading it would produce the same skip); failures
+ *     do not, so the next wake retries the same range.
+ *
+ * The gap guard is the backstop for the case none of the above covers: an
+ * agent disabled for a week, or a pod fleet down overnight. Replaying days of
+ * backlog in one window would blow the event cap and hand the model a useless
+ * artifact, so the watermark jumps forward and the skip is recorded in the
+ * window header where the agent can see it.
+ */
+
+import { prisma } from "../db.js";
+import type { AwakeningConfig } from "./config.js";
+
+export interface WindowBounds {
+  startMs: number;
+  endMs: number;
+  gap: { skippedMs: number } | null;
+}
+
+/**
+ * Compute the next window from a stored watermark.
+ * Returns null when not enough time has passed for a non-empty window.
+ */
+export function sealWindow(
+  watermarkAt: Date,
+  config: AwakeningConfig,
+  nowMs: number = Date.now(),
+): WindowBounds | null {
+  const endMs = nowMs - config.cursor.replicaSafetyMs;
+  let startMs = watermarkAt.getTime();
+  if (endMs <= startMs) return null;
+
+  const maxSpanMs = config.periodMs * config.cursor.maxCatchupWindows;
+  let gap: { skippedMs: number } | null = null;
+  if (endMs - startMs > maxSpanMs) {
+    const jumpedTo = endMs - maxSpanMs;
+    gap = { skippedMs: jumpedTo - startMs };
+    startMs = jumpedTo;
+  }
+
+  return { startMs, endMs, gap };
+}
+
+/**
+ * Move the watermark forward. Compare-and-set: the UPDATE is a no-op if
+ * another pod already advanced it past `toMs`, so this can never rewind.
+ * Returns true when this call is the one that moved it.
+ */
+export async function advanceWatermark(
+  agentId: string,
+  toMs: number,
+  lastMessageId: string | null,
+): Promise<boolean> {
+  const to = new Date(toMs);
+  const result = await prisma.agentAwakeningState.updateMany({
+    where: { agentId, watermarkAt: { lt: to } },
+    data: { watermarkAt: to, watermarkMessageId: lastMessageId },
+  });
+  return result.count > 0;
+}
+
+/**
+ * Schedule the next wake.
+ *
+ * Deterministic jitter derived from the agent id, not random: it spreads a
+ * fleet of agents that share a period across the whole window instead of
+ * stampeding on the same tick, and it stays stable across restarts so an
+ * agent's beat does not wander.
+ */
+export function computeNextDueAt(
+  agentId: string,
+  config: AwakeningConfig,
+  consecutiveFailures: number,
+  nowMs: number = Date.now(),
+): Date {
+  const jitter = deterministicJitter(agentId, Math.floor(config.periodMs * 0.1));
+  // Exponential backoff on repeated failure, capped so a recovered agent
+  // rejoins its normal beat within one hour rather than hours later.
+  const backoffFactor = consecutiveFailures > 0 ? Math.min(2 ** consecutiveFailures, 8) : 1;
+  return new Date(nowMs + config.periodMs * backoffFactor + jitter);
+}
+
+/** Stable non-negative hash of the agent id, in [0, range). */
+export function deterministicJitter(agentId: string, range: number): number {
+  if (range <= 0) return 0;
+  let hash = 2166136261;
+  for (let i = 0; i < agentId.length; i++) {
+    hash ^= agentId.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) % range;
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/dispatch.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/dispatch.ts
@@ -1,0 +1,284 @@
+/**
+ * Builds and fires the xyne-claw run for an awakened window.
+ *
+ * Deliberately mirrors queue/scheduled-jobs-worker.ts, which is the proven
+ * headless dispatch path: same /internal/run endpoint, same provider
+ * resolution, same __persistedByCaller opt-out so we own the AgentRun row and
+ * it gets the right triggerSource instead of racing the pod's own insert.
+ *
+ * Two things are specific to awakening:
+ *  - the window artifact rides along as `contextFiles`, which xyne-claw writes
+ *    into the session's .context/ directory before the agent starts;
+ *  - the operating-contract skill is inlined rather than seeded, so it is
+ *    present on every awakened run by construction.
+ *
+ * Pre-flight is FAIL-CLOSED on identity: an unattended run must act as the
+ * agent's own app identity or not at all. Falling back to a user token would
+ * mean a background loop acting with a human's credentials.
+ */
+
+import { prisma } from "../db.js";
+import { CONFIG } from "../config.js";
+import { decrypt } from "../crypto.js";
+import { agentRunRepository } from "../repositories/index.js";
+import { ensureUserExists } from "../lib/users-jit.js";
+import { chatMessageRepository } from "../repositories/index.js";
+import { setSession } from "../lib/session-context.js";
+import { resolveAgentProviderConfigs } from "../lib/agent-provider-config.js";
+import { renderWindow } from "./render.js";
+import { HEARTBEAT_SKILL, REFLEX_SKILL } from "./skills.js";
+import { buildWritePermissions } from "./write-policy.js";
+import { buildOperatingContract } from "./contract.js";
+import type { AgentSpacesIdentity, AwakeningWindow } from "./types.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-dispatch");
+
+export class AwakeningIdentityError extends Error {
+  constructor(agentSlug: string, reason: string) {
+    super(`Agent "${agentSlug}" cannot run unattended: ${reason}`);
+    this.name = "AwakeningIdentityError";
+  }
+}
+
+interface AgentIdentityRow {
+  id: string;
+  slug: string;
+  orgId: string;
+  config: unknown;
+  spacesAppId: string | null;
+  spacesAppUserId: string | null;
+  spacesAppToken: string | null;
+}
+
+/**
+ * Decrypt and validate the agent's Spaces app identity.
+ * Throws rather than degrading — see the fail-closed note above.
+ */
+export function resolveAgentIdentity(agent: AgentIdentityRow, workspaceId: string): AgentSpacesIdentity {
+  if (!agent.spacesAppId) throw new AwakeningIdentityError(agent.slug, "no Spaces app is linked");
+  if (!agent.spacesAppUserId) throw new AwakeningIdentityError(agent.slug, "no Spaces app user id");
+  if (!agent.spacesAppToken) throw new AwakeningIdentityError(agent.slug, "no Spaces app token");
+
+  const [ciphertext, iv, authTag] = agent.spacesAppToken.split(":");
+  if (!ciphertext || !iv || !authTag) {
+    throw new AwakeningIdentityError(agent.slug, "app token is not in the expected encrypted format");
+  }
+
+  let appToken: string;
+  try {
+    appToken = decrypt(ciphertext, iv, authTag, CONFIG.encryptionKey);
+  } catch (err) {
+    throw new AwakeningIdentityError(
+      agent.slug,
+      `app token failed to decrypt (${err instanceof Error ? err.message : "unknown"})`,
+    );
+  }
+  if (!appToken) throw new AwakeningIdentityError(agent.slug, "app token decrypted to an empty string");
+
+  return { appToken, spacesAppId: agent.spacesAppId, spacesAppUserId: agent.spacesAppUserId, workspaceId };
+}
+
+/** The task text the agent is woken with. The window artifact carries the data. */
+function buildTask(w: AwakeningWindow): string {
+  const s = w.signals;
+  return [
+    `You have woken on a ${w.kind}. Nobody triggered this run.`,
+    "",
+    `A window of everything that happened in your watched channels has been collected for you.`,
+    `Read \`.context/heartbeat/WINDOW.md\` first — it is the overview, and it points at the detail.`,
+    "",
+    `Window: ${new Date(w.startMs).toISOString()} → ${new Date(w.endMs).toISOString()}`,
+    `Events: ${s.eventCount} (${s.humanEventCount} from humans across ${s.distinctSenders} people and ${s.distinctThreads} threads)`,
+    `Needing attention: ${s.unansweredThreads} unanswered thread(s), ${s.mentionsOfMe} direct mention(s) of you, ${s.actionSignals} action signal(s)`,
+    "",
+    `Follow the ${w.kind === "reflex" ? "xyne-reflex" : "xyne-heartbeat"} skill. Doing nothing is a valid and`,
+    "common outcome — act only where you can genuinely add something.",
+  ].join("\n");
+}
+
+export interface DispatchResult {
+  sessionId: string | null;
+  dispatched: boolean;
+  reason?: string;
+}
+
+/**
+ * Fire the run. Returns the claw sessionId on success.
+ * The caller owns idempotency (the AgentAwakeningRun row) and the watermark.
+ */
+export async function dispatchAwakening(
+  window: AwakeningWindow,
+  agent: AgentIdentityRow,
+  identity: AgentSpacesIdentity,
+  idempotencyKey: string,
+): Promise<DispatchResult> {
+  // The run route derives the org from the RUN'S USER, never from the request
+  // body or headers — requireAuth strips x-org-id inbound so a caller can
+  // never inject one. An awakened run has no human session, so the bot's own
+  // Spaces user must exist locally, carrying the agent's org, before dispatch.
+  const mirrored = await ensureUserExists(identity.spacesAppUserId, "awakening", agent.orgId);
+  if (!mirrored) {
+    return {
+      sessionId: null,
+      dispatched: false,
+      reason: `could not mirror the agent's Spaces user ${identity.spacesAppUserId} into org ${agent.orgId}`,
+    };
+  }
+
+  const rendered = renderWindow(window);
+  const conversationId = `awaken_${window.agentId}_${window.startMs}`;
+
+  // Fold the run's write policy into the agent config as per-tool denials.
+  // Enforced at claw-auth's MCP call boundary, so it holds regardless of what
+  // the model decides to try.
+  const baseConfig = (agent.config ?? {}) as Record<string, unknown>;
+  const existingPermissions =
+    (baseConfig["toolPermissions"] as Record<string, string> | undefined) ?? {};
+  const awakenedAgentConfig: Record<string, unknown> = {
+    ...baseConfig,
+    toolPermissions: buildWritePermissions(window.config, existingPermissions),
+  };
+
+  const { providerConfigs, providerOrder, parent: providerParent } = await resolveAgentProviderConfigs(
+    agent as Parameters<typeof resolveAgentProviderConfigs>[0],
+    { headlessBulk: true },
+  ).catch(() => ({ providerConfigs: {}, providerOrder: [] as string[], parent: undefined as string | undefined }));
+
+  const dispatchPayload = {
+    userId: identity.spacesAppUserId,
+    task: buildTask(window),
+    agentSlug: agent.slug,
+    orgId: window.orgId,
+    channelId: "",
+    conversationId,
+    traceId: conversationId,
+    callbackUrl: `${CONFIG.internalUrl}/claw/api/v1/awakening/${idempotencyKey}/result`,
+    progressUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/progress`,
+    idempotencyKey,
+    detached: true,
+    // Distinguishes an unattended run from a scheduled or user-triggered one.
+    // xyne-claw keys the write guard and the tool set off this.
+    eventType: "awakening",
+    awakening: {
+      kind: window.kind,
+      writePolicy: window.config.writePolicy,
+      shadow: window.config.shadow,
+      windowStartMs: window.startMs,
+      windowEndMs: window.endMs,
+      entryPath: rendered.entryPath,
+      // Live injection applies to reflex runs only: a heartbeat is a deliberate
+      // pass over a sealed window, and mutating that window mid-run would make
+      // its own artifact a lie.
+      injectEnabled: window.kind === "reflex" && window.config.reflex.injectEnabled,
+    },
+    contextFiles: rendered.files,
+    additionalInstructions: buildOperatingContract(window),
+    skills: [window.kind === "reflex" ? REFLEX_SKILL : HEARTBEAT_SKILL],
+    // We insert the AgentRun ourselves (below) so it carries triggerSource
+    // "heartbeat"; without this the pod also inserts one tagged "spaces" and
+    // the two race on the sessionId unique constraint.
+    __persistedByCaller: true,
+    agentConfig: awakenedAgentConfig,
+    ...(providerParent ? { provider: providerParent } : {}),
+    ...(Object.keys(providerConfigs).length > 0 ? { providerConfigs } : {}),
+    ...(providerOrder.length > 1 ? { providerOrder } : {}),
+  };
+
+  const res = await fetch(`${CONFIG.internalUrl}/claw/api/v1/internal/run`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+    },
+    body: JSON.stringify(dispatchPayload),
+  });
+
+  const body = (await res.json().catch(() => null)) as
+    | { success?: boolean; sessionId?: string; error?: string }
+    | null;
+
+  if (!res.ok || !body?.success) {
+    const reason = body?.error ?? `HTTP ${res.status}`;
+    log.warn(`[awakening] dispatch failed agent=${agent.slug} kind=${window.kind}: ${reason}`);
+    return { sessionId: null, dispatched: false, reason };
+  }
+
+  const sessionId = body.sessionId ?? null;
+  if (sessionId) {
+    // Persist the run's SessionContext.
+    //
+    // Load-bearing for requirement 3 ("the agent gets a human's hands"):
+    // routes/mcp.ts decides at TOOL-LISTING time whether Spaces is served in
+    // APP mode (the xyne-spaces-app-tools server, which owns the ungated
+    // `apps-send-message`) or USER mode. That decision reads this context and
+    // keys off `isAutomation`. With no context the run silently falls back to
+    // user mode, where the only post tool is HITL-gated — so an unattended
+    // agent raises an approval card that nobody will ever click, and appears
+    // to simply say nothing.
+    //
+    // An awakened run IS an app-user run with no human in the thread, which is
+    // exactly what that flag means.
+    await setSession(sessionId, {
+      mentionedUserId: identity.spacesAppUserId,
+      senderId: identity.spacesAppUserId,
+      senderName: agent.slug,
+      // No single channel: an awakened agent decides which of its watched
+      // channels to act in, and passes the target explicitly to each tool.
+      channelId: "",
+      channelName: "",
+      conversationId,
+      task: `${window.kind} window`,
+      agentId: agent.id,
+      agentOrgId: window.orgId,
+      agentSlug: agent.slug,
+      responseMode: "conversation",
+      // Read by routes/mcp.ts to grant this run the bot-identity send tool and
+      // the Spaces subagent. Without it the run has no way to speak at all.
+      triggerSource: window.kind,
+      // The agent posts through tools, choosing thread and wording itself.
+      // Its final answer is a report for the operator, not a channel message.
+      suppressThreadReply: true,
+      isAutomation: true,
+      appToken: identity.appToken,
+      spacesAppId: identity.spacesAppId,
+      spacesAppUserId: identity.spacesAppUserId,
+      workspaceId: identity.workspaceId,
+      traceId: conversationId,
+    }).catch((e) =>
+      log.warn(`[awakening] setSession failed for ${sessionId}: ${e instanceof Error ? e.message : e}`),
+    );
+
+    // The chat UI renders a conversation from ChatMessage rows, not from
+    // AgentRun. Without this opening turn an awakened conversation exists in
+    // the run list but its thread is empty and will not open.
+    await chatMessageRepository
+      .create({
+        conversationId,
+        agentSlug: agent.slug,
+        userId: identity.spacesAppUserId,
+        role: "user",
+        content: dispatchPayload.task,
+        status: "completed",
+        orgId: window.orgId,
+      })
+      .catch((e) => log.warn(`[awakening] user ChatMessage failed: ${e instanceof Error ? e.message : e}`));
+
+    await agentRunRepository
+      .start({
+        sessionId,
+        userId: identity.spacesAppUserId,
+        agentSlug: agent.slug,
+        orgId: window.orgId,
+        triggerSource: window.kind,
+        task: `${window.kind} window ${new Date(window.startMs).toISOString()}`,
+        conversationId,
+      })
+      .catch((e) => log.warn(`[awakening] AgentRun.start failed: ${e instanceof Error ? e.message : e}`));
+  }
+
+  log.info(
+    `[awakening] dispatched agent=${agent.slug} kind=${window.kind} events=${window.events.length} session=${sessionId}`,
+  );
+  return { sessionId, dispatched: true };
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/gate.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/gate.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+import { evaluateGate } from "./gate.js";
+import { computeSignals } from "./signals.js";
+import { markUnanswered } from "./collector.js";
+import { AWAKENING_DEFAULTS, type AwakeningConfig } from "./config.js";
+import type { WindowEvent, WindowSignals } from "./types.js";
+
+const cfg = (over: Partial<AwakeningConfig["gate"]> = {}): AwakeningConfig => ({
+  ...AWAKENING_DEFAULTS,
+  gate: { ...AWAKENING_DEFAULTS.gate, ...over },
+});
+
+const sig = (over: Partial<WindowSignals> = {}): WindowSignals => ({
+  ...computeSignals([]),
+  eventCount: 1,
+  humanEventCount: 1,
+  ...over,
+});
+
+describe("evaluateGate — skip rules (the cost control)", () => {
+  it("skips an empty window", () => {
+    expect(evaluateGate({ signals: computeSignals([]), config: cfg(), consecutiveSkips: 0 })).toEqual({
+      decision: "skip",
+      rule: "empty_window",
+    });
+  });
+
+  it("skips a window with no human activity — this is how an agent avoids talking to itself", () => {
+    const out = evaluateGate({
+      signals: sig({ eventCount: 40, humanEventCount: 0, selfEventCount: 10, botEventCount: 30 }),
+      config: cfg(),
+      consecutiveSkips: 0,
+    });
+    expect(out).toEqual({ decision: "skip", rule: "no_human_activity" });
+  });
+
+  it("skips below the configured human-event floor", () => {
+    const out = evaluateGate({
+      signals: sig({ eventCount: 2, humanEventCount: 2 }),
+      config: cfg({ minHumanEvents: 5 }),
+      consecutiveSkips: 0,
+    });
+    expect(out).toEqual({ decision: "skip", rule: "below_min_human_events" });
+  });
+
+  it("skips chatter with nothing actionable in it", () => {
+    const out = evaluateGate({
+      signals: sig({ eventCount: 30, humanEventCount: 30, unansweredThreads: 0, questions: 0 }),
+      config: cfg(),
+      consecutiveSkips: 0,
+    });
+    expect(out).toEqual({ decision: "skip", rule: "no_actionable_signal" });
+  });
+});
+
+describe("evaluateGate — run rules", () => {
+  it("always runs on a direct mention, even in an otherwise dead window", () => {
+    const out = evaluateGate({
+      signals: sig({ eventCount: 1, humanEventCount: 1, mentionsOfMe: 1 }),
+      config: cfg({ minHumanEvents: 100 }),
+      consecutiveSkips: 0,
+    });
+    expect(out).toEqual({ decision: "run", rule: "direct_mention" });
+  });
+
+  it("mention beats the no-human-activity skip (a mention by a bot still concerns the agent)", () => {
+    const out = evaluateGate({
+      signals: sig({ eventCount: 1, humanEventCount: 0, mentionsOfMe: 1 }),
+      config: cfg(),
+      consecutiveSkips: 0,
+    });
+    expect(out.decision).toBe("run");
+  });
+
+  it("runs on an escalation signal ahead of any volume rule", () => {
+    const out = evaluateGate({
+      signals: sig({ eventCount: 1, humanEventCount: 1, actionSignals: 1 }),
+      config: cfg({ minHumanEvents: 50 }),
+      consecutiveSkips: 0,
+    });
+    expect(out).toEqual({ decision: "run", rule: "escalation_signal" });
+  });
+
+  it("runs when a thread is left unanswered", () => {
+    const out = evaluateGate({
+      signals: sig({ eventCount: 5, humanEventCount: 5, unansweredThreads: 2 }),
+      config: cfg(),
+      consecutiveSkips: 0,
+    });
+    expect(out).toEqual({ decision: "run", rule: "unanswered_thread" });
+  });
+
+  it("runs on an open question", () => {
+    const out = evaluateGate({
+      signals: sig({ eventCount: 5, humanEventCount: 5, questions: 1 }),
+      config: cfg(),
+      consecutiveSkips: 0,
+    });
+    expect(out).toEqual({ decision: "run", rule: "open_question" });
+  });
+});
+
+describe("evaluateGate — anti-starvation", () => {
+  it("forces a run once the skip streak reaches the threshold", () => {
+    const signals = sig({ eventCount: 10, humanEventCount: 0 });
+    expect(evaluateGate({ signals, config: cfg({ forceRunEveryNSkips: 3 }), consecutiveSkips: 2 }).decision).toBe("skip");
+    expect(evaluateGate({ signals, config: cfg({ forceRunEveryNSkips: 3 }), consecutiveSkips: 3 })).toEqual({
+      decision: "run",
+      rule: "forced_after_skips",
+    });
+  });
+
+  it("is disabled at 0 no matter how long the streak", () => {
+    const out = evaluateGate({
+      signals: sig({ eventCount: 10, humanEventCount: 0 }),
+      config: cfg({ forceRunEveryNSkips: 0 }),
+      consecutiveSkips: 999,
+    });
+    expect(out.decision).toBe("skip");
+  });
+
+  it("never forces a run on a genuinely empty window — there is nothing to act on", () => {
+    const out = evaluateGate({
+      signals: computeSignals([]),
+      config: cfg({ forceRunEveryNSkips: 1 }),
+      consecutiveSkips: 50,
+    });
+    expect(out).toEqual({ decision: "skip", rule: "empty_window" });
+  });
+});
+
+// --- signals + unanswered marking -------------------------------------------
+
+function ev(over: Partial<WindowEvent>): WindowEvent {
+  return {
+    L: 0,
+    kind: "message",
+    at: new Date(over.atMs ?? 0).toISOString(),
+    atMs: 0,
+    id: "m1",
+    ch: "ch_1",
+    chName: "eng",
+    cv: "cv_1",
+    cvTitle: "t",
+    sender: "Ann",
+    senderId: "u_1",
+    isHuman: true,
+    isMe: false,
+    root: false,
+    mentionsMe: false,
+    unanswered: false,
+    covered: false,
+    coveredBy: null,
+    question: false,
+    actionSignals: [],
+    edited: false,
+    chars: 0,
+    text: "",
+    ...over,
+  };
+}
+
+describe("markUnanswered", () => {
+  it("marks the last human message of a thread", () => {
+    const events = [
+      ev({ id: "a", atMs: 1, cv: "cv_1" }),
+      ev({ id: "b", atMs: 2, cv: "cv_1" }),
+    ];
+    markUnanswered(events);
+    expect(events[0]!.unanswered).toBe(false);
+    expect(events[1]!.unanswered).toBe(true);
+  });
+
+  it("does NOT mark a thread whose last message is the agent itself", () => {
+    const events = [
+      ev({ id: "a", atMs: 1, cv: "cv_1" }),
+      ev({ id: "b", atMs: 2, cv: "cv_1", isHuman: false, isMe: true }),
+    ];
+    markUnanswered(events);
+    expect(events.some((e) => e.unanswered)).toBe(false);
+  });
+
+  it("does not mark a thread whose last message is another bot", () => {
+    const events = [ev({ id: "a", atMs: 1, cv: "cv_1", isHuman: false })];
+    markUnanswered(events);
+    expect(events[0]!.unanswered).toBe(false);
+  });
+
+  it("tracks each thread independently", () => {
+    const events = [
+      ev({ id: "a", atMs: 1, cv: "cv_1" }),
+      ev({ id: "b", atMs: 2, cv: "cv_2", isHuman: false, isMe: true }),
+      ev({ id: "c", atMs: 3, cv: "cv_1" }),
+    ];
+    markUnanswered(events);
+    expect(events.find((e) => e.id === "c")!.unanswered).toBe(true);
+    expect(events.find((e) => e.id === "b")!.unanswered).toBe(false);
+  });
+});
+
+describe("computeSignals", () => {
+  it("separates human, bot and self events — self must never count as human", () => {
+    const s = computeSignals([
+      ev({ id: "a", senderId: "u_1" }),
+      ev({ id: "b", senderId: "u_2" }),
+      ev({ id: "c", isHuman: false, isMe: true, senderId: "bot" }),
+      ev({ id: "d", isHuman: false, senderId: "other-bot" }),
+    ]);
+    expect(s.humanEventCount).toBe(2);
+    expect(s.selfEventCount).toBe(1);
+    expect(s.botEventCount).toBe(1);
+    expect(s.distinctSenders).toBe(2);
+  });
+
+  it("ignores questions and action signals raised by the agent itself", () => {
+    const s = computeSignals([
+      ev({ isHuman: false, isMe: true, question: true, actionSignals: ["urgent"] }),
+    ]);
+    expect(s.questions).toBe(0);
+    expect(s.actionSignals).toBe(0);
+  });
+
+  it("counts distinct threads, channels and new threads", () => {
+    const s = computeSignals([
+      ev({ cv: "cv_1", ch: "ch_1", root: true }),
+      ev({ cv: "cv_1", ch: "ch_1" }),
+      ev({ cv: "cv_2", ch: "ch_2", root: true }),
+    ]);
+    expect(s.distinctThreads).toBe(2);
+    expect(s.channelsWithActivity).toBe(2);
+    expect(s.newThreads).toBe(2);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/gate.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/gate.ts
@@ -1,0 +1,105 @@
+/**
+ * The pre-LLM triage gate: decides whether a collected window is worth waking
+ * the model for.
+ *
+ * This is where the cost control lives. An agent watching busy channels wakes
+ * 48 times a day; most of those windows contain nothing that needs a decision.
+ * Every rule here is deterministic and free — no LLM call, no extra query —
+ * so a skip costs a few hundred microseconds instead of a run.
+ *
+ * Rules are ORDERED and the first match wins. Order encodes priority: an
+ * explicit mention beats a quiet window, and the anti-starvation rule beats
+ * everything so an agent that keeps skipping still checks in periodically.
+ */
+
+import type { AwakeningConfig } from "./config.js";
+import type { GateOutcome, WindowSignals } from "./types.js";
+
+export interface GateContext {
+  signals: WindowSignals;
+  config: AwakeningConfig;
+  /** Consecutive skips BEFORE this window. Drives the anti-starvation rule. */
+  consecutiveSkips: number;
+}
+
+interface Rule {
+  id: string;
+  evaluate: (ctx: GateContext) => "run" | "skip" | "continue";
+}
+
+const RULES: Rule[] = [
+  {
+    // Somebody addressed the agent directly. Always worth a run — this is the
+    // one case where a human is actively waiting on it.
+    id: "direct_mention",
+    evaluate: ({ signals }) => (signals.mentionsOfMe > 0 ? "run" : "continue"),
+  },
+  {
+    // Escalation language outranks volume: one "P1, who can look at this"
+    // matters more than fifty chatty messages.
+    id: "escalation_signal",
+    evaluate: ({ signals }) => (signals.actionSignals > 0 ? "run" : "continue"),
+  },
+  {
+    // Nothing but the agent's own posts and other bots. Waking here is how an
+    // agent ends up talking to itself.
+    id: "no_human_activity",
+    evaluate: ({ signals }) => (signals.humanEventCount === 0 ? "skip" : "continue"),
+  },
+  {
+    id: "below_min_human_events",
+    evaluate: ({ signals, config }) =>
+      signals.humanEventCount < config.gate.minHumanEvents ? "skip" : "continue",
+  },
+  {
+    // Humans are talking and nobody has answered the last word in some thread.
+    id: "unanswered_thread",
+    evaluate: ({ signals }) => (signals.unansweredThreads > 0 ? "run" : "continue"),
+  },
+  {
+    id: "open_question",
+    evaluate: ({ signals }) => (signals.questions > 0 ? "run" : "continue"),
+  },
+  {
+    // Chatter with no question, no mention, no escalation and nothing left
+    // hanging. Read it next window as history instead of paying for it now.
+    id: "no_actionable_signal",
+    evaluate: () => "skip",
+  },
+];
+
+/**
+ * Anti-starvation: after N consecutive skips, run anyway. Guarantees an agent
+ * with a strict gate still gets periodic situational awareness, and bounds how
+ * stale its memory can become. 0 disables it.
+ */
+function forcedByStarvation(ctx: GateContext): boolean {
+  const n = ctx.config.gate.forceRunEveryNSkips;
+  return n > 0 && ctx.consecutiveSkips >= n;
+}
+
+export function evaluateGate(ctx: GateContext): GateOutcome {
+  if (ctx.signals.eventCount === 0) {
+    return { decision: "skip", rule: "empty_window" };
+  }
+
+  for (const rule of RULES) {
+    const result = rule.evaluate(ctx);
+    if (result === "run") return { decision: "run", rule: rule.id };
+    if (result === "skip") {
+      if (forcedByStarvation(ctx)) return { decision: "run", rule: "forced_after_skips" };
+      return { decision: "skip", rule: rule.id };
+    }
+  }
+
+  return forcedByStarvation(ctx)
+    ? { decision: "run", rule: "forced_after_skips" }
+    : { decision: "skip", rule: "no_actionable_signal" };
+}
+
+/** Rule ids, exported so tests and the admin UI can enumerate them. */
+export const GATE_RULE_IDS = [
+  "empty_window",
+  ...RULES.map((r) => r.id),
+  "forced_after_skips",
+] as const;

--- a/apps/xyne-claw-auth/backend/src/awakening/inbox.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/inbox.ts
@@ -1,0 +1,143 @@
+/**
+ * The live-injection inbox: how events that arrive DURING a run reach it.
+ *
+ * Multi-pod design note — this is a PULL, not a push.
+ *
+ * claw runs many pods behind one Service, and a session lives in one pod's
+ * memory (`activeRuns` in xyne-claw/src/routes/run.ts is an in-process Map).
+ * Pushing an injection would mean routing to the exact pod holding the
+ * session, which needs pod discovery and breaks the moment the fleet scales.
+ *
+ * Pull costs nothing to avoid that, because of a property of the SDK: steering
+ * messages are delivered only "after the current assistant turn finishes
+ * executing its tool calls" (pi-agent-core types.d.ts). A pushed steer and a
+ * pulled steer therefore land at exactly the same moment — the next turn
+ * boundary. Pull has identical latency, needs no routing, and the pod that
+ * owns the run is the one that asks.
+ *
+ * So: claw-auth writes batches here; the owning claw pod drains them at its own
+ * turn boundaries over the same S2S boundary it already uses for session locks.
+ */
+
+import { redisService } from "../redis.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-inbox");
+
+/** Long enough to outlive a slow turn, short enough that a dead run's batch expires. */
+const INBOX_TTL_SECONDS = 3_600;
+/** Hard ceiling on queued batches, so a runaway producer cannot grow the list unbounded. */
+const MAX_QUEUED_BATCHES = 20;
+
+function inboxKey(sessionId: string): string {
+  return `claw:awk:inbox:${sessionId}`;
+}
+
+function statsKey(sessionId: string): string {
+  return `claw:awk:inject:${sessionId}`;
+}
+
+export interface InjectionBatch {
+  /** Monotonic per session — lets the agent see it missed nothing. */
+  ordinal: number;
+  eventCount: number;
+  /**
+   * Start of the window these events came from. The reflex watermark advances
+   * as soon as a batch is QUEUED, so if the run ends before draining it, this
+   * is what lets the watermark be rolled back to exactly where those events
+   * begin instead of stepping over them forever.
+   */
+  windowStartMs?: number;
+  /** Rendered text handed straight to the model. */
+  text: string;
+  createdAtMs: number;
+  /** True when this is the last injection the cap allows. */
+  isFinal: boolean;
+}
+
+export interface InjectionStats {
+  used: number;
+  lastAtMs: number;
+}
+
+export async function readInjectionStats(sessionId: string): Promise<InjectionStats> {
+  try {
+    const raw = await redisService.getConnection().get(statsKey(sessionId));
+    if (!raw) return { used: 0, lastAtMs: 0 };
+    const parsed = JSON.parse(raw) as InjectionStats;
+    return { used: Number(parsed.used) || 0, lastAtMs: Number(parsed.lastAtMs) || 0 };
+  } catch {
+    return { used: 0, lastAtMs: 0 };
+  }
+}
+
+/**
+ * Queue a batch for the running session.
+ *
+ * Caps are enforced by the CALLER (which knows the agent's config); this
+ * function only records that an injection happened and refuses to let the list
+ * grow without bound if a session stops draining.
+ */
+export async function pushInjection(sessionId: string, batch: InjectionBatch): Promise<boolean> {
+  try {
+    const redis = redisService.getConnection();
+    const key = inboxKey(sessionId);
+    const depth = await redis.llen(key);
+    if (depth >= MAX_QUEUED_BATCHES) {
+      log.warn(`[awakening] inbox full for session=${sessionId} (${depth}); dropping batch ${batch.ordinal}`);
+      return false;
+    }
+
+    await redis.rpush(key, JSON.stringify(batch));
+    await redis.expire(key, INBOX_TTL_SECONDS);
+
+    const stats = await readInjectionStats(sessionId);
+    await redis.set(
+      statsKey(sessionId),
+      JSON.stringify({ used: stats.used + 1, lastAtMs: batch.createdAtMs } satisfies InjectionStats),
+      "EX",
+      INBOX_TTL_SECONDS,
+    );
+    return true;
+  } catch (err) {
+    log.warn(`[awakening] inbox push failed session=${sessionId}: ${err instanceof Error ? err.message : err}`);
+    return false;
+  }
+}
+
+/**
+ * Atomically take everything queued for a session.
+ *
+ * LRANGE+DEL in a MULTI so a concurrent push is either fully included or stays
+ * for the next drain — a batch can never be read and then silently discarded.
+ */
+export async function drainInbox(sessionId: string): Promise<InjectionBatch[]> {
+  try {
+    const key = inboxKey(sessionId);
+    const results = await redisService.getConnection().multi().lrange(key, 0, -1).del(key).exec();
+    const raw = results?.[0]?.[1] as string[] | undefined;
+    if (!raw?.length) return [];
+
+    const batches: InjectionBatch[] = [];
+    for (const item of raw) {
+      try {
+        batches.push(JSON.parse(item) as InjectionBatch);
+      } catch {
+        log.warn(`[awakening] dropping unparseable inbox entry for session=${sessionId}`);
+      }
+    }
+    return batches.sort((a, b) => a.ordinal - b.ordinal);
+  } catch (err) {
+    log.warn(`[awakening] inbox drain failed session=${sessionId}: ${err instanceof Error ? err.message : err}`);
+    return [];
+  }
+}
+
+/** Clear a finished session's inbox and counters. Best-effort. */
+export async function clearInbox(sessionId: string): Promise<void> {
+  try {
+    await redisService.getConnection().del(inboxKey(sessionId), statsKey(sessionId));
+  } catch {
+    // TTLs will reap it anyway.
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/lifecycle.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/lifecycle.ts
@@ -1,0 +1,79 @@
+/**
+ * Keeps agent_awakening_state in sync with agent.config.awakening.
+ *
+ * Called on every agent config write. The state row is scheduler-owned data
+ * derived from config, so it must be created the moment awakening is switched
+ * on and parked the moment it is switched off — otherwise the tick either
+ * never sees the agent, or keeps waking one that was disabled.
+ *
+ * First-enable seeding matters more than it looks:
+ *
+ *   watermarkAt starts at NOW, not at zero. A new awakened agent must not
+ *   wake up and immediately ingest the channel's entire history — it would
+ *   blow the event cap, produce a useless artifact, and quite possibly reply
+ *   to a months-old thread.
+ *
+ *   nextDueAt is spread by a deterministic per-agent jitter, so enabling
+ *   awakening across a fleet does not line every agent up on the same tick.
+ */
+
+import { prisma } from "../db.js";
+import { resolveAwakeningConfig } from "./config.js";
+import { deterministicJitter } from "./cursor.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-lifecycle");
+
+export async function syncAwakeningState(
+  agentId: string,
+  orgId: string,
+  agentConfig: unknown,
+): Promise<void> {
+  const config = resolveAwakeningConfig(agentConfig);
+  const existing = await prisma.agentAwakeningState.findUnique({ where: { agentId } });
+
+  if (!config.enabled) {
+    if (existing?.enabled) {
+      await prisma.agentAwakeningState.update({
+        where: { agentId },
+        data: { enabled: false, lastError: null },
+      });
+      log.info(`[awakening] disabled agent=${agentId}`);
+    }
+    return;
+  }
+
+  const now = Date.now();
+  if (!existing) {
+    await prisma.agentAwakeningState.create({
+      data: {
+        agentId,
+        orgId,
+        enabled: true,
+        // Spread the first beat across the period so a bulk enable does not stampede.
+        nextDueAt: new Date(now + deterministicJitter(agentId, config.periodMs)),
+        watermarkAt: new Date(now),
+      },
+    });
+    log.info(`[awakening] enabled agent=${agentId} period=${config.periodMs}ms`);
+    return;
+  }
+
+  if (!existing.enabled) {
+    // Re-enabling after a pause: reset the watermark to now rather than
+    // replaying everything that happened while the agent was off.
+    await prisma.agentAwakeningState.update({
+      where: { agentId },
+      data: {
+        enabled: true,
+        orgId,
+        watermarkAt: new Date(now),
+        nextDueAt: new Date(now + deterministicJitter(agentId, config.periodMs)),
+        consecutiveFailures: 0,
+        consecutiveSkips: 0,
+        lastError: null,
+      },
+    });
+    log.info(`[awakening] re-enabled agent=${agentId}`);
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/lock.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/lock.ts
@@ -1,0 +1,128 @@
+/**
+ * One lock per agent, spanning BOTH wake kinds.
+ *
+ * The agent has one brain. If a heartbeat and a reflex run at the same time
+ * they read overlapping windows, reach the same conclusion, and both post it —
+ * the single worst failure this feature can have, and one that looks fine in
+ * every log until someone reads the channel. So the lock is per AGENT, not per
+ * kind, and a reflex that finds the lock held routes its events to the
+ * injection inbox of the run that already holds it instead of starting a
+ * second one.
+ *
+ * TTL-bounded with a holder token, mirroring xyne-claw/src/session-lock.ts:
+ *  - the holder token is the sessionId, so only the run that took the lock can
+ *    release it, and a late release from a dead run cannot free a newer one;
+ *  - a pod that dies holding the lock frees it when the TTL lapses, so there is
+ *    no permanently stuck agent;
+ *  - it is refreshed while the run is alive so a genuinely long run is not
+ *    interrupted by its own lock expiring.
+ *
+ * FAIL-CLOSED: if Redis is unreachable, acquisition fails and the wake is
+ * skipped. A missed wake is recoverable — the watermark holds the events and
+ * the next beat sees them. A double post is not.
+ */
+
+import { redisService } from "../redis.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-lock");
+
+/** Generous relative to a normal run; the refresh loop keeps a long one alive. */
+export const AWAKENING_LOCK_TTL_MS = Number(process.env["AWAKENING_LOCK_TTL_MS"] ?? 20 * 60_000);
+
+function lockKey(agentId: string): string {
+  return `claw:awk:lock:${agentId}`;
+}
+
+export interface LockHolder {
+  sessionId: string;
+  kind: string;
+  acquiredAtMs: number;
+}
+
+/**
+ * Take the lock for `agentId`. Returns false when another run holds it, or
+ * when Redis is unavailable (fail-closed).
+ */
+export async function acquireAgentLock(
+  agentId: string,
+  holder: LockHolder,
+  ttlMs: number = AWAKENING_LOCK_TTL_MS,
+): Promise<boolean> {
+  try {
+    const result = await redisService
+      .getConnection()
+      .set(lockKey(agentId), JSON.stringify(holder), "PX", ttlMs, "NX");
+    return result === "OK";
+  } catch (err) {
+    log.warn(
+      `[awakening] lock acquire failed for agent=${agentId} (failing closed): ${err instanceof Error ? err.message : err}`,
+    );
+    return false;
+  }
+}
+
+/** Who holds the lock, or null if it is free / unreadable. */
+export async function readAgentLock(agentId: string): Promise<LockHolder | null> {
+  try {
+    const raw = await redisService.getConnection().get(lockKey(agentId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as LockHolder;
+    return typeof parsed?.sessionId === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare-and-delete: frees the lock only if `sessionId` still owns it.
+ *
+ * The check matters. Without it, a run that finished after its TTIL lapsed
+ * would delete a lock a DIFFERENT run had since taken, and the two would
+ * overlap — the exact failure the lock exists to prevent.
+ */
+const RELEASE_SCRIPT = `
+if redis.call("GET", KEYS[1]) == false then return 0 end
+local holder = cjson.decode(redis.call("GET", KEYS[1]))
+if holder["sessionId"] == ARGV[1] then
+  redis.call("DEL", KEYS[1])
+  return 1
+end
+return 0
+`;
+
+export async function releaseAgentLock(agentId: string, sessionId: string): Promise<boolean> {
+  try {
+    const freed = await redisService.getConnection().eval(RELEASE_SCRIPT, 1, lockKey(agentId), sessionId);
+    return freed === 1;
+  } catch (err) {
+    log.warn(`[awakening] lock release failed agent=${agentId}: ${err instanceof Error ? err.message : err}`);
+    return false;
+  }
+}
+
+/** Extend the TTL while a run is still alive. Only the holder may refresh. */
+const REFRESH_SCRIPT = `
+if redis.call("GET", KEYS[1]) == false then return 0 end
+local holder = cjson.decode(redis.call("GET", KEYS[1]))
+if holder["sessionId"] == ARGV[1] then
+  redis.call("PEXPIRE", KEYS[1], tonumber(ARGV[2]))
+  return 1
+end
+return 0
+`;
+
+export async function refreshAgentLock(
+  agentId: string,
+  sessionId: string,
+  ttlMs: number = AWAKENING_LOCK_TTL_MS,
+): Promise<boolean> {
+  try {
+    const ok = await redisService
+      .getConnection()
+      .eval(REFRESH_SCRIPT, 1, lockKey(agentId), sessionId, String(ttlMs));
+    return ok === 1;
+  } catch {
+    return false;
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/message-text.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/message-text.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { messageToText, threadTitleFrom } from "./message-text.js";
+
+describe("messageToText", () => {
+  it("unwraps the editor's paragraph markup", () => {
+    expect(messageToText('<p class="m-0 leading-6">hey ask ai, can you help?</p>')).toBe(
+      "hey ask ai, can you help?",
+    );
+  });
+
+  it("keeps a trailing question mark reachable for question detection", () => {
+    const text = messageToText('<p class="m-0 leading-6">is the deploy done?</p>');
+    expect(/\?\s*$/.test(text)).toBe(true);
+  });
+
+  it("separates consecutive paragraphs with a newline, not a join", () => {
+    expect(messageToText("<p>first line</p><p>second line</p>")).toBe("first line\nsecond line");
+  });
+
+  it("drops empty paragraphs instead of leaving blank runs", () => {
+    expect(messageToText("<p>only this</p><p></p>")).toBe("only this");
+  });
+
+  it("renders <br> as a line break", () => {
+    expect(messageToText("a<br>b<br/>c")).toBe("a\nb\nc");
+  });
+
+  it("renders list items as dashes", () => {
+    expect(messageToText("<ul><li>one</li><li>two</li></ul>")).toBe("- one\n- two");
+  });
+
+  it("keeps a user mention as copy-pasteable shorthand with the id", () => {
+    const html =
+      '<span data-mention="" data-mention-type="user" data-user-id="u_123" data-username="Arjun Rao" class="chat-input-mention">@Arjun Rao</span> please look';
+    expect(messageToText(html)).toBe("@Arjun Rao[u_123] please look");
+  });
+
+  it("preserves the mentioned user id so self-mention detection still works", () => {
+    const html =
+      '<p><span data-mention="" data-mention-type="user" data-user-id="bot_9" data-username="Ask AI">@Ask AI</span> ping</p>';
+    expect(messageToText(html)).toContain("bot_9");
+  });
+
+  it("renders a group mention in group shorthand", () => {
+    const html =
+      '<span data-mention="" data-mention-type="group" data-group-id="g1" data-group-name="Oncall" data-group-alias="oncall">@oncall</span>';
+    expect(messageToText(html)).toBe("@oncall[group:g1:Oncall]");
+  });
+
+  it("renders @channel and @here specials", () => {
+    const html =
+      '<span data-mention="" data-mention-type="channel" class="chat-input-special-mention">@channel</span> heads up';
+    expect(messageToText(html)).toBe("@channel heads up");
+  });
+
+  it("substitutes custom emoji images with their alt text", () => {
+    expect(messageToText('nice <img src="x.png" alt=":shipit:"> work')).toBe("nice :shipit: work");
+  });
+
+  it("decodes named and numeric entities", () => {
+    expect(messageToText("<p>a &amp; b &lt;c&gt; &#8212; &#x2014; d&nbsp;e</p>")).toBe(
+      "a & b <c> — — d e",
+    );
+  });
+
+  it("strips script and style bodies rather than printing them", () => {
+    expect(messageToText("<p>hi</p><script>alert(1)</script><style>.a{color:red}</style>")).toBe("hi");
+  });
+
+  it("passes plain text through untouched", () => {
+    expect(messageToText("just a plain message")).toBe("just a plain message");
+  });
+
+  it("returns empty string for null, undefined and blank", () => {
+    expect(messageToText(null)).toBe("");
+    expect(messageToText(undefined)).toBe("");
+    expect(messageToText("   ")).toBe("");
+  });
+
+  it("collapses runaway blank lines", () => {
+    expect(messageToText("<p>a</p><p></p><p></p><p></p><p>b</p>")).toBe("a\nb");
+  });
+
+  it("never throws on malformed markup", () => {
+    expect(() => messageToText("<p>unclosed <span data-mention-type=\"user\"")).not.toThrow();
+  });
+
+  it("shrinks the string it is given rather than inflating context", () => {
+    const html = '<p class="m-0 leading-6">short</p>';
+    expect(messageToText(html).length).toBeLessThan(html.length);
+  });
+});
+
+describe("threadTitleFrom", () => {
+  const block = [
+    ":::initialMessage",
+    "messageId: m1",
+    "conversationId: c1",
+    "senderId: u1",
+    'content: <p class="m-0 leading-6">5xx spike on /txn/authorize</p>',
+    "msgType: USER",
+    "createdAt: 1786030327975",
+    ":::",
+  ].join("\n");
+
+  it("reads the content field instead of the block marker", () => {
+    expect(threadTitleFrom(block)).toBe("5xx spike on /txn/authorize");
+  });
+
+  it("does not title every thread ':::initialMessage'", () => {
+    expect(threadTitleFrom(block)).not.toContain("initialMessage");
+  });
+
+  it("stops at the next metadata key on a multi-line content value", () => {
+    const multi = [
+      ":::initialMessage",
+      "content: first line",
+      "second line of the same message",
+      "msgType: USER",
+      ":::",
+    ].join("\n");
+    expect(threadTitleFrom(multi)).toBe("first line");
+  });
+
+  it("falls back to plain text when there is no metadata block", () => {
+    expect(threadTitleFrom("just a title")).toBe("just a title");
+  });
+
+  it("truncates long titles with an ellipsis", () => {
+    const long = `content: ${"x".repeat(200)}`;
+    const title = threadTitleFrom(`:::initialMessage\n${long}\nmsgType: USER\n:::`);
+    expect(title).toHaveLength(80);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("reports untitled for empty, null and contentless blocks", () => {
+    expect(threadTitleFrom(null)).toBe("(untitled thread)");
+    expect(threadTitleFrom("")).toBe("(untitled thread)");
+    expect(threadTitleFrom(":::initialMessage\nmsgType: USER\n:::")).toBe("(untitled thread)");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/message-text.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/message-text.ts
@@ -1,0 +1,154 @@
+/**
+ * Spaces message HTML → readable plain text for the awakening window.
+ *
+ * Spaces stores what the rich-text editor produced, so a real message is
+ * `<p class="m-0 leading-6">hey</p>`, not `hey`. Handing that to the model
+ * wasted context on markup, and — worse — silently broke the signal
+ * extractors that read the text: `isQuestion` tests for a trailing `?`, which
+ * never matches when the string ends in `</p>`, so no real message was ever
+ * detected as a question.
+ *
+ * Written here rather than reusing Spaces' `extractPlainTextFromHtml`: that
+ * lives in another service and leans on `html-to-text`, which claw-auth does
+ * not declare as a dependency (it currently resolves only via workspace
+ * hoisting). This runs over every event of every window, must never throw on
+ * the critical path, and has to do something a generic converter would not —
+ * keep mention identity.
+ */
+
+/**
+ * Mentions become the SAME bracketed shorthand the send tool accepts
+ * (`@Name[userId]`, `@Alias[group:ID:Name]`), so the agent can copy a mention
+ * straight out of the window into a reply, and so the user id survives into
+ * the text instead of being flattened to a bare display name.
+ */
+const USER_MENTION_RE =
+  /<span[^>]*data-mention-type="user"[^>]*>.*?<\/span>/gi;
+const GROUP_MENTION_RE =
+  /<span[^>]*data-mention-type="group"[^>]*>.*?<\/span>/gi;
+const SPECIAL_MENTION_RE =
+  /<span[^>]*data-mention-type="(channel|here)"[^>]*>.*?<\/span>/gi;
+
+const ENTITIES: Record<string, string> = {
+  amp: "&", lt: "<", gt: ">", quot: '"', apos: "'", nbsp: " ",
+  hellip: "…", mdash: "—", ndash: "–", rsquo: "’", lsquo: "‘",
+  ldquo: "“", rdquo: "”", middot: "·", bull: "•",
+};
+
+function attr(tag: string, name: string): string {
+  const m = new RegExp(`${name}="([^"]*)"`, "i").exec(tag);
+  return m?.[1] ?? "";
+}
+
+function decodeEntities(input: string): string {
+  return input.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (whole, body: string) => {
+    if (body.startsWith("#")) {
+      const code = body[1] === "x" || body[1] === "X"
+        ? Number.parseInt(body.slice(2), 16)
+        : Number.parseInt(body.slice(1), 10);
+      return Number.isFinite(code) && code > 0 && code <= 0x10ffff
+        ? String.fromCodePoint(code)
+        : whole;
+    }
+    return ENTITIES[body.toLowerCase()] ?? whole;
+  });
+}
+
+/**
+ * Convert one message body to text.
+ *
+ * Never throws: anything unexpected falls back to a blunt tag strip, because a
+ * single malformed message must not be able to take down a window collection.
+ */
+export function messageToText(raw: string | null | undefined): string {
+  const input = (raw ?? "").trim();
+  if (!input) return "";
+  // Overwhelmingly common for bot posts and API-authored messages.
+  if (!input.includes("<") && !input.includes("&")) return input;
+
+  try {
+    let out = input
+      .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, " ")
+      .replace(/<!--[\s\S]*?-->/g, " ");
+
+    out = out
+      .replace(USER_MENTION_RE, (tag) => {
+        const name = attr(tag, "data-username");
+        const id = attr(tag, "data-user-id");
+        return name ? (id ? `@${name}[${id}]` : `@${name}`) : "@someone";
+      })
+      .replace(GROUP_MENTION_RE, (tag) => {
+        const alias = attr(tag, "data-group-alias") || attr(tag, "data-group-name");
+        const id = attr(tag, "data-group-id");
+        const name = attr(tag, "data-group-name");
+        return alias ? (id ? `@${alias}[group:${id}:${name}]` : `@${alias}`) : "@group";
+      })
+      .replace(SPECIAL_MENTION_RE, (tag) => `@${attr(tag, "data-mention-type")}`);
+
+    // Custom emoji render as <img alt=":shipit:">; the alt text is the emoji.
+    out = out.replace(/<img[^>]*>/gi, (tag) => attr(tag, "alt") || attr(tag, "title") || "");
+
+    out = out
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<li[^>]*>/gi, "\n- ")
+      .replace(/<\/(p|div|li|ul|ol|pre|blockquote|h[1-6]|tr|table)>/gi, "\n")
+      .replace(/<(p|div|ul|ol|pre|blockquote|h[1-6])[^>]*>/gi, "\n")
+      .replace(/<td[^>]*>/gi, " ")
+      .replace(/<[^>]+>/g, "");
+
+    return normalize(decodeEntities(out));
+  } catch {
+    return normalize(decodeEntities(input.replace(/<[^>]+>/g, " ")));
+  }
+}
+
+/**
+ * Blank lines are collapsed away entirely, not preserved as paragraph breaks:
+ * the window is a scanning artifact (one line per event in WINDOW.md, one JSON
+ * object per line in events.jsonl), so vertical whitespace costs context and
+ * buys nothing. Line structure inside a message is kept; empty runs are not.
+ */
+function normalize(text: string): string {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t\u00a0]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .replace(/\n{2,}/g, "\n")
+    .trim();
+}
+
+/**
+ * Thread title from a conversation's `initial_message_md`.
+ *
+ * That column is not markdown despite the name — it is a fenced metadata block
+ * (`:::initialMessage`, then `key: value` lines, then `:::`). Taking its first
+ * non-empty line, as this used to, titled EVERY real thread ":::initialMessage".
+ * The title is the `content:` value, which runs until the next `key:` line and
+ * is itself message HTML.
+ */
+export function threadTitleFrom(initialMessageMd: string | null | undefined, maxLength = 80): string {
+  const raw = (initialMessageMd ?? "").trim();
+  if (!raw) return "(untitled thread)";
+
+  const body = raw.includes(":::initialMessage") ? extractContentField(raw) : raw;
+  const text = messageToText(body).split("\n").find((line) => line.trim().length > 0) ?? "";
+  const cleaned = text.replace(/[#*_`>]/g, "").trim();
+  if (!cleaned) return "(untitled thread)";
+  return cleaned.length > maxLength ? `${cleaned.slice(0, maxLength - 1)}…` : cleaned;
+}
+
+function extractContentField(block: string): string {
+  const lines = block.split("\n");
+  const start = lines.findIndex((line) => /^content:/.test(line));
+  if (start < 0) return "";
+
+  const collected = [lines[start]!.replace(/^content:\s*/, "")];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    // The block's own keys terminate the value; anything else is a continuation
+    // of a multi-line message.
+    if (/^[a-zA-Z][a-zA-Z0-9]*:\s/.test(line) || line.trim() === ":::") break;
+    collected.push(line);
+  }
+  return collected.join("\n");
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/prior-runs-coverage.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/prior-runs-coverage.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { markCoverage, renderPriorRuns, type PriorRun } from "./prior-runs.js";
+import type { WindowEvent } from "./types.js";
+
+const T = 1_700_000_000_000;
+
+const prior = (over: Partial<PriorRun> = {}): PriorRun => ({
+  kind: "reflex",
+  windowStartMs: T,
+  windowEndMs: T + 300_000,
+  outcome: "ran",
+  eventCount: 3,
+  sessionId: "s1",
+  startedAt: new Date(T + 10_000),
+  completedAt: new Date(T + 290_000),
+  result: "acked the spike",
+  status: "completed",
+  covers: true,
+  ...over,
+});
+
+const ev = (atMs: number, over: Partial<WindowEvent> = {}): WindowEvent => ({
+  L: 0, kind: "message", at: new Date(atMs).toISOString(), atMs, id: `m${atMs}`,
+  ch: "ch_1", chName: "eng", cv: "cv_1", cvTitle: "t", sender: "Ann", senderId: "u_1",
+  isHuman: true, isMe: false, root: false, mentionsMe: false, unanswered: false,
+  covered: false, coveredBy: null, question: false, actionSignals: [], edited: false,
+  chars: 0, text: "", ...over,
+});
+
+describe("markCoverage", () => {
+  it("marks events inside a covering run's window", () => {
+    const events = [ev(T + 100_000), ev(T + 200_000)];
+    markCoverage(events, [prior()]);
+    expect(events.every((e) => e.covered)).toBe(true);
+    expect(events[0]!.coveredBy).toContain("reflex@");
+  });
+
+  it("leaves events AFTER the prior run uncovered", () => {
+    const events = [ev(T + 100_000), ev(T + 400_000)];
+    markCoverage(events, [prior()]);
+    expect(events[0]!.covered).toBe(true);
+    expect(events[1]!.covered).toBe(false);
+    expect(events[1]!.coveredBy).toBeNull();
+  });
+
+  it("leaves events BEFORE the prior run uncovered", () => {
+    const events = [ev(T - 60_000)];
+    markCoverage(events, [prior()]);
+    expect(events[0]!.covered).toBe(false);
+  });
+
+  it("treats the window as half-open — the exact start instant is not covered", () => {
+    const events = [ev(T), ev(T + 1)];
+    markCoverage(events, [prior()]);
+    expect(events[0]!.covered).toBe(false);
+    expect(events[1]!.covered).toBe(true);
+  });
+
+  /**
+   * The rule that is easiest to get backwards: a run that did not act covers
+   * nothing. Marking its events handled is how work silently disappears.
+   */
+  it("a FAILED prior run covers nothing", () => {
+    const events = [ev(T + 100_000)];
+    markCoverage(events, [prior({ covers: false, outcome: "failed", status: "failed" })]);
+    expect(events[0]!.covered).toBe(false);
+  });
+
+  it("a SHADOW run covers nothing — nobody saw its output", () => {
+    const events = [ev(T + 100_000)];
+    markCoverage(events, [prior({ covers: false, outcome: "shadow" })]);
+    expect(events[0]!.covered).toBe(false);
+  });
+
+  it("a SKIPPED run covers nothing", () => {
+    const events = [ev(T + 100_000)];
+    markCoverage(events, [prior({ covers: false, outcome: "skipped" })]);
+    expect(events[0]!.covered).toBe(false);
+  });
+
+  it("an in-flight run DOES cover, so the heartbeat does not race it", () => {
+    const events = [ev(T + 100_000)];
+    markCoverage(events, [prior({ completedAt: null, status: "running", covers: true })]);
+    expect(events[0]!.covered).toBe(true);
+  });
+
+  it("with several priors, the first covering one wins", () => {
+    const events = [ev(T + 100_000)];
+    markCoverage(events, [
+      prior({ covers: false, outcome: "failed" }),
+      prior({ kind: "reflex", startedAt: new Date(T + 20_000) }),
+    ]);
+    expect(events[0]!.covered).toBe(true);
+  });
+
+  it("no priors leaves everything uncovered", () => {
+    const events = [ev(T + 100_000)];
+    markCoverage(events, []);
+    expect(events[0]!.covered).toBe(false);
+  });
+
+  it("re-marking is idempotent — a re-render cannot flip a verdict", () => {
+    const events = [ev(T + 400_000, { covered: true, coveredBy: "stale" })];
+    markCoverage(events, [prior()]);
+    expect(events[0]!.covered).toBe(false);
+    expect(events[0]!.coveredBy).toBeNull();
+  });
+});
+
+describe("renderPriorRuns", () => {
+  it("says plainly when nothing ran before", () => {
+    expect(renderPriorRuns([])).toContain("Everything in this window is new to you");
+  });
+
+  it("includes what a covering run actually said", () => {
+    expect(renderPriorRuns([prior()])).toContain("acked the spike");
+  });
+
+  it("flags a failed run as unhandled", () => {
+    const md = renderPriorRuns([prior({ covers: false, outcome: "failed" })]);
+    expect(md).toContain("Treat its events as unhandled");
+  });
+
+  it("explains that a shadow run posted nothing", () => {
+    const md = renderPriorRuns([prior({ covers: false, outcome: "shadow" })]);
+    expect(md).toContain("posted nothing");
+  });
+
+  it("marks an in-flight run and tells the agent to keep clear", () => {
+    const md = renderPriorRuns([prior({ completedAt: null, result: null })]);
+    expect(md).toContain("IN FLIGHT");
+    expect(md).toContain("Leave the threads it is working on alone");
+  });
+
+  it("truncates a very long prior result rather than flooding the artifact", () => {
+    const md = renderPriorRuns([prior({ result: "x".repeat(10_000) })]);
+    expect(md.length).toBeLessThan(6_000);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/prior-runs.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/prior-runs.ts
@@ -1,0 +1,163 @@
+/**
+ * Requirement 7: a heartbeat must see what the reflexes already did.
+ *
+ * Without this the heartbeat re-derives a period the reflexes have already
+ * acted on and answers questions that were answered twenty minutes ago —
+ * which reads, in the channel, as an agent that is not paying attention.
+ *
+ * Two details that are easy to get backwards and both matter:
+ *
+ *  1. OVERLAP, not containment. A reflex that started BEFORE the heartbeat's
+ *     window and ran into it still consumed events the heartbeat is about to
+ *     see. Selecting by containment (`startedAt` inside the window) silently
+ *     misses exactly the runs most likely to have already handled something.
+ *
+ *  2. A FAILED reflex covers NOTHING. It woke, it read the events, and it
+ *     produced no action — so the heartbeat must treat those events as
+ *     untouched. Marking them covered because a run existed is how work
+ *     silently disappears.
+ */
+
+import { prisma } from "../db.js";
+import type { WindowEvent } from "./types.js";
+
+export interface PriorRun {
+  kind: string;
+  windowStartMs: number;
+  windowEndMs: number;
+  outcome: string;
+  eventCount: number;
+  sessionId: string | null;
+  startedAt: Date;
+  completedAt: Date | null;
+  /** The reflex's own answer, when it finished and produced one. */
+  result: string | null;
+  status: string | null;
+  /** True when this run's events should be considered handled. */
+  covers: boolean;
+}
+
+/** True when a prior run actually did something the heartbeat should not redo. */
+function coversItsEvents(outcome: string, runStatus: string | null): boolean {
+  // "shadow" runs reason but never post, so they cover nothing a human saw.
+  if (outcome !== "ran") return false;
+  // Still running counts as covering: the heartbeat must not race it.
+  return runStatus === null || runStatus === "running" || runStatus === "completed";
+}
+
+/**
+ * Load the awakened runs whose window OVERLAPS [startMs, endMs), newest last.
+ * `excludeIdempotencyKey` drops the heartbeat's own in-progress row.
+ */
+export async function loadOverlappingRuns(
+  agentId: string,
+  startMs: number,
+  endMs: number,
+  excludeIdempotencyKey?: string,
+): Promise<PriorRun[]> {
+  const rows = await prisma.agentAwakeningRun.findMany({
+    where: {
+      agentId,
+      windowStartMs: { lt: BigInt(endMs) },
+      windowEndMs: { gt: BigInt(startMs) },
+      ...(excludeIdempotencyKey ? { idempotencyKey: { not: excludeIdempotencyKey } } : {}),
+    },
+    orderBy: { startedAt: "asc" },
+    take: 50,
+  });
+  if (rows.length === 0) return [];
+
+  const sessionIds = rows.map((r) => r.sessionId).filter((s): s is string => !!s);
+  const runs = sessionIds.length
+    ? await prisma.agentRun.findMany({
+        where: { sessionId: { in: sessionIds } },
+        select: { sessionId: true, status: true, result: true },
+      })
+    : [];
+  const bySession = new Map(runs.map((r) => [r.sessionId, r]));
+
+  return rows.map((r) => {
+    const run = r.sessionId ? bySession.get(r.sessionId) : undefined;
+    const status = run?.status ?? null;
+    return {
+      kind: r.kind,
+      windowStartMs: Number(r.windowStartMs),
+      windowEndMs: Number(r.windowEndMs),
+      outcome: r.outcome,
+      eventCount: r.eventCount,
+      sessionId: r.sessionId,
+      startedAt: r.startedAt,
+      completedAt: r.completedAt,
+      result: run?.result ?? null,
+      status,
+      covers: coversItsEvents(r.outcome, status),
+    };
+  });
+}
+
+/**
+ * Stamp each event with whether a prior run already handled it.
+ *
+ * An event is covered when it falls inside the window of a run that actually
+ * acted. Written onto the event so `grep '"covered":false'` answers "what is
+ * genuinely new since the last reflex" in one command.
+ */
+export function markCoverage(events: WindowEvent[], priors: PriorRun[]): void {
+  const covering = priors.filter((p) => p.covers);
+  for (const e of events) {
+    const by = covering.find((p) => e.atMs > p.windowStartMs && e.atMs <= p.windowEndMs);
+    e.covered = Boolean(by);
+    e.coveredBy = by ? `${by.kind}@${new Date(by.startedAt).toISOString().slice(11, 19)}` : null;
+  }
+}
+
+/** The `prior-sessions.md` artifact: what already ran, and what it said. */
+export function renderPriorRuns(priors: PriorRun[]): string {
+  if (priors.length === 0) {
+    return [
+      "# Prior awakened runs in this window",
+      "",
+      "None. Everything in this window is new to you.",
+      "",
+    ].join("\n");
+  }
+
+  const lines = [
+    "# Prior awakened runs in this window",
+    "",
+    "These runs already saw part of this window. Do not redo what they did.",
+    "",
+    "| # | kind | window | outcome | events | covers |",
+    "|---|---|---|---|---:|---|",
+  ];
+
+  priors.forEach((p, i) => {
+    const from = new Date(p.windowStartMs).toISOString().slice(11, 19);
+    const to = new Date(p.windowEndMs).toISOString().slice(11, 19);
+    const state = p.completedAt ? p.outcome : `${p.outcome} (IN FLIGHT)`;
+    lines.push(`| ${i + 1} | ${p.kind} | ${from}–${to} | ${state} | ${p.eventCount} | ${p.covers ? "yes" : "no"} |`);
+  });
+
+  lines.push("");
+  priors.forEach((p, i) => {
+    lines.push(`## ${i + 1}. ${p.kind} — ${new Date(p.startedAt).toISOString()}`);
+    if (!p.covers) {
+      lines.push(
+        "",
+        p.outcome === "shadow"
+          ? "_Shadow run: it reasoned but posted nothing, so nobody has seen this. Treat its events as unhandled._"
+          : "_This run did not complete successfully. Treat its events as unhandled._",
+      );
+    }
+    if (p.result) {
+      lines.push("", "What it said:", "", "```", p.result.slice(0, 4000), "```");
+    } else if (p.completedAt) {
+      lines.push("", "_It produced no visible output._");
+    } else {
+      lines.push("", "_Still running. Leave the threads it is working on alone._");
+    }
+    lines.push("");
+  });
+
+  return lines.join("\n");
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/rate-limit.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/rate-limit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const store = new Map<string, string>();
+const redisMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  incr: vi.fn(),
+  expire: vi.fn(),
+}));
+vi.mock("../redis.js", () => ({ redisService: { getConnection: () => redisMock } }));
+
+const { peekRunRate, consumeRunRate } = await import("./rate-limit.js");
+
+beforeEach(() => {
+  store.clear();
+  redisMock.get.mockReset().mockImplementation(async (k: string) => store.get(k) ?? null);
+  redisMock.incr.mockReset().mockImplementation(async (k: string) => {
+    const next = Number(store.get(k) ?? 0) + 1;
+    store.set(k, String(next));
+    return next;
+  });
+  redisMock.expire.mockReset().mockResolvedValue(1);
+});
+
+describe("peekRunRate", () => {
+  it("allows when under the cap and does NOT consume budget", async () => {
+    expect(await peekRunRate("a1", 4)).toEqual({ allowed: true, used: 0 });
+    expect(await peekRunRate("a1", 4)).toEqual({ allowed: true, used: 0 });
+    expect(redisMock.incr).not.toHaveBeenCalled();
+  });
+
+  it("blocks once the cap is reached", async () => {
+    for (let i = 0; i < 4; i++) await consumeRunRate("a2");
+    expect(await peekRunRate("a2", 4)).toEqual({ allowed: false, used: 4 });
+  });
+
+  it("fails open when Redis is down — an outage must not silence every agent", async () => {
+    redisMock.get.mockRejectedValue(new Error("connection refused"));
+    expect(await peekRunRate("a3", 1)).toEqual({ allowed: true, used: 0 });
+  });
+
+  it("treats a corrupt counter as zero rather than blocking forever", async () => {
+    redisMock.get.mockResolvedValue("not-a-number");
+    expect(await peekRunRate("a4", 4)).toEqual({ allowed: true, used: 0 });
+  });
+});
+
+describe("consumeRunRate", () => {
+  it("increments and sets a TTL on the first use of an hour bucket", async () => {
+    await consumeRunRate("b1");
+    expect(redisMock.incr).toHaveBeenCalledTimes(1);
+    expect(redisMock.expire).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-set the TTL on later increments", async () => {
+    await consumeRunRate("b2");
+    await consumeRunRate("b2");
+    await consumeRunRate("b2");
+    expect(redisMock.incr).toHaveBeenCalledTimes(3);
+    expect(redisMock.expire).toHaveBeenCalledTimes(1);
+  });
+
+  it("never throws when Redis is down", async () => {
+    redisMock.incr.mockRejectedValue(new Error("down"));
+    await expect(consumeRunRate("b3")).resolves.toBeUndefined();
+  });
+
+  it("only the agent that ran spends its own budget", async () => {
+    await consumeRunRate("b4");
+    await consumeRunRate("b4");
+    expect(await peekRunRate("b4", 3)).toEqual({ allowed: true, used: 2 });
+    expect(await peekRunRate("b5", 3)).toEqual({ allowed: true, used: 0 });
+  });
+});
+
+/**
+ * The behaviour this split exists to guarantee: skipped and failed windows are
+ * free. An agent that skips its quiet hours must still be able to run when
+ * something finally happens.
+ */
+describe("skips and failures are free", () => {
+  it("lets an agent run after many skipped windows", async () => {
+    for (let i = 0; i < 50; i++) expect((await peekRunRate("c1", 4)).allowed).toBe(true);
+    expect((await peekRunRate("c1", 4)).allowed).toBe(true);
+  });
+
+  it("lets a failing agent keep retrying", async () => {
+    for (let i = 0; i < 10; i++) expect((await peekRunRate("c2", 2)).allowed).toBe(true);
+    await consumeRunRate("c2");
+    await consumeRunRate("c2");
+    expect((await peekRunRate("c2", 2)).allowed).toBe(false);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/rate-limit.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/rate-limit.ts
@@ -1,0 +1,64 @@
+/**
+ * Per-agent run rate cap — the backstop that bounds cost when everything else
+ * goes wrong (a misconfigured period, an event flood, a loop).
+ *
+ * Split into PEEK and CONSUME deliberately. The cap must bound runs that
+ * actually happened, not wake attempts: a window that the triage gate skips
+ * costs nothing, and a window that fails to dispatch delivered nothing. If
+ * either burned budget, an agent in a quiet hour would rate-limit itself out
+ * of the one window that mattered, and a failing agent could never retry.
+ *
+ * A fixed-window counter, not a sliding one: an awakened agent runs
+ * single-digit times per hour, so boundary imprecision is irrelevant and it
+ * costs one INCR instead of a sorted-set scan.
+ *
+ * FAIL-OPEN: if Redis is unreachable the wake proceeds. The tick loop already
+ * bounds how often a wake can be attempted, so a Redis outage must not also
+ * silence every agent.
+ */
+
+import { redisService } from "../redis.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-rate");
+
+/** Two hours, so the previous bucket survives long enough to be diagnosed. */
+const BUCKET_TTL_SECONDS = 7_200;
+
+function bucketKey(agentId: string, nowMs: number = Date.now()): string {
+  return `claw:awk:rate:${agentId}:${Math.floor(nowMs / 3_600_000)}`;
+}
+
+export interface RateDecision {
+  allowed: boolean;
+  used: number;
+}
+
+/** Read the current hour's run count WITHOUT consuming budget. */
+export async function peekRunRate(agentId: string, maxPerHour: number): Promise<RateDecision> {
+  try {
+    const raw = await redisService.getConnection().get(bucketKey(agentId));
+    const used = raw ? Number(raw) : 0;
+    if (!Number.isFinite(used)) return { allowed: true, used: 0 };
+    if (used >= maxPerHour) {
+      log.warn(`[awakening] rate cap reached agent=${agentId} used=${used} max=${maxPerHour}`);
+      return { allowed: false, used };
+    }
+    return { allowed: true, used };
+  } catch (err) {
+    log.warn(`[awakening] rate peek failed (allowing) agent=${agentId}: ${err instanceof Error ? err.message : err}`);
+    return { allowed: true, used: 0 };
+  }
+}
+
+/** Record that a run was actually dispatched. Best-effort; never throws. */
+export async function consumeRunRate(agentId: string): Promise<void> {
+  try {
+    const redis = redisService.getConnection();
+    const key = bucketKey(agentId);
+    const used = await redis.incr(key);
+    if (used === 1) await redis.expire(key, BUCKET_TTL_SECONDS);
+  } catch (err) {
+    log.warn(`[awakening] rate consume failed agent=${agentId}: ${err instanceof Error ? err.message : err}`);
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/reflex.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/reflex.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { decideReflex, renderInjection, type ReflexContext } from "./reflex.js";
+import { AWAKENING_DEFAULTS, type AwakeningConfig } from "./config.js";
+
+const cfg = (over: Partial<AwakeningConfig["reflex"]> = {}): AwakeningConfig => ({
+  ...AWAKENING_DEFAULTS,
+  reflex: { ...AWAKENING_DEFAULTS.reflex, ...over },
+});
+
+const ctx = (over: Partial<ReflexContext> = {}): ReflexContext => ({
+  count: 0,
+  config: cfg(),
+  busyWithSessionId: null,
+  sinceLastRunMs: Number.POSITIVE_INFINITY,
+  injectionsUsed: 0,
+  sinceLastInjectionMs: Number.POSITIVE_INFINITY,
+  ...over,
+});
+
+describe("idle agent — deciding whether to fire", () => {
+  it("waits below the threshold", () => {
+    expect(decideReflex(ctx({ count: 24, config: cfg({ threshold: 25 }) }))).toEqual({ action: "wait", count: 24 });
+  });
+
+  it("fires exactly at the threshold", () => {
+    expect(decideReflex(ctx({ count: 25, config: cfg({ threshold: 25 }) }))).toEqual({ action: "fire", count: 25 });
+  });
+
+  it("fires above the threshold", () => {
+    expect(decideReflex(ctx({ count: 500, config: cfg({ threshold: 25 }) })).action).toBe("fire");
+  });
+
+  it("holds when the minimum gap between reflex runs has not elapsed", () => {
+    const d = decideReflex(
+      ctx({ count: 100, config: cfg({ threshold: 25, minIntervalMs: 300_000 }), sinceLastRunMs: 60_000 }),
+    );
+    expect(d).toEqual({ action: "hold", count: 100, reason: "min_interval" });
+  });
+
+  it("fires once the minimum gap has elapsed", () => {
+    const d = decideReflex(
+      ctx({ count: 100, config: cfg({ threshold: 25, minIntervalMs: 300_000 }), sinceLastRunMs: 300_000 }),
+    );
+    expect(d.action).toBe("fire");
+  });
+
+  it("never waits on a zero threshold floor — count 0 still waits", () => {
+    expect(decideReflex(ctx({ count: 0, config: cfg({ threshold: 1 }) })).action).toBe("wait");
+  });
+});
+
+/**
+ * The single most important property in this file: while a run is in flight,
+ * NOTHING may start a second one. Two concurrent awakened runs on one agent
+ * read overlapping windows and both post.
+ */
+describe("busy agent — never starts a second run", () => {
+  const busy = { busyWithSessionId: "sess_1" };
+
+  it("injects instead of firing when the injection threshold is met", () => {
+    const d = decideReflex(ctx({ ...busy, count: 10, config: cfg({ threshold: 25, injectThreshold: 10 }) }));
+    expect(d).toEqual({ action: "inject", count: 10, sessionId: "sess_1" });
+  });
+
+  it("does not fire even when the RUN threshold is massively exceeded", () => {
+    const d = decideReflex(ctx({ ...busy, count: 10_000, config: cfg({ threshold: 25 }) }));
+    expect(d.action).not.toBe("fire");
+    expect(d.action).toBe("inject");
+  });
+
+  it("waits below the injection threshold", () => {
+    expect(decideReflex(ctx({ ...busy, count: 3, config: cfg({ injectThreshold: 10 }) })).action).toBe("wait");
+  });
+
+  it("holds once the per-session injection cap is reached", () => {
+    const d = decideReflex(
+      ctx({ ...busy, count: 100, config: cfg({ injectThreshold: 10, maxInjectionsPerSession: 3 }), injectionsUsed: 3 }),
+    );
+    expect(d).toEqual({ action: "hold", count: 100, reason: "injection_cap_reached" });
+  });
+
+  it("holds inside the minimum gap between injections", () => {
+    const d = decideReflex(
+      ctx({
+        ...busy,
+        count: 100,
+        config: cfg({ injectThreshold: 10, injectMinIntervalMs: 60_000 }),
+        sinceLastInjectionMs: 10_000,
+      }),
+    );
+    expect(d).toEqual({ action: "hold", count: 100, reason: "injection_min_interval" });
+  });
+
+  it("holds when injection is switched off entirely", () => {
+    const d = decideReflex(ctx({ ...busy, count: 100, config: cfg({ injectEnabled: false }) }));
+    expect(d).toEqual({ action: "hold", count: 100, reason: "injection_disabled" });
+  });
+
+  it("a cap of 0 disables injection from the very first batch", () => {
+    const d = decideReflex(
+      ctx({ ...busy, count: 100, config: cfg({ injectThreshold: 1, maxInjectionsPerSession: 0 }) }),
+    );
+    expect(d).toEqual({ action: "hold", count: 100, reason: "injection_cap_reached" });
+  });
+
+  it("injects again once the gap has passed and budget remains", () => {
+    const d = decideReflex(
+      ctx({
+        ...busy,
+        count: 50,
+        config: cfg({ injectThreshold: 10, maxInjectionsPerSession: 3, injectMinIntervalMs: 60_000 }),
+        injectionsUsed: 1,
+        sinceLastInjectionMs: 90_000,
+      }),
+    );
+    expect(d.action).toBe("inject");
+  });
+});
+
+describe("renderInjection", () => {
+  it("numbers the update and states the remaining budget", () => {
+    const text = renderInjection(1, 12, 2, ["- thread A: 5 msgs"]);
+    expect(text).toContain("[Live update 1 — 12 new event(s) arrived while you were working]");
+    expect(text).toContain("up to 2 more live update(s)");
+    expect(text).toContain("- thread A: 5 msgs");
+  });
+
+  it("says plainly when it is the final update, so the agent stops waiting for more", () => {
+    const text = renderInjection(3, 4, 0, []);
+    expect(text).toContain("LAST live update");
+    expect(text).not.toContain("more live update(s) in this run");
+  });
+
+  it("tells the agent it need not acknowledge the update", () => {
+    expect(renderInjection(1, 1, 1, [])).toContain("do not need to acknowledge");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/reflex.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/reflex.ts
@@ -1,0 +1,174 @@
+/**
+ * The reflex check: has enough happened to be worth reacting to RIGHT NOW?
+ *
+ * Runs far more often than a heartbeat but costs far less. It does not collect
+ * a window — it asks Spaces for a COUNT of events since the reflex watermark
+ * and compares that to a threshold. A `count` operation returns a scalar, so
+ * the check is one cheap query however busy the channels are, and the
+ * expensive collect only happens once the threshold is actually crossed.
+ *
+ * Three outcomes:
+ *   below threshold  → do nothing, check again next interval
+ *   threshold + free → dispatch a reflex run
+ *   threshold + busy → the agent is already awake; route the new events to the
+ *                      running session's inbox instead of starting a second
+ *                      run (requirement 6 — the agent adapts mid-task)
+ */
+
+import { boundedInteract } from "./spaces-read.js";
+import type { AgentSpacesIdentity, ResolvedChannel } from "./types.js";
+import type { AwakeningConfig } from "./config.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-reflex");
+
+/** Conversation prefilter cap for the count path. */
+const COUNT_THREAD_CAP = 500;
+
+/**
+ * Count events in the watched channels since `sinceMs`.
+ *
+ * Two stages, like the collector, because Message has no channelId: find the
+ * threads a watched channel touched, then count their messages in the window.
+ * Messages from the agent itself are NOT excluded here — that is done by the
+ * collector when the window is actually built. This count is a trigger signal,
+ * not a decision; over-counting slightly costs one extra cheap check, while the
+ * loop guard that really matters lives in the gate.
+ */
+export async function countEventsSince(
+  channels: ResolvedChannel[],
+  sinceMs: number,
+  untilMs: number,
+  identity: AgentSpacesIdentity,
+): Promise<number> {
+  if (channels.length === 0) return 0;
+  const auth = { token: identity.appToken, workspaceId: identity.workspaceId };
+
+  const conversations = await boundedInteract<Array<{ conversationId: string }>>(
+    {
+      model: "conversation",
+      operation: "findMany",
+      where: {
+        channelId: { in: channels.map((c) => c.id) },
+        lastActivityAt: { gte: new Date(sinceMs).toISOString() },
+      },
+      orderBy: [{ lastActivityAt: "desc" }],
+      take: COUNT_THREAD_CAP,
+    },
+    auth,
+  );
+  if (conversations.length === 0) return 0;
+
+  const count = await boundedInteract<number>(
+    {
+      model: "message",
+      operation: "count",
+      where: {
+        conversationId: { in: conversations.map((c) => c.conversationId) },
+        createdAt: { gt: new Date(sinceMs).toISOString(), lte: new Date(untilMs).toISOString() },
+        isDeleted: { equals: false },
+        // Exclude the agent's own posts from the TRIGGER count. Without this an
+        // agent that replies to N threads re-triggers itself on its own output,
+        // which is the classic way this feature becomes an infinite loop.
+        senderId: { not: identity.spacesAppUserId },
+      },
+      take: 1,
+    },
+    auth,
+  );
+
+  return typeof count === "number" ? count : 0;
+}
+
+export type ReflexDecision =
+  | { action: "wait"; count: number }
+  | { action: "fire"; count: number }
+  | { action: "inject"; count: number; sessionId: string }
+  | { action: "hold"; count: number; reason: string };
+
+export interface ReflexContext {
+  count: number;
+  config: AwakeningConfig;
+  /** sessionId of a run already in flight for this agent, if any. */
+  busyWithSessionId: string | null;
+  /** ms since the last reflex dispatch; Infinity when there has never been one. */
+  sinceLastRunMs: number;
+  /** Injections already delivered to the in-flight session. */
+  injectionsUsed: number;
+  /** ms since the last injection into that session; Infinity when none. */
+  sinceLastInjectionMs: number;
+}
+
+/**
+ * Pure decision function — no I/O, so every branch is table-testable.
+ */
+export function decideReflex(ctx: ReflexContext): ReflexDecision {
+  const { count, config, busyWithSessionId } = ctx;
+  const { threshold, minIntervalMs, injectEnabled, injectThreshold, maxInjectionsPerSession, injectMinIntervalMs } =
+    config.reflex;
+
+  if (busyWithSessionId) {
+    // The agent is already awake. Never start a second run — feed this one.
+    if (!injectEnabled) return { action: "hold", count, reason: "injection_disabled" };
+    if (count < injectThreshold) return { action: "wait", count };
+    if (ctx.injectionsUsed >= maxInjectionsPerSession) {
+      return { action: "hold", count, reason: "injection_cap_reached" };
+    }
+    if (ctx.sinceLastInjectionMs < injectMinIntervalMs) {
+      return { action: "hold", count, reason: "injection_min_interval" };
+    }
+    return { action: "inject", count, sessionId: busyWithSessionId };
+  }
+
+  if (count < threshold) return { action: "wait", count };
+  if (ctx.sinceLastRunMs < minIntervalMs) return { action: "hold", count, reason: "min_interval" };
+  return { action: "fire", count };
+}
+
+/** Render an injection batch for the model. */
+export function renderInjection(
+  ordinal: number,
+  eventCount: number,
+  remaining: number,
+  outline: string[],
+): string {
+  const lines = [
+    `[Live update ${ordinal} — ${eventCount} new event(s) arrived while you were working]`,
+    "",
+    ...outline,
+    "",
+  ];
+
+  if (remaining <= 0) {
+    lines.push(
+      "This is the LAST live update you will get for this run. Anything that arrives after it",
+      "will be handled by a later wake, so finish on what you have rather than waiting for more.",
+    );
+  } else {
+    lines.push(`You may receive up to ${remaining} more live update(s) in this run.`);
+  }
+
+  lines.push(
+    "",
+    "Adapt if this changes what you were about to do. If it does not, carry on —",
+    "you do not need to acknowledge this update.",
+  );
+  return lines.join("\n");
+}
+
+export function logDecision(agentSlug: string, decision: ReflexDecision, busy = false): void {
+  // A "wait" while the agent is BUSY is the live-injection path accumulating,
+  // and it is the state operators most often need to see when asking "why did
+  // my mid-run events not arrive?". A "wait" while idle is the steady state and
+  // stays silent — it happens every check interval, for every agent.
+  if (decision.action === "wait") {
+    if (busy) {
+      log.info(`[awakening] reflex agent=${agentSlug} action=wait events=${decision.count} (run in flight — below injectThreshold)`);
+    }
+    return;
+  }
+  log.info(
+    `[awakening] reflex agent=${agentSlug} action=${decision.action} events=${decision.count}` +
+      ("reason" in decision ? ` reason=${decision.reason}` : ""),
+  );
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/render.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/render.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest";
+import { renderWindow, renderEventsJsonl, renderWindowMarkdown, assignLineNumbers, EVENTS_PATH } from "./render.js";
+import { computeSignals } from "./signals.js";
+import { AWAKENING_DEFAULTS } from "./config.js";
+import type { AwakeningWindow, WindowEvent } from "./types.js";
+
+function ev(over: Partial<WindowEvent> = {}): WindowEvent {
+  const atMs = over.atMs ?? 1_700_000_000_000;
+  return {
+    L: 0,
+    kind: "message",
+    at: new Date(atMs).toISOString(),
+    atMs,
+    id: "msg_1",
+    ch: "ch_1",
+    chName: "eng-payments",
+    cv: "cv_1",
+    cvTitle: "5xx spike",
+    sender: "Priya Nair",
+    senderId: "u_1",
+    isHuman: true,
+    isMe: false,
+    root: false,
+    mentionsMe: false,
+    unanswered: false,
+    covered: false,
+    coveredBy: null,
+    question: false,
+    actionSignals: [],
+    edited: false,
+    chars: 5,
+    text: "hello",
+    ...over,
+  };
+}
+
+function win(events: WindowEvent[], over: Partial<AwakeningWindow> = {}): AwakeningWindow {
+  return {
+    agentId: "ag_1",
+    agentSlug: "ops-sentinel",
+    orgId: "org_1",
+    kind: "heartbeat",
+    startMs: 1_700_000_000_000,
+    endMs: 1_700_000_600_000,
+    channels: [{ id: "ch_1", name: "eng-payments", lastActivityAt: 0 }],
+    silentChannels: [{ id: "ch_2", name: "ops-quiet", lastActivityAt: 0 }],
+    events,
+    signals: computeSignals(events),
+    truncated: false,
+    gap: null,
+    priorRuns: [],
+    config: AWAKENING_DEFAULTS,
+    ...over,
+  };
+}
+
+/**
+ * events.jsonl grep-ability is a FORMAT CONTRACT. WINDOW.md and the heartbeat
+ * skill both print recipes like `grep '"unanswered":true'`; a key rename or a
+ * quoted boolean silently breaks every one of them.
+ */
+describe("renderEventsJsonl — the grep contract", () => {
+  it("emits unquoted booleans that the advertised recipes match exactly", () => {
+    const line = renderEventsJsonl([ev({ unanswered: true, mentionsMe: true, isMe: false, question: true })]);
+    expect(line).toContain('"unanswered":true');
+    expect(line).toContain('"mentionsMe":true');
+    expect(line).toContain('"isMe":false');
+    expect(line).toContain('"question":true');
+  });
+
+  it("keeps a stable key order with text last", () => {
+    const keys = Object.keys(JSON.parse(renderEventsJsonl([ev()])));
+    expect(keys[0]).toBe("L");
+    expect(keys.at(-1)).toBe("text");
+    expect(keys).toEqual([
+      "L", "kind", "at", "id", "ch", "chName", "cv", "cvTitle", "sender", "senderId",
+      "isHuman", "isMe", "root", "mentionsMe", "unanswered", "covered", "coveredBy",
+      "question", "actionSignals", "edited", "chars", "text",
+    ]);
+  });
+
+  it("assigns 1-based sequential line numbers", () => {
+    const events = assignLineNumbers([ev({ id: "a" }), ev({ id: "b" }), ev({ id: "c" })]);
+    const lines = renderEventsJsonl(events).split("\n");
+    expect(lines).toHaveLength(3);
+    expect(events.map((e) => e.L)).toEqual([1, 2, 3]);
+    expect(JSON.parse(lines[0]!).L).toBe(1);
+  });
+
+  it("writes one line per event with no pretty-printing", () => {
+    const out = renderEventsJsonl([ev({ text: "line one\nline two" }), ev()]);
+    expect(out.split("\n")).toHaveLength(2);
+  });
+
+  it("renders an empty window as an empty string", () => {
+    expect(renderEventsJsonl([])).toBe("");
+  });
+
+  it("matches the escalation recipe printed in WINDOW.md", () => {
+    const line = renderEventsJsonl([ev({ actionSignals: ["escalation", "urgent"] })]);
+    expect(line).toContain('"actionSignals":["escalation');
+  });
+});
+
+describe("renderWindow", () => {
+  it("produces the three artifact files and points at WINDOW.md", () => {
+    const out = renderWindow(win([ev()]));
+    expect(out.files.map((f) => f.path)).toEqual([
+      "heartbeat/events.jsonl",
+      "heartbeat/WINDOW.md",
+      "heartbeat/CURSOR.json",
+    ]);
+    expect(out.entryPath).toBe(".context/heartbeat/WINDOW.md");
+  });
+
+  it("keeps outline anchors and jsonl line numbers in agreement", () => {
+    const events = [ev({ id: "a" }), ev({ id: "b", atMs: 1_700_000_100_000 })];
+    const out = renderWindow(win(events));
+    const md = out.files.find((f) => f.path.endsWith("WINDOW.md"))!.content;
+    // The outline cites L1–L2; the jsonl must actually have those line numbers.
+    expect(md).toContain("L1–L2");
+    expect(out.files[0]!.content.split("\n")).toHaveLength(2);
+  });
+
+  it("emits valid JSON in CURSOR.json", () => {
+    const out = renderWindow(win([ev()]));
+    const cursor = JSON.parse(out.files.find((f) => f.path.endsWith("CURSOR.json"))!.content);
+    expect(cursor.agentSlug).toBe("ops-sentinel");
+    expect(cursor.signals.eventCount).toBe(1);
+  });
+});
+
+describe("renderWindowMarkdown", () => {
+  it("surfaces truncation loudly — a silent cut reads as a quiet window", () => {
+    const md = renderWindowMarkdown(win([ev()], { truncated: true }));
+    expect(md).toContain("truncated: true");
+    expect(md).toMatch(/This window was truncated/);
+  });
+
+  it("surfaces a gap so the agent knows it missed events", () => {
+    const md = renderWindowMarkdown(win([ev()], { gap: { skippedMs: 7_200_000 } }));
+    expect(md).toContain("120m skipped");
+    expect(md).toMatch(/\*\*Gap:\*\* 120 minutes/);
+  });
+
+  it("states the write policy and shadow flag the run is bound by", () => {
+    const md = renderWindowMarkdown(
+      win([ev()], { config: { ...AWAKENING_DEFAULTS, writePolicy: "observe", shadow: true } }),
+    );
+    expect(md).toContain("writePolicy: observe");
+    expect(md).toContain("shadow: true");
+  });
+
+  it("lists watched-but-silent channels as useful negative space", () => {
+    expect(renderWindowMarkdown(win([ev()]))).toContain("ops-quiet");
+  });
+
+  it("tags mentions, unanswered and action signals in the outline", () => {
+    const md = renderWindowMarkdown(
+      win([ev({ mentionsMe: true, unanswered: true, actionSignals: ["urgent"] })]),
+    );
+    expect(md).toContain("MENTION");
+    expect(md).toContain("UNANSWERED");
+    expect(md).toContain("urgent");
+  });
+
+  it("marks the agent's own messages so it never answers itself", () => {
+    expect(renderWindowMarkdown(win([ev({ isMe: true, isHuman: false })]))).toContain("[you]");
+  });
+
+  it("tells the agent it has no bash", () => {
+    expect(renderWindowMarkdown(win([ev()]))).toMatch(/do \*\*not\*\* have bash/);
+  });
+
+  it("advertises grep recipes against the real events path", () => {
+    const md = renderWindowMarkdown(win([ev()]));
+    expect(md).toContain(`.context/${EVENTS_PATH}`);
+    expect(md).toContain(`grep '"unanswered":true'`);
+  });
+
+  it("renders an empty window without throwing", () => {
+    expect(() => renderWindowMarkdown(win([]))).not.toThrow();
+  });
+});
+
+describe("thread line anchors", () => {
+  const at = (n: number) => 1_700_000_000_000 + n * 1000;
+
+  it("writes a contiguous range as L<from>–L<to>", () => {
+    const md = renderWindowMarkdown(
+      win([ev({ id: "a", cv: "cv_1", atMs: at(1) }), ev({ id: "b", cv: "cv_1", atMs: at(2) })]),
+    );
+    expect(md).toContain("(2 events, L1–L2)");
+  });
+
+  it("writes a single-event thread as one line, not a range", () => {
+    expect(renderWindowMarkdown(win([ev({ id: "a", cv: "cv_1" })]))).toContain("(1 event, L1)");
+  });
+
+  it("lists exact lines when a thread is interleaved with others", () => {
+    // cv_1 lands on lines 1 and 3; rendering that as L1–L3 would invite a read
+    // that is one-third someone else's thread.
+    const md = renderWindowMarkdown(
+      win([
+        ev({ id: "a", cv: "cv_1", cvTitle: "first", atMs: at(1) }),
+        ev({ id: "b", cv: "cv_2", cvTitle: "second", atMs: at(2) }),
+        ev({ id: "c", cv: "cv_1", cvTitle: "first", atMs: at(3) }),
+      ]),
+    );
+    expect(md).toContain("(2 events, lines L1, L3)");
+    expect(md).not.toContain("L1–L3");
+  });
+
+  it("falls back to a grep hint for a badly fragmented thread", () => {
+    const events = Array.from({ length: 20 }, (_, i) =>
+      ev({ id: `m${i}`, cv: i % 2 === 0 ? "cv_even" : "cv_odd", atMs: at(i) }),
+    );
+    const md = renderWindowMarkdown(win(events));
+    expect(md).toMatch(/10 lines between L1 and L19 — grep '"cv":"cv_even"'/);
+  });
+});
+
+describe("requirement 7 — prior runs in this window", () => {
+  const prior = (over: Partial<import("./prior-runs.js").PriorRun> = {}) => ({
+    kind: "reflex",
+    windowStartMs: 1_700_000_000_000,
+    windowEndMs: 1_700_000_300_000,
+    outcome: "ran",
+    eventCount: 5,
+    sessionId: "s1",
+    startedAt: new Date(1_700_000_010_000),
+    completedAt: new Date(1_700_000_290_000),
+    result: "Replied in cv_1 acking the spike.",
+    status: "completed",
+    covers: true,
+    ...over,
+  });
+
+  it("omits the section entirely when nothing ran before", () => {
+    const md = renderWindowMarkdown(win([ev()]));
+    expect(md).not.toContain("What already happened");
+    expect(md).toContain("## 4. Outline");
+  });
+
+  it("summarises prior runs and points at the detail file", () => {
+    const md = renderWindowMarkdown(win([ev()], { priorRuns: [prior()] }));
+    expect(md).toContain("## 3. What already happened in this window");
+    expect(md).toContain("1 earlier awakened run(s) overlap this window; 1 of them acted");
+    expect(md).toContain(".context/heartbeat/prior-sessions.md");
+  });
+
+  it("warns about an in-flight run so the heartbeat does not race it", () => {
+    const md = renderWindowMarkdown(win([ev()], { priorRuns: [prior({ completedAt: null })] }));
+    expect(md).toContain("STILL IN FLIGHT");
+  });
+
+  it("counts what is NOT already handled and gives the grep for it", () => {
+    const events = [ev({ id: "a", covered: true }), ev({ id: "b" }), ev({ id: "c" })];
+    const md = renderWindowMarkdown(win(events, { priorRuns: [prior()] }));
+    expect(md).toContain("2 of 3 events are NOT already handled");
+    expect(md).toContain(`grep '"covered":false'`);
+  });
+
+  it("tags a handled event in the outline", () => {
+    const md = renderWindowMarkdown(win([ev({ covered: true, coveredBy: "reflex@09:02:40" })], { priorRuns: [prior()] }));
+    expect(md).toContain("handled by reflex@09:02:40");
+  });
+
+  it("emits prior-sessions.md only when there are prior runs", () => {
+    expect(renderWindow(win([ev()])).files.map((f) => f.path)).not.toContain("heartbeat/prior-sessions.md");
+    expect(renderWindow(win([ev()], { priorRuns: [prior()] })).files.map((f) => f.path)).toContain(
+      "heartbeat/prior-sessions.md",
+    );
+  });
+
+  it("keeps coverage greppable in events.jsonl", () => {
+    const line = renderEventsJsonl([ev({ covered: true, coveredBy: "reflex@09:02:40" })]);
+    expect(line).toContain('"covered":true');
+    expect(line).toContain('"coveredBy":"reflex@09:02:40"');
+  });
+});
+
+describe("reply targets — ids as tool arguments, not just data", () => {
+  it("prints the exact channelId/conversationId needed to reply to each thread", () => {
+    const md = renderWindowMarkdown(
+      win([ev({ ch: "ch_7Ka2", cv: "cv_9x1qP" })], {
+        config: { ...AWAKENING_DEFAULTS, shadow: false, writePolicy: "reply" },
+      }),
+    );
+    expect(md).toContain('reply here → `channelId: "ch_7Ka2", conversationId: "cv_9x1qP"`');
+  });
+
+  it("tells the agent its final answer is not delivered", () => {
+    const md = renderWindowMarkdown(
+      win([ev()], { config: { ...AWAKENING_DEFAULTS, shadow: false, writePolicy: "act" } }),
+    );
+    expect(md).toMatch(/call the Spaces send-message tool/);
+    expect(md).toMatch(/posts nothing/);
+  });
+
+  it("omits the send-message instruction when the run cannot write", () => {
+    const shadow = renderWindowMarkdown(win([ev()], { config: { ...AWAKENING_DEFAULTS, shadow: true } }));
+    expect(shadow).not.toMatch(/call the Spaces send-message tool/);
+    const observe = renderWindowMarkdown(
+      win([ev()], { config: { ...AWAKENING_DEFAULTS, shadow: false, writePolicy: "observe" } }),
+    );
+    expect(observe).not.toMatch(/call the Spaces send-message tool/);
+  });
+
+  it("still shows reply targets per thread even in shadow, so the agent can name where it would post", () => {
+    const md = renderWindowMarkdown(win([ev({ ch: "ch_1", cv: "cv_1" })]));
+    expect(md).toContain('reply here → `channelId: "ch_1", conversationId: "cv_1"`');
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/render.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/render.ts
@@ -1,0 +1,357 @@
+/**
+ * Renders a collected window into the files the agent reads.
+ *
+ * Shape of the deal with the model: WINDOW.md is the overview and is small
+ * enough to read whole; events.jsonl is the full detail and is GREPPED, not
+ * read. The outline in WINDOW.md carries line anchors into events.jsonl so the
+ * agent can jump straight to a range instead of scanning.
+ *
+ * events.jsonl grep-ability is a FORMAT CONTRACT, not a nicety: keys are
+ * emitted in a fixed order, booleans are unquoted, and `text` is last so a
+ * truncation is visually obvious. That is what makes `grep '"unanswered":true'`
+ * an exact match. Changing the key order silently breaks the recipes printed
+ * in WINDOW.md and in the heartbeat skill.
+ *
+ * The agent has read/grep/find/ls but NO bash (xyne-claw excludes it from the
+ * tool allowlist), so every recipe below is expressed as a single grep.
+ */
+
+import type { AwakeningWindow, WindowEvent } from "./types.js";
+import { renderPriorRuns } from "./prior-runs.js";
+
+/** Files land under the session's .context/ dir, which xyne-claw sanitizes. */
+export const ARTIFACT_DIR = "heartbeat";
+export const WINDOW_PATH = `${ARTIFACT_DIR}/WINDOW.md`;
+export const EVENTS_PATH = `${ARTIFACT_DIR}/events.jsonl`;
+export const CURSOR_PATH = `${ARTIFACT_DIR}/CURSOR.json`;
+export const PRIOR_PATH = `${ARTIFACT_DIR}/prior-sessions.md`;
+
+export interface RenderedWindow {
+  files: Array<{ path: string; content: string }>;
+  /** The path the agent is told to read first. */
+  entryPath: string;
+}
+
+function iso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function hhmmss(ms: number): string {
+  return new Date(ms).toISOString().slice(11, 19);
+}
+
+function durationLabel(ms: number): string {
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  return `${hours}h${mins % 60 ? `${mins % 60}m` : ""}`;
+}
+
+/**
+ * Stamp each event with its 1-based line number in events.jsonl.
+ *
+ * Done ONCE, up front, so the outline in WINDOW.md and the file itself can
+ * never disagree. Previously the numbering was a side effect of rendering the
+ * jsonl, which made WINDOW.md silently wrong if it was rendered first.
+ */
+export function assignLineNumbers(events: WindowEvent[]): WindowEvent[] {
+  events.forEach((e, i) => {
+    e.L = i + 1;
+  });
+  return events;
+}
+
+/** One JSON object per line with a FIXED key order. Pure — call assignLineNumbers first. */
+export function renderEventsJsonl(events: WindowEvent[]): string {
+  return events
+    .map((e) => {
+      return JSON.stringify({
+        L: e.L,
+        kind: e.kind,
+        at: e.at,
+        id: e.id,
+        ch: e.ch,
+        chName: e.chName,
+        cv: e.cv,
+        cvTitle: e.cvTitle,
+        sender: e.sender,
+        senderId: e.senderId,
+        isHuman: e.isHuman,
+        isMe: e.isMe,
+        root: e.root,
+        mentionsMe: e.mentionsMe,
+        unanswered: e.unanswered,
+        covered: e.covered,
+        coveredBy: e.coveredBy,
+        question: e.question,
+        actionSignals: e.actionSignals,
+        edited: e.edited,
+        chars: e.chars,
+        text: e.text,
+      });
+    })
+    .join("\n");
+}
+
+function renderMetrics(w: AwakeningWindow): string {
+  const s = w.signals;
+  const rows: Array<[string, number, string]> = [
+    ["events", s.eventCount, ""],
+    ["human events", s.humanEventCount, "excludes bots and your own messages"],
+    ["your own messages", s.selfEventCount, ""],
+    ["other bot messages", s.botEventCount, ""],
+    ["distinct senders", s.distinctSenders, ""],
+    ["distinct threads", s.distinctThreads, ""],
+    ["new threads", s.newThreads, ""],
+    ["unanswered threads", s.unansweredThreads, "last message is human, nobody replied"],
+    ["direct mentions of you", s.mentionsOfMe, ""],
+    ["questions", s.questions, ""],
+    ["action signals", s.actionSignals, "urgent / blocked / escalation / request"],
+  ];
+  const uncovered = w.events.filter((e) => !e.covered).length;
+  if (w.priorRuns.length > 0) {
+    rows.push(["events NOT already handled", uncovered, `grep '"covered":false' .context/${EVENTS_PATH}`]);
+  }
+  return [
+    "| signal | value | notes |",
+    "|---|---:|---|",
+    ...rows.map(([label, value, note]) => `| ${label} | ${value} | ${note} |`),
+  ].join("\n");
+}
+
+function renderChannels(w: AwakeningWindow): string {
+  const byChannel = new Map<string, { events: number; humans: number; unanswered: Set<string> }>();
+  for (const e of w.events) {
+    const entry = byChannel.get(e.ch) ?? { events: 0, humans: 0, unanswered: new Set<string>() };
+    entry.events++;
+    if (e.isHuman) entry.humans++;
+    if (e.unanswered) entry.unanswered.add(e.cv);
+    byChannel.set(e.ch, entry);
+  }
+
+  const lines = [
+    "| channel | id | events | humans | unanswered |",
+    "|---|---|---:|---:|---:|",
+  ];
+  for (const ch of w.channels) {
+    const entry = byChannel.get(ch.id);
+    if (!entry) continue;
+    lines.push(`| ${ch.name} | \`${ch.id}\` | ${entry.events} | ${entry.humans} | ${entry.unanswered.size} |`);
+  }
+
+  if (w.silentChannels.length > 0) {
+    lines.push("");
+    lines.push(`Watched but silent this window: ${w.silentChannels.map((c) => `\`${c.name}\``).join(", ")}.`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Describe a thread's line positions in events.jsonl.
+ *
+ * A range is only written as `L4–L5` when the lines are genuinely contiguous.
+ * Threads interleave, so a thread at lines 1, 2 and 10 rendered as "L1–L10"
+ * would invite a read(offset:1, limit:10) that is 70% other threads' events.
+ * Non-contiguous threads get their exact lines instead.
+ */
+function describeLines(list: WindowEvent[]): string {
+  const lines = list.map((e) => e.L);
+  const first = lines[0] ?? 0;
+  const last = lines[lines.length - 1] ?? 0;
+  const contiguous = lines.length === last - first + 1;
+  if (contiguous) return lines.length === 1 ? `L${first}` : `L${first}–L${last}`;
+  if (lines.length <= 8) return `lines ${lines.map((l) => `L${l}`).join(", ")}`;
+  return `${lines.length} lines between L${first} and L${last} — grep '"cv":"${list[0]?.cv ?? ""}"' for exactly these`;
+}
+
+/** Thread-grouped outline with line anchors into events.jsonl. */
+function renderOutline(w: AwakeningWindow): string {
+  const threads = new Map<string, WindowEvent[]>();
+  for (const e of w.events) {
+    const list = threads.get(e.cv) ?? [];
+    list.push(e);
+    threads.set(e.cv, list);
+  }
+
+  const blocks: string[] = [];
+  for (const [cv, list] of threads) {
+    const first = list[0];
+    if (!first) continue;
+    blocks.push(
+      `### ${first.chName} / \`${cv}\` — "${first.cvTitle}" (${list.length} ${list.length === 1 ? "event" : "events"}, ${describeLines(list)})`,
+    );
+    // The exact arguments needed to reply here. The ids are already on every
+    // events.jsonl line, but as data fields — spelling them out as tool
+    // parameters is what turns "I should reply to this" into an actual call.
+    blocks.push(`reply here → \`channelId: "${first.ch}", conversationId: "${cv}"\``);
+    blocks.push("```");
+    for (const e of list) {
+      const tags = [
+        e.isMe ? "you" : "",
+        e.mentionsMe ? "MENTION" : "",
+        e.unanswered ? "UNANSWERED" : "",
+        e.covered ? `handled by ${e.coveredBy}` : "",
+        e.question ? "question" : "",
+        ...e.actionSignals,
+      ].filter(Boolean);
+      const suffix = tags.length > 0 ? `  [${tags.join(", ")}]` : "";
+      const text = e.text.length > 90 ? `${e.text.slice(0, 87)}…` : e.text;
+      blocks.push(
+        `L${String(e.L).padEnd(4)} ${hhmmss(e.atMs)}  ${e.sender.padEnd(18).slice(0, 18)}  ${text.replace(/\n/g, " ")}${suffix}`,
+      );
+    }
+    blocks.push("```");
+    blocks.push("");
+  }
+  return blocks.join("\n");
+}
+
+const GREP_RECIPES = [
+  ["unanswered threads", `grep '"unanswered":true' .context/${EVENTS_PATH}`],
+  ["mentions of you", `grep '"mentionsMe":true' .context/${EVENTS_PATH}`],
+  ["open questions", `grep '"question":true' .context/${EVENTS_PATH}`],
+  ["escalations", `grep '"actionSignals":\\["escalation' .context/${EVENTS_PATH}`],
+  ["one thread", `grep '"cv":"<conversationId>"' .context/${EVENTS_PATH}`],
+  ["one person", `grep '"sender":"<name>"' .context/${EVENTS_PATH}`],
+  ["exclude your own posts", `grep '"isMe":false' .context/${EVENTS_PATH}`],
+  ["not yet handled by an earlier run", `grep '"covered":false' .context/${EVENTS_PATH}`],
+];
+
+/** Section 3: a short summary; the detail lives in prior-sessions.md. */
+function renderPriorSection(w: AwakeningWindow): string[] {
+  if (w.priorRuns.length === 0) return [];
+  const acted = w.priorRuns.filter((p) => p.covers);
+  const inFlight = w.priorRuns.filter((p) => !p.completedAt);
+  const uncovered = w.events.filter((e) => !e.covered).length;
+
+  return [
+    "## 3. What already happened in this window",
+    "",
+    `${w.priorRuns.length} earlier awakened run(s) overlap this window; ${acted.length} of them acted.`,
+    `${uncovered} of ${w.events.length} events are NOT already handled.`,
+    inFlight.length > 0
+      ? `${inFlight.length} run(s) are STILL IN FLIGHT — leave the threads they are working on alone.`
+      : "",
+    "",
+    `Full detail, including what each one said: \`.context/${PRIOR_PATH}\`.`,
+    "",
+  ].filter((l) => l !== "");
+}
+
+export function renderWindowMarkdown(w: AwakeningWindow): string {
+  assignLineNumbers(w.events);
+  const frontmatter = [
+    "---",
+    "artifact: xyne-window",
+    "version: 1",
+    `kind: ${w.kind}`,
+    `agent: ${w.agentSlug}`,
+    `windowStart: ${iso(w.startMs)}`,
+    `windowEnd: ${iso(w.endMs)}`,
+    `sealedAt: ${iso(Date.now())}`,
+    `events: ${w.events.length}`,
+    `truncated: ${w.truncated}`,
+    `gap: ${w.gap ? `${Math.round(w.gap.skippedMs / 60_000)}m skipped` : "none"}`,
+    `writePolicy: ${w.config.writePolicy}`,
+    `shadow: ${w.config.shadow}`,
+    "---",
+  ].join("\n");
+
+  const truncationNote = w.truncated
+    ? `\n> **This window was truncated** at ${w.config.limits.maxEvents} events. Older events in the window were dropped; treat the oldest entries as incomplete.\n`
+    : "";
+
+  const gapNote = w.gap
+    ? `\n> **Gap:** ${Math.round(w.gap.skippedMs / 60_000)} minutes before this window were skipped (the agent was not running). You did NOT see those events and will not get another chance to.\n`
+    : "";
+
+  return [
+    frontmatter,
+    "",
+    `# ${w.kind === "heartbeat" ? "Heartbeat" : "Reflex"} window — ${w.agentSlug}`,
+    "",
+    `Window \`${hhmmss(w.startMs)} → ${hhmmss(w.endMs)}\` (${durationLabel(w.endMs - w.startMs)}).`,
+    "Everything in this window is already collected below. Read this file top to bottom",
+    "BEFORE opening anything else, and do not re-search Spaces for events inside it.",
+    truncationNote,
+    gapNote,
+    "## 1. Metrics",
+    "",
+    renderMetrics(w),
+    "",
+    "## 2. Channels",
+    "",
+    renderChannels(w),
+    "",
+    ...renderPriorSection(w),
+    "## 4. Outline — every event, oldest first",
+    "",
+    `Index into \`.context/${EVENTS_PATH}\` (${w.events.length} lines, one JSON object per line, chronological).`,
+    "`L` is the line number — read a range directly with",
+    `\`read(path=".context/${EVENTS_PATH}", offset=<L>, limit=<n>)\`.`,
+    "",
+    ...(w.config.shadow || w.config.writePolicy === "observe"
+      ? []
+      : [
+          "**To reply to any thread below, call the Spaces send-message tool** with the",
+          "`channelId` / `conversationId` printed under its heading. Writing a reply as your",
+          "final answer posts nothing — this run's output is not delivered to anyone.",
+          "",
+        ]),
+    renderOutline(w),
+    "## 5. Files",
+    "",
+    "| path | what |",
+    "|---|---|",
+    `| \`.context/${WINDOW_PATH}\` | this file |`,
+    `| \`.context/${EVENTS_PATH}\` | ${w.events.length} events, one per line. GREP THIS. |`,
+    `| \`.context/${CURSOR_PATH}\` | exact window bounds and coverage proof |`,
+    ...(w.priorRuns.length > 0
+      ? [`| \`.context/${PRIOR_PATH}\` | what earlier runs in this window already did |`]
+      : []),
+    "",
+    "### Grep recipes",
+    "",
+    "You have `read`, `grep`, `find` and `ls`. You do **not** have bash.",
+    "",
+    ...GREP_RECIPES.map(([what, cmd]) => `- ${what}: \`${cmd}\``),
+    "",
+  ].join("\n");
+}
+
+function renderCursor(w: AwakeningWindow): string {
+  return JSON.stringify(
+    {
+      agentSlug: w.agentSlug,
+      kind: w.kind,
+      windowStart: iso(w.startMs),
+      windowEnd: iso(w.endMs),
+      replicaSafetyMs: w.config.cursor.replicaSafetyMs,
+      overlapMs: w.config.cursor.overlapMs,
+      events: w.events.length,
+      truncated: w.truncated,
+      gapSkippedMs: w.gap?.skippedMs ?? 0,
+      channels: w.channels.map((c) => ({ id: c.id, name: c.name })),
+      signals: w.signals,
+    },
+    null,
+    2,
+  );
+}
+
+/** Render the full artifact set. */
+export function renderWindow(w: AwakeningWindow): RenderedWindow {
+  assignLineNumbers(w.events);
+  const events = renderEventsJsonl(w.events);
+  return {
+    entryPath: `.context/${WINDOW_PATH}`,
+    files: [
+      { path: EVENTS_PATH, content: events },
+      { path: WINDOW_PATH, content: renderWindowMarkdown(w) },
+      { path: CURSOR_PATH, content: renderCursor(w) },
+      ...(w.priorRuns.length > 0
+        ? [{ path: PRIOR_PATH, content: renderPriorRuns(w.priorRuns) }]
+        : []),
+    ],
+  };
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/send-tool.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/send-tool.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { AWAKENING_SEND_TOOL, withAwakeningSendTool } from "./send-tool.js";
+
+describe("withAwakeningSendTool", () => {
+  it("appends the send tool to an existing direct allowlist", () => {
+    const out = withAwakeningSendTool({ tools: { direct: ["spaces-search"] } });
+    expect((out["tools"] as { direct: string[] }).direct).toEqual([
+      "spaces-search",
+      AWAKENING_SEND_TOOL,
+    ]);
+  });
+
+  it("creates tools.direct when the config has no tools block", () => {
+    const out = withAwakeningSendTool({ systemPrompt: "x" });
+    expect((out["tools"] as { direct: string[] }).direct).toEqual([AWAKENING_SEND_TOOL]);
+    expect(out["systemPrompt"]).toBe("x");
+  });
+
+  it("is idempotent", () => {
+    const once = withAwakeningSendTool({ tools: { direct: [AWAKENING_SEND_TOOL] } });
+    const twice = withAwakeningSendTool(once);
+    expect((twice["tools"] as { direct: string[] }).direct).toEqual([AWAKENING_SEND_TOOL]);
+  });
+
+  it("preserves sibling tool groups and other config keys", () => {
+    const out = withAwakeningSendTool({
+      modelId: "m",
+      tools: { direct: ["a"], subagents: ["spaces"], custom: ["web-search"] },
+    });
+    const tools = out["tools"] as Record<string, unknown>;
+    expect(tools["subagents"]).toEqual(["spaces"]);
+    expect(tools["custom"]).toEqual(["web-search"]);
+    expect(out["modelId"]).toBe("m");
+  });
+
+  it("does not mutate the input config", () => {
+    const input = { tools: { direct: ["a"] } };
+    withAwakeningSendTool(input);
+    expect(input.tools.direct).toEqual(["a"]);
+  });
+
+  it("drops non-string entries rather than forwarding them", () => {
+    const out = withAwakeningSendTool({ tools: { direct: ["a", 7, null] } });
+    expect((out["tools"] as { direct: string[] }).direct).toEqual(["a", AWAKENING_SEND_TOOL]);
+  });
+
+  it("tolerates a non-array direct value", () => {
+    const out = withAwakeningSendTool({ tools: { direct: "nope" } });
+    expect((out["tools"] as { direct: string[] }).direct).toEqual([AWAKENING_SEND_TOOL]);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/send-tool.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/send-tool.ts
@@ -1,0 +1,36 @@
+/**
+ * The bot-identity send tool, granted per-run to awakened (heartbeat / reflex)
+ * runs.
+ *
+ * `apps-send-message` is deliberately absent from the agent tool picker — it
+ * posts as the bot rather than as the human — so a strict `tools.direct`
+ * allowlist always excludes it. For an awakened run that is fatal rather than
+ * merely restrictive: nobody is in a thread to receive the agent's final
+ * answer, so this tool is its only voice.
+ *
+ * The grant has to be applied in TWO places, because two independent gates
+ * filter the palette: claw-auth's MCP listing (routes/mcp.ts) and claw's own
+ * re-filter against the forwarded agent config (applyAgentToolFilter in
+ * xyne-claw/src/routes/run.ts). Both are per-run and in-memory; the stored
+ * agent config is never modified and interactive runs are unaffected.
+ */
+
+export const AWAKENING_SEND_TOOL = "apps-send-message";
+
+function withTool(direct: unknown, toolName: string): string[] {
+  const existing = Array.isArray(direct)
+    ? direct.filter((value): value is string => typeof value === "string")
+    : [];
+  return existing.includes(toolName) ? existing : [...existing, toolName];
+}
+
+/** Append the send tool to `tools.direct` of a full agent config record. */
+export function withAwakeningSendTool(
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  const tools = (config["tools"] as Record<string, unknown> | undefined) ?? {};
+  return {
+    ...config,
+    tools: { ...tools, direct: withTool(tools["direct"], AWAKENING_SEND_TOOL) },
+  };
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/signals.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/signals.ts
@@ -1,0 +1,56 @@
+/**
+ * Derives the counts the gate decides on and the agent reads.
+ *
+ * Pure: takes events, returns numbers. Everything expensive already happened
+ * in the collector. Keeping this side-effect-free is what lets the gate be
+ * table-tested exhaustively without a database.
+ */
+
+import type { WindowEvent, WindowSignals } from "./types.js";
+
+export function computeSignals(events: WindowEvent[]): WindowSignals {
+  const senders = new Set<string>();
+  const threads = new Set<string>();
+  const channels = new Set<string>();
+  const unansweredThreads = new Set<string>();
+
+  let humanEventCount = 0;
+  let botEventCount = 0;
+  let selfEventCount = 0;
+  let newThreads = 0;
+  let mentionsOfMe = 0;
+  let questions = 0;
+  let actionSignals = 0;
+
+  for (const e of events) {
+    threads.add(e.cv);
+    if (e.ch) channels.add(e.ch);
+
+    if (e.isMe) selfEventCount++;
+    else if (e.isHuman) {
+      humanEventCount++;
+      senders.add(e.senderId);
+    } else botEventCount++;
+
+    if (e.root) newThreads++;
+    if (e.mentionsMe) mentionsOfMe++;
+    if (e.question && e.isHuman) questions++;
+    if (e.actionSignals.length > 0 && e.isHuman) actionSignals++;
+    if (e.unanswered) unansweredThreads.add(e.cv);
+  }
+
+  return {
+    eventCount: events.length,
+    humanEventCount,
+    botEventCount,
+    selfEventCount,
+    distinctSenders: senders.size,
+    distinctThreads: threads.size,
+    newThreads,
+    unansweredThreads: unansweredThreads.size,
+    mentionsOfMe,
+    questions,
+    actionSignals,
+    channelsWithActivity: channels.size,
+  };
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/skills.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/skills.ts
@@ -1,0 +1,192 @@
+/**
+ * The skills injected into an awakened run.
+ *
+ * Shipped as inline constants on the /run payload rather than as seeded
+ * Skill + AgentSkill rows. A seeded skill is inert until BOTH the row exists
+ * and it is attached to the agent — per org, per environment — which is a
+ * silent-failure mode: the agent wakes, has no operating contract, and
+ * improvises. Inlining makes the skill a property of the dispatch, so it is
+ * present on every awakened run by construction.
+ *
+ * xyne-claw materializes these via writeSessionSkills() into the session's
+ * skill directory as SKILL.md.
+ */
+
+export interface AwakeningSkill {
+  slug: string;
+  name: string;
+  description: string;
+  content: string;
+}
+
+export const HEARTBEAT_SKILL: AwakeningSkill = {
+  // Namespaced: pi resolves skills by name and first-registered wins, so a
+  // generic word like "heartbeat" could collide with a user-authored skill.
+  slug: "xyne-heartbeat",
+  name: "xyne-heartbeat",
+  description:
+    "How to work a heartbeat window: nobody asked you to run. Read the collected window first, decide whether anything actually needs you, act narrowly, and leave a trace. Use this whenever a run begins with a heartbeat window artifact.",
+  content: `# Heartbeat
+
+You woke up on a timer. **No human asked you anything.** Nobody is watching a
+spinner waiting for your reply. That changes what a good run looks like.
+
+## 1. Read the window before you do anything
+
+A window artifact has already been collected for you at
+\`.context/heartbeat/WINDOW.md\`. Read it top to bottom **first**.
+
+It contains the complete set of events from your watched channels for this
+period. Do **not** re-search Spaces for anything inside the window — it is
+already there, and a second fetch just costs time and risks a different answer.
+
+The detail lives in \`.context/heartbeat/events.jsonl\`, one JSON object per
+line, chronological. **Grep it, do not read it whole.** The recipes are printed
+at the bottom of WINDOW.md. You have \`read\`, \`grep\`, \`find\` and \`ls\`.
+You do **not** have bash.
+
+To read a specific range, use the \`L\` line anchors from the outline:
+\`read(path=".context/heartbeat/events.jsonl", offset=<L>, limit=<n>)\`.
+
+## 2. Decide whether anything needs you
+
+The default outcome of a heartbeat is **doing nothing**, and that is a success,
+not a failure. You are a periodic check, not a participant with a quota.
+
+Act when you find:
+- a direct mention of you that nobody has answered
+- an unanswered question you can actually answer
+- an escalation or blocker where you can add a concrete fact
+- something you previously committed to following up on
+
+Do **not** act when:
+- the conversation is between humans and is going fine without you
+- you would only be acknowledging, agreeing, or summarizing back at people
+- someone else already answered
+- you already said this in a previous window
+
+Silence is the correct output for most windows. If nothing needs you, say so in
+one line and stop.
+
+## 3. Nothing you write here is delivered
+
+This is the one way an awakened run differs from answering a person. When a human
+asks you something, your final message IS the reply and the platform posts it for
+you. **That does not happen here.** Nobody is watching this run's output; it is a
+log entry an operator may read later.
+
+To say something to people you MUST call the Spaces **send-message** tool (on the
+Spaces app-tools server) yourself, passing:
+- \`channelId\` — the \`ch\` field on the relevant events.jsonl line
+- \`conversationId\` — the \`cv\` field, to reply inside an existing thread
+
+Writing a beautifully-worded reply as your final answer posts NOTHING. If you
+concluded that a thread needs a reply, call the tool. If you concluded nothing
+needs saying, call no tool and say so in one line.
+
+## 4. Act narrowly
+
+When you do act:
+- Reply **in the thread** where the conversation is happening, not in the channel.
+- Answer one thing well rather than commenting on everything.
+- Tag a specific person only when you need something from that person.
+- Say what you know and what you do not. You are working from a window of
+  messages, not from full context.
+
+Your write permissions for this run are stated in the WINDOW.md frontmatter as
+\`writePolicy\`:
+- \`observe\` — you may not post at all. Reason and record; that is the whole job.
+- \`reply\` — you may reply inside existing threads only.
+- \`act\` — you may also start new threads.
+
+If \`shadow: true\`, you have no write tools at all. Do the full reasoning and
+state precisely what you *would* have posted and where. That output is being
+read by a human evaluating whether to let you post for real.
+
+## 5. Never talk to yourself
+
+Your own messages are marked \`"isMe":true\` in events.jsonl and are counted
+separately in the metrics table. Never treat your own post as something that
+needs a response. If a thread's only recent activity is yours, leave it alone.
+
+## 6. Leave a trace
+
+Before you finish, write down what you did and what you are watching for, so
+the next heartbeat does not redo your work or contradict you. Keep it short and
+factual — what you acted on, what you deliberately skipped, and what you expect
+to still be open next window.
+`,
+};
+
+export const REFLEX_SKILL: AwakeningSkill = {
+  slug: "xyne-reflex",
+  name: "xyne-reflex",
+  description:
+    "How to work a reflex wake: enough activity piled up that you were woken to react NOW. Move fast, handle the one or two things that need handling, and leave synthesis to the heartbeat. Use this whenever a run begins with a reflex window artifact.",
+  content: `# Reflex
+
+Enough happened in your channels that you were woken to react **now**. Nobody
+asked you a question directly — a threshold was crossed.
+
+You are the fast path, not the thorough one. A heartbeat will run later over
+this same period and do the synthesis. Your job is the handful of things that
+would be worse for waiting.
+
+## 1. Read the window, then move
+
+The events are already collected at \`.context/heartbeat/WINDOW.md\`. Read it,
+then act. Do **not** open a broad investigation — if something needs real
+digging, say so briefly and leave it for the heartbeat.
+
+Grep \`.context/heartbeat/events.jsonl\` for the specifics. You have \`read\`,
+\`grep\`, \`find\` and \`ls\`. You do **not** have bash.
+
+## 2. Nothing you write here is delivered
+
+When a human asks you something, your final message IS the reply and the platform
+posts it. **Not here.** This run's output is a log entry nobody is waiting on.
+
+To say something you MUST call the Spaces **send-message** tool yourself, passing
+\`channelId\` (the \`ch\` field) and, for a thread reply, \`conversationId\` (the \`cv\`
+field) from the relevant events.jsonl line.
+
+Deciding a thread needs a reply and then just writing that reply as your answer
+posts nothing at all. Call the tool, or state plainly that you are staying silent.
+
+## 3. Handle what is time-sensitive, ignore the rest
+
+React to:
+- someone who mentioned you and is waiting
+- a question you can answer correctly in one reply
+- an escalation where a fact you already know would help right now
+
+Leave alone:
+- anything needing research to answer well — that is the heartbeat's job
+- ongoing human conversation that is going fine
+- anything already answered
+
+Handling **nothing** is a perfectly good reflex. Volume triggered this wake, and
+volume is not the same as need.
+
+## 4. Live updates arrive while you work
+
+New events may be handed to you mid-run, marked
+\`[Live update N — M new event(s) arrived while you were working]\`.
+
+- Fold them into what you are doing. If they change your conclusion, change it.
+- If they do not, carry on. You do **not** need to acknowledge them.
+- The update says how many more you may get. When it says it is the LAST one,
+  stop expecting more and finish on what you have.
+- Never restart your work from scratch because an update arrived.
+
+## 5. Never talk to yourself
+
+Your own messages are \`"isMe":true\` in events.jsonl and are excluded from the
+count that woke you. If a thread's only recent activity is yours, leave it.
+
+## 6. Be brief
+
+A reflex reply should be short and concrete. If you find yourself writing
+several paragraphs, that is a sign this belonged to the heartbeat instead.
+`,
+};

--- a/apps/xyne-claw-auth/backend/src/awakening/spaces-read.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/spaces-read.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const interactMock = vi.hoisted(() => vi.fn());
+vi.mock("../mcp/servers/xyne-spaces-client.js", () => ({ interact: interactMock }));
+
+const { boundedInteract, pageBounded, UnboundedQueryError, SPACES_MAX_TAKE } = await import("./spaces-read.js");
+
+const auth = { token: "t", workspaceId: "ws" };
+
+beforeEach(() => interactMock.mockReset());
+
+/**
+ * Guards the verified gap in the Spaces query validator: `take` is capped only
+ * when SUPPLIED, so an omitted take is an unbounded findMany on a hot table.
+ */
+describe("boundedInteract", () => {
+  it("refuses a findMany with no take", async () => {
+    await expect(boundedInteract({ model: "message", operation: "findMany" }, auth)).rejects.toThrow(
+      UnboundedQueryError,
+    );
+    expect(interactMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a zero or negative take", async () => {
+    await expect(boundedInteract({ model: "message", operation: "findMany", take: 0 }, auth)).rejects.toThrow();
+    await expect(boundedInteract({ model: "message", operation: "findMany", take: -1 }, auth)).rejects.toThrow();
+    await expect(
+      boundedInteract({ model: "message", operation: "findMany", take: NaN }, auth),
+    ).rejects.toThrow();
+  });
+
+  it("allows a count with no take — it returns a scalar, not rows", async () => {
+    interactMock.mockResolvedValue(7);
+    await expect(boundedInteract({ model: "message", operation: "count" }, auth)).resolves.toBe(7);
+  });
+
+  it("clamps a take above MAX_TAKE instead of letting Spaces reject it", async () => {
+    interactMock.mockResolvedValue([]);
+    await boundedInteract({ model: "message", operation: "findMany", take: 99_999 }, auth);
+    expect(interactMock.mock.calls[0]![0].take).toBe(SPACES_MAX_TAKE);
+  });
+
+  it("passes a valid query through untouched", async () => {
+    interactMock.mockResolvedValue([{ id: 1 }]);
+    const out = await boundedInteract({ model: "message", operation: "findMany", take: 10 }, auth);
+    expect(out).toEqual([{ id: 1 }]);
+  });
+});
+
+describe("pageBounded", () => {
+  it("stops on a short page", async () => {
+    interactMock.mockResolvedValueOnce([{ id: "a" }, { id: "b" }]);
+    const out = await pageBounded<{ id: string }>(
+      { model: "message", operation: "findMany" },
+      auth,
+      100,
+      10,
+      (last) => ({ id: { gt: last.id } }),
+    );
+    expect(out).toHaveLength(2);
+    expect(interactMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("pages until the limit and never exceeds it", async () => {
+    interactMock
+      .mockResolvedValueOnce([{ id: "a" }, { id: "b" }])
+      .mockResolvedValueOnce([{ id: "c" }, { id: "d" }])
+      .mockResolvedValueOnce([{ id: "e" }]);
+    const out = await pageBounded<{ id: string }>(
+      { model: "message", operation: "findMany" },
+      auth,
+      5,
+      2,
+      (last) => ({ id: { gt: last.id } }),
+    );
+    expect(out.map((r) => r.id)).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  it("advances the keyset cursor from the last row of each page", async () => {
+    interactMock
+      .mockResolvedValueOnce([{ id: "a" }, { id: "b" }])
+      .mockResolvedValueOnce([{ id: "c" }]);
+    await pageBounded<{ id: string }>(
+      { model: "message", operation: "findMany", where: { x: 1 } },
+      auth,
+      10,
+      2,
+      (last) => ({ id: { gt: last.id } }),
+    );
+    expect(interactMock.mock.calls[1]![0].where).toEqual({ AND: [{ x: 1 }, { id: { gt: "b" } }] });
+  });
+
+  it("stops when advance returns null", async () => {
+    interactMock.mockResolvedValueOnce([{ id: "a" }, { id: "b" }]);
+    const out = await pageBounded<{ id: string }>(
+      { model: "message", operation: "findMany" },
+      auth,
+      10,
+      2,
+      () => null,
+    );
+    expect(out).toHaveLength(2);
+    expect(interactMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles an empty first page", async () => {
+    interactMock.mockResolvedValueOnce([]);
+    const out = await pageBounded({ model: "message", operation: "findMany" }, auth, 10, 5, () => null);
+    expect(out).toEqual([]);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/spaces-read.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/spaces-read.ts
@@ -1,0 +1,84 @@
+/**
+ * Every Spaces read on the awakening path goes through here.
+ *
+ * Why this wrapper exists: the Spaces query validator caps `take` at MAX_TAKE
+ * (apps/backend/src/services/pythonQuery/validator.ts) — but the cap is
+ * declared `.optional()`, so it only binds when `take` is SUPPLIED. An AST
+ * with no `take` is an unbounded findMany against Spaces' hottest tables
+ * (messages, conversations). A background loop that runs for every awakened
+ * agent, every period, forever is exactly the caller that must never emit one.
+ *
+ * boundedInteract() therefore refuses an AST without an explicit positive
+ * `take` — a programming error, surfaced loudly in dev rather than silently
+ * becoming a table scan in prod.
+ */
+
+import { interact, type QueryAST, type SpacesAuthContext } from "../mcp/servers/xyne-spaces-client.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-spaces-read");
+
+/** Mirrors MAX_TAKE in the Spaces validator. Kept local so this stays dependency-free. */
+export const SPACES_MAX_TAKE = 1000;
+
+export class UnboundedQueryError extends Error {
+  constructor(model: string) {
+    super(`Refusing to run an unbounded Spaces query on "${model}": every awakening read must set an explicit take`);
+    this.name = "UnboundedQueryError";
+  }
+}
+
+/**
+ * Run a Spaces query AST with a mandatory, in-range `take`.
+ * `count` operations are exempt — they return a scalar, not rows.
+ */
+export async function boundedInteract<T>(ast: QueryAST, auth: SpacesAuthContext): Promise<T> {
+  if (ast.operation !== "count") {
+    if (typeof ast.take !== "number" || !Number.isFinite(ast.take) || ast.take <= 0) {
+      throw new UnboundedQueryError(ast.model);
+    }
+    if (ast.take > SPACES_MAX_TAKE) {
+      log.warn(`[awakening] take=${ast.take} on ${ast.model} exceeds MAX_TAKE; clamping to ${SPACES_MAX_TAKE}`);
+      ast.take = SPACES_MAX_TAKE;
+    }
+  }
+  return (await interact(ast, auth)) as T;
+}
+
+/**
+ * Keyset-paginate a bounded query until `limit` rows are collected or the
+ * source is exhausted. Keyset (not skip/offset) because offset pagination over
+ * a live table both drifts as rows arrive and degrades linearly with depth.
+ *
+ * `advance` returns the `where` fragment that resumes strictly AFTER the last
+ * row of the previous page; returning null stops paging.
+ */
+export async function pageBounded<T>(
+  base: QueryAST,
+  auth: SpacesAuthContext,
+  limit: number,
+  pageSize: number,
+  advance: (lastRow: T) => Record<string, unknown> | null,
+): Promise<T[]> {
+  const out: T[] = [];
+  let cursor: Record<string, unknown> | null = null;
+
+  while (out.length < limit) {
+    const take = Math.min(pageSize, limit - out.length, SPACES_MAX_TAKE);
+    const where = cursor ? { AND: [base.where ?? {}, cursor] } : base.where;
+    const page = await boundedInteract<T[]>(
+      { ...base, take, ...(where ? { where } : {}) },
+      auth,
+    );
+    if (!Array.isArray(page) || page.length === 0) break;
+    out.push(...page);
+    if (page.length < take) break;
+
+    const last = page[page.length - 1];
+    if (last === undefined) break;
+    cursor = advance(last);
+    if (!cursor) break;
+  }
+
+  return out.slice(0, limit);
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/types.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared shapes for the awakening pipeline.
+ *
+ * A WindowEvent is the pipeline's unit of currency: one thing that happened in
+ * a watched channel during a window. Collectors produce them, signals score
+ * them, the gate counts them, and the renderer writes them to disk as the
+ * events.jsonl the agent greps. Adding a new event source means adding a
+ * collector that returns these — nothing downstream changes.
+ */
+
+import type { AwakeningConfig } from "./config.js";
+import type { PriorRun } from "./prior-runs.js";
+
+export interface ResolvedChannel {
+  id: string;
+  name: string;
+  lastActivityAt: number;
+}
+
+export interface WindowEvent {
+  /** 1-based line number in events.jsonl; assigned by the renderer, not the collector. */
+  L: number;
+  kind: "message";
+  /** ISO timestamp. */
+  at: string;
+  atMs: number;
+  id: string;
+  ch: string;
+  chName: string;
+  cv: string;
+  cvTitle: string;
+  sender: string;
+  senderId: string;
+  isHuman: boolean;
+  /** True when this event was produced by the awakened agent itself. */
+  isMe: boolean;
+  root: boolean;
+  mentionsMe: boolean;
+  /** Last message in its thread within this window AND authored by a human. */
+  unanswered: boolean;
+  /** True when a prior awakened run in this window already acted on this event. */
+  covered: boolean;
+  /** Which prior run covered it, for the agent to reference. */
+  coveredBy: string | null;
+  question: boolean;
+  actionSignals: string[];
+  edited: boolean;
+  chars: number;
+  text: string;
+}
+
+/** Counts the gate decides on, and the metrics table the agent reads. */
+export interface WindowSignals {
+  eventCount: number;
+  humanEventCount: number;
+  botEventCount: number;
+  selfEventCount: number;
+  distinctSenders: number;
+  distinctThreads: number;
+  newThreads: number;
+  unansweredThreads: number;
+  mentionsOfMe: number;
+  questions: number;
+  actionSignals: number;
+  channelsWithActivity: number;
+}
+
+export interface AwakeningWindow {
+  agentId: string;
+  agentSlug: string;
+  orgId: string;
+  kind: "heartbeat" | "reflex";
+  startMs: number;
+  endMs: number;
+  channels: ResolvedChannel[];
+  /** Channels resolved but silent this window — useful negative space for the agent. */
+  silentChannels: ResolvedChannel[];
+  events: WindowEvent[];
+  signals: WindowSignals;
+  /** True when the event cap cut the window short. */
+  truncated: boolean;
+  /** Set when the watermark had to jump forward after an outage. */
+  gap: { skippedMs: number } | null;
+  /** Awakened runs whose window overlaps this one (requirement 7). */
+  priorRuns: PriorRun[];
+  config: AwakeningConfig;
+}
+
+export type GateOutcome =
+  | { decision: "run"; rule: string }
+  | { decision: "skip"; rule: string };
+
+/** Auth for reads/writes performed as the agent's Spaces app identity. */
+export interface AgentSpacesIdentity {
+  appToken: string;
+  spacesAppId: string;
+  spacesAppUserId: string;
+  workspaceId: string;
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/workspace.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/workspace.ts
@@ -1,0 +1,50 @@
+/**
+ * Resolves which Spaces workspace an awakened agent reads and acts in.
+ *
+ * Every Spaces query is tenant-scoped, so a wrong or empty workspaceId either
+ * fails the ACL check or — worse — reads the wrong tenant. The mapping lives
+ * in SurfaceTenantLink (orgId ↔ Spaces workspaceId).
+ *
+ * An org with exactly one linked workspace resolves automatically, which is
+ * the common case. An org with several MUST pin one in
+ * `config.awakening.workspaceId`: guessing between tenants is exactly the
+ * mistake that must never happen silently, so this throws instead.
+ */
+
+import { prisma } from "../db.js";
+
+export class WorkspaceResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WorkspaceResolutionError";
+  }
+}
+
+export async function resolveWorkspaceId(orgId: string, configured?: string): Promise<string> {
+  const links = await prisma.surfaceTenantLink.findMany({
+    where: { orgId, surfaceType: "spaces" },
+    select: { surfaceTenantId: true },
+    orderBy: { createdAt: "asc" },
+  });
+
+  if (configured) {
+    const known = links.some((l) => l.surfaceTenantId === configured);
+    if (!known) {
+      throw new WorkspaceResolutionError(
+        `configured workspaceId "${configured}" is not linked to this org`,
+      );
+    }
+    return configured;
+  }
+
+  const first = links[0]?.surfaceTenantId;
+  if (links.length === 0 || !first) {
+    throw new WorkspaceResolutionError("no Spaces workspace is linked to this org");
+  }
+  if (links.length > 1) {
+    throw new WorkspaceResolutionError(
+      `org has ${links.length} linked Spaces workspaces; set config.awakening.workspaceId to pick one`,
+    );
+  }
+  return first;
+}

--- a/apps/xyne-claw-auth/backend/src/awakening/workspace.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/workspace.ts
@@ -2,16 +2,31 @@
  * Resolves which Spaces workspace an awakened agent reads and acts in.
  *
  * Every Spaces query is tenant-scoped, so a wrong or empty workspaceId either
- * fails the ACL check or — worse — reads the wrong tenant. The mapping lives
- * in SurfaceTenantLink (orgId ↔ Spaces workspaceId).
+ * fails the ACL check or — worse — reads the wrong tenant.
  *
- * An org with exactly one linked workspace resolves automatically, which is
- * the common case. An org with several MUST pin one in
- * `config.awakening.workspaceId`: guessing between tenants is exactly the
- * mistake that must never happen silently, so this throws instead.
+ * The authoritative answer is the AGENT'S OWN BOT USER. Spaces stores
+ * `workspaceId` on every user row, and an agent's bot is a user like any other,
+ * so "which workspace is this agent in?" has exactly one answer and needs no
+ * configuration. That also makes a multi-workspace org a non-problem: the bot
+ * is in one of them, and that is the one it can act in.
+ *
+ * This used to read ONLY the org→workspace map in SurfaceTenantLink, which was
+ * wrong twice over. Nothing in the product ever writes that table for Spaces
+ * (the sole writer is prisma/seed.ts, for local dev), so it is empty in
+ * production and awakening was the only consumer that treated it as required —
+ * it disabled two live agents in prod on 2026-08-26 for an org that had simply
+ * never been seeded. And every other consumer already resolves the right way:
+ * credentials-loader.ts does bot-user-first for the app-tools MCP.
+ *
+ * SurfaceTenantLink survives as a FALLBACK for an agent whose bot user cannot
+ * be read (Spaces DB unreachable, or a bot row that predates the column).
  */
 
+import { getWorkspaceIdForUser } from "../lib/spaces-db.js";
 import { prisma } from "../db.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-workspace");
 
 export class WorkspaceResolutionError extends Error {
   constructor(message: string) {
@@ -20,16 +35,34 @@ export class WorkspaceResolutionError extends Error {
   }
 }
 
-export async function resolveWorkspaceId(orgId: string, configured?: string): Promise<string> {
+async function orgLinks(orgId: string): Promise<string[]> {
   const links = await prisma.surfaceTenantLink.findMany({
     where: { orgId, surfaceType: "spaces" },
     select: { surfaceTenantId: true },
     orderBy: { createdAt: "asc" },
   });
+  return links.map((l) => l.surfaceTenantId);
+}
+
+export async function resolveWorkspaceId(
+  orgId: string,
+  spacesAppUserId: string | null | undefined,
+  configured?: string,
+): Promise<string> {
+  const botWorkspaceId = spacesAppUserId
+    ? await getWorkspaceIdForUser(spacesAppUserId, "awakening").catch(() => null)
+    : null;
 
   if (configured) {
-    const known = links.some((l) => l.surfaceTenantId === configured);
-    if (!known) {
+    // An explicit pin must not be able to aim an agent at a tenant its bot is
+    // not in — it could not read there anyway, and silently trying is exactly
+    // the cross-tenant mistake this function exists to prevent.
+    if (botWorkspaceId && configured !== botWorkspaceId) {
+      throw new WorkspaceResolutionError(
+        `configured workspaceId "${configured}" is not the workspace this agent's bot belongs to ("${botWorkspaceId}")`,
+      );
+    }
+    if (!botWorkspaceId && !(await orgLinks(orgId)).includes(configured)) {
       throw new WorkspaceResolutionError(
         `configured workspaceId "${configured}" is not linked to this org`,
       );
@@ -37,14 +70,22 @@ export async function resolveWorkspaceId(orgId: string, configured?: string): Pr
     return configured;
   }
 
-  const first = links[0]?.surfaceTenantId;
-  if (links.length === 0 || !first) {
-    throw new WorkspaceResolutionError("no Spaces workspace is linked to this org");
+  if (botWorkspaceId) return botWorkspaceId;
+
+  const links = await orgLinks(orgId);
+  const first = links[0];
+  if (!first) {
+    throw new WorkspaceResolutionError(
+      "cannot determine this agent's Spaces workspace: its bot user has no workspace in Spaces " +
+      "and no Spaces workspace is linked to this org",
+    );
   }
   if (links.length > 1) {
     throw new WorkspaceResolutionError(
-      `org has ${links.length} linked Spaces workspaces; set config.awakening.workspaceId to pick one`,
+      `org has ${links.length} linked Spaces workspaces and the agent's bot user could not be read; ` +
+      "set config.awakening.workspaceId to pick one",
     );
   }
+  log.info(`[awakening] workspace resolved from org link (bot user unreadable) orgId=${orgId} workspaceId=${first}`);
   return first;
 }

--- a/apps/xyne-claw-auth/backend/src/awakening/write-policy.test.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/write-policy.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { buildWritePermissions, isReadOnlyRun } from "./write-policy.js";
+import { AWAKENING_DEFAULTS, type AwakeningConfig, type WritePolicy } from "./config.js";
+
+const cfg = (writePolicy: WritePolicy, shadow = false): AwakeningConfig => ({
+  ...AWAKENING_DEFAULTS,
+  writePolicy,
+  shadow,
+});
+
+const APP_POST = "xyne-spaces-app-tools__apps-send-message";
+const USER_POST = "xyne-spaces__user-send-message";
+const CREATE_TICKET = "xyne-spaces__spaces-create-ticket";
+const UPDATE_TICKET = "xyne-spaces__spaces-update-ticket";
+const EDIT_CANVAS = "xyne-spaces__spaces-edit-canvas";
+
+describe("observe — no outbound writes at all", () => {
+  const p = buildWritePermissions(cfg("observe"));
+
+  it("denies the ungated bot post tool — the whole point of the guard", () => {
+    expect(p[APP_POST]).toBe("deny");
+  });
+
+  it("denies posting as the user", () => {
+    expect(p[USER_POST]).toBe("deny");
+  });
+
+  it("denies every durable mutation", () => {
+    for (const t of [CREATE_TICKET, UPDATE_TICKET, EDIT_CANVAS]) expect(p[t]).toBe("deny");
+  });
+});
+
+describe("reply — threads only", () => {
+  const p = buildWritePermissions(cfg("reply"));
+
+  it("leaves the bot post tool available so it can actually reply", () => {
+    expect(p[APP_POST]).toBeUndefined();
+  });
+
+  it("still denies durable mutations", () => {
+    for (const t of [CREATE_TICKET, UPDATE_TICKET, EDIT_CANVAS]) expect(p[t]).toBe("deny");
+  });
+
+  it("still denies posting as the human user", () => {
+    expect(p[USER_POST]).toBe("deny");
+  });
+});
+
+describe("act — full surface", () => {
+  it("denies nothing", () => {
+    expect(buildWritePermissions(cfg("act"))).toEqual({});
+  });
+});
+
+describe("shadow overrides everything", () => {
+  it("reduces act to observe", () => {
+    const p = buildWritePermissions(cfg("act", true));
+    expect(p[APP_POST]).toBe("deny");
+    expect(p[CREATE_TICKET]).toBe("deny");
+  });
+
+  it("reduces reply to observe", () => {
+    expect(buildWritePermissions(cfg("reply", true))[APP_POST]).toBe("deny");
+  });
+
+  it("is the default posture for a newly enabled agent", () => {
+    expect(AWAKENING_DEFAULTS.shadow).toBe(true);
+    expect(buildWritePermissions(AWAKENING_DEFAULTS)[APP_POST]).toBe("deny");
+  });
+});
+
+describe("merging with the agent's existing permissions", () => {
+  it("preserves unrelated settings", () => {
+    const p = buildWritePermissions(cfg("observe"), { "github__create-issue": "ask" });
+    expect(p["github__create-issue"]).toBe("ask");
+    expect(p[APP_POST]).toBe("deny");
+  });
+
+  it("a policy denial overrides a permissive existing setting", () => {
+    const p = buildWritePermissions(cfg("observe"), { [APP_POST]: "allow" });
+    expect(p[APP_POST]).toBe("deny");
+  });
+
+  it("does not mutate the input map", () => {
+    const existing = { [APP_POST]: "allow" };
+    buildWritePermissions(cfg("observe"), existing);
+    expect(existing[APP_POST]).toBe("allow");
+  });
+});
+
+describe("isReadOnlyRun", () => {
+  it("is true for shadow or observe, false otherwise", () => {
+    expect(isReadOnlyRun(cfg("act", true))).toBe(true);
+    expect(isReadOnlyRun(cfg("observe"))).toBe(true);
+    expect(isReadOnlyRun(cfg("reply"))).toBe(false);
+    expect(isReadOnlyRun(cfg("act"))).toBe(false);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/awakening/write-policy.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/write-policy.ts
@@ -1,0 +1,87 @@
+/**
+ * Turns an awakened run's writePolicy into concrete per-tool denials.
+ *
+ * Why this is enforced with tool permissions rather than by prompting:
+ * `apps-send-message` acts as the bot identity and is UNGATED by design (see
+ * mcp/adapters/xyne-spaces.ts) — it exists precisely so an agent can post
+ * autonomously. For an unattended run that is the whole risk surface, and an
+ * instruction in a system prompt is not a control. The permission map is
+ * evaluated at the MCP call boundary in claw-auth, so a denied tool cannot be
+ * reached however the model is persuaded to try.
+ *
+ * "deny" is used rather than "ask": an approval card raised by a heartbeat at
+ * 3am has nobody to click it, so "ask" would be a silent hang rather than a
+ * clear refusal.
+ *
+ * Policies:
+ *   observe — no outbound writes at all. Reason, and record.
+ *   reply   — may reply inside existing threads; may not start new ones or
+ *             mutate tickets/canvases.
+ *   act     — full write surface the agent normally has.
+ * `shadow` overrides all three down to observe.
+ */
+
+import type { AwakeningConfig } from "./config.js";
+
+const SPACES = "xyne-spaces";
+const SPACES_APP = "xyne-spaces-app-tools";
+
+/** Tool permission keys are `${serverType}__${toolName}` — see xyne-claw/src/mcp.ts. */
+function key(serverType: string, tool: string): string {
+  return `${serverType}__${tool}`;
+}
+
+/** Posts a message as the bot. The one genuinely autonomous write. */
+const APP_MESSAGE_TOOLS = ["apps-send-message"];
+
+/** Posts as the human user; HITL-gated in normal runs, impossible in an unattended one. */
+const USER_MESSAGE_TOOLS = ["user-send-message"];
+
+/** Creates or mutates durable objects — never allowed below "act". */
+const MUTATION_TOOLS = [
+  "spaces-create-ticket",
+  "spaces-create-bulk-tickets",
+  "spaces-update-ticket",
+  "spaces-update-bulk-tickets",
+  "spaces-schedule-call",
+  "spaces-create-canvas",
+  "spaces-edit-canvas",
+  "spaces-upload-to-kb",
+];
+
+/**
+ * The permission map for a run, merged over whatever the agent already has.
+ * Existing per-tool settings are preserved unless this policy denies the tool —
+ * a denial always wins.
+ */
+export function buildWritePermissions(
+  config: AwakeningConfig,
+  existing: Record<string, string> = {},
+): Record<string, string> {
+  const effective = config.shadow ? "observe" : config.writePolicy;
+  const denied: string[] = [];
+
+  if (effective === "observe") {
+    denied.push(
+      ...APP_MESSAGE_TOOLS.map((t) => key(SPACES_APP, t)),
+      ...APP_MESSAGE_TOOLS.map((t) => key(SPACES, t)),
+      ...USER_MESSAGE_TOOLS.map((t) => key(SPACES, t)),
+      ...MUTATION_TOOLS.map((t) => key(SPACES, t)),
+    );
+  } else if (effective === "reply") {
+    // Messaging stays available (that IS replying); durable mutations do not.
+    denied.push(
+      ...USER_MESSAGE_TOOLS.map((t) => key(SPACES, t)),
+      ...MUTATION_TOOLS.map((t) => key(SPACES, t)),
+    );
+  }
+
+  const permissions: Record<string, string> = { ...existing };
+  for (const k of denied) permissions[k] = "deny";
+  return permissions;
+}
+
+/** True when the run may not produce any outbound Spaces write. */
+export function isReadOnlyRun(config: AwakeningConfig): boolean {
+  return config.shadow || config.writePolicy === "observe";
+}

--- a/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.awakening.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.awakening.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { validateAwakeningConfig } from "./agent-config-validation.js";
+
+const ok = (awakening: unknown) => validateAwakeningConfig({ awakening });
+
+describe("validateAwakeningConfig — accepts", () => {
+  it("an absent or empty block", () => {
+    expect(validateAwakeningConfig(undefined)).toEqual({ ok: true });
+    expect(validateAwakeningConfig({})).toEqual({ ok: true });
+    expect(ok(null)).toEqual({ ok: true });
+    expect(ok({})).toEqual({ ok: true });
+  });
+
+  it("a fully specified valid block", () => {
+    expect(
+      ok({
+        enabled: true,
+        kind: "both",
+        shadow: false,
+        writePolicy: "act",
+        periodMs: 1_800_000,
+        workspaceId: "ws_1",
+        channels: { include: ["ch_1"], includePattern: ["^eng-"], excludePattern: ["-archive$"], maxChannels: 10 },
+        gate: { minHumanEvents: 2, forceRunEveryNSkips: 4 },
+        limits: { maxEvents: 500, maxActiveThreads: 100, maxRunsPerHour: 6 },
+        cursor: { replicaSafetyMs: 15_000, overlapMs: 60_000, maxCatchupWindows: 3 },
+      }),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe("validateAwakeningConfig — rejects with a reason", () => {
+  it("a non-object block", () => {
+    expect(ok("yes").error).toMatch(/awakening must be an object/);
+    expect(ok([]).ok).toBe(false);
+  });
+
+  it("a period below the floor — a typo must not make an agent wake every second", () => {
+    expect(ok({ periodMs: 1000 }).error).toMatch(/periodMs must be an integer between 300000 and 86400000/);
+    expect(ok({ periodMs: 60_000 }).ok).toBe(false);
+  });
+
+  it("a period above a day", () => {
+    expect(ok({ periodMs: 48 * 60 * 60_000 }).ok).toBe(false);
+  });
+
+  it("a non-integer period", () => {
+    expect(ok({ periodMs: 1_800_000.5 }).ok).toBe(false);
+    expect(ok({ periodMs: "30m" }).ok).toBe(false);
+  });
+
+  it("an unknown kind or writePolicy", () => {
+    expect(ok({ kind: "sideways" }).error).toMatch(/kind must be one of/);
+    expect(ok({ writePolicy: "destroy" }).error).toMatch(/writePolicy must be one of/);
+  });
+
+  it("a non-boolean enabled / shadow", () => {
+    expect(ok({ enabled: "true" }).ok).toBe(false);
+    expect(ok({ shadow: 1 }).ok).toBe(false);
+  });
+
+  it("an invalid regular expression", () => {
+    expect(ok({ channels: { includePattern: ["([a-z"] } }).error).toMatch(/not a valid regular expression/);
+  });
+
+  it("a catastrophic-backtracking pattern shape", () => {
+    expect(ok({ channels: { includePattern: ["(a+)+$"] } }).error).toMatch(/nested quantifier/);
+    expect(ok({ channels: { excludePattern: ["(x*)*"] } }).ok).toBe(false);
+  });
+
+  it("an oversized or over-numerous pattern list", () => {
+    expect(ok({ channels: { includePattern: ["a".repeat(201)] } }).error).toMatch(/too long/);
+    expect(ok({ channels: { includePattern: Array.from({ length: 11 }, (_, i) => `p${i}`) } }).error).toMatch(
+      /too many patterns/,
+    );
+  });
+
+  it("a non-string-array channel list", () => {
+    expect(ok({ channels: { include: [1, 2] } }).error).toMatch(/must be an array of strings/);
+    expect(ok({ channels: "eng" }).ok).toBe(false);
+  });
+
+  it("out-of-range limits and gate values", () => {
+    expect(ok({ limits: { maxRunsPerHour: 0 } }).ok).toBe(false);
+    expect(ok({ limits: { maxRunsPerHour: 1000 } }).ok).toBe(false);
+    expect(ok({ limits: { maxEvents: 1 } }).ok).toBe(false);
+    expect(ok({ gate: { minHumanEvents: -1 } }).ok).toBe(false);
+    expect(ok({ channels: { maxChannels: 500 } }).ok).toBe(false);
+    expect(ok({ cursor: { maxCatchupWindows: 0 } }).ok).toBe(false);
+  });
+
+  it("a non-string workspaceId", () => {
+    expect(ok({ workspaceId: 42 }).ok).toBe(false);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
@@ -215,7 +215,7 @@ const AWAKENING_MIN_PERIOD_MS = 5 * 60_000;
 // Mirrors AWAKENING_BOUNDS.instructionsLength.max — resolveAwakeningConfig
 // truncates silently, so the API rejects loudly instead of saving something
 // the runtime would quietly cut in half.
-const AWAKENING_MAX_INSTRUCTIONS = 4_000;
+const AWAKENING_MAX_INSTRUCTIONS = 10_000;
 const AWAKENING_MAX_PERIOD_MS = 24 * 60 * 60_000;
 const AWAKENING_MAX_PATTERNS = 10;
 const AWAKENING_MAX_PATTERN_LEN = 200;

--- a/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
@@ -199,3 +199,161 @@ export function validateAgentModelConfig(config: Record<string, unknown> | undef
   if (!fp.ok) return fp;
   return validateOutputFormat(config["outputFormat"]);
 }
+
+/**
+ * config.awakening — the settings that let an agent wake and act without a
+ * human trigger (see awakening/config.ts for the runtime shape and clamps).
+ *
+ * Validated here rather than only clamped at read time because these knobs are
+ * dangerous in a way modelSettings are not: a bad period or an unbounded regex
+ * governs a background loop that spends money and posts publicly. An admin
+ * gets a 400 with a reason instead of a silently-degraded agent.
+ */
+const AWAKENING_KIND_VALUES = ["heartbeat", "reflex", "both"];
+const AWAKENING_WRITE_POLICIES = ["observe", "reply", "act"];
+const AWAKENING_MIN_PERIOD_MS = 5 * 60_000;
+// Mirrors AWAKENING_BOUNDS.instructionsLength.max — resolveAwakeningConfig
+// truncates silently, so the API rejects loudly instead of saving something
+// the runtime would quietly cut in half.
+const AWAKENING_MAX_INSTRUCTIONS = 4_000;
+const AWAKENING_MAX_PERIOD_MS = 24 * 60 * 60_000;
+const AWAKENING_MAX_PATTERNS = 10;
+const AWAKENING_MAX_PATTERN_LEN = 200;
+/** Nested quantifiers are the classic catastrophic-backtracking shape. */
+const REDOS_SHAPE = /\([^)]*[+*][^)]*\)[+*]/;
+
+function validateStringArray(raw: unknown, label: string): ConfigValidationResult {
+  if (raw === undefined) return { ok: true };
+  if (!Array.isArray(raw) || raw.some((v) => typeof v !== "string")) {
+    return fail(`${label} must be an array of strings`);
+  }
+  return { ok: true };
+}
+
+function validatePatternArray(raw: unknown, label: string): ConfigValidationResult {
+  const base = validateStringArray(raw, label);
+  if (!base.ok) return base;
+  if (raw === undefined) return { ok: true };
+
+  const patterns = raw as string[];
+  if (patterns.length > AWAKENING_MAX_PATTERNS) {
+    return fail(`${label} has too many patterns (max ${AWAKENING_MAX_PATTERNS})`);
+  }
+  for (const src of patterns) {
+    if (src.length > AWAKENING_MAX_PATTERN_LEN) {
+      return fail(`${label} entry is too long (max ${AWAKENING_MAX_PATTERN_LEN} chars)`);
+    }
+    if (REDOS_SHAPE.test(src)) {
+      return fail(`${label} entry "${src.slice(0, 40)}" has a nested quantifier and could hang matching`);
+    }
+    try {
+      new RegExp(src, "i");
+    } catch {
+      return fail(`${label} entry "${src.slice(0, 40)}" is not a valid regular expression`);
+    }
+  }
+  return { ok: true };
+}
+
+function validateIntRange(raw: unknown, label: string, min: number, max: number): ConfigValidationResult {
+  if (raw === undefined) return { ok: true };
+  if (typeof raw !== "number" || !Number.isInteger(raw) || raw < min || raw > max) {
+    return fail(`${label} must be an integer between ${min} and ${max}`);
+  }
+  return { ok: true };
+}
+
+export function validateAwakeningConfig(config: Record<string, unknown> | undefined): ConfigValidationResult {
+  if (!config) return { ok: true };
+  const raw = config["awakening"];
+  if (raw === undefined || raw === null) return { ok: true };
+  if (!isPlainObject(raw)) return fail("awakening must be an object");
+
+  if (raw["enabled"] !== undefined && typeof raw["enabled"] !== "boolean") {
+    return fail("awakening.enabled must be a boolean");
+  }
+  if (raw["shadow"] !== undefined && typeof raw["shadow"] !== "boolean") {
+    return fail("awakening.shadow must be a boolean");
+  }
+  if (raw["kind"] !== undefined && !AWAKENING_KIND_VALUES.includes(raw["kind"] as string)) {
+    return fail(`awakening.kind must be one of: ${AWAKENING_KIND_VALUES.join(", ")}`);
+  }
+  if (raw["writePolicy"] !== undefined && !AWAKENING_WRITE_POLICIES.includes(raw["writePolicy"] as string)) {
+    return fail(`awakening.writePolicy must be one of: ${AWAKENING_WRITE_POLICIES.join(", ")}`);
+  }
+
+  if (raw["instructions"] !== undefined) {
+    if (typeof raw["instructions"] !== "string") return fail("awakening.instructions must be a string");
+    if ((raw["instructions"] as string).length > AWAKENING_MAX_INSTRUCTIONS) {
+      return fail(`awakening.instructions must be at most ${AWAKENING_MAX_INSTRUCTIONS} characters`);
+    }
+  }
+
+  const period = validateIntRange(raw["periodMs"], "awakening.periodMs", AWAKENING_MIN_PERIOD_MS, AWAKENING_MAX_PERIOD_MS);
+  if (!period.ok) return period;
+
+  if (raw["channels"] !== undefined) {
+    const ch = raw["channels"];
+    if (!isPlainObject(ch)) return fail("awakening.channels must be an object");
+    for (const [key, label] of [
+      ["include", "awakening.channels.include"],
+      ["exclude", "awakening.channels.exclude"],
+    ] as const) {
+      const r = validateStringArray(ch[key], label);
+      if (!r.ok) return r;
+    }
+    for (const [key, label] of [
+      ["includePattern", "awakening.channels.includePattern"],
+      ["excludePattern", "awakening.channels.excludePattern"],
+    ] as const) {
+      const r = validatePatternArray(ch[key], label);
+      if (!r.ok) return r;
+    }
+    const max = validateIntRange(ch["maxChannels"], "awakening.channels.maxChannels", 1, 100);
+    if (!max.ok) return max;
+  }
+
+  if (raw["limits"] !== undefined) {
+    const lim = raw["limits"];
+    if (!isPlainObject(lim)) return fail("awakening.limits must be an object");
+    for (const [key, min, max] of [
+      ["maxEvents", 10, 5000],
+      ["maxActiveThreads", 5, 1000],
+      ["maxRunsPerHour", 1, 60],
+    ] as const) {
+      const r = validateIntRange(lim[key], `awakening.limits.${key}`, min, max);
+      if (!r.ok) return r;
+    }
+  }
+
+  if (raw["gate"] !== undefined) {
+    const gate = raw["gate"];
+    if (!isPlainObject(gate)) return fail("awakening.gate must be an object");
+    for (const [key, min, max] of [
+      ["minHumanEvents", 0, 1000],
+      ["forceRunEveryNSkips", 0, 100],
+    ] as const) {
+      const r = validateIntRange(gate[key], `awakening.gate.${key}`, min, max);
+      if (!r.ok) return r;
+    }
+  }
+
+  if (raw["cursor"] !== undefined) {
+    const cursor = raw["cursor"];
+    if (!isPlainObject(cursor)) return fail("awakening.cursor must be an object");
+    for (const [key, min, max] of [
+      ["replicaSafetyMs", 0, 300_000],
+      ["overlapMs", 0, 900_000],
+      ["maxCatchupWindows", 1, 50],
+    ] as const) {
+      const r = validateIntRange(cursor[key], `awakening.cursor.${key}`, min, max);
+      if (!r.ok) return r;
+    }
+  }
+
+  if (raw["workspaceId"] !== undefined && typeof raw["workspaceId"] !== "string") {
+    return fail("awakening.workspaceId must be a string");
+  }
+
+  return { ok: true };
+}

--- a/apps/xyne-claw-auth/backend/src/lib/agent-owned-runs.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-owned-runs.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { isAgentOwnedRun } from "./agent-owned-runs.js";
+
+/**
+ * The cross-user redaction exists to protect a HUMAN's private Spaces data in
+ * a tool result. An awakened run has no human owner — it runs as the agent's
+ * own bot identity — so the redaction protects nobody and only blinds the
+ * admin who has to decide whether to take the agent out of shadow mode.
+ */
+describe("isAgentOwnedRun", () => {
+  it("is true for the unattended wake kinds", () => {
+    expect(isAgentOwnedRun("heartbeat")).toBe(true);
+    expect(isAgentOwnedRun("reflex")).toBe(true);
+  });
+
+  it("is false for every human-triggered source — those stay redacted", () => {
+    for (const src of ["spaces", "chat", "api", "slack", "automation", "scheduled"]) {
+      expect(isAgentOwnedRun(src)).toBe(false);
+    }
+  });
+
+  it("fails closed on a missing or unknown source", () => {
+    expect(isAgentOwnedRun(undefined)).toBe(false);
+    expect(isAgentOwnedRun(null)).toBe(false);
+    expect(isAgentOwnedRun("")).toBe(false);
+    expect(isAgentOwnedRun("something-new")).toBe(false);
+  });
+
+  it("is exact, not a prefix match", () => {
+    expect(isAgentOwnedRun("heartbeat-x")).toBe(false);
+    expect(isAgentOwnedRun("Heartbeat")).toBe(false);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/lib/agent-owned-runs.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-owned-runs.ts
@@ -1,0 +1,25 @@
+/**
+ * Which runs belong to the AGENT rather than to a person.
+ *
+ * The cross-user redaction in agent-chat.ts withholds tool RESULT bodies when
+ * an admin inspects a run they do not own, because a tool result carries that
+ * user's private Spaces data — their DMs, their private-channel text.
+ *
+ * That rationale does not apply to an awakened run. Nobody triggered it, it is
+ * owned by the agent's own bot identity, and every tool it called ran under the
+ * agent's app token against the channels an admin explicitly configured it to
+ * watch. There is no human whose privacy the redaction protects — only an admin
+ * who cannot see what the agent they configured actually did, which is the one
+ * thing they need in order to trust it enough to take it out of shadow mode.
+ *
+ * Deliberately keyed on triggerSource rather than on "is this a bot user", so a
+ * human-triggered run stays redacted even when an agent identity happens to own
+ * a row.
+ */
+
+/** Trigger sources for runs that no human initiated and no human owns. */
+const AGENT_OWNED_TRIGGER_SOURCES: ReadonlySet<string> = new Set(["heartbeat", "reflex"]);
+
+export function isAgentOwnedRun(triggerSource: string | null | undefined): boolean {
+  return !!triggerSource && AGENT_OWNED_TRIGGER_SOURCES.has(triggerSource);
+}

--- a/apps/xyne-claw-auth/backend/src/lib/credentials-loader.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/credentials-loader.ts
@@ -182,6 +182,67 @@ export async function loadEffectiveCredentials(
     return null;
   }
 
+  // xyne-spaces-app-tools: resolved HERE, before the agent-pin cascade. The
+  // adapter declares credentialFields: [] — there is no per-user or per-agent
+  // secret to store — but an AgentMcpConnection row is still seeded for the
+  // agent so /mcp/tools lists the server in the picker, and that row carries
+  // EMPTY creds by design. Resolving it through the cascade would spawn the
+  // child with no url and no token, and every Spaces call (including
+  // apps-send-message) fails with "Spaces base URL is not configured".
+  // Same short-circuit, same reason, as xyne-dashboard above.
+  //
+  // The MCP server runs with the AGENT'S spacesAppToken
+  // (each agent has its own bot identity, set when the agent was created).
+  // We resolve using the agent in scope so cross-agent calls don't leak the
+  // wrong bot's token. If no agentSlug is in context (admin / health-check
+  // paths) we have no agent identity to act as — return null and let the
+  // caller decide what to do.
+  if (serverType === "xyne-spaces-app-tools") {
+    if (!agentSlug) {
+      log.info(`[creds-loader] xyne-spaces-app-tools userId=${userId} → no agentSlug in context; cannot resolve app_token`);
+      return null;
+    }
+    const credOrgId = agentOrgId
+      ?? (await prisma.user.findUnique({ where: { id: userId }, select: { orgId: true } }))?.orgId
+      ?? undefined;
+    if (!credOrgId) {
+      log.info(`[creds-loader] xyne-spaces-app-tools userId=${userId} agent=${agentSlug} → no org context; cannot resolve app_token`);
+      return null;
+    }
+    const agent = await prisma.agent.findUnique({
+      where: { orgId_slug: { orgId: credOrgId, slug: agentSlug } },
+    });
+    if (agent?.spacesAppToken) {
+      const parts = agent.spacesAppToken.split(":");
+      if (parts.length === 3 && parts[0] && parts[1] && parts[2]) {
+        try {
+          const appToken = decrypt(parts[0], parts[1], parts[2], CONFIG.encryptionKey);
+          const workspaceId = await resolveSpacesAppToolsWorkspaceId(userId, credOrgId, agentSlug);
+          log.info(`[creds-loader] xyne-spaces-app-tools userId=${userId} agent=${agentSlug} → resolved app_token from agent row workspaceId=${workspaceId ?? "(none)"}`);
+          return {
+            source: "agent",
+            connectionId: `app-tools:${agent.id}`,
+            credentials: {
+              url: CONFIG.spacesInternalUrl,
+              app_token: appToken,
+              // Identity the app-mode registry tools act as. Without it
+              // XYNE_USER_ID reaches the child empty and every tool that needs
+              // to know who it is — spaces-whoami first among them — fails with
+              // "Could not determine current user."
+              ...(agent.spacesAppUserId ? { userId: agent.spacesAppUserId } : {}),
+              ...(workspaceId ? { workspaceId } : {}),
+            },
+            isUserOwned: false,
+          };
+        } catch {
+          log.error(`[creds-loader] xyne-spaces-app-tools: failed to decrypt agent=${agentSlug} spacesAppToken`);
+        }
+      }
+    }
+    log.info(`[creds-loader] xyne-spaces-app-tools userId=${userId} agent=${agentSlug} → no spacesAppToken on agent; cannot resolve`);
+    return null;
+  }
+
   // 1. Agent-pinned creds win when present. Only checked if the caller
   //    provided an agentSlug (i.e. the call is happening inside an agent's
   //    session — direct admin/health calls pass undefined and skip this).
@@ -255,13 +316,6 @@ export async function loadEffectiveCredentials(
     if (live) return live;
   }
 
-  // xyne-spaces-app-tools: empty credentialFields by design — there is no
-  // per-user secret. The MCP server runs with the AGENT'S spacesAppToken
-  // (each agent has its own bot identity, set when the agent was created).
-  // We resolve using the agent in scope so cross-agent calls don't leak the
-  // wrong bot's token. If no agentSlug is in context (admin / health-check
-  // paths) we have no agent identity to act as — return null and let the
-  // caller decide what to do.
   // heisenberg: shared/global stdio proxy with no per-user secret. The base
   // URL comes from deployment config (HEISENBERG_BASE_URL or a code default).
   if (serverType === "heisenberg") {
@@ -292,47 +346,6 @@ export async function loadEffectiveCredentials(
       },
       isUserOwned: false,
     };
-  }
-
-  if (serverType === "xyne-spaces-app-tools") {
-    if (!agentSlug) {
-      log.info(`[creds-loader] xyne-spaces-app-tools userId=${userId} → no agentSlug in context; cannot resolve app_token`);
-      return null;
-    }
-    const credOrgId = agentOrgId
-      ?? (await prisma.user.findUnique({ where: { id: userId }, select: { orgId: true } }))?.orgId
-      ?? undefined;
-    if (!credOrgId) {
-      log.info(`[creds-loader] xyne-spaces-app-tools userId=${userId} agent=${agentSlug} → no org context; cannot resolve app_token`);
-      return null;
-    }
-    const agent = await prisma.agent.findUnique({
-      where: { orgId_slug: { orgId: credOrgId, slug: agentSlug } },
-    });
-    if (agent?.spacesAppToken) {
-      const parts = agent.spacesAppToken.split(":");
-      if (parts.length === 3 && parts[0] && parts[1] && parts[2]) {
-        try {
-          const appToken = decrypt(parts[0], parts[1], parts[2], CONFIG.encryptionKey);
-          const workspaceId = await resolveSpacesAppToolsWorkspaceId(userId, credOrgId, agentSlug);
-          log.info(`[creds-loader] xyne-spaces-app-tools userId=${userId} agent=${agentSlug} → resolved app_token from agent row workspaceId=${workspaceId ?? "(none)"}`);
-          return {
-            source: "agent",
-            connectionId: `app-tools:${agent.id}`,
-            credentials: {
-              url: CONFIG.spacesInternalUrl,
-              app_token: appToken,
-              ...(workspaceId ? { workspaceId } : {}),
-            },
-            isUserOwned: false,
-          };
-        } catch {
-          log.error(`[creds-loader] xyne-spaces-app-tools: failed to decrypt agent=${agentSlug} spacesAppToken`);
-        }
-      }
-    }
-    log.info(`[creds-loader] xyne-spaces-app-tools userId=${userId} agent=${agentSlug} → no spacesAppToken on agent; cannot resolve`);
-    return null;
   }
 
   const userConn = await prisma.userMcpConnection.findFirst({

--- a/apps/xyne-claw-auth/backend/src/lib/live-conversation-bus.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/live-conversation-bus.ts
@@ -30,7 +30,11 @@ const channelFor = (conversationId: string) => CHANNEL_PREFIX + conversationId;
 
 export type LiveEvent =
   | { type: "label"; conversationId: string; agentSlug?: string | undefined; userId: string; toolLabel: string; ts: number }
-  | { type: "invocation"; conversationId: string; agentSlug?: string | undefined; userId: string; toolInvocation: unknown; ts: number }
+  // `triggerSource` rides along so the SSE viewer can apply the SAME redaction
+  // rule to a live tool call that it applies to a stored one — an agent-owned
+  // run (heartbeat / reflex) has no private user data to protect, so its
+  // results stay readable to admins instead of arriving pre-redacted.
+  | { type: "invocation"; conversationId: string; agentSlug?: string | undefined; userId: string; toolInvocation: unknown; triggerSource?: string | undefined; ts: number }
   // Coalesced assistant text/reasoning fragments (one event per ~250ms batch) so
   // VIEWERS (reloaded tabs, Spaces) stream the answer live instead of seeing it
   // appear all-at-once on `done`. Either/both fields may be present per batch.

--- a/apps/xyne-claw-auth/backend/src/lib/session-context.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/session-context.ts
@@ -115,7 +115,7 @@ export interface SessionContext {
   slackDelivery?: SlackDeliveryTarget;
   /** Surface that dispatched this run. Used by MCP tool filtering to apply
    *  surface-scoped default tools without mutating the stored agent config. */
-  triggerSource?: "spaces" | "scheduled" | "chat" | "api" | "automation" | "slack";
+  triggerSource?: "spaces" | "scheduled" | "chat" | "api" | "automation" | "slack" | "heartbeat" | "reflex";
   /**
    * When true, the result-forward branch resolves the agent's plain `@Name`
    * mentions into clickable/notifying Spaces mentions (name→userId via

--- a/apps/xyne-claw-auth/backend/src/lib/spaces-db.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/spaces-db.ts
@@ -174,6 +174,7 @@ export type SpacesAuthCaller =
   | "write-action"
   | "clone-owner-dm"
   | "skill-update-owner-dm"
+  | "awakening"
   | "unknown";
 
 export async function getSpacesAuthForUser(

--- a/apps/xyne-claw-auth/backend/src/main.ts
+++ b/apps/xyne-claw-auth/backend/src/main.ts
@@ -11,6 +11,11 @@ import { errorMiddleware } from "./lib/http.js";
 import { serversRouter } from "./routes/servers.js";
 import { connectionsRouter } from "./routes/connections.js";
 import { mcpRouter } from "./routes/mcp.js";
+import { awakeningRouter } from "./routes/awakening.js";
+import { ensureTickScheduler, closeAwakeningQueues } from "./queue/awakening-queue.js";
+import { initAwakeningTickWorker, closeAwakeningTickWorker } from "./queue/awakening-tick-worker.js";
+import { initAwakeningWindowWorker, closeAwakeningWindowWorker } from "./queue/awakening-window-worker.js";
+import { initAwakeningReflexWorker, closeAwakeningReflexWorker } from "./queue/awakening-reflex-worker.js";
 import { runRouter } from "./routes/run.js";
 import { runStreamRouter, runStreamInternalRouter } from "./routes/run-stream.js";
 import { usersRouter } from "./routes/users.js";
@@ -274,6 +279,9 @@ app.use(`${BASE}/internal`, requireStrictS2S, runRouter);
 app.use(`${BASE}/run/stream`, runStreamRouter);
 app.use(`${BASE}/internal/run-stream`, requireStrictS2S, runStreamInternalRouter);
 app.use(BASE, runRouter);
+// Awakening: the result callback self-protects with requireStrictS2S and the
+// status route carries its own admin gate, so no mount-level auth here.
+app.use(BASE, awakeningRouter);
 // No mount-level auth on /webhook by design: it mixes auth schemes per route.
 // POST / , /result and /progress are S2S callbacks; POST /:agentSlug is hit
 // directly by Spaces and self-protects via verifySpacesSignature (per-agent
@@ -369,6 +377,16 @@ listen(CONFIG.port, () => {
     initDailyBriefCron();
     initFailureCuratorWorker();
     initOrphanFinalizerWorker();
+    // Awakened agents: one fleet-wide tick fans out to per-agent window jobs.
+    // ensureTickScheduler is idempotent, so every pod calling it converges on
+    // a single scheduler — which is also what makes a Redis wipe self-heal on
+    // the next boot instead of silently stopping every awakened agent.
+    initAwakeningTickWorker();
+    initAwakeningWindowWorker();
+    initAwakeningReflexWorker();
+    void ensureTickScheduler().catch((err) =>
+      log.error("[boot] awakening tick scheduler registration failed:", err),
+    );
   // Upsert custom tools from the shared registry so newly added tools (e.g.
     // google-sheets-create, google-forms-create) show up in the agent UI on
     // restart without needing a manual POST /tools/sync call.
@@ -401,6 +419,10 @@ async function shutdown(signal: string): Promise<void> {
     await closeEntityExtractionQueue().catch(() => {});
     closeFailureCuratorWorker();
     closeOrphanFinalizerWorker();
+    await closeAwakeningTickWorker().catch(() => {});
+    await closeAwakeningWindowWorker().catch(() => {});
+    await closeAwakeningReflexWorker().catch(() => {});
+    await closeAwakeningQueues().catch(() => {});
     await closeQueue().catch(() => {});
     await closeDailyBriefWorker().catch(() => {});
     await closeDailyBriefQueue().catch(() => {});

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/spaces-base-url.test.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/spaces-base-url.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveBaseUrl } from "./xyne-spaces-client.js";
+
+const KEYS = ["XYNE_SPACES_URL", "SPACES_BACKEND_URL"] as const;
+
+describe("resolveBaseUrl", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
+    for (const k of KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("falls back to SPACES_BACKEND_URL when XYNE_SPACES_URL is blank", () => {
+    process.env["XYNE_SPACES_URL"] = "";
+    process.env["SPACES_BACKEND_URL"] = "http://localhost:3001";
+    expect(resolveBaseUrl()).toBe("http://localhost:3001");
+  });
+
+  it("falls back when XYNE_SPACES_URL is whitespace only", () => {
+    process.env["XYNE_SPACES_URL"] = "   ";
+    process.env["SPACES_BACKEND_URL"] = "http://localhost:3001";
+    expect(resolveBaseUrl()).toBe("http://localhost:3001");
+  });
+
+  it("prefers XYNE_SPACES_URL when it is set", () => {
+    process.env["XYNE_SPACES_URL"] = "http://spaces.internal";
+    process.env["SPACES_BACKEND_URL"] = "http://localhost:3001";
+    expect(resolveBaseUrl()).toBe("http://spaces.internal");
+  });
+
+  it("prefers a non-blank override over both env vars", () => {
+    process.env["XYNE_SPACES_URL"] = "http://spaces.internal";
+    expect(resolveBaseUrl("http://override")).toBe("http://override");
+  });
+
+  it("ignores a blank override", () => {
+    process.env["SPACES_BACKEND_URL"] = "http://localhost:3001";
+    expect(resolveBaseUrl("")).toBe("http://localhost:3001");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(resolveBaseUrl("http://localhost:3001///")).toBe("http://localhost:3001");
+  });
+
+  it("returns empty when nothing is configured", () => {
+    expect(resolveBaseUrl()).toBe("");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-client.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-client.ts
@@ -53,12 +53,14 @@ export function isFlowSchemaRejection(err: unknown): boolean {
   );
 }
 
-function resolveBaseUrl(override?: string): string {
-  const raw = override
-    ?? process.env["XYNE_SPACES_URL"]
-    ?? process.env["SPACES_BACKEND_URL"]
-    ?? "";
-  return raw.replace(/\/+$/, "");
+// `??` alone is not enough here: the adapter always writes XYNE_SPACES_URL into
+// the child's env, so a credential set without a `url` leaves it defined-but-
+// empty, which shadows SPACES_BACKEND_URL and takes the whole server down with
+// "Spaces base URL is not configured". Treat blank as unset at every level.
+export function resolveBaseUrl(override?: string): string {
+  const candidates = [override, process.env["XYNE_SPACES_URL"], process.env["SPACES_BACKEND_URL"]];
+  const raw = candidates.find((value) => typeof value === "string" && value.trim().length > 0) ?? "";
+  return raw.trim().replace(/\/+$/, "");
 }
 
 // Extract Spaces userId from the JWT token's `sub` claim (user tokens)

--- a/apps/xyne-claw-auth/backend/src/middleware/requestLogger.ts
+++ b/apps/xyne-claw-auth/backend/src/middleware/requestLogger.ts
@@ -3,6 +3,29 @@ import { randomUUID } from "node:crypto";
 import { logger, loggerContext, type LogContext } from "../logger.js";
 
 /**
+ * Endpoints that are machine-to-machine and fire many times a second, where the
+ * access log tells an operator nothing they cannot get from the run itself.
+ *
+ * `/webhook/progress` is the loud one: claw posts a `stream_rate` telemetry
+ * sample once per second for every streaming run, plus one per tool call, so a
+ * couple of concurrent runs bury every other line in the log. The requests are
+ * still served and still traced — only the start/end pair drops to `debug`.
+ *
+ * Override with QUIET_REQUEST_PATHS (comma-separated substrings); set it empty
+ * to log everything again.
+ */
+const QUIET_REQUEST_PATHS: readonly string[] = (
+  process.env["QUIET_REQUEST_PATHS"] ?? "/webhook/progress"
+)
+  .split(",")
+  .map((entry) => entry.trim())
+  .filter((entry) => entry.length > 0);
+
+function isQuietPath(url: string): boolean {
+  return QUIET_REQUEST_PATHS.some((quiet) => url.includes(quiet));
+}
+
+/**
  * Establishes an AsyncLocalStorage log context per request so every downstream
  * log line carries `requestId` (and `traceId`/`sessionId` when provided),
  * and emits structured request start/end with duration. Mirrors the xyne
@@ -19,7 +42,8 @@ export function requestLogger(req: Request, res: Response, next: NextFunction): 
 
   loggerContext.run(context, () => {
     const startedAt = Date.now();
-    logger.info("Request start", {
+    const level = isQuietPath(req.originalUrl || req.url) ? "debug" : "info";
+    logger[level]("Request start", {
       component: "http",
       event: "request_start",
       method: req.method,
@@ -28,7 +52,7 @@ export function requestLogger(req: Request, res: Response, next: NextFunction): 
     });
 
     res.on("finish", () => {
-      logger.info("Request end", {
+      logger[level]("Request end", {
         component: "http",
         event: "request_end",
         method: req.method,

--- a/apps/xyne-claw-auth/backend/src/queue/awakening-queue.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/awakening-queue.ts
@@ -1,0 +1,125 @@
+/**
+ * Queues for the awakening pipeline.
+ *
+ * TWO queues, one repeatable scheduler:
+ *
+ *   agent-awakening-tick   — ONE repeatable job for the whole fleet. Every
+ *                            TICK_MS it claims the agents that are due and
+ *                            fans them out. Deliberately not one repeatable
+ *                            job per agent: BullMQ schedulers live in Redis
+ *                            with no auto-reconcile from Postgres (see the
+ *                            comment in main.ts), so a Redis wipe would
+ *                            silently stop every agent forever. With a single
+ *                            tick, due-ness lives in Postgres and a wipe costs
+ *                            exactly one missed tick.
+ *
+ *   agent-awakening-window — the per-agent work. Retried with backoff; a
+ *                            failure here must not lose the wake.
+ */
+
+import { Queue } from "bullmq";
+import { redisService } from "../redis.js";
+
+export interface AwakeningWindowJobData {
+  agentId: string;
+  orgId: string;
+  kind: "heartbeat" | "reflex";
+  /** Stamped at claim time so a delayed job can tell how late it is. */
+  claimedAtMs: number;
+}
+
+export interface AwakeningReflexJobData {
+  agentId: string;
+  orgId: string;
+  claimedAtMs: number;
+}
+
+export const TICK_QUEUE_NAME = "agent-awakening-tick";
+export const REFLEX_QUEUE_NAME = "agent-awakening-reflex";
+export const WINDOW_QUEUE_NAME = "agent-awakening-window";
+export const TICK_SCHEDULER_ID = "awakening-tick";
+
+/** How often the fleet is scanned for due agents. */
+export const TICK_INTERVAL_MS = Number(process.env["AWAKENING_TICK_MS"] ?? 60_000);
+
+let tickQueue: Queue | undefined;
+let windowQueue: Queue<AwakeningWindowJobData> | undefined;
+let reflexQueue: Queue<AwakeningReflexJobData> | undefined;
+
+export function getTickQueue(): Queue {
+  if (!tickQueue) {
+    tickQueue = new Queue(TICK_QUEUE_NAME, {
+      connection: redisService.getConnection(),
+      // The tick is self-rescheduling and idempotent: a dropped tick is
+      // recovered by the next one, so retrying a failed tick only risks
+      // double-claiming. Never retry.
+      defaultJobOptions: { attempts: 1, removeOnComplete: true, removeOnFail: true },
+    });
+  }
+  return tickQueue;
+}
+
+export function getWindowQueue(): Queue<AwakeningWindowJobData> {
+  if (!windowQueue) {
+    windowQueue = new Queue<AwakeningWindowJobData>(WINDOW_QUEUE_NAME, {
+      connection: redisService.getConnection(),
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: "exponential", delay: 5_000 },
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    });
+  }
+  return windowQueue;
+}
+
+/**
+ * Register the single fleet-wide tick. Idempotent by design — calling it on
+ * every pod boot converges on one scheduler, which is what makes recovery
+ * from a Redis wipe automatic.
+ */
+export async function ensureTickScheduler(): Promise<void> {
+  await getTickQueue().upsertJobScheduler(
+    TICK_SCHEDULER_ID,
+    { every: TICK_INTERVAL_MS },
+    { name: "awakening-tick", data: {} },
+  );
+}
+
+/**
+ * Reflex checks get their own queue so a burst of them can never starve the
+ * heartbeat queue — they run on a much faster cadence and are far more numerous.
+ */
+export function getReflexQueue(): Queue<AwakeningReflexJobData> {
+  if (!reflexQueue) {
+    reflexQueue = new Queue<AwakeningReflexJobData>(REFLEX_QUEUE_NAME, {
+      connection: redisService.getConnection(),
+      // A missed reflex check costs nothing: the next one re-counts the same
+      // window from the same watermark. Retrying just adds duplicate load.
+      defaultJobOptions: { attempts: 1, removeOnComplete: true, removeOnFail: true },
+    });
+  }
+  return reflexQueue;
+}
+
+export async function enqueueReflexCheck(data: AwakeningReflexJobData): Promise<void> {
+  await getReflexQueue().add("reflex", data, { jobId: `awk-reflex-${data.agentId}-${data.claimedAtMs}` });
+}
+
+export async function enqueueWindow(data: AwakeningWindowJobData): Promise<void> {
+  // jobId derived from the claim instant: if the same agent is somehow claimed
+  // twice for the same beat, BullMQ de-duplicates instead of running twice.
+  await getWindowQueue().add("window", data, {
+    jobId: `awk-${data.kind}-${data.agentId}-${data.claimedAtMs}`,
+  });
+}
+
+export async function closeAwakeningQueues(): Promise<void> {
+  await tickQueue?.close().catch(() => {});
+  await windowQueue?.close().catch(() => {});
+  await reflexQueue?.close().catch(() => {});
+  tickQueue = undefined;
+  windowQueue = undefined;
+  reflexQueue = undefined;
+}

--- a/apps/xyne-claw-auth/backend/src/queue/awakening-reflex-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/awakening-reflex-worker.ts
@@ -72,7 +72,7 @@ async function processReflex(job: Job<AwakeningReflexJobData>): Promise<void> {
   if (!config.enabled || !participatesIn(config, "reflex")) return;
 
   try {
-    const workspaceId = await resolveWorkspaceId(orgId, config.workspaceId);
+    const workspaceId = await resolveWorkspaceId(orgId, agent.spacesAppUserId, config.workspaceId);
     const identity = resolveAgentIdentity(agent, workspaceId);
 
     const sinceMs = (state.reflexWatermarkAt ?? state.watermarkAt).getTime();
@@ -199,6 +199,9 @@ async function processReflex(job: Job<AwakeningReflexJobData>): Promise<void> {
           reflexWatermarkAt: new Date(untilMs),
           reflexLastRunAt: new Date(),
           reflexNextCheckAt: nextCheckAt(config.reflex.checkIntervalMs),
+          // The heartbeat path clears this via markSuccess; a reflex-only agent
+          // has no such path, so a resolved error would otherwise stick forever.
+          lastError: null,
         },
       });
     } catch (err) {
@@ -206,10 +209,18 @@ async function processReflex(job: Job<AwakeningReflexJobData>): Promise<void> {
       throw err;
     }
   } catch (err) {
-    if (err instanceof AwakeningIdentityError || err instanceof WorkspaceResolutionError) {
+    // Fail-closed on identity (see the window worker), retry on workspace.
+    if (err instanceof AwakeningIdentityError) {
       await prisma.agentAwakeningState
         .update({ where: { agentId }, data: { enabled: false, lastError: String(err.message).slice(0, 500) } })
         .catch(() => undefined);
+      return;
+    }
+    if (err instanceof WorkspaceResolutionError) {
+      await prisma.agentAwakeningState
+        .update({ where: { agentId }, data: { lastError: String(err.message).slice(0, 500) } })
+        .catch(() => undefined);
+      log.warn(`[awakening] reflex skipped agent=${agent.slug} (workspace unresolved): ${err.message}`);
       return;
     }
     log.error(`[awakening] reflex check failed agent=${agent.slug}: ${err instanceof Error ? err.message : err}`);

--- a/apps/xyne-claw-auth/backend/src/queue/awakening-reflex-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/awakening-reflex-worker.ts
@@ -1,0 +1,237 @@
+/**
+ * The reflex check worker: one cheap COUNT per agent per interval, escalating
+ * to a full collect only when enough has actually happened.
+ *
+ * Claimed with the same `FOR UPDATE SKIP LOCKED` pattern as the heartbeat tick
+ * so it is safe on every pod, but against `reflexNextCheckAt` — reflex runs on
+ * its own, much faster cadence.
+ *
+ * Watermark discipline mirrors the heartbeat worker, with one addition: on an
+ * INJECT the reflex watermark still advances, because those events have been
+ * handed to the live session and must not be counted toward the next trigger.
+ * Handed to, not necessarily read by — a run can end with batches still queued,
+ * so the result callback rolls the watermark back over anything undelivered
+ * (rewindWatermarkForUndelivered in routes/awakening.ts).
+ */
+
+import { Worker, type Job } from "bullmq";
+import { redisService } from "../redis.js";
+import { prisma } from "../db.js";
+import { resolveAwakeningConfig, participatesIn } from "../awakening/config.js";
+import { resolveAwakeningChannels } from "../awakening/channel-resolver.js";
+import { collectWindow } from "../awakening/collector.js";
+import { computeSignals } from "../awakening/signals.js";
+import { countEventsSince, decideReflex, renderInjection, logDecision } from "../awakening/reflex.js";
+import { acquireAgentLock, readAgentLock, releaseAgentLock } from "../awakening/lock.js";
+import { pushInjection, readInjectionStats } from "../awakening/inbox.js";
+import { dispatchAwakening, resolveAgentIdentity, AwakeningIdentityError } from "../awakening/dispatch.js";
+import { resolveWorkspaceId, WorkspaceResolutionError } from "../awakening/workspace.js";
+import { peekRunRate, consumeRunRate } from "../awakening/rate-limit.js";
+import { REFLEX_QUEUE_NAME, type AwakeningReflexJobData } from "./awakening-queue.js";
+import type { AwakeningWindow } from "../awakening/types.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-reflex-worker");
+
+let worker: Worker<AwakeningReflexJobData> | undefined;
+
+function nextCheckAt(intervalMs: number): Date {
+  return new Date(Date.now() + intervalMs);
+}
+
+/** One-line-per-thread outline for an injection batch. */
+function outlineFor(window: AwakeningWindow): string[] {
+  const byThread = new Map<string, { title: string; channel: string; n: number; last: string }>();
+  for (const e of window.events) {
+    const entry = byThread.get(e.cv) ?? { title: e.cvTitle, channel: e.chName, n: 0, last: "" };
+    entry.n++;
+    entry.last = e.text.length > 100 ? `${e.text.slice(0, 97)}…` : e.text;
+    byThread.set(e.cv, entry);
+  }
+  return [...byThread.entries()].map(
+    ([cv, t]) => `- ${t.channel} / \`${cv}\` — "${t.title}" (${t.n} new): ${t.last.replace(/\n/g, " ")}`,
+  );
+}
+
+async function processReflex(job: Job<AwakeningReflexJobData>): Promise<void> {
+  const { agentId, orgId } = job.data;
+
+  const state = await prisma.agentAwakeningState.findUnique({ where: { agentId } });
+  if (!state?.enabled) return;
+
+  const agent = await prisma.agent.findUnique({
+    where: { id: agentId },
+    select: {
+      id: true, slug: true, orgId: true, config: true,
+      spacesAppId: true, spacesAppUserId: true, spacesAppToken: true,
+    },
+  });
+  if (!agent) return;
+
+  const config = resolveAwakeningConfig(agent.config);
+  if (!config.enabled || !participatesIn(config, "reflex")) return;
+
+  try {
+    const workspaceId = await resolveWorkspaceId(orgId, config.workspaceId);
+    const identity = resolveAgentIdentity(agent, workspaceId);
+
+    const sinceMs = (state.reflexWatermarkAt ?? state.watermarkAt).getTime();
+    const untilMs = Date.now() - config.cursor.replicaSafetyMs;
+    if (untilMs <= sinceMs) return;
+
+    const resolved = await resolveAwakeningChannels(agentId, config.channels, identity, config.reflex.checkIntervalMs);
+    if (resolved.channels.length === 0) return;
+
+    const count = await countEventsSince(resolved.channels, sinceMs, untilMs, identity);
+    const holder = await readAgentLock(agentId);
+    const stats = holder ? await readInjectionStats(holder.sessionId) : { used: 0, lastAtMs: 0 };
+
+    const decision = decideReflex({
+      count,
+      config,
+      busyWithSessionId: holder?.sessionId ?? null,
+      sinceLastRunMs: state.reflexLastRunAt ? Date.now() - state.reflexLastRunAt.getTime() : Number.POSITIVE_INFINITY,
+      injectionsUsed: stats.used,
+      sinceLastInjectionMs: stats.lastAtMs ? Date.now() - stats.lastAtMs : Number.POSITIVE_INFINITY,
+    });
+    logDecision(agent.slug, decision, !!holder);
+
+    if (decision.action === "wait" || decision.action === "hold") return;
+
+    // Both remaining actions need the actual events, not just a count.
+    const collected = await collectWindow(resolved.channels, sinceMs, untilMs, identity, config);
+    if (collected.events.length === 0) return;
+
+    const window: AwakeningWindow = {
+      agentId,
+      agentSlug: agent.slug,
+      orgId,
+      kind: "reflex",
+      startMs: sinceMs,
+      endMs: untilMs,
+      channels: resolved.channels.filter((c) => collected.activeChannels.has(c.id)),
+      silentChannels: resolved.channels.filter((c) => !collected.activeChannels.has(c.id)),
+      events: collected.events,
+      signals: computeSignals(collected.events),
+      truncated: collected.truncated,
+      gap: null,
+      priorRuns: [],
+      config,
+    };
+
+    if (decision.action === "inject") {
+      const ordinal = stats.used + 1;
+      const remaining = Math.max(0, config.reflex.maxInjectionsPerSession - ordinal);
+      const pushed = await pushInjection(decision.sessionId, {
+        ordinal,
+        eventCount: window.events.length,
+        windowStartMs: sinceMs,
+        text: renderInjection(ordinal, window.events.length, remaining, outlineFor(window)),
+        createdAtMs: Date.now(),
+        isFinal: remaining <= 0,
+      });
+      // Only advance once the batch is safely queued. A dropped push must leave
+      // the events to be re-counted, not silently vanish.
+      if (pushed) {
+        await prisma.agentAwakeningState.update({
+          where: { agentId },
+          data: { reflexWatermarkAt: new Date(untilMs), reflexNextCheckAt: nextCheckAt(config.reflex.checkIntervalMs) },
+        });
+        await prisma.agentAwakeningRun.updateMany({
+          where: { sessionId: decision.sessionId },
+          data: { injectionsUsed: ordinal },
+        });
+      }
+      return;
+    }
+
+    // action === "fire"
+    const rate = await peekRunRate(agentId, config.limits.maxRunsPerHour);
+    if (!rate.allowed) return;
+
+    const idempotencyKey = `awk_reflex_${agentId}_${sinceMs}`;
+    // Placeholder holder: the lock must be taken BEFORE dispatch (otherwise a
+    // second pod could dispatch in the gap), so it is keyed on the idempotency
+    // key and re-keyed to the real sessionId once claw returns one.
+    if (!(await acquireAgentLock(agentId, { sessionId: idempotencyKey, kind: "reflex", acquiredAtMs: Date.now() }))) {
+      return;
+    }
+
+    try {
+      const result = await dispatchAwakening(window, agent, identity, idempotencyKey);
+      if (!result.dispatched) {
+        await releaseAgentLock(agentId, idempotencyKey);
+        throw new Error(`reflex dispatch failed: ${result.reason ?? "unknown"}`);
+      }
+
+      // Re-key the lock to the real session so the result callback and the
+      // injection path can both find it.
+      if (result.sessionId) {
+        await releaseAgentLock(agentId, idempotencyKey);
+        await acquireAgentLock(agentId, {
+          sessionId: result.sessionId,
+          kind: "reflex",
+          acquiredAtMs: Date.now(),
+        });
+      }
+
+      await consumeRunRate(agentId);
+      await prisma.agentAwakeningRun.create({
+        data: {
+          agentId,
+          orgId,
+          kind: "reflex",
+          windowStartMs: BigInt(sinceMs),
+          windowEndMs: BigInt(untilMs),
+          outcome: config.shadow ? "shadow" : "ran",
+          eventCount: window.events.length,
+          signals: window.signals as unknown as object,
+          idempotencyKey,
+          ...(result.sessionId ? { sessionId: result.sessionId } : {}),
+        },
+      }).catch((err: { code?: string }) => {
+        if (err?.code !== "P2002") throw err;
+      });
+
+      await prisma.agentAwakeningState.update({
+        where: { agentId },
+        data: {
+          reflexWatermarkAt: new Date(untilMs),
+          reflexLastRunAt: new Date(),
+          reflexNextCheckAt: nextCheckAt(config.reflex.checkIntervalMs),
+        },
+      });
+    } catch (err) {
+      await releaseAgentLock(agentId, idempotencyKey).catch(() => undefined);
+      throw err;
+    }
+  } catch (err) {
+    if (err instanceof AwakeningIdentityError || err instanceof WorkspaceResolutionError) {
+      await prisma.agentAwakeningState
+        .update({ where: { agentId }, data: { enabled: false, lastError: String(err.message).slice(0, 500) } })
+        .catch(() => undefined);
+      return;
+    }
+    log.error(`[awakening] reflex check failed agent=${agent.slug}: ${err instanceof Error ? err.message : err}`);
+    throw err;
+  }
+}
+
+export function initAwakeningReflexWorker(): Worker<AwakeningReflexJobData> {
+  if (worker) return worker;
+  worker = new Worker<AwakeningReflexJobData>(REFLEX_QUEUE_NAME, processReflex, {
+    connection: redisService.getConnection(),
+    concurrency: Number(process.env["AWAKENING_REFLEX_CONCURRENCY"] ?? 10),
+  });
+  worker.on("failed", (job, err) =>
+    log.error(`[awakening] reflex job ${job?.data.agentId ?? job?.id} failed: ${err.message}`),
+  );
+  worker.on("error", (err) => log.error(`[awakening] reflex worker error: ${err.message}`));
+  log.info("[awakening] reflex worker started");
+  return worker;
+}
+
+export async function closeAwakeningReflexWorker(): Promise<void> {
+  await worker?.close().catch(() => {});
+  worker = undefined;
+}

--- a/apps/xyne-claw-auth/backend/src/queue/awakening-tick-kind.test.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/awakening-tick-kind.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveAwakeningConfig, participatesIn } from "../awakening/config.js";
+
+/**
+ * Regression guard for the bug where the heartbeat tick cleared
+ * `state.enabled` for any agent that did not do heartbeats — which silently
+ * killed every reflex-only agent, because the reflex claim scan requires
+ * `enabled = TRUE`.
+ *
+ * The tick worker itself needs Redis + Prisma to exercise, so this pins the
+ * predicate the fix keys off: `enabled` and "participates in this kind" are
+ * two different questions and must never be collapsed.
+ */
+describe("wake-kind participation", () => {
+  const cfg = (kind: string) => resolveAwakeningConfig({ awakening: { enabled: true, kind } });
+
+  it("reflex-only agents do not participate in heartbeat", () => {
+    expect(participatesIn(cfg("reflex"), "heartbeat")).toBe(false);
+  });
+
+  it("reflex-only agents are still ENABLED — the reflex scan needs that", () => {
+    expect(cfg("reflex").enabled).toBe(true);
+    expect(participatesIn(cfg("reflex"), "reflex")).toBe(true);
+  });
+
+  it("heartbeat-only agents do not participate in reflex but stay enabled", () => {
+    expect(participatesIn(cfg("heartbeat"), "reflex")).toBe(false);
+    expect(cfg("heartbeat").enabled).toBe(true);
+  });
+
+  it("both participates in each kind", () => {
+    expect(participatesIn(cfg("both"), "heartbeat")).toBe(true);
+    expect(participatesIn(cfg("both"), "reflex")).toBe(true);
+  });
+
+  it("a disabled agent is disabled regardless of kind", () => {
+    const off = resolveAwakeningConfig({ awakening: { enabled: false, kind: "both" } });
+    expect(off.enabled).toBe(false);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/queue/awakening-tick-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/awakening-tick-worker.ts
@@ -1,0 +1,237 @@
+/**
+ * The fleet tick: claims every agent whose next beat is due and fans them out.
+ *
+ * The claim is a single atomic UPDATE … WHERE id IN (SELECT … FOR UPDATE SKIP
+ * LOCKED) that ALSO pushes nextDueAt forward. That combination is what makes
+ * the tick safe to run on every pod concurrently: two pods scanning at the
+ * same instant cannot claim the same agent, because the first one's row lock
+ * makes the second skip it, and by the time the lock is released nextDueAt is
+ * already in the future so the row no longer matches.
+ *
+ * Claiming BEFORE the work happens (rather than after) means a crashed pod
+ * costs one skipped beat rather than a hot loop of re-claims. The watermark is
+ * what guarantees no events are lost in that case — the next beat's window
+ * simply starts where the crashed one would have.
+ */
+
+import { Worker, type Job } from "bullmq";
+import { redisService } from "../redis.js";
+import { prisma } from "../db.js";
+import { resolveAwakeningConfig, participatesIn } from "../awakening/config.js";
+import { computeNextDueAt } from "../awakening/cursor.js";
+import { enqueueWindow, enqueueReflexCheck, TICK_QUEUE_NAME } from "./awakening-queue.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-tick");
+
+/**
+ * How far out a cadence is parked when the agent does not participate in that
+ * wake kind. Long enough that the scan stops paying for it every tick, short
+ * enough that flipping `kind` in the UI takes effect within the hour.
+ */
+const IDLE_REPARK_MS = 60 * 60_000;
+
+/** Global kill switch. Set to "1" to stop every awakened agent everywhere. */
+function killed(): boolean {
+  return process.env["AWAKENING_DISABLED"] === "1";
+}
+
+/** Most agents claimed per tick, so one tick cannot enqueue unbounded work. */
+const FANOUT_BATCH = Number(process.env["AWAKENING_FANOUT_BATCH"] ?? 100);
+
+let worker: Worker | undefined;
+
+/**
+ * Claim agents whose reflex check is due. Same SKIP LOCKED shape as the
+ * heartbeat claim, against the reflex cadence column.
+ *
+ * A NULL reflexNextCheckAt means "never checked" and is treated as due, so an
+ * agent that has reflex switched on starts checking immediately rather than
+ * waiting for a first write to the column.
+ */
+export async function claimDueReflexChecks(limit: number): Promise<ClaimedRow[]> {
+  const provisionalNext = new Date(Date.now() + 60_000);
+  return prisma.$queryRaw<ClaimedRow[]>`
+    UPDATE "agent_awakening_state" AS s
+       SET "reflexNextCheckAt" = ${provisionalNext}
+     WHERE s."id" IN (
+       SELECT "id" FROM "agent_awakening_state"
+        WHERE "enabled" = TRUE
+          AND ("reflexNextCheckAt" IS NULL OR "reflexNextCheckAt" <= NOW())
+        ORDER BY "reflexNextCheckAt" ASC NULLS FIRST
+        LIMIT ${limit}
+        FOR UPDATE SKIP LOCKED
+     )
+ RETURNING s."id", s."agentId", s."orgId", s."consecutiveFailures"
+  `;
+}
+
+export interface ClaimedRow {
+  id: string;
+  agentId: string;
+  orgId: string;
+  consecutiveFailures: number;
+}
+
+/**
+ * Atomically claim due agents and push their next beat out.
+ *
+ * nextDueAt is advanced by a provisional period here and corrected by the
+ * window worker once it has read the agent's real config — the tick would
+ * otherwise have to read and parse every agent's JSON config just to compute a
+ * timestamp, on every tick, for the whole fleet.
+ */
+export async function claimDueAgents(limit: number): Promise<ClaimedRow[]> {
+  const provisionalNext = new Date(Date.now() + 60_000);
+  return prisma.$queryRaw<ClaimedRow[]>`
+    UPDATE "agent_awakening_state" AS s
+       SET "nextDueAt"  = ${provisionalNext},
+           "lastTickAt" = NOW()
+     WHERE s."id" IN (
+       SELECT "id" FROM "agent_awakening_state"
+        WHERE "enabled" = TRUE
+          AND "nextDueAt" <= NOW()
+        ORDER BY "nextDueAt" ASC
+        LIMIT ${limit}
+        FOR UPDATE SKIP LOCKED
+     )
+ RETURNING s."id", s."agentId", s."orgId", s."consecutiveFailures"
+  `;
+}
+
+async function processTick(_job: Job): Promise<void> {
+  if (killed()) return;
+
+  const claimedAtMs = Date.now();
+
+  // Reflex checks run on their own, much faster cadence and are claimed
+  // independently. They MUST be fanned out before any early return below —
+  // gating them on a heartbeat being due would mean reflex only ever fires in
+  // the same minute as a heartbeat, which is exactly the responsiveness the
+  // reflex exists to provide.
+  await fanOutReflexChecks(claimedAtMs).catch((err) =>
+    log.error(`[awakening] reflex fan-out failed: ${err instanceof Error ? err.message : err}`),
+  );
+
+  const claimed = await claimDueAgents(FANOUT_BATCH);
+  if (claimed.length === 0) return;
+
+  let enqueued = 0;
+
+  for (const row of claimed) {
+    const agent = await prisma.agent
+      .findUnique({ where: { id: row.agentId }, select: { config: true, enabled: true } })
+      .catch(() => null);
+
+    // The agent was deleted or disabled out from under the state row. Park it
+    // rather than retrying every tick forever.
+    if (!agent || !agent.enabled) {
+      await prisma.agentAwakeningState
+        .update({ where: { id: row.id }, data: { enabled: false, lastError: "agent missing or disabled" } })
+        .catch(() => undefined);
+      continue;
+    }
+
+    const config = resolveAwakeningConfig(agent.config);
+    if (!config.enabled) {
+      await prisma.agentAwakeningState
+        .update({ where: { id: row.id }, data: { enabled: false, lastError: null } })
+        .catch(() => undefined);
+      continue;
+    }
+
+    // Not a heartbeat agent — park the HEARTBEAT cadence only.
+    //
+    // `state.enabled` means "awakening is on for this agent", and the reflex
+    // claim scan requires it. Clearing it here (which this used to do) let the
+    // first heartbeat tick permanently kill a reflex-only agent: the row was
+    // disabled, and no reflex check ever ran again. Push nextDueAt out instead,
+    // so the row stops being claimed by this scan and stays live for reflex.
+    if (!participatesIn(config, "heartbeat")) {
+      await prisma.agentAwakeningState
+        .update({ where: { id: row.id }, data: { nextDueAt: new Date(Date.now() + IDLE_REPARK_MS) } })
+        .catch(() => undefined);
+      continue;
+    }
+
+    // Correct the provisional nextDueAt now that the real period is known.
+    await prisma.agentAwakeningState
+      .update({
+        where: { id: row.id },
+        data: { nextDueAt: computeNextDueAt(row.agentId, config, row.consecutiveFailures) },
+      })
+      .catch(() => undefined);
+
+    await enqueueWindow({ agentId: row.agentId, orgId: row.orgId, kind: "heartbeat", claimedAtMs })
+      .then(() => {
+        enqueued++;
+      })
+      .catch((err) => log.warn(`[awakening] enqueue failed agent=${row.agentId}: ${err?.message ?? err}`));
+  }
+
+  log.info(`[awakening] tick claimed=${claimed.length} enqueued=${enqueued}`);
+}
+
+/**
+ * Reflex checks ride the same tick. They are claimed separately (own cadence
+ * column, own queue) but scanning both in one tick avoids a second scheduler
+ * and keeps the whole feature behind a single repeatable job.
+ */
+async function fanOutReflexChecks(claimedAtMs: number): Promise<void> {
+  const claimed = await claimDueReflexChecks(FANOUT_BATCH);
+  if (claimed.length === 0) return;
+
+  let enqueued = 0;
+  for (const row of claimed) {
+    const agent = await prisma.agent
+      .findUnique({ where: { id: row.agentId }, select: { config: true, enabled: true } })
+      .catch(() => null);
+    if (!agent?.enabled) continue;
+
+    const config = resolveAwakeningConfig(agent.config);
+    // Same shape as the heartbeat gate, and the same reason to re-park rather
+    // than fall through: the claim already wrote a provisional +60s, so simply
+    // skipping would leave a heartbeat-only agent due again on the very next
+    // tick, forever, for every tick of its life.
+    if (!config.enabled || !participatesIn(config, "reflex")) {
+      await prisma.agentAwakeningState
+        .update({ where: { id: row.id }, data: { reflexNextCheckAt: new Date(Date.now() + IDLE_REPARK_MS) } })
+        .catch(() => undefined);
+      continue;
+    }
+
+    await prisma.agentAwakeningState
+      .update({
+        where: { id: row.id },
+        data: { reflexNextCheckAt: new Date(Date.now() + config.reflex.checkIntervalMs) },
+      })
+      .catch(() => undefined);
+
+    await enqueueReflexCheck({ agentId: row.agentId, orgId: row.orgId, claimedAtMs })
+      .then(() => { enqueued++; })
+      .catch((err) => log.warn(`[awakening] reflex enqueue failed agent=${row.agentId}: ${err?.message ?? err}`));
+  }
+
+  if (enqueued > 0) log.info(`[awakening] reflex checks enqueued=${enqueued}`);
+}
+
+export function initAwakeningTickWorker(): Worker {
+  if (worker) return worker;
+
+  worker = new Worker(TICK_QUEUE_NAME, processTick, {
+    connection: redisService.getConnection(),
+    // Strictly 1: the claim is safe under concurrency, but there is no reason
+    // to run two scans of the same table at the same instant.
+    concurrency: 1,
+  });
+
+  worker.on("failed", (_job, err) => log.error(`[awakening] tick failed: ${err.message}`));
+  worker.on("error", (err) => log.error(`[awakening] tick worker error: ${err.message}`));
+  log.info(`[awakening] tick worker started (interval=${process.env["AWAKENING_TICK_MS"] ?? 60_000}ms)`);
+  return worker;
+}
+
+export async function closeAwakeningTickWorker(): Promise<void> {
+  await worker?.close().catch(() => {});
+  worker = undefined;
+}

--- a/apps/xyne-claw-auth/backend/src/queue/awakening-window-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/awakening-window-worker.ts
@@ -1,0 +1,264 @@
+/**
+ * The per-agent window pipeline: resolve channels → collect → score → gate →
+ * render → dispatch.
+ *
+ * The load-bearing rule is the WATERMARK DISPOSITION at each stage, because it
+ * decides what happens to the events in a window that did not produce a run:
+ *
+ *   skipped (gate said no)  → ADVANCE. The window was read and judged boring;
+ *                             re-reading it would produce the same verdict.
+ *   dispatched              → ADVANCE. The agent has the events now.
+ *   failed (anything threw) → DO NOT ADVANCE. The next beat retries the same
+ *                             range, so no event is ever silently dropped.
+ *
+ * Every stage that can fail is wrapped so a single bad agent can never take
+ * the fleet's worker down; the failure is recorded on the agent's own state
+ * row and the beat backs off exponentially from there.
+ */
+
+import { Worker, type Job } from "bullmq";
+import { redisService } from "../redis.js";
+import { prisma } from "../db.js";
+import { resolveAwakeningConfig } from "../awakening/config.js";
+import { resolveAwakeningChannels } from "../awakening/channel-resolver.js";
+import { collectWindow } from "../awakening/collector.js";
+import { computeSignals } from "../awakening/signals.js";
+import { evaluateGate } from "../awakening/gate.js";
+import { sealWindow, advanceWatermark } from "../awakening/cursor.js";
+import { loadOverlappingRuns, markCoverage } from "../awakening/prior-runs.js";
+import { dispatchAwakening, resolveAgentIdentity, AwakeningIdentityError } from "../awakening/dispatch.js";
+import { resolveWorkspaceId, WorkspaceResolutionError } from "../awakening/workspace.js";
+import { peekRunRate, consumeRunRate } from "../awakening/rate-limit.js";
+import { acquireAgentLock, releaseAgentLock } from "../awakening/lock.js";
+import { WINDOW_QUEUE_NAME, type AwakeningWindowJobData } from "./awakening-queue.js";
+import type { AwakeningWindow } from "../awakening/types.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-window");
+
+let worker: Worker<AwakeningWindowJobData> | undefined;
+
+/** Records the wake attempt. Unique on idempotencyKey, so a retry is a no-op. */
+async function recordRun(
+  window: AwakeningWindow,
+  idempotencyKey: string,
+  outcome: "ran" | "skipped" | "failed" | "shadow",
+  extra: { skipReason?: string; sessionId?: string | null } = {},
+): Promise<void> {
+  await prisma.agentAwakeningRun
+    .create({
+      data: {
+        agentId: window.agentId,
+        orgId: window.orgId,
+        kind: window.kind,
+        windowStartMs: BigInt(window.startMs),
+        windowEndMs: BigInt(window.endMs),
+        outcome,
+        eventCount: window.events.length,
+        signals: window.signals as unknown as object,
+        idempotencyKey,
+        ...(extra.skipReason ? { skipReason: extra.skipReason } : {}),
+        ...(extra.sessionId ? { sessionId: extra.sessionId } : {}),
+        ...(outcome !== "ran" ? { completedAt: new Date() } : {}),
+      },
+    })
+    .catch((err) => {
+      // P2002 = another pod already recorded this exact wake. That is the
+      // idempotency guard doing its job, not an error.
+      if ((err as { code?: string })?.code !== "P2002") {
+        log.warn(`[awakening] recordRun failed agent=${window.agentId}: ${err?.message ?? err}`);
+      }
+    });
+}
+
+async function markFailure(agentId: string, message: string): Promise<void> {
+  await prisma.agentAwakeningState
+    .update({
+      where: { agentId },
+      data: { consecutiveFailures: { increment: 1 }, lastError: message.slice(0, 500) },
+    })
+    .catch(() => undefined);
+}
+
+async function markSuccess(agentId: string, skipped: boolean): Promise<void> {
+  await prisma.agentAwakeningState
+    .update({
+      where: { agentId },
+      data: {
+        consecutiveFailures: 0,
+        lastError: null,
+        consecutiveSkips: skipped ? { increment: 1 } : { set: 0 },
+      },
+    })
+    .catch(() => undefined);
+}
+
+async function processWindow(job: Job<AwakeningWindowJobData>): Promise<void> {
+  const { agentId, orgId, kind } = job.data;
+
+  const state = await prisma.agentAwakeningState.findUnique({ where: { agentId } });
+  if (!state || !state.enabled) return;
+
+  const agent = await prisma.agent.findUnique({
+    where: { id: agentId },
+    select: {
+      id: true,
+      slug: true,
+      orgId: true,
+      config: true,
+      spacesAppId: true,
+      spacesAppUserId: true,
+      spacesAppToken: true,
+    },
+  });
+  if (!agent) return;
+
+  const config = resolveAwakeningConfig(agent.config);
+  if (!config.enabled) return;
+
+  const bounds = sealWindow(state.watermarkAt, config);
+  if (!bounds) return;
+
+  const idempotencyKey = `awk_${kind}_${agentId}_${bounds.startMs}`;
+
+  // Empty shell used for the failure/skip records before collection succeeds.
+  const emptyWindow: AwakeningWindow = {
+    agentId,
+    agentSlug: agent.slug,
+    orgId,
+    kind,
+    startMs: bounds.startMs,
+    endMs: bounds.endMs,
+    channels: [],
+    silentChannels: [],
+    events: [],
+    signals: computeSignals([]),
+    truncated: false,
+    gap: bounds.gap,
+    priorRuns: [],
+    config,
+  };
+
+  try {
+    const workspaceId = await resolveWorkspaceId(orgId, config.workspaceId);
+    const identity = resolveAgentIdentity(agent, workspaceId);
+
+    const rate = await peekRunRate(agentId, config.limits.maxRunsPerHour);
+    if (!rate.allowed) {
+      await recordRun(emptyWindow, idempotencyKey, "skipped", { skipReason: "rate_limited" });
+      await advanceWatermark(agentId, bounds.endMs, null);
+      await markSuccess(agentId, true);
+      return;
+    }
+
+    const resolved = await resolveAwakeningChannels(agentId, config.channels, identity, config.periodMs);
+    if (resolved.channels.length === 0) {
+      await recordRun(emptyWindow, idempotencyKey, "skipped", { skipReason: "no_channels" });
+      await advanceWatermark(agentId, bounds.endMs, null);
+      await markSuccess(agentId, true);
+      return;
+    }
+
+    const collected = await collectWindow(resolved.channels, bounds.startMs, bounds.endMs, identity, config);
+
+    // Requirement 7: what did the reflexes already handle in this window?
+    // Loaded BEFORE the signals are computed so coverage is on the events the
+    // gate then scores — an event a reflex already answered should not be what
+    // wakes the heartbeat.
+    const priorRuns = await loadOverlappingRuns(agentId, bounds.startMs, bounds.endMs, idempotencyKey).catch(
+      () => [],
+    );
+    markCoverage(collected.events, priorRuns);
+    const signals = computeSignals(collected.events);
+
+    const window: AwakeningWindow = {
+      ...emptyWindow,
+      priorRuns,
+      channels: resolved.channels.filter((c) => collected.activeChannels.has(c.id)),
+      silentChannels: resolved.channels.filter((c) => !collected.activeChannels.has(c.id)),
+      events: collected.events,
+      signals,
+      truncated: collected.truncated,
+    };
+
+    const gate = evaluateGate({ signals, config, consecutiveSkips: state.consecutiveSkips });
+    if (gate.decision === "skip") {
+      await recordRun(window, idempotencyKey, "skipped", { skipReason: gate.rule });
+      await advanceWatermark(agentId, bounds.endMs, null);
+      await markSuccess(agentId, true);
+      log.info(`[awakening] skip agent=${agent.slug} rule=${gate.rule} events=${signals.eventCount}`);
+      return;
+    }
+
+    // One lock per agent across BOTH wake kinds. If a reflex is already awake
+    // for this agent, the heartbeat stands down rather than running beside it —
+    // two awakened runs on one agent read overlapping windows and both post.
+    if (!(await acquireAgentLock(agentId, { sessionId: idempotencyKey, kind, acquiredAtMs: Date.now() }))) {
+      await recordRun(window, idempotencyKey, "skipped", { skipReason: "agent_busy" });
+      await markSuccess(agentId, true);
+      log.info(`[awakening] skip agent=${agent.slug} rule=agent_busy (another awakened run is in flight)`);
+      return;
+    }
+
+    const result = await dispatchAwakening(window, agent, identity, idempotencyKey);
+    if (!result.dispatched) {
+      await releaseAgentLock(agentId, idempotencyKey);
+      // Dispatch failure is a real failure: the events were never delivered,
+      // so the watermark must not move.
+      await recordRun(window, idempotencyKey, "failed", { skipReason: result.reason ?? "dispatch_failed" });
+      await markFailure(agentId, result.reason ?? "dispatch failed");
+      throw new Error(`dispatch failed: ${result.reason ?? "unknown"}`);
+    }
+
+    // Re-key the lock from the idempotency key to the real session id, so the
+    // result callback and the injection path can both find it.
+    if (result.sessionId) {
+      await releaseAgentLock(agentId, idempotencyKey);
+      await acquireAgentLock(agentId, { sessionId: result.sessionId, kind, acquiredAtMs: Date.now() });
+    }
+
+    // Budget is consumed only once a run is genuinely in flight.
+    await consumeRunRate(agentId);
+    await recordRun(window, idempotencyKey, config.shadow ? "shadow" : "ran", { sessionId: result.sessionId });
+    await advanceWatermark(agentId, bounds.endMs, collected.events.at(-1)?.id ?? null);
+    await markSuccess(agentId, false);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    // A broken identity is a CONFIG problem, not a transient one. Retrying it
+    // every beat just burns the queue; disable and surface it to the admin.
+    if (err instanceof AwakeningIdentityError || err instanceof WorkspaceResolutionError) {
+      await prisma.agentAwakeningState
+        .update({ where: { agentId }, data: { enabled: false, lastError: message.slice(0, 500) } })
+        .catch(() => undefined);
+      log.error(`[awakening] disabled agent=${agent.slug}: ${message}`);
+      return;
+    }
+
+    await releaseAgentLock(agentId, idempotencyKey).catch(() => undefined);
+    await markFailure(agentId, message);
+    log.error(`[awakening] window failed agent=${agent.slug}: ${message}`);
+    throw err;
+  }
+}
+
+export function initAwakeningWindowWorker(): Worker<AwakeningWindowJobData> {
+  if (worker) return worker;
+
+  worker = new Worker<AwakeningWindowJobData>(WINDOW_QUEUE_NAME, processWindow, {
+    connection: redisService.getConnection(),
+    concurrency: Number(process.env["AWAKENING_WINDOW_CONCURRENCY"] ?? 5),
+  });
+
+  worker.on("failed", (job, err) =>
+    log.error(`[awakening] window job ${job?.data.agentId ?? job?.id} failed: ${err.message}`),
+  );
+  worker.on("error", (err) => log.error(`[awakening] window worker error: ${err.message}`));
+  log.info("[awakening] window worker started");
+  return worker;
+}
+
+export async function closeAwakeningWindowWorker(): Promise<void> {
+  await worker?.close().catch(() => {});
+  worker = undefined;
+}

--- a/apps/xyne-claw-auth/backend/src/queue/awakening-window-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/awakening-window-worker.ts
@@ -140,7 +140,7 @@ async function processWindow(job: Job<AwakeningWindowJobData>): Promise<void> {
   };
 
   try {
-    const workspaceId = await resolveWorkspaceId(orgId, config.workspaceId);
+    const workspaceId = await resolveWorkspaceId(orgId, agent.spacesAppUserId, config.workspaceId);
     const identity = resolveAgentIdentity(agent, workspaceId);
 
     const rate = await peekRunRate(agentId, config.limits.maxRunsPerHour);
@@ -225,13 +225,26 @@ async function processWindow(job: Job<AwakeningWindowJobData>): Promise<void> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
 
-    // A broken identity is a CONFIG problem, not a transient one. Retrying it
-    // every beat just burns the queue; disable and surface it to the admin.
-    if (err instanceof AwakeningIdentityError || err instanceof WorkspaceResolutionError) {
+    // A broken identity is a CONFIG problem AND unfixable by waiting: an agent
+    // with no bot identity must never fall back to a user token, so it stops.
+    if (err instanceof AwakeningIdentityError) {
       await prisma.agentAwakeningState
         .update({ where: { agentId }, data: { enabled: false, lastError: message.slice(0, 500) } })
         .catch(() => undefined);
       log.error(`[awakening] disabled agent=${agent.slug}: ${message}`);
+      return;
+    }
+
+    // A workspace that will not resolve is an operator-fixable gap — a bot user
+    // not yet mirrored into Spaces, a Spaces DB blip, a tenant link nobody
+    // seeded. Record it so the admin can SEE it, but stay enabled and try again
+    // on the normal cadence: disabling here meant a five-minute fix needed a
+    // human to notice and re-save the agent (prod, 2026-08-26).
+    if (err instanceof WorkspaceResolutionError) {
+      await prisma.agentAwakeningState
+        .update({ where: { agentId }, data: { lastError: message.slice(0, 500) } })
+        .catch(() => undefined);
+      log.warn(`[awakening] window skipped agent=${agent.slug} (workspace unresolved): ${message}`);
       return;
     }
 

--- a/apps/xyne-claw-auth/backend/src/repositories/agentRunRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRunRepository.ts
@@ -92,7 +92,7 @@ export interface StartRunInput {
   userId: string;
   agentSlug: string;
   orgId: string;
-  triggerSource: "spaces" | "scheduled" | "chat" | "api" | "automation" | "slack";
+  triggerSource: "spaces" | "scheduled" | "chat" | "api" | "automation" | "slack" | "heartbeat" | "reflex";
   task: string;
   conversationId?: string | null;
   scheduledJobId?: string | null;
@@ -664,7 +664,9 @@ export const agentRunRepository = {
   listSessionAclForConversation: (conversationId: string) =>
     prisma.agentRun.findMany({
       where: { conversationId },
-      select: { sessionId: true, userId: true, usedUserToken: true },
+      // triggerSource: an awakened run (heartbeat / reflex) has no human owner,
+      // so the cross-user tool-result redaction must not apply to it.
+      select: { sessionId: true, userId: true, usedUserToken: true, triggerSource: true },
     }),
 
   /**

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -1,3 +1,4 @@
+import { isAgentOwnedRun } from "../lib/agent-owned-runs.js";
 import { Router, type Request, type RequestHandler, type Response } from "express";
 import { errMsg } from "../lib/errors.js";
 import { isAgentInvocableBy } from "xyne-claw-shared";
@@ -143,6 +144,18 @@ const internalRouter = Router();
 // ran, but withhold the returned content (a tool's result carries the user's
 // private Spaces data — message/DM/channel text). See the All Runs ACL.
 const REDACTED_TOOL_RESULT = "[result hidden — another user's run]";
+
+/**
+ * An awakened run (heartbeat / reflex) is owned by the agent's own bot
+ * identity, not by a person, so there is no user privacy for the cross-user
+ * redaction to protect — and an admin needs to read exactly what it did.
+ * See lib/agent-owned-runs.ts.
+ */
+function shouldRedactRun(crossUser: boolean, runUserId: string | null | undefined, requesterId: string, triggerSource?: string | null): boolean {
+  if (!crossUser) return false;
+  if (runUserId === requesterId) return false;
+  return !isAgentOwnedRun(triggerSource);
+}
 
 /**
  * Strip RESULT bodies from a run's tool invocations while preserving every
@@ -2288,7 +2301,7 @@ router.get("/:slug/chat/:convId/messages", async (req: Request<{ slug: string; c
         const visibleInvocations = withoutFollowUpRecorderInvocations(invocations as unknown[]);
         if (visibleInvocations.length > 0) {
           invocationsByMsgId[linkedId] =
-            crossUser && run.userId !== userId
+            shouldRedactRun(crossUser, run.userId, userId, run.triggerSource)
               ? redactToolResults(visibleInvocations)
               : visibleInvocations;
         }
@@ -2325,7 +2338,7 @@ router.get("/:slug/chat/:convId/messages", async (req: Request<{ slug: string; c
         // chips sharing the Spaces mark cost one copy, not N.
         if (visibleInvocations.length > 0) {
           invocationsByMsgId[msg.id] =
-            crossUser && run.userId !== userId
+            shouldRedactRun(crossUser, run.userId, userId, run.triggerSource)
               ? redactToolResults(visibleInvocations)
               : visibleInvocations;
         }
@@ -2475,7 +2488,7 @@ router.get("/:slug/chat/:convId/live", async (req: Request<{ slug: string; convI
         const visibleInvocations = withoutFollowUpRecorderInvocations(invs as unknown[]);
         if (visibleInvocations.length > 0) {
           invocationsByMsgId[msg.id] =
-            crossUser && run.userId !== userId
+            shouldRedactRun(crossUser, run.userId, userId, run.triggerSource)
               ? redactToolResults(visibleInvocations)
               : visibleInvocations;
         }
@@ -2491,7 +2504,7 @@ router.get("/:slug/chat/:convId/live", async (req: Request<{ slug: string; convI
         const visibleInvocations = withoutFollowUpRecorderInvocations(
           r.toolInvocations as unknown[],
         );
-        return crossUser && r.userId !== userId
+        return shouldRedactRun(crossUser, r.userId, userId, r.triggerSource)
           ? redactToolResults(visibleInvocations)
           : visibleInvocations;
       });
@@ -2519,7 +2532,10 @@ router.get("/:slug/chat/:convId/live", async (req: Request<{ slug: string; convI
     if (evt.agentSlug && evt.agentSlug !== slug) return; // scope to this agent
     if (!allow(evt.userId)) return;
     let data: LiveEvent = evt;
-    if (evt.type === "invocation" && crossUser && evt.userId !== userId) {
+    // Same rule as the stored transcript above — without this an awakened run
+    // streamed its tool results pre-redacted and only became readable after it
+    // completed and the viewer refetched from Postgres.
+    if (evt.type === "invocation" && shouldRedactRun(crossUser, evt.userId, userId, evt.triggerSource)) {
       data = { ...evt, toolInvocation: redactToolResults([evt.toolInvocation])[0] };
     }
     try {
@@ -2734,11 +2750,21 @@ router.get("/:slug/chat/:convId/debug", async (req: Request<{ slug: string; conv
         aclRuns.filter((r) => r.usedUserToken && r.userId !== requesterId).map((r) => r.sessionId),
       );
       const ownerBySession = new Map(aclRuns.map((r) => [r.sessionId, r.userId]));
-      const ownsSession = (sid: string | undefined): boolean => !!sid && ownerBySession.get(sid) === requesterId;
+      // Awakened runs have no human owner, so "readable" for them means the
+      // admin can read them — that IS the audit trail for an agent acting
+      // unattended. See lib/agent-owned-runs.ts.
+      const agentOwnedSessions = new Set(
+        aclRuns.filter((r) => isAgentOwnedRun(r.triggerSource)).map((r) => r.sessionId),
+      );
+      const readable = (sid: string | undefined, ownerUserId?: string | null): boolean =>
+        ownerUserId === requesterId ||
+        (!!sid && (agentOwnedSessions.has(sid) || ownerBySession.get(sid) === requesterId));
+      const ownsSession = (sid: string | undefined): boolean =>
+        !!sid && (agentOwnedSessions.has(sid) || ownerBySession.get(sid) === requesterId);
 
       const d = body.data;
       const hideDebugSession = d.debugSession?.sessionId ? hiddenSessionIds.has(d.debugSession.sessionId) : false;
-      const debugSessionOwned = d.debugSession?.userId === requesterId;
+      const debugSessionOwned = readable(d.debugSession?.sessionId, d.debugSession?.userId);
       body.data = {
         ...d,
         debugSession: hideDebugSession
@@ -2754,7 +2780,9 @@ router.get("/:slug/chat/:convId/debug", async (req: Request<{ slug: string; conv
         runs: (d.runs ?? [])
           .filter((r) => !hiddenSessionIds.has(r.data?.sessionId ?? ""))
           .map((r) =>
-            r.data?.userId === requesterId ? r : { ...r, data: redactResultKeysDeep(r.data) as typeof r.data },
+            readable(r.data?.sessionId, r.data?.userId)
+              ? r
+              : { ...r, data: redactResultKeysDeep(r.data) as typeof r.data },
           ),
         subagents: (d.subagents ?? [])
           .filter((s) => !hiddenSessionIds.has(s.data?.parentSessionId ?? ""))

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -31,7 +31,8 @@ import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { s2sKeyMatches } from "../middleware/require-auth.js";
 import { writeAuditLog } from "../lib/audit.js";
 import { buildAvailableToolsCatalog } from "./tools.js";
-import { validateAgentModelConfig } from "../lib/agent-config-validation.js";
+import { validateAgentModelConfig, validateAwakeningConfig } from "../lib/agent-config-validation.js";
+import { syncAwakeningState } from "../awakening/lifecycle.js";
 import { auditModelSettingsChange } from "../lib/model-settings-audit.js";
 import { validateKbGrants } from "../lib/spaces-kb.js";
 import { ORG_SCOPED_SLUGS } from "../lib/org-scoped-slugs.js";
@@ -740,6 +741,11 @@ router.put("/:slug", async (req: Request<{ slug: string }>, res: Response) => {
         res.status(400).json({ success: false, error: configCheck.error });
         return;
       }
+      const awakeningCheck = validateAwakeningConfig(normalizedConfig as Record<string, unknown>);
+      if (!awakeningCheck.ok) {
+        res.status(400).json({ success: false, error: awakeningCheck.error });
+        return;
+      }
       logAgentConfigWriteDiff(existing.slug, requesterId ?? undefined, existing.config, normalizedConfig);
       data.config = normalizedConfig as Prisma.InputJsonValue;
     }
@@ -794,6 +800,15 @@ router.put("/:slug", async (req: Request<{ slug: string }>, res: Response) => {
     }
 
     const agent = await agentRepository.update(req.params.slug, existing.orgId, data);
+
+    // Create/park the scheduler state row so the awakening tick starts or
+    // stops seeing this agent. Best-effort: a failure here must not fail the
+    // config write — the next write, or a manual re-enable, reconciles it.
+    if (normalizedConfig !== undefined) {
+      await syncAwakeningState(existing.id, existing.orgId, normalizedConfig).catch((e) =>
+        log.warn(`[agents] syncAwakeningState failed for ${existing.slug}:`, e instanceof Error ? e.message : e),
+      );
+    }
 
     // Model-settings audit — which model actually serves this agent's runs.
     // Written only when config.modelSettings really changed, so the

--- a/apps/xyne-claw-auth/backend/src/routes/awakening-surface-tools.test.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/awakening-surface-tools.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const getSessionMock = vi.hoisted(() => vi.fn());
+vi.mock("./webhook.js", () => ({ getSession: getSessionMock }));
+
+const { withSurfaceDefaultToolsConfig } = await import("./mcp.js");
+
+const baseConfig = { direct: ["spaces-search", "spaces-messages"], custom: [], subagents: [] };
+
+beforeEach(() => getSessionMock.mockReset());
+
+/**
+ * An awakened run has no thread its final answer is posted into, so the
+ * bot-identity send tool is the ONLY way it can speak. It never appears in the
+ * agent tool picker, so every configured agent's strict `direct` allowlist
+ * excludes it — and the run goes silent. Observed live 2026-08-25.
+ */
+describe("withSurfaceDefaultToolsConfig — awakened runs", () => {
+  for (const kind of ["heartbeat", "reflex"]) {
+    it(`grants apps-send-message on a ${kind} run`, async () => {
+      getSessionMock.mockResolvedValue({ triggerSource: kind, isAutomation: true, spacesAppId: "a", spacesAppUserId: "u" });
+      const out = await withSurfaceDefaultToolsConfig(baseConfig as never, "sess", "app");
+      expect(out?.direct).toContain("apps-send-message");
+    });
+  }
+
+  it("does NOT grant it on an interactive Spaces run", async () => {
+    getSessionMock.mockResolvedValue({ triggerSource: "spaces", spacesAppId: "a", spacesAppUserId: "u" });
+    const out = await withSurfaceDefaultToolsConfig(baseConfig as never, "sess", "app");
+    expect(out?.direct).not.toContain("apps-send-message");
+  });
+
+  it("does NOT grant it on a scheduled run", async () => {
+    getSessionMock.mockResolvedValue({ triggerSource: "scheduled", spacesAppId: "a", spacesAppUserId: "u" });
+    const out = await withSurfaceDefaultToolsConfig(baseConfig as never, "sess", "app");
+    expect(out?.direct).not.toContain("apps-send-message");
+  });
+
+  it("keeps every tool the agent already had", async () => {
+    getSessionMock.mockResolvedValue({ triggerSource: "reflex", isAutomation: true, spacesAppId: "a", spacesAppUserId: "u" });
+    const out = await withSurfaceDefaultToolsConfig(baseConfig as never, "sess", "app");
+    expect(out?.direct).toEqual(expect.arrayContaining(["spaces-search", "spaces-messages"]));
+  });
+
+  it("is idempotent when the tool is already allowed", async () => {
+    getSessionMock.mockResolvedValue({ triggerSource: "reflex", isAutomation: true, spacesAppId: "a", spacesAppUserId: "u" });
+    const cfg = { ...baseConfig, direct: [...baseConfig.direct, "apps-send-message"] };
+    const out = await withSurfaceDefaultToolsConfig(cfg as never, "sess", "app");
+    expect((out?.direct ?? []).filter((t: string) => t === "apps-send-message")).toHaveLength(1);
+  });
+
+  it("does not mutate the stored config object", async () => {
+    getSessionMock.mockResolvedValue({ triggerSource: "reflex", isAutomation: true, spacesAppId: "a", spacesAppUserId: "u" });
+    const cfg = { direct: ["spaces-search"], custom: [], subagents: [] };
+    await withSurfaceDefaultToolsConfig(cfg as never, "sess", "app");
+    expect(cfg.direct).toEqual(["spaces-search"]);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/routes/awakening-tools.test.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/awakening-tools.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { filterMcpServerToolsForAgentConfig, buildAgentToolAllowSet } from "./mcp-agent-tools.js";
+
+/**
+ * An awakened run's ONLY way to speak is the bot-identity send tool. It never
+ * appears in the agent tool picker (it acts as the bot, so it is deliberately
+ * not offered for interactive runs), so a strict `tools.direct` allowlist —
+ * which every configured agent has — silently drops it. The agent then reasons
+ * correctly, decides to reply, finds no tool, and says nothing.
+ * Observed live 2026-08-25 on ask-ai.
+ */
+const APP_SERVER = {
+  serverType: "xyne-spaces-app-tools",
+  serverName: "Xyne Spaces App Tools",
+  tools: [
+    { name: "spaces-search", description: "", inputSchema: {} },
+    { name: "spaces-messages", description: "", inputSchema: {} },
+    { name: "apps-send-message", description: "", inputSchema: {} },
+    { name: "ping", description: "", inputSchema: {} },
+  ],
+  writeTools: ["apps-send-message"],
+} as never;
+
+const noop = () => null;
+
+describe("apps-send-message under a strict agent allowlist", () => {
+  it("is DROPPED when the agent's direct list omits it (the live bug)", () => {
+    const config = { direct: ["spaces-search", "spaces-messages"] };
+    const out = filterMcpServerToolsForAgentConfig(APP_SERVER, config as never, noop as never);
+    expect(out?.tools.map((t) => t.name)).toEqual(["spaces-search", "spaces-messages"]);
+    expect(out?.tools.some((t) => t.name === "apps-send-message")).toBe(false);
+  });
+
+  it("is KEPT once it is injected into the direct list", () => {
+    const config = { direct: ["spaces-search", "spaces-messages", "apps-send-message"] };
+    const out = filterMcpServerToolsForAgentConfig(APP_SERVER, config as never, noop as never);
+    expect(out?.tools.map((t) => t.name)).toContain("apps-send-message");
+  });
+
+  it("keeps it listed as a write tool so the HITL/deny layer still sees it", () => {
+    const config = { direct: ["apps-send-message"] };
+    const out = filterMcpServerToolsForAgentConfig(APP_SERVER, config as never, noop as never);
+    expect(out?.writeTools).toContain("apps-send-message");
+  });
+
+  it("injecting it does not widen anything else", () => {
+    const base = { direct: ["spaces-search"] };
+    const withSend = { direct: ["spaces-search", "apps-send-message"] };
+    const a = filterMcpServerToolsForAgentConfig(APP_SERVER, base as never, noop as never);
+    const b = filterMcpServerToolsForAgentConfig(APP_SERVER, withSend as never, noop as never);
+    const added = b!.tools.filter((t) => !a!.tools.some((x) => x.name === t.name)).map((t) => t.name);
+    expect(added).toEqual(["apps-send-message"]);
+  });
+
+  it("the allow set records it as an exact tool name", () => {
+    const allow = buildAgentToolAllowSet({ direct: ["apps-send-message"] } as never);
+    expect(allow.toolExact.has("apps-send-message")).toBe(true);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/routes/awakening.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/awakening.ts
@@ -1,0 +1,262 @@
+/**
+ * Routes for the awakening pipeline.
+ *
+ * The result callback is deliberately its OWN route rather than reusing
+ * /webhook/result: that handler is a long shared hot path carrying every
+ * user-facing delivery concern (thread replies, cards, follow-ups, twin
+ * routing). An unattended run needs none of it — it needs to close its ledger
+ * row. Keeping them separate means awakening can never regress human chat, and
+ * a change to human chat delivery can never silently alter what an unattended
+ * agent does.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { prisma } from "../db.js";
+import { requireAuth, requireNoAccessToken, requireStrictS2S } from "../middleware/require-auth.js";
+import { requireClawAdmin } from "../middleware/agent-acl.js";
+import { agentRunRepository, chatMessageRepository } from "../repositories/index.js";
+import type { FinalizeRunInput } from "../repositories/agentRunRepository.js";
+import { releaseAgentLock } from "../awakening/lock.js";
+import { clearInbox, drainInbox } from "../awakening/inbox.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-routes");
+
+export const awakeningRouter: Router = Router();
+
+interface ResultBody {
+  sessionId?: string;
+  status?: string;
+  result?: string;
+  error?: string;
+  // Run telemetry claw sends with every terminal callback. An unattended run
+  // has no human watching it live, so the stored row is the ONLY record an
+  // admin can review afterwards — dropping these left the activity view
+  // showing a result with no tools, no token cost and no timings.
+  reasoning?: string;
+  provider?: string;
+  model?: string;
+  toolsUsed?: unknown;
+  toolInvocations?: unknown;
+  tokenUsage?: FinalizeRunInput["tokenUsage"];
+  latency?: FinalizeRunInput["latency"];
+}
+
+/**
+ * Give back the events a finished run never actually consumed.
+ *
+ * The reflex watermark advances the moment a batch is QUEUED, not when the run
+ * drains it — deliberately, so a slow drain cannot re-trigger the same events.
+ * But a run can end with batches still queued (it converged, failed, or simply
+ * stopped calling tools), and clearing the inbox at that point would step the
+ * watermark permanently over events nobody ever saw.
+ *
+ * So before clearing, take what is left and roll the watermark back to the
+ * START of the earliest undelivered window. Those events are then re-counted on
+ * the next check and land in the next run. Only ever moves the watermark
+ * BACKWARDS, and only past events this session was given but did not read.
+ */
+async function rewindWatermarkForUndelivered(agentId: string, sessionId: string): Promise<void> {
+  try {
+    const undelivered = await drainInbox(sessionId);
+    if (undelivered.length === 0) return;
+
+    const starts = undelivered
+      .map((batch) => batch.windowStartMs)
+      .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+    if (starts.length === 0) return;
+
+    const rewindTo = new Date(Math.min(...starts));
+    const state = await prisma.agentAwakeningState.findUnique({
+      where: { agentId },
+      select: { reflexWatermarkAt: true },
+    });
+    // Never move it forward, and never rewind past a watermark that some other
+    // run has already legitimately pushed further back.
+    if (state?.reflexWatermarkAt && state.reflexWatermarkAt <= rewindTo) return;
+
+    await prisma.agentAwakeningState.update({
+      where: { agentId },
+      data: { reflexWatermarkAt: rewindTo, reflexNextCheckAt: new Date() },
+    });
+    log.info(
+      `[awakening] rewound reflex watermark agent=${agentId} to ${rewindTo.toISOString()} ` +
+      `(${undelivered.length} undelivered batch(es) from session=${sessionId})`,
+    );
+  } catch (err) {
+    log.warn(
+      `[awakening] watermark rewind failed session=${sessionId}: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+/** claw sends tool names as a string[]; be defensive about anything else. */
+function toolNames(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const names = value.filter((entry): entry is string => typeof entry === "string");
+  return names.length > 0 ? names : undefined;
+}
+
+/**
+ * POST /awakening/:idempotencyKey/result — terminal callback from xyne-claw.
+ *
+ * Idempotent by construction: it writes completedAt on a row keyed by the same
+ * idempotencyKey the dispatch used, so a duplicate delivery (retry, recovery
+ * refire) just rewrites the same values.
+ */
+awakeningRouter.post("/awakening/:idempotencyKey/result", requireStrictS2S, async (req: Request, res: Response) => {
+  const { idempotencyKey } = req.params as { idempotencyKey?: string };
+  if (!idempotencyKey) {
+    res.status(400).json({ success: false, error: "idempotencyKey is required" });
+    return;
+  }
+
+  const body = (req.body ?? {}) as ResultBody;
+  const failed = body.status === "failed" || Boolean(body.error);
+
+  // Ack first, reconcile after: xyne-claw must never block on our bookkeeping,
+  // and every write below is best-effort and independently retryable.
+  res.json({ success: true });
+
+  await prisma.agentAwakeningRun
+    .updateMany({
+      where: { idempotencyKey },
+      data: {
+        completedAt: new Date(),
+        ...(failed ? { outcome: "failed", skipReason: (body.error ?? "run failed").slice(0, 500) } : {}),
+      },
+    })
+    .catch((err: unknown) =>
+      log.warn(
+        `[awakening] result bookkeeping failed key=${idempotencyKey}: ${err instanceof Error ? err.message : err}`,
+      ),
+    );
+
+  if (body.sessionId) {
+    // Persist the agent's answer as the assistant turn, so the awakened
+    // conversation opens and reads like any other in the chat UI. Mirrors what
+    // the scheduled-job result route does — the shared /webhook/result path
+    // does it too, but awakening deliberately does not go through there.
+    const run = await agentRunRepository.findBySessionId(body.sessionId).catch(() => null);
+    if (run?.conversationId && (body.result?.trim() || body.error)) {
+      await chatMessageRepository
+        .create({
+          conversationId: run.conversationId,
+          agentSlug: run.agentSlug,
+          userId: run.userId,
+          role: "assistant",
+          content: body.result?.trim() || `Run failed: ${body.error ?? "unknown error"}`,
+          status: failed ? "failed" : "completed",
+          orgId: run.orgId ?? "",
+        })
+        .catch((err: unknown) =>
+          log.warn(
+            `[awakening] assistant ChatMessage failed key=${idempotencyKey}: ${err instanceof Error ? err.message : err}`,
+          ),
+        );
+    }
+
+    await agentRunRepository
+      .finalize(body.sessionId, {
+        status: failed ? "failed" : "completed",
+        ...(body.result ? { result: body.result } : {}),
+        ...(body.error ? { error: body.error } : {}),
+        ...(body.reasoning ? { reasoning: body.reasoning } : {}),
+        ...(body.provider ? { provider: body.provider } : {}),
+        ...(body.model ? { model: body.model } : {}),
+        ...(toolNames(body.toolsUsed) ? { toolsUsed: toolNames(body.toolsUsed)! } : {}),
+        ...(body.toolInvocations !== undefined ? { toolInvocations: body.toolInvocations } : {}),
+        ...(body.tokenUsage ? { tokenUsage: body.tokenUsage } : {}),
+        ...(body.latency ? { latency: body.latency } : {}),
+      })
+      .catch((err: unknown) =>
+        log.warn(`[awakening] AgentRun.finalize failed: ${err instanceof Error ? err.message : err}`),
+      );
+  }
+
+  // Free the agent so the next wake can proceed, and drop any injection batch
+  // the finished run never drained. Both are keyed on the session, so a stale
+  // callback from an older run cannot free a newer run's lock.
+  const row = await prisma.agentAwakeningRun
+    .findUnique({ where: { idempotencyKey }, select: { agentId: true, sessionId: true } })
+    .catch(() => null);
+  const sessionId = body.sessionId ?? row?.sessionId;
+  if (row?.agentId && sessionId) {
+    await releaseAgentLock(row.agentId, sessionId).catch(() => undefined);
+    await rewindWatermarkForUndelivered(row.agentId, sessionId);
+    await clearInbox(sessionId).catch(() => undefined);
+  }
+
+  log.info(`[awakening] result key=${idempotencyKey} status=${failed ? "failed" : "completed"}`);
+});
+
+/**
+ * POST /awakening/inbox/:sessionId/drain — the live-injection pull.
+ *
+ * Called by the claw pod that OWNS the session, at its own turn boundaries.
+ * That is the whole point of making this a pull: claw is horizontally scaled
+ * and a session lives in one pod's memory, so nothing outside that pod can
+ * address it. The pod asking for its own mail needs no routing at all.
+ *
+ * Returns and CLEARS whatever is queued. A batch handed out here is considered
+ * delivered — the caller steers it into the session immediately, and a pod
+ * that dies mid-turn loses at most one batch, which the next reflex re-counts.
+ */
+awakeningRouter.post("/awakening/inbox/:sessionId/drain", requireStrictS2S, async (req: Request, res: Response) => {
+  const { sessionId } = req.params as { sessionId?: string };
+  if (!sessionId) {
+    res.status(400).json({ success: false, error: "sessionId is required" });
+    return;
+  }
+
+  const batches = await drainInbox(sessionId);
+  res.json({
+    success: true,
+    batches: batches.map((b) => ({
+      ordinal: b.ordinal,
+      eventCount: b.eventCount,
+      text: b.text,
+      isFinal: b.isFinal,
+    })),
+  });
+});
+
+/**
+ * GET /awakening/:agentId/status — operator view of one agent's beat.
+ * Answers "is it running, when is the next beat, why did it skip".
+ */
+awakeningRouter.get(
+  "/awakening/:agentId/status",
+  requireAuth,
+  requireNoAccessToken,
+  requireClawAdmin,
+  async (req: Request, res: Response) => {
+  const { agentId } = req.params as { agentId?: string };
+  if (!agentId) {
+    res.status(400).json({ success: false, error: "agentId is required" });
+    return;
+  }
+
+  const [state, recent] = await Promise.all([
+    prisma.agentAwakeningState.findUnique({ where: { agentId } }),
+    prisma.agentAwakeningRun.findMany({
+      where: { agentId },
+      orderBy: { startedAt: "desc" },
+      take: 20,
+    }),
+  ]);
+
+  res.json({
+    success: true,
+    data: {
+      state,
+      // BigInt is not JSON-serializable; window bounds go out as numbers.
+      recent: recent.map((r) => ({
+        ...r,
+        windowStartMs: Number(r.windowStartMs),
+        windowEndMs: Number(r.windowEndMs),
+      })),
+    },
+  });
+  },
+);

--- a/apps/xyne-claw-auth/backend/src/routes/mcp.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/mcp.ts
@@ -1,4 +1,5 @@
 import { Router, type Request, type Response } from "express";
+import { AWAKENING_SEND_TOOL } from "../awakening/send-tool.js";
 import { errMsg } from "../lib/errors.js";
 import crypto from "node:crypto";
 import { prisma } from "../db.js";
@@ -700,6 +701,28 @@ async function loadSlackSurfaceCredentials(
   };
 }
 
+/**
+ * Add a tool to the agent's `direct` allowlist for THIS run only.
+ *
+ * `apps-send-message` never appears in the agent tool picker (it acts as the
+ * bot identity, so it is deliberately not offered for interactive runs), which
+ * means a strict `tools.direct` allowlist always excludes it. For an AWAKENED
+ * run that is fatal rather than merely restrictive: nobody is in a thread to
+ * receive the agent's final answer, so this tool is the ONLY way it can speak.
+ * Without it the agent reasons correctly, decides to reply, finds no tool, and
+ * says nothing — the whole feature is inert. (Observed live 2026-08-25.)
+ *
+ * Per-run and in-memory: the stored agent config is untouched, and interactive
+ * runs of the same agent are unaffected.
+ */
+function withDirectTool(config: AgentToolsConfig, toolName: string): AgentToolsConfig {
+  const direct = Array.isArray(config.direct)
+    ? config.direct.filter((value): value is string => typeof value === "string")
+    : [];
+  if (direct.includes(toolName)) return config;
+  return { ...config, direct: [...direct, toolName] };
+}
+
 function withSubagent(config: AgentToolsConfig, subagentName: string): AgentToolsConfig {
   const subagents = Array.isArray(config.subagents)
     ? config.subagents.filter((value): value is string => typeof value === "string")
@@ -714,7 +737,7 @@ function withSubagent(config: AgentToolsConfig, subagentName: string): AgentTool
  * override forwarded to claw, so without this a surface-default virtual group
  * is created and then immediately filtered back out.
  */
-async function withSurfaceDefaultToolsConfig(
+export async function withSurfaceDefaultToolsConfig(
   config: AgentToolsConfig | undefined,
   sessionId: string,
   sessionSpacesAppId?: string,
@@ -763,6 +786,15 @@ async function withSurfaceDefaultToolsConfig(
       log.info(`[mcp/tools] spaces default injected from session spacesAppId (run-context absent) app=${sessionSpacesAppId}`);
     }
     effective = withSubagent(effective, "spaces");
+  }
+
+  // An awakened run (heartbeat / reflex) has no thread its answer is posted
+  // into, so the bot-identity send tool is its only voice. Grant it for this
+  // run regardless of the agent's stored allowlist; the write POLICY
+  // (observe / reply / act, plus shadow) still governs whether the call is
+  // permitted — see awakening/write-policy.ts, enforced at /mcp/call.
+  if (runCtx?.triggerSource === "heartbeat" || runCtx?.triggerSource === "reflex") {
+    effective = withDirectTool(effective, AWAKENING_SEND_TOOL);
   }
 
   return effective;
@@ -1569,6 +1601,21 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
         `[mcp/call] user=${userId} server=${serverType} tool=${tool} permission=${effectivePermission}${requiresApproval ? " (gateway approval required, forced ask)" : ""}`,
       );
 
+      // Hard deny. Distinct from "ask": there is no approval that unblocks it,
+      // because there is nobody to ask. Used by unattended runs (an awakened
+      // agent in shadow or observe mode) where a write must be impossible
+      // rather than merely queued behind a card no human will ever click.
+      if (effectivePermission === "deny") {
+        log.info(`[mcp/call] denied ${serverType}/${tool} for user=${userId} (permission=deny)`);
+        res.json({
+          success: true,
+          data: {
+            content: `Blocked: this run is not permitted to call ${tool}. It is running without write access; describe what you would have done instead.`,
+          },
+        });
+        return;
+      }
+
       if (effectivePermission === "ask") {
         const action = { serverType, tool, params: params ?? {}, userId };
         const signature = signAction(action);
@@ -1700,6 +1747,21 @@ router.post("/:sessionId/mcp/call", async (req: Request<{ sessionId: string }>, 
         isWriteTool,
       },
     );
+
+    // Hard deny. Distinct from "ask": there is no approval that unblocks it,
+    // because there is nobody to ask. Used by unattended runs (an awakened
+    // agent in shadow or observe mode) where a write must be impossible
+    // rather than merely queued behind a card no human will ever click.
+    if (effectivePermission === "deny") {
+      log.info(`[mcp/call] denied ${serverType}/${tool} for user=${userId} (permission=deny)`);
+      res.json({
+        success: true,
+        data: {
+          content: `Blocked: this run is not permitted to call ${tool}. It is running without write access; describe what you would have done instead.`,
+        },
+      });
+      return;
+    }
 
     if (effectivePermission === "ask") {
       const validationError = await validateWriteAction(serverType, tool, effectiveParams, {

--- a/apps/xyne-claw-auth/backend/src/routes/metrics.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/metrics.ts
@@ -1184,3 +1184,251 @@ metricsRouter.post("/improvements/backfill", async (req: Request, res: Response)
     res.status(500).json({ error: err instanceof Error ? err.message : "Internal server error" });
   }
 });
+
+/**
+ * GET /metrics/awakening — activity for agents that wake on their own.
+ *
+ * Awakened runs are deliberately absent from the rest of this file's numbers:
+ * they have no `userId`, so the user-scoped filters every other endpoint
+ * applies would drop them, and mixing unattended runs into per-user latency
+ * would skew it. They still need to be observable — an awakened agent posts in
+ * public with nobody watching — so they get their own rollup.
+ *
+ * Three questions this answers, which is what operating the feature actually
+ * requires: is it running, what is it deciding, and is anything broken.
+ * Scoped by org only; there is no user dimension to scope by.
+ */
+metricsRouter.get("/awakening", async (req: Request, res: Response) => {
+  try {
+    const { orgFilter, scopeOrgId } = await resolveMetricsScope(req, "/metrics/awakening");
+    const days = parseDays(req);
+    const windowEnd = new Date();
+    const windowStart = new Date(windowEnd.getTime() - days * 24 * 60 * 60 * 1000);
+
+    const [totalsRaw, perDayRaw, byAgentRaw, skipRaw, statesRaw] = await Promise.all([
+      prisma.$queryRaw<Array<{
+        runs: bigint; ran: bigint; skipped: bigint; failed: bigint; shadow: bigint;
+        injections: bigint; events: bigint;
+      }>>`
+        SELECT
+          COUNT(*)                                        AS runs,
+          COUNT(*) FILTER (WHERE outcome = 'ran')         AS ran,
+          COUNT(*) FILTER (WHERE outcome = 'skipped')     AS skipped,
+          COUNT(*) FILTER (WHERE outcome = 'failed')      AS failed,
+          COUNT(*) FILTER (WHERE outcome = 'shadow')      AS shadow,
+          COALESCE(SUM("injectionsUsed"), 0)              AS injections,
+          COALESCE(SUM("eventCount"), 0)                  AS events
+        FROM "agent_awakening_runs"
+        WHERE "startedAt" >= ${windowStart} AND "startedAt" < ${windowEnd} ${orgFilter}
+      `,
+      prisma.$queryRaw<Array<{
+        day: Date; ran: bigint; skipped: bigint; failed: bigint;
+      }>>`
+        SELECT
+          date_trunc('day', "startedAt")::date            AS day,
+          COUNT(*) FILTER (WHERE outcome IN ('ran','shadow')) AS ran,
+          COUNT(*) FILTER (WHERE outcome = 'skipped')     AS skipped,
+          COUNT(*) FILTER (WHERE outcome = 'failed')      AS failed
+        FROM "agent_awakening_runs"
+        WHERE "startedAt" >= ${windowStart} AND "startedAt" < ${windowEnd} ${orgFilter}
+        GROUP BY 1 ORDER BY 1 ASC
+      `,
+      prisma.$queryRaw<Array<{
+        agent_id: string; agent_slug: string | null; kind: string; runs: bigint; ran: bigint;
+        skipped: bigint; failed: bigint; events: bigint; last_run_at: Date | null;
+      }>>`
+        SELECT
+          r."agentId"                                     AS agent_id,
+          a.slug                                          AS agent_slug,
+          r.kind                                          AS kind,
+          COUNT(*)                                        AS runs,
+          COUNT(*) FILTER (WHERE r.outcome IN ('ran','shadow')) AS ran,
+          COUNT(*) FILTER (WHERE r.outcome = 'skipped')   AS skipped,
+          COUNT(*) FILTER (WHERE r.outcome = 'failed')    AS failed,
+          COALESCE(SUM(r."eventCount"), 0)                AS events,
+          MAX(r."startedAt")                              AS last_run_at
+        FROM "agent_awakening_runs" r
+        LEFT JOIN "agents" a ON a.id = r."agentId"
+        WHERE r."startedAt" >= ${windowStart} AND r."startedAt" < ${windowEnd}
+          ${scopeOrgId ? Prisma.sql`AND r."orgId" = ${scopeOrgId}` : Prisma.empty}
+        GROUP BY 1, 2, 3
+        ORDER BY runs DESC
+        LIMIT 50
+      `,
+      prisma.$queryRaw<Array<{ reason: string | null; count: bigint }>>`
+        SELECT "skipReason" AS reason, COUNT(*) AS count
+        FROM "agent_awakening_runs"
+        WHERE "startedAt" >= ${windowStart} AND "startedAt" < ${windowEnd}
+          AND outcome = 'skipped' ${orgFilter}
+        GROUP BY 1 ORDER BY count DESC LIMIT 20
+      `,
+      // Current health, independent of the window: an agent the workers switched
+      // off has no recent runs BY DEFINITION, so it would be invisible above.
+      prisma.$queryRaw<Array<{
+        agent_slug: string | null; enabled: boolean; last_error: string | null;
+        next_due_at: Date | null; reflex_next_check_at: Date | null;
+        consecutive_failures: number;
+      }>>`
+        SELECT
+          a.slug                    AS agent_slug,
+          s.enabled                 AS enabled,
+          s."lastError"             AS last_error,
+          s."nextDueAt"             AS next_due_at,
+          s."reflexNextCheckAt"     AS reflex_next_check_at,
+          s."consecutiveFailures"   AS consecutive_failures
+        FROM "agent_awakening_state" s
+        LEFT JOIN "agents" a ON a.id = s."agentId"
+        WHERE TRUE ${scopeOrgId ? Prisma.sql`AND s."orgId" = ${scopeOrgId}` : Prisma.empty}
+        ORDER BY s.enabled DESC, a.slug ASC
+        LIMIT 100
+      `,
+    ]);
+
+    const t = totalsRaw[0];
+    res.json({
+      days,
+      totals: {
+        runs: Number(t?.runs ?? 0),
+        ran: Number(t?.ran ?? 0),
+        skipped: Number(t?.skipped ?? 0),
+        failed: Number(t?.failed ?? 0),
+        shadow: Number(t?.shadow ?? 0),
+        injections: Number(t?.injections ?? 0),
+        events: Number(t?.events ?? 0),
+      },
+      perDay: perDayRaw.map((r) => ({
+        day: r.day.toISOString().slice(0, 10),
+        ran: Number(r.ran),
+        skipped: Number(r.skipped),
+        failed: Number(r.failed),
+      })),
+      byAgent: byAgentRaw.map((r) => ({
+        agentId: r.agent_id,
+        agentSlug: r.agent_slug ?? "(deleted agent)",
+        kind: r.kind,
+        runs: Number(r.runs),
+        ran: Number(r.ran),
+        skipped: Number(r.skipped),
+        failed: Number(r.failed),
+        events: Number(r.events),
+        lastRunAt: r.last_run_at ? r.last_run_at.toISOString() : null,
+      })),
+      skipReasons: skipRaw.map((r) => ({
+        reason: r.reason ?? "(unspecified)",
+        count: Number(r.count),
+      })),
+      agents: statesRaw.map((r) => ({
+        agentSlug: r.agent_slug ?? "(deleted agent)",
+        enabled: r.enabled,
+        lastError: r.last_error,
+        nextDueAt: r.next_due_at ? r.next_due_at.toISOString() : null,
+        reflexNextCheckAt: r.reflex_next_check_at ? r.reflex_next_check_at.toISOString() : null,
+        consecutiveFailures: Number(r.consecutive_failures ?? 0),
+      })),
+    });
+  } catch (err) {
+    log.error("[metrics/awakening] error:", err);
+    res.status(500).json({ error: err instanceof Error ? err.message : "Internal server error" });
+  }
+});
+
+/**
+ * GET /metrics/awakening/:agentId/runs — one agent's wake history, paginated.
+ *
+ * The drill-down behind the Awakened agents section. Every wake ATTEMPT is a
+ * row here, not just the ones that acted, because "why did it stay quiet" is
+ * the question operators actually have — `skipReason` carries the gate rule
+ * that fired.
+ *
+ * `conversationId` is joined from agent_runs so each acting wake links straight
+ * to the transcript; a skipped wake never dispatched one and has none.
+ *
+ * `kind` narrows to heartbeat or reflex. The rollup above lists one row PER
+ * WAKE KIND, so drilling into an agent's heartbeat row must not return its
+ * reflex wakes as well.
+ */
+metricsRouter.get("/awakening/:agentId/runs", async (req: Request<{ agentId: string }>, res: Response) => {
+  try {
+    const { scopeOrgId } = await resolveMetricsScope(req, "/metrics/awakening/runs");
+    const { agentId } = req.params;
+    const days = parseDays(req);
+    const windowEnd = new Date();
+    const windowStart = new Date(windowEnd.getTime() - days * 24 * 60 * 60 * 1000);
+
+    const limit = Math.min(Math.max(Number(req.query["limit"]) || 20, 1), 100);
+    const offset = Math.max(Number(req.query["offset"]) || 0, 0);
+
+    // Org scoping is applied to the RUN rows, not just the agent, so an admin
+    // scoped to one org cannot page through another org's history by id.
+    const scope = scopeOrgId ? Prisma.sql`AND r."orgId" = ${scopeOrgId}` : Prisma.empty;
+
+    const kindRaw = String(req.query["kind"] ?? "");
+    const kindFilter = kindRaw === "heartbeat" || kindRaw === "reflex"
+      ? Prisma.sql`AND r.kind = ${kindRaw}`
+      : Prisma.empty;
+
+    const [rowsRaw, countRaw] = await Promise.all([
+      prisma.$queryRaw<Array<{
+        id: string; kind: string; outcome: string; skip_reason: string | null;
+        event_count: number; injections_used: number; session_id: string | null;
+        conversation_id: string | null; run_status: string | null;
+        window_start_ms: bigint; window_end_ms: bigint;
+        started_at: Date; completed_at: Date | null;
+      }>>`
+        SELECT
+          r.id                AS id,
+          r.kind              AS kind,
+          r.outcome           AS outcome,
+          r."skipReason"      AS skip_reason,
+          r."eventCount"      AS event_count,
+          r."injectionsUsed"  AS injections_used,
+          r."sessionId"       AS session_id,
+          ar."conversationId" AS conversation_id,
+          ar.status           AS run_status,
+          r."windowStartMs"   AS window_start_ms,
+          r."windowEndMs"     AS window_end_ms,
+          r."startedAt"       AS started_at,
+          r."completedAt"     AS completed_at
+        FROM "agent_awakening_runs" r
+        LEFT JOIN "agent_runs" ar ON ar."sessionId" = r."sessionId"
+        WHERE r."agentId" = ${agentId}
+          AND r."startedAt" >= ${windowStart} AND r."startedAt" < ${windowEnd}
+          ${scope} ${kindFilter}
+        ORDER BY r."startedAt" DESC
+        LIMIT ${limit} OFFSET ${offset}
+      `,
+      prisma.$queryRaw<Array<{ count: bigint }>>`
+        SELECT COUNT(*) AS count
+        FROM "agent_awakening_runs" r
+        WHERE r."agentId" = ${agentId}
+          AND r."startedAt" >= ${windowStart} AND r."startedAt" < ${windowEnd}
+          ${scope} ${kindFilter}
+      `,
+    ]);
+
+    res.json({
+      total: Number(countRaw[0]?.count ?? 0),
+      limit,
+      offset,
+      runs: rowsRaw.map((r) => ({
+        id: r.id,
+        kind: r.kind,
+        outcome: r.outcome,
+        skipReason: r.skip_reason,
+        eventCount: Number(r.event_count ?? 0),
+        injectionsUsed: Number(r.injections_used ?? 0),
+        sessionId: r.session_id,
+        conversationId: r.conversation_id,
+        runStatus: r.run_status,
+        windowStartMs: Number(r.window_start_ms),
+        windowEndMs: Number(r.window_end_ms),
+        startedAt: r.started_at.toISOString(),
+        completedAt: r.completed_at ? r.completed_at.toISOString() : null,
+        durationMs: r.completed_at ? r.completed_at.getTime() - r.started_at.getTime() : null,
+      })),
+    });
+  } catch (err) {
+    log.error("[metrics/awakening/runs] error:", err);
+    res.status(500).json({ error: err instanceof Error ? err.message : "Internal server error" });
+  }
+});

--- a/apps/xyne-claw-auth/backend/src/routes/run.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run.ts
@@ -43,6 +43,7 @@ import {
   type ProviderConfig,
 } from "../lib/agent-provider-config.js";
 import { resolveFastMode } from "../lib/fast-mode.js";
+import { withAwakeningSendTool } from "../awakening/send-tool.js";
 import { redisService } from "../redis.js";
 import {
   requireAuth,
@@ -188,7 +189,7 @@ function requireRunCaller(req: Request, res: Response, next: NextFunction): void
   return requireUserAuth(req, res, next);
 }
 
-type AgentRunTriggerSource = "spaces" | "scheduled" | "chat" | "api" | "automation" | "slack";
+type AgentRunTriggerSource = "spaces" | "scheduled" | "chat" | "api" | "automation" | "slack" | "heartbeat" | "reflex";
 
 function triggerSourceForEventType(eventType: unknown, requested: unknown): AgentRunTriggerSource {
   if (requested === "slack") return "slack";
@@ -771,7 +772,7 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
       }
       req.body = sanitized;
     }
-    const { task, context, conversationId, piSessionConversationId, agentSlug, callbackUrl, callbackSecret, channelId, deliverTo, projectId, projectName, cwd, eventType, triggerSource, slackDelivery, traceId, provider, providerOrder, providerOverride, subagentProviders, subagentProviderMode, providerConfigs, progressUrl, attachments, recordingRefs, contextFiles, attachedContext, ticketIds, canvasIds, callIds, idempotencyKey: requestedIdempotencyKey, isRegenerate, detached, fastMode, resumedFromHandoff, generateFollowUpSuggestions } = req.body as {
+    const { task, context, conversationId, piSessionConversationId, agentSlug, callbackUrl, callbackSecret, channelId, deliverTo, projectId, projectName, cwd, eventType, triggerSource, slackDelivery, traceId, provider, providerOrder, providerOverride, subagentProviders, subagentProviderMode, providerConfigs, progressUrl, attachments, recordingRefs, contextFiles, skills: bodySkills, attachedContext, ticketIds, canvasIds, callIds, idempotencyKey: requestedIdempotencyKey, isRegenerate, detached, fastMode, resumedFromHandoff, generateFollowUpSuggestions } = req.body as {
       task?: string;
       context?: string;
       conversationId?: string;
@@ -805,6 +806,7 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
       attachments?: Array<{ fileName: string; mimeType: string; data: string }>;
       recordingRefs?: RunRecordingRef[];
       contextFiles?: Array<{ path: string; content: string }>;
+      skills?: Array<{ slug?: string; name: string; description?: string; content: string }>;
       attachedContext?: Array<{
         type: "channel" | "ticket" | "canvas" | "call";
         id: string;
@@ -1370,6 +1372,80 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
       ? injectedCallbackUrl
       : (callbackUrl ?? injectedCallbackUrl);
 
+    // Same S2S trust rule as skills: only an internal caller (the awakening
+    // dispatcher) may declare a run unattended, since the block governs the
+    // run's write policy and its live-injection wiring.
+    const awakeningBlock =
+      s2sKeyMatches(req.headers["x-s2s-key"]) &&
+      (req.body as { awakening?: unknown }).awakening &&
+      typeof (req.body as { awakening?: unknown }).awakening === "object"
+        ? ((req.body as { awakening?: Record<string, unknown> }).awakening as Record<string, unknown>)
+        : undefined;
+
+    // An AWAKENED run (heartbeat / reflex) must have its SessionContext in place
+    // BEFORE claw is dispatched: claw lists its MCP tools within milliseconds of
+    // the POST returning, and that listing reads the context to decide app-mode
+    // vs user-mode and to grant the bot-identity send tool. Writing the context
+    // after the dispatch resolves is a race the run usually loses — the agent
+    // then comes up with no way to speak at all.
+    //
+    // `awakening` is only honoured from an S2S caller (see awakeningBlock), so
+    // this cannot be used to self-declare an unattended run from a browser.
+    if (awakeningBlock) {
+      try {
+        const [ciphertext, iv, authTag] = (agent.spacesAppToken ?? "").split(":");
+        const appToken =
+          ciphertext && iv && authTag ? decrypt(ciphertext, iv, authTag, CONFIG.encryptionKey) : "";
+        const kind = String((awakeningBlock as Record<string, unknown>)["kind"] ?? "");
+        const { setSession } = await import("./webhook.js");
+        await setSession(sessionId, {
+          mentionedUserId: agent.spacesAppUserId ?? "",
+          senderId: agent.spacesAppUserId ?? "",
+          senderName: agentSlug || "assistant",
+          channelId: "",
+          channelName: "",
+          conversationId: conversationId ?? "",
+          task: task.trim(),
+          agentId: agent.id,
+          agentOrgId: agent.orgId,
+          agentSlug: agentSlug || "assistant",
+          responseMode: "conversation",
+          // Read by routes/mcp.ts: app-mode Spaces tools + the send tool.
+          triggerSource: kind === "reflex" ? "reflex" : "heartbeat",
+          isAutomation: true,
+          // The agent posts through tools, choosing thread and wording itself;
+          // its final answer is an operator log line, not a channel message.
+          suppressThreadReply: true,
+          appToken,
+          spacesAppId: agent.spacesAppId ?? "",
+          spacesAppUserId: agent.spacesAppUserId ?? "",
+          ...(traceId ? { traceId } : {}),
+        });
+      } catch (sessionErr) {
+        log.warn(
+          `[run] failed to store awakening session context sessionId=${sessionId}:`,
+          sessionErr instanceof Error ? sessionErr.message : sessionErr,
+        );
+      }
+    }
+
+    // Grant the bot-identity send tool for THIS run only. claw re-applies the
+    // agent's tools allowlist against the config forwarded here
+    // (applyAgentToolFilter in xyne-claw/src/routes/run.ts), so listing the
+    // tool at the claw-auth MCP boundary is not enough on its own — claw would
+    // strip it right back out of the palette. `apps-send-message` is never in
+    // the picker, so a strict allowlist always excludes it, and an awakened run
+    // has no thread its final answer is posted into: without this the agent
+    // decides to reply, finds no tool, and says nothing.
+    //
+    // Mirrors withSurfaceDefaultToolsConfig in routes/mcp.ts; both are per-run
+    // and leave the stored agent config untouched. The write POLICY
+    // (observe / reply / act, plus shadow) still governs whether a call is
+    // permitted — see awakening/write-policy.ts, enforced at /mcp/call.
+    if (awakeningBlock) {
+      mergedAgentConfig = withAwakeningSendTool(mergedAgentConfig);
+    }
+
     if (injectedCallbackUrl) {
       try {
         const [ciphertext, iv, authTag] = (agent.spacesAppToken ?? "").split(":");
@@ -1470,6 +1546,34 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
     // Shared request body for both transports. SSE consumers (run-stream.ts)
     // pass progressUrl/callbackUrl too — claw ignores them in SSE mode since
     // the response stream IS the channel.
+    // Caller-supplied skills, merged with the agent's attached ones.
+    //
+    // S2S ONLY. A skill's content becomes agent instructions, so accepting one
+    // from a browser session would let any user rewrite what their agent is
+    // told to do for that run. Trusted internal callers (the awakening
+    // dispatcher, which inlines its operating contract rather than depending
+    // on a per-org seeded row) are the only ones allowed to add them.
+    const callerSkills =
+      s2sKeyMatches(req.headers["x-s2s-key"]) && Array.isArray(bodySkills)
+        ? bodySkills.filter(
+            (sk): sk is { slug?: string; name: string; description?: string; content: string } =>
+              !!sk && typeof sk.name === "string" && typeof sk.content === "string",
+          )
+        : [];
+    const agentSkills = agent.skills ?? [];
+    // Agent-attached skills win a slug collision — an org's own skill must not
+    // be silently shadowed by a caller-supplied one.
+    const takenSlugs = new Set(agentSkills.map((sk) => sk.slug ?? sk.name));
+    const mergedSkills = [
+      ...agentSkills,
+      ...callerSkills.map((sk) => ({
+        slug: sk.slug ?? sk.name,
+        name: sk.name,
+        description: sk.description ?? "",
+        content: sk.content,
+      })).filter((sk) => !takenSlugs.has(sk.slug)),
+    ];
+
     const forwardBody = {
       sessionId,
       idempotencyKey,
@@ -1499,7 +1603,8 @@ router.post("/run", requireRunCaller, async (req: Request, res: Response) => {
         ? { providerConfigs: effectiveProviderConfigs }
         : {}),
       ...(cwd ? { cwd } : {}),
-      ...(agent.skills ? { skills: agent.skills } : {}),
+      ...(mergedSkills.length > 0 ? { skills: mergedSkills } : {}),
+      ...(awakeningBlock ? { awakening: awakeningBlock } : {}),
       ...(progressUrl ? { progressUrl } : {}),
       ...(attachments?.length ? { attachments } : {}),
       ...(normalizedRecordingRefs.length ? { recordingRefs: normalizedRecordingRefs } : {}),

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -7923,6 +7923,7 @@ router.post("/progress", requireStrictS2S, async (req: Request, res: Response) =
               agentSlug: ctx.agentSlug,
               userId: ctx.senderId,
               toolInvocation,
+              ...(ctx.triggerSource ? { triggerSource: ctx.triggerSource } : {}),
               ts: Date.now(),
             });
           }

--- a/apps/xyne-claw-auth/docs/awakening.md
+++ b/apps/xyne-claw-auth/docs/awakening.md
@@ -204,8 +204,8 @@ All of it lives under `agent.config.awakening`. Two layers validate it:
 | `periodMs` | int | `1_800_000` (30m) | Heartbeat period. Range 5m – 24h |
 | `writePolicy` | `observe` \| `reply` \| `act` | `reply` | Enforced as tool denials, §7.1 |
 | `shadow` | boolean | `true` | Overrides `writePolicy` down to `observe` |
-| `instructions` | string | `""` | Owner-written guidance, ≤ 4000 chars. §7.3 |
-| `workspaceId` | string? | — | Explicit Spaces workspace, when the org maps to more than one |
+| `instructions` | string | `""` | Owner-written guidance, ≤ 10000 chars. §7.3 |
+| `workspaceId` | string? | — | Rarely needed. The workspace is resolved from the agent's own bot user; this only pins it when that user cannot be read, and it must match the bot's workspace |
 
 ### 4.2 Channels
 
@@ -721,7 +721,7 @@ but cannot make a run mute or make it answer itself.
 
 ### 7.3 Operator instructions
 
-`awakening.instructions`, up to 4000 chars, edited in the Awakening tab. Meant
+`awakening.instructions`, up to 10000 chars, edited in the Awakening tab. Meant
 for tone and triage — *"Keep it short and warm. Jump in when someone is blocked
 or waiting on an answer. Stay out of social chatter."* It is advisory by
 construction: it cannot override the write policy or the bounds.
@@ -902,6 +902,22 @@ plus the last 20 runs.
 > at all. A reflex blocked by `maxRunsPerHour` leaves no trace whatsoever. See
 > §14 open defect 12.
 
+**Metrics page.** The workspace view has an **Awakened agents** section
+(`GET /metrics/awakening`, rendered by `AwakeningActivityCard`): wakes vs acted
+vs stayed-quiet vs failed for the window, a per-agent breakdown by wake kind, the
+distribution of gate skip reasons, and a banner listing agents the workers have
+stopped along with their `lastError`. It fetches separately from the rest of the
+page because awakened runs have no `userId` — the user-scoped filters every
+other metrics endpoint applies would drop them. The section hides itself
+entirely for a workspace where nothing has ever woken.
+
+Clicking an agent expands its full wake history, paginated
+(`GET /metrics/awakening/:agentId/runs`, 20 per page). Every wake ATTEMPT is a
+row — a skipped wake carries the gate rule that fired, which is usually what you
+opened it to find out — and a wake that dispatched links straight to its
+transcript. Org scoping is applied to the RUN rows, not just the agent, so an
+admin scoped to one org cannot page through another org's history by id.
+
 **Logs.** Dispatch, gate decisions, channel truncation, watermark rewinds, and
 injection batches all log at `info`. A reflex `wait` **while a run is in flight**
 also logs, because that is the state operators most often need when asking "why
@@ -972,7 +988,7 @@ must be set on **every** API pod to have any effect.
 | `rate-limit.ts` | `peekRunRate` / `consumeRunRate` |
 | `inbox.ts` | Injection batch queue |
 | `reflex.ts` | `countEventsSince`, `decideReflex`, `renderInjection` |
-| `workspace.ts` | org → Spaces workspace resolution |
+| `workspace.ts` | Spaces workspace resolution — bot user first, org link as fallback |
 
 **claw-auth — elsewhere**
 
@@ -1003,6 +1019,9 @@ carried.
 | 1 | **`kind: "reflex"` agents were permanently killed.** The heartbeat tick cleared `state.enabled` for any agent that did not participate in *heartbeat*, and the reflex claim scan requires `enabled = TRUE`. The first heartbeat tick that claimed a reflex-only agent disabled it forever. | `enabled` and "participates in this kind" are now two different questions. A non-participating cadence is **parked** (`nextDueAt`/`reflexNextCheckAt` pushed out by `IDLE_REPARK_MS`), never disabled. Regression test in `awakening-tick-kind.test.ts`. |
 | 2 | **The config editor deleted settings it does not model.** `AwakeningSettings` has no control for `workspaceId`, `limits.maxActiveThreads`, `cursor.overlapMs` or `cursor.maxCatchupWindows`, and the tab persisted `{...agent.config, awakening: draft}` — replacing the block wholesale. Opening the tab and pressing Save reset four settings the admin never touched. | The save path now merges over the stored block, section by section, so unmodeled keys survive. |
 
+| 3 | **Workspace resolution read the wrong source.** `resolveWorkspaceId` consulted only `SurfaceTenantLink` (org → workspace). Nothing in the product ever writes that table for Spaces — the sole writer is `prisma/seed.ts` — so it is empty in production, and a `WorkspaceResolutionError` then **permanently disabled** the agent. Two live prod agents were switched off this way on 2026-08-26, while the UI still showed them enabled. | Resolve from the agent's **own bot user** (`users.workspaceId` in Spaces, via `getWorkspaceIdForUser`), exactly as `credentials-loader.ts` already did for app-tools; fall back to the link table only when that user cannot be read. Needs no configuration, and a multi-workspace org is no longer ambiguous — the bot is in exactly one. 12 tests. |
+| 4 | **A recoverable gap was treated as fatal, invisibly.** `WorkspaceResolutionError` was grouped with `AwakeningIdentityError` and cleared `state.enabled`; the tab reads `config.awakening.enabled`, so the agent kept rendering as on. | Only identity failures disable now (an agent with no bot identity must never fall back to a user token). A workspace error records `lastError`, stays enabled and retries on the normal cadence — and clears itself on the next success, on both the heartbeat and reflex paths. The tab shows a banner when the state row disagrees with the config. |
+
 ### Open
 
 | # | Defect | Impact |
@@ -1020,7 +1039,7 @@ carried.
 | 12 | **The reflex path records almost nothing.** A run row is created only on `fire`; `wait`, every `hold`, `inject`, rate-limited, lock-busy, no-channels and empty-collect all return silently. | A reflex blocked by `maxRunsPerHour` produces no row *and* no log, where the heartbeat records `skipReason: "rate_limited"`. §11's "answers why it did/didn't wake" holds for heartbeat only. |
 | 13 | **A retried window keeps the wrong outcome.** Dispatch failure records `outcome="failed"` *and* throws, triggering the BullMQ retry (`attempts: 3`). The retry recomputes an identical `idempotencyKey`, so the success-path insert hits `P2002` and is swallowed. | The row stays `failed` with `sessionId` NULL for a wake that actually ran — so `/status` lies, and the injection bookkeeping keyed on `sessionId` can never match it. `markFailure` also fires up to 3× for one beat, driving the backoff to 2³ = 8 (4 h at the default period, not the "within one hour" the code comment promises). |
 | 14 | **A dead claw pod loses injected events permanently.** The §8.2 rewind runs only in the result callback. If the owning pod dies, no callback fires: the batch expires with its 1 h TTL, the reflex watermark stays advanced past those events, and the lock is held until its own TTL. Nothing reaps `agent_awakening_runs` rows with `completedAt IS NULL`. | Blast radius is one inbox (≤ 20 batches) per dead run. Recovery is manual. |
-| 15 | **No product path re-enables a self-disabled agent.** Both workers set `enabled: false` on `AwakeningIdentityError` / `WorkspaceResolutionError`. `/status` is read-only, and `syncAwakeningState` re-enables only via a PUT. | The runbook is "fix the identity, then press Save" — which is not discoverable and is nowhere in the UI. |
+| 15 | **Re-enabling a self-disabled agent is still a PUT.** `AwakeningIdentityError` (only) sets `enabled: false`, and `syncAwakeningState` re-enables solely via a PUT. | Now at least visible — the tab shows a "switched off" banner with `lastError` and tells the admin to press Save (see Fixed #4). A dedicated re-enable action would be better than overloading Save. |
 
 | 16 | **`reflex.checkIntervalMs` below `AWAKENING_TICK_MS` is a silent no-op.** Reflex rows are claimed by the fleet tick, so the effective cadence is `max(checkIntervalMs, tickIntervalMs)` — 60s by default. The UI's `REFLEX_CHECK_OPTIONS` offers 15s and 30s, and `AWAKENING_BOUNDS.reflexCheckIntervalMs.MIN` is 15s, so the editor lets an admin pick values that can never be honoured. | Directly defeats live injection on short runs: a run must survive a full tick to be injectable, so anything finishing in under ~60s never receives an update no matter how the reflex knobs are set. Either raise the UI's floor to the tick interval, or drive the tick from the smallest configured reflex interval. |
 
@@ -1044,8 +1063,9 @@ Two related notes that are working as intended but read as surprises:
 - **Steering only lands at a turn boundary.** An agent that stops calling tools
   cannot be reached again; queued batches are returned to the next wake.
 - **Heartbeat windows are sealed.** Injection is reflex-only by design.
-- **One workspace per agent.** `workspaceId` picks it when the org maps to more
-  than one; there is no multi-workspace fan-out.
+- **One workspace per agent.** The agent's bot user belongs to exactly one
+  Spaces workspace and that is the one it acts in; there is no multi-workspace
+  fan-out. An org with several workspaces needs one agent per workspace.
 - **`maxChannels` truncation is silent to the channel, visible to the agent** —
   it is recorded in the artifact header, not surfaced as an admin alert.
 - **An awakened run has an effective 20-minute ceiling** while defect 10 stands.

--- a/apps/xyne-claw-auth/docs/awakening.md
+++ b/apps/xyne-claw-auth/docs/awakening.md
@@ -1,0 +1,1053 @@
+# Awakened Agents — Architecture & Operations
+
+**Status:** Landed · heartbeat + reflex + live injection all verified end-to-end against a live workspace
+**Services touched:** `xyne-claw-auth` (control plane), `xyne-claw` (agent runtime), `apps/backend` (Spaces)
+**Last updated:** 2026-08
+
+---
+
+## 0. What this is
+
+Every other way an agent runs in this platform starts with a human: a mention in
+Spaces, a chat message, an API call, a scheduled job somebody configured for a
+specific purpose. **Awakening is the path where nobody starts it.** The agent
+wakes on its own, is handed everything that happened in the channels it watches
+since it last looked, decides whether any of it is worth acting on, and acts —
+posting into threads with its own bot identity.
+
+The metaphor the feature was designed around, and the one the code is named for:
+a **heartbeat** circulates **blood** (events) from the **lungs** (people talking
+in channels) to the **brain** (the agent). A **reflex** is the faster, shallower
+loop that fires when enough happens at once to be worth reacting to *now*.
+
+Two wake kinds, both optional per agent:
+
+| Kind | Trigger | Cost per check | Typical use |
+|---|---|---|---|
+| **Heartbeat** | wall clock (`periodMs`, default 30m) | full window collect | periodic situational awareness, catching what threads got dropped |
+| **Reflex** | event volume (`reflex.threshold` events since its watermark) | one `COUNT` query | reacting fast when a burst of activity happens |
+
+An agent can run `heartbeat`, `reflex`, or `both`. With `both`, the heartbeat
+also reads what the reflexes already did, so it doesn't answer a question a
+reflex answered twenty minutes ago (§9).
+
+### Design constraints this was built under
+
+1. **Critical path — must never break.** Every stage fails closed or fails
+   open deliberately, never by accident. A broken window must not take down an
+   agent; a broken agent must not take down the tick loop.
+2. **Multi-pod is the production reality.** claw-auth, claw and Spaces all run
+   horizontally scaled. Nothing may assume a single instance.
+3. **Configurable, with real bounds.** Every number is an admin knob with a
+   clamped range and a safe default.
+4. **Extensible backbone.** Adding a wake kind, a gate rule or an artifact file
+   must not require touching the exactly-once machinery.
+
+---
+
+## 1. Vocabulary
+
+| Term | Meaning |
+|---|---|
+| **Window** | A half-open time range `(watermarkAt, now − replicaSafetyMs]` and everything that happened in the watched channels inside it. |
+| **Watermark** | Exclusive upper bound of the last *sealed* window. Two separate ones per agent: `watermarkAt` (heartbeat) and `reflexWatermarkAt`. |
+| **Seal** | Closing a window at a fixed instant. Windows never close at `now()` — see §5.1. |
+| **Gate** | The ordered rule table that decides whether a collected window is worth a run at all. |
+| **Artifact** | The set of files written into the run's `.context/heartbeat/` directory: `WINDOW.md`, `events.jsonl`, `CURSOR.json`, `prior-sessions.md`. |
+| **Contract** | The `additionalInstructions` block every awakened run receives, telling it the one thing its priors get wrong: its final answer is not delivered to anyone. |
+| **Injection** | New events handed to a run that is already in flight, so it adapts mid-task. |
+| **Agent lock** | The Redis key that guarantees one awakened run per agent at a time. |
+
+---
+
+## 2. Architecture at a glance
+
+```mermaid
+flowchart TB
+  subgraph SPACES["apps/backend — Spaces"]
+    PG[("Postgres<br/>read replica")]
+    QAPI["POST /api/query/claw<br/>(Prisma query AST)"]
+    POST["POST /chat/postMessage<br/>(app token)"]
+    QAPI --> PG
+  end
+
+  subgraph AUTH["xyne-claw-auth — control plane"]
+    TICK["tick worker<br/>agent-awakening-tick"]
+    WIN["window worker<br/>agent-awakening-window"]
+    RFX["reflex worker<br/>agent-awakening-reflex"]
+    COL["collector + signals + gate"]
+    REN["render → artifact"]
+    DIS["dispatch"]
+    MCP["MCP boundary<br/>tool listing + call"]
+    CB["result callback<br/>+ inbox drain"]
+    ST[("agent_awakening_state<br/>agent_awakening_runs")]
+    RDS[("Redis<br/>lock / inbox / rate / chan cache")]
+  end
+
+  subgraph CLAW["xyne-claw — agent runtime"]
+    RUN["POST /internal/run"]
+    SESS["PI session<br/>+ .context/ files"]
+    INB["awakening-inbox<br/>(pull poller)"]
+  end
+
+  TICK -->|claim due| ST
+  TICK -->|fan out| WIN
+  TICK -->|fan out| RFX
+  WIN --> COL
+  RFX -->|cheap COUNT| QAPI
+  COL --> QAPI
+  COL --> REN --> DIS
+  DIS -->|HTTP + S2S| RUN
+  RUN --> SESS
+  SESS -->|tools| MCP
+  MCP --> POST
+  SESS -->|progress| CB
+  SESS -->|result| CB
+  INB <-->|drain| CB
+  RFX -->|queue batch| RDS
+  INB -.->|poll| RDS
+  DIS --> ST
+  CB --> ST
+```
+
+**Ownership:** claw-auth owns *everything about deciding to wake* — scheduling,
+collection, gating, artifact rendering, safety policy, bookkeeping. claw owns
+*running the agent*. claw knows almost nothing about awakening: it receives an
+`awakening` block, writes the context files, and installs one extra poller.
+
+---
+
+## 3. Data model
+
+Two tables. Both live in claw-auth's Postgres. All status/kind fields are plain
+`String` — Postgres enums are frozen repo-wide by
+`scripts/validate-no-new-enums.sh`.
+
+### 3.1 `agent_awakening_state` — one row per agent
+
+| Column | Type | Meaning |
+|---|---|---|
+| `agentId` | String `@unique` | The agent this state belongs to |
+| `orgId` | String | Tenant |
+| `enabled` | Boolean = false | Master switch; mirrors `config.awakening.enabled` |
+| `nextDueAt` | DateTime | Heartbeat due time. What the tick claim scans. |
+| `lastTickAt` | DateTime? | Last time this row was claimed |
+| `watermarkAt` | DateTime | Exclusive upper bound of the last sealed **heartbeat** window |
+| `watermarkMessageId` | String? | Tie-breaker for events sharing `watermarkAt` to the millisecond |
+| `consecutiveFailures` | Int = 0 | Backoff state — this *is* the circuit breaker, no separate machine |
+| `consecutiveSkips` | Int = 0 | Feeds the anti-starvation rule (`forceRunEveryNSkips`) |
+| `lastError` | Text? | Last failure reason, surfaced in the admin status endpoint |
+| `reflexNextCheckAt` | DateTime? | Reflex due time — separate, much faster cadence |
+| `reflexWatermarkAt` | DateTime? | Reflex's **own** watermark |
+| `reflexLastRunAt` | DateTime? | Enforces `reflex.minIntervalMs` |
+
+Indexes: `(enabled, nextDueAt)` and `(enabled, reflexNextCheckAt)` — the two hot
+claim scans — plus `(orgId)`.
+
+> **Why two watermarks.** The two wake kinds are *meant* to see the same events
+> for different reasons: the reflex reacts fast and shallow, the heartbeat later
+> synthesises the whole period **and reads what the reflexes already did**.
+> Sharing one watermark would let a reflex consume events the heartbeat then
+> never sees.
+
+### 3.2 `agent_awakening_runs` — one row per wake *attempt*
+
+Written whether or not a run was dispatched. Serves three jobs at once: the
+idempotency guard, the admin health view, and the §9 overlap lookup.
+
+| Column | Type | Meaning |
+|---|---|---|
+| `kind` | String | `"heartbeat"` \| `"reflex"` |
+| `windowStartMs`, `windowEndMs` | BigInt | Window bounds as epoch millis — BigInt so a JS `Date` round-trip cannot lose precision on the overlap query |
+| `outcome` | String | `"ran"` \| `"skipped"` \| `"failed"` \| `"shadow"` |
+| `skipReason` | String? | Which gate rule fired, when skipped |
+| `eventCount` | Int | Events in the window |
+| `signals` | Json? | Denormalized signal counts the gate decided on — answers "why did/didn't it wake" without re-deriving the window |
+| `sessionId` | String? | The claw session, once dispatched |
+| `idempotencyKey` | String `@unique` | The duplicate-dispatch guard |
+| `injectionsUsed` | Int = 0 | Live-injection batches queued for this run |
+| `startedAt`, `completedAt` | DateTime | |
+
+Indexes: `(agentId, windowStartMs)` for the overlap lookup, `(orgId, startedAt)`
+for the admin list.
+
+### 3.3 Redis keys
+
+| Key | Shape | TTL | Purpose |
+|---|---|---|---|
+| `claw:awk:lock:{agentId}` | JSON `{sessionId, kind, acquiredAtMs}` | run-scoped | One awakened run per agent. `SET NX PX`; released and refreshed by Lua CAS on `sessionId`. |
+| `claw:awk:inbox:{sessionId}` | Redis list of batch JSON | 3600s | Queued live-injection batches, max 20 |
+| `claw:awk:inject:{sessionId}` | JSON `{used, lastAtMs}` | 3600s | Injection counters for the cap and min-interval |
+| `claw:awk:rate:{agentId}:{bucket}` | counter | 7200s | Runs-per-hour limiter; 2h TTL so the previous bucket survives long enough to diagnose |
+| `claw:awk:chan:{agentId}:{rulesHash}` | resolved channel list | `checkIntervalMs`-scoped | Channel resolution cache, keyed by a hash of the rules so a config edit invalidates it |
+
+---
+
+## 4. Configuration reference
+
+All of it lives under `agent.config.awakening`. Two layers validate it:
+
+- **`validateAwakeningConfig`** (`src/lib/agent-config-validation.ts`) runs on
+  the save path and **rejects with 400** — wrong types, unknown enum values,
+  out-of-range integers, over-long instructions.
+- **`resolveAwakeningConfig`** (`src/awakening/config.ts`) runs on every read and
+  **never throws**. It clamps, coerces and falls back to defaults. A stored
+  config that somehow went bad must not be able to disable a working agent or
+  crash a worker.
+
+### 4.1 Top level
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `enabled` | boolean | `false` | Master switch |
+| `kind` | `heartbeat` \| `reflex` \| `both` | `heartbeat` | |
+| `periodMs` | int | `1_800_000` (30m) | Heartbeat period. Range 5m – 24h |
+| `writePolicy` | `observe` \| `reply` \| `act` | `reply` | Enforced as tool denials, §7.1 |
+| `shadow` | boolean | `true` | Overrides `writePolicy` down to `observe` |
+| `instructions` | string | `""` | Owner-written guidance, ≤ 4000 chars. §7.3 |
+| `workspaceId` | string? | — | Explicit Spaces workspace, when the org maps to more than one |
+
+### 4.2 Channels
+
+| Key | Type | Default | Notes |
+|---|---|---|---|
+| `channels.include` | string[] | `[]` | Channel ids |
+| `channels.includePattern` | string[] | `[]` | Regexes over channel **name**. Max 10 patterns, 200 chars each |
+| `channels.exclude` | string[] | `[]` | Ids; exclusion always wins |
+| `channels.excludePattern` | string[] | `[]` | Regexes; exclusion always wins |
+| `channels.maxChannels` | int | `25` | Range 1 – 100. Truncation is surfaced to the agent in the artifact |
+
+> **Rules can only narrow, never widen.** The candidate set is the channels the
+> agent's bot is *actually a member of*. A catch-all `.*` resolves to exactly
+> what the bot can already read, never to a channel nobody added it to. Regex
+> matching runs under a 50 ms wall-clock budget so a pathological pattern cannot
+> stall the tick, and an uncompilable pattern is dropped with a warning rather
+> than failing the run.
+
+### 4.3 Gate and limits
+
+| Key | Type | Default | Range | Notes |
+|---|---|---|---|---|
+| `gate.minHumanEvents` | int | `1` | 0 – 1000 | Below this, skip |
+| `gate.forceRunEveryNSkips` | int | `0` | 0 – 100 | Anti-starvation; 0 disables |
+| `limits.maxEvents` | int | `1500` | 10 – 5000 | Window event cap |
+| `limits.maxActiveThreads` | int | `400` | 5 – 1000 | Thread prefilter cap |
+| `limits.maxRunsPerHour` | int | `4` | 1 – 60 | Hard ceiling on dispatches |
+
+### 4.4 Reflex
+
+| Key | Type | Default | Range | Notes |
+|---|---|---|---|---|
+| `reflex.checkIntervalMs` | int | `60_000` | 15s – 1h | How often the cheap COUNT runs. **Effective value is `max(this, AWAKENING_TICK_MS)`** — see §14 defect 16 |
+| `reflex.threshold` | int | `25` | 1 – 1000 | Events since the reflex watermark that trigger a wake |
+| `reflex.minIntervalMs` | int | `300_000` | 0 – 24h | Floor between two reflex runs |
+| `reflex.injectEnabled` | boolean | `true` | | Live injection master switch |
+| `reflex.injectThreshold` | int | `10` | 1 – 1000 | New events needed to interrupt a running agent |
+| `reflex.maxInjectionsPerSession` | int | `3` | 0 – 20 | A run still has to converge |
+| `reflex.injectMinIntervalMs` | int | `60_000` | 0 – 1h | Floor between two injections into one session |
+
+### 4.5 Cursor
+
+| Key | Type | Default | Range | Notes |
+|---|---|---|---|---|
+| `cursor.replicaSafetyMs` | int | `30_000` | 0 – 300s | How far behind `now` a window closes. **This is the floor on end-to-end latency** — see §8.3 |
+| `cursor.overlapMs` | int | `120_000` | 0 – 15m | Re-scan band below the watermark, de-duplicated against a seen-set |
+| `cursor.maxCatchupWindows` | int | `4` | 1 – 50 | Backlog cap before the gap guard jumps the watermark forward |
+
+### 4.6 Where an admin sets this
+
+Agent detail → **Awakening** tab (`AwakeningTab.tsx`). Sections:
+**Safety** (shadow, write policy, max runs/hour) · **Run instructions**
+(free-text guidance) · **When it wakes** (kind, period, reflex knobs) ·
+**Channels** (includes, patterns, excludes, cap) · **Gate** (min human events,
+anti-starvation) · **Live updates** (injection knobs, replica safety margin,
+plus a computed line telling the admin the actual injection latency their
+settings produce).
+
+The client mirrors `AWAKENING_BOUNDS` in `frontend/src/v3/lib/awakeningBounds.ts`
+purely to shape the editor. The server re-clamps and re-validates everything it
+is sent, so the UI can never widen a real bound.
+
+---
+
+## 5. The pipeline, stage by stage
+
+### 5.0 Tick and claim
+
+One repeatable BullMQ job for the whole fleet — `agent-awakening-tick`, every
+`AWAKENING_TICK_MS` (default 60s), worker concurrency strictly 1.
+
+> **Deliberately not one repeatable job per agent.** A per-agent repeatable set
+> drifts: a rename or a missed cleanup silently stops an agent forever. With a
+> single scheduler, every pod boot converges on the same one job.
+
+Each tick claims due rows with `FOR UPDATE SKIP LOCKED` and immediately writes a
+provisional `nextDueAt = now + 60s`:
+
+```sql
+UPDATE "agent_awakening_state" AS s
+   SET "nextDueAt" = $provisional, "lastTickAt" = NOW()
+ WHERE s."id" IN (
+   SELECT "id" FROM "agent_awakening_state"
+    WHERE "enabled" = TRUE AND "nextDueAt" <= NOW()
+    ORDER BY "nextDueAt" ASC
+    LIMIT $limit
+    FOR UPDATE SKIP LOCKED
+ )
+RETURNING ...
+```
+
+`claimDueReflexChecks` is the same shape against `reflexNextCheckAt`. **This is
+the multi-pod safety story at the scheduling layer:** N pods can run the same
+tick concurrently and each agent is claimed by exactly one of them. Verified
+under test with 25 agents × 6 simulated pods — every agent claimed exactly once.
+
+> **Ordering constraint:** `fanOutReflexChecks` must run **before** the
+> heartbeat early-return in `processTick`. It didn't originally, and the effect
+> was that reflexes only fired on ticks where a heartbeat also happened to be
+> due.
+
+Claimed agents are fanned out onto `agent-awakening-window` (concurrency
+`AWAKENING_WINDOW_CONCURRENCY`, default 5) and `agent-awakening-reflex`
+(`AWAKENING_REFLEX_CONCURRENCY`, default 10).
+
+> **The tick is the floor on every cadence.** `reflex.checkIntervalMs` sets
+> `reflexNextCheckAt`, but the row is only *claimed* when the tick runs. With
+> the default `AWAKENING_TICK_MS=60_000`, a configured 15s reflex interval still
+> checks once a minute. The scheduler is registered with `upsertJobScheduler`
+> under a stable id, so changing the interval and restarting cleanly replaces
+> the schedule.
+
+### 5.1 Sealing the window
+
+`sealWindow(watermarkAt, config, now)` → `{ startMs, endMs, gap }`.
+
+Three invariants, each guarding a specific failure:
+
+1. **A window never closes at `now()`.** Spaces reads hit a **read replica**, so
+   rows written moments ago may not have replicated. Sealing at
+   `now − replicaSafetyMs` and stepping the watermark to that same instant is
+   what stops the cursor from stepping over unreplicated rows forever.
+2. **The watermark never rewinds.** It advances by compare-and-set that only
+   moves forward, so two pods racing on one agent can at worst repeat work —
+   never un-see events.
+3. **A failed window does not advance it.** Skips do (the window was genuinely
+   empty or boring; re-reading produces the same skip). Failures don't, so the
+   next wake retries the same range.
+
+**Gap guard.** If `endMs − startMs > periodMs × maxCatchupWindows` (an agent
+disabled for a week, a fleet down overnight), the watermark jumps forward and
+the skipped span is recorded in the window header where the agent can see it.
+Replaying days of backlog into one window would blow the event cap and hand the
+model a useless artifact.
+
+### 5.2 Resolving channels
+
+`resolveAwakeningChannels(agentId, rules, identity, ttlMs)`:
+
+1. Read the channels the bot is a member of (Spaces `channelParticipant` + `channel`).
+2. Apply include/exclude ids and patterns — pure, in `channel-rules.ts`, split
+   out precisely so the rule semantics test without Redis, a DB or an env file.
+3. Cap at `maxChannels`, recording truncation.
+4. Cache in Redis under a key that includes `hashChannelRules(rules)`.
+
+**Stale-ok on failure:** if the live lookup fails but a cached list exists, the
+cached one is used. A Spaces blip degrades freshness, it does not stop the agent.
+
+### 5.3 Collecting
+
+`collectWindow(channels, sinceMs, untilMs, identity, config)`. **Two stages,
+because `Message` has no `channelId` column:**
+
+1. `conversation` where `channelId IN (...)` and `lastActivityAt >= since`,
+   ordered by `lastActivityAt desc`, capped at `maxActiveThreads`.
+2. `message` where `conversationId IN (...)`, `createdAt` in the window,
+   `isDeleted = false` — keyset-paged.
+3. A **third** query resolves sender display names, because the Spaces query AST
+   supports neither `select` nor `include` (both are silently dropped by
+   `QueryASTSchema`), so a relation select is a no-op and every row comes back
+   whole. Without this the artifact is full of raw cuids and the agent cannot
+   address anyone by name.
+
+**Where this reads from:** `boundedInteract` → `interact` → `POST /api/query/claw`
+→ `readReplicaDb[model].findMany(...)` — **Postgres read replica, not Vespa.**
+This is deliberate and differs from the digital-twin memory path, which is
+Vespa-first. Awakening needs an exhaustive, ordered, keyset-paged scan of a
+channel × time window; Vespa's HTTP surface caps at limit 200 / offset 1000, has
+only day-granular date filters, and is eventually consistent behind a Bull
+queue. Postgres gives exact window boundaries and no index lag.
+
+**`boundedInteract` throws `UnboundedQueryError`** on any `findMany` without an
+explicit `take`. `QueryASTSchema` makes `take` optional, so `MAX_TAKE` binds only
+when supplied — an omitted `take` is an unbounded scan of Spaces' hot tables. A
+background loop must not be able to issue one.
+
+**Text extraction.** Spaces stores what the rich-text editor produced, so a real
+message is `<p class="m-0 leading-6">hey</p>`. `messageToText` converts to
+readable text before any signal runs, preserving mention identity as
+`@Name[userId]` — the same shorthand the send tool accepts, so the agent can copy
+a mention straight from the window into a reply. `mentionsMe` is still evaluated
+against the **raw** HTML, because that is where a mention's user id lives as a
+span attribute.
+
+`markUnanswered` then flags, per thread, the last event when it is a human
+message nobody replied to.
+
+### 5.4 Signals
+
+Twelve counts, computed purely from the events (`signals.ts`):
+
+`eventCount` · `humanEventCount` · `botEventCount` · `selfEventCount` ·
+`distinctSenders` · `distinctThreads` · `newThreads` · `unansweredThreads` ·
+`mentionsOfMe` · `questions` · `actionSignals` · `channelsWithActivity`
+
+### 5.5 The gate
+
+An **ordered rule table**. First rule to return `run` or `skip` decides;
+`continue` falls through. `empty_window` is checked before the table.
+
+| # | Rule | Condition | Outcome | Rationale |
+|---|---|---|---|---|
+| — | `empty_window` | `eventCount === 0` | **skip** | Nothing happened |
+| 1 | `direct_mention` | `mentionsOfMe > 0` | **run** | Somebody is actively waiting on it |
+| 2 | `escalation_signal` | `actionSignals > 0` | **run** | One "P1, who can look at this" outranks fifty chatty messages |
+| 3 | `no_human_activity` | `humanEventCount === 0` | **skip** | Only its own posts and other bots — this is how an agent ends up talking to itself |
+| 4 | `below_min_human_events` | `humanEventCount < gate.minHumanEvents` | **skip** | |
+| 5 | `unanswered_thread` | `unansweredThreads > 0` | **run** | Humans talking, last word unanswered |
+| 6 | `open_question` | `questions > 0` | **run** | |
+| 7 | `no_actionable_signal` | always | **skip** | Chatter with nothing hanging — read it next window as history |
+
+**Anti-starvation override:** any `skip` becomes a `run` (rule
+`forced_after_skips`) once `consecutiveSkips >= gate.forceRunEveryNSkips`, when
+that is non-zero. It bounds how stale an agent's situational awareness can get.
+
+### 5.6 Rendering the artifact
+
+The window becomes files written into the session's `.context/heartbeat/`
+directory. The design principle: **an overview the agent reads top-to-bottom,
+pointing at detail it can grep.** Nothing forces the whole window through the
+context window.
+
+| File | Contents |
+|---|---|
+| `WINDOW.md` | The entry point. Front-matter (kind, bounds, event count, truncation, gap, writePolicy, shadow), then §1 Metrics, §2 Channels, §3 What already happened, §4 Outline of every event grouped by thread, §5 Files + grep recipes |
+| `events.jsonl` | One JSON object per line, chronological, **fixed key order** so greps are stable |
+| `CURSOR.json` | Exact window bounds and coverage proof |
+| `prior-sessions.md` | What earlier runs overlapping this window already did (§9) |
+
+`events.jsonl` fields, in emission order:
+
+```
+L, kind, at, id, ch, chName, cv, cvTitle, sender, senderId,
+isHuman, isMe, root, mentionsMe, unanswered, covered, coveredBy,
+question, actionSignals, edited, chars, text
+```
+
+`L` is the line number, assigned by an explicit `assignLineNumbers()` pass —
+originally `renderWindowMarkdown` depended on `renderEventsJsonl` having
+assigned it first, a hidden ordering dependency that broke when the two were
+called out of order.
+
+Every thread heading in the outline prints the ids needed to answer it:
+
+```
+### awkfix-eng-alerts / `awkfix_cv_5` — "quick question about retries" (4 events, L26–L29)
+reply here → `channelId: "awkfix_ch_alerts", conversationId: "awkfix_cv_5"`
+```
+
+Line ranges use `describeLines()`, which renders non-contiguous sets correctly —
+lines 1, 2 and 10 read as `L1–L2, L10`, not the misleading `L1–L10`.
+
+### 5.7 Dispatch
+
+`dispatchAwakening(window, agent, identity, idempotencyKey)` mirrors
+`queue/scheduled-jobs-worker.ts`, the proven headless dispatch path.
+
+**Pre-flight is fail-closed on identity.** An unattended run acts as the agent's
+own app identity or not at all — `AwakeningIdentityError` disables the agent
+rather than falling back to a user token, which would mean a background loop
+acting with a human's credentials.
+
+Ordering, and it matters:
+
+1. Acquire the agent lock **before** dispatch, keyed on the idempotency key
+   (otherwise a second pod could dispatch in the gap).
+2. `ensureUserExists(botId, "awakening", agent.orgId)` — org is derived from the
+   run's user, never from the request (`x-org-id` is stripped inbound).
+3. POST `/claw/api/v1/internal/run`.
+4. Re-key the lock to the real `sessionId` so the result callback and the
+   injection path can both find it.
+5. Insert the `AgentRun` row ourselves (`__persistedByCaller: true`) so it
+   carries `triggerSource: "heartbeat" | "reflex"` — without it the pod inserts
+   its own row tagged `"spaces"` and the two race on the `sessionId` unique
+   constraint.
+6. Write the `SessionContext` (§6.2).
+7. Create the user-turn `ChatMessage` so the conversation opens in the chat UI.
+
+---
+
+### 5.8 End-to-end sequences
+
+**A heartbeat wake that runs.**
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant T as tick worker
+  participant DB as Postgres (state)
+  participant W as window worker
+  participant SP as Spaces
+  participant D as dispatch
+  participant C as claw
+  participant CB as result callback
+
+  T->>DB: claimDueAgents (SKIP LOCKED, nextDueAt = now+60s)
+  T->>W: enqueue {agentId, kind: heartbeat}
+  W->>DB: read state + agent config
+  W->>W: sealWindow → (watermarkAt, now−replicaSafety]
+  W->>SP: resolve channels (cache, stale-ok)
+  W->>SP: conversations → messages → sender names
+  W->>W: signals → gate → decision = run
+  W->>DB: loadPriorRuns (overlap) → mark covered
+  W->>W: render WINDOW.md / events.jsonl / CURSOR.json / prior-sessions.md
+  W->>DB: peekRunRate (under cap)
+  D->>D: acquire agent lock (idempotencyKey)
+  D->>C: POST /internal/run (+ contextFiles, contract, skill, awakening block)
+  C-->>D: {sessionId}
+  D->>D: re-key lock to sessionId
+  D->>DB: consumeRunRate · insert AgentRun (triggerSource=heartbeat) · AgentAwakeningRun
+  D->>DB: write SessionContext (isAutomation, triggerSource)
+  D->>DB: insert user-turn ChatMessage
+  C->>C: read WINDOW.md, decide, call apps-send-message
+  C->>CB: POST /awakening/{key}/result
+  CB->>DB: assistant ChatMessage · finalize AgentRun · completedAt
+  CB->>DB: release lock · rewind undelivered · clear inbox
+  W->>DB: advance watermarkAt (CAS, forward only)
+```
+
+**A reflex wake.** Same tail, different head: the tick claims
+`reflexNextCheckAt`, the worker runs one `COUNT` since `reflexWatermarkAt`, and
+only escalates to a full `collectWindow` once `decideReflex` returns `fire` or
+`inject`. Below threshold it does nothing at all — that is the whole point of
+the cheap check.
+
+`decideReflex` is pure, and has six terminal states. This is the table to reach
+for when asking *"why did my mid-run events not arrive?"*:
+
+| Agent busy? | Condition | Decision | Meaning |
+|---|---|---|---|
+| no | `count < reflex.threshold` | `wait` | Not enough has happened yet |
+| no | `sinceLastRunMs < reflex.minIntervalMs` | `hold: min_interval` | Fired too recently |
+| no | otherwise | **`fire`** | Dispatch a new reflex run |
+| yes | `!reflex.injectEnabled` | `hold: injection_disabled` | Injection turned off for this agent |
+| yes | `count < reflex.injectThreshold` | `wait` | Accumulating — logged, because this is the common confusion |
+| yes | `injectionsUsed >= maxInjectionsPerSession` | `hold: injection_cap_reached` | The run still has to converge |
+| yes | `sinceLastInjectionMs < injectMinIntervalMs` | `hold: injection_min_interval` | Too soon after the last update |
+| yes | otherwise | **`inject`** | Queue a batch for the running session |
+
+Remember that "busy" means the **agent lock** is held, and that only a `fire`
+writes an `agent_awakening_runs` row (§14 defect 12) — so for every other state
+the log line is the only evidence.
+
+**A mid-run injection, end to end.**
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant H as human in Spaces
+  participant RFX as reflex worker
+  participant R as Redis inbox
+  participant A as claw session (owning pod)
+  participant M as PI model loop
+
+  H->>H: posts N messages
+  Note over RFX: visible only after replicaSafetyMs
+  RFX->>RFX: COUNT → decideReflex → inject (lock held)
+  RFX->>R: rpush {ordinal, windowStartMs, eventCount, text, isFinal}
+  RFX->>RFX: reflexWatermarkAt = untilMs · injectionsUsed = ordinal
+  M->>A: beforeToolCall (chained after installToolBudget)
+  A->>A: ≥ AWAKENING_INBOX_POLL_MS since last poll?
+  A-->>R: POST /awakening/inbox/{sessionId}/drain (not awaited)
+  R-->>A: batches (LRANGE + DEL in MULTI)
+  A->>A: skip ordinals already seen
+  A->>M: steer(<system>Live update N …</system>)
+  M->>M: delivered at the NEXT turn boundary
+```
+
+The poll is deliberately **not awaited** inside `beforeToolCall` — a tool call
+must not wait on the inbox. The practical consequence: a batch drained during
+tool call *N* is usually consumed at the boundary after the drain resolves,
+which may be a later boundary than the one immediately following that call.
+
+**A window that fails.** The worker throws (Spaces unreachable, dispatch 500).
+`consecutiveFailures` increments and pushes `nextDueAt` out exponentially; the
+**watermark does not move**, so the next successful wake re-reads the same
+range. The agent lock is released in the `catch`. `outcome = "failed"` is
+recorded. The first success resets the counter.
+
+**A window that skips.** The gate returns `skip`. `consecutiveSkips` increments,
+the watermark **does** advance (re-reading would produce the same skip), and the
+run row records `outcome = "skipped"` with the rule id in `skipReason`. Once
+`consecutiveSkips` reaches `forceRunEveryNSkips`, the next skip is overridden to
+a run.
+
+---
+
+## 6. Service contracts
+
+### 6.1 claw-auth → claw: `POST /claw/api/v1/internal/run`
+
+Header `x-s2s-key`. The awakening-specific parts of the body:
+
+| Field | Value |
+|---|---|
+| `eventType` | `"awakening"` |
+| `detached` | `true` |
+| `conversationId` | `awaken_{agentId}_{windowEndMs}` |
+| `callbackUrl` | `{internalUrl}/claw/api/v1/awakening/{idempotencyKey}/result` |
+| `progressUrl` | `{internalUrl}/claw/api/v1/webhook/progress` |
+| `idempotencyKey` | `awk_{kind}_{agentId}_{windowStartMs}` |
+| `contextFiles` | The rendered artifact — claw writes them into `.context/` before the agent starts |
+| `additionalInstructions` | The operating contract (§7.2) |
+| `skills` | `[xyne-heartbeat]` or `[xyne-reflex]` |
+| `agentConfig` | Stored config **plus** the per-run `apps-send-message` grant |
+| `__persistedByCaller` | `true` |
+| `awakening` | See below |
+
+```jsonc
+"awakening": {
+  "kind": "heartbeat" | "reflex",
+  "writePolicy": "observe" | "reply" | "act",
+  "shadow": false,
+  "windowStartMs": 1787648780399,
+  "windowEndMs": 1787650580399,
+  "entryPath": ".context/heartbeat/WINDOW.md",
+  // Reflex only: a heartbeat is a deliberate pass over a SEALED window, and
+  // mutating that window mid-run would make its own artifact a lie.
+  "injectEnabled": true
+}
+```
+
+The `awakening` block is only honoured from an **S2S caller**. A browser cannot
+self-declare a run unattended and thereby claim the bot-identity send tool.
+
+### 6.2 The SessionContext
+
+Written by claw-auth **before** forwarding to claw, not after. This is
+load-bearing and was a real bug: claw lists its MCP tools within milliseconds of
+the POST returning, and that listing reads this context to decide app-mode vs
+user-mode. Writing it after the dispatch resolved was a race the run usually
+lost, and the agent then came up with no way to speak at all.
+
+| Field | Value | Read by |
+|---|---|---|
+| `triggerSource` | `"heartbeat"` \| `"reflex"` | `routes/mcp.ts` (tool grant), `agent-chat.ts` (admin visibility), `webhook.ts` (live events) |
+| `isAutomation` | `true` | `routes/mcp.ts` — selects **app-mode** Spaces |
+| `suppressThreadReply` | `true` | The final answer is an operator log line, not a channel message |
+| `senderId` / `mentionedUserId` | the bot's `spacesAppUserId` | Spaces tools |
+| `channelId` | `""` | No single channel — the agent picks per tool call |
+| `appToken` | decrypted app token | Spaces app calls |
+
+### 6.3 claw → claw-auth
+
+| Route | Auth | Purpose |
+|---|---|---|
+| `POST /awakening/:idempotencyKey/result` | `requireStrictS2S` | Terminal callback. Idempotent by construction — writes `completedAt` on a row keyed by the same idempotency key the dispatch used. |
+| `POST /awakening/inbox/:sessionId/drain` | `requireStrictS2S` | Destructive drain of queued injection batches |
+| `GET /awakening/:agentId/status` | `requireAuth` + `requireNoAccessToken` + `requireClawAdmin` | Admin health: state row + last 20 runs |
+
+The result callback **acks first, reconciles after** — claw must never block on
+claw-auth's bookkeeping, and every write after the ack is best-effort and
+independently retryable. It persists the assistant turn, finalizes the
+`AgentRun` (status, result, `toolsUsed`, `toolInvocations`, token usage,
+provider/model, latency), releases the agent lock, rewinds the watermark over any
+undelivered injection batches (§8.2), and clears the inbox.
+
+> The result route is deliberately **its own route**, not `/webhook/result`.
+> That handler is a long shared hot path carrying every user-facing delivery
+> concern — thread replies, cards, follow-ups, twin routing. An unattended run
+> needs none of it. Keeping them separate means awakening can never regress
+> human chat, and a change to human chat delivery can never silently alter what
+> an unattended agent does.
+
+---
+
+## 7. Making the agent able to act — and bounding it
+
+### 7.1 Write policy is enforced, not prompted
+
+`apps-send-message` acts as the bot identity and is **ungated by design** — it
+exists precisely so an agent can post autonomously. For an unattended run that
+is the whole risk surface, and an instruction in a system prompt is not a
+control. `buildWritePermissions` turns the policy into concrete per-tool
+denials, evaluated at the **MCP call boundary** in claw-auth, so a denied tool
+cannot be reached however the model is persuaded to try.
+
+| Policy | `apps-send-message` | `user-send-message` | ticket/canvas/call mutations |
+|---|---|---|---|
+| `observe` | deny | deny | deny |
+| `reply` | allow (existing threads) | deny | deny |
+| `act` | allow | deny | allow |
+| `shadow: true` | — overrides everything down to `observe` — |||
+
+`user-send-message` is denied at every level: it posts as the *human*, and is
+HITL-gated in normal runs — impossible in an unattended one.
+
+> **"deny", not "ask".** An approval card raised by a heartbeat at 3am has
+> nobody to click it, so "ask" would be a silent hang rather than a clear refusal.
+
+### 7.2 The operating contract
+
+Every awakened run gets `additionalInstructions` built by
+`buildOperatingContract(window)`. It exists because of a real observed failure:
+an agent read the window, correctly identified an unanswered mention aimed at
+it, composed an excellent reply — **and posted nothing**, because in every other
+kind of run the platform delivers the final answer for it.
+
+Structure, in order:
+
+1. *"You are running UNATTENDED."*
+2. **How to actually say something** — the final answer is not delivered; call
+   the send tool with the `channelId`/`conversationId` printed in the artifact.
+   Under `observe`/`shadow` this branch instead says there is no send tool and
+   asks it to state what it *would* have posted.
+3. **From your operator** — the admin's `instructions` (§7.3), if set.
+4. **Bounds** — never reply to your own messages; the window is already
+   collected, don't re-search; silence is a correct and common outcome.
+
+The ordering is deliberate: operator guidance sits **after** the delivery
+mechanics and **before** the non-negotiable bounds, so it can shape judgement
+but cannot make a run mute or make it answer itself.
+
+### 7.3 Operator instructions
+
+`awakening.instructions`, up to 4000 chars, edited in the Awakening tab. Meant
+for tone and triage — *"Keep it short and warm. Jump in when someone is blocked
+or waiting on an answer. Stay out of social chatter."* It is advisory by
+construction: it cannot override the write policy or the bounds.
+
+### 7.4 The tool grant, and the two gates
+
+`apps-send-message` never appears in the agent tool picker, so a strict
+`tools.direct` allowlist always excludes it. For an awakened run that is fatal
+rather than restrictive — nobody is in a thread to receive the answer.
+
+The grant must be applied in **two independent places**, because two separate
+gates filter the palette:
+
+1. **claw-auth's MCP listing** — `withSurfaceDefaultToolsConfig` in
+   `routes/mcp.ts`, feeding `enforceMcpToolsListing`.
+2. **claw's own re-filter** — `applyAgentToolFilter` in
+   `xyne-claw/src/routes/run.ts`, which re-applies `tools.direct` against the
+   forwarded `agentConfig` and would strip the tool right back out.
+
+Both use the shared helper in `src/awakening/send-tool.ts`. Both are per-run and
+in-memory; the stored agent config is never modified and interactive runs of the
+same agent are unaffected.
+
+> **Debug signal:** the agent's `session_tools` event lists exactly the
+> intersection of `config.tools.direct` with the server's registry. A tool
+> present in the MCP server's ListTools but absent there means a *config* gate
+> dropped it, not the server.
+
+Note that an awakened run is an **app-mode** run, so `userOnly` Spaces tools
+(`spaces-update-ticket`, `spaces-update-bulk-tickets`, `spaces-upload-to-kb`,
+`user-send-message`) are not listed at all — they execute against
+user-session-only routes and could only 401.
+
+### 7.5 Skills
+
+Two, inlined on dispatch rather than seeded so they are present on every
+awakened run by construction: **`xyne-heartbeat`** (work a periodic review) and
+**`xyne-reflex`** (work a fast reaction; move quickly, handle the one or two
+things that need handling).
+
+---
+
+## 8. Live injection — events that arrive mid-run
+
+Requirement: while a run is working, keep collecting; after enough new events,
+hand them to the running session so it adapts instead of finishing on stale
+input.
+
+### 8.1 Why pull, not push
+
+claw is horizontally scaled and a session lives in **one pod's memory**
+(`activeRuns` is an in-process `Map`). Pushing would require routing to that
+exact pod — pod discovery that breaks the moment the fleet scales.
+
+Pull costs nothing to avoid that, because of a property of the SDK: a steering
+message is delivered only *"after the current assistant turn finishes executing
+its tool calls"*. A pushed steer and a pulled steer therefore land at **exactly
+the same instant** — the next turn boundary. Identical latency, no routing, and
+the pod that owns the run is the one asking.
+
+The poll rides `beforeToolCall`, the same hook `installToolBudget` uses for
+convergence nudges. `AWAKENING_INBOX_POLL_MS` (default 20s) floors the rate;
+`AWAKENING_INBOX_TIMEOUT_MS` (default 5s) bounds the drain. Batches are deduped
+by `ordinal`, since a destructive drain plus a retry could otherwise steer the
+same events twice.
+
+**Fail-open throughout.** A failed drain is logged and the run continues. Live
+injection is an enhancement; a Redis or claw-auth blip must never break a run
+that is otherwise working.
+
+### 8.2 The flow, and the event-loss bug it had
+
+```mermaid
+sequenceDiagram
+  participant RFX as reflex worker
+  participant R as Redis inbox
+  participant CLAW as claw session
+  participant CB as result callback
+
+  RFX->>RFX: COUNT since reflexWatermarkAt
+  Note over RFX: agent lock held → decision = inject
+  RFX->>R: rpush batch {ordinal, windowStartMs, text}
+  RFX->>RFX: advance reflexWatermarkAt = untilMs
+  CLAW->>R: drain (at a turn boundary)
+  R-->>CLAW: batches
+  CLAW->>CLAW: steer(<system>Live update N</system>)
+  CB->>R: run ended — drain leftovers
+  CB->>CB: rewind watermark to min(windowStartMs)
+```
+
+The watermark advances when a batch is **queued**, not when it is read —
+deliberately, so a slow drain cannot re-trigger the same events. But a run can
+end with batches still queued (it converged, failed, or simply stopped calling
+tools), and clearing the inbox there would step the watermark permanently over
+events nobody ever saw. So each batch records its `windowStartMs`, and the
+result callback rolls the watermark **back** over anything undelivered. It only
+ever moves backwards, and only past events that session was handed but did not
+read.
+
+### 8.3 Injection latency — the thing to tune
+
+A new event cannot reach a running agent faster than:
+
+```
+replicaSafetyMs + (up to) max(reflex.checkIntervalMs, AWAKENING_TICK_MS)
+```
+
+With the defaults that is **30s + up to 60s ≈ 90s**, and `injectThreshold`
+events must have accumulated inside that. **A run that finishes faster than that
+will never receive an injection** — its events go to the next wake instead.
+This is why `replicaSafetyMs` is exposed in the UI with a computed latency line.
+Setting it to 0 makes injection responsive on a single-writer Spaces; on a
+replicated deployment it will silently drop events that had not replicated when
+the window sealed.
+
+---
+
+## 9. Requirement 7 — a heartbeat sees what the reflexes did
+
+Without this the heartbeat re-derives a period the reflexes already acted on and
+answers questions that were answered twenty minutes ago — which reads, in the
+channel, as an agent that is not paying attention.
+
+`loadPriorRuns` selects prior runs by **overlap, not containment**. A reflex that
+started *before* the heartbeat's window and ran into it still consumed events the
+heartbeat is about to see; selecting by containment misses exactly the runs most
+likely to have already handled something.
+
+**A failed reflex covers nothing.** It woke, it read the events, and it produced
+no action — so the heartbeat must treat those events as untouched. Marking them
+covered because a run existed is how work silently disappears.
+
+Covered events are flagged in `events.jsonl` (`covered`, `coveredBy`) and
+annotated inline in the outline (`[handled by reflex@11:29:50]`), and the prior
+runs' own answers are written to `prior-sessions.md`.
+
+---
+
+## 10. Failure, recovery, and multi-pod safety
+
+| Concern | Mechanism |
+|---|---|
+| Two pods claim the same agent | `FOR UPDATE SKIP LOCKED` on the claim scan |
+| Two runs for the same agent overlap | Redis agent lock, `SET NX PX`, released by Lua CAS on `sessionId`. **Not refreshed** — see the run ceiling in §15 |
+| Duplicate dispatch | `agent_awakening_runs.idempotencyKey` unique constraint (`P2002` swallowed) |
+| Watermark corruption under a race | Compare-and-set that only moves forward |
+| Repeated failures | `consecutiveFailures` drives exponential `nextDueAt` backoff; first success resets. This *is* the circuit breaker. |
+| Runaway wakes | `limits.maxRunsPerHour`, split into `peekRunRate` (check) and `consumeRunRate` (commit) so blocked *attempts* don't burn the budget |
+| Self-triggering loop | The reflex COUNT excludes the agent's own posts (`senderId != spacesAppUserId`); the gate's `no_human_activity` rule is the second guard |
+| Backlog after an outage | Gap guard jumps the watermark and records the skip in the artifact |
+| Spaces read failure | Channel cache serves stale; a failed window does not advance the watermark |
+| Unbounded query against Spaces | `boundedInteract` throws `UnboundedQueryError` |
+| Bad stored config | `resolveAwakeningConfig` never throws — clamps and defaults |
+| Identity missing | `AwakeningIdentityError` disables the agent; never falls back to a user token |
+
+---
+
+## 11. Observability
+
+**Admin UI.** Awakened runs appear in the agent's activity list with
+`triggerSource` `heartbeat`/`reflex`, and their conversations open like any
+other. Tool results are readable to admins viewing with `allRuns=1` — awakened
+runs are agent-owned and have no private user data to protect, so
+`isAgentOwnedRun()` exempts them from the cross-user redaction, on both the
+stored transcript and the **live SSE stream** (the live path carries
+`triggerSource` on the event for exactly this).
+
+**Database.** `agent_awakening_runs` answers "why did/didn't it wake" without
+re-deriving anything: `outcome`, `skipReason` (the gate rule id), and the
+denormalized `signals`. `GET /awakening/:agentId/status` returns the state row
+plus the last 20 runs.
+
+> **This is only true of the heartbeat path.** The window worker records a row
+> for every terminal state — `rate_limited`, `no_channels`, the gate rule,
+> `agent_busy`, `dispatch_failed`, `ran`/`shadow`. The **reflex** worker creates
+> a row *only when it fires*: `wait`, every `hold` reason, `inject`,
+> rate-limited, lock-busy, no-channels and empty-collect all return with no row
+> at all. A reflex blocked by `maxRunsPerHour` leaves no trace whatsoever. See
+> §14 open defect 12.
+
+**Logs.** Dispatch, gate decisions, channel truncation, watermark rewinds, and
+injection batches all log at `info`. A reflex `wait` **while a run is in flight**
+also logs, because that is the state operators most often need when asking "why
+did my mid-run events not arrive?" — an idle `wait` stays silent, since it
+happens every interval for every agent.
+
+> `/webhook/progress` is deliberately logged at `debug` (`QUIET_REQUEST_PATHS`):
+> claw posts a `stream_rate` telemetry sample once per second per streaming run,
+> which otherwise buries every other line in the log.
+
+---
+
+## 12. Rollout playbook
+
+1. **Enable with `shadow: true`.** The agent reasons and records what it *would*
+   have posted, with no write tools at all. This is the default.
+2. **Narrow the channels.** Start with `include` ids, not patterns.
+3. **Watch `agent_awakening_runs`.** Check `outcome`/`skipReason` distribution.
+   Lots of `no_actionable_signal` means the gate is doing its job; lots of
+   `empty_window` means the period is too short for the channel.
+4. **Read what it would have said** in the run results before clearing shadow.
+5. **Clear shadow with `writePolicy: "reply"`.** Thread replies only — it cannot
+   start new threads or mutate anything.
+6. **Only then consider `act`.** The UI shows a warning banner for
+   `!shadow && writePolicy === "act"`, which is the configuration where an agent
+   can start new threads with nobody reviewing it first.
+7. Keep `maxRunsPerHour` low to start. Skipped checks are free and don't count.
+
+> **After creating, cloning, importing or seeding an agent, open it and press
+> Save once.** `syncAwakeningState` — the only thing that creates the
+> `agent_awakening_state` row — is wired into `PUT /agents/:slug` and nothing
+> else. An agent created or cloned with `awakening.enabled: true` renders as
+> enabled in the UI and never wakes, because no state row exists for the tick
+> scan to claim. See §14 open defect 11.
+
+**The kill switch drains, it does not stop.** `AWAKENING_DISABLED` is checked in
+exactly one place — the tick worker, before fan-out. Window and reflex jobs
+already on the queue still run (and still retry up to 3× with exponential
+backoff), and in-flight claw runs are not aborted. It is also per-pod env, so it
+must be set on **every** API pod to have any effect.
+
+---
+
+## 13. File map
+
+**claw-auth — `src/awakening/`**
+
+| File | Responsibility |
+|---|---|
+| `config.ts` | `AwakeningConfig`, bounds, defaults, `resolveAwakeningConfig`, `hashChannelRules`, `participatesIn` |
+| `types.ts` | `AwakeningWindow`, `WindowEvent`, `AgentSpacesIdentity`, `ResolvedChannel` |
+| `cursor.ts` | `sealWindow`, watermark CAS, gap guard |
+| `channel-rules.ts` | Pure include/exclude/pattern semantics |
+| `channel-resolver.ts` | Membership lookup + Redis cache, stale-ok |
+| `spaces-read.ts` | `boundedInteract`, `pageBounded`, `UnboundedQueryError` |
+| `collector.ts` | Two-stage window collect, sender names, `markUnanswered` |
+| `message-text.ts` | Message HTML → text, mention shorthand, thread titles |
+| `signals.ts` | The twelve signal counts |
+| `gate.ts` | Ordered rule table, anti-starvation |
+| `render.ts` | `WINDOW.md`, `events.jsonl`, `CURSOR.json` |
+| `prior-runs.ts` | Requirement 7 overlap + coverage |
+| `contract.ts` | The operating contract text |
+| `skills.ts` | `xyne-heartbeat`, `xyne-reflex` |
+| `write-policy.ts` | Policy → per-tool denials |
+| `send-tool.ts` | The per-run `apps-send-message` grant (both gates) |
+| `dispatch.ts` | Build + fire the claw run, own the `AgentRun` row |
+| `lock.ts` | Agent lock (SET NX PX + Lua CAS) |
+| `rate-limit.ts` | `peekRunRate` / `consumeRunRate` |
+| `inbox.ts` | Injection batch queue |
+| `reflex.ts` | `countEventsSince`, `decideReflex`, `renderInjection` |
+| `workspace.ts` | org → Spaces workspace resolution |
+
+**claw-auth — elsewhere**
+
+`src/queue/awakening-queue.ts`, `awakening-tick-worker.ts`,
+`awakening-window-worker.ts`, `awakening-reflex-worker.ts` ·
+`src/routes/awakening.ts` · awakening branches in `src/routes/run.ts`,
+`src/routes/mcp.ts`, `src/routes/agent-chat.ts` · `src/lib/agent-owned-runs.ts`
+
+**claw** — `src/awakening-inbox.ts`, plus the `awakening` option threaded
+through `src/routes/run.ts` and the `installAwakeningInbox` call in
+`src/agent.ts`.
+
+**frontend** — `src/v3/lib/awakeningBounds.ts`,
+`src/v3/components/agent-detail/tabs/AwakeningTab.tsx`.
+
+---
+
+## 14. Audit findings — open defects
+
+A cross-subsystem read of this feature (2026-08) turned up the following. Two
+were fixed in the same pass; the rest are recorded here rather than silently
+carried.
+
+### Fixed
+
+| # | Defect | Fix |
+|---|---|---|
+| 1 | **`kind: "reflex"` agents were permanently killed.** The heartbeat tick cleared `state.enabled` for any agent that did not participate in *heartbeat*, and the reflex claim scan requires `enabled = TRUE`. The first heartbeat tick that claimed a reflex-only agent disabled it forever. | `enabled` and "participates in this kind" are now two different questions. A non-participating cadence is **parked** (`nextDueAt`/`reflexNextCheckAt` pushed out by `IDLE_REPARK_MS`), never disabled. Regression test in `awakening-tick-kind.test.ts`. |
+| 2 | **The config editor deleted settings it does not model.** `AwakeningSettings` has no control for `workspaceId`, `limits.maxActiveThreads`, `cursor.overlapMs` or `cursor.maxCatchupWindows`, and the tab persisted `{...agent.config, awakening: draft}` — replacing the block wholesale. Opening the tab and pressing Save reset four settings the admin never touched. | The save path now merges over the stored block, section by section, so unmodeled keys survive. |
+
+### Open
+
+| # | Defect | Impact |
+|---|---|---|
+| 3 | **`validateAwakeningConfig` has no `reflex` branch.** All seven reflex knobs are accepted verbatim by the API; only `resolveAwakeningConfig` clamps them at read time. | An out-of-range reflex value saves with a 200 and is silently clamped later, instead of a 400 with a reason — the opposite of the two-layer contract in §4. |
+| 4 | **The validator is only wired into `PUT /agents/:slug`.** `POST /agents` calls `validateAgentModelConfig` only. | An agent *created* with a full awakening block bypasses validation entirely, including the ReDoS-shape pattern check. |
+| 5 | **A rate-limited skip advances the watermark** (`awakening-window-worker.ts`, `outcome="skipped"`, `skipReason="rate_limited"`). | Those events are never re-read by any later heartbeat. This contradicts the §5.1 invariant that only a *genuinely boring* window may advance the cursor: an agent that hits `maxRunsPerHour` loses that window's events rather than deferring them. |
+| 6 | **The lock re-key after dispatch is a non-atomic release-then-acquire.** Between the `DEL` and the `SET NX` the agent is momentarily unlocked. | A second pod's claim landing in that window could dispatch a concurrent run. Narrow, but real; a Lua re-key would close it. |
+| 7 | **No gap guard on the reflex path.** The heartbeat uses `sealWindow` (with `maxCatchupWindows`); the reflex worker computes `sinceMs` straight from `reflexWatermarkAt` with no ceiling. | After a long outage a reflex can attempt an unbounded catch-up window. |
+| 8 | **Injection env vars are parsed with bare `Number(...)` at module load.** A non-numeric `AWAKENING_INBOX_POLL_MS` yields `NaN`, and `Date.now() - lastPollMs >= NaN` is always false. | The poller silently never drains and live updates die with no error. |
+| 9 | **Delivered injections are not in run telemetry.** `installAwakeningInbox` returns a tracker with an `injected` counter and the call site discards it. | `injectionsUsed` records what was *queued*, not what the agent actually absorbed; the only evidence of delivery is a log line. |
+
+| 10 | **The agent lock is never refreshed.** `refreshAgentLock` exists in `lock.ts` and its only caller in the repo is a test script. | The lock is a hard `AWAKENING_LOCK_TTL_MS` (default **20 min**) ceiling. A run that exceeds it loses its lock, the next tick acquires cleanly, and the agent is **double-dispatched** — the exact double-post the lock exists to prevent. Either wire a refresh or treat 20 min as a hard run ceiling. |
+| 11 | **Create and clone never seed the state row.** `syncAwakeningState` is called only from `PUT /agents/:slug`; `POST /agents` and `POST /agents/:slug/clone` do not call it. | An agent created or cloned with `awakening.enabled: true` shows as enabled and never wakes. Compounds defect 4 (create also skips the validator). Workaround is in §12. |
+| 12 | **The reflex path records almost nothing.** A run row is created only on `fire`; `wait`, every `hold`, `inject`, rate-limited, lock-busy, no-channels and empty-collect all return silently. | A reflex blocked by `maxRunsPerHour` produces no row *and* no log, where the heartbeat records `skipReason: "rate_limited"`. §11's "answers why it did/didn't wake" holds for heartbeat only. |
+| 13 | **A retried window keeps the wrong outcome.** Dispatch failure records `outcome="failed"` *and* throws, triggering the BullMQ retry (`attempts: 3`). The retry recomputes an identical `idempotencyKey`, so the success-path insert hits `P2002` and is swallowed. | The row stays `failed` with `sessionId` NULL for a wake that actually ran — so `/status` lies, and the injection bookkeeping keyed on `sessionId` can never match it. `markFailure` also fires up to 3× for one beat, driving the backoff to 2³ = 8 (4 h at the default period, not the "within one hour" the code comment promises). |
+| 14 | **A dead claw pod loses injected events permanently.** The §8.2 rewind runs only in the result callback. If the owning pod dies, no callback fires: the batch expires with its 1 h TTL, the reflex watermark stays advanced past those events, and the lock is held until its own TTL. Nothing reaps `agent_awakening_runs` rows with `completedAt IS NULL`. | Blast radius is one inbox (≤ 20 batches) per dead run. Recovery is manual. |
+| 15 | **No product path re-enables a self-disabled agent.** Both workers set `enabled: false` on `AwakeningIdentityError` / `WorkspaceResolutionError`. `/status` is read-only, and `syncAwakeningState` re-enables only via a PUT. | The runbook is "fix the identity, then press Save" — which is not discoverable and is nowhere in the UI. |
+
+| 16 | **`reflex.checkIntervalMs` below `AWAKENING_TICK_MS` is a silent no-op.** Reflex rows are claimed by the fleet tick, so the effective cadence is `max(checkIntervalMs, tickIntervalMs)` — 60s by default. The UI's `REFLEX_CHECK_OPTIONS` offers 15s and 30s, and `AWAKENING_BOUNDS.reflexCheckIntervalMs.MIN` is 15s, so the editor lets an admin pick values that can never be honoured. | Directly defeats live injection on short runs: a run must survive a full tick to be injectable, so anything finishing in under ~60s never receives an update no matter how the reflex knobs are set. Either raise the UI's floor to the tick interval, or drive the tick from the smallest configured reflex interval. |
+
+Two related notes that are working as intended but read as surprises:
+
+- **`cursor.overlapMs` applies only to the stage-1 conversation prefilter**, not
+  to the message time range. It buys tolerance for `lastActivityAt` lag, not
+  re-reading of messages below the watermark.
+- **`peekRunRate`/`consumeRunRate` is not atomic**, and the counter uses a fixed
+  hour bucket, so two pods can both pass the check and an hour edge allows up to
+  2× `maxRunsPerHour`. Accepted deliberately: the imprecision is irrelevant at
+  single-digit runs/hour.
+
+---
+
+## 15. Known limits
+
+- **Injection needs a slow run.** See §8.3. A run shorter than
+  `replicaSafetyMs + max(checkIntervalMs, AWAKENING_TICK_MS)` will never receive
+  one. With stock settings that is ~90s, and most reflex runs finish in 15–20s.
+- **Steering only lands at a turn boundary.** An agent that stops calling tools
+  cannot be reached again; queued batches are returned to the next wake.
+- **Heartbeat windows are sealed.** Injection is reflex-only by design.
+- **One workspace per agent.** `workspaceId` picks it when the org maps to more
+  than one; there is no multi-workspace fan-out.
+- **`maxChannels` truncation is silent to the channel, visible to the agent** —
+  it is recorded in the artifact header, not surfaced as an admin alert.
+- **An awakened run has an effective 20-minute ceiling** while defect 10 stands.
+  Past `AWAKENING_LOCK_TTL_MS` the agent lock expires and a second run can be
+  dispatched on top of the first.

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -729,6 +729,38 @@ export async function updateAgent(
   return data.data;
 }
 
+/**
+ * Live awakening state for an agent — the row the background workers actually
+ * read, which is NOT the same flag as `config.awakening.enabled` that the
+ * editor writes. When a worker cannot resolve an agent's identity it disables
+ * that row and records why; without surfacing this the tab shows a toggle that
+ * is on while the agent is switched off.
+ */
+export interface AwakeningStatus {
+  state: {
+    enabled: boolean;
+    lastError: string | null;
+    nextDueAt: string | null;
+    reflexNextCheckAt: string | null;
+    consecutiveFailures: number;
+  } | null;
+  recent: Array<{
+    kind: string;
+    outcome: string;
+    skipReason: string | null;
+    eventCount: number;
+    startedAt: string;
+  }>;
+}
+
+export async function getAwakeningStatus(agentId: string): Promise<AwakeningStatus> {
+  const data = await request<{ success: boolean; data: AwakeningStatus }>(
+    `${AUTH_API_URL}/api/v1/awakening/${agentId}/status`,
+    { method: "GET" },
+  );
+  return data.data;
+}
+
 export async function updateAgentDesignSystem(
   slug: string,
   designSystem: string | null,
@@ -5633,6 +5665,93 @@ export async function fetchGlobalMetrics(userId: string, days: 1 | 7 | 30 = 7, o
   applyAdminOrgScope(qs, orgScope);
   return request<GlobalMetrics>(
     `${AUTH_API_URL}/api/v1/metrics/global?${qs.toString()}`,
+    { headers: { "x-user-id": userId } },
+  );
+}
+
+/**
+ * Activity for agents that wake on their own. Kept out of the main metrics
+ * payload because awakened runs have no `userId` — the user-scoped filters the
+ * other endpoints apply would drop them entirely.
+ */
+export interface AwakeningActivity {
+  days: number;
+  totals: {
+    runs: number; ran: number; skipped: number; failed: number;
+    shadow: number; injections: number; events: number;
+  };
+  perDay: Array<{ day: string; ran: number; skipped: number; failed: number }>;
+  byAgent: Array<{
+    agentId: string; agentSlug: string; kind: string; runs: number; ran: number;
+    skipped: number; failed: number; events: number; lastRunAt: string | null;
+  }>;
+  skipReasons: Array<{ reason: string; count: number }>;
+  agents: Array<{
+    agentSlug: string; enabled: boolean; lastError: string | null;
+    nextDueAt: string | null; reflexNextCheckAt: string | null;
+    consecutiveFailures: number;
+  }>;
+}
+
+export async function fetchAwakeningActivity(
+  userId: string,
+  days: 1 | 7 | 30 = 7,
+  orgScope?: AdminOrgScope,
+): Promise<AwakeningActivity> {
+  const qs = new URLSearchParams();
+  qs.set("days", String(days));
+  applyAdminOrgScope(qs, orgScope);
+  return request<AwakeningActivity>(
+    `${AUTH_API_URL}/api/v1/metrics/awakening?${qs.toString()}`,
+    { headers: { "x-user-id": userId } },
+  );
+}
+
+/** One wake ATTEMPT — skipped wakes are rows too, and carry the gate rule. */
+export interface AwakeningRun {
+  id: string;
+  kind: string;
+  outcome: string;
+  skipReason: string | null;
+  eventCount: number;
+  injectionsUsed: number;
+  sessionId: string | null;
+  /** Present only when the wake actually dispatched — links to the transcript. */
+  conversationId: string | null;
+  runStatus: string | null;
+  windowStartMs: number;
+  windowEndMs: number;
+  startedAt: string;
+  completedAt: string | null;
+  durationMs: number | null;
+}
+
+export interface AwakeningRunsPage {
+  total: number;
+  limit: number;
+  offset: number;
+  runs: AwakeningRun[];
+}
+
+export async function fetchAwakeningRuns(
+  userId: string,
+  agentId: string,
+  days: 1 | 7 | 30 = 7,
+  limit = 20,
+  offset = 0,
+  orgScope?: AdminOrgScope,
+  /** "heartbeat" | "reflex" — the rollup lists one row per kind, so a
+   *  drill-down must stay scoped to the row that was clicked. */
+  kind?: string,
+): Promise<AwakeningRunsPage> {
+  const qs = new URLSearchParams();
+  qs.set("days", String(days));
+  qs.set("limit", String(limit));
+  qs.set("offset", String(offset));
+  if (kind) qs.set("kind", kind);
+  applyAdminOrgScope(qs, orgScope);
+  return request<AwakeningRunsPage>(
+    `${AUTH_API_URL}/api/v1/metrics/awakening/${encodeURIComponent(agentId)}/runs?${qs.toString()}`,
     { headers: { "x-user-id": userId } },
   );
 }

--- a/apps/xyne-claw-auth/frontend/src/v3/components/MetricsPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/MetricsPageV3.tsx
@@ -18,6 +18,8 @@ import {
 } from "recharts";
 import {
   fetchGlobalMetrics, fetchAgentMetrics, listAgents,
+  fetchAwakeningActivity, type AwakeningActivity,
+  fetchAwakeningRuns, type AwakeningRun,
   fetchAgentImprovements, applyImprovement, dismissImprovement,
   type GlobalMetrics, type GlobalMetricsDayBucket, type AgentMetrics,
   type SlowSession, type ToolLatencyRow, type AgentSentiment, type GlobalMetricsProviderRow,
@@ -79,10 +81,13 @@ export function MetricsPanel({
   fetcher,
   showLeaderboard = false,
   onAgentClick,
+  orgScope,
 }: {
   userId: string;
   fetcher: (userId: string, days: 1 | 7 | 30) => Promise<GlobalMetrics | AgentMetrics>;
   showLeaderboard?: boolean;
+  /** Passed through to the awakening rollup, which fetches independently. */
+  orgScope?: AdminOrgScope;
   /** When the workspace leaderboard renders an agent, clicking it bubbles up
    *  so the parent page can pivot to that agent's view. */
   onAgentClick?: (agentSlug: string) => void;
@@ -194,6 +199,9 @@ export function MetricsPanel({
             <Card title="Tool latency for this agent" subtitle={`Top ${data.toolLatency.length} tools by cumulative time — find the one dragging the agent down`}>
               <ToolLatencyTable rows={data.toolLatency} />
             </Card>
+          )}
+          {showLeaderboard && (
+            <AwakeningActivityCard userId={userId} days={days} orgScope={orgScope} />
           )}
           {data.slowSessions.length > 0 && (
             <Card title="Slowest sessions" subtitle={`Top ${data.slowSessions.length} by total wall-clock — expand a row for the tool breakdown`}>
@@ -378,10 +386,315 @@ export function MetricsPageV3({ userId }: MetricsPageV3Props) {
           fetcher={fetcher}
           showLeaderboard={!selectedAgent}
           onAgentClick={(slug) => setSelectedAgent(slug)}
+          orgScope={adminOrgScope}
         />
       </div>
     </div>
   );
+}
+
+/**
+ * Awakening rollup — agents that ran with nobody triggering them.
+ *
+ * Fetches independently rather than riding the main metrics payload: awakened
+ * runs live in their own table (`agent_awakening_runs`) with no `userId`, and
+ * folding unattended runs into per-user latency would skew it.
+ *
+ * Renders nothing at all when no agent in the org has ever woken, so the
+ * section stays invisible for workspaces that do not use the feature.
+ */
+function AwakeningActivityCard({
+  userId,
+  days,
+  orgScope,
+}: {
+  userId: string;
+  days: 1 | 7 | 30;
+  orgScope?: AdminOrgScope;
+}) {
+  const [data, setData] = useState<AwakeningActivity | null>(null);
+  const [failed, setFailed] = useState(false);
+  // Keyed by agent AND kind: the rollup lists one row per wake kind, so keying
+  // on agentId alone expanded an agent's heartbeat and reflex rows together.
+  const [openRow, setOpenRow] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setFailed(false);
+    fetchAwakeningActivity(userId, days, orgScope)
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch(() => { if (!cancelled) setFailed(true); });
+    return () => { cancelled = true; };
+  }, [userId, days, orgScope]);
+
+  if (failed || !data) return null;
+  // Never configured here — do not show an empty shell.
+  if (data.agents.length === 0 && data.totals.runs === 0) return null;
+
+  const { totals } = data;
+  const stopped = data.agents.filter((a) => !a.enabled || a.lastError);
+
+  return (
+    <Card
+      title="Awakened agents"
+      subtitle="Runs that nobody triggered — the agent woke on a heartbeat or a reflex and decided for itself whether to act."
+    >
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-[12px] mb-[16px]">
+        <Tile label="Wakes" value={String(totals.runs)} sub={`${totals.events} events collected`} />
+        <Tile
+          label="Acted"
+          value={String(totals.ran)}
+          sub={totals.shadow > 0 ? `${totals.shadow} in shadow` : undefined}
+        />
+        <Tile
+          label="Stayed quiet"
+          value={String(totals.skipped)}
+          sub="gate found nothing worth doing"
+        />
+        <Tile
+          label="Failed"
+          value={String(totals.failed)}
+          sub={totals.injections > 0 ? `${totals.injections} live updates` : undefined}
+          subTone={totals.failed > 0 ? "bad" : "flat"}
+        />
+      </div>
+
+      {stopped.length > 0 && (
+        <div className="mb-[16px] rounded-lg border border-amber-300/60 bg-amber-50 p-3 dark:border-amber-900/60 dark:bg-amber-950/30">
+          <div className="text-[12px] font-medium text-amber-900 dark:text-amber-200 mb-1">
+            {stopped.length} agent{stopped.length === 1 ? "" : "s"} not waking
+          </div>
+          {stopped.slice(0, 5).map((a) => (
+            <div key={a.agentSlug} className="text-[12px] text-amber-800 dark:text-amber-300">
+              <span className="font-mono">{a.agentSlug}</span>
+              {a.lastError ? ` — ${a.lastError}` : " — switched off"}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {data.byAgent.length > 0 && (
+        <table className="w-full text-[12px]">
+          <thead className="text-xyne-fg-muted">
+            <tr className="text-left border-b border-xyne-border">
+              <th className="py-2 font-medium">Agent</th>
+              <th className="py-2 font-medium">Kind</th>
+              <th className="py-2 font-medium text-right">Wakes</th>
+              <th className="py-2 font-medium text-right">Acted</th>
+              <th className="py-2 font-medium text-right">Quiet</th>
+              <th className="py-2 font-medium text-right">Failed</th>
+              <th className="py-2 font-medium text-right">Events</th>
+              <th className="py-2 font-medium text-right">Last wake</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.byAgent.map((r) => (
+              <React.Fragment key={`${r.agentId}:${r.kind}`}>
+              <tr
+                className="border-b border-xyne-border/50 cursor-pointer hover:bg-xyne-bg-secondary/60"
+                onClick={() => setOpenRow(openRow === rowKey(r) ? null : rowKey(r))}
+              >
+                <td className="py-2 font-mono text-xyne-fg-primary">
+                  <span className="mr-1 inline-block w-3 text-xyne-fg-muted">
+                    {openRow === rowKey(r) ? "▾" : "▸"}
+                  </span>
+                  {r.agentSlug}
+                </td>
+                <td className="py-2 text-xyne-fg-muted">{r.kind}</td>
+                <td className="py-2 text-right text-xyne-fg-primary">{r.runs}</td>
+                <td className="py-2 text-right text-xyne-fg-primary">{r.ran}</td>
+                <td className="py-2 text-right text-xyne-fg-muted">{r.skipped}</td>
+                <td className={"py-2 text-right " + (r.failed > 0 ? "text-red-500" : "text-xyne-fg-muted")}>
+                  {r.failed}
+                </td>
+                <td className="py-2 text-right text-xyne-fg-muted">{r.events}</td>
+                <td className="py-2 text-right text-xyne-fg-muted">
+                  {r.lastRunAt ? new Date(r.lastRunAt).toLocaleString() : "—"}
+                </td>
+              </tr>
+              {openRow === rowKey(r) && (
+                <tr>
+                  <td colSpan={8} className="p-0">
+                    <AwakeningRunsPanel
+                      userId={userId}
+                      agentId={r.agentId}
+                      agentSlug={r.agentSlug}
+                      kind={r.kind}
+                      days={days}
+                      orgScope={orgScope}
+                    />
+                  </td>
+                </tr>
+              )}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {data.skipReasons.length > 0 && (
+        <div className="mt-[16px]">
+          <div className="text-[12px] text-xyne-fg-muted mb-2">
+            Why it stayed quiet — a healthy agent skips far more often than it acts.
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {data.skipReasons.map((r) => (
+              <span
+                key={r.reason}
+                className="rounded-full bg-xyne-bg-secondary px-3 py-1 text-[12px] text-xyne-fg-muted"
+              >
+                <span className="font-mono">{r.reason}</span> · {r.count}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+const RUNS_PAGE_SIZE = 20;
+
+/** The rollup is one row per (agent, wake kind) — both are needed to identify a row. */
+const rowKey = (r: { agentId: string; kind: string }): string => `${r.agentId}:${r.kind}`;
+
+/**
+ * One agent's wake history, paginated.
+ *
+ * Lists every wake ATTEMPT, not just the ones that acted — a skipped wake
+ * carries the gate rule that fired, which is usually the thing you opened this
+ * to find out. Wakes that dispatched link to their transcript; skipped ones
+ * never created a conversation and have nothing to link to.
+ */
+function AwakeningRunsPanel({
+  userId,
+  agentId,
+  agentSlug,
+  kind,
+  days,
+  orgScope,
+}: {
+  userId: string;
+  agentId: string;
+  agentSlug: string;
+  /** Narrows to the wake kind of the row that was clicked. */
+  kind: string;
+  days: 1 | 7 | 30;
+  orgScope?: AdminOrgScope;
+}) {
+  const [runs, setRuns] = useState<AwakeningRun[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset paging when the window changes — offset 40 is meaningless against a
+  // freshly narrowed result set.
+  useEffect(() => { setOffset(0); }, [days, agentId, kind]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchAwakeningRuns(userId, agentId, days, RUNS_PAGE_SIZE, offset, orgScope, kind)
+      .then((page) => {
+        if (cancelled) return;
+        setRuns(page.runs);
+        setTotal(page.total);
+      })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [userId, agentId, kind, days, offset, orgScope]);
+
+  const from = total === 0 ? 0 : offset + 1;
+  const to = Math.min(offset + RUNS_PAGE_SIZE, total);
+
+  return (
+    <div className="bg-xyne-bg-secondary/40 px-3 py-3 border-b border-xyne-border/50">
+      {error ? (
+        <div className="text-[12px] text-red-500">Failed to load sessions: {error}</div>
+      ) : loading && runs.length === 0 ? (
+        <Skeleton className="h-[120px] w-full" />
+      ) : runs.length === 0 ? (
+        <div className="text-[12px] text-xyne-fg-muted">
+          No {kind} wakes for {agentSlug} in this window.
+        </div>
+      ) : (
+        <>
+          <table className="w-full text-[12px]">
+            <thead className="text-xyne-fg-muted">
+              <tr className="text-left border-b border-xyne-border/60">
+                <th className="py-1.5 font-medium">When</th>
+                <th className="py-1.5 font-medium">Outcome</th>
+                <th className="py-1.5 font-medium">Why</th>
+                <th className="py-1.5 font-medium text-right">Events</th>
+                <th className="py-1.5 font-medium text-right">Updates</th>
+                <th className="py-1.5 font-medium text-right">Took</th>
+                <th className="py-1.5 font-medium text-right">Transcript</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((r) => (
+                <tr key={r.id} className="border-b border-xyne-border/30">
+                  <td className="py-1.5 text-xyne-fg-primary whitespace-nowrap">
+                    {new Date(r.startedAt).toLocaleString()}
+                  </td>
+                  <td className={"py-1.5 " + outcomeTone(r.outcome)}>{r.outcome}</td>
+                  <td className="py-1.5 font-mono text-xyne-fg-muted">{r.skipReason ?? "—"}</td>
+                  <td className="py-1.5 text-right text-xyne-fg-muted">{r.eventCount}</td>
+                  <td className="py-1.5 text-right text-xyne-fg-muted">
+                    {r.injectionsUsed > 0 ? r.injectionsUsed : "—"}
+                  </td>
+                  <td className="py-1.5 text-right text-xyne-fg-muted">{fmtMs(r.durationMs)}</td>
+                  <td className="py-1.5 text-right">
+                    {r.conversationId ? (
+                      <a
+                        className="text-blue-500 hover:underline"
+                        href={`/claw/v3/chat?agent=${encodeURIComponent(agentSlug)}&conversation=${encodeURIComponent(r.conversationId)}&allRuns=1`}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        open
+                      </a>
+                    ) : (
+                      <span className="text-xyne-fg-muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="mt-2 flex items-center justify-between text-[12px] text-xyne-fg-muted">
+            <span>{from}–{to} of {total}</span>
+            <div className="flex items-center gap-2">
+              <button
+                disabled={offset === 0 || loading}
+                onClick={() => setOffset(Math.max(0, offset - RUNS_PAGE_SIZE))}
+                className="rounded-md border border-xyne-border px-2 py-1 disabled:opacity-40 hover:text-xyne-fg-primary"
+              >
+                Previous
+              </button>
+              <button
+                disabled={to >= total || loading}
+                onClick={() => setOffset(offset + RUNS_PAGE_SIZE)}
+                className="rounded-md border border-xyne-border px-2 py-1 disabled:opacity-40 hover:text-xyne-fg-primary"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function outcomeTone(outcome: string): string {
+  if (outcome === "failed") return "text-red-500";
+  if (outcome === "skipped") return "text-xyne-fg-muted";
+  if (outcome === "shadow") return "text-amber-500";
+  return "text-xyne-fg-primary";
 }
 
 /* ── building blocks ──────────────────────────────────────────────────── */

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailRightColumn.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/AgentDetailRightColumn.tsx
@@ -14,6 +14,7 @@ import {
   CircleDashedIcon,
   CpuIcon,
   CopyIcon,
+  PulseIcon,
 } from "@phosphor-icons/react";
 import type { Agent } from "../../../lib/types";
 import type { ScheduledJob } from "../../../lib/types";
@@ -28,6 +29,8 @@ import {
   revokeDelegationRequest,
 } from "../../../lib/api";
 import { withAdminRequestAlert } from "../../../lib/admin-request-notice";
+import { AwakeningTab } from "./tabs/AwakeningTab";
+import { readAwakening, summarize as summarizeAwakening } from "../../lib/awakeningBounds";
 import type { AgentPermissions } from "../../lib/agentPermissions";
 import { useSnackbar } from "../ui/Snackbar";
 import { RunHistoryTab } from "./tabs/RunHistoryTab";
@@ -58,6 +61,7 @@ export type TabId =
   | "workflows"
   | "mcp"
   | "model"
+  | "awakening"
   | "requests";
 
 function fmtNum(n: number): string {
@@ -273,6 +277,8 @@ export function AgentDetailRightColumn({
   const privacyStatus = privacyWhitelisted
     ? `Whitelist · ${privacyCount} ${privacyCount === 1 ? "person" : "people"}`
     : "Everyone can call it";
+  // Awakening (config.awakening) — whether this agent acts unattended.
+  const awakeningStatus = summarizeAwakening(readAwakening(agent.config));
   const pendingRequestCount = cloneRequests.length + delegationRequests.length;
   const activeDelegationCount = activeDelegations.length;
   const requestStatus =
@@ -313,6 +319,14 @@ export function AgentDetailRightColumn({
       status: peopleStatus,
       icon: UsersThreeIcon,
       show: true,
+    },
+    {
+      id: "awakening",
+      label: "Awakening",
+      status: awakeningStatus,
+      icon: PulseIcon,
+      // Editor-only: it governs whether the agent acts unattended.
+      show: permissions.canEdit,
     },
     {
       id: "privacy",
@@ -407,6 +421,9 @@ export function AgentDetailRightColumn({
             <ContributorsTab agent={agent} userId={userId} permissions={permissions} />
           )}
           {activeTab === "memory" && <MemoryTab agent={agent} canDelete={permissions.canEdit} />}
+          {activeTab === "awakening" && (
+            <AwakeningTab agent={agent} canEdit={permissions.canEdit} onAgentUpdated={onAgentUpdated} />
+          )}
           {activeTab === "privacy" && (
             <PrivacyTab
               agent={agent}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/AwakeningTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/AwakeningTab.tsx
@@ -1,0 +1,712 @@
+import { useState, useCallback, useMemo } from "react";
+import { PulseIcon, WarningIcon, EyeIcon, CircleNotchIcon, XIcon } from "@phosphor-icons/react";
+import { updateAgent } from "../../../../lib/api";
+import type { Agent } from "../../../../lib/types";
+import { useSnackbar } from "../../ui/Snackbar";
+import {
+  readAwakening,
+  AWAKENING_BOUNDS,
+  AWAKENING_KINDS,
+  WRITE_POLICIES,
+  KIND_LABELS,
+  WRITE_POLICY_LABELS,
+  PERIOD_OPTIONS,
+  REFLEX_CHECK_OPTIONS,
+  REFLEX_MIN_INTERVAL_OPTIONS,
+  INJECT_MIN_INTERVAL_OPTIONS,
+  REPLICA_SAFETY_OPTIONS,
+  formatDuration,
+  clampToBound,
+  type AwakeningSettings,
+  type AwakeningKindValue,
+  type WritePolicyValue,
+} from "../../../lib/awakeningBounds";
+
+interface Props {
+  agent: Agent;
+  canEdit: boolean;
+  onAgentUpdated?: (agent: Agent) => void;
+}
+
+/**
+ * Awakening panel — when this agent wakes up on its own, and what it may do.
+ *
+ * Deliberately BATCH-saved with an explicit Save button, unlike the
+ * immediate-save panels (Privacy, People). These knobs are interdependent: a
+ * half-applied set (a threshold saved before the interval that bounds it, or
+ * shadow cleared before the channel list is narrowed) can put a live agent
+ * into a configuration nobody intended. One atomic write, or none.
+ *
+ * agent.config is FULL-REPLACED server-side, so every write spreads the
+ * existing config first — dropping that spread silently deletes every other
+ * config block the agent has.
+ */
+export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
+  const { show: showSnackbar } = useSnackbar();
+  const saved = useMemo(() => readAwakening(agent.config), [agent.config]);
+  const [draft, setDraft] = useState<AwakeningSettings>(saved);
+  const [saving, setSaving] = useState(false);
+
+  const dirty = useMemo(() => JSON.stringify(draft) !== JSON.stringify(saved), [draft, saved]);
+  const showsHeartbeat = draft.kind !== "reflex";
+  const showsReflex = draft.kind !== "heartbeat";
+
+  const set = <K extends keyof AwakeningSettings>(key: K, value: AwakeningSettings[K]): void =>
+    setDraft((d) => ({ ...d, [key]: value }));
+  const setNested = <S extends "channels" | "gate" | "limits" | "reflex" | "cursor">(
+    section: S,
+    patch: Partial<AwakeningSettings[S]>,
+  ): void => setDraft((d) => ({ ...d, [section]: { ...d[section], ...patch } }));
+
+  const persist = useCallback(async () => {
+    setSaving(true);
+    // Spread first: the server replaces `config` wholesale.
+    // Merge over the STORED awakening block rather than replacing it. The
+    // editor models a subset of AwakeningConfig (workspaceId, maxActiveThreads,
+    // cursor.overlapMs and cursor.maxCatchupWindows have no control), and
+    // replacing the block wholesale silently deleted every key the form does
+    // not know about — so opening this tab and pressing Save reset settings the
+    // admin never touched.
+    const storedAwakening = (agent.config?.["awakening"] ?? {}) as Record<string, unknown>;
+    const storedCursor = (storedAwakening["cursor"] ?? {}) as Record<string, unknown>;
+    const storedLimits = (storedAwakening["limits"] ?? {}) as Record<string, unknown>;
+    const nextConfig: Record<string, unknown> = {
+      ...agent.config,
+      awakening: {
+        ...storedAwakening,
+        ...draft,
+        cursor: { ...storedCursor, ...draft.cursor },
+        limits: { ...storedLimits, ...draft.limits },
+        channels: { ...(storedAwakening["channels"] as object ?? {}), ...draft.channels },
+        gate: { ...(storedAwakening["gate"] as object ?? {}), ...draft.gate },
+        reflex: { ...(storedAwakening["reflex"] as object ?? {}), ...draft.reflex },
+      },
+    };
+    try {
+      const updated = await updateAgent(agent.slug, { config: nextConfig });
+      onAgentUpdated?.(updated);
+      showSnackbar({ variant: "success", title: draft.enabled ? "Awakening saved" : "Awakening disabled" });
+    } catch (err) {
+      showSnackbar({
+        variant: "error",
+        title: "Failed to save",
+        // Surface the server's reason — it is the validator explaining which
+        // knob was rejected and why, which is exactly what the admin needs.
+        description: err instanceof Error ? err.message : undefined,
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [agent.config, agent.slug, draft, onAgentUpdated, showSnackbar]);
+
+  return (
+    <div className="flex flex-col gap-6 pb-24">
+      <Header enabled={draft.enabled} canEdit={canEdit} onToggle={(v) => set("enabled", v)} />
+
+      {draft.enabled && (
+        <>
+          {!draft.shadow && draft.writePolicy === "act" && <LiveWarning />}
+
+          <Section
+            title="Safety"
+            hint="What the agent is allowed to do once it is awake. Start in shadow mode."
+          >
+            <Toggle
+              label="Shadow mode"
+              hint="The agent reasons and records what it WOULD have posted, but has no write tools at all. The safest way to find out whether it is useful."
+              checked={draft.shadow}
+              disabled={!canEdit}
+              onChange={(v) => set("shadow", v)}
+            />
+            <Choice<WritePolicyValue>
+              label="Write policy"
+              disabled={!canEdit || draft.shadow}
+              disabledHint={draft.shadow ? "Shadow mode overrides this — nothing is posted." : undefined}
+              value={draft.writePolicy}
+              options={WRITE_POLICIES}
+              labels={WRITE_POLICY_LABELS}
+              onChange={(v) => set("writePolicy", v)}
+            />
+            <NumberField
+              label="Max runs per hour"
+              hint="Hard ceiling on how often this agent may actually run. Skipped checks are free and do not count."
+              value={draft.limits.maxRunsPerHour}
+              bound={AWAKENING_BOUNDS.maxRunsPerHour}
+              disabled={!canEdit}
+              onChange={(v) => setNested("limits", { maxRunsPerHour: v })}
+            />
+          </Section>
+
+          <Section
+            title="Run instructions"
+            hint="Your own guidance for awakened runs — tone, what is worth reacting to, what to leave alone. Appended to the built-in operating contract, which always has the last word on delivery rules and safety bounds."
+          >
+            <TextAreaField
+              label="Guidance"
+              hint="Optional. Written to the agent every time it wakes. Example: “Keep it casual and short. Jump in when someone is blocked or asking for a reminder. Stay out of social chatter.”"
+              value={draft.instructions}
+              max={AWAKENING_BOUNDS.instructionsLength.MAX}
+              disabled={!canEdit}
+              onChange={(v) => set("instructions", v)}
+            />
+          </Section>
+
+          <Section title="When it wakes" hint="A heartbeat wakes on the clock; a reflex wakes on volume.">
+            <Choice<AwakeningKindValue>
+              label="Trigger"
+              value={draft.kind}
+              options={AWAKENING_KINDS}
+              labels={KIND_LABELS}
+              disabled={!canEdit}
+              onChange={(v) => set("kind", v)}
+            />
+            {showsHeartbeat && (
+              <SelectField
+                label="Heartbeat period"
+                hint="How often it reviews the whole period."
+                value={draft.periodMs}
+                options={PERIOD_OPTIONS}
+                format={formatDuration}
+                disabled={!canEdit}
+                onChange={(v) => set("periodMs", v)}
+              />
+            )}
+            {showsReflex && (
+              <>
+                <NumberField
+                  label="Reflex threshold"
+                  hint="Wake once this many new events have piled up in the watched channels."
+                  value={draft.reflex.threshold}
+                  bound={AWAKENING_BOUNDS.reflexThreshold}
+                  disabled={!canEdit}
+                  onChange={(v) => setNested("reflex", { threshold: v })}
+                />
+                <SelectField
+                  label="Reflex check interval"
+                  hint="How often the event count is checked. This is a cheap count, not a full read."
+                  value={draft.reflex.checkIntervalMs}
+                  options={REFLEX_CHECK_OPTIONS}
+                  format={formatDuration}
+                  disabled={!canEdit}
+                  onChange={(v) => setNested("reflex", { checkIntervalMs: v })}
+                />
+                <SelectField
+                  label="Minimum gap between reflexes"
+                  hint="However busy a channel gets, two reflex runs stay at least this far apart."
+                  value={draft.reflex.minIntervalMs}
+                  options={REFLEX_MIN_INTERVAL_OPTIONS}
+                  format={formatDuration}
+                  disabled={!canEdit}
+                  onChange={(v) => setNested("reflex", { minIntervalMs: v })}
+                />
+              </>
+            )}
+          </Section>
+
+          <Section
+            title="Which channels"
+            hint="Rules are always narrowed to channels the agent's bot is actually a member of. Leave everything empty to watch every channel it is in."
+          >
+            <ListField
+              label="Channel IDs"
+              placeholder="ch_abc123"
+              values={draft.channels.include}
+              disabled={!canEdit}
+              onChange={(v) => setNested("channels", { include: v })}
+            />
+            <ListField
+              label="Name patterns"
+              placeholder="^eng-"
+              hint="Case-insensitive regular expressions matched against the channel name."
+              values={draft.channels.includePattern}
+              disabled={!canEdit}
+              onChange={(v) => setNested("channels", { includePattern: v })}
+            />
+            <ListField
+              label="Excluded name patterns"
+              placeholder="-archive$"
+              hint="Applied after the include rules. Exclusion always wins."
+              values={draft.channels.excludePattern}
+              disabled={!canEdit}
+              onChange={(v) => setNested("channels", { excludePattern: v })}
+            />
+            <NumberField
+              label="Max channels"
+              hint="If more match, the least recently active are dropped."
+              value={draft.channels.maxChannels}
+              bound={AWAKENING_BOUNDS.maxChannels}
+              disabled={!canEdit}
+              onChange={(v) => setNested("channels", { maxChannels: v })}
+            />
+          </Section>
+
+          <Section
+            title="When it bothers to act"
+            hint="Most windows contain nothing that needs an agent. These decide when a wake is worth the cost."
+          >
+            <NumberField
+              label="Minimum human events"
+              hint="Below this many messages from real people, the window is skipped without running the model."
+              value={draft.gate.minHumanEvents}
+              bound={AWAKENING_BOUNDS.minHumanEvents}
+              disabled={!canEdit}
+              onChange={(v) => setNested("gate", { minHumanEvents: v })}
+            />
+            <NumberField
+              label="Force a run after N skips"
+              hint="Guarantees the agent still checks in during a quiet stretch. 0 disables it."
+              value={draft.gate.forceRunEveryNSkips}
+              bound={AWAKENING_BOUNDS.forceRunEveryNSkips}
+              disabled={!canEdit}
+              onChange={(v) => setNested("gate", { forceRunEveryNSkips: v })}
+            />
+            <NumberField
+              label="Max events per window"
+              hint="A window larger than this is truncated, and the agent is told so."
+              value={draft.limits.maxEvents}
+              bound={AWAKENING_BOUNDS.maxEvents}
+              disabled={!canEdit}
+              onChange={(v) => setNested("limits", { maxEvents: v })}
+            />
+          </Section>
+
+          {showsReflex && (
+            <Section
+              title="Live updates"
+              hint="While a reflex run is working, new events can be handed to it so it adapts mid-task instead of finishing on stale input."
+            >
+              <Toggle
+                label="Send live updates into a running reflex"
+                checked={draft.reflex.injectEnabled}
+                disabled={!canEdit}
+                onChange={(v) => setNested("reflex", { injectEnabled: v })}
+              />
+              {draft.reflex.injectEnabled && (
+                <>
+                  <NumberField
+                    label="Events per update"
+                    hint="How many new events must arrive before the running agent is interrupted with them."
+                    value={draft.reflex.injectThreshold}
+                    bound={AWAKENING_BOUNDS.injectThreshold}
+                    disabled={!canEdit}
+                    onChange={(v) => setNested("reflex", { injectThreshold: v })}
+                  />
+                  <NumberField
+                    label="Max updates per run"
+                    hint="A run still has to finish. Beyond this, new events wait for the next wake."
+                    value={draft.reflex.maxInjectionsPerSession}
+                    bound={AWAKENING_BOUNDS.maxInjectionsPerSession}
+                    disabled={!canEdit}
+                    onChange={(v) => setNested("reflex", { maxInjectionsPerSession: v })}
+                  />
+                  <SelectField
+                    label="Minimum gap between updates"
+                    value={draft.reflex.injectMinIntervalMs}
+                    options={INJECT_MIN_INTERVAL_OPTIONS}
+                    format={formatDuration}
+                    disabled={!canEdit}
+                    onChange={(v) => setNested("reflex", { injectMinIntervalMs: v })}
+                  />
+                  <SelectField
+                    label="Replica safety margin"
+                    hint="How far behind now a window closes, so a Spaces read replica that is briefly behind cannot cause events to be skipped. This is the floor on how fast anything can reach the agent: a new event becomes visible after this margin, and is picked up on the following check."
+                    value={draft.cursor.replicaSafetyMs}
+                    options={REPLICA_SAFETY_OPTIONS}
+                    format={formatDuration}
+                    disabled={!canEdit}
+                    onChange={(v) => setNested("cursor", { replicaSafetyMs: v })}
+                  />
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                    A live update reaches a running agent roughly{" "}
+                    {formatDuration(draft.cursor.replicaSafetyMs + draft.reflex.checkIntervalMs)} after the events
+                    land, once {draft.reflex.injectThreshold} of them have arrived. A run that finishes faster than
+                    that will never receive one — its events go to the next wake instead.
+                  </p>
+                </>
+              )}
+            </Section>
+          )}
+        </>
+      )}
+
+      {canEdit && dirty && (
+        <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-neutral-200 bg-white/95 px-1 py-3 backdrop-blur dark:border-neutral-800 dark:bg-neutral-950/95">
+          <span className="text-xs text-neutral-500">Unsaved changes</span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setDraft(saved)}
+              disabled={saving}
+              className="rounded-lg px-3 py-1.5 text-sm text-neutral-600 hover:bg-neutral-100 disabled:opacity-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+            >
+              Discard
+            </button>
+            <button
+              type="button"
+              onClick={() => void persist()}
+              disabled={saving}
+              className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+            >
+              {saving && <CircleNotchIcon size={14} className="animate-spin" />}
+              Save
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── pieces ──────────────────────────────────────────────────────────────────
+
+function Header({
+  enabled,
+  canEdit,
+  onToggle,
+}: {
+  enabled: boolean;
+  canEdit: boolean;
+  onToggle: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+      <div className="flex gap-3">
+        <PulseIcon size={20} weight="bold" className="mt-0.5 shrink-0 text-indigo-500" />
+        <div>
+          <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">Awakening</h3>
+          <p className="mt-1 max-w-prose text-xs leading-relaxed text-neutral-500 dark:text-neutral-400">
+            Let this agent wake up on its own and act on what happened in its channels, without anybody
+            triggering it. It reads a collected window of events, decides whether anything needs doing, and
+            acts only within the limits set below.
+          </p>
+        </div>
+      </div>
+      <Switch checked={enabled} disabled={!canEdit} onChange={onToggle} />
+    </div>
+  );
+}
+
+function LiveWarning() {
+  return (
+    <div className="flex gap-3 rounded-xl border border-amber-300 bg-amber-50 p-4 dark:border-amber-800/60 dark:bg-amber-950/30">
+      <WarningIcon size={18} weight="fill" className="mt-0.5 shrink-0 text-amber-600" />
+      <p className="text-xs leading-relaxed text-amber-900 dark:text-amber-200">
+        This agent can post to channels and start new threads with nobody reviewing it first. Turn shadow
+        mode on and read a few windows before allowing this.
+      </p>
+    </div>
+  );
+}
+
+function Section({ title, hint, children }: { title: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-4">
+      <div>
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+          {title}
+        </h4>
+        {hint && <p className="mt-1 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
+      </div>
+      <div className="flex flex-col gap-4 rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Switch({
+  checked,
+  disabled,
+  onChange,
+}: {
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`relative h-6 w-11 shrink-0 rounded-full transition-colors disabled:opacity-50 ${
+        checked ? "bg-indigo-600" : "bg-neutral-300 dark:bg-neutral-700"
+      }`}
+    >
+      <span
+        className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+          checked ? "translate-x-[22px]" : "translate-x-0.5"
+        }`}
+      />
+    </button>
+  );
+}
+
+function Toggle({
+  label,
+  hint,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
+        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
+      </div>
+      <Switch checked={checked} disabled={disabled} onChange={onChange} />
+    </div>
+  );
+}
+
+function Choice<T extends string>({
+  label,
+  value,
+  options,
+  labels,
+  disabled,
+  disabledHint,
+  onChange,
+}: {
+  label: string;
+  value: T;
+  options: readonly T[];
+  labels: Record<T, { label: string; hint: string }>;
+  disabled?: boolean;
+  disabledHint?: string;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-2 text-sm text-neutral-800 dark:text-neutral-200">
+        {label}
+        {disabledHint && (
+          <span className="flex items-center gap-1 text-xs text-neutral-500">
+            <EyeIcon size={12} /> {disabledHint}
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-2">
+        {options.map((opt) => (
+          <button
+            key={opt}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(opt)}
+            className={`rounded-lg border p-3 text-left transition-colors disabled:opacity-50 ${
+              value === opt
+                ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-950/30"
+                : "border-neutral-200 hover:border-neutral-300 dark:border-neutral-800 dark:hover:border-neutral-700"
+            }`}
+          >
+            <div className="text-sm text-neutral-900 dark:text-neutral-100">{labels[opt].label}</div>
+            <div className="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">{labels[opt].hint}</div>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function NumberField({
+  label,
+  hint,
+  value,
+  bound,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  value: number;
+  bound: { MIN: number; MAX: number; DEFAULT: number };
+  disabled?: boolean;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
+        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
+        <p className="mt-0.5 text-[11px] text-neutral-400">
+          {bound.MIN}–{bound.MAX}
+        </p>
+      </div>
+      <input
+        type="number"
+        min={bound.MIN}
+        max={bound.MAX}
+        value={value}
+        disabled={disabled}
+        // Clamp on blur, not on change: clamping mid-typing makes "10" become
+        // the minimum the instant "1" is typed, which fights the user.
+        onChange={(e) => onChange(Number(e.target.value))}
+        onBlur={(e) => onChange(clampToBound(Number(e.target.value), bound))}
+        className="w-24 shrink-0 rounded-lg border border-neutral-200 px-3 py-1.5 text-sm disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900"
+      />
+    </div>
+  );
+}
+
+/**
+ * Multi-line free text with a live character budget. Truncation happens
+ * server-side too (resolveAwakeningConfig), so the counter is a courtesy, not
+ * the enforcement point.
+ */
+function TextAreaField({
+  label,
+  hint,
+  value,
+  max,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  value: string;
+  max: number;
+  disabled?: boolean;
+  onChange: (v: string) => void;
+}) {
+  const over = value.length > max;
+  return (
+    <div className="flex flex-col gap-2">
+      <div>
+        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
+        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
+      </div>
+      <textarea
+        rows={6}
+        value={value}
+        disabled={disabled}
+        maxLength={max}
+        placeholder="No extra guidance — the agent runs on its contract and skill alone."
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full resize-y rounded-lg border border-neutral-200 px-3 py-2 text-sm leading-relaxed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900"
+      />
+      <p className={`text-[11px] ${over ? "text-red-500" : "text-neutral-400"}`}>
+        {value.length}/{max}
+      </p>
+    </div>
+  );
+}
+
+function SelectField({
+  label,
+  hint,
+  value,
+  options,
+  format,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  value: number;
+  options: readonly number[];
+  format: (v: number) => string;
+  disabled?: boolean;
+  onChange: (v: number) => void;
+}) {
+  // A stored value outside the offered set (hand-edited config, or a list that
+  // changed) must still be visible rather than silently snapping to another.
+  const choices = options.includes(value) ? options : [value, ...options].sort((a, b) => a - b);
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
+        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
+      </div>
+      <select
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-32 shrink-0 rounded-lg border border-neutral-200 px-3 py-1.5 text-sm disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900"
+      >
+        {choices.map((o) => (
+          <option key={o} value={o}>
+            {format(o)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function ListField({
+  label,
+  hint,
+  placeholder,
+  values,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  hint?: string;
+  placeholder: string;
+  values: string[];
+  disabled?: boolean;
+  onChange: (v: string[]) => void;
+}) {
+  const [entry, setEntry] = useState("");
+  const add = (): void => {
+    const v = entry.trim();
+    if (!v || values.includes(v)) return;
+    onChange([...values, v]);
+    setEntry("");
+  };
+
+  return (
+    <div>
+      <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
+      {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {values.map((v) => (
+          <span
+            key={v}
+            className="flex items-center gap-1 rounded-md bg-neutral-100 px-2 py-1 font-mono text-xs dark:bg-neutral-800"
+          >
+            {v}
+            {!disabled && (
+              <button type="button" onClick={() => onChange(values.filter((x) => x !== v))} aria-label={`Remove ${v}`}>
+                <XIcon size={11} />
+              </button>
+            )}
+          </span>
+        ))}
+        {values.length === 0 && <span className="text-xs text-neutral-400">None</span>}
+      </div>
+      {!disabled && (
+        <div className="mt-2 flex gap-2">
+          <input
+            value={entry}
+            placeholder={placeholder}
+            onChange={(e) => setEntry(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                add();
+              }
+            }}
+            className="flex-1 rounded-lg border border-neutral-200 px-3 py-1.5 font-mono text-xs dark:border-neutral-800 dark:bg-neutral-900"
+          />
+          <button
+            type="button"
+            onClick={add}
+            className="rounded-lg border border-neutral-200 px-3 py-1.5 text-xs hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-800"
+          >
+            Add
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/AwakeningTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/AwakeningTab.tsx
@@ -1,8 +1,10 @@
-import { useState, useCallback, useMemo } from "react";
-import { PulseIcon, WarningIcon, EyeIcon, CircleNotchIcon, XIcon } from "@phosphor-icons/react";
-import { updateAgent } from "../../../../lib/api";
+import { useState, useCallback, useMemo, useEffect } from "react";
+import { PulseIcon, WarningIcon, CircleNotchIcon, XIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { updateAgent, getAwakeningStatus, type AwakeningStatus } from "../../../../lib/api";
 import type { Agent } from "../../../../lib/types";
 import { useSnackbar } from "../../ui/Snackbar";
+import { InfoIcon } from "../../ui/Tooltip";
+import { Switch } from "../../ui/Switch";
 import {
   readAwakening,
   AWAKENING_BOUNDS,
@@ -40,12 +42,36 @@ interface Props {
  * agent.config is FULL-REPLACED server-side, so every write spreads the
  * existing config first — dropping that spread silently deletes every other
  * config block the agent has.
+ *
+ * LAYOUT: there are ~15 interdependent knobs here, and reading them as a flat
+ * list is what made this panel hard to configure. Three things fix that, and
+ * they are the reason for the structure below:
+ *   1. A plain-English SUMMARY at the top, recomputed from the draft, so the
+ *      combined effect of the knobs never has to be simulated in your head.
+ *   2. NUMBERED STEPS in the order the decision is actually made.
+ *   3. Per-knob explanations live in hover tooltips, not permanent paragraphs —
+ *      the rows stay one line each, so the whole config is scannable.
+ * Knobs whose default is almost always right sit behind an "Advanced"
+ * disclosure rather than competing with the ones that matter.
  */
 export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
   const { show: showSnackbar } = useSnackbar();
   const saved = useMemo(() => readAwakening(agent.config), [agent.config]);
   const [draft, setDraft] = useState<AwakeningSettings>(saved);
   const [saving, setSaving] = useState(false);
+  // The worker-owned state row. `config.awakening.enabled` (what the toggle
+  // edits) and `state.enabled` (what the workers read) are different flags, and
+  // a worker that hits an unrecoverable error clears the latter. Fetch it so a
+  // switched-off agent cannot keep rendering as enabled.
+  const [status, setStatus] = useState<AwakeningStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAwakeningStatus(agent.id)
+      .then((s) => { if (!cancelled) setStatus(s); })
+      .catch(() => { /* status is diagnostic only — never block the editor */ });
+    return () => { cancelled = true; };
+  }, [agent.id, saved]);
 
   const dirty = useMemo(() => JSON.stringify(draft) !== JSON.stringify(saved), [draft, saved]);
   const showsHeartbeat = draft.kind !== "reflex";
@@ -100,26 +126,33 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
   }, [agent.config, agent.slug, draft, onAgentUpdated, showSnackbar]);
 
   return (
-    <div className="flex flex-col gap-6 pb-24">
+    <div className="flex flex-col gap-5 p-4 pb-24">
       <Header enabled={draft.enabled} canEdit={canEdit} onToggle={(v) => set("enabled", v)} />
+
+      {draft.enabled && status?.state && !status.state.enabled && (
+        <SystemDisabledNotice lastError={status.state.lastError} />
+      )}
 
       {draft.enabled && (
         <>
           {!draft.shadow && draft.writePolicy === "act" && <LiveWarning />}
 
-          <Section
-            title="Safety"
-            hint="What the agent is allowed to do once it is awake. Start in shadow mode."
+          <Summary draft={draft} />
+
+          <Step
+            n={1}
+            title="What it may do"
+            hint="Start in shadow mode and read a few windows before letting it post."
           >
-            <Toggle
+            <Row
               label="Shadow mode"
-              hint="The agent reasons and records what it WOULD have posted, but has no write tools at all. The safest way to find out whether it is useful."
-              checked={draft.shadow}
-              disabled={!canEdit}
-              onChange={(v) => set("shadow", v)}
-            />
+              info="The agent reasons and records what it WOULD have posted, but is given no write tools at all. The safest way to find out whether it is useful before it can say anything."
+            >
+              <Switch checked={draft.shadow} disabled={!canEdit} onChange={(v) => set("shadow", v)} />
+            </Row>
             <Choice<WritePolicyValue>
               label="Write policy"
+              info="What the agent is allowed to post once it is out of shadow mode. Observe posts nothing; Reply only joins conversations that already exist; Act may also open new threads nobody asked for."
               disabled={!canEdit || draft.shadow}
               disabledHint={draft.shadow ? "Shadow mode overrides this — nothing is posted." : undefined}
               value={draft.writePolicy}
@@ -129,31 +162,19 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
             />
             <NumberField
               label="Max runs per hour"
-              hint="Hard ceiling on how often this agent may actually run. Skipped checks are free and do not count."
+              info="Hard ceiling on how often this agent may actually run, whatever the triggers below ask for. Checks that decide to skip are free and do not count against it."
               value={draft.limits.maxRunsPerHour}
               bound={AWAKENING_BOUNDS.maxRunsPerHour}
+              unit="runs/h"
               disabled={!canEdit}
               onChange={(v) => setNested("limits", { maxRunsPerHour: v })}
             />
-          </Section>
+          </Step>
 
-          <Section
-            title="Run instructions"
-            hint="Your own guidance for awakened runs — tone, what is worth reacting to, what to leave alone. Appended to the built-in operating contract, which always has the last word on delivery rules and safety bounds."
-          >
-            <TextAreaField
-              label="Guidance"
-              hint="Optional. Written to the agent every time it wakes. Example: “Keep it casual and short. Jump in when someone is blocked or asking for a reminder. Stay out of social chatter.”"
-              value={draft.instructions}
-              max={AWAKENING_BOUNDS.instructionsLength.MAX}
-              disabled={!canEdit}
-              onChange={(v) => set("instructions", v)}
-            />
-          </Section>
-
-          <Section title="When it wakes" hint="A heartbeat wakes on the clock; a reflex wakes on volume.">
+          <Step n={2} title="When it wakes" hint="A heartbeat wakes on the clock; a reflex wakes on volume.">
             <Choice<AwakeningKindValue>
               label="Trigger"
+              info="Heartbeat reviews everything that happened since the last wake, on a fixed timer. Reflex reacts as soon as enough activity piles up, and sees only that burst. Choosing both gives you a fast reaction plus a periodic sweep."
               value={draft.kind}
               options={AWAKENING_KINDS}
               labels={KIND_LABELS}
@@ -163,7 +184,7 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
             {showsHeartbeat && (
               <SelectField
                 label="Heartbeat period"
-                hint="How often it reviews the whole period."
+                info="How often it wakes and reviews the whole period. Every event since the previous heartbeat is in that window, so a longer period means fewer, larger runs."
                 value={draft.periodMs}
                 options={PERIOD_OPTIONS}
                 format={formatDuration}
@@ -175,15 +196,16 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
               <>
                 <NumberField
                   label="Reflex threshold"
-                  hint="Wake once this many new events have piled up in the watched channels."
+                  info="Wake once this many new events have piled up across the watched channels. Lower means twitchier and more runs; higher means it waits for a real burst."
                   value={draft.reflex.threshold}
                   bound={AWAKENING_BOUNDS.reflexThreshold}
+                  unit="events"
                   disabled={!canEdit}
                   onChange={(v) => setNested("reflex", { threshold: v })}
                 />
                 <SelectField
                   label="Reflex check interval"
-                  hint="How often the event count is checked. This is a cheap count, not a full read."
+                  info="How often the pending-event count is checked. This is a cheap count, not a full read, so a short interval is inexpensive — it sets how quickly a burst can be noticed."
                   value={draft.reflex.checkIntervalMs}
                   options={REFLEX_CHECK_OPTIONS}
                   format={formatDuration}
@@ -192,7 +214,7 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
                 />
                 <SelectField
                   label="Minimum gap between reflexes"
-                  hint="However busy a channel gets, two reflex runs stay at least this far apart."
+                  info="However busy a channel gets, two reflex runs stay at least this far apart. This is your protection against a flood turning into a run per minute."
                   value={draft.reflex.minIntervalMs}
                   options={REFLEX_MIN_INTERVAL_OPTIONS}
                   format={formatDuration}
@@ -201,14 +223,16 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
                 />
               </>
             )}
-          </Section>
+          </Step>
 
-          <Section
-            title="Which channels"
-            hint="Rules are always narrowed to channels the agent's bot is actually a member of. Leave everything empty to watch every channel it is in."
+          <Step
+            n={3}
+            title="Where it looks"
+            hint="Leave everything empty to watch every channel the agent's bot is already in."
           >
             <ListField
               label="Channel IDs"
+              info="Exact channel IDs to watch. Combined with the name patterns below — a channel matching either one is included."
               placeholder="ch_abc123"
               values={draft.channels.include}
               disabled={!canEdit}
@@ -216,128 +240,159 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
             />
             <ListField
               label="Name patterns"
+              info="Case-insensitive regular expressions matched against the channel name. Example: ^eng- watches every channel whose name starts with eng-."
               placeholder="^eng-"
-              hint="Case-insensitive regular expressions matched against the channel name."
               values={draft.channels.includePattern}
               disabled={!canEdit}
               onChange={(v) => setNested("channels", { includePattern: v })}
             />
             <ListField
               label="Excluded name patterns"
+              info="Applied after the include rules. Exclusion always wins, so this is the reliable way to keep the agent out of a channel."
               placeholder="-archive$"
-              hint="Applied after the include rules. Exclusion always wins."
               values={draft.channels.excludePattern}
               disabled={!canEdit}
               onChange={(v) => setNested("channels", { excludePattern: v })}
             />
-            <NumberField
-              label="Max channels"
-              hint="If more match, the least recently active are dropped."
-              value={draft.channels.maxChannels}
-              bound={AWAKENING_BOUNDS.maxChannels}
-              disabled={!canEdit}
-              onChange={(v) => setNested("channels", { maxChannels: v })}
-            />
-          </Section>
+            <Advanced>
+              <NumberField
+                label="Max channels"
+                info="Safety ceiling on how many channels one wake may cover. If more match the rules above, the least recently active are dropped."
+                value={draft.channels.maxChannels}
+                bound={AWAKENING_BOUNDS.maxChannels}
+                unit="channels"
+                disabled={!canEdit}
+                onChange={(v) => setNested("channels", { maxChannels: v })}
+              />
+            </Advanced>
+          </Step>
 
-          <Section
+          <Step
+            n={4}
             title="When it bothers to act"
-            hint="Most windows contain nothing that needs an agent. These decide when a wake is worth the cost."
+            hint="Most windows contain nothing worth waking a model for. These decide which ones are."
           >
             <NumberField
               label="Minimum human events"
-              hint="Below this many messages from real people, the window is skipped without running the model."
+              info="Below this many messages from real people, the window is skipped without ever running the model — so it costs nothing. Bot and agent chatter does not count towards it."
               value={draft.gate.minHumanEvents}
               bound={AWAKENING_BOUNDS.minHumanEvents}
+              unit="events"
               disabled={!canEdit}
               onChange={(v) => setNested("gate", { minHumanEvents: v })}
             />
-            <NumberField
-              label="Force a run after N skips"
-              hint="Guarantees the agent still checks in during a quiet stretch. 0 disables it."
-              value={draft.gate.forceRunEveryNSkips}
-              bound={AWAKENING_BOUNDS.forceRunEveryNSkips}
-              disabled={!canEdit}
-              onChange={(v) => setNested("gate", { forceRunEveryNSkips: v })}
-            />
-            <NumberField
-              label="Max events per window"
-              hint="A window larger than this is truncated, and the agent is told so."
-              value={draft.limits.maxEvents}
-              bound={AWAKENING_BOUNDS.maxEvents}
-              disabled={!canEdit}
-              onChange={(v) => setNested("limits", { maxEvents: v })}
-            />
-          </Section>
+            <Advanced>
+              <NumberField
+                label="Force a run after N skips"
+                info="Guarantees the agent still checks in during a quiet stretch, even when the gate above keeps skipping. Set 0 to disable and let quiet periods stay quiet."
+                value={draft.gate.forceRunEveryNSkips}
+                bound={AWAKENING_BOUNDS.forceRunEveryNSkips}
+                unit="skips"
+                disabled={!canEdit}
+                onChange={(v) => setNested("gate", { forceRunEveryNSkips: v })}
+              />
+              <NumberField
+                label="Max events per window"
+                info="A window bigger than this is truncated before the agent sees it, and the agent is told that it was. Guards the context window on a very busy period."
+                value={draft.limits.maxEvents}
+                bound={AWAKENING_BOUNDS.maxEvents}
+                unit="events"
+                disabled={!canEdit}
+                onChange={(v) => setNested("limits", { maxEvents: v })}
+              />
+            </Advanced>
+          </Step>
 
           {showsReflex && (
-            <Section
+            <Step
+              n={5}
               title="Live updates"
-              hint="While a reflex run is working, new events can be handed to it so it adapts mid-task instead of finishing on stale input."
+              hint="Hand new events to a reflex run that is already working, so it adapts mid-task instead of finishing on stale input."
             >
-              <Toggle
+              <Row
                 label="Send live updates into a running reflex"
-                checked={draft.reflex.injectEnabled}
-                disabled={!canEdit}
-                onChange={(v) => setNested("reflex", { injectEnabled: v })}
-              />
+                info="Without this, events that land while the agent is working wait for the next wake. With it, they are handed to the run in progress."
+              >
+                <Switch
+                  checked={draft.reflex.injectEnabled}
+                  disabled={!canEdit}
+                  onChange={(v) => setNested("reflex", { injectEnabled: v })}
+                />
+              </Row>
               {draft.reflex.injectEnabled && (
                 <>
                   <NumberField
                     label="Events per update"
-                    hint="How many new events must arrive before the running agent is interrupted with them."
+                    info="How many new events must arrive before the running agent is interrupted with them. Too low and you interrupt it constantly; too high and it never hears anything mid-run."
                     value={draft.reflex.injectThreshold}
                     bound={AWAKENING_BOUNDS.injectThreshold}
+                    unit="events"
                     disabled={!canEdit}
                     onChange={(v) => setNested("reflex", { injectThreshold: v })}
                   />
                   <NumberField
                     label="Max updates per run"
-                    hint="A run still has to finish. Beyond this, new events wait for the next wake."
+                    info="A run still has to finish. Once it has taken this many updates, later events wait for the next wake instead."
                     value={draft.reflex.maxInjectionsPerSession}
                     bound={AWAKENING_BOUNDS.maxInjectionsPerSession}
+                    unit="updates"
                     disabled={!canEdit}
                     onChange={(v) => setNested("reflex", { maxInjectionsPerSession: v })}
                   />
-                  <SelectField
-                    label="Minimum gap between updates"
-                    value={draft.reflex.injectMinIntervalMs}
-                    options={INJECT_MIN_INTERVAL_OPTIONS}
-                    format={formatDuration}
-                    disabled={!canEdit}
-                    onChange={(v) => setNested("reflex", { injectMinIntervalMs: v })}
-                  />
-                  <SelectField
-                    label="Replica safety margin"
-                    hint="How far behind now a window closes, so a Spaces read replica that is briefly behind cannot cause events to be skipped. This is the floor on how fast anything can reach the agent: a new event becomes visible after this margin, and is picked up on the following check."
-                    value={draft.cursor.replicaSafetyMs}
-                    options={REPLICA_SAFETY_OPTIONS}
-                    format={formatDuration}
-                    disabled={!canEdit}
-                    onChange={(v) => setNested("cursor", { replicaSafetyMs: v })}
-                  />
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                    A live update reaches a running agent roughly{" "}
-                    {formatDuration(draft.cursor.replicaSafetyMs + draft.reflex.checkIntervalMs)} after the events
-                    land, once {draft.reflex.injectThreshold} of them have arrived. A run that finishes faster than
-                    that will never receive one — its events go to the next wake instead.
-                  </p>
+                  <LatencyNote draft={draft} />
+                  <Advanced>
+                    <SelectField
+                      label="Minimum gap between updates"
+                      info="Two live updates into the same run stay at least this far apart, so a burst cannot interrupt the agent repeatedly in a few seconds."
+                      value={draft.reflex.injectMinIntervalMs}
+                      options={INJECT_MIN_INTERVAL_OPTIONS}
+                      format={formatDuration}
+                      disabled={!canEdit}
+                      onChange={(v) => setNested("reflex", { injectMinIntervalMs: v })}
+                    />
+                    <SelectField
+                      label="Replica safety margin"
+                      info="How far behind 'now' a window closes, so a Spaces read replica that is briefly behind cannot cause events to be skipped. This is the floor on how fast anything can reach the agent: an event becomes visible after this margin and is picked up on the following check. Only set it to 0 on a deployment with no read replica."
+                      value={draft.cursor.replicaSafetyMs}
+                      options={REPLICA_SAFETY_OPTIONS}
+                      format={formatDuration}
+                      disabled={!canEdit}
+                      onChange={(v) => setNested("cursor", { replicaSafetyMs: v })}
+                    />
+                  </Advanced>
                 </>
               )}
-            </Section>
+            </Step>
           )}
+
+          <Step
+            n={showsReflex ? 6 : 5}
+            title="Guidance"
+            hint="Your own instructions for awakened runs. Appended to the built-in operating contract, which always has the last word on delivery rules and safety bounds."
+          >
+            <TextAreaField
+              label="Run instructions"
+              info="Optional. Written to the agent every time it wakes — tone, what is worth reacting to, what to leave alone."
+              value={draft.instructions}
+              max={AWAKENING_BOUNDS.instructionsLength.MAX}
+              disabled={!canEdit}
+              onChange={(v) => set("instructions", v)}
+            />
+          </Step>
         </>
       )}
 
       {canEdit && dirty && (
-        <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-neutral-200 bg-white/95 px-1 py-3 backdrop-blur dark:border-neutral-800 dark:bg-neutral-950/95">
-          <span className="text-xs text-neutral-500">Unsaved changes</span>
+        // -mx-4 px-4 cancels the page padding so the bar spans the panel edge
+        // to edge, the way a docked footer should.
+        <div className="sticky bottom-0 -mx-4 flex items-center justify-between gap-3 border-t border-xyne-border bg-xyne-surface/95 px-4 py-3 backdrop-blur">
+          <span className="text-[12px] text-xyne-fg-tertiary">Unsaved changes</span>
           <div className="flex gap-2">
             <button
               type="button"
               onClick={() => setDraft(saved)}
               disabled={saving}
-              className="rounded-lg px-3 py-1.5 text-sm text-neutral-600 hover:bg-neutral-100 disabled:opacity-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+              className="rounded-lg px-3 py-1.5 text-[13px] text-xyne-fg-secondary hover:bg-xyne-surface-subtle disabled:opacity-50"
             >
               Discard
             </button>
@@ -345,7 +400,7 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
               type="button"
               onClick={() => void persist()}
               disabled={saving}
-              className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+              className="flex items-center gap-2 rounded-lg bg-xyne-brand px-4 py-1.5 text-[13px] font-medium text-xyne-fg-inverse hover:bg-xyne-brand-hover disabled:opacity-50"
             >
               {saving && <CircleNotchIcon size={14} className="animate-spin" />}
               Save
@@ -354,6 +409,85 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
         </div>
       )}
     </div>
+  );
+}
+
+// ── summary ─────────────────────────────────────────────────────────────────
+
+/**
+ * Plain-English restatement of the whole draft. The knobs are interdependent
+ * (a reflex threshold means nothing without its check interval; the gate can
+ * silence a heartbeat entirely), and reading them as isolated numbers is what
+ * made this panel hard to reason about. Recomputed live so it also doubles as
+ * a preview of unsaved edits.
+ */
+function Summary({ draft }: { draft: AwakeningSettings }) {
+  const lines: string[] = [];
+
+  if (draft.kind !== "reflex") lines.push(`Wakes every ${formatDuration(draft.periodMs)} and reviews the whole period.`);
+  if (draft.kind !== "heartbeat") {
+    lines.push(
+      `Wakes when ${draft.reflex.threshold} events pile up, checked every ${formatDuration(draft.reflex.checkIntervalMs)}` +
+        (draft.reflex.minIntervalMs > 0 ? `, never closer than ${formatDuration(draft.reflex.minIntervalMs)} apart.` : "."),
+    );
+  }
+
+  const ch = draft.channels;
+  const scoped = ch.include.length + ch.includePattern.length;
+  lines.push(
+    scoped === 0
+      ? `Watches every channel its bot is in, up to ${ch.maxChannels}.`
+      : `Watches ${scoped} channel rule${scoped === 1 ? "" : "s"}, up to ${ch.maxChannels} channels.` +
+        (ch.excludePattern.length ? ` ${ch.excludePattern.length} exclusion${ch.excludePattern.length === 1 ? "" : "s"} applied last.` : ""),
+  );
+
+  lines.push(
+    draft.gate.minHumanEvents > 0
+      ? `Skips any window with fewer than ${draft.gate.minHumanEvents} human message${draft.gate.minHumanEvents === 1 ? "" : "s"}.`
+      : "Runs on every wake, even an empty window.",
+  );
+  lines.push(`At most ${draft.limits.maxRunsPerHour} run${draft.limits.maxRunsPerHour === 1 ? "" : "s"} per hour.`);
+
+  const live = !draft.shadow;
+  const outcome = draft.shadow
+    ? "Posts nothing — shadow mode records what it would have said."
+    : `${WRITE_POLICY_LABELS[draft.writePolicy].label}: ${WRITE_POLICY_LABELS[draft.writePolicy].hint.toLowerCase()}`;
+
+  return (
+    <div className="rounded-xl border border-xyne-border-subtle bg-xyne-surface-subtle p-4">
+      <div className="text-[11px] font-semibold uppercase tracking-wide text-xyne-fg-tertiary">
+        What this configuration does
+      </div>
+      <ul className="mt-2 flex flex-col gap-1">
+        {lines.map((l) => (
+          <li key={l} className="text-[12px] leading-relaxed text-xyne-fg-secondary">
+            {l}
+          </li>
+        ))}
+        <li
+          className={`mt-1 text-[12px] font-medium leading-relaxed ${
+            live ? "text-xyne-warning-fg" : "text-xyne-success-fg"
+          }`}
+        >
+          {outcome}
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+/** The end-to-end latency of a live update — a number nobody can derive by
+ *  reading the two knobs that produce it, so state it outright. */
+function LatencyNote({ draft }: { draft: AwakeningSettings }) {
+  return (
+    <p className="rounded-lg bg-xyne-surface-sunken px-3 py-2 text-[11px] leading-relaxed text-xyne-fg-tertiary">
+      A live update reaches a running agent roughly{" "}
+      <span className="font-medium text-xyne-fg-secondary">
+        {formatDuration(draft.cursor.replicaSafetyMs + draft.reflex.checkIntervalMs)}
+      </span>{" "}
+      after the events land, once {draft.reflex.injectThreshold} of them have arrived. A run that finishes faster
+      than that will never receive one — its events go to the next wake instead.
+    </p>
   );
 }
 
@@ -369,28 +503,28 @@ function Header({
   onToggle: (v: boolean) => void;
 }) {
   return (
-    <div className="flex items-start justify-between gap-4 rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+    <div className="flex items-start justify-between gap-4 rounded-xl border border-xyne-border bg-xyne-surface p-4">
       <div className="flex gap-3">
-        <PulseIcon size={20} weight="bold" className="mt-0.5 shrink-0 text-indigo-500" />
+        <PulseIcon size={20} weight="bold" className="mt-0.5 shrink-0 text-xyne-brand" />
         <div>
-          <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">Awakening</h3>
-          <p className="mt-1 max-w-prose text-xs leading-relaxed text-neutral-500 dark:text-neutral-400">
+          <h3 className="text-[13px] font-semibold text-xyne-fg-primary">Awakening</h3>
+          <p className="mt-1 max-w-prose text-[12px] leading-relaxed text-xyne-fg-tertiary">
             Let this agent wake up on its own and act on what happened in its channels, without anybody
             triggering it. It reads a collected window of events, decides whether anything needs doing, and
             acts only within the limits set below.
           </p>
         </div>
       </div>
-      <Switch checked={enabled} disabled={!canEdit} onChange={onToggle} />
+      <Switch checked={enabled} disabled={!canEdit} onChange={onToggle} ariaLabel="Enable awakening" />
     </div>
   );
 }
 
 function LiveWarning() {
   return (
-    <div className="flex gap-3 rounded-xl border border-amber-300 bg-amber-50 p-4 dark:border-amber-800/60 dark:bg-amber-950/30">
-      <WarningIcon size={18} weight="fill" className="mt-0.5 shrink-0 text-amber-600" />
-      <p className="text-xs leading-relaxed text-amber-900 dark:text-amber-200">
+    <div className="flex gap-3 rounded-xl border border-xyne-warning-border bg-xyne-warning-bg p-4">
+      <WarningIcon size={18} weight="fill" className="mt-0.5 shrink-0 text-xyne-warning-fg" />
+      <p className="text-[12px] leading-relaxed text-xyne-warning-fg">
         This agent can post to channels and start new threads with nobody reviewing it first. Turn shadow
         mode on and read a few windows before allowing this.
       </p>
@@ -398,77 +532,115 @@ function LiveWarning() {
   );
 }
 
-function Section({ title, hint, children }: { title: string; hint?: string; children: React.ReactNode }) {
+/**
+ * Shown when the agent is enabled in config but the background workers have
+ * switched it off. Re-enabling is a side effect of saving, so the fix is to
+ * clear the underlying cause and press Save — say that plainly.
+ */
+function SystemDisabledNotice({ lastError }: { lastError: string | null }) {
   return (
-    <section className="flex flex-col gap-4">
-      <div>
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
-          {title}
-        </h4>
-        {hint && <p className="mt-1 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
+    <div className="rounded-xl border border-xyne-warning-border bg-xyne-warning-bg p-4">
+      <div className="text-[13px] font-medium text-xyne-warning-fg">
+        Awakening is switched off for this agent
       </div>
-      <div className="flex flex-col gap-4 rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+      <p className="mt-1 text-[12px] text-xyne-warning-fg">
+        It is enabled here, but the background workers stopped it and it is not waking.
+      </p>
+      {lastError && (
+        <p className="mt-2 break-words font-mono text-[11px] text-xyne-warning-fg">{lastError}</p>
+      )}
+      <p className="mt-2 text-[12px] text-xyne-warning-fg">
+        Fix the cause above, then press Save to switch it back on.
+      </p>
+    </div>
+  );
+}
+
+/** One numbered stage of the configuration, in the order the decision is made. */
+function Step({
+  n,
+  title,
+  hint,
+  children,
+}: {
+  n: number;
+  title: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-start gap-2.5">
+        <span className="mt-px flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-xyne-surface-sunken text-[11px] font-semibold text-xyne-fg-secondary">
+          {n}
+        </span>
+        <div>
+          <h4 className="text-[13px] font-semibold text-xyne-fg-primary">{title}</h4>
+          {hint && <p className="mt-0.5 max-w-prose text-[12px] leading-relaxed text-xyne-fg-tertiary">{hint}</p>}
+        </div>
+      </div>
+      <div className="flex flex-col divide-y divide-xyne-border-subtle rounded-xl border border-xyne-border bg-xyne-surface px-4">
         {children}
       </div>
     </section>
   );
 }
 
-function Switch({
-  checked,
-  disabled,
-  onChange,
+/**
+ * A single control row: label (+ hover explainer) on the left, control on the
+ * right. Every knob renders through this, so the rows line up and the panel
+ * reads as a list of decisions rather than a wall of prose.
+ */
+function Row({
+  label,
+  info,
+  note,
+  children,
 }: {
-  checked: boolean;
-  disabled?: boolean;
-  onChange: (v: boolean) => void;
+  label: string;
+  info?: string;
+  note?: string;
+  children: React.ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      disabled={disabled}
-      onClick={() => onChange(!checked)}
-      className={`relative h-6 w-11 shrink-0 rounded-full transition-colors disabled:opacity-50 ${
-        checked ? "bg-indigo-600" : "bg-neutral-300 dark:bg-neutral-700"
-      }`}
-    >
-      <span
-        className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
-          checked ? "translate-x-[22px]" : "translate-x-0.5"
-        }`}
-      />
-    </button>
+    <div className="flex min-h-[52px] items-center justify-between gap-4 py-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[13px] text-xyne-fg-primary">{label}</span>
+          {info && <InfoIcon text={info} />}
+        </div>
+        {note && <p className="mt-0.5 text-[11px] text-xyne-fg-tertiary">{note}</p>}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">{children}</div>
+    </div>
   );
 }
 
-function Toggle({
-  label,
-  hint,
-  checked,
-  disabled,
-  onChange,
-}: {
-  label: string;
-  hint?: string;
-  checked: boolean;
-  disabled?: boolean;
-  onChange: (v: boolean) => void;
-}) {
+/**
+ * Rarely-touched knobs, folded away by default. The defaults for everything in
+ * here are right for almost every agent, and showing them next to the knobs
+ * that actually need a decision is what made the panel feel unconfigurable.
+ */
+function Advanced({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
-        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-      </div>
-      <Switch checked={checked} disabled={disabled} onChange={onChange} />
+    <div className="py-3">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-[12px] text-xyne-fg-tertiary hover:text-xyne-fg-secondary"
+      >
+        <CaretRightIcon size={11} weight="bold" className={`transition-transform ${open ? "rotate-90" : ""}`} />
+        Advanced
+      </button>
+      {open && <div className="mt-1 flex flex-col divide-y divide-xyne-border-subtle">{children}</div>}
     </div>
   );
 }
 
 function Choice<T extends string>({
   label,
+  info,
   value,
   options,
   labels,
@@ -477,6 +649,7 @@ function Choice<T extends string>({
   onChange,
 }: {
   label: string;
+  info?: string;
   value: T;
   options: readonly T[];
   labels: Record<T, { label: string; hint: string }>;
@@ -485,30 +658,31 @@ function Choice<T extends string>({
   onChange: (v: T) => void;
 }) {
   return (
-    <div>
-      <div className="mb-2 flex items-center gap-2 text-sm text-neutral-800 dark:text-neutral-200">
-        {label}
-        {disabledHint && (
-          <span className="flex items-center gap-1 text-xs text-neutral-500">
-            <EyeIcon size={12} /> {disabledHint}
-          </span>
-        )}
+    <div className="py-3">
+      <div className="mb-2 flex items-center gap-1.5">
+        <span className="text-[13px] text-xyne-fg-primary">{label}</span>
+        {info && <InfoIcon text={info} />}
+        {disabledHint && <span className="text-[11px] text-xyne-fg-tertiary">— {disabledHint}</span>}
       </div>
-      <div className="flex flex-col gap-2">
+      {/* Radio cards rather than a <select>: each option carries its own
+          one-line consequence, which is the whole reason this knob is hard to
+          pick blind. */}
+      <div className="flex flex-col gap-1.5">
         {options.map((opt) => (
           <button
             key={opt}
             type="button"
             disabled={disabled}
+            aria-pressed={value === opt}
             onClick={() => onChange(opt)}
-            className={`rounded-lg border p-3 text-left transition-colors disabled:opacity-50 ${
+            className={`rounded-lg border px-3 py-2 text-left transition-colors disabled:opacity-50 ${
               value === opt
-                ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-950/30"
-                : "border-neutral-200 hover:border-neutral-300 dark:border-neutral-800 dark:hover:border-neutral-700"
+                ? "border-xyne-border-focus bg-xyne-surface-subtle"
+                : "border-xyne-border-subtle hover:border-xyne-border-strong"
             }`}
           >
-            <div className="text-sm text-neutral-900 dark:text-neutral-100">{labels[opt].label}</div>
-            <div className="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">{labels[opt].hint}</div>
+            <div className="text-[13px] text-xyne-fg-primary">{labels[opt].label}</div>
+            <div className="mt-0.5 text-[11px] text-xyne-fg-tertiary">{labels[opt].hint}</div>
           </button>
         ))}
       </div>
@@ -518,28 +692,29 @@ function Choice<T extends string>({
 
 function NumberField({
   label,
-  hint,
+  info,
   value,
   bound,
+  unit,
   disabled,
   onChange,
 }: {
   label: string;
-  hint?: string;
+  info?: string;
   value: number;
   bound: { MIN: number; MAX: number; DEFAULT: number };
+  unit?: string;
   disabled?: boolean;
   onChange: (v: number) => void;
 }) {
+  // The range and the default belong in the hover explainer, not as permanent
+  // grey text under every single field — fifteen of those is the noise that
+  // buried the labels that matter.
+  const explain = [info, `Allowed ${bound.MIN}–${bound.MAX}. Default ${bound.DEFAULT}.`]
+    .filter(Boolean)
+    .join(" ");
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
-        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-        <p className="mt-0.5 text-[11px] text-neutral-400">
-          {bound.MIN}–{bound.MAX}
-        </p>
-      </div>
+    <Row label={label} info={explain}>
       <input
         type="number"
         min={bound.MIN}
@@ -550,58 +725,16 @@ function NumberField({
         // the minimum the instant "1" is typed, which fights the user.
         onChange={(e) => onChange(Number(e.target.value))}
         onBlur={(e) => onChange(clampToBound(Number(e.target.value), bound))}
-        className="w-24 shrink-0 rounded-lg border border-neutral-200 px-3 py-1.5 text-sm disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900"
+        className="w-20 rounded-lg border border-xyne-border bg-xyne-surface px-2.5 py-1.5 text-right text-[13px] text-xyne-fg-primary focus:border-xyne-border-focus focus:outline-none disabled:opacity-50"
       />
-    </div>
-  );
-}
-
-/**
- * Multi-line free text with a live character budget. Truncation happens
- * server-side too (resolveAwakeningConfig), so the counter is a courtesy, not
- * the enforcement point.
- */
-function TextAreaField({
-  label,
-  hint,
-  value,
-  max,
-  disabled,
-  onChange,
-}: {
-  label: string;
-  hint?: string;
-  value: string;
-  max: number;
-  disabled?: boolean;
-  onChange: (v: string) => void;
-}) {
-  const over = value.length > max;
-  return (
-    <div className="flex flex-col gap-2">
-      <div>
-        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-      </div>
-      <textarea
-        rows={6}
-        value={value}
-        disabled={disabled}
-        maxLength={max}
-        placeholder="No extra guidance — the agent runs on its contract and skill alone."
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full resize-y rounded-lg border border-neutral-200 px-3 py-2 text-sm leading-relaxed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900"
-      />
-      <p className={`text-[11px] ${over ? "text-red-500" : "text-neutral-400"}`}>
-        {value.length}/{max}
-      </p>
-    </div>
+      {unit && <span className="w-14 text-[11px] text-xyne-fg-tertiary">{unit}</span>}
+    </Row>
   );
 }
 
 function SelectField({
   label,
-  hint,
+  info,
   value,
   options,
   format,
@@ -609,7 +742,7 @@ function SelectField({
   onChange,
 }: {
   label: string;
-  hint?: string;
+  info?: string;
   value: number;
   options: readonly number[];
   format: (v: number) => string;
@@ -620,16 +753,12 @@ function SelectField({
   // changed) must still be visible rather than silently snapping to another.
   const choices = options.includes(value) ? options : [value, ...options].sort((a, b) => a - b);
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
-        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-      </div>
+    <Row label={label} info={info}>
       <select
         value={value}
         disabled={disabled}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="w-32 shrink-0 rounded-lg border border-neutral-200 px-3 py-1.5 text-sm disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900"
+        className="w-[136px] rounded-lg border border-xyne-border bg-xyne-surface px-2.5 py-1.5 text-[13px] text-xyne-fg-primary focus:border-xyne-border-focus focus:outline-none disabled:opacity-50"
       >
         {choices.map((o) => (
           <option key={o} value={o}>
@@ -637,20 +766,66 @@ function SelectField({
           </option>
         ))}
       </select>
+    </Row>
+  );
+}
+
+/**
+ * Multi-line free text with a live character budget. Truncation happens
+ * server-side too (resolveAwakeningConfig), so the counter is a courtesy, not
+ * the enforcement point.
+ */
+function TextAreaField({
+  label,
+  info,
+  value,
+  max,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  info?: string;
+  value: string;
+  max: number;
+  disabled?: boolean;
+  onChange: (v: string) => void;
+}) {
+  const over = value.length > max;
+  return (
+    <div className="flex flex-col gap-2 py-3">
+      <div className="flex items-center gap-1.5">
+        <span className="text-[13px] text-xyne-fg-primary">{label}</span>
+        {info && <InfoIcon text={info} />}
+      </div>
+      <textarea
+        rows={6}
+        value={value}
+        disabled={disabled}
+        maxLength={max}
+        placeholder={
+          "No extra guidance — the agent runs on its contract and skill alone.\n\n" +
+          "Example: Keep it casual and short. Jump in when someone is blocked or asking for a reminder. Stay out of social chatter."
+        }
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full resize-y rounded-lg border border-xyne-border bg-xyne-surface px-3 py-2 text-[13px] leading-relaxed text-xyne-fg-primary placeholder:text-xyne-fg-placeholder focus:border-xyne-border-focus focus:outline-none disabled:opacity-50"
+      />
+      <p className={`text-[11px] ${over ? "text-xyne-error-fg" : "text-xyne-fg-tertiary"}`}>
+        {value.length}/{max}
+      </p>
     </div>
   );
 }
 
 function ListField({
   label,
-  hint,
+  info,
   placeholder,
   values,
   disabled,
   onChange,
 }: {
   label: string;
-  hint?: string;
+  info?: string;
   placeholder: string;
   values: string[];
   disabled?: boolean;
@@ -665,27 +840,38 @@ function ListField({
   };
 
   return (
-    <div>
-      <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-      {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-      <div className="mt-2 flex flex-wrap gap-1.5">
-        {values.map((v) => (
-          <span
-            key={v}
-            className="flex items-center gap-1 rounded-md bg-neutral-100 px-2 py-1 font-mono text-xs dark:bg-neutral-800"
-          >
-            {v}
-            {!disabled && (
-              <button type="button" onClick={() => onChange(values.filter((x) => x !== v))} aria-label={`Remove ${v}`}>
-                <XIcon size={11} />
-              </button>
-            )}
-          </span>
-        ))}
-        {values.length === 0 && <span className="text-xs text-neutral-400">None</span>}
+    <div className="flex flex-col gap-2 py-3">
+      <div className="flex items-center gap-1.5">
+        <span className="text-[13px] text-xyne-fg-primary">{label}</span>
+        {info && <InfoIcon text={info} />}
+        <span className="ml-auto text-[11px] text-xyne-fg-tertiary">
+          {values.length === 0 ? "none" : `${values.length} set`}
+        </span>
       </div>
+      {values.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {values.map((v) => (
+            <span
+              key={v}
+              className="flex items-center gap-1 rounded-md border border-xyne-border-subtle bg-xyne-surface-sunken px-2 py-1 font-mono text-[11px] text-xyne-fg-secondary"
+            >
+              {v}
+              {!disabled && (
+                <button
+                  type="button"
+                  onClick={() => onChange(values.filter((x) => x !== v))}
+                  aria-label={`Remove ${v}`}
+                  className="text-xyne-fg-tertiary hover:text-xyne-fg-primary"
+                >
+                  <XIcon size={11} />
+                </button>
+              )}
+            </span>
+          ))}
+        </div>
+      )}
       {!disabled && (
-        <div className="mt-2 flex gap-2">
+        <div className="flex gap-2">
           <input
             value={entry}
             placeholder={placeholder}
@@ -696,12 +882,13 @@ function ListField({
                 add();
               }
             }}
-            className="flex-1 rounded-lg border border-neutral-200 px-3 py-1.5 font-mono text-xs dark:border-neutral-800 dark:bg-neutral-900"
+            className="min-w-0 flex-1 rounded-lg border border-xyne-border bg-xyne-surface px-3 py-1.5 font-mono text-[11px] text-xyne-fg-primary placeholder:text-xyne-fg-placeholder focus:border-xyne-border-focus focus:outline-none"
           />
           <button
             type="button"
             onClick={add}
-            className="rounded-lg border border-neutral-200 px-3 py-1.5 text-xs hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-800"
+            disabled={!entry.trim()}
+            className="shrink-0 rounded-lg border border-xyne-border px-3 py-1.5 text-[12px] text-xyne-fg-secondary hover:bg-xyne-surface-subtle disabled:opacity-40"
           >
             Add
           </button>

--- a/apps/xyne-claw-auth/frontend/src/v3/lib/awakeningBounds.ts
+++ b/apps/xyne-claw-auth/frontend/src/v3/lib/awakeningBounds.ts
@@ -43,7 +43,7 @@ export const AWAKENING_BOUNDS = {
   injectThreshold: { MIN: 1, MAX: 1_000, DEFAULT: 10 },
   maxInjectionsPerSession: { MIN: 0, MAX: 20, DEFAULT: 3 },
   injectMinIntervalMs: { MIN: 0, MAX: 3_600_000, DEFAULT: 60_000 },
-  instructionsLength: { MIN: 0, MAX: 4_000, DEFAULT: 0 },
+  instructionsLength: { MIN: 0, MAX: 10_000, DEFAULT: 0 },
   replicaSafetyMs: { MIN: 0, MAX: 300_000, DEFAULT: 30_000 },
 } as const;
 

--- a/apps/xyne-claw-auth/frontend/src/v3/lib/awakeningBounds.ts
+++ b/apps/xyne-claw-auth/frontend/src/v3/lib/awakeningBounds.ts
@@ -1,0 +1,226 @@
+/**
+ * awakeningBounds — the knobs that govern an "awakened" agent, one that wakes
+ * and acts without anybody triggering it.
+ *
+ * SINGLE SOURCE OF TRUTH for the CLIENT. Keep in sync with the runtime
+ * authority in xyne-claw-auth/backend/src/awakening/config.ts
+ * (AWAKENING_BOUNDS + resolveAwakeningConfig) and the API-layer validator in
+ * lib/agent-config-validation.ts (validateAwakeningConfig).
+ *
+ * The server re-clamps everything it is sent and rejects out-of-range values
+ * with a 400, so these constants only shape what the editor offers — the UI
+ * can never widen a real bound.
+ */
+
+export const AWAKENING_KINDS = ["heartbeat", "reflex", "both"] as const;
+export type AwakeningKindValue = (typeof AWAKENING_KINDS)[number];
+
+export const WRITE_POLICIES = ["observe", "reply", "act"] as const;
+export type WritePolicyValue = (typeof WRITE_POLICIES)[number];
+
+export const KIND_LABELS: Record<AwakeningKindValue, { label: string; hint: string }> = {
+  heartbeat: { label: "Heartbeat only", hint: "Wakes on a timer and reviews the whole period." },
+  reflex: { label: "Reflex only", hint: "Wakes when enough activity piles up. Fast and shallow." },
+  both: { label: "Heartbeat + reflex", hint: "Reacts quickly, and reviews the period on a timer." },
+};
+
+export const WRITE_POLICY_LABELS: Record<WritePolicyValue, { label: string; hint: string }> = {
+  observe: { label: "Observe", hint: "Reads and reasons. Posts nothing at all." },
+  reply: { label: "Reply in threads", hint: "May reply where a conversation is already happening." },
+  act: { label: "Act", hint: "May also start new threads in the channel." },
+};
+
+export const AWAKENING_BOUNDS = {
+  periodMs: { MIN: 5 * 60_000, MAX: 24 * 60 * 60_000, DEFAULT: 30 * 60_000 },
+  maxChannels: { MIN: 1, MAX: 100, DEFAULT: 25 },
+  minHumanEvents: { MIN: 0, MAX: 1_000, DEFAULT: 1 },
+  forceRunEveryNSkips: { MIN: 0, MAX: 100, DEFAULT: 0 },
+  maxEvents: { MIN: 10, MAX: 5_000, DEFAULT: 1_500 },
+  maxRunsPerHour: { MIN: 1, MAX: 60, DEFAULT: 4 },
+  reflexCheckIntervalMs: { MIN: 15_000, MAX: 3_600_000, DEFAULT: 60_000 },
+  reflexThreshold: { MIN: 1, MAX: 1_000, DEFAULT: 25 },
+  reflexMinIntervalMs: { MIN: 0, MAX: 24 * 60 * 60_000, DEFAULT: 300_000 },
+  injectThreshold: { MIN: 1, MAX: 1_000, DEFAULT: 10 },
+  maxInjectionsPerSession: { MIN: 0, MAX: 20, DEFAULT: 3 },
+  injectMinIntervalMs: { MIN: 0, MAX: 3_600_000, DEFAULT: 60_000 },
+  instructionsLength: { MIN: 0, MAX: 4_000, DEFAULT: 0 },
+  replicaSafetyMs: { MIN: 0, MAX: 300_000, DEFAULT: 30_000 },
+} as const;
+
+/** Discrete choices offered for duration knobs, in milliseconds. */
+export const PERIOD_OPTIONS: readonly number[] = [
+  5 * 60_000, 10 * 60_000, 15 * 60_000, 30 * 60_000, 60 * 60_000, 2 * 60 * 60_000,
+  4 * 60 * 60_000, 8 * 60 * 60_000, 24 * 60 * 60_000,
+];
+
+export const REFLEX_CHECK_OPTIONS: readonly number[] = [
+  15_000, 30_000, 60_000, 120_000, 300_000, 600_000,
+];
+
+export const REFLEX_MIN_INTERVAL_OPTIONS: readonly number[] = [
+  0, 60_000, 300_000, 600_000, 1_800_000, 3_600_000,
+];
+
+export const INJECT_MIN_INTERVAL_OPTIONS: readonly number[] = [0, 30_000, 60_000, 300_000, 600_000];
+
+/**
+ * Replica safety margin. 0 is offered because a single-writer / no-replica
+ * Spaces has nothing to lag behind, and it is the only way to make live updates
+ * reach a short run — but it is not the default, because on a replicated
+ * deployment it silently drops events that had not replicated when the window
+ * sealed.
+ */
+export const REPLICA_SAFETY_OPTIONS: readonly number[] = [0, 5_000, 10_000, 30_000, 60_000, 120_000];
+
+type Bound = { MIN: number; MAX: number; DEFAULT: number };
+
+export function clampToBound(raw: unknown, bound: Bound): number {
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return bound.DEFAULT;
+  return Math.min(bound.MAX, Math.max(bound.MIN, Math.floor(raw)));
+}
+
+/** Human label for a millisecond duration, e.g. "30m", "2h", "45s". */
+export function formatDuration(ms: number): string {
+  if (ms === 0) return "no minimum";
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  const mins = Math.round(ms / 60_000);
+  if (mins < 60) return `${mins}m`;
+  const hours = mins / 60;
+  return Number.isInteger(hours) ? `${hours}h` : `${(mins / 60).toFixed(1)}h`;
+}
+
+export interface AwakeningSettings {
+  enabled: boolean;
+  kind: AwakeningKindValue;
+  shadow: boolean;
+  writePolicy: WritePolicyValue;
+  /** Free-text guidance appended to every awakened run's operating contract. */
+  instructions: string;
+  periodMs: number;
+  channels: {
+    include: string[];
+    includePattern: string[];
+    exclude: string[];
+    excludePattern: string[];
+    maxChannels: number;
+  };
+  gate: { minHumanEvents: number; forceRunEveryNSkips: number };
+  limits: { maxEvents: number; maxRunsPerHour: number };
+  cursor: { replicaSafetyMs: number };
+  reflex: {
+    checkIntervalMs: number;
+    threshold: number;
+    minIntervalMs: number;
+    injectEnabled: boolean;
+    injectThreshold: number;
+    maxInjectionsPerSession: number;
+    injectMinIntervalMs: number;
+  };
+}
+
+export const AWAKENING_DEFAULTS: AwakeningSettings = {
+  // Off, shadowed and thread-only: a newly awakened agent must not be able to
+  // post to a channel before a human has looked at what it would have said.
+  enabled: false,
+  kind: "heartbeat",
+  shadow: true,
+  writePolicy: "reply",
+  instructions: "",
+  periodMs: AWAKENING_BOUNDS.periodMs.DEFAULT,
+  channels: {
+    include: [],
+    includePattern: [],
+    exclude: [],
+    excludePattern: [],
+    maxChannels: AWAKENING_BOUNDS.maxChannels.DEFAULT,
+  },
+  gate: {
+    minHumanEvents: AWAKENING_BOUNDS.minHumanEvents.DEFAULT,
+    forceRunEveryNSkips: AWAKENING_BOUNDS.forceRunEveryNSkips.DEFAULT,
+  },
+  limits: {
+    maxEvents: AWAKENING_BOUNDS.maxEvents.DEFAULT,
+    maxRunsPerHour: AWAKENING_BOUNDS.maxRunsPerHour.DEFAULT,
+  },
+  cursor: { replicaSafetyMs: AWAKENING_BOUNDS.replicaSafetyMs.DEFAULT },
+  reflex: {
+    checkIntervalMs: AWAKENING_BOUNDS.reflexCheckIntervalMs.DEFAULT,
+    threshold: AWAKENING_BOUNDS.reflexThreshold.DEFAULT,
+    minIntervalMs: AWAKENING_BOUNDS.reflexMinIntervalMs.DEFAULT,
+    injectEnabled: true,
+    injectThreshold: AWAKENING_BOUNDS.injectThreshold.DEFAULT,
+    maxInjectionsPerSession: AWAKENING_BOUNDS.maxInjectionsPerSession.DEFAULT,
+    injectMinIntervalMs: AWAKENING_BOUNDS.injectMinIntervalMs.DEFAULT,
+  },
+};
+
+function stringArray(raw: unknown): string[] {
+  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === "string" && v.trim().length > 0) : [];
+}
+
+function pick<T extends string>(raw: unknown, allowed: readonly T[], fallback: T): T {
+  return typeof raw === "string" && (allowed as readonly string[]).includes(raw) ? (raw as T) : fallback;
+}
+
+/** Read the awakening block out of an agent config, filling every gap with a default. */
+export function readAwakening(config: Record<string, unknown> | undefined): AwakeningSettings {
+  const raw = config?.["awakening"] as Record<string, unknown> | undefined;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return structuredClone(AWAKENING_DEFAULTS);
+
+  const ch = (raw["channels"] ?? {}) as Record<string, unknown>;
+  const gate = (raw["gate"] ?? {}) as Record<string, unknown>;
+  const limits = (raw["limits"] ?? {}) as Record<string, unknown>;
+  const reflex = (raw["reflex"] ?? {}) as Record<string, unknown>;
+  const cursor = (raw["cursor"] ?? {}) as Record<string, unknown>;
+  const D = AWAKENING_DEFAULTS;
+
+  return {
+    enabled: typeof raw["enabled"] === "boolean" ? raw["enabled"] : D.enabled,
+    kind: pick(raw["kind"], AWAKENING_KINDS, D.kind),
+    shadow: typeof raw["shadow"] === "boolean" ? raw["shadow"] : D.shadow,
+    writePolicy: pick(raw["writePolicy"], WRITE_POLICIES, D.writePolicy),
+    instructions:
+      typeof raw["instructions"] === "string"
+        ? raw["instructions"].slice(0, AWAKENING_BOUNDS.instructionsLength.MAX)
+        : D.instructions,
+    periodMs: clampToBound(raw["periodMs"], AWAKENING_BOUNDS.periodMs),
+    channels: {
+      include: stringArray(ch["include"]),
+      includePattern: stringArray(ch["includePattern"]),
+      exclude: stringArray(ch["exclude"]),
+      excludePattern: stringArray(ch["excludePattern"]),
+      maxChannels: clampToBound(ch["maxChannels"], AWAKENING_BOUNDS.maxChannels),
+    },
+    gate: {
+      minHumanEvents: clampToBound(gate["minHumanEvents"], AWAKENING_BOUNDS.minHumanEvents),
+      forceRunEveryNSkips: clampToBound(gate["forceRunEveryNSkips"], AWAKENING_BOUNDS.forceRunEveryNSkips),
+    },
+    limits: {
+      maxEvents: clampToBound(limits["maxEvents"], AWAKENING_BOUNDS.maxEvents),
+      maxRunsPerHour: clampToBound(limits["maxRunsPerHour"], AWAKENING_BOUNDS.maxRunsPerHour),
+    },
+    cursor: { replicaSafetyMs: clampToBound(cursor["replicaSafetyMs"], AWAKENING_BOUNDS.replicaSafetyMs) },
+    reflex: {
+      checkIntervalMs: clampToBound(reflex["checkIntervalMs"], AWAKENING_BOUNDS.reflexCheckIntervalMs),
+      threshold: clampToBound(reflex["threshold"], AWAKENING_BOUNDS.reflexThreshold),
+      minIntervalMs: clampToBound(reflex["minIntervalMs"], AWAKENING_BOUNDS.reflexMinIntervalMs),
+      injectEnabled: typeof reflex["injectEnabled"] === "boolean" ? reflex["injectEnabled"] : D.reflex.injectEnabled,
+      injectThreshold: clampToBound(reflex["injectThreshold"], AWAKENING_BOUNDS.injectThreshold),
+      maxInjectionsPerSession: clampToBound(
+        reflex["maxInjectionsPerSession"],
+        AWAKENING_BOUNDS.maxInjectionsPerSession,
+      ),
+      injectMinIntervalMs: clampToBound(reflex["injectMinIntervalMs"], AWAKENING_BOUNDS.injectMinIntervalMs),
+    },
+  };
+}
+
+/** One-line status for the dashboard card. */
+export function summarize(s: AwakeningSettings): string {
+  if (!s.enabled) return "Off";
+  const parts: string[] = [];
+  if (s.kind !== "reflex") parts.push(`every ${formatDuration(s.periodMs)}`);
+  if (s.kind !== "heartbeat") parts.push(`reflex at ${s.reflex.threshold} events`);
+  parts.push(s.shadow ? "shadow" : WRITE_POLICY_LABELS[s.writePolicy].label.toLowerCase());
+  return parts.join(" · ");
+}

--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -48,6 +48,7 @@ import { writeSessionSkills, deleteSessionSkills } from "./session-skills.js";
 import { installLlmCallMetrics } from "./llm-call-metrics.js";
 import { installFastMode, isAdaptiveThinkingClaudeModel, type ModelSpeed } from "./model-speed.js";
 import { installToolBudget } from "./tool-budget.js";
+import { installAwakeningInbox } from "./awakening-inbox.js";
 import type { FastToolRuntimeController } from "./tool-catalog.js";
 
 const log = createLogger("agent");
@@ -1780,6 +1781,14 @@ export interface RunTaskOptions {
     isRequested: () => boolean;
     registerSummaryRequest: (requestSummary: () => Promise<boolean>) => void;
   } | undefined;
+  /** Awakened run (heartbeat / reflex). Presence enables live event injection
+   *  and tells the run it was not triggered by a human. */
+  awakening?: {
+    kind: string;
+    writePolicy: string;
+    shadow: boolean;
+    injectEnabled?: boolean;
+  } | undefined;
 }
 
 const FAST_MODE_ACTIVE_TOOLS_CUSTOM_TYPE = "xyne.fastMode.activeToolSet";
@@ -1847,6 +1856,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     resumedFromHandoff,
     handoff,
     gracefulInterrupt,
+    awakening,
   } = opts;
   let lastHandoffTurn = 0;
   const recordHandoffBoundary = (turn: number): void => {
@@ -2340,6 +2350,13 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
   const toolBudget = installToolBudget(session.agent, {
     sessionId: sessionId ?? conversationId ?? "unknown",
   });
+
+  // Awakened runs pull new events in at turn boundaries so the agent can adapt
+  // mid-task. Installed after the tool budget so both hooks chain (each wraps
+  // the previous beforeToolCall rather than replacing it).
+  if (awakening?.injectEnabled && sessionId) {
+    installAwakeningInbox(session.agent, { sessionId });
+  }
 
   // verifyResponses: wire the submit-response tool's evidence accessor to the
   // live transcript. Set BEFORE any prompt so the tool — which verifies inside

--- a/apps/xyne-claw/src/awakening-inbox.ts
+++ b/apps/xyne-claw/src/awakening-inbox.ts
@@ -1,0 +1,166 @@
+/**
+ * Live event injection for awakened runs — the claw side.
+ *
+ * While an awakened agent is working, new events keep arriving in the channels
+ * it watches. Once enough pile up, claw-auth queues them; this module pulls
+ * them into the running session so the agent adapts mid-task instead of
+ * finishing on stale input.
+ *
+ * WHY PULL, NOT PUSH. claw is horizontally scaled and a session lives in ONE
+ * pod's memory (`activeRuns` is an in-process Map), so an inbound push would
+ * have to be routed to that exact pod — pod discovery that breaks whenever the
+ * fleet scales. Pull costs nothing to avoid it, because the SDK delivers a
+ * steering message only "after the current assistant turn finishes executing
+ * its tool calls" (pi-agent-core types.d.ts). A pushed steer and a pulled steer
+ * therefore arrive at the SAME instant — the next turn boundary. Identical
+ * latency, no routing, and the pod that owns the run is the one asking.
+ *
+ * The poll rides `beforeToolCall`, the same hook installToolBudget uses to
+ * steer convergence nudges (see tool-budget.ts) — a proven in-production
+ * pattern rather than new machinery on the turn loop.
+ */
+
+import type { AgentMessage, BeforeToolCallContext, BeforeToolCallResult } from "@earendil-works/pi-agent-core";
+import { SERVER } from "./config.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("awakening-inbox");
+
+type BeforeToolCall = (
+  context: BeforeToolCallContext,
+  signal?: AbortSignal,
+) => Promise<BeforeToolCallResult | undefined>;
+
+type InjectableAgent = {
+  beforeToolCall?: BeforeToolCall;
+  steer(message: AgentMessage): void;
+};
+
+interface InboxBatch {
+  ordinal: number;
+  eventCount: number;
+  text: string;
+  isFinal: boolean;
+}
+
+export interface AwakeningInboxOptions {
+  sessionId: string;
+  /** Floor between polls, so a tool-heavy turn does not hammer claw-auth. */
+  pollIntervalMs?: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = Number(process.env["AWAKENING_INBOX_POLL_MS"] ?? 20_000);
+const DRAIN_TIMEOUT_MS = Number(process.env["AWAKENING_INBOX_TIMEOUT_MS"] ?? 5_000);
+
+/**
+ * Wrap injected text so the model can tell it apart from its own task input.
+ * Mirrors the `<system>` convention tool-budget.ts already uses for steering.
+ */
+function asInjectionMessage(text: string): AgentMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text: `<system>${text}</system>` }],
+    timestamp: Date.now(),
+  };
+}
+
+async function drain(sessionId: string): Promise<InboxBatch[]> {
+  if (!SERVER.s2sKey) return [];
+  const base = SERVER.authServiceUrl.replace(/\/$/, "");
+  const url = `${base}/claw/api/v1/awakening/inbox/${encodeURIComponent(sessionId)}/drain`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-s2s-key": SERVER.s2sKey },
+    signal: AbortSignal.timeout(DRAIN_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`drain returned HTTP ${res.status}`);
+
+  const body = (await res.json()) as { success?: boolean; batches?: InboxBatch[] };
+  return Array.isArray(body.batches) ? body.batches : [];
+}
+
+export interface AwakeningInboxTracker {
+  readonly injected: number;
+  /**
+   * Force a poll now. Nothing calls this on the normal path: a steer is only
+   * consumed at a turn boundary, and the last turn boundary a run has is the
+   * one that precedes its final tool call — which the hook below already
+   * covers. Kept for callers that drive the session themselves.
+   */
+  poll: () => Promise<number>;
+}
+
+/**
+ * Install the poller on an awakened run.
+ *
+ * FAIL-OPEN throughout: a failed drain is logged and the run continues. Live
+ * injection is an enhancement, and a Redis or claw-auth blip must never be able
+ * to break a run that is otherwise working. Undelivered events are not lost:
+ * claw-auth's result callback rolls its reflex watermark back over any batch
+ * this run was handed but never drained, so the next check re-counts them.
+ */
+export function installAwakeningInbox(
+  agent: InjectableAgent,
+  opts: AwakeningInboxOptions,
+): AwakeningInboxTracker {
+  const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const baseBeforeToolCall = agent.beforeToolCall;
+  const seen = new Set<number>();
+  let injected = 0;
+  let lastPollMs = 0;
+  let inFlight: Promise<number> | null = null;
+
+  const pollOnce = async (): Promise<number> => {
+    lastPollMs = Date.now();
+    let batches: InboxBatch[];
+    try {
+      batches = await drain(opts.sessionId);
+    } catch (err) {
+      log.warn(
+        `[awakening] inbox drain failed session=${opts.sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 0;
+    }
+
+    let delivered = 0;
+    for (const batch of batches) {
+      // The drain is destructive, so a duplicate ordinal means a retry
+      // re-delivered something already steered in. Steering it twice would
+      // read to the model as two separate bursts of the same events.
+      if (seen.has(batch.ordinal)) continue;
+      seen.add(batch.ordinal);
+      try {
+        agent.steer(asInjectionMessage(batch.text));
+        injected++;
+        delivered++;
+        log.info(
+          `[awakening] injected batch=${batch.ordinal} events=${batch.eventCount} session=${opts.sessionId}${batch.isFinal ? " (final)" : ""}`,
+        );
+      } catch (err) {
+        log.warn(`[awakening] steer failed session=${opts.sessionId}: ${err instanceof Error ? err.message : err}`);
+      }
+    }
+    return delivered;
+  };
+
+  agent.beforeToolCall = async (context, signal) => {
+    if (Date.now() - lastPollMs >= pollIntervalMs && !inFlight) {
+      // Deliberately NOT awaited: a tool call must not wait on the inbox. The
+      // steered message lands at the next turn boundary either way, which is
+      // the earliest the SDK would deliver it even if we blocked here.
+      inFlight = pollOnce().finally(() => {
+        inFlight = null;
+      });
+      inFlight.catch(() => undefined);
+    }
+    return await baseBeforeToolCall?.(context, signal);
+  };
+
+  return {
+    get injected() {
+      return injected;
+    },
+    poll: pollOnce,
+  };
+}

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -468,6 +468,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
     mode,
     experiment: rawExperiment,
     planContinuation,
+    awakening,
     generateFollowUpSuggestions: shouldGenerateFollowUpSuggestions,
   } = req.body as {
     userId?: string;
@@ -529,6 +530,16 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
     attachments?: Array<{ fileName: string; mimeType: string; data: string }>;
     recordingRefs?: Array<{ attachmentId: string; fileName: string; mimeType: string; fileSize: number }>;
     contextFiles?: Array<{ path: string; content: string }>;
+    /** Set by claw-auth's awakening dispatcher for an unattended run. */
+    awakening?: {
+      kind: string;
+      writePolicy: string;
+      shadow: boolean;
+      injectEnabled?: boolean;
+      windowStartMs?: number;
+      windowEndMs?: number;
+      entryPath?: string;
+    };
     additionalInstructions?: string;
     researchContext?: {
       type: string;
@@ -852,6 +863,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
       planContinuation,
       shouldGenerateFollowUpSuggestions,
       typeof callbackUrl === "string" ? callbackUrl : undefined,
+      awakening,
     ).finally(() => {
       if (activeRun.handoffCapTimer) clearTimeout(activeRun.handoffCapTimer);
       if (activeRun.gracefulInterruptSummaryTimer) clearTimeout(activeRun.gracefulInterruptSummaryTimer);
@@ -978,6 +990,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
         planContinuation,
         shouldGenerateFollowUpSuggestions,
         typeof callbackUrl === "string" ? callbackUrl : undefined,
+        awakening,
       );
     } catch (err) {
       processTaskError = err;
@@ -1081,6 +1094,7 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
     planContinuation,
     shouldGenerateFollowUpSuggestions,
     typeof callbackUrl === "string" ? callbackUrl : undefined,
+    awakening,
   ).finally(() => {
     if (activeRun.handoffCapTimer) clearTimeout(activeRun.handoffCapTimer);
     if (activeRun.gracefulInterruptSummaryTimer) clearTimeout(activeRun.gracefulInterruptSummaryTimer);
@@ -1532,6 +1546,16 @@ async function processTask(
   planContinuation?: boolean,
   shouldGenerateFollowUpSuggestions?: boolean,
   lateFollowUpCallbackUrl?: string,
+  /** Present when claw-auth woke this agent on its own (heartbeat / reflex). */
+  awakening?: {
+    kind: string;
+    writePolicy: string;
+    shadow: boolean;
+    injectEnabled?: boolean;
+    windowStartMs?: number;
+    windowEndMs?: number;
+    entryPath?: string;
+  },
 ): Promise<void> {
   // Query prefetch (opt-in, `agentConfig.prefetchContext`). Fired at the TOP of
   // the run so the fast-model extractor overlaps the expensive setup that
@@ -4037,6 +4061,16 @@ async function processTask(
             if (active) active.requestGracefulInterruptSummary = requestSummary;
           },
         },
+        ...(awakening
+          ? {
+              awakening: {
+                kind: awakening.kind,
+                writePolicy: awakening.writePolicy,
+                shadow: awakening.shadow,
+                ...(awakening.injectEnabled !== undefined ? { injectEnabled: awakening.injectEnabled } : {}),
+              },
+            }
+          : {}),
       });
 
     // Capture provider-fallback context so an empty FINAL result can tell the


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
