### PR TITLE
feat: add command navigation shortcuts

### DIFF
--- a/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
+++ b/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
@@ -49,7 +49,7 @@ const AppNavigator = (): ReactElement => {
         <button
           type='button'
           aria-label='Search'
-          onClick={() => invokeShortcut('mod+k')}
+          onClick={() => invokeShortcut('mod+g')}
           className={buttonClass}
           data-track-category='APP_NAVIGATOR'
           data-track-name='OPEN_SEARCH'

--- a/apps/dashboard/src/components/GlobalTopBar/GlobalTopBar.tsx
+++ b/apps/dashboard/src/components/GlobalTopBar/GlobalTopBar.tsx
@@ -43,7 +43,7 @@ const NavigationAndSearch = (): ReactElement => {
   const maxIndexRef = useRef(0);
   const [searchOpen, setSearchOpen] = useState(false);
   // Restore the previous query only when the overlay is opened by clicking the
-  // header search bar on the results screen — the global Cmd+K shortcut and the
+  // header search bar on the results screen — the global Cmd+G shortcut and the
   // empty-state still open with a blank input.
   const [restoreQuery, setRestoreQuery] = useState(false);
   // Cmd+F (screen mode) opens this bar pre-scoped with an in:<channel> chip; the
@@ -67,7 +67,7 @@ const NavigationAndSearch = (): ReactElement => {
     setCanGoForward(currentIndex < maxIndexRef.current);
   }, [location]);
 
-  // Listen for the screen-mode search-bar activation event. Cmd+K dispatches it
+  // Listen for the screen-mode search-bar activation event. Cmd+G dispatches it
   // with no detail (empty bar); Cmd+F dispatches it with an in:<channel> mention
   // so the bar opens pre-scoped; Cmd+/ dispatches it with `command: true` so the bar
   // opens seeded with `/`. Either way it opens with no query restore.
@@ -105,7 +105,7 @@ const NavigationAndSearch = (): ReactElement => {
       setSearchOpen(true);
       return;
     }
-    const success = invokeShortcut('mod+k');
+    const success = invokeShortcut('mod+g');
     if (!success) toast.error('Search unavailable');
   };
 

