### PR TITLE
fix: XYNE-17871 fixed external call ui bug

### DIFF
--- a/apps/dashboard-external/package.json
+++ b/apps/dashboard-external/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@livekit/components-react": "^2.9.15",
     "@livekit/components-styles": "^1.1.6",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@rocicorp/zero": "1.9.0",
     "@tanstack/react-query": "^5.90.9",
     "@xstate/react": "^6.0.0",

--- a/apps/dashboard-external/src/App.tsx
+++ b/apps/dashboard-external/src/App.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { Provider as TooltipProvider } from '@radix-ui/react-tooltip';
 import { Toaster } from 'sonner';
 import { ExternalLobbyPage } from './routes/ExternalLobby/ExternalLobbyPage';
 
@@ -33,9 +34,20 @@ const router = createBrowserRouter([
 
 export default function App() {
   return (
-    <>
+    // FullCallView is shared with the dashboard, and its CallControls use Tooltip
+    // ~16 times. Radix's Tooltip.Root throws without a Provider ancestor, and the
+    // dashboard mounts one at its own root — so reusing that view here means
+    // mounting one too, or the call view crashes on render.
+    //
+    // Imported from @radix-ui/react-tooltip rather than @/components/ui/Tooltip
+    // on purpose: the dashboard's TooltipProvider is a thin wrapper over this
+    // same primitive, and going direct keeps dashboard-external off the
+    // approved-entry-point list that .dependency-cruiser.cjs enforces.
+    //
+    // delayDuration matches the dashboard so tooltips feel identical in both.
+    <TooltipProvider delayDuration={0}>
       <RouterProvider router={router} />
       <Toaster theme="dark" position="top-right" richColors />
-    </>
+    </TooltipProvider>
   );
 }

--- a/apps/dashboard/src/components/Call/useTelepresenceEnabled.ts
+++ b/apps/dashboard/src/components/Call/useTelepresenceEnabled.ts
@@ -1,4 +1,4 @@
-import { useCacConfig } from '@xyne/shared/hooks';
+import { useOptionalCacConfig } from '@xyne/shared/hooks';
 import {
   TELEPRESENCE_CAC_KEY,
   DEFAULT_TELEPRESENCE_CAC_CONFIG,
@@ -14,7 +14,9 @@ import {
  *   2. the user's email is in config.allowedEmails
  */
 export function useTelepresenceEnabled(userEmail: string | null | undefined): boolean {
-  const { config } = useCacConfig<TelepresenceCacConfig>({
+  // Optional variant: FullCallView is reused by dashboard-external, which mounts
+  // no HttpClientProvider, and the throwing `useCacConfig` crashed that render.
+  const { config } = useOptionalCacConfig<TelepresenceCacConfig>({
     key: TELEPRESENCE_CAC_KEY,
     fallbackConfig: DEFAULT_TELEPRESENCE_CAC_CONFIG,
   });

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -15,7 +15,7 @@ export {
 export { AffinityService } from "../services/affinityService.js";
 export type { AffinityWeights } from "../services/affinityService.js";
 
-export { useCacConfig } from "./useCacConfig.js";
+export { useCacConfig, useOptionalCacConfig } from "./useCacConfig.js";
 
 export { useChannelRecentSenders } from "./useChannelRecentSenders.js";
 export { useDmAffinityRank } from "./useDmAffinityRank.js";

--- a/packages/shared/src/hooks/useCacConfig.ts
+++ b/packages/shared/src/hooks/useCacConfig.ts
@@ -1,5 +1,5 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
-import { useHttpClient } from './HttpClientContext.js';
+import { useHttpClient, useOptionalHttpClient } from './HttpClientContext.js';
 
 type CacConfigResponse<TConfig> = {
   key: string;
@@ -22,6 +22,52 @@ export const useCacConfig = <TConfig>({
     queryKey: ['cac-config', key],
     queryFn: (): Promise<CacConfigResponse<TConfig>> =>
       httpClient.get<CacConfigResponse<TConfig>>(`/cac-config/${key}`),
+    staleTime: 60 * 60 * 1000,
+    retry: 1,
+  });
+
+  return {
+    ...query,
+    config: query.data?.config ?? fallbackConfig,
+  };
+};
+
+/**
+ * Same as `useCacConfig`, for surfaces that may render without an
+ * HttpClientProvider.
+ *
+ * `useCacConfig` reaches the flag through `useHttpClient`, which throws when no
+ * provider is mounted. That is the right default for the dashboard, where a
+ * missing provider is a wiring bug. It is wrong for a surface that legitimately
+ * has none: dashboard-external mounts only QueryClient and Router (no auth, no
+ * Zero — it is served on a public domain) yet reuses FullCallView, so reading a
+ * flag there threw during render and React Router showed an error page instead
+ * of the call.
+ *
+ * Here a missing client is not an error, it is simply "no answer" — the same
+ * position as a failed request — so the query never starts and the caller gets
+ * `fallbackConfig`. Every CAC caller already treats that as "feature off", so
+ * such a surface degrades to disabled rather than broken.
+ *
+ * Prefer `useCacConfig`. Reach for this one only where a provider genuinely may
+ * not exist, so that a real wiring bug in the dashboard still fails loudly.
+ */
+export const useOptionalCacConfig = <TConfig>({
+  key,
+  fallbackConfig,
+}: UseCacConfigOptions<TConfig>): UseQueryResult<CacConfigResponse<TConfig>> & {
+  config: TConfig;
+} => {
+  const httpClient = useOptionalHttpClient();
+  const query = useQuery<CacConfigResponse<TConfig>>({
+    queryKey: ['cac-config', key],
+    // Non-null assertion is safe: `enabled` keeps the fetcher from running while
+    // the client is null, and react-query re-evaluates it if one appears later.
+    queryFn: (): Promise<CacConfigResponse<TConfig>> =>
+      httpClient!.get<CacConfigResponse<TConfig>>(`/cac-config/${key}`),
+    enabled: httpClient !== null,
+    // Matched to useCacConfig so the two share the ['cac-config', key] cache
+    // entry rather than fighting over it with different freshness rules.
     staleTime: 60 * 60 * 1000,
     retry: 1,
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1323,6 +1323,9 @@ importers:
       '@livekit/components-styles':
         specifier: ^1.1.6
         version: 1.2.0
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@rocicorp/zero':
         specifier: 1.9.0
         version: 1.9.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))
@@ -7906,79 +7909,66 @@ packages:
     resolution: {integrity: sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.3':
     resolution: {integrity: sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.3':
     resolution: {integrity: sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.3':
     resolution: {integrity: sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.3':
     resolution: {integrity: sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.3':
     resolution: {integrity: sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.3':
     resolution: {integrity: sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.3':
     resolution: {integrity: sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.3':
     resolution: {integrity: sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.3':
     resolution: {integrity: sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.3':
     resolution: {integrity: sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.3':
     resolution: {integrity: sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.3':
     resolution: {integrity: sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.3':
     resolution: {integrity: sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==}
@@ -12331,6 +12321,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard
  - dashboard-external

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

External call links were broken — a guest opening a shared call link got React Router's error page instead of the call.

```
Error: useHttpClient must be used within an HttpClientProvider
    at useTelepresenceEnabled
React Router caught the following error during render
```
<img width="1920" height="1420" alt="Screenshot_2026-08-26_17-59-01 (1)" src="https://github.com/user-attachments/assets/9606b489-0830-4560-b8ae-5a04f4d34cf7" />

<img width="1929" height="1409" alt="Screenshot_2026-08-26_18-02-05 (1)" src="https://github.com/user-attachments/assets/0586a345-75ae-42d5-b4c6-2c1d95d51bed" />



**Root cause.** `dashboard-external` has no call UI of its own — it imports `FullCallView` straight from the dashboard (an approved entry point). That component calls `useTelepresenceEnabled` → `useCacConfig` → `useHttpClient`, which throws by design when no `HttpClientProvider` is mounted. `dashboard-external` deliberately mounts only `QueryClient` + `Router` (no auth, no Zero — it's served on a public domain), so reading a feature flag became a render crash.

**Pre-existing, not a recent regression.** Both the hook in `FullCallView` and `dashboard-external` reusing `FullCallView` arrived in `770c54669` (repo restructure). Verified by checking out `1408493a8` and reproducing the identical error there. Also not telepresence-specific — swapping in an unrelated CAC hook produces the same crash, so the fault is `useCacConfig` itself.

### Two fixes, because there are two missing providers

**1. `useOptionalCacConfig` — a sibling hook for surfaces that legitimately have no provider.**

`useCacConfig` is left **byte-identical** and still throws. That's the right default for the dashboard, where a missing provider is a wiring bug and should fail loudly. The new variant uses `useOptionalHttpClient()` with `enabled: httpClient !== null`, so a missing client is "no answer" — the same position as a failed request — and the caller gets `fallbackConfig`. Every CAC caller already treats that as "feature off", so a provider-less surface degrades to **disabled** rather than **broken**. Same `['cac-config', key]` query key and `staleTime`, so both hooks share one cache entry.

`useTelepresenceEnabled` switches to it — one line.

**2. `TooltipProvider` in `dashboard-external`.**

Fixing the CAC crash exposes the next one, previously unreachable. Both live in `FullCallView` at different points: `useTelepresenceEnabled` runs at line 166 (component body), `CallControls` renders at line 566 (JSX) and uses `Tooltip` 16 times. Hooks run before children render, so the CAC throw aborted the render before Radix's `Tooltip.Root` was ever reached.

Imported from `@radix-ui/react-tooltip` rather than `@/components/ui/Tooltip` deliberately — the dashboard's `TooltipProvider` is a thin pass-through to that same primitive, and going direct keeps `dashboard-external` off the approved-entry-point list `.dependency-cruiser.cjs` guards (stays at four). `delayDuration={0}` matches the dashboard.

`@radix-ui/react-tooltip@^1.2.8` added to `dashboard-external` (same version the dashboard uses) — required, not cosmetic: vite resolved it via its fallback plugin but `tsc` didn't, failing with `Cannot find module`.

6 files, +71 / −19.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

Also `apps/dashboard-external` (not listed above).

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed**
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

No env or URL changes. One new dependency (`@radix-ui/react-tooltip`), already used by the dashboard at the same version.

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots

---

## How did you test it?

https://github.com/user-attachments/assets/82462c61-be0d-4def-ad06-c300eff97937

**Reproduced first**, through the real guest flow: run `dashboard-external`, start a call as a normal user, open the call link in incognito. Confirmed the crash, then confirmed each fix removes it — the CAC fix surfaced the Tooltip error, and the Tooltip fix cleared that too.

**Attribution verified against a pre-PR checkout.** Built and ran `



dashboard-external` at `1408493a8` in a throwaway worktree and got the identical error at `useTelepresenceEnabled`. Confirmed all five links of the chain exist at that commit: `useCacConfig` uses the throwing `useHttpClient`, `FullCallView:165` calls `useTelepresenceEnabled`, `dashboard-external` mounts no provider, `ExternalCallView:158` renders `FullCallView`, and `HttpClientContext.tsx:24` throws.

**Three probe routes** in `dashboard-external` (temporary, all removed):

| Case | Result |
|---|---|
| Fixed hook, no provider | `telepresence=false` — no throw, no console errors |
| **Control**: `useSpeakerIdentificationEnabled` (untouched `useCacConfig`) | **still throws** — global behaviour unchanged |
| Fixed hook wrapped in `HttpClientProvider` with a recording stub client | `enabled=true`, `fetched=["/cac-config/xyne_telepresence_config"]` |

The control matters most: a missing provider in the dashboard still fails loudly, which is the property worth preserving.

**Blast-radius check on `useCacConfig`'s callers.** All 12 (11 in dashboard + `useMentionSearch` in shared) destructure only `{ config }` — none read `isLoading`, `status`, `error` or `data` — so nothing downstream is affected by the `enabled: false` path.

**`depcruise`** on `dashboard-external` reports the same single pre-existing violation (`ExternalLobbyPage → usePlatform`), nothing new.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- neither dashboard has a test runner (no vitest/jest, zero test files); verification ran as temporary probe routes, removed afterwards -->

### Manual

**Users**
- [x] Single user
- [x] Two users at once (host + external guest)
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout
- [x] Email + password, plus an unauthenticated guest via an external call link

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — n/a, no Zero changes

**Surface & data**
- [x] Web browser (incl. incognito as the guest)
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [x] Error paths — no provider, provider present, unrelated CAC hook as control

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass <!-- not run; no backend files touched -->
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass <!-- typecheck clean; build not run -->
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` <!-- added by editing package.json + install; version matches the dashboard's ^1.2.8 -->
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*` <!-- branch ok: fix/external-active-call-ui-bug; needs ticket id in the commit -->
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

