### PR TITLE
feat: port SDLC track and artifact-type claw tools from main

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/sdlc-baseline-run-context.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/sdlc-baseline-run-context.ts
@@ -63,8 +63,7 @@ export function parseSdlcAgentRunContext(value: unknown): Record<string, unknown
   ) return null;
   if (
     input["operation"] === "artifact" &&
-    (!["PRD", "TECH_DOC"].includes(String(artifact["kind"] ?? "")) ||
-      !nonEmptyString(execution["workflowExecutionId"]) ||
+    (!nonEmptyString(execution["workflowExecutionId"]) ||
       !nonEmptyString(execution["sessionId"]))
   ) return null;
   if (

--- a/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/servers/xyne-spaces-tools.ts
@@ -15,6 +15,7 @@ import {
   spacesFetchText,
   appFetch,
   appFetchBuffer,
+  type SpacesAuthContext,
 } from "./xyne-spaces-client.js";
 import { esc, queryDirect, type DirectSearchResponse } from "./vespa-direct.js";
 import { buildYqlFromParams, AREA_NAMES, AREA_ALIASES, describeAreasForPrompt } from "./vespa-search-areas.js";
@@ -4203,12 +4204,12 @@ const spacesCreateTicket: ToolDef = {
       sdlcRepoId: {
         type: "string",
         description:
-          "Required with sourceCanvasId when creating an implementation ticket for an SDLC Tech Doc. The SDLC repository ID from repository mode.",
+          "Required with sourceCanvasId when creating an implementation ticket for an SDLC artifact. The SDLC repository ID from repository mode.",
       },
       sourceCanvasId: {
         type: "string",
         description:
-          "Required with sdlcRepoId when creating an implementation ticket for an SDLC Tech Doc. The Tech Doc canvas ID to link to the new ticket.",
+          "Required with sdlcRepoId when creating an implementation ticket for an SDLC artifact. The artifact canvas ID to link to the new ticket.",
       },
       priority: {
         type: "string",
@@ -4284,10 +4285,10 @@ const spacesCreateTicket: ToolDef = {
               targetId: data.id,
               relationType: "TICKET",
             }),
-          });
+          }, sdlcSpacesAuth());
         } catch (linkError) {
           return err(
-            `Ticket ${data.xyneId} was created, but its Tech Doc link failed: ${errMsg(linkError)}. Do not create a duplicate ticket.`,
+            `Ticket ${data.xyneId} was created, but its artifact link failed: ${errMsg(linkError)}. Do not create a duplicate ticket.`,
           );
         }
       }