--- a/apps/dashboard/src/components/UserGuide/FeatureDemo.tsx
+++ b/apps/dashboard/src/components/UserGuide/FeatureDemo.tsx
@@ -687,7 +687,7 @@ function threadsScenes(): SceneConfig[] {
 
 function searchScenes(): SceneConfig[] {
   return [
-    // Step 0: Cmd+K shortcut hint
+    // Step 0: Cmd+G shortcut hint
     {
       cx: 50,
       cy: 50,
@@ -702,7 +702,7 @@ function searchScenes(): SceneConfig[] {
                     Search anything...
                   </span>
                   <kbd className='text-[8px] bg-muted rounded px-1 border border-border text-muted-foreground'>
-                    ⌘K
+                    ⌘G
                   </kbd>
                 </div>
                 <div className='space-y-0.5 text-[9px] text-muted-foreground'>
@@ -1704,7 +1704,7 @@ function genericScenes(visualKey: string): SceneConfig[] {
     shortcuts: {
       title: 'Shortcuts',
       icon: <Wrench size={10} />,
-      lines: ['⌘K — Global Search', '⌘⇧M — New Direct Message', '? — Open shortcuts modal'],
+      lines: ['⌘G — Global Search', '⌘⇧M — New Direct Message', '? — Open shortcuts modal'],
     },
     'call-recording-share': {
       title: 'Call Context',

--- a/apps/dashboard/src/hooks/useGlobalShortcuts.ts
+++ b/apps/dashboard/src/hooks/useGlobalShortcuts.ts
@@ -3,7 +3,7 @@ import type { PanelImperativeHandle } from 'react-resizable-panels';
 import type { RefObject } from 'react';
 import { CHAT_SIDEBAR_KEYBOARD_STEP } from '../routes/ChatScreen/chatSidebarWidth';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useSelector } from '@xstate/react';
 import { roomActor } from '../machines/roomMachine';
 import { browserPanelActor } from '../machines/browserPanelMachine';
@@ -29,6 +29,27 @@ export const useGlobalShortcuts = ({ leftPanelRef }: UseGlobalShortcutsProps): v
     workspaceId?: string;
   }>();
   const isChatOpen = useSelector(roomActor, state => state.context.isChatOpen);
+  const maxHistoryIndexRef = useRef(0);
+
+  useEffect(() => {
+    const historyState = window.history.state as { idx?: number } | null;
+    const currentIndex = historyState?.idx ?? 0;
+    maxHistoryIndexRef.current = Math.max(maxHistoryIndexRef.current, currentIndex);
+  }, [location]);
+
+  const navigateInHistory = useCallback(
+    (delta: -1 | 1) => {
+      const historyState = window.history.state as { idx?: number } | null;
+      const currentIndex = historyState?.idx ?? 0;
+      const canNavigate =
+        delta === -1 ? currentIndex > 0 : currentIndex < maxHistoryIndexRef.current;
+
+      if (canNavigate) {
+        void navigate(delta);
+      }
+    },
+    [navigate],
+  );
 
   // The top-level panel is percentage-sized; the ChatScreen sidebar is pixel-pinned,
   // so each gets its own step.
@@ -91,12 +112,12 @@ export const useGlobalShortcuts = ({ leftPanelRef }: UseGlobalShortcutsProps): v
 
   // Go back in navigation history
   useShortcutById('global.goBack', () => {
-    void navigate(-1);
+    navigateInHistory(-1);
   });
 
   // Go forward in navigation history
   useShortcutById('global.goForward', () => {
-    void navigate(1);
+    navigateInHistory(1);
   });
 
   // Toggle right sidebar (close thread panel if open)

--- a/apps/dashboard/src/shortcuts/catalog.ts
+++ b/apps/dashboard/src/shortcuts/catalog.ts
@@ -17,7 +17,7 @@ export interface ShortcutDefinition {
 export const shortcuts = {
   // ===== GLOBAL NAVIGATION =====
   'global.search': {
-    keys: ['mod+k', 'mod+g'],
+    keys: ['mod+g'],
     scope: 'global',
     allowInInputs: true,
     priority: 100,
@@ -51,22 +51,24 @@ export const shortcuts = {
     allowInInputs: true,
   },
   'global.goBack': {
-    keys: ['mod+['],
+    keys: ['mod+j'],
+    displayKeys: ['mod+j'],
     scope: 'global',
     description: 'Go back in navigation history',
     category: 'Navigation',
     priority: 50,
-    allowInInputs: true,
-    useKey: true,
+    allowInInputs: false,
+    preventDefault: true,
   },
   'global.goForward': {
-    keys: ['mod+]'],
+    keys: ['mod+k'],
+    displayKeys: ['mod+k'],
     scope: 'global',
     description: 'Go forward in navigation history',
     category: 'Navigation',
     priority: 50,
-    allowInInputs: true,
-    useKey: true,
+    allowInInputs: false,
+    preventDefault: true,
   },
   'global.goToRailItem': {
     keys: ['mod+1', 'mod+2', 'mod+3', 'mod+4', 'mod+5', 'mod+6', 'mod+7', 'mod+8', 'mod+9'],


### PR DESCRIPTION
## Summary
- adds Cmd/Meta+J for app history back and Cmd/Meta+K for app history forward
- ignores these shortcuts while focus is inside inputs, textareas, selects, or contenteditable elements
- guards navigation so the shortcut only moves when the React Router history stack has a back/forward entry
- moves global search invocation to Cmd/Meta+G where the existing search shortcut remains registered

## Validation
- `git diff --check`
- `pnpm -C apps/dashboard exec eslint src/shortcuts/catalog.ts src/hooks/useGlobalShortcuts.ts src/components/AppNavigator/AppNavigator.tsx src/components/GlobalTopBar/GlobalTopBar.tsx src/components/UserGuide/FeatureDemo.tsx` (passes with existing warnings only)
- `pnpm -C apps/dashboard typecheck` could not complete because the sandbox is missing existing dependencies/types for `@pierre/trees/react`, `@codesandbox/sandpack-react`, and `@huggingface/transformers`, plus pre-existing `intent.worker.ts` typing errors
