### PR TITLE
fix: XYNE-59705 close WAPT findings 003, 004, 009 and 012

### DIFF
--- a/apps/xyne-claw-auth/backend/src/repositories/agentRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRepository.ts
@@ -47,7 +47,49 @@ const INCLUDE_TOOLS_SKILLS = {
   collections: true,
 } as const;
 
+/**
+ * The one definition of "this user may use this agent": org-global, owned, or
+ * explicitly shared. Kept beside `listVisible`, which applies the same rule to
+ * the agent list, so a change to what "visible" means cannot drift between the
+ * list a user is shown and the agents they can actually address.
+ *
+ * Org scoping is applied separately by the caller — it is a different question
+ * (which tenant) from this one (which agent within it).
+ */
+export function agentVisibleToUser(userId: string): Prisma.AgentWhereInput {
+  return {
+    OR: [{ scope: "global" }, { ownerUserId: userId }, { shares: { some: { userId } } }],
+  };
+}
+
 export const agentRepository = {
+  /**
+   * Resolve a slug to an agent the caller is actually allowed to use.
+   *
+   * `findBySlug` scopes by org only, which makes every agent in an org
+   * addressable by slug regardless of whether it is private to another user.
+   * Execution paths — chatting, regenerating, forking — must use this instead:
+   * the slug is caller-supplied, so org scoping alone is tenant isolation, not
+   * authorization.
+   *
+   * Returns null both when the agent does not exist and when it exists but is
+   * not visible, so callers 404 either way. That is deliberate: a distinct 403
+   * would confirm the slug to someone probing for other users' private agents.
+   */
+  findBySlugVisibleTo: (slug: string, orgId: string | null | undefined, userId: string | null | undefined) => {
+    if (!orgId) {
+      log.error("[agentRepository.findBySlugVisibleTo] missing orgId; refusing global slug lookup", { slug });
+      return Promise.resolve(null);
+    }
+    if (!userId) {
+      log.error("[agentRepository.findBySlugVisibleTo] missing userId; refusing unscoped slug lookup", { slug });
+      return Promise.resolve(null);
+    }
+    return prisma.agent.findFirst({
+      where: { AND: [{ orgId, slug }, agentVisibleToUser(userId)] },
+    });
+  },
+
   findBySlug: (slug: string, orgId?: string | null) => {
     if (!orgId) {
       log.error("[agentRepository.findBySlug] missing orgId; refusing global slug lookup", { slug });

--- a/apps/xyne-claw-auth/backend/src/routes/admin.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/admin.ts
@@ -154,6 +154,22 @@ router.get("/roles/check/:userId", async (req: Request<{ userId: string }>, res:
   }
 });
 
+// Everything below this line is admin-only.
+//
+// Guarding each route individually meant a route added without the guard was
+// served to any authenticated caller, and several were: the dashboard reads,
+// the error-pipeline reads, and a fork-conversation write. Default-deny here
+// makes the guard the property of the router rather than something each new
+// route has to remember.
+//
+// This sits AFTER `/roles/check/:userId` deliberately. That route answers "is
+// the caller an admin" for the frontend and must stay reachable by non-admins;
+// it already resolves the requester itself and ignores the path parameter.
+// Routes registered above keep their explicit `requireClawAdmin` — redundant
+// now, but harmless, and removing them would make this ordering load-bearing
+// in a way that is easy to break later.
+router.use(requireClawAdmin);
+
 router.get("/audit-logs", requireClawAdmin, async (req: Request, res: Response) => {
   try {
     const scope = getAdminOrgScope(req, "/admin/audit-logs");

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -216,6 +216,15 @@ interface PendingStream {
   /** Parent ref the assistant placeholder was created under. Echoed in `done`
    *  so the frontend can stitch the optimistic message into the tree. */
   assistantParentId?: string;
+  /** Whether this subscriber may receive `debug` frames.
+   *
+   *  The debug frame carries the agent's full system prompt, instructions and
+   *  tool-use policy. The stored-history endpoint already withholds it from
+   *  callers without elevated access; the live stream did not, so the same
+   *  content was readable by any user who could start a run. Resolved once when
+   *  the stream is opened — the callback handler that forwards frames runs on
+   *  an S2S request from xyne-claw and has no end-user identity of its own. */
+  allowDebug?: boolean;
 }
 const pendingStreams = new Map<string, PendingStream>();
 
@@ -295,7 +304,12 @@ function ensureChatEventsSubscriber(): void {
     const stream = pendingStreams.get(msg.callbackId);
     if (!stream) return; // stream lives on another pod (or already resolved)
     if (msg.kind === "progress") {
-      for (const e of msg.events) stream.sendEvent(e.event, e.data);
+      // Same withholding as the same-pod path above: the pod that owns the
+      // subscriber is the only one that knows whether it may see `debug`.
+      for (const e of msg.events) {
+        if (e.event === "debug" && !stream.allowDebug) continue;
+        stream.sendEvent(e.event, e.data);
+      }
       return;
     }
     stream.sendEvent("debug_artifacts_ready", {
@@ -765,7 +779,7 @@ router.get("/:slug/context/search", async (req: Request<{ slug: string }>, res: 
       return;
     }
 
-    const agent = await agentRepository.findBySlug(req.params.slug, getOrgId(req));
+    const agent = await agentRepository.findBySlugVisibleTo(req.params.slug, getOrgId(req), getRequesterId(req));
     if (!agent) {
       log.warn(`[agent-chat/context-search] agent org-scoped miss slug=${req.params.slug} orgId=${getOrgId(req) ?? "none"} userId=${userId}`);
       res.status(404).json({ success: false, error: "Agent not found" });
@@ -815,7 +829,7 @@ router.get("/:slug/litellm-models", async (req: Request<{ slug: string }>, res: 
       res.status(401).json({ success: false, error: "x-user-id header is required" });
       return;
     }
-    const agent = await agentRepository.findBySlug(req.params.slug, getOrgId(req));
+    const agent = await agentRepository.findBySlugVisibleTo(req.params.slug, getOrgId(req), getRequesterId(req));
     if (!agent) {
       res.status(404).json({ success: false, error: "Agent not found" });
       return;
@@ -967,7 +981,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
         ].join("\n")
       : "";
 
-    const agent = await agentRepository.findBySlug(slug, getOrgId(req));
+    const agent = await agentRepository.findBySlugVisibleTo(slug, getOrgId(req), userId);
     if (!agent) {
       log.warn(`[agent-chat/chat] agent org-scoped miss slug=${slug} orgId=${getOrgId(req) ?? "none"} userId=${userId}`);
       res.status(404).json({ success: false, error: "Agent not found" });
@@ -1207,6 +1221,15 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       "X-Accel-Buffering": "no", // disable proxy buffering (istio/nginx)
     });
 
+    // Whether this subscriber may receive `debug` frames. Same predicate the
+    // stored-history endpoint uses for `debugEvents`, so a caller sees the same
+    // debug content live as it would on replay. Resolved here, before the SSE
+    // promise, because the callback that forwards frames arrives on a separate
+    // S2S request with no end-user identity of its own.
+    const debugIsAdmin = await isClawAdmin(userId);
+    const debugEditAccess = debugIsAdmin ? null : await getAgentEditAccess(userId, slug, getOrgId(req));
+    const allowDebug = debugIsAdmin || Boolean(debugEditAccess?.canEdit);
+
     // Send conversationId immediately
     res.write(`event: meta\ndata: ${JSON.stringify({ conversationId })}\n\n`);
 
@@ -1248,6 +1271,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
         resolve,
         setClosed: () => { closed = true; },
         assistantMessageId: assistantMsg.id,
+        allowDebug,
         ...(createdUserMessageId ? { userMessageId: createdUserMessageId } : {}),
         ...(assistantParentId ? { assistantParentId } : {}),
       });
@@ -1708,7 +1732,14 @@ internalRouter.post("/:slug/chat/:convId/progress", async (req: Request<{ slug: 
 
   if (events.length > 0 && callbackId) {
     if (stream) {
-      for (const e of events) stream.sendEvent(e.event, e.data);
+      // `debug` is withheld unless the subscriber was resolved as elevated when
+      // the stream opened. Filtered at delivery rather than at construction
+      // because the same `events` array is also published cross-pod, where the
+      // receiving pod owns the subscriber and applies this same check.
+      for (const e of events) {
+        if (e.event === "debug" && !stream.allowDebug) continue;
+        stream.sendEvent(e.event, e.data);
+      }
     } else {
       publishChatEvent({ kind: "progress", callbackId, events });
     }
@@ -1816,7 +1847,7 @@ internalRouter.post("/:slug/chat/:convId/callback", async (req: Request<{ slug: 
   let includeCitations = false;
   try {
     const agentRow = callbackOrgId
-      ? await agentRepository.findBySlug(req.params.slug, callbackOrgId)
+      ? await agentRepository.findBySlugVisibleTo(req.params.slug, callbackOrgId, userId)
       : null;
     const replyOpts = (agentRow?.config as { replyOptions?: { includeCitations?: boolean } } | undefined)?.replyOptions;
     if (replyOpts && replyOpts.includeCitations === true) includeCitations = true;
@@ -1894,7 +1925,7 @@ internalRouter.post("/:slug/chat/:convId/callback", async (req: Request<{ slug: 
   let persisted: { messageId: string; persistedAttachments: PersistedAttachment[] } | null = null;
   if (userId && callbackOrgId) {
     try {
-      const agent = await agentRepository.findBySlug(req.params.slug, callbackOrgId);
+      const agent = await agentRepository.findBySlugVisibleTo(req.params.slug, callbackOrgId, userId);
       if (!agent) {
         log.warn(`[agent-chat/result] agent org-scoped miss slug=${req.params.slug} orgId=${callbackOrgId ?? "none"} userId=${userId ?? "none"} sessionId=${req.params.convId}`);
         res.status(404).json({ success: false, error: "Agent not found" });


### PR DESCRIPTION
Remediation for the Payatu web assessment (`JP_XYNE_Space Web_WAPT_Report_20Aug26_v1.0`, tested 13 Jul – 13 Aug).

Every finding below was verified against **both** `main` and `feature/deploy-xyneclaw` before fixing. They are identical on both, so this lands on `main` and cherry-picks to the deploy branch without adaptation.


## Status of all 13 findings

| ID | Finding | Sev | Status |
|---|---|---|---|
| 001 | Broken tool authorization | HIGH | Fixed (pre-existing) |
| 002 | Data exfiltration | HIGH | Business justified |
| 003 | IDOR — private agents | HIGH | **Fixed here** |
| 004 | Improper authorization | MED | **Fixed here** |
| 005 | Sensitive data exposure | MED | Business justified |
| 006 | Lack of rate limiting | LOW | Edge |
| 007 | CSR injection | LOW | Not applicable — code removed |
| 008 | Improper device revocation | LOW | Not applicable — code removed |
| 009 | Client-side control | LOW | **Fixed here** |
| 010 | Blind SSRF | LOW | Open |
| 011 | No AV on uploads | LOW | Open |
| 012 | System prompt leakage | LOW | **Fixed here** |
| 013 | Weak TLS ciphers | LOW | Open |

5 fixed · 2 business justified · 2 not applicable · 3 open · 1 at edge

Every finding was checked against **both** `main` and `feature/deploy-xyneclaw`. None differed between the two.

## Fixed here

### PY-JP-003 — IDOR on private agents · HIGH

`findBySlug` scoped by `orgId` alone, so every agent in an org was addressable by slug regardless of owner. The chat routes take that slug from the caller, so org scoping was tenant isolation, not authorization — the report's proof was one user chatting with another's private `Payatu` agent by editing the slug.

Adds `findBySlugVisibleTo`, which ANDs the predicate `listVisible` already uses for the agent list — org-global, owned, or explicitly shared. Reusing it rather than writing a second rule keeps the list a user is shown and the agents they can address from drifting apart. All five slug-resolution sites in `agent-chat.ts` now use it.

Returns `null` for *not visible* as well as *not found*, so both 404. A distinct 403 would confirm a slug's existence to someone probing.

### PY-JP-004 / PY-JP-009 — admin endpoints open to any authenticated user · MEDIUM / LOW

The admin router guarded routes individually with no default, and **nine** had been added without it — four dashboard reads, four error-pipeline reads, and a `POST /error-pipeline/fork-conversation` **write**. Payatu named two.

**009 is the same defect, not a separate one.** The re-enabled "Admin Only" button works because the server route behind it never checked. One fix closes both.

Replaced with `router.use(requireClawAdmin)` so the guard is a property of the router and new routes are protected by default.

Placed deliberately **after** `/roles/check/:userId` — that route is how the frontend asks whether the caller is an admin, must stay reachable by non-admins, and already resolves the requester itself while ignoring the path parameter. A blanket guard at the top of the file would have broken the admin UI for everyone.

### PY-JP-012 — system prompt leaked in the live debug frame · LOW

The stored-history endpoint already withheld `debugEvents` from callers without elevated access. The live SSE path pushed the same content unconditionally, so an agent's full system prompt, instructions and tool-use policy were readable by anyone who could start a run.

Subscriber privilege is now resolved once when the stream opens — using the same predicate as the history endpoint — and stored on `PendingStream`. It has to be resolved there because the callback that forwards frames arrives on a separate S2S request from `xyne-claw` with no end-user identity.

Filtering is applied at delivery in **both** dispatch paths, same-pod and the cross-pod Redis forward, since the pod owning the subscriber is the only one that knows whether it may see the frame.

## Not in this change

**PY-JP-006 — rate limiting.** To be handled at the edge. No rate-limiting middleware exists in claw-auth or claw, and the Spaces global limiter is commented out in `app.ts`.

Two things worth checking when the edge rules are written: in-cluster S2S calls between Spaces and claw do not traverse the edge, so agent creation reached through an automation path would not be limited by them; and the reported proof was 50 authenticated creations from one session, which per-user limiting catches and per-IP limiting does not reliably.

**PY-JP-010 — blind SSRF.** Real SSRF defence already exists: `mcpgateway/services/http-client.ts` blocks `169.254.0.0/16` and `surfaces/external-api/const.ts` blocks `metadata.google.internal`. Neither of the reported vectors uses it — the agent web-fetch tool in `apps/xyne-claw/src/custom-tools.ts` calls bare `fetch()`, and the provider Base URL is unvalidated. The fix is to route both through the existing guarded client, which crosses a package boundary and deserves its own change.

**PY-JP-011 — AV scanning on uploads.** Open. Needs a scanner service — ClamAV as a sidecar, or a cloud scanning API. There is no code-only fix: the decisions are whether to scan synchronously and add upload latency or asynchronously and briefly serve unscanned files, and whether detection rejects, quarantines or flags.

Separately, and more immediately actionable: the report notes the chat interface only allows images. I could not confirm that is enforced server-side — the attachments upload route is not in claw-auth, it posts through to Spaces. If that restriction is client-side only, arbitrary file types are already storable, which is a real code fix and worth checking before the AV work.

## Assessed and not fixed

**PY-JP-002 (data exfiltration) and PY-JP-005 (cloud metadata in responses)** — accepted as business justified. Neither is a missing check: `doctor-agent` legitimately holds shell and archive capability, and `infra-doctor`'s discovery tools legitimately return infrastructure detail. Worth recording that the justification rests on those agents being restricted to trusted users, since that is the control doing the work. Note 002 is the residue of PY-JP-001 — that fix stopped arbitrary agents *mounting* shell tools, it did not remove the capability from agents designed to hold it.

**PY-JP-007 (CSR injection) and PY-JP-008 (device revocation)** — not applicable; the device-enrolment code has been removed. There are no device routes in this repository.

**PY-JP-013 (weak TLS ciphers, TLS 1.1)** — open. The Spaces domain is behind mTLS, which constrains who can reach it, but the cipher suites and protocol versions still need tightening at the load balancer. Not application code.

## Verification

Backend typecheck unchanged at **68 pre-existing errors** before and after. gitleaks clean.

Not covered by tests — `agent-chat.ts` has no test file, and the debug-frame gating in particular is worth exercising by hand: start a run as a non-elevated user and confirm no `debug` SSE frame arrives, then repeat as an agent owner and confirm it does.

