### PR TITLE
fix: allow thread cleanup after parent message deletion

### DIFF
--- a/apps/backend/src/zero/acl/tables/conversations-acl.test.ts
+++ b/apps/backend/src/zero/acl/tables/conversations-acl.test.ts
@@ -1,0 +1,78 @@
+jest.mock('@xyne/shared', () => ({
+  ChannelVisibility: { PUBLIC: 'PUBLIC' },
+  schema: { tables: {} },
+}));
+
+jest.mock('../../queries', () => ({
+  zql: {
+    conversations: {
+      where: jest.fn(() => ({
+        related: jest.fn(() => ({ one: jest.fn() })),
+      })),
+    },
+    messages: {
+      where: jest.fn(),
+    },
+    channels: {
+      where: jest.fn(() => ({ one: jest.fn() })),
+    },
+    channel_participants: {
+      where: jest.fn(() => ({
+        where: jest.fn(() => ({ one: jest.fn() })),
+      })),
+    },
+  },
+}));
+
+import type { Transaction } from '@rocicorp/zero';
+import type { Schema } from '@xyne/shared';
+import type { QueryContext } from '../core/types';
+import { ConversationsACL } from './conversations-acl';
+
+const context: QueryContext = {
+  userID: 'user-1',
+  workspaceId: 'workspace-1',
+  role: 'MEMBER',
+  orgRole: 'MEMBER',
+  memberId: 'member-1',
+};
+
+function transactionReturning(...rows: unknown[]): Transaction<Schema> {
+  return {
+    run: jest.fn().mockImplementation(() => Promise.resolve(rows.shift())),
+  } as unknown as Transaction<Schema>;
+}
+
+describe('ConversationsACL.canDelete', () => {
+  const acl = new ConversationsACL(context);
+
+  it('allows empty-thread cleanup after message deletion removes all messages', async () => {
+    const tx = transactionReturning(
+      {
+        conversationId: 'conversation-1',
+        createdBy: 'user-2',
+        channel: { workspaceId: context.workspaceId, isArchived: false },
+      },
+      { channel: { workspaceId: context.workspaceId } },
+      [],
+    );
+
+    await expect(acl.canDelete({ conversationId: 'conversation-1' }, tx)).resolves.toBeUndefined();
+  });
+
+  it("does not allow deleting another user's conversation while messages still exist", async () => {
+    const tx = transactionReturning(
+      {
+        conversationId: 'conversation-1',
+        createdBy: 'user-2',
+        channel: { workspaceId: context.workspaceId, isArchived: false },
+      },
+      { channel: { workspaceId: context.workspaceId } },
+      [{ messageId: 'message-1' }],
+    );
+
+    await expect(acl.canDelete({ conversationId: 'conversation-1' }, tx)).rejects.toThrow(
+      'Conversation delete failed: only the conversation creator can delete it',
+    );
+  });
+});

--- a/apps/backend/src/zero/acl/tables/conversations-acl.ts
+++ b/apps/backend/src/zero/acl/tables/conversations-acl.ts
@@ -89,6 +89,19 @@ export class ConversationsACL extends BaseACL<'conversations'> {
     if (conversation.createdBy === this.ctx.userID || conversation.createdBy === 'user') {
       return;
     }
+
+    // Message deletion can legitimately remove the last visible reply from a
+    // thread whose initial message was already tombstoned. By the time the
+    // mutator deletes the conversation, all messages have been removed. Allow
+    // that empty-thread cleanup without giving users permission to delete
+    // conversations that still contain messages owned by others.
+    const remainingMessages = await tx.run(
+      zql.messages.where('conversationId', conversation.conversationId),
+    );
+    if (remainingMessages.length === 0) {
+      return;
+    }
+
     throw new MutationACLError('Conversation delete failed: only the conversation creator can delete it', 'conversations');
   }
 }

