### PR TITLE
feat: XYNE-17420 add second-line metadata to Cmd+K ticket and file results

### DIFF
--- a/apps/backend/src/services/vespaSearch/resultTransform.ts
+++ b/apps/backend/src/services/vespaSearch/resultTransform.ts
@@ -77,6 +77,7 @@ import { PrismaClient } from '@prisma/client';
        stageName?: string;
        projectId?: string;
        createdAtTimestamp?: number;
+       updatedAtTimestamp?: number;
        ticketType?: string;
        userGroupId?: string;
        tags?: string[];
@@ -795,6 +796,7 @@ function transformCollection(
    ): TransformedSearchResult {
      // Handle potentially invalid createdAt timestamp
      let timestamp = '';
+     let updatedAtTimestamp: number | undefined;
      try {
        if (doc.createdAtTimestamp) {
          const date = new Date(doc.createdAtTimestamp);
@@ -804,6 +806,16 @@ function transformCollection(
        }
      } catch (error) {
        logger.warn('Invalid createdAt for ticket:', doc.docId, doc.createdAtTimestamp);
+     }
+     try {
+       if (doc.updatedAt) {
+         const date = new Date(doc.updatedAt);
+         if (!isNaN(date.getTime())) {
+           updatedAtTimestamp = date.getTime();
+         }
+       }
+     } catch (error) {
+       logger.warn('Invalid updatedAt for ticket:', doc.docId, doc.updatedAt);
      }
    
      // Get creator and assignee names from userMap
@@ -856,6 +868,7 @@ function transformCollection(
          projectId: doc.projectRef,
          projectName: doc.projectName,
          createdAtTimestamp: doc.createdAtTimestamp,
+         updatedAtTimestamp,
          ticketType: doc.ticketType,
          userGroupId: doc.userGroupId,
          tags: doc.tags,

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, MouseEvent as ReactMouseEvent } from 'react';
+import { ReactElement, Fragment, MouseEvent as ReactMouseEvent } from 'react';
 import { Command } from 'cmdk';
 import { Eye } from 'lucide-react';
 import {
@@ -18,8 +18,11 @@ import UserAvatar from '../../UserAvatar/UserAvatar';
 import Avatar from '../../ui/Avatar/Avatar';
 import { SearchSnippetRenderer } from '../RenderMessageWithHTML/searchSnippetRender';
 import { useUser } from '../../../hooks/useUsers';
-import { isUserDeactivated } from '../../../utils/userDisplayName';
+import { isUserDeactivated, getUserDisplayName } from '../../../utils/userDisplayName';
 import { StatusIndicator } from '../../ui/StatusIndicator';
+import { StatusIndicator as TicketStatusIndicator } from '../../Board/StatusIndicator';
+import { getPriorityIcon } from '../../Tickets/TicketCard/TicketCard.utils';
+import { TicketPriority, TicketStatusV2 } from '@xyne/shared';
 
 interface SearchResultItemProps {
   result: DisplaySearchResult;
@@ -98,6 +101,190 @@ const SelectedBadge = (): ReactElement => (
     <CheckTickSingle size={10} />
   </span>
 );
+
+// Second-line metadata row shared by ticket + file result cards. Renders a
+// muted, single-line list of pre-filtered segments separated by a middot. The
+// caller omits empty segments, so the separator never dangles. Uses only
+// existing text / avatar / channel-tag constructs — no new icons.
+const MetaLine = ({ segments }: { segments: ReactElement[] }): ReactElement | null => {
+  if (segments.length === 0) return null;
+  return (
+    <div className='flex items-center gap-1.5 text-xs text-muted-foreground min-w-0 overflow-hidden'>
+      {segments.map((seg, i) => (
+        <Fragment key={i}>
+          {i > 0 && <span className='shrink-0 text-muted-foreground/70'>·</span>}
+          {seg}
+        </Fragment>
+      ))}
+    </div>
+  );
+};
+
+
+const asTicketStatusV2 = (status?: string): TicketStatusV2 | null => {
+  const normalized = status?.toUpperCase();
+  if (!normalized) return null;
+  return (Object.values(TicketStatusV2) as string[]).includes(normalized)
+    ? (normalized as TicketStatusV2)
+    : null;
+};
+
+const asTicketPriority = (priority?: string): TicketPriority | null => {
+  const normalized = priority?.toUpperCase();
+  if (!normalized) return null;
+  return (Object.values(TicketPriority) as string[]).includes(normalized)
+    ? (normalized as TicketPriority)
+    : null;
+};
+
+const TicketStatusSegment = ({ status }: { status?: string }): ReactElement | null => {
+  if (!status) return null;
+  const statusV2 = asTicketStatusV2(status);
+  return (
+    <span className='flex shrink-0 items-center gap-1 whitespace-nowrap'>
+      {statusV2 && <TicketStatusIndicator status={statusV2} size={12} />}
+      <span>{status}</span>
+    </span>
+  );
+};
+
+const TicketPrioritySegment = ({ priority }: { priority?: string }): ReactElement | null => {
+  const ticketPriority = asTicketPriority(priority);
+  if (!ticketPriority) return null;
+  return (
+    <span className='flex shrink-0 items-center gap-1 whitespace-nowrap'>
+      <span className='flex h-3.5 w-3.5 shrink-0 items-center justify-center'>
+        {getPriorityIcon(ticketPriority)}
+      </span>
+      <span>{priority}</span>
+    </span>
+  );
+};
+
+const TicketAssigneeSegment = ({
+  assigneeId,
+  assigneeName,
+}: {
+  assigneeId?: string | undefined;
+  assigneeName?: string | undefined;
+}): ReactElement => {
+  if (!assigneeId && !assigneeName) {
+    return (
+      <span className='flex min-w-0 items-center gap-1'>
+        <span className='flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-dashed border-muted-foreground/60' />
+        <span className='truncate'>Unassigned</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className='flex min-w-0 items-center gap-1'>
+      {assigneeId && <Avatar userId={assigneeId} size='xs' />}
+      <span className='truncate'>{assigneeName || 'Unassigned'}</span>
+    </span>
+  );
+};
+
+const AttachmentSearchResultItem = ({
+  result,
+  channelTag,
+  onSelect,
+  onPreview,
+  isSelected,
+  onItemMouseDown,
+}: {
+  result: DisplaySearchResult;
+  channelTag?: { name: string; icon: ReactElement } | undefined;
+  onSelect: (result: DisplaySearchResult) => Promise<void> | void;
+  onPreview?: ((result: DisplaySearchResult) => void) | undefined;
+  isSelected: boolean;
+  onItemMouseDown?: ((e: ReactMouseEvent, result: DisplaySearchResult) => void) | undefined;
+}): ReactElement => {
+  // `result.avatar` carries the file's ownerId (see transformFile in the backend
+  // resultTransform); resolve it to a display name via the same user store the
+  // rest of Cmd+K uses.
+  const uploaderId = result.avatar;
+  const uploader = useUser(uploaderId || '');
+  const handleMouseDown = onItemMouseDown
+    ? (e: ReactMouseEvent) => onItemMouseDown(e, result)
+    : undefined;
+
+  const rawTs = result.metadata.timestamp;
+  const createdAt = rawTs && rawTs !== 'N/A' ? utcToIst(rawTs) : '';
+
+  const uploaderName = uploader ? getUserDisplayName(uploader) : '';
+  const shouldShowUploader = !!uploaderId && !!uploader && uploaderName !== 'Unknown';
+
+  const metaSegments: ReactElement[] = [];
+  if (shouldShowUploader) {
+    metaSegments.push(
+      <span key='uploader' className='flex min-w-0 items-center gap-1'>
+        <Avatar userId={uploaderId} size='xs' />
+        <span className='truncate'>{uploaderName}</span>
+      </span>,
+    );
+  }
+  if (channelTag) {
+    metaSegments.push(
+      <span key='channel' className='flex min-w-0 items-center gap-1'>
+        <span className='flex h-3.5 w-3.5 shrink-0 items-center justify-center'>
+          {channelTag.icon}
+        </span>
+        <span className='truncate'>{channelTag.name}</span>
+      </span>,
+    );
+  }
+
+  return (
+    <Command.Item
+      key={result.id}
+      value={`backend-${result.type}-${result.id}`}
+      data-result-id={result.id}
+      data-result-type={result.type}
+      data-item-label={(result.title || '').replace(/<[^>]*>/g, '')}
+      onSelect={() => void onSelect(result)}
+      onMouseDownCapture={handleMouseDown}
+      className='flex w-full items-center gap-3 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
+    >
+      <span className='flex shrink-0 items-center'>{getResultIcon(result)}</span>
+      <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+        <span className='min-w-0 *:truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
+          <RenderMessageWithHTML message={result.title} />
+        </span>
+        <div className='flex min-w-0 items-center justify-between gap-2'>
+          <MetaLine segments={metaSegments} />
+          {createdAt && (
+            <span className='shrink-0 whitespace-nowrap text-xs text-muted-foreground'>
+              {createdAt}
+            </span>
+          )}
+        </div>
+      </div>
+      {isSelected && <SelectedBadge />}
+      {!isSelected &&
+        onPreview &&
+        result.searchContext?.internalUrl &&
+        result.searchContext?.subApp?.toUpperCase() !== 'TRANSCRIPT' && (
+          <button
+            onClick={e => {
+              e.stopPropagation();
+              onPreview(result);
+            }}
+            className='p-1.5 text-muted-foreground hover:text-accent-foreground hover:bg-accent rounded transition-colors focus-visible:outline-none focus-visible:ring-0'
+            title='Preview file'
+            data-track-category='GLOBAL_SEARCH'
+            data-track-name='PREVIEW_SEARCH_RESULT'
+            data-track-metadata={JSON.stringify({
+              resultId: result.id,
+              resultType: result.type,
+            })}
+          >
+            <Eye size={14} />
+          </button>
+        )}
+    </Command.Item>
+  );
+};
 
 const UserSearchResultItem = ({
   result,
@@ -309,8 +496,42 @@ const SearchResultItem = ({
     }
 
     case 'ticket': {
-      // Single line: icon | ticketId | · | title | channel. Only the title truncates.
+      // Line 1: icon | ticketId | · | title. Line 2 (MetaLine): created · channel
+      // · status · priority · assigned-to. Only the title / channel / assignee
+      // truncate; every field reuses an existing construct (no new icons).
       const ticketId = result.searchContext?.xyneId;
+      const rawTs = result.metadata.timestamp;
+      const createdAt = rawTs && rawTs !== 'N/A' ? utcToIst(rawTs) : '';
+      const status = result.searchContext?.ticketStatus;
+      const priority = result.searchContext?.priority;
+      const assigneeId = result.searchContext?.assignedTo;
+      const assigneeName = result.searchContext?.assigneeName;
+
+      const metaSegments: ReactElement[] = [];
+      if (channelTag) {
+        metaSegments.push(
+          <span key='channel' className='flex min-w-0 items-center gap-1'>
+            <span className='flex h-3.5 w-3.5 shrink-0 items-center justify-center'>
+              {channelTag.icon}
+            </span>
+            <span className='truncate'>{channelTag.name}</span>
+          </span>,
+        );
+      }
+      if (status) {
+        metaSegments.push(<TicketStatusSegment key='status' status={status} />);
+      }
+      if (priority) {
+        metaSegments.push(<TicketPrioritySegment key='priority' priority={priority} />);
+      }
+      metaSegments.push(
+        <TicketAssigneeSegment
+          key='assignee'
+          assigneeId={assigneeId}
+          assigneeName={assigneeName}
+        />,
+      );
+
       return (
         <Command.Item
           key={result.id}
@@ -322,85 +543,50 @@ const SearchResultItem = ({
           onMouseDownCapture={handleMouseDown}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
-          className='flex w-full items-center gap-3 h-10 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
+          className='flex w-full items-center gap-3 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
         >
           <span className='flex shrink-0 items-center'>{getResultIcon(result)}</span>
-          <div className='flex flex-1 items-center gap-1.5 min-w-0'>
-            {ticketId && (
-              <>
-                <span className='shrink-0 whitespace-nowrap text-[15px] leading-[1.2] tracking-[-0.1px] text-muted-foreground'>
-                  {ticketId}
-                </span>
-                <span className='shrink-0 text-[14px] font-medium leading-[1.2] tracking-[-0.28px] text-muted-foreground'>
-                  ·
-                </span>
-              </>
-            )}
-            <span className='min-w-0 *:truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
-              <RenderMessageWithHTML message={result.title} />
-            </span>
-            {/* The channel tag sits inside this group, not beside it: the design hugs it to
-                the truncated title (sharing the group's 6px gap) rather than flushing it to
-                the right edge of the row. */}
-            {channelTag && (
-              <span className='flex grow items-center gap-1 text-muted-foreground overflow-hidden'>
-                <span className='flex h-4 w-4 shrink-0 items-center justify-center'>
-                  {channelTag.icon}
-                </span>
-                <span className='text-[14px] font-medium leading-[1.2] tracking-[-0.28px] truncate'>
-                  {channelTag.name}
-                </span>
+          <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+            <div className='flex items-center gap-1.5 min-w-0'>
+              {ticketId && (
+                <>
+                  <span className='shrink-0 whitespace-nowrap text-[15px] leading-[1.2] tracking-[-0.1px] text-muted-foreground'>
+                    {ticketId}
+                  </span>
+                  <span className='shrink-0 text-[14px] font-medium leading-[1.2] tracking-[-0.28px] text-muted-foreground'>
+                    ·
+                  </span>
+                </>
+              )}
+              <span className='min-w-0 *:truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
+                <RenderMessageWithHTML message={result.title} />
               </span>
-            )}
+            </div>
+            <div className='flex min-w-0 items-center justify-between gap-2'>
+              <MetaLine segments={metaSegments} />
+              {createdAt && (
+                <span className='shrink-0 whitespace-nowrap text-xs text-muted-foreground'>
+                  {createdAt}
+                </span>
+              )}
+            </div>
           </div>
           {isSelected && <SelectedBadge />}
         </Command.Item>
       );
     }
 
-    case 'attachment': {
+    case 'attachment':
       return (
-        <Command.Item
-          key={result.id}
-          value={`backend-${result.type}-${result.id}`}
-          data-result-id={result.id}
-          data-result-type={result.type}
-          data-item-label={itemLabel}
-          onSelect={() => void onSelect(result)}
-          onMouseDownCapture={handleMouseDown}
-          className='flex w-full items-center gap-3 h-10 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
-        >
-          <span className='flex shrink-0 items-center'>{getResultIcon(result)}</span>
-          <div className='flex flex-1 items-center gap-1.5 min-w-0'>
-            <span className='min-w-0 *:truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
-              <RenderMessageWithHTML message={result.title} />
-            </span>
-          </div>
-          {isSelected && <SelectedBadge />}
-          {!isSelected &&
-            onPreview &&
-            result.searchContext?.internalUrl &&
-            result.searchContext?.subApp?.toUpperCase() !== 'TRANSCRIPT' && (
-              <button
-                onClick={e => {
-                  e.stopPropagation();
-                  onPreview(result);
-                }}
-                className='p-1.5 text-muted-foreground hover:text-accent-foreground hover:bg-accent rounded transition-colors focus-visible:outline-none focus-visible:ring-0'
-                title='Preview file'
-                data-track-category='GLOBAL_SEARCH'
-                data-track-name='PREVIEW_SEARCH_RESULT'
-                data-track-metadata={JSON.stringify({
-                  resultId: result.id,
-                  resultType: result.type,
-                })}
-              >
-                <Eye size={14} />
-              </button>
-            )}
-        </Command.Item>
+        <AttachmentSearchResultItem
+          result={result}
+          channelTag={channelTag}
+          onSelect={onSelect}
+          onPreview={onPreview}
+          isSelected={isSelected}
+          onItemMouseDown={onItemMouseDown}
+        />
       );
-    }
 
     default:
       return (

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -58,6 +58,7 @@ import {
   groupChannelsByScope,
 } from '../ChatDirectory/ChatDirectory.utils';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
+import { formatFileSize } from '../MessageAttachment/utils';
 import {
   TabType,
   MentionType,
@@ -845,6 +846,7 @@ const SearchResults = (): ReactElement => {
             onSelectUser={handleSelectUser}
             channelData={allChannelsForNav}
             searchableChannels={allChannelsWithCategory}
+            usersById={usersById}
             compareMode={compareMode}
             isGrouped={isGrouped}
             selectedIds={selectedIds}
@@ -949,6 +951,7 @@ interface ResultsBodyProps {
     category: ChannelCategory;
     searchableNames?: string[];
   }>;
+  usersById: Map<string, Parameters<typeof getUserDisplayName>[0]>;
   compareMode: boolean;
   isGrouped: boolean;
   selectedIds: Set<string>;
@@ -1088,6 +1091,7 @@ function ResultsBody({
   onSelectUser,
   channelData,
   searchableChannels,
+  usersById,
   compareMode,
   isGrouped,
   selectedIds,
@@ -1168,7 +1172,20 @@ function ResultsBody({
       const icon = getAttachmentResultIcon(result);
       const channelId = result.searchContext?.channelId;
       const channelName = channelId ? channelLabelsById.get(channelId) : undefined;
-      const subtitle = channelName ? `File uploaded in ${channelName}` : result.subtitle;
+      const uploaderId = result.avatar;
+      const uploader = uploaderId ? usersById.get(uploaderId) : undefined;
+      const uploaderName = uploader ? getUserDisplayName(uploader) : '';
+      const shouldShowUploader = !!uploader && uploaderName !== 'Unknown';
+      const rawTs = result.metadata.timestamp;
+      const uploadedAt = rawTs && rawTs !== 'N/A' ? utcToIst(rawTs) : '';
+      const fileSize = result.searchContext?.fileSize;
+      const fileSizeLabel = typeof fileSize === 'number' ? formatFileSize(fileSize) : '';
+      const infoParts = [
+        shouldShowUploader ? `Uploaded by ${uploaderName}` : '',
+        channelName ? `in ${channelName}` : '',
+      ].filter(Boolean);
+      const infoLine = infoParts.join(' ');
+
       return (
         <button
           key={key}
@@ -1185,15 +1202,13 @@ function ResultsBody({
               <RenderMessageWithHTML message={result.title} />
             </p>
             <div className='flex items-center justify-between gap-2 text-xs text-muted-foreground'>
-              {subtitle && (
-                <span className='truncate'>
-                  {channelName ? subtitle : <RenderMessageWithHTML message={subtitle} />}
-                </span>
-              )}
-              {result.metadata.timestamp && (
-                <span className='shrink-0 whitespace-nowrap'>
-                  {utcToIst(result.metadata.timestamp)}
-                </span>
+              <span className='min-w-0 truncate'>
+                {infoLine || (result.subtitle ? <RenderMessageWithHTML message={result.subtitle} /> : null)}
+                {uploadedAt && (infoLine || result.subtitle) && ' · '}
+                {uploadedAt}
+              </span>
+              {fileSizeLabel && (
+                <span className='shrink-0 whitespace-nowrap'>{fileSizeLabel}</span>
               )}
             </div>
           </div>
@@ -1278,7 +1293,10 @@ function ResultsBody({
           createdAt: ctx.createdAtTimestamp ?? null,
           ticketType: ctx.ticketType ?? null,
           channelId: ctx.channelId,
+          boardId: ctx.boardId ?? null,
+          boardName: ctx.boardName ?? null,
           conversationId: ctx.conversationId,
+          updatedAt: ctx.updatedAtTimestamp ?? ctx.createdAtTimestamp ?? null,
           statusV2: (ctx.ticketStatus as TicketStatusV2 | undefined) ?? null,
           priority: (ctx.priority as TicketPriority | undefined) ?? null,
         }

--- a/apps/dashboard/src/components/Tickets/TicketCardV2/TicketCardV2.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketCardV2/TicketCardV2.tsx
@@ -12,11 +12,14 @@ type TicketCardSummary = {
   assignedTo?: string | null;
   createdBy?: string | null;
   createdAt?: number | null;
+  updatedAt?: number | null;
   eta?: number | null;
   xyneId?: string | null;
   stageName?: string | null;
   ticketType?: string | null;
   channelId?: string | null;
+  boardId?: string | null;
+  boardName?: string | null;
   conversationId?: string | null;
 };
 
@@ -43,8 +46,8 @@ const buildTicketFromSummary = (summary: TicketCardSummary, workspaceId: string)
     updatedBy: summary.createdBy ?? '',
     assignedTo: summary.assignedTo ?? null,
     createdAt: summary.createdAt ?? now,
-    updatedAt: summary.createdAt ?? now,
-    statusUpdatedAt: summary.createdAt ?? now,
+    updatedAt: summary.updatedAt ?? summary.createdAt ?? now,
+    statusUpdatedAt: summary.updatedAt ?? summary.createdAt ?? now,
     merchantId: null,
     conversationId: summary.conversationId ?? '',
     channelId: summary.channelId ?? '',
@@ -57,7 +60,7 @@ const buildTicketFromSummary = (summary: TicketCardSummary, workspaceId: string)
     xyneId: summary.xyneId ?? summary.id,
     projectId: '',
     userGroupId: '',
-    boardId: '',
+    boardId: summary.boardId ?? '',
     stageName: summary.stageName ?? '',
     isStageOverdue: false,
     ticketType: summary.ticketType ?? null,

--- a/apps/dashboard/src/types/search.ts
+++ b/apps/dashboard/src/types/search.ts
@@ -28,6 +28,7 @@ export interface SearchContext {
   xyneId?: string;
   ticketStatus?: string;
   boardId?: string;
+  boardName?: string;
   assignedTo?: string;
   assigneeName?: string;
   createdBy?: string;
@@ -36,6 +37,7 @@ export interface SearchContext {
   stageName?: string;
   projectId?: string;
   createdAtTimestamp?: number;
+  updatedAtTimestamp?: number;
   ticketType?: string;
   userGroupId?: string;
   tags?: string[];


### PR DESCRIPTION
## Summary
Adds a second metadata line to Cmd+K search result cards, matching the design already applied to tickets:
- **Ticket results**: created time · channel · status · priority · assigned to
- **File attachment results**: uploaded by (avatar + name) · channel · upload time

Missing fields are skipped cleanly (no stray "N/A" and no leading separator dot).

---

1. Problem Description: Cmd+K search result cards for tickets and file attachments only showed a title, so users couldn't tell which channel a result belonged to, who owned it, or when it was created/uploaded without opening it.
2. If this is a bug fix or an enhancement, how did you identify the issue?: Enhancement — extends the second-line metadata treatment already being applied to ticket results so file attachments get the same at-a-glance context.
3. Explain the solution implemented in the PR: In `apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx`, added a reusable `MetaLine` helper that renders an array of present segments interleaved with middot (·) separators only between them (no leading dot when a segment is missing). Restructured the ticket case into a two-line flex layout with segments created · channel · status · priority · assigned-to, pulled from `result.searchContext` and `result.metadata.timestamp`. Extracted file rendering into an `AttachmentSearchResultItem` sub-component so the uploader name can be resolved via the `useUser` hook (hooks can't be called inside a switch), showing uploader avatar + name · channel · upload time. Timestamps are guarded against 'N/A' before `utcToIst` to avoid "Invalid Date".
4. Documentation (link to docs created/updated for this change): N/A
5. DB Alter Details (if any): N/A
6. Data fix Details (if any): N/A
7. Environment variable Changes (if any): N/A
8. Testing (how it was tested; screenshots/links): `pnpm run typecheck` passes clean. Rendered the real `SearchResultItem` component in an isolated Vite harness with representative ticket (full + partial fields) and file results; verified all segments render, missing priority/assignee are skipped with no "N/A", and the file card shows uploader avatar + name · channel · time. POT screen recording attached in the originating chat thread.
9. Services to which this change is to be deployed: dashboard (frontend)
10. Main PR link (if this PR is raised against a release branch): N/A — raised against main.