### PR TITLE
feat: XYNE-57690 radar execution tracking engine

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -549,6 +549,9 @@ ENABLE_DELAYED_MESSAGE_WORKER=false
 ENABLE_EMAIL_FETCH_WORKER=false
 ENABLE_ETA_DEADLINE_WORKER=false
 ENABLE_NOTIFICATION_WORKER=false
+# Radar execution engine (XYNE-57690): enqueue on message insert, and the
+# drain worker that parses and applies. Both off by default.
+ENABLE_RADAR_EXECUTION=false
 ENABLE_RECAP_SCHEDULER=true
 ENABLE_SCHEDULED_MESSAGE_WORKER=false
 ENABLE_SLACK_MIGRATION_WORKER=false
@@ -629,6 +632,17 @@ PULSE_AUTHORIZATION=
 PULSE_ENABLED_CHANNELS=
 PYTHON_AGENT_URL=http://localhost:8001
 QUESTION_TIMEOUT_MINUTES=2
+# Radar parser tuning. MODEL and the dedicated key are OPTIONAL: remove the
+# RADAR_EXECUTION_LITELLM_API_KEY line below to fall back to the org's
+# provisioned LiteLLM service account and its default model. A dedicated key
+# gives Radar its own rate limit and spend. The value below is a placeholder,
+# NOT a working key — replace it or delete the line; copying it verbatim gives
+# Radar a bogus key instead of the fallback.
+RADAR_EXECUTION_LITELLM_API_KEY=your-radar-litellm-api-key
+RADAR_EXECUTION_WORKER_CONCURRENCY=3
+RADAR_MAX_WINDOW_MESSAGES=200
+RADAR_PARSER_MODEL=open-fast
+RADAR_RUN_LOG_RETENTION_DAYS=3
 RECAP_CLEANUP_CRON=30 23 * * *
 RECAP_GENERATION_CRON=15 0 * * *
 RECAP_RETENTION_DAYS=30

--- a/apps/backend/prisma/migrations/20260827080000_add_radar_execution_tables/migration.sql
+++ b/apps/backend/prisma/migrations/20260827080000_add_radar_execution_tables/migration.sql
@@ -1,0 +1,117 @@
+-- CreateTable
+CREATE TABLE "non_zero"."execution_items" (
+    "workspaceId" TEXT NOT NULL,
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "channelId" TEXT NOT NULL,
+    "sourceMessageId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "contextSummary" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'open',
+    -- NOT NULL is load-bearing: a NULL array makes "pendingOn" @> ARRAY[me]
+    -- evaluate to NULL rather than false, so the row would silently vanish
+    -- from BOTH feeds -- including the NOT(...) branch of Waiting On, breaking
+    -- the "an ownerless item stays in its requester's Waiting On" rule.
+    "requestedBy" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "pendingOn" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "resolvedAt" TIMESTAMP(3),
+
+    CONSTRAINT "execution_items_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "non_zero"."execution_thread_states" (
+    "workspaceId" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "watermarkCreatedAt" TIMESTAMP(3) NOT NULL,
+    "watermarkMsgId" TEXT NOT NULL,
+    -- Consecutive parser failures on the window above the watermark. A failed
+    -- parse deliberately leaves the watermark put, so without this a window the
+    -- parser can never handle would be re-parsed by every later message.
+    "consecutiveFailures" INTEGER NOT NULL DEFAULT 0,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "execution_thread_states_pkey" PRIMARY KEY ("conversationId")
+);
+
+-- CreateTable
+CREATE TABLE "non_zero"."execution_item_mutations" (
+    "workspaceId" TEXT NOT NULL,
+    "id" TEXT NOT NULL,
+    "itemId" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "op" TEXT NOT NULL,
+    "actorType" TEXT NOT NULL,
+    "actorId" TEXT,
+    "sourceMessageId" TEXT,
+    "payload" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "execution_item_mutations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "non_zero"."execution_run_logs" (
+    "workspaceId" TEXT NOT NULL,
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "gatePassed" BOOLEAN NOT NULL,
+    "gateReason" TEXT NOT NULL,
+    "windowSize" INTEGER NOT NULL,
+    "parserRan" BOOLEAN NOT NULL DEFAULT false,
+    "proposedOps" JSONB,
+    "validOps" JSONB,
+    "droppedOps" JSONB,
+    "applied" JSONB,
+    "assessment" TEXT,
+    "error" TEXT,
+    "durationMs" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "execution_run_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "non_zero"."radar_teams" (
+    "workspaceId" TEXT NOT NULL,
+    "id" TEXT NOT NULL,
+    "ownerId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "memberIds" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "radar_teams_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "execution_items_conversationId_status_idx" ON "non_zero"."execution_items"("conversationId", "status");
+
+
+
+-- CreateIndex
+CREATE INDEX "execution_items_pendingOn_idx" ON "non_zero"."execution_items" USING GIN ("pendingOn");
+
+-- CreateIndex
+CREATE INDEX "execution_items_requestedBy_idx" ON "non_zero"."execution_items" USING GIN ("requestedBy");
+
+
+
+-- CreateIndex
+CREATE INDEX "execution_item_mutations_itemId_createdAt_idx" ON "non_zero"."execution_item_mutations"("itemId", "createdAt");
+
+
+
+-- CreateIndex
+CREATE INDEX "execution_run_logs_conversationId_createdAt_idx" ON "non_zero"."execution_run_logs"("conversationId", "createdAt");
+
+
+-- CreateIndex
+-- Serves the retention sweep, which filters on createdAt alone and so cannot
+-- use either composite index above.
+CREATE INDEX "execution_run_logs_createdAt_idx" ON "non_zero"."execution_run_logs"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "radar_teams_workspaceId_ownerId_idx" ON "non_zero"."radar_teams"("workspaceId", "ownerId");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4646,3 +4646,129 @@ model EntityAlias {
   @@map("entity_aliases")
   @@schema("non_zero")
 }
+
+// ─── Radar execution engine (Part A) ─────────────────────────────────────────
+// Execution items: one row per actionable ask, carrying the ownership tuple
+// (requestedBy, pendingOn). Written only by the transactional applier (LLM
+// parser output post-validation, or manual CTAs); read by the feed queries.
+model ExecutionItem {
+  workspaceId     String // denormalized tenant key (stamped on insert)
+  id              String    @id @default(cuid())
+  conversationId  String // thread this item lives in (no FK constraint)
+  channelId       String // denormalized for ACL joins (no FK constraint)
+  sourceMessageId String // message that created the ask; >1 item per source = split
+  title           String
+  contextSummary  String?
+  status          String    @default("open") // open | resolved (String: no new PG enums)
+  requestedBy     String[]  @default([]) // who asked (userIds); NOT NULL — see migration
+  pendingOn       String[]  @default([]) // whose turn it is; [] = ownerless or resolved
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+  resolvedAt      DateTime?
+
+  // Only indexes an actual query drives off. workspaceId is never the selective
+  // predicate here — every read pairs it with a GIN array match, a
+  // conversationId, or an id, so the planner drives off that and applies
+  // workspaceId as a filter. Leading with it produced write cost for nothing.
+  @@index([conversationId, status]) // gate: tracked-thread check + resolve-all
+  @@index([pendingOn], type: Gin) // feed: Pending Me membership
+  @@index([requestedBy], type: Gin) // feed: Waiting On membership
+  @@map("execution_items")
+  @@schema("non_zero")
+}
+
+// Per-thread parse watermark ("bookmark"): the last message the parser has
+// consumed. messageId is a cuid (not monotonic), so ordering is the composite
+// (createdAt, messageId) compared lexicographically — the same comparator the
+// window query and the advance use. Separate from items so it survives
+// all-resolved threads.
+model ExecutionThreadState {
+  workspaceId        String // denormalized tenant key (stamped on insert)
+  conversationId     String   @id
+  watermarkCreatedAt DateTime
+  watermarkMsgId     String
+  // Circuit breaker for a window the parser cannot handle. A failed parse
+  // leaves the watermark where it is (that is what makes retries safe), so a
+  // window that fails DETERMINISTICALLY would be re-parsed by every later
+  // message forever, billing a shared LLM quota with no upper bound. Counting
+  // consecutive failures lets the drain give up on that window and move on.
+  consecutiveFailures Int      @default(0)
+  updatedAt          DateTime @updatedAt
+
+  // No secondary index: every access is a lookup by the conversationId PK.
+  @@map("execution_thread_states")
+  @@schema("non_zero")
+}
+
+// Radar execution engine: append-only audit of every ledger mutation — who/what
+// changed an item and from which message. The watermark arbitration between the
+// LLM parser and manual CTAs is only auditable because every write lands here
+// in the same transaction as the item change.
+model ExecutionItemMutation {
+  workspaceId     String // denormalized tenant key (stamped on insert)
+  id              String   @id @default(cuid())
+  itemId          String
+  conversationId  String
+  op              String // create | resolve | reassign | reopen (String: no new PG enums)
+  actorType       String // llm | manual
+  actorId         String? // userId for manual CTAs, null for the parser
+  sourceMessageId String?
+  payload         Json? // op fields as proposed (title, pendingOn, ...) for replay/debug
+  createdAt       DateTime @default(now())
+
+  // The only reader is the debug trail, which fetches one item's history.
+  @@index([itemId, createdAt])
+  @@map("execution_item_mutations")
+  @@schema("non_zero")
+}
+
+// Radar execution engine: one row per worker drain pass — the debug trail the
+// Radar debug panel reads. Captures the gate decision, the parser's proposed
+// operations, what the validator dropped and what was applied, so "did it
+// process and what did the LLM say" is answerable without grepping logs.
+model ExecutionRunLog {
+  workspaceId    String // denormalized tenant key (stamped on insert)
+  id             String   @id @default(cuid())
+  conversationId String
+  gatePassed     Boolean
+  gateReason     String // tracked-thread | new-mention | skip
+  windowSize     Int
+  parserRan      Boolean  @default(false)
+  proposedOps    Json? // parser output post schema-validation
+  validOps       Json? // survivors of the validator
+  droppedOps     Json? // validator rejects, with reasons
+  applied        Json? // applier counts { created, resolved, reassigned }
+  assessment     String? // model's one-sentence read of the window (why ops / why none)
+  error          String?
+  durationMs     Int?
+  createdAt      DateTime @default(now())
+
+  // Debug is thread-scoped only, so a workspace-led index has no reader.
+  @@index([conversationId, createdAt])
+  // The retention sweep filters on createdAt alone, which neither composite
+  // above can serve (wrong leading column) — without this, every hourly sweep
+  // seq-scans the whole table, including the majority that delete nothing.
+  // Near-free to maintain: createdAt only increases, so inserts always land on
+  // the rightmost leaf.
+  @@index([createdAt])
+  @@map("execution_run_logs")
+  @@schema("non_zero")
+}
+
+// Radar execution engine: viewer-defined team lenses. A team is a personal,
+// named set of users; the team feed shows open items involving those members,
+// filtered by the VIEWER's channel access (DMs / private channels the viewer
+// is not in stay invisible — the lens never widens ACL).
+model RadarTeam {
+  workspaceId String // denormalized tenant key (stamped on insert)
+  id          String   @id @default(cuid())
+  ownerId     String // creator — teams are private to the viewer who made them
+  name        String
+  memberIds   String[] @default([])
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([workspaceId, ownerId])
+  @@map("radar_teams")
+  @@schema("non_zero")
+}

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -36,6 +36,7 @@ import channelRoutes from '@/routes/channels';
 import microsoftDeskAuthRoutes from '@/integrations/routes/microsoft-desk-auth';
 import conversationRoutes from '@/routes/conversations';
 import conversationLabelRoutes from '@/routes/conversationLabels';
+import radarExecutionRoutes from '@/routes/radarExecution';
 import organizationRoutes from '@/routes/organizations';
 import invitationRoutes from '@/routes/invitations';
 import communityRoutes from '@/routes/community';
@@ -478,6 +479,7 @@ export class App {
     this.app.use('/api/conversations/claw', authenticateUserOrApp, conversationRoutes);
     this.app.use('/api/conversations', authMiddleware.authenticate, conversationRoutes);
     this.app.use('/api/conversation-labels', authMiddleware.authenticate, conversationLabelRoutes);
+    this.app.use('/api/radar', authMiddleware.authenticate, radarExecutionRoutes);
     this.app.use('/api/organizations', authMiddleware.authenticate, organizationRoutes);
     this.app.use('/api/invitations', invitationRoutes);
     this.app.use('/api/users', authMiddleware.authenticate, userRoutes);
@@ -1029,6 +1031,12 @@ export class App {
     const { delayedMessageQueue } = await import('@/queues/delayedMessageQueue');
     await delayedMessageQueue.initialize();
 
+    const { radarExecutionQueue, isRadarExecutionEnabled } = await import('@/queues/radarExecutionQueue');
+    if (isRadarExecutionEnabled()) {
+      logger.info('Initializing radar execution queue (producer)...');
+      await radarExecutionQueue.initialize();
+    }
+
     logger.info('Initializing message classification queue (producer)...');
     const { messageClassificationQueue } = await import('@/queues/messageClassificationQueue');
     await messageClassificationQueue.initialize();
@@ -1099,6 +1107,10 @@ export class App {
 
       // Close SDLC producer queue
       await sdlcQueue.close();
+
+      // Close radar execution producer queue (initialized above when enabled)
+      const { radarExecutionQueue: radarQueue } = await import('@/queues/radarExecutionQueue');
+      await radarQueue.close();
 
       // Close tag generation pipeline queue
       await tagGenerationPipeline.close();

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -119,6 +119,20 @@ const envSchema = Joi.object({
 
   DESK_TICKET_DEBUG: Joi.boolean().default(false),
   ENABLE_EMAIL_CLASSIFICATION_WORKER: Joi.boolean().default(false),
+  // One switch for the whole feature, read by both processes: the API gates
+  // its producer on it, the worker gates its drain loop on it. A separate
+  // worker flag only bought states that are a no-op or actively bad (enqueuing
+  // with nothing draining), and idling the worker alone is a replicas:0
+  // decision, not a config one. Toggling loses nothing — watermarks persist,
+  // so the next enqueue replays everything above them.
+  ENABLE_RADAR_EXECUTION: Joi.boolean().default(false),
+  RADAR_PARSER_MODEL: Joi.string().default('open-fast'),
+  RADAR_EXECUTION_LITELLM_API_KEY: Joi.string().allow('').default(''),
+  // Kept as a knob deliberately: this is the hard ceiling on how much text can
+  // enter one parse, so it is the emergency brake on parser spend.
+  RADAR_MAX_WINDOW_MESSAGES: Joi.number().integer().min(1).default(200),
+  RADAR_EXECUTION_WORKER_CONCURRENCY: Joi.number().integer().min(1).default(3),
+  RADAR_RUN_LOG_RETENTION_DAYS: Joi.number().integer().min(1).default(3),
   ENABLE_TEAM_INTELLIGENCE_WORKER: Joi.boolean().default(false),
   TEAM_INTELLIGENCE_USER_JOB_CONCURRENCY: Joi.number().integer().min(1).default(2),
   TEAM_INTELLIGENCE_TEAM_JOB_CONCURRENCY: Joi.number().integer().min(1).default(2),
@@ -694,6 +708,22 @@ export const config = {
   enableEmailFetchWorker: envVars.ENABLE_EMAIL_FETCH_WORKER,
   deskTicketDebug: envVars.DESK_TICKET_DEBUG as boolean,
   enableEmailClassificationWorker: envVars.ENABLE_EMAIL_CLASSIFICATION_WORKER,
+  // Radar execution engine. Two switches: enqueue on message insert, and run
+  // the drain worker. A gated window always goes to the parser and a valid
+  // transition is always applied — there is no separate dry-run mode.
+  radar: {
+    enabled: envVars.ENABLE_RADAR_EXECUTION as boolean,
+    // Required once radar is enabled — a blank model throws at parse time.
+    parserModel: envVars.RADAR_PARSER_MODEL as string,
+    // Blank falls back to the shared LITELLM_API_KEY. A dedicated key keeps
+    // radar's rate limit and spend off the quota other features draw on.
+    litellmApiKey: envVars.RADAR_EXECUTION_LITELLM_API_KEY as string,
+    maxWindowMessages: envVars.RADAR_MAX_WINDOW_MESSAGES as number,
+    workerConcurrency: envVars.RADAR_EXECUTION_WORKER_CONCURRENCY as number,
+    // execution_run_logs is the fastest-growing table here — one row per
+    // drain pass, carrying full LLM payloads. Swept on a timer by the worker.
+    runLogRetentionDays: envVars.RADAR_RUN_LOG_RETENTION_DAYS as number,
+  },
   enableTeamIntelligenceWorker: envVars.ENABLE_TEAM_INTELLIGENCE_WORKER,
   teamIntelligence: {
     model: envVars.TEAM_INTELLIGENCE_LLM_MODEL as string,

--- a/apps/backend/src/database/acl/acl-factory.ts
+++ b/apps/backend/src/database/acl/acl-factory.ts
@@ -175,6 +175,18 @@ export class ACLFactory {
       return new BaseQueryACL(ctx, prisma)
     case 'summaryTemplate':
       return new BaseQueryACL(ctx, prisma)
+    // Radar execution engine: non_zero derived data, workspace-scoped; the
+    // feed API layers thread-membership checks in its own queries.
+    case 'executionItem':
+      return new BaseQueryACL(ctx, prisma)
+    case 'executionThreadState':
+      return new BaseQueryACL(ctx, prisma)
+    case 'executionItemMutation':
+      return new BaseQueryACL(ctx, prisma)
+    case 'executionRunLog':
+      return new BaseQueryACL(ctx, prisma)
+    case 'radarTeam':
+      return new BaseQueryACL(ctx, prisma)
     case 'channel':
       return new ChannelsACL(ctx, prisma)
     case 'channelBoardMapping':

--- a/apps/backend/src/queues/radarExecutionQueue.ts
+++ b/apps/backend/src/queues/radarExecutionQueue.ts
@@ -1,0 +1,131 @@
+import Bull from 'bull';
+import { config } from '@/config/env';
+import { logger } from '@/utils/logger';
+import { redisService } from '@/services/redisService';
+
+export interface RadarExecutionJobData {
+  conversationId: string;
+}
+
+/** Per-thread quiet period before a window is parsed. A product decision
+ *  (how fast Radar reacts), not an ops lever. */
+const DEBOUNCE_MS = 5_000;
+
+export function isRadarExecutionEnabled(): boolean {
+  return config.radar.enabled;
+}
+
+class RadarExecutionQueue {
+  private queue: Bull.Queue<RadarExecutionJobData> | null = null;
+  private isInitialized = false;
+  private isInitializing = false;
+
+  async initialize(): Promise<void> {
+    if (this.isInitialized || this.isInitializing) return;
+    this.isInitializing = true;
+
+    try {
+      this.queue = new Bull<RadarExecutionJobData>('radar-execution', {
+        redis: {
+          ...redisService.getRedisConfig(),
+          lazyConnect: false,
+        },
+        defaultJobOptions: {
+          attempts: 2,
+          backoff: { type: 'exponential', delay: 5000 },
+          removeOnComplete: true,
+          // Deviates from the repo's removeOnFail:false convention on purpose:
+          // jobId is a stable, reused conversationId, so a retained failed job
+          // would silently block that thread's enqueues forever (Bull ignores
+          // adds whose jobId exists in any state). Failures are logged by the
+          // 'failed' listener below instead.
+          removeOnFail: true,
+        },
+        settings: {
+          lockDuration: 2 * 60 * 1000,
+          stalledInterval: 60 * 1000,
+          maxStalledCount: 1,
+        },
+      });
+
+      this.setupEventListeners();
+      this.isInitialized = true;
+      logger.info('[RADAR-EXECUTION-QUEUE] Initialized');
+    } catch (error) {
+      logger.error('[RADAR-EXECUTION-QUEUE] Failed to initialize:', error);
+      this.isInitialized = false;
+    } finally {
+      this.isInitializing = false;
+    }
+  }
+
+  /**
+   * Enqueue a "something happened in this thread" signal. Fire-and-forget by
+   * contract: never throws, so the chat write path can never be blocked.
+   *
+   * jobId = conversationId + delay gives per-thread debounce: while a job for
+   * this thread is delayed/waiting/active, further adds are no-ops, and the
+   * worker reads everything above the thread's watermark when the job runs.
+   */
+  async enqueueThread(conversationId: string): Promise<void> {
+    if (!isRadarExecutionEnabled()) return;
+
+    try {
+      if (!this.isInitialized) {
+        await this.initialize();
+      }
+      if (!this.queue) return;
+
+      await this.queue.add(
+        { conversationId },
+        { jobId: conversationId, delay: DEBOUNCE_MS },
+      );
+    } catch (error) {
+      logger.error('[RADAR-EXECUTION-QUEUE] Failed to enqueue thread:', {
+        conversationId,
+        error,
+      });
+    }
+  }
+
+  private setupEventListeners(): void {
+    if (!this.queue) return;
+
+    this.queue.on('failed', (job, err) => {
+      logger.error(
+        `[RADAR-EXECUTION-QUEUE] Job ${job.id} failed — conversation ${job.data.conversationId}:`,
+        err,
+      );
+    });
+
+    this.queue.on('stalled', job => {
+      logger.warn(`[RADAR-EXECUTION-QUEUE] Job ${job.id} stalled — conversation ${job.data.conversationId}`);
+    });
+
+    this.queue.on('error', err => {
+      logger.error('[RADAR-EXECUTION-QUEUE] Queue error:', err);
+    });
+  }
+
+  getQueue(): Bull.Queue<RadarExecutionJobData> {
+    if (!this.queue) {
+      throw new Error('[RADAR-EXECUTION-QUEUE] Queue not initialized — call initialize() first');
+    }
+    return this.queue;
+  }
+
+  get isReady(): boolean {
+    return this.isInitialized && this.queue !== null;
+  }
+
+  async close(): Promise<void> {
+    if (this.queue) {
+      await this.queue.close();
+      this.queue = null;
+      this.isInitialized = false;
+      logger.info('[RADAR-EXECUTION-QUEUE] Closed');
+    }
+  }
+}
+
+export const radarExecutionQueue = new RadarExecutionQueue();

--- a/apps/backend/src/routes/radarExecution.ts
+++ b/apps/backend/src/routes/radarExecution.ts
@@ -1,0 +1,242 @@
+import { Router, type Request, type Response } from 'express';
+import { logger } from '@/utils/logger';
+import { RadarActionError, radarManualActions } from '@/services/radar/radarManualActions';
+import { radarFeedService } from '@/services/radar/radarFeedService';
+import { radarTeamService } from '@/services/radar/radarTeamService';
+
+const router = Router();
+
+function getAuthContext(req: Request): { userId: string; workspaceId: string } | null {
+  const userId = req.user?.id;
+  const workspaceId = req.user?.workspaceId;
+  if (!userId || !workspaceId) return null;
+  return { userId, workspaceId };
+}
+
+function sendUnauthorized(res: Response): void {
+  res.status(401).json({ success: false, error: 'Unauthorized' });
+}
+
+function handleActionError(res: Response, err: RadarActionError): void {
+  res
+    .status(err.code === 'not-found' ? 404 : 400)
+    .json({ success: false, error: err.message });
+}
+
+router.post('/items/:itemId/resolve', async (req: Request<{ itemId: string }>, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    const result = await radarManualActions.resolveItem(auth, req.params.itemId);
+    res.json({ success: true, data: result });
+  } catch (err) {
+    if (err instanceof RadarActionError) {
+      handleActionError(res, err);
+      return;
+    }
+    logger.error('[radar-execution] resolve failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to resolve execution item' });
+  }
+});
+
+router.post(
+  '/threads/:conversationId/resolve-all',
+  async (req: Request<{ conversationId: string }>, res: Response) => {
+    try {
+      const auth = getAuthContext(req);
+      if (!auth) {
+        sendUnauthorized(res);
+        return;
+      }
+      const result = await radarManualActions.resolveAllInThread(auth, req.params.conversationId);
+      res.json({ success: true, data: result });
+    } catch (err) {
+      if (err instanceof RadarActionError) {
+        handleActionError(res, err);
+        return;
+      }
+      logger.error('[radar-execution] resolve-all failed:', err);
+      res.status(500).json({ success: false, error: 'Failed to resolve thread items' });
+    }
+  },
+);
+
+router.get('/feed/pending-me', async (req: Request, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    const threads = await radarFeedService.pendingMe(auth);
+    res.json({ success: true, data: { threads } });
+  } catch (err) {
+    logger.error('[radar-execution] pending-me feed failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to load feed' });
+  }
+});
+
+router.get('/teams', async (req: Request, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    res.json({ success: true, data: { teams: await radarTeamService.listTeams(auth) } });
+  } catch (err) {
+    logger.error('[radar-execution] list teams failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to list teams' });
+  }
+});
+
+router.post('/teams', async (req: Request, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    const { name, memberIds } = req.body as { name?: unknown; memberIds?: unknown };
+    if (typeof name !== 'string' || !Array.isArray(memberIds) || memberIds.some(id => typeof id !== 'string')) {
+      res.status(400).json({ success: false, error: 'name and memberIds[] are required' });
+      return;
+    }
+    const team = await radarTeamService.createTeam(auth, name, memberIds);
+    res.json({ success: true, data: team });
+  } catch (err) {
+    if (err instanceof RadarActionError) {
+      handleActionError(res, err);
+      return;
+    }
+    logger.error('[radar-execution] create team failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to create team' });
+  }
+});
+
+router.patch('/teams/:teamId', async (req: Request<{ teamId: string }>, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    const { name, memberIds } = req.body as { name?: unknown; memberIds?: unknown };
+    if (typeof name !== 'string' || !Array.isArray(memberIds) || memberIds.some(id => typeof id !== 'string')) {
+      res.status(400).json({ success: false, error: 'name and memberIds[] are required' });
+      return;
+    }
+    const team = await radarTeamService.updateTeam(auth, req.params.teamId, name, memberIds);
+    res.json({ success: true, data: team });
+  } catch (err) {
+    if (err instanceof RadarActionError) {
+      handleActionError(res, err);
+      return;
+    }
+    logger.error('[radar-execution] update team failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to update team' });
+  }
+});
+
+router.delete('/teams/:teamId', async (req: Request<{ teamId: string }>, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    await radarTeamService.deleteTeam(auth, req.params.teamId);
+    res.json({ success: true });
+  } catch (err) {
+    if (err instanceof RadarActionError) {
+      handleActionError(res, err);
+      return;
+    }
+    logger.error('[radar-execution] delete team failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to delete team' });
+  }
+});
+
+router.get('/feed/team/:teamId', async (req: Request<{ teamId: string }>, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    const items = await radarTeamService.teamFeed(auth, req.params.teamId);
+    res.json({ success: true, data: { items } });
+  } catch (err) {
+    if (err instanceof RadarActionError) {
+      handleActionError(res, err);
+      return;
+    }
+    logger.error('[radar-execution] team feed failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to load team feed' });
+  }
+});
+
+router.get('/debug/items/:itemId', async (req: Request<{ itemId: string }>, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    const trail = await radarFeedService.debugItemTrail(auth, req.params.itemId);
+    if (!trail) {
+      res.status(404).json({ success: false, error: 'Execution item not found' });
+      return;
+    }
+    res.json({ success: true, data: trail });
+  } catch (err) {
+    logger.error('[radar-execution] debug item trail failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to load item trail' });
+  }
+});
+
+router.get('/debug/runs', async (req: Request, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    const conversationId =
+      typeof req.query.conversationId === 'string' ? req.query.conversationId.trim() : '';
+    if (!conversationId) {
+      // Debug is per-thread by design — there is no workspace-wide listing.
+      res.status(400).json({ success: false, error: 'conversationId is required' });
+      return;
+    }
+    const result = await radarFeedService.debugRuns(auth, conversationId);
+    if (!result) {
+      res.status(404).json({ success: false, error: 'Thread not found' });
+      return;
+    }
+    res.json({ success: true, data: result });
+  } catch (err) {
+    logger.error('[radar-execution] debug runs failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to load debug runs' });
+  }
+});
+
+router.get('/feed/waiting-on', async (req: Request, res: Response) => {
+  try {
+    const auth = getAuthContext(req);
+    if (!auth) {
+      sendUnauthorized(res);
+      return;
+    }
+    const threads = await radarFeedService.waitingOn(auth);
+    res.json({ success: true, data: { threads } });
+  } catch (err) {
+    logger.error('[radar-execution] waiting-on feed failed:', err);
+    res.status(500).json({ success: false, error: 'Failed to load feed' });
+  }
+});
+
+export default router;

