### PR TITLE
fix: show agent display name in progress pill

### DIFF
--- a/apps/backend/src/apps/controllers/chatController.ts
+++ b/apps/backend/src/apps/controllers/chatController.ts
@@ -94,6 +94,7 @@ const AgentProgressBodySchema = z.object({
   conversationId: z.string().min(1).trim(),
   channelId: z.string().min(1).trim().optional(),
   agentSlug: z.string().min(1).trim().optional(),
+  agentName: z.string().min(1).trim().optional(),
   toolLabel: z.string().optional(),
   status: z.enum(['working', 'done']).default('working'),
   triggeredByUserId: z.string().min(1).trim().optional(), // human who started the run — gates the Stop button
@@ -419,7 +420,7 @@ export class ChatController {
         res.status(400).json({ error: 'Validation error', code: 'VALIDATION_ERROR', details: parsed.error.errors });
         return;
       }
-      const { conversationId, channelId, agentSlug, toolLabel, status, triggeredByUserId, sessionId } = parsed.data;
+      const { conversationId, channelId, agentSlug, agentName, toolLabel, status, triggeredByUserId, sessionId } = parsed.data;
       const userId = req.user!.id; // agent's spacesAppUserId from the verified app token
 
       // Resolve channelId if only conversationId was given — dashboard subscribes on channel.
@@ -443,15 +444,18 @@ export class ChatController {
         return;
       }
 
-      // Tool-label updates from the runner don't carry the triggerer; carry it
-      // forward from the existing hash field so the Stop button stays visible to
-      // the initiator across the whole run (and after a thread reopen/rehydrate).
+      // Tool-label updates from the runner don't carry all presentation metadata;
+      // carry it forward from the existing hash field so the Stop button and display
+      // name survive across the whole run (and after a thread reopen/rehydrate).
       let resolvedTriggeredBy = triggeredByUserId ?? null;
-      if (!resolvedTriggeredBy && status !== 'done') {
+      let resolvedAgentName = agentName ?? null;
+      if ((!resolvedTriggeredBy || !resolvedAgentName) && status !== 'done') {
         const existingRaw = await redisService.getHashField(stateKey, userId);
         if (existingRaw) {
           try {
-            resolvedTriggeredBy = (JSON.parse(existingRaw) as { triggeredByUserId?: string }).triggeredByUserId ?? null;
+            const existing = JSON.parse(existingRaw) as { triggeredByUserId?: string; agentName?: string };
+            resolvedTriggeredBy = resolvedTriggeredBy ?? existing.triggeredByUserId ?? null;
+            resolvedAgentName = resolvedAgentName ?? existing.agentName ?? null;
           } catch { /* ignore malformed */ }
         }
       }
@@ -461,6 +465,7 @@ export class ChatController {
         conversationId,
         channelId: resolvedChannelId,
         agentSlug,
+        agentName: resolvedAgentName ?? agentSlug ?? null,
         agentUserId: userId,
         sessionId: sessionId ?? null,
         toolLabel: toolLabel ?? null,
@@ -485,7 +490,7 @@ export class ChatController {
         messageId: `agent_progress_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
         conversationId,
         senderId: userId,
-        senderName: agentSlug ?? 'agent',
+        senderName: resolvedAgentName ?? agentSlug ?? 'agent',
         content: JSON.stringify({ type: 'agent_progress', data: payload }),
         msgType: MessageType.SYSTEM as const,
         createdAt: new Date(),

--- a/apps/dashboard/src/components/Chat/ChatInput/AgentProgressIndicator.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/AgentProgressIndicator.tsx
@@ -82,7 +82,7 @@ export function AgentProgressIndicator({
           <span key={a.agentUserId ?? a.agentSlug ?? 'agent'} style={rowStyle}>
             <AgentSpinner variant={a.variant} size={12} />
             <span className='truncate max-w-[320px]'>
-              {a.agentSlug ? <strong className='mr-1'>{a.agentSlug}</strong> : null}
+              {a.agentName ? <strong className='mr-1'>{a.agentName}</strong> : null}
               {a.toolLabel ?? 'working…'}
             </span>
           </span>

--- a/apps/dashboard/src/hooks/useAgentProgress.ts
+++ b/apps/dashboard/src/hooks/useAgentProgress.ts
@@ -21,6 +21,7 @@ import { MessageType } from '@xyne/shared';
  */
 export interface ActiveAgent {
   agentSlug: string | null;
+  agentName: string | null;
   agentUserId: string | null;
   toolLabel: string | null;
   /** Human who started the run — only this user may stop it (gates the Stop button). */
@@ -36,6 +37,7 @@ interface AgentProgressData {
     conversationId?: string;
     channelId?: string;
     agentSlug?: string | null;
+    agentName?: string | null;
     agentUserId?: string | null;
     /** Run id. Scopes done-suppression so a straggler from a finished run can't resurrect the spinner. */
     sessionId?: string | null;
@@ -90,6 +92,7 @@ export function useAgentProgress(sessionId: string | undefined): UseAgentProgres
       .get<{
         data?: Array<{
           agentSlug?: string | null;
+          agentName?: string | null;
           agentUserId?: string | null;
           sessionId?: string | null;
           toolLabel?: string | null;
@@ -110,6 +113,7 @@ export function useAgentProgress(sessionId: string | undefined): UseAgentProgres
             if (d.sessionId && doneSessionsRef.current.has(d.sessionId)) continue; // its run already ended live — don't resurrect
             next.set(key, {
               agentSlug: d.agentSlug ?? null,
+              agentName: d.agentName ?? d.agentSlug ?? null,
               agentUserId: d.agentUserId ?? null,
               toolLabel: d.toolLabel ?? null,
               triggeredByUserId: d.triggeredByUserId ?? null,
@@ -165,6 +169,7 @@ export function useAgentProgress(sessionId: string | undefined): UseAgentProgres
             : pickRandomAgentSpinnerVariant(existing?.variant);
         next.set(key, {
           agentSlug: d.agentSlug ?? null,
+          agentName: d.agentName ?? d.agentSlug ?? null,
           agentUserId: d.agentUserId ?? null,
           toolLabel: nextLabel,
           // Tool-label updates may omit the triggerer; keep the first value seen.

--- a/apps/xyne-claw-auth/backend/src/lib/session-context.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/session-context.ts
@@ -46,6 +46,8 @@ export interface SessionContext {
   agentId?: string;
   agentOrgId?: string | null;
   agentSlug?: string | undefined;
+  /** Display name shown in Spaces transient progress surfaces. */
+  agentName?: string | undefined;
   responseMode: "conversation" | "approval";
   /**
    * Suppress the thread reply for this run entirely.

--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -2108,6 +2108,7 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
               conversationId: planConversationId,
               channelId: planChannelId,
               agentSlug: planAgentSlug,
+              agentName: agent.name,
               spacesAppUserId: agent.spacesAppUserId ?? undefined,
               appToken,
               toolLabel: "Starting the plan…",

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -1081,6 +1081,7 @@ async function postGoalPhase(
         conversationId: fields.conversationId,
         ...(fields.channelId ? { channelId: fields.channelId } : {}),
         ...(fields.agentSlug ? { agentSlug: fields.agentSlug } : {}),
+        ...(fields.agentName ? { agentName: fields.agentName } : {}),
         userId: fields.spacesAppUserId,
         toolLabel: label,
         status: "working",
@@ -2180,7 +2181,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
     // tool calls), not as a permanent chat message — the goal loop's meta lines
     // shouldn't clutter the thread. The terminal outcome stays a real message.
     await postGoalPhase(
-      { conversationId: payload.conversationId, channelId: payload.channelId, agentSlug: agent.slug, spacesAppUserId: agent.spacesAppUserId, appToken: agent.appToken },
+      { conversationId: payload.conversationId, channelId: payload.channelId, agentSlug: agent.slug, agentName: agent.name, spacesAppUserId: agent.spacesAppUserId, appToken: agent.appToken },
       intercept.replyToUser,
     );
   } else {
@@ -2609,6 +2610,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
             agentId: agent.id,
             agentOrgId: agent.orgId,
             agentSlug: agent.slug,
+            agentName: agent.name,
           responseMode: "conversation",
           appToken: agent.appToken,
           spacesAppId: agent.spacesAppId,
@@ -2987,6 +2989,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
       agentId: agent.id,
       agentOrgId: agent.orgId,
       agentSlug: agent.slug,
+      agentName: agent.name,
       responseMode: eventType === "USER_MENTIONED" ? "approval" as const : "conversation" as const,
       appToken: agent.appToken,
       spacesAppId: agent.spacesAppId,
@@ -3148,6 +3151,7 @@ async function handleWebhook(req: Request, res: Response): Promise<void> {
               conversationId: payload.conversationId,
               channelId: payload.channelId,
               agentSlug: agent.slug,
+              agentName: agent.name,
               userId: agent.spacesAppUserId,
               toolLabel: "Working on it...",
               status: "working",
@@ -3892,6 +3896,7 @@ export async function handleAutomationWebhook(
       agentId: agent.id,
       agentOrgId: agent.orgId,
       agentSlug: agent.slug,
+      agentName: agent.name,
       responseMode: "conversation",
       appToken,
       spacesAppId: agent.spacesAppId!,
@@ -4223,6 +4228,7 @@ export async function handleAutomationWebhook(
       conversationId: payload.conversationId ?? "",
       task: task!,
       agentSlug: agent.slug,
+      agentName: agent.name,
       responseMode: "conversation",
       appToken: decryptStoredField(agent.spacesAppToken!),
       spacesAppId: agent.spacesAppId!,
@@ -5265,6 +5271,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       conversationId: ctx.conversationId,
       channelId: ctx.channelId,
       agentSlug: ctx.agentSlug,
+      agentName: ctx.agentName,
       userId: ctx.spacesAppUserId,
       status: "done",
     }, ctx.appToken).catch((err) =>
@@ -5534,6 +5541,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
             conversationId: ctx.conversationId,
             channelId: ctx.channelId,
             agentSlug: ctx.agentSlug,
+            agentName: ctx.agentName,
             spacesAppUserId: ctx.spacesAppUserId,
             appToken: ctx.appToken,
             toolLabel: "Starting the plan…",
@@ -7413,6 +7421,7 @@ router.post("/progress", requireStrictS2S, async (req: Request, res: Response) =
         conversationId: ctx.conversationId,
         channelId: ctx.channelId,
         agentSlug: ctx.agentSlug,
+        agentName: ctx.agentName,
         userId: ctx.spacesAppUserId,
         toolLabel,
         status: "working",

--- a/apps/xyne-claw-auth/backend/src/surfaces/spaces/client.ts
+++ b/apps/xyne-claw-auth/backend/src/surfaces/spaces/client.ts
@@ -104,6 +104,7 @@ export async function emitAgentWorkingSignal(opts: {
   conversationId?: string | undefined;
   channelId?: string | undefined;
   agentSlug?: string | undefined;
+  agentName?: string | undefined;
   spacesAppUserId?: string | undefined;
   appToken?: string | undefined;
   toolLabel?: string;
@@ -116,6 +117,7 @@ export async function emitAgentWorkingSignal(opts: {
         conversationId: opts.conversationId,
         channelId: opts.channelId,
         agentSlug: opts.agentSlug,
+        agentName: opts.agentName,
         userId: opts.spacesAppUserId,
         toolLabel: opts.toolLabel ?? "Working on it...",
         status: "working",


### PR DESCRIPTION
1. Problem Description:
The transient agent activity pill above the chat input displayed the agent slug (for example, `xyne-spaces-architect`) instead of the configured display name users see elsewhere.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in Spaces thread by Harsh Sharma.

3. Explain the solution implemented in the PR:
- Carry `agentName` alongside `agentSlug` in the Claw Auth session context and all Spaces `/chat/agentProgress` calls.
- Accept and persist `agentName` in the Spaces backend Redis progress payload, preserving it across tool-label-only updates and rehydrate.
- Render `agentName` in the dashboard `AgentProgressIndicator`, with slug fallback for older/incomplete progress payloads.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `pnpm --filter xyne-spaces-dashboard typecheck` ✅
- `pnpm --filter xyne-spaces-backend typecheck` ✅
- `pnpm --filter xyne-claw-auth typecheck` attempted; fails on existing generated Prisma/client type issues unrelated to this change in the sandbox (`@prisma/client` exports missing such as `Prisma`, `PrismaClient`).
- `git diff --check` ✅

9. Services to which this change is to be deployed:
- `xyne-backend`
- `xyne-claw-auth`
- dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A