--- a/apps/backend/src/zero/acl/tables/messages-acl.test.ts
+++ b/apps/backend/src/zero/acl/tables/messages-acl.test.ts
@@ -11,6 +11,7 @@ jest.mock('../../queries', () => ({
     },
     conversations: {
       where: jest.fn(() => ({
+        one: jest.fn(),
         related: jest.fn(() => ({ one: jest.fn() })),
       })),
     },
@@ -72,6 +73,42 @@ describe('MessagesACL.canDelete', () => {
 
     await expect(acl.canDelete({ messageId: 'message-1' }, tx)).rejects.toThrow(
       'Message not found in this workspace',
+    );
+  });
+
+  it('allows cleanup of a deleted initial-message tombstone after the last reply is removed', async () => {
+    const tx = transactionReturning(
+      {
+        messageId: 'root-message',
+        conversationId: 'conversation-1',
+        senderId: 'user-2',
+        msgType: 'USER',
+        isDeleted: true,
+      },
+      { channel: { workspaceId: context.workspaceId } },
+      { initialMessageId: 'root-message' },
+      [{ messageId: 'root-message' }],
+    );
+
+    await expect(acl.canDelete({ messageId: 'root-message' }, tx)).resolves.toBeUndefined();
+  });
+
+  it("does not allow deleting another user's tombstoned initial message while replies still exist", async () => {
+    const tx = transactionReturning(
+      {
+        messageId: 'root-message',
+        conversationId: 'conversation-1',
+        senderId: 'user-2',
+        msgType: 'USER',
+        isDeleted: true,
+      },
+      { channel: { workspaceId: context.workspaceId } },
+      { initialMessageId: 'root-message' },
+      [{ messageId: 'root-message' }, { messageId: 'reply-message' }],
+    );
+
+    await expect(acl.canDelete({ messageId: 'root-message' }, tx)).rejects.toThrow(
+      'Message delete failed: only the original sender can delete this message',
     );
   });
 });

--- a/apps/backend/src/zero/acl/tables/messages-acl.ts
+++ b/apps/backend/src/zero/acl/tables/messages-acl.ts
@@ -73,6 +73,31 @@ export class MessagesACL extends BaseACL<'messages'> {
     if (message.senderId === this.ctx.userID || message.msgType === MessageType.SYSTEM) {
       return;
     }
+
+    const conversation = await tx.run(
+      zql.conversations.where('conversationId', message.conversationId).one(),
+    );
+
+    // When the initial message of a thread is deleted while replies still exist,
+    // the message is kept as a tombstone so the thread remains visible. Deleting
+    // the final reply later needs to remove that tombstone and then the empty
+    // conversation. Allow that cleanup only when this message is the deleted
+    // initial message and there are no other messages left in the conversation.
+    // This keeps the normal "only sender can delete" rule for live messages and
+    // for tombstones that still anchor visible replies.
+    if (conversation?.initialMessageId === message.messageId && message.isDeleted) {
+      const remainingMessages = await tx.run(
+        zql.messages.where('conversationId', message.conversationId),
+      );
+      const hasOtherMessages = remainingMessages.some(
+        remainingMessage => remainingMessage.messageId !== message.messageId,
+      );
+
+      if (!hasOtherMessages) {
+        return;
+      }
+    }
+
     throw new MutationACLError('Message delete failed: only the original sender can delete this message', 'messages');
   }
 }


### PR DESCRIPTION
1. Problem Description:
When a parent/root message in a thread is deleted while replies still exist, the root message is kept as a deleted tombstone so the thread remains visible. If a user then deletes the remaining replies, the UI reports success but cleanup can fail to remove the tombstoned root message/conversation from the DB because ACL checks still treat the tombstone and empty conversation as owned by the original creator.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in Spaces: after deleting the parent message, deleting thread replies shows success but rows remain in DB.

3. Explain the solution implemented in the PR:
Allow the message ACL to delete a tombstoned initial message only when it is the conversation initial message and no other messages remain. Allow the conversation ACL to delete an empty conversation during this cleanup path, while still rejecting deletion of another user's non-empty conversations/messages. Added targeted ACL tests for both the allowed cleanup and denied non-cleanup cases.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
Ran: `cd apps/backend && NODE_OPTIONS=--max-old-space-size=8192 LIVEKIT_API_KEY=test-livekit-key LIVEKIT_API_SECRET=test-livekit-secret pnpm exec dotenv -e .env.local -- pnpm test -- messages-acl.test.ts conversations-acl.test.ts --runInBand`
Result: 2 test suites passed, 6 tests passed.

9. Services to which this change is to be deployed:
backend

10. Main PR link (if this PR is raised against a release branch):
N/A