--- a/apps/backend/src/services/radar/radarAcl.ts
+++ b/apps/backend/src/services/radar/radarAcl.ts
@@ -1,0 +1,80 @@
+import { DatabaseClient } from '@/database/client';
+import { repositories } from '@/database/repositories';
+
+const prisma = DatabaseClient.getInstance();
+
+interface AclAuth {
+  userId: string;
+  workspaceId: string;
+}
+
+export interface ChannelAccess {
+  allowed: boolean;
+  visibility: string;
+}
+
+/**
+ * Radar is gated by the app's own conversation-access rule (see
+ * websocketService.canAccessConversation): workspace match fail-closed, then
+ * the parent channel's ACL. Being named on an item never widens access.
+ *
+ * Stricter in one respect: visibility is an ALLOW-list. `Channel.visibility`
+ * is an unconstrained String, so a future value must fail CLOSED — Radar puts
+ * many channels on one page, where fail-open costs far more than it does for a
+ * single-thread subscription.
+ */
+const PUBLIC_VISIBILITY = 'PUBLIC';
+
+export async function canAccessConversation(
+  auth: AclAuth,
+  conversationId: string,
+): Promise<boolean> {
+  if (!conversationId) return false;
+  const conversation = await repositories.conversations.findById(conversationId);
+  if (!conversation) return false;
+  if (conversation.workspaceId && conversation.workspaceId !== auth.workspaceId) return false;
+  return canAccessChannel(auth, conversation.channelId);
+}
+
+/**
+ * Prefer canAccessConversation where a conversationId exists: the conversation
+ * row is authoritative, while an item's channelId is a creation-time stamp.
+ */
+export async function canAccessChannel(auth: AclAuth, channelId: string): Promise<boolean> {
+  if (!channelId) return false;
+  const channel = await repositories.channels.findById(channelId);
+  if (!channel) return false;
+  if (channel.workspaceId && channel.workspaceId !== auth.workspaceId) return false;
+  if (channel.visibility === PUBLIC_VISIBILITY) return true;
+  return repositories.channelParticipants.isParticipant(channelId, auth.userId);
+}
+
+/** Batch form for feed filtering: same rule, two queries instead of N. */
+export async function viewerChannelAccess(
+  auth: AclAuth,
+  channelIds: string[],
+): Promise<Map<string, ChannelAccess>> {
+  const unique = [...new Set(channelIds)];
+  if (unique.length === 0) return new Map();
+  const channels = await prisma.channel.findMany({
+    where: { id: { in: unique } },
+    select: { id: true, workspaceId: true, visibility: true },
+  });
+  // Membership unlocks everything that is not PUBLIC, not just 'PRIVATE'.
+  const gatedIds = channels.filter(c => c.visibility !== PUBLIC_VISIBILITY).map(c => c.id);
+  const memberships = gatedIds.length
+    ? await prisma.channelParticipant.findMany({
+        where: { channelId: { in: gatedIds }, userId: auth.userId },
+        select: { channelId: true },
+      })
+    : [];
+  const memberOf = new Set(memberships.map(m => m.channelId));
+  return new Map(
+    channels.map(c => {
+      const inWorkspace = !c.workspaceId || c.workspaceId === auth.workspaceId;
+      const allowed =
+        inWorkspace && (c.visibility === PUBLIC_VISIBILITY || memberOf.has(c.id));
+      return [c.id, { allowed, visibility: c.visibility }];
+    }),
+  );
+}

--- a/apps/backend/src/services/radar/radarApplier.ts
+++ b/apps/backend/src/services/radar/radarApplier.ts
@@ -1,0 +1,154 @@
+import type { Prisma } from '@prisma/client';
+import { DatabaseClient } from '@/database/client';
+import { logger } from '@/utils/logger';
+import type { ParserOperation } from '@/services/radar/radarParser';
+
+const prisma = DatabaseClient.getInstance();
+
+/** Headroom over Prisma's 5s default for a whole-thread resolve-all batch. */
+const APPLY_TRANSACTION_TIMEOUT_MS = 30_000;
+
+/** Enforced here, not only in the validator: resolve-all bypasses that path. */
+const MAX_OPERATIONS_PER_TRANSACTION = 200;
+
+export interface ApplyParams {
+  workspaceId: string;
+  conversationId: string;
+  channelId: string;
+  /** Validator-approved operations only — the applier trusts its input. */
+  operations: ParserOperation[];
+  /** The window's last message: items + audit + watermark commit atomically. */
+  watermark: { createdAt: Date; messageId: string };
+  actorType: 'llm' | 'manual';
+  actorId?: string;
+}
+
+export interface ApplyResult {
+  created: number;
+  resolved: number;
+  reassigned: number;
+}
+
+/**
+ * The ledger's only writer. Items, audit mutations and the watermark advance
+ * land in ONE transaction: either the window is fully consumed, or the
+ * watermark stays put and Bull replays it. That atomicity is what makes the
+ * parser retry-safe with no idempotency bookkeeping.
+ */
+class RadarApplier {
+  async apply(params: ApplyParams): Promise<ApplyResult> {
+    const { workspaceId, conversationId, channelId, watermark } = params;
+    const result: ApplyResult = { created: 0, resolved: 0, reassigned: 0 };
+    const operations = params.operations.slice(0, MAX_OPERATIONS_PER_TRANSACTION);
+    if (params.operations.length > operations.length) {
+      logger.warn('[RADAR-APPLIER] Operation batch truncated', {
+        conversationId,
+        received: params.operations.length,
+        applied: operations.length,
+      });
+    }
+
+    await prisma.$transaction(
+      async tx => {
+        // One createMany at the end: a round-trip per op overruns the budget.
+        const auditRows: Prisma.ExecutionItemMutationCreateManyInput[] = [];
+
+        for (const op of operations) {
+          switch (op.op) {
+            case 'create': {
+              const item = await tx.executionItem.create({
+                data: {
+                  workspaceId,
+                  conversationId,
+                  channelId,
+                  sourceMessageId: op.sourceMessageId,
+                  title: op.title ?? '',
+                  contextSummary: op.contextSummary ?? null,
+                  requestedBy: op.requestedBy ?? [],
+                  pendingOn: op.pendingOn ?? [],
+                },
+              });
+              auditRows.push(this.auditRow(params, op, item.id));
+              result.created++;
+              break;
+            }
+            // Guarded updateMany, not update-by-id: two concurrent resolves
+            // must not both succeed. count === 0 means someone got there
+            // first. The predicates also stop a mis-scoped id cross-tenant.
+            case 'resolve': {
+              const { count } = await tx.executionItem.updateMany({
+                where: { id: op.itemId, workspaceId, conversationId, status: 'open' },
+                data: { status: 'resolved', resolvedAt: new Date(), pendingOn: [] },
+              });
+              if (count === 0) break;
+              auditRows.push(this.auditRow(params, op, op.itemId as string));
+              result.resolved++;
+              break;
+            }
+            case 'reassign': {
+              const { count } = await tx.executionItem.updateMany({
+                where: { id: op.itemId, workspaceId, conversationId, status: 'open' },
+                data: { pendingOn: op.pendingOn ?? [] },
+              });
+              if (count === 0) break;
+              auditRows.push(this.auditRow(params, op, op.itemId as string));
+              result.reassigned++;
+              break;
+            }
+          }
+        }
+
+        if (auditRows.length > 0) {
+          await tx.executionItemMutation.createMany({ data: auditRows });
+        }
+
+        await tx.executionThreadState.upsert({
+          where: { conversationId },
+          create: {
+            conversationId,
+            workspaceId,
+            watermarkCreatedAt: watermark.createdAt,
+            watermarkMsgId: watermark.messageId,
+          },
+          update: {
+            watermarkCreatedAt: watermark.createdAt,
+            watermarkMsgId: watermark.messageId,
+            // A window that applied cleanly clears the poison counter: the
+            // breaker should only trip on failures that are CONSECUTIVE.
+            consecutiveFailures: 0,
+          },
+        });
+      },
+      // Prisma's 5s default is a batch-size cliff: a resolve-all over a busy
+      // thread would hit P2028 and roll the whole batch back.
+      { timeout: APPLY_TRANSACTION_TIMEOUT_MS },
+    );
+
+    return result;
+  }
+
+  private auditRow(
+    params: ApplyParams,
+    op: ParserOperation,
+    itemId: string,
+  ): Prisma.ExecutionItemMutationCreateManyInput {
+    return {
+      workspaceId: params.workspaceId,
+      conversationId: params.conversationId,
+      itemId,
+      op: op.op,
+      actorType: params.actorType,
+      actorId: params.actorId ?? null,
+      sourceMessageId: op.sourceMessageId ?? null,
+      payload: {
+        title: op.title,
+        contextSummary: op.contextSummary,
+        requestedBy: op.requestedBy,
+        pendingOn: op.pendingOn,
+        reason: op.reason,
+      },
+    };
+  }
+}
+
+export const radarApplier = new RadarApplier();

