### PR TITLE
feat: SDLC resource access backfill endpoint

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -92,6 +92,7 @@ import projectRoutes from '@/routes/projects';
 import ticketReportRoutes from '@/routes/ticketReports';
 import boardRoutes from '@/routes/boards';
 import boardConfigCopyRoutes from '@/routes/boardConfigCopy';
+import { sdlcAccessBackfillRouter } from '@/controllers/sdlcAccessBackfillController';
 import searchMetricsRoutes from '@/routes/searchMetrics';
 import knowledgeRoutes from '@/routes/knowledge';
 import vespaSearchRoutes from '@/routes/vespaSearch';
@@ -607,6 +608,7 @@ export class App {
 
     // Project routes (auth and ACL required)
     this.app.use('/api/projects', authMiddleware.authenticate, projectRoutes);
+    this.app.use('/api/sdlc-backfill', sdlcAccessBackfillRouter);
     this.app.use('/api/sdlc/claw', authenticateUserOrApp, sdlcClawRoutes);
     this.app.use('/api/sdlc', authMiddleware.authenticate, sdlcRoutes);
 

--- a/apps/backend/src/controllers/sdlcAccessBackfillController.ts
+++ b/apps/backend/src/controllers/sdlcAccessBackfillController.ts
@@ -8,7 +8,7 @@ import { authorize } from '@/middleware/authorize';
 const TAG = '[SdlcAccessBackfill]';
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-const BATCH_DELAY_MS = 60_000;
+const BATCH_DELAY_MS = 10_000;
 
 const DEFAULT_RESOURCE_NAME = 'SDLC';
 const DEFAULT_ACCESS_TYPE = 'WRITE';

--- a/apps/backend/src/controllers/sdlcAccessBackfillController.ts
+++ b/apps/backend/src/controllers/sdlcAccessBackfillController.ts
@@ -1,0 +1,170 @@
+import { Request, Response, Router } from 'express';
+import { AccessType } from '@xyne/shared';
+import { db } from '@/database/client';
+import { logger } from '@/utils/logger';
+import { authMiddleware } from '@/middleware/auth';
+import { authorize } from '@/middleware/authorize';
+
+const TAG = '[SdlcAccessBackfill]';
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const BATCH_DELAY_MS = 60_000;
+
+const DEFAULT_RESOURCE_NAME = 'SDLC';
+const DEFAULT_ACCESS_TYPE = 'WRITE';
+const DEFAULT_BATCH_SIZE = 10;
+const MAX_BATCH_SIZE = 200;
+
+interface BackfillBody {
+  workspaceId?: unknown;
+  resourceName?: unknown;
+  accessType?: unknown;
+  batchSize?: unknown;
+  dryRun?: unknown;
+}
+
+interface BackfillParams {
+  workspaceId: string;
+  resourceName: string;
+  accessType: string;
+  batchSize: number;
+  dryRun: boolean;
+}
+
+function parseBody(body: BackfillBody): BackfillParams {
+  const workspaceId = typeof body.workspaceId === 'string' ? body.workspaceId.trim() : '';
+  if (!workspaceId) throw new Error('workspaceId is required');
+  const resourceName =
+    typeof body.resourceName === 'string' && body.resourceName.trim()
+      ? body.resourceName.trim()
+      : DEFAULT_RESOURCE_NAME;
+  const accessType =
+    typeof body.accessType === 'string' && body.accessType.trim()
+      ? body.accessType.trim().toUpperCase()
+      : DEFAULT_ACCESS_TYPE;
+  if (!['READ', 'WRITE', 'ADMIN'].includes(accessType)) {
+    throw new Error('accessType must be READ, WRITE, or ADMIN');
+  }
+  const batchSize = body.batchSize === undefined ? DEFAULT_BATCH_SIZE : Number(body.batchSize);
+  if (!Number.isInteger(batchSize) || batchSize < 1 || batchSize > MAX_BATCH_SIZE) {
+    throw new Error(`batchSize must be an integer between 1 and ${MAX_BATCH_SIZE}`);
+  }
+  return { workspaceId, resourceName, accessType, batchSize, dryRun: body.dryRun !== false };
+}
+
+async function runBackfill(params: BackfillParams, resourceId: string): Promise<void> {
+  let cursor: string | undefined;
+  let scanned = 0;
+  let granted = 0;
+  let skipped = 0;
+  let batches = 0;
+
+  for (;;) {
+    const users = await db.user.findMany({
+      where: { workspaceId: params.workspaceId, userType: 'USER', status: 'ACTIVE' },
+      select: { id: true },
+      orderBy: { id: 'asc' },
+      take: params.batchSize,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    });
+    if (users.length === 0) break;
+    batches += 1;
+    scanned += users.length;
+    cursor = users[users.length - 1]!.id;
+
+    const userIds = users.map((user) => user.id);
+    const existing = await db.resourceAccess.findMany({
+      where: { resourceId, userId: { in: userIds } },
+      select: { userId: true },
+    });
+    const existingIds = new Set(existing.map((row) => row.userId));
+    const missingIds = userIds.filter((id) => !existingIds.has(id));
+    skipped += userIds.length - missingIds.length;
+
+    if (missingIds.length > 0 && !params.dryRun) {
+      const result = await db.resourceAccess.createMany({
+        data: missingIds.map((userId) => ({
+          workspaceId: params.workspaceId,
+          userId,
+          resourceId,
+          accessType: params.accessType,
+        })),
+        skipDuplicates: true,
+      });
+      granted += result.count;
+    } else {
+      granted += missingIds.length;
+    }
+
+    logger.info(`${TAG} batch ${batches}: scanned=${users.length} granted=${missingIds.length} skipped=${userIds.length - missingIds.length}`);
+    if (users.length < params.batchSize) break;
+    await sleep(BATCH_DELAY_MS);
+  }
+
+  logger.info(
+    `${TAG} completed dryRun=${params.dryRun} resource=${params.resourceName} accessType=${params.accessType} batches=${batches} scanned=${scanned} granted=${granted} skipped=${skipped}`,
+  );
+}
+
+export class SdlcAccessBackfillController {
+  /**
+   * Kick off the backfill: grant the resource access to every ACTIVE user
+   * (userType USER) in the workspace that does not already have ANY access
+   * row for the resource. One resource_access row per user; users with an
+   * existing row (any accessType) are skipped. Batches of batchSize with a
+   * pause between them.
+   *
+   * Responds 202 immediately after validation; the backfill runs in the
+   * background — monitor progress and the final summary in the logs.
+   *
+   * SAFETY: dryRun defaults to true — a preview run (no rows created, logs
+   * report what WOULD be granted) unless the caller explicitly sends
+   * dryRun: false. Idempotent — safe to re-run.
+   */
+  static run = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const params = parseBody(req.body as BackfillBody);
+      const resource = await db.resource.findUnique({ where: { name: params.resourceName } });
+      if (!resource) {
+        res.status(404).json({ success: false, error: `Resource '${params.resourceName}' not found` });
+        return;
+      }
+
+      logger.info(
+        `${TAG} started workspaceId=${params.workspaceId} resource=${params.resourceName} accessType=${params.accessType} batchSize=${params.batchSize} dryRun=${params.dryRun}`,
+      );
+      void runBackfill(params, resource.id).catch((error) => {
+        logger.error(`${TAG} failed`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+
+      res.status(202).json({
+        success: true,
+        message: 'Backfill started — monitor progress in logs',
+        resourceName: params.resourceName,
+        accessType: params.accessType,
+        batchSize: params.batchSize,
+        dryRun: params.dryRun,
+      });
+    } catch (error) {
+      res.status(400).json({ success: false, error: error instanceof Error ? error.message : String(error) });
+    }
+  };
+}
+
+/**
+ * POST /api/sdlc-backfill/run
+ *   Body: { workspaceId, batchSize? = 10, resourceName? = 'SDLC',
+ *           accessType? = 'WRITE', dryRun? = true }
+ *   dryRun defaults to true (preview); send dryRun: false to perform writes.
+ *   Responds 202 immediately; the backfill runs async — monitor in logs.
+ * Access: USER-MANAGEMENT Admin only.
+ */
+export const sdlcAccessBackfillRouter = Router();
+sdlcAccessBackfillRouter.post(
+  '/run',
+  authMiddleware.authenticate,
+  authorize('USER-MANAGEMENT', AccessType.ADMIN),
+  SdlcAccessBackfillController.run,
+);


### PR DESCRIPTION
Async backfill that grants SDLC WRITE resource_access to every ACTIVE user in a workspace that has no existing row for the resource. Batched with a 60s pause between batches; dryRun defaults to true (preview), dryRun: false performs writes. Responds 202 immediately; progress is logged under [SdlcAccessBackfill]. Mounted at /api/sdlc-backfill/run behind authenticate + USER-MANAGEMENT ADMIN.


Claude-Session: https://claude.ai/code/session_01Lrm9YdnRGVYBZijLjim4Js

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
