### PR TITLE
feat: add LiteLLM model picker and fallback toggle

### DIFF
--- a/apps/xyne-claw-auth/backend/src/config.ts
+++ b/apps/xyne-claw-auth/backend/src/config.ts
@@ -70,7 +70,7 @@ export const CONFIG = {
   // key that lives on the platform proxy can leave the credential's baseUrl
   // blank and hit this. Trailing slashes stripped so `${base}/v1/models` joins
   // cleanly.
-  litellmBaseUrl: (process.env["LITELLM_BASE_URL"] ?? "https://grid.ai.example.com").replace(/\/+$/, ""),
+  litellmBaseUrl: (process.env["LITELLM_BASE_URL"] ?? "https://grid.ai.juspay.net").replace(/\/+$/, ""),
   /**
    * Flip the claw → claw-auth transport from per-chunk HTTP POSTs to a single
    * SSE stream. When on, run-stream.ts opens an SSE connection to claw's

--- a/apps/xyne-claw-auth/backend/src/routes/settings.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/settings.ts
@@ -22,7 +22,7 @@ const log = createLogger("settings");
 
 const router = Router();
 
-const VALID_PROVIDERS = new Set(["spaces", "copilot", "claude", "codex"]);
+const VALID_PROVIDERS = new Set(["spaces", "copilot", "claude", "codex", "litellm"]);
 
 const GITHUB_CLIENT_ID = "Ov23li8tweQw6odWQebz";
 const GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code";
@@ -557,6 +557,47 @@ router.get("/codex/models", asyncHandler(async (req: Request, res: Response) => 
     .filter((m): m is { id: string } => Boolean(m.id))
     .filter((m) => /^(gpt-|o\d|chatgpt-)/i.test(m.id))
     .map((m) => ({ id: m.id, name: m.id }));
+  ok(res, models);
+}));
+
+
+// POST /settings/provider-credentials/litellm/models — list models for a just-typed
+// or saved personal LiteLLM/Grid key. Mirrors the agent-scoped endpoint so the
+// user settings screen can show exactly the models this key is allowed to call
+// before the credential is saved. Never returns or logs the raw key.
+router.post("/provider-credentials/litellm/models", asyncHandler(async (req: Request, res: Response) => {
+  const userId = requireRequester(req);
+  const body = (req.body ?? {}) as { apiKey?: string; baseUrl?: string };
+  const typedKey = (body.apiKey ?? "").trim();
+
+  let apiKey = typedKey;
+  let baseUrl = (body.baseUrl ?? "").trim();
+  if (!apiKey) {
+    const cred = await userProviderCredentialsRepository.findByUserAndProvider(userId, "litellm");
+    if (!cred?.encryptedKey || !cred.iv || !cred.authTag) {
+      throw badRequest("LiteLLM is not configured. Enter an API key first.");
+    }
+    apiKey = decrypt(cred.encryptedKey, cred.iv, cred.authTag, CONFIG.encryptionKey);
+    if (!baseUrl) baseUrl = cred.baseUrl ?? "";
+  }
+
+  const root = (baseUrl || CONFIG.litellmBaseUrl).replace(/\/+$/, "");
+  log.info(`[settings] litellm/models fetching ${root}/v1/models (keyLen=${apiKey.length}, source=${typedKey ? "typed" : "saved-cred"})`);
+  const upstream = await fetch(`${root}/v1/models`, {
+    headers: { Authorization: `Bearer ${apiKey}`, "User-Agent": "xyne-claw-auth" },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!upstream.ok) {
+    const text = await upstream.text().catch(() => "");
+    log.warn(`[settings] litellm/models upstream ${upstream.status} at ${root}/v1/models: ${text.slice(0, 200)}`);
+    throw new HttpError(502, `Models endpoint ${upstream.status}: ${text.slice(0, 200)}`);
+  }
+
+  const payload = (await upstream.json()) as { data?: Array<{ id?: string }> };
+  const models = (payload.data ?? [])
+    .filter((m): m is { id: string } => Boolean(m.id))
+    .map((m) => ({ id: m.id, name: m.id }))
+    .sort((a, b) => a.name.localeCompare(b.name));
   ok(res, models);
 }));
 

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -3675,6 +3675,17 @@ export async function shareMyProviderCredential(
   return data.data;
 }
 
+export async function listLitellmModelsForUser(
+  userId: string,
+  payload?: { apiKey?: string; baseUrl?: string },
+): Promise<Array<{ id: string; name: string }>> {
+  const data = await request<{ success: boolean; data: Array<{ id: string; name: string }> }>(
+    `${AUTH_API_URL}/api/v1/settings/provider-credentials/litellm/models`,
+    { method: "POST", headers: { "x-user-id": userId }, body: JSON.stringify(payload ?? {}) },
+  );
+  return data.data;
+}
+
 export async function deleteProviderCredential(userId: string, provider: string): Promise<void> {
   await request<{ success: boolean }>(
     `${AUTH_API_URL}/api/v1/settings/provider-credentials/${encodeURIComponent(provider)}`,

--- a/apps/xyne-claw-auth/frontend/src/v3/components/SettingsPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/SettingsPageV3.tsx
@@ -23,6 +23,7 @@ import {
   listCopilotModelsForUser,
   listClaudeModelsForUser,
   listCodexModelsForUser,
+  listLitellmModelsForUser,
   startCodexOauth,
   exchangeCodexOauth,
   shareMyProviderCredential,
@@ -70,6 +71,11 @@ const PROVIDER_META: Record<
     name: "OpenAI (Codex)",
     description: "Code generation and editing",
     icon: CodeIcon,
+  },
+  litellm: {
+    name: "LiteLLM (own key)",
+    description: "Use models allowed by your Grid/LiteLLM key",
+    icon: SparkleIcon,
   },
 };
 
@@ -734,7 +740,7 @@ function CopilotConfigForm({
   );
 }
 
-/* ── Generic provider config (Claude + Codex) ──────────────────────── */
+/* ── Generic provider config (Claude + Codex + LiteLLM) ─────────────── */
 
 function GenericProviderConfigForm({
   provider,
@@ -751,6 +757,7 @@ function GenericProviderConfigForm({
 }) {
   const isClaude = provider === "claude";
   const isCodex = provider === "codex";
+  const isLitellm = provider === "litellm";
   const supportsOauth = isClaude || isCodex;
 
   const [existing, setExisting] = useState<ProviderCredential | undefined>();
@@ -777,39 +784,54 @@ function GenericProviderConfigForm({
         const cred = creds.find((c) => c.provider === provider);
         setExisting(cred);
         if (cred) {
-          setModel(cred.model ?? (isClaude ? "claude-sonnet-4-5" : "gpt-4.1"));
-          setBaseUrl(cred.baseUrl ?? (isClaude ? "https://api.anthropic.com" : "https://api.openai.com/v1"));
+          setModel(cred.model ?? (isClaude ? "claude-sonnet-4-5" : isLitellm ? "private-large" : "gpt-4.1"));
+          setBaseUrl(cred.baseUrl ?? (isClaude ? "https://api.anthropic.com" : isLitellm ? "" : "https://api.openai.com/v1"));
           setAuthType(cred.authType === "oauth_token" ? "oauth_token" : "api_key");
           if (cred.reasoningEffort === "low" || cred.reasoningEffort === "medium" || cred.reasoningEffort === "high") {
             setReasoningEffort(cred.reasoningEffort);
           }
         } else {
-          setModel(isClaude ? "claude-sonnet-4-5" : "gpt-4.1");
-          setBaseUrl(isClaude ? "https://api.anthropic.com" : "https://api.openai.com/v1");
+          setModel(isClaude ? "claude-sonnet-4-5" : isLitellm ? "private-large" : "gpt-4.1");
+          setBaseUrl(isClaude ? "https://api.anthropic.com" : isLitellm ? "" : "https://api.openai.com/v1");
         }
       })
       .catch(() => {});
-  }, [provider, userId, isClaude]);
+  }, [provider, userId, isClaude, isLitellm]);
 
-  // Fetch models when connected
+  // Fetch models when connected. LiteLLM additionally supports a just-typed key
+  // so the user can pick from the Grid/LiteLLM allow-list before saving.
   useEffect(() => {
-    if (!existing?.hasApiKey) return;
+    const typedKey = apiKey.trim();
+    const typedBase = baseUrl.trim();
+    if (!isLitellm && !existing?.hasApiKey) return;
+    if (isLitellm && !typedKey && !existing?.hasApiKey) return;
+
+    let cancelled = false;
     setModelsErr(null);
-    const fetcher = isClaude ? listClaudeModelsForUser : listCodexModelsForUser;
-    fetcher(userId)
-      .then((rows) =>
-        setModels(
-          rows.map((r) => ({
-            id: r.id,
-            displayName: (r as { name?: string; displayName?: string }).displayName ?? (r as { name?: string }).name ?? r.id,
-          })),
-        ),
-      )
-      .catch((e) => {
-        setModels(null);
-        setModelsErr(e instanceof Error ? e.message : "Failed to load models");
-      });
-  }, [provider, existing?.hasApiKey, userId, isClaude]);
+    const t = setTimeout(() => {
+      const promise = isLitellm
+        ? listLitellmModelsForUser(userId, typedKey ? { apiKey: typedKey, ...(typedBase ? { baseUrl: typedBase } : {}) } : (typedBase ? { baseUrl: typedBase } : undefined))
+        : (isClaude ? listClaudeModelsForUser : listCodexModelsForUser)(userId);
+
+      promise
+        .then((rows) => {
+          if (cancelled) return;
+          setModels(
+            rows.map((r) => ({
+              id: r.id,
+              displayName: (r as { name?: string; displayName?: string }).displayName ?? (r as { name?: string }).name ?? r.id,
+            })),
+          );
+        })
+        .catch((e) => {
+          if (cancelled) return;
+          setModels(null);
+          setModelsErr(e instanceof Error ? e.message : "Failed to load models");
+        });
+    }, isLitellm ? 400 : 0);
+
+    return () => { cancelled = true; clearTimeout(t); };
+  }, [provider, existing?.hasApiKey, userId, isClaude, isLitellm, apiKey, baseUrl]);
 
   const hasKey = existing?.hasApiKey ?? false;
   const isOauth = authType === "oauth_token";