--- a/apps/backend/src/services/radar/radarExecutionService.ts
+++ b/apps/backend/src/services/radar/radarExecutionService.ts
@@ -1,0 +1,494 @@
+import { config } from '@/config/env';
+import { DatabaseClient } from '@/database/client';
+import { logger } from '@/utils/logger';
+import { extractUserMentions } from '@/utils/mentionParser';
+import {
+  radarParser,
+  type ParserOpenItem,
+  type ParserWindowMessage,
+} from '@/services/radar/radarParser';
+import { validateTransitions } from '@/services/radar/radarValidator';
+import { radarApplier } from '@/services/radar/radarApplier';
+
+const prisma = DatabaseClient.getInstance();
+
+// Cap per drain iteration so one job never loads an unbounded window; the
+// drain loop below picks up whatever a full window clipped.
+const MAX_WINDOW_MESSAGES = config.radar.maxWindowMessages;
+
+// Already-processed messages below the watermark that ride along with each
+// parse as read-only context — the model sees what the thread was about, but
+// the validator rejects any operation citing them.
+const CONTEXT_MESSAGES = 10;
+
+/**
+ * Consecutive parser failures on one window before the drain gives up on it and
+ * advances past it. Without this, a window the parser deterministically cannot
+ * handle is re-parsed by every subsequent message in the thread, indefinitely.
+ */
+const MAX_CONSECUTIVE_FAILURES = 3;
+
+/** Users.status — deactivated accounts must never be assigned an item. */
+const ACTIVE_USER_STATUS = 'ACTIVE';
+
+// First contact with a thread has no watermark row. Rather than parsing the
+// thread's entire history, bootstrap the watermark at now - lookback: the job
+// was triggered by a fresh message, so the fresh burst is what matters.
+const BOOTSTRAP_LOOKBACK_MS = 60 * 60 * 1000;
+
+/**
+ * Radar execution engine — one call per drained job, one thread at a time.
+ *
+ * Drain loop: read everything above the thread's watermark, gate it, advance
+ * the watermark, repeat until the window is empty. Looping until empty is what
+ * closes Bull's active-window gap — an add during processing is deduped away,
+ * but its messages sit above the watermark, so the loop still sees them.
+ *
+ * Watermark ordering is the composite (createdAt, messageId): messageId is a
+ * cuid, not monotonic, so it only breaks ties within one timestamp.
+ *
+ * Every pass is recorded in execution_run_logs, which is where "what did it
+ * decide, and why" is answered.
+ */
+interface RunLogDraft {
+  workspaceId: string;
+  conversationId: string;
+  gatePassed: boolean;
+  gateReason: string;
+  windowSize: number;
+  parserRan: boolean;
+  proposedOps?: unknown;
+  validOps?: unknown;
+  droppedOps?: unknown;
+  applied?: unknown;
+  assessment?: string;
+  error?: string;
+}
+
+class RadarExecutionService {
+  async processThread(conversationId: string): Promise<void> {
+    for (;;) {
+      const state = await prisma.executionThreadState.findUnique({
+        where: { conversationId },
+      });
+
+      const floor = state
+        ? { createdAt: state.watermarkCreatedAt, messageId: state.watermarkMsgId }
+        : { createdAt: new Date(Date.now() - BOOTSTRAP_LOOKBACK_MS), messageId: '' };
+
+      const window = await prisma.message.findMany({
+        where: {
+          conversationId,
+          isDeleted: false,
+          msgType: { not: 'SYSTEM' },
+          // Private-visibility messages never enter Radar: items cite thread
+          // content, and a restricted message must not leak through a card.
+          visibleTo: null,
+          OR: [
+            { createdAt: { gt: floor.createdAt } },
+            { createdAt: floor.createdAt, messageId: { gt: floor.messageId } },
+          ],
+        },
+        orderBy: [{ createdAt: 'asc' }, { messageId: 'asc' }],
+        take: MAX_WINDOW_MESSAGES,
+        select: {
+          messageId: true,
+          senderId: true,
+          content: true,
+          createdAt: true,
+          workspaceId: true,
+          sender: { select: { name: true } },
+        },
+      });
+
+      if (window.length === 0) {
+        return; // drained — the job may complete
+      }
+
+      // Gate: two deterministic branches — a tracked thread (any reply may
+      // move a ball), or an untracked one with a resolved @mention. No
+      // heuristics; the only probabilistic judgment belongs to the parser.
+      const openItems = await this.loadOpenItems(conversationId);
+      const tracked = openItems.length > 0;
+
+      // Per-message mentions feed both the gate and the parser's closed
+      // assignment sources (pendingOn may only come from these + self-claim).
+      const mentionsByMessage = new Map(
+        window.map(m => [m.messageId, extractUserMentions(m.content)]),
+      );
+      const mentionedUserIds = [...new Set([...mentionsByMessage.values()].flat())];
+      const gatePassed = tracked || mentionedUserIds.length > 0;
+
+      // Debug trail for the Radar debug panel: one row per drain pass,
+      // written best-effort — observability must never break the pipeline.
+      const startedAt = Date.now();
+      const run: RunLogDraft = {
+        workspaceId: window[0].workspaceId,
+        conversationId,
+        gatePassed,
+        gateReason: gatePassed ? (tracked ? 'tracked-thread' : 'new-mention') : 'skip',
+        windowSize: window.length,
+        parserRan: false,
+      };
+
+      if (gatePassed) {
+        logger.info('[RADAR-EXECUTION] Gate PASS', {
+          conversationId,
+          windowSize: window.length,
+          reason: tracked ? 'tracked-thread' : 'new-mention',
+          openItemCount: openItems.length,
+          mentionedUserIds,
+          bootstrap: !state,
+        });
+        // Valid operations + audit + watermark commit in ONE transaction, and a
+        // failure propagates: Bull retries, the watermark stays put, and the
+        // whole window is replayed.
+        try {
+          run.parserRan = true;
+          // Already-consumed messages just below the watermark, sent as
+          // read-only context so the model understands mid-thread windows.
+          const context = await this.loadContextMessages(conversationId, floor);
+          const contextMentions = new Map(
+            context.map(m => [m.messageId, extractUserMentions(m.content)]),
+          );
+          // id -> name for everyone involved so far, so the model can match
+          // a name typed in prose to an id (history-based assignment).
+          const involvedIds = [
+            ...new Set([
+              ...openItems.flatMap(i => [...i.requested_by, ...i.pending_on]),
+              ...[...mentionsByMessage.values()].flat(),
+              ...[...contextMentions.values()].flat(),
+            ]),
+          ];
+          // ONE name lookup per window, shared by known_users and by both
+          // toParserMessages calls below — these used to be three overlapping
+          // queries against the same table.
+          const nameById = new Map<string, string>([
+            ...window.map(m => [m.senderId, m.sender?.name ?? 'Unknown'] as const),
+            ...context.map(m => [m.senderId, m.sender?.name ?? 'Unknown'] as const),
+          ]);
+          const unresolvedIds = involvedIds.filter(id => !nameById.has(id));
+          if (unresolvedIds.length > 0) {
+            const involvedUsers = await prisma.user.findMany({
+              where: { id: { in: unresolvedIds } },
+              select: { id: true, name: true },
+            });
+            for (const u of involvedUsers) nameById.set(u.id, u.name);
+          }
+          const knownUsers = Object.fromEntries(nameById);
+          const transitions = await radarParser.parseWindow(
+            openItems,
+            this.toParserMessages(window, mentionsByMessage, nameById),
+            knownUsers,
+            this.toParserMessages(context, contextMentions, nameById),
+          );
+          run.proposedOps = transitions.operations;
+          run.assessment = transitions.assessment;
+          const windowSenders = new Map(window.map(m => [m.messageId, m.senderId]));
+          // Legal assignees: window mentions + senders, plus everyone already
+          // involved in the thread's open items or the context tail — the
+          // parser may infer an assignee from that history (user decision,
+          // Aug 27).
+          const candidateUserIds = [
+            ...new Set([
+              ...mentionedUserIds,
+              ...window.map(m => m.senderId),
+              ...openItems.flatMap(i => [...i.requested_by, ...i.pending_on]),
+              ...context.map(m => m.senderId).filter((id): id is string => id !== null),
+              ...[...contextMentions.values()].flat(),
+            ]),
+          ];
+          const allowedUserIds = await this.realWorkspaceUsers(
+            window[0].workspaceId,
+            candidateUserIds,
+          );
+          const { valid, dropped } = validateTransitions(transitions.operations, {
+            openItems,
+            windowSenders,
+            // Mention ids are regex-scraped out of message HTML, so they are
+            // attacker-authored: narrow them to ids that are really users in
+            // this workspace before they can land in the ledger.
+            allowedUserIds,
+          });
+          await this.directDmOwnerless(valid, conversationId, windowSenders, allowedUserIds);
+          run.validOps = valid;
+          run.droppedOps = dropped;
+          const last = window[window.length - 1];
+          const conversation = await prisma.conversation.findUniqueOrThrow({
+            where: { conversationId },
+            select: { channelId: true },
+          });
+          const applied = await radarApplier.apply({
+            workspaceId: last.workspaceId,
+            conversationId,
+            channelId: conversation.channelId,
+            operations: valid,
+            watermark: { createdAt: last.createdAt, messageId: last.messageId },
+            actorType: 'llm',
+          });
+          run.applied = applied;
+          logger.info('[RADAR-EXECUTION] Applied transitions', {
+            conversationId,
+            ...applied,
+            dropped,
+          });
+          await this.recordRun(run, startedAt);
+          continue; // watermark advanced inside the apply transaction
+        } catch (error) {
+          run.error = error instanceof Error ? error.message : String(error);
+          const failures = (state?.consecutiveFailures ?? 0) + 1;
+          const last = window[window.length - 1];
+
+          if (failures >= MAX_CONSECUTIVE_FAILURES) {
+            // Poison window. Holding the watermark is what makes a TRANSIENT
+            // failure safe to retry, but it makes a DETERMINISTIC one bill
+            // forever: every later message in the thread re-parses the same
+            // content, and removeOnFail means the job vanishes so nothing
+            // breaks the loop. Consume the window instead and let the thread
+            // move on — the run log keeps the error for diagnosis.
+            logger.error('[RADAR-EXECUTION] Skipping window after repeated parser failures', {
+              conversationId,
+              failures,
+              windowSize: window.length,
+              error: run.error,
+            });
+            run.error = `${run.error} (window skipped after ${failures} consecutive failures)`;
+            await this.saveWatermark(conversationId, last, 0);
+            await this.recordRun(run, startedAt);
+            continue;
+          }
+
+          await this.saveWatermark(
+            conversationId,
+            { workspaceId: last.workspaceId, createdAt: floor.createdAt, messageId: floor.messageId },
+            failures,
+          );
+          await this.recordRun(run, startedAt);
+          throw error;
+        }
+      } else {
+        logger.info('[RADAR-EXECUTION] Gate skip — untracked thread, no new @mention', {
+          conversationId,
+          windowSize: window.length,
+          bootstrap: !state,
+        });
+      }
+
+      // Consume the window either way, or it is re-scanned forever. On a gate
+      // pass the advance happens inside the applier's transaction instead.
+      await this.saveWatermark(conversationId, window[window.length - 1], 0);
+      await this.recordRun(run, startedAt);
+    }
+  }
+
+  /**
+   * Failures are swallowed so the debug trail can never break the pipeline, but
+   * awaited: an un-awaited insert per drain pass left an unbounded number of
+   * writes in flight, each holding a pool connection.
+   */
+  /**
+   * Watermark and failure count in one write. Passing the current floor back in
+   * records a failure without consuming the window, keeping retries safe.
+   */
+  private async saveWatermark(
+    conversationId: string,
+    at: { workspaceId: string; createdAt: Date; messageId: string },
+    consecutiveFailures: number,
+  ): Promise<void> {
+    await prisma.executionThreadState.upsert({
+      where: { conversationId },
+      create: {
+        conversationId,
+        workspaceId: at.workspaceId,
+        watermarkCreatedAt: at.createdAt,
+        watermarkMsgId: at.messageId,
+        consecutiveFailures,
+      },
+      update: {
+        watermarkCreatedAt: at.createdAt,
+        watermarkMsgId: at.messageId,
+        consecutiveFailures,
+      },
+    });
+  }
+
+  private async recordRun(run: RunLogDraft, startedAt: number): Promise<void> {
+    await prisma.executionRunLog
+      .create({
+        data: {
+          workspaceId: run.workspaceId,
+          conversationId: run.conversationId,
+          gatePassed: run.gatePassed,
+          gateReason: run.gateReason,
+          windowSize: run.windowSize,
+          parserRan: run.parserRan,
+          proposedOps: run.proposedOps as object | undefined,
+          validOps: run.validOps as object | undefined,
+          droppedOps: run.droppedOps as object | undefined,
+          applied: run.applied as object | undefined,
+          assessment: run.assessment ?? null,
+          error: run.error ?? null,
+          durationMs: Date.now() - startedAt,
+        },
+      })
+      .catch(error =>
+        logger.warn('[RADAR-EXECUTION] Failed to record run log', {
+          conversationId: run.conversationId,
+          error,
+        }),
+      );
+  }
+
+  /**
+   * DMs are implicitly directed: an ownerless create in a DM belongs to the
+   * person being spoken to — the counterpart, or the author themself in a
+   * self-DM (a note-to-self is always pending on its author). Deterministic
+   * post-validation step, not LLM judgment: direction is structural in a DM.
+   * Channel-thread ownerless items are untouched (genuinely unowned).
+   */
+  private async directDmOwnerless(
+    valid: Array<{ op: string; sourceMessageId: string; pendingOn?: string[] }>,
+    conversationId: string,
+    windowSenders: Map<string, string>,
+    allowedUserIds: Set<string>,
+  ): Promise<void> {
+    const ownerless = valid.filter(
+      op => op.op === 'create' && (op.pendingOn ?? []).length === 0,
+    );
+    if (ownerless.length === 0) return;
+
+    const conversation = await prisma.conversation.findUnique({
+      where: { conversationId },
+      select: {
+        channel: {
+          select: { scopeType: true, participants: { select: { userId: true } } },
+        },
+      },
+    });
+    if (conversation?.channel?.scopeType !== 'DM') return;
+
+    // This runs AFTER validateTransitions, so it has to re-apply the same
+    // allow-list itself — otherwise a stale participant row would be the one
+    // id that reaches the ledger unverified.
+    const participants = conversation.channel.participants
+      .map(p => p.userId)
+      .filter(id => allowedUserIds.has(id));
+    for (const op of ownerless) {
+      const author = windowSenders.get(op.sourceMessageId);
+      const counterparts = participants.filter(id => id !== author);
+      const self = author && allowedUserIds.has(author) ? [author] : [];
+      op.pendingOn = counterparts.length > 0 ? counterparts : self;
+    }
+  }
+
+  /**
+   * The last few already-consumed messages at/below the watermark, oldest
+   * first — parser context only. Same visibility rules as the window
+   * (visibleTo-restricted messages never enter Radar); the validator drops
+   * any operation citing these ids, so context cannot produce transitions.
+   */
+  private async loadContextMessages(
+    conversationId: string,
+    floor: { createdAt: Date; messageId: string },
+  ) {
+    if (CONTEXT_MESSAGES <= 0) return [];
+    const rows = await prisma.message.findMany({
+      where: {
+        conversationId,
+        isDeleted: false,
+        msgType: { not: 'SYSTEM' },
+        visibleTo: null,
+        OR: [
+          { createdAt: { lt: floor.createdAt } },
+          { createdAt: floor.createdAt, messageId: { lte: floor.messageId } },
+        ],
+      },
+      orderBy: [{ createdAt: 'desc' }, { messageId: 'desc' }],
+      take: CONTEXT_MESSAGES,
+      select: {
+        messageId: true,
+        senderId: true,
+        content: true,
+        createdAt: true,
+        workspaceId: true,
+        sender: { select: { name: true } },
+      },
+    });
+    return rows.reverse();
+  }
+
+  /**
+   * The subset of candidate ids that are ACTIVE users of this workspace.
+   * Everything upstream (mention scraping, the model's output) is untrusted
+   * text; this is the last point before ids reach the ledger. Deactivated
+   * accounts are excluded so a suspended user cannot be handed new work.
+   */
+  private async realWorkspaceUsers(
+    workspaceId: string,
+    candidateIds: string[],
+  ): Promise<Set<string>> {
+    if (candidateIds.length === 0) return new Set();
+    const users = await prisma.user.findMany({
+      where: { id: { in: candidateIds }, workspaceId, status: ACTIVE_USER_STATUS },
+      select: { id: true },
+    });
+    return new Set(users.map(u => u.id));
+  }
+
+  private async loadOpenItems(conversationId: string): Promise<ParserOpenItem[]> {
+    const items = await prisma.executionItem.findMany({
+      where: { conversationId, status: 'open' },
+      select: {
+        id: true,
+        title: true,
+        contextSummary: true,
+        requestedBy: true,
+        pendingOn: true,
+      },
+    });
+    return items.map(i => ({
+      id: i.id,
+      title: i.title,
+      context: i.contextSummary,
+      requested_by: i.requestedBy,
+      pending_on: i.pendingOn,
+    }));
+  }
+
+  /**
+   * Pure shaping — the caller supplies nameById so one lookup serves the
+   * window, the context tail and known_users. The model reasons over names but
+   * must answer in ids, so each message carries both.
+   */
+  private toParserMessages(
+    window: Array<{
+      messageId: string;
+      senderId: string | null;
+      content: string;
+      createdAt: Date;
+      sender: { name: string } | null;
+    }>,
+    mentionsByMessage: Map<string, string[]>,
+    nameById: Map<string, string>,
+  ): ParserWindowMessage[] {
+    return window.map(m => ({
+      id: m.messageId,
+      author: { id: m.senderId ?? 'unknown', name: m.sender?.name ?? 'Unknown' },
+      text: stripHtml(m.content),
+      mentions: (mentionsByMessage.get(m.messageId) ?? []).map(id => ({
+        id,
+        name: nameById.get(id) ?? id,
+      })),
+      timestamp_iso: m.createdAt.toISOString(),
+    }));
+  }
+}
+
+const stripHtml = (html: string): string =>
+  html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+export const radarExecutionService = new RadarExecutionService();

