### PR TITLE
fix: cmdk attachment preview url

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -1134,6 +1134,7 @@ const ChannelCommandMenu = ({
     fileUrl: string;
     mimeType: string;
     fileSize: number;
+    attachmentId?: string;
   } | null>(null);
   const [previewTicket, setPreviewTicket] = useState<DisplaySearchResult | null>(null);
   const [hoveredResult, setHoveredResult] = useState<DisplaySearchResult | null>(null);
@@ -1989,15 +1990,27 @@ const ChannelCommandMenu = ({
   const handleFilePreview = useCallback(
     (result: DisplaySearchResult): void => {
       // Handle attachment preview - show file preview modal
-      if (result.type !== 'attachment' || !result.searchContext?.internalUrl) {
+      if (result.type !== 'attachment' || !result.searchContext) {
+        return;
+      }
+
+      const { attachmentId, internalUrl, subApp } = result.searchContext;
+      const normalizedSubApp = subApp?.toUpperCase();
+      const isMessageAttachment =
+        normalizedSubApp === 'CHAT_ATTACHMENT' || normalizedSubApp === 'TICKET_ATTACHMENT';
+      const fileUrl =
+        isMessageAttachment && attachmentId ? `/attachments/${attachmentId}/download` : internalUrl;
+
+      if (!fileUrl) {
         return;
       }
 
       setPreviewFile({
         fileName: result.title,
-        fileUrl: result.searchContext.internalUrl,
+        fileUrl,
         mimeType: result.searchContext.mimeType || 'application/octet-stream',
         fileSize: result.searchContext.fileSize || 0,
+        ...(isMessageAttachment && attachmentId ? { attachmentId } : {}),
       });
       onOpenChange(false);
     },
@@ -2939,6 +2952,7 @@ const ChannelCommandMenu = ({
           fileUrl={previewFile.fileUrl}
           mimeType={previewFile.mimeType}
           fileSize={previewFile.fileSize}
+          {...(previewFile.attachmentId ? { attachmentId: previewFile.attachmentId } : {})}
         />
       )}
     </>


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Fixes Cmd+K file preview eye-button 404s for chat/ticket attachments.

Cmd+K search results currently receive `searchContext.internalUrl` from Vespa. For chat/ticket attachments that value is the raw stored attachment URL/path (`urlInternal`), which can be stale or unsuitable for the dashboard preview fetch. The preview modal should use the canonical authenticated attachment download route instead.

This PR makes Cmd+K preview build `/attachments/:attachmentId/download` for `CHAT_ATTACHMENT` and `TICKET_ATTACHMENT`, while preserving existing `internalUrl` behavior for other file result types such as collection files.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?

POT recorded in the Spaces thread.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — focused dashboard component wiring change; validated with lint and diff/POT evidence.

Focused checks run:
- `git diff --check` — passed.
- `pnpm --filter xyne-spaces-dashboard exec eslint src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx` — 0 errors; existing warnings only.
- `pnpm --filter xyne-spaces-dashboard typecheck` — change-specific `ChannelCommandMenu` TypeScript error was fixed; command remains blocked by unrelated existing `src/services/onDeviceIntent/intent.worker.ts` errors for `@huggingface/transformers` and nullable loading types.

### Manual

- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [x] Error paths — verified the new code falls back to `internalUrl` for non-chat/ticket file result types and returns early if no file URL is available.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind