### PR TITLE
fix:XYNE-59882 support group and channel mentions in comments and img sourceURL fix

### DIFF
--- a/apps/backend/src/controllers/canvasController.ts
+++ b/apps/backend/src/controllers/canvasController.ts
@@ -26,6 +26,8 @@ import {
   getCanvasById,
 } from '../services/canvasService.js';
 
+const sanitizeLogValue = (value: string): string => value.replace(/[\r\n]/g, '');
+
 export class CanvasController {
   private messageAttachmentRepository: MessageAttachmentRepository;
 
@@ -80,7 +82,7 @@ export class CanvasController {
       });
       await enqueueCanvasPermissionRefresh(canvasId).catch((error) =>
         logger.warn(
-          `[CANVAS-MENTIONS] Failed to enqueue permission refresh for canvas ${canvasId}: ${error instanceof Error ? error.message : 'Unknown error'}`
+          `[CANVAS-MENTIONS] Failed to enqueue permission refresh for canvas ${sanitizeLogValue(canvasId)}: ${error instanceof Error ? sanitizeLogValue(error.message) : 'Unknown error'}`
         )
       );
       return true;
@@ -126,7 +128,7 @@ export class CanvasController {
     });
     await enqueueCanvasPermissionRefresh(canvasId).catch((error) =>
       logger.warn(
-        `[CANVAS-MENTIONS] Failed to enqueue permission refresh for canvas ${canvasId}: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `[CANVAS-MENTIONS] Failed to enqueue permission refresh for canvas ${sanitizeLogValue(canvasId)}: ${error instanceof Error ? sanitizeLogValue(error.message) : 'Unknown error'}`
       )
     );
     return true;

--- a/apps/backend/src/controllers/canvasController.ts
+++ b/apps/backend/src/controllers/canvasController.ts
@@ -34,7 +34,7 @@ export class CanvasController {
   constructor(messageAttachmentRepository: MessageAttachmentRepository) {
     this.messageAttachmentRepository = messageAttachmentRepository;
   }
-
+  //ensuring the mentioned group or channel has access to the canvas before creating a comment mention notification
   private async ensureCommentMentionTargetAccess({
     canvasId,
     mentionType,

--- a/apps/backend/src/controllers/canvasController.ts
+++ b/apps/backend/src/controllers/canvasController.ts
@@ -10,7 +10,11 @@ import { notificationService } from '../services/notificationService.js';
 import { slackService } from '../services/slackService.js';
 import { activityService } from '../services/activity/activityService.js';
 import { DatabaseClient } from '@/database/client';
-import { getGroupMembersForNotification } from '../utils/mentionUtils.js';
+import {
+  getChannelParticipantsForMention,
+  getGroupMembersForNotification,
+} from '../utils/mentionUtils.js';
+import { enqueueCanvasPermissionRefresh } from '../services/canvasPermissionSync.js';
 import { getSlackRecipientEmails } from '../utils/notificationHelper.js';
 import { cleanupProxiedFile } from '../utils/attachmentUtils';
 import { v4 as uuidv4 } from 'uuid';
@@ -29,7 +33,106 @@ export class CanvasController {
     this.messageAttachmentRepository = messageAttachmentRepository;
   }
 
-    createCanvas = async (req: Request, res: Response): Promise<void> => {
+  private async ensureCommentMentionTargetAccess({
+    canvasId,
+    mentionType,
+    mentionId,
+    userId,
+    workspaceId,
+  }: {
+    canvasId: string;
+    mentionType: 'group' | 'channel';
+    mentionId: string;
+    userId: string;
+    workspaceId: string;
+  }): Promise<boolean> {
+    const db = DatabaseClient.getInstance();
+    const now = new Date();
+
+    if (mentionType === 'group') {
+      const group = await db.userGroup.findFirst({
+        where: {
+          id: mentionId,
+          workspaceId,
+          isActive: true,
+        },
+        select: { id: true },
+      });
+      if (!group) return false;
+
+      await db.canvasParticipant.upsert({
+        where: {
+          canvasId_userGroupId: {
+            canvasId,
+            userGroupId: mentionId,
+          },
+        },
+        create: {
+          id: uuidv4(),
+          workspaceId,
+          canvasId,
+          userGroupId: mentionId,
+          role: CanvasRole.VIEWER,
+          joinedAt: now,
+          updatedAt: now,
+        },
+        update: {},
+      });
+      await enqueueCanvasPermissionRefresh(canvasId).catch((error) =>
+        logger.warn(
+          `[CANVAS-MENTIONS] Failed to enqueue permission refresh for canvas ${canvasId}: ${error instanceof Error ? error.message : 'Unknown error'}`
+        )
+      );
+      return true;
+    }
+
+    const channel = await db.channel.findFirst({
+      where: {
+        id: mentionId,
+        workspaceId,
+        scopeType: 'DEFAULT',
+        isArchived: false,
+      },
+      select: { id: true },
+    });
+    if (!channel) return false;
+
+    const actorInChannel = await db.channelParticipant.findFirst({
+      where: {
+        channelId: mentionId,
+        userId,
+      },
+      select: { id: true },
+    });
+    if (!actorInChannel) return false;
+
+    await db.canvasParticipant.upsert({
+      where: {
+        canvasId_channelId: {
+          canvasId,
+          channelId: mentionId,
+        },
+      },
+      create: {
+        id: uuidv4(),
+        workspaceId,
+        canvasId,
+        channelId: mentionId,
+        role: CanvasRole.VIEWER,
+        joinedAt: now,
+        updatedAt: now,
+      },
+      update: {},
+    });
+    await enqueueCanvasPermissionRefresh(canvasId).catch((error) =>
+      logger.warn(
+        `[CANVAS-MENTIONS] Failed to enqueue permission refresh for canvas ${canvasId}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      )
+    );
+    return true;
+  }
+
+  createCanvas = async (req: Request, res: Response): Promise<void> => {
     try {
       const userId = req.user?.id;
       if (!userId) {
@@ -60,8 +163,8 @@ export class CanvasController {
             title,
             content: [],
             workspaceId: req.user!.workspaceId!,
-            createdBy: creatorId,  // <-- AUTHENTICATED USER
-            channelId: channelId || null,  // <-- ASSOCIATE WITH CHANNEL IF PROVIDED
+            createdBy: creatorId, // <-- AUTHENTICATED USER
+            channelId: channelId || null, // <-- ASSOCIATE WITH CHANNEL IF PROVIDED
             visibility: visibility === 'PUBLIC' ? 'PUBLIC' : 'PRIVATE',
             isTemplate: false,
             isCollaborative: true,
@@ -76,7 +179,7 @@ export class CanvasController {
             id: participantId,
             canvasId,
             workspaceId: req.user!.workspaceId!,
-            userId: creatorId,  // <-- AUTHENTICATED USER IS OWNER
+            userId: creatorId, // <-- AUTHENTICATED USER IS OWNER
             role: CanvasRole.OWNER,
             joinedAt: now,
             updatedAt: now,
@@ -128,7 +231,7 @@ export class CanvasController {
         await canvasAuthService.requireEditAccess(canvasId, userId);
       } catch (error) {
         logger.warn(`[CANVAS-UPLOAD] Permission denied for user ${userId} on canvas ${canvasId}`, {
-          error: error instanceof Error ? error.message : 'Unknown error'
+          error: error instanceof Error ? error.message : 'Unknown error',
         });
         await cleanupProxiedFile(file, { logPrefix: 'CANVAS-UPLOAD' });
         res.status(403).json({ error: 'Permission denied' });
@@ -156,7 +259,10 @@ export class CanvasController {
       const uploadResults = await uploadFiles([file]);
 
       if (!uploadResults || uploadResults.length === 0) {
-        logger.error('[CANVAS-UPLOAD] The file upload service did not return a valid result for file:', { fileName: file.originalname });
+        logger.error(
+          '[CANVAS-UPLOAD] The file upload service did not return a valid result for file:',
+          { fileName: file.originalname }
+        );
         await cleanupProxiedFile(file, { logPrefix: 'CANVAS-UPLOAD' });
         res.status(500).json({ error: 'Failed to process the uploaded file.' });
         return;
@@ -218,14 +324,14 @@ export class CanvasController {
 
   /**
    * POST /api/canvas/:canvasId/mentions
-   * Event-based: notify users when a user/group is selected from the @ mention menu.
-   * Body: { mentionType: 'user' | 'group', mentionId: string, blockId: string, canvasTitle: string }
+   * Event-based: notify users when a user/group/channel is selected from the mention menu.
+   * Body: { mentionType: 'user' | 'group' | 'channel', mentionId: string, blockId: string, canvasTitle: string }
    *
    * One API call per mention selection. No counting/deduplication - react to events.
    */
   handleMentions = async (req: Request, res: Response): Promise<void> => {
     const CanvasMentionSchema = z.object({
-      mentionType: z.enum(['user', 'group']),
+      mentionType: z.enum(['user', 'group', 'channel']),
       mentionId: z.string().min(1),
       blockId: z.string().min(1),
       commentThreadId: z.string().optional(),
@@ -247,8 +353,15 @@ export class CanvasController {
         return;
       }
 
-      const { mentionType, mentionId, blockId, commentThreadId, canvasTitle, mentionContext, slackUrl } =
-        validatedBody.data;
+      const {
+        mentionType,
+        mentionId,
+        blockId,
+        commentThreadId,
+        canvasTitle,
+        mentionContext,
+        slackUrl,
+      } = validatedBody.data;
       const userId = req.user?.id;
 
       if (!userId) {
@@ -273,9 +386,34 @@ export class CanvasController {
       // Fetch canvas to get channelId
       const canvasRecord = await db.canvas.findUnique({
         where: { id: canvasId },
-        select: { channelId: true },
+        select: { channelId: true, createdBy: true, workspaceId: true },
       });
+      if (!canvasRecord) {
+        res.status(404).json({ error: 'Canvas not found' });
+        return;
+      }
       const canvasChannelId = canvasRecord?.channelId;
+      let commentMentionTargetAccessEnsured = false;
+
+      if (mentionContext === 'comment' && (mentionType === 'group' || mentionType === 'channel')) {
+        const hasMentionTargetAccess = await this.ensureCommentMentionTargetAccess({
+          canvasId,
+          mentionType,
+          mentionId,
+          userId,
+          workspaceId: canvasRecord.workspaceId,
+        });
+
+        if (!hasMentionTargetAccess) {
+          res.status(200).json({
+            success: true,
+            notified: 0,
+            skipped: [{ mentionType, mentionId, reason: 'MENTION_TARGET_NOT_ACCESSIBLE' }],
+          });
+          return;
+        }
+        commentMentionTargetAccessEnsured = true;
+      }
 
       // Fetch channel name if canvas is linked to a channel
       const channel = canvasChannelId
@@ -287,8 +425,9 @@ export class CanvasController {
       const channelName = channel?.name;
 
       // Resolve mentioned users
-      const mentionedUsers: { userId: string; mentionSource: 'direct' | 'group' }[] = [];
-      
+      const mentionedUsers: { userId: string; mentionSource: 'direct' | 'group' | 'channel' }[] =
+        [];
+
       if (mentionType === 'user' && mentionId !== userId) {
         mentionedUsers.push({ userId: mentionId, mentionSource: 'direct' });
       } else if (mentionType === 'group') {
@@ -298,6 +437,13 @@ export class CanvasController {
             mentionedUsers.push({ userId: m.userId, mentionSource: 'group' });
           }
         }
+      } else if (mentionType === 'channel') {
+        const members = await getChannelParticipantsForMention(mentionId).catch(() => []);
+        for (const m of members) {
+          if (m.userId !== userId) {
+            mentionedUsers.push({ userId: m.userId, mentionSource: 'channel' });
+          }
+        }
       }
 
       if (mentionedUsers.length === 0) {
@@ -305,51 +451,66 @@ export class CanvasController {
         return;
       }
 
-      // Batch check canvas access for all mentioned users in a single query
-      const uniqueUserIds = [...new Set(mentionedUsers.map(u => u.userId))];
-      
-      // Fetch canvas details, canvas participants, sender name, and mentioned users' emails in one batch
-      const [canvas, canvasParticipants, sender, mentionedUserRecords] = await Promise.all([
-        db.canvas.findUnique({
-          where: { id: canvasId },
-          select: { createdBy: true },
-        }),
-        db.canvasParticipant.findMany({
-          where: {
-            canvasId,
-            userId: { in: uniqueUserIds },
-          },
-          select: { userId: true },
-        }),
+      const uniqueUserIds = [...new Set(mentionedUsers.map((u) => u.userId))];
+
+      // Fetch canvas details, sender name, and mentioned users' emails in one batch.
+      // Canvas access itself must use canvasAuthService because access can be direct,
+      // group-shared, channel-shared, public visibility, or guest container access.
+      const [sender, mentionedUserRecords] = await Promise.all([
         db.user.findUnique({ where: { id: userId }, select: { name: true } }),
         db.user.findMany({
           where: { id: { in: uniqueUserIds } },
           select: { id: true, email: true },
         }),
       ]);
-      
-      // Determine which users have access (canvas creator or canvas participant)
-      const canvasParticipantIds = new Set(canvasParticipants.map(p => p.userId));
-      const usersWithAccessIds = uniqueUserIds.filter(uid => 
-        uid === canvas?.createdBy || 
-        canvasParticipantIds.has(uid)
-      );
+
+      const usersWithAccessIds = commentMentionTargetAccessEnsured
+        ? uniqueUserIds
+        : (
+            await Promise.all(
+              uniqueUserIds.map(async (uid) => ({
+                uid,
+                hasAccess:
+                  uid === canvasRecord.createdBy ||
+                  (await canvasAuthService.checkCanvasAccess(canvasId, uid)).hasAccess,
+              }))
+            )
+          )
+            .filter((result) => result.hasAccess)
+            .map((result) => result.uid);
+      const skippedMentionTargets =
+        mentionType === 'user' && !usersWithAccessIds.includes(mentionId)
+          ? [{ mentionType, mentionId, reason: 'NO_CANVAS_ACCESS' }]
+          : [];
 
       if (usersWithAccessIds.length === 0) {
-        res.status(200).json({ success: true, notified: 0 });
+        res.status(200).json({
+          success: true,
+          notified: 0,
+          skipped: skippedMentionTargets,
+        });
         return;
       }
 
       // Filter to users with access and create activities
-      const mentionedUsersWithAccess = mentionedUsers.filter(u => usersWithAccessIds.includes(u.userId));
-      const activities = mentionedUsersWithAccess.map(u => ({
+      const mentionedUsersWithAccess = mentionedUsers.filter((u) =>
+        usersWithAccessIds.includes(u.userId)
+      );
+      const activities = mentionedUsersWithAccess.map((u) => ({
         id: uuidv4(),
         userId: u.userId,
         actorId: userId,
-        actorAction: u.mentionSource === 'direct' ? 'mentioned_user' : 'group_mention',
+        actorAction:
+          u.mentionSource === 'direct'
+            ? 'mentioned_user'
+            : u.mentionSource === 'group'
+              ? 'group_mention'
+              : 'channel_mention',
         actionSource: mentionContext === 'comment' ? 'canvas_comment' : 'canvas',
-        actionSourceId: mentionContext === 'comment' && commentThreadId ? commentThreadId : canvasId,
+        actionSourceId:
+          mentionContext === 'comment' && commentThreadId ? commentThreadId : canvasId,
         channelId: canvasChannelId ?? undefined,
+        workspaceId: canvasRecord.workspaceId ?? req.user?.workspaceId,
         canvasId: canvasId,
         blockId: blockId ?? undefined,
         classification: ActivityClassification.PENDING,
@@ -360,8 +521,8 @@ export class CanvasController {
       const usersWithAccessSet = new Set(usersWithAccessIds);
       const userEmailMap = new Map(
         mentionedUserRecords
-          .filter(u => u.email && usersWithAccessSet.has(u.id))
-          .map(u => [u.id, u.email!])
+          .filter((u) => u.email && usersWithAccessSet.has(u.id))
+          .map((u) => [u.id, u.email!])
       );
       const mentionedEmails = Array.from(userEmailMap.values());
 
@@ -383,12 +544,19 @@ export class CanvasController {
           blockId,
           commentThreadId,
           canvasChannelId ?? undefined,
-          mentionContext,
+          mentionContext
         );
 
-        slackRecipientEmails = getSlackRecipientEmails(mentionedEmails, deliveredUserIds, userEmailMap);
+        slackRecipientEmails = getSlackRecipientEmails(
+          mentionedEmails,
+          deliveredUserIds,
+          userEmailMap
+        );
       } catch (error) {
-        logger.error('[CANVAS-MENTIONS] Spaces notification failed — sending Slack to all recipients', { error });
+        logger.error(
+          '[CANVAS-MENTIONS] Spaces notification failed — sending Slack to all recipients',
+          { error }
+        );
       }
 
       // Step 3: Send Slack notifications only to users who didn't receive app notification
@@ -396,12 +564,13 @@ export class CanvasController {
         slackRecipientEmails,
         senderName,
         canvasTitle ?? 'Canvas',
-        slackUrl!,
+        slackUrl!
       );
 
       res.status(200).json({
         success: true,
         notified: usersWithAccessIds.length,
+        skipped: skippedMentionTargets,
       });
     } catch (error) {
       logger.error('[CANVAS-MENTIONS] Error sending mention notifications:', error);

--- a/apps/dashboard/src/components/Activity/ActivityItem.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItem.tsx
@@ -50,6 +50,15 @@ export const ActivityItem = memo(function ActivityItem({
       return <MessageMentionActivity activity={activity} isExpanded={isExpanded} />;
 
     case 'group_mention':
+      if (activity.canvasId) {
+        return <CanvasMentionActivity activity={activity} isExpanded={isExpanded} />;
+      }
+      return <MessageMentionActivity activity={activity} isExpanded={isExpanded} />;
+
+    case 'channel_mention':
+      if (activity.canvasId) {
+        return <CanvasMentionActivity activity={activity} isExpanded={isExpanded} />;
+      }
       return <MessageMentionActivity activity={activity} isExpanded={isExpanded} />;
 
     case 'keyword_match':

--- a/apps/dashboard/src/components/Canvas/CanvasCommentsPanel/CanvasCommentsPanel.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasCommentsPanel/CanvasCommentsPanel.tsx
@@ -9,7 +9,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
-import { CanvasCommentThreadStatus } from '@xyne/shared';
+import { CanvasCommentThreadStatus, ChannelScopeType, ChannelVisibility } from '@xyne/shared';
 import { useUserGroupSearch } from '@xyne/shared/hooks';
 import { motion } from 'framer-motion';
 import { v4 as uuidv4 } from 'uuid';
@@ -18,15 +18,15 @@ import { toast } from 'sonner';
 import { useAuth } from '../../../hooks/useAuth';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useMentionSearch } from '../../../hooks/useMentionSearch';
+import { searchChannels, useAllChannels, useAllVisibleChannels } from '../../../hooks/useChannels';
+import { useUserGroups } from '../../../hooks/useUserGroup';
 import { useUsers } from '../../../hooks/useUsers';
 import { useZero } from '../../../hooks/useZero';
 import { queries } from '../../../zero/queries';
 import { mutators } from '../../../zero/mutators';
 import { cn } from '../../../utils/classNames';
-import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { logger, Event } from '../../../utils/logger';
 import { apiInstance } from '../../../services/clients/apiClient';
-import { MentionRenderer } from '../../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
 import Avatar from '../../ui/Avatar/Avatar';
 import Button from '../../ui/Button';
 import { InputBox } from '../../ui/InputBox';
@@ -39,6 +39,16 @@ import {
   DropdownMenuTrigger,
 } from '../../ui/dropdown-menu';
 import { formatRelativeCommentTime } from '../canvasCommentTime';
+import {
+  CanvasCommentBody,
+  extractCanvasCommentMentionRefsFromHtml,
+  getCanvasMentionNoAccessUserIds,
+  isCanvasCommentMentionRefRetained,
+  parseCanvasCommentMentionRef,
+  parseCanvasCommentMentionRefs,
+  type CanvasCommentMentionRef,
+  type CanvasMentionNotificationResponse,
+} from '../canvasCommentMentions';
 
 type UserLite = {
   id: string;
@@ -133,91 +143,6 @@ interface CanvasCommentThreadSectionProps {
 const getDisplayName = (user?: UserLite | null): string =>
   user?.displayName || user?.name || user?.email || 'Unknown';
 
-const extractMentionedUserIdsFromHtml = (html: string, fallbackIds: string[]): string[] => {
-  const ids = new Set<string>();
-  const mentionRegex = /data-user-id="([^"]+)"/g;
-  let match: RegExpExecArray | null;
-
-  while ((match = mentionRegex.exec(html)) !== null) {
-    const userId = match[1];
-    if (userId) ids.add(userId);
-  }
-
-  if (ids.size === 0) {
-    fallbackIds.forEach(userId => ids.add(userId));
-  }
-
-  return [...ids];
-};
-
-const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const parseMentionedUserIds = (mentionedUserIds?: string | null): string[] => {
-  if (!mentionedUserIds) return [];
-  try {
-    const parsed: unknown = JSON.parse(mentionedUserIds);
-    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
-  } catch {
-    return [];
-  }
-};
-
-const renderCommentBody = (
-  body: string,
-  mentionedUserIds: string[],
-  users: UserLite[],
-): React.ReactNode[] => {
-  if (mentionedUserIds.length === 0 || !body) return [body];
-
-  const mentionTargets = mentionedUserIds
-    .map(userId => {
-      const user = users.find(candidate => candidate.id === userId);
-      const displayName = user ? getUserDisplayName(user) : '';
-      return displayName ? { userId, token: `@${displayName}`, displayName } : null;
-    })
-    .filter((target): target is { userId: string; token: string; displayName: string } =>
-      Boolean(target),
-    )
-    .sort((a, b) => b.token.length - a.token.length);
-
-  if (mentionTargets.length === 0) return [body];
-
-  const tokenPattern = mentionTargets.map(target => escapeRegExp(target.token)).join('|');
-  const tokenRegex = new RegExp(`(${tokenPattern})`, 'g');
-  const nodes: React.ReactNode[] = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-
-  while ((match = tokenRegex.exec(body)) !== null) {
-    const token = match[0];
-    const start = match.index;
-    if (start > lastIndex) {
-      nodes.push(body.slice(lastIndex, start));
-    }
-
-    const target = mentionTargets.find(candidate => candidate.token === token);
-    if (target) {
-      nodes.push(
-        <MentionRenderer
-          key={`${target.userId}-${start}`}
-          userId={target.userId}
-          fallbackName={target.displayName}
-        />,
-      );
-    } else {
-      nodes.push(token);
-    }
-
-    lastIndex = start + token.length;
-  }
-
-  if (lastIndex < body.length) {
-    nodes.push(body.slice(lastIndex));
-  }
-
-  return nodes.length > 0 ? nodes : [body];
-};
-
 function CanvasCommentComposer({
   id,
   channelId,
@@ -232,10 +157,18 @@ function CanvasCommentComposer({
 }: CanvasCommentComposerProps): React.JSX.Element {
   const selectedMentionIdsRef = useRef<Set<string>>(new Set());
   const [fallbackMentionQuery, setFallbackMentionQuery] = useState('');
+  const [channelSearchQuery, setChannelSearchQuery] = useState('');
   const { results, allUsers, searchMentions } = useMentionSearch(channelId, undefined, undefined, {
     includeSpecialMentions: false,
   });
   const fallbackGroups = useUserGroupSearch(fallbackMentionQuery, 10);
+  const visibleChannels = useAllVisibleChannels();
+  const channelResults = useMemo(
+    () => searchChannels(visibleChannels, channelSearchQuery, 10),
+    [channelSearchQuery, visibleChannels],
+  );
+  const allChannels = useAllChannels();
+  const allGroups = useUserGroups();
 
   const fallbackMentionItems = useMemo<MentionResult[]>(
     () => [
@@ -271,6 +204,20 @@ function CanvasCommentComposer({
       .slice(0, 8);
   }, [channelId, currentUserId, fallbackMentionItems, fallbackMentionQuery, results]);
 
+  const channelItems = useMemo(
+    () =>
+      channelResults
+        .filter(channel => channel.scopeType === ChannelScopeType.DEFAULT)
+        .map(channel => ({
+          id: channel.id,
+          name: channel.name,
+          isPrivate: channel.visibility === ChannelVisibility.PRIVATE,
+          ...(channel.description && { description: channel.description }),
+          hasAccess: true,
+        })),
+    [channelResults],
+  );
+
   const handleMentionSearch = (query: string): void => {
     setFallbackMentionQuery(query);
     searchMentions(query);
@@ -286,13 +233,10 @@ function CanvasCommentComposer({
     const body = content.trim();
     if (!body) return;
 
-    const retainedFallbackMentionIds = fallbackMentionedUserIds.filter(userId => {
-      const mention = allUsers.find(
-        candidate => candidate.type === 'user' && candidate.id === userId,
-      );
-      return mention ? body.includes(`@${mention.name}`) : true;
-    });
-    const mentionedUserIds = extractMentionedUserIdsFromHtml(html, [
+    const retainedFallbackMentionIds = fallbackMentionedUserIds.filter(mentionRef =>
+      isCanvasCommentMentionRefRetained(mentionRef, body, allUsers, allGroups, allChannels),
+    );
+    const mentionedUserIds = extractCanvasCommentMentionRefsFromHtml(html, [
       ...selectedMentionIdsRef.current,
       ...retainedFallbackMentionIds,
     ]);
@@ -309,6 +253,8 @@ function CanvasCommentComposer({
         mentionItems={mentionItems}
         onMentionSearch={handleMentionSearch}
         onMentionSelect={handleMentionSelect}
+        channelItems={channelItems}
+        onChannelSearch={setChannelSearchQuery}
         placeholder={placeholder}
         value={value}
         disabled={disabled}
@@ -480,7 +426,7 @@ function CanvasCommentThreadSection({
                 currentUserId={currentUserId}
                 placeholder='Edit comment'
                 value={comment.body}
-                fallbackMentionedUserIds={parseMentionedUserIds(comment.mentionedUserIds)}
+                fallbackMentionedUserIds={parseCanvasCommentMentionRefs(comment.mentionedUserIds)}
                 minHeightClassName='min-h-[38px]'
                 onSubmit={payload => onUpdateComment(thread, comment, payload)}
                 actions={
@@ -505,13 +451,15 @@ function CanvasCommentThreadSection({
                   isDeleted && 'italic text-muted-foreground',
                 )}
               >
-                {isDeleted
-                  ? 'Comment deleted'
-                  : renderCommentBody(
-                      comment.body,
-                      parseMentionedUserIds(comment.mentionedUserIds),
-                      allUsers,
-                    )}
+                {isDeleted ? (
+                  'Comment deleted'
+                ) : (
+                  <CanvasCommentBody
+                    body={comment.body}
+                    mentionIds={parseCanvasCommentMentionRefs(comment.mentionedUserIds)}
+                    users={allUsers}
+                  />
+                )}
               </p>
             )}
           </div>
@@ -617,28 +565,50 @@ export function CanvasCommentsPanel({
     { value: CanvasCommentThreadStatus.RESOLVED, label: 'Resolved', count: resolvedCount },
   ];
 
+  const showNoAccessMentionWarning = useCallback(
+    (
+      response?: CanvasMentionNotificationResponse,
+      fallbackMention?: CanvasCommentMentionRef,
+    ): void => {
+      getCanvasMentionNoAccessUserIds(response, fallbackMention).forEach(mentionedUserId => {
+        const mentionedUser = allUsers.find(candidate => candidate.id === mentionedUserId);
+        const displayName = mentionedUser ? getDisplayName(mentionedUser) : 'This person';
+
+        toast.warning('Mention not sent', {
+          description: `${displayName} doesn't have access to this canvas.`,
+        });
+      });
+    },
+    [allUsers],
+  );
+
   const sendMentionNotifications = useCallback(
     (blockId: string, mentionedUserIds: string[], commentThreadId?: string): void => {
-      const uniqueMentionedUserIds = [...new Set(mentionedUserIds)].filter(
-        mentionedUserId => mentionedUserId && mentionedUserId !== user?.id,
-      );
-      if (uniqueMentionedUserIds.length === 0) return;
+      const uniqueMentionRefs = [...new Set(mentionedUserIds)].filter(mentionId => {
+        const ref = parseCanvasCommentMentionRef(mentionId);
+        return ref.id && !(ref.type === 'user' && ref.id === user?.id);
+      });
+      if (uniqueMentionRefs.length === 0) return;
 
       const path = `redirected?type=canvas&canvasId=${encodeURIComponent(canvasId)}&blockId=${encodeURIComponent(blockId)}${
         commentThreadId ? `&commentThreadId=${encodeURIComponent(commentThreadId)}` : ''
       }`;
       const slackUrl = `${window.location.origin}/launch?path=${encodeURIComponent(path)}`;
 
-      uniqueMentionedUserIds.forEach(mentionId => {
+      uniqueMentionRefs.forEach(mentionRef => {
+        const mention = parseCanvasCommentMentionRef(mentionRef);
         apiInstance
           .post(`/canvas/${canvasId}/mentions`, {
-            mentionType: 'user',
-            mentionId,
+            mentionType: mention.type,
+            mentionId: mention.id,
             blockId,
             commentThreadId,
             canvasTitle,
             mentionContext: 'comment',
             slackUrl,
+          })
+          .then(response => {
+            showNoAccessMentionWarning(response.data as CanvasMentionNotificationResponse, mention);
           })
           .catch(error => {
             logger.error(Event.API_CALL_FAILED, {
@@ -648,7 +618,7 @@ export function CanvasCommentsPanel({
           });
       });
     },
-    [canvasId, canvasTitle, user?.id],
+    [canvasId, canvasTitle, showNoAccessMentionWarning, user?.id],
   );
 
   const selectedTextAnchor =
@@ -743,7 +713,9 @@ export function CanvasCommentsPanel({
     void mutationResult.server
       .then(result => {
         if (result.type !== 'error') {
-          const previousMentionedUserIds = new Set(parseMentionedUserIds(comment.mentionedUserIds));
+          const previousMentionedUserIds = new Set(
+            parseCanvasCommentMentionRefs(comment.mentionedUserIds),
+          );
           const newlyMentionedUserIds = mentionedUserIds.filter(
             mentionedUserId => !previousMentionedUserIds.has(mentionedUserId),
           );

--- a/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
@@ -31,10 +31,14 @@ import { filterSuggestionItems } from '@blocknote/core/extensions';
 import '@blocknote/core/fonts/inter.css';
 import '@blocknote/mantine/style.css';
 import { en } from '@blocknote/core/locales';
-import { PresentationModal, usePresentation } from 'blocknote-layout-extensions';
+import {
+  PresentationModal,
+  usePresentation,
+  getMentionSuggestionMenuItems as getMentionSuggestionMenuItemsUntyped,
+  insertGroupMention as insertGroupMentionUntyped,
+  asBlockNoteEditorForView,
+} from 'blocknote-layout-extensions';
 import { getWhiteboardSlashMenuItems } from 'blocknote-layout-extensions';
-import { getMentionSuggestionMenuItems, insertGroupMention } from 'blocknote-layout-extensions';
-import { asBlockNoteEditorForView } from 'blocknote-layout-extensions';
 import { buildMentionProps, CanvasMentionContext } from '../CanvasMentionSpec';
 import { useCanvasBlockShortcuts, withBlockShortcutBadges } from '../canvasBlockShortcuts';
 import { withHeadingsTogether, withUnifiedUpload } from '../canvasSlashMenu';
@@ -97,6 +101,34 @@ const canvasDictionary = {
     emptyDocument: "Write something, or press '/' for commands",
   },
 };
+
+type CanvasEditorForView = ReturnType<typeof asBlockNoteEditorForView>;
+type MentionSuggestionUser = {
+  id: string;
+  username: string;
+  email: string;
+  picture?: string | null;
+};
+type MentionSuggestionOptions = {
+  onUserSearch: (query: string) => Promise<MentionSuggestionUser[]>;
+  currentUserId?: string;
+};
+type GroupMentionTarget = {
+  id: string;
+  name: string;
+  alias?: string | null;
+};
+
+const getMentionSuggestionMenuItems = getMentionSuggestionMenuItemsUntyped as unknown as (
+  editor: CanvasEditorForView,
+  query: string,
+  options: MentionSuggestionOptions,
+) => Promise<DefaultReactSuggestionItem[]>;
+
+const insertGroupMention = insertGroupMentionUntyped as unknown as (
+  editor: CanvasEditorForView,
+  group: GroupMentionTarget,
+) => void;
 
 // Content size limit in bytes
 const CONTENT_SIZE_MAX_THRESHOLD = 100 * 1024; // 100KB - block save

--- a/apps/dashboard/src/components/Canvas/CanvasInlineCommentThread/CanvasInlineCommentThread.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasInlineCommentThread/CanvasInlineCommentThread.tsx
@@ -1,22 +1,21 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Check, RotateCcw, X } from 'lucide-react';
 import { useUserGroupSearch } from '@xyne/shared/hooks';
-import { CanvasCommentThreadStatus } from '@xyne/shared';
+import { CanvasCommentThreadStatus, ChannelScopeType, ChannelVisibility } from '@xyne/shared';
 import { v4 as uuidv4 } from 'uuid';
 import { toast } from 'sonner';
 
 import { useAuth } from '../../../hooks/useAuth';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useMentionSearch } from '../../../hooks/useMentionSearch';
+import { searchChannels, useAllVisibleChannels } from '../../../hooks/useChannels';
 import { useUsers } from '../../../hooks/useUsers';
 import { useZero } from '../../../hooks/useZero';
 import { queries } from '../../../zero/queries';
 import { mutators } from '../../../zero/mutators';
 import { cn } from '../../../utils/classNames';
-import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { logger, Event } from '../../../utils/logger';
 import { apiInstance } from '../../../services/clients/apiClient';
-import { MentionRenderer } from '../../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
 import Avatar from '../../ui/Avatar/Avatar';
 import { InputBox } from '../../ui/InputBox';
 import type { MentionResult } from '../../ui/InputBox';
@@ -25,6 +24,15 @@ import { formatRelativeCommentTime } from '../canvasCommentTime';
 import type { CanvasCommentAnchor } from '../CanvasCommentsPanel/CanvasCommentsPanel';
 import { OverlayZIndexContext } from '../../../contexts/OverlayZIndexContext';
 import type { CanvasCommentHighlightThread } from '../useCanvasCommentHighlights';
+import {
+  CanvasCommentBody,
+  extractCanvasCommentMentionRefsFromHtml,
+  getCanvasMentionNoAccessUserIds,
+  parseCanvasCommentMentionRef,
+  parseCanvasCommentMentionRefs,
+  type CanvasCommentMentionRef,
+  type CanvasMentionNotificationResponse,
+} from '../canvasCommentMentions';
 
 type UserLite = {
   id: string;
@@ -60,33 +68,6 @@ interface CanvasInlineCommentThreadProps {
   onCreateThreadFailed?: ((anchor: CanvasCommentAnchor) => void) | undefined;
 }
 
-const extractMentionedUserIdsFromHtml = (html: string, fallbackIds: string[]): string[] => {
-  const ids = new Set<string>();
-  const mentionRegex = /data-user-id="([^"]+)"/g;
-  let match: RegExpExecArray | null;
-
-  while ((match = mentionRegex.exec(html)) !== null) {
-    const userId = match[1];
-    if (userId) ids.add(userId);
-  }
-
-  if (ids.size === 0) {
-    fallbackIds.forEach(userId => ids.add(userId));
-  }
-
-  return [...ids];
-};
-
-const parseMentionedUserIds = (mentionedUserIds?: string | null): string[] => {
-  if (!mentionedUserIds) return [];
-  try {
-    const parsed: unknown = JSON.parse(mentionedUserIds);
-    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
-  } catch {
-    return [];
-  }
-};
-
 const getDisplayName = (user?: UserLite | null): string =>
   user?.displayName || user?.name || user?.email || 'Unknown';
 
@@ -97,35 +78,6 @@ const getCommentAuthor = (
   comment
     ? (users.find(candidate => candidate.id === comment.createdBy) ?? comment.createdByUser ?? null)
     : null;
-
-const renderCommentBody = (
-  body: string,
-  mentionedUserIds: string[],
-  users: UserLite[],
-): React.ReactNode[] => {
-  if (mentionedUserIds.length === 0 || !body) return [body];
-
-  const nodes: React.ReactNode[] = [];
-  let remaining = body;
-  mentionedUserIds.forEach(userId => {
-    const user = users.find(candidate => candidate.id === userId);
-    const displayName = user ? getUserDisplayName(user) : '';
-    const token = displayName ? `@${displayName}` : '';
-    if (!token || !remaining.includes(token)) return;
-    const [before, ...afterParts] = remaining.split(token);
-    if (before) nodes.push(before);
-    nodes.push(
-      <MentionRenderer
-        key={`${userId}-${nodes.length}`}
-        userId={userId}
-        fallbackName={displayName}
-      />,
-    );
-    remaining = afterParts.join(token);
-  });
-  if (remaining) nodes.push(remaining);
-  return nodes.length > 0 ? nodes : [body];
-};
 
 const CARD_MAX_WIDTH = 470;
 const CARD_GAP = 10;
@@ -197,12 +149,18 @@ export function CanvasInlineCommentThread({
   const [hasEntered, setHasEntered] = useState(false);
   const [createdThread, setCreatedThread] = useState<CanvasCommentHighlightThread | null>(null);
   const [mentionQuery, setMentionQuery] = useState('');
+  const [channelSearchQuery, setChannelSearchQuery] = useState('');
   const {
     results,
     allUsers: mentionUsers,
     searchMentions,
   } = useMentionSearch(channelId, undefined, undefined, { includeSpecialMentions: false });
   const fallbackGroups = useUserGroupSearch(mentionQuery, 10);
+  const visibleChannels = useAllVisibleChannels();
+  const channelResults = useMemo(
+    () => searchChannels(visibleChannels, channelSearchQuery, 10),
+    [channelSearchQuery, visibleChannels],
+  );
   const currentThread = createdThread ?? thread;
   const currentThreadId = currentThread?.id;
   const [comments = []] = useCachedQuery(
@@ -306,16 +264,48 @@ export function CanvasInlineCommentThread({
       .slice(0, 8);
   }, [channelId, fallbackGroups, mentionQuery, mentionUsers, results, user?.id]);
 
+  const channelItems = useMemo(
+    () =>
+      channelResults
+        .filter(channel => channel.scopeType === ChannelScopeType.DEFAULT)
+        .map(channel => ({
+          id: channel.id,
+          name: channel.name,
+          isPrivate: channel.visibility === ChannelVisibility.PRIVATE,
+          ...(channel.description && { description: channel.description }),
+          hasAccess: true,
+        })),
+    [channelResults],
+  );
+
+  const showNoAccessMentionWarning = useCallback(
+    (
+      response?: CanvasMentionNotificationResponse,
+      fallbackMention?: CanvasCommentMentionRef,
+    ): void => {
+      getCanvasMentionNoAccessUserIds(response, fallbackMention).forEach(mentionedUserId => {
+        const mentionedUser = allUsers.find(candidate => candidate.id === mentionedUserId);
+        const displayName = mentionedUser ? getDisplayName(mentionedUser) : 'This person';
+
+        toast.warning('Mention not sent', {
+          description: `${displayName} doesn't have access to this canvas.`,
+        });
+      });
+    },
+    [allUsers],
+  );
+
   if (!currentThread && !activeAnchor) return null;
 
   const sendMentionNotifications = (
     mentionedUserIds: string[],
     options?: { blockId?: string; commentThreadId?: string },
   ): void => {
-    const uniqueMentionedUserIds = [...new Set(mentionedUserIds)].filter(
-      mentionedUserId => mentionedUserId && mentionedUserId !== user?.id,
-    );
-    if (uniqueMentionedUserIds.length === 0) return;
+    const uniqueMentionRefs = [...new Set(mentionedUserIds)].filter(mentionId => {
+      const mention = parseCanvasCommentMentionRef(mentionId);
+      return mention.id && !(mention.type === 'user' && mention.id === user?.id);
+    });
+    if (uniqueMentionRefs.length === 0) return;
 
     const blockId = options?.blockId ?? currentThread?.blockId ?? activeAnchor?.blockId;
     const commentThreadId = options?.commentThreadId ?? currentThread?.id;
@@ -324,16 +314,20 @@ export function CanvasInlineCommentThread({
     const path = `redirected?type=canvas&canvasId=${encodeURIComponent(canvasId)}&blockId=${encodeURIComponent(blockId)}&commentThreadId=${encodeURIComponent(commentThreadId)}`;
     const slackUrl = `${window.location.origin}/launch?path=${encodeURIComponent(path)}`;
 
-    uniqueMentionedUserIds.forEach(mentionId => {
+    uniqueMentionRefs.forEach(mentionRef => {
+      const mention = parseCanvasCommentMentionRef(mentionRef);
       apiInstance
         .post(`/canvas/${canvasId}/mentions`, {
-          mentionType: 'user',
-          mentionId,
+          mentionType: mention.type,
+          mentionId: mention.id,
           blockId,
           commentThreadId,
           canvasTitle,
           mentionContext: 'comment',
           slackUrl,
+        })
+        .then(response => {
+          showNoAccessMentionWarning(response.data as CanvasMentionNotificationResponse, mention);
         })
         .catch(error => {
           logger.error(Event.API_CALL_FAILED, {
@@ -396,7 +390,7 @@ export function CanvasInlineCommentThread({
   const handleReply = (content: string, html: string): void => {
     const body = content.trim();
     if (!body) return;
-    const mentionedUserIds = extractMentionedUserIdsFromHtml(html, [
+    const mentionedUserIds = extractCanvasCommentMentionRefsFromHtml(html, [
       ...selectedMentionIdsRef.current,
     ]);
     selectedMentionIdsRef.current.clear();
@@ -537,11 +531,11 @@ export function CanvasInlineCommentThread({
                 </div>
                 {isInitialComment && anchorQuote && renderAnchorQuote()}
                 <p className='ml-[33px] mt-[3px] whitespace-pre-wrap break-words text-[13.5px] leading-[1.55] text-foreground [text-wrap:pretty]'>
-                  {renderCommentBody(
-                    comment.body,
-                    parseMentionedUserIds(comment.mentionedUserIds),
-                    allUsers,
-                  )}
+                  <CanvasCommentBody
+                    body={comment.body}
+                    mentionIds={parseCanvasCommentMentionRefs(comment.mentionedUserIds)}
+                    users={allUsers}
+                  />
                 </p>
               </div>
             );
@@ -595,6 +589,8 @@ export function CanvasInlineCommentThread({
               onMentionSelect={mention => {
                 if (mention.type === 'user') selectedMentionIdsRef.current.add(mention.id);
               }}
+              channelItems={channelItems}
+              onChannelSearch={setChannelSearchQuery}
               placeholder={
                 isDraft ? 'Comment — @AI to edit the selection…' : 'Reply — @AI to edit…'
               }

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -59,8 +59,10 @@ import {
 import { apiInstance } from '../../../services/clients/apiClient';
 import type { CanvasParticipant, CollaborativeCanvasEditorRef } from '../Canvas.types';
 import { filterSuggestionItems } from '@blocknote/core/extensions';
-import { getWhiteboardSlashMenuItems } from 'blocknote-layout-extensions';
-import { insertGroupMention } from 'blocknote-layout-extensions';
+import {
+  getWhiteboardSlashMenuItems,
+  insertGroupMention as insertGroupMentionUntyped,
+} from 'blocknote-layout-extensions';
 import { buildMentionProps, CanvasMentionContext } from '../CanvasMentionSpec';
 import { useCanvasBlockShortcuts, withBlockShortcutBadges } from '../canvasBlockShortcuts';
 import { withHeadingsTogether, withUnifiedUpload } from '../canvasSlashMenu';
@@ -114,6 +116,22 @@ const buildCanvasDictionary = (placeholder: string): typeof en => ({
 });
 
 const canvasDictionary = buildCanvasDictionary(DEFAULT_CANVAS_PLACEHOLDER);
+
+type CollaborativeCanvasEditorForView = BlockNoteEditor<
+  BlockSchema,
+  InlineContentSchema,
+  StyleSchema
+>;
+type GroupMentionTarget = {
+  id: string;
+  name: string;
+  alias?: string | null;
+};
+
+const insertGroupMention = insertGroupMentionUntyped as unknown as (
+  editor: CollaborativeCanvasEditorForView,
+  group: GroupMentionTarget,
+) => void;
 
 interface CollaborativeCanvasEditorProps {
   canvasId: string;

--- a/apps/dashboard/src/components/Canvas/canvasCommentMentions.tsx
+++ b/apps/dashboard/src/components/Canvas/canvasCommentMentions.tsx
@@ -1,0 +1,278 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ChannelVisibility } from '@xyne/shared';
+
+import {
+  ChannelMentionRenderer,
+  GroupMentionRenderer,
+  MentionRenderer,
+} from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { useAllChannels } from '../../hooks/useChannels';
+import { useUserGroups } from '../../hooks/useUserGroup';
+import { getUserDisplayName } from '../../utils/userDisplayName';
+
+type UserLite = {
+  id: string;
+  name?: string;
+  displayName?: string | null;
+  email?: string;
+};
+
+type GroupLite = {
+  id: string;
+  name: string;
+  alias?: string | null;
+};
+
+type ChannelLite = {
+  id: string;
+  name: string;
+  visibility?: ChannelVisibility | null;
+};
+
+export type CanvasCommentMentionType = 'user' | 'group' | 'channel';
+
+export interface CanvasCommentMentionRef {
+  type: CanvasCommentMentionType;
+  id: string;
+}
+
+export interface CanvasMentionNotificationResponse {
+  success?: boolean;
+  notified?: number;
+  skipped?: {
+    mentionType: CanvasCommentMentionType;
+    mentionId: string;
+    reason: string;
+  }[];
+}
+
+export const serializeCanvasCommentMentionRef = (mention: CanvasCommentMentionRef): string =>
+  mention.type === 'user' ? mention.id : `${mention.type}:${mention.id}`;
+
+export const parseCanvasCommentMentionRef = (value: string): CanvasCommentMentionRef => {
+  if (value.startsWith('group:')) {
+    return { type: 'group', id: value.slice('group:'.length) };
+  }
+  if (value.startsWith('channel:')) {
+    return { type: 'channel', id: value.slice('channel:'.length) };
+  }
+  if (value.startsWith('user:')) {
+    return { type: 'user', id: value.slice('user:'.length) };
+  }
+  return { type: 'user', id: value };
+};
+
+const extractAttributeValues = (
+  html: string,
+  spanPattern: RegExp,
+  attributePattern: RegExp,
+): string[] => {
+  const ids = new Set<string>();
+  let match: RegExpExecArray | null;
+
+  while ((match = spanPattern.exec(html)) !== null) {
+    const span = match[0];
+    const attributeMatch = span.match(attributePattern);
+    const id = attributeMatch?.[1];
+    if (id) ids.add(id);
+  }
+
+  return [...ids];
+};
+
+export const extractCanvasCommentMentionRefsFromHtml = (
+  html: string,
+  fallbackMentionIds: string[] = [],
+): string[] => {
+  const refs = new Set<string>();
+
+  fallbackMentionIds.forEach(id => refs.add(id));
+
+  extractAttributeValues(
+    html,
+    /<span[^>]*data-mention-type=["']user["'][^>]*>/g,
+    /data-user-id=["']([^"']+)["']/,
+  ).forEach(id => refs.add(serializeCanvasCommentMentionRef({ type: 'user', id })));
+
+  extractAttributeValues(
+    html,
+    /<span[^>]*data-mention-type=["']group["'][^>]*>/g,
+    /data-group-id=["']([^"']+)["']/,
+  ).forEach(id => refs.add(serializeCanvasCommentMentionRef({ type: 'group', id })));
+
+  extractAttributeValues(
+    html,
+    /<span[^>]*data-channel-mention[^>]*>/g,
+    /data-channel-id=["']([^"']+)["']/,
+  ).forEach(id => refs.add(serializeCanvasCommentMentionRef({ type: 'channel', id })));
+
+  return [...refs];
+};
+
+export const parseCanvasCommentMentionRefs = (mentionedUserIds?: string | null): string[] => {
+  if (!mentionedUserIds) return [];
+  try {
+    const parsed: unknown = JSON.parse(mentionedUserIds);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
+  } catch {
+    return [];
+  }
+};
+
+export const getCanvasMentionNoAccessUserIds = (
+  response?: CanvasMentionNotificationResponse,
+  fallbackMention?: CanvasCommentMentionRef,
+): string[] => {
+  const skippedUserIds =
+    response?.skipped
+      ?.filter(skip => skip.mentionType === 'user' && skip.reason === 'NO_CANVAS_ACCESS')
+      .map(skip => skip.mentionId) ?? [];
+
+  if (skippedUserIds.length > 0) return skippedUserIds;
+  if (fallbackMention?.type === 'user' && response?.notified === 0) return [fallbackMention.id];
+
+  return [];
+};
+
+export const isCanvasCommentMentionRefRetained = (
+  mentionRef: string,
+  body: string,
+  users: UserLite[],
+  groups: GroupLite[],
+  channels: ChannelLite[],
+): boolean => {
+  const ref = parseCanvasCommentMentionRef(mentionRef);
+
+  if (ref.type === 'user') {
+    const user = users.find(candidate => candidate.id === ref.id);
+    const displayName = user ? getUserDisplayName(user) : '';
+    return displayName ? body.includes(`@${displayName}`) : true;
+  }
+
+  if (ref.type === 'group') {
+    const group = groups.find(candidate => candidate.id === ref.id);
+    if (!group) return true;
+    return [group.alias, group.name].some(name => Boolean(name) && body.includes(`@${name}`));
+  }
+
+  const channel = channels.find(candidate => candidate.id === ref.id);
+  if (!channel) return true;
+  return body.includes(`#${channel.name}`) || body.includes(`🔒${channel.name}`);
+};
+
+interface MentionTarget {
+  ref: CanvasCommentMentionRef;
+  token: string;
+  node: React.ReactNode;
+}
+
+function CanvasCommentGroupMention({ groupId }: { groupId: string }): React.JSX.Element {
+  const groups = useUserGroups();
+  const group = groups.find(candidate => candidate.id === groupId);
+  const groupName = group?.name ?? groupId;
+  const alias = group?.alias ?? groupName;
+  return <GroupMentionRenderer groupId={groupId} groupName={groupName} alias={alias} />;
+}
+
+function CanvasCommentChannelMention({ channelId }: { channelId: string }): React.JSX.Element {
+  const navigate = useNavigate();
+  const channels = useAllChannels();
+  const channel = channels.find(candidate => candidate.id === channelId);
+  return (
+    <ChannelMentionRenderer
+      channelId={channelId}
+      channelName={channel?.name ?? channelId}
+      isPrivate={channel?.visibility === ChannelVisibility.PRIVATE}
+      navigate={navigate}
+    />
+  );
+}
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export function CanvasCommentBody({
+  body,
+  mentionIds,
+  users,
+}: {
+  body: string;
+  mentionIds: string[];
+  users: UserLite[];
+}): React.JSX.Element {
+  const groups = useUserGroups();
+  const channels = useAllChannels();
+
+  if (mentionIds.length === 0 || !body) return <>{body}</>;
+
+  const targets = mentionIds.flatMap((value): MentionTarget[] => {
+    const ref = parseCanvasCommentMentionRef(value);
+
+    if (ref.type === 'user') {
+      const user = users.find(candidate => candidate.id === ref.id);
+      const displayName = user ? getUserDisplayName(user) : '';
+      return displayName
+        ? [
+            {
+              ref,
+              token: `@${displayName}`,
+              node: <MentionRenderer userId={ref.id} fallbackName={displayName} />,
+            },
+          ]
+        : [];
+    }
+
+    if (ref.type === 'group') {
+      const group = groups.find(candidate => candidate.id === ref.id);
+      const groupName = group?.name ?? ref.id;
+      const alias = group?.alias ?? groupName;
+      const tokens = new Set([`@${alias}`, `@${groupName}`]);
+      return [...tokens].map(token => ({
+        ref,
+        token,
+        node: <CanvasCommentGroupMention groupId={ref.id} />,
+      }));
+    }
+
+    const channel = channels.find(candidate => candidate.id === ref.id);
+    const channelName = channel?.name ?? ref.id;
+    return [`#${channelName}`, `🔒${channelName}`].map(token => ({
+      ref,
+      token,
+      node: <CanvasCommentChannelMention channelId={ref.id} />,
+    }));
+  });
+
+  if (targets.length === 0) return <>{body}</>;
+
+  const tokenToTarget = new Map<string, MentionTarget>();
+  targets.forEach(target => tokenToTarget.set(target.token, target));
+  const tokenPattern = [...tokenToTarget.keys()]
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegExp)
+    .join('|');
+
+  if (!tokenPattern) return <>{body}</>;
+
+  const tokenRegex = new RegExp(`(${tokenPattern})`, 'g');
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenRegex.exec(body)) !== null) {
+    const token = match[0];
+    const target = tokenToTarget.get(token);
+    if (!target) continue;
+    const start = match.index;
+    if (start > lastIndex) nodes.push(body.slice(lastIndex, start));
+    nodes.push(
+      <React.Fragment key={`${target.ref.type}-${target.ref.id}-${start}`}>
+        {target.node}
+      </React.Fragment>,
+    );
+    lastIndex = start + token.length;
+  }
+
+  if (lastIndex < body.length) nodes.push(body.slice(lastIndex));
+  return <>{nodes.length > 0 ? nodes : body}</>;
+}

--- a/apps/dashboard/src/utils/canvasUtils.ts
+++ b/apps/dashboard/src/utils/canvasUtils.ts
@@ -24,7 +24,18 @@ export const removeUnknownBlocks = <T extends { type?: string; children?: unknow
 export const knownBlockTypesOf = (schema: unknown): ReadonlySet<string> =>
   new Set(Object.keys((schema as { blockSchema: Record<string, unknown> }).blockSchema));
 
+const isAlreadyResolvableFileSource = (source: string): boolean =>
+  source.startsWith('data:') ||
+  source.startsWith('blob:') ||
+  source.startsWith('http://') ||
+  source.startsWith('https://') ||
+  source.startsWith('/');
+
 export const resolveFileUrl = async (attachmentId: string): Promise<string> => {
+  if (isAlreadyResolvableFileSource(attachmentId)) {
+    return attachmentId;
+  }
+
   try {
     const blob = await createPreviewUrl(attachmentId);
 


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard
pot : [POT](https://drive.google.com/file/d/14NNnq3iI7E6i90z9ZuVRhBVB6VbeudTW/view?usp=sharing)
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
