### PR TITLE
fix: XYNE-54658 agent discovery + connector suggestions (claw only)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/agent-card.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/agent-card.ts
@@ -268,6 +268,7 @@ export interface AgentRowLike {
   systemPrompt: string;
   modelId?: string | null;
   color?: string | null;
+  scope?: string | null;
 }
 
 /**
@@ -282,11 +283,15 @@ export function identityFromAgentRow(
   row: AgentRowLike,
   resolved: ResolvedCapabilities,
   builtBy?: string,
+  owner?: { name?: string | null; id?: string | null },
 ): AgentIdentity {
   return agentIdentity({
     name: row.name,
     slug: row.slug,
     ...(builtBy ? { builtBy } : {}),
+    ...(owner?.name ? { ownedBy: owner.name } : {}),
+    ...(owner?.id ? { ownedById: owner.id } : {}),
+    ...(row.scope ? { scope: row.scope } : {}),
     description: row.description ?? "",
     systemPrompt: row.systemPrompt,
     ...(row.modelId ? { modelId: row.modelId } : {}),

--- a/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
@@ -1,0 +1,149 @@
+/**
+ * Maps what a user asked for onto connectors that could do it.
+ *
+ * Exists because prompt-driven suggestion is unreliable: the model has to
+ * notice the gap, know the connector exists, know it is not connected, and
+ * choose to call a tool. It frequently gets one of those wrong — most often by
+ * assuming a connector is already connected and explaining the shortfall in
+ * prose instead of offering the fix.
+ *
+ * So the server decides too. After a run, the user's own words are matched
+ * against these signals; any connector that matches and is NOT connected can be
+ * offered regardless of what the model did.
+ *
+ * Two kinds of signal, deliberately kept apart:
+ *
+ *   `domains`  — matched by parsing URLs out of the text and comparing the
+ *                HOSTNAME exactly (or as a subdomain). Never by regex: a
+ *                substring test for "github.com" also matches
+ *                `github.com.attacker.net` and `evil-github.com`, which is the
+ *                unanchored-host bug CodeQL flags.
+ *
+ *   `keywords` — whole-word prose matches ("summarise my figma file"). These
+ *                never touch URLs, so anchoring does not apply. Kept
+ *                conservative: a product's own name, never a generic word like
+ *                "document" or "search", since a wrong card is worse than none.
+ */
+
+export interface ConnectorHint {
+  /** `mcp_servers.type` this hint points at. */
+  serverType: string;
+  /** Registrable hostnames. Subdomains match; lookalikes do not. */
+  domains?: readonly string[];
+  /** Whole-word prose signals, lowercase. */
+  keywords?: readonly string[];
+}
+
+export const CONNECTOR_HINTS: readonly ConnectorHint[] = [
+  { serverType: "github", domains: ["github.com"], keywords: ["github"] },
+  { serverType: "bitbucket", domains: ["bitbucket.org"], keywords: ["bitbucket"] },
+  {
+    serverType: "google",
+    domains: ["docs.google.com", "drive.google.com", "sheets.google.com", "mail.google.com"],
+    keywords: ["gmail", "google doc", "google docs", "google drive", "google sheet", "google sheets", "google calendar", "google meet"],
+  },
+  {
+    serverType: "microsoft",
+    domains: ["outlook.com", "outlook.office.com", "sharepoint.com"],
+    keywords: ["onedrive", "outlook", "teams", "sharepoint"],
+  },
+  { serverType: "slack", domains: ["slack.com"], keywords: ["slack"] },
+  { serverType: "notion", domains: ["notion.so"], keywords: ["notion"] },
+  { serverType: "figma", domains: ["figma.com"], keywords: ["figma"] },
+  { serverType: "jira", domains: ["atlassian.net"], keywords: ["jira"] },
+  { serverType: "asana", domains: ["asana.com"], keywords: ["asana"] },
+  { serverType: "linear", domains: ["linear.app"], keywords: ["linear"] },
+  { serverType: "grafana", keywords: ["grafana"] },
+  { serverType: "shopify", domains: ["myshopify.com"], keywords: ["shopify"] },
+  { serverType: "hubspot", domains: ["hubspot.com"], keywords: ["hubspot"] },
+  { serverType: "salesforce", domains: ["salesforce.com", "force.com"], keywords: ["salesforce"] },
+  { serverType: "intercom", domains: ["intercom.com"], keywords: ["intercom"] },
+  { serverType: "amplitude", domains: ["amplitude.com"], keywords: ["amplitude"] },
+  { serverType: "mixpanel", domains: ["mixpanel.com"], keywords: ["mixpanel"] },
+  { serverType: "bigquery", keywords: ["bigquery"] },
+  { serverType: "databricks", domains: ["databricks.com"], keywords: ["databricks"] },
+];
+
+/** Finds http(s) URLs; the host itself is then parsed, never regex-matched. */
+const URL_PATTERN = /https?:\/\/[^\s<>"')\]]+/gi;
+
+interface FoundUrl {
+  host: string;
+  at: number;
+}
+
+function extractUrls(text: string): FoundUrl[] {
+  const found: FoundUrl[] = [];
+  for (const match of text.matchAll(URL_PATTERN)) {
+    try {
+      const host = new URL(match[0]).hostname.toLowerCase().replace(/\.$/, "");
+      if (host) found.push({ host, at: match.index ?? 0 });
+    } catch {
+      /* not a usable URL — ignore */
+    }
+  }
+  return found;
+}
+
+/**
+ * True when `host` IS the domain or a subdomain of it.
+ *
+ * The dot in the suffix check is what makes this safe: "github.com" matches
+ * `api.github.com` but not `github.com.attacker.net` (different registrable
+ * domain) or `evil-github.com` (no dot boundary).
+ */
+function hostMatches(host: string, domain: string): boolean {
+  return host === domain || host.endsWith(`.${domain}`);
+}
+
+/** Escapes a keyword so it cannot smuggle regex syntax into the matcher. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Blanks out URLs so keyword matching only ever sees prose.
+ *
+ * Without this, `github.com.attacker.net` would trip the "github" KEYWORD even
+ * though its hostname was correctly rejected — reintroducing the lookalike bug
+ * through the back door. Replaced with spaces of equal length so the character
+ * offsets used for ordering stay accurate.
+ */
+function maskUrls(text: string): string {
+  return text.replace(URL_PATTERN, (match) => " ".repeat(match.length));
+}
+
+function keywordIndex(text: string, keyword: string): number {
+  const pattern = new RegExp(`\\b${escapeRegExp(keyword)}\\b`, "i");
+  return text.search(pattern);
+}
+
+/** Connector types the text implies, in the order they first appear. */
+export function connectorTypesFromText(text: string): string[] {
+  if (!text.trim()) return [];
+
+  const urls = extractUrls(text);
+  const prose = maskUrls(text);
+  const hits: { serverType: string; at: number }[] = [];
+
+  for (const hint of CONNECTOR_HINTS) {
+    let earliest = -1;
+
+    for (const domain of hint.domains ?? []) {
+      for (const url of urls) {
+        if (hostMatches(url.host, domain) && (earliest === -1 || url.at < earliest)) {
+          earliest = url.at;
+        }
+      }
+    }
+
+    for (const keyword of hint.keywords ?? []) {
+      const at = keywordIndex(prose, keyword);
+      if (at >= 0 && (earliest === -1 || at < earliest)) earliest = at;
+    }
+
+    if (earliest >= 0) hits.push({ serverType: hint.serverType, at: earliest });
+  }
+
+  return hits.sort((a, b) => a.at - b.at).map((h) => h.serverType);
+}

--- a/apps/xyne-claw-auth/backend/src/routes/settings.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/settings.ts
@@ -11,6 +11,7 @@ import { getRequesterId, isClawAdmin , requireRequester} from "../middleware/age
 import { prisma } from "../db.js";
 import { writeAuditLog } from "../lib/audit.js";
 import { encrypt, decrypt } from "../crypto.js";
+import { extractClaudeBearer } from "../lib/claude-creds.js";
 import { extractCodexBearer } from "../lib/codex-creds.js";
 import { CONFIG } from "../config.js";
 import { redisService } from "../redis.js";
@@ -467,7 +468,8 @@ router.get("/claude/models", asyncHandler(async (req: Request, res: Response) =>
     throw badRequest("Claude is not configured. Save an API key first.");
   }
   try {
-    const apiKey = decrypt(cred.encryptedKey, cred.iv, cred.authTag, CONFIG.encryptionKey);
+    const decrypted = decrypt(cred.encryptedKey, cred.iv, cred.authTag, CONFIG.encryptionKey);
+    const apiKey = extractClaudeBearer(decrypted);
     const models = await fetchAnthropicModels(apiKey, cred.baseUrl ?? undefined, cred.authType ?? undefined);
     ok(res, models);
   } catch (err) {
@@ -569,5 +571,157 @@ function decodeJwtChatgptAccountId(jwt: string): string | undefined {
     return undefined;
   }
 }
+
+// ── Claude browser sign-in (user-scoped) ──────────────────────────────────────
+// Mirrors the agent-scoped flow in agents.ts, but writes the user's own
+// credential. Anthropic's Claude Code flow is PKCE with the verifier doubling
+// as `state`, and its redirect lands on localhost:53692 — a port only the
+// Claude Code CLI listens on — so the browser cannot post back to us. The user
+// copies the code (or the whole redirect URL) and pastes it into /exchange.
+//
+// Captures a REFRESHABLE token, unlike a pasted `claude setup-token` value.
+const USER_CLAUDE_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const USER_CLAUDE_AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
+const USER_CLAUDE_TOKEN_URL = "https://platform.claude.com/v1/oauth/token";
+const USER_CLAUDE_REDIRECT_URI = "http://localhost:53692/callback";
+const USER_CLAUDE_SCOPES =
+  "org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
+const USER_CLAUDE_PKCE_PREFIX = "claude-pkce-user:";
+const USER_CLAUDE_PKCE_TTL = 600;
+
+function generateUserClaudePkce(): { verifier: string; challenge: string } {
+  const verifier = crypto.randomBytes(32).toString("base64url");
+  const challenge = crypto.createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+router.post("/provider-credentials/claude/oauth/start", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "x-user-id header required" });
+      return;
+    }
+
+    const { verifier, challenge } = generateUserClaudePkce();
+    const state = verifier;
+    await redisService
+      .getConnection()
+      .set(`${USER_CLAUDE_PKCE_PREFIX}${userId}:${state}`, verifier, "EX", USER_CLAUDE_PKCE_TTL);
+
+    const url = new URL(USER_CLAUDE_AUTHORIZE_URL);
+    url.searchParams.set("code", "true");
+    url.searchParams.set("client_id", USER_CLAUDE_CLIENT_ID);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("redirect_uri", USER_CLAUDE_REDIRECT_URI);
+    url.searchParams.set("scope", USER_CLAUDE_SCOPES);
+    url.searchParams.set("code_challenge", challenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("state", state);
+
+    res.json({
+      success: true,
+      data: { url: url.toString(), state, expiresIn: USER_CLAUDE_PKCE_TTL },
+    });
+  } catch (err) {
+    log.error("[settings] claude/oauth/start error:", err);
+    res.status(500).json({ success: false, error: "Failed to start Claude login" });
+  }
+});
+
+router.post("/provider-credentials/claude/oauth/exchange", async (req: Request, res: Response) => {
+  try {
+    const userId = getRequesterId(req);
+    if (!userId) {
+      res.status(401).json({ success: false, error: "x-user-id header required" });
+      return;
+    }
+
+    let { code, state } = (req.body ?? {}) as { code?: string; state?: string };
+
+    // Tolerate a full redirect URL, "code#state", or a bare code — users paste
+    // whichever of the three the browser happened to show them.
+    let raw = (code ?? "").trim();
+    if (raw.startsWith("http") || raw.includes("code=")) {
+      try {
+        const u = raw.startsWith("http") ? new URL(raw) : new URL(`http://x?${raw}`);
+        code = u.searchParams.get("code") ?? code;
+        state = u.searchParams.get("state") ?? state;
+        raw = (code ?? "").trim();
+      } catch {
+        /* keep original */
+      }
+    }
+    if (raw.includes("#")) {
+      const [c, s] = raw.split("#", 2);
+      code = c;
+      if (!state && s) state = s;
+    }
+
+    if (!code || !state) {
+      res.status(400).json({ success: false, error: "code and state are required" });
+      return;
+    }
+
+    const redis = redisService.getConnection();
+    const key = `${USER_CLAUDE_PKCE_PREFIX}${userId}:${state}`;
+    const verifier = await redis.get(key);
+    if (!verifier) {
+      res.status(400).json({ success: false, error: "Sign-in expired — start again" });
+      return;
+    }
+    await redis.del(key);
+
+    const tokRes = await fetch(USER_CLAUDE_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        client_id: USER_CLAUDE_CLIENT_ID,
+        code,
+        state,
+        redirect_uri: USER_CLAUDE_REDIRECT_URI,
+        code_verifier: verifier,
+      }),
+    });
+    if (!tokRes.ok) {
+      const text = await tokRes.text().catch(() => "");
+      res.status(502).json({
+        success: false,
+        error: `Anthropic token exchange failed: ${tokRes.status} ${text.slice(0, 200)}`,
+      });
+      return;
+    }
+
+    const tokens = (await tokRes.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+    };
+    if (!tokens.access_token || !tokens.refresh_token) {
+      res.status(502).json({ success: false, error: "Anthropic did not return tokens" });
+      return;
+    }
+
+    const bundle = JSON.stringify({
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_at: Date.now() + (tokens.expires_in ?? 3600) * 1000,
+    });
+    const enc = encrypt(bundle, CONFIG.encryptionKey);
+    await userProviderCredentialsRepository.upsert(userId, "claude", {
+      encryptedKey: enc.ciphertext,
+      iv: enc.iv,
+      authTag: enc.authTag,
+      authType: "oauth_token",
+      baseUrl: "https://api.anthropic.com",
+    });
+
+    res.json({ success: true, data: { connected: true } });
+  } catch (err) {
+    log.error("[settings] claude/oauth/exchange error:", err);
+    res.status(500).json({ success: false, error: "Claude login exchange failed" });
+  }
+});
 
 export const settingsRouter = router;

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -125,6 +125,9 @@ import {
   buildGoalSuggestionFlow,
   buildPlanFlow,
   buildAgentCardFlow,
+  buildAgentSummaryFlow,
+  buildMcpSuggestFlow,
+  MAX_AGENT_LIST_CARDS,
   buildCodeFlow,
   buildDiffFlow,
   buildChartFlow,
@@ -140,6 +143,7 @@ import type { TwinDelivery, UiWidget, PrProvider, PrStatus } from "xyne-claw-sha
 import { isAgentInvocableBy } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 import { tools as xyneSpacesTools } from "../mcp/servers/xyne-spaces-tools.js";
+import { connectorTypesFromText } from "../lib/connector-hints.js";
 
 const clog = createLogger("webhook");
 const SDLC_AGENT_TOOL_PROFILE = buildSdlcAgentToolProfile(
@@ -592,6 +596,27 @@ import {
   zipAttachmentsToBuffer,
   prepareAgentResultForPosting,
 } from "../surfaces/spaces/attachments.js";
+
+/** Owner display name + id for an agent's card chin ("Created by @x"). */
+/** Connectors shown before the card defers to "Browse MCPs". */
+const MCP_SUGGEST_ROSTER_SAMPLE = 5;
+
+/** Agents listed on the roster card before it defers to "Browse agents". */
+const AGENT_SUMMARY_SAMPLE = 5;
+
+/** Cap on connectors the server offers unprompted, so a card never becomes a list. */
+const MCP_SUGGEST_INFERRED_MAX = 3;
+
+async function agentOwnerCredit(
+  ownerUserId: string | null | undefined,
+): Promise<{ name?: string | null; id?: string | null } | undefined> {
+  if (!ownerUserId) return undefined;
+  const owner = await prisma.user
+    .findUnique({ where: { id: ownerUserId }, select: { id: true, name: true } })
+    .catch(() => null);
+  return owner?.name ? { name: owner.name, id: owner.id } : undefined;
+}
+
 
 function experimentCounts(findings: Array<{ status: string }>): { conjecture: number; proved: number; refuted: number } {
   return {
@@ -4678,7 +4703,14 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // the same card serves other agent surfaces (a read-only profile next).
     pendingAgentCard?:
       | { variant: "draft"; agent: DraftAgentSpec }
-      | { variant: "profile"; slug?: string };
+      | { variant: "profile"; slug?: string }
+      // "which agents can do X?" — a stack of read-only cards, capped server-side.
+      | { variant: "profile-list"; slugs: string[] }
+      // "list all my agents" — counts only, with a link into the library.
+      | { variant: "summary" };
+    // Connector cards to post alongside the reply, so the user can connect
+    // without leaving the conversation.
+    pendingConnectorSuggestions?: { serverTypes: string[]; title?: string; listAll?: boolean };
   };
 
   const sessionId = payload.sessionId ?? "";
@@ -5982,9 +6014,10 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
           catalog,
           ctx.senderId,
         );
+        const ownerCredit = await agentOwnerCredit(row.ownerUserId);
         const flow = withSpacesAppId(
           buildAgentCardFlow(
-            { variant: "profile", agent: identityFromAgentRow(row, resolved) },
+            { variant: "profile", agent: identityFromAgentRow(row, resolved, undefined, ownerCredit) },
             {
               agentSlug: ctx.agentSlug!,
               targetSlug,
@@ -6011,6 +6044,238 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       });
     }
   }
+  // Fall back to the server's own reading of the request when the model did not
+  // ask for cards. It routinely misses the moment — most often by assuming a
+  // connector is already connected — and a missing capability is exactly when
+  // the user most needs the offer. Only unconnected connectors survive the
+  // filter below, so a wrong guess costs nothing.
+  // Fail-safe: this runs before the reply is posted, so a throw here would cost
+  // the user their answer. A suggestion is never worth that.
+  let inferredTypes: string[] = [];
+  if (!payload.pendingConnectorSuggestions) {
+    try {
+      inferredTypes = connectorTypesFromText(ctx.task ?? "").slice(0, MCP_SUGGEST_INFERRED_MAX);
+    } catch (err) {
+      log.warn("[mcp-suggest] connector inference failed (non-fatal)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  const pendingConnectorSuggestions =
+    payload.pendingConnectorSuggestions ??
+    (inferredTypes.length > 0 ? { serverTypes: inferredTypes, inferred: true } : undefined);
+  if (pendingConnectorSuggestions && agentCardDeliverable) {
+    try {
+      // Roster mode: the user asked what exists, so the SERVER picks the sample
+      // — the model must not decide which connectors represent the catalog.
+      const listAll = pendingConnectorSuggestions.listAll === true;
+      const totalCount = listAll
+        ? await prisma.mcpServer.count({ where: { enabled: true } })
+        : undefined;
+
+      // Resolve every requested type against the catalog. The model supplies
+      // names only — descriptions and display names come from the row, and an
+      // unknown type is dropped rather than rendered as an empty card.
+      const rows = listAll
+        ? await prisma.mcpServer.findMany({
+            where: { enabled: true },
+            select: { id: true, type: true, name: true, description: true },
+            orderBy: { name: "asc" },
+            take: MCP_SUGGEST_ROSTER_SAMPLE,
+          })
+        : await prisma.mcpServer.findMany({
+            where: { type: { in: pendingConnectorSuggestions.serverTypes }, enabled: true },
+            select: { id: true, type: true, name: true, description: true },
+          });
+      const byType = new Map(rows.map((row) => [row.type, row]));
+
+      const existing = await prisma.userMcpConnection.findMany({
+        where: { userId: ctx.senderId, mcpServerId: { in: rows.map((r) => r.id) } },
+        select: { mcpServerId: true },
+      });
+      const connectedIds = new Set(existing.map((c) => c.mcpServerId));
+
+      // Roster mode is already ordered by the query; otherwise preserve the
+      // model's ordering, since it ranked them by relevance.
+      const ordered = listAll
+        ? rows
+        : pendingConnectorSuggestions.serverTypes
+            .map((type) => byType.get(type))
+            .filter((row): row is NonNullable<typeof row> => !!row);
+
+      const inferred = (pendingConnectorSuggestions as { inferred?: boolean }).inferred === true;
+
+      const connectors = ordered
+        // An inferred card is unsolicited, so it only earns its place when it
+        // offers something new. A model-requested card still lists connected
+        // ones, because the user asked to see them.
+        .filter((row) => !inferred || !connectedIds.has(row.id))
+        .map((row) => ({
+          serverType: row.type,
+          name: row.name,
+          ...(row.description ? { description: row.description } : {}),
+          connected: connectedIds.has(row.id),
+        }));
+
+      if (connectors.length === 0) {
+        log.info(
+          `[mcp-suggest] skipped — none of ${pendingConnectorSuggestions.serverTypes.join(", ")} are known connectors`,
+        );
+      } else {
+        const flow = withSpacesAppId(
+          buildMcpSuggestFlow({
+            connectors,
+            ...(pendingConnectorSuggestions.title
+              ? { title: pendingConnectorSuggestions.title }
+              : listAll
+                ? { title: "Connectors you can add" }
+                : {}),
+            ...(listAll ? { browseAll: true } : {}),
+            ...(inferred && !pendingConnectorSuggestions.title
+              ? { title: "Connect to unlock this" }
+              : {}),
+            ...(totalCount !== undefined ? { totalCount } : {}),
+            screenKey: `${ctx.senderId}-${connectors.map((c) => c.serverType).join("-")}`,
+            ...(ctx.agentSlug ? { agentSlug: ctx.agentSlug } : {}),
+            userId: ctx.senderId,
+            conversationId: ctx.conversationId,
+            channelId: ctx.channelId,
+          }),
+          ctx.spacesAppId,
+        );
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          flow,
+          userId: ctx.spacesAppUserId,
+        }, ctx.appToken);
+        log.info(`[mcp-suggest] posted ${connectors.length} connector cards conv=${ctx.conversationId}`);
+      }
+    } catch (err) {
+      log.warn("Failed to post connector suggestions (non-fatal)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (pendingAgentCard?.variant === "summary" && agentCardDeliverable && ctx.agentOrgId) {
+    try {
+      const [total, globalCount, sampleAgents] = await Promise.all([
+        prisma.agent.count({ where: { orgId: ctx.agentOrgId, enabled: true } }),
+        prisma.agent.count({ where: { orgId: ctx.agentOrgId, enabled: true, scope: "global" } }),
+        // Sample rows for the card. The SERVER picks them — the model must not
+        // decide which agents represent the roster.
+        prisma.agent.findMany({
+          where: { orgId: ctx.agentOrgId, enabled: true },
+          select: { slug: true, name: true, description: true },
+          orderBy: { name: "asc" },
+          take: AGENT_SUMMARY_SAMPLE,
+        }),
+      ]);
+
+      if (total === 0) {
+        log.info(`[agent-card] summary skipped — no agents in org ${ctx.agentOrgId}`);
+      } else {
+        const flow = withSpacesAppId(
+          buildAgentSummaryFlow(
+            {
+              total,
+              global: globalCount,
+              personal: total - globalCount,
+              agents: sampleAgents.map((a) => ({
+                slug: a.slug,
+                name: a.name,
+                ...(a.description ? { description: a.description } : {}),
+              })),
+            },
+            {
+              agentSlug: ctx.agentSlug!,
+              userId: ctx.senderId,
+              conversationId: ctx.conversationId,
+              channelId: ctx.channelId,
+            },
+          ),
+          ctx.spacesAppId,
+        );
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          flow,
+          userId: ctx.spacesAppUserId,
+        }, ctx.appToken);
+        postedAgentProfileCard = true;
+        log.info(`[agent-card] posted roster summary (${total}) conv=${ctx.conversationId}`);
+      }
+    } catch (err) {
+      log.warn("Failed to post agent summary card (non-fatal)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  if (pendingAgentCard?.variant === "profile-list" && agentCardDeliverable && ctx.agentOrgId) {
+    try {
+      const unique = [
+        ...new Set(pendingAgentCard.slugs.map((slug) => slug.trim()).filter((slug) => slug.length > 0)),
+      ];
+      const capped = unique.slice(0, MAX_AGENT_LIST_CARDS);
+
+      // Matches are rendered as compact roster rows, not full profile cards:
+      // "which agents can review PRs?" wants a scannable shortlist, and five
+      // stacked identity cards buries it. Each row opens the agent's own page.
+      const rows = [];
+      for (const slug of capped) {
+        const row = await agentRepository.findBySlug(slug, ctx.agentOrgId);
+        if (!row) {
+          log.info(`[agent-card] list row skipped — no agent "${slug}" in org ${ctx.agentOrgId}`);
+          continue;
+        }
+        rows.push({
+          slug: row.slug,
+          name: row.name,
+          ...(row.description ? { description: row.description } : {}),
+        });
+      }
+
+      if (rows.length === 0) {
+        log.info(`[agent-card] list card skipped — none of ${unique.length} slugs resolved`);
+      } else {
+        const flow = withSpacesAppId(
+          buildAgentSummaryFlow(
+            {
+              total: rows.length,
+              agents: rows,
+            },
+            {
+              agentSlug: ctx.agentSlug!,
+              userId: ctx.senderId,
+              conversationId: ctx.conversationId,
+              channelId: ctx.channelId,
+            },
+            // Matches, not the whole roster — so the header counts what was
+            // found rather than claiming every agent in the org.
+            `${rows.length} ${rows.length === 1 ? "agent" : "agents"} that can help`,
+          ),
+          ctx.spacesAppId,
+        );
+        await spacesAppFetch("/chat/postMessage", {
+          channelId: ctx.channelId,
+          conversationId: ctx.conversationId,
+          flow,
+          userId: ctx.spacesAppUserId,
+        }, ctx.appToken);
+        postedAgentProfileCard = true;
+        log.info(`[agent-card] posted ${rows.length} matching agents conv=${ctx.conversationId}`);
+      }
+    } catch (err) {
+      // Non-fatal: the reply itself still posts below.
+      log.warn("Failed to post matching agent card (non-fatal)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
   if (
     pendingAgentCard?.variant === "draft" &&
     ctx.responseMode === "conversation" &&

--- a/apps/xyne-claw/src/describe-agent.ts
+++ b/apps/xyne-claw/src/describe-agent.ts
@@ -27,7 +27,7 @@ export const DESCRIBE_AGENT_TOOL_NAME = "describe-agent";
 
 /** Shared ref the tool writes into; read back by run.ts. */
 export interface DescribeAgentRef {
-  value?: Extract<PendingAgentCard, { variant: "profile" }>;
+  value?: Extract<PendingAgentCard, { variant: "profile" | "profile-list" | "summary" }>;
   /** Repeat calls after the first — telemetry only, the first target stands. */
   duplicates?: number;
 }
@@ -45,6 +45,15 @@ export function buildDescribeAgentTool(ref: DescribeAgentRef): ToolDefinition {
       "Omit `slug` to describe YOURSELF (the usual case). Pass a slug only when the user",
       "asked about a DIFFERENT agent by name.",
       "",
+      "When the user asks WHICH agents can help with something (\"list agents that review PRs\"),",
+      "pass `slugs` with the matching agents, best match first — they render as a stack of the",
+      "same cards. Use list_agents first to find them. Prefer this over naming them in prose.",
+      "",
+      "When the user asks to see ALL their agents (\"list all my agents\", \"what agents do we",
+      "have?\"), pass `summary: true` instead. That posts a count with a link to the agent",
+      "library — the right answer when the roster is long. The SERVER counts them, so do not",
+      "state a number yourself and do not list the agents in text.",
+      "",
       "This does not end your turn — if the user asked something else as well, answer it",
       "normally in the same reply. Do not also describe your tools in text; the card",
       "covers that. Call it at most once per reply.",
@@ -57,6 +66,17 @@ export function buildDescribeAgentTool(ref: DescribeAgentRef): ToolDefinition {
           type: "string",
           description:
             "Optional. The agent to describe, e.g. 'ticket-triage'. Omit to describe yourself.",
+        },
+        summary: {
+          type: "boolean",
+          description:
+            "Set true to show a roster summary (total agent count + a link to the library) instead of individual cards. Use for 'list all my agents'.",
+        },
+        slugs: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional. Several agents to show as a stack of cards, e.g. when the user asks which agents can help with X. Use INSTEAD of `slug`, and instead of listing agents in prose. Order them best-match first; the server caps how many render and summarises the rest.",
         },
       },
       required: [],
@@ -76,6 +96,41 @@ export function buildDescribeAgentTool(ref: DescribeAgentRef): ToolDefinition {
       }
 
       const p = (params as Record<string, unknown> | undefined) ?? {};
+
+      if (p["summary"] === true) {
+        ref.value = { variant: "summary" };
+        log.info("[describe-agent] queued roster summary card");
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "A roster summary with the agent count and a link to the library will be shown with your reply. Do NOT state a count or list the agents in text — the card carries both. Say at most one short line.",
+            },
+          ],
+          details: { summary: true },
+        };
+      }
+
+      const rawList = Array.isArray(p["slugs"]) ? (p["slugs"] as unknown[]) : [];
+      const slugs = rawList
+        .filter((s): s is string => typeof s === "string")
+        .map((s) => s.trim().slice(0, 80))
+        .filter((s) => s.length > 0);
+
+      if (slugs.length > 0) {
+        ref.value = { variant: "profile-list", slugs };
+        log.info(`[describe-agent] queued ${slugs.length} profile cards: ${slugs.join(", ")}`);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Capability cards for ${slugs.length} agent(s) will be shown with your reply — each one lists its real tools and integrations. Do NOT also list these agents or their tools in text; say at most one short line about why they fit.`,
+            },
+          ],
+          details: { slugs },
+        };
+      }
+
       const slug = typeof p["slug"] === "string" ? p["slug"].trim().slice(0, 80) : "";
       ref.value = { variant: "profile", ...(slug ? { slug } : {}) };
       log.info(`[describe-agent] queued profile card for ${slug || "self"}`);

--- a/apps/xyne-claw/src/propose-agent.ts
+++ b/apps/xyne-claw/src/propose-agent.ts
@@ -64,7 +64,9 @@ export interface ProposedAgentSpec {
  */
 export type PendingAgentCard =
   | { variant: "draft"; agent: ProposedAgentSpec }
-  | { variant: "profile"; slug?: string };
+  | { variant: "profile"; slug?: string }
+  | { variant: "profile-list"; slugs: string[] }
+  | { variant: "summary" };
 
 /** Shared ref the tool writes the accepted draft into (mirrors ProposePlanRef). */
 export interface ProposeAgentRef {

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -119,6 +119,7 @@ import { buildProposePlanTool, PROPOSE_PLAN_TOOL_NAME, type ProposePlanRef } fro
 import { presentationCatalogDefaultOn, isFreePresentationTool, buildPresentationPrimer } from "../presentation-catalog.js";
 import { buildProposeAgentTool, type ProposeAgentRef } from "../propose-agent.js";
 import { buildDescribeAgentTool, type DescribeAgentRef } from "../describe-agent.js";
+import { buildSuggestConnectorsTool, type SuggestConnectorsRef } from "../suggest-connectors.js";
 import { buildEmitBriefTool, EMIT_BRIEF_TOOL_NAME, type EmitBriefRef } from "../daily-brief.js";
 import {
   buildSuggestGoalTool,
@@ -1707,6 +1708,7 @@ async function processTask(
   // alongside the others so the catch handler can still ship a queued card when
   // the turn ends some other way.
   const describeAgentRef: DescribeAgentRef = {};
+  const suggestConnectorsRef: SuggestConnectorsRef = {};
   // Hoisted for the same reason: emit_brief (daily-brief mode's terminal tool)
   // fires abortRun, so the brief is recovered from ref.value in the catch block
   // and shipped as `dailyBrief` on the callback.
@@ -3038,6 +3040,9 @@ async function processTask(
       !isDailyBrief;
     if (describeAgentAvailable) {
       allTools.push(buildDescribeAgentTool(describeAgentRef));
+      // Same gate as describe-agent: a connector card is only worth posting
+      // where a human is watching and can press Connect.
+      allTools.push(buildSuggestConnectorsTool(suggestConnectorsRef));
     }
 
 
@@ -4577,6 +4582,9 @@ async function processTask(
       // A draft (terminal, normally recovered in the catch) wins over a profile
       // card if a turn somehow produced both — the decision surface matters more
       // than the description.
+      ...(suggestConnectorsRef.value
+        ? { pendingConnectorSuggestions: suggestConnectorsRef.value }
+        : {}),
       ...(proposeAgentRef.value || describeAgentRef.value
         ? { pendingAgentCard: proposeAgentRef.value ?? describeAgentRef.value }
         : {}),
@@ -4761,6 +4769,9 @@ async function processTask(
         // A queued capability card must survive the copilot terminal path too,
         // or "what can you do?" silently loses its card on those agents.
         ...(describeAgentRef.value ? { pendingAgentCard: describeAgentRef.value } : {}),
+        ...(suggestConnectorsRef.value
+          ? { pendingConnectorSuggestions: suggestConnectorsRef.value }
+          : {}),
         ...(pendingGoalSuggestion ? { pendingGoalSuggestion } : {}),
         ...(dedupedPendingActionsAtError.length > 0 ? { pendingActions: dedupedPendingActionsAtError } : {}),
         ...(attachmentsAtError.length > 0 ? { attachments: attachmentsAtError } : {}),

--- a/apps/xyne-claw/src/suggest-connectors.ts
+++ b/apps/xyne-claw/src/suggest-connectors.ts
@@ -1,0 +1,155 @@
+/**
+ * suggest-connectors — surfaces connector cards inside the conversation.
+ *
+ * Covers the moments where an integration is the real answer:
+ *   1. the user pastes a link to a service (Google Doc, GitHub repo, Figma file)
+ *   2. mid-task, when the work needs an account the user has not connected
+ *   3. when the user asks to connect something by name, or to list what exists
+ *
+ * Deliberately NOT wired into agent creation: propose-agent is terminal, so a
+ * suggestion would have to precede the draft, and that ordering constraint made
+ * the flow unreliable. Agent creation stays as it is.
+ *
+ * Deliberately NOT terminal (like describe-agent): the card is an attachment to
+ * the reply, so the model can explain why it needs Google Drive AND post the
+ * card to connect it in the same turn.
+ *
+ * The model names connector types; the SERVER resolves each one against the
+ * catalog and drops anything it does not recognise. Nothing the model writes
+ * reaches the card's title or description, so it cannot invent an integration
+ * or misdescribe what one does.
+ */
+
+import { Type } from "@sinclair/typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("suggest-connectors");
+
+export const SUGGEST_CONNECTORS_TOOL_NAME = "suggest-connectors";
+
+export interface PendingConnectorSuggestions {
+  serverTypes: string[];
+  title?: string;
+  /** The user asked to see what exists — server picks the sample and adds Browse. */
+  listAll?: boolean;
+}
+
+export interface SuggestConnectorsRef {
+  value?: PendingConnectorSuggestions;
+  /** Repeat calls after the first — telemetry only, the first set stands. */
+  duplicates?: number;
+}
+
+const MAX_SUGGESTIONS = 6;
+
+export function buildSuggestConnectorsTool(ref: SuggestConnectorsRef): ToolDefinition {
+  return {
+    name: SUGGEST_CONNECTORS_TOOL_NAME,
+    label: "Suggest Connectors",
+    description: [
+      "MANDATORY for any question about connectors / MCPs / integrations. These are shown as",
+      "cards with Connect buttons — you MUST NOT answer such questions in prose.",
+      "",
+      "Call it with `listAll: true` (and no serverTypes) whenever the user asks what connectors",
+      "or MCPs exist — e.g. \"list all the MCPs\", \"list down all the connectors\", \"what",
+      "integrations do we have\", \"show me the MCPs\". Do NOT enumerate them in text: the card",
+      "shows a sample plus a Browse button, and the server owns the list.",
+      "",
+      "Call it with `serverTypes` (most relevant first) when:",
+      "  • the user PASTES A LINK to a service — a Google Doc/Drive/Sheet, a GitHub or",
+      "    Bitbucket repo or PR, a Figma file, a Notion page, a Jira ticket — and that",
+      "    connector is not connected. Read the domain, post its card, then say what you",
+      "    will do once it is on. Do this even if they only ask a question about the link.",
+      "  • a task needs an account that is not connected (e.g. summarising a Google Doc",
+      "    without Google connected),",
+      "  • the user asks to connect something by name (\"connect Figma\").",
+      "",
+      "The server fills in each name, description and connected state from the catalog and skips",
+      "unknown types, so never describe the connectors yourself.",
+      "",
+      "This does not end your turn. Call it at most once per reply.",
+    ].join("\n"),
+    parameters: Type.Unsafe({
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        serverTypes: {
+          type: "array",
+          items: { type: "string" },
+          description: "Connector types to show, most relevant first. e.g. ['google','github'].",
+        },
+        listAll: {
+          type: "boolean",
+          description:
+            "True when the user asked to browse or list the available connectors, rather than naming specific ones.",
+        },
+        title: {
+          type: "string",
+          description:
+            "Optional heading, e.g. 'Connectors that could help this agent' or 'Connect Google to continue'.",
+        },
+      },
+      required: [],
+    }),
+    async execute(_toolCallId: string, params: unknown) {
+      if (ref.value !== undefined) {
+        ref.duplicates = (ref.duplicates ?? 0) + 1;
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Connector cards are already queued for this reply. Do not call suggest-connectors again; continue with the rest of your answer.",
+            },
+          ],
+          details: { duplicate: true },
+        };
+      }
+
+      const p = (params as Record<string, unknown> | undefined) ?? {};
+      const raw = Array.isArray(p["serverTypes"]) ? (p["serverTypes"] as unknown[]) : [];
+      const serverTypes = [
+        ...new Set(
+          raw
+            .filter((t): t is string => typeof t === "string")
+            .map((t) => t.trim().toLowerCase())
+            .filter((t) => t.length > 0),
+        ),
+      ].slice(0, MAX_SUGGESTIONS);
+
+      const listAll = p["listAll"] === true;
+
+      if (serverTypes.length === 0 && !listAll) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Rejected: name at least one connector type in `serverTypes`, or pass `listAll: true` to show what is available.",
+            },
+          ],
+          details: { rejected: true },
+        };
+      }
+
+      const title = typeof p["title"] === "string" ? p["title"].trim().slice(0, 120) : "";
+      ref.value = { serverTypes, ...(title ? { title } : {}), ...(listAll ? { listAll: true } : {}) };
+      log.info(
+        listAll
+          ? "[suggest-connectors] queued roster listing"
+          : `[suggest-connectors] queued ${serverTypes.length}: ${serverTypes.join(", ")}`,
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: listAll
+              ? "A connector list with a Browse button will be shown with your reply. Do NOT list the connectors in your text — say at most one short line."
+              : `Connector cards for ${serverTypes.join(", ")} will be shown with your reply, each with a Connect button. Do NOT list or describe these connectors in your text — say at most one short line about why they help.`,
+          },
+        ],
+        details: { serverTypes, listAll },
+      };
+    },
+  };
+}

--- a/packages/xyne-claw-shared/src/flow/agent-card.ts
+++ b/packages/xyne-claw-shared/src/flow/agent-card.ts
@@ -71,6 +71,12 @@ export interface AgentIdentity {
   slug: string;
   /** Handle credited under the name ("Built by @fractal-agent"). */
   builtBy?: string;
+  /** Owner's display name, credited in the card chin. */
+  ownedBy?: string;
+  /** Owner's user id, for the avatar beside that credit. */
+  ownedById?: string;
+  /** Reach: 'global' is org-wide, 'personal' belongs to one user. */
+  scope?: 'personal' | 'global';
   description?: string;
   systemPrompt?: string;
   modelId?: string;
@@ -134,6 +140,9 @@ export function agentIdentity(input: {
   name: string;
   slug: string;
   builtBy?: string | null;
+  ownedBy?: string | null;
+  ownedById?: string | null;
+  scope?: string | null;
   description?: string | null;
   systemPrompt?: string | null;
   modelId?: string | null;
@@ -151,6 +160,11 @@ export function agentIdentity(input: {
   // plain handle wherever else it is used.
   const builtBy = trimmed(input.builtBy, 80)?.replace(/^@+/, "");
   if (builtBy) identity.builtBy = builtBy;
+  const ownedBy = trimmed(input.ownedBy, 80)?.replace(/^@+/, "");
+  if (ownedBy) identity.ownedBy = ownedBy;
+  const ownedById = trimmed(input.ownedById, 80);
+  if (ownedById) identity.ownedById = ownedById;
+  if (input.scope === 'global' || input.scope === 'personal') identity.scope = input.scope;
   const description = trimmed(input.description, MAX_DESC);
   if (description) identity.description = description;
   const systemPrompt = trimmed(input.systemPrompt, MAX_CARD_PROMPT);
@@ -227,6 +241,106 @@ export function buildAgentCardFlow(props: AgentCardProps, data: AgentCardData): 
       ...(data.requestId ? { requestId: data.requestId } : {}),
       agentSlug: data.agentSlug,
       ...(data.targetSlug ? { targetSlug: data.targetSlug } : {}),
+      userId: data.userId,
+      ...(data.conversationId ? { conversationId: data.conversationId } : {}),
+      ...(data.channelId ? { channelId: data.channelId } : {}),
+    })
+    .build();
+}
+
+export const MAX_AGENT_LIST_CARDS = 5;
+
+export interface AgentListCardData extends Omit<AgentCardData, 'targetSlug'> {
+  totalMatches?: number;
+}
+
+export function buildAgentListFlow(
+  agents: AgentIdentity[],
+  data: AgentListCardData,
+  max: number = MAX_AGENT_LIST_CARDS,
+): FlowDefinition {
+  const shown = agents.slice(0, Math.max(1, max));
+  const total = data.totalMatches ?? agents.length;
+  const hidden = Math.max(0, total - shown.length);
+
+  const builder = new FlowBuilder(`agent-list-${data.userId}-${shown.map((a) => a.slug).join('-')}`);
+
+  shown.forEach((agent, i) => {
+    builder.addComponent({
+      id: `${AGENT_COMPONENT_ID}-${agent.slug}`,
+      type: 'agent',
+      props: { variant: 'profile', agent },
+      ...(i < shown.length - 1 ? { style: { margin: '0 0 12px 0' } } : {}),
+    });
+  });
+
+  if (hidden > 0) {
+    builder.addText('agent-list-overflow', `+${hidden} more`, { variant: 'muted', size: 'sm' });
+  }
+
+  return builder
+    .setData({
+      actionType: 'agent-card',
+      variant: 'profile',
+      agentSlug: data.agentSlug,
+      userId: data.userId,
+      ...(data.conversationId ? { conversationId: data.conversationId } : {}),
+      ...(data.channelId ? { channelId: data.channelId } : {}),
+    })
+    .build();
+}
+
+export interface AgentSummaryRow {
+  slug: string;
+  name: string;
+  description?: string;
+}
+
+export interface AgentSummaryCounts {
+  total: number;
+  global?: number;
+  personal?: number;
+  agents?: AgentSummaryRow[];
+}
+
+/**
+ * Roster summary card — "you have N agents", with a link into the library.
+ *
+ * The counts come from the server's own query, never from the model: an agent
+ * asked "how many agents do we have?" must not answer from memory. There is no
+ * route in the payload — the dashboard node builds the library link from the
+ * workspace it is already in.
+ */
+export function buildAgentSummaryFlow(
+  counts: AgentSummaryCounts,
+  data: Omit<AgentCardData, 'targetSlug' | 'requestId'>,
+  /** Overrides the default "N agents available" heading. */
+  label?: string,
+): FlowDefinition {
+  return new FlowBuilder(`agent-summary-${data.userId}`)
+    .addComponent({
+      id: 'agent-summary',
+      type: 'agent_summary',
+      props: {
+        total: counts.total,
+        ...(label ? { label } : {}),
+        ...(counts.global !== undefined ? { global: counts.global } : {}),
+        ...(counts.personal !== undefined ? { personal: counts.personal } : {}),
+        ...(counts.agents?.length
+          ? {
+              agents: counts.agents.map((a) => ({
+                slug: a.slug,
+                name: a.name,
+                ...(a.description ? { description: a.description } : {}),
+              })),
+            }
+          : {}),
+      },
+    })
+    .setData({
+      actionType: 'agent-card',
+      variant: 'summary',
+      agentSlug: data.agentSlug,
       userId: data.userId,
       ...(data.conversationId ? { conversationId: data.conversationId } : {}),
       ...(data.channelId ? { channelId: data.channelId } : {}),

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -30,6 +30,8 @@ type FlowComponentType =
   | 'link'
   | 'plan'
   | 'agent'
+  | 'agent_summary'
+  | 'mcp_suggest'
   | 'mcpConfigure'
   | 'pr'
   | 'user_question'
@@ -1226,6 +1228,59 @@ export function buildChartFlow(chart: ChartArtifact): FlowDefinition {
       fallbackText: chart.caption?.trim()
         ? chart.caption.trim()
         : `${chart.type} chart · ${pointCount} point${pointCount === 1 ? '' : 's'}`,
+    })
+    .build();
+}
+
+export interface McpSuggestConnector {
+  serverType: string;
+  name: string;
+  description?: string;
+  connected?: boolean;
+}
+
+/**
+ * Connector suggestions posted into a conversation.
+ *
+ * Rows carry display data only. The dashboard node resolves the live server id
+ * from the catalog when Connect is pressed, so a card that has been sitting in
+ * a thread cannot act on a connector that has since changed.
+ */
+export function buildMcpSuggestFlow(context: {
+  connectors: McpSuggestConnector[];
+  title?: string;
+  reason?: string;
+  browseAll?: boolean;
+  totalCount?: number;
+  screenKey: string;
+  agentSlug?: string;
+  userId: string;
+  conversationId?: string;
+  channelId?: string;
+}): FlowDefinition {
+  return new FlowBuilder(`mcp-suggest-${context.screenKey}`)
+    .addComponent({
+      id: 'mcp-suggest',
+      type: 'mcp_suggest',
+      props: {
+        ...(context.title ? { title: context.title } : {}),
+        ...(context.reason ? { reason: context.reason } : {}),
+        ...(context.browseAll ? { browseAll: true } : {}),
+        ...(context.totalCount !== undefined ? { totalCount: context.totalCount } : {}),
+        connectors: context.connectors.map((c) => ({
+          serverType: c.serverType,
+          name: c.name,
+          ...(c.description ? { description: c.description } : {}),
+          ...(c.connected !== undefined ? { connected: c.connected } : {}),
+        })),
+      },
+    })
+    .setData({
+      actionType: 'mcp-suggest',
+      ...(context.agentSlug ? { agentSlug: context.agentSlug } : {}),
+      userId: context.userId,
+      ...(context.conversationId ? { conversationId: context.conversationId } : {}),
+      ...(context.channelId ? { channelId: context.channelId } : {}),
     })
     .build();
 }

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -26,11 +26,11 @@ export {
 } from "./skill-diff/index.js";
 export type { SkillDiff, SkillForAuthz, ApproverResolution, SkillApprovalAuthz, SkillFileUpdateAuthz } from "./skill-diff/index.js";
 export { createSkillTool, updateSkillTool } from "./tools/skill-management/index.js";
-export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildCapacityRetryFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow, buildMcpConfigureFlow, buildCodeFlow, buildDiffFlow, buildTicketFlow, buildTicketProposalFlow, buildChartFlow } from "./flow/builder.js";
+export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildPromoteProviderFlow, buildCapacityRetryFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow, buildMcpConfigureFlow, buildMcpSuggestFlow, type McpSuggestConnector, buildCodeFlow, buildDiffFlow, buildTicketFlow, buildTicketProposalFlow, buildChartFlow } from "./flow/builder.js";
 export type { FlowDefinition, FlowComponent, FlowAction, SelectOption, TicketArtifact, ChartArtifact } from "./flow/builder.js";
 export { buildPlanFlow, PLAN_COMPONENT_ID } from "./flow/plan-flow.js";
 export { isFlowJsonContent, parseFlowJsonComponents, extractTextFromFlowJson, extractCleanTextFromFlowJson } from "./flow/flow-text.js";
-export { buildAgentCardFlow, agentIdentity, AGENT_COMPONENT_ID } from "./flow/agent-card.js";
+export { buildAgentCardFlow, buildAgentListFlow, buildAgentSummaryFlow, agentIdentity, AGENT_COMPONENT_ID, MAX_AGENT_LIST_CARDS } from "./flow/agent-card.js";
 export { validateMcpProposal } from "./flow/mcp-proposal.js";
 export type { McpProposal, McpProposalResult } from "./flow/mcp-proposal.js";
 export type {


### PR DESCRIPTION
Claw-side slice of #886, split out for the claw deploy branch. Same work, restricted to `apps/xyne-claw`, `apps/xyne-claw-auth` and `packages/xyne-claw-shared` — no dashboard or `packages/shared` changes ride along. #886 stays as-is.

## Type of Change

- [x] New feature
- [x] Enhancement
- [x] Bug fix

## Description

**Connector suggestions** — new `suggest-connectors` tool in claw, available to every agent (registered after the per-agent config filters, so no config flag needed). claw-auth also infers connectors from the user's own message (`connector-hints.ts`: a pasted GitHub link, "figma", "grafana"…), checks which of those the user hasn't connected, and posts the card itself.

The model only names connector types — names, descriptions and connected state all come from `mcp_servers` / `user_mcp_connections`, so it can't invent a connector or claim something is connected when it isn't. Inference is wrapped in try/catch: a failed suggestion can never cost the user their answer.

**Agent discovery** — `describe-agent` gains two modes beyond the single card:
- `summary: true` → roster card (total + org-wide/personal breakdown, sampled rows, browse footer)
- `slugs: [...]` → a stack of profile cards, best match first

The server does the counting and the tool instructs the model not to state a number or list agents in prose.

**Claude sign-in (claw-auth)** — user-scoped PKCE start/exchange routes for Anthropic. Also fixes the models call: a browser sign-in stores a JSON bundle, but the route was passing it to Anthropic as a raw bearer and getting a 401. Now goes through `extractClaudeBearer`, which handles both a bundle and a bare pasted key.

**Flow builders** (`xyne-claw-shared`) — `buildMcpSuggestFlow`, `buildAgentSummaryFlow`, `buildAgentListFlow` and the `mcp_suggest` component type.

## Areas Touched

- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package (`xyne-claw-shared` only)

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

Claude sign-in reuses the existing credential encryption key and Redis; PKCE verifiers are stored under `claude-pkce-user:` with a 10-minute TTL.

## API Contract

- [x] New endpoints (additive, claw-auth)

- `POST /provider-credentials/claude/oauth/start`
- `POST /provider-credentials/claude/oauth/exchange`

No existing contract changed. `GET /settings/claude/models` keeps its shape — it was returning 401/400 and now resolves the bearer correctly.

---

## Rollout note

The cards only render where the consuming build knows the `mcp_suggest` component. `xyne-claw-shared` inlines its own FlowUI types (it deliberately does not depend on `@xyne/shared`), so this PR compiles and deploys standalone — but the dashboard + `@xyne/shared` half in #886 must ship before the cards display anywhere. Until then the flows are posted and simply not rendered by older clients.

## How did you test it?

Manually against a local stack, confirmed from `agent_runs` and the posted messages (on the #886 branch, which carries the same claw code plus the renderer):

- "list all the MCPs" → connector card with 5 rows + Browse MCPs
- pasted a Google Doc link → Google connector card
- "list all my agents" → roster card with counts
- Settings: Sign in with Claude → paste callback URL → model list loads

### Automated

- [x] Not covered by tests — no existing harness for flow builders or claw tool wiring

### Manual

**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