--- a/apps/backend/src/services/radar/radarFeedService.ts
+++ b/apps/backend/src/services/radar/radarFeedService.ts
@@ -1,0 +1,301 @@
+import { DatabaseClient } from '@/database/client';
+import { canAccessConversation, viewerChannelAccess } from '@/services/radar/radarAcl';
+
+const prisma = DatabaseClient.getInstance();
+
+/** Feeds page per thread-card, not per item; this bounds what the viewer sees. */
+export const MAX_FEED_ITEMS = 500;
+/** Over-fetch: capping before the ACL filter would silently shorten the feed. */
+export const FEED_SCAN_LIMIT = MAX_FEED_ITEMS * 4;
+const THREAD_PREVIEW_CHARS = 200;
+/** Worker runs shown in one thread's debug drawer, newest first. */
+const MAX_DEBUG_RUNS = 50;
+
+interface AuthContext {
+  userId: string;
+  workspaceId: string;
+}
+
+export interface FeedItem {
+  id: string;
+  conversationId: string;
+  channelId: string;
+  sourceMessageId: string;
+  title: string;
+  contextSummary: string | null;
+  requestedBy: string[];
+  pendingOn: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** The conversation columns the feed needs, read once per request. */
+interface FeedConversation {
+  conversationId: string;
+  channelId: string;
+  initial_message_md: string | null;
+  lastActivityAt: Date;
+}
+
+export interface FeedThreadCard {
+  conversationId: string;
+  channelId: string;
+  threadPreview: string | null;
+  lastActivityAt: Date | null;
+  items: FeedItem[];
+}
+
+/**
+ * The two GIN-backed reads the engine exists to serve:
+ *
+ * - Pending Me: pendingOn ∋ me.
+ * - Waiting On: requestedBy ∋ me, minus items I also hold. An ownerless item
+ *   (pendingOn: []) stays here — tracked, nobody on the hook yet.
+ */
+class RadarFeedService {
+  async pendingMe(auth: AuthContext): Promise<FeedThreadCard[]> {
+    return this.buildFeed(auth, { pendingOn: { has: auth.userId } });
+  }
+
+  async waitingOn(auth: AuthContext): Promise<FeedThreadCard[]> {
+    return this.buildFeed(auth, {
+      requestedBy: { has: auth.userId },
+      NOT: { pendingOn: { has: auth.userId } },
+    });
+  }
+
+  /**
+   * Read items, narrow to what the viewer may open, group into thread cards.
+   *
+   * The conversation rows are fetched ONCE and threaded through both halves:
+   * the ACL filter needs channelId, the card builder needs the preview and
+   * last activity, and fetching them separately meant two queries against the
+   * same table with overlapping ids in a single request.
+   */
+  private async buildFeed(
+    auth: AuthContext,
+    filter: Record<string, unknown>,
+  ): Promise<FeedThreadCard[]> {
+    const items = await this.openItems(auth, filter);
+    if (items.length === 0) return [];
+    const conversations = await this.conversationsFor(items.map(i => i.conversationId));
+    return this.groupByThread(await this.aclFilter(auth, items, conversations), conversations);
+  }
+
+  /**
+   * Viewer channel ACL over the whole feature: even the viewer's own feeds
+   * are narrowed to channels they may open — being mentioned in a private
+   * channel they're not part of must not leak that thread through a card.
+   */
+  private async aclFilter(
+    auth: AuthContext,
+    items: FeedItem[],
+    conversations: Map<string, FeedConversation>,
+  ): Promise<FeedItem[]> {
+    if (items.length === 0) return items;
+    // Resolve each item's channel from its conversation rather than trusting
+    // item.channelId, which is stamped at creation and never refreshed. An
+    // item whose conversation has since vanished is denied.
+    const access = await viewerChannelAccess(
+      auth,
+      [...conversations.values()].map(c => c.channelId),
+    );
+    return items
+      .filter(i => {
+        const channelId = conversations.get(i.conversationId)?.channelId;
+        return channelId ? access.get(channelId)?.allowed : false;
+      })
+      .slice(0, MAX_FEED_ITEMS);
+  }
+
+  /**
+   * conversationId -> everything the feed needs from the conversation row, in
+   * one query: the channel for the ACL check, plus the preview and activity
+   * stamp the cards render.
+   */
+  private async conversationsFor(
+    conversationIds: string[],
+  ): Promise<Map<string, FeedConversation>> {
+    const unique = [...new Set(conversationIds)];
+    if (unique.length === 0) return new Map();
+    const conversations = await prisma.conversation.findMany({
+      where: { conversationId: { in: unique } },
+      select: {
+        conversationId: true,
+        channelId: true,
+        initial_message_md: true,
+        lastActivityAt: true,
+      },
+    });
+    return new Map(conversations.map(c => [c.conversationId, c]));
+  }
+
+  /**
+   * Debug panel, per-item trail: the item row, its append-only mutation
+   * history (who did what, when), the actual messages that produced each
+   * mutation, and where the thread's watermark currently sits relative to
+   * its latest message.
+   */
+  async debugItemTrail(auth: AuthContext, itemId: string) {
+    const item = await prisma.executionItem.findUnique({ where: { id: itemId } });
+    if (!item || item.workspaceId !== auth.workspaceId) return null;
+    // Authorize against the conversation, not item.channelId: that column is a
+    // stamp taken when the item was created and is never refreshed.
+    if (!(await canAccessConversation(auth, item.conversationId))) return null;
+    const mutations = await prisma.executionItemMutation.findMany({
+      where: { itemId },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    const messageIds = [
+      ...new Set(
+        [item.sourceMessageId, ...mutations.map(m => m.sourceMessageId)].filter(
+          (id): id is string => !!id,
+        ),
+      ),
+    ];
+    const messages = messageIds.length
+      ? await prisma.message.findMany({
+          where: { messageId: { in: messageIds } },
+          select: {
+            messageId: true,
+            senderId: true,
+            content: true,
+            createdAt: true,
+            sender: { select: { name: true } },
+          },
+        })
+      : [];
+    const stripHtml = (html: string): string =>
+      html.replace(/<[^>]*>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
+    const sourceMessages = Object.fromEntries(
+      messages.map(m => [
+        m.messageId,
+        {
+          senderId: m.senderId,
+          senderName: m.sender?.name ?? 'Unknown',
+          text: stripHtml(m.content).slice(0, 300),
+          createdAt: m.createdAt,
+        },
+      ]),
+    );
+
+    const [threadState, latestMessage] = await Promise.all([
+      prisma.executionThreadState.findUnique({
+        where: { conversationId: item.conversationId },
+        select: { watermarkCreatedAt: true, watermarkMsgId: true, updatedAt: true },
+      }),
+      prisma.message.findFirst({
+        where: { conversationId: item.conversationId, isDeleted: false },
+        orderBy: [{ createdAt: 'desc' }, { messageId: 'desc' }],
+        select: { messageId: true, createdAt: true },
+      }),
+    ]);
+
+    return { item, mutations, sourceMessages, threadState, latestMessage };
+  }
+
+  /**
+   * Debug panel: the most recent worker runs, newest first. When scoped to
+   * one thread, also reports the watermark ("processed till here") relative
+   * to the thread's latest message.
+   *
+   * Thread-scoped ONLY, deliberately. This used to accept no conversationId
+   * and return the workspace's newest runs across every thread. That listing
+   * was ACL-filtered, but it was still a cross-thread window over assessments
+   * and parser payloads handed to any authenticated caller — and nothing ever
+   * called it, since the drawer always opens on one thread. It also filtered
+   * AFTER taking the newest N, so a viewer in few channels could get an empty
+   * list while runs existed. Requiring the id removes all of that.
+   */
+  async debugRuns(auth: AuthContext, conversationId: string) {
+    // ACL first: a pasted conversationId must not open a thread the viewer
+    // couldn't reach through chat itself. Denied and unknown look identical.
+    if (!(await canAccessConversation(auth, conversationId))) {
+      return null;
+    }
+
+    const runs = await prisma.executionRunLog.findMany({
+      where: { workspaceId: auth.workspaceId, conversationId },
+      orderBy: { createdAt: 'desc' },
+      take: MAX_DEBUG_RUNS,
+    });
+
+    const [threadState, latestMessage, items] = await Promise.all([
+      prisma.executionThreadState.findUnique({
+        where: { conversationId },
+        select: { watermarkCreatedAt: true, watermarkMsgId: true, updatedAt: true },
+      }),
+      prisma.message.findFirst({
+        where: { conversationId, isDeleted: false },
+        orderBy: [{ createdAt: 'desc' }, { messageId: 'desc' }],
+        select: { messageId: true, createdAt: true },
+      }),
+      // Every item the thread ever produced (resolved included), so a debug
+      // lookup by thread id can render the full trail set.
+      prisma.executionItem.findMany({
+        where: { conversationId, workspaceId: auth.workspaceId },
+        orderBy: { createdAt: 'asc' },
+        select: { id: true, title: true, status: true },
+      }),
+    ]);
+    return { runs, threadState, latestMessage, items };
+  }
+
+  private openItems(auth: AuthContext, filter: Record<string, unknown>): Promise<FeedItem[]> {
+    return prisma.executionItem.findMany({
+      where: {
+        workspaceId: auth.workspaceId,
+        status: 'open',
+        ...filter,
+      },
+      orderBy: { updatedAt: 'desc' },
+      take: FEED_SCAN_LIMIT,
+      select: {
+        id: true,
+        conversationId: true,
+        channelId: true,
+        sourceMessageId: true,
+        title: true,
+        contextSummary: true,
+        requestedBy: true,
+        pendingOn: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  private groupByThread(
+    items: FeedItem[],
+    conversations: Map<string, FeedConversation>,
+  ): FeedThreadCard[] {
+    if (items.length === 0) return [];
+
+    const cards = new Map<string, FeedThreadCard>();
+    for (const item of items) {
+      let card = cards.get(item.conversationId);
+      if (!card) {
+        const conversation = conversations.get(item.conversationId);
+        card = {
+          conversationId: item.conversationId,
+          channelId: item.channelId,
+          threadPreview:
+            conversation?.initial_message_md?.slice(0, THREAD_PREVIEW_CHARS) ?? null,
+          lastActivityAt: conversation?.lastActivityAt ?? null,
+          items: [],
+        };
+        cards.set(item.conversationId, card);
+      }
+      card.items.push(item);
+    }
+
+    // Newest thread activity first; items inside a card are already
+    // updatedAt-desc from the query.
+    return [...cards.values()].sort(
+      (a, b) => (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
+    );
+  }
+}
+
+export const radarFeedService = new RadarFeedService();

--- a/apps/backend/src/services/radar/radarManualActions.ts
+++ b/apps/backend/src/services/radar/radarManualActions.ts
@@ -1,0 +1,124 @@
+import { DatabaseClient } from '@/database/client';
+import { radarApplier } from '@/services/radar/radarApplier';
+import { canAccessConversation } from '@/services/radar/radarAcl';
+import type { ParserOperation } from '@/services/radar/radarParser';
+
+const prisma = DatabaseClient.getInstance();
+
+/** One click resolves at most this many; the rest survive for the next one. */
+const MAX_RESOLVE_ALL_ITEMS = 200;
+
+export class RadarActionError extends Error {
+  constructor(
+    public code: 'not-found' | 'bad-request',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'RadarActionError';
+  }
+}
+
+interface AuthContext {
+  userId: string;
+  workspaceId: string;
+}
+
+/**
+ * Manual CTAs — sync, no queue, no LLM. Resolve is the only manual verb; who
+ * holds the ball is the parser's job.
+ *
+ * Each action goes through the applier's transaction and slams the watermark
+ * to the latest message, so a parser job drained afterwards can never
+ * re-litigate what a person just decided from a stale window.
+ */
+class RadarManualActionsService {
+  async resolveItem(auth: AuthContext, itemId: string) {
+    const item = await this.loadOpenItem(auth, itemId);
+    return this.applyManual(auth, item.conversationId, item.channelId, [
+      { op: 'resolve', itemId: item.id },
+    ]);
+  }
+
+  async resolveAllInThread(auth: AuthContext, conversationId: string) {
+    // ACL before the lookup: checking after made "empty thread" (200) and
+    // "denied" (404) an oracle for whether a conversation has open items.
+    if (!(await canAccessConversation(auth, conversationId))) {
+      throw new RadarActionError('not-found', 'Execution item not found');
+    }
+    // Bounded: the remainder stays open for the next click, which beats a
+    // transaction that times out and rolls the whole batch back.
+    const items = await prisma.executionItem.findMany({
+      where: { conversationId, workspaceId: auth.workspaceId, status: 'open' },
+      select: { id: true, channelId: true },
+      take: MAX_RESOLVE_ALL_ITEMS,
+    });
+    if (items.length === 0) {
+      return { created: 0, resolved: 0, reassigned: 0 };
+    }
+    return this.applyManual(
+      auth,
+      conversationId,
+      items[0].channelId,
+      items.map(i => ({ op: 'resolve' as const, itemId: i.id })),
+    );
+  }
+
+  private async loadOpenItem(auth: AuthContext, itemId: string) {
+    const item = await prisma.executionItem.findUnique({
+      where: { id: itemId },
+      select: {
+        id: true,
+        workspaceId: true,
+        conversationId: true,
+        channelId: true,
+        status: true,
+      },
+    });
+    if (!item || item.workspaceId !== auth.workspaceId) {
+      throw new RadarActionError('not-found', 'Execution item not found');
+    }
+    // Same rule as reading, and resolved from the conversation rather than the
+    // item's channelId stamp: acting on an item requires access to its thread.
+    if (!(await canAccessConversation(auth, item.conversationId))) {
+      throw new RadarActionError('not-found', 'Execution item not found');
+    }
+    if (item.status !== 'open') {
+      throw new RadarActionError('bad-request', 'Execution item is not open');
+    }
+    return item;
+  }
+
+  private async applyManual(
+    auth: AuthContext,
+    conversationId: string,
+    channelId: string,
+    operations: Array<Omit<ParserOperation, 'sourceMessageId'>>,
+  ) {
+    // Watermark := latest message. Anything at or before "now" is consumed —
+    // the parser only ever sees messages sent after this action.
+    const latest = await prisma.message.findFirst({
+      where: { conversationId, isDeleted: false },
+      orderBy: [{ createdAt: 'desc' }, { messageId: 'desc' }],
+      select: { messageId: true, createdAt: true },
+    });
+    const watermark = latest
+      ? { createdAt: latest.createdAt, messageId: latest.messageId }
+      : { createdAt: new Date(), messageId: '' };
+
+    return radarApplier.apply({
+      workspaceId: auth.workspaceId,
+      conversationId,
+      channelId,
+      // A CTA acts "as of" the latest message — recorded as its source in audit.
+      operations: operations.map(op => ({
+        ...op,
+        sourceMessageId: watermark.messageId,
+      })) as ParserOperation[],
+      watermark,
+      actorType: 'manual',
+      actorId: auth.userId,
+    });
+  }
+}
+
+export const radarManualActions = new RadarManualActionsService();

--- a/apps/backend/src/services/radar/radarParser.ts
+++ b/apps/backend/src/services/radar/radarParser.ts
@@ -1,0 +1,283 @@
+import { config } from '@/config/env';
+import { logger } from '@/utils/logger';
+import { logLLMCallStart } from '@/agents/agentLogger';
+import { formatErrors, validate } from '@/services/entityExtraction/pipeline';
+
+const TAG = '[RADAR-PARSER]';
+const AGENT_NAME = 'RadarParser';
+
+/** 429s are transient concurrency limits on the shared endpoint — back off, don't fail. */
+const RATE_LIMIT_MAX_RETRIES = 6;
+/** Schema-repair round-trips after the first response. */
+const MAX_REPAIR_ATTEMPTS = 2;
+const REQUEST_TIMEOUT_MS = 300_000;
+
+/** Per-message text cap so one pasted log dump can't blow the prompt budget. */
+const MAX_MESSAGE_TEXT_CHARS = 2000;
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export interface ParserWindowMessage {
+  id: string;
+  author: { id: string; name: string };
+  text: string;
+  /** Users explicitly @mentioned in this message — the only legal pending_on sources. */
+  mentions: Array<{ id: string; name: string }>;
+  timestamp_iso: string;
+}
+
+export interface ParserOpenItem {
+  id: string;
+  title: string;
+  context: string | null;
+  requested_by: string[];
+  pending_on: string[];
+}
+
+export interface ParserOperation {
+  op: 'create' | 'resolve' | 'reassign';
+  sourceMessageId: string;
+  title?: string;
+  contextSummary?: string;
+  requestedBy?: string[];
+  pendingOn?: string[];
+  itemId?: string;
+  /** One-sentence model justification — surfaced in the debug trail. */
+  reason?: string;
+}
+
+export interface ParsedTransitions {
+  operations: ParserOperation[];
+  /** The model's one-sentence read of the window — why these ops, or why none. */
+  assessment?: string;
+}
+
+/**
+ * Everything the model may return, structurally. Per-op required fields
+ * (create needs title, resolve/reassign need itemId) are the validator box's
+ * job — the pipeline validator can't express conditionals, and in dark mode
+ * a structurally-loose op is still worth logging.
+ */
+const TRANSITIONS_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['operations', 'assessment'],
+  properties: {
+    assessment: { type: 'string' },
+    operations: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['op', 'sourceMessageId'],
+        properties: {
+          op: { enum: ['create', 'resolve', 'reassign'] },
+          sourceMessageId: { type: 'string' },
+          title: { type: 'string' },
+          contextSummary: { type: 'string' },
+          requestedBy: { type: 'array', items: { type: 'string' } },
+          pendingOn: { type: 'array', items: { type: 'string' } },
+          itemId: { type: 'string' },
+          reason: { type: 'string' },
+        },
+      },
+    },
+  },
+};
+
+const SYSTEM_PROMPT = `You are the state-transition parser of Radar, an execution-tracking engine for workplace chat.
+
+Radar tracks "execution items": concrete asks or commitments inside a thread. Each item has requested_by (who is waiting on it) and pending_on (who must act next — who "holds the ball"). An item is a ball being passed, not a task board entry.
+
+You receive one thread's current state:
+- open_items: the thread's currently open items.
+- new_messages: messages that arrived since the last parse, in chronological order. Each lists its author and the users it explicitly @mentions.
+- context_messages: the last few ALREADY-PROCESSED messages from just before new_messages, oldest first. Read them to understand what the thread is about, but they were handled in earlier passes: never cite one as a sourceMessageId, and never create an item for an ask that appears only there.
+- known_users: id -> name for everyone involved so far (authors, mentions, item participants). Use it to match a name in prose to an id.
+
+Decide which state transitions the new messages imply. Operations:
+
+1. "create" — a new concrete ask or commitment that no open item already covers. title: short imperative summary of what must happen. contextSummary: one sentence of context. requestedBy: who is asking/waiting (usually the author). pendingOn: who must act.
+   An ask includes a DIRECT QUESTION aimed at a specific person: asking someone for a status, an answer, a review, an update or a decision puts the ball with them until they respond. "@dev-bot what's the status of PR 25?" IS a trackable item (pendingOn: dev-bot, title: "Share the status of PR 25").
+2. "resolve" — an open item is FULFILLED: the thing asked for was actually delivered (the information given, the work verifiably done), the requester confirmed or accepted the outcome, or the ask was explicitly withdrawn/cancelled. itemId: the open item's id.
+3. "reassign" — the ball moved on an open item: it was explicitly handed to someone, someone claimed it, or the ball bounced back to the asker: a clarifying question, a dispute ("works for me", "cannot reproduce", "I don't think that's a bug"), or any reply the requester must now verify, confirm or answer before the item can close. itemId + new pendingOn (a bounce-back goes to requested_by).
+
+A reply is not fulfillment. When the assignee responds without delivering what was asked — they push back, can't reproduce, disagree, answer partially, or hand back a question — the item stays OPEN and the ball moves to whoever must act next (usually the requester, via reassign). Only the requester's confirmation, an objectively delivered result, or an explicit withdrawal closes an item.
+
+Assignment rules:
+- pendingOn may contain user ids that appear anywhere in this input: a message's mentions list, a message author (e.g. claiming the work — "I'll take this"), or the requested_by / pending_on of an open item (the thread's history — someone already involved can be inferred as the assignee when the conversation clearly points at them).
+- Answer in ids only — never invent an id for a name you cannot match to one given in this input.
+- An actionable ask with no inferable assignee is still tracked: create it with pendingOn: [].
+- Every operation cites sourceMessageId: the message in this window that caused it.
+- Every operation includes reason: ONE short sentence explaining why this operation follows from the messages (e.g. why this person holds the ball, or what confirmed completion).
+
+Be conservative about chatter: greetings, acknowledgements, thanks, FYIs and status updates someone volunteers produce NO operations — an empty operations array is the normal answer for such windows. A bare @mention with no request text is a HANDOFF, not noise: tagging someone under shared content (a report, a table, a log, an error) or into a thread puts that content in front of them — create an item pending on the mentioned user, titled from what the content or thread is about (e.g. "Review the tagging coverage report"). The ONLY exception is an explicit cc: when the message itself marks the mention as informational — "cc @x", "fyi @x", "looping in @x for visibility" — it is not an ask, create nothing. But do not confuse conservatism with dropping real asks: a request or question directed at a mentioned user is never chatter. Do not create an item for something an open item already covers; do not resolve on a vague "ok" unless it clearly confirms completion.
+
+Besides operations, ALWAYS return assessment: ONE short sentence giving your overall read of this window — what the messages were and why you produced these operations. When operations is empty this matters most: say exactly why nothing is trackable (e.g. "bare mention used as a cc on a shared report — no ask directed at anyone").
+
+Coverage is judged by WHAT is asked, not by who is asked or where. A tracked thread's follow-ups often add NEW asks: if "share the status of X" is already open and someone then asks "is this affecting Y too? can you confirm", that is a DIFFERENT ask — create a second item. One message can carry several distinct asks; create one item per distinct ask. A new ask whose target is not mentioned in this window still gets created, with pendingOn: [] — never drop a real ask because nobody was tagged.`;
+
+interface LiteLLMResponse {
+  choices?: Array<{ message?: { content?: string } }>;
+}
+
+/**
+ * One LiteLLM /chat/completions call. Plain fetch, mirroring
+ * services/messageClassification — single-shot, no tools.
+ */
+async function callLiteLLM(
+  auth: { apiKey: string; baseUrl: string; keyName: string },
+  model: string,
+  messages: Array<{ role: string; content: string }>,
+): Promise<string> {
+  const url = `${auth.baseUrl.replace(/\/$/, '')}/chat/completions`;
+  const supportsThinkingToggle = /glm/i.test(model);
+
+  logLLMCallStart(AGENT_NAME, model, auth.keyName);
+
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${auth.apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        // State transitions want determinism, not variety.
+        temperature: 0,
+        ...(supportsThinkingToggle && { chat_template_kwargs: { enable_thinking: false } }),
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    if (response.status === 429 && attempt < RATE_LIMIT_MAX_RETRIES) {
+      const waitMs = Math.min(30_000, 1500 * 2 ** attempt) + Math.floor(Math.random() * 500);
+      logger.warn(`${TAG} Rate limited, backing off`, { attempt: attempt + 1, waitMs, model });
+      await response.body?.cancel();
+      await sleep(waitMs);
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`LiteLLM error: ${response.status} ${(await response.text()).slice(0, 500)}`);
+    }
+    const data = (await response.json()) as LiteLLMResponse;
+    return data.choices?.[0]?.message?.content ?? '';
+  }
+}
+
+/** Tolerates code fences, <think> traces and surrounding prose around the JSON. */
+function tryParseJson(raw: string): { ok: true; value: unknown } | { ok: false; error: string } {
+  const cleaned = raw
+    .replace(/<think>[\s\S]*?<\/think>/gi, '')
+    .trim()
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim();
+  const attempt = (candidate: string) => {
+    try {
+      return { ok: true as const, value: JSON.parse(candidate) };
+    } catch {
+      return null;
+    }
+  };
+  const direct = attempt(cleaned);
+  if (direct) return direct;
+  const start = cleaned.indexOf('{');
+  const end = cleaned.lastIndexOf('}');
+  if (start !== -1 && end > start) {
+    const sliced = attempt(cleaned.slice(start, end + 1));
+    if (sliced) return sliced;
+  }
+  return { ok: false, error: cleaned.slice(0, 200) || '(empty response)' };
+}
+
+class RadarParser {
+  /**
+   * One parse call per drained window. Returns the model's proposed
+   * transitions after schema validation with repair retries; throws when the
+   * model can't produce schema-valid output (the caller treats a parser
+   * failure as non-fatal in dark mode).
+   */
+  async parseWindow(
+    openItems: ParserOpenItem[],
+    newMessages: ParserWindowMessage[],
+    knownUsers: Record<string, string> = {},
+    contextMessages: ParserWindowMessage[] = [],
+  ): Promise<ParsedTransitions> {
+    // Same resolution as entity extraction (entityLlmClient.ts): radar's own
+    // key when one is minted, otherwise the shared gateway key. A dedicated key
+    // keeps radar's rate limit and spend off the quota other features use.
+    const apiKey = config.radar.litellmApiKey || config.litellm.apiKey;
+    const baseUrl = config.litellm.baseUrl;
+    const keyName = config.radar.litellmApiKey
+      ? 'RADAR_EXECUTION_LITELLM_API_KEY'
+      : 'LITELLM_API_KEY';
+    if (!apiKey || !baseUrl) {
+      throw new Error('LiteLLM is not configured: set LITELLM_BASE_URL and an API key');
+    }
+
+    const model = config.radar.parserModel;
+    if (!model) {
+      throw new Error('No model configured: set RADAR_PARSER_MODEL');
+    }
+
+    const input = {
+      open_items: openItems,
+      new_messages: newMessages.map(m => ({
+        ...m,
+        text: m.text.slice(0, MAX_MESSAGE_TEXT_CHARS),
+      })),
+      context_messages: contextMessages.map(m => ({
+        ...m,
+        text: m.text.slice(0, MAX_MESSAGE_TEXT_CHARS),
+      })),
+      known_users: knownUsers,
+    };
+
+    const messages = [
+      {
+        role: 'system',
+        content:
+          `${SYSTEM_PROMPT}\n\nRespond with JSON only — no prose, no code fences — ` +
+          `matching this JSON Schema:\n${JSON.stringify(TRANSITIONS_SCHEMA)}`,
+      },
+      { role: 'user', content: JSON.stringify(input, null, 2) },
+    ];
+
+    let lastError = '';
+    for (let attempt = 0; attempt <= MAX_REPAIR_ATTEMPTS; attempt++) {
+      const raw = await callLiteLLM({ apiKey, baseUrl, keyName }, model, messages);
+      const parsed = tryParseJson(raw);
+
+      if (!parsed.ok) {
+        lastError = `Response was not valid JSON: ${parsed.error}`;
+      } else {
+        const errors = validate(parsed.value, TRANSITIONS_SCHEMA);
+        if (errors.length === 0) return parsed.value as ParsedTransitions;
+        lastError = formatErrors(errors);
+      }
+
+      logger.warn(`${TAG} response rejected, retrying`, {
+        attempt: attempt + 1,
+        error: lastError.slice(0, 300),
+      });
+      messages.push({ role: 'assistant', content: raw.slice(0, 4000) });
+      messages.push({
+        role: 'user',
+        content:
+          `That response did not match the required schema:\n${lastError}\n\n` +
+          `Return only valid JSON matching the schema. No prose, no code fences.`,
+      });
+    }
+
+    throw new Error(
+      `Parser failed to produce schema-valid transitions after ${MAX_REPAIR_ATTEMPTS + 1} attempts. ` +
+        `Last error: ${lastError}`,
+    );
+  }
+}
+
+export const radarParser = new RadarParser();

--- a/apps/backend/src/services/radar/radarTeamService.ts
+++ b/apps/backend/src/services/radar/radarTeamService.ts
@@ -1,0 +1,168 @@
+import { DatabaseClient } from '@/database/client';
+import { RadarActionError } from '@/services/radar/radarManualActions';
+import { viewerChannelAccess } from '@/services/radar/radarAcl';
+import {
+  FEED_SCAN_LIMIT,
+  MAX_FEED_ITEMS,
+  type FeedItem,
+} from '@/services/radar/radarFeedService';
+
+const prisma = DatabaseClient.getInstance();
+
+const MAX_TEAM_MEMBERS = 25;
+/** Users.status — deactivated accounts must not be assignable. */
+const ACTIVE_USER_STATUS = 'ACTIVE';
+
+interface AuthContext {
+  userId: string;
+  workspaceId: string;
+}
+
+export interface TeamFeedItem extends FeedItem {
+  channelVisibility: string;
+}
+
+/**
+ * Viewer-defined team lenses. A team is a personal named set of users; its
+ * feed is every open item involving a member — whether or not the viewer is a
+ * participant — but strictly narrowed by the VIEWER's channel access:
+ *
+ * - DM / group-DM threads are visible only to their own participants,
+ * - PRIVATE channels only when the viewer is a channel participant,
+ * - PUBLIC channels always (any workspace member could open the thread).
+ *
+ * Message-level privacy needs no filter here: visibleTo-restricted messages
+ * never enter a radar window, so no item ever cites one. The lens can narrow
+ * what the members' items show; it can never widen what the viewer may see.
+ */
+class RadarTeamService {
+  async listTeams(auth: AuthContext) {
+    return prisma.radarTeam.findMany({
+      where: { workspaceId: auth.workspaceId, ownerId: auth.userId },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async createTeam(auth: AuthContext, name: string, memberIds: string[]) {
+    const unique = [...new Set(memberIds)];
+    if (!name.trim()) throw new RadarActionError('bad-request', 'Team name is required');
+    if (unique.length === 0) throw new RadarActionError('bad-request', 'Pick at least one member');
+    if (unique.length > MAX_TEAM_MEMBERS) {
+      throw new RadarActionError('bad-request', `At most ${MAX_TEAM_MEMBERS} members`);
+    }
+    const known = await prisma.user.count({
+      where: { id: { in: unique }, workspaceId: auth.workspaceId, status: ACTIVE_USER_STATUS },
+    });
+    if (known !== unique.length) {
+      throw new RadarActionError('bad-request', 'memberIds contains unknown users');
+    }
+    return prisma.radarTeam.create({
+      data: {
+        workspaceId: auth.workspaceId,
+        ownerId: auth.userId,
+        name: name.trim(),
+        memberIds: unique,
+      },
+    });
+  }
+
+  async updateTeam(auth: AuthContext, teamId: string, name: string, memberIds: string[]) {
+    const team = await prisma.radarTeam.findUnique({ where: { id: teamId } });
+    if (!team || team.workspaceId !== auth.workspaceId || team.ownerId !== auth.userId) {
+      throw new RadarActionError('not-found', 'Team not found');
+    }
+    const unique = [...new Set(memberIds)];
+    if (!name.trim()) throw new RadarActionError('bad-request', 'Team name is required');
+    if (unique.length === 0) throw new RadarActionError('bad-request', 'Pick at least one member');
+    if (unique.length > MAX_TEAM_MEMBERS) {
+      throw new RadarActionError('bad-request', `At most ${MAX_TEAM_MEMBERS} members`);
+    }
+    const known = await prisma.user.count({
+      where: { id: { in: unique }, workspaceId: auth.workspaceId, status: ACTIVE_USER_STATUS },
+    });
+    if (known !== unique.length) {
+      throw new RadarActionError('bad-request', 'memberIds contains unknown users');
+    }
+    return prisma.radarTeam.update({
+      where: { id: teamId },
+      data: { name: name.trim(), memberIds: unique },
+    });
+  }
+
+  async deleteTeam(auth: AuthContext, teamId: string) {
+    const team = await prisma.radarTeam.findUnique({ where: { id: teamId } });
+    if (!team || team.workspaceId !== auth.workspaceId || team.ownerId !== auth.userId) {
+      throw new RadarActionError('not-found', 'Team not found');
+    }
+    await prisma.radarTeam.delete({ where: { id: teamId } });
+  }
+
+  async teamFeed(auth: AuthContext, teamId: string): Promise<TeamFeedItem[]> {
+    const team = await prisma.radarTeam.findUnique({ where: { id: teamId } });
+    if (!team || team.workspaceId !== auth.workspaceId || team.ownerId !== auth.userId) {
+      throw new RadarActionError('not-found', 'Team not found');
+    }
+
+    // "Between members" semantics: the union of every within-team pair (and
+    // larger combinations) — requester is a member AND the ball sits with a
+    // member. A member's ownerless ask (pendingOn: []) stays visible: it is
+    // the member's open ask with no counterpart yet. An item between a member
+    // and an outsider is NOT the team's business and stays out.
+    const items = await prisma.executionItem.findMany({
+      where: {
+        workspaceId: auth.workspaceId,
+        status: 'open',
+        AND: [
+          { requestedBy: { hasSome: team.memberIds } },
+          {
+            OR: [
+              { pendingOn: { hasSome: team.memberIds } },
+              { pendingOn: { isEmpty: true } },
+            ],
+          },
+        ],
+      },
+      orderBy: { updatedAt: 'desc' },
+      // Over-fetch, then cap AFTER the ACL filter — capping first lets items
+      // the viewer can't see eat the budget and silently shorten the feed.
+      take: FEED_SCAN_LIMIT,
+      select: {
+        id: true,
+        conversationId: true,
+        channelId: true,
+        sourceMessageId: true,
+        title: true,
+        contextSummary: true,
+        requestedBy: true,
+        pendingOn: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    if (items.length === 0) return [];
+
+    // Viewer's channel ACL — resolved from each item's conversation, not its
+    // denormalized channelId stamp. Anything not PUBLIC requires membership.
+    const conversations = await prisma.conversation.findMany({
+      where: { conversationId: { in: [...new Set(items.map(i => i.conversationId))] } },
+      select: { conversationId: true, channelId: true },
+    });
+    const channelByConversation = new Map(
+      conversations.map(c => [c.conversationId, c.channelId]),
+    );
+    const access = await viewerChannelAccess(auth, [...channelByConversation.values()]);
+    return items
+      .filter(item => {
+        const channelId = channelByConversation.get(item.conversationId);
+        return channelId ? access.get(channelId)?.allowed : false;
+      })
+      .map(item => ({
+        ...item,
+        channelVisibility:
+          access.get(channelByConversation.get(item.conversationId) ?? '')?.visibility ?? 'PUBLIC',
+      }))
+      .slice(0, MAX_FEED_ITEMS);
+  }
+}
+
+export const radarTeamService = new RadarTeamService();

--- a/apps/backend/src/services/radar/radarValidator.ts
+++ b/apps/backend/src/services/radar/radarValidator.ts
@@ -1,0 +1,146 @@
+import type { ParserOpenItem, ParserOperation } from '@/services/radar/radarParser';
+
+/**
+ * The trust boundary between the parser and the ledger. The model's output is
+ * a proposal; nothing it says is taken on faith:
+ *
+ * - referenced items must exist AND be open (resolved stays resolved — a
+ *   resolve/reassign of anything else is dropped, not "fixed"),
+ * - pendingOn/requestedBy are filtered to the window's legal user set
+ *   (explicit @mentions + message senders — the closed assignment sources;
+ *   a name the model guessed simply disappears, which can legally leave an
+ *   item ownerless),
+ * - sourceMessageId must cite a message actually in the window,
+ * - structural no-ops (reassign to the current pendingOn, duplicate resolves)
+ *   are dropped so the applier never writes an empty mutation.
+ *
+ * Pure function: all context is passed in, nothing is read or written here.
+ */
+
+export interface ValidationContext {
+  openItems: ParserOpenItem[];
+  /** messageId -> senderId for every message in the window. */
+  windowSenders: Map<string, string>;
+  /** The closed legal user set: window @mentions + window senders. */
+  allowedUserIds: Set<string>;
+}
+
+export interface DroppedOperation {
+  op: ParserOperation;
+  reason: string;
+}
+
+export interface ValidationResult {
+  valid: ParserOperation[];
+  dropped: DroppedOperation[];
+}
+
+/** Hard caps on model output: transaction budget and feed layout both bound. */
+const MAX_OPERATIONS = 50;
+const MAX_TITLE_CHARS = 200;
+const MAX_CONTEXT_CHARS = 500;
+
+export function validateTransitions(
+  operations: ParserOperation[],
+  ctx: ValidationContext,
+): ValidationResult {
+  const openById = new Map(ctx.openItems.map(i => [i.id, i]));
+  const valid: ParserOperation[] = [];
+  const dropped: DroppedOperation[] = [];
+  const resolvedThisPass = new Set<string>();
+
+  const legalUsers = (ids: string[] | undefined): string[] =>
+    [...new Set(ids ?? [])].filter(id => ctx.allowedUserIds.has(id));
+
+  let batch = operations;
+  if (batch.length > MAX_OPERATIONS) {
+    // Truncate by PRIORITY, not position: resolve/reassign survive ahead of
+    // creates, so an over-long response can't close an item while dropping the
+    // create that superseded it.
+    const priority = (op: ParserOperation): number => (op.op === 'create' ? 1 : 0);
+    const ordered = [...batch].sort((a, b) => priority(a) - priority(b));
+    for (const op of ordered.slice(MAX_OPERATIONS)) {
+      dropped.push({ op, reason: `over the ${MAX_OPERATIONS}-operation cap for one window` });
+    }
+    batch = ordered.slice(0, MAX_OPERATIONS);
+  }
+
+  for (const op of batch) {
+    if (!ctx.windowSenders.has(op.sourceMessageId)) {
+      dropped.push({ op, reason: 'sourceMessageId not in window' });
+      continue;
+    }
+
+    switch (op.op) {
+      case 'create': {
+        if (!op.title?.trim()) {
+          dropped.push({ op, reason: 'create without title' });
+          continue;
+        }
+        const pendingOn = legalUsers(op.pendingOn);
+        let requestedBy = legalUsers(op.requestedBy);
+        if (requestedBy.length === 0) {
+          // Falls back to the sender, but through the same allow-list, so
+          // nothing reaches the ledger unverified.
+          const sender = ctx.windowSenders.get(op.sourceMessageId);
+          requestedBy = sender ? legalUsers([sender]) : [];
+        }
+        valid.push({
+          ...op,
+          // Truncate rather than drop: an over-long title is still a real ask.
+          title: op.title.trim().slice(0, MAX_TITLE_CHARS),
+          contextSummary: op.contextSummary?.trim().slice(0, MAX_CONTEXT_CHARS),
+          pendingOn,
+          requestedBy,
+        });
+        continue;
+      }
+
+      case 'resolve': {
+        if (!op.itemId || !openById.has(op.itemId)) {
+          dropped.push({ op, reason: 'resolve of unknown or non-open item' });
+          continue;
+        }
+        if (resolvedThisPass.has(op.itemId)) {
+          dropped.push({ op, reason: 'duplicate resolve in one pass' });
+          continue;
+        }
+        resolvedThisPass.add(op.itemId);
+        valid.push(op);
+        continue;
+      }
+
+      case 'reassign': {
+        const item = op.itemId ? openById.get(op.itemId) : undefined;
+        if (!item) {
+          dropped.push({ op, reason: 'reassign of unknown or non-open item' });
+          continue;
+        }
+        if (resolvedThisPass.has(item.id)) {
+          dropped.push({ op, reason: 'reassign of item resolved in same pass' });
+          continue;
+        }
+        const pendingOn = legalUsers(op.pendingOn);
+        if (pendingOn.length === 0) {
+          // An empty pendingOn would drop the item out of everyone's Pending
+          // Me. The model omitting the field is not the same as deciding
+          // nobody holds the ball, so a reassign must name someone legal.
+          dropped.push({ op, reason: 'reassign with no legal assignee' });
+          continue;
+        }
+        const current = [...item.pending_on].sort().join(',');
+        if (pendingOn.slice().sort().join(',') === current) {
+          dropped.push({ op, reason: 'no-op reassign (pendingOn unchanged)' });
+          continue;
+        }
+        valid.push({ ...op, pendingOn });
+        continue;
+      }
+
+      default:
+        dropped.push({ op, reason: `unknown op "${(op as ParserOperation).op}"` });
+    }
+  }
+
+  return { valid, dropped };
+}

--- a/apps/backend/src/worker.ts
+++ b/apps/backend/src/worker.ts
@@ -41,6 +41,7 @@ import { emailFetchWorker } from '@/workers/emailFetchWorker';
 import { teamIntelligenceWorker } from '@/workers/teamIntelligenceWorker';
 import { emailClassificationWorker } from '@/workers/emailClassificationWorker';
 import { emailClassificationQueue } from '@/queues/emailClassificationQueue';
+import { radarExecutionWorker } from '@/workers/radarExecutionWorker';
 import { autoDraftWorker } from '@/workers/autoDraftWorker';
 import { entityExtractionWorker } from '@/workers/entityExtractionWorker';
 import { sdlcWorker } from '@/workers/sdlcWorker';
@@ -300,6 +301,21 @@ class WorkerService {
         await emailClassificationWorker.start();
       }
 
+      if (appConfig.radar.enabled) {
+        logger.info('Starting radar execution worker...');
+        // Guarded, unlike its neighbours: an unguarded throw reaches the outer
+        // catch, which exits the process — taking unrelated workers down with
+        // a dark-launched feature none of them depend on.
+        try {
+          await radarExecutionWorker.start();
+        } catch (error) {
+          logger.error(
+            '[RADAR-EXECUTION-WORKER] Failed to start; continuing without it',
+            error,
+          );
+        }
+      }
+
       if (appConfig.enableAiProvisioningWorker) {
         logger.info('Starting AI provisioning worker...');
         await aiProvisioningWorker.start();
@@ -502,6 +518,10 @@ class WorkerService {
 
       if (appConfig.enableEmailClassificationWorker) {
         await emailClassificationWorker.shutdown();
+      }
+
+      if (appConfig.radar.enabled) {
+        await radarExecutionWorker.shutdown();
       }
 
       if (appConfig.enableAiProvisioningWorker) {

--- a/apps/backend/src/workers/radarExecutionWorker.ts
+++ b/apps/backend/src/workers/radarExecutionWorker.ts
@@ -1,0 +1,150 @@
+import Bull from 'bull';
+import { config } from '@/config/env';
+import { logger } from '@/utils/logger';
+import { radarExecutionQueue, type RadarExecutionJobData } from '@/queues/radarExecutionQueue';
+import { radarExecutionService } from '@/services/radar/radarExecutionService';
+import { DatabaseClient } from '@/database/client';
+import { runAsServiceActor, runAsSystem } from '@/database/tenant/context';
+
+const prisma = DatabaseClient.getInstance();
+
+// Concurrency is across THREADS only: jobId = conversationId means Bull never
+// holds two live jobs for the same conversation, so each thread is processed
+// serially by construction while different threads drain in parallel.
+const CONCURRENCY = config.radar.workerConcurrency;
+
+const RUN_LOG_RETENTION_DAYS = config.radar.runLogRetentionDays;
+/** Retention is a housekeeping floor, not a deadline — hourly is plenty. */
+const RUN_LOG_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+const RUN_LOG_SWEEP_BATCH_SIZE = 5_000;
+const RUN_LOG_SWEEP_BATCH_PAUSE_MS = 250;
+/** Bounds one sweep's work; the remainder is picked up by the next tick. */
+const RUN_LOG_SWEEP_MAX_BATCHES = 40;
+
+class RadarExecutionWorker {
+  private isInitialized = false;
+  private sweepTimer: NodeJS.Timeout | null = null;
+
+  async start(): Promise<void> {
+    if (this.isInitialized) return;
+
+    await radarExecutionQueue.initialize();
+
+    const queue = radarExecutionQueue.getQueue();
+
+    // Jobs are added unnamed (see radarExecutionQueue.enqueueThread), so the
+    // processor is registered unnamed too.
+    queue.process(CONCURRENCY, async (job: Bull.Job<RadarExecutionJobData>) => {
+      return this.processJob(job);
+    });
+
+    queue.on('failed', (job, err) => {
+      logger.error(
+        `[RADAR-EXECUTION-WORKER] Job ${job.id} permanently failed — conversation ${job.data.conversationId}:`,
+        err,
+      );
+    });
+
+    this.startRunLogSweep();
+
+    this.isInitialized = true;
+    logger.info(`[RADAR-EXECUTION-WORKER] Started, ready to process jobs (concurrency=${CONCURRENCY})`);
+  }
+
+  /**
+   * execution_run_logs grows one row per drain pass and carries LLM payloads,
+   * so it is swept on a timer; items and mutations are never touched.
+   *
+   * Batched rather than one DELETE: the first sweep after a long run could
+   * match millions of rows, and each batch being its own transaction keeps
+   * locks short and the work interruptible.
+   */
+  private sweepRunLogs(): Promise<void> {
+    // Retention spans every tenant by design: runAsSystem leaves the query
+    // unfiltered and marks it intentional for the ACL extension.
+    return runAsSystem(() => this.sweepRunLogsUnscoped());
+  }
+
+  private async sweepRunLogsUnscoped(): Promise<void> {
+    const cutoff = new Date(Date.now() - RUN_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+    let deleted = 0;
+    try {
+      for (let batch = 0; batch < RUN_LOG_SWEEP_MAX_BATCHES; batch++) {
+        const stale = await prisma.executionRunLog.findMany({
+          where: { createdAt: { lt: cutoff } },
+          select: { id: true },
+          take: RUN_LOG_SWEEP_BATCH_SIZE,
+        });
+        if (stale.length === 0) break;
+        const { count } = await prisma.executionRunLog.deleteMany({
+          where: { id: { in: stale.map(r => r.id) } },
+        });
+        deleted += count;
+        // Breathe so a large backlog doesn't monopolise the pool.
+        await new Promise(resolve => setTimeout(resolve, RUN_LOG_SWEEP_BATCH_PAUSE_MS));
+      }
+      if (deleted > 0) {
+        logger.info('[RADAR-EXECUTION-WORKER] Swept run logs', {
+          deleted,
+          olderThanDays: RUN_LOG_RETENTION_DAYS,
+        });
+      }
+    } catch (error) {
+      // Retention must never take the worker down.
+      logger.warn('[RADAR-EXECUTION-WORKER] Run-log sweep failed', { deleted, error });
+    }
+  }
+
+  private startRunLogSweep(): void {
+    // Jittered, with no sweep on boot: nothing elects a leader, so overlapping
+    // replicas are expected and survivable (a second sweeper finds fewer
+    // rows) — but N replicas sweeping the instant they come up is not.
+    const jitterMs = Math.floor(Math.random() * RUN_LOG_SWEEP_INTERVAL_MS);
+    this.sweepTimer = setTimeout(() => {
+      void this.sweepRunLogs();
+      this.sweepTimer = setInterval(
+        () => void this.sweepRunLogs(),
+        RUN_LOG_SWEEP_INTERVAL_MS,
+      );
+      this.sweepTimer.unref?.();
+    }, jitterMs);
+    this.sweepTimer.unref?.();
+  }
+
+  private async processJob(job: Bull.Job<RadarExecutionJobData>): Promise<void> {
+    const { conversationId } = job.data;
+
+    // Background job → no HTTP tenant scope. Resolve the thread's workspace
+    // and open a tenant context so writes get workspaceId stamped.
+    const conversation = await prisma.conversation.findUnique({
+      where: { conversationId },
+      select: { workspaceId: true },
+    });
+    if (!conversation?.workspaceId) {
+      // Nothing to process (thread gone or unstamped) — completing the job is
+      // correct; a retry would find the same state.
+      logger.warn('[RADAR-EXECUTION-WORKER] Conversation not found or has no workspaceId, skipping', {
+        conversationId,
+      });
+      return;
+    }
+
+    return runAsServiceActor('radar-execution-worker', conversation.workspaceId, () =>
+      radarExecutionService.processThread(conversationId),
+    );
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.sweepTimer) {
+      // Covers both phases: the jittered setTimeout and the interval it starts.
+      clearTimeout(this.sweepTimer);
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+    await radarExecutionQueue.close();
+    this.isInitialized = false;
+    logger.info('[RADAR-EXECUTION-WORKER] Shut down');
+  }
+}
+
+export const radarExecutionWorker = new RadarExecutionWorker();

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -9,6 +9,7 @@ import { notificationService } from '@/services/notificationService';
 import { slackService } from '@/services/slackService';
 import { handleUnreadCount } from '@/zero/utils/unreadCountUtlis';
 import { vespaQueue } from '@/queues/vespaQueue';
+import { radarExecutionQueue } from '@/queues/radarExecutionQueue';
 import { fileSchema, SubApp } from '@/vespa/src/types';
 import { isSupportedMimeType } from '@/services/fileProcessor';
 import {
@@ -356,6 +357,11 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
       }
       return;
     }
+
+    // Radar execution engine: fire-and-forget thread signal. enqueueThread
+    // never throws and no-ops unless ENABLE_RADAR_EXECUTION=true, so this can
+    // never block or fail the message path.
+    void radarExecutionQueue.enqueueThread(message.conversationId);
 
     // Resolve link preview asynchronously (fire-and-forget)
     // Tries internal app link first, then external OG preview

--- a/apps/dashboard/src/api/radarApi.ts
+++ b/apps/dashboard/src/api/radarApi.ts
@@ -1,0 +1,178 @@
+import { apiInstance } from '../services/clients/apiClient';
+
+interface SuccessEnvelope<T> {
+  success: true;
+  data: T;
+}
+
+export interface RadarFeedItem {
+  id: string;
+  conversationId: string;
+  channelId: string;
+  sourceMessageId: string;
+  title: string;
+  contextSummary: string | null;
+  requestedBy: string[];
+  pendingOn: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RadarThreadCard {
+  conversationId: string;
+  channelId: string;
+  threadPreview: string | null;
+  lastActivityAt: string | null;
+  items: RadarFeedItem[];
+}
+
+export interface RadarApplyResult {
+  created: number;
+  resolved: number;
+  reassigned: number;
+}
+
+export interface RadarRunLog {
+  id: string;
+  conversationId: string;
+  gatePassed: boolean;
+  gateReason: string;
+  windowSize: number;
+  parserRan: boolean;
+  proposedOps: unknown[] | null;
+  validOps: unknown[] | null;
+  droppedOps: unknown[] | null;
+  applied: { created: number; resolved: number; reassigned: number } | null;
+  /** Model's one-sentence read of the window — why these ops, or why none. */
+  assessment: string | null;
+  error: string | null;
+  durationMs: number | null;
+  createdAt: string;
+}
+
+async function unwrap<T>(promise: Promise<{ data: SuccessEnvelope<T> }>): Promise<T> {
+  const res = await promise;
+  return res.data.data;
+}
+
+export function fetchRadarPendingMe(): Promise<RadarThreadCard[]> {
+  return unwrap(
+    apiInstance.get<SuccessEnvelope<{ threads: RadarThreadCard[] }>>('/radar/feed/pending-me'),
+  ).then(d => d.threads);
+}
+
+export function fetchRadarWaitingOn(): Promise<RadarThreadCard[]> {
+  return unwrap(
+    apiInstance.get<SuccessEnvelope<{ threads: RadarThreadCard[] }>>('/radar/feed/waiting-on'),
+  ).then(d => d.threads);
+}
+
+export interface RadarItemMutation {
+  id: string;
+  itemId: string;
+  op: string;
+  actorType: 'llm' | 'manual';
+  actorId: string | null;
+  sourceMessageId: string | null;
+  payload: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface RadarTrailMessage {
+  senderId: string;
+  senderName: string;
+  text: string;
+  createdAt: string;
+}
+
+export interface RadarItemTrail {
+  item: RadarFeedItem & { status: string; resolvedAt: string | null };
+  mutations: RadarItemMutation[];
+  sourceMessages: Record<string, RadarTrailMessage>;
+  threadState: { watermarkCreatedAt: string; watermarkMsgId: string; updatedAt: string } | null;
+  latestMessage: { messageId: string; createdAt: string } | null;
+}
+
+export function fetchRadarItemTrail(itemId: string): Promise<RadarItemTrail> {
+  return unwrap(
+    apiInstance.get<SuccessEnvelope<RadarItemTrail>>(
+      `/radar/debug/items/${encodeURIComponent(itemId)}`,
+    ),
+  );
+}
+
+export interface RadarTeam {
+  id: string;
+  name: string;
+  memberIds: string[];
+  createdAt: string;
+}
+
+export interface RadarTeamFeedItem extends RadarFeedItem {
+  channelVisibility: string;
+}
+
+export function fetchRadarTeams(): Promise<RadarTeam[]> {
+  return unwrap(apiInstance.get<SuccessEnvelope<{ teams: RadarTeam[] }>>('/radar/teams')).then(
+    d => d.teams,
+  );
+}
+
+export function createRadarTeam(name: string, memberIds: string[]): Promise<RadarTeam> {
+  return unwrap(apiInstance.post<SuccessEnvelope<RadarTeam>>('/radar/teams', { name, memberIds }));
+}
+
+export function updateRadarTeam(
+  teamId: string,
+  name: string,
+  memberIds: string[],
+): Promise<RadarTeam> {
+  return unwrap(
+    apiInstance.patch<SuccessEnvelope<RadarTeam>>(`/radar/teams/${encodeURIComponent(teamId)}`, {
+      name,
+      memberIds,
+    }),
+  );
+}
+
+export function deleteRadarTeam(teamId: string): Promise<void> {
+  return apiInstance.delete(`/radar/teams/${encodeURIComponent(teamId)}`).then(() => undefined);
+}
+
+export function fetchRadarTeamFeed(teamId: string): Promise<RadarTeamFeedItem[]> {
+  return unwrap(
+    apiInstance.get<SuccessEnvelope<{ items: RadarTeamFeedItem[] }>>(
+      `/radar/feed/team/${encodeURIComponent(teamId)}`,
+    ),
+  ).then(d => d.items);
+}
+
+export interface RadarRunsResult {
+  runs: RadarRunLog[];
+  threadState: { watermarkCreatedAt: string; watermarkMsgId: string; updatedAt: string } | null;
+  latestMessage: { messageId: string; createdAt: string } | null;
+  /** Every item the thread produced (resolved included) when scoped to one thread. */
+  items: Array<{ id: string; title: string; status: string }>;
+}
+
+/** Debug is per-thread: the endpoint has no workspace-wide listing. */
+export function fetchRadarDebugRuns(conversationId: string): Promise<RadarRunsResult> {
+  const query = `?conversationId=${encodeURIComponent(conversationId)}`;
+  return unwrap(apiInstance.get<SuccessEnvelope<RadarRunsResult>>(`/radar/debug/runs${query}`));
+}
+
+export function resolveRadarItem(itemId: string): Promise<RadarApplyResult> {
+  return unwrap(
+    apiInstance.post<SuccessEnvelope<RadarApplyResult>>(
+      `/radar/items/${encodeURIComponent(itemId)}/resolve`,
+    ),
+  );
+}
+
+export function resolveAllRadarItems(conversationId: string): Promise<RadarApplyResult> {
+  return unwrap(
+    apiInstance.post<SuccessEnvelope<RadarApplyResult>>(
+      `/radar/threads/${encodeURIComponent(conversationId)}/resolve-all`,
+    ),
+  );
+}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -9,6 +9,8 @@ import {
   type ComponentType,
 } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { Radar as RadarIcon } from 'lucide-react';
+import { useRadarEnabled } from '../../../hooks/radarCacConfig';
 import { useLastVisitedChannel } from '../../../hooks/useLastVisitedChannel';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { useShortcutById } from '../../../shortcuts';
@@ -224,6 +226,10 @@ const ChatDirectory = ({
   const listContainerRef = useRef<HTMLDivElement>(null);
   const context = useAuthContextValues();
   const auth = useAuth();
+  // Radar rollout is runtime CAC (radar_config), not a build-time flag:
+  // enabling it must not need a dashboard rebuild, and the pilot runs on an
+  // allowedEmails subset first.
+  const radarEnabled = useRadarEnabled(auth.user?.email);
   const { selfDmChannelId, landingChannelId } = auth;
   const zero = useZero();
   const lastVisitedChannelId = useLastVisitedChannel(workspaceId ?? '');
@@ -819,6 +825,26 @@ const ChatDirectory = ({
                 </span>
               )}
             </button>
+            {radarEnabled && (
+              <button
+                className={cn(
+                  'flex items-center justify-start gap-3 w-full px-3 py-2 text-sm font-medium tracking-[-0.14px] rounded-[10px] border border-transparent transition-colors hover:bg-sidebar-accent hover:border-sidebar-border',
+                  location.pathname.includes('/chat/dir/radar')
+                    ? 'text-sidebar-accent-foreground font-semibold bg-sidebar-accent'
+                    : 'text-sidebar-foreground hover:text-sidebar-accent-foreground',
+                )}
+                onClick={() => {
+                  void navigate('/chat/dir/radar');
+                }}
+                data-track-category='CHAT_SIDEBAR'
+                data-track-name='OPEN_RADAR'
+              >
+                <span className='size-4 flex items-center justify-center shrink-0'>
+                  <RadarIcon className='size-4' />
+                </span>
+                <span className='flex-1 min-w-0 text-left truncate block'>Radar</span>
+              </button>
+            )}
           </div>
 
           <div className='py-3 w-full hidden md:block' />

--- a/apps/dashboard/src/components/RadarPanel/RadarPanel.tsx
+++ b/apps/dashboard/src/components/RadarPanel/RadarPanel.tsx
@@ -1,0 +1,1185 @@
+import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import { formatDistanceToNow } from 'date-fns';
+import {
+  Bug,
+  Check,
+  CheckCircle,
+  ChevronDown,
+  Hash,
+  Hourglass,
+  Loader2,
+  Radar as RadarIcon,
+  RefreshCw,
+  X,
+  Zap,
+} from 'lucide-react';
+import {
+  createRadarTeam,
+  deleteRadarTeam,
+  fetchRadarDebugRuns,
+  fetchRadarItemTrail,
+  fetchRadarPendingMe,
+  fetchRadarTeamFeed,
+  fetchRadarTeams,
+  fetchRadarWaitingOn,
+  resolveAllRadarItems,
+  resolveRadarItem,
+  updateRadarTeam,
+  RadarItemTrail,
+  RadarRunLog,
+  RadarRunsResult,
+  RadarTeam,
+  RadarTeamFeedItem,
+  RadarThreadCard,
+  RadarFeedItem,
+} from '../../api/radarApi';
+import { ChannelScopeType } from '@xyne/shared';
+import { useAuth } from '../../hooks/useAuth';
+import { useRadarEnabled } from '../../hooks/radarCacConfig';
+import { useUsersById } from '../../hooks/useUsers';
+import { useAllChannels } from '../../hooks/useChannels';
+import { cn } from '../../utils/classNames';
+
+type RadarTab = 'all' | 'pending' | 'waiting';
+
+const AVATAR_COLORS = [
+  'bg-sky-600',
+  'bg-violet-600',
+  'bg-amber-600',
+  'bg-emerald-600',
+  'bg-rose-500',
+  'bg-indigo-600',
+] as const;
+
+/** Avatars rendered before the stack collapses into a +N chip. */
+const AVATARS_SHOWN = 3;
+
+const colorFor = (id: string): string => {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) >>> 0;
+  return AVATAR_COLORS[h % AVATAR_COLORS.length] ?? AVATAR_COLORS[0];
+};
+
+const initialsOf = (name: string): string =>
+  name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map(w => w[0]?.toUpperCase() ?? '')
+    .join('');
+
+/**
+ * Radar — the execution feed. Card-based views over the open-item ledger:
+ * Pending me (I hold the ball) and Waiting on (I asked, someone else acts),
+ * grouped per thread with per-item and per-thread resolve. Threads open in a
+ * side panel; the Debug drawer shows the worker's run trail.
+ */
+const RadarPanel = (): ReactElement => {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  // The router is built at module scope, so the rollout gate has to live here:
+  // with radar_config off (or this user outside allowedEmails) the route is
+  // reachable by URL but renders nothing and issues no requests.
+  const radarEnabled = useRadarEnabled(user?.email);
+  const params = useParams<{ channelId?: string; conversationId?: string }>();
+  const usersById = useUsersById();
+  const channels = useAllChannels();
+  const [tab, setTab] = useState<RadarTab>('pending');
+  const [pending, setPending] = useState<RadarThreadCard[]>([]);
+  const [waiting, setWaiting] = useState<RadarThreadCard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  // One debug surface: the card's Debug button opens this thread-scoped view
+  // (watermark position, per-item trails with the model's reasoning, runs).
+  const [threadDebug, setThreadDebug] = useState<{
+    conversationId: string;
+    loading: boolean;
+    trails: RadarItemTrail[];
+    runs: RadarRunLog[];
+    threadState: RadarRunsResult['threadState'];
+    latestMessage: RadarRunsResult['latestMessage'];
+    /** Lookup 404: unknown thread, or one the viewer has no channel access to. */
+    notFound?: boolean;
+  } | null>(null);
+  const [teams, setTeams] = useState<RadarTeam[]>([]);
+  const [scope, setScope] = useState<string>('me');
+  const [teamItems, setTeamItems] = useState<RadarTeamFeedItem[]>([]);
+  const [teamForm, setTeamForm] = useState<
+    { mode: 'create' } | { mode: 'edit'; teamId: string } | null
+  >(null);
+  const [teamName, setTeamName] = useState('');
+  const [teamMembers, setTeamMembers] = useState<Set<string>>(new Set());
+  const [memberAdd, setMemberAdd] = useState('');
+  const [teamSaving, setTeamSaving] = useState(false);
+  const [debugLookup, setDebugLookup] = useState('');
+  // Client-side channel filter (DMs included), rendered beside Scope.
+  const [filterChannels, setFilterChannels] = useState<Set<string>>(new Set());
+  const [channelFilterOpen, setChannelFilterOpen] = useState(false);
+
+  // Works from a bare conversation id (the debug lookup box) as well as a
+  // card: the runs endpoint reports the thread's items (resolved included),
+  // and the server enforces the viewer's channel ACL — a pasted id for a
+  // thread the viewer can't open comes back 404.
+  const openThreadDebugById = (conversationId: string) => {
+    setThreadDebug({
+      conversationId,
+      loading: true,
+      trails: [],
+      runs: [],
+      threadState: null,
+      latestMessage: null,
+    });
+    void fetchRadarDebugRuns(conversationId)
+      .then(async runsResult => {
+        const trails = await Promise.all(
+          (runsResult.items ?? []).map(i => fetchRadarItemTrail(i.id).catch(() => null)),
+        );
+        setThreadDebug({
+          conversationId,
+          loading: false,
+          trails: trails.filter((t): t is RadarItemTrail => t !== null),
+          runs: runsResult.runs,
+          threadState: runsResult.threadState,
+          latestMessage: runsResult.latestMessage,
+        });
+      })
+      .catch(() =>
+        setThreadDebug({
+          conversationId,
+          loading: false,
+          trails: [],
+          runs: [],
+          threadState: null,
+          latestMessage: null,
+          notFound: true,
+        }),
+      );
+  };
+  const openThreadDebug = (card: RadarThreadCard) => openThreadDebugById(card.conversationId);
+
+  // Thread opens beside the feed (recap-style), not as a redirect.
+  const showThreadPanel = !!params.conversationId;
+  const closeThreadPanel = useCallback((): void => {
+    void navigate('/chat/dir/radar');
+  }, [navigate]);
+
+  // Monotonic request id. Switching scope (me -> team A -> team B) fires
+  // overlapping requests, and without this whichever response lands last wins
+  // — which can be team A's. Only the newest request may touch state.
+  const requestSeq = useRef(0);
+
+  const load = useCallback(
+    async (background = false) => {
+      const seq = ++requestSeq.current;
+      const isCurrent = (): boolean => seq === requestSeq.current;
+      if (!background) setLoading(true);
+      try {
+        if (scope === 'me') {
+          const [p, w] = await Promise.all([fetchRadarPendingMe(), fetchRadarWaitingOn()]);
+          if (!isCurrent()) return;
+          setPending(p);
+          setWaiting(w);
+        } else {
+          const items = await fetchRadarTeamFeed(scope);
+          if (!isCurrent()) return;
+          setTeamItems(items);
+        }
+      } catch {
+        if (!background && isCurrent()) {
+          setPending([]);
+          setWaiting([]);
+          setTeamItems([]);
+        }
+      } finally {
+        if (!background && isCurrent()) setLoading(false);
+      }
+    },
+    [scope],
+  );
+
+  useEffect(() => {
+    if (!radarEnabled) return;
+    void fetchRadarTeams()
+      .then(setTeams)
+      .catch(() => {});
+  }, [radarEnabled]);
+
+  useEffect(() => {
+    if (!radarEnabled) return;
+    void load();
+    // No timer. Each feed read is two GIN scans plus channel-ACL lookups, and
+    // a poll pays that on every open tab forever — including backgrounded ones
+    // nobody is reading. The feed refreshes on the events that mean "the user
+    // is looking now": mount, switching tabs, returning to the window, and the
+    // explicit Refresh control.
+    // visibilitychange only: returning to the tab from another app fires BOTH
+    // focus and visibilitychange, which sent two concurrent copies of every
+    // feed request. visibilitychange alone covers tab switches and app
+    // switches; the sequence guard in load() handles anything that still
+    // overlaps.
+    const refresh = (): void => {
+      if (document.visibilityState === 'visible') void load(true);
+    };
+    document.addEventListener('visibilitychange', refresh);
+    return () => {
+      document.removeEventListener('visibilitychange', refresh);
+    };
+  }, [load, radarEnabled]);
+
+  const channelById = useMemo(() => new Map(channels.map(c => [c.id, c])), [channels]);
+
+  const nameOf = (userId: string): string => usersById.get(userId)?.name ?? 'Someone';
+
+  const isDirectMessage = (scopeType: string | null | undefined): boolean =>
+    scopeType === ChannelScopeType.DM || scopeType === ChannelScopeType.GROUP_DM;
+
+  const channelLabel = (channelId: string): string => {
+    const channel = channelById.get(channelId);
+    if (!channel) return '#thread';
+    if (isDirectMessage(channel.scopeType)) return 'Direct message';
+    return `#${channel.name}`;
+  };
+
+  // Filter list needs DMs told apart: name the counterpart(s) when the DM
+  // channel's name is the participant id list (how seeds store them).
+  const filterChannelLabel = (channelId: string): string => {
+    const channel = channelById.get(channelId);
+    if (!channel) return '#thread';
+    if (isDirectMessage(channel.scopeType)) {
+      const selfId = localStorage.getItem('user_id');
+      const others = (channel.name ?? '')
+        .split(',')
+        .map(s => s.trim())
+        .filter(id => id !== selfId && usersById.has(id))
+        .map(id => usersById.get(id)?.name ?? '');
+      return others.length ? `DM · ${others.join(', ')}` : 'Direct message';
+    }
+    return `#${channel.name}`;
+  };
+
+  const openThread = (card: RadarThreadCard) =>
+    void navigate(`/chat/dir/radar/${card.channelId}/${card.conversationId}`);
+
+  const withBusy = async (key: string, fn: () => Promise<unknown>) => {
+    setBusyKey(key);
+    try {
+      await fn();
+      await load(true);
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const cardUsers = (card: RadarThreadCard): string[] => [
+    ...new Set(card.items.flatMap(i => [...i.requestedBy, ...i.pendingOn])),
+  ];
+
+  const selfId = localStorage.getItem('user_id');
+  const nameTag = (id: string): string => (id === selfId ? 'you' : `@${nameOf(id)}`);
+
+  const sentAgo = (card: RadarThreadCard): string => {
+    const latest = card.items.reduce(
+      (max, i) => Math.max(max, new Date(i.updatedAt).getTime()),
+      card.lastActivityAt ? new Date(card.lastActivityAt).getTime() : 0,
+    );
+    return latest ? formatDistanceToNow(latest, { addSuffix: true }) : '';
+  };
+
+  // Mock-style meta line: waiting cards say who the ball is with; pending
+  // cards say who asked and who holds it.
+  const cardMeta = (card: RadarThreadCard, kind: 'pending' | 'waiting'): string => {
+    const holders = [...new Set(card.items.flatMap(i => i.pendingOn))];
+    const requesters = [...new Set(card.items.flatMap(i => i.requestedBy))];
+    const ago = sentAgo(card);
+    if (kind === 'waiting') {
+      const to = holders.map(nameTag).join(', ') || 'nobody yet';
+      return `${channelLabel(card.channelId)} · Sent ${ago} to ${to}`;
+    }
+    const by = requesters.map(nameTag).join(', ') || 'someone';
+    const on = holders.map(nameTag).join(', ') || 'nobody';
+    return `${channelLabel(card.channelId)} · Sent ${ago} by ${by} · pending on ${on}`;
+  };
+
+  const pill = (which: RadarTab, label: string, icon: ReactElement) => (
+    <button
+      className={cn(
+        'flex items-center gap-2 px-4 py-2 text-sm font-semibold rounded-full border transition-colors',
+        tab === which
+          ? 'bg-foreground text-background border-foreground'
+          : 'bg-card text-muted-foreground border-border hover:text-foreground hover:bg-accent/50',
+      )}
+      data-track-category='RADAR'
+      data-track-name='SWITCH_TAB'
+      onClick={() => {
+        setTab(which);
+        // Switching tabs is the "show me what's current" gesture now that
+        // nothing polls — refetch quietly behind the already-rendered list.
+        void load(true);
+      }}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+
+  const badge = (kind: 'pending' | 'waiting', count: number) => (
+    <span
+      className={cn(
+        'flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold',
+        kind === 'pending' ? 'bg-[#e8604c]/10 text-[#e8604c]' : 'bg-muted text-muted-foreground',
+      )}
+    >
+      {kind === 'pending' ? <Zap className='size-3' /> : <Hourglass className='size-3' />}
+      {kind === 'pending' ? (scope === 'me' ? 'Pending Me' : 'Pending Team') : 'Waiting On'}
+      {count > 1 ? ` (${count} Items)` : ''}
+    </span>
+  );
+
+  const renderItemBody = (card: RadarThreadCard, item: RadarFeedItem, index: number | null) => {
+    const itemKey = `item:${item.id}`;
+    return (
+      <div
+        key={item.id}
+        className={cn('group flex items-start gap-2', index !== null && index > 0 && 'mt-3')}
+      >
+        <div className='flex-1 min-w-0'>
+          <button
+            data-track-category='RADAR'
+            data-track-name='OPEN_THREAD_FROM_ITEM'
+            className='text-left font-bold text-foreground hover:underline text-[15px]'
+            onClick={() => openThread(card)}
+          >
+            {index !== null ? `${index + 1}. ${item.title}` : item.title}
+          </button>
+          {item.contextSummary && (
+            <ul className='mt-1.5 space-y-1'>
+              <li className='flex items-start gap-2 text-sm text-muted-foreground'>
+                <span className='mt-[7px] size-1 rounded-full bg-muted-foreground shrink-0' />
+                <span>
+                  {item.contextSummary}{' '}
+                  <button
+                    className='inline-flex px-1.5 rounded bg-muted text-[11px] font-semibold text-muted-foreground hover:text-foreground align-middle'
+                    data-track-category='RADAR'
+                    data-track-name='OPEN_SOURCE_THREAD'
+                    title='Open source thread'
+                    onClick={() => openThread(card)}
+                  >
+                    [1]
+                  </button>
+                </span>
+              </li>
+            </ul>
+          )}
+        </div>
+        <button
+          data-track-category='RADAR'
+          data-track-name='RESOLVE_ITEM'
+          title='Resolve this item'
+          className='p-1.5 rounded-lg text-muted-foreground hover:text-emerald-600 hover:bg-accent transition-colors disabled:opacity-50 shrink-0 opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
+          disabled={busyKey === itemKey}
+          onClick={() => void withBusy(itemKey, () => resolveRadarItem(item.id))}
+        >
+          {busyKey === itemKey ? (
+            <Loader2 className='size-4 animate-spin' />
+          ) : (
+            <CheckCircle className='size-4' />
+          )}
+        </button>
+      </div>
+    );
+  };
+
+  const renderCard = (card: RadarThreadCard, kind: 'pending' | 'waiting') => {
+    const key = `${kind}:${card.conversationId}`;
+    const busy = busyKey === key;
+    const multi = card.items.length > 1;
+    const involved = cardUsers(card);
+    const involvedNames = involved.map(nameOf).join(', ');
+
+    return (
+      <div
+        key={key}
+        className='relative group/card rounded-2xl border border-border bg-card text-card-foreground border-l-[3px] border-l-[#e8604c] shadow-sm'
+      >
+        <div className='px-5 pt-4 flex items-center gap-3'>
+          {badge(kind, card.items.length)}
+          <span
+            className='relative flex -space-x-1.5 group/avatars'
+            aria-label={`Involved: ${involvedNames}`}
+          >
+            {involved.slice(0, AVATARS_SHOWN).map(id => (
+              <span
+                key={id}
+                className={cn(
+                  'size-6 rounded-full text-white text-[10px] font-bold flex items-center justify-center ring-2 ring-card',
+                  colorFor(id),
+                )}
+              >
+                {initialsOf(nameOf(id))}
+              </span>
+            ))}
+            {involved.length > AVATARS_SHOWN && (
+              <span className='size-6 rounded-full bg-muted text-muted-foreground text-[10px] font-bold flex items-center justify-center ring-2 ring-card'>
+                +{involved.length - AVATARS_SHOWN}
+              </span>
+            )}
+            {/* Initials alone don't say who these people are — name them on
+                hover. Styled rather than a native title so it appears without
+                the browser's ~1s delay and matches the rest of the panel.
+                Width is capped and wrapping left on: a thread with nine
+                participants produced a 754px single-line tooltip that ran off
+                the right edge of the viewport. */}
+            <span
+              aria-hidden='true'
+              className='pointer-events-none absolute left-0 top-full z-50 mt-1.5 hidden w-max max-w-64 rounded-lg border border-border bg-popover px-2.5 py-1.5 text-xs font-medium leading-relaxed text-popover-foreground shadow-lg group-hover/avatars:block'
+            >
+              {involvedNames}
+            </span>
+          </span>
+          <span className='text-sm text-muted-foreground truncate'>{cardMeta(card, kind)}</span>
+        </div>
+
+        <div className='px-5 pt-3 pb-4'>
+          {card.items.map((item, i) => renderItemBody(card, item, multi ? i : null))}
+
+          {multi && (
+            <div className='mt-4 flex items-center gap-2'>
+              <button
+                className='flex items-center gap-1.5 px-4 py-1.5 rounded-full bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 disabled:opacity-50'
+                disabled={busy}
+                data-track-category='RADAR'
+                data-track-name='RESOLVE_ALL_ITEMS'
+                onClick={() => void withBusy(key, () => resolveAllRadarItems(card.conversationId))}
+              >
+                {busy ? <Loader2 className='size-4 animate-spin' /> : <Check className='size-4' />}
+                Resolve All
+              </button>
+            </div>
+          )}
+        </div>
+        <button
+          data-track-category='RADAR'
+          data-track-name='OPEN_THREAD_DEBUG'
+          title="This thread's entire run history"
+          className='absolute bottom-2.5 right-3 flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-semibold text-muted-foreground hover:text-foreground hover:bg-accent transition-colors opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100'
+          onClick={() => openThreadDebug(card)}
+        >
+          <Bug className='size-3.5' />
+          Debug
+        </button>
+      </div>
+    );
+  };
+
+  // Single-team model: "Only Me" vs "Me + Team". The first team is THE team.
+  const team = teams[0] ?? null;
+  const activeTeam = scope === 'me' ? null : (teams.find(t => t.id === scope) ?? null);
+  const teamMemberSet = useMemo(() => new Set(activeTeam?.memberIds ?? []), [activeTeam]);
+  const inTeam = (ids: string[]) => ids.some(id => teamMemberSet.has(id));
+
+  let cards: Array<{ card: RadarThreadCard; kind: 'pending' | 'waiting' }>;
+  if (!activeTeam) {
+    cards = [
+      ...(tab !== 'waiting' ? pending.map(card => ({ card, kind: 'pending' as const })) : []),
+      ...(tab !== 'pending' ? waiting.map(card => ({ card, kind: 'waiting' as const })) : []),
+    ];
+  } else {
+    // An item between two members is BOTH pending (the holder is a member)
+    // and waited-on (the requester is a member) — it shows under both tabs.
+    const filtered = teamItems.filter(item => {
+      const pendingHit = inTeam(item.pendingOn);
+      const waitingHit = inTeam(item.requestedBy);
+      return tab === 'all' ? pendingHit || waitingHit : tab === 'pending' ? pendingHit : waitingHit;
+    });
+    const byConversation = new Map<string, RadarThreadCard>();
+    for (const item of filtered) {
+      let card = byConversation.get(item.conversationId);
+      if (!card) {
+        card = {
+          conversationId: item.conversationId,
+          channelId: item.channelId,
+          threadPreview: null,
+          lastActivityAt: null,
+          items: [],
+        };
+        byConversation.set(item.conversationId, card);
+      }
+      card.items.push(item);
+    }
+    cards = [...byConversation.values()].map(card => ({
+      card,
+      kind:
+        tab === 'waiting'
+          ? ('waiting' as const)
+          : tab === 'pending'
+            ? ('pending' as const)
+            : inTeam(card.items.flatMap(i => i.pendingOn))
+              ? ('pending' as const)
+              : ('waiting' as const),
+    }));
+  }
+
+  // Options come from the UNfiltered scope, so a selection never empties the list.
+  const channelOptions = [...new Set(cards.map(c => c.card.channelId))];
+  if (filterChannels.size) {
+    cards = cards.filter(({ card }) => filterChannels.has(card.channelId));
+  }
+
+  const runBadge = (run: RadarRunLog) =>
+    run.error ? (
+      <span className='px-2 py-0.5 rounded-full text-[11px] font-semibold bg-red-500/10 text-red-500'>
+        error
+      </span>
+    ) : run.gatePassed ? (
+      <span className='px-2 py-0.5 rounded-full text-[11px] font-semibold bg-emerald-500/10 text-emerald-600'>
+        gate PASS · {run.gateReason}
+      </span>
+    ) : (
+      <span className='px-2 py-0.5 rounded-full text-[11px] font-semibold bg-muted text-muted-foreground'>
+        gate skip
+      </span>
+    );
+
+  const opCount = (ops: unknown[] | null): number => (Array.isArray(ops) ? ops.length : 0);
+
+  // Debug JSON is unreadable with raw cuids — swap every known user id for
+  // its @name before rendering.
+  const humanizeIds = (value: unknown): string => {
+    let json = JSON.stringify(value, null, 1);
+    for (const [id, user] of usersById) {
+      json = json.split(id).join(`@${user.name}`);
+    }
+    return json;
+  };
+
+  const channelFilter = (
+    <span className='relative ml-4'>
+      {channelFilterOpen && (
+        <button
+          type='button'
+          aria-label='Close channel filter'
+          className='fixed inset-0 z-30 cursor-default'
+          data-track-category='RADAR'
+          data-track-name='CLOSE_CHANNEL_FILTER'
+          onClick={() => setChannelFilterOpen(false)}
+        />
+      )}
+      <button
+        className={cn(
+          'inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold transition-colors',
+          filterChannels.size > 0 || channelFilterOpen
+            ? 'bg-accent text-foreground'
+            : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+        )}
+        data-track-category='RADAR'
+        data-track-name='TOGGLE_CHANNEL_FILTER'
+        onClick={() => setChannelFilterOpen(open => !open)}
+      >
+        Channel
+        {filterChannels.size > 0 && (
+          <span className='min-w-4 h-4 px-1 rounded-full bg-[#e8604c] text-white text-[10px] font-bold flex items-center justify-center'>
+            {filterChannels.size}
+          </span>
+        )}
+        <ChevronDown
+          className={cn('size-3.5 transition-transform', channelFilterOpen && 'rotate-180')}
+        />
+      </button>
+      {channelFilterOpen && (
+        <div className='absolute left-0 top-full mt-1.5 z-40 w-64 rounded-xl border border-border bg-popover text-popover-foreground shadow-xl py-1.5'>
+          <div className='max-h-60 overflow-y-auto'>
+            {channelOptions.length === 0 && (
+              <div className='px-3 py-2 text-xs text-muted-foreground'>Nothing to filter yet.</div>
+            )}
+            {channelOptions.map(id => (
+              <button
+                key={id}
+                data-track-category='RADAR'
+                data-track-name='FILTER_BY_CHANNEL'
+                className='w-full flex items-center gap-2.5 text-left px-3 py-1.5 text-sm hover:bg-accent'
+                onClick={() => {
+                  setFilterChannels(prev => {
+                    const next = new Set(prev);
+                    if (next.has(id)) next.delete(id);
+                    else next.add(id);
+                    return next;
+                  });
+                }}
+              >
+                <span className='size-6 shrink-0 rounded-lg bg-muted text-muted-foreground flex items-center justify-center'>
+                  <Hash className='size-3.5' />
+                </span>
+                <span className='truncate flex-1'>{filterChannelLabel(id)}</span>
+                {filterChannels.has(id) && <Check className='size-4 shrink-0 text-[#e8604c]' />}
+              </button>
+            ))}
+          </div>
+          {filterChannels.size > 0 && (
+            <div className='mt-1 pt-1.5 border-t border-border px-3'>
+              <button
+                className='text-xs font-semibold text-muted-foreground hover:text-foreground'
+                data-track-category='RADAR'
+                data-track-name='CLEAR_CHANNEL_FILTER'
+                onClick={() => setFilterChannels(new Set())}
+              >
+                Clear
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </span>
+  );
+
+  const submitTeamForm = () => {
+    if (!teamForm) return;
+    setTeamSaving(true);
+    // "Me + Team": the viewer is always part of their own team.
+    const memberIds = [...new Set([...(selfId ? [selfId] : []), ...teamMembers])];
+    const name = teamName.trim() || 'Team';
+    const request =
+      teamForm.mode === 'create'
+        ? createRadarTeam(name, memberIds)
+        : updateRadarTeam(teamForm.teamId, name, memberIds);
+    void request
+      .then(saved => {
+        setTeams(prev =>
+          teamForm.mode === 'create'
+            ? [...prev, saved]
+            : prev.map(t => (t.id === saved.id ? saved : t)),
+        );
+        if (teamForm.mode === 'create') setScope(saved.id);
+        setTeamForm(null);
+        setTeamName('');
+        setTeamMembers(new Set());
+        void load(true);
+      })
+      .catch(() => {})
+      .finally(() => setTeamSaving(false));
+  };
+
+  const memberMatches =
+    memberAdd.trim().length > 0
+      ? [...usersById.values()]
+          .filter(u => !teamMembers.has(u.id))
+          .filter(u => u.name.toLowerCase().includes(memberAdd.trim().toLowerCase()))
+          .slice(0, 6)
+      : [];
+
+  const teamFormPopover = (
+    <div className='absolute left-0 top-full mt-2 z-30 w-80 rounded-2xl bg-card border border-border p-4 shadow-xl text-left'>
+      <div className='text-sm font-bold text-foreground mb-2'>Team members</div>
+      <div className='space-y-1 mb-2'>
+        {[...teamMembers].map(id => (
+          <div key={id} className='flex items-center gap-2.5 px-1 py-1 text-sm text-foreground'>
+            <span
+              className={cn(
+                'size-7 rounded-full text-white text-[10px] font-bold flex items-center justify-center',
+                colorFor(id),
+              )}
+            >
+              {initialsOf(nameOf(id))}
+            </span>
+            @{nameOf(id)}
+            {id === selfId ? (
+              <span className='ml-auto text-[11px] font-semibold text-muted-foreground'>you</span>
+            ) : (
+              <button
+                className='ml-auto p-1 rounded text-muted-foreground hover:text-red-500'
+                data-track-category='RADAR'
+                data-track-name='REMOVE_TEAM_MEMBER'
+                title='Remove member'
+                onClick={() =>
+                  setTeamMembers(prev => {
+                    const next = new Set(prev);
+                    next.delete(id);
+                    return next;
+                  })
+                }
+              >
+                <X className='size-4' />
+              </button>
+            )}
+          </div>
+        ))}
+        {teamMembers.size === 0 && (
+          <div className='text-xs text-muted-foreground px-1 py-1'>No members yet.</div>
+        )}
+      </div>
+      <div className='relative'>
+        <input
+          className='w-full px-3 py-2 rounded-lg border border-border bg-background text-sm text-foreground'
+          data-track-category='RADAR'
+          data-track-name='SEARCH_TEAM_MEMBER'
+          placeholder='+ Add member @mention'
+          value={memberAdd}
+          onChange={e => setMemberAdd(e.target.value)}
+        />
+        {memberMatches.length > 0 && (
+          <div className='absolute left-0 right-0 top-full mt-1 z-40 rounded-xl border border-border bg-popover text-popover-foreground shadow-lg py-1 max-h-44 overflow-y-auto'>
+            {memberMatches.map(u => (
+              <button
+                key={u.id}
+                data-track-category='RADAR'
+                data-track-name='ADD_TEAM_MEMBER'
+                className='w-full flex items-center gap-2 text-left px-3 py-1.5 text-sm hover:bg-accent'
+                onClick={() => {
+                  setTeamMembers(prev => new Set(prev).add(u.id));
+                  setMemberAdd('');
+                }}
+              >
+                <span
+                  className={cn(
+                    'size-5 rounded-full text-white text-[9px] font-bold flex items-center justify-center',
+                    colorFor(u.id),
+                  )}
+                >
+                  {initialsOf(u.name)}
+                </span>
+                @{u.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className='mt-3 pt-3 border-t border-border flex items-center gap-3'>
+        {teamForm?.mode === 'edit' && team && (
+          <button
+            data-track-category='RADAR'
+            data-track-name='DELETE_TEAM'
+            className='text-xs font-semibold text-red-500/80 hover:text-red-500'
+            onClick={() => {
+              void deleteRadarTeam(team.id).then(() => {
+                setTeams([]);
+                setScope('me');
+                setTeamForm(null);
+              });
+            }}
+          >
+            Remove team
+          </button>
+        )}
+        <span className='ml-auto flex items-center gap-3'>
+          <button
+            className='text-sm font-semibold text-muted-foreground hover:text-foreground'
+            data-track-category='RADAR'
+            data-track-name='CANCEL_TEAM_FORM'
+            onClick={() => setTeamForm(null)}
+          >
+            Cancel
+          </button>
+          <button
+            className='px-4 py-1.5 rounded-full bg-primary text-primary-foreground text-sm font-semibold hover:opacity-90 disabled:opacity-50'
+            disabled={teamSaving || teamMembers.size === 0}
+            data-track-category='RADAR'
+            data-track-name='SAVE_TEAM'
+            onClick={submitTeamForm}
+          >
+            {teamSaving ? 'Saving…' : 'Save'}
+          </button>
+        </span>
+      </div>
+    </div>
+  );
+
+  if (!radarEnabled) return <div className='h-full w-full bg-background' />;
+
+  return (
+    <div className='flex h-full w-full overflow-hidden bg-background'>
+      <div className={cn('flex flex-col h-full min-w-0', showThreadPanel ? 'w-1/2' : 'flex-1')}>
+        <div className='flex items-center gap-3 px-6 pt-6 pb-4'>
+          <RadarIcon className='size-5 text-foreground' />
+          <h1 className='text-xl font-bold text-foreground'>Radar</h1>
+          <button
+            title='Refresh the feed'
+            className='p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50'
+            disabled={loading}
+            data-track-category='RADAR'
+            data-track-name='REFRESH_FEED'
+            onClick={() => void load(true)}
+          >
+            <RefreshCw className='size-4' />
+          </button>
+          <div className='ml-auto flex items-center gap-1.5'>
+            <Bug className='size-3.5 text-muted-foreground' />
+            <input
+              className='w-56 px-2.5 py-1 rounded-lg border border-border bg-card text-xs text-foreground placeholder:text-muted-foreground'
+              data-track-category='RADAR'
+              data-track-name='DEBUG_THREAD_LOOKUP'
+              placeholder='Debug a thread id… ⏎'
+              title='Paste a conversation id and press Enter to open its thread debug'
+              value={debugLookup}
+              onChange={e => setDebugLookup(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && debugLookup.trim()) {
+                  openThreadDebugById(debugLookup.trim());
+                }
+              }}
+            />
+          </div>
+        </div>
+        <div className='flex items-center gap-2 px-6 pb-3'>
+          {pill('all', 'All', <span />)}
+          {pill(
+            'pending',
+            scope === 'me' ? 'Pending Me' : 'Pending Team',
+            <Zap className='size-4' />,
+          )}
+          {pill('waiting', 'Waiting On', <Hourglass className='size-4' />)}
+        </div>
+        <div className='flex items-center gap-2 px-6 pb-5'>
+          <span className='text-xs font-semibold text-muted-foreground uppercase tracking-wide'>
+            Scope
+          </span>
+          <div className='inline-flex items-center rounded-full border border-border bg-card p-0.5 shadow-sm'>
+            <button
+              className={cn(
+                'px-4 py-1.5 rounded-full text-sm font-semibold transition-colors',
+                scope === 'me'
+                  ? 'bg-foreground text-background'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+              data-track-category='RADAR'
+              data-track-name='SET_SCOPE_ONLY_ME'
+              onClick={() => setScope('me')}
+            >
+              Only Me
+            </button>
+            <span className='relative'>
+              <button
+                data-track-category='RADAR'
+                data-track-name='SET_SCOPE_TEAM'
+                title={
+                  team
+                    ? scope === team.id
+                      ? 'Click again to edit team members'
+                      : undefined
+                    : 'Pick your team members'
+                }
+                className={cn(
+                  'px-4 py-1.5 rounded-full text-sm font-semibold transition-colors',
+                  scope !== 'me'
+                    ? 'bg-foreground text-background'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+                onClick={() => {
+                  if (!team) {
+                    setTeamName('Team');
+                    setTeamMembers(new Set(selfId ? [selfId] : []));
+                    setMemberAdd('');
+                    setTeamForm(f => (f ? null : { mode: 'create' }));
+                    return;
+                  }
+                  if (scope === team.id) {
+                    // Second click on the active segment opens the editor.
+                    setTeamName(team.name);
+                    setTeamMembers(new Set(team.memberIds));
+                    setMemberAdd('');
+                    setTeamForm(f => (f ? null : { mode: 'edit', teamId: team.id }));
+                  } else {
+                    setScope(team.id);
+                  }
+                }}
+              >
+                Me + Team{team ? ` (${team.memberIds.length})` : ''} ▾
+              </button>
+              {teamForm && teamFormPopover}
+            </span>
+          </div>
+          {channelFilter}
+        </div>
+
+        <div className='flex-1 overflow-y-auto px-6 pb-8'>
+          {loading ? (
+            <div className='flex items-center gap-2 text-muted-foreground text-sm py-8'>
+              <Loader2 className='size-4 animate-spin' /> Loading…
+            </div>
+          ) : cards.length === 0 ? (
+            <div className='text-muted-foreground text-sm py-8'>
+              {tab === 'waiting'
+                ? "You're not waiting on anyone."
+                : tab === 'pending'
+                  ? 'Nothing pending on you. Enjoy the quiet.'
+                  : 'Nothing on the radar.'}
+            </div>
+          ) : (
+            <div className='space-y-4 max-w-3xl'>
+              {cards.map(({ card, kind }) => renderCard(card, kind))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {threadDebug && (
+        <div className='w-[440px] shrink-0 h-full border-l border-border bg-card flex flex-col'>
+          <div className='px-4 py-3 border-b border-border'>
+            <div className='flex items-center gap-2'>
+              <Bug className='size-4 text-foreground' />
+              <span className='text-sm font-bold text-foreground'>Thread debug</span>
+              <button
+                className='ml-auto p-1 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent'
+                data-track-category='RADAR'
+                data-track-name='CLOSE_THREAD_DEBUG'
+                onClick={() => setThreadDebug(null)}
+              >
+                <X className='size-4' />
+              </button>
+            </div>
+            <div
+              className='mt-0.5 text-[11px] font-mono text-muted-foreground truncate'
+              title={threadDebug.conversationId}
+            >
+              {threadDebug.conversationId}
+            </div>
+          </div>
+          {threadDebug.loading ? (
+            <div className='flex items-center gap-2 text-muted-foreground text-sm px-4 py-6'>
+              <Loader2 className='size-4 animate-spin' /> Loading…
+            </div>
+          ) : threadDebug.notFound ? (
+            <div className='text-muted-foreground text-sm px-4 py-6'>
+              Thread not found — either the id is wrong or you don&apos;t have access to that
+              conversation.
+            </div>
+          ) : (
+            <div className='flex-1 overflow-y-auto'>
+              <div className='px-4 py-3 border-b border-border'>
+                <div className='text-[11px] font-bold uppercase tracking-wide text-muted-foreground'>
+                  Processed till
+                </div>
+                {threadDebug.threadState ? (
+                  <div className='mt-1 flex items-center gap-2 text-xs'>
+                    <span className='text-foreground font-semibold'>
+                      {formatDistanceToNow(new Date(threadDebug.threadState.watermarkCreatedAt), {
+                        addSuffix: true,
+                      })}
+                    </span>
+                    {threadDebug.latestMessage &&
+                      (threadDebug.threadState.watermarkMsgId ===
+                      threadDebug.latestMessage.messageId ? (
+                        <span className='px-2 py-0.5 rounded-full text-[11px] font-semibold bg-emerald-500/10 text-emerald-600'>
+                          caught up
+                        </span>
+                      ) : (
+                        <span className='px-2 py-0.5 rounded-full text-[11px] font-semibold bg-amber-500/10 text-amber-600'>
+                          behind latest message
+                        </span>
+                      ))}
+                  </div>
+                ) : (
+                  <div className='mt-1 text-xs text-muted-foreground'>
+                    nothing yet — thread never drained
+                  </div>
+                )}
+              </div>
+
+              <div className='px-4 pt-3 pb-1 text-[11px] font-bold uppercase tracking-wide text-muted-foreground'>
+                Items · {threadDebug.trails.length}
+              </div>
+              {threadDebug.trails.map(itemTrail => (
+                <div
+                  key={itemTrail.item.id}
+                  className='mx-4 my-2 rounded-xl border border-border bg-background p-3'
+                >
+                  <div className='flex items-start gap-2'>
+                    <span className='text-sm font-bold text-foreground leading-snug'>
+                      {itemTrail.item.title}
+                    </span>
+                    <span
+                      className={cn(
+                        'ml-auto shrink-0 px-2 py-0.5 rounded-full text-[11px] font-semibold',
+                        itemTrail.item.status === 'open'
+                          ? 'bg-amber-500/10 text-amber-600'
+                          : 'bg-emerald-500/10 text-emerald-600',
+                      )}
+                    >
+                      {itemTrail.item.status}
+                    </span>
+                  </div>
+                  <div className='mt-1.5 grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-xs'>
+                    <span className='text-muted-foreground'>Pending on</span>
+                    <span className='text-foreground font-semibold'>
+                      {itemTrail.item.pendingOn.length
+                        ? itemTrail.item.pendingOn.map(nameOf).join(', ')
+                        : 'nobody'}
+                    </span>
+                    <span className='text-muted-foreground'>Asked by</span>
+                    <span className='text-foreground font-semibold'>
+                      {itemTrail.item.requestedBy.map(nameOf).join(', ') || '—'}
+                    </span>
+                  </div>
+                  <div className='mt-2.5 space-y-2.5 border-l-2 border-border pl-3'>
+                    {itemTrail.mutations.map(m => {
+                      const source = m.sourceMessageId
+                        ? itemTrail.sourceMessages[m.sourceMessageId]
+                        : undefined;
+                      return (
+                        <div key={m.id} className='text-xs'>
+                          <div className='flex items-center gap-2'>
+                            <span
+                              className={cn(
+                                'px-2 py-0.5 rounded-full text-[11px] font-semibold',
+                                m.op === 'create'
+                                  ? 'bg-emerald-500/10 text-emerald-600'
+                                  : m.op === 'resolve'
+                                    ? 'bg-sky-500/10 text-sky-600'
+                                    : 'bg-amber-500/10 text-amber-600',
+                              )}
+                            >
+                              {m.op}
+                            </span>
+                            <span className='font-semibold text-foreground'>
+                              {m.actorType === 'llm' ? 'LLM parser' : nameOf(m.actorId ?? '')}
+                            </span>
+                            <span className='ml-auto text-muted-foreground'>
+                              {formatDistanceToNow(new Date(m.createdAt), { addSuffix: true })}
+                            </span>
+                          </div>
+                          {source && (
+                            <div className='mt-1.5 px-2 py-1.5 rounded-lg bg-accent/40 border-l-2 border-[#e8604c]'>
+                              <div className='text-[10px] font-bold uppercase tracking-wide text-muted-foreground'>
+                                Triggered by
+                              </div>
+                              <div className='mt-0.5 text-muted-foreground'>
+                                <span className='font-semibold text-foreground'>
+                                  {source.senderName}:
+                                </span>{' '}
+                                “{source.text}”
+                              </div>
+                            </div>
+                          )}
+                          {typeof m.payload?.['reason'] === 'string' && (
+                            <div className='mt-1.5 px-2 py-1.5 rounded-lg bg-[#e8604c]/5'>
+                              <div className='text-[10px] font-bold uppercase tracking-wide text-[#e8604c]'>
+                                Reasoning
+                              </div>
+                              <div className='mt-0.5 text-foreground'>{m.payload['reason']}</div>
+                            </div>
+                          )}
+                          {m.payload &&
+                            (() => {
+                              const rest = Object.fromEntries(
+                                Object.entries(m.payload).filter(
+                                  ([k, v]) => k !== 'reason' && v !== null && v !== undefined,
+                                ),
+                              );
+                              return Object.keys(rest).length > 0 ? (
+                                <details className='mt-1'>
+                                  <summary className='cursor-pointer text-muted-foreground hover:text-foreground'>
+                                    payload
+                                  </summary>
+                                  <pre className='mt-1 p-2 rounded-lg bg-muted overflow-x-auto text-[11px] leading-4'>
+                                    {humanizeIds(rest)}
+                                  </pre>
+                                </details>
+                              ) : null;
+                            })()}
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+              {threadDebug.trails.length === 0 && (
+                <div className='px-4 py-3 text-xs text-muted-foreground'>
+                  No items were created in this thread.
+                </div>
+              )}
+
+              <div className='px-4 pt-3 pb-1 text-[11px] font-bold uppercase tracking-wide text-muted-foreground'>
+                Worker runs · {threadDebug.runs.length}
+              </div>
+              <div className='px-4 pb-4 space-y-2'>
+                {threadDebug.runs.map(run => (
+                  <div
+                    key={run.id}
+                    className='rounded-xl border border-border bg-background p-3 text-xs'
+                  >
+                    <div className='flex items-center gap-2'>
+                      {runBadge(run)}
+                      <span className='text-muted-foreground'>
+                        {formatDistanceToNow(new Date(run.createdAt), { addSuffix: true })}
+                      </span>
+                      {run.durationMs !== null && (
+                        <span className='ml-auto text-muted-foreground'>{run.durationMs}ms</span>
+                      )}
+                    </div>
+                    {run.assessment && (
+                      <div className='mt-1.5 px-2 py-1.5 rounded-lg bg-[#e8604c]/5'>
+                        <div className='text-[10px] font-bold uppercase tracking-wide text-[#e8604c]'>
+                          Model&apos;s read
+                        </div>
+                        <div className='mt-0.5 text-foreground break-words'>{run.assessment}</div>
+                      </div>
+                    )}
+                    {run.error && (
+                      <div className='mt-1.5 text-red-500 break-words'>{run.error}</div>
+                    )}
+                    <div className='mt-1.5 flex flex-wrap items-center gap-1.5'>
+                      <span className='px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-semibold'>
+                        {run.windowSize} msg{run.windowSize === 1 ? '' : 's'}
+                      </span>
+                      {run.parserRan ? (
+                        <>
+                          <span className='px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-semibold'>
+                            proposed {opCount(run.proposedOps)}
+                          </span>
+                          <span className='px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-semibold'>
+                            valid {opCount(run.validOps)}
+                          </span>
+                          {opCount(run.droppedOps) > 0 && (
+                            <span className='px-2 py-0.5 rounded-full bg-red-500/10 text-red-500 font-semibold'>
+                              dropped {opCount(run.droppedOps)}
+                            </span>
+                          )}
+                        </>
+                      ) : (
+                        <span className='px-2 py-0.5 rounded-full bg-muted text-muted-foreground font-semibold'>
+                          parser skipped
+                        </span>
+                      )}
+                      {run.applied && (
+                        <span className='px-2 py-0.5 rounded-full bg-emerald-500/10 text-emerald-600 font-semibold'>
+                          applied +{run.applied.created} ✓{run.applied.resolved} ↺
+                          {run.applied.reassigned}
+                        </span>
+                      )}
+                    </div>
+                    {run.parserRan && (
+                      <details className='mt-1.5'>
+                        <summary className='cursor-pointer text-muted-foreground hover:text-foreground'>
+                          raw operations
+                        </summary>
+                        <pre className='mt-1 p-2 rounded-lg bg-muted overflow-x-auto text-[11px] leading-4'>
+                          {humanizeIds({
+                            proposed: run.proposedOps,
+                            valid: run.validOps,
+                            dropped: run.droppedOps,
+                          })}
+                        </pre>
+                      </details>
+                    )}
+                  </div>
+                ))}
+                {threadDebug.runs.length === 0 && (
+                  <div className='py-2 text-xs text-muted-foreground'>No runs recorded.</div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {showThreadPanel && (
+        <div className='w-1/2 shrink-0 flex flex-col h-full bg-background border-l border-border'>
+          <div className='flex-1 h-full overflow-hidden'>
+            <Outlet context={{ onClose: closeThreadPanel }} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default RadarPanel;

--- a/apps/dashboard/src/components/RadarPanel/index.ts
+++ b/apps/dashboard/src/components/RadarPanel/index.ts
@@ -1,0 +1,1 @@
+export { default, default as RadarPanel } from './RadarPanel';

--- a/apps/dashboard/src/hooks/radarCacConfig.ts
+++ b/apps/dashboard/src/hooks/radarCacConfig.ts
@@ -1,0 +1,47 @@
+import { useCacConfig } from '@xyne/shared/hooks';
+
+/**
+ * Rollout switch for Radar. CAC rather than a VITE_ constant so enabling it
+ * needs no dashboard rebuild, and so a staged rollout can name accounts.
+ *
+ *   key:   radar_config
+ *   value: { "enabled": true, "allowedEmails": ["pilot@example.com"] }
+ *
+ * An empty allowedEmails means everyone. While off, the sidebar entry is
+ * hidden and the route renders nothing.
+ */
+
+export const RADAR_CAC_KEY = 'radar_config';
+
+export interface RadarCacConfig {
+  enabled: boolean;
+  allowedEmails: string[];
+}
+
+export const DEFAULT_RADAR_CAC_CONFIG: RadarCacConfig = {
+  enabled: false,
+  allowedEmails: [],
+};
+
+/** One rule, so the nav entry and the route guard cannot disagree. */
+export function isRadarAllowed(
+  config: RadarCacConfig,
+  userEmail: string | null | undefined,
+): boolean {
+  if (!config.enabled) return false;
+  const allowed = config.allowedEmails ?? [];
+  if (allowed.length === 0) return true;
+
+  const normalizedEmail = userEmail?.toLowerCase();
+  return !!normalizedEmail && allowed.some(e => e.toLowerCase() === normalizedEmail);
+}
+
+/** Denies while CAC is loading or unreachable, so a failed fetch hides Radar. */
+export function useRadarEnabled(userEmail: string | null | undefined): boolean {
+  const { config } = useCacConfig<RadarCacConfig>({
+    key: RADAR_CAC_KEY,
+    fallbackConfig: DEFAULT_RADAR_CAC_CONFIG,
+  });
+
+  return isRadarAllowed(config, userEmail);
+}

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -110,6 +110,7 @@ import BookmarksPanel from '../components/Chat/BookmarksPanel/BookmarksPanel';
 import DraftsAndSentPage from '../pages/DraftsAndSentPage';
 import UserThreads from '../components/Chat/UserThreads/UserThreads';
 import { RecapPanel } from '../components/RecapPanel';
+import { RadarPanel } from '../components/RadarPanel';
 import { RouterErrorFallback } from '../components/ErrorBoundary';
 import NotFoundScreen from './NotFoundScreen/NotFoundScreen';
 import ChatRedirect from '../components/Chat/ChatRedirect/ChatRedirect';
@@ -1225,6 +1226,28 @@ export const router = createBrowserRouter(
                             {
                               path: ':channelId',
                               element: <RecapPanel />,
+                              children: [
+                                {
+                                  path: ':conversationId',
+                                  element: <ThreadMessages />,
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        // Radar (must come before :channelId). The route stays
+                        // registered because the router is built at module scope;
+                        // the CAC rollout gate lives inside RadarPanel itself.
+                        {
+                          path: 'radar',
+                          children: [
+                            {
+                              index: true,
+                              element: <RadarPanel />,
+                            },
+                            {
+                              path: ':channelId',
+                              element: <RadarPanel />,
                               children: [
                                 {
                                   path: ':conversationId',


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

**XYNE-57690 — Radar Part A: execution tracking.**

Radar answers two questions a chat workspace can't today: *what is pending on me*, and *what am I waiting on from someone else*. It tracks "execution items" — a concrete ask or commitment inside a thread, modelled as a ball being passed: `requestedBy` (who is waiting) and `pendingOn` (who must act next).

Pipeline, one thread at a time:

1. **Enqueue** — a message insert side-effect adds a Bull job keyed by `conversationId` (5s debounce, so a burst collapses into one pass). `jobId = conversationId` means a thread is never processed by two live jobs at once.
2. **Drain + gate** — the worker reads every message above the thread's composite watermark `(createdAt, messageId)` and applies a *deterministic* gate: the thread is already tracked (has open items), or the window contains a resolved `@mention`. No heuristics — the only probabilistic judgment belongs to the LLM. One job drains at most 20 windows and re-enqueues the remainder, so a thread far behind can't run unbounded work inside a single job.
3. **Parse** — a gated window goes to a LiteLLM call with the thread's open items, the new messages, the last ten already-processed messages as read-only context, and an id→name map. It returns `create` / `resolve` / `reassign` operations, each with a one-sentence `reason`, plus an overall `assessment` of the window.
4. **Validate** — a pure trust boundary over the model's output: items must exist and be open, assignees must be in the window's legal user set (window `@mentions` + senders), `sourceMessageId` must cite a message in the window, no-ops dropped.
5. **Apply** — items, append-only audit mutations, and the watermark advance commit in **one transaction**, which is what makes the parser retry-safe with no idempotency bookkeeping.
6. **Read** — two GIN-backed feeds (Pending Me / Waiting On), a personal "Me + Team" lens, and a per-thread debug drawer.

Notable behaviour the prompt encodes: a reply is **not** fulfilment — pushback like "works for me" bounces the ball back to the requester instead of closing the item; a bare `@mention` on shared content is a **handoff** (creates an item), while an explicit `cc @x` / `fyi @x` is not.

Everything Radar reads or writes is gated by the app's own conversation-access rule (`radarAcl` mirrors `websocketService.canAccessConversation`): workspace match fail-closed, then the parent channel's ACL, where anything not `PUBLIC` (DMs and group DMs included) requires the viewer's `channel_participants` row. Visibility is an **allow-list**, deliberately stricter than the websocket check — `Channel.visibility` is an unconstrained String column, and Radar concentrates content from many channels onto one page, so an unknown future value must fail closed. Being named on an item never widens what a viewer may open, a radar team never widens it either, and `visibleTo`-restricted messages never enter a window in the first place.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [x] Adds/modifies a **query or ACL**

If any of the above:

- [x] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — *N/A, no mutators*
- [x] No `Date.now()` / `uuid()` generated inside a mutator — *N/A, no mutators*
- [x] Optimistic client result matches the server result — *N/A, Radar reads over REST, not Zero*
- [x] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [x] Matching Prisma model + migration, client regenerated

> All five new models live in the **`non_zero`** schema, so they are deliberately *not* exported into `createSchema()` and are not Zero-synced — the schema-migration check confirms this ("in the non_zero schema — skipping Zero sync check"). The only ACL touch is `acl-factory.ts`, where each new model needs a `BaseQueryACL` case because that switch is exhaustive (no `default:` branch is allowed — the repo guard checks this). The dashboard reads Radar over plain REST endpoints, not Zero queries.

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [x] Prisma schema modified (`apps/backend/prisma`)
- [x] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [x] Clients regenerated (`db:generate`)
- [x] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [x] Backward compatible with deployed code
- [x] Backfill is idempotent — *N/A, no backfill*

<!-- Rollout / rollback notes: -->
One migration, `20260827080000_add_radar_execution_tables`, creating five tables in the `non_zero` schema and touching nothing existing:

| table | purpose |
| --- | --- |
| `execution_items` | the ledger — one row per tracked ask |
| `execution_thread_states` | per-thread watermark (how far the worker has processed) |
| `execution_item_mutations` | append-only audit of every create/resolve/reassign |
| `execution_run_logs` | one row per worker pass — gate decision, model output, what applied |
| `radar_teams` | personal team lenses (owner-scoped) |

Purely additive, so it is safe to deploy ahead of the code and safe to leave in place on rollback. Status/op columns are `String`, not PG enums, per the enum freeze. Every model carries a non-nullable `workspaceId`.

Two schema decisions worth flagging for review:

- **Seven indexes, each with a named reader.** `workspaceId` is never the selective predicate in this feature — every read pairs it with a GIN array match, a `conversationId`, or an `id`, so the planner drives off that and applies `workspaceId` as a cheap filter. Any index led by `workspaceId` would be write cost for nothing, so none were kept. `execution_run_logs` additionally carries a bare `(createdAt)` index, which is what the retention sweep drives off (neither composite can serve a `createdAt`-only predicate).
- **`requestedBy` / `pendingOn` are `NOT NULL`.** A NULL array makes `pendingOn @> ARRAY[me]` evaluate to NULL rather than false, which would silently drop the row from *both* feeds — including the `NOT (...)` branch of Waiting On, breaking the "an ownerless item stays in its requester's Waiting On" rule. Prisma won't write NULL, so this is latent rather than live, but it's free to close while the tables are empty.

`execution_run_logs` is the fastest-growing table (one row per drain pass, carrying LLM payloads) and is swept hourly in bounded batches under the repo's cross-workspace scope (`runAsSystem`), retaining 3 days. Items and audit mutations are the durable record and are never swept.

With the feature flag off, the migration is inert — nothing enqueues, nothing drains, nothing writes.

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [x] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed**
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [x] Feature flag or runtime config changed

If any of the above:

- [x] Key added to **all** relevant env files — `apps/backend/.env.example`
- [x] Env setup / secret scripts and docker compose updated — *N/A, no new service or secret; all keys are optional with off-by-default values*
- [x] Verified in every consumer with its own base URL — *N/A, no base URL changed*
- [x] Google / Microsoft OAuth redirect URIs still resolve — *untouched*
- [x] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->
Backend only, six keys, all in `apps/backend/.env.example`, all inert by default:

| key | default | what it does |
| --- | --- | --- |
| `ENABLE_RADAR_EXECUTION` | `false` | the whole feature — read by **both** processes: the API gates its producer on it, the worker gates its drain loop on it |
| `RADAR_PARSER_MODEL` | *(blank)* | overrides the model; blank uses the org service account's default |
| `RADAR_EXECUTION_LITELLM_API_KEY` | *(blank)* | dedicated key so Radar's rate limit and spend are its own; blank falls back to the org LiteLLM service account |
| `RADAR_MAX_WINDOW_MESSAGES` | `200` | hard ceiling on how much text enters one parse — the brake on parser spend |
| `RADAR_EXECUTION_WORKER_CONCURRENCY` | `3` | threads drained in parallel |
| `RADAR_RUN_LOG_RETENTION_DAYS` | `3` | how long the debug trail is kept |

This mirrors how entity extraction is configured (`ENABLE_ENTITY_EXTRACTION` plus a `config.entityExtraction.*` block), which is the repo's dominant pattern — one flag per feature, ~18 of them; no feature here splits a producer flag from a consumer flag.

A separate worker flag was deliberately **not** kept. It only bought states that are a no-op (worker on, producer off) or actively bad (producer on, worker off), and toggling the single flag loses nothing because watermarks persist — the next enqueue replays everything above them. Idling the worker alone is a `replicas: 0` decision, not a config one.

Four values are constants rather than env keys, because they're decisions rather than levers someone would turn in production without a code change: context depth (10 messages), bootstrap lookback (1h), debounce (5s), and the per-job drain cap (20 windows).

**Frontend rollout is CAC, not an env var.** The dashboard gate is the Superposition key `radar_config`:

```json
{ "enabled": false, "allowedEmails": [] }
```

Off by default; an empty `allowedEmails` means everyone once enabled. This is deliberately CAC rather than a `VITE_*` constant — enabling Radar must not require rebuilding and redeploying the dashboard, and a staged rollout needs a per-user allowlist that a build-time constant can't express. While it's off, the sidebar entry is hidden and the route renders nothing. No dashboard env keys were added.

## API Contract

- [ ] No API changes
- [x] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots

All new, mounted at `/api/radar` behind `authMiddleware.authenticate`, all workspace- and channel-ACL scoped:

| method | path | purpose |
| --- | --- | --- |
| `GET` | `/feed/pending-me` | items where the ball is with me |
| `GET` | `/feed/waiting-on` | items I asked for |
| `POST` | `/items/:itemId/resolve` | resolve one item |
| `POST` | `/threads/:conversationId/resolve-all` | resolve every open item in a thread |
| `GET` / `POST` | `/teams` | list / create a team lens |
| `PATCH` / `DELETE` | `/teams/:teamId` | edit / delete |
| `GET` | `/feed/team/:teamId` | the team lens feed |
| `GET` | `/debug/items/:itemId` | one item's full trail |
| `GET` | `/debug/runs?conversationId=…` | one thread's worker runs — **`conversationId` is required** |

Debug is thread-scoped by design: there is no workspace-wide run listing, so a caller must name a conversation they can already open. A thread the caller cannot open returns **404**, indistinguishable from "does not exist", so ids can't be probed — and the ACL check runs *before* the item lookup, so an empty-but-accessible thread and an inaccessible one are also indistinguishable.

---

## How did you test it?

Two layers, both against a live local stack (backend + worker + dashboard + real LiteLLM calls).

**1. A scripted end-to-end harness — 83/83 assertions passing.** It builds a real fixture (a private DM between two users, a private group channel containing a third, and a public channel), runs the real `processThread()` for each, then asserts the whole matrix. Every ACL cell was checked across `pending-me`, `waiting-on`, thread debug, item trail, resolve, and resolve-all:

| | X (in DM) | Y (in DM) | Z (in group only) | W (outsider) | other workspace |
| --- | --- | --- | --- | --- | --- |
| private DM, X↔Y | ✅ | ✅ | ❌ | ❌ | ❌ |
| private group, X+Y+Z | ✅ | ✅ | ✅ | ❌ | ❌ |
| public channel | ✅ | ✅ | ✅ | ✅ | ❌ |

The harness also asserts that a denied probe leaves the item untouched (no partial writes on a rejected resolve), that the watermark lands exactly on the window's last message, that audit rows are written, that a double resolve is a clean no-op rather than an error, and that a resolved item leaves the feed.

**2. The real UI**, driven through the browser as two different users.

- **Team escalation — the case worth reviewing.** Logged in as the third user, created a radar team containing *both* DM participants, then read the team feed over HTTP: the team feed returned the public and group items but **not** the X↔Y DM item, and `debug/runs` + `resolve-all` on that DM both returned 404. A team selects *whose* items you're asking about; channel access still decides which of them you may see.
- **Ball passing.** "@QA Alert Bot can you fix the login timeout on staging" → item created pending on the bot. The bot replies "It is working for me, I could not reproduce it" → item stayed **open** and bounced back to the requester, with the model's reason surfaced in the drawer.
- **Handoff vs cc.** A bare `@mention` creates an item; the same content with `fyi @mention` creates nothing, with the assessment explaining why.
- **Debug drawer**: watermark + caught-up state, item state, per-mutation TRIGGERED BY (the source message) and REASONING, worker runs with the model's read and the op counters. Debug-by-thread-id works for an accessible thread and shows "Thread not found — either the id is wrong or you don't have access to that conversation" for one the viewer can't open.
- **Resolve CTA** clicked in the UI; confirmed in the DB as `resolve / manual / <that user's id>`.

### Automated

- [ ] Backend unit tests
- [ ] Claw tests
- [ ] End-to-end suite
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- why? -->

> No automated tests land in this PR. The pipeline's two interesting halves are an LLM call (non-deterministic) and a DB transaction, and both were verified end-to-end by the harness above instead. The deterministic, pure pieces — `radarValidator` (trust boundary) and `radarAcl` (visibility) — are the right unit-test targets and are worth a follow-up; they take plain inputs and need no fixtures.

### Manual

**Users**
- [x] Single user
- [x] Two users at once (two accounts / two browsers) — no cross-user leakage
- [x] Different roles or permission levels (ACL boundaries)
- [x] Different workspaces / spaces — data stays scoped

> ACL boundaries were tested as participant vs non-participant of a channel/DM, plus an outsider to both and a user in a second workspace — all five viewers in the matrix above.

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh
- [ ] Offline then reconnect
- [ ] Concurrent edits on the same entity by two users

> N/A — Radar does not go through Zero. It reads REST and **does not poll**: the feed refreshes on an explicit Refresh button, on switching tabs within the panel, and on `visibilitychange` when the browser tab is returned to.

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [x] Narrow viewport
- [ ] Dark theme
- [x] Empty state
- [x] Large / realistic data volume
- [x] Error paths (network failure, denied permission, invalid input)

> Checked at 800 / 1000 / 1100 / 1440px. The feed and debug drawer sit side by side down to ~1100px; below that the feed column shrinks correctly. Error paths covered: denied permission (404 on a foreign thread), invalid input (a bad conversation id renders "Thread not found…", and a missing `conversationId` on `/debug/runs` is a 400), and parser failure (a schema-invalid model response is retried, then recorded on the run log with the error). Dark theme not checked.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>` — *N/A, no new dependencies*
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

> Squashed to a single commit and rebased onto current `main`. Every CI leg was re-run locally *after* the rebase, with main's dependency set installed, so the local run matches the merge context CI actually builds: dashboard `format:check` / `lint:errors-only` / `typecheck` / `build`, backend typecheck + build, Zero↔Prisma column parity, schema-migration validation, tenant-key validation, the enum guard, and gitleaks — all green.
>
> **Blast radius.** The worker's Radar startup is wrapped in its own try/catch, unlike its neighbours, on purpose: an unguarded throw reaches the outer handler which exits the process, which would take AI provisioning, auto-draft, entity extraction and SDLC down with a feature none of them depend on. The API also closes the Radar producer queue on shutdown, alongside the other producer queues.
>
> **Observability is structured rather than log grepping**: `execution_run_logs` records one row per worker pass — the gate decision and why, the model's proposed operations, what the validator dropped, what was applied, the model's own one-sentence read of the window, and the duration. The debug drawer surfaces exactly that per thread, which is how every behaviour above was verified.

### Known gaps, deliberately left

- **`execution_item_mutations` has no retention.** It's the audit ledger — who changed what, when — and I'd rather keep it permanent than sweep it. If volume becomes real, the cheap first move is dropping the `payload` JSONB on old rows, which keeps the audit and sheds the bulk.
- **No FKs, so `execution_items` orphan if a conversation is hard-deleted.** The feed fails closed (the channel lookup returns nothing and the item is filtered out), so it isn't a leak — just dead rows with no cleanup path. `relationMode = "prisma"` means no FKs anywhere in this schema, so a fix would be hand-written cross-schema SQL; not worth it at this volume.
- **The retention sweep has no leader election.** Overlapping replicas are survivable by construction — batched deletes mean a second sweeper simply finds fewer rows — and the sweep starts on a jittered timer with no run at boot, so a rolling deploy doesn't fire N simultaneous sweeps.