@@ -970,7 +992,7 @@ function GenericProviderConfigForm({
           label={isOauth ? (isClaude ? "OAuth Token" : "ChatGPT OAuth Token") : "API Key"}
           value={apiKey}
           onChange={(e) => setApiKey(e.target.value)}
-          placeholder={hasKey ? "••••••••" : "sk-…"}
+          placeholder={hasKey ? "••••••••" : isLitellm ? "JUSPAY_GRID_API_KEY" : "sk-…"}
           hint={hasKey ? "Leave blank to keep current" : undefined}
         />
       )}
@@ -989,7 +1011,12 @@ function GenericProviderConfigForm({
         {modelsErr && <p className="mt-1 text-[11px] text-xyne-warning-fg">Couldn&apos;t fetch models — {modelsErr}</p>}
       </div>
 
-      <TextField label="Base URL" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} />
+      <TextField
+        label="Base URL"
+        value={baseUrl}
+        onChange={(e) => setBaseUrl(e.target.value)}
+        placeholder={isLitellm ? "blank = https://grid.ai.juspay.net" : undefined}
+      />
 
       <div>
         <label className="mb-1.5 block text-[12px] font-medium text-xyne-fg-secondary">

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ProviderTabV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ProviderTabV3.tsx
@@ -236,6 +236,12 @@ export function ProviderTabV3({ agent, userId }: Props) {
   const [alwaysOn, setAlwaysOn] = useState<boolean>(seedAlwaysOn);
   const [savedAlwaysOn, setSavedAlwaysOn] = useState<boolean>(seedAlwaysOn);
 
+  /** Whether a failed configured provider may fall through to the keyless
+   * Spaces/platform provider. Defaults on to preserve existing agents. */
+  const seedFallbackToSpaces = (agent.config as Record<string, unknown> | undefined)?.["providerFallbackToSpaces"] !== false;
+  const [fallbackToSpaces, setFallbackToSpaces] = useState<boolean>(seedFallbackToSpaces);
+  const [savedFallbackToSpaces, setSavedFallbackToSpaces] = useState<boolean>(seedFallbackToSpaces);
+
   /**
    * Which provider the agent's SUBAGENTS run on, when they have no explicit
    * per-subagent override:
@@ -317,6 +323,7 @@ export function ProviderTabV3({ agent, userId }: Props) {
   const orderIsDirty =
     JSON.stringify(providerOrder) !== JSON.stringify(savedOrder) ||
     alwaysOn !== savedAlwaysOn ||
+    fallbackToSpaces !== savedFallbackToSpaces ||
     subagentMode !== savedSubagentMode ||
     automationMode !== savedAutomationMode ||
     fastMode !== savedFastMode ||
@@ -573,6 +580,11 @@ export function ProviderTabV3({ agent, userId }: Props) {
       // backend treats undefined as true anyway.
       if (alwaysOn) delete cfg.providerAlwaysOn;
       else cfg.providerAlwaysOn = false;
+      // Provider failure policy. Default is to fall through to Spaces; when the
+      // owner turns this off, a bad/expired/out-of-quota provider fails visibly
+      // instead of silently answering from the platform key.
+      if (fallbackToSpaces) delete cfg.providerFallbackToSpaces;
+      else cfg.providerFallbackToSpaces = false;
       // Subagent provider routing. Omit when "spaces" (the default) to keep the
       // JSON config minimal — the backend/runtime treat undefined as "spaces".
       if (subagentMode === "parent") cfg.subagentProviderMode = "parent";
@@ -606,12 +618,15 @@ export function ProviderTabV3({ agent, userId }: Props) {
       await updateAgent(agent.slug, { config: cfg });
       // Keep the prop-derived config in step (the Spaces row merges against it).
       const live = agent.config as Record<string, unknown>;
+      if (cfg.providerFallbackToSpaces !== undefined) live["providerFallbackToSpaces"] = cfg.providerFallbackToSpaces;
+      else delete live["providerFallbackToSpaces"];
       if (cfg.modelSettings) live["modelSettings"] = cfg.modelSettings;
       else delete live["modelSettings"];
       // Mirror the just-saved state so future edits compute against it
       // and the dirty check clears (button returns to its quiet default).
       setSavedOrder([...providerOrder]);
       setSavedAlwaysOn(alwaysOn);
+      setSavedFallbackToSpaces(fallbackToSpaces);
       setSavedSubagentMode(subagentMode);
       setSavedAutomationMode(automationMode);
       setSavedFastMode(fastMode);
@@ -778,6 +793,23 @@ export function ProviderTabV3({ agent, userId }: Props) {
                     On /upgrade
                   </button>
                 </div>
+              </div>
+            </div>
+
+            {/* Provider failure policy — controls only the implicit terminal
+                fallback to the Spaces/platform provider. Explicit provider-order
+                entries above still behave as configured. */}
+            <div className="mb-4 rounded-lg border border-xyne-border bg-xyne-surface-subtle p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-[13px] font-medium text-xyne-fg-primary">Fallback to Spaces provider</div>
+                  <p className="mt-1 text-[12px] text-xyne-fg-secondary leading-relaxed">
+                    {fallbackToSpaces
+                      ? "On — if the selected provider is invalid, out of quota, or unavailable, the run can continue on the Spaces platform provider."
+                      : "Off — provider credential failures fail visibly instead of silently answering from the Spaces platform provider."}
+                  </p>
+                </div>
+                <Switch checked={fallbackToSpaces} onChange={setFallbackToSpaces} ariaLabel="Fallback to Spaces provider" />
               </div>
             </div>
 

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -3953,7 +3953,8 @@ async function processTask(
     //   - First entry = the current parent (runtimeProvider).
     //   - Subsequent entries = remaining providers from `providerOrder`
     //     for which we actually have credentials in `providerConfigs`.
-    //   - Final entry = "spaces" (Kimi) unless the parent already was it.
+    //   - Final entry = "spaces" (Kimi) unless the parent already was it and
+    //     agentConfig.providerFallbackToSpaces has not been explicitly disabled.
     type Attempt = {
       provider: string | undefined;
       config: typeof providerConfig | undefined;
@@ -3970,8 +3971,11 @@ async function processTask(
         attempts.push({ provider: p, config: cfg });
       }
     }
-    if (runtimeProvider && runtimeProvider !== "spaces") {
+    const providerFallbackToSpaces = agentConfig?.["providerFallbackToSpaces"] !== false;
+    if (runtimeProvider && runtimeProvider !== "spaces" && providerFallbackToSpaces) {
       attempts.push({ provider: "spaces", config: undefined });
+    } else if (runtimeProvider && runtimeProvider !== "spaces" && !providerFallbackToSpaces) {
+      clog.info(`[agent] provider fallback to spaces disabled session=${sessionId} provider=${runtimeProvider}`);
     }
     const attemptByProvider = new Map(
       attempts
@@ -4136,7 +4140,7 @@ async function processTask(
             }
           }
           log(
-            `Quota fallback: ${from} → ${to}. Underlying: ${lastFallbackUnderlying}`,
+            `Provider fallback: ${from} → ${to}. Underlying: ${lastFallbackUnderlying}`,
           );
         },
         onEmpty: (provider, terminal) => {


### PR DESCRIPTION
1. Problem Description:
LiteLLM/Grid provider configuration in Claw needed the same model-list UX in user settings that already existed in the agent provider screen. The default LiteLLM base URL also pointed at the example host, and agent owners needed a way to prevent failed user/agent credentials from silently falling back to the Spaces platform provider.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Requested in Spaces thread. Existing branch inspection showed agent-level LiteLLM model fetching was already present, but the user settings surface lacked a LiteLLM model endpoint/UI path. Thread context also showed the example Grid host caused ENOTFOUND and should default to http://grid.ai.juspay.net.

3. Explain the solution implemented in the PR:
- Adds `litellm` to user provider credentials and adds `POST /settings/provider-credentials/litellm/models` to fetch allowed models using either a just-typed key or saved encrypted credential.
- Wires SettingsPageV3 to show LiteLLM as a user provider and debounce model-list fetches before save.
- Changes claw-auth default LiteLLM base URL from `https://grid.ai.example.com` to `http://grid.ai.juspay.net`.
- Adds an agent Provider tab toggle for `config.providerFallbackToSpaces`.
- Updates Claw runtime fallback attempt construction so `providerFallbackToSpaces: false` does not append terminal `spaces` fallback after a configured provider fails.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A — uses existing JSON agent config and existing provider credential tables.

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
No new env vars. Existing `LITELLM_BASE_URL` still overrides the default; fallback default changed to `http://grid.ai.juspay.net`.

8. Testing (how it was tested; screenshots/links):
- `pnpm --filter xyne-claw-auth-ui typecheck` — passed.
- `pnpm --filter xyne-claw test provider-fallback.test.ts` — passed, 11 tests.
- `git diff --check` — passed.
- `pnpm --filter xyne-claw-auth typecheck` — attempted; failed on pre-existing branch errors outside touched files (for example `src/awakening/dispatch.ts`, `src/awakening/prior-runs.ts`, Prisma generated exports). No new `settings.ts`/`config.ts` errors surfaced after grep.
- `pnpm --filter xyne-claw typecheck` — attempted; failed on pre-existing branch errors outside touched `routes/run.ts` (`@earendil-works/pi-ai` exports, `model-speed.ts`, missing `sanitize-html`). No `routes/run.ts` errors surfaced after grep.

9. Services to which this change is to be deployed:
claw-auth backend, claw-auth frontend, xyne-claw runtime.

10. Main PR link (if this PR is raised against a release branch):
N/A — base is `feature/deploy-xyneclaw`.

Branch was pushed and verified with `git ls-remote --heads origin feature/xyne-litellm-models-fallback` returning `ec535d71251c53e5149c8406ac478a3add04e34e refs/heads/feature/xyne-litellm-models-fallback`.

Requested reviewer: @AnuragDwivedi (note: the `create_pull_request` tool used here does not support assigning reviewers automatically; please add manually if it was not applied).