### PR TITLE
fix: derive label filter tags from loaded tickets in My Tickets view

### DIFF
--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -2974,10 +2974,15 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   const lastSentFilteredTicketIdsRef = useRef<string | null>(null);
 
   const availableTags = useMemo(() => {
-    if (!projectTags || projectTags.length === 0) return undefined;
-    const uniqueTags = new Set(projectTags.map(tag => tag.name));
-    return Array.from(uniqueTags).sort();
-  }, [projectTags]);
+    if (projectTags && projectTags.length > 0) {
+      const uniqueTags = new Set(projectTags.map(tag => tag.name));
+      return Array.from(uniqueTags).sort();
+    }
+    // My Tickets view (no project context): derive tags from already-loaded tickets
+    const tagSet = new Set<string>();
+    tagsByTicketId.forEach(tags => tags.forEach(tag => tagSet.add(tag.name)));
+    return tagSet.size > 0 ? Array.from(tagSet).sort() : undefined;
+  }, [projectTags, tagsByTicketId]);
 
   const availableStages = useMemo(() => {
     if (!stages || stages.length === 0) return undefined;


### PR DESCRIPTION
## Bug

In the Kanban board **My Tickets** view (no project selected), the **Labels** filter submenu was always empty — no labels appeared for selection.

## Root Cause

- `effectiveProjectId` is `undefined` in My Tickets view (`KanbanBoardScreen.tsx:1067`) because no project is selected.
- The `projectTags` query is disabled when `effectiveProjectId` is undefined (`KanbanBoardScreen.tsx:1753`: `enabled: !!effectiveProjectId`).
- The `availableTags` memo returned `undefined` when `projectTags` was empty (`KanbanBoardScreen.tsx:2977`).
- `TagsSubmenu` received `[]` → rendered an empty submenu (`TicketFiltersDropdown.tsx:635`).

## Fix

Modified the `availableTags` useMemo to fall back to deriving tags from `tagsByTicketId` (already computed from loaded kanban tickets at line 1777) when `projectTags` is unavailable.

**One file changed, 9 insertions, 4 deletions.** No backend/ACL changes — uses data already loaded in the frontend.

### Before
```typescript
const availableTags = useMemo(() => {
  if (!projectTags || projectTags.length === 0) return undefined;
  const uniqueTags = new Set(projectTags.map(tag => tag.name));
  return Array.from(uniqueTags).sort();
}, [projectTags]);
```

### After
```typescript
const availableTags = useMemo(() => {
  if (projectTags && projectTags.length > 0) {
    const uniqueTags = new Set(projectTags.map(tag => tag.name));
    return Array.from(uniqueTags).sort();
  }
  // My Tickets view (no project context): derive tags from already-loaded tickets
  const tagSet = new Set<string>();
  tagsByTicketId.forEach(tags => tags.forEach(tag => tagSet.add(tag.name)));
  return tagSet.size > 0 ? Array.from(tagSet).sort() : undefined;
}, [projectTags, tagsByTicketId]);
```

## Verification

- **TypeScript typecheck**: `npx tsc --noEmit` — **PASSED** (0 errors)
- **POT**: Sandbox browser reproduction was blocked by a Zero sync connection issue in the kata VM (WebSocket never established despite correct env config). The fix is verified by typecheck and code analysis with all file:line references confirmed.

## Test Cases

1. **My Tickets view with tagged tickets**: Labels submenu shows all tags from loaded tickets (was empty before fix).
2. **My Tickets view with no tags**: Labels submenu remains empty (returns `undefined`, same as before).
3. **Project-scoped Kanban view**: Behavior unchanged — `projectTags` takes priority, fallback never triggers.
4. **My Tickets view with mixed tags**: All unique tag names across all visible tickets appear, sorted alphabetically.
5. **Filtering by tag**: Selecting a label correctly filters tickets by that tag name.

## Risk

- **Low**: The fix adds a fallback path that only activates when `projectTags` is empty. When `projectTags` is available, behavior is identical to before.
- `tagsByTicketId` is already computed and in scope — no new data fetching or queries.
- Return type is unchanged: `string[] | undefined`.