### PR TITLE
feat: XYNE-55539 activity actor filter

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -43,6 +43,7 @@ import {
   TicketReferenceRelation,
   DelayedMessageStatus,
   RecapEntityType,
+  UserType,
 } from '@xyne/shared';
 
 export const zql = createBuilder(schema);
@@ -2910,8 +2911,9 @@ export const queries: AnyQueryRegistry = defineQueries({
       types: z.array(z.string()),
       classification: z.array(z.nativeEnum(ActivityClassification)).optional(),
       isRead: z.boolean().optional(),
+      actorTypes: z.array(z.nativeEnum(UserType)).optional(),
     }),
-    ({ args: { limit, start, types, classification, isRead } }) => {
+    ({ args: { limit, start, types, classification, isRead, actorTypes } }) => {
       let query = zql.activities;
 
       if (types.length > 0) {
@@ -2928,6 +2930,16 @@ export const queries: AnyQueryRegistry = defineQueries({
 
       if (isRead !== undefined) {
         query = query.where('isRead', isRead);
+      }
+
+      // Actor kind lives on users.userType, not on the activity row, so this has to
+      // reach through the `actor` relationship. Must stay in step with the client
+      // definition in packages/shared/src/zero/queries.ts — this is the copy the
+      // server actually executes via handleQueryRequest.
+      if (actorTypes && actorTypes.length > 0) {
+        query = query.whereExists('actor', (actor: any) =>
+          actor.where('userType', 'IN', actorTypes)
+        );
       }
 
       query = query.orderBy('updatedAt', 'desc').orderBy('id', 'desc');

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -17,7 +17,8 @@ import * as Tabs from '@radix-ui/react-tabs';
 import * as Switch from '@radix-ui/react-switch';
 import { cn } from '../../../utils/classNames';
 import type { ActivityWithRelated } from '../../../types/activity';
-import { ActivityClassification } from '@xyne/shared';
+import { ActivityClassification, UserType } from '@xyne/shared';
+import { Bot, UserUser02 } from '@xyne/icons';
 import { groupActivities, type ActivityFeedItem } from '../activityGrouping';
 import {
   mixpanelService,
@@ -120,6 +121,27 @@ export const isDirectUserMention = (messageContent: string, userId: string): boo
   return userMentions.includes(userId);
 };
 
+type ActorFilter = 'all' | 'user' | 'agent';
+
+// Agent covers both automated actor kinds; only USER is a human. `all` maps to
+// undefined so the query drops the actor filter entirely rather than matching
+// every type — the three orphan rows have an actorId that resolves to no user.
+const ACTOR_FILTER_TYPES: Record<ActorFilter, UserType[] | undefined> = {
+  all: undefined,
+  user: [UserType.USER],
+  agent: [UserType.BOT, UserType.APP],
+};
+
+const ACTOR_FILTER_OPTIONS: Array<{
+  value: ActorFilter;
+  label: string;
+  icon?: ComponentType<{ size?: number; className?: string }>;
+}> = [
+  { value: 'all', label: 'All' },
+  { value: 'user', label: 'User', icon: UserUser02 },
+  { value: 'agent', label: 'Agent', icon: Bot },
+];
+
 const TABS: TabConfig[] = [
   { value: 'all', label: 'All', filter: isAllVisibleActivity },
   {
@@ -213,6 +235,11 @@ const ActivityListView = (): ReactElement => {
 
   // All hooks must be called before any conditional returns
   const [activeTab, setActiveTab] = useState<ActivityTab>('all');
+  const [actorFilter, setActorFilter] = useState<ActorFilter>(() => {
+    const stored = window.localStorage.getItem('activity_actor_filter');
+    return stored === 'all' || stored === 'user' || stored === 'agent' ? stored : 'all';
+  });
+
   const [showUnreadOnly, setShowUnreadOnly] = useState<boolean>(() => {
     const unread = window.localStorage.getItem('activity_unread_toggle');
     return unread === 'true';
@@ -283,6 +310,11 @@ const ActivityListView = (): ReactElement => {
     setShowUnreadOnly(checked);
     window.localStorage.setItem('activity_unread_toggle', String(checked));
     activityVirtuosoRef.current?.scrollToIndex({ index: 0, align: 'start', behavior: 'auto' });
+  }, []);
+
+  const handleActorFilterChange = useCallback((next: ActorFilter): void => {
+    setActorFilter(next);
+    window.localStorage.setItem('activity_actor_filter', next);
   }, []);
 
   const handleActionableToggle = useCallback((checked: boolean): void => {
@@ -373,7 +405,7 @@ const ActivityListView = (): ReactElement => {
     setHasMore(true);
     setIsLoading(true);
     activityLoadStartTimeRef.current = Date.now();
-  }, [activeTab, showUnreadOnly]);
+  }, [activeTab, showUnreadOnly, actorFilter]);
 
   const getClassificationFilter = (tab: ActivityTab): ActivityClassification[] | undefined => {
     switch (tab) {
@@ -397,8 +429,9 @@ const ActivityListView = (): ReactElement => {
         types: currentTypes,
         classification: classificationFilter,
         ...(showUnreadOnly ? { isRead: false } : {}),
+        ...(ACTOR_FILTER_TYPES[actorFilter] ? { actorTypes: ACTOR_FILTER_TYPES[actorFilter] } : {}),
       }),
-    [PAGE_SIZE, fetchCursor, currentTypes, classificationFilter, showUnreadOnly],
+    [PAGE_SIZE, fetchCursor, currentTypes, classificationFilter, showUnreadOnly, actorFilter],
   );
 
   const [activitiesPage, activitiesDetails, activitiesMeta] = useCachedQuery(activitiesQuery, {
@@ -880,7 +913,7 @@ const ActivityListView = (): ReactElement => {
             {/* Unread-only filter */}
             <label
               htmlFor='activity-unread-toggle'
-              className='flex h-7 items-center gap-2 px-2 rounded-[10px] cursor-pointer select-none transition-colors hover:bg-sidebar-accent'
+              className='flex h-7 items-center gap-2 px-2 rounded-[10px] cursor-pointer select-none transition-colors hover:bg-foreground/[6%]'
             >
               <span className='text-sm font-medium text-muted-foreground'>Unread</span>
               <Switch.Root
@@ -907,6 +940,57 @@ const ActivityListView = (): ReactElement => {
                 />
               </Switch.Root>
             </label>
+
+            {/* Agent / User actor filter */}
+            <div
+              role='radiogroup'
+              aria-label='Filter activity by actor'
+              className='flex items-center gap-0.5 rounded-xl bg-foreground/[6%] p-0.5'
+            >
+              {ACTOR_FILTER_OPTIONS.map(option => {
+                const isActive = option.value === actorFilter;
+                const Icon = option.icon;
+                const showLabel = isActive || !Icon;
+
+                return (
+                  <button
+                    key={option.value}
+                    type='button'
+                    role='radio'
+                    aria-checked={isActive}
+                    aria-label={option.label}
+                    onClick={() => handleActorFilterChange(option.value)}
+                    className={cn(
+                      'flex items-center rounded-[10px] pl-2 pr-2.5 py-1',
+                      'transition-[background-color,color,box-shadow] duration-300 ease-in-out',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+                      isActive
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                    data-track-category='ACTIVITY'
+                    data-track-name='ACTOR_FILTER_TOGGLE'
+                    data-track-metadata={JSON.stringify({ filter_value: option.value })}
+                    data-testid={`activity-actor-filter-${option.value}`}
+                  >
+                    {Icon && <Icon size={14} className='shrink-0' />}
+                    <span
+                      className={cn(
+                        'grid overflow-hidden transition-[grid-template-columns,opacity,margin] duration-300 ease-in-out',
+                        Icon ? 'ml-1' : null,
+                        showLabel
+                          ? 'grid-cols-[1fr] opacity-100'
+                          : 'grid-cols-[0fr] opacity-0 ml-0',
+                      )}
+                    >
+                      <span className='min-w-0 overflow-hidden whitespace-nowrap text-xs font-medium tracking-[-0.28px]'>
+                        {option.label}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
 
             {/* 3-dot menu with Actionable Toggle and View Toggle (Desktop & Mobile) */}
             <div className='relative' ref={mobileMenuRef}>

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -41,6 +41,7 @@ import {
   DelayedMessageStatus,
   RecapEntityType,
   UserResponsibility,
+  UserType,
 } from './schema.js';
 
 export const zql = createBuilder(schema);
@@ -2329,8 +2330,9 @@ export const queries = defineQueries({
       types: z.array(z.string()),
       classification: z.array(z.nativeEnum(ActivityClassification)).optional(),
       isRead: z.boolean().optional(),
+      actorTypes: z.array(z.nativeEnum(UserType)).optional(),
     }),
-    ({ args: { limit, start, types, classification, isRead } }) => {
+    ({ args: { limit, start, types, classification, isRead, actorTypes } }) => {
       let query = zql.activities;
 
       if (types.length > 0) {
@@ -2347,6 +2349,16 @@ export const queries = defineQueries({
 
       if (isRead !== undefined) {
         query = query.where('isRead', isRead);
+      }
+
+      // Actor kind lives on users.userType, not on the activity row, so this has to
+      // reach through the `actor` relationship. Filtering here rather than on the
+      // client keeps `limit` meaningful — a client-side filter would page over all
+      // activities and hand back short or empty pages.
+      if (actorTypes && actorTypes.length > 0) {
+        query = query.whereExists('actor', (actor: any) =>
+          actor.where('userType', 'IN', actorTypes),
+        );
       }
 
       query = query.orderBy('updatedAt', 'desc').orderBy('id', 'desc');


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

### POT

https://drive.google.com/file/d/1RWE81AMXUXrJXFgexb9pWwLX-RTdahce/view?usp=sharing

Adds an **All / User / Agent** filter to the Activity sidebar header, so activity generated by agents can be separated from activity generated by people.

Most of this diff is one dashboard component. The two lines that matter for review are in `packages/shared` and `apps/backend` — the sections below explain why they were unavoidable.

### Why this can't be done on the client

Three facts force the filter server-side:

1. **Actor kind is not on the activity row.** `activities` stores only `actorId`. Whether that actor is a person or an agent lives on `users.userType` — `USER | BOT | APP`. Agents are the `APP` users (Ask AI, Claw, Digital Twin, Assistant, …) plus `BOT` users.

2. **The relationship already existed but was never requested.** `activityTableRelationships` defines `actor: one({ sourceField: ['actorId'], destField: ['id'], destSchema: userTable })`, but no query had ever pulled it — `related('actor')` had zero hits repo-wide before this change.

3. **`limit` is applied before any client-side filter.** The Activity list is cursor-paginated via `userActivitiesPaginatedV2`. Filtering the returned page in React would page over *all* activities and hand back short or empty pages, and would break the cursor. The existing `types` and `classification` filters are server-side args for exactly this reason; `actorTypes` follows that precedent.

So the query gains one optional arg and one predicate:

```ts
actorTypes: z.array(z.nativeEnum(UserType)).optional(),
…
if (actorTypes && actorTypes.length > 0) {
  query = query.whereExists('actor', (actor: any) =>
    actor.where('userType', 'IN', actorTypes),
  );
}
```

`whereExists` is the established mechanism here — 37 existing uses in the shared file, several with `IN`, and the query immediately below this one already does a two-level `whereExists` on `activities`.

### Why the same change appears in two files

`userActivitiesPaginatedV2` is **hand-duplicated across two registries**:

| File | Role |
|---|---|
| `packages/shared/src/zero/queries.ts` | what the dashboard imports and calls |
| `apps/backend/src/zero/queries.ts` | what `apps/backend/src/zero/server.ts` hands to `handleQueryRequest` — the definition the server actually executes |

Changing only the shared copy would ship a filter that works in local dev and **silently no-ops against a deployed backend**, because the server's zod schema would not declare `actorTypes` — the arg would be stripped or rejected and every activity would come back unfiltered. Both copies now carry the identical arg and predicate, and the backend copy has a comment pointing at the shared one.

Nothing enforces this pairing. The PR template warns about it for mutators (*"Server and client mutators mirror each other"*) but there is no equivalent rule for queries and no codegen. Worth a separate ticket: the two registries have drifted more broadly — 241 queries in shared vs 273 in backend, and two queries the dashboard calls (`dmChannelsLatestMessagesPaginated`, `getAllBoardsList`) are missing from the backend registry entirely. Out of scope here, but the same class of problem.

### No schema or data changes

`actorTypes` is optional and additive, so older clients that don't send it are unaffected. No migration, no backfill, no new column — actor kind is read through the existing relationship rather than denormalised onto `activities`. Denormalising would be cheaper per query but needs a migration, a backfill, and a write path to keep it correct when a user's type changes; not worth it for a sidebar filter.

`Services-Requiring-Redeployment` lists **backend** and **dashboard** for this reason — the backend must ship the updated query definition for the filter to apply.

### Dashboard

- Segmented control in the Activity sidebar header, next to the unread toggle.
- **Agent = `BOT` + `APP`**; User = `USER`.
- `All` maps to `undefined`, not `[USER, BOT, APP]`, so the predicate is skipped entirely. Passing every type would silently drop activities whose `actorId` resolves to no user.
- Selection persists to `localStorage` (`activity_actor_filter`), matching the unread toggle beside it; pagination resets on change.

### Known behaviour worth knowing when testing

Several activity cards display an actor that is **not** `activity.actorId` — `MessageMentionActivity`, `KeywordMatchActivity`, `DirectMessageActivity`, `MessageRepliedActivity` and `SlashCommandArtifactActivity` render `useUser(message.senderId)`; `ReactionAddedActivity` renders `useUser(reaction.userId)`. Filtering is on `actorId`, so these agree in normal data. The exception is `eta_*`, where `EtaActivity` hardcodes the name "Xyne" — those rows still filter by their real actor type but always display "Xyne". Pre-existing UI behaviour, not introduced here.



## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind

