### PR TITLE
fix: imports, types

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/settings.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/settings.ts
@@ -16,7 +16,9 @@ import { extractCodexBearer } from "../lib/codex-creds.js";
 import { CONFIG } from "../config.js";
 import { redisService } from "../redis.js";
 import { fetchAnthropicModels } from "./agents.js";
+import { createLogger } from "../logger.js";
 
+const log = createLogger("settings");
 
 const router = Router();
 

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -607,6 +607,18 @@ const AGENT_SUMMARY_SAMPLE = 5;
 /** Cap on connectors the server offers unprompted, so a card never becomes a list. */
 const MCP_SUGGEST_INFERRED_MAX = 3;
 
+/**
+ * Connector cards to post alongside a reply. The model requests these
+ * explicitly (`title`/`listAll`); the server fills the same shape when it
+ * infers a suggestion from the message text (`inferred`).
+ */
+type PendingConnectorSuggestions = {
+  serverTypes: string[];
+  title?: string;
+  listAll?: boolean;
+  inferred?: boolean;
+};
+
 async function agentOwnerCredit(
   ownerUserId: string | null | undefined,
 ): Promise<{ name?: string | null; id?: string | null } | undefined> {
@@ -4710,7 +4722,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       | { variant: "summary" };
     // Connector cards to post alongside the reply, so the user can connect
     // without leaving the conversation.
-    pendingConnectorSuggestions?: { serverTypes: string[]; title?: string; listAll?: boolean };
+    pendingConnectorSuggestions?: PendingConnectorSuggestions;
   };
 
   const sessionId = payload.sessionId ?? "";
@@ -6062,7 +6074,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     }
   }
 
-  const pendingConnectorSuggestions =
+  const pendingConnectorSuggestions: PendingConnectorSuggestions | undefined =
     payload.pendingConnectorSuggestions ??
     (inferredTypes.length > 0 ? { serverTypes: inferredTypes, inferred: true } : undefined);
   if (pendingConnectorSuggestions && agentCardDeliverable) {
@@ -6104,7 +6116,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
             .map((type) => byType.get(type))
             .filter((row): row is NonNullable<typeof row> => !!row);
 
-      const inferred = (pendingConnectorSuggestions as { inferred?: boolean }).inferred === true;
+      const inferred = pendingConnectorSuggestions.inferred === true;
 
       const connectors = ordered
         // An inferred card is unsolicited, so it only earns its place when it


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
