### PR TITLE
fix: workspace resolution + ui + metrics for awakening

### DIFF
--- a/apps/xyne-claw-auth/backend/src/awakening/config.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/config.ts
@@ -140,7 +140,7 @@ export const AWAKENING_BOUNDS = {
   injectMinIntervalMs: { min: 0, max: 3_600_000, default: 60_000 },
   /** Cap on owner-written run guidance — long enough for real direction,
    *  short enough that it cannot crowd out the window itself. */
-  instructionsLength: { max: 4_000 },
+  instructionsLength: { max: 10_000 },
   /** Guards against a pathological or hostile channel-name pattern. */
   patternLength: { max: 200 },
   patternCount: { max: 10 },

--- a/apps/xyne-claw-auth/backend/src/awakening/workspace.ts
+++ b/apps/xyne-claw-auth/backend/src/awakening/workspace.ts
@@ -2,16 +2,31 @@
  * Resolves which Spaces workspace an awakened agent reads and acts in.
  *
  * Every Spaces query is tenant-scoped, so a wrong or empty workspaceId either
- * fails the ACL check or — worse — reads the wrong tenant. The mapping lives
- * in SurfaceTenantLink (orgId ↔ Spaces workspaceId).
+ * fails the ACL check or — worse — reads the wrong tenant.
  *
- * An org with exactly one linked workspace resolves automatically, which is
- * the common case. An org with several MUST pin one in
- * `config.awakening.workspaceId`: guessing between tenants is exactly the
- * mistake that must never happen silently, so this throws instead.
+ * The authoritative answer is the AGENT'S OWN BOT USER. Spaces stores
+ * `workspaceId` on every user row, and an agent's bot is a user like any other,
+ * so "which workspace is this agent in?" has exactly one answer and needs no
+ * configuration. That also makes a multi-workspace org a non-problem: the bot
+ * is in one of them, and that is the one it can act in.
+ *
+ * This used to read ONLY the org→workspace map in SurfaceTenantLink, which was
+ * wrong twice over. Nothing in the product ever writes that table for Spaces
+ * (the sole writer is prisma/seed.ts, for local dev), so it is empty in
+ * production and awakening was the only consumer that treated it as required —
+ * it disabled two live agents in prod on 2026-08-26 for an org that had simply
+ * never been seeded. And every other consumer already resolves the right way:
+ * credentials-loader.ts does bot-user-first for the app-tools MCP.
+ *
+ * SurfaceTenantLink survives as a FALLBACK for an agent whose bot user cannot
+ * be read (Spaces DB unreachable, or a bot row that predates the column).
  */
 
+import { getWorkspaceIdForUser } from "../lib/spaces-db.js";
 import { prisma } from "../db.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("awakening-workspace");
 
 export class WorkspaceResolutionError extends Error {
   constructor(message: string) {
@@ -20,16 +35,34 @@ export class WorkspaceResolutionError extends Error {
   }
 }
 
-export async function resolveWorkspaceId(orgId: string, configured?: string): Promise<string> {
+async function orgLinks(orgId: string): Promise<string[]> {
   const links = await prisma.surfaceTenantLink.findMany({
     where: { orgId, surfaceType: "spaces" },
     select: { surfaceTenantId: true },
     orderBy: { createdAt: "asc" },
   });
+  return links.map((l) => l.surfaceTenantId);
+}
+
+export async function resolveWorkspaceId(
+  orgId: string,
+  spacesAppUserId: string | null | undefined,
+  configured?: string,
+): Promise<string> {
+  const botWorkspaceId = spacesAppUserId
+    ? await getWorkspaceIdForUser(spacesAppUserId, "awakening").catch(() => null)
+    : null;
 
   if (configured) {
-    const known = links.some((l) => l.surfaceTenantId === configured);
-    if (!known) {
+    // An explicit pin must not be able to aim an agent at a tenant its bot is
+    // not in — it could not read there anyway, and silently trying is exactly
+    // the cross-tenant mistake this function exists to prevent.
+    if (botWorkspaceId && configured !== botWorkspaceId) {
+      throw new WorkspaceResolutionError(
+        `configured workspaceId "${configured}" is not the workspace this agent's bot belongs to ("${botWorkspaceId}")`,
+      );
+    }
+    if (!botWorkspaceId && !(await orgLinks(orgId)).includes(configured)) {
       throw new WorkspaceResolutionError(
         `configured workspaceId "${configured}" is not linked to this org`,
       );
@@ -37,14 +70,22 @@ export async function resolveWorkspaceId(orgId: string, configured?: string): Pr
     return configured;
   }
 
-  const first = links[0]?.surfaceTenantId;
-  if (links.length === 0 || !first) {
-    throw new WorkspaceResolutionError("no Spaces workspace is linked to this org");
+  if (botWorkspaceId) return botWorkspaceId;
+
+  const links = await orgLinks(orgId);
+  const first = links[0];
+  if (!first) {
+    throw new WorkspaceResolutionError(
+      "cannot determine this agent's Spaces workspace: its bot user has no workspace in Spaces " +
+      "and no Spaces workspace is linked to this org",
+    );
   }
   if (links.length > 1) {
     throw new WorkspaceResolutionError(
-      `org has ${links.length} linked Spaces workspaces; set config.awakening.workspaceId to pick one`,
+      `org has ${links.length} linked Spaces workspaces and the agent's bot user could not be read; ` +
+      "set config.awakening.workspaceId to pick one",
     );
   }
+  log.info(`[awakening] workspace resolved from org link (bot user unreadable) orgId=${orgId} workspaceId=${first}`);
   return first;
 }

--- a/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-config-validation.ts
@@ -215,7 +215,7 @@ const AWAKENING_MIN_PERIOD_MS = 5 * 60_000;
 // Mirrors AWAKENING_BOUNDS.instructionsLength.max — resolveAwakeningConfig
 // truncates silently, so the API rejects loudly instead of saving something
 // the runtime would quietly cut in half.
-const AWAKENING_MAX_INSTRUCTIONS = 4_000;
+const AWAKENING_MAX_INSTRUCTIONS = 10_000;
 const AWAKENING_MAX_PERIOD_MS = 24 * 60 * 60_000;
 const AWAKENING_MAX_PATTERNS = 10;
 const AWAKENING_MAX_PATTERN_LEN = 200;

--- a/apps/xyne-claw-auth/backend/src/queue/awakening-reflex-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/awakening-reflex-worker.ts
@@ -72,7 +72,7 @@ async function processReflex(job: Job<AwakeningReflexJobData>): Promise<void> {
   if (!config.enabled || !participatesIn(config, "reflex")) return;
 
   try {
-    const workspaceId = await resolveWorkspaceId(orgId, config.workspaceId);
+    const workspaceId = await resolveWorkspaceId(orgId, agent.spacesAppUserId, config.workspaceId);
     const identity = resolveAgentIdentity(agent, workspaceId);
 
     const sinceMs = (state.reflexWatermarkAt ?? state.watermarkAt).getTime();
@@ -199,6 +199,9 @@ async function processReflex(job: Job<AwakeningReflexJobData>): Promise<void> {
           reflexWatermarkAt: new Date(untilMs),
           reflexLastRunAt: new Date(),
           reflexNextCheckAt: nextCheckAt(config.reflex.checkIntervalMs),
+          // The heartbeat path clears this via markSuccess; a reflex-only agent
+          // has no such path, so a resolved error would otherwise stick forever.
+          lastError: null,
         },
       });
     } catch (err) {
@@ -206,10 +209,18 @@ async function processReflex(job: Job<AwakeningReflexJobData>): Promise<void> {
       throw err;
     }
   } catch (err) {
-    if (err instanceof AwakeningIdentityError || err instanceof WorkspaceResolutionError) {
+    // Fail-closed on identity (see the window worker), retry on workspace.
+    if (err instanceof AwakeningIdentityError) {
       await prisma.agentAwakeningState
         .update({ where: { agentId }, data: { enabled: false, lastError: String(err.message).slice(0, 500) } })
         .catch(() => undefined);
+      return;
+    }
+    if (err instanceof WorkspaceResolutionError) {
+      await prisma.agentAwakeningState
+        .update({ where: { agentId }, data: { lastError: String(err.message).slice(0, 500) } })
+        .catch(() => undefined);
+      log.warn(`[awakening] reflex skipped agent=${agent.slug} (workspace unresolved): ${err.message}`);
       return;
     }
     log.error(`[awakening] reflex check failed agent=${agent.slug}: ${err instanceof Error ? err.message : err}`);

--- a/apps/xyne-claw-auth/backend/src/queue/awakening-window-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/awakening-window-worker.ts
@@ -140,7 +140,7 @@ async function processWindow(job: Job<AwakeningWindowJobData>): Promise<void> {
   };
 
   try {
-    const workspaceId = await resolveWorkspaceId(orgId, config.workspaceId);
+    const workspaceId = await resolveWorkspaceId(orgId, agent.spacesAppUserId, config.workspaceId);
     const identity = resolveAgentIdentity(agent, workspaceId);
 
     const rate = await peekRunRate(agentId, config.limits.maxRunsPerHour);
@@ -225,13 +225,26 @@ async function processWindow(job: Job<AwakeningWindowJobData>): Promise<void> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
 
-    // A broken identity is a CONFIG problem, not a transient one. Retrying it
-    // every beat just burns the queue; disable and surface it to the admin.
-    if (err instanceof AwakeningIdentityError || err instanceof WorkspaceResolutionError) {
+    // A broken identity is a CONFIG problem AND unfixable by waiting: an agent
+    // with no bot identity must never fall back to a user token, so it stops.
+    if (err instanceof AwakeningIdentityError) {
       await prisma.agentAwakeningState
         .update({ where: { agentId }, data: { enabled: false, lastError: message.slice(0, 500) } })
         .catch(() => undefined);
       log.error(`[awakening] disabled agent=${agent.slug}: ${message}`);
+      return;
+    }
+
+    // A workspace that will not resolve is an operator-fixable gap — a bot user
+    // not yet mirrored into Spaces, a Spaces DB blip, a tenant link nobody
+    // seeded. Record it so the admin can SEE it, but stay enabled and try again
+    // on the normal cadence: disabling here meant a five-minute fix needed a
+    // human to notice and re-save the agent (prod, 2026-08-26).
+    if (err instanceof WorkspaceResolutionError) {
+      await prisma.agentAwakeningState
+        .update({ where: { agentId }, data: { lastError: message.slice(0, 500) } })
+        .catch(() => undefined);
+      log.warn(`[awakening] window skipped agent=${agent.slug} (workspace unresolved): ${message}`);
       return;
     }
 

--- a/apps/xyne-claw-auth/backend/src/routes/metrics.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/metrics.ts
@@ -1184,3 +1184,251 @@ metricsRouter.post("/improvements/backfill", async (req: Request, res: Response)
     res.status(500).json({ error: err instanceof Error ? err.message : "Internal server error" });
   }
 });
+
+/**
+ * GET /metrics/awakening — activity for agents that wake on their own.
+ *
+ * Awakened runs are deliberately absent from the rest of this file's numbers:
+ * they have no `userId`, so the user-scoped filters every other endpoint
+ * applies would drop them, and mixing unattended runs into per-user latency
+ * would skew it. They still need to be observable — an awakened agent posts in
+ * public with nobody watching — so they get their own rollup.
+ *
+ * Three questions this answers, which is what operating the feature actually
+ * requires: is it running, what is it deciding, and is anything broken.
+ * Scoped by org only; there is no user dimension to scope by.
+ */
+metricsRouter.get("/awakening", async (req: Request, res: Response) => {
+  try {
+    const { orgFilter, scopeOrgId } = await resolveMetricsScope(req, "/metrics/awakening");
+    const days = parseDays(req);
+    const windowEnd = new Date();
+    const windowStart = new Date(windowEnd.getTime() - days * 24 * 60 * 60 * 1000);
+
+    const [totalsRaw, perDayRaw, byAgentRaw, skipRaw, statesRaw] = await Promise.all([
+      prisma.$queryRaw<Array<{
+        runs: bigint; ran: bigint; skipped: bigint; failed: bigint; shadow: bigint;
+        injections: bigint; events: bigint;
+      }>>`
+        SELECT
+          COUNT(*)                                        AS runs,
+          COUNT(*) FILTER (WHERE outcome = 'ran')         AS ran,
+          COUNT(*) FILTER (WHERE outcome = 'skipped')     AS skipped,
+          COUNT(*) FILTER (WHERE outcome = 'failed')      AS failed,
+          COUNT(*) FILTER (WHERE outcome = 'shadow')      AS shadow,
+          COALESCE(SUM("injectionsUsed"), 0)              AS injections,
+          COALESCE(SUM("eventCount"), 0)                  AS events
+        FROM "agent_awakening_runs"
+        WHERE "startedAt" >= ${windowStart} AND "startedAt" < ${windowEnd} ${orgFilter}
+      `,
+      prisma.$queryRaw<Array<{
+        day: Date; ran: bigint; skipped: bigint; failed: bigint;
+      }>>`
+        SELECT
+          date_trunc('day', "startedAt")::date            AS day,
+          COUNT(*) FILTER (WHERE outcome IN ('ran','shadow')) AS ran,
+          COUNT(*) FILTER (WHERE outcome = 'skipped')     AS skipped,
+          COUNT(*) FILTER (WHERE outcome = 'failed')      AS failed
+        FROM "agent_awakening_runs"
+        WHERE "startedAt" >= ${windowStart} AND "startedAt" < ${windowEnd} ${orgFilter}
+        GROUP BY 1 ORDER BY 1 ASC
+      `,
+      prisma.$queryRaw<Array<{
+        agent_id: string; agent_slug: string | null; kind: string; runs: bigint; ran: bigint;
+        skipped: bigint; failed: bigint; events: bigint; last_run_at: Date | null;
+      }>>`
+        SELECT
+          r."agentId"                                     AS agent_id,
+          a.slug                                          AS agent_slug,
+          r.kind                                          AS kind,
+          COUNT(*)                                        AS runs,
+          COUNT(*) FILTER (WHERE r.outcome IN ('ran','shadow')) AS ran,
+          COUNT(*) FILTER (WHERE r.outcome = 'skipped')   AS skipped,
+          COUNT(*) FILTER (WHERE r.outcome = 'failed')    AS failed,
+          COALESCE(SUM(r."eventCount"), 0)                AS events,
+          MAX(r."startedAt")                              AS last_run_at
+        FROM "agent_awakening_runs" r
+        LEFT JOIN "agents" a ON a.id = r."agentId"
+        WHERE r."startedAt" >= ${windowStart} AND r."startedAt" < ${windowEnd}
+          ${scopeOrgId ? Prisma.sql`AND r."orgId" = ${scopeOrgId}` : Prisma.empty}
+        GROUP BY 1, 2, 3
+        ORDER BY runs DESC
+        LIMIT 50
+      `,
+      prisma.$queryRaw<Array<{ reason: string | null; count: bigint }>>`
+        SELECT "skipReason" AS reason, COUNT(*) AS count
+        FROM "agent_awakening_runs"
+        WHERE "startedAt" >= ${windowStart} AND "startedAt" < ${windowEnd}
+          AND outcome = 'skipped' ${orgFilter}
+        GROUP BY 1 ORDER BY count DESC LIMIT 20
+      `,
+      // Current health, independent of the window: an agent the workers switched
+      // off has no recent runs BY DEFINITION, so it would be invisible above.
+      prisma.$queryRaw<Array<{
+        agent_slug: string | null; enabled: boolean; last_error: string | null;
+        next_due_at: Date | null; reflex_next_check_at: Date | null;
+        consecutive_failures: number;
+      }>>`
+        SELECT
+          a.slug                    AS agent_slug,
+          s.enabled                 AS enabled,
+          s."lastError"             AS last_error,
+          s."nextDueAt"             AS next_due_at,
+          s."reflexNextCheckAt"     AS reflex_next_check_at,
+          s."consecutiveFailures"   AS consecutive_failures
+        FROM "agent_awakening_state" s
+        LEFT JOIN "agents" a ON a.id = s."agentId"
+        WHERE TRUE ${scopeOrgId ? Prisma.sql`AND s."orgId" = ${scopeOrgId}` : Prisma.empty}
+        ORDER BY s.enabled DESC, a.slug ASC
+        LIMIT 100
+      `,
+    ]);
+
+    const t = totalsRaw[0];
+    res.json({
+      days,
+      totals: {
+        runs: Number(t?.runs ?? 0),
+        ran: Number(t?.ran ?? 0),
+        skipped: Number(t?.skipped ?? 0),
+        failed: Number(t?.failed ?? 0),
+        shadow: Number(t?.shadow ?? 0),
+        injections: Number(t?.injections ?? 0),
+        events: Number(t?.events ?? 0),
+      },
+      perDay: perDayRaw.map((r) => ({
+        day: r.day.toISOString().slice(0, 10),
+        ran: Number(r.ran),
+        skipped: Number(r.skipped),
+        failed: Number(r.failed),
+      })),
+      byAgent: byAgentRaw.map((r) => ({
+        agentId: r.agent_id,
+        agentSlug: r.agent_slug ?? "(deleted agent)",
+        kind: r.kind,
+        runs: Number(r.runs),
+        ran: Number(r.ran),
+        skipped: Number(r.skipped),
+        failed: Number(r.failed),
+        events: Number(r.events),
+        lastRunAt: r.last_run_at ? r.last_run_at.toISOString() : null,
+      })),
+      skipReasons: skipRaw.map((r) => ({
+        reason: r.reason ?? "(unspecified)",
+        count: Number(r.count),
+      })),
+      agents: statesRaw.map((r) => ({
+        agentSlug: r.agent_slug ?? "(deleted agent)",
+        enabled: r.enabled,
+        lastError: r.last_error,
+        nextDueAt: r.next_due_at ? r.next_due_at.toISOString() : null,
+        reflexNextCheckAt: r.reflex_next_check_at ? r.reflex_next_check_at.toISOString() : null,
+        consecutiveFailures: Number(r.consecutive_failures ?? 0),
+      })),
+    });
+  } catch (err) {
+    log.error("[metrics/awakening] error:", err);
+    res.status(500).json({ error: err instanceof Error ? err.message : "Internal server error" });
+  }
+});
+
+/**
+ * GET /metrics/awakening/:agentId/runs — one agent's wake history, paginated.
+ *
+ * The drill-down behind the Awakened agents section. Every wake ATTEMPT is a
+ * row here, not just the ones that acted, because "why did it stay quiet" is
+ * the question operators actually have — `skipReason` carries the gate rule
+ * that fired.
+ *
+ * `conversationId` is joined from agent_runs so each acting wake links straight
+ * to the transcript; a skipped wake never dispatched one and has none.
+ *
+ * `kind` narrows to heartbeat or reflex. The rollup above lists one row PER
+ * WAKE KIND, so drilling into an agent's heartbeat row must not return its
+ * reflex wakes as well.
+ */
+metricsRouter.get("/awakening/:agentId/runs", async (req: Request<{ agentId: string }>, res: Response) => {
+  try {
+    const { scopeOrgId } = await resolveMetricsScope(req, "/metrics/awakening/runs");
+    const { agentId } = req.params;
+    const days = parseDays(req);
+    const windowEnd = new Date();
+    const windowStart = new Date(windowEnd.getTime() - days * 24 * 60 * 60 * 1000);
+
+    const limit = Math.min(Math.max(Number(req.query["limit"]) || 20, 1), 100);
+    const offset = Math.max(Number(req.query["offset"]) || 0, 0);
+
+    // Org scoping is applied to the RUN rows, not just the agent, so an admin
+    // scoped to one org cannot page through another org's history by id.
+    const scope = scopeOrgId ? Prisma.sql`AND r."orgId" = ${scopeOrgId}` : Prisma.empty;
+
+    const kindRaw = String(req.query["kind"] ?? "");
+    const kindFilter = kindRaw === "heartbeat" || kindRaw === "reflex"
+      ? Prisma.sql`AND r.kind = ${kindRaw}`
+      : Prisma.empty;
+
+    const [rowsRaw, countRaw] = await Promise.all([
+      prisma.$queryRaw<Array<{
+        id: string; kind: string; outcome: string; skip_reason: string | null;
+        event_count: number; injections_used: number; session_id: string | null;
+        conversation_id: string | null; run_status: string | null;
+        window_start_ms: bigint; window_end_ms: bigint;
+        started_at: Date; completed_at: Date | null;
+      }>>`
+        SELECT
+          r.id                AS id,
+          r.kind              AS kind,
+          r.outcome           AS outcome,
+          r."skipReason"      AS skip_reason,
+          r."eventCount"      AS event_count,
+          r."injectionsUsed"  AS injections_used,
+          r."sessionId"       AS session_id,
+          ar."conversationId" AS conversation_id,
+          ar.status           AS run_status,
+          r."windowStartMs"   AS window_start_ms,
+          r."windowEndMs"     AS window_end_ms,
+          r."startedAt"       AS started_at,
+          r."completedAt"     AS completed_at
+        FROM "agent_awakening_runs" r
+        LEFT JOIN "agent_runs" ar ON ar."sessionId" = r."sessionId"
+        WHERE r."agentId" = ${agentId}
+          AND r."startedAt" >= ${windowStart} AND r."startedAt" < ${windowEnd}
+          ${scope} ${kindFilter}
+        ORDER BY r."startedAt" DESC
+        LIMIT ${limit} OFFSET ${offset}
+      `,
+      prisma.$queryRaw<Array<{ count: bigint }>>`
+        SELECT COUNT(*) AS count
+        FROM "agent_awakening_runs" r
+        WHERE r."agentId" = ${agentId}
+          AND r."startedAt" >= ${windowStart} AND r."startedAt" < ${windowEnd}
+          ${scope} ${kindFilter}
+      `,
+    ]);
+
+    res.json({
+      total: Number(countRaw[0]?.count ?? 0),
+      limit,
+      offset,
+      runs: rowsRaw.map((r) => ({
+        id: r.id,
+        kind: r.kind,
+        outcome: r.outcome,
+        skipReason: r.skip_reason,
+        eventCount: Number(r.event_count ?? 0),
+        injectionsUsed: Number(r.injections_used ?? 0),
+        sessionId: r.session_id,
+        conversationId: r.conversation_id,
+        runStatus: r.run_status,
+        windowStartMs: Number(r.window_start_ms),
+        windowEndMs: Number(r.window_end_ms),
+        startedAt: r.started_at.toISOString(),
+        completedAt: r.completed_at ? r.completed_at.toISOString() : null,
+        durationMs: r.completed_at ? r.completed_at.getTime() - r.started_at.getTime() : null,
+      })),
+    });
+  } catch (err) {
+    log.error("[metrics/awakening/runs] error:", err);
+    res.status(500).json({ error: err instanceof Error ? err.message : "Internal server error" });
+  }
+});

--- a/apps/xyne-claw-auth/docs/awakening.md
+++ b/apps/xyne-claw-auth/docs/awakening.md
@@ -204,8 +204,8 @@ All of it lives under `agent.config.awakening`. Two layers validate it:
 | `periodMs` | int | `1_800_000` (30m) | Heartbeat period. Range 5m – 24h |
 | `writePolicy` | `observe` \| `reply` \| `act` | `reply` | Enforced as tool denials, §7.1 |
 | `shadow` | boolean | `true` | Overrides `writePolicy` down to `observe` |
-| `instructions` | string | `""` | Owner-written guidance, ≤ 4000 chars. §7.3 |
-| `workspaceId` | string? | — | Explicit Spaces workspace, when the org maps to more than one |
+| `instructions` | string | `""` | Owner-written guidance, ≤ 10000 chars. §7.3 |
+| `workspaceId` | string? | — | Rarely needed. The workspace is resolved from the agent's own bot user; this only pins it when that user cannot be read, and it must match the bot's workspace |
 
 ### 4.2 Channels
 
@@ -721,7 +721,7 @@ but cannot make a run mute or make it answer itself.
 
 ### 7.3 Operator instructions
 
-`awakening.instructions`, up to 4000 chars, edited in the Awakening tab. Meant
+`awakening.instructions`, up to 10000 chars, edited in the Awakening tab. Meant
 for tone and triage — *"Keep it short and warm. Jump in when someone is blocked
 or waiting on an answer. Stay out of social chatter."* It is advisory by
 construction: it cannot override the write policy or the bounds.
@@ -902,6 +902,22 @@ plus the last 20 runs.
 > at all. A reflex blocked by `maxRunsPerHour` leaves no trace whatsoever. See
 > §14 open defect 12.
 
+**Metrics page.** The workspace view has an **Awakened agents** section
+(`GET /metrics/awakening`, rendered by `AwakeningActivityCard`): wakes vs acted
+vs stayed-quiet vs failed for the window, a per-agent breakdown by wake kind, the
+distribution of gate skip reasons, and a banner listing agents the workers have
+stopped along with their `lastError`. It fetches separately from the rest of the
+page because awakened runs have no `userId` — the user-scoped filters every
+other metrics endpoint applies would drop them. The section hides itself
+entirely for a workspace where nothing has ever woken.
+
+Clicking an agent expands its full wake history, paginated
+(`GET /metrics/awakening/:agentId/runs`, 20 per page). Every wake ATTEMPT is a
+row — a skipped wake carries the gate rule that fired, which is usually what you
+opened it to find out — and a wake that dispatched links straight to its
+transcript. Org scoping is applied to the RUN rows, not just the agent, so an
+admin scoped to one org cannot page through another org's history by id.
+
 **Logs.** Dispatch, gate decisions, channel truncation, watermark rewinds, and
 injection batches all log at `info`. A reflex `wait` **while a run is in flight**
 also logs, because that is the state operators most often need when asking "why
@@ -972,7 +988,7 @@ must be set on **every** API pod to have any effect.
 | `rate-limit.ts` | `peekRunRate` / `consumeRunRate` |
 | `inbox.ts` | Injection batch queue |
 | `reflex.ts` | `countEventsSince`, `decideReflex`, `renderInjection` |
-| `workspace.ts` | org → Spaces workspace resolution |
+| `workspace.ts` | Spaces workspace resolution — bot user first, org link as fallback |
 
 **claw-auth — elsewhere**
 
@@ -1003,6 +1019,9 @@ carried.
 | 1 | **`kind: "reflex"` agents were permanently killed.** The heartbeat tick cleared `state.enabled` for any agent that did not participate in *heartbeat*, and the reflex claim scan requires `enabled = TRUE`. The first heartbeat tick that claimed a reflex-only agent disabled it forever. | `enabled` and "participates in this kind" are now two different questions. A non-participating cadence is **parked** (`nextDueAt`/`reflexNextCheckAt` pushed out by `IDLE_REPARK_MS`), never disabled. Regression test in `awakening-tick-kind.test.ts`. |
 | 2 | **The config editor deleted settings it does not model.** `AwakeningSettings` has no control for `workspaceId`, `limits.maxActiveThreads`, `cursor.overlapMs` or `cursor.maxCatchupWindows`, and the tab persisted `{...agent.config, awakening: draft}` — replacing the block wholesale. Opening the tab and pressing Save reset four settings the admin never touched. | The save path now merges over the stored block, section by section, so unmodeled keys survive. |
 
+| 3 | **Workspace resolution read the wrong source.** `resolveWorkspaceId` consulted only `SurfaceTenantLink` (org → workspace). Nothing in the product ever writes that table for Spaces — the sole writer is `prisma/seed.ts` — so it is empty in production, and a `WorkspaceResolutionError` then **permanently disabled** the agent. Two live prod agents were switched off this way on 2026-08-26, while the UI still showed them enabled. | Resolve from the agent's **own bot user** (`users.workspaceId` in Spaces, via `getWorkspaceIdForUser`), exactly as `credentials-loader.ts` already did for app-tools; fall back to the link table only when that user cannot be read. Needs no configuration, and a multi-workspace org is no longer ambiguous — the bot is in exactly one. 12 tests. |
+| 4 | **A recoverable gap was treated as fatal, invisibly.** `WorkspaceResolutionError` was grouped with `AwakeningIdentityError` and cleared `state.enabled`; the tab reads `config.awakening.enabled`, so the agent kept rendering as on. | Only identity failures disable now (an agent with no bot identity must never fall back to a user token). A workspace error records `lastError`, stays enabled and retries on the normal cadence — and clears itself on the next success, on both the heartbeat and reflex paths. The tab shows a banner when the state row disagrees with the config. |
+
 ### Open
 
 | # | Defect | Impact |
@@ -1020,7 +1039,7 @@ carried.
 | 12 | **The reflex path records almost nothing.** A run row is created only on `fire`; `wait`, every `hold`, `inject`, rate-limited, lock-busy, no-channels and empty-collect all return silently. | A reflex blocked by `maxRunsPerHour` produces no row *and* no log, where the heartbeat records `skipReason: "rate_limited"`. §11's "answers why it did/didn't wake" holds for heartbeat only. |
 | 13 | **A retried window keeps the wrong outcome.** Dispatch failure records `outcome="failed"` *and* throws, triggering the BullMQ retry (`attempts: 3`). The retry recomputes an identical `idempotencyKey`, so the success-path insert hits `P2002` and is swallowed. | The row stays `failed` with `sessionId` NULL for a wake that actually ran — so `/status` lies, and the injection bookkeeping keyed on `sessionId` can never match it. `markFailure` also fires up to 3× for one beat, driving the backoff to 2³ = 8 (4 h at the default period, not the "within one hour" the code comment promises). |
 | 14 | **A dead claw pod loses injected events permanently.** The §8.2 rewind runs only in the result callback. If the owning pod dies, no callback fires: the batch expires with its 1 h TTL, the reflex watermark stays advanced past those events, and the lock is held until its own TTL. Nothing reaps `agent_awakening_runs` rows with `completedAt IS NULL`. | Blast radius is one inbox (≤ 20 batches) per dead run. Recovery is manual. |
-| 15 | **No product path re-enables a self-disabled agent.** Both workers set `enabled: false` on `AwakeningIdentityError` / `WorkspaceResolutionError`. `/status` is read-only, and `syncAwakeningState` re-enables only via a PUT. | The runbook is "fix the identity, then press Save" — which is not discoverable and is nowhere in the UI. |
+| 15 | **Re-enabling a self-disabled agent is still a PUT.** `AwakeningIdentityError` (only) sets `enabled: false`, and `syncAwakeningState` re-enables solely via a PUT. | Now at least visible — the tab shows a "switched off" banner with `lastError` and tells the admin to press Save (see Fixed #4). A dedicated re-enable action would be better than overloading Save. |
 
 | 16 | **`reflex.checkIntervalMs` below `AWAKENING_TICK_MS` is a silent no-op.** Reflex rows are claimed by the fleet tick, so the effective cadence is `max(checkIntervalMs, tickIntervalMs)` — 60s by default. The UI's `REFLEX_CHECK_OPTIONS` offers 15s and 30s, and `AWAKENING_BOUNDS.reflexCheckIntervalMs.MIN` is 15s, so the editor lets an admin pick values that can never be honoured. | Directly defeats live injection on short runs: a run must survive a full tick to be injectable, so anything finishing in under ~60s never receives an update no matter how the reflex knobs are set. Either raise the UI's floor to the tick interval, or drive the tick from the smallest configured reflex interval. |
 
@@ -1044,8 +1063,9 @@ Two related notes that are working as intended but read as surprises:
 - **Steering only lands at a turn boundary.** An agent that stops calling tools
   cannot be reached again; queued batches are returned to the next wake.
 - **Heartbeat windows are sealed.** Injection is reflex-only by design.
-- **One workspace per agent.** `workspaceId` picks it when the org maps to more
-  than one; there is no multi-workspace fan-out.
+- **One workspace per agent.** The agent's bot user belongs to exactly one
+  Spaces workspace and that is the one it acts in; there is no multi-workspace
+  fan-out. An org with several workspaces needs one agent per workspace.
 - **`maxChannels` truncation is silent to the channel, visible to the agent** —
   it is recorded in the artifact header, not surfaced as an admin alert.
 - **An awakened run has an effective 20-minute ceiling** while defect 10 stands.

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -729,6 +729,38 @@ export async function updateAgent(
   return data.data;
 }
 
+/**
+ * Live awakening state for an agent — the row the background workers actually
+ * read, which is NOT the same flag as `config.awakening.enabled` that the
+ * editor writes. When a worker cannot resolve an agent's identity it disables
+ * that row and records why; without surfacing this the tab shows a toggle that
+ * is on while the agent is switched off.
+ */
+export interface AwakeningStatus {
+  state: {
+    enabled: boolean;
+    lastError: string | null;
+    nextDueAt: string | null;
+    reflexNextCheckAt: string | null;
+    consecutiveFailures: number;
+  } | null;
+  recent: Array<{
+    kind: string;
+    outcome: string;
+    skipReason: string | null;
+    eventCount: number;
+    startedAt: string;
+  }>;
+}
+
+export async function getAwakeningStatus(agentId: string): Promise<AwakeningStatus> {
+  const data = await request<{ success: boolean; data: AwakeningStatus }>(
+    `${AUTH_API_URL}/api/v1/awakening/${agentId}/status`,
+    { method: "GET" },
+  );
+  return data.data;
+}
+
 export async function updateAgentDesignSystem(
   slug: string,
   designSystem: string | null,
@@ -5633,6 +5665,93 @@ export async function fetchGlobalMetrics(userId: string, days: 1 | 7 | 30 = 7, o
   applyAdminOrgScope(qs, orgScope);
   return request<GlobalMetrics>(
     `${AUTH_API_URL}/api/v1/metrics/global?${qs.toString()}`,
+    { headers: { "x-user-id": userId } },
+  );
+}
+
+/**
+ * Activity for agents that wake on their own. Kept out of the main metrics
+ * payload because awakened runs have no `userId` — the user-scoped filters the
+ * other endpoints apply would drop them entirely.
+ */
+export interface AwakeningActivity {
+  days: number;
+  totals: {
+    runs: number; ran: number; skipped: number; failed: number;
+    shadow: number; injections: number; events: number;
+  };
+  perDay: Array<{ day: string; ran: number; skipped: number; failed: number }>;
+  byAgent: Array<{
+    agentId: string; agentSlug: string; kind: string; runs: number; ran: number;
+    skipped: number; failed: number; events: number; lastRunAt: string | null;
+  }>;
+  skipReasons: Array<{ reason: string; count: number }>;
+  agents: Array<{
+    agentSlug: string; enabled: boolean; lastError: string | null;
+    nextDueAt: string | null; reflexNextCheckAt: string | null;
+    consecutiveFailures: number;
+  }>;
+}
+
+export async function fetchAwakeningActivity(
+  userId: string,
+  days: 1 | 7 | 30 = 7,
+  orgScope?: AdminOrgScope,
+): Promise<AwakeningActivity> {
+  const qs = new URLSearchParams();
+  qs.set("days", String(days));
+  applyAdminOrgScope(qs, orgScope);
+  return request<AwakeningActivity>(
+    `${AUTH_API_URL}/api/v1/metrics/awakening?${qs.toString()}`,
+    { headers: { "x-user-id": userId } },
+  );
+}
+
+/** One wake ATTEMPT — skipped wakes are rows too, and carry the gate rule. */
+export interface AwakeningRun {
+  id: string;
+  kind: string;
+  outcome: string;
+  skipReason: string | null;
+  eventCount: number;
+  injectionsUsed: number;
+  sessionId: string | null;
+  /** Present only when the wake actually dispatched — links to the transcript. */
+  conversationId: string | null;
+  runStatus: string | null;
+  windowStartMs: number;
+  windowEndMs: number;
+  startedAt: string;
+  completedAt: string | null;
+  durationMs: number | null;
+}
+
+export interface AwakeningRunsPage {
+  total: number;
+  limit: number;
+  offset: number;
+  runs: AwakeningRun[];
+}
+
+export async function fetchAwakeningRuns(
+  userId: string,
+  agentId: string,
+  days: 1 | 7 | 30 = 7,
+  limit = 20,
+  offset = 0,
+  orgScope?: AdminOrgScope,
+  /** "heartbeat" | "reflex" — the rollup lists one row per kind, so a
+   *  drill-down must stay scoped to the row that was clicked. */
+  kind?: string,
+): Promise<AwakeningRunsPage> {
+  const qs = new URLSearchParams();
+  qs.set("days", String(days));
+  qs.set("limit", String(limit));
+  qs.set("offset", String(offset));
+  if (kind) qs.set("kind", kind);
+  applyAdminOrgScope(qs, orgScope);
+  return request<AwakeningRunsPage>(
+    `${AUTH_API_URL}/api/v1/metrics/awakening/${encodeURIComponent(agentId)}/runs?${qs.toString()}`,
     { headers: { "x-user-id": userId } },
   );
 }

--- a/apps/xyne-claw-auth/frontend/src/v3/components/MetricsPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/MetricsPageV3.tsx
@@ -18,6 +18,8 @@ import {
 } from "recharts";
 import {
   fetchGlobalMetrics, fetchAgentMetrics, listAgents,
+  fetchAwakeningActivity, type AwakeningActivity,
+  fetchAwakeningRuns, type AwakeningRun,
   fetchAgentImprovements, applyImprovement, dismissImprovement,
   type GlobalMetrics, type GlobalMetricsDayBucket, type AgentMetrics,
   type SlowSession, type ToolLatencyRow, type AgentSentiment, type GlobalMetricsProviderRow,
@@ -79,10 +81,13 @@ export function MetricsPanel({
   fetcher,
   showLeaderboard = false,
   onAgentClick,
+  orgScope,
 }: {
   userId: string;
   fetcher: (userId: string, days: 1 | 7 | 30) => Promise<GlobalMetrics | AgentMetrics>;
   showLeaderboard?: boolean;
+  /** Passed through to the awakening rollup, which fetches independently. */
+  orgScope?: AdminOrgScope;
   /** When the workspace leaderboard renders an agent, clicking it bubbles up
    *  so the parent page can pivot to that agent's view. */
   onAgentClick?: (agentSlug: string) => void;
@@ -194,6 +199,9 @@ export function MetricsPanel({
             <Card title="Tool latency for this agent" subtitle={`Top ${data.toolLatency.length} tools by cumulative time — find the one dragging the agent down`}>
               <ToolLatencyTable rows={data.toolLatency} />
             </Card>
+          )}
+          {showLeaderboard && (
+            <AwakeningActivityCard userId={userId} days={days} orgScope={orgScope} />
           )}
           {data.slowSessions.length > 0 && (
             <Card title="Slowest sessions" subtitle={`Top ${data.slowSessions.length} by total wall-clock — expand a row for the tool breakdown`}>
@@ -378,10 +386,315 @@ export function MetricsPageV3({ userId }: MetricsPageV3Props) {
           fetcher={fetcher}
           showLeaderboard={!selectedAgent}
           onAgentClick={(slug) => setSelectedAgent(slug)}
+          orgScope={adminOrgScope}
         />
       </div>
     </div>
   );
+}
+
+/**
+ * Awakening rollup — agents that ran with nobody triggering them.
+ *
+ * Fetches independently rather than riding the main metrics payload: awakened
+ * runs live in their own table (`agent_awakening_runs`) with no `userId`, and
+ * folding unattended runs into per-user latency would skew it.
+ *
+ * Renders nothing at all when no agent in the org has ever woken, so the
+ * section stays invisible for workspaces that do not use the feature.
+ */
+function AwakeningActivityCard({
+  userId,
+  days,
+  orgScope,
+}: {
+  userId: string;
+  days: 1 | 7 | 30;
+  orgScope?: AdminOrgScope;
+}) {
+  const [data, setData] = useState<AwakeningActivity | null>(null);
+  const [failed, setFailed] = useState(false);
+  // Keyed by agent AND kind: the rollup lists one row per wake kind, so keying
+  // on agentId alone expanded an agent's heartbeat and reflex rows together.
+  const [openRow, setOpenRow] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setFailed(false);
+    fetchAwakeningActivity(userId, days, orgScope)
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch(() => { if (!cancelled) setFailed(true); });
+    return () => { cancelled = true; };
+  }, [userId, days, orgScope]);
+
+  if (failed || !data) return null;
+  // Never configured here — do not show an empty shell.
+  if (data.agents.length === 0 && data.totals.runs === 0) return null;
+
+  const { totals } = data;
+  const stopped = data.agents.filter((a) => !a.enabled || a.lastError);
+
+  return (
+    <Card
+      title="Awakened agents"
+      subtitle="Runs that nobody triggered — the agent woke on a heartbeat or a reflex and decided for itself whether to act."
+    >
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-[12px] mb-[16px]">
+        <Tile label="Wakes" value={String(totals.runs)} sub={`${totals.events} events collected`} />
+        <Tile
+          label="Acted"
+          value={String(totals.ran)}
+          sub={totals.shadow > 0 ? `${totals.shadow} in shadow` : undefined}
+        />
+        <Tile
+          label="Stayed quiet"
+          value={String(totals.skipped)}
+          sub="gate found nothing worth doing"
+        />
+        <Tile
+          label="Failed"
+          value={String(totals.failed)}
+          sub={totals.injections > 0 ? `${totals.injections} live updates` : undefined}
+          subTone={totals.failed > 0 ? "bad" : "flat"}
+        />
+      </div>
+
+      {stopped.length > 0 && (
+        <div className="mb-[16px] rounded-lg border border-amber-300/60 bg-amber-50 p-3 dark:border-amber-900/60 dark:bg-amber-950/30">
+          <div className="text-[12px] font-medium text-amber-900 dark:text-amber-200 mb-1">
+            {stopped.length} agent{stopped.length === 1 ? "" : "s"} not waking
+          </div>
+          {stopped.slice(0, 5).map((a) => (
+            <div key={a.agentSlug} className="text-[12px] text-amber-800 dark:text-amber-300">
+              <span className="font-mono">{a.agentSlug}</span>
+              {a.lastError ? ` — ${a.lastError}` : " — switched off"}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {data.byAgent.length > 0 && (
+        <table className="w-full text-[12px]">
+          <thead className="text-xyne-fg-muted">
+            <tr className="text-left border-b border-xyne-border">
+              <th className="py-2 font-medium">Agent</th>
+              <th className="py-2 font-medium">Kind</th>
+              <th className="py-2 font-medium text-right">Wakes</th>
+              <th className="py-2 font-medium text-right">Acted</th>
+              <th className="py-2 font-medium text-right">Quiet</th>
+              <th className="py-2 font-medium text-right">Failed</th>
+              <th className="py-2 font-medium text-right">Events</th>
+              <th className="py-2 font-medium text-right">Last wake</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.byAgent.map((r) => (
+              <React.Fragment key={`${r.agentId}:${r.kind}`}>
+              <tr
+                className="border-b border-xyne-border/50 cursor-pointer hover:bg-xyne-bg-secondary/60"
+                onClick={() => setOpenRow(openRow === rowKey(r) ? null : rowKey(r))}
+              >
+                <td className="py-2 font-mono text-xyne-fg-primary">
+                  <span className="mr-1 inline-block w-3 text-xyne-fg-muted">
+                    {openRow === rowKey(r) ? "▾" : "▸"}
+                  </span>
+                  {r.agentSlug}
+                </td>
+                <td className="py-2 text-xyne-fg-muted">{r.kind}</td>
+                <td className="py-2 text-right text-xyne-fg-primary">{r.runs}</td>
+                <td className="py-2 text-right text-xyne-fg-primary">{r.ran}</td>
+                <td className="py-2 text-right text-xyne-fg-muted">{r.skipped}</td>
+                <td className={"py-2 text-right " + (r.failed > 0 ? "text-red-500" : "text-xyne-fg-muted")}>
+                  {r.failed}
+                </td>
+                <td className="py-2 text-right text-xyne-fg-muted">{r.events}</td>
+                <td className="py-2 text-right text-xyne-fg-muted">
+                  {r.lastRunAt ? new Date(r.lastRunAt).toLocaleString() : "—"}
+                </td>
+              </tr>
+              {openRow === rowKey(r) && (
+                <tr>
+                  <td colSpan={8} className="p-0">
+                    <AwakeningRunsPanel
+                      userId={userId}
+                      agentId={r.agentId}
+                      agentSlug={r.agentSlug}
+                      kind={r.kind}
+                      days={days}
+                      orgScope={orgScope}
+                    />
+                  </td>
+                </tr>
+              )}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {data.skipReasons.length > 0 && (
+        <div className="mt-[16px]">
+          <div className="text-[12px] text-xyne-fg-muted mb-2">
+            Why it stayed quiet — a healthy agent skips far more often than it acts.
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {data.skipReasons.map((r) => (
+              <span
+                key={r.reason}
+                className="rounded-full bg-xyne-bg-secondary px-3 py-1 text-[12px] text-xyne-fg-muted"
+              >
+                <span className="font-mono">{r.reason}</span> · {r.count}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+const RUNS_PAGE_SIZE = 20;
+
+/** The rollup is one row per (agent, wake kind) — both are needed to identify a row. */
+const rowKey = (r: { agentId: string; kind: string }): string => `${r.agentId}:${r.kind}`;
+
+/**
+ * One agent's wake history, paginated.
+ *
+ * Lists every wake ATTEMPT, not just the ones that acted — a skipped wake
+ * carries the gate rule that fired, which is usually the thing you opened this
+ * to find out. Wakes that dispatched link to their transcript; skipped ones
+ * never created a conversation and have nothing to link to.
+ */
+function AwakeningRunsPanel({
+  userId,
+  agentId,
+  agentSlug,
+  kind,
+  days,
+  orgScope,
+}: {
+  userId: string;
+  agentId: string;
+  agentSlug: string;
+  /** Narrows to the wake kind of the row that was clicked. */
+  kind: string;
+  days: 1 | 7 | 30;
+  orgScope?: AdminOrgScope;
+}) {
+  const [runs, setRuns] = useState<AwakeningRun[]>([]);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset paging when the window changes — offset 40 is meaningless against a
+  // freshly narrowed result set.
+  useEffect(() => { setOffset(0); }, [days, agentId, kind]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchAwakeningRuns(userId, agentId, days, RUNS_PAGE_SIZE, offset, orgScope, kind)
+      .then((page) => {
+        if (cancelled) return;
+        setRuns(page.runs);
+        setTotal(page.total);
+      })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : String(e)); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [userId, agentId, kind, days, offset, orgScope]);
+
+  const from = total === 0 ? 0 : offset + 1;
+  const to = Math.min(offset + RUNS_PAGE_SIZE, total);
+
+  return (
+    <div className="bg-xyne-bg-secondary/40 px-3 py-3 border-b border-xyne-border/50">
+      {error ? (
+        <div className="text-[12px] text-red-500">Failed to load sessions: {error}</div>
+      ) : loading && runs.length === 0 ? (
+        <Skeleton className="h-[120px] w-full" />
+      ) : runs.length === 0 ? (
+        <div className="text-[12px] text-xyne-fg-muted">
+          No {kind} wakes for {agentSlug} in this window.
+        </div>
+      ) : (
+        <>
+          <table className="w-full text-[12px]">
+            <thead className="text-xyne-fg-muted">
+              <tr className="text-left border-b border-xyne-border/60">
+                <th className="py-1.5 font-medium">When</th>
+                <th className="py-1.5 font-medium">Outcome</th>
+                <th className="py-1.5 font-medium">Why</th>
+                <th className="py-1.5 font-medium text-right">Events</th>
+                <th className="py-1.5 font-medium text-right">Updates</th>
+                <th className="py-1.5 font-medium text-right">Took</th>
+                <th className="py-1.5 font-medium text-right">Transcript</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runs.map((r) => (
+                <tr key={r.id} className="border-b border-xyne-border/30">
+                  <td className="py-1.5 text-xyne-fg-primary whitespace-nowrap">
+                    {new Date(r.startedAt).toLocaleString()}
+                  </td>
+                  <td className={"py-1.5 " + outcomeTone(r.outcome)}>{r.outcome}</td>
+                  <td className="py-1.5 font-mono text-xyne-fg-muted">{r.skipReason ?? "—"}</td>
+                  <td className="py-1.5 text-right text-xyne-fg-muted">{r.eventCount}</td>
+                  <td className="py-1.5 text-right text-xyne-fg-muted">
+                    {r.injectionsUsed > 0 ? r.injectionsUsed : "—"}
+                  </td>
+                  <td className="py-1.5 text-right text-xyne-fg-muted">{fmtMs(r.durationMs)}</td>
+                  <td className="py-1.5 text-right">
+                    {r.conversationId ? (
+                      <a
+                        className="text-blue-500 hover:underline"
+                        href={`/claw/v3/chat?agent=${encodeURIComponent(agentSlug)}&conversation=${encodeURIComponent(r.conversationId)}&allRuns=1`}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        open
+                      </a>
+                    ) : (
+                      <span className="text-xyne-fg-muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="mt-2 flex items-center justify-between text-[12px] text-xyne-fg-muted">
+            <span>{from}–{to} of {total}</span>
+            <div className="flex items-center gap-2">
+              <button
+                disabled={offset === 0 || loading}
+                onClick={() => setOffset(Math.max(0, offset - RUNS_PAGE_SIZE))}
+                className="rounded-md border border-xyne-border px-2 py-1 disabled:opacity-40 hover:text-xyne-fg-primary"
+              >
+                Previous
+              </button>
+              <button
+                disabled={to >= total || loading}
+                onClick={() => setOffset(offset + RUNS_PAGE_SIZE)}
+                className="rounded-md border border-xyne-border px-2 py-1 disabled:opacity-40 hover:text-xyne-fg-primary"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function outcomeTone(outcome: string): string {
+  if (outcome === "failed") return "text-red-500";
+  if (outcome === "skipped") return "text-xyne-fg-muted";
+  if (outcome === "shadow") return "text-amber-500";
+  return "text-xyne-fg-primary";
 }
 
 /* ── building blocks ──────────────────────────────────────────────────── */

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/AwakeningTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/AwakeningTab.tsx
@@ -1,8 +1,10 @@
-import { useState, useCallback, useMemo } from "react";
-import { PulseIcon, WarningIcon, EyeIcon, CircleNotchIcon, XIcon } from "@phosphor-icons/react";
-import { updateAgent } from "../../../../lib/api";
+import { useState, useCallback, useMemo, useEffect } from "react";
+import { PulseIcon, WarningIcon, CircleNotchIcon, XIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { updateAgent, getAwakeningStatus, type AwakeningStatus } from "../../../../lib/api";
 import type { Agent } from "../../../../lib/types";
 import { useSnackbar } from "../../ui/Snackbar";
+import { InfoIcon } from "../../ui/Tooltip";
+import { Switch } from "../../ui/Switch";
 import {
   readAwakening,
   AWAKENING_BOUNDS,
@@ -40,12 +42,36 @@ interface Props {
  * agent.config is FULL-REPLACED server-side, so every write spreads the
  * existing config first — dropping that spread silently deletes every other
  * config block the agent has.
+ *
+ * LAYOUT: there are ~15 interdependent knobs here, and reading them as a flat
+ * list is what made this panel hard to configure. Three things fix that, and
+ * they are the reason for the structure below:
+ *   1. A plain-English SUMMARY at the top, recomputed from the draft, so the
+ *      combined effect of the knobs never has to be simulated in your head.
+ *   2. NUMBERED STEPS in the order the decision is actually made.
+ *   3. Per-knob explanations live in hover tooltips, not permanent paragraphs —
+ *      the rows stay one line each, so the whole config is scannable.
+ * Knobs whose default is almost always right sit behind an "Advanced"
+ * disclosure rather than competing with the ones that matter.
  */
 export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
   const { show: showSnackbar } = useSnackbar();
   const saved = useMemo(() => readAwakening(agent.config), [agent.config]);
   const [draft, setDraft] = useState<AwakeningSettings>(saved);
   const [saving, setSaving] = useState(false);
+  // The worker-owned state row. `config.awakening.enabled` (what the toggle
+  // edits) and `state.enabled` (what the workers read) are different flags, and
+  // a worker that hits an unrecoverable error clears the latter. Fetch it so a
+  // switched-off agent cannot keep rendering as enabled.
+  const [status, setStatus] = useState<AwakeningStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAwakeningStatus(agent.id)
+      .then((s) => { if (!cancelled) setStatus(s); })
+      .catch(() => { /* status is diagnostic only — never block the editor */ });
+    return () => { cancelled = true; };
+  }, [agent.id, saved]);
 
   const dirty = useMemo(() => JSON.stringify(draft) !== JSON.stringify(saved), [draft, saved]);
   const showsHeartbeat = draft.kind !== "reflex";
@@ -100,26 +126,33 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
   }, [agent.config, agent.slug, draft, onAgentUpdated, showSnackbar]);
 
   return (
-    <div className="flex flex-col gap-6 pb-24">
+    <div className="flex flex-col gap-5 p-4 pb-24">
       <Header enabled={draft.enabled} canEdit={canEdit} onToggle={(v) => set("enabled", v)} />
+
+      {draft.enabled && status?.state && !status.state.enabled && (
+        <SystemDisabledNotice lastError={status.state.lastError} />
+      )}
 
       {draft.enabled && (
         <>
           {!draft.shadow && draft.writePolicy === "act" && <LiveWarning />}
 
-          <Section
-            title="Safety"
-            hint="What the agent is allowed to do once it is awake. Start in shadow mode."
+          <Summary draft={draft} />
+
+          <Step
+            n={1}
+            title="What it may do"
+            hint="Start in shadow mode and read a few windows before letting it post."
           >
-            <Toggle
+            <Row
               label="Shadow mode"
-              hint="The agent reasons and records what it WOULD have posted, but has no write tools at all. The safest way to find out whether it is useful."
-              checked={draft.shadow}
-              disabled={!canEdit}
-              onChange={(v) => set("shadow", v)}
-            />
+              info="The agent reasons and records what it WOULD have posted, but is given no write tools at all. The safest way to find out whether it is useful before it can say anything."
+            >
+              <Switch checked={draft.shadow} disabled={!canEdit} onChange={(v) => set("shadow", v)} />
+            </Row>
             <Choice<WritePolicyValue>
               label="Write policy"
+              info="What the agent is allowed to post once it is out of shadow mode. Observe posts nothing; Reply only joins conversations that already exist; Act may also open new threads nobody asked for."
               disabled={!canEdit || draft.shadow}
               disabledHint={draft.shadow ? "Shadow mode overrides this — nothing is posted." : undefined}
               value={draft.writePolicy}
@@ -129,31 +162,19 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
             />
             <NumberField
               label="Max runs per hour"
-              hint="Hard ceiling on how often this agent may actually run. Skipped checks are free and do not count."
+              info="Hard ceiling on how often this agent may actually run, whatever the triggers below ask for. Checks that decide to skip are free and do not count against it."
               value={draft.limits.maxRunsPerHour}
               bound={AWAKENING_BOUNDS.maxRunsPerHour}
+              unit="runs/h"
               disabled={!canEdit}
               onChange={(v) => setNested("limits", { maxRunsPerHour: v })}
             />
-          </Section>
+          </Step>
 
-          <Section
-            title="Run instructions"
-            hint="Your own guidance for awakened runs — tone, what is worth reacting to, what to leave alone. Appended to the built-in operating contract, which always has the last word on delivery rules and safety bounds."
-          >
-            <TextAreaField
-              label="Guidance"
-              hint="Optional. Written to the agent every time it wakes. Example: “Keep it casual and short. Jump in when someone is blocked or asking for a reminder. Stay out of social chatter.”"
-              value={draft.instructions}
-              max={AWAKENING_BOUNDS.instructionsLength.MAX}
-              disabled={!canEdit}
-              onChange={(v) => set("instructions", v)}
-            />
-          </Section>
-
-          <Section title="When it wakes" hint="A heartbeat wakes on the clock; a reflex wakes on volume.">
+          <Step n={2} title="When it wakes" hint="A heartbeat wakes on the clock; a reflex wakes on volume.">
             <Choice<AwakeningKindValue>
               label="Trigger"
+              info="Heartbeat reviews everything that happened since the last wake, on a fixed timer. Reflex reacts as soon as enough activity piles up, and sees only that burst. Choosing both gives you a fast reaction plus a periodic sweep."
               value={draft.kind}
               options={AWAKENING_KINDS}
               labels={KIND_LABELS}
@@ -163,7 +184,7 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
             {showsHeartbeat && (
               <SelectField
                 label="Heartbeat period"
-                hint="How often it reviews the whole period."
+                info="How often it wakes and reviews the whole period. Every event since the previous heartbeat is in that window, so a longer period means fewer, larger runs."
                 value={draft.periodMs}
                 options={PERIOD_OPTIONS}
                 format={formatDuration}
@@ -175,15 +196,16 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
               <>
                 <NumberField
                   label="Reflex threshold"
-                  hint="Wake once this many new events have piled up in the watched channels."
+                  info="Wake once this many new events have piled up across the watched channels. Lower means twitchier and more runs; higher means it waits for a real burst."
                   value={draft.reflex.threshold}
                   bound={AWAKENING_BOUNDS.reflexThreshold}
+                  unit="events"
                   disabled={!canEdit}
                   onChange={(v) => setNested("reflex", { threshold: v })}
                 />
                 <SelectField
                   label="Reflex check interval"
-                  hint="How often the event count is checked. This is a cheap count, not a full read."
+                  info="How often the pending-event count is checked. This is a cheap count, not a full read, so a short interval is inexpensive — it sets how quickly a burst can be noticed."
                   value={draft.reflex.checkIntervalMs}
                   options={REFLEX_CHECK_OPTIONS}
                   format={formatDuration}
@@ -192,7 +214,7 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
                 />
                 <SelectField
                   label="Minimum gap between reflexes"
-                  hint="However busy a channel gets, two reflex runs stay at least this far apart."
+                  info="However busy a channel gets, two reflex runs stay at least this far apart. This is your protection against a flood turning into a run per minute."
                   value={draft.reflex.minIntervalMs}
                   options={REFLEX_MIN_INTERVAL_OPTIONS}
                   format={formatDuration}
@@ -201,14 +223,16 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
                 />
               </>
             )}
-          </Section>
+          </Step>
 
-          <Section
-            title="Which channels"
-            hint="Rules are always narrowed to channels the agent's bot is actually a member of. Leave everything empty to watch every channel it is in."
+          <Step
+            n={3}
+            title="Where it looks"
+            hint="Leave everything empty to watch every channel the agent's bot is already in."
           >
             <ListField
               label="Channel IDs"
+              info="Exact channel IDs to watch. Combined with the name patterns below — a channel matching either one is included."
               placeholder="ch_abc123"
               values={draft.channels.include}
               disabled={!canEdit}
@@ -216,128 +240,159 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
             />
             <ListField
               label="Name patterns"
+              info="Case-insensitive regular expressions matched against the channel name. Example: ^eng- watches every channel whose name starts with eng-."
               placeholder="^eng-"
-              hint="Case-insensitive regular expressions matched against the channel name."
               values={draft.channels.includePattern}
               disabled={!canEdit}
               onChange={(v) => setNested("channels", { includePattern: v })}
             />
             <ListField
               label="Excluded name patterns"
+              info="Applied after the include rules. Exclusion always wins, so this is the reliable way to keep the agent out of a channel."
               placeholder="-archive$"
-              hint="Applied after the include rules. Exclusion always wins."
               values={draft.channels.excludePattern}
               disabled={!canEdit}
               onChange={(v) => setNested("channels", { excludePattern: v })}
             />
-            <NumberField
-              label="Max channels"
-              hint="If more match, the least recently active are dropped."
-              value={draft.channels.maxChannels}
-              bound={AWAKENING_BOUNDS.maxChannels}
-              disabled={!canEdit}
-              onChange={(v) => setNested("channels", { maxChannels: v })}
-            />
-          </Section>
+            <Advanced>
+              <NumberField
+                label="Max channels"
+                info="Safety ceiling on how many channels one wake may cover. If more match the rules above, the least recently active are dropped."
+                value={draft.channels.maxChannels}
+                bound={AWAKENING_BOUNDS.maxChannels}
+                unit="channels"
+                disabled={!canEdit}
+                onChange={(v) => setNested("channels", { maxChannels: v })}
+              />
+            </Advanced>
+          </Step>
 
-          <Section
+          <Step
+            n={4}
             title="When it bothers to act"
-            hint="Most windows contain nothing that needs an agent. These decide when a wake is worth the cost."
+            hint="Most windows contain nothing worth waking a model for. These decide which ones are."
           >
             <NumberField
               label="Minimum human events"
-              hint="Below this many messages from real people, the window is skipped without running the model."
+              info="Below this many messages from real people, the window is skipped without ever running the model — so it costs nothing. Bot and agent chatter does not count towards it."
               value={draft.gate.minHumanEvents}
               bound={AWAKENING_BOUNDS.minHumanEvents}
+              unit="events"
               disabled={!canEdit}
               onChange={(v) => setNested("gate", { minHumanEvents: v })}
             />
-            <NumberField
-              label="Force a run after N skips"
-              hint="Guarantees the agent still checks in during a quiet stretch. 0 disables it."
-              value={draft.gate.forceRunEveryNSkips}
-              bound={AWAKENING_BOUNDS.forceRunEveryNSkips}
-              disabled={!canEdit}
-              onChange={(v) => setNested("gate", { forceRunEveryNSkips: v })}
-            />
-            <NumberField
-              label="Max events per window"
-              hint="A window larger than this is truncated, and the agent is told so."
-              value={draft.limits.maxEvents}
-              bound={AWAKENING_BOUNDS.maxEvents}
-              disabled={!canEdit}
-              onChange={(v) => setNested("limits", { maxEvents: v })}
-            />
-          </Section>
+            <Advanced>
+              <NumberField
+                label="Force a run after N skips"
+                info="Guarantees the agent still checks in during a quiet stretch, even when the gate above keeps skipping. Set 0 to disable and let quiet periods stay quiet."
+                value={draft.gate.forceRunEveryNSkips}
+                bound={AWAKENING_BOUNDS.forceRunEveryNSkips}
+                unit="skips"
+                disabled={!canEdit}
+                onChange={(v) => setNested("gate", { forceRunEveryNSkips: v })}
+              />
+              <NumberField
+                label="Max events per window"
+                info="A window bigger than this is truncated before the agent sees it, and the agent is told that it was. Guards the context window on a very busy period."
+                value={draft.limits.maxEvents}
+                bound={AWAKENING_BOUNDS.maxEvents}
+                unit="events"
+                disabled={!canEdit}
+                onChange={(v) => setNested("limits", { maxEvents: v })}
+              />
+            </Advanced>
+          </Step>
 
           {showsReflex && (
-            <Section
+            <Step
+              n={5}
               title="Live updates"
-              hint="While a reflex run is working, new events can be handed to it so it adapts mid-task instead of finishing on stale input."
+              hint="Hand new events to a reflex run that is already working, so it adapts mid-task instead of finishing on stale input."
             >
-              <Toggle
+              <Row
                 label="Send live updates into a running reflex"
-                checked={draft.reflex.injectEnabled}
-                disabled={!canEdit}
-                onChange={(v) => setNested("reflex", { injectEnabled: v })}
-              />
+                info="Without this, events that land while the agent is working wait for the next wake. With it, they are handed to the run in progress."
+              >
+                <Switch
+                  checked={draft.reflex.injectEnabled}
+                  disabled={!canEdit}
+                  onChange={(v) => setNested("reflex", { injectEnabled: v })}
+                />
+              </Row>
               {draft.reflex.injectEnabled && (
                 <>
                   <NumberField
                     label="Events per update"
-                    hint="How many new events must arrive before the running agent is interrupted with them."
+                    info="How many new events must arrive before the running agent is interrupted with them. Too low and you interrupt it constantly; too high and it never hears anything mid-run."
                     value={draft.reflex.injectThreshold}
                     bound={AWAKENING_BOUNDS.injectThreshold}
+                    unit="events"
                     disabled={!canEdit}
                     onChange={(v) => setNested("reflex", { injectThreshold: v })}
                   />
                   <NumberField
                     label="Max updates per run"
-                    hint="A run still has to finish. Beyond this, new events wait for the next wake."
+                    info="A run still has to finish. Once it has taken this many updates, later events wait for the next wake instead."
                     value={draft.reflex.maxInjectionsPerSession}
                     bound={AWAKENING_BOUNDS.maxInjectionsPerSession}
+                    unit="updates"
                     disabled={!canEdit}
                     onChange={(v) => setNested("reflex", { maxInjectionsPerSession: v })}
                   />
-                  <SelectField
-                    label="Minimum gap between updates"
-                    value={draft.reflex.injectMinIntervalMs}
-                    options={INJECT_MIN_INTERVAL_OPTIONS}
-                    format={formatDuration}
-                    disabled={!canEdit}
-                    onChange={(v) => setNested("reflex", { injectMinIntervalMs: v })}
-                  />
-                  <SelectField
-                    label="Replica safety margin"
-                    hint="How far behind now a window closes, so a Spaces read replica that is briefly behind cannot cause events to be skipped. This is the floor on how fast anything can reach the agent: a new event becomes visible after this margin, and is picked up on the following check."
-                    value={draft.cursor.replicaSafetyMs}
-                    options={REPLICA_SAFETY_OPTIONS}
-                    format={formatDuration}
-                    disabled={!canEdit}
-                    onChange={(v) => setNested("cursor", { replicaSafetyMs: v })}
-                  />
-                  <p className="text-xs text-neutral-500 dark:text-neutral-400">
-                    A live update reaches a running agent roughly{" "}
-                    {formatDuration(draft.cursor.replicaSafetyMs + draft.reflex.checkIntervalMs)} after the events
-                    land, once {draft.reflex.injectThreshold} of them have arrived. A run that finishes faster than
-                    that will never receive one — its events go to the next wake instead.
-                  </p>
+                  <LatencyNote draft={draft} />
+                  <Advanced>
+                    <SelectField
+                      label="Minimum gap between updates"
+                      info="Two live updates into the same run stay at least this far apart, so a burst cannot interrupt the agent repeatedly in a few seconds."
+                      value={draft.reflex.injectMinIntervalMs}
+                      options={INJECT_MIN_INTERVAL_OPTIONS}
+                      format={formatDuration}
+                      disabled={!canEdit}
+                      onChange={(v) => setNested("reflex", { injectMinIntervalMs: v })}
+                    />
+                    <SelectField
+                      label="Replica safety margin"
+                      info="How far behind 'now' a window closes, so a Spaces read replica that is briefly behind cannot cause events to be skipped. This is the floor on how fast anything can reach the agent: an event becomes visible after this margin and is picked up on the following check. Only set it to 0 on a deployment with no read replica."
+                      value={draft.cursor.replicaSafetyMs}
+                      options={REPLICA_SAFETY_OPTIONS}
+                      format={formatDuration}
+                      disabled={!canEdit}
+                      onChange={(v) => setNested("cursor", { replicaSafetyMs: v })}
+                    />
+                  </Advanced>
                 </>
               )}
-            </Section>
+            </Step>
           )}
+
+          <Step
+            n={showsReflex ? 6 : 5}
+            title="Guidance"
+            hint="Your own instructions for awakened runs. Appended to the built-in operating contract, which always has the last word on delivery rules and safety bounds."
+          >
+            <TextAreaField
+              label="Run instructions"
+              info="Optional. Written to the agent every time it wakes — tone, what is worth reacting to, what to leave alone."
+              value={draft.instructions}
+              max={AWAKENING_BOUNDS.instructionsLength.MAX}
+              disabled={!canEdit}
+              onChange={(v) => set("instructions", v)}
+            />
+          </Step>
         </>
       )}
 
       {canEdit && dirty && (
-        <div className="sticky bottom-0 flex items-center justify-between gap-3 border-t border-neutral-200 bg-white/95 px-1 py-3 backdrop-blur dark:border-neutral-800 dark:bg-neutral-950/95">
-          <span className="text-xs text-neutral-500">Unsaved changes</span>
+        // -mx-4 px-4 cancels the page padding so the bar spans the panel edge
+        // to edge, the way a docked footer should.
+        <div className="sticky bottom-0 -mx-4 flex items-center justify-between gap-3 border-t border-xyne-border bg-xyne-surface/95 px-4 py-3 backdrop-blur">
+          <span className="text-[12px] text-xyne-fg-tertiary">Unsaved changes</span>
           <div className="flex gap-2">
             <button
               type="button"
               onClick={() => setDraft(saved)}
               disabled={saving}
-              className="rounded-lg px-3 py-1.5 text-sm text-neutral-600 hover:bg-neutral-100 disabled:opacity-50 dark:text-neutral-300 dark:hover:bg-neutral-800"
+              className="rounded-lg px-3 py-1.5 text-[13px] text-xyne-fg-secondary hover:bg-xyne-surface-subtle disabled:opacity-50"
             >
               Discard
             </button>
@@ -345,7 +400,7 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
               type="button"
               onClick={() => void persist()}
               disabled={saving}
-              className="flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-indigo-500 disabled:opacity-50"
+              className="flex items-center gap-2 rounded-lg bg-xyne-brand px-4 py-1.5 text-[13px] font-medium text-xyne-fg-inverse hover:bg-xyne-brand-hover disabled:opacity-50"
             >
               {saving && <CircleNotchIcon size={14} className="animate-spin" />}
               Save
@@ -354,6 +409,85 @@ export function AwakeningTab({ agent, canEdit, onAgentUpdated }: Props) {
         </div>
       )}
     </div>
+  );
+}
+
+// ── summary ─────────────────────────────────────────────────────────────────
+
+/**
+ * Plain-English restatement of the whole draft. The knobs are interdependent
+ * (a reflex threshold means nothing without its check interval; the gate can
+ * silence a heartbeat entirely), and reading them as isolated numbers is what
+ * made this panel hard to reason about. Recomputed live so it also doubles as
+ * a preview of unsaved edits.
+ */
+function Summary({ draft }: { draft: AwakeningSettings }) {
+  const lines: string[] = [];
+
+  if (draft.kind !== "reflex") lines.push(`Wakes every ${formatDuration(draft.periodMs)} and reviews the whole period.`);
+  if (draft.kind !== "heartbeat") {
+    lines.push(
+      `Wakes when ${draft.reflex.threshold} events pile up, checked every ${formatDuration(draft.reflex.checkIntervalMs)}` +
+        (draft.reflex.minIntervalMs > 0 ? `, never closer than ${formatDuration(draft.reflex.minIntervalMs)} apart.` : "."),
+    );
+  }
+
+  const ch = draft.channels;
+  const scoped = ch.include.length + ch.includePattern.length;
+  lines.push(
+    scoped === 0
+      ? `Watches every channel its bot is in, up to ${ch.maxChannels}.`
+      : `Watches ${scoped} channel rule${scoped === 1 ? "" : "s"}, up to ${ch.maxChannels} channels.` +
+        (ch.excludePattern.length ? ` ${ch.excludePattern.length} exclusion${ch.excludePattern.length === 1 ? "" : "s"} applied last.` : ""),
+  );
+
+  lines.push(
+    draft.gate.minHumanEvents > 0
+      ? `Skips any window with fewer than ${draft.gate.minHumanEvents} human message${draft.gate.minHumanEvents === 1 ? "" : "s"}.`
+      : "Runs on every wake, even an empty window.",
+  );
+  lines.push(`At most ${draft.limits.maxRunsPerHour} run${draft.limits.maxRunsPerHour === 1 ? "" : "s"} per hour.`);
+
+  const live = !draft.shadow;
+  const outcome = draft.shadow
+    ? "Posts nothing — shadow mode records what it would have said."
+    : `${WRITE_POLICY_LABELS[draft.writePolicy].label}: ${WRITE_POLICY_LABELS[draft.writePolicy].hint.toLowerCase()}`;
+
+  return (
+    <div className="rounded-xl border border-xyne-border-subtle bg-xyne-surface-subtle p-4">
+      <div className="text-[11px] font-semibold uppercase tracking-wide text-xyne-fg-tertiary">
+        What this configuration does
+      </div>
+      <ul className="mt-2 flex flex-col gap-1">
+        {lines.map((l) => (
+          <li key={l} className="text-[12px] leading-relaxed text-xyne-fg-secondary">
+            {l}
+          </li>
+        ))}
+        <li
+          className={`mt-1 text-[12px] font-medium leading-relaxed ${
+            live ? "text-xyne-warning-fg" : "text-xyne-success-fg"
+          }`}
+        >
+          {outcome}
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+/** The end-to-end latency of a live update — a number nobody can derive by
+ *  reading the two knobs that produce it, so state it outright. */
+function LatencyNote({ draft }: { draft: AwakeningSettings }) {
+  return (
+    <p className="rounded-lg bg-xyne-surface-sunken px-3 py-2 text-[11px] leading-relaxed text-xyne-fg-tertiary">
+      A live update reaches a running agent roughly{" "}
+      <span className="font-medium text-xyne-fg-secondary">
+        {formatDuration(draft.cursor.replicaSafetyMs + draft.reflex.checkIntervalMs)}
+      </span>{" "}
+      after the events land, once {draft.reflex.injectThreshold} of them have arrived. A run that finishes faster
+      than that will never receive one — its events go to the next wake instead.
+    </p>
   );
 }
 
@@ -369,28 +503,28 @@ function Header({
   onToggle: (v: boolean) => void;
 }) {
   return (
-    <div className="flex items-start justify-between gap-4 rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+    <div className="flex items-start justify-between gap-4 rounded-xl border border-xyne-border bg-xyne-surface p-4">
       <div className="flex gap-3">
-        <PulseIcon size={20} weight="bold" className="mt-0.5 shrink-0 text-indigo-500" />
+        <PulseIcon size={20} weight="bold" className="mt-0.5 shrink-0 text-xyne-brand" />
         <div>
-          <h3 className="text-sm font-medium text-neutral-900 dark:text-neutral-100">Awakening</h3>
-          <p className="mt-1 max-w-prose text-xs leading-relaxed text-neutral-500 dark:text-neutral-400">
+          <h3 className="text-[13px] font-semibold text-xyne-fg-primary">Awakening</h3>
+          <p className="mt-1 max-w-prose text-[12px] leading-relaxed text-xyne-fg-tertiary">
             Let this agent wake up on its own and act on what happened in its channels, without anybody
             triggering it. It reads a collected window of events, decides whether anything needs doing, and
             acts only within the limits set below.
           </p>
         </div>
       </div>
-      <Switch checked={enabled} disabled={!canEdit} onChange={onToggle} />
+      <Switch checked={enabled} disabled={!canEdit} onChange={onToggle} ariaLabel="Enable awakening" />
     </div>
   );
 }
 
 function LiveWarning() {
   return (
-    <div className="flex gap-3 rounded-xl border border-amber-300 bg-amber-50 p-4 dark:border-amber-800/60 dark:bg-amber-950/30">
-      <WarningIcon size={18} weight="fill" className="mt-0.5 shrink-0 text-amber-600" />
-      <p className="text-xs leading-relaxed text-amber-900 dark:text-amber-200">
+    <div className="flex gap-3 rounded-xl border border-xyne-warning-border bg-xyne-warning-bg p-4">
+      <WarningIcon size={18} weight="fill" className="mt-0.5 shrink-0 text-xyne-warning-fg" />
+      <p className="text-[12px] leading-relaxed text-xyne-warning-fg">
         This agent can post to channels and start new threads with nobody reviewing it first. Turn shadow
         mode on and read a few windows before allowing this.
       </p>
@@ -398,77 +532,115 @@ function LiveWarning() {
   );
 }
 
-function Section({ title, hint, children }: { title: string; hint?: string; children: React.ReactNode }) {
+/**
+ * Shown when the agent is enabled in config but the background workers have
+ * switched it off. Re-enabling is a side effect of saving, so the fix is to
+ * clear the underlying cause and press Save — say that plainly.
+ */
+function SystemDisabledNotice({ lastError }: { lastError: string | null }) {
   return (
-    <section className="flex flex-col gap-4">
-      <div>
-        <h4 className="text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
-          {title}
-        </h4>
-        {hint && <p className="mt-1 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
+    <div className="rounded-xl border border-xyne-warning-border bg-xyne-warning-bg p-4">
+      <div className="text-[13px] font-medium text-xyne-warning-fg">
+        Awakening is switched off for this agent
       </div>
-      <div className="flex flex-col gap-4 rounded-xl border border-neutral-200 p-4 dark:border-neutral-800">
+      <p className="mt-1 text-[12px] text-xyne-warning-fg">
+        It is enabled here, but the background workers stopped it and it is not waking.
+      </p>
+      {lastError && (
+        <p className="mt-2 break-words font-mono text-[11px] text-xyne-warning-fg">{lastError}</p>
+      )}
+      <p className="mt-2 text-[12px] text-xyne-warning-fg">
+        Fix the cause above, then press Save to switch it back on.
+      </p>
+    </div>
+  );
+}
+
+/** One numbered stage of the configuration, in the order the decision is made. */
+function Step({
+  n,
+  title,
+  hint,
+  children,
+}: {
+  n: number;
+  title: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-start gap-2.5">
+        <span className="mt-px flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-xyne-surface-sunken text-[11px] font-semibold text-xyne-fg-secondary">
+          {n}
+        </span>
+        <div>
+          <h4 className="text-[13px] font-semibold text-xyne-fg-primary">{title}</h4>
+          {hint && <p className="mt-0.5 max-w-prose text-[12px] leading-relaxed text-xyne-fg-tertiary">{hint}</p>}
+        </div>
+      </div>
+      <div className="flex flex-col divide-y divide-xyne-border-subtle rounded-xl border border-xyne-border bg-xyne-surface px-4">
         {children}
       </div>
     </section>
   );
 }
 
-function Switch({
-  checked,
-  disabled,
-  onChange,
+/**
+ * A single control row: label (+ hover explainer) on the left, control on the
+ * right. Every knob renders through this, so the rows line up and the panel
+ * reads as a list of decisions rather than a wall of prose.
+ */
+function Row({
+  label,
+  info,
+  note,
+  children,
 }: {
-  checked: boolean;
-  disabled?: boolean;
-  onChange: (v: boolean) => void;
+  label: string;
+  info?: string;
+  note?: string;
+  children: React.ReactNode;
 }) {
   return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      disabled={disabled}
-      onClick={() => onChange(!checked)}
-      className={`relative h-6 w-11 shrink-0 rounded-full transition-colors disabled:opacity-50 ${
-        checked ? "bg-indigo-600" : "bg-neutral-300 dark:bg-neutral-700"
-      }`}
-    >
-      <span
-        className={`absolute top-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
-          checked ? "translate-x-[22px]" : "translate-x-0.5"
-        }`}
-      />
-    </button>
+    <div className="flex min-h-[52px] items-center justify-between gap-4 py-3">
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[13px] text-xyne-fg-primary">{label}</span>
+          {info && <InfoIcon text={info} />}
+        </div>
+        {note && <p className="mt-0.5 text-[11px] text-xyne-fg-tertiary">{note}</p>}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">{children}</div>
+    </div>
   );
 }
 
-function Toggle({
-  label,
-  hint,
-  checked,
-  disabled,
-  onChange,
-}: {
-  label: string;
-  hint?: string;
-  checked: boolean;
-  disabled?: boolean;
-  onChange: (v: boolean) => void;
-}) {
+/**
+ * Rarely-touched knobs, folded away by default. The defaults for everything in
+ * here are right for almost every agent, and showing them next to the knobs
+ * that actually need a decision is what made the panel feel unconfigurable.
+ */
+function Advanced({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
-        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-      </div>
-      <Switch checked={checked} disabled={disabled} onChange={onChange} />
+    <div className="py-3">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1 text-[12px] text-xyne-fg-tertiary hover:text-xyne-fg-secondary"
+      >
+        <CaretRightIcon size={11} weight="bold" className={`transition-transform ${open ? "rotate-90" : ""}`} />
+        Advanced
+      </button>
+      {open && <div className="mt-1 flex flex-col divide-y divide-xyne-border-subtle">{children}</div>}
     </div>
   );
 }
 
 function Choice<T extends string>({
   label,
+  info,
   value,
   options,
   labels,
@@ -477,6 +649,7 @@ function Choice<T extends string>({
   onChange,
 }: {
   label: string;
+  info?: string;
   value: T;
   options: readonly T[];
   labels: Record<T, { label: string; hint: string }>;
@@ -485,30 +658,31 @@ function Choice<T extends string>({
   onChange: (v: T) => void;
 }) {
   return (
-    <div>
-      <div className="mb-2 flex items-center gap-2 text-sm text-neutral-800 dark:text-neutral-200">
-        {label}
-        {disabledHint && (
-          <span className="flex items-center gap-1 text-xs text-neutral-500">
-            <EyeIcon size={12} /> {disabledHint}
-          </span>
-        )}
+    <div className="py-3">
+      <div className="mb-2 flex items-center gap-1.5">
+        <span className="text-[13px] text-xyne-fg-primary">{label}</span>
+        {info && <InfoIcon text={info} />}
+        {disabledHint && <span className="text-[11px] text-xyne-fg-tertiary">— {disabledHint}</span>}
       </div>
-      <div className="flex flex-col gap-2">
+      {/* Radio cards rather than a <select>: each option carries its own
+          one-line consequence, which is the whole reason this knob is hard to
+          pick blind. */}
+      <div className="flex flex-col gap-1.5">
         {options.map((opt) => (
           <button
             key={opt}
             type="button"
             disabled={disabled}
+            aria-pressed={value === opt}
             onClick={() => onChange(opt)}
-            className={`rounded-lg border p-3 text-left transition-colors disabled:opacity-50 ${
+            className={`rounded-lg border px-3 py-2 text-left transition-colors disabled:opacity-50 ${
               value === opt
-                ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-950/30"
-                : "border-neutral-200 hover:border-neutral-300 dark:border-neutral-800 dark:hover:border-neutral-700"
+                ? "border-xyne-border-focus bg-xyne-surface-subtle"
+                : "border-xyne-border-subtle hover:border-xyne-border-strong"
             }`}
           >
-            <div className="text-sm text-neutral-900 dark:text-neutral-100">{labels[opt].label}</div>
-            <div className="mt-0.5 text-xs text-neutral-500 dark:text-neutral-400">{labels[opt].hint}</div>
+            <div className="text-[13px] text-xyne-fg-primary">{labels[opt].label}</div>
+            <div className="mt-0.5 text-[11px] text-xyne-fg-tertiary">{labels[opt].hint}</div>
           </button>
         ))}
       </div>
@@ -518,28 +692,29 @@ function Choice<T extends string>({
 
 function NumberField({
   label,
-  hint,
+  info,
   value,
   bound,
+  unit,
   disabled,
   onChange,
 }: {
   label: string;
-  hint?: string;
+  info?: string;
   value: number;
   bound: { MIN: number; MAX: number; DEFAULT: number };
+  unit?: string;
   disabled?: boolean;
   onChange: (v: number) => void;
 }) {
+  // The range and the default belong in the hover explainer, not as permanent
+  // grey text under every single field — fifteen of those is the noise that
+  // buried the labels that matter.
+  const explain = [info, `Allowed ${bound.MIN}–${bound.MAX}. Default ${bound.DEFAULT}.`]
+    .filter(Boolean)
+    .join(" ");
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
-        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-        <p className="mt-0.5 text-[11px] text-neutral-400">
-          {bound.MIN}–{bound.MAX}
-        </p>
-      </div>
+    <Row label={label} info={explain}>
       <input
         type="number"
         min={bound.MIN}
@@ -550,58 +725,16 @@ function NumberField({
         // the minimum the instant "1" is typed, which fights the user.
         onChange={(e) => onChange(Number(e.target.value))}
         onBlur={(e) => onChange(clampToBound(Number(e.target.value), bound))}
-        className="w-24 shrink-0 rounded-lg border border-neutral-200 px-3 py-1.5 text-sm disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900"
+        className="w-20 rounded-lg border border-xyne-border bg-xyne-surface px-2.5 py-1.5 text-right text-[13px] text-xyne-fg-primary focus:border-xyne-border-focus focus:outline-none disabled:opacity-50"
       />
-    </div>
-  );
-}
-
-/**
- * Multi-line free text with a live character budget. Truncation happens
- * server-side too (resolveAwakeningConfig), so the counter is a courtesy, not
- * the enforcement point.
- */
-function TextAreaField({
-  label,
-  hint,
-  value,
-  max,
-  disabled,
-  onChange,
-}: {
-  label: string;
-  hint?: string;
-  value: string;
-  max: number;
-  disabled?: boolean;
-  onChange: (v: string) => void;
-}) {
-  const over = value.length > max;
-  return (
-    <div className="flex flex-col gap-2">
-      <div>
-        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-      </div>
-      <textarea
-        rows={6}
-        value={value}
-        disabled={disabled}
-        maxLength={max}
-        placeholder="No extra guidance — the agent runs on its contract and skill alone."
-        onChange={(e) => onChange(e.target.value)}
-        className="w-full resize-y rounded-lg border border-neutral-200 px-3 py-2 text-sm leading-relaxed disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900"
-      />
-      <p className={`text-[11px] ${over ? "text-red-500" : "text-neutral-400"}`}>
-        {value.length}/{max}
-      </p>
-    </div>
+      {unit && <span className="w-14 text-[11px] text-xyne-fg-tertiary">{unit}</span>}
+    </Row>
   );
 }
 
 function SelectField({
   label,
-  hint,
+  info,
   value,
   options,
   format,
@@ -609,7 +742,7 @@ function SelectField({
   onChange,
 }: {
   label: string;
-  hint?: string;
+  info?: string;
   value: number;
   options: readonly number[];
   format: (v: number) => string;
@@ -620,16 +753,12 @@ function SelectField({
   // changed) must still be visible rather than silently snapping to another.
   const choices = options.includes(value) ? options : [value, ...options].sort((a, b) => a - b);
   return (
-    <div className="flex items-start justify-between gap-4">
-      <div>
-        <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-        {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-      </div>
+    <Row label={label} info={info}>
       <select
         value={value}
         disabled={disabled}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="w-32 shrink-0 rounded-lg border border-neutral-200 px-3 py-1.5 text-sm disabled:opacity-50 dark:border-neutral-800 dark:bg-neutral-900"
+        className="w-[136px] rounded-lg border border-xyne-border bg-xyne-surface px-2.5 py-1.5 text-[13px] text-xyne-fg-primary focus:border-xyne-border-focus focus:outline-none disabled:opacity-50"
       >
         {choices.map((o) => (
           <option key={o} value={o}>
@@ -637,20 +766,66 @@ function SelectField({
           </option>
         ))}
       </select>
+    </Row>
+  );
+}
+
+/**
+ * Multi-line free text with a live character budget. Truncation happens
+ * server-side too (resolveAwakeningConfig), so the counter is a courtesy, not
+ * the enforcement point.
+ */
+function TextAreaField({
+  label,
+  info,
+  value,
+  max,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  info?: string;
+  value: string;
+  max: number;
+  disabled?: boolean;
+  onChange: (v: string) => void;
+}) {
+  const over = value.length > max;
+  return (
+    <div className="flex flex-col gap-2 py-3">
+      <div className="flex items-center gap-1.5">
+        <span className="text-[13px] text-xyne-fg-primary">{label}</span>
+        {info && <InfoIcon text={info} />}
+      </div>
+      <textarea
+        rows={6}
+        value={value}
+        disabled={disabled}
+        maxLength={max}
+        placeholder={
+          "No extra guidance — the agent runs on its contract and skill alone.\n\n" +
+          "Example: Keep it casual and short. Jump in when someone is blocked or asking for a reminder. Stay out of social chatter."
+        }
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full resize-y rounded-lg border border-xyne-border bg-xyne-surface px-3 py-2 text-[13px] leading-relaxed text-xyne-fg-primary placeholder:text-xyne-fg-placeholder focus:border-xyne-border-focus focus:outline-none disabled:opacity-50"
+      />
+      <p className={`text-[11px] ${over ? "text-xyne-error-fg" : "text-xyne-fg-tertiary"}`}>
+        {value.length}/{max}
+      </p>
     </div>
   );
 }
 
 function ListField({
   label,
-  hint,
+  info,
   placeholder,
   values,
   disabled,
   onChange,
 }: {
   label: string;
-  hint?: string;
+  info?: string;
   placeholder: string;
   values: string[];
   disabled?: boolean;
@@ -665,27 +840,38 @@ function ListField({
   };
 
   return (
-    <div>
-      <div className="text-sm text-neutral-800 dark:text-neutral-200">{label}</div>
-      {hint && <p className="mt-0.5 max-w-prose text-xs text-neutral-500 dark:text-neutral-400">{hint}</p>}
-      <div className="mt-2 flex flex-wrap gap-1.5">
-        {values.map((v) => (
-          <span
-            key={v}
-            className="flex items-center gap-1 rounded-md bg-neutral-100 px-2 py-1 font-mono text-xs dark:bg-neutral-800"
-          >
-            {v}
-            {!disabled && (
-              <button type="button" onClick={() => onChange(values.filter((x) => x !== v))} aria-label={`Remove ${v}`}>
-                <XIcon size={11} />
-              </button>
-            )}
-          </span>
-        ))}
-        {values.length === 0 && <span className="text-xs text-neutral-400">None</span>}
+    <div className="flex flex-col gap-2 py-3">
+      <div className="flex items-center gap-1.5">
+        <span className="text-[13px] text-xyne-fg-primary">{label}</span>
+        {info && <InfoIcon text={info} />}
+        <span className="ml-auto text-[11px] text-xyne-fg-tertiary">
+          {values.length === 0 ? "none" : `${values.length} set`}
+        </span>
       </div>
+      {values.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {values.map((v) => (
+            <span
+              key={v}
+              className="flex items-center gap-1 rounded-md border border-xyne-border-subtle bg-xyne-surface-sunken px-2 py-1 font-mono text-[11px] text-xyne-fg-secondary"
+            >
+              {v}
+              {!disabled && (
+                <button
+                  type="button"
+                  onClick={() => onChange(values.filter((x) => x !== v))}
+                  aria-label={`Remove ${v}`}
+                  className="text-xyne-fg-tertiary hover:text-xyne-fg-primary"
+                >
+                  <XIcon size={11} />
+                </button>
+              )}
+            </span>
+          ))}
+        </div>
+      )}
       {!disabled && (
-        <div className="mt-2 flex gap-2">
+        <div className="flex gap-2">
           <input
             value={entry}
             placeholder={placeholder}
@@ -696,12 +882,13 @@ function ListField({
                 add();
               }
             }}
-            className="flex-1 rounded-lg border border-neutral-200 px-3 py-1.5 font-mono text-xs dark:border-neutral-800 dark:bg-neutral-900"
+            className="min-w-0 flex-1 rounded-lg border border-xyne-border bg-xyne-surface px-3 py-1.5 font-mono text-[11px] text-xyne-fg-primary placeholder:text-xyne-fg-placeholder focus:border-xyne-border-focus focus:outline-none"
           />
           <button
             type="button"
             onClick={add}
-            className="rounded-lg border border-neutral-200 px-3 py-1.5 text-xs hover:bg-neutral-50 dark:border-neutral-800 dark:hover:bg-neutral-800"
+            disabled={!entry.trim()}
+            className="shrink-0 rounded-lg border border-xyne-border px-3 py-1.5 text-[12px] text-xyne-fg-secondary hover:bg-xyne-surface-subtle disabled:opacity-40"
           >
             Add
           </button>

--- a/apps/xyne-claw-auth/frontend/src/v3/lib/awakeningBounds.ts
+++ b/apps/xyne-claw-auth/frontend/src/v3/lib/awakeningBounds.ts
@@ -43,7 +43,7 @@ export const AWAKENING_BOUNDS = {
   injectThreshold: { MIN: 1, MAX: 1_000, DEFAULT: 10 },
   maxInjectionsPerSession: { MIN: 0, MAX: 20, DEFAULT: 3 },
   injectMinIntervalMs: { MIN: 0, MAX: 3_600_000, DEFAULT: 60_000 },
-  instructionsLength: { MIN: 0, MAX: 4_000, DEFAULT: 0 },
+  instructionsLength: { MIN: 0, MAX: 10_000, DEFAULT: 0 },
   replicaSafetyMs: { MIN: 0, MAX: 300_000, DEFAULT: 30_000 },
 } as const;
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
