### PR TITLE
fix: XYNE-58277 All the click metrics to sudoquery (#1099)

### DIFF
--- a/apps/backend/src/services/activityTrackingService.ts
+++ b/apps/backend/src/services/activityTrackingService.ts
@@ -2,6 +2,8 @@ import { ActivityEventRepository, CreateActivityEventInput } from '@/database/re
 import { logger } from '@/utils/logger';
 import { ActivityEventPayload } from '@xyne/shared';
 import { triggerNudgesFromActivity } from '@/services/nudges/nudgeTriggerService';
+import { sudoQueryService } from '@/services/hyperAnalytics/sudoQueryService';
+import { resolveModule } from '@/services/hyperAnalytics/moduleRoutes';
 
 export type { ActivityEventPayload };
 
@@ -12,7 +14,43 @@ class ActivityTrackingService {
     this.repository = new ActivityEventRepository();
   }
 
+  private emitToSudoQuery(payload: ActivityEventPayload): void {
+    try {
+      const resolved = resolveModule(payload.url);
+      // Named individually rather than spreading context_metadata: that object
+      // also holds free text and, for INPUT_CHANGE events, the raw typed value.
+      const meta = payload.context_metadata ?? {};
+
+      sudoQueryService.identify({ id: payload.user_id });
+      sudoQueryService.track('ui_action', {
+        action: `${payload.event_category}/${payload.event_name}`,
+        category: payload.event_category,
+        name: payload.event_name,
+        trigger: payload.trigger_type,
+        platform: payload.platform,
+        url: payload.url,
+        ...(resolved && { module: resolved.module, workspaceId: resolved.workspaceId }),
+        // Carries the channel for DB_MUTATION events, whose url is 'backend'.
+        // Click events get it from the url instead and rarely set this key.
+        ...(typeof meta.channelId === 'string' && { channelId: meta.channelId }),
+        ...(typeof meta.path === 'string' && { path: meta.path }),
+        ...(typeof meta.label === 'string' && { label: meta.label }),
+        ...(typeof meta.tabValue === 'string' && { tabValue: meta.tabValue }),
+        ...(typeof meta.tab === 'string' && { tab: meta.tab }),
+        ...(Array.isArray(meta.fields) && {
+          fields: meta.fields.filter(f => typeof f === 'string').join(','),
+        }),
+      });
+    } catch (err) {
+      logger.debug('[ActionMetrics] sudoQuery track failed (non-blocking)', { error: err });
+    }
+  }
+
   async saveActivityEvent(payload: ActivityEventPayload): Promise<void> {
+    // Emitted before the write so a database failure cannot suppress the
+    // metric — the two sinks are independent.
+    this.emitToSudoQuery(payload);
+
     try {
       const createInput: CreateActivityEventInput = {
         userId: payload.user_id,

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -378,6 +378,7 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
 
     userActivityTrackingService.trackMessageSent(this.ctx.userID, {
       messageId,
+      ...(conversation?.channelId && { channelId: conversation.channelId }),
       hasAttachment: message.hasAttachment,
     }).catch(error => {
       logger.error('[UserActivityTracking] Failed to track message sent activity:', {

--- a/apps/dashboard/src/components/AnalyticsDashboard/QueryDashboardScreen.tsx
+++ b/apps/dashboard/src/components/AnalyticsDashboard/QueryDashboardScreen.tsx
@@ -548,6 +548,8 @@ export const QueryDashboardScreen: React.FC = () => {
               <div className='flex items-center gap-3'>
                 <Button
                   onClick={handleCloseModal}
+                  data-track-category='ANALYTICS'
+                  data-track-name='CLOSE_QUERY_MODAL'
                   variant='ghost'
                   size='iconSm'
                   className='text-foreground hover:bg-muted/60 rounded-lg transition-colors'
@@ -562,6 +564,8 @@ export const QueryDashboardScreen: React.FC = () => {
                 <Button
                   variant='secondary'
                   onClick={handleCloseModal}
+                  data-track-category='ANALYTICS'
+                  data-track-name='CLOSE_QUERY_MODAL'
                   className='hover:bg-muted/70 border-border/50 transition-all'
                 >
                   Cancel

--- a/apps/dashboard/src/components/Apps/AppsTable/AppsTable.tsx
+++ b/apps/dashboard/src/components/Apps/AppsTable/AppsTable.tsx
@@ -252,6 +252,8 @@ export const AppsTable = ({
                   e.stopPropagation();
                   void handleCopyBotUserId(app);
                 }}
+                data-track-category='Apps'
+                data-track-name='COPY_BOT_USER_ID'
                 title='Copy bot user ID'
                 className='h-6 w-6 p-0'
               >
@@ -326,6 +328,8 @@ export const AppsTable = ({
               variant='ghost'
               size='sm'
               onClick={() => void handleCopyToken(app.id)}
+              data-track-category='Apps'
+              data-track-name='COPY_APP_TOKEN'
               disabled={!canCopy}
               className='h-6 w-6 p-0'
               title={
@@ -354,6 +358,8 @@ export const AppsTable = ({
               variant='ghost'
               size='sm'
               onClick={() => void handleCopySigningSecret(app.id)}
+              data-track-category='Apps'
+              data-track-name='COPY_APP_SIGNING_SECRET'
               disabled={!canCopy}
               className='h-6 w-6 p-0'
               title={

--- a/apps/dashboard/src/components/Apps/CreateAppForm/CreateAppForm.tsx
+++ b/apps/dashboard/src/components/Apps/CreateAppForm/CreateAppForm.tsx
@@ -120,6 +120,8 @@ export const CreateAppForm = ({ onSuccess, onCancel }: CreateAppFormProps): Reac
         <Button
           variant='outline'
           onClick={onCancel}
+          data-track-category='Apps'
+          data-track-name='CANCEL_CREATE_APP'
           disabled={createAppMutation.isPending}
           type='button'
         >

--- a/apps/dashboard/src/components/Apps/EditAppForm/EditAppForm.tsx
+++ b/apps/dashboard/src/components/Apps/EditAppForm/EditAppForm.tsx
@@ -86,6 +86,8 @@ const CommandRow = ({
           size='sm'
           className='h-7 w-7 p-0'
           onClick={() => onEdit(command)}
+          data-track-category='app-command'
+          data-track-name='EDIT_COMMAND'
           title='Edit command'
         >
           <Pencil size={13} />
@@ -96,6 +98,8 @@ const CommandRow = ({
           size='sm'
           className='h-7 w-7 p-0 text-destructive hover:text-destructive'
           onClick={() => onDelete(command.commandName)}
+          data-track-category='app-command'
+          data-track-name='DELETE_COMMAND'
           title='Delete command'
         >
           <Trash2 size={13} />
@@ -247,6 +251,8 @@ const CommandFormInline = ({
           size='sm'
           className='h-7'
           onClick={onCancel}
+          data-track-category='app-command'
+          data-track-name='CANCEL_COMMAND_FORM'
           disabled={saving}
         >
           <X size={13} className='mr-1' /> Cancel
@@ -256,6 +262,8 @@ const CommandFormInline = ({
           size='sm'
           className='h-7'
           onClick={() => void handleSave()}
+          data-track-category='app-command'
+          data-track-name='SAVE_COMMAND'
           disabled={saving}
         >
           <Check size={13} className='mr-1' />
@@ -310,6 +318,8 @@ const ShortcutRow = ({
           size='sm'
           className='h-7 w-7 p-0'
           onClick={() => onEdit(shortcut)}
+          data-track-category='app-shortcut'
+          data-track-name='EDIT_SHORTCUT'
           title='Edit shortcut'
         >
           <Pencil size={13} />
@@ -320,6 +330,8 @@ const ShortcutRow = ({
           size='sm'
           className='h-7 w-7 p-0 text-destructive hover:text-destructive'
           onClick={() => onDelete(shortcut.commandName)}
+          data-track-category='app-shortcut'
+          data-track-name='DELETE_SHORTCUT'
           title='Delete shortcut'
         >
           <Trash2 size={13} />
@@ -451,6 +463,8 @@ const ShortcutFormInline = ({
           size='sm'
           className='h-7'
           onClick={onCancel}
+          data-track-category='app-shortcut'
+          data-track-name='CANCEL_SHORTCUT_FORM'
           disabled={saving}
         >
           <X size={13} className='mr-1' /> Cancel
@@ -460,6 +474,8 @@ const ShortcutFormInline = ({
           size='sm'
           className='h-7'
           onClick={() => void handleSave()}
+          data-track-category='app-shortcut'
+          data-track-name='SAVE_SHORTCUT'
           disabled={saving}
         >
           <Check size={13} className='mr-1' />
@@ -666,6 +682,8 @@ const PermissionsSection = ({
             variant='outline'
             className='h-7 text-xs'
             onClick={() => void handleSave()}
+            data-track-category='Apps'
+            data-track-name='SAVE_APP'
             disabled={locked || !loaded}
           >
             {saving ? 'Saving…' : 'Save Permissions'}
@@ -677,6 +695,8 @@ const PermissionsSection = ({
               variant='default'
               className='h-7 text-xs'
               onClick={() => void handleActivate()}
+              data-track-category='Apps'
+              data-track-name='ACTIVATE_APP_INSTALL'
               disabled={activating || locked}
               title='Re-sync this install to activate pending permission changes'
             >
@@ -1420,6 +1440,8 @@ export const EditAppForm = ({
                       variant='outline'
                       size='sm'
                       onClick={handleUploadClick}
+                      data-track-category='Apps'
+                      data-track-name='UPLOAD_BOT_AVATAR'
                       disabled={isLoading || !canEditInstallSettings}
                       className='gap-1'
                       title='Upload bot profile picture'
@@ -1449,6 +1471,8 @@ export const EditAppForm = ({
                     variant='outline'
                     size='sm'
                     onClick={() => setShowCreateForm(true)}
+                    data-track-category='INCOMING_WEBHOOKS'
+                    data-track-name='OPEN_CREATE_WEBHOOK_FORM'
                     className='gap-1 w-full mt-2'
                   >
                     <Plus size={14} />
@@ -1607,6 +1631,8 @@ export const EditAppForm = ({
                       type='button'
                       size='sm'
                       onClick={() => void handleCreateWebhook()}
+                      data-track-category='INCOMING_WEBHOOKS'
+                      data-track-name='CREATE_WEBHOOK'
                       disabled={
                         isCreating ||
                         !webhookName.trim() ||
@@ -1631,6 +1657,8 @@ export const EditAppForm = ({
                         setProjectBoards([]);
                         setSelectedBoardId('');
                       }}
+                      data-track-category='INCOMING_WEBHOOKS'
+                      data-track-name='CANCEL_CREATE_WEBHOOK'
                     >
                       Cancel
                     </Button>
@@ -1759,6 +1787,8 @@ export const EditAppForm = ({
                       variant='outline'
                       size='sm'
                       onClick={() => handleCopyWebhookUrl(webhook.webhookUrl)}
+                      data-track-category='INCOMING_WEBHOOKS'
+                      data-track-name='COPY_WEBHOOK_URL'
                       className='shrink-0'
                     >
                       <Copy size={14} />
@@ -1780,6 +1810,8 @@ export const EditAppForm = ({
                       size='sm'
                       disabled={!hasPrev}
                       onClick={() => fetchWebhooks(webhookOffset - WEBHOOK_PAGE_SIZE)}
+                      data-track-category='INCOMING_WEBHOOKS'
+                      data-track-name='WEBHOOKS_PREV_PAGE'
                       className='h-7 w-7 p-0'
                     >
                       <ChevronLeft size={14} />
@@ -1790,6 +1822,8 @@ export const EditAppForm = ({
                       size='sm'
                       disabled={!hasNext}
                       onClick={() => fetchWebhooks(webhookOffset + WEBHOOK_PAGE_SIZE)}
+                      data-track-category='INCOMING_WEBHOOKS'
+                      data-track-name='WEBHOOKS_NEXT_PAGE'
                       className='h-7 w-7 p-0'
                     >
                       <ChevronRight size={14} />
@@ -1817,6 +1851,8 @@ export const EditAppForm = ({
                       setEditingCommand(null);
                       setShowCommandForm(true);
                     }}
+                    data-track-category='app-command'
+                    data-track-name='OPEN_CREATE_COMMAND_FORM'
                   >
                     <Plus size={12} /> Add Command
                   </Button>
@@ -1878,6 +1914,8 @@ export const EditAppForm = ({
                       setEditingShortcut(null);
                       setShowShortcutForm(true);
                     }}
+                    data-track-category='app-shortcut'
+                    data-track-name='OPEN_CREATE_SHORTCUT_FORM'
                   >
                     <Plus size={12} /> Add Shortcut
                   </Button>
@@ -1935,7 +1973,14 @@ export const EditAppForm = ({
       </div>
 
       <div className='flex gap-2 justify-end p-4 border-t border-border bg-background shrink-0'>
-        <Button variant='outline' onClick={onCancel} disabled={isLoading} type='button'>
+        <Button
+          variant='outline'
+          onClick={onCancel}
+          data-track-category='Apps'
+          data-track-name='CANCEL_APP_FORM'
+          disabled={isLoading}
+          type='button'
+        >
           {activeSection === 'basic' ? 'Cancel' : 'Close'}
         </Button>
         {/* Save Changes only persists the Basic info fields (description + webhook URL); the other
@@ -1972,6 +2017,8 @@ export const EditAppForm = ({
               variant='outline'
               size='sm'
               onClick={() => setRevokeTargetId(null)}
+              data-track-category='Apps'
+              data-track-name='CANCEL_REVOKE_INSTALL'
             >
               Cancel
             </Button>

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/ConditionEditor.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionEditor/ConditionEditor.tsx
@@ -101,7 +101,13 @@ export function ConditionEditor({
         ))}
       </div>
       <div className='flex gap-2'>
-        <Button variant='outline' size='sm' onClick={addLeaf}>
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={addLeaf}
+          data-track-category='automation-builder'
+          data-track-name='ADD_CONDITION_LEAF'
+        >
           <Plus className='size-4' />
           Add condition
         </Button>

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionalCard/ConditionalCard.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/ConditionalCard/ConditionalCard.tsx
@@ -174,6 +174,8 @@ export function ConditionalCard({
                 variant='outline'
                 size='sm'
                 onClick={() => setEditorOpen(true)}
+                data-track-category='automation-builder'
+                data-track-name='conditional-open-editor'
                 className='gap-1.5'
               >
                 <Pencil className='size-3.5' />

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaForm.tsx
@@ -743,7 +743,14 @@ function ArrayField({
           ))}
         </div>
       )}
-      <Button variant='outline' size='sm' onClick={handleAdd} className='self-start'>
+      <Button
+        variant='outline'
+        size='sm'
+        onClick={handleAdd}
+        data-track-category='automation-builder'
+        data-track-name='ADD_SCHEMA_FIELD'
+        className='self-start'
+      >
         <Plus className='size-4' />
         Add entry
       </Button>
@@ -822,7 +829,15 @@ function RecordField({
           variableSources={variableSources}
         />
       ))}
-      <Button type='button' variant='outline' size='sm' onClick={handleAdd} className='self-start'>
+      <Button
+        type='button'
+        variant='outline'
+        size='sm'
+        onClick={handleAdd}
+        data-track-category='automation-builder'
+        data-track-name='ADD_SCHEMA_FIELD'
+        className='self-start'
+      >
         <Plus className='mr-1 size-3.5' />
         Add row
       </Button>

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaJsonEditor.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SchemaForm/SchemaJsonEditor.tsx
@@ -115,7 +115,14 @@ export function SchemaJsonEditor({
           )}
         </div>
         {isEmpty && !readOnly && example && (
-          <Button type='button' variant='outline' size='sm' onClick={insertExample}>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={insertExample}
+            data-track-category='automation-builder'
+            data-track-name='INSERT_SCHEMA_EXAMPLE'
+          >
             Insert example
           </Button>
         )}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/WebhookStepForm.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/WebhookStepForm.tsx
@@ -687,7 +687,14 @@ function HeadersEditor({
           </div>
         ))
       )}
-      <Button variant='outline' size='sm' onClick={addRow} className='self-start'>
+      <Button
+        variant='outline'
+        size='sm'
+        onClick={addRow}
+        data-track-category='automation-builder'
+        data-track-name='ADD_WEBHOOK_ROW'
+        className='self-start'
+      >
         <Plus className='size-4' />
         Add header
       </Button>

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/SwitchCard/SwitchCard.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/SwitchCard/SwitchCard.tsx
@@ -242,6 +242,8 @@ export function SwitchCard({
                         variant='outline'
                         size='sm'
                         onClick={() => setEditingCaseIndex(caseIndex)}
+                        data-track-category='automation-builder'
+                        data-track-name='switch-open-case-editor'
                         className='gap-1 h-7 text-xs'
                       >
                         <Pencil className='size-3' />
@@ -376,7 +378,12 @@ export function SwitchCard({
               >
                 Cancel
               </Button>
-              <Button size='sm' onClick={handleCaseConditionSave}>
+              <Button
+                size='sm'
+                onClick={handleCaseConditionSave}
+                data-track-category='automation-builder'
+                data-track-name='SAVE_SWITCH_CASE'
+              >
                 Save condition
               </Button>
             </div>

--- a/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
@@ -201,6 +201,8 @@ export function RunHistory({
                   onClick={() => {
                     void fetchNextPage();
                   }}
+                  data-track-category='automation-runs'
+                  data-track-name='LOAD_MORE_RUNS'
                 >
                   {isFetchingNextPage ? 'Loading…' : 'Load more'}
                 </Button>

--- a/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationsList/AutomationsList.tsx
@@ -228,7 +228,12 @@ export function AutomationsList({
               Approvals
             </Button>
           </Link>
-          <Button onClick={onCreate} className='font-semibold'>
+          <Button
+            onClick={onCreate}
+            data-track-category='automations-list'
+            data-track-name='CREATE_AUTOMATION'
+            className='font-semibold'
+          >
             <Plus className='size-4' />
             New automation
           </Button>
@@ -462,7 +467,12 @@ function EmptyState({
         Build a no-code workflow that runs on a trigger — a schedule, a manual click, or an event
         from your workspace.
       </p>
-      <Button size='sm' onClick={onCreate}>
+      <Button
+        size='sm'
+        onClick={onCreate}
+        data-track-category='automations-list'
+        data-track-name='CREATE_AUTOMATION'
+      >
         <Plus className='size-4' />
         Create your first automation
       </Button>

--- a/apps/dashboard/src/components/Board/BoardCreateScreen/BoardCreateScreen.tsx
+++ b/apps/dashboard/src/components/Board/BoardCreateScreen/BoardCreateScreen.tsx
@@ -173,12 +173,19 @@ const BoardCreateScreen = ({
 
           {/* Right Section */}
           <div className='flex items-center gap-3'>
-            <Button variant='secondary' onClick={onClose}>
+            <Button
+              variant='secondary'
+              onClick={onClose}
+              data-track-category='BOARD_CREATE'
+              data-track-name='CLOSE_BOARD_CREATE'
+            >
               Cancel
             </Button>
             <Button
               className='bg-[#6276BE] hover:bg-[#5060A0] text-white'
               onClick={handleCreateNew}
+              data-track-category='BOARD_CREATE'
+              data-track-name='CREATE_BOARD'
             >
               <Plus size={14} />
               Create Board

--- a/apps/dashboard/src/components/Board/BoardEditScreen/BoardEditScreen.tsx
+++ b/apps/dashboard/src/components/Board/BoardEditScreen/BoardEditScreen.tsx
@@ -1450,7 +1450,13 @@ const BoardEditScreen = ({
       <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
         <div className='bg-background rounded-lg p-8 text-center'>
           <p className='text-xyne-gray-600 mb-4'>Board not found</p>
-          <Button onClick={onClose}>Close</Button>
+          <Button
+            onClick={onClose}
+            data-track-category='form'
+            data-track-name='CLOSE_BOARD_NOT_FOUND'
+          >
+            Close
+          </Button>
         </div>
       </div>
     );
@@ -1461,7 +1467,13 @@ const BoardEditScreen = ({
       <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
         <div className='bg-background rounded-lg p-8 text-center'>
           <p className='text-xyne-gray-600 mb-4'>Project not found</p>
-          <Button onClick={onClose}>Close</Button>
+          <Button
+            onClick={onClose}
+            data-track-category='form'
+            data-track-name='CLOSE_PROJECT_NOT_FOUND'
+          >
+            Close
+          </Button>
         </div>
       </div>
     );
@@ -1487,12 +1499,19 @@ const BoardEditScreen = ({
             </span>
           </div>
           <div className='flex items-center gap-3'>
-            <Button variant='secondary' onClick={onClose}>
+            <Button
+              variant='secondary'
+              onClick={onClose}
+              data-track-category='form'
+              data-track-name='CANCEL_BOARD_EDIT'
+            >
               Cancel
             </Button>
             <Button
               className='bg-[#6276BE] hover:bg-[#5060A0] text-white disabled:opacity-50'
               onClick={() => void handleSave()}
+              data-track-category='form'
+              data-track-name='SAVE_BOARD_EDIT'
               disabled={hasPendingOptionDecision}
               title={
                 hasPendingOptionDecision

--- a/apps/dashboard/src/components/Board/BoardRolesConfigScreen/BoardRolesConfigScreen.tsx
+++ b/apps/dashboard/src/components/Board/BoardRolesConfigScreen/BoardRolesConfigScreen.tsx
@@ -312,7 +312,13 @@ const BoardRolesConfigScreen = ({
       <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
         <div className='bg-background rounded-lg p-8 text-center'>
           <p className='text-muted-foreground mb-4'>Board not found</p>
-          <Button onClick={onClose}>Close</Button>
+          <Button
+            onClick={onClose}
+            data-track-category='BOARD_ROLE_CONFIG'
+            data-track-name='CLOSE_BOARD_ROLES'
+          >
+            Close
+          </Button>
         </div>
       </div>
     );
@@ -324,19 +330,32 @@ const BoardRolesConfigScreen = ({
         {/* ── Top bar ── */}
         <header className='flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0'>
           <div className='flex items-center gap-2 min-w-0'>
-            <Button variant='ghost' size='sm' onClick={() => (onBack ? onBack() : onClose())}>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => (onBack ? onBack() : onClose())}
+              data-track-category='BOARD_ROLE_CONFIG'
+              data-track-name='BOARD_ROLES_BACK'
+            >
               <ArrowLeft size={15} /> Back
             </Button>
             <span className='text-sm font-medium text-foreground truncate'>Configure roles</span>
             {boardName && <Badge variant='secondary'>{boardName}</Badge>}
           </div>
           <div className='flex items-center gap-2'>
-            <Button variant='secondary' onClick={onClose}>
+            <Button
+              variant='secondary'
+              onClick={onClose}
+              data-track-category='BOARD_ROLE_CONFIG'
+              data-track-name='CANCEL_BOARD_ROLES'
+            >
               Cancel
             </Button>
             <Button
               className='bg-[#185FA5] hover:bg-[#0C447C] text-white'
               onClick={() => void handleSave()}
+              data-track-category='BOARD_ROLE_CONFIG'
+              data-track-name='SAVE_BOARD_ROLES'
             >
               Finish
             </Button>

--- a/apps/dashboard/src/components/Board/BoardStageConfigScreen/BoardStageConfigScreen.tsx
+++ b/apps/dashboard/src/components/Board/BoardStageConfigScreen/BoardStageConfigScreen.tsx
@@ -2237,7 +2237,13 @@ const BoardStageConfigScreen = ({
       <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
         <div className='bg-background rounded-lg p-8 text-center'>
           <p className='text-xyne-gray-600 mb-4'>Board not found</p>
-          <Button onClick={onClose}>Close</Button>
+          <Button
+            onClick={onClose}
+            data-track-category='board_config'
+            data-track-name='CLOSE_STAGE_CONFIG'
+          >
+            Close
+          </Button>
         </div>
       </div>
     );
@@ -2266,12 +2272,19 @@ const BoardStageConfigScreen = ({
           </div>
 
           <div className='flex items-center gap-3'>
-            <Button variant='secondary' onClick={onClose}>
+            <Button
+              variant='secondary'
+              onClick={onClose}
+              data-track-category='board_config'
+              data-track-name='CANCEL_STAGE_CONFIG'
+            >
               Cancel
             </Button>
             <Button
               className='bg-[#6276BE] hover:bg-[#5060A0] text-white'
               onClick={() => void handleSave()}
+              data-track-category='board_config'
+              data-track-name='SAVE_STAGE_CONFIG'
             >
               {onNext ? 'Next' : 'Finish'}
             </Button>

--- a/apps/dashboard/src/components/Board/BoardsTable/BoardsTable.tsx
+++ b/apps/dashboard/src/components/Board/BoardsTable/BoardsTable.tsx
@@ -365,6 +365,8 @@ export const BoardsTable = ({
                       size='iconSm'
                       className='h-5 w-5 p-0 text-muted-foreground hover:text-foreground'
                       onClick={e => handleCopyId(e, board.id)}
+                      data-track-category='Board'
+                      data-track-name='COPY_BOARD_ID'
                       title='Copy board ID'
                     >
                       {copiedBoardId === board.id ? <Check size={12} /> : <Copy size={12} />}

--- a/apps/dashboard/src/components/Board/CreateFormSlideOut/CreateFormSlideOut.tsx
+++ b/apps/dashboard/src/components/Board/CreateFormSlideOut/CreateFormSlideOut.tsx
@@ -74,6 +74,8 @@ const SelectDropdown = ({
           <DropdownMenuItem
             key={option.value}
             onClick={() => onChange(option.value)}
+            data-track-category='board_config'
+            data-track-name='SELECT_FORM_OPTION'
             className={value === option.value ? 'bg-muted font-medium' : ''}
           >
             {option.label}
@@ -1013,6 +1015,8 @@ export const CreateFormSlideOut = ({
           )}
           <Button
             onClick={() => void handleSave()}
+            data-track-category='board_config'
+            data-track-name='SAVE_FORM'
             disabled={!isValid || isSubmitting}
             className='w-full bg-[#6276be] hover:bg-[#5060a0] disabled:bg-[#c9cccf] disabled:cursor-not-allowed text-white rounded-[8px] py-[6px] text-[13px] font-medium'
           >

--- a/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
+++ b/apps/dashboard/src/components/Call/CallParticipantsSelectionModal/CallParticipantsSelectionModal.tsx
@@ -220,7 +220,14 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
           <h2 className='text-[15px] font-semibold text-foreground leading-5'>
             Start an Instant Call
           </h2>
-          <Button variant='outline' size='icon' className='size-7 rounded-lg' onClick={handleClose}>
+          <Button
+            variant='outline'
+            size='icon'
+            className='size-7 rounded-lg'
+            onClick={handleClose}
+            data-track-category='CALL_PARTICIPANTS_SELECTION_MODAL'
+            data-track-name='CLOSE_PARTICIPANTS_MODAL'
+          >
             <X className='size-4' />
           </Button>
         </div>
@@ -313,12 +320,16 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
               size='sm'
               className='rounded-lg text-[13px]'
               onClick={handleClose}
+              data-track-category='CALL_PARTICIPANTS_SELECTION_MODAL'
+              data-track-name='CANCEL_PARTICIPANTS_SELECTION'
             >
               Cancel
             </Button>
             <Button
               size='sm'
               onClick={handleSubmit}
+              data-track-category='CALL_PARTICIPANTS_SELECTION_MODAL'
+              data-track-name='CONFIRM_PARTICIPANTS_SELECTION'
               disabled={selectedParticipants.length === 0}
               className='rounded-lg text-[13px] bg-primary hover:bg-primary hover:opacity-80 disabled:opacity-20 disabled:cursor-not-allowed'
             >

--- a/apps/dashboard/src/components/Call/DeleteCallModal/DeleteCallModal.tsx
+++ b/apps/dashboard/src/components/Call/DeleteCallModal/DeleteCallModal.tsx
@@ -80,12 +80,16 @@ export const DeleteCallModal: React.FC<DeleteCallModalProps> = ({
               variant='outline'
               className='h-9 rounded-[8px] px-5 py-2.5 gap-2'
               onClick={onClose}
+              data-track-category='calls'
+              data-track-name='CANCEL_DELETE_CALL'
             >
               Cancel
             </Button>
             <Button
               className='h-9 rounded-[8px] px-5 py-2.5 gap-2 bg-destructive hover:bg-destructive/90 text-destructive-foreground border-0'
               onClick={handleConfirm}
+              data-track-category='calls'
+              data-track-name='CONFIRM_DELETE_CALL'
             >
               Delete
             </Button>

--- a/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
+++ b/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
@@ -237,6 +237,8 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
               tabIndex={-1}
               className='size-7 rounded-lg'
               onClick={handleClose}
+              data-track-category='calls'
+              data-track-name='CLOSE_INSTANT_CALL_MODAL'
               data-testid='instant-call-modal-close'
             >
               <X className='size-4' />
@@ -263,6 +265,8 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
                 size='sm'
                 className='rounded-lg text-[13px]'
                 onClick={handleClose}
+                data-track-category='calls'
+                data-track-name='CANCEL_INSTANT_CALL'
                 data-testid='instant-call-cancel-button'
               >
                 Cancel
@@ -271,6 +275,8 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
                 size='sm'
                 type='submit'
                 onClick={handleSubmit}
+                data-track-category='calls'
+                data-track-name='START_INSTANT_CALL'
                 disabled={selectedParticipants.length === 0}
                 className='rounded-lg text-[13px] bg-primary hover:bg-primary hover:opacity-80 disabled:opacity-20 disabled:cursor-not-allowed'
                 data-testid='instant-call-start-button'

--- a/apps/dashboard/src/components/Call/PresentationMode/PresentationModeOverlay.tsx
+++ b/apps/dashboard/src/components/Call/PresentationMode/PresentationModeOverlay.tsx
@@ -95,6 +95,8 @@ export function PresentationModeOverlay({
           transition={{ duration: 0.25, ease: 'easeInOut' }}
           // Fallback: click anywhere to exit when fullscreen API is unavailable
           onClick={fullscreenFailed ? onExit : undefined}
+          data-track-category='CALLS'
+          data-track-name='EXIT_PRESENTATION_MODE'
         >
           {participant ? (
             <ParticipantTile

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/InvitationPreviewStep.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/InvitationPreviewStep.tsx
@@ -282,7 +282,13 @@ export const InvitationPreviewStep: React.FC<InvitationPreviewStepProps> = ({
 
       {/* ── Footer ──────────────────────────────────────────────────────── */}
       <div className='flex justify-between items-center border-t p-3 shrink-0'>
-        <Button variant='ghost' onClick={onBack} disabled={isSubmitting}>
+        <Button
+          variant='ghost'
+          onClick={onBack}
+          data-track-category='calls'
+          data-track-name='BACK_FROM_INVITATION_PREVIEW'
+          disabled={isSubmitting}
+        >
           Back
         </Button>
         <div className='flex items-center gap-3'>
@@ -290,7 +296,12 @@ export const InvitationPreviewStep: React.FC<InvitationPreviewStepProps> = ({
             Sending to <strong className='text-foreground'>{recipients.length}</strong> external
             {recipients.length === 1 ? '' : 's'} as a reply.
           </p>
-          <Button onClick={onSend} disabled={isSubmitting}>
+          <Button
+            onClick={onSend}
+            data-track-category='calls'
+            data-track-name='SEND_CALL_INVITATION'
+            disabled={isSubmitting}
+          >
             {isSubmitting ? 'Sending…' : 'Send & schedule'}
           </Button>
         </div>

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -1038,6 +1038,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                 type='button'
                 className='size-7 rounded-lg'
                 onClick={handleClose}
+                data-track-category='calls'
+                data-track-name='CLOSE_SCHEDULE_CALL_MODAL'
               >
                 <X className='size-4' />
               </Button>
@@ -1372,6 +1374,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                                   <DropdownMenuItem
                                     className='text-sm rounded-lg p-2'
                                     onClick={() => setIsRecurring(false)}
+                                    data-track-category='calls'
+                                    data-track-name='SET_NOT_RECURRING'
                                   >
                                     Does Not Repeat
                                   </DropdownMenuItem>
@@ -1382,6 +1386,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                                       setRecurrenceFrequency('DAY');
                                       setRecurrenceDays([]);
                                     }}
+                                    data-track-category='calls'
+                                    data-track-name='SET_RECURRING_DAILY'
                                   >
                                     Daily
                                   </DropdownMenuItem>
@@ -1392,6 +1398,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                                       setRecurrenceFrequency('WEEK');
                                       setRecurrenceDays(['MO', 'TU', 'WE', 'TH', 'FR']);
                                     }}
+                                    data-track-category='calls'
+                                    data-track-name='SET_RECURRING_WEEKLY'
                                   >
                                     Every Weekday (Mon – Fri)
                                   </DropdownMenuItem>
@@ -1406,6 +1414,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                                           setMonthlyType('monthly_nth_weekday');
                                           setRecurrenceDays([]);
                                         }}
+                                        data-track-category='calls'
+                                        data-track-name='SET_RECURRING_MONTHLY'
                                       >
                                         Monthly on {ordinalWord} {weekday}
                                       </DropdownMenuItem>
@@ -1429,6 +1439,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                                       setIsRecurring(true);
                                       setShowCustomPanel(true);
                                     }}
+                                    data-track-category='calls'
+                                    data-track-name='OPEN_CUSTOM_RECURRENCE'
                                   >
                                     Custom…
                                   </DropdownMenuItem>
@@ -1763,6 +1775,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                                           );
                                         }
                                       }}
+                                      data-track-category='calls'
+                                      data-track-name='CANCEL_CUSTOM_RECURRENCE'
                                       className='rounded-lg text-sm leading-5 bg-transparent h-8 gap-2.5'
                                     >
                                       Cancel
@@ -1783,6 +1797,8 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                                         }
                                         setShowCustomPanel(false);
                                       }}
+                                      data-track-category='calls'
+                                      data-track-name='APPLY_CUSTOM_RECURRENCE'
                                       className='rounded-lg text-sm leading-5 bg-primary h-8 gap-2.5'
                                     >
                                       Done
@@ -2006,6 +2022,8 @@ const SubmitFooter: React.FC<{
         size='sm'
         className='rounded-lg text-[13px] px-4 h-9'
         onClick={onCancel}
+        data-track-category='calls'
+        data-track-name='CANCEL_SCHEDULE_CALL'
         disabled={isSubmitting}
         type='button'
       >

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/CallRow.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/CallRow.tsx
@@ -84,6 +84,8 @@ export function CallRow({
             e.stopPropagation();
             onJoinCall(call);
           }}
+          data-track-category='Calls'
+          data-track-name='JOIN_UPCOMING_CALL'
           className={cn(
             'shrink-0 text-sm',
             isActive

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallActionsMenu.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallActionsMenu.tsx
@@ -37,6 +37,8 @@ export function UpcomingCallActionsMenuItems({
     <>
       <DropdownMenuItem
         onClick={handleCopyLink}
+        data-track-category='calls'
+        data-track-name='COPY_UPCOMING_CALL_LINK'
         className='flex items-center gap-2 text-sm font-medium rounded-lg'
       >
         <Copy className='size-4' />
@@ -48,6 +50,8 @@ export function UpcomingCallActionsMenuItems({
             e.stopPropagation();
             onEdit();
           }}
+          data-track-category='calls'
+          data-track-name='EDIT_UPCOMING_CALL'
           className='flex items-center gap-2 text-sm font-medium rounded-lg'
         >
           <Pencil className='size-4' strokeWidth={2.2} />
@@ -60,6 +64,8 @@ export function UpcomingCallActionsMenuItems({
             e.stopPropagation();
             onCancel();
           }}
+          data-track-category='calls'
+          data-track-name='CANCEL_UPCOMING_CALL'
           className='flex items-center gap-2 text-sm font-medium text-destructive focus:text-destructive rounded-lg'
         >
           <Trash2 className='size-4' strokeWidth={2.2} />

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallsList.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallsList.tsx
@@ -83,6 +83,8 @@ export function UpcomingCallsList({
               variant='outline'
               size='sm'
               onClick={() => onJoinCall(call)}
+              data-track-category='Calls'
+              data-track-name='JOIN_UPCOMING_CALL'
               tabIndex={0}
               className={cn(
                 'w-full justify-center sm:w-auto sm:shrink-0 transition-opacity duration-150',

--- a/apps/dashboard/src/components/Canvas/CanvasAttachmentModal/CanvasAttachmentModal.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasAttachmentModal/CanvasAttachmentModal.tsx
@@ -140,7 +140,12 @@ export const CanvasAttachmentModal: React.FC<CanvasAttachmentModalProps> = ({
           </Button>
 
           <div className='flex items-center gap-3'>
-            <Button variant='secondary' onClick={handleClose}>
+            <Button
+              variant='secondary'
+              onClick={handleClose}
+              data-track-category='CANVAS'
+              data-track-name='CLOSE_CANVAS_ATTACHMENT_MODAL'
+            >
               Cancel
             </Button>
             <Button

--- a/apps/dashboard/src/components/Canvas/CanvasMentionSpec/CanvasMentionSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasMentionSpec/CanvasMentionSpec.tsx
@@ -169,6 +169,8 @@ const MentionRender = ({ inlineContent }: MentionRenderProps) => {
                 onClick={() => {
                   grantGroupMentionAccess(props.groupId, role);
                 }}
+                data-track-category='CANVAS'
+                data-track-name='GRANT_GROUP_MENTION_ACCESS'
               >
                 {formatCanvasRoleLabel(role)}
               </Button>
@@ -207,6 +209,8 @@ const MentionRender = ({ inlineContent }: MentionRenderProps) => {
                   role,
                 );
               }}
+              data-track-category='CANVAS'
+              data-track-name='GRANT_USER_MENTION_ACCESS'
             >
               {role.charAt(0) + role.slice(1).toLowerCase()}
             </Button>

--- a/apps/dashboard/src/components/Canvas/CanvasRow.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasRow.tsx
@@ -183,12 +183,22 @@ export const CanvasRow: React.FC<CanvasRowProps> = ({
             </DropdownMenuTrigger>
             <DropdownMenuContent align='end' className='w-44'>
               {onDuplicate && (
-                <DropdownMenuItem className='gap-2' onClick={() => onDuplicate(canvas)}>
+                <DropdownMenuItem
+                  className='gap-2'
+                  onClick={() => onDuplicate(canvas)}
+                  data-track-category='CANVAS'
+                  data-track-name='DUPLICATE_CANVAS'
+                >
                   <CopyDefault size={14} className='shrink-0' />
                   <span className='flex-1'>Duplicate</span>
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem className='gap-2' onClick={() => setShareOpen(true)}>
+              <DropdownMenuItem
+                className='gap-2'
+                onClick={() => setShareOpen(true)}
+                data-track-category='CANVAS'
+                data-track-name='OPEN_SHARE_CANVAS'
+              >
                 <Share01 size={14} className='shrink-0' />
                 <span className='flex-1'>Share</span>
               </DropdownMenuItem>
@@ -213,6 +223,8 @@ export const CanvasRow: React.FC<CanvasRowProps> = ({
                   {onDelete && (
                     <DropdownMenuItem
                       onClick={() => onDelete(canvas.id)}
+                      data-track-category='CANVAS'
+                      data-track-name='DELETE_CANVAS'
                       className='gap-2 text-destructive focus:text-destructive'
                     >
                       <DeleteDustbin01 size={14} className='shrink-0' />

--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -1315,6 +1315,8 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                                   <DropdownMenuItem
                                     className='gap-2'
                                     onClick={handleExportMarkdown}
+                                    data-track-category='CANVAS'
+                                    data-track-name='EXPORT_MARKDOWN'
                                     data-testid='canvas-export-markdown'
                                   >
                                     <Markdown size={16} className='shrink-0' />
@@ -1323,6 +1325,8 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                                   <DropdownMenuItem
                                     className='gap-2'
                                     onClick={handleExportPdf}
+                                    data-track-category='CANVAS'
+                                    data-track-name='EXPORT_PDF'
                                     data-testid='canvas-export-pdf'
                                   >
                                     <File02PdfFormat size={16} className='shrink-0' />
@@ -1336,6 +1340,8 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                                 onClick={() => {
                                   editorRef.current?.handlePresent();
                                 }}
+                                data-track-category='CANVAS'
+                                data-track-name='PRESENT_CANVAS'
                                 data-testid='canvas-present-item'
                               >
                                 <PlaySquare size={16} className='shrink-0' />
@@ -1356,6 +1362,8 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                                         setSelectedTheme(theme.value);
                                         editorRef.current?.handleThemeChange(theme.value);
                                       }}
+                                      data-track-category='CANVAS'
+                                      data-track-name='SELECT_CANVAS_THEME'
                                     >
                                       <span className='flex-1 truncate'>{theme.label}</span>
                                       {selectedTheme === theme.value && (
@@ -1453,7 +1461,13 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                   <span className='font-medium text-foreground'>{previewUpdatedAtText}</span>
                 </div>
                 <div className='flex items-center gap-2'>
-                  <Button variant='secondary' size='sm' onClick={handleBackToCurrentVersion}>
+                  <Button
+                    variant='secondary'
+                    size='sm'
+                    onClick={handleBackToCurrentVersion}
+                    data-track-category='CANVAS'
+                    data-track-name='BACK_TO_CURRENT_VERSION'
+                  >
                     Back to current
                   </Button>
                   {hasVersionDiff && (
@@ -1461,6 +1475,8 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                       variant={showVersionDiff ? 'default' : 'secondary'}
                       size='sm'
                       onClick={() => setShowVersionDiff(prev => !prev)}
+                      data-track-category='CANVAS'
+                      data-track-name='TOGGLE_VERSION_DIFF'
                       aria-pressed={showVersionDiff}
                     >
                       <GitCompare size={14} />
@@ -1472,6 +1488,8 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                       variant='default'
                       size='sm'
                       onClick={() => void handleRestoreVersion(previewVersion)}
+                      data-track-category='CANVAS'
+                      data-track-name='RESTORE_CANVAS_VERSION'
                       loading={restoringVersionId === previewVersion.id}
                     >
                       <RotateCcw size={14} />

--- a/apps/dashboard/src/components/Canvas/CanvasShareModal/CanvasShareModal.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasShareModal/CanvasShareModal.tsx
@@ -626,6 +626,8 @@ export const CanvasShareModal: React.FC<CanvasShareModalProps> = ({
                 size='sm'
                 disabled={guestInvite.isLoading || !guestInvite.email.trim()}
                 onClick={() => void guestInvite.sendInvite()}
+                data-track-category='CANVAS'
+                data-track-name='SEND_CANVAS_GUEST_INVITE'
                 className='gap-2'
               >
                 {guestInvite.isLoading ? (
@@ -737,7 +739,12 @@ export const CanvasShareModal: React.FC<CanvasShareModalProps> = ({
           {hasPendingChanges ? (
             <span className='text-xs italic text-muted-foreground'>Unsaved changes</span>
           ) : null}
-          <Button size='sm' onClick={handleDone}>
+          <Button
+            size='sm'
+            onClick={handleDone}
+            data-track-category='CANVAS'
+            data-track-name='DONE_CANVAS_SHARE'
+          >
             {hasPendingChanges ? 'Share' : 'Done'}
           </Button>
         </div>

--- a/apps/dashboard/src/components/Canvas/CanvasTab/CanvasTab.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTab/CanvasTab.tsx
@@ -1110,7 +1110,13 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
               <span className='font-medium text-foreground'>{previewUpdatedAtText}</span>
             </div>
             <div className='flex items-center gap-2'>
-              <Button variant='secondary' size='sm' onClick={handleBackToCurrentVersion}>
+              <Button
+                variant='secondary'
+                size='sm'
+                onClick={handleBackToCurrentVersion}
+                data-track-category='CANVAS'
+                data-track-name='BACK_TO_CURRENT_VERSION'
+              >
                 Back to current
               </Button>
               {hasVersionDiff && (
@@ -1118,6 +1124,8 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
                   variant={showVersionDiff ? 'default' : 'secondary'}
                   size='sm'
                   onClick={() => setShowVersionDiff(prev => !prev)}
+                  data-track-category='CANVAS'
+                  data-track-name='TOGGLE_VERSION_DIFF'
                   aria-pressed={showVersionDiff}
                 >
                   <GitCompare size={14} />
@@ -1129,6 +1137,8 @@ const CanvasTab: React.FC<CanvasTabProps> = ({ channelId }): ReactElement => {
                   variant='default'
                   size='sm'
                   onClick={() => void handleRestoreVersion(previewVersion)}
+                  data-track-category='CANVAS'
+                  data-track-name='RESTORE_CANVAS_VERSION'
                   loading={restoringVersionId === previewVersion.id}
                 >
                   <RotateCcw size={14} />

--- a/apps/dashboard/src/components/Canvas/CanvasVersionHistory/CanvasVersionHistory.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasVersionHistory/CanvasVersionHistory.tsx
@@ -100,6 +100,8 @@ export const CanvasVersionHistory = ({
             variant='ghost'
             size='iconSm'
             onClick={onClose}
+            data-track-category='CANVAS'
+            data-track-name='CLOSE_VERSION_HISTORY'
             aria-label='Close version history'
           >
             <X size={16} />
@@ -185,6 +187,8 @@ export const CanvasVersionHistory = ({
                               onClick={() => {
                                 void onMakeCopy(version);
                               }}
+                              data-track-category='CANVAS'
+                              data-track-name='COPY_CANVAS_VERSION'
                               disabled={isRestoring || isRenaming || isCopying}
                             >
                               <Copy size={14} />
@@ -192,6 +196,8 @@ export const CanvasVersionHistory = ({
                             </DropdownMenuItem>
                             <DropdownMenuItem
                               onClick={() => onRestore(version)}
+                              data-track-category='CANVAS'
+                              data-track-name='RESTORE_CANVAS_VERSION'
                               disabled={isRestoring || isRenaming || isCopying}
                             >
                               <RotateCcw size={14} />
@@ -199,6 +205,8 @@ export const CanvasVersionHistory = ({
                             </DropdownMenuItem>
                             <DropdownMenuItem
                               onClick={() => openRenameDialog(version)}
+                              data-track-category='CANVAS'
+                              data-track-name='OPEN_RENAME_VERSION'
                               disabled={isRestoring || isRenaming || isCopying}
                             >
                               <Pencil size={14} />
@@ -245,7 +253,13 @@ export const CanvasVersionHistory = ({
             placeholder='Version name'
           />
           <div className='flex justify-end gap-2'>
-            <Button type='button' variant='secondary' onClick={closeRenameDialog}>
+            <Button
+              type='button'
+              variant='secondary'
+              onClick={closeRenameDialog}
+              data-track-category='CANVAS'
+              data-track-name='CANCEL_RENAME_VERSION'
+            >
               Cancel
             </Button>
             <Button

--- a/apps/dashboard/src/components/Chat/AddSectionForm/AddSectionForm.tsx
+++ b/apps/dashboard/src/components/Chat/AddSectionForm/AddSectionForm.tsx
@@ -119,7 +119,14 @@ export const AddSectionForm = ({
         {showError && <p className='text-sm text-destructive'>{nameError}</p>}
       </div>
       <div className='flex justify-end gap-3 pt-2'>
-        <Button variant='outline' size='default' type='button' onClick={onCancel}>
+        <Button
+          variant='outline'
+          size='default'
+          type='button'
+          onClick={onCancel}
+          data-track-category='CHAT_SIDEBAR'
+          data-track-name='CANCEL_ADD_SECTION'
+        >
           Cancel
         </Button>
         <Tooltip content={nameError ?? ''} side='top' {...(!nameError && { open: false })}>

--- a/apps/dashboard/src/components/Chat/BookmarkItem/BookmarkItem.tsx
+++ b/apps/dashboard/src/components/Chat/BookmarkItem/BookmarkItem.tsx
@@ -406,10 +406,17 @@ export const BookmarkItem = ({
                 e.stopPropagation();
                 setIsCustomReminderModalOpen(false);
               }}
+              data-track-category='CHAT_BOOKMARK'
+              data-track-name='OPEN_CUSTOM_REMINDER'
             >
               Cancel
             </Button>
-            <Button onClick={handleSaveCustomReminder} disabled={!customReminderDate}>
+            <Button
+              onClick={handleSaveCustomReminder}
+              data-track-category='CHAT_BOOKMARK'
+              data-track-name='SAVE_CUSTOM_REMINDER'
+              disabled={!customReminderDate}
+            >
               Save
             </Button>
           </div>

--- a/apps/dashboard/src/components/Chat/ChannelInformation/ChannelSettings.tsx
+++ b/apps/dashboard/src/components/Chat/ChannelInformation/ChannelSettings.tsx
@@ -338,6 +338,8 @@ export const ChannelSettings: React.FC<ChannelSettingsProps> = ({
                   <Button
                     variant='secondary'
                     onClick={handleOpenWorkspaceSettings}
+                    data-track-category='CHANNEL_SETTINGS'
+                    data-track-name='OPEN_WORKSPACE_SETTINGS'
                     className='shrink-0'
                   >
                     Manage in Workspace Management
@@ -350,6 +352,8 @@ export const ChannelSettings: React.FC<ChannelSettingsProps> = ({
                 <Button
                   variant='secondary'
                   onClick={() => void handleCopyChannelEmail()}
+                  data-track-category='CHANNEL_SETTINGS'
+                  data-track-name='COPY_CHANNEL_EMAIL'
                   className='shrink-0'
                 >
                   Copy
@@ -490,11 +494,18 @@ export const ChannelSettings: React.FC<ChannelSettingsProps> = ({
               again.
             </p>
             <div className='flex justify-end gap-3'>
-              <Button variant='secondary' onClick={() => setShowUnarchiveDialog(false)}>
+              <Button
+                variant='secondary'
+                onClick={() => setShowUnarchiveDialog(false)}
+                data-track-category='CHANNEL_SETTINGS'
+                data-track-name='CANCEL_UNARCHIVE_CHANNEL'
+              >
                 Cancel
               </Button>
               <Button
                 onClick={handleUnarchiveChannel}
+                data-track-category='CHANNEL_SETTINGS'
+                data-track-name='CONFIRM_UNARCHIVE_CHANNEL'
                 className='bg-green-600 text-white hover:bg-green-700'
               >
                 Unarchive Channel
@@ -523,11 +534,18 @@ export const ChannelSettings: React.FC<ChannelSettingsProps> = ({
               and available in search.
             </p>
             <div className='flex justify-end gap-3'>
-              <Button variant='secondary' onClick={() => setShowArchiveDialog(false)}>
+              <Button
+                variant='secondary'
+                onClick={() => setShowArchiveDialog(false)}
+                data-track-category='CHANNEL_SETTINGS'
+                data-track-name='CANCEL_ARCHIVE_CHANNEL'
+              >
                 Cancel
               </Button>
               <Button
                 onClick={handleArchiveChannel}
+                data-track-category='CHANNEL_SETTINGS'
+                data-track-name='CONFIRM_ARCHIVE_CHANNEL'
                 className='bg-amber-600 text-white hover:bg-amber-700'
               >
                 Archive Channel

--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -1511,6 +1511,8 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
                 variant='ghost'
                 className='w-full justify-start'
                 onClick={e => handleReminderPresetSelect(option.option, e)}
+                data-track-category='CHAT_BUBBLE'
+                data-track-name='SELECT_REMINDER_PRESET'
               >
                 {option.label}
               </Button>
@@ -1584,10 +1586,20 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
             </div>
 
             <div className='flex justify-end gap-2 pt-2'>
-              <Button variant='outline' onClick={() => setIsCustomReminderModalOpen(false)}>
+              <Button
+                variant='outline'
+                onClick={() => setIsCustomReminderModalOpen(false)}
+                data-track-category='CHAT_BUBBLE'
+                data-track-name='CANCEL_CUSTOM_REMINDER'
+              >
                 Cancel
               </Button>
-              <Button onClick={handleSaveCustomReminder} disabled={!customReminderDate}>
+              <Button
+                onClick={handleSaveCustomReminder}
+                data-track-category='CHAT_BUBBLE'
+                data-track-name='SAVE_CUSTOM_REMINDER'
+                disabled={!customReminderDate}
+              >
                 Save
               </Button>
             </div>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -4513,6 +4513,8 @@ const ChannelCommandMenu = ({
                     variant='secondary'
                     size='sm'
                     onClick={toggleDeskMergeMode}
+                    data-track-category='SEARCH'
+                    data-track-name='TOGGLE_DESK_MERGE_MODE'
                     className={MERGE_BAR_BUTTON_NO_RING}
                   >
                     Cancel
@@ -4529,6 +4531,8 @@ const ChannelCommandMenu = ({
                       variant='ghost'
                       size='sm'
                       onClick={clearDeskMergeSelection}
+                      data-track-category='SEARCH'
+                      data-track-name='CLEAR_DESK_MERGE_SELECTION'
                       className={MERGE_BAR_BUTTON_NO_RING}
                     >
                       Clear
@@ -4537,6 +4541,8 @@ const ChannelCommandMenu = ({
                       variant='secondary'
                       size='sm'
                       onClick={toggleDeskMergeMode}
+                      data-track-category='SEARCH'
+                      data-track-name='TOGGLE_DESK_MERGE_MODE'
                       className={MERGE_BAR_BUTTON_NO_RING}
                     >
                       Cancel
@@ -4545,6 +4551,8 @@ const ChannelCommandMenu = ({
                       size='sm'
                       disabled={selectedMergeTickets.size < 2}
                       onClick={() => setShowMergeDialog(true)}
+                      data-track-category='SEARCH'
+                      data-track-name='OPEN_MERGE_DIALOG'
                       className={MERGE_BAR_BUTTON_NO_RING}
                     >
                       Merge {selectedMergeTickets.size > 0 ? `(${selectedMergeTickets.size})` : ''}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelItemV2.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelItemV2.tsx
@@ -275,6 +275,8 @@ const ChannelItemV2 = memo(
                             e.stopPropagation();
                             onMoveToSection?.(channel.id, section.id);
                           }}
+                          data-track-category='CHAT_SIDEBAR'
+                          data-track-name='MOVE_CHANNEL_TO_SECTION'
                         >
                           {section.emoji && (
                             <span className='shrink-0'>{renderEmoji(section.emoji, 'size-4')}</span>
@@ -298,6 +300,8 @@ const ChannelItemV2 = memo(
                         e.stopPropagation();
                         onMoveToSection?.(channel.id, null);
                       }}
+                      data-track-category='CHAT_SIDEBAR'
+                      data-track-name='REMOVE_CHANNEL_FROM_SECTION'
                     >
                       <FolderRemove size={14} className='shrink-0' />
                       <span className='flex-1'>Remove from section</span>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -1363,6 +1363,8 @@ const ChatDirectory = ({
           <div className='flex items-center justify-between gap-2'>
             <button
               onClick={() => void navigate('/chat')}
+              data-track-category='CHAT_SIDEBAR'
+              data-track-name='BACK_TO_CHAT'
               className='h-8 px-4 flex items-center justify-center rounded-[999px] border border-[#FFF] bg-[linear-gradient(180deg,_#FFF_0%,_#FAFAFA_100%)] shadow-[inset_0_4px_6px_0_#F5F5F5,0_0_12px_0_#E5E5E5] min-[500px]:hidden z-30 '
             >
               Chat
@@ -1370,6 +1372,8 @@ const ChatDirectory = ({
             <div className='z-30'>
               <button
                 onClick={() => setIsCommandMenuOpen(true)}
+                data-track-category='CHAT_SIDEBAR'
+                data-track-name='OPEN_COMMAND_MENU'
                 className='h-8 px-2 flex items-center justify-center rounded-[999px] border border-[#FFF] bg-[linear-gradient(180deg,_#FFF_0%,_#FAFAFA_100%)] shadow-[inset_0_4px_6px_0_#F5F5F5,0_0_12px_0_#E5E5E5] min-[500px]:hidden z-30'
               >
                 <SearchDefault size={16} />
@@ -1381,11 +1385,15 @@ const ChatDirectory = ({
         {/* Desktop */}
         {/* <div className=' sticky top-0 z-50 hidden min-[500px]:block pt-4 bg-sidebar-background'>
           <div className='pb-6 flex items-center justify-between'>
-            <button onClick={() => void navigate('/chat')} className='cursor-pointer'>
+            <button onClick={() => void navigate('/chat')}
+              data-track-category='CHAT_SIDEBAR'
+              data-track-name='BACK_TO_CHAT' className='cursor-pointer'>
               <h2 className='text-black font-inter text-base font-semibold leading-normal'>Chat</h2>
             </button>
             <button
               onClick={() => setIsCommandMenuOpen(true)}
+              data-track-category='CHAT_SIDEBAR'
+              data-track-name='OPEN_COMMAND_MENU'
               className='size-8 items-center justify-center hidden min-[500px]:flex cursor-pointer'
             >
               <SearchDefault size={16} />
@@ -1419,6 +1427,9 @@ const ChatDirectory = ({
             onClick={() => {
               void navigate('/chat/bookmarks');
             }}
+            data-track-category='CHAT_SIDEBAR'
+            data-track-name='OPEN_BOOKMARKS'
+            data-track-metadata={JSON.stringify({ overdueRemindersCount })}
           />
           <hr className='border-border mt-4' />
         </div> */}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ManageSectionChannelsDialog.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ManageSectionChannelsDialog.tsx
@@ -191,7 +191,14 @@ export const ManageSectionChannelsDialog = ({
       </div>
 
       <div className='flex justify-end gap-3 pt-2'>
-        <Button type='button' variant='outline' size='default' onClick={onClose}>
+        <Button
+          type='button'
+          variant='outline'
+          size='default'
+          onClick={onClose}
+          data-track-category='CHAT_SIDEBAR'
+          data-track-name='CANCEL_MANAGE_SECTION_CHANNELS'
+        >
           Cancel
         </Button>
         <Button
@@ -199,6 +206,8 @@ export const ManageSectionChannelsDialog = ({
           variant='default'
           size='default'
           onClick={handleSave}
+          data-track-category='CHAT_SIDEBAR'
+          data-track-name='SAVE_MANAGE_SECTION_CHANNELS'
           className='bg-action-primary text-action-primary-foreground hover:bg-action-primary/90'
         >
           Save

--- a/apps/dashboard/src/components/Chat/ChatDirectory/MobileChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/MobileChatDirectory.tsx
@@ -229,6 +229,8 @@ const MobileChatDirectory = ({
                           e.stopPropagation();
                           setChannelSortOrder(ChannelSortOrder.UNREAD);
                         }}
+                        data-track-category='MOBILE_CHAT_DIRECTORY'
+                        data-track-name='SORT_CHANNELS_BY_UNREAD'
                         className='gap-2'
                       >
                         <NotificationBellOn size={14} className='shrink-0' />
@@ -242,6 +244,8 @@ const MobileChatDirectory = ({
                           e.stopPropagation();
                           setChannelSortOrder(ChannelSortOrder.RECENCY);
                         }}
+                        data-track-category='MOBILE_CHAT_DIRECTORY'
+                        data-track-name='SORT_CHANNELS_BY_RECENCY'
                         className='gap-2'
                       >
                         <ClockDefault size={14} className='shrink-0' />
@@ -255,6 +259,8 @@ const MobileChatDirectory = ({
                           e.stopPropagation();
                           setChannelSortOrder(ChannelSortOrder.ALPHABETICAL);
                         }}
+                        data-track-category='MOBILE_CHAT_DIRECTORY'
+                        data-track-name='SORT_CHANNELS_BY_ALPHABETICAL'
                         className='gap-2'
                       >
                         <ListSortAlphabetically size={14} className='shrink-0' />

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SortableSection.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SortableSection.tsx
@@ -149,6 +149,8 @@ const SortableSection = ({
                 e.stopPropagation();
                 onRename(section);
               }}
+              data-track-category='CHAT_SIDEBAR'
+              data-track-name='RENAME_SECTION'
             >
               <span className='flex size-5 shrink-0 items-center justify-center'>
                 <PencilEdit size={16} />
@@ -161,6 +163,8 @@ const SortableSection = ({
                 e.stopPropagation();
                 onManageChannels(section);
               }}
+              data-track-category='CHAT_SIDEBAR'
+              data-track-name='MANAGE_SECTION_CHANNELS'
             >
               <span className='flex size-5 shrink-0 items-center justify-center'>
                 <ListCheck size={16} />
@@ -173,6 +177,8 @@ const SortableSection = ({
                 e.stopPropagation();
                 onCreateSection();
               }}
+              data-track-category='CHAT_SIDEBAR'
+              data-track-name='CREATE_SECTION'
             >
               <span className='flex size-5 shrink-0 items-center justify-center'>
                 <FolderPlus size={16} />
@@ -194,6 +200,8 @@ const SortableSection = ({
                 e.stopPropagation();
                 onDelete(section);
               }}
+              data-track-category='CHAT_SIDEBAR'
+              data-track-name='DELETE_SECTION'
             >
               <span className='flex size-5 shrink-0 items-center justify-center'>
                 <DeleteDustbin02 size={16} />

--- a/apps/dashboard/src/components/Chat/ConversationHeader/ConversationHeader.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationHeader/ConversationHeader.tsx
@@ -345,6 +345,8 @@ const ConversationHeader = ({
                   setInfoDefaultTab('notifications');
                   setIsInfoOpen(true);
                 }}
+                data-track-category='CHANNELS'
+                data-track-name='OPEN_CHANNEL_NOTIFICATIONS'
                 className={cn('h-7 w-7 rounded-lg', actionIconClass)}
               >
                 <span className='shrink-0'>
@@ -427,11 +429,18 @@ const ConversationHeader = ({
                     setInfoDefaultTab('about');
                     setIsInfoOpen(true);
                   }}
+                  data-track-category='CHANNELS'
+                  data-track-name='OPEN_CHANNEL_ABOUT'
                 >
                   <InformationCircle size={16} className='shrink-0' />
                   Channel details
                 </DropdownMenuItem>
-                <DropdownMenuItem className='gap-2' onClick={() => handleOpenAllLinks()}>
+                <DropdownMenuItem
+                  className='gap-2'
+                  onClick={() => handleOpenAllLinks()}
+                  data-track-category='CHANNELS'
+                  data-track-name='OPEN_ALL_CHANNEL_LINKS'
+                >
                   <ExternalLinkSquare size={16} className='shrink-0' />
                   Open all links
                 </DropdownMenuItem>
@@ -449,6 +458,8 @@ const ConversationHeader = ({
                           key={section.id}
                           className='gap-2'
                           onClick={() => handleMoveToSection(section.id)}
+                          data-track-category='CHANNELS'
+                          data-track-name='MOVE_CHANNEL_TO_SECTION'
                         >
                           {section.emoji && (
                             <span className='shrink-0'>{renderEmoji(section.emoji, 'size-4')}</span>
@@ -469,6 +480,8 @@ const ConversationHeader = ({
                     <DropdownMenuItem
                       className='gap-2 text-destructive focus:text-destructive'
                       onClick={handleLeaveChannel}
+                      data-track-category='CHANNELS'
+                      data-track-name='LEAVE_CHANNEL'
                     >
                       <UserArrowRight size={16} className='shrink-0' />
                       Leave channel
@@ -483,6 +496,8 @@ const ConversationHeader = ({
               variant='ghost'
               size='sm'
               onClick={onClose}
+              data-track-category='CHANNELS'
+              data-track-name='CLOSE_CONVERSATION_HEADER'
               className={cn('h-7 w-7 rounded-lg', actionIconClass)}
               aria-label='Close'
             >

--- a/apps/dashboard/src/components/Chat/CreateSectionDialog/CreateSectionDialog.tsx
+++ b/apps/dashboard/src/components/Chat/CreateSectionDialog/CreateSectionDialog.tsx
@@ -360,7 +360,14 @@ export const CreateSectionDialog = ({
       <div className='flex items-center justify-between pt-2'>
         <span className='text-sm text-muted-foreground'>Step 2 of 2</span>
         <div className='flex gap-3'>
-          <Button type='button' variant='outline' size='default' onClick={handleSkip}>
+          <Button
+            type='button'
+            variant='outline'
+            size='default'
+            onClick={handleSkip}
+            data-track-category='CHAT_SIDEBAR'
+            data-track-name='SKIP_ADD_CHANNELS_TO_SECTION'
+          >
             Skip
           </Button>
           <Button
@@ -368,6 +375,8 @@ export const CreateSectionDialog = ({
             variant='default'
             size='default'
             onClick={handleAddChannels}
+            data-track-category='CHAT_SIDEBAR'
+            data-track-name='ADD_CHANNELS_TO_SECTION'
             disabled={selected.size === 0}
             className='bg-action-primary text-action-primary-foreground hover:bg-action-primary/90'
           >

--- a/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmsPage.tsx
@@ -535,6 +535,8 @@ const DmsPage = (): ReactElement => {
                   setDmSearchQuery('');
                   setShowDmSearchDropdown(false);
                 }}
+                data-track-category='DM'
+                data-track-name='CLEAR_DM_SEARCH'
                 aria-label='Clear search'
                 variant='link'
                 size='icon'
@@ -707,6 +709,8 @@ const DmsPage = (): ReactElement => {
                       setDmSearchQuery('');
                       setShowDmSearchDropdown(false);
                     }}
+                    data-track-category='DM'
+                    data-track-name='CLEAR_DM_SEARCH'
                     aria-label='Clear search'
                     variant='link'
                     size='icon'

--- a/apps/dashboard/src/components/Chat/EmailRefetch/DlMemberSyncDialog.tsx
+++ b/apps/dashboard/src/components/Chat/EmailRefetch/DlMemberSyncDialog.tsx
@@ -261,10 +261,22 @@ export const DlMemberSyncDialog: React.FC<DlMemberSyncDialogProps> = ({
             )}
 
             <div className='flex justify-end gap-2 pt-1'>
-              <Button variant='outline' type='button' onClick={() => handleOpenChange(false)}>
+              <Button
+                variant='outline'
+                type='button'
+                onClick={() => handleOpenChange(false)}
+                data-track-category='Support'
+                data-track-name='CLOSE_DL_SYNC_DIALOG'
+              >
                 Cancel
               </Button>
-              <Button type='button' disabled={!isRangeReady} onClick={() => setStep('provider')}>
+              <Button
+                type='button'
+                disabled={!isRangeReady}
+                onClick={() => setStep('provider')}
+                data-track-category='Support'
+                data-track-name='DL_SYNC_BACK_TO_PROVIDER'
+              >
                 Next
               </Button>
             </div>
@@ -285,6 +297,8 @@ export const DlMemberSyncDialog: React.FC<DlMemberSyncDialogProps> = ({
                     onClick={() => {
                       void handleProviderSelect('microsoft');
                     }}
+                    data-track-category='Support'
+                    data-track-name='DL_SYNC_SELECT_MICROSOFT'
                     disabled={isRedirecting}
                   >
                     {isRedirecting ? (
@@ -302,6 +316,8 @@ export const DlMemberSyncDialog: React.FC<DlMemberSyncDialogProps> = ({
                     onClick={() => {
                       void handleProviderSelect('google');
                     }}
+                    data-track-category='Support'
+                    data-track-name='DL_SYNC_SELECT_GOOGLE'
                     disabled={isRedirecting}
                   >
                     {isRedirecting ? (
@@ -321,7 +337,13 @@ export const DlMemberSyncDialog: React.FC<DlMemberSyncDialogProps> = ({
             </div>
 
             <div className='flex justify-end gap-2 pt-1'>
-              <Button variant='outline' type='button' onClick={() => setStep('range')}>
+              <Button
+                variant='outline'
+                type='button'
+                onClick={() => setStep('range')}
+                data-track-category='Support'
+                data-track-name='DL_SYNC_BACK_TO_RANGE'
+              >
                 Back
               </Button>
             </div>

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
@@ -619,6 +619,8 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
                             <DropdownMenuItem
                               key={shortcut.commandName}
                               onClick={() => onRunShortcut?.(shortcut)}
+                              data-track-category='HOVER_ACTIONS_TOOLBAR'
+                              data-track-name='RUN_SHORTCUT'
                             >
                               <span className='w-4 h-4 mr-2 flex items-center justify-center text-muted-foreground'>
                                 <Zap className='w-3.5 h-3.5' />
@@ -634,7 +636,11 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
                           {messageShortcuts.length > 3 && (
                             <>
                               <DropdownMenuSeparator />
-                              <DropdownMenuItem onClick={onShowAllShortcuts}>
+                              <DropdownMenuItem
+                                onClick={onShowAllShortcuts}
+                                data-track-category='HOVER_ACTIONS_TOOLBAR'
+                                data-track-name='SHOW_ALL_SHORTCUTS'
+                              >
                                 <span className='w-4 h-4 mr-2 flex items-center justify-center text-muted-foreground'>
                                   <Zap className='w-4 h-4' />
                                 </span>

--- a/apps/dashboard/src/components/Chat/Info/Info.tsx
+++ b/apps/dashboard/src/components/Chat/Info/Info.tsx
@@ -949,12 +949,20 @@ const ChannelMembers = ({
               : 'This person will lose access to the channel but may rejoin later.'}
           </p>
           <div className='flex justify-end gap-3'>
-            <Button variant='secondary' onClick={() => setRemoveDialogOpen(false)} className='px-6'>
+            <Button
+              variant='secondary'
+              onClick={() => setRemoveDialogOpen(false)}
+              data-track-category='CHAT_INFO'
+              data-track-name='CANCEL_REMOVE_PARTICIPANT'
+              className='px-6'
+            >
               Cancel
             </Button>
             <Button
               variant='destructive'
               onClick={() => userToRemove && handleRemoveParticipant(userToRemove.id)}
+              data-track-category='CHAT_INFO'
+              data-track-name='CONFIRM_REMOVE_PARTICIPANT'
               className='px-6'
             >
               Remove

--- a/apps/dashboard/src/components/Chat/MessageAttachment/DeleteButton.tsx
+++ b/apps/dashboard/src/components/Chat/MessageAttachment/DeleteButton.tsx
@@ -118,6 +118,8 @@ export const DeleteButton = memo<DeleteButtonProps>(
                   e.stopPropagation();
                   setShowDeleteConfirm(false);
                 }}
+                data-track-category='MESSAGE_ATTACHMENT'
+                data-track-name='CLOSE_DELETE_ATTACHMENT_DIALOG'
                 variant='secondary'
                 aria-label='Close dialog'
               >
@@ -141,6 +143,8 @@ export const DeleteButton = memo<DeleteButtonProps>(
                   e.stopPropagation();
                   setShowDeleteConfirm(false);
                 }}
+                data-track-category='MESSAGE_ATTACHMENT'
+                data-track-name='CANCEL_DELETE_ATTACHMENT'
                 disabled={isDeleting}
                 variant='secondary'
               >
@@ -152,6 +156,8 @@ export const DeleteButton = memo<DeleteButtonProps>(
                   e.stopPropagation();
                   void handleConfirmDelete();
                 }}
+                data-track-category='MESSAGE_ATTACHMENT'
+                data-track-name='CONFIRM_DELETE_ATTACHMENT'
                 disabled={isDeleting}
                 variant='destructive'
               >

--- a/apps/dashboard/src/components/Chat/Nudges/SurfaceNudgeCard.tsx
+++ b/apps/dashboard/src/components/Chat/Nudges/SurfaceNudgeCard.tsx
@@ -394,6 +394,8 @@ export const SurfaceNudgeCard: React.FC<SurfaceNudgeCardProps> = ({
               variant='outline'
               disabled={isActing}
               onClick={handleReview}
+              data-track-category='NUDGES'
+              data-track-name='REVIEW_NUDGE'
               className='h-8 rounded-[8px] border-border px-[10px] text-sm text-muted-foreground hover:bg-muted/50'
             >
               <Eye className='h-4 w-4' />
@@ -414,6 +416,8 @@ export const SurfaceNudgeCard: React.FC<SurfaceNudgeCardProps> = ({
               variant='outline'
               disabled={isActing}
               onClick={handleOpenRelatedTicket}
+              data-track-category='NUDGES'
+              data-track-name='OPEN_NUDGE_TICKET'
               className='h-8 rounded-lg border-border px-3 text-sm text-foreground'
             >
               Open ticket
@@ -431,6 +435,8 @@ export const SurfaceNudgeCard: React.FC<SurfaceNudgeCardProps> = ({
               variant='outline'
               disabled={isActing}
               onClick={handleOpenRelatedMessage}
+              data-track-category='NUDGES'
+              data-track-name='OPEN_NUDGE_MESSAGE'
               className='h-8 rounded-lg border-border px-3 text-sm text-foreground'
             >
               View message
@@ -448,6 +454,8 @@ export const SurfaceNudgeCard: React.FC<SurfaceNudgeCardProps> = ({
               variant='outline'
               disabled={isActing}
               onClick={() => setIsScheduleCallModalOpen(true)}
+              data-track-category='NUDGES'
+              data-track-name='OPEN_NUDGE_SCHEDULE_CALL'
               className='h-8 rounded-lg border-border px-3 text-sm text-foreground'
             >
               <Phone className='mr-1 h-3.5 w-3.5' />
@@ -470,6 +478,8 @@ export const SurfaceNudgeCard: React.FC<SurfaceNudgeCardProps> = ({
             variant='ghost'
             disabled={isActing}
             onClick={handleDismiss}
+            data-track-category='NUDGES'
+            data-track-name='DISMISS_NUDGE'
             className='text-muted-foreground'
           >
             Dismiss

--- a/apps/dashboard/src/components/Chat/Nudges/SurfaceNudgeResult.tsx
+++ b/apps/dashboard/src/components/Chat/Nudges/SurfaceNudgeResult.tsx
@@ -53,6 +53,8 @@ export const SurfaceNudgeResult: React.FC<SurfaceNudgeResultProps> = ({
               }`,
             )
           }
+          data-track-category='NUDGES'
+          data-track-name='OPEN_NUDGE_RESULT_CREATED_TICKET'
         >
           Open ticket
         </Button>
@@ -83,6 +85,8 @@ export const SurfaceNudgeResult: React.FC<SurfaceNudgeResultProps> = ({
               }`,
             )
           }
+          data-track-category='NUDGES'
+          data-track-name='OPEN_NUDGE_RESULT_TICKET'
         >
           Open ticket
         </Button>
@@ -113,6 +117,8 @@ export const SurfaceNudgeResult: React.FC<SurfaceNudgeResultProps> = ({
                 : `${baseRoute}/${targetChannelId}`,
             )
           }
+          data-track-category='NUDGES'
+          data-track-name='OPEN_NUDGE_RESULT_MESSAGE'
         >
           View message
         </Button>

--- a/apps/dashboard/src/components/Chat/SearchResults/compare/CompareSelectRow.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/compare/CompareSelectRow.tsx
@@ -34,6 +34,8 @@ export function CompareSelectRow({
       aria-pressed={selected}
       aria-disabled={!hasDebug}
       onClick={hasDebug ? onToggle : undefined}
+      data-track-category='SEARCH_COMPARE'
+      data-track-name='TOGGLE_COMPARE_ROW'
       onKeyDown={e => {
         if (hasDebug && (e.key === 'Enter' || e.key === ' ')) {
           e.preventDefault();

--- a/apps/dashboard/src/components/Chat/SearchResults/compare/SearchCompareDialog.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/compare/SearchCompareDialog.tsx
@@ -71,6 +71,8 @@ export function SearchCompareDialog({
           <div
             className='absolute inset-0 bg-background/70 backdrop-blur-sm'
             onClick={onClose}
+            data-track-category='SEARCH_COMPARE'
+            data-track-name='CLOSE_COMPARE_BACKDROP'
             aria-hidden
           />
 
@@ -102,6 +104,8 @@ export function SearchCompareDialog({
               </div>
               <button
                 onClick={onClose}
+                data-track-category='SEARCH_COMPARE'
+                data-track-name='CLOSE_COMPARE_DIALOG'
                 title='Close'
                 className='ml-auto shrink-0 p-2 rounded-md text-muted-foreground hover:bg-muted active:scale-[0.96] transition'
               >
@@ -162,6 +166,8 @@ export function SearchCompareDialog({
                           </span>
                           <button
                             onClick={() => onToggleRelevant(r.id)}
+                            data-track-category='SEARCH_COMPARE'
+                            data-track-name='TOGGLE_RESULT_RELEVANT'
                             title={
                               isRelevant ? 'Unmark relevant' : 'Mark as a correct / relevant result'
                             }
@@ -178,6 +184,8 @@ export function SearchCompareDialog({
                           </button>
                           <button
                             onClick={() => onRemove(r.id)}
+                            data-track-category='SEARCH_COMPARE'
+                            data-track-name='REMOVE_FROM_COMPARISON'
                             title='Remove from comparison'
                             className='ml-auto shrink-0 p-1 rounded text-muted-foreground hover:bg-muted hover:text-foreground active:scale-[0.96] transition'
                           >

--- a/apps/dashboard/src/components/Chat/ThreadContextPanel/ThreadContextPanel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadContextPanel/ThreadContextPanel.tsx
@@ -94,6 +94,8 @@ const ThreadContextPanel = ({
           className='w-full text-xs'
           disabled={items.length === 0}
           onClick={onConfirm}
+          data-track-category='THREAD_CONTEXT'
+          data-track-name='CONFIRM_THREAD_CONTEXT'
         >
           Add to Thread
         </Button>

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -1244,6 +1244,8 @@ export const ThreadMessages = ({
                         threadInfo,
                       });
                     }}
+                    data-track-category='THREAD_PANEL'
+                    data-track-name='OPEN_XYNE_AI_FROM_THREAD'
                     className='h-7 w-7 rounded-lg'
                   >
                     <XyneAIStar />
@@ -1302,7 +1304,12 @@ export const ThreadMessages = ({
                     </DropdownMenuItem>
                   )}
                   {!isMobile && (
-                    <DropdownMenuItem className='gap-2' onClick={openTicketDetailsExpandedView}>
+                    <DropdownMenuItem
+                      className='gap-2'
+                      onClick={openTicketDetailsExpandedView}
+                      data-track-category='THREAD_PANEL'
+                      data-track-name='OPEN_TICKET_EXPANDED_VIEW'
+                    >
                       <MaximizeTwoArrow size={16} className='shrink-0' />
                       <span className='flex-1'>Expand view</span>
                     </DropdownMenuItem>
@@ -1348,12 +1355,22 @@ export const ThreadMessages = ({
                     </DropdownMenuItem>
                   )}
                   {isElectronApp() && !isStandaloneWindow() && (
-                    <DropdownMenuItem className='gap-2' onClick={openInNewWindow}>
+                    <DropdownMenuItem
+                      className='gap-2'
+                      onClick={openInNewWindow}
+                      data-track-category='THREAD_PANEL'
+                      data-track-name='OPEN_THREAD_IN_NEW_WINDOW'
+                    >
                       <ExternalLinkSquare size={16} className='shrink-0' />
                       <span className='flex-1'>Open in new window</span>
                     </DropdownMenuItem>
                   )}
-                  <DropdownMenuItem className='gap-2' onClick={handleCopyTicketViewLink}>
+                  <DropdownMenuItem
+                    className='gap-2'
+                    onClick={handleCopyTicketViewLink}
+                    data-track-category='THREAD_PANEL'
+                    data-track-name='COPY_TICKET_LINK'
+                  >
                     <LinkSlant size={16} className='shrink-0' />
                     <span className='flex-1'>Copy ticket link</span>
                   </DropdownMenuItem>
@@ -1363,6 +1380,8 @@ export const ThreadMessages = ({
                 <Tooltip content='Close'>
                   <Button
                     onClick={resolvedOnClose ?? handleCloseTicketDetailsThread}
+                    data-track-category='THREAD_PANEL'
+                    data-track-name='CLOSE_TICKET_DETAILS_THREAD'
                     className={cn('h-7 w-7 rounded-lg', actionIconClass)}
                     variant='ghost'
                     size='sm'
@@ -1423,6 +1442,8 @@ export const ThreadMessages = ({
                         variant='ghost'
                         size='sm'
                         onClick={resolvedOnClose}
+                        data-track-category='THREAD_PANEL'
+                        data-track-name='CLOSE_THREAD_PANEL'
                         aria-label='Close thread panel'
                       >
                         <X size={20} />
@@ -1561,6 +1582,8 @@ export const ThreadMessages = ({
                         className={cn('h-7 w-7 rounded-lg shrink-0', actionIconClass)}
                         style={APP_NO_DRAG_STYLE}
                         onClick={() => void navigate(`/newWindow/chat/dir/${derivedChannelId}`)}
+                        data-track-category='THREAD_PANEL'
+                        data-track-name='BACK_TO_CHANNEL'
                         aria-label='Back to channel'
                       >
                         <ArrowLeft size={16} />
@@ -1610,6 +1633,8 @@ export const ThreadMessages = ({
                             threadInfo,
                           });
                         }}
+                        data-track-category='THREAD_PANEL'
+                        data-track-name='OPEN_XYNE_AI_FROM_THREAD'
                         className='h-7 w-7 rounded-lg'
                       >
                         <XyneAIStar />
@@ -1717,7 +1742,12 @@ export const ThreadMessages = ({
                         </DropdownMenuItem>
                       )}
                       {isElectronApp() && !isStandaloneWindow() && (
-                        <DropdownMenuItem className='gap-2' onClick={openInNewWindow}>
+                        <DropdownMenuItem
+                          className='gap-2'
+                          onClick={openInNewWindow}
+                          data-track-category='THREAD_PANEL'
+                          data-track-name='OPEN_THREAD_IN_NEW_WINDOW'
+                        >
                           <ExternalLinkSquare size={16} className='shrink-0' />
                           <span className='flex-1'>Open in new window</span>
                         </DropdownMenuItem>

--- a/apps/dashboard/src/components/Chat/UnreadsInbox/UnreadsInbox.tsx
+++ b/apps/dashboard/src/components/Chat/UnreadsInbox/UnreadsInbox.tsx
@@ -150,6 +150,8 @@ const UnreadsInbox = (): ReactElement => {
                               e.stopPropagation();
                               handleMarkAsRead(channel.id);
                             }}
+                            data-track-category='UNREADS_INBOX'
+                            data-track-name='MARK_AS_READ'
                           >
                             <Check className='w-3.5 h-3.5' />
                           </Button>

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ActivityConfigDialog.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ActivityConfigDialog.tsx
@@ -90,6 +90,8 @@ export const ActivityConfigDialog = ({
           </h2>
           <button
             onClick={onClose}
+            data-track-category='XYNE_AI_SIDEBAR'
+            data-track-name='CLOSE_ACTIVITY_CONFIG'
             className='p-1 hover:bg-accent rounded transition-colors'
             type='button'
           >
@@ -138,6 +140,8 @@ export const ActivityConfigDialog = ({
               id='blacklist'
               checked={isBlacklisted}
               onChange={e => handleBlacklistChange(e.target.checked)}
+              data-track-category='XYNE_AI_SIDEBAR'
+              data-track-name='TOGGLE_ACTIVITY_BLACKLIST'
               className='w-4 h-4 text-destructive border-border rounded focus:ring-destructive/20'
             />
             <label htmlFor='blacklist' className='flex-1 text-sm text-destructive cursor-pointer'>
@@ -210,6 +214,8 @@ export const ActivityConfigDialog = ({
         <div className='flex justify-end gap-2 px-4 py-3 border-t border-border bg-muted'>
           <button
             onClick={onClose}
+            data-track-category='XYNE_AI_SIDEBAR'
+            data-track-name='CANCEL_ACTIVITY_CONFIG'
             className='px-4 py-2 text-sm font-medium text-muted-foreground bg-background border border-border rounded-md hover:bg-muted transition-colors'
             type='button'
           >
@@ -217,6 +223,8 @@ export const ActivityConfigDialog = ({
           </button>
           <button
             onClick={handleSave}
+            data-track-category='XYNE_AI_SIDEBAR'
+            data-track-name='SAVE_ACTIVITY_CONFIG'
             className='px-4 py-2 text-sm font-medium text-action-primary-foreground bg-action-primary rounded-md hover:bg-action-primary/90 transition-colors'
             type='button'
           >

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/AliasManager.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/AliasManager.tsx
@@ -51,6 +51,8 @@ export const AliasManager = ({
           </div>
           <button
             onClick={onClose}
+            data-track-category='XYNE_AI_SIDEBAR'
+            data-track-name='CLOSE_ALIAS_MANAGER'
             className='p-1 hover:bg-accent rounded transition-colors'
             type='button'
           >
@@ -123,6 +125,8 @@ export const AliasManager = ({
                         <div className='flex items-center justify-end gap-2'>
                           <button
                             onClick={() => onEdit(alias)}
+                            data-track-category='XYNE_AI_SIDEBAR'
+                            data-track-name='EDIT_ACTIVITY_ALIAS'
                             className='p-1.5 text-muted-foreground hover:text-primary hover:bg-muted rounded transition-colors'
                             title='Edit alias'
                             type='button'
@@ -133,6 +137,8 @@ export const AliasManager = ({
                             <div className='flex items-center gap-1'>
                               <button
                                 onClick={() => handleConfirmDelete(alias.id)}
+                                data-track-category='XYNE_AI_SIDEBAR'
+                                data-track-name='CONFIRM_DELETE_ALIAS'
                                 className='px-2 py-1 text-xs font-medium text-destructive-foreground bg-destructive rounded hover:bg-destructive/90 transition-colors'
                                 type='button'
                               >
@@ -140,6 +146,8 @@ export const AliasManager = ({
                               </button>
                               <button
                                 onClick={handleCancelDelete}
+                                data-track-category='XYNE_AI_SIDEBAR'
+                                data-track-name='CANCEL_DELETE_ALIAS'
                                 className='px-2 py-1 text-xs font-medium text-muted-foreground bg-muted rounded hover:bg-accent transition-colors'
                                 type='button'
                               >
@@ -149,6 +157,8 @@ export const AliasManager = ({
                           ) : (
                             <button
                               onClick={() => handleDeleteClick(alias.id)}
+                              data-track-category='XYNE_AI_SIDEBAR'
+                              data-track-name='START_DELETE_ALIAS'
                               className='p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded transition-colors'
                               title='Delete alias'
                               type='button'
@@ -170,6 +180,8 @@ export const AliasManager = ({
         <div className='flex justify-end px-4 py-3 border-t border-border bg-muted flex-shrink-0'>
           <button
             onClick={onClose}
+            data-track-category='XYNE_AI_SIDEBAR'
+            data-track-name='CLOSE_ALIAS_MANAGER'
             className='px-4 py-2 text-sm font-medium text-muted-foreground bg-background border border-border rounded-md hover:bg-muted transition-colors'
             type='button'
           >

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/UserActivityItem.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/UserActivityItem.tsx
@@ -174,6 +174,8 @@ const getRedirection = (
       <button
         type='button'
         onClick={handleClick}
+        data-track-category='XYNE_AI_SIDEBAR'
+        data-track-name='OPEN_ACTIVITY_ITEM'
         className='flex-shrink-0 p-1 hover:bg-accent rounded transition-colors cursor-pointer'
         title={`Go to ${url}`}
       >
@@ -261,11 +263,15 @@ export const UserActivityItem = ({
       <button
         type='button'
         onClick={handleClick}
+        data-track-category='XYNE_AI_SIDEBAR'
+        data-track-name='OPEN_ACTIVITY_ITEM'
         className='w-full flex items-center gap-2 px-4 py-1 text-left'
       >
         {/* Expand/Collapse Chevron */}
         <div
           onClick={handleToggleExpand}
+          data-track-category='XYNE_AI_SIDEBAR'
+          data-track-name='TOGGLE_ACTIVITY_DETAILS'
           className='flex-shrink-0 p-1.5 hover:bg-accent rounded transition-colors cursor-pointer self-start'
           role='button'
           tabIndex={0}
@@ -314,6 +320,8 @@ export const UserActivityItem = ({
         {onConfigure && canConfigure && (
           <button
             onClick={handleConfigure}
+            data-track-category='XYNE_AI_SIDEBAR'
+            data-track-name='CONFIGURE_ACTIVITY'
             className='rounded'
             title='Configure activity'
             type='button'

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/UserActivityPanel.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/UserActivityPanel.tsx
@@ -241,6 +241,8 @@ export const UserActivityPanel = ({
         <div className='flex items-center gap-2'>
           <button
             onClick={handleClose}
+            data-track-category='XYNE_AI_SIDEBAR'
+            data-track-name='CLOSE_ACTIVITY_PANEL'
             className={
               isMobile ? mobileActionButtonClass : 'p-1 hover:bg-accent rounded transition-colors'
             }
@@ -257,6 +259,8 @@ export const UserActivityPanel = ({
           {canManageUserActivity && (
             <button
               onClick={() => setAliasManagerOpen(true)}
+              data-track-category='XYNE_AI_SIDEBAR'
+              data-track-name='OPEN_ALIAS_MANAGER'
               className='p-2 rounded-lg outline outline-1 outline-offset-[-1px] outline-border flex justify-center items-center gap-2 overflow-hidden hover:bg-accent transition-colors'
               title='Manage activity aliases'
               type='button'
@@ -267,6 +271,8 @@ export const UserActivityPanel = ({
           {!isMobile && (
             <button
               onClick={handleXyneAIClose}
+              data-track-category='XYNE_AI_SIDEBAR'
+              data-track-name='CLOSE_XYNE_AI'
               className='p-2 rounded-lg outline outline-1 outline-offset-[-1px] outline-border flex justify-center items-center gap-2.5 overflow-hidden hover:bg-accent transition-colors'
             >
               <X className='w-4 h-4 text-muted-foreground' />
@@ -334,6 +340,8 @@ export const UserActivityPanel = ({
         <div className='p-4 border-t border-border flex-shrink-0'>
           <button
             onClick={handleAddToChat}
+            data-track-category='XYNE_AI_SIDEBAR'
+            data-track-name='ADD_ACTIVITY_TO_CHAT'
             className='w-full py-2.5 px-4 bg-action-primary hover:bg-action-primary/90 text-action-primary-foreground text-sm font-medium rounded-lg transition-colors'
           >
             Add {selectedCount} {selectedCount === 1 ? 'activity' : 'activities'} to chat

--- a/apps/dashboard/src/components/ClawAgents/ClawAgentDetailHeader.tsx
+++ b/apps/dashboard/src/components/ClawAgents/ClawAgentDetailHeader.tsx
@@ -110,6 +110,8 @@ export const ClawAgentDetailHeader = ({
             size='sm'
             loading={moderating !== null}
             onClick={() => onModerate(isGlobal ? 'demote' : 'promote')}
+            data-track-category='Claw Agents'
+            data-track-name='MODERATE_AGENT'
           >
             {!moderating &&
               (isGlobal ? <ArrowDown className='size-4' /> : <ArrowUp className='size-4' />)}
@@ -131,13 +133,23 @@ export const ClawAgentDetailHeader = ({
             size='sm'
             loading={publishing}
             onClick={onPublish}
+            data-track-category='Claw Agents'
+            data-track-name='PUBLISH_AGENT'
           >
             {!publishing && <Globe className='size-4' />}
             <span className='hidden sm:inline'>{publishing ? 'Publishing…' : 'Publish'}</span>
           </Button>
         )}
 
-        <Button type='button' variant='outline' size='sm' loading={cloning} onClick={onClone}>
+        <Button
+          type='button'
+          variant='outline'
+          size='sm'
+          loading={cloning}
+          onClick={onClone}
+          data-track-category='Claw Agents'
+          data-track-name='CLONE_AGENT'
+        >
           {!cloning && <Copy className='size-4' />}
           <span className='hidden sm:inline'>
             {permissions.canEdit ? 'Clone' : 'Request clone'}
@@ -151,6 +163,8 @@ export const ClawAgentDetailHeader = ({
             loading={saving}
             disabled={!dirty}
             onClick={onSave}
+            data-track-category='Claw Agents'
+            data-track-name='SAVE_AGENT'
             title={dirty ? 'Save changes' : 'Nothing to save'}
           >
             {!saving && <Save className='size-4' />}
@@ -179,6 +193,8 @@ export const ClawAgentDetailHeader = ({
               variant='ghost'
               size='iconSm'
               onClick={onDelete}
+              data-track-category='Claw Agents'
+              data-track-name='DELETE_AGENT'
               aria-label='Delete agent'
               className='text-muted-foreground hover:text-destructive'
             >

--- a/apps/dashboard/src/components/ClawAgents/CloneAgentDialog.tsx
+++ b/apps/dashboard/src/components/ClawAgents/CloneAgentDialog.tsx
@@ -69,6 +69,8 @@ export const CloneAgentDialog = ({
             variant='outline'
             size='sm'
             onClick={() => onOpenChange(false)}
+            data-track-category='Claw Agents'
+            data-track-name='CANCEL_CLONE_AGENT'
             disabled={submitting}
           >
             Cancel

--- a/apps/dashboard/src/components/ClawAgents/ConfirmDialog.tsx
+++ b/apps/dashboard/src/components/ClawAgents/ConfirmDialog.tsx
@@ -43,6 +43,8 @@ export const ConfirmDialog = ({
           variant='outline'
           size='sm'
           onClick={() => onOpenChange(false)}
+          data-track-category='Claw Agents'
+          data-track-name='CANCEL_CONFIRM_DIALOG'
           disabled={loading}
         >
           {cancelLabel}
@@ -53,6 +55,8 @@ export const ConfirmDialog = ({
           size='sm'
           loading={loading}
           onClick={onConfirm}
+          data-track-category='Claw Agents'
+          data-track-name='CONFIRM_DIALOG_ACTION'
         >
           {confirmLabel}
         </Button>

--- a/apps/dashboard/src/components/ClawAgents/PromptVersionHistory.tsx
+++ b/apps/dashboard/src/components/ClawAgents/PromptVersionHistory.tsx
@@ -82,6 +82,8 @@ export const PromptVersionHistory = ({
                           loading={activate.isPending && activate.variables === version.version}
                           disabled={activate.isPending}
                           onClick={() => void restore(version.version)}
+                          data-track-category='Claw Agents'
+                          data-track-name='RESTORE_PROMPT_VERSION'
                           className='ml-auto'
                         >
                           <RotateCcw className='size-3.5' /> Activate

--- a/apps/dashboard/src/components/ClawAgents/RenameHandleDialog.tsx
+++ b/apps/dashboard/src/components/ClawAgents/RenameHandleDialog.tsx
@@ -105,6 +105,8 @@ export const RenameHandleDialog = ({
             variant='outline'
             size='sm'
             onClick={() => onOpenChange(false)}
+            data-track-category='Claw Agents'
+            data-track-name='CANCEL_RENAME_HANDLE'
             disabled={submitting}
           >
             Cancel

--- a/apps/dashboard/src/components/ClawAgents/digitalTwin/DigitalTwinEnablePanel.tsx
+++ b/apps/dashboard/src/components/ClawAgents/digitalTwin/DigitalTwinEnablePanel.tsx
@@ -209,7 +209,12 @@ export const DigitalTwinEnablePanel = (): ReactElement => {
 
           {/* CTA */}
           <div className='mt-6 flex flex-wrap items-center gap-x-4 gap-y-2'>
-            <Button onClick={submit} loading={enableMutation.isPending}>
+            <Button
+              onClick={submit}
+              data-track-category='Claw Agents'
+              data-track-name='ENABLE_DIGITAL_TWIN'
+              loading={enableMutation.isPending}
+            >
               {enableMutation.isPending ? 'Enabling…' : 'Enable & start'}
               {!enableMutation.isPending && <ArrowRight className='size-4' />}
             </Button>

--- a/apps/dashboard/src/components/ClawAgents/digitalTwin/DisableModal.tsx
+++ b/apps/dashboard/src/components/ClawAgents/digitalTwin/DisableModal.tsx
@@ -25,13 +25,22 @@ export const DisableModal = ({
       description='Disabling stops the Twin from responding to mentions and pauses the nightly curator. Your approved memories and candidates remain unless you choose to delete them.'
       footer={
         <>
-          <Button variant='ghost' size='sm' onClick={onClose} disabled={disableMutation.isPending}>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={onClose}
+            data-track-category='Claw Agents'
+            data-track-name='CANCEL_DISABLE_DIGITAL_TWIN'
+            disabled={disableMutation.isPending}
+          >
             Cancel
           </Button>
           <Button
             variant='destructive'
             size='sm'
             onClick={submit}
+            data-track-category='Claw Agents'
+            data-track-name='DISABLE_DIGITAL_TWIN'
             loading={disableMutation.isPending}
           >
             Disable

--- a/apps/dashboard/src/components/ClawAgents/digitalTwin/EnableModal.tsx
+++ b/apps/dashboard/src/components/ClawAgents/digitalTwin/EnableModal.tsx
@@ -51,10 +51,23 @@ export const EnableModal = ({
       title={mode === 'enable' ? 'Enable Digital Twin' : 'Backfill history'}
       footer={
         <>
-          <Button variant='ghost' size='sm' onClick={onClose} disabled={enabling}>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={onClose}
+            data-track-category='Claw Agents'
+            data-track-name='CANCEL_ENABLE_DIGITAL_TWIN'
+            disabled={enabling}
+          >
             Cancel
           </Button>
-          <Button size='sm' onClick={submit} loading={enabling}>
+          <Button
+            size='sm'
+            onClick={submit}
+            data-track-category='Claw Agents'
+            data-track-name='ENABLE_DIGITAL_TWIN'
+            loading={enabling}
+          >
             {ctaLabel}
             {!enabling && <ArrowRight className='size-3.5' />}
           </Button>

--- a/apps/dashboard/src/components/ClawAgents/digitalTwin/UploadModal.tsx
+++ b/apps/dashboard/src/components/ClawAgents/digitalTwin/UploadModal.tsx
@@ -84,12 +84,21 @@ export const UploadModal = ({
       description='Attach a markdown file (e.g. an “about me”, working preferences, project context). The curator extracts candidate memories and adds them under the Documents cluster for your review.'
       footer={
         <>
-          <Button variant='ghost' size='sm' onClick={close} disabled={uploadMutation.isPending}>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={close}
+            data-track-category='Claw Agents'
+            data-track-name='CANCEL_DIGITAL_TWIN_UPLOAD'
+            disabled={uploadMutation.isPending}
+          >
             Cancel
           </Button>
           <Button
             size='sm'
             onClick={submit}
+            data-track-category='Claw Agents'
+            data-track-name='UPLOAD_DIGITAL_TWIN_FILE'
             loading={uploadMutation.isPending}
             disabled={!filename || !content.trim()}
           >

--- a/apps/dashboard/src/components/ClawAgents/metrics/ImprovementsCard.tsx
+++ b/apps/dashboard/src/components/ClawAgents/metrics/ImprovementsCard.tsx
@@ -62,10 +62,26 @@ const ImprovementRow = ({
         Marking handled records a manual change; it does not edit the agent.
       </p>
       <div className='flex shrink-0 gap-2'>
-        <Button type='button' variant='outline' size='sm' disabled={busy} onClick={onDismiss}>
+        <Button
+          type='button'
+          variant='outline'
+          size='sm'
+          disabled={busy}
+          onClick={onDismiss}
+          data-track-category='Claw Agents'
+          data-track-name='DISMISS_IMPROVEMENT'
+        >
           Dismiss
         </Button>
-        <Button type='button' size='sm' loading={busy} disabled={busy} onClick={onApply}>
+        <Button
+          type='button'
+          size='sm'
+          loading={busy}
+          disabled={busy}
+          onClick={onApply}
+          data-track-category='Claw Agents'
+          data-track-name='APPLY_IMPROVEMENT'
+        >
           Mark as handled
         </Button>
       </div>

--- a/apps/dashboard/src/components/DynamicDashboard/ComponentGrid/ComponentTile.tsx
+++ b/apps/dashboard/src/components/DynamicDashboard/ComponentGrid/ComponentTile.tsx
@@ -255,7 +255,12 @@ const ComponentTile = ({
                 <Copy size={14} className='mr-2' />
                 Duplicate
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setDeleteOpen(true)} className='text-rose-600'>
+              <DropdownMenuItem
+                onClick={() => setDeleteOpen(true)}
+                data-track-category='DYNAMIC_DASHBOARD'
+                data-track-name='OPEN_DELETE_COMPONENT_CONFIRM'
+                className='text-rose-600'
+              >
                 <Trash2 size={14} className='mr-2' />
                 Delete
               </DropdownMenuItem>

--- a/apps/dashboard/src/components/DynamicDashboard/CreateDashboardModal.tsx
+++ b/apps/dashboard/src/components/DynamicDashboard/CreateDashboardModal.tsx
@@ -160,10 +160,20 @@ export const CreateDashboardModal = ({ onClose }: CreateDashboardModalProps): Re
         </div>
       </div>
       <div className='flex items-center justify-end gap-2 mt-5'>
-        <Button variant='ghost' onClick={onClose}>
+        <Button
+          variant='ghost'
+          onClick={onClose}
+          data-track-category='DYNAMIC_DASHBOARD'
+          data-track-name='CANCEL_CREATE_DASHBOARD'
+        >
           Cancel
         </Button>
-        <Button onClick={handleCreateClick} disabled={!name.trim() || isCreating}>
+        <Button
+          onClick={handleCreateClick}
+          data-track-category='DYNAMIC_DASHBOARD'
+          data-track-name='CREATE_DASHBOARD'
+          disabled={!name.trim() || isCreating}
+        >
           {isCreating ? (
             <Loader2 size={14} className='mr-1.5 animate-spin' />
           ) : (

--- a/apps/dashboard/src/components/DynamicDashboard/DashboardVariablesBar.tsx
+++ b/apps/dashboard/src/components/DynamicDashboard/DashboardVariablesBar.tsx
@@ -395,10 +395,21 @@ const VariableEditor = ({
         auto-upgrade <code>equals</code> filters to <code>in</code>.
       </p>
       <div className='flex justify-end gap-2 pt-1'>
-        <Button variant='ghost' onClick={onCancel}>
+        <Button
+          variant='ghost'
+          onClick={onCancel}
+          data-track-category='DYNAMIC_DASHBOARD'
+          data-track-name='CANCEL_DASHBOARD_VARIABLES'
+        >
           Cancel
         </Button>
-        <Button onClick={handleSave}>{initial ? 'Save changes' : 'Create variable'}</Button>
+        <Button
+          onClick={handleSave}
+          data-track-category='DYNAMIC_DASHBOARD'
+          data-track-name='SAVE_DASHBOARD_VARIABLES'
+        >
+          {initial ? 'Save changes' : 'Create variable'}
+        </Button>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/DynamicDashboard/ai/ClearChatConfirmOverlay.tsx
+++ b/apps/dashboard/src/components/DynamicDashboard/ai/ClearChatConfirmOverlay.tsx
@@ -34,10 +34,20 @@ export const ClearChatConfirmOverlay = ({
         </div>
       </div>
       <div className='flex items-center justify-end gap-2 mt-5'>
-        <Button variant='secondary' onClick={onCancel}>
+        <Button
+          variant='secondary'
+          onClick={onCancel}
+          data-track-category='DYNAMIC_DASHBOARD'
+          data-track-name='CANCEL_CLEAR_AI_CHAT'
+        >
           Cancel
         </Button>
-        <Button variant='destructive' onClick={onConfirm}>
+        <Button
+          variant='destructive'
+          onClick={onConfirm}
+          data-track-category='DYNAMIC_DASHBOARD'
+          data-track-name='CONFIRM_CLEAR_AI_CHAT'
+        >
           Clear history
         </Button>
       </div>

--- a/apps/dashboard/src/components/DynamicDashboard/componentEditor/ResetDraftsConfirmOverlay.tsx
+++ b/apps/dashboard/src/components/DynamicDashboard/componentEditor/ResetDraftsConfirmOverlay.tsx
@@ -44,10 +44,21 @@ export const ResetDraftsConfirmOverlay = ({
           </div>
         </div>
         <div className='flex items-center justify-end gap-2 mt-5'>
-          <Button variant='secondary' onClick={onCancel}>
+          <Button
+            variant='secondary'
+            onClick={onCancel}
+            data-track-category='COMPONENT_EDITOR'
+            data-track-name='CANCEL_RESET_DRAFTS'
+          >
             Cancel
           </Button>
-          <Button onClick={onConfirm}>Reset &amp; continue</Button>
+          <Button
+            onClick={onConfirm}
+            data-track-category='COMPONENT_EDITOR'
+            data-track-name='CONFIRM_RESET_DRAFTS'
+          >
+            Reset &amp; continue
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/components/FileViewer/CitationPdfViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/CitationPdfViewer.tsx
@@ -309,6 +309,8 @@ export const CitationPdfViewer: React.FC<CitationPdfViewerProps> = ({
               {/* eslint-disable local-rules/require-tracking-on-click */}
               <button
                 onClick={() => goToPage(currentVisiblePage - 1)}
+                data-track-category='FILE_VIEWER'
+                data-track-name='PDF_PREV_PAGE'
                 disabled={currentVisiblePage <= 1}
                 className='flex items-center gap-1 px-3 py-1 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white disabled:text-gray-400 dark:disabled:text-gray-600 disabled:cursor-not-allowed transition-colors'
               >
@@ -347,6 +349,8 @@ export const CitationPdfViewer: React.FC<CitationPdfViewerProps> = ({
 
               <button
                 onClick={() => goToPage(currentVisiblePage + 1)}
+                data-track-category='FILE_VIEWER'
+                data-track-name='PDF_NEXT_PAGE'
                 disabled={currentVisiblePage >= numPages}
                 className='flex items-center gap-1 px-3 py-1 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white disabled:text-gray-400 dark:disabled:text-gray-600 disabled:cursor-not-allowed transition-colors'
               >

--- a/apps/dashboard/src/components/Project/ProjectCard/ProjectCard.tsx
+++ b/apps/dashboard/src/components/Project/ProjectCard/ProjectCard.tsx
@@ -94,6 +94,8 @@ export const ProjectCard = ({
               size='iconSm'
               className='h-5 w-5 p-0 text-muted-foreground hover:text-foreground'
               onClick={handleCopyId}
+              data-track-category='Projects'
+              data-track-name='COPY_PROJECT_ID'
               title='Copy project ID'
             >
               {copied ? <Check size={12} /> : <Copy size={12} />}

--- a/apps/dashboard/src/components/Project/ProjectSidebar/ViewsSidebarSection.tsx
+++ b/apps/dashboard/src/components/Project/ProjectSidebar/ViewsSidebarSection.tsx
@@ -357,10 +357,22 @@ const ViewsSidebarSection = (): ReactElement => {
             )}
           />
           <div className='flex justify-end gap-2'>
-            <Button variant='ghost' size='sm' onClick={() => setRenameTarget(null)}>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => setRenameTarget(null)}
+              data-track-category='Projects'
+              data-track-name='CANCEL_RENAME_VIEW'
+            >
               Cancel
             </Button>
-            <Button size='sm' onClick={() => void submitRename()} disabled={!renameDraft.trim()}>
+            <Button
+              size='sm'
+              onClick={() => void submitRename()}
+              data-track-category='Projects'
+              data-track-name='CONFIRM_RENAME_VIEW'
+              disabled={!renameDraft.trim()}
+            >
               Save
             </Button>
           </div>
@@ -389,10 +401,22 @@ const ViewsSidebarSection = (): ReactElement => {
             </div>
           </div>
           <div className='flex justify-end gap-2'>
-            <Button variant='ghost' size='sm' onClick={() => setDeleteTarget(null)}>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => setDeleteTarget(null)}
+              data-track-category='Projects'
+              data-track-name='CANCEL_DELETE_VIEW'
+            >
               Cancel
             </Button>
-            <Button variant='destructive' size='sm' onClick={() => void confirmDelete()}>
+            <Button
+              variant='destructive'
+              size='sm'
+              onClick={() => void confirmDelete()}
+              data-track-category='Projects'
+              data-track-name='CONFIRM_DELETE_VIEW'
+            >
               Delete
             </Button>
           </div>

--- a/apps/dashboard/src/components/QueryBuilderComponents/FilterRuleBuilder.tsx
+++ b/apps/dashboard/src/components/QueryBuilderComponents/FilterRuleBuilder.tsx
@@ -971,6 +971,8 @@ export const FilterRuleBuilder: React.FC<FilterRuleBuilderProps> = ({
           variant='ghost'
           size='iconSm'
           onClick={() => removeCondition(condition.id)}
+          data-track-category='QueryBuilder'
+          data-track-name='REMOVE_FILTER_CONDITION'
           className='text-red-600 hover:bg-red-50'
         >
           <X className='w-4 h-4' />
@@ -1017,7 +1019,14 @@ export const FilterRuleBuilder: React.FC<FilterRuleBuilderProps> = ({
       </div>
 
       {/* Add condition button */}
-      <Button variant='outline' size='sm' onClick={addCondition} className='w-full'>
+      <Button
+        variant='outline'
+        size='sm'
+        onClick={addCondition}
+        data-track-category='QueryBuilder'
+        data-track-name='ADD_FILTER_CONDITION'
+        className='w-full'
+      >
         <Plus className='w-4 h-4 mr-2' />
         Add Condition
       </Button>

--- a/apps/dashboard/src/components/Release/ChangeCards.tsx
+++ b/apps/dashboard/src/components/Release/ChangeCards.tsx
@@ -187,6 +187,8 @@ const ChangeCard = ({
       <button
         type='button'
         onClick={() => setOpen(prev => !prev)}
+        data-track-category='Release'
+        data-track-name='TOGGLE_CHANGE_CARD'
         className='w-full flex items-center gap-2 px-4 py-3 hover:bg-muted/40 transition-colors text-left'
       >
         <span className='text-xs text-muted-foreground w-3 shrink-0'>{open ? '▼' : '▶'}</span>

--- a/apps/dashboard/src/components/Release/QAOwnerPicker.tsx
+++ b/apps/dashboard/src/components/Release/QAOwnerPicker.tsx
@@ -87,6 +87,8 @@ export const QAOwnerPicker = ({
             type='button'
             className='w-full rounded-sm px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted'
             onClick={() => handleSelect(null)}
+            data-track-category='Release'
+            data-track-name='CLEAR_QA_OWNER'
           >
             Clear
           </button>
@@ -100,6 +102,8 @@ export const QAOwnerPicker = ({
               u.id === testedBy && 'font-semibold',
             )}
             onClick={() => handleSelect(u.id)}
+            data-track-category='Release'
+            data-track-name='SELECT_QA_OWNER'
           >
             {u.name ?? u.email}
           </button>

--- a/apps/dashboard/src/components/Release/ReleaseConfigWizard/ReleaseConfigWizard.tsx
+++ b/apps/dashboard/src/components/Release/ReleaseConfigWizard/ReleaseConfigWizard.tsx
@@ -107,6 +107,8 @@ const SelectionCard = ({
   <button
     type='button'
     onClick={onClick}
+    data-track-category='Release'
+    data-track-name='WIZARD_STEP_CLICK'
     disabled={isDisabled}
     aria-disabled={isDisabled}
     className={cn(
@@ -331,6 +333,8 @@ const ApplicationRow = ({
         <button
           type='button'
           onClick={() => onRemove(app.id)}
+          data-track-category='Release'
+          data-track-name='REMOVE_WIZARD_APP'
           className='text-muted-foreground hover:text-destructive transition-colors p-1 rounded hover:bg-destructive/10'
           aria-label={isLocked ? 'Delete on save' : 'Remove'}
           title={isLocked ? 'This application will be deleted on Save' : 'Remove'}
@@ -557,7 +561,14 @@ const Step3Applications = ({
       </div>
 
       {allowApplicationListChanges && (
-        <Button variant='secondary' onClick={onAddApplication} className='w-full' size='sm'>
+        <Button
+          variant='secondary'
+          onClick={onAddApplication}
+          data-track-category='Release'
+          data-track-name='ADD_APPLICATION'
+          className='w-full'
+          size='sm'
+        >
           + Add Another Application
         </Button>
       )}
@@ -775,6 +786,8 @@ const ReleaseConfigWizardForm = ({
           <Button
             variant='secondary'
             onClick={showCancelOnLeft ? onClose : form.handleBack}
+            data-track-category='Release'
+            data-track-name='WIZARD_BACK_OR_CANCEL'
             disabled={form.isSaving}
           >
             {showCancelOnLeft ? (
@@ -787,13 +800,21 @@ const ReleaseConfigWizardForm = ({
           </Button>
 
           {form.currentStep < 2 ? (
-            <Button variant='default' onClick={form.handleNext} disabled={!canProceed}>
+            <Button
+              variant='default'
+              onClick={form.handleNext}
+              data-track-category='Release'
+              data-track-name='WIZARD_NEXT'
+              disabled={!canProceed}
+            >
               Next <ChevronRight size={16} />
             </Button>
           ) : (
             <Button
               variant='default'
               onClick={() => void form.handleSave()}
+              data-track-category='Release'
+              data-track-name='SAVE_RELEASE_CONFIG'
               disabled={!canSave || form.isSaving}
             >
               {form.isSaving

--- a/apps/dashboard/src/components/ResourceAccess/ResourceAccessModal/ResourceAccessModal.tsx
+++ b/apps/dashboard/src/components/ResourceAccess/ResourceAccessModal/ResourceAccessModal.tsx
@@ -425,6 +425,8 @@ export const ResourceAccessModal = ({
                               onClick={() =>
                                 handleAccessChange(resource.id, option.value as AccessType | 'NONE')
                               }
+                              data-track-category='RESOURCE_ACCESS'
+                              data-track-name='SET_RESOURCE_ACCESS'
                               className='text-xs'
                             >
                               <span className='flex-1'>{option.label}</span>
@@ -451,10 +453,21 @@ export const ResourceAccessModal = ({
 
         {/* Footer */}
         <div className='border-t border-border p-6 flex gap-3 justify-end bg-background'>
-          <Button variant='outline' onClick={onClose} disabled={loading}>
+          <Button
+            variant='outline'
+            onClick={onClose}
+            data-track-category='RESOURCE_ACCESS'
+            data-track-name='CANCEL_RESOURCE_ACCESS'
+            disabled={loading}
+          >
             Cancel
           </Button>
-          <Button onClick={() => void handleSave()} disabled={loading}>
+          <Button
+            onClick={() => void handleSave()}
+            data-track-category='RESOURCE_ACCESS'
+            data-track-name='SAVE_RESOURCE_ACCESS'
+            disabled={loading}
+          >
             {loading ? 'Saving...' : 'Save Changes'}
           </Button>
         </div>
@@ -471,12 +484,20 @@ export const ResourceAccessModal = ({
                 {pendingAction === 'deactivate' && ' They will lose access to the workspace.'}
               </p>
               <div className='flex gap-3 justify-end'>
-                <Button variant='outline' onClick={handleCancelAction} disabled={activationLoading}>
+                <Button
+                  variant='outline'
+                  onClick={handleCancelAction}
+                  data-track-category='USER_ACTIVATION'
+                  data-track-name='CANCEL_ACTIVATION_ACTION'
+                  disabled={activationLoading}
+                >
                   Cancel
                 </Button>
                 <Button
                   variant={pendingAction === 'activate' ? 'default' : 'destructive'}
                   onClick={() => void handleConfirmAction()}
+                  data-track-category='USER_ACTIVATION'
+                  data-track-name='CONFIRM_ACTIVATION_ACTION'
                   disabled={activationLoading}
                 >
                   {activationLoading

--- a/apps/dashboard/src/components/ResourceAccess/UserListView/UserListView.tsx
+++ b/apps/dashboard/src/components/ResourceAccess/UserListView/UserListView.tsx
@@ -84,7 +84,13 @@ const UserRow = ({
 
       {/* Actions Column */}
       <div className='w-32 flex justify-end'>
-        <Button variant='secondary' size='sm' onClick={handleEditClick}>
+        <Button
+          variant='secondary'
+          size='sm'
+          onClick={handleEditClick}
+          data-track-category='RESOURCE_ACCESS'
+          data-track-name='EDIT_USER_ACCESS'
+        >
           Edit
         </Button>
       </div>
@@ -163,6 +169,8 @@ export const UserListView = ({ users, onEditResource }: UserListViewProps): Reac
               variant='ghost'
               size='sm'
               onClick={handlePrevPage}
+              data-track-category='RESOURCE_ACCESS'
+              data-track-name='USER_LIST_PREV_PAGE'
               disabled={currentPage === 1}
               className='h-8 w-8 p-0'
             >
@@ -175,6 +183,8 @@ export const UserListView = ({ users, onEditResource }: UserListViewProps): Reac
               variant='ghost'
               size='sm'
               onClick={handleNextPage}
+              data-track-category='RESOURCE_ACCESS'
+              data-track-name='USER_LIST_NEXT_PAGE'
               disabled={currentPage === totalPages}
               className='h-8 w-8 p-0'
             >

--- a/apps/dashboard/src/components/Roles/RoleDetailHeader.tsx
+++ b/apps/dashboard/src/components/Roles/RoleDetailHeader.tsx
@@ -83,10 +83,24 @@ const RoleDetailHeader = ({
           className='h-8 min-w-0 flex-1 text-sm'
         />
         <div className='flex shrink-0 items-center gap-1.5'>
-          <Button size='sm' onClick={onSaveEdit} disabled={!canSaveEdit} loading={saving}>
+          <Button
+            size='sm'
+            onClick={onSaveEdit}
+            data-track-category='ROLES'
+            data-track-name='SAVE_ROLE_EDIT'
+            disabled={!canSaveEdit}
+            loading={saving}
+          >
             <Check size={14} /> Save
           </Button>
-          <Button size='sm' variant='outline' onClick={onCancelEdit} disabled={saving}>
+          <Button
+            size='sm'
+            variant='outline'
+            onClick={onCancelEdit}
+            data-track-category='ROLES'
+            data-track-name='CANCEL_ROLE_EDIT'
+            disabled={saving}
+          >
             <X size={14} /> Cancel
           </Button>
         </div>

--- a/apps/dashboard/src/components/ScheduledMessage/ScheduledMessageFilters.tsx
+++ b/apps/dashboard/src/components/ScheduledMessage/ScheduledMessageFilters.tsx
@@ -79,6 +79,8 @@ export const ScheduledMessageFilters = ({
         {hasActiveFilters && (
           <Button
             onClick={() => onFiltersChange({ channelIds: [], createdByIds: [] })}
+            data-track-category='scheduled-message'
+            data-track-name='CLEAR_SCHEDULED_MESSAGE_FILTERS'
             variant='ghost'
             size='sm'
             className='ml-auto flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground'

--- a/apps/dashboard/src/components/ScheduledMessage/ScheduledMessageModal.tsx
+++ b/apps/dashboard/src/components/ScheduledMessage/ScheduledMessageModal.tsx
@@ -542,13 +542,23 @@ const ScheduledMessageModal = ({
           <div className='flex justify-between pt-4'>
             <div>
               {isEditMode && canEdit && (
-                <Button type='button' onClick={() => void handleDelete()}>
+                <Button
+                  type='button'
+                  onClick={() => void handleDelete()}
+                  data-track-category='scheduled-message'
+                  data-track-name='DELETE_SCHEDULED_MESSAGE'
+                >
                   Delete
                 </Button>
               )}
             </div>
             <div className='flex gap-2'>
-              <Button type='button' onClick={() => onOpenChange(false)}>
+              <Button
+                type='button'
+                onClick={() => onOpenChange(false)}
+                data-track-category='scheduled-message'
+                data-track-name='CLOSE_SCHEDULED_MESSAGE_MODAL'
+              >
                 Cancel
               </Button>
               <Button type='submit' disabled={(!canEdit && isEditMode) || isSubmitting}>

--- a/apps/dashboard/src/components/Settings/Views/ProfileView.tsx
+++ b/apps/dashboard/src/components/Settings/Views/ProfileView.tsx
@@ -348,6 +348,8 @@ const ProfileView = ({
                 variant='ghost'
                 size='lg'
                 onClick={handleClearStatus}
+                data-track-category='PROFILE'
+                data-track-name='CLEAR_STATUS'
                 className='flex-shrink-0 p-1 h-auto hover:bg-accent min-w-[20px]'
                 title='Clear status'
               >

--- a/apps/dashboard/src/components/Settings/Views/SetStatusView.tsx
+++ b/apps/dashboard/src/components/Settings/Views/SetStatusView.tsx
@@ -139,6 +139,8 @@ export const StatusSuggestionsView: React.FC<StatusViewProps> = ({ setView }) =>
           variant='ghost'
           size='sm'
           onClick={() => setView('default')}
+          data-track-category='STATUS'
+          data-track-name='BACK_TO_STATUS_DEFAULT'
           className='size-7 p-0 text-muted-foreground hover:text-foreground rounded-lg border border-border hover:bg-muted'
         >
           <ChevronLeft className='size-4' />
@@ -419,6 +421,8 @@ export const StatusEditView: React.FC<StatusEditViewProps> = ({ setView, initial
           variant='ghost'
           size='sm'
           onClick={() => setView('default')}
+          data-track-category='STATUS'
+          data-track-name='BACK_TO_STATUS_DEFAULT'
           className='size-7 p-0 text-muted-foreground hover:text-foreground rounded-lg border border-border hover:bg-muted'
         >
           <X className='size-4' />
@@ -561,6 +565,8 @@ export const StatusEditView: React.FC<StatusEditViewProps> = ({ setView, initial
         <Button
           variant='ghost'
           onClick={() => setView('default')}
+          data-track-category='STATUS'
+          data-track-name='CANCEL_SET_STATUS'
           className='text-foreground hover:bg-muted'
         >
           Cancel
@@ -569,6 +575,8 @@ export const StatusEditView: React.FC<StatusEditViewProps> = ({ setView, initial
           onClick={() => {
             void handleSave();
           }}
+          data-track-category='STATUS'
+          data-track-name='SAVE_STATUS'
           disabled={!selectedEmoji && !statusText.trim()}
           className='ml-auto px-6 text-white disabled:opacity-50 disabled:cursor-not-allowed'
           style={{ backgroundColor: '#6276BE' }}

--- a/apps/dashboard/src/components/Settings/VoiceSignatureModal/VoiceSignatureModal.tsx
+++ b/apps/dashboard/src/components/Settings/VoiceSignatureModal/VoiceSignatureModal.tsx
@@ -421,7 +421,13 @@ export const VoiceSignatureModal: React.FC<VoiceSignatureModalProps> = ({
 
           {/* Footer */}
           <div className='flex justify-end border-t border-border px-5 py-3.5'>
-            <Button variant='outline' size='sm' onClick={handleClose}>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={handleClose}
+              data-track-category='voice-signature'
+              data-track-name='CLOSE_VOICE_SIGNATURE_MODAL'
+            >
               {isProcessing ? 'Processing…' : 'Done'}
             </Button>
           </div>

--- a/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
+++ b/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
@@ -2400,6 +2400,8 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
                     variant='ghost'
                     size='icon'
                     onClick={resetDuplicateState}
+                    data-track-category='TICKETS'
+                    data-track-name='RESET_DUPLICATE_STATE'
                     className='size-6 '
                   >
                     <X strokeWidth={2.33} className='size-3.5' />

--- a/apps/dashboard/src/components/Tickets/RCAPanelView/RCAPanelView.tsx
+++ b/apps/dashboard/src/components/Tickets/RCAPanelView/RCAPanelView.tsx
@@ -376,10 +376,21 @@ export const RCAPanelView = ({ ticketId }: RCAPanelViewProps): React.ReactElemen
           <h3 className='text-lg font-semibold text-foreground'>Unsaved changes</h3>
           <p className='mt-2 text-sm text-muted-foreground'>{confirmDialog.message}</p>
           <div className='mt-6 flex justify-end gap-2'>
-            <Button type='button' variant='outline' onClick={() => closeConfirmDialog(false)}>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => closeConfirmDialog(false)}
+              data-track-category='RCA'
+              data-track-name='CANCEL_RCA_CONFIRM'
+            >
               Skip Save
             </Button>
-            <Button type='button' onClick={() => closeConfirmDialog(true)}>
+            <Button
+              type='button'
+              onClick={() => closeConfirmDialog(true)}
+              data-track-category='RCA'
+              data-track-name='CONFIRM_RCA_ACTION'
+            >
               Save and Continue
             </Button>
           </div>

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -3061,6 +3061,9 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                 variant='ghost'
                 size='sm'
                 onClick={handleCopyTicketViewLink}
+                data-track-category='Tickets'
+                data-track-name='COPY_TICKET_LINK'
+                data-track-metadata={JSON.stringify({ ticketId: ticket?.id })}
                 aria-label='Copy Ticket'
               >
                 <LinkIcon size={20} />
@@ -3076,6 +3079,12 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                     `${baseRoute}/${ticket.channelId}/${ticket.conversationId}#thread-summary`,
                   );
                 }}
+                data-track-category='Tickets'
+                data-track-name='SUMMARIZE_THREAD'
+                data-track-metadata={JSON.stringify({
+                  ticketId: ticket?.id,
+                  channelId: ticket?.channelId,
+                })}
                 title='Summarize thread'
               >
                 <Sparkles size={20} />
@@ -3087,6 +3096,9 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                 variant='ghost'
                 size='sm'
                 onClick={() => setShowArchiveConfirmDialog(true)}
+                data-track-category='Tickets'
+                data-track-name='OPEN_ARCHIVE_TICKET_CONFIRM'
+                data-track-metadata={JSON.stringify({ ticketId: ticket?.id })}
                 disabled={ticket?.isArchived}
                 aria-label='Archive Ticket'
               >
@@ -3099,6 +3111,9 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                 variant='ghost'
                 size='sm'
                 onClick={handleMinimizeExpandedView}
+                data-track-category='Tickets'
+                data-track-name='MINIMIZE_EXPANDED_VIEW'
+                data-track-metadata={JSON.stringify({ ticketId: ticket?.id })}
                 aria-label='Copy Ticket'
               >
                 <Minimize2 size={20} />
@@ -4866,11 +4881,18 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
             </p>
 
             <div className='flex justify-end gap-3'>
-              <Button variant='secondary' onClick={() => setShowArchiveConfirmDialog(false)}>
+              <Button
+                variant='secondary'
+                onClick={() => setShowArchiveConfirmDialog(false)}
+                data-track-category='Tickets'
+                data-track-name='CANCEL_ARCHIVE_TICKET'
+              >
                 Cancel
               </Button>
               <Button
                 onClick={handleArchiveTicket}
+                data-track-category='Tickets'
+                data-track-name='CONFIRM_ARCHIVE_TICKET'
                 className='bg-destructive text-destructive-foreground hover:bg-destructive/90'
               >
                 Archive Ticket
@@ -4941,11 +4963,18 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
             </p>
 
             <div className='flex justify-end gap-3'>
-              <Button variant='secondary' onClick={() => setShowBoardChangeConfirmDialog(false)}>
+              <Button
+                variant='secondary'
+                onClick={() => setShowBoardChangeConfirmDialog(false)}
+                data-track-category='Tickets'
+                data-track-name='CANCEL_BOARD_CHANGE'
+              >
                 Cancel
               </Button>
               <Button
                 onClick={confirmBoardChange}
+                data-track-category='Tickets'
+                data-track-name='CONFIRM_BOARD_CHANGE'
                 className='bg-primary text-primary-foreground hover:opacity-90'
               >
                 Confirm

--- a/apps/dashboard/src/components/UserGroup/AssignmentConfigScreen/AssignmentConfigScreen.tsx
+++ b/apps/dashboard/src/components/UserGroup/AssignmentConfigScreen/AssignmentConfigScreen.tsx
@@ -1072,7 +1072,12 @@ export const AssignmentConfigScreen = ({
                       </Select>
                     </div>
 
-                    <Button variant='outline' onClick={() => setIsRotationModalOpen(true)}>
+                    <Button
+                      variant='outline'
+                      onClick={() => setIsRotationModalOpen(true)}
+                      data-track-category='UserGroups'
+                      data-track-name='OPEN_ON_CALL_ROTATION_MODAL'
+                    >
                       <Settings02 size={16} />
                       Configure on-call sets
                     </Button>

--- a/apps/dashboard/src/components/UserGroup/OnCallRotationModal/OnCallRotationModal.tsx
+++ b/apps/dashboard/src/components/UserGroup/OnCallRotationModal/OnCallRotationModal.tsx
@@ -235,13 +235,21 @@ export const OnCallRotationModal = ({
             <p className='text-xs text-muted-foreground mt-0.5'>{groupName}</p>
           </div>
           <div className='flex items-center gap-2'>
-            <Button variant='secondary' size='sm' onClick={onClose}>
+            <Button
+              variant='secondary'
+              size='sm'
+              onClick={onClose}
+              data-track-category='UserGroups'
+              data-track-name='CANCEL_ON_CALL_ROTATION'
+            >
               Cancel
             </Button>
             <Button
               variant='default'
               size='sm'
               onClick={handleDone}
+              data-track-category='UserGroups'
+              data-track-name='SAVE_ON_CALL_ROTATION'
               disabled={hasEmptySet}
               className='bg-[#6276BE] hover:bg-[#5060A0]'
             >
@@ -252,7 +260,13 @@ export const OnCallRotationModal = ({
 
         {/* Action Bar */}
         <div className='px-6 py-4 bg-muted/30 border-b border-border flex items-end justify-end'>
-          <Button variant='outline' size='sm' onClick={handleCreateSet}>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={handleCreateSet}
+            data-track-category='UserGroups'
+            data-track-name='CREATE_ON_CALL_SET'
+          >
             <Plus className='w-4 h-4' />
             Create New Set
           </Button>

--- a/apps/dashboard/src/components/UserGroup/UserGroupListItem/UserGroupListItem.tsx
+++ b/apps/dashboard/src/components/UserGroup/UserGroupListItem/UserGroupListItem.tsx
@@ -114,6 +114,8 @@ export const UserGroupListItem = ({
             size='iconSm'
             className='size-5 p-0 text-muted-foreground hover:text-foreground'
             onClick={handleCopyId}
+            data-track-category='UserGroups'
+            data-track-name='COPY_USER_GROUP_ID'
             title='Copy user group ID'
             aria-label='Copy user group ID'
           >

--- a/apps/dashboard/src/components/flowUI/nodes/ButtonNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ButtonNode.tsx
@@ -86,6 +86,8 @@ export const ButtonNode: React.FC<ButtonNodeProps> = ({ node }) => {
     <div className='pt-2'>
       <Button
         onClick={handleClick}
+        data-track-category='flowUI'
+        data-track-name='CLICK_FLOW_BUTTON'
         disabled={isDisabled()}
         variant={getVariant()}
         size={getSize()}

--- a/apps/dashboard/src/components/knowledgeBase/upload/FileUploadZone.tsx
+++ b/apps/dashboard/src/components/knowledgeBase/upload/FileUploadZone.tsx
@@ -197,6 +197,8 @@ export const FileUploadZone: React.FC<FileUploadZoneProps> = ({
                 folderInputRef.current?.click();
               }
             }}
+            data-track-category='knowledge-base'
+            data-track-name='OPEN_FILE_PICKER'
             disabled={disabled}
           >
             <FolderOpen size={16} />

--- a/apps/dashboard/src/components/knowledgeBase/upload/ShareCollectionModal.tsx
+++ b/apps/dashboard/src/components/knowledgeBase/upload/ShareCollectionModal.tsx
@@ -308,6 +308,8 @@ export const ShareCollectionModal = ({
                   <DropdownMenuContent align='start' className='w-56'>
                     <DropdownMenuItem
                       onClick={() => pickVisibility('public')}
+                      data-track-category='knowledge-base'
+                      data-track-name='SET_COLLECTION_PUBLIC'
                       className='flex items-start gap-2 cursor-pointer'
                     >
                       <Globe size={16} className='mt-0.5 text-muted-foreground flex-shrink-0' />
@@ -323,6 +325,8 @@ export const ShareCollectionModal = ({
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       onClick={() => pickVisibility('private')}
+                      data-track-category='knowledge-base'
+                      data-track-name='SET_COLLECTION_PRIVATE'
                       className='flex items-start gap-2 cursor-pointer'
                     >
                       <Lock size={16} className='mt-0.5 text-muted-foreground flex-shrink-0' />
@@ -470,7 +474,13 @@ export const ShareCollectionModal = ({
 
         {/* Submit Button */}
         <div className='flex justify-end gap-2'>
-          <Button variant='outline' onClick={handleClose} disabled={isLoading}>
+          <Button
+            variant='outline'
+            onClick={handleClose}
+            disabled={isLoading}
+            data-track-category='knowledge-base'
+            data-track-name='CANCEL_SHARE_COLLECTION'
+          >
             Cancel
           </Button>
           <Button
@@ -479,6 +489,8 @@ export const ShareCollectionModal = ({
             onClick={() => {
               void handleShare();
             }}
+            data-track-category='knowledge-base'
+            data-track-name='SHARE_COLLECTION'
             className='px-4 py-2 bg-muted-foreground text-background rounded-lg hover:bg-muted-foreground/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors'
           >
             <Share2 size={16} />

--- a/apps/dashboard/src/components/knowledgeBase/viewer/FileViewerPanel.tsx
+++ b/apps/dashboard/src/components/knowledgeBase/viewer/FileViewerPanel.tsx
@@ -222,6 +222,8 @@ export const FileViewerPanel: React.FC<{
             onClick={() => {
               handleBackNavigation();
             }}
+            data-track-category='knowledge-base'
+            data-track-name='BACK_FROM_FILE_VIEWER'
           >
             <ArrowLeft size={16} />
             Back to Collections
@@ -255,6 +257,8 @@ export const FileViewerPanel: React.FC<{
               onClick={() => {
                 handleBackNavigation();
               }}
+              data-track-category='knowledge-base'
+              data-track-name='BACK_FROM_FILE_VIEWER'
             >
               <ArrowLeft size={16} />
               Back

--- a/apps/dashboard/src/components/knowledgeBaseV2/KnowledgeBaseV2Screen.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/KnowledgeBaseV2Screen.tsx
@@ -837,11 +837,19 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align='end'>
-                  <DropdownMenuItem onClick={onPickFiles}>
+                  <DropdownMenuItem
+                    onClick={onPickFiles}
+                    data-track-category='knowledge-base'
+                    data-track-name='PICK_KB_FILES'
+                  >
                     <File className='h-4 w-4' strokeWidth={1.75} />
                     Upload files
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => folderInputRef.current?.click()}>
+                  <DropdownMenuItem
+                    onClick={() => folderInputRef.current?.click()}
+                    data-track-category='knowledge-base'
+                    data-track-name='PICK_KB_FOLDER'
+                  >
                     <FolderOpen className='h-4 w-4' strokeWidth={1.75} />
                     Upload folder
                   </DropdownMenuItem>

--- a/apps/dashboard/src/components/ui/ArrayObjectField/ArrayObjectField.tsx
+++ b/apps/dashboard/src/components/ui/ArrayObjectField/ArrayObjectField.tsx
@@ -115,6 +115,8 @@ export const ArrayObjectField: React.FC<ArrayObjectFieldProps> = ({
               variant='ghost'
               size='icon'
               onClick={() => handleRemove(index)}
+              data-track-category='form'
+              data-track-name='REMOVE_ARRAY_ITEM'
               className='h-8 w-8 text-muted-foreground hover:text-destructive transition-colors shrink-0'
               title='Remove item'
             >
@@ -129,6 +131,8 @@ export const ArrayObjectField: React.FC<ArrayObjectFieldProps> = ({
         variant='outline'
         size='sm'
         onClick={handleCreateNew}
+        data-track-category='form'
+        data-track-name='ADD_ARRAY_ITEM'
         className={cn(
           'flex items-center self-start gap-1.5 text-[10px] h-7 px-2 font-semibold uppercase tracking-wider transition-all',
           error &&

--- a/apps/dashboard/src/components/ui/Checkbox/Checkbox.tsx
+++ b/apps/dashboard/src/components/ui/Checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
-import { ReactElement, useEffect, useRef } from 'react';
+import { ComponentPropsWithoutRef, ReactElement, useEffect, useRef } from 'react';
 
-interface CheckboxProps {
+interface CheckboxProps extends Omit<ComponentPropsWithoutRef<'input'>, 'onChange' | 'size'> {
   checked: boolean;
   onChange: (checked: boolean) => void;
   label?: string;
@@ -25,6 +25,7 @@ export function Checkbox({
   disabled = false,
   size = 'md',
   truncateLabel = false,
+  ...rest
 }: CheckboxProps): ReactElement {
   const sm = size === 'sm';
   const inputRef = useRef<HTMLInputElement>(null);
@@ -64,9 +65,17 @@ export function Checkbox({
             ...(ariaLabel ? { 'aria-label': ariaLabel } : {})
           }
           onChange={e => onChange(e.target.checked)}
+          // Default tag so every Checkbox is captured even when the call site
+          // adds nothing. `rest` is spread after it, so a call site passing
+          // data-track-category/name overrides these — same as any other
+          // element. globalClickTracker ignores clicks on inputs, so this is
+          // picked up by its change listener as a SELECTION_CHANGE.
+          data-track-category='CHECKBOX'
+          data-track-name={label ?? 'CHECKBOX'}
           className={`absolute inset-0 w-full h-full opacity-0 m-0 p-0 ${
             disabled ? 'cursor-not-allowed' : 'cursor-pointer'
           }`}
+          {...rest}
         />
         {indeterminate ? (
           <svg

--- a/apps/dashboard/src/components/ui/DateRangeFilter/DateRangeFilter.tsx
+++ b/apps/dashboard/src/components/ui/DateRangeFilter/DateRangeFilter.tsx
@@ -186,6 +186,8 @@ export const CalendarView: React.FC<{
         <button
           type='button'
           onClick={prevMonth}
+          data-track-category='DATE_RANGE_FILTER'
+          data-track-name='PREV_MONTH'
           className='p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted'
         >
           <ChevronLeft className='size-4' />
@@ -194,6 +196,8 @@ export const CalendarView: React.FC<{
         <button
           type='button'
           onClick={nextMonth}
+          data-track-category='DATE_RANGE_FILTER'
+          data-track-name='NEXT_MONTH'
           className='p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted'
         >
           <ChevronRight className='size-4' />
@@ -218,6 +222,8 @@ export const CalendarView: React.FC<{
               key={day}
               type='button'
               onClick={() => handleDayClick(day)}
+              data-track-category='DATE_RANGE_FILTER'
+              data-track-name='SELECT_DAY'
               onMouseEnter={() => setHoverDate(new Date(year, month, day))}
               onMouseLeave={() => setHoverDate(null)}
               className={cn(
@@ -303,6 +309,8 @@ export const DateRangeFilter: React.FC<DateRangeFilterProps> = ({
                 key={preset.label}
                 type='button'
                 onClick={() => handlePresetSelect(preset)}
+                data-track-category='DATE_RANGE_FILTER'
+                data-track-name='SELECT_PRESET'
                 className={cn(
                   'flex w-full items-center rounded-sm px-2 py-1.5 text-sm select-none',
                   activePreset === preset.label
@@ -334,6 +342,8 @@ export const DateRangeFilter: React.FC<DateRangeFilterProps> = ({
                 type='button'
                 data-id='date-range-clear'
                 onClick={handleClear}
+                data-track-category='DATE_RANGE_FILTER'
+                data-track-name='CLEAR_RANGE'
                 className='p-0.5 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted'
               >
                 <X className='size-3' />

--- a/apps/dashboard/src/components/ui/DateTimePicker/DateTimePicker.tsx
+++ b/apps/dashboard/src/components/ui/DateTimePicker/DateTimePicker.tsx
@@ -162,12 +162,16 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
               onClick={() =>
                 setViewDate(new Date(viewDate.setFullYear(viewDate.getFullYear() - 1)))
               }
+              data-track-category='DATE_TIME_PICKER'
+              data-track-name='PREV_YEAR'
               className='p-1 hover:bg-secondary rounded text-muted-foreground'
             >
               <ChevronsLeft className='w-4 h-4' />
             </button>
             <button
               onClick={() => setViewDate(new Date(viewDate.setMonth(viewDate.getMonth() - 1)))}
+              data-track-category='DATE_TIME_PICKER'
+              data-track-name='PREV_MONTH'
               className='p-1 hover:bg-secondary rounded text-muted-foreground'
             >
               <ChevronLeft className='w-4 h-4' />
@@ -179,6 +183,8 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
           <div className='flex gap-0.5'>
             <button
               onClick={() => setViewDate(new Date(viewDate.setMonth(viewDate.getMonth() + 1)))}
+              data-track-category='DATE_TIME_PICKER'
+              data-track-name='NEXT_MONTH'
               className='p-1 hover:bg-secondary rounded text-muted-foreground'
             >
               <ChevronRight className='w-4 h-4' />
@@ -187,6 +193,8 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
               onClick={() =>
                 setViewDate(new Date(viewDate.setFullYear(viewDate.getFullYear() + 1)))
               }
+              data-track-category='DATE_TIME_PICKER'
+              data-track-name='NEXT_YEAR'
               className='p-1 hover:bg-secondary rounded text-muted-foreground'
             >
               <ChevronsRight className='w-4 h-4' />
@@ -301,6 +309,8 @@ export const DateTimePicker: React.FC<DateTimePickerProps> = ({
 
         <button
           onClick={handleConfirm}
+          data-track-category='DATE_TIME_PICKER'
+          data-track-name='CONFIRM_DATE_TIME'
           disabled={isConfirmDisabled}
           className={cn(
             'mt-6 w-full py-2.5 text-xs font-bold rounded-lg transition-all',
@@ -386,6 +396,8 @@ const MonthView: React.FC<{
       <button
         key={i}
         onClick={() => onSelect(d)}
+        data-track-category='DATE_TIME_PICKER'
+        data-track-name='SELECT_DAY'
         disabled={isBeforeToday}
         className={cn(
           'aspect-square text-[12px] rounded-lg transition-all flex items-center justify-center',

--- a/apps/dashboard/src/components/ui/EditorToolbar/EditorToolbar.tsx
+++ b/apps/dashboard/src/components/ui/EditorToolbar/EditorToolbar.tsx
@@ -287,6 +287,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             <button
               type='button'
               onClick={handleBold}
+              data-track-category='EDITOR_TOOLBAR'
+              data-track-name='FORMAT_BOLD'
               onMouseDown={e => e.preventDefault()}
               className={buttonClass(isActive.bold)}
               aria-label='Bold'
@@ -300,6 +302,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             <button
               type='button'
               onClick={handleItalic}
+              data-track-category='EDITOR_TOOLBAR'
+              data-track-name='FORMAT_ITALIC'
               className={buttonClass(isActive.italic)}
               aria-label='Italic'
               aria-pressed={isActive.italic}
@@ -312,6 +316,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             <button
               type='button'
               onClick={handleUnderline}
+              data-track-category='EDITOR_TOOLBAR'
+              data-track-name='FORMAT_UNDERLINE'
               className={buttonClass(isActive.underline)}
               aria-label='Underline'
               aria-pressed={isActive.underline}
@@ -324,6 +330,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             <button
               type='button'
               onClick={handleStrikethrough}
+              data-track-category='EDITOR_TOOLBAR'
+              data-track-name='FORMAT_STRIKETHROUGH'
               className={buttonClass(isActive.strike)}
               aria-label='Strikethrough'
               aria-pressed={isActive.strike}
@@ -336,6 +344,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             <button
               type='button'
               onClick={handleClearFormatting}
+              data-track-category='EDITOR_TOOLBAR'
+              data-track-name='CLEAR_FORMATTING'
               onMouseDown={e => e.preventDefault()}
               className={buttonClass(false)}
               aria-label='Clear formatting'
@@ -350,6 +360,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 <button
                   type='button'
                   onClick={handleCode}
+                  data-track-category='EDITOR_TOOLBAR'
+                  data-track-name='FORMAT_INLINE_CODE'
                   onMouseDown={e => e.preventDefault()}
                   className={buttonClass(isActive.code)}
                   aria-label='Inline code'
@@ -363,6 +375,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 <button
                   type='button'
                   onClick={handleCodeBlock}
+                  data-track-category='EDITOR_TOOLBAR'
+                  data-track-name='FORMAT_CODE_BLOCK'
                   className={buttonClass(isActive.codeBlock)}
                   aria-label='Code block'
                   aria-pressed={isActive.codeBlock}
@@ -383,6 +397,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 <button
                   type='button'
                   onClick={handleLink}
+                  data-track-category='EDITOR_TOOLBAR'
+                  data-track-name='OPEN_LINK_DIALOG'
                   className={buttonClass(isActive.link)}
                   aria-label='Insert link'
                   aria-pressed={isActive.link}
@@ -401,6 +417,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 </h2>
                 <button
                   onClick={() => setOpen(false)}
+                  data-track-category='EDITOR_TOOLBAR'
+                  data-track-name='CLOSE_LINK_DIALOG'
                   className='p-1 hover:bg-accent rounded text-muted-foreground hover:text-muted-foreground'
                 >
                   <MultipleCrossCancelDefault className='h-4 w-4' />
@@ -433,6 +451,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 {isActive.link && (
                   <Button
                     onClick={removeLink}
+                    data-track-category='EDITOR_TOOLBAR'
+                    data-track-name='REMOVE_LINK'
                     className='rounded px-2 py-1 text-xs text-red-500 hover:bg-red-500/10 hover:text-red-600 dark:text-red-400 dark:hover:bg-red-400/10 dark:hover:text-red-300'
                     variant='ghost'
                   >
@@ -442,6 +462,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                 <div className='flex gap-2 ml-auto'>
                   <Button
                     onClick={() => setOpen(false)}
+                    data-track-category='EDITOR_TOOLBAR'
+                    data-track-name='CANCEL_LINK'
                     variant='secondary'
                     className='rounded px-3 py-1.5 text-xs text-foreground'
                   >
@@ -449,6 +471,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                   </Button>
                   <Button
                     onClick={applyLink}
+                    data-track-category='EDITOR_TOOLBAR'
+                    data-track-name='APPLY_LINK'
                     disabled={!linkUrl.trim()}
                     className='rounded bg-primary px-3 py-1.5 text-xs text-white disabled:opacity-50 disabled:text-white'
                   >
@@ -475,6 +499,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                     setImageTab('upload');
                     setImageOpen(prev => !prev);
                   }}
+                  data-track-category='EDITOR_TOOLBAR'
+                  data-track-name='OPEN_IMAGE_MENU'
                   className={buttonClass(imageOpen)}
                   aria-label='Insert image'
                 >
@@ -489,6 +515,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                     <button
                       type='button'
                       onClick={() => setImageTab('upload')}
+                      data-track-category='EDITOR_TOOLBAR'
+                      data-track-name='IMAGE_TAB_UPLOAD'
                       className={`flex-1 py-2 text-xs font-medium transition-colors ${imageTab === 'upload' ? 'text-primary border-b-2 border-primary' : 'text-muted-foreground hover:text-foreground'}`}
                     >
                       Upload
@@ -496,6 +524,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                     <button
                       type='button'
                       onClick={() => setImageTab('url')}
+                      data-track-category='EDITOR_TOOLBAR'
+                      data-track-name='IMAGE_TAB_URL'
                       className={`flex-1 py-2 text-xs font-medium transition-colors ${imageTab === 'url' ? 'text-primary border-b-2 border-primary' : 'text-muted-foreground hover:text-foreground'}`}
                     >
                       URL
@@ -507,6 +537,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                       <button
                         type='button'
                         onClick={() => fileInputRef.current?.click()}
+                        data-track-category='EDITOR_TOOLBAR'
+                        data-track-name='IMAGE_CHOOSE_FROM_DEVICE'
                         className='w-full flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:bg-accent rounded-lg transition-colors'
                       >
                         <PhotoImageDefault className='h-4 w-4 shrink-0' />
@@ -526,6 +558,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
                         <button
                           type='button'
                           onClick={insertImageFromUrl}
+                          data-track-category='EDITOR_TOOLBAR'
+                          data-track-name='INSERT_IMAGE_FROM_URL'
                           disabled={!imageUrl.trim()}
                           className='w-full py-1.5 text-xs font-medium bg-primary text-white rounded-lg disabled:opacity-50 hover:opacity-90 transition-opacity'
                         >
@@ -546,6 +580,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
               <button
                 type='button'
                 onClick={handleBlockquote}
+                data-track-category='EDITOR_TOOLBAR'
+                data-track-name='FORMAT_BLOCKQUOTE'
                 className={buttonClass(isActive.blockquote)}
                 aria-label='Quote'
                 aria-pressed={isActive.blockquote}
@@ -559,6 +595,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             <button
               type='button'
               onClick={handleBulletList}
+              data-track-category='EDITOR_TOOLBAR'
+              data-track-name='FORMAT_BULLET_LIST'
               className={buttonClass(isActive.bulletList)}
               aria-label='Bullet list'
               aria-pressed={isActive.bulletList}
@@ -571,6 +609,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
             <button
               type='button'
               onClick={handleOrderedList}
+              data-track-category='EDITOR_TOOLBAR'
+              data-track-name='FORMAT_NUMBERED_LIST'
               className={buttonClass(isActive.orderedList)}
               aria-label='Numbered list'
               aria-pressed={isActive.orderedList}
@@ -591,6 +631,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
               <button
                 type='button'
                 onClick={handleTaskList}
+                data-track-category='EDITOR_TOOLBAR'
+                data-track-name='FORMAT_TASK_LIST'
                 className={buttonClass(isActive.taskList)}
                 aria-label='Task list'
                 aria-pressed={isActive.taskList}
@@ -605,6 +647,8 @@ export const EditorToolbar: React.FC<EditorToolbarProps> = ({
               <button
                 type='button'
                 onClick={handleBlockquote}
+                data-track-category='EDITOR_TOOLBAR'
+                data-track-name='FORMAT_BLOCKQUOTE'
                 className={buttonClass(isActive.blockquote)}
                 aria-label='Quote'
                 aria-pressed={isActive.blockquote}

--- a/apps/dashboard/src/components/ui/EditorToolbar/EmojiPickerButton.tsx
+++ b/apps/dashboard/src/components/ui/EditorToolbar/EmojiPickerButton.tsx
@@ -76,7 +76,11 @@ export const AddCustomEmojiModal: React.FC<AddCustomEmojiModalProps> = ({
         {/* Header */}
         <div className='flex items-center justify-between px-6 py-4 border-b'>
           <h2 className='text-lg font-semibold'>Add emoji</h2>
-          <button onClick={onClose}>
+          <button
+            onClick={onClose}
+            data-track-category='EDITOR_TOOLBAR'
+            data-track-name='CLOSE_EMOJI_PICKER'
+          >
             <X className='h-5 w-5 text-muted-foreground hover:text-foreground' />
           </button>
         </div>
@@ -138,6 +142,8 @@ export const AddCustomEmojiModal: React.FC<AddCustomEmojiModalProps> = ({
         <div className='flex justify-end gap-3 px-6 py-4 border-t'>
           <button
             onClick={onClose}
+            data-track-category='EDITOR_TOOLBAR'
+            data-track-name='CANCEL_ADD_CUSTOM_EMOJI'
             disabled={isLoading}
             className='px-4 py-2 rounded hover:bg-accent disabled:opacity-40'
           >
@@ -145,6 +151,8 @@ export const AddCustomEmojiModal: React.FC<AddCustomEmojiModalProps> = ({
           </button>
           <button
             onClick={handleSave}
+            data-track-category='EDITOR_TOOLBAR'
+            data-track-name='SAVE_CUSTOM_EMOJI'
             disabled={!file || !name || isLoading}
             className='px-4 py-2 rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-40'
           >
@@ -195,6 +203,8 @@ export const EmojiPickerButton: React.FC<EmojiPickerButtonProps> = ({
       type='button'
       disabled={disabled}
       onClick={() => setEmojiOpen(true)}
+      data-track-category='EDITOR_TOOLBAR'
+      data-track-name='OPEN_EMOJI_PICKER'
       className={`p-1.5 rounded hover:bg-accent ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
       aria-label='Insert emoji'
       data-testid='insert-emoji-btn'
@@ -254,6 +264,8 @@ export const EmojiPickerButton: React.FC<EmojiPickerButtonProps> = ({
                 setShowAddEmoji(true);
                 setUploadError(undefined);
               }}
+              data-track-category='EDITOR_TOOLBAR'
+              data-track-name='START_ADD_CUSTOM_EMOJI'
             >
               Add Emoji
             </button>

--- a/apps/dashboard/src/components/ui/EditorToolbar/MobileEditorToolbar.tsx
+++ b/apps/dashboard/src/components/ui/EditorToolbar/MobileEditorToolbar.tsx
@@ -158,6 +158,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
       <button
         type='button'
         onClick={onClose}
+        data-track-category='MOBILE_EDITOR_TOOLBAR'
+        data-track-name='CLOSE_TOOLBAR'
         className='p-2 rounded-full bg-action-primary text-action-primary-foreground hover:bg-action-primary/90 transition-colors flex items-center justify-center flex-shrink-0 mr-1'
         aria-label='Close formatting toolbar'
         onMouseDown={e => e.preventDefault()}
@@ -171,6 +173,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleBold}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='FORMAT_BOLD'
           className={buttonClass(isActive.bold)}
           aria-label='Bold'
           aria-pressed={isActive.bold}
@@ -183,6 +187,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleItalic}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='FORMAT_ITALIC'
           className={buttonClass(isActive.italic)}
           aria-label='Italic'
           aria-pressed={isActive.italic}
@@ -195,6 +201,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleStrikethrough}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='FORMAT_STRIKETHROUGH'
           className={buttonClass(isActive.strike)}
           aria-label='Strikethrough'
           aria-pressed={isActive.strike}
@@ -207,6 +215,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleClearFormatting}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='CLEAR_FORMATTING'
           className={buttonClass(false)}
           aria-label='Clear formatting'
           onMouseDown={e => e.preventDefault()}
@@ -218,6 +228,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleCode}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='FORMAT_INLINE_CODE'
           className={buttonClass(isActive.code)}
           aria-label='Inline code'
           aria-pressed={isActive.code}
@@ -233,6 +245,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleCodeBlock}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='FORMAT_CODE_BLOCK'
           className={buttonClass(isActive.codeBlock)}
           aria-label='Code block'
           aria-pressed={isActive.codeBlock}
@@ -245,6 +259,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleLink}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='OPEN_LINK_PROMPT'
           className={buttonClass(isActive.link)}
           aria-label='Insert link'
           aria-pressed={isActive.link}
@@ -260,6 +276,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleBlockquote}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='FORMAT_BLOCKQUOTE'
           className={buttonClass(isActive.blockquote)}
           aria-label='Quote'
           aria-pressed={isActive.blockquote}
@@ -272,6 +290,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleBulletList}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='FORMAT_BULLET_LIST'
           className={buttonClass(isActive.bulletList)}
           aria-label='Bullet list'
           aria-pressed={isActive.bulletList}
@@ -284,6 +304,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
         <button
           type='button'
           onClick={handleOrderedList}
+          data-track-category='MOBILE_EDITOR_TOOLBAR'
+          data-track-name='FORMAT_NUMBERED_LIST'
           className={buttonClass(isActive.orderedList)}
           aria-label='Numbered list'
           aria-pressed={isActive.orderedList}
@@ -297,6 +319,8 @@ export const MobileEditorToolbar: React.FC<MobileEditorToolbarProps> = ({
       <button
         type='button'
         onClick={onSend}
+        data-track-category='MOBILE_EDITOR_TOOLBAR'
+        data-track-name='SEND_MESSAGE'
         disabled={disabled || isSending || !hasContent}
         className={`
           p-2 rounded-full transition-all duration-300 flex items-center justify-center flex-shrink-0 ml-1

--- a/apps/dashboard/src/components/ui/EntitySelector/EntityMultiSelector.tsx
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntityMultiSelector.tsx
@@ -187,6 +187,8 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
                 e.stopPropagation();
                 removeValue(opt.value);
               }}
+              data-track-category='ENTITY_PICKER'
+              data-track-name='REMOVE_SELECTED_VALUE'
               className='text-muted-foreground hover:text-muted-foreground'
             >
               <X className='size-2.5' strokeWidth={2.5} />
@@ -213,6 +215,8 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
                   e.stopPropagation();
                   onMultiSelect([]);
                 }}
+                data-track-category='ENTITY_PICKER'
+                data-track-name='CLEAR_ALL_SELECTED'
                 className='text-muted-foreground hover:text-muted-foreground'
               >
                 <X className='size-2.5' strokeWidth={2.5} />
@@ -276,6 +280,8 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
                             type='button'
                             className='flex w-full items-center gap-2 px-2 py-1.5 rounded text-sm hover:bg-accent'
                             onClick={() => toggleValue(option.value)}
+                            data-track-category='ENTITY_PICKER'
+                            data-track-name='TOGGLE_OPTION'
                           >
                             <span
                               className={cn(
@@ -337,6 +343,8 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
                           onCreateOption?.(searchValue.trim());
                           setSearchValue('');
                         }}
+                        data-track-category='ENTITY_PICKER'
+                        data-track-name='CREATE_OPTION'
                       >
                         <Plus className='size-3' strokeWidth={2.5} />
                         <span className='truncate text-xs'>

--- a/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.tsx
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.tsx
@@ -180,6 +180,8 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
         handleOpenChange(false);
         setSearchValue('');
       }}
+      data-track-category='ENTITY_PICKER'
+      data-track-name='CLEAR_SELECTION'
     >
       <span className='flex h-5 w-5 flex-none items-center justify-center'>
         <div className='w-5 h-5 rounded-full bg-border flex items-center justify-center'>
@@ -208,6 +210,8 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
               : 'cursor-pointer text-foreground hover:bg-accent'
         }`}
         onClick={() => !option.disabled && handleSelect(option.value)}
+        data-track-category='ENTITY_PICKER'
+        data-track-name='SELECT_OPTION'
         onKeyDown={(e): void => {
           if ((e.key === 'Enter' || e.key === ' ') && !option.disabled) {
             e.preventDefault();
@@ -279,6 +283,8 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
         {showClearButton && selectedOption ? (
           <button
             onClick={handleClear}
+            data-track-category='ENTITY_PICKER'
+            data-track-name='CLEAR_SELECTION'
             className='flex-shrink-0 hover:bg-accent rounded p-0.5 transition-colors'
           >
             <X className='w-3 h-3 text-muted-foreground' />
@@ -376,6 +382,8 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
         {showClearButton && selectedOption ? (
           <button
             onClick={handleClear}
+            data-track-category='ENTITY_PICKER'
+            data-track-name='CLEAR_SELECTION'
             className='flex-shrink-0 hover:bg-accent rounded p-0.5 transition-colors'
           >
             <X className='w-3 h-3 text-muted-foreground' />

--- a/apps/dashboard/src/components/ui/FileBubble/FileBubble.tsx
+++ b/apps/dashboard/src/components/ui/FileBubble/FileBubble.tsx
@@ -67,6 +67,8 @@ export const FileBubble: React.FC<FileBubbleProps> = ({
         type='button'
         className='shrink-0 cursor-pointer'
         onClick={handleClick}
+        data-track-category='MESSAGE'
+        data-track-name='OPEN_FILE_BUBBLE'
         title={attachment.originalFilename}
       >
         <div className='pointer-events-none'>
@@ -83,6 +85,8 @@ export const FileBubble: React.FC<FileBubbleProps> = ({
         className='w-full text-left p-3 bg-card hover:bg-accent
            rounded-xl border border-border shadow-sm transition cursor-pointer'
         onClick={handleClick}
+        data-track-category='MESSAGE'
+        data-track-name='OPEN_FILE_BUBBLE'
       >
         {/* Attachment Preview */}
         <div className='flex items-center gap-3'>

--- a/apps/dashboard/src/components/ui/FilterPills/FilterPills.tsx
+++ b/apps/dashboard/src/components/ui/FilterPills/FilterPills.tsx
@@ -44,6 +44,9 @@ export const FilterPills = <T extends string>({
           role='tab'
           aria-selected={isActive}
           onClick={() => onTabChange(tab.value)}
+          data-track-category='FILTER_PILLS'
+          data-track-name='CHANGE_FILTER_TAB'
+          data-track-metadata={JSON.stringify({ tab: tab.value })}
           className={cn(
             'flex shrink-0 items-center gap-1 rounded-full border px-3 py-1.5 text-base transition-colors',
             'min-[700px]:px-2.5 min-[700px]:py-1 min-[700px]:text-sm',

--- a/apps/dashboard/src/components/ui/GenericMentionPopover/GenericMentionPopover.tsx
+++ b/apps/dashboard/src/components/ui/GenericMentionPopover/GenericMentionPopover.tsx
@@ -35,6 +35,8 @@ export const GenericMentionHoverPopover: React.FC<GenericMentionHoverPopoverProp
       role='button'
       tabIndex={0}
       onClick={onClick}
+      data-track-category='MENTION'
+      data-track-name='OPEN_MENTION'
       onKeyDown={e => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();

--- a/apps/dashboard/src/components/ui/GroupMentionPopover/GroupMentionPopover.tsx
+++ b/apps/dashboard/src/components/ui/GroupMentionPopover/GroupMentionPopover.tsx
@@ -48,6 +48,8 @@ export const GroupHoverWrapper: React.FC<GroupHoverWrapperProps> = ({ groupId, c
           e.stopPropagation();
           handleViewGroup();
         }}
+        data-track-category='MENTION'
+        data-track-name='OPEN_GROUP_FROM_MENTION'
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
@@ -110,6 +112,8 @@ export const GroupHoverWrapper: React.FC<GroupHoverWrapperProps> = ({ groupId, c
         <div className='flex justify-end px-4 py-3 border-t border-muted-foreground/20'>
           <button
             onClick={handleViewGroup}
+            data-track-category='MENTION'
+            data-track-name='OPEN_GROUP_FROM_MENTION'
             className='inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium bg-muted hover:bg-accent rounded-md transition-colors'
           >
             <ExternalLink className='size-4' />

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -1792,6 +1792,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                             handleAttachClick();
                             setIsPlusMenuOpen(false);
                           }}
+                          data-track-category='CHAT_INPUT'
+                          data-track-name='ATTACH_FILE'
                         >
                           <Plus className='h-4 w-4' /> Upload Files
                           <ShortcutHint keys='mod+o' className='ml-auto pl-6' />
@@ -1801,6 +1803,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                             setIsTranscriptSelectorOpen(true);
                             setIsPlusMenuOpen(false);
                           }}
+                          data-track-category='CHAT_INPUT'
+                          data-track-name='ATTACH_TRANSCRIPT'
                         >
                           <FileText className='h-4 w-4' /> Add Call Summary
                         </DropdownMenuItem>
@@ -1809,6 +1813,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                             setIsCanvasAttachmentModalOpen(true);
                             setIsPlusMenuOpen(false);
                           }}
+                          data-track-category='CHAT_INPUT'
+                          data-track-name='ATTACH_CANVAS'
                         >
                           <FileText className='h-4 w-4' /> Canvas
                         </DropdownMenuItem>
@@ -1860,6 +1866,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                         onClick={() => {
                           editor?.chain().focus().insertContent('@').run();
                         }}
+                        data-track-category='CHAT_INPUT'
+                        data-track-name='INSERT_USER_MENTION'
                         className='p-1.5 rounded hover:bg-accent transition-all duration-200 ease-in-out'
                         aria-label='Mention user'
                         data-testid='mention-user-btn'
@@ -1882,6 +1890,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                         onClick={() => {
                           editor?.chain().focus().insertContent('#').run();
                         }}
+                        data-track-category='CHAT_INPUT'
+                        data-track-name='INSERT_CHANNEL_MENTION'
                         className='p-1.5 rounded hover:bg-accent transition-all duration-200 ease-in-out'
                         aria-label='Mention channel'
                         disabled={disabled || isSending}
@@ -1901,6 +1911,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                       <button
                         type='button'
                         onClick={() => setShowFormatToolbar(prev => !prev)}
+                        data-track-category='CHAT_INPUT'
+                        data-track-name='TOGGLE_FORMAT_TOOLBAR'
                         className={`p-1.5 rounded transition-all duration-200 ease-in-out ${
                           showFormatToolbar
                             ? 'bg-accent text-foreground'
@@ -1943,6 +1955,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                       <button
                         type='button'
                         onClick={onCancel}
+                        data-track-category='CHAT_INPUT'
+                        data-track-name='CANCEL_EDITING'
                         className='p-2 rounded-md bg-muted text-foreground hover:bg-border transition-all duration-200 ease-in-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#FF4F4F] focus-visible:outline-offset-2'
                         aria-label='Cancel editing'
                       >
@@ -2028,6 +2042,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                                     setIsSendMenuOpen(false);
                                     onCreateTicket(editor?.getText().trim() || '');
                                   }}
+                                  data-track-category='CHAT_INPUT'
+                                  data-track-name='CREATE_TICKET_FROM_INPUT'
                                 >
                                   <Ticket className='h-4 w-4' /> Create a ticket
                                 </DropdownMenuItem>
@@ -2038,6 +2054,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                                     setIsSendMenuOpen(false);
                                     openScheduleDialog();
                                   }}
+                                  data-track-category='CHAT_INPUT'
+                                  data-track-name='OPEN_SCHEDULE_DIALOG'
                                 >
                                   <Clock className='h-4 w-4' /> Schedule message
                                 </DropdownMenuItem>
@@ -2103,6 +2121,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                                   void handleSend();
                                   setIsSendMenuOpen(false);
                                 }}
+                                data-track-category='CHAT_INPUT'
+                                data-track-name='SEND_FROM_MENU'
                               >
                                 <ArrowUp className='h-4 w-4' /> Send now
                               </DropdownMenuItem>
@@ -2111,6 +2131,8 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                                   setIsSendMenuOpen(false);
                                   openScheduleDialog();
                                 }}
+                                data-track-category='CHAT_INPUT'
+                                data-track-name='OPEN_SCHEDULE_DIALOG'
                               >
                                 <Clock className='h-4 w-4' /> Schedule message
                               </DropdownMenuItem>

--- a/apps/dashboard/src/components/ui/InputBox/MobileEditor.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/MobileEditor.tsx
@@ -187,6 +187,8 @@ export const MobileEditor: React.FC<MobileEditorProps> = ({
             if ((e.target as HTMLElement).closest('button')) return;
             handleEditorClick();
           }}
+          data-track-category='CHAT_INPUT'
+          data-track-name='FOCUS_MOBILE_EDITOR'
           onKeyDown={e => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
@@ -202,6 +204,8 @@ export const MobileEditor: React.FC<MobileEditorProps> = ({
               e.stopPropagation();
               onAttachClick();
             }}
+            data-track-category='CHAT_INPUT'
+            data-track-name='ATTACH_FILES'
             disabled={disabled || isSending}
             className='p-2 text-foreground hover:text-muted-foreground transition-colors flex-shrink-0'
             aria-label='Attach files'
@@ -236,6 +240,8 @@ export const MobileEditor: React.FC<MobileEditorProps> = ({
                 e.stopPropagation();
                 onVoiceToggle();
               }}
+              data-track-category='CHAT_INPUT'
+              data-track-name='TOGGLE_VOICE_INPUT'
               disabled={disabled || isSending || isVoiceTranscribing}
               className={`p-2 rounded-full transition-colors flex-shrink-0 ${
                 isVoiceRecording
@@ -273,6 +279,8 @@ export const MobileEditor: React.FC<MobileEditorProps> = ({
                 <button
                   type='button'
                   onClick={onAttachClick}
+                  data-track-category='CHAT_INPUT'
+                  data-track-name='ATTACH_FILES'
                   disabled={disabled || isSending}
                   className='p-2 text-foreground hover:text-muted-foreground transition-colors'
                   aria-label='Attach files'
@@ -286,6 +294,8 @@ export const MobileEditor: React.FC<MobileEditorProps> = ({
               <button
                 type='button'
                 onClick={() => onShowFormattingToolbar?.()}
+                data-track-category='CHAT_INPUT'
+                data-track-name='OPEN_FORMAT_TOOLBAR'
                 className='p-2 rounded-full hover:bg-accent active:bg-accent transition-colors'
                 aria-label='Text formatting'
                 onMouseDown={e => e.preventDefault()}
@@ -327,6 +337,8 @@ export const MobileEditor: React.FC<MobileEditorProps> = ({
                     editor?.chain().focus().insertContent('@').run();
                     onMentionClick();
                   }}
+                  data-track-category='CHAT_INPUT'
+                  data-track-name='INSERT_USER_MENTION'
                   className='p-2 rounded-full hover:bg-accent active:bg-accent transition-colors'
                   aria-label='Mention user'
                   onMouseDown={e => e.preventDefault()}
@@ -343,6 +355,8 @@ export const MobileEditor: React.FC<MobileEditorProps> = ({
                     editor?.chain().focus().insertContent('#').run();
                     onChannelClick();
                   }}
+                  data-track-category='CHAT_INPUT'
+                  data-track-name='INSERT_CHANNEL_MENTION'
                   className='p-2 rounded-full hover:bg-accent active:bg-accent transition-colors'
                   aria-label='Mention channel'
                   onMouseDown={e => e.preventDefault()}
@@ -355,6 +369,8 @@ export const MobileEditor: React.FC<MobileEditorProps> = ({
                 <button
                   type='button'
                   onClick={onVoiceToggle}
+                  data-track-category='CHAT_INPUT'
+                  data-track-name='TOGGLE_VOICE_INPUT'
                   disabled={disabled || isSending || isVoiceTranscribing}
                   className={`p-2 rounded-full transition-colors ${
                     isVoiceRecording
@@ -379,6 +395,8 @@ export const MobileEditor: React.FC<MobileEditorProps> = ({
                 <button
                   type='button'
                   onClick={onSend}
+                  data-track-category='CHAT_INPUT'
+                  data-track-name='SEND_MESSAGE'
                   disabled={disabled || isSending || !hasContent}
                   className={`
                 p-2 rounded-full transition-all duration-300 flex items-center justify-center

--- a/apps/dashboard/src/components/ui/MentionText/MentionText.tsx
+++ b/apps/dashboard/src/components/ui/MentionText/MentionText.tsx
@@ -131,6 +131,8 @@ export const MentionText: React.FC<MentionTextProps> = props => {
           role='button'
           tabIndex={0}
           onClick={handleChannelClick}
+          data-track-category='MENTION'
+          data-track-name='OPEN_CHANNEL_FROM_MENTION'
           onKeyDown={handleKeyDown}
           className='text-[color:var(--mention-color)] bg-[var(--mention-channel-bg)] hover:bg-[var(--mention-channel-hover-bg)] px-1 py-[2px] rounded-[4px] font-normal cursor-pointer no-underline transition-colors duration-200 inline whitespace-nowrap leading-inherit align-baseline hover:text-[color:var(--mention-hover-color)]'
         >
@@ -186,6 +188,8 @@ export const MentionText: React.FC<MentionTextProps> = props => {
         role='button'
         tabIndex={0}
         onClick={handleGroupClick}
+        data-track-category='MENTION'
+        data-track-name='OPEN_GROUP_FROM_MENTION'
         onKeyDown={handleKeyDown}
         className='text-[color:var(--mention-group-color)] font-normal cursor-pointer no-underline transition-colors duration-200 inline whitespace-nowrap leading-inherit align-baseline hover:text-[color:var(--mention-hover-color)]'
       >

--- a/apps/dashboard/src/components/ui/MessageBubble/AppActions.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/AppActions.tsx
@@ -65,6 +65,9 @@ export const AppActions: React.FC<AppActionsProps> = ({
           <button
             key={action.actionId}
             onClick={() => void handleClick(action)}
+            data-track-category='MESSAGE'
+            data-track-name='CLICK_APP_ACTION'
+            data-track-metadata={JSON.stringify({ actionId: action.actionId })}
             disabled={isLoading || loadingAction !== null}
             className='inline-flex items-center rounded-md px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:opacity-80 disabled:opacity-50 disabled:cursor-not-allowed'
             style={{ backgroundColor: action.color }}

--- a/apps/dashboard/src/components/ui/MessageBubble/CallBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/CallBubble.tsx
@@ -58,6 +58,8 @@ export const GeneratePRDButton: React.FC<{
       <button
         type='button'
         onClick={() => setIsModalOpen(true)}
+        data-track-category='MESSAGE'
+        data-track-name='OPEN_CALL_DETAILS'
         disabled={isLoading}
         className='p-2 hover:bg-accent rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground'
         title={isCanvasCreated ? 'Generate Another PRD' : 'Generate PRD'}
@@ -107,6 +109,8 @@ const GenerateSummaryButton: React.FC<{
       <button
         type='button'
         onClick={() => setIsModalOpen(true)}
+        data-track-category='MESSAGE'
+        data-track-name='OPEN_CALL_DETAILS'
         disabled={isLoading}
         className='p-2 hover:bg-accent rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground'
         title={isCanvasCreated ? 'Generate Another Summary' : 'Generate Summary'}
@@ -172,6 +176,8 @@ const ChatWithAskAIButton: React.FC<{
     <button
       type='button'
       onClick={handleClick}
+      data-track-category='MESSAGE'
+      data-track-name='CHAT_WITH_CALL_TRANSCRIPT'
       className='p-2 hover:bg-accent rounded-lg transition-colors text-muted-foreground hover:text-foreground'
       title='Chat with Transcript'
     >

--- a/apps/dashboard/src/components/ui/MessageBubble/ChannelEmailCard.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/ChannelEmailCard.tsx
@@ -47,6 +47,8 @@ export const ChannelEmailCard: React.FC<ChannelEmailCardProps> = ({
       <button
         type='button'
         onClick={() => setExpanded(prev => !prev)}
+        data-track-category='MESSAGE'
+        data-track-name='TOGGLE_EMAIL_CARD'
         className='flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-muted/40 transition-colors'
       >
         <Mail className='h-4 w-4 shrink-0 text-muted-foreground' />

--- a/apps/dashboard/src/components/ui/MessageBubble/CreateDocumentModal.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/CreateDocumentModal.tsx
@@ -119,10 +119,22 @@ export const CreateDocumentModal: React.FC<CreateDocumentModalProps> = ({
           )}
 
           <div className='flex justify-end gap-2 mt-4'>
-            <Button variant='outline' onClick={onClose} disabled={isLoading}>
+            <Button
+              variant='outline'
+              onClick={onClose}
+              data-track-category='MESSAGE'
+              data-track-name='CANCEL_CREATE_DOCUMENT'
+              disabled={isLoading}
+            >
               Cancel
             </Button>
-            <Button onClick={handleGenerate} loading={isLoading} disabled={isGenerateDisabled}>
+            <Button
+              onClick={handleGenerate}
+              data-track-category='MESSAGE'
+              data-track-name='GENERATE_DOCUMENT'
+              loading={isLoading}
+              disabled={isGenerateDisabled}
+            >
               Generate
             </Button>
           </div>

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -280,7 +280,12 @@ const AttachmentsBlock: React.FC<AttachmentsBlockProps> = ({
                 ? `${activeAttachments.length} files`
                 : activeAttachments[0]?.originalFilename}
             </span>
-            <button type='button' onClick={() => setIsExpanded(!isExpanded)}>
+            <button
+              type='button'
+              onClick={() => setIsExpanded(!isExpanded)}
+              data-track-category='MESSAGE'
+              data-track-name='TOGGLE_ATTACHMENT_LIST'
+            >
               {isExpanded ? (
                 <ChevronDown className='w-4 h-4 text-muted-foreground' />
               ) : (
@@ -299,6 +304,8 @@ const AttachmentsBlock: React.FC<AttachmentsBlockProps> = ({
                     void downloadAttachment(attachment.id, attachment.originalFilename);
                   });
                 }}
+                data-track-category='MESSAGE'
+                data-track-name='DOWNLOAD_ALL_ATTACHMENTS'
                 className='flex items-center gap-2 text-muted-foreground hover:text-foreground'
               >
                 <span>Download all</span>
@@ -889,6 +896,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
             ) : showAvatar && sender?.userType === UserType.APP ? (
               <div
                 onClick={() => handleUserClick(sender.id)}
+                data-track-category='MESSAGE'
+                data-track-name='OPEN_SENDER_PROFILE_FROM_AVATAR'
                 className='cursor-pointer'
                 role='button'
                 tabIndex={0}
@@ -991,6 +1000,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
             ) : showAvatar && sender ? (
               <div
                 onClick={() => handleUserClick(sender.id)}
+                data-track-category='MESSAGE'
+                data-track-name='OPEN_SENDER_PROFILE_FROM_AVATAR'
                 className='cursor-pointer'
                 role='button'
                 tabIndex={0}
@@ -1086,6 +1097,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                     <Button
                       variant='ghost'
                       onClick={() => handleUserClick(sender.id)}
+                      data-track-category='MESSAGE'
+                      data-track-name='OPEN_SENDER_PROFILE_FROM_NAME'
                       className={`${isMobile ? 'text-[15px] leading-tight font-semibold tracking-tight' : 'text-sm font-medium'} text-foreground hover:underline p-0 h-auto min-w-0`}
                       aria-label={`View ${getUserDisplayName(sender) || 'user'} profile`}
                     >
@@ -1106,6 +1119,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                         <Button
                           variant='ghost'
                           onClick={() => handleUserClick(sender.id)}
+                          data-track-category='MESSAGE'
+                          data-track-name='OPEN_SENDER_PROFILE_FROM_NAME'
                           className='text-sm font-semibold text-foreground hover:underline p-0 h-auto min-w-0'
                           aria-label={`View ${getUserDisplayName(sender) || 'user'} profile`}
                         >
@@ -1147,6 +1162,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
               <Tooltip content={formatFullTimestamp(message.createdAt)} side='top'>
                 <h3
                   onClick={searchItemView ? undefined : handleTimestampClick}
+                  data-track-category='MESSAGE'
+                  data-track-name='OPEN_THREAD_FROM_TIMESTAMP'
                   onKeyDown={
                     searchItemView
                       ? undefined
@@ -1366,6 +1383,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                         <button
                           type='button'
                           onClick={() => handleUserClick(forwardedMessageData.originalSenderId)}
+                          data-track-category='MESSAGE'
+                          data-track-name='OPEN_ORIGINAL_SENDER_PROFILE'
                           className='text-xs font-medium text-foreground hover:underline cursor-pointer bg-transparent border-0 p-0'
                         >
                           {getUserDisplayName(originalSender) ||
@@ -1790,6 +1809,8 @@ export const ReactionView = ({
                   });
                   e.stopPropagation();
                 }}
+                data-track-category='MESSAGE'
+                data-track-name='TOGGLE_REACTION'
                 onTouchStart={e => {
                   if (isMobile) {
                     e.stopPropagation();

--- a/apps/dashboard/src/components/ui/MessageBubble/MobileAttachmentsGrid.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MobileAttachmentsGrid.tsx
@@ -133,6 +133,8 @@ export const MobileAttachmentsGrid: React.FC<MobileAttachmentsGridProps> = ({ at
                       <button
                         type='button'
                         onClick={handleOpenAll}
+                        data-track-category='MESSAGE'
+                        data-track-name='OPEN_ALL_ATTACHMENTS'
                         className='absolute inset-0 bg-black/60 flex items-center justify-center rounded-lg'
                       >
                         <span className='text-white text-2xl font-semibold'>+{remainingCount}</span>
@@ -165,7 +167,13 @@ export const MobileAttachmentsGrid: React.FC<MobileAttachmentsGridProps> = ({ at
                       <span className='font-medium text-sm'>
                         {formatAttachmentSummary(attachments)}
                       </span>
-                      <button type='button' onClick={handleClose} className='p-2'>
+                      <button
+                        type='button'
+                        onClick={handleClose}
+                        data-track-category='MESSAGE'
+                        data-track-name='CLOSE_ATTACHMENTS_GRID'
+                        className='p-2'
+                      >
                         <X className='w-6 h-6' />
                       </button>
                     </div>

--- a/apps/dashboard/src/components/ui/MessageBubble/MobileReactionDrawer.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MobileReactionDrawer.tsx
@@ -256,6 +256,8 @@ export default function MobileReactionDrawer({
                         <button
                           key={idx}
                           onClick={() => paginate(idx + 1 - currentTabIndex)}
+                          data-track-category='MESSAGE'
+                          data-track-name='SWITCH_REACTION_TAB'
                           className='flex items-start gap-3 px-2 py-2 w-full text-left hover:bg-accent active:bg-accent rounded-lg transition-colors'
                         >
                           <span className='*:text-2xl flex-shrink-0'>
@@ -275,6 +277,8 @@ export default function MobileReactionDrawer({
                           <>
                             <button
                               onClick={() => handleUserClick(user.userId)}
+                              data-track-category='MESSAGE'
+                              data-track-name='OPEN_REACTOR_PROFILE'
                               key={idx}
                               className='flex items-center gap-3 px-2 py-2'
                             >

--- a/apps/dashboard/src/components/ui/MessageBubble/NonParticipantActions.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/NonParticipantActions.tsx
@@ -176,6 +176,8 @@ export const NonParticipantActions: React.FC<NonParticipantActionsProps> = ({
                 className='bg-secondary text-secondary-foreground hover:bg-accent'
                 size='sm'
                 onClick={() => void handleAddToChannel()}
+                data-track-category='MESSAGE'
+                data-track-name='ADD_USER_TO_CHANNEL'
                 disabled={isLoading}
               >
                 {isLoading ? 'Adding...' : 'Add Them'}
@@ -185,6 +187,8 @@ export const NonParticipantActions: React.FC<NonParticipantActionsProps> = ({
               className='bg-secondary text-secondary-foreground hover:bg-accent'
               size='sm'
               onClick={() => void handleIgnore()}
+              data-track-category='MESSAGE'
+              data-track-name='IGNORE_NON_PARTICIPANT'
               disabled={isLoading}
             >
               {canAddMembers ? 'Do Nothing' : 'Got it'}

--- a/apps/dashboard/src/components/ui/MessageBubble/PostedInLink.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/PostedInLink.tsx
@@ -114,6 +114,8 @@ export const PostedInLink: React.FC<PostedInLinkProps> = ({
     <button
       type='button'
       onClick={handleClick}
+      data-track-category='MESSAGE'
+      data-track-name='OPEN_POSTED_IN_CHANNEL'
       disabled={!hasAccess}
       className={`flex items-center gap-1.5 text-xs mt-2 ${
         hasAccess

--- a/apps/dashboard/src/components/ui/MessageBubble/PulseCreateActionableModal.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/PulseCreateActionableModal.tsx
@@ -159,6 +159,8 @@ export const PulseCreateActionableModal: React.FC<PulseCreateActionableModalProp
       onClick={e => {
         if (e.target === e.currentTarget) onClose();
       }}
+      data-track-category='MESSAGE'
+      data-track-name='CLOSE_PULSE_MODAL_BACKDROP'
       onKeyDown={e => {
         if (e.key === 'Escape') onClose();
       }}
@@ -181,6 +183,8 @@ export const PulseCreateActionableModal: React.FC<PulseCreateActionableModalProp
           <button
             type='button'
             onClick={onClose}
+            data-track-category='MESSAGE'
+            data-track-name='CLOSE_PULSE_MODAL'
             className='text-muted-foreground hover:text-foreground transition-colors rounded-md p-1 hover:bg-accent'
             aria-label='Close modal'
           >
@@ -205,6 +209,8 @@ export const PulseCreateActionableModal: React.FC<PulseCreateActionableModalProp
                   id='pulse-merchant'
                   type='button'
                   onClick={handleEditMerchantClick}
+                  data-track-category='MESSAGE'
+                  data-track-name='START_EDIT_PULSE_MERCHANT'
                   disabled={submitting}
                   className='border border-border rounded-lg px-3 py-2 text-sm text-foreground bg-muted hover:bg-accent transition-colors flex items-center justify-between text-left focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent disabled:opacity-60 disabled:cursor-not-allowed w-full'
                 >
@@ -266,6 +272,8 @@ export const PulseCreateActionableModal: React.FC<PulseCreateActionableModalProp
                               key={org.orgId}
                               type='button'
                               onClick={() => handleSelectOrg(org)}
+                              data-track-category='MESSAGE'
+                              data-track-name='SELECT_PULSE_ORG'
                               className={`w-full text-left px-3 py-2 text-xs transition-colors border-none cursor-pointer ${
                                 isCurrentOrg
                                   ? 'bg-accent text-action-primary font-medium'
@@ -282,6 +290,8 @@ export const PulseCreateActionableModal: React.FC<PulseCreateActionableModalProp
                     <button
                       type='button'
                       onClick={() => setIsEditingMerchant(false)}
+                      data-track-category='MESSAGE'
+                      data-track-name='CANCEL_EDIT_PULSE_MERCHANT'
                       className='text-xs text-muted-foreground hover:text-foreground'
                     >
                       Cancel
@@ -348,6 +358,8 @@ export const PulseCreateActionableModal: React.FC<PulseCreateActionableModalProp
             <button
               type='button'
               onClick={onClose}
+              data-track-category='MESSAGE'
+              data-track-name='CANCEL_PULSE_MODAL'
               disabled={submitting}
               className='px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground rounded-lg hover:bg-accent transition disabled:opacity-50'
             >

--- a/apps/dashboard/src/components/ui/MessageBubble/PulseTickets.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/PulseTickets.tsx
@@ -110,6 +110,8 @@ export const PulseTickets: React.FC<PulseTicketsProps> = ({
                     type='checkbox'
                     checked={isSelected}
                     onChange={() => toggleSelection(item.itemId)}
+                    data-track-category='MESSAGE'
+                    data-track-name='TOGGLE_PULSE_TICKET'
                     className='mt-1 h-4 w-4 shrink-0 rounded border-input cursor-pointer'
                   />
                   <label htmlFor={checkboxId} className='text-sm text-left flex-1 cursor-pointer'>
@@ -135,6 +137,8 @@ export const PulseTickets: React.FC<PulseTicketsProps> = ({
         <div className='pt-1 ml-4'>
           <button
             onClick={startCreation}
+            data-track-category='MESSAGE'
+            data-track-name='START_TICKET_FROM_PULSE'
             className='text-sm font-medium text-action-primary hover:underline bg-transparent border-none p-0 cursor-pointer'
           >
             Create Actionable ({selectedIds.length})

--- a/apps/dashboard/src/components/ui/MessageBubble/ThreadMessageIndicators.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/ThreadMessageIndicators.tsx
@@ -31,6 +31,8 @@ export const ThreadInfoIndicator: React.FC<ThreadInfoIndicatorProps> = ({
           `/chat/dir/${channelId}/${threadInfo.conversationId}/#origin=${threadInfo.conversationId}&messageId=${messageId}`,
         )
       }
+      data-track-category='MESSAGE'
+      data-track-name='OPEN_THREAD_FROM_INDICATOR'
       onKeyDown={e => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
@@ -71,6 +73,8 @@ export const AlsoSentToChannelIndicator: React.FC<AlsoSentToChannelIndicatorProp
           const messageLink = `/chat/dir/${channelId}#origin=${childConversationId}`;
           void navigate(messageLink);
         }}
+        data-track-category='MESSAGE'
+        data-track-name='COPY_THREAD_LINK'
         className='text-xs text-primary hover:text-primary/80 hover:underline mt-1 p-0 h-auto'
       >
         Also sent to{' '}
@@ -116,6 +120,8 @@ export const ViewNewerRepliesButton: React.FC<ViewNewerRepliesButtonProps> = ({
     >
       <button
         onClick={handleOpenParentThread}
+        data-track-category='MESSAGE'
+        data-track-name='OPEN_PARENT_THREAD'
         className={`flex items-center gap-2 text-xs bg-transparent border-0 cursor-pointer transition-opacity duration-200 hover:opacity-80 flex-1 ${
           isMe ? 'max-[500px]:justify-end' : ''
         }`}

--- a/apps/dashboard/src/components/ui/MessageBubble/TicketSuggestions.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/TicketSuggestions.tsx
@@ -119,6 +119,8 @@ export const TicketSuggestions: React.FC<TicketSuggestionsProps> = ({
           <div className='flex-1 min-w-0'>
             <button
               onClick={() => handleNavigateToTicket(created)}
+              data-track-category='MESSAGE'
+              data-track-name='OPEN_SUGGESTED_TICKET'
               className='text-sm text-left hover:underline focus:outline-none bg-transparent border-none p-0'
             >
               <span className='font-semibold text-primary'>{created.xyneId}</span>
@@ -143,6 +145,8 @@ export const TicketSuggestions: React.FC<TicketSuggestionsProps> = ({
               className='mt-1 h-4 w-4 shrink-0 rounded border-border cursor-pointer'
               disabled={isUpdating}
               onChange={() => toggleSelection(suggestion.suggestionId)}
+              data-track-category='MESSAGE'
+              data-track-name='TOGGLE_TICKET_SUGGESTION'
             />
             <label htmlFor={checkboxId} className='text-sm text-left flex-1 cursor-pointer'>
               <span className='font-medium text-foreground'>{suggestion.title}</span>
@@ -160,6 +164,8 @@ export const TicketSuggestions: React.FC<TicketSuggestionsProps> = ({
         <div className='pt-1'>
           <button
             onClick={startCreation}
+            data-track-category='MESSAGE'
+            data-track-name='START_TICKET_FROM_SUGGESTION'
             disabled={isUpdating}
             className='text-sm font-medium text-primary hover:underline disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-none p-0'
           >

--- a/apps/dashboard/src/components/ui/MobileProfileMenu/MobileProfileMenu.tsx
+++ b/apps/dashboard/src/components/ui/MobileProfileMenu/MobileProfileMenu.tsx
@@ -68,6 +68,8 @@ export const MobileProfileMenu = ({ userId }: MobileProfileMenuProps): ReactElem
           setView('default');
           setIsOpen(true);
         }}
+        data-track-category='MOBILE_PROFILE_MENU'
+        data-track-name='OPEN_USER_MENU'
       >
         {hasValidStatus && (
           <span className='text-[19px] leading-none flex items-center justify-center shrink-0'>

--- a/apps/dashboard/src/components/ui/MultiSelect/MultiSelect.tsx
+++ b/apps/dashboard/src/components/ui/MultiSelect/MultiSelect.tsx
@@ -156,6 +156,8 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
                       <button
                         type='button'
                         onClick={e => handleRemovePill(option.value, e)}
+                        data-track-category='ENTITY_PICKER'
+                        data-track-name='REMOVE_SELECTED_PILL'
                         className={cn(
                           'ml-0.5 rounded-full p-0.5 text-muted-foreground',
                           'hover:bg-accent hover:text-foreground',
@@ -263,6 +265,8 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
                       role='option'
                       aria-selected={isSelected}
                       onClick={() => toggleSelection(option.value)}
+                      data-track-category='ENTITY_PICKER'
+                      data-track-name='TOGGLE_OPTION'
                       onMouseEnter={() => setFocusedIndex(index)}
                       className={cn(
                         'flex w-full cursor-pointer select-none items-center gap-3 rounded-sm px-3 py-2 text-sm outline-none transition-colors',

--- a/apps/dashboard/src/components/ui/SearchChannel/SearchChannel.tsx
+++ b/apps/dashboard/src/components/ui/SearchChannel/SearchChannel.tsx
@@ -173,6 +173,8 @@ export const SearchChannel: React.FC<SearchChannelProps> = ({
                 <button
                   type='button'
                   onClick={() => handleTagRemove(c)}
+                  data-track-category='ENTITY_PICKER'
+                  data-track-name='REMOVE_CHANNEL_CHIP'
                   className='rounded-full p-0.5 transition-colors'
                   aria-label={`Remove ${c.name}`}
                 >

--- a/apps/dashboard/src/components/ui/SearchUser/SearchUser.tsx
+++ b/apps/dashboard/src/components/ui/SearchUser/SearchUser.tsx
@@ -191,6 +191,8 @@ export const SearchUser: React.FC<SearchUserProps> = ({
                 <button
                   type='button'
                   onClick={() => handleTagRemove(user)}
+                  data-track-category='ENTITY_PICKER'
+                  data-track-name='REMOVE_USER_CHIP'
                   className='rounded-full p-0.5 transition-colors'
                   aria-label={`Remove ${getUserDisplayName(user)}`}
                 >
@@ -285,6 +287,8 @@ export const SearchUser: React.FC<SearchUserProps> = ({
                         : 'hover:bg-accent hover:text-accent-foreground',
                     )}
                     onClick={() => handleUserSelect(user)}
+                    data-track-category='ENTITY_PICKER'
+                    data-track-name='SELECT_USER'
                     onMouseEnter={() => setSelectedIndex(index)}
                     onKeyDown={e => {
                       if (e.key === 'Enter' || e.key === ' ') {

--- a/apps/dashboard/src/components/ui/SearchUser/SearchUserV2.tsx
+++ b/apps/dashboard/src/components/ui/SearchUser/SearchUserV2.tsx
@@ -419,6 +419,8 @@ const UserPill = forwardRef<
         size='icon'
         variant='ghost'
         onClick={handleClick}
+        data-track-category='ENTITY_PICKER'
+        data-track-name='REMOVE_USER_CHIP'
         className='ml-1 hover:bg-accent rounded p-0.5 size-4'
         aria-label={`Remove ${getUserDisplayName(user)} from list`}
       >

--- a/apps/dashboard/src/components/ui/SearchUserGroups/SearchUserGroups.tsx
+++ b/apps/dashboard/src/components/ui/SearchUserGroups/SearchUserGroups.tsx
@@ -147,6 +147,8 @@ export const SearchUserGroups: React.FC<SearchUserGroupsProps> = ({
                 <button
                   type='button'
                   onClick={() => handleTagRemove(g)}
+                  data-track-category='ENTITY_PICKER'
+                  data-track-name='REMOVE_GROUP_CHIP'
                   className='rounded-full p-0.5 transition-colors'
                   aria-label={`Remove ${g.name}`}
                 >

--- a/apps/dashboard/src/components/ui/SegmentedToggle/SegmentedToggle.tsx
+++ b/apps/dashboard/src/components/ui/SegmentedToggle/SegmentedToggle.tsx
@@ -73,6 +73,9 @@ export function SegmentedToggle<T extends string>({
             type='button'
             data-slot='segmented-toggle-item'
             onClick={() => onChange(option.value)}
+            data-track-category='SEGMENTED_TOGGLE'
+            data-track-name='CHANGE_SEGMENT'
+            data-track-metadata={JSON.stringify({ value: option.value })}
             title={option.title}
             className={cn(
               'relative z-10 flex h-full items-center justify-center gap-1.5 rounded-full whitespace-nowrap',

--- a/apps/dashboard/src/components/ui/Select/FilterMultiSelect.tsx
+++ b/apps/dashboard/src/components/ui/Select/FilterMultiSelect.tsx
@@ -132,6 +132,8 @@ export const FilterMultiSelect: React.FC<FilterMultiSelectProps> = ({
                       <button
                         type='button'
                         onClick={e => removePill(opt.value, e)}
+                        data-track-category='ENTITY_PICKER'
+                        data-track-name='REMOVE_FILTER_PILL'
                         className='ml-0.5 rounded-full p-px text-muted-foreground hover:text-foreground'
                         aria-label={`Remove ${opt.label}`}
                       >
@@ -211,6 +213,8 @@ export const FilterMultiSelect: React.FC<FilterMultiSelectProps> = ({
                     role='option'
                     aria-selected={isSelected}
                     onClick={() => toggle(option.value)}
+                    data-track-category='ENTITY_PICKER'
+                    data-track-name='TOGGLE_FILTER_OPTION'
                     onMouseEnter={() => setFocusedIndex(index)}
                     className={cn(
                       'relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none transition-colors',
@@ -237,6 +241,8 @@ export const FilterMultiSelect: React.FC<FilterMultiSelectProps> = ({
               <button
                 type='button'
                 onClick={() => onChange([])}
+                data-track-category='ENTITY_PICKER'
+                data-track-name='CLEAR_ALL_FILTERS'
                 className='w-full rounded-sm px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors text-center'
               >
                 Clear all

--- a/apps/dashboard/src/components/ui/Switch.tsx
+++ b/apps/dashboard/src/components/ui/Switch.tsx
@@ -37,6 +37,12 @@ export const Switch: React.FC<SwitchProps> = ({
         aria-label={ariaLabel}
         onClick={() => !disabled && onCheckedChange(!checked)}
         disabled={disabled}
+        // Tagged here rather than at each call site so every Switch in the app
+        // is captured. `id` is the stable per-switch identifier; aria-label and
+        // label are fallbacks for the callers that omit it.
+        data-track-category='SWITCH'
+        data-track-name={id ?? ariaLabel ?? label ?? 'TOGGLE'}
+        data-track-metadata={JSON.stringify({ toChecked: !checked })}
         className={cn(
           'relative inline-flex shrink-0 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
           isDesk ? 'focus-visible:ring-desk-accent/40' : 'focus-visible:ring-primary/40',

--- a/apps/dashboard/src/components/ui/Table/TableBody.tsx
+++ b/apps/dashboard/src/components/ui/Table/TableBody.tsx
@@ -31,6 +31,8 @@ export function TableBody<TData extends Record<string, unknown>>({
             key={rowKey}
             data-slot='table-row'
             onClick={onRowClick ? () => onRowClick(row, rowIndex) : undefined}
+            data-track-category='TABLE'
+            data-track-name='OPEN_ROW'
             className={cn(
               'border-b border-border last:border-b-0',
               hoverable && 'hover:bg-muted/50',

--- a/apps/dashboard/src/components/ui/Table/TableHeader.tsx
+++ b/apps/dashboard/src/components/ui/Table/TableHeader.tsx
@@ -53,6 +53,9 @@ export function TableHeader<TData extends Record<string, unknown>>({
                 col.headerClassName,
               )}
               onClick={isSortable ? () => onSortChange(col.field) : undefined}
+              data-track-category='TABLE'
+              data-track-name='SORT_COLUMN'
+              data-track-metadata={JSON.stringify({ field: col.field })}
             >
               <div className='flex items-center justify-between gap-1.5'>
                 <span>{col.renderHeader ? col.renderHeader() : col.header}</span>

--- a/apps/dashboard/src/components/ui/Table/TablePagination.tsx
+++ b/apps/dashboard/src/components/ui/Table/TablePagination.tsx
@@ -42,6 +42,8 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
       <div className='flex items-center gap-2'>
         <button
           onClick={() => onPageChange(currentPage - 1)}
+          data-track-category='TABLE'
+          data-track-name='PREV_PAGE'
           disabled={currentPage <= 1}
           className='p-1.5 rounded-full border border-border hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed'
         >
@@ -52,6 +54,8 @@ export const TablePagination: React.FC<TablePaginationProps> = ({
         </span>
         <button
           onClick={() => onPageChange(currentPage + 1)}
+          data-track-category='TABLE'
+          data-track-name='NEXT_PAGE'
           disabled={currentPage >= totalPages}
           className='p-1.5 rounded-full border border-border hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed'
         >

--- a/apps/dashboard/src/components/ui/TagChipInput/TagChipInput.tsx
+++ b/apps/dashboard/src/components/ui/TagChipInput/TagChipInput.tsx
@@ -57,6 +57,8 @@ export const TagChipInput: React.FC<TagChipInputProps> = ({
             <button
               type='button'
               onClick={() => removeTag(index)}
+              data-track-category='ENTITY_PICKER'
+              data-track-name='REMOVE_TAG_CHIP'
               className='rounded p-0.5 hover:bg-accent'
               aria-label={`Remove ${tag}`}
             >

--- a/apps/dashboard/src/components/ui/UserMentionPopover/UserMentionPopover.tsx
+++ b/apps/dashboard/src/components/ui/UserMentionPopover/UserMentionPopover.tsx
@@ -137,6 +137,8 @@ const UserHoverWrapperInner: React.FC<UserHoverWrapperProps> = ({
           e.stopPropagation();
           handleProfileClick();
         }}
+        data-track-category='MENTION'
+        data-track-name='OPEN_USER_PROFILE_FROM_MENTION'
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
@@ -162,6 +164,8 @@ const UserHoverWrapperInner: React.FC<UserHoverWrapperProps> = ({
             e.stopPropagation();
             handleProfileClick();
           }}
+          data-track-category='MENTION'
+          data-track-name='OPEN_USER_PROFILE_FROM_MENTION'
           onKeyDown={e => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
@@ -229,6 +233,8 @@ const UserHoverWrapperInner: React.FC<UserHoverWrapperProps> = ({
               variant='secondary'
               size='default'
               onClick={handleSendMessage}
+              data-track-category='MENTION'
+              data-track-name='SEND_MESSAGE_FROM_MENTION'
               className='flex items-center gap-2'
             >
               <ChatDefault className='size-4' />
@@ -238,6 +244,8 @@ const UserHoverWrapperInner: React.FC<UserHoverWrapperProps> = ({
               variant='secondary'
               size='default'
               onClick={handleHuddleClick}
+              data-track-category='MENTION'
+              data-track-name='START_HUDDLE_FROM_MENTION'
               className='flex items-center gap-2'
             >
               <Headphones className='size-4' />

--- a/apps/dashboard/src/components/ui/UserProfile/UserProfile.tsx
+++ b/apps/dashboard/src/components/ui/UserProfile/UserProfile.tsx
@@ -352,6 +352,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
             <div
               className='relative group cursor-pointer'
               onClick={handlePictureClick}
+              data-track-category='USER_PROFILE'
+              data-track-name='CHANGE_PROFILE_PICTURE'
               onKeyDown={e => {
                 if (e.key === 'Enter') handlePictureClick();
               }}
@@ -421,6 +423,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                 />
                 <button
                   onClick={handleSaveEdit}
+                  data-track-category='USER_PROFILE'
+                  data-track-name='SAVE_TEAM'
                   className='p-1 text-green-600 hover:bg-green-50 rounded'
                   title='Save'
                 >
@@ -428,6 +432,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                 </button>
                 <button
                   onClick={handleCancelEdit}
+                  data-track-category='USER_PROFILE'
+                  data-track-name='CANCEL_EDIT_TEAM'
                   className='p-1 text-muted-foreground hover:bg-accent rounded'
                   title='Cancel'
                 >
@@ -452,6 +458,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
           ) : isOwnProfile ? (
             <button
               onClick={() => handleStartEdit('team')}
+              data-track-category='USER_PROFILE'
+              data-track-name='START_EDIT_TEAM'
               className='mt-1 text-sm text-action-primary hover:opacity-80 flex items-center gap-1 transition-opacity'
             >
               <span>+ Add Team Name</span>
@@ -492,6 +500,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
             <div className='flex items-center gap-2 mt-4'>
               <Button
                 onClick={handleMessageClick}
+                data-track-category='USER_PROFILE'
+                data-track-name='SEND_MESSAGE_TO_USER'
                 className='flex items-center gap-2 px-4 py-2 border border-input bg-background hover:bg-accent text-foreground rounded-lg'
                 variant='outline'
               >
@@ -500,6 +510,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
               </Button>
               <Button
                 onClick={handleHuddleClick}
+                data-track-category='USER_PROFILE'
+                data-track-name='START_HUDDLE_WITH_USER'
                 className='flex items-center gap-2 px-4 py-2 border border-input bg-background hover:bg-accent text-foreground rounded-lg'
                 variant='outline'
               >
@@ -523,6 +535,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                   : 'border-border bg-muted',
               )}
               onClick={() => setIsStatusModalOpen(true)}
+              data-track-category='USER_PROFILE'
+              data-track-name='OPEN_STATUS_MODAL'
               onKeyDown={e => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
@@ -553,6 +567,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                     variant='ghost'
                     size='sm'
                     onClick={handleClearStatus}
+                    data-track-category='USER_PROFILE'
+                    data-track-name='CLEAR_STATUS'
                     className='flex-shrink-0 p-1 h-auto hover:bg-accent min-w-[20px]'
                     title='Clear status'
                   >
@@ -610,6 +626,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                     setEditingField(null);
                     setSelectedManagerUsers([]);
                   }}
+                  data-track-category='USER_PROFILE'
+                  data-track-name='CANCEL_EDIT_MANAGER'
                   className='px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground'
                 >
                   Cancel
@@ -630,6 +648,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                     setEditingField(null);
                     setSelectedManagerUsers([]);
                   }}
+                  data-track-category='USER_PROFILE'
+                  data-track-name='SAVE_MANAGER'
                   className='px-3 py-1.5 text-sm bg-gray-900 text-white rounded hover:bg-gray-800'
                 >
                   Save
@@ -649,6 +669,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                 setEditingField('manager');
                 setSelectedManagerUsers([]);
               }}
+              data-track-category='USER_PROFILE'
+              data-track-name='START_EDIT_MANAGER'
               className='text-sm text-action-primary hover:opacity-80 flex items-center gap-1 transition-opacity'
             >
               <span>+ Add Manager</span>
@@ -677,6 +699,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                   size='iconSm'
                   className='h-5 w-5 p-0 text-muted-foreground hover:text-foreground'
                   onClick={handleCopyUserId}
+                  data-track-category='USER_PROFILE'
+                  data-track-name='COPY_USER_ID'
                   title='Copy user ID'
                 >
                   {copiedUserId ? <Check className='size-3' /> : <Copy className='size-3' />}
@@ -710,6 +734,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                   {isOwnProfile && userProfile?.displayName && editingField !== 'displayName' && (
                     <button
                       onClick={() => handleStartEdit('displayName', userProfile.displayName)}
+                      data-track-category='USER_PROFILE'
+                      data-track-name='START_EDIT_DISPLAY_NAME'
                       className='text-muted-foreground hover:text-muted-foreground'
                       title='Edit display name'
                     >
@@ -735,6 +761,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                       />
                       <button
                         onClick={handleSaveEdit}
+                        data-track-category='USER_PROFILE'
+                        data-track-name='SAVE_DISPLAY_NAME'
                         className='p-1 text-green-600 hover:bg-green-50 rounded'
                         title='Save'
                       >
@@ -742,6 +770,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                       </button>
                       <button
                         onClick={handleCancelEdit}
+                        data-track-category='USER_PROFILE'
+                        data-track-name='CANCEL_EDIT_DISPLAY_NAME'
                         className='p-1 text-muted-foreground hover:bg-accent rounded'
                         title='Cancel'
                       >
@@ -755,6 +785,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                 ) : isOwnProfile ? (
                   <button
                     onClick={() => handleStartEdit('displayName', userProfile?.displayName)}
+                    data-track-category='USER_PROFILE'
+                    data-track-name='START_EDIT_DISPLAY_NAME'
                     className='mt-1 text-sm text-action-primary hover:opacity-80 transition-opacity'
                   >
                     + Add Display Name
@@ -776,6 +808,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                   {isOwnProfile && userProfile?.phoneNumber && editingField !== 'phoneNumber' && (
                     <button
                       onClick={() => handleStartEdit('phoneNumber', userProfile.phoneNumber)}
+                      data-track-category='USER_PROFILE'
+                      data-track-name='START_EDIT_PHONE_NUMBER'
                       className='text-muted-foreground hover:text-muted-foreground'
                       title='Edit phone number'
                     >
@@ -801,6 +835,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                       />
                       <button
                         onClick={handleSaveEdit}
+                        data-track-category='USER_PROFILE'
+                        data-track-name='SAVE_PHONE_NUMBER'
                         className='p-1 text-green-600 hover:bg-green-50 rounded'
                         title='Save'
                       >
@@ -808,6 +844,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                       </button>
                       <button
                         onClick={handleCancelEdit}
+                        data-track-category='USER_PROFILE'
+                        data-track-name='CANCEL_EDIT_PHONE_NUMBER'
                         className='p-1 text-muted-foreground hover:bg-accent rounded'
                         title='Cancel'
                       >
@@ -821,6 +859,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                 ) : (
                   <button
                     onClick={() => handleStartEdit('phoneNumber')}
+                    data-track-category='USER_PROFILE'
+                    data-track-name='START_EDIT_PHONE_NUMBER'
                     className='mt-1 text-sm text-action-primary hover:opacity-80 transition-opacity'
                   >
                     + Add Phone Number
@@ -866,6 +906,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                   {isOwnProfile && userProfile?.dob && editingField !== 'dob' && (
                     <button
                       onClick={() => handleStartEdit('dob', userProfile.dob)}
+                      data-track-category='USER_PROFILE'
+                      data-track-name='START_EDIT_BIRTH_DATE'
                       className='text-muted-foreground hover:text-muted-foreground'
                       title='Edit birth date'
                     >
@@ -890,6 +932,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                       />
                       <button
                         onClick={handleSaveEdit}
+                        data-track-category='USER_PROFILE'
+                        data-track-name='SAVE_BIRTH_DATE'
                         className='p-1 text-green-600 hover:bg-green-50 rounded'
                         title='Save'
                       >
@@ -897,6 +941,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                       </button>
                       <button
                         onClick={handleCancelEdit}
+                        data-track-category='USER_PROFILE'
+                        data-track-name='CANCEL_EDIT_BIRTH_DATE'
                         className='p-1 text-muted-foreground hover:bg-accent rounded'
                         title='Cancel'
                       >
@@ -919,6 +965,8 @@ export const UserProfile: React.FC<UserProfileProps> = ({
                 ) : (
                   <button
                     onClick={() => handleStartEdit('dob')}
+                    data-track-category='USER_PROFILE'
+                    data-track-name='START_EDIT_BIRTH_DATE'
                     className='mt-1 text-sm text-action-primary hover:opacity-80 transition-opacity'
                   >
                     + Add Birth Date

--- a/apps/dashboard/src/components/ui/files/AttachmentPreview.tsx
+++ b/apps/dashboard/src/components/ui/files/AttachmentPreview.tsx
@@ -337,6 +337,8 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
                     e.stopPropagation();
                     onRemove();
                   }}
+                  data-track-category='MESSAGE_ATTACHMENT'
+                  data-track-name='REMOVE_ATTACHMENT'
                 >
                   <X className='size-3.5 text-red-600' strokeWidth={2.33} />
                 </button>
@@ -361,6 +363,8 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
             type='button'
             className='absolute inset-0 cursor-default'
             onClick={() => setVideoLightboxUrl(null)}
+            data-track-category='MESSAGE_ATTACHMENT'
+            data-track-name='CLOSE_VIDEO_LIGHTBOX'
             aria-label='Close video lightbox'
             tabIndex={-1}
           />
@@ -368,6 +372,8 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
             <button
               type='button'
               onClick={() => setVideoLightboxUrl(null)}
+              data-track-category='MESSAGE_ATTACHMENT'
+              data-track-name='CLOSE_VIDEO_LIGHTBOX'
               className='absolute -top-3 -right-3 z-10 flex items-center justify-center size-7 rounded-full bg-black/70 hover:bg-black text-white transition-colors border border-white/20'
               aria-label='Close video'
             >
@@ -395,6 +401,8 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
             onPreview?.();
           }
         }}
+        data-track-category='MESSAGE_ATTACHMENT'
+        data-track-name='OPEN_ATTACHMENT_PREVIEW'
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
@@ -430,6 +438,8 @@ export const AttachmentPreview: React.FC<AttachmentPreviewProps> = ({
               e.stopPropagation();
               onRemove();
             }}
+            data-track-category='MESSAGE_ATTACHMENT'
+            data-track-name='REMOVE_ATTACHMENT'
             className={`absolute -top-2 -right-2 p-1 bg-background hover:bg-destructive/10 rounded-full transition-colors shadow-md border border-border z-10 ${
               isMobile ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
             }`}

--- a/apps/dashboard/src/components/ui/files/FilePill.tsx
+++ b/apps/dashboard/src/components/ui/files/FilePill.tsx
@@ -268,6 +268,8 @@ export const FilePill: React.FC<FilePillProps> = ({
         className,
       )}
       onClick={onClick}
+      data-track-category='MESSAGE_ATTACHMENT'
+      data-track-name='OPEN_FILE_PILL'
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
       onKeyDown={
@@ -322,6 +324,8 @@ export const FilePill: React.FC<FilePillProps> = ({
               e.stopPropagation();
               onDownload();
             }}
+            data-track-category='MESSAGE_ATTACHMENT'
+            data-track-name='DOWNLOAD_FILE_PILL'
             className='p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors'
             title='Download'
             aria-label={`Download ${fileName}`}
@@ -338,6 +342,8 @@ export const FilePill: React.FC<FilePillProps> = ({
               e.stopPropagation();
               onDelete();
             }}
+            data-track-category='MESSAGE_ATTACHMENT'
+            data-track-name='DELETE_FILE_PILL'
             className='p-1.5 rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors'
             title='Delete'
             aria-label={`Delete ${fileName}`}
@@ -354,6 +360,8 @@ export const FilePill: React.FC<FilePillProps> = ({
               e.stopPropagation();
               onRemove();
             }}
+            data-track-category='MESSAGE_ATTACHMENT'
+            data-track-name='REMOVE_FILE_PILL'
             className='p-1.5 rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors'
             title='Remove'
             aria-label={`Remove ${fileName}`}

--- a/apps/dashboard/src/components/ui/files/HtmlPreviewCard.tsx
+++ b/apps/dashboard/src/components/ui/files/HtmlPreviewCard.tsx
@@ -142,6 +142,8 @@ export const HtmlPreviewCard: React.FC<HtmlPreviewCardProps> = ({
         className,
       )}
       onClick={onOpen}
+      data-track-category='MESSAGE_ATTACHMENT'
+      data-track-name='OPEN_HTML_PREVIEW'
       role='button'
       tabIndex={0}
       onKeyDown={e => {
@@ -231,6 +233,8 @@ export const HtmlPreviewCard: React.FC<HtmlPreviewCardProps> = ({
             e.stopPropagation();
             onOpen();
           }}
+          data-track-category='MESSAGE_ATTACHMENT'
+          data-track-name='OPEN_HTML_PREVIEW'
           className='flex shrink-0 items-center justify-center rounded-[6px] p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
           title='Open preview'
           aria-label={`Open ${fileName}`}

--- a/apps/dashboard/src/components/ui/files/MediaViewer.tsx
+++ b/apps/dashboard/src/components/ui/files/MediaViewer.tsx
@@ -186,6 +186,8 @@ export const MediaViewer: React.FC<MediaViewerProps> = ({
       aria-label='File viewer - click or press Enter to close'
       className='fixed inset-0 z-[9999] flex items-center justify-center bg-black/95 pointer-events-auto'
       onClick={onClose}
+      data-track-category='FILE_VIEWER'
+      data-track-name='CLOSE_MEDIA_VIEWER_BACKDROP'
       onKeyDown={(e): void => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
@@ -204,6 +206,8 @@ export const MediaViewer: React.FC<MediaViewerProps> = ({
                 e.stopPropagation();
                 handleDownload();
               }}
+              data-track-category='FILE_VIEWER'
+              data-track-name='DOWNLOAD_FROM_MEDIA_VIEWER'
               className='p-2 rounded-full hover:bg-background/10 transition-colors text-white'
               title='Download file'
             >
@@ -212,6 +216,8 @@ export const MediaViewer: React.FC<MediaViewerProps> = ({
           )}
           <button
             onClick={onClose}
+            data-track-category='FILE_VIEWER'
+            data-track-name='CLOSE_MEDIA_VIEWER'
             className='p-2 rounded-full hover:bg-background/10 transition-colors text-white'
             title='Close (Esc)'
           >
@@ -237,6 +243,8 @@ export const MediaViewer: React.FC<MediaViewerProps> = ({
             </div>
             <button
               onClick={onClose}
+              data-track-category='FILE_VIEWER'
+              data-track-name='CLOSE_MEDIA_VIEWER'
               className='px-6 py-2 bg-muted-foreground text-white rounded-lg hover:bg-foreground transition-colors'
             >
               Close

--- a/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskConnectionCard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskConnectionCard.tsx
@@ -119,6 +119,8 @@ export const DeskConnectionCard = ({
               variant='secondary'
               size='sm'
               onClick={() => setShowDisconnectConfirm(false)}
+              data-track-category='desk-integration'
+              data-track-name='CANCEL_DISCONNECT'
               disabled={isDisconnecting}
             >
               Cancel

--- a/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskIntegrationCard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskIntegrationCard.tsx
@@ -143,6 +143,8 @@ export const DeskIntegrationCard = ({
               variant='secondary'
               size='sm'
               onClick={() => setShowDisconnectConfirm(false)}
+              data-track-category='desk-integration'
+              data-track-name='CANCEL_DISCONNECT'
               disabled={isDisconnecting}
             >
               Cancel

--- a/apps/dashboard/src/components/xyne-desk/EmailComposer/EmailComposer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailComposer/EmailComposer.tsx
@@ -2921,6 +2921,8 @@ export const EmailComposer = ({
                         const base = channelId ? `${supportBase}/${channelId}` : supportBase;
                         void composerNavigate(`${base}?openSettings=signatures`);
                       }}
+                      data-track-category='Support'
+                      data-track-name='OPEN_SUPPORT_FROM_COMPOSER'
                       className='text-xs text-muted-foreground'
                     >
                       Manage signatures
@@ -2928,6 +2930,8 @@ export const EmailComposer = ({
                     <DropdownMenuSeparator />
                     <DropdownMenuItem
                       onClick={() => setSelectedSignatureId(null)}
+                      data-track-category='Support'
+                      data-track-name='CLEAR_EMAIL_SIGNATURE'
                       className={!selectedSignatureId ? 'font-medium' : ''}
                     >
                       No signature
@@ -2936,6 +2940,8 @@ export const EmailComposer = ({
                       <DropdownMenuItem
                         key={sig.id}
                         onClick={() => setSelectedSignatureId(sig.id)}
+                        data-track-category='Support'
+                        data-track-name='SELECT_EMAIL_SIGNATURE'
                         className={selectedSignatureId === sig.id ? 'font-medium' : ''}
                       >
                         {sig.name}

--- a/apps/dashboard/src/components/xyne-desk/EmailEditor/EmailEditorToolbar.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailEditor/EmailEditorToolbar.tsx
@@ -739,6 +739,8 @@ export const EmailEditorToolbar: React.FC<EmailEditorToolbarProps> = ({
             {isActive.link && (
               <Button
                 onClick={removeLink}
+                data-track-category='email-editor'
+                data-track-name='REMOVE_LINK'
                 className='rounded px-2 py-1 text-xs text-red-500 hover:bg-red-500/10 hover:text-red-600 dark:text-red-400 dark:hover:bg-red-400/10 dark:hover:text-red-300'
                 variant='ghost'
               >
@@ -748,6 +750,8 @@ export const EmailEditorToolbar: React.FC<EmailEditorToolbarProps> = ({
             <div className='flex gap-2 ml-auto'>
               <Button
                 onClick={() => setLinkDialogOpen(false)}
+                data-track-category='email-editor'
+                data-track-name='CANCEL_LINK'
                 variant='secondary'
                 className='rounded px-3 py-1.5 text-xs text-foreground'
               >
@@ -755,6 +759,8 @@ export const EmailEditorToolbar: React.FC<EmailEditorToolbarProps> = ({
               </Button>
               <Button
                 onClick={applyLink}
+                data-track-category='email-editor'
+                data-track-name='APPLY_LINK'
                 disabled={!linkUrl.trim()}
                 className='rounded bg-primary px-3 py-1.5 text-xs text-white disabled:opacity-50 disabled:text-white'
               >

--- a/apps/dashboard/src/components/xyne-desk/WorkspaceDeskEmailCard/WorkspaceDeskEmailCard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/WorkspaceDeskEmailCard/WorkspaceDeskEmailCard.tsx
@@ -183,6 +183,8 @@ export const WorkspaceDeskEmailCard = (): ReactElement => {
               variant='secondary'
               size='sm'
               onClick={() => setShowDisconnectConfirm(false)}
+              data-track-category='workspace-desk-email'
+              data-track-name='CANCEL_DISCONNECT'
               disabled={isDisconnecting}
             >
               Cancel

--- a/apps/dashboard/src/routes/AppsScreen/AppsScreen.tsx
+++ b/apps/dashboard/src/routes/AppsScreen/AppsScreen.tsx
@@ -487,7 +487,14 @@ const AppsScreen = (): ReactElement => {
                 Showing {filteredApps.length} of {searchTotal}
               </span>
               {hasMore && (
-                <Button variant='outline' size='sm' onClick={loadMore} disabled={isSearching}>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  onClick={loadMore}
+                  data-track-category='Apps'
+                  data-track-name='LOAD_MORE_APPS'
+                  disabled={isSearching}
+                >
                   {isSearching ? 'Loading…' : 'Load more'}
                 </Button>
               )}
@@ -501,6 +508,8 @@ const AppsScreen = (): ReactElement => {
                 variant='outline'
                 size='sm'
                 onClick={handlePreviousPage}
+                data-track-category='Apps'
+                data-track-name='APPS_PREV_PAGE'
                 disabled={!hasPreviousPage}
                 className='gap-1'
               >
@@ -512,6 +521,8 @@ const AppsScreen = (): ReactElement => {
                 variant='outline'
                 size='sm'
                 onClick={handleNextPage}
+                data-track-category='Apps'
+                data-track-name='APPS_NEXT_PAGE'
                 disabled={!hasNextPage}
                 className='gap-1'
               >

--- a/apps/dashboard/src/routes/CallHistoryScreen/CallCard.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CallCard.tsx
@@ -365,6 +365,8 @@ export const CallCard = ({
                           e.stopPropagation();
                           handleGotoTranscript?.();
                         }}
+                        data-track-category='calls'
+                        data-track-name='GOTO_TRANSCRIPT'
                         disabled={!isUserChannelMember || !handleGotoTranscript}
                         className='text-sm font-medium rounded-lg'
                       >
@@ -376,6 +378,8 @@ export const CallCard = ({
                             e.stopPropagation();
                             onViewExternalChat();
                           }}
+                          data-track-category='calls'
+                          data-track-name='VIEW_EXTERNAL_CHAT'
                           className='text-sm font-medium rounded-lg'
                         >
                           View External Chat
@@ -386,6 +390,8 @@ export const CallCard = ({
                           e.stopPropagation();
                           handleDownloadTranscript?.();
                         }}
+                        data-track-category='calls'
+                        data-track-name='DOWNLOAD_TRANSCRIPT'
                         disabled={!hasTranscript}
                         className='text-sm font-medium rounded-lg'
                       >
@@ -396,6 +402,8 @@ export const CallCard = ({
                           e.stopPropagation();
                           onCallClick();
                         }}
+                        data-track-category='calls'
+                        data-track-name='OPEN_CALL'
                         className='text-sm font-medium rounded-lg'
                       >
                         Start Call
@@ -493,6 +501,8 @@ export const CallCard = ({
                         e.stopPropagation();
                         handleGotoTranscript?.();
                       }}
+                      data-track-category='calls'
+                      data-track-name='GOTO_TRANSCRIPT'
                       disabled={!isUserChannelMember || !handleGotoTranscript}
                       className='text-sm font-medium rounded-lg'
                     >
@@ -504,6 +514,8 @@ export const CallCard = ({
                           e.stopPropagation();
                           onViewExternalChat();
                         }}
+                        data-track-category='calls'
+                        data-track-name='VIEW_EXTERNAL_CHAT'
                         className='text-sm font-medium rounded-lg'
                       >
                         External Huddle
@@ -514,6 +526,8 @@ export const CallCard = ({
                         e.stopPropagation();
                         handleDownloadTranscript?.();
                       }}
+                      data-track-category='calls'
+                      data-track-name='DOWNLOAD_TRANSCRIPT'
                       disabled={!hasTranscript}
                       className='text-sm font-medium rounded-lg'
                     >
@@ -531,6 +545,8 @@ export const CallCard = ({
                     >
                       <Button
                         onClick={handleGotoTranscript}
+                        data-track-category='calls'
+                        data-track-name='GOTO_TRANSCRIPT'
                         variant='outline'
                         size='icon'
                         disabled={!isUserChannelMember || !handleGotoTranscript}
@@ -547,6 +563,8 @@ export const CallCard = ({
                     <span className={!hasTranscript ? 'cursor-not-allowed' : ''}>
                       <Button
                         onClick={handleDownloadTranscript}
+                        data-track-category='calls'
+                        data-track-name='DOWNLOAD_TRANSCRIPT'
                         variant='outline'
                         size='icon'
                         disabled={!hasTranscript}
@@ -580,6 +598,8 @@ export const CallCard = ({
                     e.stopPropagation();
                     onCallClick();
                   }}
+                  data-track-category='calls'
+                  data-track-name='OPEN_CALL'
                   variant='outline'
                   data-testid='call-join-button'
                   className={cn(

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawAgentCreateScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawAgentCreateScreen.tsx
@@ -115,23 +115,44 @@ const ClawAgentCreateScreen = (): ReactElement => {
             widthClass,
           )}
         >
-          <Button variant='ghost' onClick={cancel}>
+          <Button
+            variant='ghost'
+            onClick={cancel}
+            data-track-category='Claw Agents'
+            data-track-name='CANCEL_CREATE_AGENT'
+          >
             Cancel
           </Button>
           <div className='flex items-center gap-2'>
             {step > 0 && (
-              <Button variant='outline' onClick={goBack}>
+              <Button
+                variant='outline'
+                onClick={goBack}
+                data-track-category='Claw Agents'
+                data-track-name='AGENT_WIZARD_BACK'
+              >
                 <ChevronLeft className='size-4' />
                 Back
               </Button>
             )}
             {step < LAST_STEP ? (
-              <Button onClick={goNext} disabled={!canNext}>
+              <Button
+                onClick={goNext}
+                data-track-category='Claw Agents'
+                data-track-name='AGENT_WIZARD_NEXT'
+                disabled={!canNext}
+              >
                 Next
                 <ChevronRight className='size-4' />
               </Button>
             ) : (
-              <Button onClick={handleCreate} loading={createMutation.isPending} disabled={!canNext}>
+              <Button
+                onClick={handleCreate}
+                data-track-category='Claw Agents'
+                data-track-name='CREATE_AGENT'
+                loading={createMutation.isPending}
+                disabled={!canNext}
+              >
                 {!createMutation.isPending && <Check className='size-4' />}
                 Create agent
               </Button>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawOrganizationScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawOrganizationScreen.tsx
@@ -111,7 +111,13 @@ const ClawOrganizationScreen = (): ReactElement => {
           <h1 className='text-base font-semibold text-foreground'>Organization unavailable</h1>
           <p className='mt-1 text-sm text-muted-foreground'>{error.message}</p>
         </div>
-        <Button variant='outline' size='sm' onClick={() => void refetch()}>
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={() => void refetch()}
+          data-track-category='Claw Agents'
+          data-track-name='RELOAD_ORGANIZATION'
+        >
           Try again
         </Button>
       </div>
@@ -209,6 +215,8 @@ const ClawOrganizationScreen = (): ReactElement => {
               loading={addMember.isPending}
               disabled={!newMember.trim()}
               onClick={() => void submitMember()}
+              data-track-category='Claw Agents'
+              data-track-name='ADD_ORGANIZATION_MEMBER'
             >
               Add member
             </Button>
@@ -288,6 +296,8 @@ const ClawOrganizationScreen = (): ReactElement => {
                             size='iconSm'
                             aria-label={`Remove ${member.email}`}
                             onClick={() => setRemoveTarget(member)}
+                            data-track-category='Claw Agents'
+                            data-track-name='OPEN_REMOVE_MEMBER_CONFIRM'
                           >
                             <Trash2 className='size-4 text-muted-foreground' />
                           </Button>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawSettingsScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawSettingsScreen.tsx
@@ -180,7 +180,13 @@ const ProviderCard = ({
       )}
 
       <div className='mt-auto flex justify-end'>
-        <Button size='sm' variant={isConnected ? 'secondary' : 'default'} onClick={onOpenDialog}>
+        <Button
+          size='sm'
+          variant={isConnected ? 'secondary' : 'default'}
+          onClick={onOpenDialog}
+          data-track-category='claw-settings'
+          data-track-name='OPEN_SETTINGS_DIALOG'
+        >
           {isConnected ? 'Configure' : 'Connect'}
         </Button>
       </div>
@@ -426,7 +432,12 @@ const CopilotConfigForm = ({
           <p className='text-sm text-muted-foreground'>
             Connect your GitHub account to use Copilot-powered code suggestions across all agents.
           </p>
-          <Button onClick={() => void startLogin()} disabled={starting}>
+          <Button
+            onClick={() => void startLogin()}
+            data-track-category='claw-settings'
+            data-track-name='START_GITHUB_LOGIN'
+            disabled={starting}
+          >
             {starting ? <Loader2 className='size-4 animate-spin' /> : <Plug className='size-4' />}
             {starting ? 'Starting...' : 'Log in with GitHub'}
           </Button>
@@ -455,12 +466,20 @@ const CopilotConfigForm = ({
             <Button
               variant='secondary'
               onClick={() => void startLogin()}
+              data-track-category='claw-settings'
+              data-track-name='RESTART_GITHUB_LOGIN'
               disabled={starting || saving}
             >
               <Github className='size-4' />
               Reconnect
             </Button>
-            <Button variant='destructive' onClick={() => void handleDisconnect()} disabled={saving}>
+            <Button
+              variant='destructive'
+              onClick={() => void handleDisconnect()}
+              data-track-category='claw-settings'
+              data-track-name='DISCONNECT_GITHUB'
+              disabled={saving}
+            >
               <Trash2 className='size-4' />
               Disconnect
             </Button>
@@ -480,6 +499,8 @@ const CopilotConfigForm = ({
               variant='ghost'
               aria-label='Copy GitHub authorization code'
               onClick={() => void navigator.clipboard.writeText(device.userCode)}
+              data-track-category='claw-settings'
+              data-track-name='COPY_GITHUB_DEVICE_CODE'
             >
               <Copy className='size-4' />
             </Button>
@@ -693,7 +714,13 @@ const GenericProviderConfigForm = ({
         {isOauth && isCodex && (
           <div className='mt-2 flex flex-col gap-2 rounded-lg border border-[var(--claw-ai-border)] bg-[var(--claw-ai-surface)] px-3 py-2.5 text-xs text-[var(--claw-ai-fg)]'>
             {!codexFlow ? (
-              <Button size='sm' onClick={() => void startCodexOAuth()} disabled={codexBusy}>
+              <Button
+                size='sm'
+                onClick={() => void startCodexOAuth()}
+                data-track-category='claw-settings'
+                data-track-name='START_CODEX_OAUTH'
+                disabled={codexBusy}
+              >
                 {codexBusy ? (
                   <Loader2 className='size-4 animate-spin' />
                 ) : (
@@ -723,6 +750,8 @@ const GenericProviderConfigForm = ({
                   <Button
                     size='sm'
                     onClick={() => void completeCodexOAuth()}
+                    data-track-category='claw-settings'
+                    data-track-name='COMPLETE_CODEX_OAUTH'
                     disabled={codexBusy || !codexCode.trim()}
                   >
                     {codexBusy ? 'Verifying...' : 'Complete sign-in'}
@@ -734,6 +763,8 @@ const GenericProviderConfigForm = ({
                       setCodexFlow(null);
                       setCodexCode('');
                     }}
+                    data-track-category='claw-settings'
+                    data-track-name='CANCEL_CODEX_OAUTH'
                   >
                     Cancel
                   </Button>
@@ -802,11 +833,23 @@ const GenericProviderConfigForm = ({
 
       <div className='flex items-center justify-end gap-2 pt-2'>
         {hasKey && (
-          <Button variant='ghost' onClick={() => void handleDelete()} disabled={deleting || saving}>
+          <Button
+            variant='ghost'
+            onClick={() => void handleDelete()}
+            data-track-category='claw-settings'
+            data-track-name='DELETE_MODEL_PROVIDER'
+            disabled={deleting || saving}
+          >
             {deleting ? 'Removing...' : 'Remove'}
           </Button>
         )}
-        <Button onClick={() => void handleSave()} loading={saving} disabled={!apiKey && !hasKey}>
+        <Button
+          onClick={() => void handleSave()}
+          data-track-category='claw-settings'
+          data-track-name='SAVE_MODEL_PROVIDER'
+          loading={saving}
+          disabled={!apiKey && !hasKey}
+        >
           {hasKey ? 'Save changes' : 'Connect'}
         </Button>
       </div>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawSkillCreateScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawSkillCreateScreen.tsx
@@ -183,11 +183,23 @@ const ClawSkillCreateScreen = (): ReactElement => {
               onChange={e => void handlePick(e.target.files, fileInputRef.current)}
             />
             <div className='flex flex-wrap items-center gap-2'>
-              <Button variant='outline' size='sm' onClick={() => dirInputRef.current?.click()}>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => dirInputRef.current?.click()}
+                data-track-category='Claw Agents'
+                data-track-name='PICK_SKILL_DIRECTORY'
+              >
                 <FolderOpen className='size-3.5' />
                 Upload folder
               </Button>
-              <Button variant='outline' size='sm' onClick={() => fileInputRef.current?.click()}>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => fileInputRef.current?.click()}
+                data-track-category='Claw Agents'
+                data-track-name='PICK_SKILL_FILES'
+              >
                 <Upload className='size-3.5' />
                 Upload files
               </Button>
@@ -215,10 +227,21 @@ const ClawSkillCreateScreen = (): ReactElement => {
             widthClass,
           )}
         >
-          <Button variant='ghost' onClick={cancel}>
+          <Button
+            variant='ghost'
+            onClick={cancel}
+            data-track-category='Claw Agents'
+            data-track-name='CANCEL_CREATE_SKILL'
+          >
             Cancel
           </Button>
-          <Button onClick={handleCreate} loading={createMutation.isPending} disabled={!canCreate}>
+          <Button
+            onClick={handleCreate}
+            data-track-category='Claw Agents'
+            data-track-name='CREATE_SKILL'
+            loading={createMutation.isPending}
+            disabled={!canCreate}
+          >
             {!createMutation.isPending && <Check className='size-4' />}
             Create skill
           </Button>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawSkillDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawSkillDetailScreen.tsx
@@ -130,10 +130,23 @@ const DirtyActions = ({
   onCancel: () => void;
 }): ReactElement => (
   <div className='flex gap-2'>
-    <Button size='sm' loading={saving} onClick={onSave}>
+    <Button
+      size='sm'
+      loading={saving}
+      onClick={onSave}
+      data-track-category='Claw Agents'
+      data-track-name='SAVE_SKILL'
+    >
       Save
     </Button>
-    <Button variant='ghost' size='sm' disabled={saving} onClick={onCancel}>
+    <Button
+      variant='ghost'
+      size='sm'
+      disabled={saving}
+      onClick={onCancel}
+      data-track-category='Claw Agents'
+      data-track-name='CANCEL_SKILL_EDIT'
+    >
       Cancel
     </Button>
   </div>
@@ -239,6 +252,8 @@ const FilesSection = ({
             size='sm'
             disabled={uploading}
             onClick={() => dirInputRef.current?.click()}
+            data-track-category='Claw Agents'
+            data-track-name='PICK_SKILL_DIRECTORY'
           >
             <FolderOpen className='size-3.5' />
             Upload folder
@@ -248,6 +263,8 @@ const FilesSection = ({
             size='sm'
             disabled={uploading}
             onClick={() => fileInputRef.current?.click()}
+            data-track-category='Claw Agents'
+            data-track-name='PICK_SKILL_FILES'
           >
             <Upload className='size-3.5' />
             Upload files
@@ -673,6 +690,8 @@ const ClawSkillDetailScreen = (): ReactElement => {
                           variant='ghost'
                           size='sm'
                           onClick={() => mdInputRef.current?.click()}
+                          data-track-category='Claw Agents'
+                          data-track-name='PICK_SKILL_MARKDOWN'
                         >
                           <Upload className='size-3.5' />
                           Upload .md
@@ -740,6 +759,8 @@ const ClawSkillDetailScreen = (): ReactElement => {
                           size='sm'
                           loading={publishing}
                           onClick={() => void handlePublish()}
+                          data-track-category='Claw Agents'
+                          data-track-name='PUBLISH_SKILL'
                         >
                           <Globe className='size-3.5' />
                           Publish
@@ -758,6 +779,8 @@ const ClawSkillDetailScreen = (): ReactElement => {
                           variant='destructive'
                           size='sm'
                           onClick={() => setShowDeleteDialog(true)}
+                          data-track-category='Claw Agents'
+                          data-track-name='OPEN_DELETE_SKILL_CONFIRM'
                         >
                           <Trash2 className='size-3.5' />
                           Delete

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawSubagentCreateScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawSubagentCreateScreen.tsx
@@ -286,6 +286,8 @@ const ClawSubagentCreateScreen = (): ReactElement => {
                   size='sm'
                   disabled={state.progressLabels.length >= 8}
                   onClick={() => update({ progressLabels: [...state.progressLabels, ''] })}
+                  data-track-category='Claw Agents'
+                  data-track-name='ADD_PROGRESS_LABEL'
                 >
                   <Plus className='size-3.5' /> Add label
                 </Button>
@@ -316,6 +318,8 @@ const ClawSubagentCreateScreen = (): ReactElement => {
                         progressLabels: state.progressLabels.filter((_, i) => i !== index),
                       })
                     }
+                    data-track-category='Claw Agents'
+                    data-track-name='REMOVE_PROGRESS_LABEL'
                     aria-label='Remove progress label'
                   >
                     <X className='size-4' />
@@ -401,24 +405,41 @@ const ClawSubagentCreateScreen = (): ReactElement => {
             widthClass,
           )}
         >
-          <Button variant='ghost' onClick={cancel}>
+          <Button
+            variant='ghost'
+            onClick={cancel}
+            data-track-category='Claw Agents'
+            data-track-name='CANCEL_CREATE_SUBAGENT'
+          >
             Cancel
           </Button>
           <div className='flex items-center gap-2'>
             {step > 0 && (
-              <Button variant='outline' onClick={goBack}>
+              <Button
+                variant='outline'
+                onClick={goBack}
+                data-track-category='Claw Agents'
+                data-track-name='SUBAGENT_WIZARD_BACK'
+              >
                 <ChevronLeft className='size-4' />
                 Back
               </Button>
             )}
             {step < LAST_STEP ? (
-              <Button onClick={goNext} disabled={!canNext}>
+              <Button
+                onClick={goNext}
+                data-track-category='Claw Agents'
+                data-track-name='SUBAGENT_WIZARD_NEXT'
+                disabled={!canNext}
+              >
                 Next
                 <ChevronRight className='size-4' />
               </Button>
             ) : (
               <Button
                 onClick={() => void handleCreate()}
+                data-track-category='Claw Agents'
+                data-track-name='CREATE_SUBAGENT'
                 loading={create.isPending}
                 disabled={!canNext}
               >

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawSubagentDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawSubagentDetailScreen.tsx
@@ -223,6 +223,8 @@ const KnowledgeTab = ({
                     progressLabels: [...current.progressLabels, ''],
                   }))
                 }
+                data-track-category='Claw Agents'
+                data-track-name='ADD_PROGRESS_LABEL'
               >
                 <Plus className='size-3.5' /> Add label
               </Button>
@@ -255,6 +257,8 @@ const KnowledgeTab = ({
                       progressLabels: current.progressLabels.filter((_, i) => i !== index),
                     }))
                   }
+                  data-track-category='Claw Agents'
+                  data-track-name='REMOVE_PROGRESS_LABEL'
                   aria-label='Remove progress label'
                 >
                   <X className='size-4' />
@@ -410,7 +414,13 @@ const ContributorsTab = ({
               }
             }}
           />
-          <Button onClick={() => void addShare()} loading={add.isPending} disabled={!input.trim()}>
+          <Button
+            onClick={() => void addShare()}
+            data-track-category='Claw Agents'
+            data-track-name='ADD_SUBAGENT_SHARE'
+            loading={add.isPending}
+            disabled={!input.trim()}
+          >
             <Plus className='size-4' /> Add
           </Button>
         </div>
@@ -443,6 +453,8 @@ const ContributorsTab = ({
                   loading={remove.isPending && remove.variables === share.userId}
                   disabled={remove.isPending}
                   onClick={() => void removeShare(share)}
+                  data-track-category='Claw Agents'
+                  data-track-name='REMOVE_SUBAGENT_SHARE'
                   aria-label={`Remove ${share.name || share.email}`}
                 >
                   <Trash2 className='size-4 text-destructive' />
@@ -647,6 +659,8 @@ const ClawSubagentDetailScreen = (): ReactElement => {
                   variant='outline'
                   size='sm'
                   onClick={() => setDeleteOpen(true)}
+                  data-track-category='Claw Agents'
+                  data-track-name='OPEN_DELETE_SUBAGENT_CONFIRM'
                   disabled={toggle.isPending}
                 >
                   <Trash2 className='size-4' /> Delete
@@ -665,6 +679,8 @@ const ClawSubagentDetailScreen = (): ReactElement => {
                 <Button
                   size='sm'
                   onClick={() => void save()}
+                  data-track-category='Claw Agents'
+                  data-track-name='SAVE_SUBAGENT'
                   loading={update.isPending}
                   disabled={!dirty || !draft.systemPrompt.trim()}
                 >

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/AgentsTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/AgentsTab.tsx
@@ -234,6 +234,8 @@ const AgentsTab = (): ReactElement => {
                 type='button'
                 className='shrink-0'
                 onClick={() => void navigate('/claw-agents/create')}
+                data-track-category='Claw Agents'
+                data-track-name='GO_TO_CREATE_AGENT'
               >
                 <Plus className='size-4' />
                 Create agent

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/CloneRequestsTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/CloneRequestsTab.tsx
@@ -69,6 +69,8 @@ const CloneRequestsTab = ({ agent }: { agent: Agent }): ReactElement => {
                     disabled={!!busyId}
                     loading={busyId === request.id && approve.isPending}
                     onClick={() => void resolve(request, 'approve')}
+                    data-track-category='Claw Agents'
+                    data-track-name='APPROVE_CLONE_REQUEST'
                   >
                     <Check className='size-4' /> Approve
                   </Button>
@@ -79,6 +81,8 @@ const CloneRequestsTab = ({ agent }: { agent: Agent }): ReactElement => {
                     disabled={!!busyId}
                     loading={busyId === request.id && reject.isPending}
                     onClick={() => void resolve(request, 'reject')}
+                    data-track-category='Claw Agents'
+                    data-track-name='REJECT_CLONE_REQUEST'
                   >
                     <X className='size-4' /> Decline
                   </Button>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ConnectionsTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ConnectionsTab.tsx
@@ -90,6 +90,8 @@ const ConnectionsTab = ({ agent, permissions }: ConnectionsTabProps): ReactEleme
                       size='iconSm'
                       disabled={remove.isPending}
                       onClick={() => void removeConnection(connection)}
+                      data-track-category='Claw Agents'
+                      data-track-name='REMOVE_CONNECTION'
                       aria-label={`Remove ${connection.displayName}`}
                       className='text-muted-foreground hover:text-destructive'
                     >

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/DigitalTwinRecallTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/DigitalTwinRecallTab.tsx
@@ -34,7 +34,14 @@ const DigitalTwinRecallTab = (): ReactElement => {
           className='w-full resize-none rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground focus:border-ring focus:outline-none'
         />
         <div className='flex items-center justify-end'>
-          <Button size='sm' disabled={!query.trim()} loading={recall.isPending} onClick={submit}>
+          <Button
+            size='sm'
+            disabled={!query.trim()}
+            loading={recall.isPending}
+            onClick={submit}
+            data-track-category='Claw Agents'
+            data-track-name='SUBMIT_DIGITAL_TWIN_RECALL'
+          >
             <Search className='size-3.5' />
             {recall.isPending ? 'Recalling…' : 'Test recall'}
           </Button>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/DigitalTwinSettingsTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/DigitalTwinSettingsTab.tsx
@@ -150,7 +150,13 @@ const DigitalTwinSettingsTab = (): ReactElement => {
       </section>
 
       <div className='mt-8 flex items-center gap-3 border-t border-border pt-6'>
-        <Button onClick={save} loading={updateMutation.isPending} disabled={!dirty}>
+        <Button
+          onClick={save}
+          data-track-category='Claw Agents'
+          data-track-name='SAVE_DIGITAL_TWIN_SETTINGS'
+          loading={updateMutation.isPending}
+          disabled={!dirty}
+        >
           Save changes
         </Button>
         {!dirty && <span className='text-xs text-muted-foreground'>No unsaved changes</span>}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/KnowledgeTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/KnowledgeTab.tsx
@@ -416,6 +416,8 @@ const KnowledgeTab = ({ agent, permissions }: KnowledgeTabProps): ReactElement =
           loading={saving}
           disabled={!dirty}
           onClick={() => void handleSave()}
+          data-track-category='Claw Agents'
+          data-track-name='SAVE_KNOWLEDGE'
         >
           {saving ? 'Saving…' : 'Save changes'}
         </Button>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/MemoryTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/MemoryTab.tsx
@@ -135,6 +135,8 @@ const MemoryTab = ({ agent, permissions }: MemoryTabProps): ReactElement => {
                       size='iconSm'
                       disabled={remove.isPending}
                       onClick={() => void deleteMemory(memory.hindsightMemoryId)}
+                      data-track-category='Claw Agents'
+                      data-track-name='DELETE_MEMORY'
                       aria-label='Delete memory'
                       className='ml-auto text-muted-foreground hover:text-destructive'
                     >

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ModelProviderTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ModelProviderTab.tsx
@@ -347,6 +347,8 @@ const ModelProviderTab = ({ agent, isActualOwner }: ModelProviderTabProps): Reac
           loading={saving}
           disabled={!dirty || temperatureConflict}
           onClick={() => void handleSave()}
+          data-track-category='Claw Agents'
+          data-track-name='SAVE_MODEL_PROVIDER'
         >
           {saving ? 'Saving…' : 'Save changes'}
         </Button>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/PersonaTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/PersonaTab.tsx
@@ -87,6 +87,8 @@ const PersonaTab = ({
               variant='ghost'
               size='sm'
               onClick={onRenameRequested}
+              data-track-category='Claw Agents'
+              data-track-name='REQUEST_RENAME_PERSONA'
               className='h-7'
             >
               <Pencil className='size-3.5' /> Rename

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ScheduleTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ScheduleTab.tsx
@@ -71,6 +71,8 @@ const EditableJob = ({
               size='iconSm'
               disabled={busy}
               onClick={onDelete}
+              data-track-category='Claw Agents'
+              data-track-name='DELETE_SCHEDULED_JOB'
               aria-label='Delete scheduled job'
               className='text-muted-foreground hover:text-destructive'
             >

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/SkillsTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/SkillsTab.tsx
@@ -252,6 +252,8 @@ const SkillsTab = (): ReactElement => {
                 type='button'
                 className='shrink-0'
                 onClick={() => void navigate('/claw-agents/skills/create')}
+                data-track-category='Claw Agents'
+                data-track-name='GO_TO_CREATE_SKILL'
               >
                 <Plus className='size-4' />
                 Create skill

--- a/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ToolsTab.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/tabs/ToolsTab.tsx
@@ -202,6 +202,8 @@ const ToolsTab = ({ agent, permissions }: ToolsTabProps): ReactElement => {
           loading={saving}
           disabled={!dirty}
           onClick={() => void handleSave()}
+          data-track-category='Claw Agents'
+          data-track-name='SAVE_TOOLS'
         >
           {saving ? 'Saving…' : 'Save changes'}
         </Button>

--- a/apps/dashboard/src/routes/ConfluenceMigrationScreen/ConfluenceMigrationScreen.tsx
+++ b/apps/dashboard/src/routes/ConfluenceMigrationScreen/ConfluenceMigrationScreen.tsx
@@ -493,6 +493,8 @@ const ConfluenceMigrationScreen = (): ReactElement => {
               <div className='flex flex-wrap items-center gap-2'>
                 <Button
                   onClick={() => void handlePreview()}
+                  data-track-category='confluence_migration'
+                  data-track-name='PREVIEW_MIGRATION'
                   disabled={!canPreview || isPreviewLoading}
                 >
                   {isPreviewLoading
@@ -504,6 +506,8 @@ const ConfluenceMigrationScreen = (): ReactElement => {
                 <Button
                   variant='outline'
                   onClick={() => setIsHistoryModalOpen(true)}
+                  data-track-category='confluence_migration'
+                  data-track-name='OPEN_MIGRATION_HISTORY'
                   disabled={history.length === 0}
                 >
                   View Imported Canvases
@@ -645,6 +649,8 @@ const ConfluenceMigrationScreen = (): ReactElement => {
                       setMigrationPhase('migrate');
                       void handleImport();
                     }}
+                    data-track-category='confluence_migration'
+                    data-track-name='START_MIGRATION'
                     disabled={isImportLoading}
                   >
                     {isImportLoading ? 'Migrating...' : 'Migrate Space'}

--- a/apps/dashboard/src/routes/InvitationScreen/AcceptInvitation.tsx
+++ b/apps/dashboard/src/routes/InvitationScreen/AcceptInvitation.tsx
@@ -246,7 +246,12 @@ export const AcceptInvitation = (): ReactElement => {
           <h1 className='text-2xl font-semibold text-foreground mb-2'>
             You are not supposed to access this invitation
           </h1>
-          <Button onClick={handleGoHome} className='w-full'>
+          <Button
+            onClick={handleGoHome}
+            data-track-category='Invitations'
+            data-track-name='GO_HOME_FROM_INVITE'
+            className='w-full'
+          >
             Go to Home
           </Button>
         </div>
@@ -263,7 +268,12 @@ export const AcceptInvitation = (): ReactElement => {
           </div>
           <h1 className='text-2xl font-semibold text-foreground mb-2'>Invitation Expired</h1>
           <p className='text-muted-foreground mb-6'>{state.message}</p>
-          <Button onClick={handleGoHome} className='w-full'>
+          <Button
+            onClick={handleGoHome}
+            data-track-category='Invitations'
+            data-track-name='GO_HOME_FROM_INVITE'
+            className='w-full'
+          >
             Go to Home
           </Button>
         </div>
@@ -280,7 +290,12 @@ export const AcceptInvitation = (): ReactElement => {
           </div>
           <h1 className='text-2xl font-semibold text-foreground mb-2'>Invalid Invitation</h1>
           <p className='text-muted-foreground mb-6'>{state.message}</p>
-          <Button onClick={handleGoHome} className='w-full'>
+          <Button
+            onClick={handleGoHome}
+            data-track-category='Invitations'
+            data-track-name='GO_HOME_FROM_INVITE'
+            className='w-full'
+          >
             Go to Home
           </Button>
         </div>
@@ -397,7 +412,12 @@ export const AcceptInvitation = (): ReactElement => {
           )}
         </div>
 
-        <Button onClick={() => void handleAccept()} className='w-full'>
+        <Button
+          onClick={() => void handleAccept()}
+          data-track-category='Invitations'
+          data-track-name='ACCEPT_INVITATION'
+          className='w-full'
+        >
           Accept Invitation
         </Button>
       </div>

--- a/apps/dashboard/src/routes/JiraMigrationScreen/JiraMigrationScreen.tsx
+++ b/apps/dashboard/src/routes/JiraMigrationScreen/JiraMigrationScreen.tsx
@@ -1673,6 +1673,8 @@ const JiraMigrationScreen = (): ReactElement => {
                     <Button
                       className='w-full lg:w-auto'
                       onClick={() => void handleMoveChannelProject()}
+                      data-track-category='jira_migration'
+                      data-track-name='MOVE_CHANNEL_PROJECT'
                       disabled={isChannelMoveLoading}
                     >
                       {isChannelMoveLoading ? 'Moving…' : 'Move Channel'}
@@ -1824,6 +1826,8 @@ const JiraMigrationScreen = (): ReactElement => {
                   <Button
                     variant={purgeDryRun ? 'outline' : 'default'}
                     onClick={() => void handlePurgeProjectMigration()}
+                    data-track-category='jira_migration'
+                    data-track-name='PURGE_PROJECT_MIGRATION'
                     disabled={isPurgeLoading}
                   >
                     {isPurgeLoading
@@ -2106,6 +2110,8 @@ const JiraMigrationScreen = (): ReactElement => {
                   <Button
                     variant={moveChannelDryRun ? 'outline' : 'default'}
                     onClick={() => void handleMoveJiraProjectChannel()}
+                    data-track-category='jira_migration'
+                    data-track-name='MOVE_JIRA_PROJECT_CHANNEL'
                     disabled={isMoveChannelLoading}
                   >
                     {isMoveChannelLoading
@@ -2359,6 +2365,8 @@ const JiraMigrationScreen = (): ReactElement => {
                   <Button
                     variant={moveDryRun ? 'outline' : 'default'}
                     onClick={() => void handleMoveJiraProjectBoard()}
+                    data-track-category='jira_migration'
+                    data-track-name='MOVE_JIRA_PROJECT_BOARD'
                     disabled={isMoveBoardLoading}
                   >
                     {isMoveBoardLoading ? 'Running…' : moveDryRun ? 'Run Dry Run' : 'Move Tickets'}
@@ -2488,6 +2496,8 @@ const JiraMigrationScreen = (): ReactElement => {
                         variant='outline'
                         className='mt-3 w-full'
                         onClick={() => void handleFetchBoards()}
+                        data-track-category='jira_migration'
+                        data-track-name='FETCH_BOARDS'
                         disabled={isFetchingBoards || !jiraProjectKey.trim()}
                       >
                         {isFetchingBoards ? 'Fetching boards…' : 'Fetch Boards'}
@@ -2760,6 +2770,8 @@ const JiraMigrationScreen = (): ReactElement => {
                               )}
                               <Button
                                 onClick={() => void handlePerBoardImport()}
+                                data-track-category='jira_migration'
+                                data-track-name='START_PER_BOARD_IMPORT'
                                 disabled={
                                   isPerBoardImportLoading ||
                                   normalizedIssueKeys.length > 0 ||
@@ -3063,6 +3075,8 @@ const JiraMigrationScreen = (): ReactElement => {
                           setPageIndex(0);
                           void handlePreview();
                         }}
+                        data-track-category='jira_migration'
+                        data-track-name='RESET_PAGINATION'
                         disabled={isPreviewLoading || isImportLoading || !canPreview}
                       >
                         {isPreviewLoading
@@ -3074,6 +3088,8 @@ const JiraMigrationScreen = (): ReactElement => {
                       <Button
                         variant='outline'
                         onClick={() => setIsHistoryModalOpen(true)}
+                        data-track-category='jira_migration'
+                        data-track-name='OPEN_MIGRATION_HISTORY'
                         disabled={migrationHistory.length === 0}
                       >
                         View Migrated Projects
@@ -3169,6 +3185,8 @@ const JiraMigrationScreen = (): ReactElement => {
                       <Button
                         variant='outline'
                         onClick={() => void handlePreview()}
+                        data-track-category='jira_migration'
+                        data-track-name='PREVIEW_MIGRATION'
                         disabled={isPreviewLoading || isImportLoading}
                       >
                         Refresh Preview
@@ -3284,6 +3302,8 @@ const JiraMigrationScreen = (): ReactElement => {
                           [...preview.jiraStatusSequence].sort((a, b) => a.localeCompare(b)),
                         )
                       }
+                      data-track-category='jira_migration'
+                      data-track-name='APPLY_STATUS_SEQUENCE'
                       disabled={preview.jiraStatusSequence.length === 0}
                     >
                       Sort A→Z
@@ -3444,11 +3464,18 @@ const JiraMigrationScreen = (): ReactElement => {
                 </div>
 
                 <div className='mt-6 flex flex-wrap items-center gap-3 border-t border-border/60 pt-5'>
-                  <Button variant='outline' onClick={() => setMigrationPhase('setup')}>
+                  <Button
+                    variant='outline'
+                    onClick={() => setMigrationPhase('setup')}
+                    data-track-category='jira_migration'
+                    data-track-name='GO_TO_SETUP_PHASE'
+                  >
                     ← Back to Configure
                   </Button>
                   <Button
                     onClick={() => setMigrationPhase('migrate')}
+                    data-track-category='jira_migration'
+                    data-track-name='GO_TO_MIGRATE_PHASE'
                     disabled={!hasCompleteStatusV2Mappings}
                   >
                     Proceed to Migration →
@@ -3523,6 +3550,8 @@ const JiraMigrationScreen = (): ReactElement => {
                   </Button>
                   <Button
                     onClick={() => void handleImport()}
+                    data-track-category='jira_migration'
+                    data-track-name='START_IMPORT'
                     disabled={isImportLoading || !hasCompleteStatusV2Mappings}
                   >
                     {isImportLoading ? 'Migrating...' : 'Migrate Tickets'}
@@ -3574,6 +3603,8 @@ const JiraMigrationScreen = (): ReactElement => {
                                 return next;
                               });
                             }}
+                            data-track-category='jira_migration'
+                            data-track-name='UPDATE_USER_EMAIL_MAPPINGS'
                           >
                             Clear
                           </Button>
@@ -3611,6 +3642,8 @@ const JiraMigrationScreen = (): ReactElement => {
                       <Button
                         variant='outline'
                         onClick={() => setResolvedUsersPage(p => Math.max(0, p - 1))}
+                        data-track-category='jira_migration'
+                        data-track-name='RESOLVED_USERS_PREV_PAGE'
                         disabled={resolvedUsersPage === 0}
                       >
                         Prev
@@ -3629,6 +3662,8 @@ const JiraMigrationScreen = (): ReactElement => {
                             ),
                           )
                         }
+                        data-track-category='jira_migration'
+                        data-track-name='RESOLVED_USERS_NEXT_PAGE'
                         disabled={
                           resolvedUsersPage >=
                           Math.max(
@@ -3809,15 +3844,30 @@ const JiraMigrationScreen = (): ReactElement => {
                   {migrationProgress.status === 'running' && (
                     <div className='mt-2 flex flex-wrap justify-end gap-2'>
                       {migrationProgress.controlStatus === 'paused' ? (
-                        <Button variant='outline' onClick={() => void handleResumeMigration()}>
+                        <Button
+                          variant='outline'
+                          onClick={() => void handleResumeMigration()}
+                          data-track-category='jira_migration'
+                          data-track-name='RESUME_MIGRATION'
+                        >
                           Resume
                         </Button>
                       ) : (
-                        <Button variant='outline' onClick={() => void handlePauseMigration()}>
+                        <Button
+                          variant='outline'
+                          onClick={() => void handlePauseMigration()}
+                          data-track-category='jira_migration'
+                          data-track-name='PAUSE_MIGRATION'
+                        >
                           Pause
                         </Button>
                       )}
-                      <Button variant='outline' onClick={() => void handleStopMigration()}>
+                      <Button
+                        variant='outline'
+                        onClick={() => void handleStopMigration()}
+                        data-track-category='jira_migration'
+                        data-track-name='STOP_MIGRATION'
+                      >
                         Stop
                       </Button>
                     </div>
@@ -4087,6 +4137,8 @@ const JiraMigrationScreen = (): ReactElement => {
                       variant='outline'
                       size='sm'
                       onClick={() => setIssueResultPage(page => Math.max(0, page - 1))}
+                      data-track-category='jira_migration'
+                      data-track-name='ISSUE_RESULTS_PREV_PAGE'
                       disabled={issueResultPage === 0}
                     >
                       Previous
@@ -4097,6 +4149,8 @@ const JiraMigrationScreen = (): ReactElement => {
                       onClick={() =>
                         setIssueResultPage(page => Math.min(issueResultPageCount - 1, page + 1))
                       }
+                      data-track-category='jira_migration'
+                      data-track-name='ISSUE_RESULTS_NEXT_PAGE'
                       disabled={issueResultPage >= issueResultPageCount - 1}
                     >
                       Next
@@ -4320,6 +4374,8 @@ const JiraMigrationScreen = (): ReactElement => {
                       variant='outline'
                       size='sm'
                       onClick={() => void handlePreviousPage()}
+                      data-track-category='jira_migration'
+                      data-track-name='PREVIEW_PREV_PAGE'
                       disabled={isPreviewLoading || pageIndex === 0}
                     >
                       Previous Page
@@ -4328,6 +4384,8 @@ const JiraMigrationScreen = (): ReactElement => {
                       variant='outline'
                       size='sm'
                       onClick={() => void handleNextPage()}
+                      data-track-category='jira_migration'
+                      data-track-name='PREVIEW_NEXT_PAGE'
                       disabled={isPreviewLoading || !preview.pagination.hasNextPage}
                     >
                       Next Page
@@ -4475,6 +4533,8 @@ const JiraMigrationScreen = (): ReactElement => {
                           variant='outline'
                           size='sm'
                           onClick={() => setCustomFieldPage(page => Math.max(0, page - 1))}
+                          data-track-category='jira_migration'
+                          data-track-name='CUSTOM_FIELDS_PREV_PAGE'
                           disabled={customFieldPage === 0}
                         >
                           Previous
@@ -4487,6 +4547,8 @@ const JiraMigrationScreen = (): ReactElement => {
                               Math.min(previewActionCounts.fieldsPageCount - 1, page + 1),
                             )
                           }
+                          data-track-category='jira_migration'
+                          data-track-name='CUSTOM_FIELDS_NEXT_PAGE'
                           disabled={customFieldPage >= previewActionCounts.fieldsPageCount - 1}
                         >
                           Next
@@ -4598,6 +4660,8 @@ const JiraMigrationScreen = (): ReactElement => {
                           variant='outline'
                           size='sm'
                           onClick={() => setIssueSamplePage(page => Math.max(0, page - 1))}
+                          data-track-category='jira_migration'
+                          data-track-name='ISSUE_SAMPLES_PREV_PAGE'
                           disabled={issueSamplePage === 0}
                         >
                           Previous
@@ -4610,6 +4674,8 @@ const JiraMigrationScreen = (): ReactElement => {
                               Math.min(previewActionCounts.issuePageCount - 1, page + 1),
                             )
                           }
+                          data-track-category='jira_migration'
+                          data-track-name='ISSUE_SAMPLES_NEXT_PAGE'
                           disabled={issueSamplePage >= previewActionCounts.issuePageCount - 1}
                         >
                           Next

--- a/apps/dashboard/src/routes/JiraMigrationScreen/WhatsAppMigrationPanel.tsx
+++ b/apps/dashboard/src/routes/JiraMigrationScreen/WhatsAppMigrationPanel.tsx
@@ -487,11 +487,18 @@ const WhatsAppMigrationPanel = (): ReactElement => {
                 <Button
                   variant='outline'
                   onClick={() => void handlePreview()}
+                  data-track-category='whatsapp-migration'
+                  data-track-name='PREVIEW_MIGRATION'
                   disabled={isPreviewLoading}
                 >
                   {isPreviewLoading ? 'Previewing…' : 'Preview Import'}
                 </Button>
-                <Button onClick={() => void handleExecute()} disabled={isExecuteLoading}>
+                <Button
+                  onClick={() => void handleExecute()}
+                  data-track-category='whatsapp-migration'
+                  data-track-name='EXECUTE_MIGRATION'
+                  disabled={isExecuteLoading}
+                >
                   {isExecuteLoading ? 'Starting…' : 'Start Import'}
                 </Button>
               </div>
@@ -610,6 +617,8 @@ const WhatsAppMigrationPanel = (): ReactElement => {
                   <Button
                     variant='outline'
                     onClick={() => void handlePurgePreview()}
+                    data-track-category='whatsapp-migration'
+                    data-track-name='PREVIEW_PURGE'
                     disabled={isPurgeLoading || !selectedPurgeSourceId}
                   >
                     {isPurgeLoading ? 'Checking…' : 'Preview Delete'}
@@ -617,6 +626,8 @@ const WhatsAppMigrationPanel = (): ReactElement => {
                   <Button
                     variant='destructive'
                     onClick={() => void handlePurgeExecute()}
+                    data-track-category='whatsapp-migration'
+                    data-track-name='EXECUTE_PURGE'
                     disabled={isPurgeLoading || !selectedPurgeSourceId}
                   >
                     {isPurgeLoading ? 'Deleting…' : 'Delete Imported Messages'}

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -3571,12 +3571,20 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                     )}
                   />
                   <div className='flex justify-end gap-2 pt-1'>
-                    <Button variant='ghost' size='sm' onClick={() => setIsSavePopoverOpen(false)}>
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      onClick={() => setIsSavePopoverOpen(false)}
+                      data-track-category='Tickets'
+                      data-track-name='CANCEL_SAVE_WORKSPACE_VIEW'
+                    >
                       Cancel
                     </Button>
                     <Button
                       size='sm'
                       onClick={handleConfirmSaveWorkspaceView}
+                      data-track-category='Tickets'
+                      data-track-name='CONFIRM_SAVE_WORKSPACE_VIEW'
                       disabled={!workspaceViewNameDraft.trim() || isSavingWorkspaceView}
                     >
                       Save
@@ -5131,11 +5139,18 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
             </p>
 
             <div className='flex justify-end gap-3'>
-              <Button variant='secondary' onClick={cancelRejectedApproval}>
+              <Button
+                variant='secondary'
+                onClick={cancelRejectedApproval}
+                data-track-category='Tickets'
+                data-track-name='CANCEL_REJECTED_APPROVAL'
+              >
                 Cancel
               </Button>
               <Button
                 onClick={confirmRejectedApproval}
+                data-track-category='Tickets'
+                data-track-name='CONFIRM_REJECTED_APPROVAL'
                 className='bg-primary text-primary-foreground hover:bg-blue-700'
               >
                 Approve
@@ -5161,7 +5176,12 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                 : `Are you sure you want to delete the saved view "${deleteViewConfirm.name}"? This action cannot be undone.`}
             </p>
             <div className='flex justify-end gap-3'>
-              <Button variant='secondary' onClick={() => setDeleteViewConfirm(null)}>
+              <Button
+                variant='secondary'
+                onClick={() => setDeleteViewConfirm(null)}
+                data-track-category='Tickets'
+                data-track-name='CANCEL_DELETE_VIEW'
+              >
                 Cancel
               </Button>
               <Button
@@ -5197,6 +5217,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                   };
                   void run();
                 }}
+                data-track-category='Tickets'
+                data-track-name='CONFIRM_DELETE_VIEW'
                 className='bg-red-500 text-white hover:bg-red-600'
               >
                 Delete

--- a/apps/dashboard/src/routes/OrganisationsScreen/JoinRequestsSection.tsx
+++ b/apps/dashboard/src/routes/OrganisationsScreen/JoinRequestsSection.tsx
@@ -130,7 +130,14 @@ export const JoinRequestsSection = ({ orgId }: JoinRequestsSectionProps): ReactE
             </p>
           </div>
         </div>
-        <Button variant='outline' size='sm' onClick={() => void loadRequests()} loading={isLoading}>
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={() => void loadRequests()}
+          data-track-category='Organisations'
+          data-track-name='RELOAD_JOIN_REQUESTS'
+          loading={isLoading}
+        >
           <RefreshCw className='h-4 w-4' />
           Refresh
         </Button>
@@ -191,6 +198,8 @@ export const JoinRequestsSection = ({ orgId }: JoinRequestsSectionProps): ReactE
                         onClick={() =>
                           void reviewRequest(request, WorkspaceJoinRequestAction.REJECT)
                         }
+                        data-track-category='Organisations'
+                        data-track-name='REJECT_JOIN_REQUEST'
                         className='text-destructive hover:bg-destructive/10 hover:text-destructive'
                       >
                         <UserX className='h-4 w-4' />
@@ -202,6 +211,8 @@ export const JoinRequestsSection = ({ orgId }: JoinRequestsSectionProps): ReactE
                         onClick={() =>
                           void reviewRequest(request, WorkspaceJoinRequestAction.APPROVE)
                         }
+                        data-track-category='Organisations'
+                        data-track-name='APPROVE_JOIN_REQUEST'
                       >
                         <UserCheck className='h-4 w-4' />
                         Approve

--- a/apps/dashboard/src/routes/ProjectDetailScreen/ReleasesSection.tsx
+++ b/apps/dashboard/src/routes/ProjectDetailScreen/ReleasesSection.tsx
@@ -61,6 +61,8 @@ export const ReleasesSection = ({ projectId }: ReleasesSectionProps): ReactEleme
             <tr
               key={ticket.id}
               onClick={() => void navigate(`/listProjects/${projectId}/releases/${ticket.id}`)}
+              data-track-category='ProjectDetail'
+              data-track-name='OPEN_RELEASE_ROW'
               className='border-t border-border hover:bg-muted/50 cursor-pointer transition-colors'
             >
               <td className='px-4 py-2 font-mono text-xs text-muted-foreground'>

--- a/apps/dashboard/src/routes/RCAScreen/RCAScreen.tsx
+++ b/apps/dashboard/src/routes/RCAScreen/RCAScreen.tsx
@@ -411,10 +411,21 @@ const RCADetailScreen = () => {
           <h3 className='text-lg font-semibold text-foreground'>Unsaved changes</h3>
           <p className='mt-2 text-sm text-muted-foreground'>{confirmDialog.message}</p>
           <div className='mt-6 flex justify-end gap-2'>
-            <Button type='button' variant='outline' onClick={() => closeConfirmDialog(false)}>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => closeConfirmDialog(false)}
+              data-track-category='RCA'
+              data-track-name='CANCEL_RCA_CONFIRM'
+            >
               Skip Save
             </Button>
-            <Button type='button' onClick={() => closeConfirmDialog(true)}>
+            <Button
+              type='button'
+              onClick={() => closeConfirmDialog(true)}
+              data-track-category='RCA'
+              data-track-name='CONFIRM_RCA_ACTION'
+            >
               Save and Continue
             </Button>
           </div>

--- a/apps/dashboard/src/routes/RCAScreen/components/COEForm.tsx
+++ b/apps/dashboard/src/routes/RCAScreen/components/COEForm.tsx
@@ -511,6 +511,8 @@ export const COEForm = ({
                     });
                   })()
             }
+            data-track-category='RCA'
+            data-track-name='DELETE_COE'
             loading={isDeleting}
             disabled={isSubmitting || deletingCoeId !== null}
             aria-label={isExisting ? `Delete COE ${index + 1}` : 'Remove COE'}
@@ -663,7 +665,13 @@ export const COEForm = ({
               </p>
             </div>
           </div>
-          <Button variant='outline' size='sm' onClick={() => onPhaseChange('impact')}>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => onPhaseChange('impact')}
+            data-track-category='RCA'
+            data-track-name='GO_TO_IMPACT_PHASE'
+          >
             Review Previous Phase
           </Button>
         </div>
@@ -783,6 +791,8 @@ export const COEForm = ({
                     status: COEStatus.OPEN,
                   });
                 }}
+                data-track-category='RCA'
+                data-track-name='ADD_COE_ACTION'
                 disabled={isSubmitting}
               >
                 <Plus className='h-3.5 w-3.5' />
@@ -805,6 +815,8 @@ export const COEForm = ({
                   type='button'
                   variant='outline'
                   onClick={() => onPhaseChange('impact')}
+                  data-track-category='RCA'
+                  data-track-name='BACK_TO_IMPACT_PHASE'
                   disabled={isSubmitting}
                 >
                   Go Back
@@ -812,6 +824,8 @@ export const COEForm = ({
                 <Button
                   type='button'
                   onClick={() => void handleSaveAll()}
+                  data-track-category='RCA'
+                  data-track-name='SAVE_ALL_COES'
                   loading={isSubmitting}
                   disabled={isSubmitting}
                 >

--- a/apps/dashboard/src/routes/RCAScreen/components/ImpactForm.tsx
+++ b/apps/dashboard/src/routes/RCAScreen/components/ImpactForm.tsx
@@ -101,6 +101,8 @@ const ImpactAttachments = ({
             size='sm'
             variant='outline'
             onClick={() => fileInputRef.current?.click()}
+            data-track-category='RCA'
+            data-track-name='UPLOAD_IMPACT_ATTACHMENT'
             disabled={isUploading}
           >
             Upload files
@@ -535,6 +537,8 @@ export const ImpactForm = ({
                     }
                   })()
             }
+            data-track-category='RCA'
+            data-track-name='DELETE_IMPACT'
             loading={isDeleting}
             disabled={isSubmitting || deletingImpactId !== null}
             aria-label={isExisting ? `Delete Impact ${index + 1}` : 'Remove Impact'}
@@ -658,6 +662,8 @@ export const ImpactForm = ({
                     size='sm'
                     variant='outline'
                     onClick={() => pendingFileInputsRef.current[id]?.click()}
+                    data-track-category='RCA'
+                    data-track-name='UPLOAD_PENDING_IMPACT_ATTACHMENT'
                     disabled={isUploadingAttachments}
                   >
                     Upload files
@@ -717,7 +723,13 @@ export const ImpactForm = ({
               </p>
             </div>
           </div>
-          <Button variant='outline' size='sm' onClick={() => onPhaseChange('rca')}>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => onPhaseChange('rca')}
+            data-track-category='RCA'
+            data-track-name='GO_TO_RCA_PHASE'
+          >
             Review Previous Phase
           </Button>
         </div>
@@ -810,6 +822,8 @@ export const ImpactForm = ({
                     files: [],
                   });
                 }}
+                data-track-category='RCA'
+                data-track-name='ADD_IMPACT'
                 disabled={isSubmitting}
               >
                 <Plus className='h-3.5 w-3.5' />
@@ -834,6 +848,8 @@ export const ImpactForm = ({
                     type='button'
                     variant='outline'
                     onClick={() => void handleSaveDraftClick()}
+                    data-track-category='RCA'
+                    data-track-name='SAVE_IMPACT_DRAFT'
                     loading={isSubmitting}
                     disabled={isSubmitting}
                   >
@@ -843,6 +859,8 @@ export const ImpactForm = ({
                 <Button
                   type='button'
                   onClick={() => void handleSaveAll()}
+                  data-track-category='RCA'
+                  data-track-name='SAVE_ALL_IMPACTS'
                   loading={isSubmitting}
                   disabled={isSubmitting}
                 >

--- a/apps/dashboard/src/routes/RCAScreen/components/RCADetailsView.tsx
+++ b/apps/dashboard/src/routes/RCAScreen/components/RCADetailsView.tsx
@@ -180,7 +180,14 @@ export const RCADetailsView = ({
           </div>
           <div className='self-start'>
             {onEdit && (
-              <Button type='button' size='sm' variant='outline' onClick={onEdit}>
+              <Button
+                type='button'
+                size='sm'
+                variant='outline'
+                onClick={onEdit}
+                data-track-category='RCA'
+                data-track-name='EDIT_RCA'
+              >
                 Edit
               </Button>
             )}

--- a/apps/dashboard/src/routes/RCAScreen/components/RCAForm.tsx
+++ b/apps/dashboard/src/routes/RCAScreen/components/RCAForm.tsx
@@ -569,6 +569,8 @@ export const RCAForm = ({
                 type='button'
                 variant='outline'
                 onClick={() => void handleSaveDraftClick()}
+                data-track-category='RCA'
+                data-track-name='SAVE_RCA_DRAFT'
                 loading={isSubmitting}
                 disabled={isSubmitting}
               >

--- a/apps/dashboard/src/routes/RCAScreen/components/RCASidebar.tsx
+++ b/apps/dashboard/src/routes/RCAScreen/components/RCASidebar.tsx
@@ -136,6 +136,8 @@ export const RCASidebar = ({
               variant='outline'
               size='sm'
               onClick={onPreviousPage}
+              data-track-category='RCA'
+              data-track-name='RCA_PREV_PAGE'
               disabled={!hasPreviousPage || isSubmitting}
               className='gap-1'
             >
@@ -146,6 +148,8 @@ export const RCASidebar = ({
               variant='outline'
               size='sm'
               onClick={onNextPage}
+              data-track-category='RCA'
+              data-track-name='RCA_NEXT_PAGE'
               disabled={!hasNextPage || isSubmitting}
               className='gap-1'
             >

--- a/apps/dashboard/src/routes/RCAScreen/components/ReleaseMappingForm.tsx
+++ b/apps/dashboard/src/routes/RCAScreen/components/ReleaseMappingForm.tsx
@@ -427,6 +427,8 @@ export const ReleaseMappingForm = ({
             type='button'
             className='gap-1'
             onClick={() => void handleAddMapping()}
+            data-track-category='RCA'
+            data-track-name='ADD_RELEASE_MAPPING'
             disabled={isSubmitting || isSaving}
           >
             <Plus className='h-4 w-4' />
@@ -504,6 +506,8 @@ export const ReleaseMappingForm = ({
                           variant='ghost'
                           className='text-destructive hover:text-destructive hover:bg-destructive/10'
                           onClick={() => void handleDeleteMapping(attribution.id)}
+                          data-track-category='RCA'
+                          data-track-name='DELETE_RELEASE_MAPPING'
                           loading={deletingId === attribution.id}
                           disabled={isSubmitting || deletingId !== null}
                           aria-label='Remove release mapping'
@@ -520,7 +524,13 @@ export const ReleaseMappingForm = ({
 
           {/* Footer */}
           <div className='sticky bottom-0 -mx-8 -mb-8 p-4 bg-background/95 backdrop-blur border-t border-border flex justify-end'>
-            <Button type='button' onClick={handleContinue} disabled={isSubmitting}>
+            <Button
+              type='button'
+              onClick={handleContinue}
+              data-track-category='RCA'
+              data-track-name='CONTINUE_FROM_RELEASE_MAPPING'
+              disabled={isSubmitting}
+            >
               Next
             </Button>
           </div>

--- a/apps/dashboard/src/routes/ReleaseDetailScreen/ReleaseDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ReleaseDetailScreen/ReleaseDetailScreen.tsx
@@ -574,6 +574,8 @@ const ReleaseDetailScreen = (): ReactElement => {
             onClick={() =>
               void navigate(`/listProjects/${projectId}`, { state: { tab: 'release' } })
             }
+            data-track-category='Release'
+            data-track-name='BACK_TO_PROJECT_RELEASES'
             className='flex items-center gap-2 text-muted-foreground hover:text-foreground mb-6 transition-colors'
           >
             <ArrowLeft size={20} />
@@ -590,6 +592,8 @@ const ReleaseDetailScreen = (): ReactElement => {
                   const w = window.open(window.location.href, '_blank');
                   w?.focus();
                 }}
+                data-track-category='Release'
+                data-track-name='OPEN_RELEASE_IN_NEW_WINDOW'
                 className='shrink-0 p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
                 title='Open in new window'
                 aria-label='Open in new window'
@@ -807,6 +811,8 @@ const ReleaseDetailScreen = (): ReactElement => {
                                         `${baseRoute}/${row.channelId}/${row.conversationId}/${row.internalTicketId}?selectedTab=details`,
                                       )
                                     }
+                                    data-track-category='Release'
+                                    data-track-name='OPEN_RELEASE_CONVERSATION'
                                   >
                                     {row.ticketId}
                                   </button>
@@ -895,6 +901,8 @@ const ReleaseDetailScreen = (): ReactElement => {
                         <button
                           type='button'
                           onClick={goPrevArtPage}
+                          data-track-category='Release'
+                          data-track-name='ARTIFACTS_PREV_PAGE'
                           disabled={artPageIndex === 0}
                           className='rounded border border-border px-2 py-1 text-xs transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
                         >
@@ -903,6 +911,8 @@ const ReleaseDetailScreen = (): ReactElement => {
                         <button
                           type='button'
                           onClick={goNextArtPage}
+                          data-track-category='Release'
+                          data-track-name='ARTIFACTS_NEXT_PAGE'
                           disabled={!artHasMore}
                           className='rounded border border-border px-2 py-1 text-xs transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
                         >
@@ -1020,6 +1030,8 @@ const ReleaseDetailScreen = (): ReactElement => {
               type='button'
               className='px-3 py-1.5 text-sm rounded border border-border hover:bg-muted transition-colors'
               onClick={failureDialog.close}
+              data-track-category='Release'
+              data-track-name='CLOSE_FAILURE_DIALOG'
             >
               Cancel
             </button>
@@ -1030,6 +1042,8 @@ const ReleaseDetailScreen = (): ReactElement => {
                 !failureDialog.state.failureReason.trim() || failureDialog.state.isSubmitting
               }
               onClick={() => void failureDialog.submit()}
+              data-track-category='Release'
+              data-track-name='SUBMIT_FAILURE_DIALOG'
             >
               {failureDialog.state.isSubmitting ? 'Saving...' : 'Submit'}
             </button>

--- a/apps/dashboard/src/routes/RoleManagementScreen/RoleManagementScreen.tsx
+++ b/apps/dashboard/src/routes/RoleManagementScreen/RoleManagementScreen.tsx
@@ -170,12 +170,21 @@ const CreateRoleDialog = ({
         />
 
         <div className='flex justify-end gap-2 mt-5'>
-          <Button variant='outline' size='sm' onClick={() => onOpenChange(false)} disabled={saving}>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            data-track-category='ROLES'
+            data-track-name='CANCEL_CREATE_ROLE'
+            disabled={saving}
+          >
             Cancel
           </Button>
           <Button
             size='sm'
             onClick={() => void handleCreate()}
+            data-track-category='ROLES'
+            data-track-name='CREATE_ROLE'
             disabled={!canSubmit}
             loading={saving}
           >
@@ -228,6 +237,8 @@ const MemberRow = ({
         size='sm'
         variant='ghost'
         onClick={() => void onRemove(mapping.id, userId)}
+        data-track-category='ROLES'
+        data-track-name='REMOVE_ROLE_MEMBER'
         disabled={removing}
         className='opacity-0 group-hover:opacity-100 transition-opacity h-7 px-2 text-muted-foreground hover:text-destructive'
       >
@@ -401,12 +412,21 @@ const AddMembersDialog = ({
         </div>
 
         <div className='flex justify-end gap-2 mt-5'>
-          <Button variant='outline' size='sm' onClick={() => onOpenChange(false)} disabled={saving}>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => onOpenChange(false)}
+            data-track-category='ROLES'
+            data-track-name='CANCEL_ADD_MEMBERS'
+            disabled={saving}
+          >
             Cancel
           </Button>
           <Button
             size='sm'
             onClick={() => void handleAdd()}
+            data-track-category='ROLES'
+            data-track-name='ADD_ROLE_MEMBERS'
             disabled={pending.size === 0 || saving}
             loading={saving}
           >
@@ -630,7 +650,13 @@ export const RoleManagementScreen = (): ReactElement => {
                   Roles are reusable named sets of users you can reference across the workspace.
                   Choose one from the list to view its members, or create a new one.
                 </p>
-                <Button size='sm' className='mt-4' onClick={() => setShowCreate(true)}>
+                <Button
+                  size='sm'
+                  className='mt-4'
+                  onClick={() => setShowCreate(true)}
+                  data-track-category='ROLES'
+                  data-track-name='OPEN_CREATE_ROLE_DIALOG'
+                >
                   <Plus size={14} /> New role
                 </Button>
               </div>
@@ -665,6 +691,8 @@ export const RoleManagementScreen = (): ReactElement => {
                         size='sm'
                         variant='outline'
                         onClick={() => setShowAddMembers(true)}
+                        data-track-category='ROLES'
+                        data-track-name='OPEN_ADD_MEMBERS_DIALOG'
                         className='mt-3'
                       >
                         <UserPlus size={14} /> Add users

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -2530,7 +2530,11 @@ const SupportScreen = (): ReactElement => {
                               </span>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align='end' className='w-80'>
-                              <DropdownMenuItem onClick={() => setShowRefetchDialog(true)}>
+                              <DropdownMenuItem
+                                onClick={() => setShowRefetchDialog(true)}
+                                data-track-category='Support'
+                                data-track-name='OPEN_EMAIL_REFETCH_DIALOG'
+                              >
                                 <RefreshCw size={14} className='mr-2 shrink-0' />
                                 <span className='flex min-w-0 flex-1 items-center justify-between gap-3'>
                                   <span className='truncate'>Fetch latest emails</span>
@@ -2551,6 +2555,8 @@ const SupportScreen = (): ReactElement => {
                                 onClick={() => {
                                   if (!isDlMemberSyncing) setShowDlMemberSyncDialog(true);
                                 }}
+                                data-track-category='Support'
+                                data-track-name='OPEN_DL_MEMBER_SYNC_DIALOG'
                                 disabled={isDlMemberSyncing}
                               >
                                 <UserPlus size={14} className='mr-2 shrink-0' />
@@ -2991,6 +2997,8 @@ const SupportScreen = (): ReactElement => {
                               size='sm'
                               className='rounded-[10px] border-border hover:bg-muted text-muted-foreground'
                               onClick={() => setFilters({})}
+                              data-track-category='Support'
+                              data-track-name='CLEAR_SUPPORT_FILTERS'
                             >
                               <div className='flex items-center gap-1.5'>
                                 <X className='w-3 h-3' />
@@ -5055,11 +5063,15 @@ export const SupportTicketDetail = ({
                         <Button
                           variant='secondary'
                           onClick={() => setShowArchiveConfirmDialog(false)}
+                          data-track-category='Support'
+                          data-track-name='CANCEL_ARCHIVE_TICKET'
                         >
                           Cancel
                         </Button>
                         <Button
                           onClick={() => handleArchiveTicket()}
+                          data-track-category='Support'
+                          data-track-name='CONFIRM_ARCHIVE_TICKET'
                           disabled={!ticket || !!ticket.isArchived || isArchivingTicket}
                           loading={isArchivingTicket}
                           className='bg-destructive text-destructive-foreground hover:bg-destructive/90'

--- a/apps/dashboard/src/routes/WhatsAppBulkMigrationScreen/WhatsAppBulkMigrationScreen.tsx
+++ b/apps/dashboard/src/routes/WhatsAppBulkMigrationScreen/WhatsAppBulkMigrationScreen.tsx
@@ -613,6 +613,8 @@ const WhatsAppBulkMigrationScreen = (): ReactElement => {
                     </div>
                     <Button
                       onClick={() => void handleStage()}
+                      data-track-category='whatsapp-migration'
+                      data-track-name='STAGE_MIGRATION'
                       disabled={!canStage}
                       loading={isStaging}
                     >
@@ -705,6 +707,8 @@ const WhatsAppBulkMigrationScreen = (): ReactElement => {
                     <div className='flex items-center gap-3'>
                       <Button
                         onClick={() => void handlePreview()}
+                        data-track-category='whatsapp-migration'
+                        data-track-name='PREVIEW_MIGRATION'
                         disabled={!canPreview}
                         loading={isPreviewing}
                         variant='secondary'
@@ -714,6 +718,8 @@ const WhatsAppBulkMigrationScreen = (): ReactElement => {
                       </Button>
                       <Button
                         onClick={() => void handleStart()}
+                        data-track-category='whatsapp-migration'
+                        data-track-name='START_MIGRATION'
                         disabled={!canStart}
                         loading={isStarting}
                       >
@@ -978,6 +984,8 @@ const WhatsAppBulkMigrationScreen = (): ReactElement => {
                   <Button
                     variant='outline'
                     onClick={() => void handlePurgePreview()}
+                    data-track-category='whatsapp-migration'
+                    data-track-name='PREVIEW_PURGE'
                     disabled={isPurgeLoading || !selectedPurgeSourceId}
                   >
                     {isPurgeLoading ? 'Checking…' : 'Preview Delete'}
@@ -985,6 +993,8 @@ const WhatsAppBulkMigrationScreen = (): ReactElement => {
                   <Button
                     variant='destructive'
                     onClick={() => void handlePurgeExecute()}
+                    data-track-category='whatsapp-migration'
+                    data-track-name='EXECUTE_PURGE'
                     disabled={isPurgeLoading || !selectedPurgeSourceId}
                   >
                     {isPurgeLoading ? 'Deleting…' : 'Delete Imported Messages'}

--- a/apps/dashboard/src/routes/WorkspaceManagementScreen/GeneralAndMembersTab.tsx
+++ b/apps/dashboard/src/routes/WorkspaceManagementScreen/GeneralAndMembersTab.tsx
@@ -263,6 +263,8 @@ export const GeneralAndMembersTab = ({
             <div className='flex items-center gap-4 pt-2'>
               <Button
                 onClick={() => void handleSaveGeneral()}
+                data-track-category='workspace-management'
+                data-track-name='SAVE_WORKSPACE_GENERAL'
                 disabled={!hasChanges || !name.trim()}
                 className='gap-2'
               >
@@ -384,6 +386,8 @@ export const GeneralAndMembersTab = ({
                         {user.role !== WorkspaceRole.ADMIN && (
                           <DropdownMenuItem
                             onClick={() => handleUpdateRole(user.id, WorkspaceRole.ADMIN)}
+                            data-track-category='workspace-management'
+                            data-track-name='SET_MEMBER_ROLE_ADMIN'
                           >
                             <Shield className='w-4 h-4 mr-2' />
                             Admin
@@ -392,6 +396,8 @@ export const GeneralAndMembersTab = ({
                         {user.role !== WorkspaceRole.MEMBER && (
                           <DropdownMenuItem
                             onClick={() => handleUpdateRole(user.id, WorkspaceRole.MEMBER)}
+                            data-track-category='workspace-management'
+                            data-track-name='SET_MEMBER_ROLE_MEMBER'
                             disabled={!canRemoveAdmin(user)}
                           >
                             <User className='w-4 h-4 mr-2' />
@@ -411,6 +417,8 @@ export const GeneralAndMembersTab = ({
                       variant='ghost'
                       size='sm'
                       onClick={() => handleRemoveMember(user.id, user.name)}
+                      data-track-category='workspace-management'
+                      data-track-name='OPEN_REMOVE_MEMBER_CONFIRM'
                       disabled={processingUserId === user.id || !canRemoveAdmin(user)}
                       className='text-destructive hover:text-destructive hover:bg-destructive/10'
                     >
@@ -455,6 +463,8 @@ export const GeneralAndMembersTab = ({
                 setShowRemoveDialog(false);
                 setUserToRemove(null);
               }}
+              data-track-category='workspace-management'
+              data-track-name='CANCEL_REMOVE_MEMBER'
               disabled={processingUserId === userToRemove?.id}
             >
               Cancel
@@ -462,6 +472,8 @@ export const GeneralAndMembersTab = ({
             <Button
               variant='destructive'
               onClick={confirmRemoveMember}
+              data-track-category='workspace-management'
+              data-track-name='CONFIRM_REMOVE_MEMBER'
               disabled={processingUserId === userToRemove?.id}
               className='gap-2'
             >

--- a/apps/dashboard/src/routes/WorkspaceManagementScreen/GuestUsersTab.tsx
+++ b/apps/dashboard/src/routes/WorkspaceManagementScreen/GuestUsersTab.tsx
@@ -185,6 +185,8 @@ export const GuestUsersTab = ({ isActive = false }: GuestUsersTabProps): ReactEl
           variant='outline'
           size='sm'
           onClick={() => void loadGuests()}
+          data-track-category='workspace-management'
+          data-track-name='RELOAD_GUEST_USERS'
           disabled={isLoading}
           className='gap-2'
         >
@@ -290,6 +292,8 @@ export const GuestUsersTab = ({ isActive = false }: GuestUsersTabProps): ReactEl
                         variant='ghost'
                         size='sm'
                         onClick={() => setRevokeTarget({ guest, access })}
+                        data-track-category='workspace-management'
+                        data-track-name='OPEN_REVOKE_GUEST_CONFIRM'
                         className='text-destructive hover:text-destructive hover:bg-destructive/10 shrink-0'
                       >
                         <Trash2 className='w-4 h-4' />
@@ -326,12 +330,20 @@ export const GuestUsersTab = ({ isActive = false }: GuestUsersTabProps): ReactEl
           </p>
 
           <div className='flex gap-3 justify-end pt-2'>
-            <Button variant='outline' onClick={() => setRevokeTarget(null)} disabled={isRevoking}>
+            <Button
+              variant='outline'
+              onClick={() => setRevokeTarget(null)}
+              data-track-category='workspace-management'
+              data-track-name='CANCEL_REVOKE_GUEST'
+              disabled={isRevoking}
+            >
               Cancel
             </Button>
             <Button
               variant='destructive'
               onClick={() => void confirmRevoke()}
+              data-track-category='workspace-management'
+              data-track-name='CONFIRM_REVOKE_GUEST'
               disabled={isRevoking}
               className='gap-2'
             >

--- a/apps/dashboard/src/routes/WorkspaceManagementScreen/InvitationsTab.tsx
+++ b/apps/dashboard/src/routes/WorkspaceManagementScreen/InvitationsTab.tsx
@@ -269,6 +269,8 @@ export const InvitationsTab = ({ isActive = false }: InvitationsTabProps): React
                     setEntityId('');
                     setChannelId('');
                   }}
+                  data-track-category='WorkspaceManagement'
+                  data-track-name='SELECT_INVITE_ROLE_ADMIN'
                   className={cn(role === WorkspaceRole.ADMIN && 'bg-accent')}
                 >
                   Admin
@@ -280,12 +282,16 @@ export const InvitationsTab = ({ isActive = false }: InvitationsTabProps): React
                     setEntityId('');
                     setChannelId('');
                   }}
+                  data-track-category='WorkspaceManagement'
+                  data-track-name='SELECT_INVITE_ROLE_MEMBER'
                   className={cn(role === WorkspaceRole.MEMBER && 'bg-accent')}
                 >
                   Member
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => setRole(WorkspaceRole.GUEST)}
+                  data-track-category='WorkspaceManagement'
+                  data-track-name='SELECT_INVITE_ROLE_GUEST'
                   className={cn(role === WorkspaceRole.GUEST && 'bg-accent')}
                 >
                   Guest
@@ -294,6 +300,8 @@ export const InvitationsTab = ({ isActive = false }: InvitationsTabProps): React
             </DropdownMenu>
             <Button
               onClick={openConfirmDialog}
+              data-track-category='WorkspaceManagement'
+              data-track-name='OPEN_INVITE_CONFIRM'
               disabled={isSubmitting || !email.trim()}
               className='gap-2'
             >
@@ -442,12 +450,16 @@ export const InvitationsTab = ({ isActive = false }: InvitationsTabProps): React
             <Button
               variant='outline'
               onClick={() => setShowConfirmDialog(false)}
+              data-track-category='WorkspaceManagement'
+              data-track-name='CANCEL_SEND_INVITATION'
               disabled={isSubmitting}
             >
               Cancel
             </Button>
             <Button
               onClick={() => void handleSendInvitation()}
+              data-track-category='WorkspaceManagement'
+              data-track-name='SEND_INVITATION'
               disabled={isSubmitting}
               className='gap-2'
             >
@@ -507,6 +519,8 @@ export const InvitationsTab = ({ isActive = false }: InvitationsTabProps): React
                     variant='ghost'
                     size='sm'
                     onClick={() => handleRevokeInvitation(invitation.id)}
+                    data-track-category='WorkspaceManagement'
+                    data-track-name='REVOKE_INVITATION'
                     className='text-destructive hover:text-destructive hover:bg-destructive/10'
                   >
                     Revoke

--- a/apps/dashboard/src/routes/WorkspaceManagementScreen/OrganizationsTab.tsx
+++ b/apps/dashboard/src/routes/WorkspaceManagementScreen/OrganizationsTab.tsx
@@ -151,7 +151,13 @@ export const OrganizationsTab = (): ReactElement => {
       <div className='space-y-4'>
         <div className='flex gap-3 items-center'>
           <h3 className='text-sm font-medium text-foreground flex-1'>Link New Organization</h3>
-          <Button onClick={() => setShowCreateDialog(true)} variant='outline' className='gap-2'>
+          <Button
+            onClick={() => setShowCreateDialog(true)}
+            data-track-category='workspace-management'
+            data-track-name='OPEN_CREATE_ORG_DIALOG'
+            variant='outline'
+            className='gap-2'
+          >
             <Plus className='w-4 h-4' />
             Create New
           </Button>
@@ -176,6 +182,8 @@ export const OrganizationsTab = (): ReactElement => {
                 variant='ghost'
                 size='sm'
                 onClick={() => setShowCreateDialog(false)}
+                data-track-category='workspace-management'
+                data-track-name='CLOSE_CREATE_ORG_DIALOG'
                 className='size-7 p-0 text-muted-foreground hover:text-foreground rounded-lg border border-border hover:bg-muted'
                 disabled={isCreatingOrg}
               >
@@ -227,12 +235,16 @@ export const OrganizationsTab = (): ReactElement => {
                 variant='outline'
                 disabled={isCreatingOrg}
                 onClick={() => setShowCreateDialog(false)}
+                data-track-category='workspace-management'
+                data-track-name='CANCEL_CREATE_ORG'
                 size='sm'
               >
                 Cancel
               </Button>
               <Button
                 onClick={handleCreateOrg}
+                data-track-category='workspace-management'
+                data-track-name='CREATE_ORG'
                 disabled={!newOrgName.trim() || isCreatingOrg}
                 className='gap-2'
                 size='sm'
@@ -266,7 +278,13 @@ export const OrganizationsTab = (): ReactElement => {
                 width='100%'
               />
             </div>
-            <Button onClick={handleAddOrg} disabled={!selectedOrgId} className='gap-2'>
+            <Button
+              onClick={handleAddOrg}
+              data-track-category='workspace-management'
+              data-track-name='ADD_ORG_TO_WORKSPACE'
+              disabled={!selectedOrgId}
+              className='gap-2'
+            >
               <Plus className='w-4 h-4' />
               Add
             </Button>
@@ -318,6 +336,8 @@ export const OrganizationsTab = (): ReactElement => {
                     variant='ghost'
                     size='sm'
                     onClick={() => handleRemoveOrg(org.orgId, org.name)}
+                    data-track-category='workspace-management'
+                    data-track-name='OPEN_REMOVE_ORG_CONFIRM'
                     disabled={removingOrgId === org.orgId}
                     className='text-destructive hover:text-destructive hover:bg-destructive/10'
                   >
@@ -378,6 +398,8 @@ export const OrganizationsTab = (): ReactElement => {
                 setShowRemoveDialog(false);
                 setOrgToRemove(null);
               }}
+              data-track-category='workspace-management'
+              data-track-name='CANCEL_REMOVE_ORG'
               disabled={removingOrgId === orgToRemove?.orgId}
             >
               Cancel
@@ -385,6 +407,8 @@ export const OrganizationsTab = (): ReactElement => {
             <Button
               variant='destructive'
               onClick={confirmRemoveOrg}
+              data-track-category='workspace-management'
+              data-track-name='CONFIRM_REMOVE_ORG'
               disabled={removingOrgId === orgToRemove?.orgId}
               className='gap-2'
             >

--- a/apps/dashboard/src/routes/WorkspaceManagementScreen/WorkspaceManagementScreen.tsx
+++ b/apps/dashboard/src/routes/WorkspaceManagementScreen/WorkspaceManagementScreen.tsx
@@ -53,7 +53,14 @@ export const WorkspaceManagementScreen = (): ReactElement => {
     <div data-testid='workspace-management-page' className='h-full bg-muted flex flex-col'>
       {/* Header */}
       <div className='flex items-center gap-4 px-6 py-4 bg-card border-b border-border'>
-        <Button variant='ghost' size='sm' onClick={handleBack} className='gap-2'>
+        <Button
+          variant='ghost'
+          size='sm'
+          onClick={handleBack}
+          data-track-category='workspace-management'
+          data-track-name='BACK_FROM_WORKSPACE_MANAGEMENT'
+          className='gap-2'
+        >
           <ChevronLeft className='w-4 h-4' />
           Back
         </Button>


### PR DESCRIPTION
* fix: XYNE-58277 All the click metrics to sudoquery

Services-Requiring-Redeployment:
  - backend
  - dashboard

Services-Requiring-Redeployment:
  - backend
  - dashboard

* fix: XYNE-58277 conflict resolved

Services-Requiring-Redeployment:
  - dashboard

---------

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
