### PR TITLE
Fix/xyne 59705 wapt debug gating all paths

### DIFF
--- a/apps/xyne-claw-auth/backend/src/repositories/agentRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRepository.ts
@@ -47,7 +47,49 @@ const INCLUDE_TOOLS_SKILLS = {
   collections: true,
 } as const;
 
+/**
+ * The one definition of "this user may use this agent": org-global, owned, or
+ * explicitly shared. Kept beside `listVisible`, which applies the same rule to
+ * the agent list, so a change to what "visible" means cannot drift between the
+ * list a user is shown and the agents they can actually address.
+ *
+ * Org scoping is applied separately by the caller — it is a different question
+ * (which tenant) from this one (which agent within it).
+ */
+export function agentVisibleToUser(userId: string): Prisma.AgentWhereInput {
+  return {
+    OR: [{ scope: "global" }, { ownerUserId: userId }, { shares: { some: { userId } } }],
+  };
+}
+
 export const agentRepository = {
+  /**
+   * Resolve a slug to an agent the caller is actually allowed to use.
+   *
+   * `findBySlug` scopes by org only, which makes every agent in an org
+   * addressable by slug regardless of whether it is private to another user.
+   * Execution paths — chatting, regenerating, forking — must use this instead:
+   * the slug is caller-supplied, so org scoping alone is tenant isolation, not
+   * authorization.
+   *
+   * Returns null both when the agent does not exist and when it exists but is
+   * not visible, so callers 404 either way. That is deliberate: a distinct 403
+   * would confirm the slug to someone probing for other users' private agents.
+   */
+  findBySlugVisibleTo: (slug: string, orgId: string | null | undefined, userId: string | null | undefined) => {
+    if (!orgId) {
+      log.error("[agentRepository.findBySlugVisibleTo] missing orgId; refusing global slug lookup", { slug });
+      return Promise.resolve(null);
+    }
+    if (!userId) {
+      log.error("[agentRepository.findBySlugVisibleTo] missing userId; refusing unscoped slug lookup", { slug });
+      return Promise.resolve(null);
+    }
+    return prisma.agent.findFirst({
+      where: { AND: [{ orgId, slug }, agentVisibleToUser(userId)] },
+    });
+  },
+
   findBySlug: (slug: string, orgId?: string | null) => {
     if (!orgId) {
       log.error("[agentRepository.findBySlug] missing orgId; refusing global slug lookup", { slug });

--- a/apps/xyne-claw-auth/backend/src/routes/admin.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/admin.ts
@@ -160,6 +160,23 @@ router.get("/audit-logs", requireClawAdmin, asyncHandler(async (req: Request, re
   }), { total, limit, offset });
 }));
 