@@ -5285,7 +5286,7 @@ const sdlcSourceReferencesSchema = {
 } as const;
 
 function sdlcMutationVariant(
-  artifactType: "WIKI" | "BASELINE" | "PRD" | "TECH_DOC",
+  artifactType: "WIKI" | "BASELINE",
   action: string,
   required: readonly string[],
   propertyOverrides: Record<string, unknown> = {},
@@ -5305,9 +5306,13 @@ function sdlcMutationVariant(
 const spacesSdlcMutateArtifact: ToolDef = {
   name: SDLC_TOOL_NAMES.mutateArtifact,
   description:
-    "Create or mutate one trusted-repository SDLC artifact. Supports PRD/Tech Doc creation, incremental " +
-    "baseline drafts, and Wiki page create/update/section/move/archive/restore actions. Trusted repository and " +
-    "execution identity is injected by the platform.",
+    "Create or mutate one trusted-repository SDLC artifact. Supports artifact create/update, incremental " +
+    "baseline drafts, and Wiki page create/update/section/move/archive/restore actions. Artifact types are canvas " +
+    "folders on the repo's SDLC channel: PRD and Tech Docs are seeded built-in types, and users can add custom " +
+    "types; list them via spaces-sdlc-list-artifact-types. To create an artifact of any type, pass its folderId " +
+    "(from that tool) plus trackId (the SDLC track it belongs to). To update an artifact, pass its canvasId and " +
+    "markdown. Link related artifacts via relatedCanvasIds. Trusted repository and execution identity is " +
+    "injected by the platform.",
   inputSchema: {
     type: "object",
     properties: {
@@ -5316,7 +5321,7 @@ const spacesSdlcMutateArtifact: ToolDef = {
       actorUserId: { type: "string", minLength: 1 },
       executionId: { type: "string", minLength: 1 },
       sessionId: { type: "string", minLength: 1 },
-      artifactType: { type: "string", enum: ["WIKI", "BASELINE", "PRD", "TECH_DOC"] },
+      artifactType: { type: "string", enum: ["WIKI", "BASELINE"] },
       baselineKind: {
         type: "string",
         enum: [...SDLC_BASELINE_KINDS],
@@ -5338,13 +5343,32 @@ const spacesSdlcMutateArtifact: ToolDef = {
       commitSha: { type: "string", pattern: SDLC_AGENT_COMMIT_REF_PATTERN },
       sourcePaths: sdlcSourcePathsSchema,
       sourceReferences: sdlcSourceReferencesSchema,
-      kind: { type: "string", enum: ["PRD", "TECH_DOC"] },
-      parentCanvasId: { type: "string", minLength: 1 },
+      folderId: { type: "string", minLength: 1, description: "The artifact-type folder id to create the artifact under; get it from spaces-sdlc-list-artifact-types. Required for every artifact create." },
+      relatedCanvasIds: { type: "array", items: { type: "string", minLength: 1 }, description: "Optional canvas ids of existing artifacts to link as related context on create." },
+      trackId: { type: "string", minLength: 1, description: "Required when creating an artifact: the SDLC track it belongs to. Get it from spaces-sdlc-list-artifacts or the user's chosen track." },
       generationCommit: { type: "string", maxLength: 255 },
       canvasId: { type: "string", minLength: 1, description: "Canonical SDLC Canvas ID from the canvas URL or artifact response" },
     },
-    required: ["artifactType", "action"],
+    required: ["action"],
     oneOf: [
+      {
+        type: "object",
+        properties: {
+          action: { const: "create" },
+          folderId: { type: "string", minLength: 1 },
+        },
+        required: ["action", "folderId", "title", "markdown", "trackId"],
+        not: { required: ["artifactType"] },
+      },
+      {
+        type: "object",
+        properties: {
+          action: { const: "update" },
+          canvasId: { type: "string", minLength: 1 },
+        },
+        required: ["action", "canvasId", "markdown"],
+        not: { required: ["artifactType"] },
+      },
       sdlcMutationVariant("WIKI", "create", ["commitSha", "path", "title", "markdown", "sourcePaths"]),
       sdlcMutationVariant("WIKI", "update", ["commitSha", "path", "expectedContentHash", "title", "markdown", "sourcePaths"]),
       sdlcMutationVariant("WIKI", "restore", ["commitSha", "path", "expectedContentHash", "title", "markdown", "sourcePaths"]),
@@ -5356,10 +5380,6 @@ const spacesSdlcMutateArtifact: ToolDef = {
       sdlcMutationVariant("BASELINE", "begin", ["baselineKind", "setupExecutionId", "workflowExecutionId", "title"]),
       sdlcMutationVariant("BASELINE", "upsert_section", ["baselineKind", "setupExecutionId", "workflowExecutionId", "title", "sectionKey", "sectionTitle", "markdown", "sourceReferences"], { markdown: { maxLength: 1_000_000 }, sourceReferences: { minItems: 1 } }),
       sdlcMutationVariant("BASELINE", "finalize", ["baselineKind", "setupExecutionId", "workflowExecutionId", "title"]),
-      sdlcMutationVariant("PRD", "create", ["title", "markdown"]),
-      sdlcMutationVariant("PRD", "update", ["canvasId", "markdown"]),
-      sdlcMutationVariant("TECH_DOC", "create", ["title", "markdown", "parentCanvasId"]),
-      sdlcMutationVariant("TECH_DOC", "update", ["canvasId", "markdown"]),
     ],
   },
   async handler(args, ctx) {
@@ -5376,7 +5396,7 @@ async function updateSdlcBaseline(args: Record<string, unknown>, ctx: HandlerCon
       method: "POST",
       headers: { "x-xyne-acting-user-id": ctx.userId },
       body: JSON.stringify(args),
-    })) as {
+    }, sdlcSpacesAuth())) as {
       artifact: {
         canvasId: string;
         viewAccessId?: string;
@@ -5405,12 +5425,11 @@ async function createSdlcArtifact(args: Record<string, unknown>, ctx: HandlerCon
       method: "POST",
       headers: { "x-xyne-acting-user-id": ctx.userId },
       body: JSON.stringify(args),
-    })) as {
+    }, sdlcSpacesAuth())) as {
       artifact: {
         canvasId: string;
         viewAccessId?: string;
         url?: string;
-        kind: string;
       };
     };
     const artifact = data.artifact;
@@ -5419,7 +5438,6 @@ async function createSdlcArtifact(args: Record<string, unknown>, ctx: HandlerCon
     return okCited(
       prefixChunk(1, "SDLC artifact created", [
         `Canvas ID: ${artifact.canvasId}`,
-        `Kind: ${artifact.kind}`,
         `URL: ${artifact.url ?? `/chat/canvas/${artifact.canvasId}`}`,
       ]),
       citations,
@@ -5438,23 +5456,21 @@ async function mutateSdlcArtifact(args: Record<string, unknown>, ctx: HandlerCon
     }
     return updateSdlcBaseline(args, ctx);
   }
-  if (artifactType === "PRD" || artifactType === "TECH_DOC") {
-    if (action === "create") {
-      return createSdlcArtifact({ ...args, kind: artifactType }, ctx);
+  const folderId = String(args["folderId"] ?? "").trim();
+  if (action === "create" && folderId) {
+    return createSdlcArtifact(args, ctx);
+  }
+  if (action === "update" && !artifactType && String(args["canvasId"] ?? "").trim()) {
+    try {
+      const data = (await spacesFetch("/api/sdlc/claw/artifacts/update", {
+        method: "POST",
+        headers: { "x-xyne-acting-user-id": ctx.userId },
+        body: JSON.stringify(args),
+      }, sdlcSpacesAuth())) as { artifact: { canvasId: string; viewAccessId?: string; url?: string } };
+      return ok(JSON.stringify(data.artifact));
+    } catch (e) {
+      return err(`Update SDLC artifact error: ${errMsg(e)}`);
     }
-    if (action === "update") {
-      try {
-        const data = (await spacesFetch("/api/sdlc/claw/artifacts/update", {
-          method: "POST",
-          headers: { "x-xyne-acting-user-id": ctx.userId },
-          body: JSON.stringify({ ...args, kind: artifactType }),
-        })) as { artifact: { canvasId: string; viewAccessId?: string; url?: string; kind: string } };
-        return ok(JSON.stringify(data.artifact));
-      } catch (e) {
-        return err(`Update SDLC artifact error: ${errMsg(e)}`);
-      }
-    }
-    return err(`${artifactType} action must be create or update.`);
   }
   if (artifactType !== "WIKI") return err("Unsupported SDLC artifactType.");
   if (action === "move") {
@@ -5544,7 +5560,7 @@ const sdlcArtifactSelectorSchema = {
       additionalProperties: false,
       properties: {
         type: { const: "SDLC_CANVAS" },
-        canvasId: { type: "string", minLength: 1, maxLength: 256, description: "Repo Knowledge, PRD, or Tech Doc Canvas ID" },
+        canvasId: { type: "string", minLength: 1, maxLength: 256, description: "Repo Knowledge or artifact Canvas ID" },
       },
       required: ["type", "canvasId"],
     },
@@ -5553,7 +5569,7 @@ const sdlcArtifactSelectorSchema = {
 
 const spacesSdlcListArtifactVersions: ToolDef = {
   name: SDLC_TOOL_NAMES.listArtifactVersions,
-  description: "List a bounded newest-first page of immutable versions for one trusted-repository SDLC Wiki page, Repo Knowledge document, PRD, or Tech Doc. Read the current artifact first and paginate only when older context is relevant; this list intentionally omits historical bodies.",
+  description: "List a bounded newest-first page of immutable versions for one trusted-repository SDLC Wiki page, Repo Knowledge document, or artifact (any type). Read the current artifact first and paginate only when older context is relevant; this list intentionally omits historical bodies.",
   inputSchema: {
     type: "object",
     properties: {
@@ -5584,15 +5600,122 @@ const spacesSdlcReadArtifactVersion: ToolDef = {
   async appHandler(args, ctx) { return callSdlcArtifactHistory("/read", args, ctx); },
 };
 
+// SDLC claw routes (/api/sdlc/claw/*) can be pointed at a dedicated SDLC backend
+// via SDLC_BACKEND_URL, mirroring the iframe's VITE_SDLC_BACKEND_URL. Unset -> the
+// call falls through to the default Spaces backend. token/session/workspace are
+// re-supplied from env because passing an auth object otherwise blanks them.
+function sdlcSpacesAuth(): SpacesAuthContext | undefined {
+  const baseUrl = process.env["SDLC_BACKEND_URL"];
+  if (!baseUrl) return undefined;
+  const token = process.env["XYNE_SPACES_TOKEN"];
+  const sessionId = process.env["XYNE_SPACES_SESSION_ID"];
+  const workspaceId = process.env["XYNE_SPACES_WORKSPACE_ID"];
+  return {
+    baseUrl,
+    ...(token !== undefined && { token }),
+    ...(sessionId !== undefined && { sessionId }),
+    ...(workspaceId !== undefined && { workspaceId }),
+  };
+}
+
+async function callSdlcTracks(
+  path: string,
+  args: Record<string, unknown>,
+  ctx: HandlerContext,
+): Promise<ToolResult> {
+  try {
+    const data = await spacesFetch(`/api/sdlc/claw/tracks${path}`, {
+      method: "POST",
+      headers: { "x-xyne-acting-user-id": ctx.userId },
+      body: JSON.stringify(args),
+    }, sdlcSpacesAuth());
+    return ok(JSON.stringify(data));
+  } catch (e) {
+    return err(`SDLC tracks error: ${errMsg(e)}`);
+  }
+}
+
+const spacesSdlcListTracks: ToolDef = {
+  name: SDLC_TOOL_NAMES.listTracks,
+  description:
+    "List the SDLC tracks (workstreams) in a trusted repository. Call this before creating a PRD or Tech Doc so the user can pick an existing track; if none fit, use spaces-sdlc-create-track.",
+  inputSchema: {
+    type: "object",
+    properties: { repoId: { type: "string", minLength: 1 } },
+    required: ["repoId"],
+  },
+  async handler(args, ctx) {
+    return callSdlcTracks("/list", args, ctx);
+  },
+  async appHandler(args, ctx) {
+    return callSdlcTracks("/list", args, ctx);
+  },
+};
+
+const spacesSdlcCreateTrack: ToolDef = {
+  name: SDLC_TOOL_NAMES.createTrack,
+  description:
+    "Create a new SDLC track (workstream) in a trusted repository. Use this when the user wants a brand-new track for a PRD/Tech Doc rather than an existing one. Returns the new track id to pass as trackId in spaces-sdlc-mutate-artifact.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      repoId: { type: "string", minLength: 1 },
+      name: { type: "string", minLength: 1, maxLength: 120 },
+      description: { type: "string", maxLength: 2000 },
+    },
+    required: ["repoId", "name"],
+  },
+  async handler(args, ctx) {
+    return callSdlcTracks("", args, ctx);
+  },
+  async appHandler(args, ctx) {
+    return callSdlcTracks("", args, ctx);
+  },
+};
+
+async function callSdlcArtifactTypes(
+  path: string,
+  args: Record<string, unknown>,
+  ctx: HandlerContext,
+): Promise<ToolResult> {
+  try {
+    const data = await spacesFetch(`/api/sdlc/claw/artifact-types${path}`, {
+      method: "POST",
+      headers: { "x-xyne-acting-user-id": ctx.userId },
+      body: JSON.stringify(args),
+    }, sdlcSpacesAuth());
+    return ok(JSON.stringify(data));
+  } catch (e) {
+    return err(`SDLC artifact types error: ${errMsg(e)}`);
+  }
+}
+
+const spacesSdlcListArtifactTypes: ToolDef = {
+  name: SDLC_TOOL_NAMES.listArtifactTypes,
+  description:
+    "List the SDLC artifact types (canvas folders) in a trusted repository. Each type is a folder on the repo's SDLC channel; PRD and Tech Doc are seeded built-in types and users can add more custom types. Call this before creating an artifact of a custom type to get its folderId, then pass that folderId to spaces-sdlc-mutate-artifact create.",
+  inputSchema: {
+    type: "object",
+    properties: { repoId: { type: "string", minLength: 1 } },
+    required: ["repoId"],
+  },
+  async handler(args, ctx) {
+    return callSdlcArtifactTypes("/list", args, ctx);
+  },
+  async appHandler(args, ctx) {
+    return callSdlcArtifactTypes("/list", args, ctx);
+  },
+};
+
 const spacesSdlcListArtifacts: ToolDef = {
   name: SDLC_TOOL_NAMES.listArtifacts,
-  description: "List current trusted-repository Wiki, Baseline, PRD, and Tech Doc artifacts. Returns bounded identity and current-state metadata without historical bodies.",
+  description: "List current trusted-repository Wiki, Baseline, and artifact documents (every artifact type, seeded or custom). Returns bounded identity and current-state metadata without historical bodies.",
   inputSchema: {
     type: "object",
     properties: {
       repoId: { type: "string" }, workspaceId: { type: "string" }, actorUserId: { type: "string" },
       executionId: { type: "string" }, sessionId: { type: "string" },
-      kinds: { type: "array", items: { type: "string", enum: ["WIKI", "BASELINE", "PRD", "TECH_DOC"] } },
+      kinds: { type: "array", items: { type: "string", enum: ["WIKI", "BASELINE", "ARTIFACT", "PRD", "TECH_DOC"] }, description: "Filter by kind. ARTIFACT covers every artifact type (seeded or custom); PRD/TECH_DOC are accepted as legacy aliases for ARTIFACT." },
       includeArchived: { type: "boolean" },
     },
     required: ["repoId", "workspaceId", "actorUserId"],
@@ -9091,6 +9214,9 @@ export const tools: ToolDef[] = [
   spacesCreateCanvas,
   spacesSdlcListArtifacts,
   spacesSdlcReadArtifact,
+  spacesSdlcListTracks,
+  spacesSdlcCreateTrack,
+  spacesSdlcListArtifactTypes,
   spacesSdlcMutateArtifact,
   spacesSdlcCreatePullRequest,
   spacesSdlcListArtifactVersions,

--- a/apps/xyne-claw-auth/backend/src/mcp/validators.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/validators.ts
@@ -319,8 +319,23 @@ register("xyne-spaces", "spaces-edit-canvas", async (params) => {
 register("xyne-spaces", SDLC_TOOL_NAMES.mutateArtifact, async (params) => {
   const artifactType = String(params["artifactType"] ?? "");
   const action = String(params["action"] ?? "");
-  if (!["WIKI", "BASELINE", "PRD", "TECH_DOC"].includes(artifactType)) {
-    return "artifactType must be WIKI, BASELINE, PRD, or TECH_DOC";
+  const folderId = String(params["folderId"] ?? "").trim();
+  if (folderId && action === "create") {
+    if (!String(params["repoId"] ?? "").trim()) return "repoId is required";
+    for (const key of ["title", "markdown", "trackId"]) {
+      if (!String(params[key] ?? "").trim()) return `${key} is required for create`;
+    }
+    return null;
+  }
+  if (!artifactType && action === "update") {
+    if (!String(params["repoId"] ?? "").trim()) return "repoId is required";
+    for (const key of ["canvasId", "markdown"]) {
+      if (!String(params[key] ?? "").trim()) return `${key} is required for update`;
+    }
+    return null;
+  }
+  if (!["WIKI", "BASELINE"].includes(artifactType)) {
+    return "artifactType must be WIKI or BASELINE (artifact creates use folderId; updates use canvasId)";
   }
   if (!String(params["repoId"] ?? "").trim()) return "repoId is required";
   if (artifactType === "BASELINE") {
@@ -333,22 +348,6 @@ register("xyne-spaces", SDLC_TOOL_NAMES.mutateArtifact, async (params) => {
     if (action === "upsert_section") {
       for (const key of ["sectionKey", "sectionTitle", "markdown"]) {
         if (!String(params[key] ?? "").trim()) return `${key} is required for upsert_section`;
-      }
-    }
-    return null;
-  }
-  if (artifactType === "PRD" || artifactType === "TECH_DOC") {
-    if (!["create", "update"].includes(action)) return `${artifactType} action must be create or update`;
-    if (action === "create") {
-      for (const key of ["title", "markdown"]) {
-        if (!String(params[key] ?? "").trim()) return `${key} is required for create`;
-      }
-      if (artifactType === "TECH_DOC" && !String(params["parentCanvasId"] ?? "").trim()) {
-        return "parentCanvasId is required for TECH_DOC create";
-      }
-    } else {
-      for (const key of ["canvasId", "markdown"]) {
-        if (!String(params[key] ?? "").trim()) return `${key} is required for update`;
       }
     }
     return null;

--- a/packages/xyne-claw-shared/src/tools/sdlc-registry.ts
+++ b/packages/xyne-claw-shared/src/tools/sdlc-registry.ts
@@ -28,6 +28,9 @@ export const SDLC_TOOL_NAMES = {
   finalizeWikiCommit: "spaces-sdlc-wiki-finalize-commit",
   gitContext: "sandbox-sdlc-git-context",
   createPullRequest: "spaces-sdlc-create-pull-request",
+  listTracks: "spaces-sdlc-list-tracks",
+  createTrack: "spaces-sdlc-create-track",
+  listArtifactTypes: "spaces-sdlc-list-artifact-types",
 } as const;
 
 export type SdlcToolName = (typeof SDLC_TOOL_NAMES)[keyof typeof SDLC_TOOL_NAMES];
@@ -43,6 +46,9 @@ export const SDLC_TOOL_CAPABILITIES: readonly SdlcToolCapability[] = [
   { name: SDLC_TOOL_NAMES.finalizeWikiCommit, transport: "direct", group: "sdlc", mutation: "write", trustedBinding: "wiki_execution" },
   { name: SDLC_TOOL_NAMES.gitContext, transport: "custom", group: "sdlc", mutation: "read", trustedBinding: "wiki_execution" },
   { name: SDLC_TOOL_NAMES.createPullRequest, transport: "direct", group: "sdlc", mutation: "write", trustedBinding: "execution_or_interactive" },
+  { name: SDLC_TOOL_NAMES.listTracks, transport: "direct", group: "sdlc", mutation: "read", trustedBinding: "repository" },
+  { name: SDLC_TOOL_NAMES.createTrack, transport: "direct", group: "sdlc", mutation: "write", trustedBinding: "repository" },
+  { name: SDLC_TOOL_NAMES.listArtifactTypes, transport: "direct", group: "sdlc", mutation: "read", trustedBinding: "repository" },
 ] as const;
 
 export const SDLC_GENERIC_SANDBOX_TOOLS = [


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Ports the Claw slice of two SDLC PRs that landed on `main` but were never brought onto `feature/deploy-xyneclaw`, the branch the Claw services actually deploy from.

The original SDLC Claw work reached this branch as #946 (the port of #692). Two `main` PRs that followed also touched Claw code and were missed:

- **#922** (`ca7008156`) — SDLC track tools and backend routing.
- **#1119** (`17226171a`, forward-porting #1086) — custom SDLC artifact types with folder-based identity.

Consequence on the deploy branch today: a Claw agent on an SDLC repository cannot list or create tracks, cannot discover custom artifact types, and `spaces-sdlc-mutate-artifact` still requires the removed `PRD`/`TECH_DOC` `artifactType`. Every `/api/sdlc/claw/*` call also goes to the default Spaces backend rather than `SDLC_BACKEND_URL`, so on a split deployment they reach the wrong service.

### From #922

- New tools `spaces-sdlc-list-tracks` and `spaces-sdlc-create-track`, backed by `/api/sdlc/claw/tracks`, plus their `SDLC_TOOL_CAPABILITIES` rows.
- `sdlcSpacesAuth()`, which points SDLC Claw routes at `SDLC_BACKEND_URL` when it is set and otherwise falls through to the default Spaces backend. Threaded into every existing `/api/sdlc/claw/*` call site.

### From #1119

- New tool `spaces-sdlc-list-artifact-types`, backed by `/api/sdlc/claw/artifact-types`. Artifact types are canvas folders on the repo's SDLC channel — PRD and Tech Doc are seeded built-ins and users can add custom types.
- `spaces-sdlc-mutate-artifact` now creates any artifact type from a `folderId` plus `trackId`, and updates from a `canvasId`. `artifactType` narrows to `WIKI | BASELINE`; `kind` and `parentCanvasId` are gone; `relatedCanvasIds` is added. `validators.ts` and `sdlc-baseline-run-context.ts` follow the same shape.

### Deliberate deviations from `main`

- New `catch` blocks use this branch's `errMsg()` helper rather than the inline `e instanceof Error ? e.message : String(e)` that `main` still carries, matching the surrounding code here. `withToolErrors` on `spacesSdlcCreatePullRequest` is left as-is.
- `/api/internal/sdlc/vcs/pull-requests` and the artifact-history endpoints do **not** get `sdlcSpacesAuth()` — `main` does not pass it there either. Kept identical so the two branches match; worth raising separately if the split deployment needs it.

### Reverse check

Diffed `main` against this branch in the other direction over the Claw directories: nothing SDLC on the deploy branch is missing from `main`. The only deploy-side deltas are the `errMsg` / `withToolErrors` refactor noted above.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package (`packages/xyne-claw-shared`)
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [x] Env variable added / renamed / removed
- [x] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

`SDLC_BACKEND_URL` is read from `process.env` on the claw-auth pod. It has no `.env` file or manifest on this branch — it must be set on the pod environment. Leaving it unset is safe and preserves today's behaviour: every SDLC Claw call keeps going to the default Spaces backend. Setting it routes `/api/sdlc/claw/*` to the dedicated SDLC backend, mirroring the iframe's `VITE_SDLC_BACKEND_URL`.

<!-- Keys added/changed: SDLC_BACKEND_URL (optional) -->

## API Contract

- [ ] No API changes
- [x] New endpoint (client side only — the Claw tools now call `/api/sdlc/claw/tracks` and `/api/sdlc/claw/artifact-types`, which already exist on the Spaces backend at `apps/backend/src/routes/sdlcClaw.ts`)
- [x] Existing contract modified (shape, status codes, auth) — `spaces-sdlc-mutate-artifact` input schema
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?

Ported the four files by hand rather than cherry-picking, because both source commits are squash merges spanning `apps/backend` and `apps/dashboard`, and `xyne-spaces-tools.ts` has diverged substantially between the branches.

Verified parity by diffing the result against `origin/main`: the only remaining SDLC differences in the touched files are the intentional `errMsg` / `withToolErrors` idiom deviations listed above. `sdlc-registry.ts` and `sdlc-baseline-run-context.ts` are now byte-identical to `main`.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [x] Claw tests — `pnpm --filter xyne-claw-shared test` (23 files, 228 tests, all passing)
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- the ported code is tool-definition wiring; the existing validator and run-context suites cover the shape changes -->

Also run:

- `pnpm --filter xyne-claw-shared typecheck` — clean.
- `pnpm --filter xyne-claw-auth typecheck` — clean.
- `pnpm run build:shared` — clean.
- `pnpm --filter xyne-claw-auth exec vitest run src/mcp` — 77 passing, 3 failing. All three failures reproduce on the unmodified branch tip (`sdlc-baseline-run-context` operation-mismatch expectation, and two `xyne-spaces-tools-list` inline snapshots) and are unrelated to this change.

### Manual

Not yet exercised end to end against a live SDLC backend. Suggested check before merge, with `SDLC_BACKEND_URL` pointed at the SDLC backend:

- `spaces-sdlc-list-artifact-types { repoId }` returns the seeded PRD / Tech Doc folders.
- `spaces-sdlc-list-tracks { repoId }` returns tracks; `spaces-sdlc-create-track { repoId, name }` returns a new id.
- `spaces-sdlc-mutate-artifact { action: "create", folderId, trackId, title, markdown, repoId }` creates a canvas without `artifactType` — the call the old validator rejected.
- `spaces-sdlc-mutate-artifact { action: "update", canvasId, markdown, repoId }` updates it.
- WIKI and BASELINE mutations still validate and route unchanged.
- Requests land on `SDLC_BACKEND_URL`, not the default Spaces host.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass (claw-auth)
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass — dashboard not touched
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` — no new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

Services-Requiring-Redeployment:
  - xyne-claw-auth
