### PR TITLE
feat: new dm person selector

### DIFF
--- a/apps/dashboard/src/components/Chat/AddDmForm/ComposeDmPanel.tsx
+++ b/apps/dashboard/src/components/Chat/AddDmForm/ComposeDmPanel.tsx
@@ -15,7 +15,7 @@ import { useAuthContextValues } from '../../../hooks/useAuth';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useDragAndDropAreaRef } from '../../../hooks/useDragAndDropAreaRef';
 import { usePlatform } from '../../../hooks/usePlatform';
-import { useActiveUsers, useUser } from '../../../hooks/useUsers';
+import { useActiveUsers, useActiveUserSearch, useUser } from '../../../hooks/useUsers';
 import { cn } from '../../../utils/classNames';
 import {
   EVENT_PROPERTIES,
@@ -204,27 +204,40 @@ export const ComposeDmPanel: React.FC = () => {
       }));
   }, [channelResults]);
 
+  const mentionUserResults = useActiveUserSearch(mentionSearchQuery, 10);
+
   const composeMentionItems = useMemo(() => {
     const query = mentionSearchQuery.trim().toLowerCase();
     const isSelfDm = selectedUsers.length === 1 && selectedUsers[0]?.id === context.userID;
-    const selectedUserMentions = selectedUsers
-      .filter(selectedUser => isSelfDm || selectedUser.id !== context.userID)
-      .filter(selectedUser => {
-        if (!query) return true;
 
-        const emailLocalPart = selectedUser.email.split('@')[0] ?? '';
-        return [
-          selectedUser.displayName,
-          selectedUser.name,
-          selectedUser.email,
-          emailLocalPart,
-        ].some(value => value?.toLowerCase().includes(query) ?? false);
-      })
-      .map(selectedUser =>
-        userToMentionResult(selectedUser, selectedUser.id === context.userID, true),
+    const matchesQuery = (candidate: User): boolean => {
+      if (!query) return true;
+
+      const emailLocalPart = candidate.email.split('@')[0] ?? '';
+      return [candidate.displayName, candidate.name, candidate.email, emailLocalPart].some(
+        value => value?.toLowerCase().includes(query) ?? false,
       );
+    };
 
-    if (selectedUsers.length <= 1) return selectedUserMentions;
+    const recipients = selectedUsers
+      .filter(selectedUser => isSelfDm || selectedUser.id !== context.userID)
+      .filter(matchesQuery);
+    const recipientIds = new Set(recipients.map(selectedUser => selectedUser.id));
+
+    const workspaceUsers = mentionUserResults.filter(
+      candidate => !recipientIds.has(candidate.id) && (isSelfDm || candidate.id !== context.userID),
+    );
+
+    const userMentions = [
+      ...recipients.map(selectedUser =>
+        userToMentionResult(selectedUser, selectedUser.id === context.userID, true),
+      ),
+      ...workspaceUsers.map(candidate =>
+        userToMentionResult(candidate, candidate.id === context.userID),
+      ),
+    ];
+
+    if (selectedUsers.length <= 1) return userMentions;
 
     // Offer @channel and @here for group DMs, matching useMentionSearch's special
     // mentions. The backend (sendInitialMessage) handles both in the initial message.
@@ -245,10 +258,10 @@ export const ComposeDmPanel: React.FC = () => {
       },
     ].filter(mention => !query || mention.name.includes(query));
 
-    if (specialMentions.length === 0) return selectedUserMentions;
+    if (specialMentions.length === 0) return userMentions;
 
-    return [...specialMentions, ...selectedUserMentions];
-  }, [mentionSearchQuery, selectedUsers, context.userID]);
+    return [...specialMentions, ...userMentions];
+  }, [mentionSearchQuery, selectedUsers, context.userID, mentionUserResults]);
 
   const channelParticipation = useGetChannelUserStatus(existingDmChannel?.id || '');
   const [latestMessage] = useCachedQuery(


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1hQMdg8GSjq0oOzDVkJYa8BcKTPBg017P/view?usp=sharing

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
