### PR TITLE
feat: XYNE-59703 suggest project-based sidebar sections

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -90,6 +90,7 @@ import {
   isDeskChannelType,
   NotificationLevel,
   computeProjectSectionSuggestions,
+  getCandidateProjectIds,
 } from '@xyne/shared';
 import { DndContext, DragOverlay, useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -293,11 +294,28 @@ const ChatDirectory = ({
     activeChannelId,
   });
 
-  const [projects] = useCachedQuery(queries.getAllProjectsList());
   const [suggestionDismissed, setSuggestionDismissed] = useState(
     () => localStorage.getItem(SECTION_SUGGESTION_DISMISSED_KEY) === 'true',
   );
   const [showOrganizer, setShowOrganizer] = useState(false);
+  const candidateProjectIdsKey = useMemo(
+    () =>
+      getCandidateProjectIds({
+        channels: channelData ?? [],
+        statuses: allChannelsUserStatus ?? [],
+      }).join(','),
+    [channelData, allChannelsUserStatus],
+  );
+  const projectsQuery = useMemo(
+    () =>
+      queries.projectsByIds({
+        projectIds: candidateProjectIdsKey ? candidateProjectIdsKey.split(',') : [],
+      }),
+    [candidateProjectIdsKey],
+  );
+  const [projects] = useCachedQuery(projectsQuery, {
+    enabled: !suggestionDismissed && candidateProjectIdsKey.length > 0,
+  });
 
   const sectionSuggestions = useMemo(
     () =>
@@ -366,7 +384,7 @@ const ChatDirectory = ({
       const sectionCount = created.length;
       const channelCount = created.reduce((sum, s) => sum + s.channelIds.length, 0);
       toast(
-        `${sectionCount} section${sectionCount === 1 ? '' : 's'} created with ${channelCount} channels.`,
+        `${sectionCount} section${sectionCount === 1 ? '' : 's'} created with ${channelCount} channel${channelCount === 1 ? '' : 's'}.`,
         {
           duration: 8000,
           action: {
@@ -1374,12 +1392,7 @@ const ChatDirectory = ({
           )}
         </Dialog>
 
-        <Dialog
-          open={showOrganizer}
-          onOpenChange={setShowOrganizer}
-          testId='section-organizer-dialog'
-          className='max-w-lg'
-        >
+        <Dialog open={showOrganizer} onOpenChange={setShowOrganizer} className='max-w-lg'>
           {showOrganizer && (
             <SectionOrganizerDialog
               suggestions={sectionSuggestions}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -72,6 +72,9 @@ import Dialog, { cn } from '../../ui/Dialog';
 
 import { useZero } from '../../../hooks/useZero';
 import { useUsersById } from '../../../hooks/useUsers';
+import { useDmAffinityRank } from '@xyne/shared/hooks';
+import { useAffinityCallback } from '../../../hooks/useAffinityCallback';
+import { affinityService } from '../../../services/affinityService';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { queries } from '../../../zero/queries';
 import { mutators } from '../../../zero/mutators';
@@ -311,18 +314,49 @@ const ChatDirectory = ({
   const [suggestionsNowMs, setSuggestionsNowMs] = useState(() => Date.now());
 
   const usersById = useUsersById();
+  const dmRank = useDmAffinityRank(context.userID);
+  const affinityVersion = useAffinityCallback();
+
+  const dmCounterpartByChannelId = useMemo(() => {
+    const counterparts = new Map<string, string>();
+    for (const channel of channelData ?? []) {
+      if (channel.scopeType !== ChannelScopeType.DM) continue;
+      const others = parseDMParticipantIds(channel).filter(id => id !== context.userID);
+      const [onlyOther] = others;
+      if (others.length === 1 && onlyOther) counterparts.set(channel.id, onlyOther);
+    }
+    return counterparts;
+  }, [channelData, context.userID]);
 
   const isBotDmChannel = useCallback(
     (channel: VisibleChannel): boolean => {
-      if (channel.scopeType !== ChannelScopeType.DM) return false;
-      const others = parseDMParticipantIds(channel).filter(id => id !== context.userID);
-      const [onlyOther] = others;
-      if (others.length !== 1 || !onlyOther) return false;
-      const userType = usersById.get(onlyOther)?.userType;
+      const otherId = dmCounterpartByChannelId.get(channel.id);
+      if (!otherId) return false;
+      const userType = usersById.get(otherId)?.userType;
       return userType === UserType.BOT || userType === UserType.APP;
     },
-    [usersById, context.userID],
+    [dmCounterpartByChannelId, usersById],
   );
+
+  const contactWeightByChannelId = useMemo(() => {
+    const weights = new Map<string, number>();
+    if (suggestionDismissed) return weights;
+    void affinityVersion;
+
+    let hasAffinity = false;
+    for (const [channelId, otherId] of dmCounterpartByChannelId) {
+      const weight = affinityService.getUserWeight(otherId);
+      if (weight > 0) hasAffinity = true;
+      weights.set(channelId, weight);
+    }
+    if (hasAffinity) return weights;
+
+    const recencyScore = new Map(dmRank.map((id, index) => [id, dmRank.length - index]));
+    for (const [channelId, otherId] of dmCounterpartByChannelId) {
+      weights.set(channelId, recencyScore.get(otherId) ?? 0);
+    }
+    return weights;
+  }, [dmCounterpartByChannelId, dmRank, suggestionDismissed, affinityVersion]);
 
   const suggestionChannels = useMemo(
     () =>
@@ -335,8 +369,9 @@ const ChatDirectory = ({
             type: channel.type,
             lastActivityAt: channel.channelStats?.lastActivityAt ?? channel.lastActivityAt ?? null,
             isBotDm: isBotDmChannel(channel),
+            contactWeight: contactWeightByChannelId.get(channel.id) ?? 0,
           })),
-    [channelData, suggestionDismissed, isBotDmChannel],
+    [channelData, suggestionDismissed, isBotDmChannel, contactWeightByChannelId],
   );
 
   const candidateProjectIdsKey = useMemo(

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -60,7 +60,10 @@ import AddChannelForm from '../AddChannelForm/AddChannelForm';
 import AddSectionForm from '../AddSectionForm/AddSectionForm';
 import CreateSectionDialog from '../CreateSectionDialog/CreateSectionDialog';
 import ProjectSectionSuggestionCard from './ProjectSectionSuggestionCard';
-import SectionOrganizerDialog, { type OrganizerGroup } from './SectionOrganizerDialog';
+import SectionOrganizerDialog, {
+  type OrganizerGroup,
+  type OrganizerMode,
+} from './SectionOrganizerDialog';
 import ManageSectionChannelsDialog from './ManageSectionChannelsDialog';
 import { AddPeopleForm } from '../AddPeopleForm/AddPeopleForm';
 import Badge from '../../ui/Badge';
@@ -89,7 +92,9 @@ import {
   ChannelScopeType,
   isDeskChannelType,
   NotificationLevel,
+  DEFAULT_ACTIVE_WINDOW_DAYS,
   computeProjectSectionSuggestions,
+  computeActivitySectionSuggestions,
   getCandidateProjectIds,
 } from '@xyne/shared';
 import { DndContext, DragOverlay, useDroppable } from '@dnd-kit/core';
@@ -298,13 +303,31 @@ const ChatDirectory = ({
     () => localStorage.getItem(SECTION_SUGGESTION_DISMISSED_KEY) === 'true',
   );
   const [showOrganizer, setShowOrganizer] = useState(false);
+  const [organizerMode, setOrganizerMode] = useState<OrganizerMode>('project');
+  const [activeWindowDays, setActiveWindowDays] = useState(DEFAULT_ACTIVE_WINDOW_DAYS);
+  const [suggestionsNowMs, setSuggestionsNowMs] = useState(() => Date.now());
+
+  const suggestionChannels = useMemo(
+    () =>
+      suggestionDismissed
+        ? []
+        : (channelData ?? []).map(channel => ({
+            id: channel.id,
+            projectId: channel.projectId,
+            scopeType: channel.scopeType,
+            type: channel.type,
+            lastActivityAt: channel.channelStats?.lastActivityAt ?? channel.lastActivityAt ?? null,
+          })),
+    [channelData, suggestionDismissed],
+  );
+
   const candidateProjectIdsKey = useMemo(
     () =>
       getCandidateProjectIds({
-        channels: channelData ?? [],
+        channels: suggestionChannels,
         statuses: allChannelsUserStatus ?? [],
       }).join(','),
-    [channelData, allChannelsUserStatus],
+    [suggestionChannels, allChannelsUserStatus],
   );
   const projectsQuery = useMemo(
     () =>
@@ -317,18 +340,45 @@ const ChatDirectory = ({
     enabled: !suggestionDismissed && candidateProjectIdsKey.length > 0,
   });
 
-  const sectionSuggestions = useMemo(
-    () =>
-      computeProjectSectionSuggestions({
-        channels: channelData ?? [],
-        statuses: allChannelsUserStatus ?? [],
-        projects: projects ?? [],
-        existingSectionNames: (channelSections ?? []).map(section => section.name),
-      }),
-    [channelData, allChannelsUserStatus, projects, channelSections],
+  const existingSectionNames = useMemo(
+    () => (channelSections ?? []).map(section => section.name),
+    [channelSections],
   );
 
-  const showSuggestionCard = !suggestionDismissed && sectionSuggestions.length > 0;
+  const projectSuggestions = useMemo(
+    () =>
+      computeProjectSectionSuggestions({
+        channels: suggestionChannels,
+        statuses: allChannelsUserStatus ?? [],
+        projects: projects ?? [],
+        existingSectionNames,
+      }),
+    [suggestionChannels, allChannelsUserStatus, projects, existingSectionNames],
+  );
+
+  const activitySuggestions = useMemo(
+    () =>
+      computeActivitySectionSuggestions({
+        channels: suggestionChannels,
+        statuses: allChannelsUserStatus ?? [],
+        existingSectionNames,
+        nowMs: suggestionsNowMs,
+        activeWindowDays,
+      }),
+    [
+      suggestionChannels,
+      allChannelsUserStatus,
+      existingSectionNames,
+      suggestionsNowMs,
+      activeWindowDays,
+    ],
+  );
+
+  const sectionSuggestions =
+    organizerMode === 'activity' ? activitySuggestions : projectSuggestions;
+
+  const showSuggestionCard =
+    !suggestionDismissed && (projectSuggestions.length > 0 || activitySuggestions.length > 0);
 
   const channelsById = useMemo(
     () => new Map((channelData ?? []).map(channel => [channel.id, channel])),
@@ -974,7 +1024,11 @@ const ChatDirectory = ({
 
           {showSuggestionCard && (
             <ProjectSectionSuggestionCard
-              onAccept={() => setShowOrganizer(true)}
+              onAccept={() => {
+                setSuggestionsNowMs(Date.now());
+                setOrganizerMode(projectSuggestions.length > 0 ? 'project' : 'activity');
+                setShowOrganizer(true);
+              }}
               onDismiss={handleDismissSuggestion}
             />
           )}
@@ -1397,7 +1451,11 @@ const ChatDirectory = ({
             <SectionOrganizerDialog
               suggestions={sectionSuggestions}
               channelsById={channelsById}
-              existingNames={(channelSections ?? []).map(s => s.name)}
+              existingNames={existingSectionNames}
+              mode={organizerMode}
+              onModeChange={setOrganizerMode}
+              activeWindowDays={activeWindowDays}
+              onActiveWindowDaysChange={setActiveWindowDays}
               onCancel={() => setShowOrganizer(false)}
               onConfirm={handleCreateSections}
             />

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -43,7 +43,7 @@ import {
 } from '../../ui/dropdown-menu';
 import { useAuthContextValues, useAuth } from '../../../hooks/useAuth';
 import { ChatDirectoryProps, ChannelCategory } from './ChatDirectory.types';
-import { keyBetween } from './ChatDirectory.utils';
+import { keyBetween, parseDMParticipantIds } from './ChatDirectory.utils';
 import { renderEmoji } from '../../../utils/customEmojiUtils';
 import { useAllUnreadCount } from '../../../hooks/useUnreadCount';
 import { useAllMentionCount } from '../../../hooks/useMentionCount';
@@ -71,6 +71,7 @@ import Avatar from '../../ui/Avatar/Avatar';
 import Dialog, { cn } from '../../ui/Dialog';
 
 import { useZero } from '../../../hooks/useZero';
+import { useUsersById } from '../../../hooks/useUsers';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { queries } from '../../../zero/queries';
 import { mutators } from '../../../zero/mutators';
@@ -93,8 +94,10 @@ import {
   isDeskChannelType,
   NotificationLevel,
   DEFAULT_ACTIVE_WINDOW_DAYS,
+  UserType,
   computeProjectSectionSuggestions,
   computeActivitySectionSuggestions,
+  computeDmSectionSuggestions,
   getCandidateProjectIds,
 } from '@xyne/shared';
 import { DndContext, DragOverlay, useDroppable } from '@dnd-kit/core';
@@ -307,6 +310,20 @@ const ChatDirectory = ({
   const [activeWindowDays, setActiveWindowDays] = useState(DEFAULT_ACTIVE_WINDOW_DAYS);
   const [suggestionsNowMs, setSuggestionsNowMs] = useState(() => Date.now());
 
+  const usersById = useUsersById();
+
+  const isBotDmChannel = useCallback(
+    (channel: VisibleChannel): boolean => {
+      if (channel.scopeType !== ChannelScopeType.DM) return false;
+      const others = parseDMParticipantIds(channel).filter(id => id !== context.userID);
+      const [onlyOther] = others;
+      if (others.length !== 1 || !onlyOther) return false;
+      const userType = usersById.get(onlyOther)?.userType;
+      return userType === UserType.BOT || userType === UserType.APP;
+    },
+    [usersById, context.userID],
+  );
+
   const suggestionChannels = useMemo(
     () =>
       suggestionDismissed
@@ -317,8 +334,9 @@ const ChatDirectory = ({
             scopeType: channel.scopeType,
             type: channel.type,
             lastActivityAt: channel.channelStats?.lastActivityAt ?? channel.lastActivityAt ?? null,
+            isBotDm: isBotDmChannel(channel),
           })),
-    [channelData, suggestionDismissed],
+    [channelData, suggestionDismissed, isBotDmChannel],
   );
 
   const candidateProjectIdsKey = useMemo(
@@ -374,11 +392,26 @@ const ChatDirectory = ({
     ],
   );
 
+  const dmSuggestions = useMemo(
+    () =>
+      computeDmSectionSuggestions({
+        channels: suggestionChannels,
+        statuses: allChannelsUserStatus ?? [],
+        existingSectionNames,
+      }),
+    [suggestionChannels, allChannelsUserStatus, existingSectionNames],
+  );
+
   const sectionSuggestions =
-    organizerMode === 'activity' ? activitySuggestions : projectSuggestions;
+    organizerMode === 'activity'
+      ? activitySuggestions
+      : organizerMode === 'dms'
+        ? dmSuggestions
+        : projectSuggestions;
 
   const showSuggestionCard =
-    !suggestionDismissed && (projectSuggestions.length > 0 || activitySuggestions.length > 0);
+    !suggestionDismissed &&
+    (projectSuggestions.length > 0 || activitySuggestions.length > 0 || dmSuggestions.length > 0);
 
   const channelsById = useMemo(
     () => new Map((channelData ?? []).map(channel => [channel.id, channel])),
@@ -1026,7 +1059,13 @@ const ChatDirectory = ({
             <ProjectSectionSuggestionCard
               onAccept={() => {
                 setSuggestionsNowMs(Date.now());
-                setOrganizerMode(projectSuggestions.length > 0 ? 'project' : 'activity');
+                setOrganizerMode(
+                  projectSuggestions.length > 0
+                    ? 'project'
+                    : activitySuggestions.length > 0
+                      ? 'activity'
+                      : 'dms',
+                );
                 setShowOrganizer(true);
               }}
               onDismiss={handleDismissSuggestion}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -59,6 +59,8 @@ import { AddDmForm, CreateDmFormData } from '../AddDmForm/AddDmForm';
 import AddChannelForm from '../AddChannelForm/AddChannelForm';
 import AddSectionForm from '../AddSectionForm/AddSectionForm';
 import CreateSectionDialog from '../CreateSectionDialog/CreateSectionDialog';
+import ProjectSectionSuggestionCard from './ProjectSectionSuggestionCard';
+import SectionOrganizerDialog, { type OrganizerGroup } from './SectionOrganizerDialog';
 import ManageSectionChannelsDialog from './ManageSectionChannelsDialog';
 import { AddPeopleForm } from '../AddPeopleForm/AddPeopleForm';
 import Badge from '../../ui/Badge';
@@ -66,7 +68,10 @@ import Avatar from '../../ui/Avatar/Avatar';
 import Dialog, { cn } from '../../ui/Dialog';
 
 import { useZero } from '../../../hooks/useZero';
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { queries } from '../../../zero/queries';
 import { mutators } from '../../../zero/mutators';
+import { toast } from 'sonner';
 import {
   useChannelSort,
   type SidebarGroup,
@@ -84,6 +89,7 @@ import {
   ChannelScopeType,
   isDeskChannelType,
   NotificationLevel,
+  computeProjectSectionSuggestions,
 } from '@xyne/shared';
 import { DndContext, DragOverlay, useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -102,6 +108,8 @@ import { useOverdueRemindersCount } from '../../../hooks/useOverdueRemindersCoun
 import { useRecapUnreadCount, usePrefetchRecap } from '../../../hooks/useRecapData';
 import { stateMachineActor, type VisibleChannel } from '../../../machines/stateMachine';
 import { usePendingDelayedMessagesCount } from '../../../hooks/useUserDelayedMessages';
+
+const SECTION_SUGGESTION_DISMISSED_KEY = 'xyne:section-suggestion-dismissed';
 
 const ContainerDropZone = ({
   id,
@@ -284,6 +292,99 @@ const ChatDirectory = ({
     mentionCounts,
     activeChannelId,
   });
+
+  const [projects] = useCachedQuery(queries.getAllProjectsList());
+  const [suggestionDismissed, setSuggestionDismissed] = useState(
+    () => localStorage.getItem(SECTION_SUGGESTION_DISMISSED_KEY) === 'true',
+  );
+  const [showOrganizer, setShowOrganizer] = useState(false);
+
+  const sectionSuggestions = useMemo(
+    () =>
+      computeProjectSectionSuggestions({
+        channels: channelData ?? [],
+        statuses: allChannelsUserStatus ?? [],
+        projects: projects ?? [],
+        existingSectionNames: (channelSections ?? []).map(section => section.name),
+      }),
+    [channelData, allChannelsUserStatus, projects, channelSections],
+  );
+
+  const showSuggestionCard = !suggestionDismissed && sectionSuggestions.length > 0;
+
+  const channelsById = useMemo(
+    () => new Map((channelData ?? []).map(channel => [channel.id, channel])),
+    [channelData],
+  );
+
+  const handleDismissSuggestion = useCallback(() => {
+    localStorage.setItem(SECTION_SUGGESTION_DISMISSED_KEY, 'true');
+    setSuggestionDismissed(true);
+    toast('You can create sections any time from the channel menu.', { duration: 5000 });
+  }, []);
+
+  const handleCreateSections = useCallback(
+    (groups: OrganizerGroup[]) => {
+      const timestamp = Date.now();
+      const created: { id: string; channelIds: string[] }[] = [];
+      let prevSectionKey = lastSectionPosition;
+
+      for (const group of groups) {
+        const sectionId = crypto.randomUUID();
+        const position = keyBetween(prevSectionKey, null);
+        prevSectionKey = position;
+
+        void zero.mutate(
+          mutators.channelSection.create({
+            id: sectionId,
+            name: group.name.trim(),
+            emoji: null,
+            position,
+            timestamp,
+          }),
+        );
+
+        let prevChannelKey: string | null = null;
+        for (const channelId of group.channelIds) {
+          const channelPosition = keyBetween(prevChannelKey, null);
+          prevChannelKey = channelPosition;
+          void zero.mutate(
+            mutators.channel.moveToSection({
+              channelId,
+              sectionId,
+              position: channelPosition,
+              timestamp,
+            }),
+          );
+        }
+
+        created.push({ id: sectionId, channelIds: group.channelIds });
+      }
+
+      setShowOrganizer(false);
+
+      const sectionCount = created.length;
+      const channelCount = created.reduce((sum, s) => sum + s.channelIds.length, 0);
+      toast(
+        `${sectionCount} section${sectionCount === 1 ? '' : 's'} created with ${channelCount} channels.`,
+        {
+          duration: 8000,
+          action: {
+            label: 'Undo',
+            onClick: () => {
+              const undoTimestamp = Date.now();
+              for (const section of created) {
+                void zero.mutate(
+                  mutators.channelSection.remove({ id: section.id, timestamp: undoTimestamp }),
+                );
+              }
+            },
+          },
+        },
+      );
+    },
+    [zero, lastSectionPosition],
+  );
 
   // Flattened, de-duplicated sidebar conversation order — mirrors exactly what
   // ChatDirectory renders (starred → custom sections → channels → DMs) so keyboard
@@ -853,6 +954,13 @@ const ChatDirectory = ({
 
           <div className='py-3 w-full hidden md:block' />
 
+          {showSuggestionCard && (
+            <ProjectSectionSuggestionCard
+              onAccept={() => setShowOrganizer(true)}
+              onDismiss={handleDismissSuggestion}
+            />
+          )}
+
           <Accordion.Root
             type='multiple'
             className='space-y-4'
@@ -1262,6 +1370,23 @@ const ChatDirectory = ({
               lastSectionPosition={lastSectionPosition}
               prioritizeType={addSectionSource === 'dms' ? 'dm' : 'channel'}
               onClose={() => setShowAddSectionForm(false)}
+            />
+          )}
+        </Dialog>
+
+        <Dialog
+          open={showOrganizer}
+          onOpenChange={setShowOrganizer}
+          testId='section-organizer-dialog'
+          className='max-w-lg'
+        >
+          {showOrganizer && (
+            <SectionOrganizerDialog
+              suggestions={sectionSuggestions}
+              channelsById={channelsById}
+              existingNames={(channelSections ?? []).map(s => s.name)}
+              onCancel={() => setShowOrganizer(false)}
+              onConfirm={handleCreateSections}
             />
           )}
         </Dialog>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ProjectSectionSuggestionCard.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ProjectSectionSuggestionCard.tsx
@@ -19,7 +19,7 @@ export const ProjectSectionSuggestionCard = ({
       <div className='flex items-start justify-between gap-2'>
         <div className='flex items-center gap-1.5 text-xs font-medium text-sidebar-foreground'>
           <FolderAi size={14} className='shrink-0 text-sidebar-primary' />
-          <span>Organize your channels/DM</span>
+          <span>Organize your sidebar</span>
         </div>
         <button
           type='button'

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ProjectSectionSuggestionCard.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ProjectSectionSuggestionCard.tsx
@@ -19,7 +19,7 @@ export const ProjectSectionSuggestionCard = ({
       <div className='flex items-start justify-between gap-2'>
         <div className='flex items-center gap-1.5 text-xs font-medium text-sidebar-foreground'>
           <FolderAi size={14} className='shrink-0 text-sidebar-primary' />
-          <span>Organize your channels</span>
+          <span>Organize your channels/DM</span>
         </div>
         <button
           type='button'

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ProjectSectionSuggestionCard.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ProjectSectionSuggestionCard.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from 'react';
+import { FolderAi, MultipleCrossCancelDefault } from '@xyne/icons';
+import { Button } from '../../ui/Button';
+
+interface ProjectSectionSuggestionCardProps {
+  onAccept: () => void;
+  onDismiss: () => void;
+}
+
+export const ProjectSectionSuggestionCard = ({
+  onAccept,
+  onDismiss,
+}: ProjectSectionSuggestionCardProps): ReactElement => {
+  return (
+    <div
+      className='mx-3 mb-4 rounded-lg border border-sidebar-accent-ring bg-sidebar-accent/40 p-3'
+      data-testid='project-section-suggestion-card'
+    >
+      <div className='flex items-start justify-between gap-2'>
+        <div className='flex items-center gap-1.5 text-xs font-medium text-sidebar-foreground'>
+          <FolderAi size={14} className='shrink-0 text-sidebar-primary' />
+          <span>Organize your channels</span>
+        </div>
+        <button
+          type='button'
+          onClick={onDismiss}
+          aria-label='Dismiss suggestion'
+          data-track-category='CHAT_SIDEBAR'
+          data-track-name='DISMISS_SECTION_SUGGESTION'
+          className='-mr-1 -mt-1 shrink-0 rounded p-0.5 text-sidebar-foreground/60 transition-colors hover:bg-sidebar-item-hover hover:text-sidebar-foreground'
+        >
+          <MultipleCrossCancelDefault size={14} />
+        </button>
+      </div>
+
+      <p className='mt-1.5 text-xs leading-relaxed text-sidebar-foreground/70'>
+        Keep everything easier to find.
+      </p>
+
+      <div className='mt-2.5 flex items-center justify-end'>
+        <Button
+          type='button'
+          variant='default'
+          size='sm'
+          onClick={onAccept}
+          data-track-category='CHAT_SIDEBAR'
+          data-track-name='ACCEPT_SECTION_SUGGESTION'
+          className='h-7 px-2.5 text-xs'
+        >
+          Try now
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectSectionSuggestionCard;

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SectionOrganizerDialog.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SectionOrganizerDialog.tsx
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ChangeEvent,
   type ReactElement,
@@ -16,9 +17,20 @@ import {
   PlusDefault,
   SearchDefault,
 } from '@xyne/icons';
-import { ChannelVisibility, type ProjectSectionSuggestion } from '@xyne/shared';
+import {
+  ChannelVisibility,
+  MAX_ACTIVE_WINDOW_DAYS,
+  MIN_ACTIVE_WINDOW_DAYS,
+  SECTION_NAME_MAX_LENGTH,
+  clampActiveWindowDays,
+  type SectionSuggestion,
+} from '@xyne/shared';
 import { Button } from '../../ui/Button';
 import { Checkbox } from '../../ui/Checkbox/Checkbox';
+import {
+  SegmentedToggle,
+  type SegmentedToggleOption,
+} from '../../ui/SegmentedToggle/SegmentedToggle';
 import { cn } from '../../../utils/classNames';
 import { isDMChannel, getDMSearchableName } from './ChatDirectory.utils';
 import type { VisibleChannel } from '../../../machines/stateMachine';
@@ -28,6 +40,11 @@ import { useUsers } from '../../../hooks/useUsers';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 const AUTO_EXPAND_MAX_CHANNELS = 25;
+
+const MODE_OPTIONS: SegmentedToggleOption<OrganizerMode>[] = [
+  { label: 'By project', value: 'project' },
+  { label: 'By activity', value: 'activity' },
+];
 const TIP_INDEX_KEY = 'xyne:section-organizer-tip-index';
 
 const SECTION_TIPS = [
@@ -40,7 +57,7 @@ const SECTION_TIPS = [
 ];
 
 export interface OrganizerGroup {
-  projectId: string;
+  id: string;
   name: string;
   channelIds: string[];
   excludedChannelIds: string[];
@@ -48,10 +65,16 @@ export interface OrganizerGroup {
   expanded: boolean;
 }
 
+export type OrganizerMode = 'project' | 'activity';
+
 interface SectionOrganizerDialogProps {
-  suggestions: readonly ProjectSectionSuggestion[];
+  suggestions: readonly SectionSuggestion[];
   channelsById: Map<string, VisibleChannel>;
   existingNames: readonly string[];
+  mode: OrganizerMode;
+  onModeChange: (mode: OrganizerMode) => void;
+  activeWindowDays: number;
+  onActiveWindowDaysChange: (days: number) => void;
   onCancel: () => void;
   onConfirm: (groups: OrganizerGroup[]) => void;
 }
@@ -103,10 +126,27 @@ const ChannelLine = ({
   );
 };
 
+const buildGroups = (
+  suggestions: readonly SectionSuggestion[],
+  totalChannels: number,
+): OrganizerGroup[] =>
+  suggestions.map(s => ({
+    id: s.id,
+    name: s.name,
+    channelIds: [...s.channelIds],
+    excludedChannelIds: [],
+    included: true,
+    expanded: totalChannels <= AUTO_EXPAND_MAX_CHANNELS,
+  }));
+
 export const SectionOrganizerDialog = ({
   suggestions,
   channelsById,
   existingNames,
+  mode,
+  onModeChange,
+  activeWindowDays,
+  onActiveWindowDaysChange,
   onCancel,
   onConfirm,
 }: SectionOrganizerDialogProps): ReactElement => {
@@ -117,15 +157,22 @@ export const SectionOrganizerDialog = ({
 
   const [filter, setFilter] = useState('');
   const [groups, setGroups] = useState<OrganizerGroup[]>(() =>
-    suggestions.map(s => ({
-      projectId: s.projectId,
-      name: s.name,
-      channelIds: [...s.channelIds],
-      excludedChannelIds: [],
-      included: true,
-      expanded: totalChannels <= AUTO_EXPAND_MAX_CHANNELS,
-    })),
+    buildGroups(suggestions, totalChannels),
   );
+
+  const suggestionsRef = useRef(suggestions);
+  const totalChannelsRef = useRef(totalChannels);
+  suggestionsRef.current = suggestions;
+  totalChannelsRef.current = totalChannels;
+
+  const isFirstRender = useRef(true);
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setGroups(buildGroups(suggestionsRef.current, totalChannelsRef.current));
+  }, [mode, activeWindowDays]);
 
   const { userID } = useAuthContextValues();
   const allUsers = useUsers();
@@ -153,14 +200,14 @@ export const SectionOrganizerDialog = ({
       .filter(g => g.channelIds.length > 0 || g.name.toLowerCase().includes(query));
   }, [groups, query, matchesQuery]);
 
-  const updateGroup = (projectId: string, patch: Partial<OrganizerGroup>): void => {
-    setGroups(prev => prev.map(g => (g.projectId === projectId ? { ...g, ...patch } : g)));
+  const updateGroup = (groupId: string, patch: Partial<OrganizerGroup>): void => {
+    setGroups(prev => prev.map(g => (g.id === groupId ? { ...g, ...patch } : g)));
   };
 
-  const toggleChannel = (projectId: string, channelId: string): void => {
+  const toggleChannel = (groupId: string, channelId: string): void => {
     setGroups(prev =>
       prev.map(g => {
-        if (g.projectId !== projectId) return g;
+        if (g.id !== groupId) return g;
         const excluded = g.excludedChannelIds.includes(channelId)
           ? g.excludedChannelIds.filter(id => id !== channelId)
           : [...g.excludedChannelIds, channelId];
@@ -185,7 +232,7 @@ export const SectionOrganizerDialog = ({
   for (const group of selectedGroups) {
     const normalized = group.name.trim().toLowerCase();
     if (!normalized || takenNames.has(normalized) || seen.has(normalized)) {
-      invalidNames.add(group.projectId);
+      invalidNames.add(group.id);
     }
     seen.add(normalized);
   }
@@ -222,6 +269,36 @@ export const SectionOrganizerDialog = ({
         </button>
       </div>
 
+      <div className='flex flex-wrap items-center justify-between gap-2'>
+        <SegmentedToggle
+          options={MODE_OPTIONS}
+          value={mode}
+          onChange={onModeChange}
+          tone='primary'
+          trackCategory='CHAT_SIDEBAR'
+          trackPrefix='ORGANIZER_SET_MODE'
+        />
+
+        {mode === 'activity' && (
+          <label className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+            Active in the last
+            <input
+              type='number'
+              min={MIN_ACTIVE_WINDOW_DAYS}
+              max={MAX_ACTIVE_WINDOW_DAYS}
+              value={activeWindowDays}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                onActiveWindowDaysChange(clampActiveWindowDays(Number(e.target.value)))
+              }
+              data-track-category='CHAT_SIDEBAR'
+              data-track-name='ORGANIZER_SET_ACTIVE_WINDOW'
+              className='w-14 rounded border border-border bg-background px-1.5 py-1 text-center text-xs text-foreground outline-none focus:ring-2 focus:ring-ring'
+            />
+            days
+          </label>
+        )}
+      </div>
+
       <div className='flex items-center gap-2 rounded-md border border-border bg-background px-2 focus-within:ring-2 focus-within:ring-ring'>
         <SearchDefault size={16} className='shrink-0 text-muted-foreground' />
         <input
@@ -239,20 +316,20 @@ export const SectionOrganizerDialog = ({
         <div className='max-h-[22rem] min-h-0 overflow-y-auto rounded-md border border-border bg-sidebar/40 p-2'>
           {visibleGroups.map(group => {
             const isOpen = (group.expanded || !!query) && group.included;
-            const hasNameError = invalidNames.has(group.projectId);
+            const hasNameError = invalidNames.has(group.id);
             return (
-              <div key={group.projectId} className='mb-1'>
+              <div key={group.id} className='mb-1'>
                 <div className='flex h-9 items-center gap-1.5 rounded-[10px] border border-transparent px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'>
                   <Checkbox
                     checked={group.included}
-                    onChange={included => updateGroup(group.projectId, { included })}
+                    onChange={included => updateGroup(group.id, { included })}
                     ariaLabel={`Include ${group.name}`}
                     label=''
                     size='sm'
                   />
                   <button
                     type='button'
-                    onClick={() => updateGroup(group.projectId, { expanded: !group.expanded })}
+                    onClick={() => updateGroup(group.id, { expanded: !group.expanded })}
                     aria-label={isOpen ? 'Collapse' : 'Expand'}
                     data-track-category='CHAT_SIDEBAR'
                     data-track-name='ORGANIZER_TOGGLE_EXPAND'
@@ -265,8 +342,8 @@ export const SectionOrganizerDialog = ({
                   </button>
                   <input
                     value={group.name}
-                    onChange={e => updateGroup(group.projectId, { name: e.target.value })}
-                    maxLength={50}
+                    onChange={e => updateGroup(group.id, { name: e.target.value })}
+                    maxLength={SECTION_NAME_MAX_LENGTH}
                     disabled={!group.included}
                     data-track-category='CHAT_SIDEBAR'
                     data-track-name='ORGANIZER_RENAME_SECTION'
@@ -291,7 +368,7 @@ export const SectionOrganizerDialog = ({
                           key={channelId}
                           channel={channel}
                           excluded={group.excludedChannelIds.includes(channelId)}
-                          onToggle={() => toggleChannel(group.projectId, channelId)}
+                          onToggle={() => toggleChannel(group.id, channelId)}
                         />
                       );
                     })}
@@ -303,7 +380,9 @@ export const SectionOrganizerDialog = ({
 
           {visibleGroups.length === 0 && (
             <div className='px-3 py-6 text-center text-sm text-muted-foreground'>
-              No channels found
+              {query || mode !== 'activity'
+                ? 'No channels found'
+                : `Everything falls on one side of ${activeWindowDays} days. Try a shorter window.`}
             </div>
           )}
         </div>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SectionOrganizerDialog.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SectionOrganizerDialog.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useState, type ChangeEvent, type ReactElement } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type ReactElement,
+} from 'react';
 import {
   ChatDefault,
   ChevronRight,
@@ -21,6 +28,16 @@ import { useUsers } from '../../../hooks/useUsers';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 const AUTO_EXPAND_MAX_CHANNELS = 25;
+const TIP_INDEX_KEY = 'xyne:section-organizer-tip-index';
+
+const SECTION_TIPS = [
+  'Drag DMs into a section anytime.',
+  'Your sections are private to you.',
+  'Click a section name to rename it.',
+  'Uncheck a section to skip it.',
+  'Use × to remove a channel and + to add it back.',
+  'Drag channels between sections anytime.',
+];
 
 export interface OrganizerGroup {
   projectId: string;
@@ -157,7 +174,10 @@ export const SectionOrganizerDialog = ({
 
   const selectedGroups = groups
     .filter(g => g.included && includedCount(g) > 0)
-    .map(g => ({ ...g, channelIds: g.channelIds.filter(id => !g.excludedChannelIds.includes(id)) }));
+    .map(g => ({
+      ...g,
+      channelIds: g.channelIds.filter(id => !g.excludedChannelIds.includes(id)),
+    }));
   const takenNames = new Set(existingNames.map(n => n.trim().toLowerCase()));
 
   const invalidNames = new Set<string>();
@@ -172,6 +192,14 @@ export const SectionOrganizerDialog = ({
 
   const canConfirm = selectedGroups.length > 0 && invalidNames.size === 0;
 
+  const [tipIndex] = useState(() => {
+    const stored = Number(localStorage.getItem(TIP_INDEX_KEY));
+    return Number.isInteger(stored) && stored >= 0 ? stored % SECTION_TIPS.length : 0;
+  });
+  useEffect(() => {
+    localStorage.setItem(TIP_INDEX_KEY, String((tipIndex + 1) % SECTION_TIPS.length));
+  }, [tipIndex]);
+
   return (
     <div className='flex max-h-[80vh] flex-col gap-4 p-4' data-testid='section-organizer-dialog'>
       <div className='flex items-start justify-between gap-2'>
@@ -180,9 +208,7 @@ export const SectionOrganizerDialog = ({
             <FolderAi size={16} className='text-primary' />
             Organize your channels
           </div>
-          <div className='mt-1 text-xs text-muted-foreground'>
-            See how your sidebar could look.
-          </div>
+          <div className='mt-1 text-xs text-muted-foreground'>See how your sidebar could look.</div>
         </div>
         <button
           type='button'
@@ -209,84 +235,82 @@ export const SectionOrganizerDialog = ({
         />
       </div>
 
-      <div className='flex min-h-0 flex-1 flex-col'>
-        <div className='min-h-0 flex-1 overflow-y-auto rounded-md border border-border bg-sidebar/40 p-2'>
-            {visibleGroups.map(group => {
-              const isOpen = (group.expanded || !!query) && group.included;
-              const hasNameError = invalidNames.has(group.projectId);
-              return (
-                <div key={group.projectId} className='mb-1'>
-                  <div className='flex h-9 items-center gap-1.5 rounded-[10px] border border-transparent px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'>
-                    <Checkbox
-                      checked={group.included}
-                      onChange={included => updateGroup(group.projectId, { included })}
-                      ariaLabel={`Include ${group.name}`}
-                      label=''
-                      size='sm'
+      <div className='flex min-h-0 flex-col'>
+        <div className='max-h-[22rem] min-h-0 overflow-y-auto rounded-md border border-border bg-sidebar/40 p-2'>
+          {visibleGroups.map(group => {
+            const isOpen = (group.expanded || !!query) && group.included;
+            const hasNameError = invalidNames.has(group.projectId);
+            return (
+              <div key={group.projectId} className='mb-1'>
+                <div className='flex h-9 items-center gap-1.5 rounded-[10px] border border-transparent px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'>
+                  <Checkbox
+                    checked={group.included}
+                    onChange={included => updateGroup(group.projectId, { included })}
+                    ariaLabel={`Include ${group.name}`}
+                    label=''
+                    size='sm'
+                  />
+                  <button
+                    type='button'
+                    onClick={() => updateGroup(group.projectId, { expanded: !group.expanded })}
+                    aria-label={isOpen ? 'Collapse' : 'Expand'}
+                    data-track-category='CHAT_SIDEBAR'
+                    data-track-name='ORGANIZER_TOGGLE_EXPAND'
+                    className='shrink-0 text-muted-foreground'
+                  >
+                    <ChevronRight
+                      size={13}
+                      className={cn('transition-transform', isOpen && 'rotate-90')}
                     />
-                    <button
-                      type='button'
-                      onClick={() => updateGroup(group.projectId, { expanded: !group.expanded })}
-                      aria-label={isOpen ? 'Collapse' : 'Expand'}
-                      data-track-category='CHAT_SIDEBAR'
-                      data-track-name='ORGANIZER_TOGGLE_EXPAND'
-                      className='shrink-0 text-muted-foreground'
-                    >
-                      <ChevronRight
-                        size={13}
-                        className={cn('transition-transform', isOpen && 'rotate-90')}
-                      />
-                    </button>
-                    <input
-                      value={group.name}
-                      onChange={e => updateGroup(group.projectId, { name: e.target.value })}
-                      maxLength={50}
-                      disabled={!group.included}
-                      data-track-category='CHAT_SIDEBAR'
-                      data-track-name='ORGANIZER_RENAME_SECTION'
-                      className={cn(
-                        'min-w-0 flex-1 border-0 border-b border-transparent bg-transparent px-0.5 py-0.5 text-sm font-medium text-foreground outline-none focus:border-b-primary',
-                        !group.included && 'text-muted-foreground line-through',
-                        hasNameError && 'border-b-destructive focus:border-b-destructive',
-                      )}
-                    />
-                    <span className='shrink-0 text-xs text-muted-foreground'>
-                      {includedCount(group)}
-                    </span>
-                  </div>
-
-                  {isOpen && (
-                    <div className='pl-6'>
-                      {group.channelIds.map(channelId => {
-                        const channel = channelsById.get(channelId);
-                        if (!channel) return null;
-                        return (
-                          <ChannelLine
-                            key={channelId}
-                            channel={channel}
-                            excluded={group.excludedChannelIds.includes(channelId)}
-                            onToggle={() => toggleChannel(group.projectId, channelId)}
-                          />
-                        );
-                      })}
-                    </div>
-                  )}
+                  </button>
+                  <input
+                    value={group.name}
+                    onChange={e => updateGroup(group.projectId, { name: e.target.value })}
+                    maxLength={50}
+                    disabled={!group.included}
+                    data-track-category='CHAT_SIDEBAR'
+                    data-track-name='ORGANIZER_RENAME_SECTION'
+                    className={cn(
+                      'min-w-0 flex-1 border-0 border-b border-transparent bg-transparent px-0.5 py-0.5 text-sm font-medium text-foreground outline-none focus:border-b-primary',
+                      !group.included && 'text-muted-foreground line-through',
+                      hasNameError && 'border-b-destructive focus:border-b-destructive',
+                    )}
+                  />
+                  <span className='shrink-0 text-xs text-muted-foreground'>
+                    {includedCount(group)}
+                  </span>
                 </div>
-              );
-            })}
 
-            {visibleGroups.length === 0 && (
-              <div className='px-3 py-6 text-center text-sm text-muted-foreground'>
-                No channels found
+                {isOpen && (
+                  <div className='pl-6'>
+                    {group.channelIds.map(channelId => {
+                      const channel = channelsById.get(channelId);
+                      if (!channel) return null;
+                      return (
+                        <ChannelLine
+                          key={channelId}
+                          channel={channel}
+                          excluded={group.excludedChannelIds.includes(channelId)}
+                          onToggle={() => toggleChannel(group.projectId, channelId)}
+                        />
+                      );
+                    })}
+                  </div>
+                )}
               </div>
-            )}
+            );
+          })}
+
+          {visibleGroups.length === 0 && (
+            <div className='px-3 py-6 text-center text-sm text-muted-foreground'>
+              No channels found
+            </div>
+          )}
         </div>
       </div>
 
       <div className='flex items-center justify-between gap-3'>
-        <span className='text-xs text-muted-foreground'>
-          DMs can be added by dragging them into a section.
-        </span>
+        <span className='text-xs text-muted-foreground'>{SECTION_TIPS[tipIndex]}</span>
         <span className={cn('inline-flex', !canConfirm && 'cursor-not-allowed')}>
           <Button
             type='button'

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SectionOrganizerDialog.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SectionOrganizerDialog.tsx
@@ -1,0 +1,310 @@
+import { useCallback, useMemo, useState, type ChangeEvent, type ReactElement } from 'react';
+import {
+  ChatDefault,
+  ChevronRight,
+  FolderAi,
+  Hashtag,
+  LockClose,
+  MultipleCrossCancelDefault,
+  PlusDefault,
+  SearchDefault,
+} from '@xyne/icons';
+import { ChannelVisibility, type ProjectSectionSuggestion } from '@xyne/shared';
+import { Button } from '../../ui/Button';
+import { Checkbox } from '../../ui/Checkbox/Checkbox';
+import { cn } from '../../../utils/classNames';
+import { isDMChannel, getDMSearchableName } from './ChatDirectory.utils';
+import type { VisibleChannel } from '../../../machines/stateMachine';
+import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
+import { useAuthContextValues } from '../../../hooks/useAuth';
+import { useUsers } from '../../../hooks/useUsers';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+
+const AUTO_EXPAND_MAX_CHANNELS = 25;
+
+export interface OrganizerGroup {
+  projectId: string;
+  name: string;
+  channelIds: string[];
+  excludedChannelIds: string[];
+  included: boolean;
+  expanded: boolean;
+}
+
+interface SectionOrganizerDialogProps {
+  suggestions: readonly ProjectSectionSuggestion[];
+  channelsById: Map<string, VisibleChannel>;
+  existingNames: readonly string[];
+  onCancel: () => void;
+  onConfirm: (groups: OrganizerGroup[]) => void;
+}
+
+const ChannelIcon = ({ channel }: { channel: VisibleChannel }): ReactElement => {
+  if (isDMChannel(channel.scopeType)) return <ChatDefault size={14} />;
+  if (channel.visibility === ChannelVisibility.PRIVATE) return <LockClose size={14} />;
+  return <Hashtag size={14} />;
+};
+
+const ChannelLine = ({
+  channel,
+  excluded,
+  onToggle,
+}: {
+  channel: VisibleChannel;
+  excluded: boolean;
+  onToggle: () => void;
+}): ReactElement => {
+  const { userID } = useAuthContextValues();
+  const { displayName } = useChannelDisplayName(channel, userID);
+  return (
+    <div
+      className={cn(
+        'group flex h-9 items-center gap-3 rounded-[10px] border border-transparent px-3 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        excluded ? 'text-muted-foreground' : 'text-sidebar-foreground',
+      )}
+    >
+      <span className='flex size-4 shrink-0 items-center justify-center text-muted-foreground'>
+        <ChannelIcon channel={channel} />
+      </span>
+      <span className={cn('min-w-0 flex-1 truncate text-sm', excluded && 'line-through')}>
+        {displayName}
+      </span>
+      <button
+        type='button'
+        onClick={onToggle}
+        aria-label={excluded ? `Add ${displayName} back` : `Remove ${displayName}`}
+        data-track-category='CHAT_SIDEBAR'
+        data-track-name={excluded ? 'ORGANIZER_RESTORE_CHANNEL' : 'ORGANIZER_REMOVE_CHANNEL'}
+        className={cn(
+          'shrink-0 rounded p-0.5 text-muted-foreground transition-opacity hover:text-foreground',
+          excluded ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+        )}
+      >
+        {excluded ? <PlusDefault size={13} /> : <MultipleCrossCancelDefault size={13} />}
+      </button>
+    </div>
+  );
+};
+
+export const SectionOrganizerDialog = ({
+  suggestions,
+  channelsById,
+  existingNames,
+  onCancel,
+  onConfirm,
+}: SectionOrganizerDialogProps): ReactElement => {
+  const totalChannels = useMemo(
+    () => suggestions.reduce((sum, s) => sum + s.channelIds.length, 0),
+    [suggestions],
+  );
+
+  const [filter, setFilter] = useState('');
+  const [groups, setGroups] = useState<OrganizerGroup[]>(() =>
+    suggestions.map(s => ({
+      projectId: s.projectId,
+      name: s.name,
+      channelIds: [...s.channelIds],
+      excludedChannelIds: [],
+      included: true,
+      expanded: totalChannels <= AUTO_EXPAND_MAX_CHANNELS,
+    })),
+  );
+
+  const { userID } = useAuthContextValues();
+  const allUsers = useUsers();
+  const userMap = useMemo(
+    () => new Map(allUsers.map(u => [u.id, getUserDisplayName(u)])),
+    [allUsers],
+  );
+
+  const query = filter.trim().toLowerCase();
+
+  const matchesQuery = useCallback(
+    (channelId: string): boolean => {
+      if (!query) return true;
+      const channel = channelsById.get(channelId);
+      if (!channel) return false;
+      return getDMSearchableName(channel, userMap, userID).toLowerCase().includes(query);
+    },
+    [query, channelsById, userMap, userID],
+  );
+
+  const visibleGroups = useMemo(() => {
+    if (!query) return groups;
+    return groups
+      .map(g => ({ ...g, channelIds: g.channelIds.filter(matchesQuery) }))
+      .filter(g => g.channelIds.length > 0 || g.name.toLowerCase().includes(query));
+  }, [groups, query, matchesQuery]);
+
+  const updateGroup = (projectId: string, patch: Partial<OrganizerGroup>): void => {
+    setGroups(prev => prev.map(g => (g.projectId === projectId ? { ...g, ...patch } : g)));
+  };
+
+  const toggleChannel = (projectId: string, channelId: string): void => {
+    setGroups(prev =>
+      prev.map(g => {
+        if (g.projectId !== projectId) return g;
+        const excluded = g.excludedChannelIds.includes(channelId)
+          ? g.excludedChannelIds.filter(id => id !== channelId)
+          : [...g.excludedChannelIds, channelId];
+        return { ...g, excludedChannelIds: excluded };
+      }),
+    );
+  };
+
+  const includedCount = (group: OrganizerGroup): number =>
+    group.channelIds.filter(id => !group.excludedChannelIds.includes(id)).length;
+
+  const selectedGroups = groups
+    .filter(g => g.included && includedCount(g) > 0)
+    .map(g => ({ ...g, channelIds: g.channelIds.filter(id => !g.excludedChannelIds.includes(id)) }));
+  const takenNames = new Set(existingNames.map(n => n.trim().toLowerCase()));
+
+  const invalidNames = new Set<string>();
+  const seen = new Set<string>();
+  for (const group of selectedGroups) {
+    const normalized = group.name.trim().toLowerCase();
+    if (!normalized || takenNames.has(normalized) || seen.has(normalized)) {
+      invalidNames.add(group.projectId);
+    }
+    seen.add(normalized);
+  }
+
+  const canConfirm = selectedGroups.length > 0 && invalidNames.size === 0;
+
+  return (
+    <div className='flex max-h-[80vh] flex-col gap-4 p-4' data-testid='section-organizer-dialog'>
+      <div className='flex items-start justify-between gap-2'>
+        <div>
+          <div className='flex items-center gap-1.5 text-base font-medium leading-tight text-foreground'>
+            <FolderAi size={16} className='text-primary' />
+            Organize your channels
+          </div>
+          <div className='mt-1 text-xs text-muted-foreground'>
+            See how your sidebar could look.
+          </div>
+        </div>
+        <button
+          type='button'
+          onClick={onCancel}
+          aria-label='Close'
+          data-track-category='CHAT_SIDEBAR'
+          data-track-name='CLOSE_SECTION_ORGANIZER'
+          className='-mr-1 -mt-1 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+        >
+          <MultipleCrossCancelDefault size={20} />
+        </button>
+      </div>
+
+      <div className='flex items-center gap-2 rounded-md border border-border bg-background px-2 focus-within:ring-2 focus-within:ring-ring'>
+        <SearchDefault size={16} className='shrink-0 text-muted-foreground' />
+        <input
+          value={filter}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setFilter(e.target.value)}
+          placeholder='Find a channel…'
+          autoComplete='off'
+          data-track-category='CHAT_SIDEBAR'
+          data-track-name='ORGANIZER_SEARCH'
+          className='flex-1 border-0 bg-transparent py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground'
+        />
+      </div>
+
+      <div className='flex min-h-0 flex-1 flex-col'>
+        <div className='min-h-0 flex-1 overflow-y-auto rounded-md border border-border bg-sidebar/40 p-2'>
+            {visibleGroups.map(group => {
+              const isOpen = (group.expanded || !!query) && group.included;
+              const hasNameError = invalidNames.has(group.projectId);
+              return (
+                <div key={group.projectId} className='mb-1'>
+                  <div className='flex h-9 items-center gap-1.5 rounded-[10px] border border-transparent px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'>
+                    <Checkbox
+                      checked={group.included}
+                      onChange={included => updateGroup(group.projectId, { included })}
+                      ariaLabel={`Include ${group.name}`}
+                      label=''
+                      size='sm'
+                    />
+                    <button
+                      type='button'
+                      onClick={() => updateGroup(group.projectId, { expanded: !group.expanded })}
+                      aria-label={isOpen ? 'Collapse' : 'Expand'}
+                      data-track-category='CHAT_SIDEBAR'
+                      data-track-name='ORGANIZER_TOGGLE_EXPAND'
+                      className='shrink-0 text-muted-foreground'
+                    >
+                      <ChevronRight
+                        size={13}
+                        className={cn('transition-transform', isOpen && 'rotate-90')}
+                      />
+                    </button>
+                    <input
+                      value={group.name}
+                      onChange={e => updateGroup(group.projectId, { name: e.target.value })}
+                      maxLength={50}
+                      disabled={!group.included}
+                      data-track-category='CHAT_SIDEBAR'
+                      data-track-name='ORGANIZER_RENAME_SECTION'
+                      className={cn(
+                        'min-w-0 flex-1 border-0 border-b border-transparent bg-transparent px-0.5 py-0.5 text-sm font-medium text-foreground outline-none focus:border-b-primary',
+                        !group.included && 'text-muted-foreground line-through',
+                        hasNameError && 'border-b-destructive focus:border-b-destructive',
+                      )}
+                    />
+                    <span className='shrink-0 text-xs text-muted-foreground'>
+                      {includedCount(group)}
+                    </span>
+                  </div>
+
+                  {isOpen && (
+                    <div className='pl-6'>
+                      {group.channelIds.map(channelId => {
+                        const channel = channelsById.get(channelId);
+                        if (!channel) return null;
+                        return (
+                          <ChannelLine
+                            key={channelId}
+                            channel={channel}
+                            excluded={group.excludedChannelIds.includes(channelId)}
+                            onToggle={() => toggleChannel(group.projectId, channelId)}
+                          />
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+
+            {visibleGroups.length === 0 && (
+              <div className='px-3 py-6 text-center text-sm text-muted-foreground'>
+                No channels found
+              </div>
+            )}
+        </div>
+      </div>
+
+      <div className='flex items-center justify-between gap-3'>
+        <span className='text-xs text-muted-foreground'>
+          DMs can be added by dragging them into a section.
+        </span>
+        <span className={cn('inline-flex', !canConfirm && 'cursor-not-allowed')}>
+          <Button
+            type='button'
+            variant='default'
+            size='default'
+            disabled={!canConfirm}
+            onClick={() => onConfirm(selectedGroups)}
+            data-track-category='CHAT_SIDEBAR'
+            data-track-name='ORGANIZER_CONFIRM'
+          >
+            {selectedGroups.length === 0
+              ? 'Create sections'
+              : `Create ${selectedGroups.length} section${selectedGroups.length === 1 ? '' : 's'}`}
+          </Button>
+        </span>
+      </div>
+    </div>
+  );
+};
+
+export default SectionOrganizerDialog;

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SectionOrganizerDialog.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SectionOrganizerDialog.tsx
@@ -44,6 +44,7 @@ const AUTO_EXPAND_MAX_CHANNELS = 25;
 const MODE_OPTIONS: SegmentedToggleOption<OrganizerMode>[] = [
   { label: 'By project', value: 'project' },
   { label: 'By activity', value: 'activity' },
+  { label: 'By DMs', value: 'dms' },
 ];
 const TIP_INDEX_KEY = 'xyne:section-organizer-tip-index';
 
@@ -65,7 +66,7 @@ export interface OrganizerGroup {
   expanded: boolean;
 }
 
-export type OrganizerMode = 'project' | 'activity';
+export type OrganizerMode = 'project' | 'activity' | 'dms';
 
 interface SectionOrganizerDialogProps {
   suggestions: readonly SectionSuggestion[];
@@ -380,9 +381,13 @@ export const SectionOrganizerDialog = ({
 
           {visibleGroups.length === 0 && (
             <div className='px-3 py-6 text-center text-sm text-muted-foreground'>
-              {query || mode !== 'activity'
+              {query
                 ? 'No channels found'
-                : `Everything falls on one side of ${activeWindowDays} days. Try a shorter window.`}
+                : mode === 'activity'
+                  ? `Everything falls on one side of ${activeWindowDays} days. Try a shorter window.`
+                  : mode === 'dms'
+                    ? 'No app, bot or group DMs to group.'
+                    : 'No channels found'}
             </div>
           )}
         </div>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SortableSection.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SortableSection.tsx
@@ -64,7 +64,7 @@ const SortableSection = ({
     id: section.id,
     data: { type: 'section' },
   });
-  // Drop zone over the section body, so a channel can be dropped into an empty section too.
+  // Drop zone over the section body, so a channel can be dropped into an empty section to.
   const { setNodeRef: setDropNodeRef } = useDroppable({
     id: `section-drop-${section.id}`,
     data: { type: 'container' },

--- a/apps/dashboard/src/components/Chat/CreateSectionDialog/CreateSectionDialog.tsx
+++ b/apps/dashboard/src/components/Chat/CreateSectionDialog/CreateSectionDialog.tsx
@@ -1,12 +1,4 @@
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type FormEvent,
-  type ReactElement,
-} from 'react';
+import { useMemo, useState, type ChangeEvent, type FormEvent, type ReactElement } from 'react';
 import { Hash, Lock, MessageCircle, Search, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { ChannelVisibility } from '@xyne/shared';
@@ -17,7 +9,6 @@ import { useZero } from '../../../hooks/useZero';
 import { mutators } from '../../../zero/mutators';
 import { keyBetween, isDMChannel, getDMSearchableName } from '../ChatDirectory/ChatDirectory.utils';
 import { SectionEmojiPicker } from '../SectionEmojiPicker';
-import { renderEmoji } from '../../../utils/customEmojiUtils';
 import type { VisibleChannel } from '../../../machines/stateMachine';
 import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
 import { useAuthContextValues } from '../../../hooks/useAuth';
@@ -30,6 +21,9 @@ interface CreateSectionDialogProps {
   lastSectionPosition: string | null;
   prioritizeType?: 'dm' | 'channel';
   onClose: () => void;
+  initialName?: string;
+  initialEmoji?: string;
+  initialSelectedChannelIds?: readonly string[];
 }
 
 const ChannelRow = ({
@@ -52,7 +46,7 @@ const ChannelRow = ({
         onChange={onToggle}
         data-track-category='CHAT_SIDEBAR'
         data-track-name='CREATE_SECTION_TOGGLE_CHANNEL'
-        className='size-4 accent-action-primary'
+        className='size-4 accent-primary'
       />
       <span className='shrink-0 text-muted-foreground'>
         {isDM ? (
@@ -74,31 +68,20 @@ export const CreateSectionDialog = ({
   lastSectionPosition,
   prioritizeType = 'channel',
   onClose,
+  initialName,
+  initialEmoji,
+  initialSelectedChannelIds,
 }: CreateSectionDialogProps): ReactElement => {
   const zero = useZero();
-  const [step, setStep] = useState<1 | 2>(1);
-  const [name, setName] = useState('');
-  const [emoji, setEmoji] = useState('');
+  const [name, setName] = useState(initialName ?? '');
+  const [emoji, setEmoji] = useState(initialEmoji ?? '');
   const [touched, setTouched] = useState(false);
-  const [createdSectionId, setCreatedSectionId] = useState<string | null>(null);
   const [filter, setFilter] = useState('');
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<Set<string>>(
+    () => new Set(initialSelectedChannelIds ?? []),
+  );
   const { userID } = useAuthContextValues();
   const allUsers = useUsers();
-
-  const showHintOnDismissRef = useRef(false);
-  useEffect(() => {
-    return () => {
-      if (showHintOnDismissRef.current) {
-        toast(
-          'Tip: drag dms/channels from the sidebar and drop them into your section to add them.',
-          {
-            duration: 5000,
-          },
-        );
-      }
-    };
-  }, []);
 
   const trimmedName = name.trim();
   const isDuplicateName = existingNames.some(
@@ -114,28 +97,6 @@ export const CreateSectionDialog = ({
           : null;
   const showError = touched && !!nameError;
 
-  const handleCreateAndContinue = (e: FormEvent): void => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (nameError) {
-      setTouched(true);
-      return;
-    }
-    const id = crypto.randomUUID();
-    const trimmedEmoji = emoji.trim();
-    void zero.mutate(
-      mutators.channelSection.create({
-        id,
-        name: trimmedName,
-        emoji: trimmedEmoji || null,
-        position: keyBetween(lastSectionPosition, null),
-        timestamp: Date.now(),
-      }),
-    );
-    showHintOnDismissRef.current = true;
-    setCreatedSectionId(id);
-    setStep(2);
-  };
   const userMap = useMemo(
     () => new Map(allUsers.map(u => [u.id, getUserDisplayName(u)])),
     [allUsers],
@@ -186,218 +147,176 @@ export const CreateSectionDialog = ({
     });
   };
 
-  const handleAddChannels = (): void => {
-    if (createdSectionId && selected.size > 0) {
-      const timestamp = Date.now();
-      let prevKey: string | null = null;
-      for (const channelId of selected) {
-        const position = keyBetween(prevKey, null);
-        void zero.mutate(
-          mutators.channel.moveToSection({
-            channelId,
-            sectionId: createdSectionId,
-            position,
-            timestamp,
-          }),
-        );
-        prevKey = position;
-      }
-      showHintOnDismissRef.current = false;
+  const handleSubmit = (e: FormEvent): void => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (nameError) {
+      setTouched(true);
+      return;
     }
-    onClose();
-  };
 
-  const handleSkip = (): void => {
-    showHintOnDismissRef.current = false;
-    toast('Tip: drag dms/channels from the sidebar and drop them into your section to add them.', {
-      duration: 5000,
-    });
-    onClose();
-  };
+    const sectionId = crypto.randomUUID();
+    const timestamp = Date.now();
 
-  const closeButton = (
-    <button
-      type='button'
-      onClick={step === 2 ? handleSkip : onClose}
-      aria-label='Close'
-      data-track-category='CHAT_SIDEBAR'
-      data-track-name='CLOSE_CREATE_SECTION'
-      className='-mr-1 -mt-1 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-    >
-      <X className='size-5' />
-    </button>
-  );
-
-  if (step === 1) {
-    return (
-      <form
-        onSubmit={handleCreateAndContinue}
-        className='space-y-4 p-4'
-        data-testid='create-section-step1'
-      >
-        <div className='flex items-start justify-between gap-2'>
-          <div className='text-xl font-medium text-foreground'>Create a section</div>
-          {closeButton}
-        </div>
-        <div className='space-y-1.5'>
-          <label htmlFor='section-name' className='text-sm font-medium text-foreground'>
-            Section name
-          </label>
-          <div
-            className={cn(
-              'flex items-center gap-1 rounded-md border bg-background px-2 transition-colors',
-              showError
-                ? 'border-destructive'
-                : 'border-border focus-within:ring-2 focus-within:ring-ring',
-            )}
-          >
-            <SectionEmojiPicker
-              value={emoji}
-              onChange={setEmoji}
-              trackName='CREATE_SECTION_EMOJI'
-            />
-            <input
-              id='section-name'
-              value={name}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                setName(e.target.value);
-                setTouched(true);
-              }}
-              onKeyDown={e => {
-                if (
-                  e.key === 'Backspace' &&
-                  emoji &&
-                  e.currentTarget.selectionStart === 0 &&
-                  e.currentTarget.selectionEnd === 0
-                ) {
-                  e.preventDefault();
-                  setEmoji('');
-                }
-              }}
-              placeholder='Ex: Project Beta'
-              maxLength={50}
-              autoFocus
-              autoComplete='off'
-              aria-invalid={showError}
-              data-track-category='CHAT_SIDEBAR'
-              data-track-name='CREATE_SECTION_NAME'
-              className='flex-1 border-0 bg-transparent py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground'
-            />
-          </div>
-          {showError && <p className='text-sm text-destructive'>{nameError}</p>}
-        </div>
-        <div className='flex items-center justify-between pt-2'>
-          <span className='text-sm text-muted-foreground'>Step 1 of 2</span>
-          <Tooltip content={nameError ?? ''} side='top' {...(!nameError && { open: false })}>
-            <span className='inline-flex'>
-              <Button
-                type='submit'
-                variant='default'
-                size='default'
-                trackId='create_section'
-                disabled={!!nameError}
-                className={cn(
-                  'bg-action-primary text-action-primary-foreground hover:bg-action-primary/90',
-                  !!nameError && 'pointer-events-none',
-                )}
-              >
-                Create and Add {itemLabelTitle}
-              </Button>
-            </span>
-          </Tooltip>
-        </div>
-      </form>
+    void zero.mutate(
+      mutators.channelSection.create({
+        id: sectionId,
+        name: trimmedName,
+        emoji: emoji.trim() || null,
+        position: keyBetween(lastSectionPosition, null),
+        timestamp,
+      }),
     );
-  }
+
+    let prevKey: string | null = null;
+    for (const channelId of selected) {
+      const position = keyBetween(prevKey, null);
+      void zero.mutate(
+        mutators.channel.moveToSection({ channelId, sectionId, position, timestamp }),
+      );
+      prevKey = position;
+    }
+
+    if (selected.size === 0) {
+      toast(
+        'Tip: drag dms/channels from the sidebar and drop them into your section to add them.',
+        { duration: 5000 },
+      );
+    }
+
+    onClose();
+  };
 
   return (
-    <div className='space-y-4 p-4' data-testid='create-section-step2'>
+    <form onSubmit={handleSubmit} className='space-y-4 p-4' data-testid='create-section-dialog'>
       <div className='flex items-start justify-between gap-2'>
-        <div>
-          <div className='text-xl font-medium text-foreground'>Add {itemLabel}</div>
-          <div className='flex items-center gap-1 text-sm text-muted-foreground'>
-            {emoji.trim() && renderEmoji(emoji.trim(), 'size-4')}
-            <span>{trimmedName}</span>
+        <div className='text-xl font-medium text-foreground'>Create a section</div>
+        <button
+          type='button'
+          onClick={onClose}
+          aria-label='Close'
+          data-track-category='CHAT_SIDEBAR'
+          data-track-name='CLOSE_CREATE_SECTION'
+          className='-mr-1 -mt-1 shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+        >
+          <X className='size-5' />
+        </button>
+      </div>
+
+      <div className='space-y-1.5'>
+        <label htmlFor='section-name' className='text-sm font-medium text-foreground'>
+          Section name
+        </label>
+        <div
+          className={cn(
+            'flex items-center gap-1 rounded-md border bg-background px-2 transition-colors',
+            showError
+              ? 'border-destructive'
+              : 'border-border focus-within:ring-2 focus-within:ring-ring',
+          )}
+        >
+          <SectionEmojiPicker value={emoji} onChange={setEmoji} trackName='CREATE_SECTION_EMOJI' />
+          <input
+            id='section-name'
+            value={name}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => {
+              setName(e.target.value);
+              setTouched(true);
+            }}
+            onKeyDown={e => {
+              if (
+                e.key === 'Backspace' &&
+                emoji &&
+                e.currentTarget.selectionStart === 0 &&
+                e.currentTarget.selectionEnd === 0
+              ) {
+                e.preventDefault();
+                setEmoji('');
+              }
+            }}
+            placeholder='Ex: Project Beta'
+            maxLength={50}
+            autoFocus
+            autoComplete='off'
+            aria-invalid={showError}
+            data-track-category='CHAT_SIDEBAR'
+            data-track-name='CREATE_SECTION_NAME'
+            className='flex-1 border-0 bg-transparent py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground'
+          />
+        </div>
+        {showError && <p className='text-sm text-destructive'>{nameError}</p>}
+      </div>
+
+      <div className='space-y-1.5'>
+        <div className='text-sm font-medium text-foreground'>{itemLabelTitle} in this section</div>
+
+        <div className='flex items-center gap-2 rounded-md border border-border bg-background px-2 focus-within:ring-2 focus-within:ring-ring'>
+          <Search className='size-4 shrink-0 text-muted-foreground' />
+          <input
+            value={filter}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setFilter(e.target.value)}
+            placeholder='Filter by name…'
+            autoComplete='off'
+            data-track-category='CHAT_SIDEBAR'
+            data-track-name='CREATE_SECTION_FILTER_CHANNELS'
+            className='flex-1 border-0 bg-transparent py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground'
+          />
+        </div>
+
+        <div className='rounded-md border border-border'>
+          <label className='flex cursor-pointer items-center justify-between gap-2 border-b border-border px-3 py-2'>
+            <span className='flex items-center gap-2 text-sm font-medium text-foreground'>
+              <input
+                type='checkbox'
+                checked={allFilteredSelected}
+                onChange={toggleSelectAll}
+                data-track-category='CHAT_SIDEBAR'
+                data-track-name='CREATE_SECTION_SELECT_ALL'
+                className='size-4 accent-primary'
+              />
+              Select all
+            </span>
+            <span className='text-xs text-muted-foreground'>{selected.size} selected</span>
+          </label>
+          <div className='max-h-64 overflow-y-auto'>
+            {filteredChannels.length === 0 ? (
+              <div className='px-3 py-6 text-center text-sm text-muted-foreground'>
+                No {itemLabel} found
+              </div>
+            ) : (
+              filteredChannels.map(channel => (
+                <ChannelRow
+                  key={channel.id}
+                  channel={channel}
+                  selected={selected.has(channel.id)}
+                  onToggle={() => toggleChannel(channel.id)}
+                />
+              ))
+            )}
           </div>
         </div>
-        {closeButton}
       </div>
 
-      <div className='flex items-center gap-2 rounded-md border border-border bg-background px-2 focus-within:ring-2 focus-within:ring-ring'>
-        <Search className='size-4 shrink-0 text-muted-foreground' />
-        <input
-          value={filter}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setFilter(e.target.value)}
-          placeholder='Filter by name…'
-          autoComplete='off'
-          data-track-category='CHAT_SIDEBAR'
-          data-track-name='CREATE_SECTION_FILTER_CHANNELS'
-          className='flex-1 border-0 bg-transparent py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground'
-        />
-      </div>
-
-      <div className='rounded-md border border-border'>
-        <label className='flex cursor-pointer items-center justify-between gap-2 border-b border-border px-3 py-2'>
-          <span className='flex items-center gap-2 text-sm font-medium text-foreground'>
-            <input
-              type='checkbox'
-              checked={allFilteredSelected}
-              onChange={toggleSelectAll}
-              data-track-category='CHAT_SIDEBAR'
-              data-track-name='CREATE_SECTION_SELECT_ALL'
-              className='size-4 accent-action-primary'
-            />
-            Select all
+      <div className='flex items-center justify-end gap-3 pt-2'>
+        <Button type='button' variant='outline' size='default' onClick={onClose}>
+          Cancel
+        </Button>
+        <Tooltip content={nameError ?? ''} side='top' {...(!nameError && { open: false })}>
+          <span className='inline-flex'>
+            <Button
+              type='submit'
+              variant='default'
+              size='default'
+              trackId='create_section'
+              disabled={!!nameError}
+              className={cn(!!nameError && 'pointer-events-none')}
+            >
+              Create section
+            </Button>
           </span>
-          <span className='text-xs text-muted-foreground'>{selected.size} selected</span>
-        </label>
-        <div className='max-h-64 overflow-y-auto'>
-          {filteredChannels.length === 0 ? (
-            <div className='px-3 py-6 text-center text-sm text-muted-foreground'>
-              No {itemLabel} found
-            </div>
-          ) : (
-            filteredChannels.map(channel => (
-              <ChannelRow
-                key={channel.id}
-                channel={channel}
-                selected={selected.has(channel.id)}
-                onToggle={() => toggleChannel(channel.id)}
-              />
-            ))
-          )}
-        </div>
+        </Tooltip>
       </div>
-
-      <div className='flex items-center justify-between pt-2'>
-        <span className='text-sm text-muted-foreground'>Step 2 of 2</span>
-        <div className='flex gap-3'>
-          <Button
-            type='button'
-            variant='outline'
-            size='default'
-            onClick={handleSkip}
-            data-track-category='CHAT_SIDEBAR'
-            data-track-name='SKIP_ADD_CHANNELS_TO_SECTION'
-          >
-            Skip
-          </Button>
-          <Button
-            type='button'
-            variant='default'
-            size='default'
-            onClick={handleAddChannels}
-            trackId='add_channels_to_section'
-            data-track-category='CHAT_SIDEBAR'
-            data-track-name='ADD_CHANNELS_TO_SECTION'
-            disabled={selected.size === 0}
-            className='bg-action-primary text-action-primary-foreground hover:bg-action-primary/90'
-          >
-            Add {itemLabelTitle}
-          </Button>
-        </div>
-      </div>
-    </div>
+    </form>
   );
 };
 

--- a/packages/shared/src/channelSectionSuggestions.ts
+++ b/packages/shared/src/channelSectionSuggestions.ts
@@ -1,0 +1,108 @@
+import { ChannelScopeType, ProjectType } from './zero/types.js';
+import { isDeskChannelType } from './utils/channel.js';
+
+export const SECTION_NAME_MAX_LENGTH = 50;
+export const DEFAULT_MIN_CHANNELS = 2;
+
+export interface SuggestionChannel {
+  id: string;
+  projectId: string;
+  scopeType: string;
+  type: string;
+}
+
+export interface SuggestionChannelStatus {
+  channelId: string;
+  sectionId?: string | null;
+  isStarred: boolean;
+  isDeleted: boolean;
+}
+
+export interface SuggestionProject {
+  id: string;
+  name: string;
+  type: string;
+}
+
+export interface ProjectSectionSuggestion {
+  projectId: string;
+  name: string;
+  channelIds: string[];
+}
+
+export interface ComputeProjectSectionSuggestionsInput {
+  channels: readonly SuggestionChannel[];
+  statuses: readonly SuggestionChannelStatus[];
+  projects: readonly SuggestionProject[];
+  existingSectionNames: readonly string[];
+  minChannels?: number;
+}
+
+const normalizeName = (name: string): string => name.trim().toLowerCase();
+
+export function computeProjectSectionSuggestions(
+  input: ComputeProjectSectionSuggestionsInput,
+): ProjectSectionSuggestion[] {
+  const {
+    channels,
+    statuses,
+    projects,
+    existingSectionNames,
+    minChannels = DEFAULT_MIN_CHANNELS,
+  } = input;
+
+  const statusByChannelId = new Map<string, SuggestionChannelStatus>();
+  for (const status of statuses) {
+    statusByChannelId.set(status.channelId, status);
+  }
+
+  const candidates = channels.filter(channel => {
+    if (channel.scopeType !== ChannelScopeType.DEFAULT) return false;
+    if (isDeskChannelType(channel.type)) return false;
+    const status = statusByChannelId.get(channel.id);
+    if (!status) return false;
+    return !status.isDeleted && !status.isStarred && !status.sectionId;
+  });
+
+  if (candidates.length === 0) return [];
+
+  const projectById = new Map(projects.map(project => [project.id, project]));
+
+  const channelIdsByProjectId = new Map<string, string[]>();
+  for (const channel of candidates) {
+    const project = projectById.get(channel.projectId);
+    if (!project || project.type === ProjectType.DM) continue;
+    const group = channelIdsByProjectId.get(channel.projectId);
+    if (group) group.push(channel.id);
+    else channelIdsByProjectId.set(channel.projectId, [channel.id]);
+  }
+
+  const takenNames = new Set(existingSectionNames.map(normalizeName));
+
+  const suggestions: ProjectSectionSuggestion[] = [];
+  for (const [projectId, channelIds] of channelIdsByProjectId) {
+    if (channelIds.length < minChannels) continue;
+    const project = projectById.get(projectId);
+    if (!project) continue;
+
+    const name = project.name.trim().slice(0, SECTION_NAME_MAX_LENGTH).trim();
+    if (!name) continue;
+
+    const normalized = normalizeName(name);
+    if (takenNames.has(normalized)) continue;
+    takenNames.add(normalized);
+
+    suggestions.push({ projectId, name, channelIds });
+  }
+
+  suggestions.sort(
+    (a, b) => b.channelIds.length - a.channelIds.length || a.name.localeCompare(b.name),
+  );
+
+  const only = suggestions.length === 1 ? suggestions[0] : undefined;
+  if (only && only.channelIds.length === candidates.length) {
+    return [];
+  }
+
+  return suggestions;
+}

--- a/packages/shared/src/channelSectionSuggestions.ts
+++ b/packages/shared/src/channelSectionSuggestions.ts
@@ -4,11 +4,33 @@ import { isDeskChannelType } from './utils/channel.js';
 export const SECTION_NAME_MAX_LENGTH = 50;
 export const DEFAULT_MIN_CHANNELS = 2;
 
+export const ACTIVE_SUGGESTION_ID = '__active__';
+export const DORMANT_SUGGESTION_ID = '__dormant__';
+export const ACTIVE_SUGGESTION_NAME = 'Active';
+export const DORMANT_SUGGESTION_NAME = 'Quiet';
+
+export const DEFAULT_ACTIVE_WINDOW_DAYS = 30;
+export const MIN_ACTIVE_WINDOW_DAYS = 1;
+export const MAX_ACTIVE_WINDOW_DAYS = 365;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const clampActiveWindowDays = (days: number): number => {
+  if (!Number.isFinite(days)) return DEFAULT_ACTIVE_WINDOW_DAYS;
+  const rounded = Math.round(days);
+  if (rounded < MIN_ACTIVE_WINDOW_DAYS) return MIN_ACTIVE_WINDOW_DAYS;
+  if (rounded > MAX_ACTIVE_WINDOW_DAYS) return MAX_ACTIVE_WINDOW_DAYS;
+  return rounded;
+};
+
+export type SectionSuggestionKind = 'project' | 'active' | 'dormant';
+
 export interface SuggestionChannel {
   id: string;
   projectId: string;
   scopeType: string;
   type: string;
+  lastActivityAt?: number | null;
 }
 
 export interface SuggestionChannelStatus {
@@ -24,8 +46,9 @@ export interface SuggestionProject {
   type: string;
 }
 
-export interface ProjectSectionSuggestion {
-  projectId: string;
+export interface SectionSuggestion {
+  id: string;
+  kind: SectionSuggestionKind;
   name: string;
   channelIds: string[];
 }
@@ -35,6 +58,15 @@ export interface ComputeProjectSectionSuggestionsInput {
   statuses: readonly SuggestionChannelStatus[];
   projects: readonly SuggestionProject[];
   existingSectionNames: readonly string[];
+  minChannels?: number;
+}
+
+export interface ComputeActivitySectionSuggestionsInput {
+  channels: readonly SuggestionChannel[];
+  statuses: readonly SuggestionChannelStatus[];
+  existingSectionNames: readonly string[];
+  nowMs: number;
+  activeWindowDays?: number;
   minChannels?: number;
 }
 
@@ -85,7 +117,7 @@ export function getCandidateProjectIds(input: CandidateProjectIdsInput): string[
 
 export function computeProjectSectionSuggestions(
   input: ComputeProjectSectionSuggestionsInput,
-): ProjectSectionSuggestion[] {
+): SectionSuggestion[] {
   const {
     channels,
     statuses,
@@ -111,7 +143,7 @@ export function computeProjectSectionSuggestions(
 
   const takenNames = new Set(existingSectionNames.map(normalizeName));
 
-  const suggestions: ProjectSectionSuggestion[] = [];
+  const suggestions: SectionSuggestion[] = [];
   for (const [projectId, channelIds] of channelIdsByProjectId) {
     if (channelIds.length < minChannels) continue;
     const project = projectById.get(projectId);
@@ -124,12 +156,59 @@ export function computeProjectSectionSuggestions(
     if (takenNames.has(normalized)) continue;
     takenNames.add(normalized);
 
-    suggestions.push({ projectId, name, channelIds });
+    suggestions.push({ id: projectId, kind: 'project', name, channelIds });
   }
 
   suggestions.sort(
     (a, b) => b.channelIds.length - a.channelIds.length || a.name.localeCompare(b.name),
   );
+
+  const only = suggestions.length === 1 ? suggestions[0] : undefined;
+  if (only && only.channelIds.length === candidates.length) {
+    return [];
+  }
+
+  return suggestions;
+}
+
+export function computeActivitySectionSuggestions(
+  input: ComputeActivitySectionSuggestionsInput,
+): SectionSuggestion[] {
+  const {
+    channels,
+    statuses,
+    existingSectionNames,
+    nowMs,
+    activeWindowDays = DEFAULT_ACTIVE_WINDOW_DAYS,
+    minChannels = DEFAULT_MIN_CHANNELS,
+  } = input;
+
+  const candidates = selectCandidates(channels, indexStatuses(statuses));
+
+  if (candidates.length === 0) return [];
+
+  const cutoff = nowMs - clampActiveWindowDays(activeWindowDays) * DAY_MS;
+
+  const activeChannelIds: string[] = [];
+  const dormantChannelIds: string[] = [];
+  for (const channel of candidates) {
+    if ((channel.lastActivityAt ?? 0) >= cutoff) activeChannelIds.push(channel.id);
+    else dormantChannelIds.push(channel.id);
+  }
+
+  const takenNames = new Set(existingSectionNames.map(normalizeName));
+
+  const suggestions: SectionSuggestion[] = [];
+  const addBucket = (id: string, kind: SectionSuggestionKind, name: string, ids: string[]): void => {
+    if (ids.length < minChannels) return;
+    const normalized = normalizeName(name);
+    if (takenNames.has(normalized)) return;
+    takenNames.add(normalized);
+    suggestions.push({ id, kind, name, channelIds: ids });
+  };
+
+  addBucket(ACTIVE_SUGGESTION_ID, 'active', ACTIVE_SUGGESTION_NAME, activeChannelIds);
+  addBucket(DORMANT_SUGGESTION_ID, 'dormant', DORMANT_SUGGESTION_NAME, dormantChannelIds);
 
   const only = suggestions.length === 1 ? suggestions[0] : undefined;
   if (only && only.channelIds.length === candidates.length) {

--- a/packages/shared/src/channelSectionSuggestions.ts
+++ b/packages/shared/src/channelSectionSuggestions.ts
@@ -9,6 +9,11 @@ export const DORMANT_SUGGESTION_ID = '__dormant__';
 export const ACTIVE_SUGGESTION_NAME = 'Active';
 export const DORMANT_SUGGESTION_NAME = 'Quiet';
 
+export const BOT_SUGGESTION_ID = '__bots__';
+export const GROUP_DM_SUGGESTION_ID = '__groupDms__';
+export const BOT_SUGGESTION_NAME = 'Apps & Bots';
+export const GROUP_DM_SUGGESTION_NAME = 'Group DMs';
+
 export const DEFAULT_ACTIVE_WINDOW_DAYS = 30;
 export const MIN_ACTIVE_WINDOW_DAYS = 1;
 export const MAX_ACTIVE_WINDOW_DAYS = 365;
@@ -23,7 +28,7 @@ export const clampActiveWindowDays = (days: number): number => {
   return rounded;
 };
 
-export type SectionSuggestionKind = 'project' | 'active' | 'dormant';
+export type SectionSuggestionKind = 'project' | 'active' | 'dormant' | 'bots' | 'groupDms';
 
 export interface SuggestionChannel {
   id: string;
@@ -31,6 +36,7 @@ export interface SuggestionChannel {
   scopeType: string;
   type: string;
   lastActivityAt?: number | null;
+  isBotDm?: boolean;
 }
 
 export interface SuggestionChannelStatus {
@@ -70,7 +76,38 @@ export interface ComputeActivitySectionSuggestionsInput {
   minChannels?: number;
 }
 
+export interface ComputeDmSectionSuggestionsInput {
+  channels: readonly SuggestionChannel[];
+  statuses: readonly SuggestionChannelStatus[];
+  existingSectionNames: readonly string[];
+  minChannels?: number;
+}
+
 const normalizeName = (name: string): string => name.trim().toLowerCase();
+
+const makeBucketAdder = (
+  suggestions: SectionSuggestion[],
+  existingSectionNames: readonly string[],
+  minChannels: number,
+): ((id: string, kind: SectionSuggestionKind, name: string, ids: string[]) => void) => {
+  const takenNames = new Set(existingSectionNames.map(normalizeName));
+  return (id, kind, name, ids) => {
+    if (ids.length < minChannels) return;
+    const normalized = normalizeName(name);
+    if (takenNames.has(normalized)) return;
+    takenNames.add(normalized);
+    suggestions.push({ id, kind, name, channelIds: ids });
+  };
+};
+
+const suppressAllEncompassing = (
+  suggestions: SectionSuggestion[],
+  candidateCount: number,
+): SectionSuggestion[] => {
+  const only = suggestions.length === 1 ? suggestions[0] : undefined;
+  if (only && only.channelIds.length === candidateCount) return [];
+  return suggestions;
+};
 
 const indexStatuses = (
   statuses: readonly SuggestionChannelStatus[],
@@ -82,6 +119,15 @@ const indexStatuses = (
   return byChannelId;
 };
 
+const isUnfiled = (
+  channelId: string,
+  statusByChannelId: Map<string, SuggestionChannelStatus>,
+): boolean => {
+  const status = statusByChannelId.get(channelId);
+  if (!status) return false;
+  return !status.isDeleted && !status.isStarred && !status.sectionId;
+};
+
 const selectCandidates = (
   channels: readonly SuggestionChannel[],
   statusByChannelId: Map<string, SuggestionChannelStatus>,
@@ -89,9 +135,21 @@ const selectCandidates = (
   channels.filter(channel => {
     if (channel.scopeType !== ChannelScopeType.DEFAULT) return false;
     if (isDeskChannelType(channel.type)) return false;
-    const status = statusByChannelId.get(channel.id);
-    if (!status) return false;
-    return !status.isDeleted && !status.isStarred && !status.sectionId;
+    return isUnfiled(channel.id, statusByChannelId);
+  });
+
+const selectDmCandidates = (
+  channels: readonly SuggestionChannel[],
+  statusByChannelId: Map<string, SuggestionChannelStatus>,
+): SuggestionChannel[] =>
+  channels.filter(channel => {
+    if (
+      channel.scopeType !== ChannelScopeType.DM &&
+      channel.scopeType !== ChannelScopeType.GROUP_DM
+    ) {
+      return false;
+    }
+    return isUnfiled(channel.id, statusByChannelId);
   });
 
 export interface CandidateProjectIdsInput {
@@ -196,24 +254,41 @@ export function computeActivitySectionSuggestions(
     else dormantChannelIds.push(channel.id);
   }
 
-  const takenNames = new Set(existingSectionNames.map(normalizeName));
-
   const suggestions: SectionSuggestion[] = [];
-  const addBucket = (id: string, kind: SectionSuggestionKind, name: string, ids: string[]): void => {
-    if (ids.length < minChannels) return;
-    const normalized = normalizeName(name);
-    if (takenNames.has(normalized)) return;
-    takenNames.add(normalized);
-    suggestions.push({ id, kind, name, channelIds: ids });
-  };
+  const addBucket = makeBucketAdder(suggestions, existingSectionNames, minChannels);
 
   addBucket(ACTIVE_SUGGESTION_ID, 'active', ACTIVE_SUGGESTION_NAME, activeChannelIds);
   addBucket(DORMANT_SUGGESTION_ID, 'dormant', DORMANT_SUGGESTION_NAME, dormantChannelIds);
 
-  const only = suggestions.length === 1 ? suggestions[0] : undefined;
-  if (only && only.channelIds.length === candidates.length) {
-    return [];
+  return suppressAllEncompassing(suggestions, candidates.length);
+}
+
+export function computeDmSectionSuggestions(
+  input: ComputeDmSectionSuggestionsInput,
+): SectionSuggestion[] {
+  const {
+    channels,
+    statuses,
+    existingSectionNames,
+    minChannels = DEFAULT_MIN_CHANNELS,
+  } = input;
+
+  const candidates = selectDmCandidates(channels, indexStatuses(statuses));
+
+  if (candidates.length === 0) return [];
+
+  const botChannelIds: string[] = [];
+  const groupDmChannelIds: string[] = [];
+  for (const channel of candidates) {
+    if (channel.scopeType === ChannelScopeType.GROUP_DM) groupDmChannelIds.push(channel.id);
+    else if (channel.isBotDm) botChannelIds.push(channel.id);
   }
 
-  return suggestions;
+  const suggestions: SectionSuggestion[] = [];
+  const addBucket = makeBucketAdder(suggestions, existingSectionNames, minChannels);
+
+  addBucket(BOT_SUGGESTION_ID, 'bots', BOT_SUGGESTION_NAME, botChannelIds);
+  addBucket(GROUP_DM_SUGGESTION_ID, 'groupDms', GROUP_DM_SUGGESTION_NAME, groupDmChannelIds);
+
+  return suppressAllEncompassing(suggestions, candidates.length);
 }

--- a/packages/shared/src/channelSectionSuggestions.ts
+++ b/packages/shared/src/channelSectionSuggestions.ts
@@ -40,6 +40,49 @@ export interface ComputeProjectSectionSuggestionsInput {
 
 const normalizeName = (name: string): string => name.trim().toLowerCase();
 
+const indexStatuses = (
+  statuses: readonly SuggestionChannelStatus[],
+): Map<string, SuggestionChannelStatus> => {
+  const byChannelId = new Map<string, SuggestionChannelStatus>();
+  for (const status of statuses) {
+    byChannelId.set(status.channelId, status);
+  }
+  return byChannelId;
+};
+
+const selectCandidates = (
+  channels: readonly SuggestionChannel[],
+  statusByChannelId: Map<string, SuggestionChannelStatus>,
+): SuggestionChannel[] =>
+  channels.filter(channel => {
+    if (channel.scopeType !== ChannelScopeType.DEFAULT) return false;
+    if (isDeskChannelType(channel.type)) return false;
+    const status = statusByChannelId.get(channel.id);
+    if (!status) return false;
+    return !status.isDeleted && !status.isStarred && !status.sectionId;
+  });
+
+export interface CandidateProjectIdsInput {
+  channels: readonly SuggestionChannel[];
+  statuses: readonly SuggestionChannelStatus[];
+  minChannels?: number;
+}
+
+export function getCandidateProjectIds(input: CandidateProjectIdsInput): string[] {
+  const { channels, statuses, minChannels = DEFAULT_MIN_CHANNELS } = input;
+
+  const counts = new Map<string, number>();
+  for (const channel of selectCandidates(channels, indexStatuses(statuses))) {
+    counts.set(channel.projectId, (counts.get(channel.projectId) ?? 0) + 1);
+  }
+
+  const ids: string[] = [];
+  for (const [projectId, count] of counts) {
+    if (count >= minChannels) ids.push(projectId);
+  }
+  return ids.sort();
+}
+
 export function computeProjectSectionSuggestions(
   input: ComputeProjectSectionSuggestionsInput,
 ): ProjectSectionSuggestion[] {
@@ -51,18 +94,7 @@ export function computeProjectSectionSuggestions(
     minChannels = DEFAULT_MIN_CHANNELS,
   } = input;
 
-  const statusByChannelId = new Map<string, SuggestionChannelStatus>();
-  for (const status of statuses) {
-    statusByChannelId.set(status.channelId, status);
-  }
-
-  const candidates = channels.filter(channel => {
-    if (channel.scopeType !== ChannelScopeType.DEFAULT) return false;
-    if (isDeskChannelType(channel.type)) return false;
-    const status = statusByChannelId.get(channel.id);
-    if (!status) return false;
-    return !status.isDeleted && !status.isStarred && !status.sectionId;
-  });
+  const candidates = selectCandidates(channels, indexStatuses(statuses));
 
   if (candidates.length === 0) return [];
 

--- a/packages/shared/src/channelSectionSuggestions.ts
+++ b/packages/shared/src/channelSectionSuggestions.ts
@@ -11,8 +11,11 @@ export const DORMANT_SUGGESTION_NAME = 'Quiet';
 
 export const BOT_SUGGESTION_ID = '__bots__';
 export const GROUP_DM_SUGGESTION_ID = '__groupDms__';
+export const FREQUENT_CONTACTS_SUGGESTION_ID = '__frequentContacts__';
 export const BOT_SUGGESTION_NAME = 'Apps & Bots';
 export const GROUP_DM_SUGGESTION_NAME = 'Group DMs';
+export const FREQUENT_CONTACTS_SUGGESTION_NAME = 'Frequent contacts';
+export const MAX_FREQUENT_CONTACTS = 8;
 
 export const DEFAULT_ACTIVE_WINDOW_DAYS = 30;
 export const MIN_ACTIVE_WINDOW_DAYS = 1;
@@ -28,7 +31,13 @@ export const clampActiveWindowDays = (days: number): number => {
   return rounded;
 };
 
-export type SectionSuggestionKind = 'project' | 'active' | 'dormant' | 'bots' | 'groupDms';
+export type SectionSuggestionKind =
+  | 'project'
+  | 'active'
+  | 'dormant'
+  | 'bots'
+  | 'groupDms'
+  | 'frequentContacts';
 
 export interface SuggestionChannel {
   id: string;
@@ -37,6 +46,7 @@ export interface SuggestionChannel {
   type: string;
   lastActivityAt?: number | null;
   isBotDm?: boolean;
+  contactWeight?: number | null;
 }
 
 export interface SuggestionChannelStatus {
@@ -81,6 +91,7 @@ export interface ComputeDmSectionSuggestionsInput {
   statuses: readonly SuggestionChannelStatus[];
   existingSectionNames: readonly string[];
   minChannels?: number;
+  maxFrequentContacts?: number;
 }
 
 const normalizeName = (name: string): string => name.trim().toLowerCase();
@@ -271,6 +282,7 @@ export function computeDmSectionSuggestions(
     statuses,
     existingSectionNames,
     minChannels = DEFAULT_MIN_CHANNELS,
+    maxFrequentContacts = MAX_FREQUENT_CONTACTS,
   } = input;
 
   const candidates = selectDmCandidates(channels, indexStatuses(statuses));
@@ -279,14 +291,29 @@ export function computeDmSectionSuggestions(
 
   const botChannelIds: string[] = [];
   const groupDmChannelIds: string[] = [];
+  const contactCandidates: SuggestionChannel[] = [];
   for (const channel of candidates) {
     if (channel.scopeType === ChannelScopeType.GROUP_DM) groupDmChannelIds.push(channel.id);
     else if (channel.isBotDm) botChannelIds.push(channel.id);
+    else if ((channel.contactWeight ?? 0) > 0) contactCandidates.push(channel);
   }
+
+  const frequentContactChannelIds = contactCandidates
+    .sort(
+      (a, b) => (b.contactWeight ?? 0) - (a.contactWeight ?? 0) || a.id.localeCompare(b.id),
+    )
+    .slice(0, maxFrequentContacts)
+    .map(channel => channel.id);
 
   const suggestions: SectionSuggestion[] = [];
   const addBucket = makeBucketAdder(suggestions, existingSectionNames, minChannels);
 
+  addBucket(
+    FREQUENT_CONTACTS_SUGGESTION_ID,
+    'frequentContacts',
+    FREQUENT_CONTACTS_SUGGESTION_NAME,
+    frequentContactChannelIds,
+  );
   addBucket(BOT_SUGGESTION_ID, 'bots', BOT_SUGGESTION_NAME, botChannelIds);
   addBucket(GROUP_DM_SUGGESTION_ID, 'groupDms', GROUP_DM_SUGGESTION_NAME, groupDmChannelIds);
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export * from './activity';
 export * from './types/index';
 export * from './config/index';
 export * from './utils/mentionRanking';
+export * from './channelSectionSuggestions';
 export * from './tags';
 export * from './board-types';
 export * from './types/workflowApproval';

--- a/packages/shared/src/utils/channel.ts
+++ b/packages/shared/src/utils/channel.ts
@@ -1,4 +1,4 @@
-import { ChannelType, DeskType } from '../zero/schema.js';
+import { ChannelType, DeskType } from '../zero/types.js';
 
 /** Channel types that feed into Xyne Desk. */
 export const DESK_CHANNEL_TYPES: ReadonlySet<ChannelType> = new Set([

--- a/packages/shared/test/channelSectionSuggestions.test.mjs
+++ b/packages/shared/test/channelSectionSuggestions.test.mjs
@@ -507,3 +507,116 @@ test('clamps the activity window to the supported range', () => {
   assert.equal(clampActiveWindowDays(Number.NaN), 30);
   assert.equal(clampActiveWindowDays(45.4), 45);
 });
+
+import { computeDmSectionSuggestions } from '../dist/channelSectionSuggestions.js';
+
+const botDm = id => channel(id, 'dmProject', { scopeType: 'DM', isBotDm: true });
+const humanDm = id => channel(id, 'dmProject', { scopeType: 'DM' });
+const groupDm = id => channel(id, 'dmProject', { scopeType: 'GROUP_DM' });
+
+const computeDm = ({ channels, statuses, existingSectionNames = [], ...rest }) =>
+  computeDmSectionSuggestions({ channels, statuses, existingSectionNames, ...rest });
+
+test('suggests Apps & Bots and Group DMs, leaving human DMs alone', () => {
+  const result = computeDm({
+    channels: [
+      botDm('b1'),
+      botDm('b2'),
+      groupDm('g1'),
+      groupDm('g2'),
+      humanDm('h1'),
+      humanDm('h2'),
+    ],
+    statuses: ['b1', 'b2', 'g1', 'g2', 'h1', 'h2'].map(id => status(id)),
+  });
+
+  assert.deepEqual(
+    result.map(s => s.kind),
+    ['bots', 'groupDms'],
+  );
+  assert.equal(result[0].name, 'Apps & Bots');
+  assert.equal(result[1].name, 'Group DMs');
+  assert.deepEqual(result[0].channelIds, ['b1', 'b2']);
+  assert.deepEqual(result[1].channelIds, ['g1', 'g2']);
+
+  const filed = result.flatMap(s => s.channelIds);
+  assert.equal(filed.includes('h1'), false);
+  assert.equal(filed.includes('h2'), false);
+});
+
+test('a group DM is never counted as a bot DM', () => {
+  const result = computeDm({
+    channels: [
+      channel('g1', 'dmProject', { scopeType: 'GROUP_DM', isBotDm: true }),
+      channel('g2', 'dmProject', { scopeType: 'GROUP_DM', isBotDm: true }),
+      humanDm('h1'),
+      humanDm('h2'),
+    ],
+    statuses: ['g1', 'g2', 'h1', 'h2'].map(id => status(id)),
+  });
+
+  assert.deepEqual(
+    result.map(s => s.kind),
+    ['groupDms'],
+  );
+  assert.deepEqual(result[0].channelIds, ['g1', 'g2']);
+});
+
+test('ignores regular channels in DM mode', () => {
+  const result = computeDm({
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      botDm('b1'),
+      botDm('b2'),
+      groupDm('g1'),
+      groupDm('g2'),
+    ],
+    statuses: ['c1', 'c2', 'b1', 'b2', 'g1', 'g2'].map(id => status(id)),
+  });
+
+  const filed = result.flatMap(s => s.channelIds);
+  assert.equal(filed.includes('c1'), false);
+  assert.equal(filed.includes('c2'), false);
+  assert.deepEqual(filed, ['b1', 'b2', 'g1', 'g2']);
+});
+
+test('excludes starred, deleted and already sectioned DMs', () => {
+  const result = computeDm({
+    channels: [botDm('b1'), botDm('b2'), botDm('b3'), groupDm('g1'), groupDm('g2')],
+    statuses: [
+      status('b1'),
+      status('b2', { isStarred: true }),
+      status('b3', { sectionId: 'existing' }),
+      status('g1'),
+      status('g2'),
+    ],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.kind),
+    ['groupDms'],
+  );
+});
+
+test('skips a DM bucket whose name is already taken', () => {
+  const result = computeDm({
+    channels: [botDm('b1'), botDm('b2'), groupDm('g1'), groupDm('g2')],
+    statuses: ['b1', 'b2', 'g1', 'g2'].map(id => status(id)),
+    existingSectionNames: ['apps & bots'],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.kind),
+    ['groupDms'],
+  );
+});
+
+test('suppresses a lone DM bucket that covers every DM candidate', () => {
+  const result = computeDm({
+    channels: [botDm('b1'), botDm('b2')],
+    statuses: ['b1', 'b2'].map(id => status(id)),
+  });
+
+  assert.deepEqual(result, []);
+});

--- a/packages/shared/test/channelSectionSuggestions.test.mjs
+++ b/packages/shared/test/channelSectionSuggestions.test.mjs
@@ -270,7 +270,7 @@ test('suggests only the first of two projects sharing a name', () => {
   });
 
   assert.equal(result.length, 1);
-  assert.equal(result[0].projectId, 'p1');
+  assert.equal(result[0].id, 'p1');
 });
 
 test('truncates long project names to the dialog limit', () => {
@@ -286,7 +286,7 @@ test('truncates long project names to the dialog limit', () => {
     statuses: [status('c1'), status('c2'), status('c3'), status('c4')],
   });
 
-  const truncated = result.find(s => s.projectId === 'p1');
+  const truncated = result.find(s => s.id === 'p1');
   assert.equal(truncated.name.length, 50);
 });
 
@@ -374,4 +374,136 @@ test('orders suggestions by channel count then name', () => {
     result.map(s => s.name),
     ['Delta', 'Gamma', 'Alpha', 'Beta'],
   );
+});
+
+import {
+  computeActivitySectionSuggestions,
+  clampActiveWindowDays,
+} from '../dist/channelSectionSuggestions.js';
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+const daysAgo = n => NOW - n * DAY;
+
+const activityChannel = (id, lastActivityAt) => channel(id, 'p1', { lastActivityAt });
+
+const computeActivity = ({ channels, statuses, existingSectionNames = [], ...rest }) =>
+  computeActivitySectionSuggestions({
+    channels,
+    statuses,
+    existingSectionNames,
+    nowMs: NOW,
+    ...rest,
+  });
+
+test('splits candidates into Active and Quiet', () => {
+  const result = computeActivity({
+    channels: [
+      activityChannel('c1', daysAgo(1)),
+      activityChannel('c2', daysAgo(5)),
+      activityChannel('c3', daysAgo(90)),
+      activityChannel('c4', daysAgo(200)),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4')],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.kind),
+    ['active', 'dormant'],
+  );
+  assert.deepEqual(result[0].channelIds, ['c1', 'c2']);
+  assert.deepEqual(result[1].channelIds, ['c3', 'c4']);
+  assert.equal(result[0].name, 'Active');
+  assert.equal(result[1].name, 'Quiet');
+});
+
+test('respects a custom activity window', () => {
+  const channels = [
+    activityChannel('c1', daysAgo(1)),
+    activityChannel('c2', daysAgo(3)),
+    activityChannel('c3', daysAgo(40)),
+    activityChannel('c4', daysAgo(50)),
+  ];
+  const statuses = [status('c1'), status('c2'), status('c3'), status('c4')];
+
+  const wide = computeActivity({ channels, statuses, activeWindowDays: 60 });
+  assert.deepEqual(wide, []);
+
+  const narrow = computeActivity({ channels, statuses, activeWindowDays: 7 });
+  assert.deepEqual(narrow.find(s => s.kind === 'active').channelIds, ['c1', 'c2']);
+  assert.deepEqual(narrow.find(s => s.kind === 'dormant').channelIds, ['c3', 'c4']);
+});
+
+test('treats a missing lastActivityAt as dormant', () => {
+  const result = computeActivity({
+    channels: [
+      activityChannel('c1', daysAgo(1)),
+      activityChannel('c2', daysAgo(2)),
+      channel('c3', 'p1'),
+      channel('c4', 'p1'),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4')],
+  });
+
+  assert.deepEqual(result.find(s => s.kind === 'dormant').channelIds, ['c3', 'c4']);
+});
+
+test('drops an activity bucket below the minimum', () => {
+  const result = computeActivity({
+    channels: [
+      activityChannel('c1', daysAgo(1)),
+      activityChannel('c2', daysAgo(2)),
+      activityChannel('c3', daysAgo(2)),
+      activityChannel('c4', daysAgo(300)),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4')],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.kind),
+    ['active'],
+  );
+});
+
+test('skips an activity bucket whose name is taken', () => {
+  const result = computeActivity({
+    channels: [
+      activityChannel('c1', daysAgo(1)),
+      activityChannel('c2', daysAgo(2)),
+      activityChannel('c3', daysAgo(300)),
+      activityChannel('c4', daysAgo(400)),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4')],
+    existingSectionNames: ['  active '],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.kind),
+    ['dormant'],
+  );
+});
+
+test('excludes starred, deleted and already sectioned channels from activity buckets', () => {
+  const result = computeActivity({
+    channels: [
+      activityChannel('c1', daysAgo(1)),
+      activityChannel('c2', daysAgo(1)),
+      activityChannel('c3', daysAgo(1)),
+    ],
+    statuses: [
+      status('c1'),
+      status('c2', { isStarred: true }),
+      status('c3', { sectionId: 'existing' }),
+    ],
+  });
+
+  assert.deepEqual(result, []);
+});
+
+test('clamps the activity window to the supported range', () => {
+  assert.equal(clampActiveWindowDays(0), 1);
+  assert.equal(clampActiveWindowDays(-5), 1);
+  assert.equal(clampActiveWindowDays(10_000), 365);
+  assert.equal(clampActiveWindowDays(Number.NaN), 30);
+  assert.equal(clampActiveWindowDays(45.4), 45);
 });

--- a/packages/shared/test/channelSectionSuggestions.test.mjs
+++ b/packages/shared/test/channelSectionSuggestions.test.mjs
@@ -1,0 +1,377 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeProjectSectionSuggestions } from '../dist/channelSectionSuggestions.js';
+
+const project = (id, name, type = 'DEFAULT') => ({ id, name, type });
+
+const channel = (id, projectId, overrides = {}) => ({
+  id,
+  projectId,
+  scopeType: 'DEFAULT',
+  type: 'DEFAULT',
+  ...overrides,
+});
+
+const status = (channelId, overrides = {}) => ({
+  channelId,
+  sectionId: null,
+  isStarred: false,
+  isDeleted: false,
+  ...overrides,
+});
+
+const compute = ({ channels, statuses, projects, existingSectionNames = [], ...rest }) =>
+  computeProjectSectionSuggestions({
+    channels,
+    statuses,
+    projects,
+    existingSectionNames,
+    ...rest,
+  });
+
+test('groups unsectioned channels by project', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p2'),
+      channel('c4', 'p2'),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4')],
+  });
+
+  assert.equal(result.length, 2);
+  assert.deepEqual(
+    result.map(s => s.name).sort(),
+    ['Infra', 'Platform'],
+  );
+});
+
+test('excludes starred channels', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p1'),
+      channel('c4', 'p2'),
+      channel('c5', 'p2'),
+    ],
+    statuses: [
+      status('c1'),
+      status('c2'),
+      status('c3', { isStarred: true }),
+      status('c4'),
+      status('c5'),
+    ],
+  });
+
+  const platform = result.find(s => s.name === 'Platform');
+  assert.deepEqual(platform.channelIds, ['c1', 'c2']);
+});
+
+test('a project drops out when the starred filter takes it below the threshold', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p2'),
+      channel('c4', 'p2'),
+      channel('c5', 'p2'),
+    ],
+    statuses: [
+      status('c1'),
+      status('c2', { isStarred: true }),
+      status('c3'),
+      status('c4'),
+      status('c5'),
+    ],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.name),
+    ['Infra'],
+  );
+});
+
+test('excludes channels already in a section', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p1'),
+      channel('c4', 'p2'),
+      channel('c5', 'p2'),
+    ],
+    statuses: [
+      status('c1'),
+      status('c2'),
+      status('c3', { sectionId: 'existing-section' }),
+      status('c4'),
+      status('c5'),
+    ],
+  });
+
+  const platform = result.find(s => s.name === 'Platform');
+  assert.deepEqual(platform.channelIds, ['c1', 'c2']);
+});
+
+test('excludes deleted statuses and channels with no status row', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p1'),
+      channel('c4', 'p1'),
+      channel('c5', 'p2'),
+      channel('c6', 'p2'),
+    ],
+    statuses: [
+      status('c1'),
+      status('c2'),
+      status('c3', { isDeleted: true }),
+      status('c5'),
+      status('c6'),
+    ],
+  });
+
+  const platform = result.find(s => s.name === 'Platform');
+  assert.deepEqual(platform.channelIds, ['c1', 'c2']);
+});
+
+test('excludes non-default scope channels', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p1', { scopeType: 'GROUP_DM' }),
+      channel('c4', 'p2'),
+      channel('c5', 'p2'),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4'), status('c5')],
+  });
+
+  const platform = result.find(s => s.name === 'Platform');
+  assert.deepEqual(platform.channelIds, ['c1', 'c2']);
+});
+
+test('excludes desk channel types', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p1', { type: 'EMAIL' }),
+      channel('c4', 'p1', { type: 'SLACK' }),
+      channel('c5', 'p2'),
+      channel('c6', 'p2'),
+    ],
+    statuses: [
+      status('c1'),
+      status('c2'),
+      status('c3'),
+      status('c4'),
+      status('c5'),
+      status('c6'),
+    ],
+  });
+
+  const platform = result.find(s => s.name === 'Platform');
+  assert.deepEqual(platform.channelIds, ['c1', 'c2']);
+});
+
+test('excludes the DM project', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('dm', 'Direct Messages', 'DM')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'dm'),
+      channel('c4', 'dm'),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4')],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.name),
+    ['Platform'],
+  );
+});
+
+test('drops groups below the minimum channel threshold', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [channel('c1', 'p1'), channel('c2', 'p1'), channel('c3', 'p2')],
+    statuses: [status('c1'), status('c2'), status('c3')],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.name),
+    ['Platform'],
+  );
+});
+
+test('honours a custom minimum channel threshold', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p1'),
+      channel('c4', 'p2'),
+      channel('c5', 'p2'),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4'), status('c5')],
+    minChannels: 3,
+  });
+
+  assert.deepEqual(
+    result.map(s => s.name),
+    ['Platform'],
+  );
+});
+
+test('skips a project whose name collides with an existing section', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p2'),
+      channel('c4', 'p2'),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4')],
+    existingSectionNames: ['  platform '],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.name),
+    ['Infra'],
+  );
+});
+
+test('suggests only the first of two projects sharing a name', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'platform')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p1'),
+      channel('c4', 'p2'),
+      channel('c5', 'p2'),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4'), status('c5')],
+  });
+
+  assert.equal(result.length, 1);
+  assert.equal(result[0].projectId, 'p1');
+});
+
+test('truncates long project names to the dialog limit', () => {
+  const longName = 'x'.repeat(80);
+  const result = compute({
+    projects: [project('p1', longName), project('p2', 'Infra')],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p2'),
+      channel('c4', 'p2'),
+    ],
+    statuses: [status('c1'), status('c2'), status('c3'), status('c4')],
+  });
+
+  const truncated = result.find(s => s.projectId === 'p1');
+  assert.equal(truncated.name.length, 50);
+});
+
+test('returns nothing when a single project holds every candidate channel', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform')],
+    channels: Array.from({ length: 14 }, (_, i) => channel(`c${i}`, 'p1')),
+    statuses: Array.from({ length: 14 }, (_, i) => status(`c${i}`)),
+  });
+
+  assert.deepEqual(result, []);
+});
+
+test('suggests a dominant project when other candidates remain outside it', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      ...Array.from({ length: 10 }, (_, i) => channel(`a${i}`, 'p1')),
+      channel('b1', 'p2'),
+    ],
+    statuses: [...Array.from({ length: 10 }, (_, i) => status(`a${i}`)), status('b1')],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.name),
+    ['Platform'],
+  );
+});
+
+test('still suggests a dominant project when a second viable project exists', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform'), project('p2', 'Infra')],
+    channels: [
+      ...Array.from({ length: 9 }, (_, i) => channel(`a${i}`, 'p1')),
+      channel('b1', 'p2'),
+      channel('b2', 'p2'),
+    ],
+    statuses: [
+      ...Array.from({ length: 9 }, (_, i) => status(`a${i}`)),
+      status('b1'),
+      status('b2'),
+    ],
+  });
+
+  assert.deepEqual(
+    result.map(s => s.name),
+    ['Platform', 'Infra'],
+  );
+});
+
+test('returns nothing when there are no candidate channels', () => {
+  const result = compute({
+    projects: [project('p1', 'Platform')],
+    channels: [channel('c1', 'p1'), channel('c2', 'p1')],
+    statuses: [status('c1', { isStarred: true }), status('c2', { sectionId: 's1' })],
+  });
+
+  assert.deepEqual(result, []);
+});
+
+test('orders suggestions by channel count then name', () => {
+  const result = compute({
+    projects: [
+      project('p1', 'Beta'),
+      project('p2', 'Alpha'),
+      project('p3', 'Gamma'),
+      project('p4', 'Delta'),
+    ],
+    channels: [
+      channel('c1', 'p1'),
+      channel('c2', 'p1'),
+      channel('c3', 'p2'),
+      channel('c4', 'p2'),
+      channel('c5', 'p3'),
+      channel('c6', 'p3'),
+      channel('c7', 'p3'),
+      channel('c8', 'p4'),
+      channel('c9', 'p4'),
+      channel('c10', 'p4'),
+    ],
+    statuses: Array.from({ length: 10 }, (_, i) => status(`c${i + 1}`)),
+  });
+
+  assert.deepEqual(
+    result.map(s => s.name),
+    ['Delta', 'Gamma', 'Alpha', 'Beta'],
+  );
+});

--- a/packages/shared/test/channelSectionSuggestions.test.mjs
+++ b/packages/shared/test/channelSectionSuggestions.test.mjs
@@ -620,3 +620,76 @@ test('suppresses a lone DM bucket that covers every DM candidate', () => {
 
   assert.deepEqual(result, []);
 });
+
+const contactDm = (id, contactWeight) => channel(id, 'dmProject', { scopeType: 'DM', contactWeight });
+
+test('suggests Frequent contacts ranked by contact weight', () => {
+  const result = computeDm({
+    channels: [
+      contactDm('d1', 3),
+      contactDm('d2', 9),
+      contactDm('d3', 5),
+      groupDm('g1'),
+      groupDm('g2'),
+    ],
+    statuses: ['d1', 'd2', 'd3', 'g1', 'g2'].map(id => status(id)),
+  });
+
+  const contacts = result.find(s => s.kind === 'frequentContacts');
+  assert.ok(contacts);
+  assert.equal(contacts.name, 'Frequent contacts');
+  assert.deepEqual(contacts.channelIds, ['d2', 'd3', 'd1']);
+});
+
+test('caps Frequent contacts at the configured maximum', () => {
+  const channels = Array.from({ length: 12 }, (_, i) => contactDm(`d${i + 1}`, 100 - i));
+  const result = computeDm({
+    channels: [...channels, groupDm('g1'), groupDm('g2')],
+    statuses: [...channels.map(c => status(c.id)), status('g1'), status('g2')],
+    maxFrequentContacts: 8,
+  });
+
+  const contacts = result.find(s => s.kind === 'frequentContacts');
+  assert.equal(contacts.channelIds.length, 8);
+  assert.deepEqual(contacts.channelIds, ['d1', 'd2', 'd3', 'd4', 'd5', 'd6', 'd7', 'd8']);
+});
+
+test('excludes zero-weight and bot DMs from Frequent contacts', () => {
+  const result = computeDm({
+    channels: [
+      contactDm('d1', 5),
+      contactDm('d2', 4),
+      contactDm('d3', 0),
+      humanDm('d4'),
+      channel('b1', 'dmProject', { scopeType: 'DM', isBotDm: true, contactWeight: 99 }),
+      channel('b2', 'dmProject', { scopeType: 'DM', isBotDm: true, contactWeight: 98 }),
+    ],
+    statuses: ['d1', 'd2', 'd3', 'd4', 'b1', 'b2'].map(id => status(id)),
+  });
+
+  const contacts = result.find(s => s.kind === 'frequentContacts');
+  assert.deepEqual(contacts.channelIds, ['d1', 'd2']);
+  const bots = result.find(s => s.kind === 'bots');
+  assert.deepEqual(bots.channelIds, ['b1', 'b2']);
+});
+
+test('produces no Frequent contacts bucket when no weights are available', () => {
+  const result = computeDm({
+    channels: [humanDm('d1'), humanDm('d2'), groupDm('g1'), groupDm('g2')],
+    statuses: ['d1', 'd2', 'g1', 'g2'].map(id => status(id)),
+  });
+
+  assert.equal(
+    result.some(s => s.kind === 'frequentContacts'),
+    false,
+  );
+});
+
+test('breaks contact-weight ties deterministically', () => {
+  const result = computeDm({
+    channels: [contactDm('zz', 5), contactDm('aa', 5), groupDm('g1'), groupDm('g2')],
+    statuses: ['zz', 'aa', 'g1', 'g2'].map(id => status(id)),
+  });
+
+  assert.deepEqual(result.find(s => s.kind === 'frequentContacts').channelIds, ['aa', 'zz']);
+});


### PR DESCRIPTION
[POT](https://drive.google.com/file/d/1wsNxqX8Jn4F-sP7qu-R1NmcaLE3v5Bfp/view?usp=sharing)
[POT-N](https://drive.google.com/file/d/1maaEpoOV50-tp66xQKWUm-gVsyI7cbLm/view?usp=sharing)
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
