### PR TITLE
fix: prevent call header navigator overlap

### DIFF
--- a/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
+++ b/apps/dashboard/src/components/AppNavigator/AppNavigator.tsx
@@ -1,9 +1,11 @@
 import { ReactElement, useEffect, useRef, useState } from 'react';
+import { useSelector } from '@xstate/react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { ArrowLeft, ArrowRight, SearchBig } from '@xyne/icons';
 import { invokeShortcut } from '../../shortcuts';
 import { cn } from '../../utils/classNames';
 import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../utils/electronApp';
+import { roomActor } from '../../machines/roomMachine';
 
 const buttonClass = cn(
   'size-7 flex items-center justify-center rounded-[10px] border border-transparent transition-colors',
@@ -31,6 +33,10 @@ const AppNavigator = (): ReactElement => {
   const location = useLocation();
   const [historyIndex, setHistoryIndex] = useState(getHistoryIndex);
   const maxHistoryIndexRef = useRef(historyIndex);
+  const shouldHideForFullCall = useSelector(
+    roomActor,
+    state => state.matches('connected') && state.context.viewMode === 'full',
+  );
 
   useEffect(() => {
     const nextHistoryIndex = getHistoryIndex();
@@ -52,6 +58,10 @@ const AppNavigator = (): ReactElement => {
       void navigate(1);
     }
   };
+
+  if (shouldHideForFullCall) {
+    return <></>;
+  }
 
   return (
     <div

--- a/apps/dashboard/src/components/Call/CallViews/FullCallView.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/FullCallView.tsx
@@ -455,7 +455,7 @@ export function FullCallView({
       <div
         className={cn(
           'flex justify-between items-center pr-4 py-3',
-          isElectron && isMac ? 'pl-20' : 'pl-4',
+          isElectron && isMac ? 'pl-24' : 'pl-4',
         )}
       >
         <div className='flex items-center gap-2'>

--- a/apps/dashboard/src/components/Call/CallViews/FullCallView.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/FullCallView.tsx
@@ -40,6 +40,7 @@ import { useAutoPresentationMode } from '../useAutoPresentationMode';
 import { PresentationModeOverlay } from '../PresentationMode/PresentationModeOverlay';
 import { formatElapsedTime } from '../../../utils/recordingUtils';
 import { logger, Event } from '../../../utils/logger';
+import { usePlatform } from '../../../hooks/usePlatform';
 
 interface FullCallViewProps {
   participants: ParticipantInfo[];
@@ -163,6 +164,7 @@ export function FullCallView({
 }: FullCallViewProps): React.ReactElement {
   // ALL HOOKS MUST BE DECLARED BEFORE ANY CONDITIONAL RETURNS
   const { user } = useAuth();
+  const { isElectron, isMac } = usePlatform();
   const isTelepresenceEnabled = useTelepresenceEnabled(user?.email);
 
   // UI state
@@ -450,7 +452,12 @@ export function FullCallView({
       )}
 
       {/* Connection Status Indicators Bar */}
-      <div className='flex justify-between items-center px-4 py-3'>
+      <div
+        className={cn(
+          'flex justify-between items-center pr-4 py-3',
+          isElectron && isMac ? 'pl-20' : 'pl-4',
+        )}
+      >
         <div className='flex items-center gap-2'>
           <div className='relative visual-regression-hide'>
             <div className='w-2 h-2 bg-green-500 rounded-full'></div>


### PR DESCRIPTION
1. Problem Description:
Full active call view currently allows the shared app navigator (back/forward/search controls) and macOS Electron traffic lights to overlap the `Call Active · n participants` header area.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported from the active call screen screenshot in Xyne Spaces. Code inspection confirmed the root navigator is rendered by `apps/dashboard/src/components/AppNavigator/AppNavigator.tsx`, while the full-call status header is rendered by `apps/dashboard/src/components/Call/CallViews/FullCallView.tsx`.

3. Explain the solution implemented in the PR:
- `AppNavigator` now returns no UI only when `roomActor` is connected and `viewMode` is `full`, so MiniCallView keeps the normal app navigator.
- `FullCallView` uses the existing `usePlatform()` hook and applies macOS Electron-only Tailwind spacing (`pl-20`, no new arbitrary bracket class) to move the call status header after native traffic lights.
- Electron window traffic-light configuration is unchanged.

[https://github.com/user-attachments/assets/555c85a9-85d9-4b25-a7b1-09edf8801f92](https://github.com/user-attachments/assets/555c85a9-85d9-4b25-a7b1-09edf8801f92)



4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
POT:
- `pnpm --dir apps/dashboard exec prettier --write src/components/AppNavigator/AppNavigator.tsx src/components/Call/CallViews/FullCallView.tsx` — passed, unchanged after formatting.
- `git diff --check` — passed.
- `pnpm --dir apps/dashboard exec eslint src/components/AppNavigator/AppNavigator.tsx src/components/Call/CallViews/FullCallView.tsx` — passed with 0 errors; existing warnings remain in `FullCallView.tsx` for missing return types at lines unrelated to this change.
- `pnpm --dir apps/dashboard typecheck` — blocked by pre-existing unrelated missing dependency/type errors in AI artifact and on-device intent files: `@pierre/trees/react`, `@codesandbox/sandpack-react`, `@huggingface/transformers`, and existing `intent.worker.ts` typing issues.
- POT video recorded in sandbox and shared in the Spaces thread.

9. Services to which this change is to be deployed:
Dashboard / Electron renderer UI

10. Main PR link (if this PR is raised against a release branch):
N/A