+// Everything below this line is admin-only.
+//
+// Guarding each route individually meant a route added without the guard was
+// served to any authenticated caller, and several were: the dashboard reads,
+// the error-pipeline reads, and a fork-conversation write. Default-deny here
+// makes the guard the property of the router rather than something each new
+// route has to remember.
+//
+// This sits AFTER `/roles/check/:userId` deliberately. That route answers "is
+// the caller an admin" for the frontend and must stay reachable by non-admins;
+// it already resolves the requester itself and ignores the path parameter.
+// Routes registered above keep their explicit `requireClawAdmin` — redundant
+// now, but harmless, and removing them would make this ordering load-bearing
+// in a way that is easy to break later.
+router.use(requireClawAdmin);
+
+
 // ── Ratings aggregation ──────────────────────────────────────────────
 
 function cutoffFromDays(daysParam: unknown): Date | null {

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -231,6 +231,15 @@ interface PendingStream {
   /** Parent ref the assistant placeholder was created under. Echoed in `done`
    *  so the frontend can stitch the optimistic message into the tree. */
   assistantParentId?: string;
+  /** Whether this subscriber may receive `debug` frames.
+   *
+   *  The debug frame carries the agent's full system prompt, instructions and
+   *  tool-use policy. The stored-history endpoint already withholds it from
+   *  callers without elevated access; the live stream did not, so the same
+   *  content was readable by any user who could start a run. Resolved once when
+   *  the stream is opened — the callback handler that forwards frames runs on
+   *  an S2S request from xyne-claw and has no end-user identity of its own. */
+  allowDebug?: boolean;
 }
 const pendingStreams = new Map<string, PendingStream>();
 
@@ -310,7 +319,12 @@ function ensureChatEventsSubscriber(): void {
     const stream = pendingStreams.get(msg.callbackId);
     if (!stream) return; // stream lives on another pod (or already resolved)
     if (msg.kind === "progress") {
-      for (const e of msg.events) stream.sendEvent(e.event, e.data);
+      // Same withholding as the same-pod path above: the pod that owns the
+      // subscriber is the only one that knows whether it may see `debug`.
+      for (const e of msg.events) {
+        if (e.event === "debug" && !stream.allowDebug) continue;
+        stream.sendEvent(e.event, e.data);
+      }
       return;
     }
     stream.sendEvent("debug_artifacts_ready", {
@@ -780,7 +794,7 @@ router.get("/:slug/context/search", async (req: Request<{ slug: string }>, res: 
       return;
     }
 
-    const agent = await agentRepository.findBySlug(req.params.slug, getOrgId(req));
+    const agent = await agentRepository.findBySlugVisibleTo(req.params.slug, getOrgId(req), getRequesterId(req));
     if (!agent) {
       log.warn(`[agent-chat/context-search] agent org-scoped miss slug=${req.params.slug} orgId=${getOrgId(req) ?? "none"} userId=${userId}`);
       res.status(404).json({ success: false, error: "Agent not found" });
@@ -863,7 +877,7 @@ router.get("/:slug/litellm-models", async (req: Request<{ slug: string }>, res: 
       res.status(401).json({ success: false, error: "x-user-id header is required" });
       return;
     }
-    const agent = await agentRepository.findBySlug(req.params.slug, getOrgId(req));
+    const agent = await agentRepository.findBySlugVisibleTo(req.params.slug, getOrgId(req), getRequesterId(req));
     if (!agent) {
       res.status(404).json({ success: false, error: "Agent not found" });
       return;
@@ -1070,7 +1084,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
         ].join("\n")
       : "";
 
-    const agent = await agentRepository.findBySlug(slug, getOrgId(req));
+    const agent = await agentRepository.findBySlugVisibleTo(slug, getOrgId(req), userId);
     if (!agent) {
       log.warn(`[agent-chat/chat] agent org-scoped miss slug=${slug} orgId=${getOrgId(req) ?? "none"} userId=${userId}`);
       res.status(404).json({ success: false, error: "Agent not found" });
@@ -1317,6 +1331,15 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
       "X-Accel-Buffering": "no", // disable proxy buffering (istio/nginx)
     });
 
+    // Whether this subscriber may receive `debug` frames. Same predicate the
+    // stored-history endpoint uses for `debugEvents`, so a caller sees the same
+    // debug content live as it would on replay. Resolved here, before the SSE
+    // promise, because the callback that forwards frames arrives on a separate
+    // S2S request with no end-user identity of its own.
+    const debugIsAdmin = await isClawAdmin(userId);
+    const debugEditAccess = debugIsAdmin ? null : await getAgentEditAccess(userId, slug, getOrgId(req));
+    const allowDebug = debugIsAdmin || Boolean(debugEditAccess?.canEdit);
+
     // Send conversationId immediately
     res.write(`event: meta\ndata: ${JSON.stringify({ conversationId })}\n\n`);
 
@@ -1358,6 +1381,7 @@ router.post("/:slug/chat", async (req: Request<{ slug: string }>, res: Response)
         resolve,
         setClosed: () => { closed = true; },
         assistantMessageId: assistantMsg.id,
+        allowDebug,
         ...(createdUserMessageId ? { userMessageId: createdUserMessageId } : {}),
         ...(assistantParentId ? { assistantParentId } : {}),
       });
@@ -1869,7 +1893,14 @@ internalRouter.post("/:slug/chat/:convId/progress", async (req: Request<{ slug: 
 
   if (events.length > 0 && callbackId) {
     if (stream) {
-      for (const e of events) stream.sendEvent(e.event, e.data);
+      // `debug` is withheld unless the subscriber was resolved as elevated when
+      // the stream opened. Filtered at delivery rather than at construction
+      // because the same `events` array is also published cross-pod, where the
+      // receiving pod owns the subscriber and applies this same check.
+      for (const e of events) {
+        if (e.event === "debug" && !stream.allowDebug) continue;
+        stream.sendEvent(e.event, e.data);
+      }
     } else {
       publishChatEvent({ kind: "progress", callbackId, events });
     }
@@ -1977,7 +2008,7 @@ internalRouter.post("/:slug/chat/:convId/callback", async (req: Request<{ slug: 
   let includeCitations = false;
   try {
     const agentRow = callbackOrgId
-      ? await agentRepository.findBySlug(req.params.slug, callbackOrgId)
+      ? await agentRepository.findBySlugVisibleTo(req.params.slug, callbackOrgId, userId)
       : null;
     const replyOpts = (agentRow?.config as { replyOptions?: { includeCitations?: boolean } } | undefined)?.replyOptions;
     if (replyOpts && replyOpts.includeCitations === true) includeCitations = true;
@@ -2055,7 +2086,7 @@ internalRouter.post("/:slug/chat/:convId/callback", async (req: Request<{ slug: 
   let persisted: { messageId: string; persistedAttachments: PersistedAttachment[] } | null = null;
   if (userId && callbackOrgId) {
     try {
-      const agent = await agentRepository.findBySlug(req.params.slug, callbackOrgId);
+      const agent = await agentRepository.findBySlugVisibleTo(req.params.slug, callbackOrgId, userId);
       if (!agent) {
         log.warn(`[agent-chat/result] agent org-scoped miss slug=${req.params.slug} orgId=${callbackOrgId ?? "none"} userId=${userId ?? "none"} sessionId=${req.params.convId}`);
         res.status(404).json({ success: false, error: "Agent not found" });

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -3181,7 +3181,13 @@ async function runAgentChatViaSse(
               }
             },
             onDebug: (_sid, debugEvent) => {
-              pendingStreams.get(callbackId)?.sendEvent("debug", { debugEvent });
+              // Same gate as the legacy /progress path (line ~325/1901): debug
+              // frames carry the full system prompt / tool policy, so only the
+              // agent's editors or a Claw admin may receive them. Without this
+              // check the SSE transport (CLAW_SSE_TRANSPORT=on) re-opens PY-JP-012.
+              const debugStream = pendingStreams.get(callbackId);
+              if (!debugStream?.allowDebug) return;
+              debugStream.sendEvent("debug", { debugEvent });
             },
             onCancelled: (_sid, reason) => {
               // Distinct cancel signal so the v3 chat UI can drop its typing

--- a/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
@@ -3,7 +3,7 @@ import { errMsg } from "../lib/errors.js";
 import { randomUUID } from "node:crypto";
 import { CONFIG } from "../config.js";
 import { requireAuth, requireNoAccessToken, requireResultToken } from "../middleware/require-auth.js";
-import { getRequesterId } from "../middleware/agent-acl.js";
+import { getRequesterId, getAgentEditAccess, isClawAdmin } from "../middleware/agent-acl.js";
 import { prisma } from "../db.js";
 import { chatMessageRepository, agentRunRepository, chatAttachmentRepository } from "../repositories/index.js";
 import { gcsService } from "../services/storageService.js";
@@ -60,6 +60,12 @@ interface PendingStream {
   reject: (error: Error) => void;
   setClosed: () => void;
   cookieHeader: string | undefined;
+  /** Whether this subscriber may receive `debug` frames. Debug frames carry the
+   *  full system prompt / instructions / tool policy (WAPT PY-JP-012), so they
+   *  must only reach the agent's owner/editors or a Claw admin. Resolved once
+   *  when the SSE opens — the internal /progress POST that forwards frames has
+   *  no end-user identity of its own. */
+  allowDebug: boolean;
 }
 
 interface StreamMeta {
@@ -175,7 +181,10 @@ function ensureStreamEventsSubscriber(): void {
     const stream = pendingStreams.get(msg.streamId);
     if (!stream) return; // stream lives on another pod (or already resolved)
     if (msg.kind === "progress") {
-      for (const e of msg.events) stream.sendEvent(e.event, e.data);
+      for (const e of msg.events) {
+        if (e.event === "debug" && !stream.allowDebug) continue;
+        stream.sendEvent(e.event, e.data);
+      }
       return;
     }
     // result
@@ -412,6 +421,14 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
       return;
     }
     const orgId = agentRow.orgId;
+
+    // Gate for `debug` SSE frames (system prompt / instructions / tool policy).
+    // Same predicate the /agent-chat stream uses: only the agent's editors or a
+    // Claw admin may watch a live debug trace. Resolved here (not in the
+    // /progress forwarder) because that forwarder is an internal S2S POST with
+    // no user identity.
+    const allowDebug = (await isClawAdmin(userId))
+      || (await getAgentEditAccess(userId, slug, orgId)).canEdit;
 
     const sdlcResolution = slug === "sdlc-agent"
       ? await resolveSdlcRepositoryForUser(
@@ -833,6 +850,7 @@ publicRouter.post("/", requireAuth, requireNoAccessToken, async (req: Request, r
           closed = true;
         },
         cookieHeader: req.headers["cookie"] as string | undefined,
+        allowDebug,
       });
 
       setTimeout(() => {
@@ -1259,7 +1277,10 @@ internalRouter.post("/:streamId/progress", (req: Request<{ streamId: string }>, 
     if (events.length > 0) {
       const localStream = pendingStreams.get(streamId);
       if (localStream) {
-        for (const e of events) localStream.sendEvent(e.event, e.data);
+        for (const e of events) {
+          if (e.event === "debug" && !localStream.allowDebug) continue;
+          localStream.sendEvent(e.event, e.data);
+        }
       } else {
         publishStreamEvent({ kind: "progress", streamId, events });
       }
@@ -1690,6 +1711,7 @@ async function runViaSseTransport(opts: RunViaSseOpts): Promise<void> {
         if (CONFIG.liveToolCallsEnabled && toolLabel) publishLiveEvent(convId, { type: "label", conversationId: convId, agentSlug: slug, userId, toolLabel, ts: Date.now() });
       },
       onDebug: (_sid, debugEvent) => {
+        if (!stream.allowDebug) return;
         stream.sendEvent("debug", { debugEvent });
       },
       onCancelled: (_sid, reason) => {


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
