### PR TITLE
fix: keep channel member action menu visible

### DIFF
--- a/apps/dashboard/src/components/Chat/Info/Info.tsx
+++ b/apps/dashboard/src/components/Chat/Info/Info.tsx
@@ -280,7 +280,7 @@ const Info = ({
     handleCallAction(handleCallClick);
   };
 
-  const popoverContainerRef = useRef<HTMLDivElement>(null);
+  const [popoverContainer, setPopoverContainer] = useState<HTMLDivElement | null>(null);
 
   const headerLinkContainerStyle =
     'flex items-center flex-col gap-y-2 border border-border p-[12px] min-w-[98px] rounded-[10px] cursor-pointer flex-1 text-muted-foreground';
@@ -296,7 +296,7 @@ const Info = ({
 
   return (
     <div
-      ref={popoverContainerRef}
+      ref={setPopoverContainer}
       className='overflow-clip h-[720px] bg-background flex flex-col'
       style={{ position: 'relative' }}
     >
@@ -486,7 +486,7 @@ const Info = ({
               channel={channel}
               participants={participants}
               channelDisplayName={channelDisplayName}
-              popoverContainer={popoverContainerRef.current}
+              popoverContainer={popoverContainer}
             />
           </Tabs.Content>
         )}
@@ -657,7 +657,13 @@ const ParticipantListItem = ({
               side='bottom'
               sideOffset={8}
               align='end'
-              {...(popoverContainer ? { container: popoverContainer } : {})}
+              {...(popoverContainer
+                ? {
+                    container: popoverContainer,
+                    collisionBoundary: popoverContainer,
+                    collisionPadding: 8,
+                  }
+                : {})}
               className='p-1 border border-border rounded-lg shadow-lg overflow-hidden z-[100]'
             >
               <div>


### PR DESCRIPTION
1. Problem Description:
The channel info dialog member list can hide the last member's action popover, so admins cannot reliably access actions like Remove for the final visible row.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in Spaces thread: the dropdown to remove users is not visible for the last user in the channel info list.

3. Explain the solution implemented in the PR:
The Info dialog now stores the popover portal container in React state once the dialog root mounts, and member action popovers use that same element as their collision boundary with padding. This lets Radix flip/reposition the menu within the dialog instead of rendering it below the clipped member list.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `pnpm exec prettier --check src/components/Chat/Info/Info.tsx` passed.
- `pnpm exec eslint src/components/Chat/Info/Info.tsx` passed with one existing warning for an untyped inline function in this file.
- `pnpm --filter xyne-spaces-dashboard typecheck` was attempted but is blocked by existing unrelated missing-module/type errors in AIScreen ReactArtifact and onDeviceIntent worker files.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A