### PR TITLE
fix: render attachments in Claw chat messages

### DIFF
--- a/apps/dashboard/src/components/Claw/ClawChat/MessageBubble.tsx
+++ b/apps/dashboard/src/components/Claw/ClawChat/MessageBubble.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../../utils/classNames';
 import type { Message } from '../../Chat/XyneAISidebar/utils/XyneAITypes';
 import { ActivityBlock } from '../../Chat/XyneAISidebar/components/ActivityBlock';
 import { PendingActionBlock } from '../../Chat/XyneAISidebar/components/PendingActionBlock';
+import { AttachmentPreview } from '../../Chat/XyneAISidebar/components/MessageItem';
 import { respondToPendingAction } from '../../../services/XyneAI/XyneAIPendingActionService';
 import { useClawConversation } from '../ClawConversationContext';
 import { ClawMarkdown } from './ClawMarkdown';
@@ -107,6 +108,13 @@ export function MessageBubble({ message, onRetry }: MessageBubbleProps): ReactEl
             <div className={cn(showActivity && 'pl-[22px]')}>
               <ClawMarkdown content={displayText} toolInvocations={message.toolInvocations} />
             </div>
+            {message.attachments && message.attachments.length > 0 && (
+              <div className={cn('mt-2 space-y-2', showActivity && 'pl-[22px]')}>
+                {message.attachments.map((attachment, index) => (
+                  <AttachmentPreview key={index} attachment={attachment} />
+                ))}
+              </div>
+            )}
             {message.isStreaming && rawText.trim().length > 0 && (
               <span className='inline-block h-3.5 w-1.5 animate-pulse bg-current align-middle' />
             )}


### PR DESCRIPTION
## Summary
Fixes the Claw agent chat UI attachment gap. The previous merged fix covered Ask AI full page / shared AI attachment handling, but the Claw chat surface has its own renderer at `apps/dashboard/src/components/Claw/ClawChat/MessageBubble.tsx`. That renderer showed activity, pending actions, and markdown, but never rendered `message.attachments`, so agent-generated files were still invisible in Claw UI.

This PR imports the shared `AttachmentPreview` component and renders it under Claw bot/user message content whenever `message.attachments` is present. Download behavior then reuses the already-fixed shared `AttachmentPreview.handleDownload`, including the `Download complete` toast.

## Changes
- `apps/dashboard/src/components/Claw/ClawChat/MessageBubble.tsx`
  - Import shared `AttachmentPreview` from `XyneAISidebar/components/MessageItem`.
  - Render attachment cards below the Claw message markdown.
  - Preserve existing activity indentation via `showActivity && 'pl-[22px]'`.

## Testing
- Targeted lint passed:
  - `cd apps/dashboard && npx eslint src/components/Claw/ClawChat/MessageBubble.tsx`
- Full dashboard typecheck was attempted, but failed on existing unrelated errors in `src/services/onDeviceIntent/intent.worker.ts`:
  - missing `@huggingface/transformers`
  - implicit `any` parameters in that worker
  - nullable `loading` return type
- POT attached in the Spaces thread:
  - `claw-ui-agent-attachments-pot.mp4`
  - `claw-ui-attachment-render.png`
  - `claw-ui-download-toast.png`

## PR template
1. Problem Description: Claw agent chat UI did not render `message.attachments`, so agent-generated files were invisible there even after the Ask AI full-page fix.
2. How the issue was identified: Traced the actual Claw UI renderer and found `apps/dashboard/src/components/Claw/ClawChat/MessageBubble.tsx` was separate from `AIChatThread.tsx` and lacked an attachment render block.
3. Solution implemented: Render the shared `AttachmentPreview` below Claw message content when attachments exist.
4. Documentation: N/A
5. DB Alter Details: N/A
6. Data fix Details: N/A
7. Environment variable Changes: N/A
8. Testing: Targeted eslint passed; POT screen recording/screenshots attached in Spaces. Full dashboard typecheck blocked by unrelated existing `onDeviceIntent/intent.worker.ts` errors.
9. Services to which this change is to be deployed: dashboard frontend.
10. Main PR link (if against a release branch): N/A