### PR TITLE
fix: render attachments in claw auth v3 chat

### DIFF
--- a/apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx
@@ -86,6 +86,7 @@ import { Menu, MenuItem } from "./ui/Menu";
 import { Menu as BaseMenu } from "@base-ui-components/react/menu";
 import { Badge } from "./ui/Badge";
 import { SidePanel } from "./ui/SidePanel";
+import { useSnackbar } from "./ui/Snackbar";
 
 /* ── helpers ─────────────────────────────────────────────────────── */
 
@@ -109,6 +110,125 @@ function fmtDateShort(iso: string): string {
   const now = new Date();
   if (d.toDateString() === now.toDateString()) return fmtTime(iso);
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatAttachmentSize(size?: number): string | null {
+  if (typeof size !== "number" || !Number.isFinite(size) || size <= 0) return null;
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(size < 10 * 1024 ? 1 : 0)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(size < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+}
+
+function attachmentKindLabel(attachment: ChatAttachmentMeta): string {
+  const name = attachment.originalFilename.toLowerCase();
+  const mime = attachment.mimeType.toLowerCase();
+  if (mime.includes("pdf") || name.endsWith(".pdf")) return "PDF";
+  if (mime.startsWith("image/")) return "Image";
+  if (mime.startsWith("video/")) return "Video";
+  if (mime.includes("zip") || name.endsWith(".zip")) return "ZIP";
+  if (mime.includes("presentation") || name.endsWith(".pptx")) return "PPTX";
+  if (mime.includes("spreadsheet") || name.endsWith(".xlsx") || name.endsWith(".csv")) return "Sheet";
+  return "File";
+}
+
+async function fetchChatAttachmentBlob(attachment: ChatAttachmentMeta, userId: string): Promise<Blob> {
+  const response = await fetch(chatAttachmentDownloadUrl(attachment.id), {
+    credentials: "include",
+    headers: { "x-user-id": userId },
+  });
+  if (!response.ok) throw new Error(`Download failed: HTTP ${response.status}`);
+  return response.blob();
+}
+
+function ChatAttachmentList({
+  attachments,
+  userId,
+  align = "left",
+}: {
+  attachments: ChatAttachmentMeta[];
+  userId: string;
+  align?: "left" | "right";
+}) {
+  const { show: showSnackbar } = useSnackbar();
+  if (!attachments.length) return null;
+
+  const openAttachment = async (attachment: ChatAttachmentMeta): Promise<void> => {
+    try {
+      const url = URL.createObjectURL(await fetchChatAttachmentBlob(attachment, userId));
+      window.open(url, "_blank", "noopener,noreferrer");
+      window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    } catch (err) {
+      showSnackbar({
+        variant: "error",
+        title: "Could not open attachment",
+        description: err instanceof Error ? err.message : undefined,
+      });
+    }
+  };
+
+  const downloadAttachment = async (attachment: ChatAttachmentMeta): Promise<void> => {
+    try {
+      const url = URL.createObjectURL(await fetchChatAttachmentBlob(attachment, userId));
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = attachment.originalFilename;
+      anchor.click();
+      window.setTimeout(() => URL.revokeObjectURL(url), 0);
+      showSnackbar({
+        variant: "success",
+        title: "Download complete",
+        description: `${attachment.originalFilename} has been downloaded successfully`,
+      });
+    } catch (err) {
+      showSnackbar({
+        variant: "error",
+        title: "Download failed",
+        description: err instanceof Error ? err.message : undefined,
+      });
+    }
+  };
+
+  return (
+    <div className={`flex flex-col gap-2 ${align === "right" ? "items-end" : "items-start"}`}>
+      {attachments.map((attachment) => {
+        const kind = attachmentKindLabel(attachment);
+        const size = formatAttachmentSize(attachment.size);
+        return (
+          <div
+            key={attachment.id}
+            data-id="chat-attachment-card"
+            className="flex w-[min(420px,75vw)] items-center gap-3 rounded-[12px] border border-xyne-border bg-xyne-surface px-3 py-2 shadow-sm"
+          >
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-xyne-surface-subtle text-[10px] font-bold uppercase text-xyne-fg-secondary ring-1 ring-xyne-border-subtle">
+              {kind === "File" ? <FileIcon size={18} /> : kind}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-[13px] font-semibold text-xyne-fg-primary">{attachment.originalFilename}</p>
+              <p className="truncate text-[11px] text-xyne-fg-muted">
+                {[kind, size].filter(Boolean).join(" · ")}
+              </p>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              <button
+                type="button"
+                className="rounded-md border border-xyne-border-subtle px-2 py-1 text-[11px] font-medium text-xyne-fg-secondary transition hover:border-xyne-border hover:bg-xyne-surface-subtle hover:text-xyne-fg-primary"
+                onClick={() => { void openAttachment(attachment); }}
+              >
+                View
+              </button>
+              <button
+                type="button"
+                className="rounded-md border border-xyne-border-subtle px-2 py-1 text-[11px] font-medium text-xyne-fg-secondary transition hover:border-xyne-border hover:bg-xyne-surface-subtle hover:text-xyne-fg-primary"
+                onClick={() => { void downloadAttachment(attachment); }}
+              >
+                Download
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 
@@ -1660,6 +1780,9 @@ function MessageThread({
                     {stripMalformedCitations(msg.content)}
                   </div>
                 )}
+                {msg.attachments && msg.attachments.length > 0 && (
+                  <ChatAttachmentList attachments={msg.attachments} userId={userId} align="right" />
+                )}
                 {ts && (
                   <span className="mr-1 flex items-center gap-1 text-[11px] text-xyne-fg-muted">
                     <TimerIcon size={10} />
@@ -1773,7 +1896,11 @@ function MessageThread({
                 </div>
               )}
 
-              {ts && !isStream && (hasText || hasInvocations) && (
+              {msg.attachments && msg.attachments.length > 0 && (
+                <ChatAttachmentList attachments={msg.attachments} userId={userId} />
+              )}
+
+              {ts && !isStream && (hasText || hasInvocations || (msg.attachments?.length ?? 0) > 0) && (
                 <div className="ml-1 flex items-center gap-2 text-[11px] text-xyne-fg-muted">
                   <span className="flex items-center gap-1">
                     <TimerIcon size={10} />


### PR DESCRIPTION
## Summary
Fixes attachment rendering/downloading in the Claw auth frontend v3 chat screen.

The earlier dashboard fixes covered the Xyne Spaces Ask AI full-page UI and the dashboard Claw wrapper, but the upcoming v3 Claw chat lives in `apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx`. That screen already persisted `ChatMsg.attachments` and used assistant attachments for Design Studio flows, but the general chat message renderer did not render attachments for regular user/assistant turns.

This PR adds a general v3 chat attachment card that:
- renders `ChatMsg.attachments` for both user and assistant messages
- uses `chatAttachmentDownloadUrl(attachment.id)` for the existing Claw auth attachment endpoint
- sends `x-user-id` with the active user id, matching existing v3 attachment fetches
- supports `View` via blob URL in a new tab
- supports `Download` via blob URL + filename
- shows the v3 snackbar success toast: `Download complete`
- shows snackbar errors when open/download fails

## Changes
- `apps/xyne-claw-auth/frontend/src/v3/components/ChatPageV3.tsx`
  - Adds `ChatAttachmentList` for generic v3 chat attachment rendering.
  - Adds attachment type/size display helpers.
  - Adds shared blob fetch helper using `chatAttachmentDownloadUrl`.
  - Renders user attachments below user messages.
  - Renders assistant attachments below assistant messages.
  - Keeps message timestamp visible for attachment-only assistant messages.

## Testing
- `cd apps/xyne-claw-auth/frontend && npm run typecheck` — passed (`EXIT=0`).

## PR template
1. Problem Description: The v3 Claw chat screen in `xyne-claw-auth-frontend` did not render generic `ChatMsg.attachments`, so generated files would still be invisible there.
2. How the issue was identified: The thread clarified that the target is the v3 chat screen on `feature/deploy-xyneclaw`. Source inspection showed `ChatPageV3.tsx` had `ChatMsg.attachments` and attachment APIs, but only used attachments for Design Studio preview, not normal chat messages.
3. Solution implemented: Added generic attachment cards with View/Download actions and v3 snackbar feedback.
4. Documentation: N/A
5. DB Alter Details: N/A
6. Data fix Details: N/A
7. Environment variable Changes: N/A
8. Testing: `apps/xyne-claw-auth/frontend` typecheck passed.
9. Services to which this change is to be deployed: `xyne-claw-auth-frontend`.
10. Main PR link (if against a release branch): N/A

Requested reviewers: Mamtha Venkattaramanujam, Pradeesh S.