### PR TITLE
fix: XYNE-55539 UI feedback

### DIFF
--- a/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
+++ b/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
@@ -3,6 +3,7 @@ import { useSelector } from '@xstate/react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ArrowLeft, ArrowRight, SearchBig } from '@xyne/icons';
 import { invokeShortcut } from '../../shortcuts';
+import { ShortcutTooltip } from '../ui/ShortcutTooltip';
 import { cn } from '../../utils/classNames';
 import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../utils/electronApp';
 import { roomActor } from '../../machines/roomMachine';
@@ -69,40 +70,46 @@ const AppNavigator = (): ReactElement => {
       style={APP_DRAG_STYLE}
     >
       <div className='flex items-center' style={APP_NO_DRAG_STYLE}>
-        <button
-          type='button'
-          aria-label='Back'
-          onClick={handleGoBack}
-          disabled={!canGoBack}
-          className={canGoBack ? buttonClass : disabledButtonClass}
-          data-track-category='APP_NAVIGATOR'
-          data-track-name='GO_BACK'
-        >
-          <ArrowLeft size={16} />
-        </button>
-        <button
-          type='button'
-          aria-label='Forward'
-          onClick={handleGoForward}
-          disabled={!canGoForward}
-          className={canGoForward ? buttonClass : disabledButtonClass}
-          data-track-category='APP_NAVIGATOR'
-          data-track-name='GO_FORWARD'
-        >
-          <ArrowRight size={16} />
-        </button>
+        <ShortcutTooltip label='Back' shortcut='global.goBack' side='bottom'>
+          <button
+            type='button'
+            aria-label='Back'
+            onClick={handleGoBack}
+            disabled={!canGoBack}
+            className={canGoBack ? buttonClass : disabledButtonClass}
+            data-track-category='APP_NAVIGATOR'
+            data-track-name='GO_BACK'
+          >
+            <ArrowLeft size={16} />
+          </button>
+        </ShortcutTooltip>
+        <ShortcutTooltip label='Forward' shortcut='global.goForward' side='bottom'>
+          <button
+            type='button'
+            aria-label='Forward'
+            onClick={handleGoForward}
+            disabled={!canGoForward}
+            className={canGoForward ? buttonClass : disabledButtonClass}
+            data-track-category='APP_NAVIGATOR'
+            data-track-name='GO_FORWARD'
+          >
+            <ArrowRight size={16} />
+          </button>
+        </ShortcutTooltip>
       </div>
       <div className='flex items-center' style={APP_NO_DRAG_STYLE}>
-        <button
-          type='button'
-          aria-label='Search'
-          onClick={() => invokeShortcut('mod+k')}
-          className={buttonClass}
-          data-track-category='APP_NAVIGATOR'
-          data-track-name='OPEN_SEARCH'
-        >
-          <SearchBig size={16} />
-        </button>
+        <ShortcutTooltip label='Search' shortcut='global.search' side='bottom'>
+          <button
+            type='button'
+            aria-label='Search'
+            onClick={() => invokeShortcut('mod+k')}
+            className={buttonClass}
+            data-track-category='APP_NAVIGATOR'
+            data-track-name='OPEN_SEARCH'
+          >
+            <SearchBig size={16} />
+          </button>
+        </ShortcutTooltip>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
+++ b/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
@@ -52,6 +52,7 @@ import {
   DropdownMenuTrigger,
 } from '../../ui/dropdown-menu';
 import Tooltip from '../../ui/Tooltip';
+import { ShortcutHint } from '../../ui/ShortcutHint';
 import { XyneTelepresenceIcon } from '../../../assets/icons/XyneTelepresenceIcon';
 
 interface ActiveCallForControls {
@@ -161,8 +162,7 @@ export function CallControls({
   const [showMicMenu, setShowMicMenu] = useState(false);
   const [showReactionPicker, setShowReactionPicker] = useState(false);
   const reactionPickerRef = useRef<HTMLDivElement>(null);
-  const { isMobile, isMac } = usePlatform();
-  const modKey = isMac ? '⌘' : 'Ctrl';
+  const { isMobile } = usePlatform();
 
   const micMenuRef = useRef<HTMLDivElement>(null);
   const cameraMenuRef = useRef<HTMLDivElement>(null);
@@ -201,13 +201,13 @@ export function CallControls({
   const micTooltip = audioTurnedOffByHost
     ? "The host turned off everyone's audio"
     : isMicEnabled
-      ? `Mute microphone (${modKey}D)`
-      : `Unmute microphone (${modKey}D, or press spacebar to speak)`;
+      ? 'Mute microphone'
+      : 'Unmute microphone (or press spacebar to speak)';
   const cameraTooltip = cameraTurnedOffByHost
     ? "The host turned off everyone's camera"
     : isCameraEnabled
-      ? `Turn off camera (${modKey}E)`
-      : `Turn on camera (${modKey}E)`;
+      ? 'Turn off camera'
+      : 'Turn on camera';
   const screenShareTooltip = screenShareBlockedByWhiteboard
     ? 'Close the shared whiteboard to start screen sharing.'
     : screenShareTurnedOffByHost
@@ -421,7 +421,15 @@ export function CallControls({
         <div className='relative' ref={micMenuRef}>
           <div className={cn('flex items-center gap-0.5 rounded-full', midnightControlGroupClass)}>
             <Tooltip
-              content={micTooltip}
+              content={
+                audioTurnedOffByHost ? (
+                  micTooltip
+                ) : (
+                  <span>
+                    {micTooltip} <ShortcutHint shortcut='huddle.toggleMute' />
+                  </span>
+                )
+              }
               side='top'
               sideOffset={8}
               collisionPadding={8}
@@ -532,7 +540,15 @@ export function CallControls({
         <div className='relative' ref={cameraMenuRef}>
           <div className={cn('flex items-center gap-0.5 rounded-full', midnightControlGroupClass)}>
             <Tooltip
-              content={cameraTooltip}
+              content={
+                cameraTurnedOffByHost ? (
+                  cameraTooltip
+                ) : (
+                  <span>
+                    {cameraTooltip} <ShortcutHint shortcut='huddle.toggleVideo' />
+                  </span>
+                )
+              }
               side='top'
               sideOffset={8}
               collisionPadding={8}

--- a/apps/dashboard/src/components/Call/CallTrigger/CallTrigger.tsx
+++ b/apps/dashboard/src/components/Call/CallTrigger/CallTrigger.tsx
@@ -4,6 +4,7 @@ import { PhoneDefault, PhoneCancel } from '@xyne/icons';
 import { useCallActions } from '../../../hooks/useCallActions';
 import { cn } from '../../../utils/classNames';
 import Tooltip from '../../ui/Tooltip';
+import { ShortcutHint } from '../../ui/ShortcutHint';
 import { ChannelScopeType } from '@xyne/shared';
 import { CallConfirmationModal } from '../CallConfirmationModal';
 import { useCallConfirmation } from '../../../hooks/useCallConfirmation';
@@ -106,7 +107,19 @@ export const CallTrigger: React.FC<CallTriggerProps> = ({
   // Default Button trigger
   return (
     <>
-      <Tooltip content={tooltipContent} side='left'>
+      <Tooltip
+        content={
+          isAlone || isNotMember ? (
+            tooltipContent
+          ) : (
+            <span className='flex items-center gap-2'>
+              {tooltipContent}
+              <ShortcutHint shortcut='huddle.toggle' />
+            </span>
+          )
+        }
+        side='left'
+      >
         <button
           onClick={handleButtonClick}
           disabled={isAlone || isNotMember}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -92,6 +92,7 @@ import SectionSettingsMenu, { MENU_ROW } from './SectionSettingsMenu';
 import SortableChannelItem from './SortableChannelItem';
 import ChannelItemV2 from './ChannelItemV2';
 import Tooltip from '../../ui/Tooltip';
+import { ShortcutHint } from '../../ui/ShortcutHint';
 import ChannelCommandMenu from './ChannelCommandMenu';
 import AppNavigator from '../../AppNavigator/AppNavigator';
 import { useThreadSidebarState } from '../../../hooks/useUnreadThreadsCount';
@@ -673,6 +674,7 @@ const ChatDirectory = ({
                 <ChatPlus className='size-4' />
               </span>
               <span className='flex-1 min-w-0 text-left truncate block'>New Message</span>
+              <ShortcutHint shortcut='global.composeMessage' />
             </button>
             <button
               className={cn(
@@ -692,6 +694,7 @@ const ChatDirectory = ({
                 <Subtask className='size-4' />
               </span>
               <span className='flex-1 min-w-0 text-left truncate block'>Threads</span>
+              <ShortcutHint shortcut='global.openThreads' />
               {threadCount > 0 && (
                 <span className='size-5 flex items-center justify-center shrink-0'>
                   <Badge

--- a/apps/dashboard/src/components/Chat/ChatInput/AgentProgressIndicator.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/AgentProgressIndicator.tsx
@@ -76,7 +76,7 @@ export function AgentProgressIndicator({
   if (agents.length === 0) return null;
 
   return (
-    <div className='mb-2 flex items-center gap-2 h-5 bg-background'>
+    <div className='flex w-full items-center gap-2 h-5 bg-background'>
       <div className='flex flex-wrap gap-3 text-[11px] text-muted-foreground flex-1 min-w-0'>
         {agents.map(a => (
           <span key={a.agentUserId ?? a.agentSlug ?? 'agent'} style={rowStyle}>

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -1100,10 +1100,6 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
           </div>
         ) : (
           <>
-            <AgentProgressIndicator
-              sessionId={agentProgressConversationId ?? currentSessionId}
-              conversationId={agentProgressConversationId}
-            />
             {showOfflineBanner && (
               <div className='px-3 py-1.5 bg-amber-50 dark:bg-amber-950/50 border border-amber-200 dark:border-amber-800 rounded text-xs text-amber-700 dark:text-amber-300 flex items-center justify-between mx-3 mb-1'>
                 <div className='flex items-center gap-1.5'>

--- a/apps/dashboard/src/components/Chat/ConversationHeader/ConversationHeader.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationHeader/ConversationHeader.tsx
@@ -25,6 +25,7 @@ import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
 import Dialog from '../../ui/Dialog';
 import * as Tabs from '@radix-ui/react-tabs';
 import { cn } from '../../../utils/classNames';
+import { ShortcutTooltip } from '../../ui/ShortcutTooltip';
 import { mutators } from '../../../zero/mutators';
 import Tooltip from '../../ui/Tooltip';
 import Info, { ChannelTab } from '../Info/Info';
@@ -381,7 +382,7 @@ const ConversationHeader = ({
             </Button>
           </Tooltip>
           {!isCompact && (
-            <Tooltip content='Search in this channel'>
+            <ShortcutTooltip label='Search in this channel' shortcut='global.findInChannel'>
               <Button
                 variant='ghost'
                 size='sm'
@@ -393,7 +394,7 @@ const ConversationHeader = ({
               >
                 <SearchDefault size={16} />
               </Button>
-            </Tooltip>
+            </ShortcutTooltip>
           )}
           {isCompact && (
             <CompactActionsMenu
@@ -513,28 +514,43 @@ const ConversationHeader = ({
           className='flex items-center justify-start gap-0.5 px-0.5 overflow-x-auto no-scrollbar'
           style={APP_NO_DRAG_STYLE}
         >
-          {channelTabs?.map(tab => (
-            <Tabs.Trigger key={tab.value} value={tab.value} asChild>
-              <button
-                data-testid={`channel-tab-${tab.value}`}
-                data-track-category='CHANNELS'
-                data-track-name='SWITCH_TAB'
-                data-track-metadata={JSON.stringify({ tabValue: tab.value })}
-                onClick={e => setActiveTab?.(tab.value || '', e)}
-                className={cn(
-                  'flex items-center justify-center gap-2 px-2.5 py-1.5 rounded-lg transition-colors duration-100 cursor-pointer',
-                  activeTab === tab.value
-                    ? 'bg-muted text-foreground'
-                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
-                )}
+          {channelTabs?.map(tab => {
+            const trigger = (
+              <Tabs.Trigger key={tab.value} value={tab.value} asChild>
+                <button
+                  data-testid={`channel-tab-${tab.value}`}
+                  data-track-category='CHANNELS'
+                  data-track-name='SWITCH_TAB'
+                  data-track-metadata={JSON.stringify({ tabValue: tab.value })}
+                  onClick={e => setActiveTab?.(tab.value || '', e)}
+                  className={cn(
+                    'flex items-center justify-center gap-2 px-2.5 py-1.5 rounded-lg transition-colors duration-100 cursor-pointer',
+                    activeTab === tab.value
+                      ? 'bg-muted text-foreground'
+                      : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                  )}
+                >
+                  <span className='shrink-0'>
+                    {cloneElement(tab.icon, { color: 'currentColor' } as { color: string })}
+                  </span>
+                  <span className={cn('text-sm font-medium tracking-[-0.28px]')}>{tab.label}</span>
+                </button>
+              </Tabs.Trigger>
+            );
+
+            if (tab.value !== 'canvas') return trigger;
+
+            return (
+              <ShortcutTooltip
+                key={tab.value}
+                label={tab.label}
+                shortcut='global.openCanvasTab'
+                side='bottom'
               >
-                <span className='shrink-0'>
-                  {cloneElement(tab.icon, { color: 'currentColor' } as { color: string })}
-                </span>
-                <span className={cn('text-sm font-medium tracking-[-0.28px]')}>{tab.label}</span>
-              </button>
-            </Tabs.Trigger>
-          ))}
+                {trigger}
+              </ShortcutTooltip>
+            );
+          })}
         </Tabs.List>
       </Tabs.Root>
 

--- a/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
@@ -266,120 +266,110 @@ export const DmListItem = ({
     );
   }
 
+  const isUnread = unreadCount > 0;
+
   return (
-    <div className='w-full border-b border-border last:border-0 mt-0'>
-      <div
-        key={`dm-${channel.id}`}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        className={cn(
-          'flex w-full items-center gap-[12px] px-4 py-3 cursor-pointer transition-colors',
-          'hover:bg-accent active:bg-accent',
-          isSelected && 'bg-input hover:bg-input active:bg-input',
+    <div
+      key={`dm-${channel.id}`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'group flex w-full font-normal items-center gap-3 px-3 py-2 text-left cursor-pointer transition-colors duration-150 h-auto rounded-[14px] border border-transparent',
+        isUnread ? 'bg-activity-sidebar-primary' : 'bg-transparent',
+        'hover:bg-sidebar-accent',
+        isSelected && 'bg-sidebar-accent border-sidebar-border',
+      )}
+      role='button'
+      tabIndex={0}
+      aria-label={`Open conversation with ${displayName}`}
+      data-track-category='DM'
+      data-track-name='OPEN_DM_CONVERSATION'
+      data-track-metadata={JSON.stringify({ channelId: channel.id, channelName: channel.name })}
+    >
+      <div className='relative flex-shrink-0'>
+        {isGroupDMChannel(channel.scopeType) ? (
+          <AvatarGroup userIds={otherParticipantIds} size='sm' isGroupDMAvatar className='size-9' />
+        ) : (
+          <Avatar
+            userId={avatarUserId}
+            size='rg'
+            className='size-9 rounded-[9px]'
+            showActiveStatus={channel.scopeType === ChannelScopeType.DM}
+          />
         )}
-        role='button'
-        tabIndex={0}
-        aria-label={`Open conversation with ${displayName}`}
-        data-track-category='DM'
-        data-track-name='OPEN_DM_CONVERSATION'
-        data-track-metadata={JSON.stringify({ channelId: channel.id, channelName: channel.name })}
-      >
-        {/* Avatar */}
-        <div className='relative shrink-0 size-10 rounded-[8px] overflow-visible'>
-          {isGroupDMChannel(channel.scopeType) ? (
-            <AvatarGroup userIds={otherParticipantIds} size='md' isGroupDMAvatar />
-          ) : (
-            <Avatar
-              userId={avatarUserId}
-              size='lg'
-              className='size-full rounded-[8px]'
-              showActiveStatus={channel.scopeType === ChannelScopeType.DM}
-            />
-          )}
+      </div>
+
+      <div className='flex flex-1 flex-col min-w-0 overflow-hidden'>
+        <div className='flex w-full items-start justify-between gap-2'>
+          <div
+            className={cn(
+              'flex items-center gap-1.5 min-w-0 flex-1 text-sm leading-snug',
+              isUnread ? 'text-foreground' : 'text-muted-foreground',
+            )}
+          >
+            <span className='font-semibold truncate min-w-0'>{displayName}</span>
+            {isDM && (
+              <StatusIndicator
+                statusEmoji={targetUser?.statusEmoji}
+                statusContent={targetUser?.statusContent}
+                statusExpiryAt={targetUser?.statusExpiryAt}
+                size='sm'
+                className='flex-shrink-0 text-[14px]'
+              />
+            )}
+          </div>
+
+          <span className='flex-shrink-0 flex items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground ml-auto sm:ml-2'>
+            {lastMessage ? formatTime(lastMessage.createdAt) : null}
+          </span>
         </div>
 
-        {/* Content Container */}
-        <div className='flex flex-1 flex-col justify-center min-w-0 gap-[4px]'>
-          {/* Top Row: Name and Time */}
-          <div className='flex items-center justify-between gap-[4px] w-full'>
-            <div className='flex items-center gap-1.5 min-w-0 flex-1'>
-              <h4 className="font-['Inter'] font-semibold text-[16px] text-foreground tracking-[-0.32px] truncate leading-[1.2]">
-                {displayName}
-              </h4>
-              {isDM && (
-                <StatusIndicator
-                  statusEmoji={targetUser?.statusEmoji}
-                  statusContent={targetUser?.statusContent}
-                  statusExpiryAt={targetUser?.statusExpiryAt}
-                  size='sm'
-                  className='text-[14px]'
-                />
-              )}
-            </div>
-            {lastMessage && (
-              <span
-                className={cn(
-                  "shrink-0 font-['Inter'] font-normal text-[12px] text-muted-foreground tracking-[-0.24px] leading-[1.2]",
-                  unreadCount > 0 && !isSelected && 'text-primary',
-                )}
-              >
-                {formatTime(lastMessage.createdAt)}
-              </span>
+        <div className='mt-px flex w-full items-center gap-2'>
+          <div
+            onClick={e => {
+              if ((e.target as HTMLElement).tagName === 'A') {
+                e.stopPropagation();
+              }
+            }}
+            onKeyDown={e => {
+              if (
+                (e.key === 'Enter' || e.key === ' ') &&
+                (e.target as HTMLElement).tagName === 'A'
+              ) {
+                e.stopPropagation();
+              }
+            }}
+            role='presentation'
+            data-track-category='DM_LIST'
+            data-track-name='PREVIEW_LINK_CONTAINER'
+            className={cn(
+              'w-full text-sm line-clamp-1 truncate break-normal whitespace-normal',
+              isUnread ? 'text-foreground' : 'text-muted-foreground',
+              // Make RenderMessageWithHTML output inline and preserve link styles
+              '[&_.message-html-root]:inline',
+              '[&_.message-html-root_*]:inline',
+              '[&_.message-html-root_pre]:!inline [&_.message-html-root_pre]:!whitespace-nowrap',
+              '[&_.message-html-root_br]:hidden',
+              '[&_.message-html-root_a]:!text-[var(--link-color)]',
+              '[&_.message-html-root_a]:!no-underline',
+              '[&_.message-html-root_a:hover]:!underline',
+              '[&_.message-html-root_a:hover]:!text-[var(--link-hover-color)]',
+              // Hide internal link semantic labels (icons, borders, etc.) in preview
+              '[&_.message-html-root_span.group\\/internal-link]:contents',
+              '[&_.message-html-root_.group\\/internal-link_a]:!border-0',
+              '[&_.message-html-root_.group\\/internal-link_a]:!bg-transparent',
+              '[&_.message-html-root_.group\\/internal-link_a]:!p-0',
+              '[&_.message-html-root_.group\\/internal-link_a_.shrink-0]:!hidden',
+              '[&_.message-html-root_.group\\/internal-link_button]:!hidden',
             )}
+          >
+            {renderMessagePreview()}
           </div>
-
-          {/* Bottom Row: Message and Badge */}
-          <div className='flex items-start justify-between gap-[4px] w-full'>
-            <p
-              onClick={e => {
-                // Prevent DM navigation when clicking links in preview
-                if ((e.target as HTMLElement).tagName === 'A') {
-                  e.stopPropagation();
-                }
-              }}
-              onKeyDown={e => {
-                // Prevent DM navigation when activating links via keyboard
-                if (
-                  (e.key === 'Enter' || e.key === ' ') &&
-                  (e.target as HTMLElement).tagName === 'A'
-                ) {
-                  e.stopPropagation();
-                }
-              }}
-              role='presentation'
-              data-track-category='DM_LIST'
-              data-track-name='PREVIEW_LINK_CONTAINER'
-              className={cn(
-                "font-['Inter'] font-normal text-[14px] text-muted-foreground tracking-[-0.28px] leading-[1.35] truncate flex-1",
-                unreadCount > 0 && !isSelected && 'text-foreground font-medium',
-                // Make RenderMessageWithHTML output inline and preserve link styles
-                '[&_.message-html-root]:inline',
-                '[&_.message-html-root_*]:inline',
-                '[&_.message-html-root_pre]:!inline [&_.message-html-root_pre]:!whitespace-nowrap',
-                '[&_.message-html-root_br]:hidden',
-                '[&_.message-html-root_a]:!text-[var(--link-color)]',
-                '[&_.message-html-root_a]:!no-underline',
-                '[&_.message-html-root_a:hover]:!underline',
-                '[&_.message-html-root_a:hover]:!text-[var(--link-hover-color)]',
-                // Hide internal link semantic labels (icons, borders, etc.) in preview
-                '[&_.message-html-root_span.group\\/internal-link]:contents',
-                '[&_.message-html-root_.group\\/internal-link_a]:!border-0',
-                '[&_.message-html-root_.group\\/internal-link_a]:!bg-transparent',
-                '[&_.message-html-root_.group\\/internal-link_a]:!p-0',
-                '[&_.message-html-root_.group\\/internal-link_a_.shrink-0]:!hidden',
-                '[&_.message-html-root_.group\\/internal-link_button]:!hidden',
-              )}
-            >
-              {renderMessagePreview()}
-            </p>
-            {unreadCount > 0 && !isSelected && (
-              <div className='shrink-0 bg-primary flex flex-col items-center justify-center px-[6px] py-px rounded-[999px] h-[18px] min-w-[18px]'>
-                <span className="font-['Geist_Mono'] text-[14px] font-semibold leading-[1.2] text-primary-foreground">
-                  {unreadCount > 9 ? '9+' : unreadCount}
-                </span>
-              </div>
-            )}
-          </div>
+          {isUnread && (
+            <span className='shrink-0 rounded-md bg-sidebar-primary px-1 text-[0.625rem] font-bold tabular-nums text-sidebar-primary-foreground'>
+              {unreadCount > 9 ? '9+' : unreadCount}
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
@@ -1,6 +1,14 @@
-import { ReactElement, useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import {
+  ComponentType,
+  ReactElement,
+  useState,
+  useRef,
+  useCallback,
+  useEffect,
+  useMemo,
+} from 'react';
 import { Search, PenBox, X } from 'lucide-react';
-import { QuestionMarkCircle } from '@xyne/icons';
+import { QuestionMarkCircle, EnvelopeDefault, Star, UserTwo, PencilEditBox } from '@xyne/icons';
 import { useAllUnreadCount } from '../../../hooks/useUnreadCount';
 import { DmListItem } from './DmListItem';
 import { useNavigate, Outlet, useParams } from 'react-router-dom';
@@ -38,6 +46,9 @@ import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { Channel, ChannelScopeType } from '@xyne/shared';
 import { StatusIndicator } from '../../ui/StatusIndicator';
 import { FilterPills, type FilterPillOption } from '../../ui/FilterPills';
+import * as Tabs from '@radix-ui/react-tabs';
+import { cn } from '../../../utils/classNames';
+import { ShortcutTooltip } from '../../ui/ShortcutTooltip';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 
 // Simple component for DM search results (no message preview)
@@ -104,12 +115,17 @@ const DmUserSearchResultItem = ({
 };
 
 // Hardcoded item heights derived from CSS (avoids DOM measurement via ref)
-// Desktop: py-3 (24px) + size-[48px] avatar + 1px border-bottom = 73px
+// Desktop: py-2 (16px) + 19px title + 1px + 20px preview + 2px border
+//          = 58px row, + 12px pb-3 wrapper gap = 70px
 // Mobile: 47px DmListItem + 16px pt-4 wrapper padding = 63px
-const DESKTOP_ITEM_HEIGHT = 75;
+const DESKTOP_ITEM_HEIGHT = 70;
 const MOBILE_ITEM_HEIGHT = 65;
 
 type DmFilterTab = 'all' | 'unread' | 'groups' | 'favorites';
+
+type DmFilterTabConfig = FilterPillOption<DmFilterTab> & {
+  Icon?: ComponentType<{ className?: string }>;
+};
 
 const getDmFilterEmptyCopy = (activeTab: DmFilterTab): { title: string; description: string } => {
   if (activeTab === 'unread') {
@@ -212,12 +228,12 @@ const DmsPage = (): ReactElement => {
     return directMessages;
   }, [activeTab, directMessages, visibleDmChannels, statusByChannelId, unreadCounts]);
 
-  const dmFilterTabs = useMemo<FilterPillOption<DmFilterTab>[]>(
+  const dmFilterTabs = useMemo<DmFilterTabConfig[]>(
     () => [
       { value: 'all', label: 'All' },
-      { value: 'unread', label: 'Unread', count: unreadDmCount },
-      { value: 'favorites', label: 'Favorites' },
-      { value: 'groups', label: 'Groups' },
+      { value: 'unread', label: 'Unread', count: unreadDmCount, Icon: EnvelopeDefault },
+      { value: 'favorites', label: 'Favourites', Icon: Star },
+      { value: 'groups', label: 'Groups', Icon: UserTwo },
     ],
     [unreadDmCount],
   );
@@ -350,7 +366,7 @@ const DmsPage = (): ReactElement => {
   const renderDmItem = useCallback(
     (_index: number, channel: Channel) => {
       return (
-        <div>
+        <div className='px-3 pb-2'>
           <DmListItem
             key={channel.id}
             channel={channel}
@@ -661,128 +677,200 @@ const DmsPage = (): ReactElement => {
             <div className='w-full h-[52px] shrink-0'>
               <AppNavigator />
             </div>
-            {/* Desktop search/header */}
-            <div className='p-4 border-t border-border'>
-              <div className='flex items-center justify-between mb-3'>
+            <div className='relative flex-1 min-h-0 flex flex-col gap-2 max-w-full overflow-hidden pt-3 border-t border-sidebar-border-muted'>
+              {/* Header: title + actions */}
+              <div className='flex items-center justify-between gap-2 px-3'>
                 <div className='flex items-center gap-2'>
-                  <h2
-                    className='text-base font-semibold leading-normal text-sidebar-accent-foreground'
-                    data-testid='dms-heading'
-                  >
+                  <h2 className='font-bold text-foreground truncate' data-testid='dms-heading'>
                     Direct Messages
                   </h2>
+                </div>
+                <div className='flex items-center gap-1'>
                   <button
                     onClick={() => startWalkthrough(true)}
-                    className='p-1 rounded-full text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors'
+                    className='p-2 flex items-center justify-center rounded-lg border border-transparent transition-colors text-muted-foreground hover:text-foreground hover:bg-accent hover:border-border'
                     aria-label='Replay Tour'
                     title='Replay Tour'
                     data-track-category='DM'
                     data-track-name='REPLAY_TOUR_DESKTOP'
                   >
-                    <QuestionMarkCircle size={18} />
+                    <QuestionMarkCircle size={16} />
                   </button>
-                </div>
-                <button
-                  id='dm-create-btn'
-                  className='size-8 flex items-center justify-center rounded-[10px] text-sidebar-secondary-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-item-hover transition-colors'
-                  onClick={handleAddDirectMessage}
-                  aria-label='Create new message'
-                  data-testid='create-new-message-btn'
-                  data-track-category='DM'
-                  data-track-name='CREATE_DM_DESKTOP'
-                >
-                  <PenBox className='size-4' />
-                </button>
-              </div>
-              <div className='relative dm-search-container'>
-                <Search className='absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground' />
-                <input
-                  id='dm-search-input'
-                  ref={dmSearchInputRef}
-                  type='text'
-                  autoFocus
-                  className='w-full pl-9 pr-8 py-2 bg-muted rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-ring'
-                  placeholder='Search DMs (Cmd+K)'
-                  value={dmSearchQuery}
-                  onChange={e => {
-                    setDmSearchQuery(e.target.value);
-                    setShowDmSearchDropdown(true);
-                  }}
-                  onFocus={() => setShowDmSearchDropdown(true)}
-                  onKeyDown={e =>
-                    handleDmSearchKeyDown(e, id => void handleDmSelect(id), handleUserSelect)
-                  }
-                  data-testid='search-messages-input'
-                  data-track-event='blur'
-                  data-track-category='DM'
-                  data-track-name='SEARCH_DMS_INPUT_DESKTOP'
-                />
-                {dmSearchQuery && (
-                  <Button
-                    className='absolute right-1 top-1/2 -translate-y-1/2 flex items-center'
-                    onClick={() => {
-                      setDmSearchQuery('');
-                      setShowDmSearchDropdown(false);
-                    }}
-                    data-track-category='DM'
-                    data-track-name='CLEAR_DM_SEARCH'
-                    aria-label='Clear search'
-                    variant='link'
-                    size='icon'
+                  <ShortcutTooltip
+                    label='New message'
+                    shortcut='global.composeMessage'
+                    side='bottom'
                   >
-                    <X className='size-4 text-muted-foreground hover:text-foreground' />
-                  </Button>
-                )}
-                {renderSearchDropdown()}
+                    <button
+                      id='dm-create-btn'
+                      className='p-2 flex items-center justify-center rounded-lg border border-transparent transition-colors text-muted-foreground hover:text-foreground hover:bg-accent hover:border-border'
+                      onClick={handleAddDirectMessage}
+                      aria-label='Create new message'
+                      data-testid='create-new-message-btn'
+                      data-track-category='DM'
+                      data-track-name='CREATE_DM_DESKTOP'
+                    >
+                      <PencilEditBox size={16} />
+                    </button>
+                  </ShortcutTooltip>
+                </div>
               </div>
-              <FilterPills
-                tabs={dmFilterTabs}
-                activeTab={activeTab}
-                onTabChange={handleDmFilterChange}
-                ariaLabel='Filter direct messages'
-                className='mt-3'
-                testIdPrefix='dm-filter'
-              />
-            </div>
 
-            <div className='flex-1 w-full overflow-hidden'>
-              {filteredDirectMessages.length === 0 ? (
-                <div className='flex flex-col items-center justify-center h-full px-6'>
-                  {activeTab === 'all' && (
-                    <img
-                      src='/images/empty-chats.svg'
-                      alt='No conversations'
-                      className='w-full max-w-[280px] h-auto mb-6 opacity-90 theme-invert'
+              <div className='px-3'>
+                <div className='relative dm-search-container'>
+                  <Search className='absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground' />
+                  <input
+                    id='dm-search-input'
+                    ref={dmSearchInputRef}
+                    type='text'
+                    autoFocus
+                    className='w-full pl-9 pr-8 py-2 bg-muted rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-ring'
+                    placeholder='Search DMs (Cmd+K)'
+                    value={dmSearchQuery}
+                    onChange={e => {
+                      setDmSearchQuery(e.target.value);
+                      setShowDmSearchDropdown(true);
+                    }}
+                    onFocus={() => setShowDmSearchDropdown(true)}
+                    onKeyDown={e =>
+                      handleDmSearchKeyDown(e, id => void handleDmSelect(id), handleUserSelect)
+                    }
+                    data-testid='search-messages-input'
+                    data-track-event='blur'
+                    data-track-category='DM'
+                    data-track-name='SEARCH_DMS_INPUT_DESKTOP'
+                  />
+                  {dmSearchQuery && (
+                    <Button
+                      className='absolute right-1 top-1/2 -translate-y-1/2 flex items-center'
+                      onClick={() => {
+                        setDmSearchQuery('');
+                        setShowDmSearchDropdown(false);
+                      }}
+                      data-track-category='DM'
+                      data-track-name='CLEAR_DM_SEARCH'
+                      aria-label='Clear search'
+                      variant='link'
+                      size='icon'
+                    >
+                      <X className='size-4 text-muted-foreground hover:text-foreground' />
+                    </Button>
+                  )}
+                  {renderSearchDropdown()}
+                </div>
+              </div>
+
+              <Tabs.Root
+                value={activeTab}
+                onValueChange={value => handleDmFilterChange(value as DmFilterTab)}
+                className='flex flex-1 min-h-0 flex-col'
+              >
+                <div className='overflow-x-auto no-scrollbar'>
+                  <Tabs.List
+                    className='flex items-center sm:justify-start min-w-max gap-0.5 px-3'
+                    data-testid='dm-tabs-list'
+                  >
+                    {dmFilterTabs.map(tab => {
+                      const IconComponent = tab.Icon;
+                      const isActive = activeTab === tab.value;
+                      const count = tab.count ?? 0;
+
+                      return (
+                        <Tabs.Trigger key={tab.value} value={tab.value} asChild>
+                          <button
+                            aria-label={tab.label}
+                            data-testid={`dm-filter-${tab.value}`}
+                            data-track-category='DM'
+                            data-track-name='TAB_CHANGE'
+                            data-track-metadata={JSON.stringify({ tab: tab.value })}
+                            className={cn(
+                              'group px-2 py-2 flex items-center transition-all duration-300 ease-in-out cursor-pointer select-none sm:px-3 justify-start rounded-lg hover:bg-foreground/[6%] focus-visible:bg-foreground/[6%] focus-visible:outline-none',
+                              isActive ? 'bg-foreground/[6%]' : 'bg-transparent',
+                            )}
+                          >
+                            {IconComponent && (
+                              <span
+                                className={cn(
+                                  'size-4 flex items-center justify-center shrink-0',
+                                  isActive
+                                    ? 'text-sidebar-accent-foreground'
+                                    : 'text-muted-foreground',
+                                )}
+                              >
+                                <IconComponent className='w-4 h-4' />
+                              </span>
+                            )}
+                            <span
+                              className={cn(
+                                'whitespace-nowrap text-sm font-medium',
+                                isActive
+                                  ? 'text-sidebar-accent-foreground'
+                                  : 'text-muted-foreground',
+                                IconComponent ? 'ml-2' : null,
+                              )}
+                            >
+                              {tab.label}
+                            </span>
+                            {count > 0 && (
+                              <span
+                                className={cn(
+                                  'ml-1.5 shrink-0 text-[0.625rem] px-1 rounded-md font-bold tabular-nums transition-colors',
+                                  isActive
+                                    ? 'bg-sidebar-primary text-sidebar-primary-foreground'
+                                    : 'bg-foreground/[6%] text-muted-foreground',
+                                )}
+                              >
+                                {count > 99 ? '99+' : count}
+                              </span>
+                            )}
+                          </button>
+                        </Tabs.Trigger>
+                      );
+                    })}
+                  </Tabs.List>
+                </div>
+
+                <Tabs.Content
+                  value={activeTab}
+                  className='relative flex flex-1 min-h-0 flex-col mt-4 focus-visible:outline-none'
+                >
+                  {filteredDirectMessages.length === 0 ? (
+                    <div className='flex-1 flex flex-col items-center justify-center text-muted-foreground px-4 py-8'>
+                      {activeTab === 'all' && (
+                        <img
+                          src='/images/empty-chats.svg'
+                          alt='No conversations'
+                          className='w-full max-w-[280px] h-auto mb-4 opacity-90 theme-invert'
+                        />
+                      )}
+                      <p className='text-base font-medium'>{filterEmptyCopy.title}</p>
+                      <p className='text-sm mt-1 text-center max-w-[250px]'>
+                        {filterEmptyCopy.description}
+                      </p>
+                    </div>
+                  ) : (
+                    <Virtuoso
+                      key={activeTab}
+                      ref={virtuosoRef}
+                      data={filteredDirectMessages}
+                      firstItemIndex={activeTab === 'all' ? firstItemIndex : 0}
+                      computeItemKey={(_, channel) => channel.id}
+                      overscan={5}
+                      increaseViewportBy={{ top: threshold, bottom: threshold }}
+                      startReached={() => {
+                        if (activeTab === 'all') void jumpToChannel();
+                      }}
+                      endReached={() => {
+                        if (activeTab === 'all') loadMore();
+                      }}
+                      components={{ Footer: () => <div className='h-16' aria-hidden='true' /> }}
+                      itemContent={renderDmItem}
+                      className='h-full no-scrollbar'
+                      data-testid='dm-list'
                     />
                   )}
-                  <h3 className='text-lg font-medium text-foreground mb-2'>
-                    {filterEmptyCopy.title}
-                  </h3>
-                  <p className='text-sm text-muted-foreground text-center max-w-[250px]'>
-                    {filterEmptyCopy.description}
-                  </p>
-                </div>
-              ) : (
-                <Virtuoso
-                  key={activeTab}
-                  ref={virtuosoRef}
-                  data={filteredDirectMessages}
-                  firstItemIndex={activeTab === 'all' ? firstItemIndex : 0}
-                  computeItemKey={(_, channel) => channel.id}
-                  fixedItemHeight={itemHeight}
-                  overscan={5}
-                  increaseViewportBy={{ top: threshold, bottom: threshold }}
-                  startReached={() => {
-                    if (activeTab === 'all') void jumpToChannel();
-                  }}
-                  endReached={() => {
-                    if (activeTab === 'all') loadMore();
-                  }}
-                  itemContent={renderDmItem}
-                  className='h-full no-scrollbar'
-                  data-testid='dm-list'
-                />
-              )}
+                </Tabs.Content>
+              </Tabs.Root>
             </div>
           </div>
         </Panel>

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
@@ -29,6 +29,7 @@ import { useAuth } from '../../../hooks/useAuth';
 import { useCanCreateTicket } from '../../../hooks/usePermissions';
 import { parseReactionsMd } from '@xyne/shared';
 import { Tooltip } from '../../ui/Tooltip/Tooltip';
+import { ShortcutHint } from '../../ui/ShortcutHint';
 import Button from '../../ui/Button';
 import { useCustomEmojis } from '../../../hooks/useCustomEmojis';
 import { useTheme } from '../../../hooks/useTheme';
@@ -406,6 +407,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
                         <EditMessageIcon className='w-4 h-4' />
                       </span>
                       Edit
+                      <ShortcutHint shortcut='message.edit' className='ml-auto pl-6 text-xs' />
                     </DropdownMenuItem>
                   )}
 
@@ -471,6 +473,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
                         <Bookmark className='w-4 h-4' />
                       </span>
                       {isBookmarked ? 'Remove bookmark' : 'Add bookmark'}
+                      <ShortcutHint shortcut='message.bookmark' className='ml-auto pl-6 text-xs' />
                     </DropdownMenuItem>
                   )}
 
@@ -543,6 +546,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
                         {isPinned ? <UnpinIcon className='w-4 h-4' /> : <Pin className='w-4 h-4' />}
                       </span>
                       {isPinned ? 'Unpin message' : 'Pin message'}
+                      <ShortcutHint shortcut='message.pin' className='ml-auto pl-6 text-xs' />
                     </DropdownMenuItem>
                   )}
 
@@ -562,6 +566,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
                         <Link className='w-4 h-4' />
                       </span>
                       Copy link
+                      <ShortcutHint shortcut='message.copyLink' className='ml-auto pl-6 text-xs' />
                     </DropdownMenuItem>
                   )}
 
@@ -667,6 +672,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
                         <Trash2 className='w-4 h-4' />
                       </span>
                       Delete
+                      <ShortcutHint shortcut='message.delete' className='ml-auto pl-6 text-xs' />
                     </DropdownMenuItem>
                   )}
                 </>

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -61,6 +61,7 @@ import { FileBubble } from '../ui/FileBubble/FileBubble';
 import { MessageType, ChannelScopeType, BaseTicketType, parseTicketMd } from '@xyne/shared';
 import { RCAPanelView } from '../Tickets/RCAPanelView';
 import Tooltip from '../ui/Tooltip';
+import { ShortcutTooltip } from '../ui/ShortcutTooltip';
 import { mixpanelService } from '../../services/Analytics/mixpanelService';
 import { EVENTS, EVENT_PROPERTIES } from '../../services/Analytics/mixpanel.types';
 import { useScope } from '../../shortcuts';
@@ -1766,7 +1767,7 @@ export const ThreadMessages = ({
 
                   {/* Close Button */}
                   {(!simpleView || resolvedOnClose) && (
-                    <Tooltip content='Close'>
+                    <ShortcutTooltip label='Close' shortcut='global.toggleRightSidebar'>
                       <Button
                         variant='ghost'
                         size='sm'
@@ -1779,7 +1780,7 @@ export const ThreadMessages = ({
                       >
                         <MultipleCrossCancelDefault size={16} />
                       </Button>
-                    </Tooltip>
+                    </ShortcutTooltip>
                   )}
                 </div>
               </div>

--- a/apps/dashboard/src/components/FileViewer/ImageViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/ImageViewer.tsx
@@ -9,6 +9,8 @@ import { BaseViewerProps } from './utils';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useMobileZoom } from '../../hooks/useMobileZoom';
 import { useScope, useShortcutById } from '../../shortcuts';
+import { ShortcutTooltip } from '../ui/ShortcutTooltip';
+import { Tooltip } from '../ui/Tooltip';
 
 const ImageViewer: React.FC<BaseViewerProps> = ({
   source,
@@ -332,55 +334,82 @@ const ImageViewer: React.FC<BaseViewerProps> = ({
               isHovered ? 'opacity-100' : 'opacity-0'
             }`}
           >
-            <button
-              onClick={handleRotate}
-              className='inline-flex items-center justify-center w-9 h-9 text-white/90 hover:text-white hover:bg-background/10 rounded-md transition-colors'
-              title='Rotate (Ctrl R)'
-              data-track-category='FileViewer'
-              data-track-name='ROTATE_IMAGE'
-              data-track-metadata={JSON.stringify({ source, fileName })}
+            <ShortcutTooltip
+              label='Rotate'
+              shortcut='viewer.image.controls'
+              keys='mod+r'
+              side='top'
             >
-              <RotateCw className='h-5 w-5' />
-            </button>
-            <button
-              onClick={handleZoomOut}
-              className='inline-flex items-center justify-center w-9 h-9 text-white/90 hover:text-white hover:bg-background/10 rounded-md transition-colors'
-              title='Zoom Out (Ctrl -)'
-              data-track-category='FileViewer'
-              data-track-name='ZOOM_OUR_IMAGE'
-              data-track-metadata={JSON.stringify({ source, fileName })}
+              <button
+                onClick={handleRotate}
+                className='inline-flex items-center justify-center w-9 h-9 text-white/90 hover:text-white hover:bg-background/10 rounded-md transition-colors'
+                aria-label='Rotate'
+                data-track-category='FileViewer'
+                data-track-name='ROTATE_IMAGE'
+                data-track-metadata={JSON.stringify({ source, fileName })}
+              >
+                <RotateCw className='h-5 w-5' />
+              </button>
+            </ShortcutTooltip>
+            <ShortcutTooltip
+              label='Zoom out'
+              shortcut='viewer.image.controls'
+              keys='mod+minus'
+              side='top'
             >
-              <ZoomOut className='h-5 w-5' />
-            </button>
+              <button
+                onClick={handleZoomOut}
+                className='inline-flex items-center justify-center w-9 h-9 text-white/90 hover:text-white hover:bg-background/10 rounded-md transition-colors'
+                aria-label='Zoom out'
+                data-track-category='FileViewer'
+                data-track-name='ZOOM_OUR_IMAGE'
+                data-track-metadata={JSON.stringify({ source, fileName })}
+              >
+                <ZoomOut className='h-5 w-5' />
+              </button>
+            </ShortcutTooltip>
 
-            <button
-              onClick={handleZoomIn}
-              className='inline-flex items-center justify-center w-9 h-9 text-white/90 hover:text-white hover:bg-background/10 rounded-md transition-colors'
-              title='Zoom In (Ctrl +)'
-              data-track-category='FileViewer'
-              data-track-name='ZOOM_IN_IMAGE'
-              data-track-metadata={JSON.stringify({ source, fileName })}
+            <ShortcutTooltip
+              label='Zoom in'
+              shortcut='viewer.image.controls'
+              keys='mod+shift+equal'
+              side='top'
             >
-              <ZoomIn className='h-5 w-5' />
-            </button>
+              <button
+                onClick={handleZoomIn}
+                className='inline-flex items-center justify-center w-9 h-9 text-white/90 hover:text-white hover:bg-background/10 rounded-md transition-colors'
+                aria-label='Zoom in'
+                data-track-category='FileViewer'
+                data-track-name='ZOOM_IN_IMAGE'
+                data-track-metadata={JSON.stringify({ source, fileName })}
+              >
+                <ZoomIn className='h-5 w-5' />
+              </button>
+            </ShortcutTooltip>
           </div>
 
-          {/* Fit to Screen & Rotate - Bottom Right */}
+          {/* Fullscreen & Open in New Window - Bottom Right */}
           <div
             className={`absolute bottom-0 right-0 z-20 flex gap-6 p-6 transition-opacity duration-300 ${
               isHovered ? 'opacity-100' : 'opacity-0'
             }`}
           >
-            <button
-              onClick={handleFullscreenToggle}
-              className='inline-flex items-center justify-center w-9 h-9 text-white/90 hover:text-white hover:bg-background/10 rounded-md transition-colors'
-              title={isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}
-              data-track-category='FileViewer'
-              data-track-name={isFullscreen ? 'EXIT_IMAGE_FULLSCREEN' : 'ENTER_IMAGE_FULLSCREEN'}
-              data-track-metadata={JSON.stringify({ source, fileName })}
-            >
-              {isFullscreen ? <Minimize2 className='h-5 w-5' /> : <Maximize2 className='h-5 w-5' />}
-            </button>
+            <Tooltip content={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'} side='top'>
+              <button
+                onClick={handleFullscreenToggle}
+                className='inline-flex items-center justify-center w-9 h-9 text-white/90 hover:text-white hover:bg-background/10 rounded-md transition-colors'
+                aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+                data-track-category='FileViewer'
+                data-track-name={isFullscreen ? 'EXIT_IMAGE_FULLSCREEN' : 'ENTER_IMAGE_FULLSCREEN'}
+                data-track-metadata={JSON.stringify({ source, fileName })}
+              >
+                {isFullscreen ? (
+                  <Minimize2 className='h-5 w-5' />
+                ) : (
+                  <Maximize2 className='h-5 w-5' />
+                )}
+              </button>
+            </Tooltip>
 
             <button
               onClick={handleOpenInNewWindow}

--- a/apps/dashboard/src/components/FileViewer/search/FindBar.tsx
+++ b/apps/dashboard/src/components/FileViewer/search/FindBar.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
 import { cn } from '../../../utils/classNames';
+import { ShortcutTooltip } from '../../ui/ShortcutTooltip';
 import { useFileSearchContext } from './FileSearchContext';
 import { MAX_MATCHES } from './types';
 
@@ -151,31 +152,33 @@ export const FindBar: React.FC = () => {
 
       <div className='mx-0.5 h-4 w-px shrink-0 bg-white/15' />
 
-      <button
-        type='button'
-        onClick={prev}
-        disabled={!hasResults}
-        className={navClass(!hasResults)}
-        title='Previous match (Shift+Enter)'
-        aria-label='Previous match'
-        data-track-category='FileViewer'
-        data-track-name='FindPrevious'
-      >
-        <ChevronUp className='h-4 w-4' />
-      </button>
+      <ShortcutTooltip label='Previous match' shortcut='viewer.findPrevious' side='bottom'>
+        <button
+          type='button'
+          onClick={prev}
+          disabled={!hasResults}
+          className={navClass(!hasResults)}
+          aria-label='Previous match'
+          data-track-category='FileViewer'
+          data-track-name='FindPrevious'
+        >
+          <ChevronUp className='h-4 w-4' />
+        </button>
+      </ShortcutTooltip>
 
-      <button
-        type='button'
-        onClick={next}
-        disabled={!hasResults}
-        className={navClass(!hasResults)}
-        title='Next match (Enter)'
-        aria-label='Next match'
-        data-track-category='FileViewer'
-        data-track-name='FindNext'
-      >
-        <ChevronDown className='h-4 w-4' />
-      </button>
+      <ShortcutTooltip label='Next match' shortcut='viewer.findNext' side='bottom'>
+        <button
+          type='button'
+          onClick={next}
+          disabled={!hasResults}
+          className={navClass(!hasResults)}
+          aria-label='Next match'
+          data-track-category='FileViewer'
+          data-track-name='FindNext'
+        >
+          <ChevronDown className='h-4 w-4' />
+        </button>
+      </ShortcutTooltip>
 
       <button
         type='button'

--- a/apps/dashboard/src/components/Settings/Settings.tsx
+++ b/apps/dashboard/src/components/Settings/Settings.tsx
@@ -18,6 +18,7 @@ import Avatar from '../ui/Avatar/Avatar';
 import { StatusIndicator } from '../ui/StatusIndicator';
 import { Button } from '../ui/Button/Button';
 import { cn } from '../../utils/classNames';
+import { ShortcutHint } from '../ui/ShortcutHint';
 import { isStatusExpired } from '../../utils/statusUtils';
 import { useChannelByName } from '../../hooks/useChannels';
 import { useSelf } from '../../hooks/useUsers';
@@ -284,6 +285,7 @@ const Settings = ({
             <div className='flex items-center p-1 gap-2 text-muted-foreground'>
               <SmilePlus className='size-4 flex-shrink-0' />
               <span className='text-xs truncate'>Set a status</span>
+              <ShortcutHint shortcut='global.setStatus' className='ml-auto text-xs' />
             </div>
           )}
         </div>
@@ -410,6 +412,7 @@ const Settings = ({
         >
           <Settings2 className='size-4' />
           Preferences
+          <ShortcutHint shortcut='global.openPreferences' className='ml-auto' />
         </Button>
       </div>
 

--- a/apps/dashboard/src/components/ui/Avatar/AvatarGroup.tsx
+++ b/apps/dashboard/src/components/ui/Avatar/AvatarGroup.tsx
@@ -154,7 +154,7 @@ const AvatarGroup = ({
         {...props}
       >
         {backUserId && (
-          <div className='absolute bottom-0 right-0 w-7 h-7 rounded-md ring-1 ring-background overflow-hidden z-10 [&_[data-slot="avatar"]]:rounded-md'>
+          <div className='absolute bottom-0 right-0 w-6 h-6 rounded-md ring-1 ring-background overflow-hidden z-10 [&_[data-slot="avatar"]]:rounded-md'>
             <Avatar
               userId={backUserId}
               size='sm'
@@ -164,7 +164,7 @@ const AvatarGroup = ({
           </div>
         )}
         {frontUserId && (
-          <div className='absolute top-0 left-0 w-7 h-7 rounded-md ring-1 ring-background overflow-hidden z-0 [&_[data-slot="avatar"]]:rounded-md'>
+          <div className='absolute top-0 left-0 w-6 h-6 rounded-md ring-1 ring-background overflow-hidden z-0 [&_[data-slot="avatar"]]:rounded-md'>
             <Avatar
               userId={frontUserId}
               size='sm'

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -1496,7 +1496,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
             </div>
           )}
           <div
-            className='flex items-center min-w-0'
+            className='flex items-center min-w-0 h-5 w-full bg-background px-[var(--composer-px)] pb-0.5'
             style={{ display: agentVisible ? 'flex' : 'none' }}
           >
             {agentSlot}

--- a/apps/dashboard/src/components/ui/InputBox/VoiceInput.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/VoiceInput.tsx
@@ -22,6 +22,7 @@ import { Loader2 } from 'lucide-react';
 import { MicOn } from '@xyne/icons';
 import { toast } from 'sonner';
 import Tooltip from '../Tooltip/Tooltip';
+import { ShortcutHint } from '../ShortcutHint';
 import type { MentionResult } from '@xyne/shared';
 import { voiceInputService } from '../../../services/VoiceInput/voiceInputService';
 import type { VoiceStreamSession } from '../../../services/VoiceInput/voiceInputService';
@@ -671,11 +672,14 @@ export const VoiceInput = forwardRef<VoiceInputHandle, VoiceInputProps>(
     return (
       <Tooltip
         content={
-          isVoiceTranscribing
-            ? 'Transcribing...'
-            : isVoiceRecording
-              ? 'Stop voice input'
-              : 'Start voice input'
+          isVoiceTranscribing ? (
+            'Transcribing...'
+          ) : (
+            <span className='flex items-center gap-2'>
+              {isVoiceRecording ? 'Stop voice input' : 'Start voice input'}
+              <ShortcutHint shortcut='composer.voiceInput' />
+            </span>
+          )
         }
         side='top'
       >

--- a/apps/dashboard/src/components/ui/ShortcutHint.tsx
+++ b/apps/dashboard/src/components/ui/ShortcutHint.tsx
@@ -1,21 +1,44 @@
 import type { ReactElement } from 'react';
 import { cn } from '../../utils/classNames';
 import { usePlatform } from '../../hooks/usePlatform';
-import { formatShortcut } from '../../shortcuts';
+import { formatShortcut, getShortcut } from '../../shortcuts';
+import type { ShortcutId } from '../../shortcuts';
+import { isElectronApp } from '../../utils/electronApp';
 
 interface ShortcutHintProps {
-  keys: string;
+  /** Literal combo, e.g. 'mod+o'. Takes precedence over `shortcut`. */
+  keys?: string;
+  /** Catalog id to read the combo from, so a rebind updates every trigger. */
+  shortcut?: ShortcutId;
   className?: string;
 }
 
-export const ShortcutHint = ({ keys, className }: ShortcutHintProps): ReactElement | null => {
-  const { isMobile, isMac } = usePlatform();
+/**
+ * Resolve the combo to advertise for a catalog entry, or undefined when the
+ * binding cannot fire here — Electron-only shortcuts are dead in the browser
+ * and must not be promised.
+ */
+export const resolveShortcutKeys = (shortcut: ShortcutId): string | undefined => {
+  const definition = getShortcut(shortcut);
+  if (!definition || (definition.electronOnly === true && !isElectronApp())) return undefined;
 
-  if (isMobile) return null;
+  const bound = definition.displayKeys ?? definition.keys;
+  return Array.isArray(bound) ? bound[0] : bound;
+};
+
+export const ShortcutHint = ({
+  keys,
+  shortcut,
+  className,
+}: ShortcutHintProps): ReactElement | null => {
+  const { isMobile, isMac } = usePlatform();
+  const combo = keys ?? (shortcut !== undefined ? resolveShortcutKeys(shortcut) : undefined);
+
+  if (isMobile || combo === undefined) return null;
 
   return (
     <span aria-hidden='true' className={cn('opacity-60 tabular-nums', className)}>
-      {formatShortcut(keys, isMac)}
+      {formatShortcut(combo, isMac)}
     </span>
   );
 };

--- a/apps/dashboard/src/components/ui/ShortcutTooltip.tsx
+++ b/apps/dashboard/src/components/ui/ShortcutTooltip.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement, ReactNode } from 'react';
+import { Tooltip } from './Tooltip';
+import type { TooltipProps } from './Tooltip';
+import { ShortcutHint, resolveShortcutKeys } from './ShortcutHint';
+import type { ShortcutId } from '../../shortcuts';
+
+export interface ShortcutTooltipProps extends Omit<TooltipProps, 'content'> {
+  /** Text shown beside the key hint, e.g. "Search". */
+  label: ReactNode;
+  /** Catalog id the trigger mirrors; the combo is read from the catalog. */
+  shortcut: ShortcutId;
+  /** Pick a specific combo when the catalog entry binds several, e.g. `mod+3`. */
+  keys?: string;
+}
+
+/**
+ * Tooltip for a control that a registered shortcut can also trigger.
+ *
+ * Falls back to the bare label when the shortcut cannot fire on this platform,
+ * so no tooltip advertises a key that does nothing.
+ */
+export const ShortcutTooltip = ({
+  label,
+  shortcut,
+  keys,
+  children,
+  ...tooltipProps
+}: ShortcutTooltipProps): ReactElement => {
+  const combo = keys ?? resolveShortcutKeys(shortcut);
+
+  return (
+    <Tooltip
+      content={
+        combo !== undefined ? (
+          <span className='flex items-center gap-2'>
+            {label}
+            <ShortcutHint keys={combo} />
+          </span>
+        ) : (
+          label
+        )
+      }
+      {...tooltipProps}
+    >
+      {children}
+    </Tooltip>
+  );
+};
+
+export default ShortcutTooltip;

--- a/apps/dashboard/src/routes/RecordingsScreen/components/RecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingsScreen/components/RecordingControlBar.tsx
@@ -7,6 +7,7 @@ import { ReactElement, useEffect, useState, useRef } from 'react';
 import { Loader2, Pause, Play } from 'lucide-react';
 import { calculateRecordingElapsedMs, formatElapsedTime } from '../../../utils/recordingUtils';
 import { Waveform } from '../../../utils/recordingWaveform';
+import { ShortcutTooltip } from '../../../components/ui/ShortcutTooltip';
 
 /**
  * Returns true when the dashboard is running inside a mobile browser or
@@ -126,21 +127,23 @@ export function RecordingControlBar({
             </button>
           </>
         ) : (
-          <button
-            onClick={onStart}
-            disabled={isStarting}
-            className='flex items-center justify-center w-14 h-14 rounded-full bg-destructive hover:bg-destructive/85 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg'
-            title='Start recording'
-            data-track-category='RecordingControlBar'
-            data-track-name='start_recording'
-          >
-            {isStarting ? (
-              <Loader2 className='w-6 h-6 text-white animate-spin' />
-            ) : (
-              /* Circle record icon */
-              <div className='w-6 h-6 rounded-full bg-background' />
-            )}
-          </button>
+          <ShortcutTooltip label='Start recording' shortcut='recording.start' side='top'>
+            <button
+              onClick={onStart}
+              disabled={isStarting}
+              className='flex items-center justify-center w-14 h-14 rounded-full bg-destructive hover:bg-destructive/85 transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg'
+              aria-label='Start recording'
+              data-track-category='RecordingControlBar'
+              data-track-name='start_recording'
+            >
+              {isStarting ? (
+                <Loader2 className='w-6 h-6 text-white animate-spin' />
+              ) : (
+                /* Circle record icon */
+                <div className='w-6 h-6 rounded-full bg-background' />
+              )}
+            </button>
+          </ShortcutTooltip>
         )}
 
         {/* Waveform bars (right side, visible when actively recording) */}

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -44,6 +44,8 @@ export const shortcuts = {
   },
   'global.openCanvasTab': {
     keys: ['mod+shift+n'],
+    // Browsers reserve this for a new incognito/private window.
+    electronOnly: true,
     scope: 'channel',
     description: 'Open canvas tab',
     category: 'Navigation',
@@ -89,6 +91,8 @@ export const shortcuts = {
   },
   'global.openThreads': {
     keys: 'mod+shift+t',
+    // Browsers reserve this for "reopen closed tab".
+    electronOnly: true,
     scope: 'global',
     description: 'Open the Threads view',
     category: 'Navigation',
@@ -115,6 +119,8 @@ export const shortcuts = {
   },
   'global.composeMessage': {
     keys: 'mod+n',
+    // Browsers reserve this for a new window.
+    electronOnly: true,
     scope: 'global',
     description: 'Compose a new message',
     category: 'Navigation',
@@ -125,6 +131,9 @@ export const shortcuts = {
   },
   'recording.start': {
     keys: 'mod+alt+x',
+    // Bound by the Electron main process (RECORDING_SHORTCUT), never by the
+    // renderer — so the combo does not exist in a browser tab.
+    electronOnly: true,
     scope: 'global',
     description: 'Start or stop recording',
     category: 'Recording',

--- a/apps/dashboard/src/shortcuts/formatShortcut.ts
+++ b/apps/dashboard/src/shortcuts/formatShortcut.ts
@@ -1,3 +1,35 @@
+const MODIFIER_SYMBOLS: Record<string, string> = {
+  mod: '⌘',
+  shift: '⇧',
+  alt: '⌥',
+  ctrl: '⌃',
+};
+
+const MODIFIER_WORDS: Record<string, string> = {
+  mod: 'Ctrl',
+  shift: 'Shift',
+  alt: 'Alt',
+  ctrl: 'Ctrl',
+};
+
+const KEY_LABELS: Record<string, string> = {
+  comma: ',',
+  equal: '=',
+  add: '+',
+  minus: '-',
+  subtract: '-',
+  up: '↑',
+  down: '↓',
+  left: '←',
+  right: '→',
+  esc: 'Esc',
+  escape: 'Esc',
+  space: 'Space',
+  enter: '↵',
+  delete: 'Del',
+  backspace: '⌫',
+};
+
 /**
  * Render a registered key combination for display, e.g. 'mod+shift+a' becomes
  * '⌘⇧A' on macOS and 'Ctrl Shift A' elsewhere.
@@ -5,13 +37,12 @@
  * Shared so the shortcuts modal, tooltips and menus can never drift apart.
  */
 export const formatShortcut = (key: string, isMac: boolean): string => {
-  return key
-    .replace('mod+', isMac ? '⌘' : 'Ctrl+')
-    .replace('shift+', isMac ? '⇧' : 'Shift+')
-    .replace('alt+', isMac ? '⌥' : 'Alt+')
-    .replace('ctrl+', isMac ? '⌃' : 'Ctrl+')
-    .split('+')
-    .map(k => k.trim())
-    .map(k => k.replace(/[a-z]/i, c => c.toUpperCase()))
-    .join(' ');
+  const parts = key.split('+');
+  const base = parts.pop() ?? '';
+  const modifiers = parts.map(
+    part => (isMac ? MODIFIER_SYMBOLS : MODIFIER_WORDS)[part.toLowerCase()] ?? part,
+  );
+  const label = KEY_LABELS[base.toLowerCase()] ?? base.replace(/[a-z]/i, c => c.toUpperCase());
+
+  return isMac ? `${modifiers.join('')}${label}` : [...modifiers, label].join(' ');
 };

--- a/apps/dashboard/src/shortcuts/hooks.ts
+++ b/apps/dashboard/src/shortcuts/hooks.ts
@@ -2,7 +2,8 @@ import { useEffect, useRef } from 'react';
 import { shortcutsActor } from '../machines/shortcutsMachine';
 import { registerShortcut } from './shortcutsRegistry';
 import type { ShortcutScope, ShortcutRegistration } from './shortcutsRegistry';
-import { shortcuts } from './catalog';
+import { getShortcut } from './catalog';
+import { isElectronApp } from '../utils/electronApp';
 import type { ShortcutDefinition, ShortcutId } from './catalog';
 
 export const useShortcut = (
@@ -80,12 +81,20 @@ export const useShortcutById = (
   handler: (event: KeyboardEvent) => void,
   overrides: ShortcutOverrides = {},
 ): void => {
-  const definition = shortcuts[id];
-  const { keys, ...baseConfig } = definition || { keys: '' };
+  const definition = getShortcut(id);
+  const { keys, ...baseConfig } = definition ?? { keys: '' };
+
+  // An `electronOnly` combo is claimed by the browser itself (new window,
+  // incognito, tab switching) and never reaches the page, so registering a
+  // handler for it in a tab only adds a listener that can never fire. Gating
+  // here means the catalog flag governs both the binding and the hint, instead
+  // of every call site repeating the check the sidebar rail does by hand.
+  const available =
+    definition !== undefined && (definition.electronOnly !== true || isElectronApp());
 
   useShortcut(keys, handler, {
     ...baseConfig,
     ...overrides,
-    enabled: definition ? (overrides.enabled ?? true) : false,
+    enabled: available ? (overrides.enabled ?? true) : false,
   });
 };


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description


### POT

Shortcuts:
https://drive.google.com/file/d/1ODHa9guAYGKnYTzTjYHrRMlS_RNISGzP/view?usp=sharing

DM Sidebar UI:
<img width="494" height="947" alt="image" src="https://github.com/user-attachments/assets/6579ce3b-6102-4b7a-b0f1-46de49b6b049" />
<img width="495" height="949" alt="image" src="https://github.com/user-attachments/assets/8841acd4-78e5-4e88-8956-044bea026048" />

Agent Processing Indicator:
<img width="584" height="135" alt="image" src="https://github.com/user-attachments/assets/abf5d1f4-7ea0-4fa5-918c-523c5f0699c0" />
<img width="588" height="126" alt="image" src="https://github.com/user-attachments/assets/430ef8a4-d012-473a-9b10-0c1a4e6e3a38" />

---

Three rounds of UI feedback, one commit each. All dashboard-only; no API, schema or config changes.

| Commit | Scope |
|---|---|
| `c0a54ffe` | Shortcut indicators — surface registered shortcuts on the controls that trigger them |
| `d0f302dc` | Agent progress indicator — remove a duplicate mount, fix its alignment |
| `43d5a6db` | DM sidebar UI — avatar sizing, unread badge, filter tabs, preview truncation |

---

### 1. Shortcut indicators (`c0a54ffe`)

Feedback was that shortcuts were undiscoverable — you had to already know them. Controls that a registered shortcut can trigger now advertise it.

**Infrastructure**

- **`ShortcutTooltip`** (new, `ui/ShortcutTooltip.tsx`) — label + key hint, reads the combo from the shortcut catalog so a rebind updates every trigger at once.
- **`ShortcutHint`** — gained a `shortcut` prop (catalog id) alongside the existing literal `keys`, for menu rows where a tooltip is the wrong affordance.
- **`formatShortcut`** — rewritten. It rendered `mod+comma` as `⌘Comma`, `alt+down` as `⌥Down`, and on Windows produced `CtrlD` with no separator. Now `⌘,` / `⌥↓` / `Ctrl D`. This also cleans up the existing shortcuts help modal.
- **`useShortcutById`** — `electronOnly` now gates *registration*, not just display. Combos the browser reserves (new window, incognito, reopen tab) no longer register a listener that can never fire. Previously each call site had to repeat the check the sidebar rail does by hand.

**Indicators added — 26 surfaces**

Hover tooltips:

| Surface | Keys | Browser |
|---|---|---|
| Back / Forward / Search (top bar) | ⌘[ · ⌘] · ⌘K | ✅ |
| Search in this channel | ⌘F | ✅ |
| Canvas tab | ⌘⇧N | ❌ |
| New message (DM header) | ⌘N | ❌ |
| Close thread panel | ⌘. | ✅ |
| Rotate / Zoom out / Zoom in (image viewer) | ⌘R · ⌘- · ⌘⇧= | ✅ |
| Previous / Next match (find bar) | ⌘⇧G · ⌘G | ✅ |
| Start recording | ⌘⌥X | ❌ |
| Mute mic / Toggle camera / Start call | ⌘D · ⌘E · ⌘⇧H | ✅ |
| Voice input | ⌘⇧M | ✅ |

Inline text (always visible in the row):

| Surface | Keys | Browser |
|---|---|---|
| New Message / Threads (chat sidebar) | ⌘N · ⌘⇧T | ❌ |
| Set a status / Preferences (settings menu) | ⌘⇧Y · ⌘, | ✅ |
| Edit / Bookmark / Pin / Copy link / Delete (message ⋮ menu) | E · B · P · L · Del | ✅ |

**5 surfaces hide their hint in a browser** — ⌘N, ⌘⇧T and ⌘⇧N are claimed by the browser itself (new window, reopen tab, incognito), and ⌘⌥X is bound in Electron main only. The tooltip still shows, just without the key. Same rule the sidebar rail already used for ⌘1–⌘9. All hints hide on mobile.

Two pre-existing bugs fixed on the way: the image viewer's zoom/rotate buttons hardcoded `title='Rotate (Ctrl R)'` — wrong on macOS — and the call controls built `⌘D` from a local `modKey` const instead of the catalog.

---

### 2. Agent progress indicator (`d0f302dc`)

The "agent is working" pill rendered **twice**, offset by ~8px.

`ChatInput` mounted `<AgentProgressIndicator>` in two places: once in normal flow above the composer, and once passed as `agentSlot` into `InputBox`'s absolutely-positioned activity bar. Both rendered whenever an agent was active.

- **Removed the in-flow copy.** It also shifted the message list by its own height on every agent start/stop, and had no `onActiveChange`, so it was invisible to the typing↔agent flip and would paint over the typing indicator. The slot copy is the one wired into that flip and the one that can't move layout.
- **`w-full` on the pill root** (was `mb-2`). In flow the root was block-level and full width for free, so `flex-1` pushed the Stop button to the right edge. As a flex item in the bar it collapsed to content width and the Stop button slid up against the label.
- **Aligned the agent chip with the typing chip** — added `h-5 w-full bg-background px-[var(--composer-px)]`, which the typing chip already had. That's what makes it start at the composer's left edge.

Also drops one WebSocket listener, one rehydrate GET and one 5s poll per composer.

---

### 3. DM sidebar UI (`43d5a6db`)

Matched against the design; typography deliberately left on the Activity list's scale.

| | Before | After |
|---|---|---|
| 1:1 avatar | 30px, `rounded-sm` | 36px, `rounded-[9px]` |
| Group DM avatar | 40px box, 28px tiles | 36px box, 24px tiles, `rounded-[4px]` |
| Row | `items-start`, `pt-2.5 pb-2` | `items-center`, `py-2` |
| Unread badge | `bg-primary`, `rounded-full`, beside the timestamp | matches the activity tab count badge, moved down beside the preview |
| Preview | `w-full` | `min-w-0 flex-1` — restores truncation |
| Filter tabs | labels collapsed via a grid transition, tooltip per tab | labels always expanded, tooltip removed |
| `DESKTOP_ITEM_HEIGHT` | 72 | 70 |

`DESKTOP_ITEM_HEIGHT` is a hand-computed constant feeding the virtualiser, so it had to move with the padding change.

Colours were left on existing tokens rather than the design's raw values — the design's `text/secondary` · `tertiary` · `disabled` opacity ramp has no equivalent here, so name, timestamp and preview keep `text-foreground` / `text-muted-foreground`.

---


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind

