### PR TITLE
fix: XYNE-60286 fix Cmd+K search keyboard navigation and mention auto…

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -3011,6 +3011,110 @@ const ChannelCommandMenu = ({
     return null;
   };
 
+  // Accept the currently highlighted mention row (user/channel/priority/DM). Shared by Enter
+  // and by Tab/ArrowRight so `from:ar` + Tab completes the mention the same way Enter would,
+  // instead of falling through to tab-cycling or the ticket-preview shortcut.
+  const acceptHighlightedMention = (): void => {
+    // Handle 'in:' trigger - Channels + DMs (NO Users)
+    if (channelTrigger === 'in:') {
+      const regularChannelCount = availableRegularChannels.length;
+
+      if (selectedMentionIndex < regularChannelCount) {
+        // Selecting a regular channel
+        const channelIndex = selectedMentionIndex;
+        if (availableRegularChannels[channelIndex]) {
+          const { channel, displayName } = availableRegularChannels[channelIndex];
+          void handleMentionSelect({
+            id: channel.id,
+            name: displayName,
+            type: MentionType.CHANNEL,
+          });
+        }
+      } else {
+        // Selecting a DM
+        const dmIndex = selectedMentionIndex - regularChannelCount;
+        if (availableDMs[dmIndex]) {
+          const { channel, displayName } = availableDMs[dmIndex];
+          void handleMentionSelect({
+            id: channel.id,
+            name: displayName,
+            type: MentionType.CHANNEL,
+          });
+        }
+      }
+      return;
+    }
+
+    // Handle 'in:#' trigger - Channels only (NO DMs)
+    if (channelTrigger === 'in:#') {
+      if (availableRegularChannels[selectedMentionIndex]) {
+        const { channel, displayName } = availableRegularChannels[selectedMentionIndex];
+        void handleMentionSelect({
+          id: channel.id,
+          name: displayName,
+          type: MentionType.CHANNEL,
+        });
+      }
+      return;
+    }
+
+    // Handle 'in:@' trigger - DMs only (NOT Users!)
+    if (channelTrigger === 'in:@') {
+      if (availableDMs[selectedMentionIndex]) {
+        const { channel, displayName } = availableDMs[selectedMentionIndex];
+        void handleMentionSelect({
+          id: channel.id,
+          name: displayName,
+          type: MentionType.CHANNEL,
+        });
+      }
+      return;
+    }
+
+    // Handle '#' trigger - only Channels (legacy combined list)
+    if (channelTrigger === '#' && availableChannels[selectedMentionIndex]) {
+      const { channel, displayName } = availableChannels[selectedMentionIndex];
+      void handleMentionSelect({
+        id: channel.id,
+        name: displayName,
+        type: MentionType.CHANNEL,
+      });
+      return;
+    }
+
+    // Handle priority value selection (closed enum, no backend)
+    if (mentionSearchType === MentionType.PRIORITY && availablePriorities[selectedMentionIndex]) {
+      const priority = availablePriorities[selectedMentionIndex];
+      void handleMentionSelect({
+        id: priority.id,
+        name: priority.name,
+        type: MentionType.PRIORITY,
+      });
+      return;
+    }
+
+    // Handle regular user mention search (@, from:, with:, assignee:)
+    if (mentionSearchType === MentionType.USER && availableUsers[selectedMentionIndex]) {
+      const user = availableUsers[selectedMentionIndex];
+      void handleMentionSelect({
+        id: user.id,
+        name: getUserDisplayName(user),
+        type: MentionType.USER,
+        ...(user.email ? { email: user.email } : {}),
+      });
+    } else if (
+      mentionSearchType === MentionType.CHANNEL &&
+      availableChannels[selectedMentionIndex]
+    ) {
+      const { channel, displayName } = availableChannels[selectedMentionIndex];
+      void handleMentionSelect({
+        id: channel.id,
+        name: displayName,
+        type: MentionType.CHANNEL,
+      });
+    }
+  };
+
   const handleCommandKeyDown = (e: React.KeyboardEvent<HTMLElement>): void => {
     // A picked target renders its own UI (composer or confirm modal) — let it own all
     // keys (typing, Enter to send/confirm, its own @/# mention pickers).
@@ -3052,6 +3156,17 @@ const ChannelCommandMenu = ({
         return;
       }
       // ArrowUp/ArrowDown fall through to the shared list-navigation below.
+    }
+
+    // ── Tab / Right Arrow: accept the highlighted mention suggestion ──────
+    // e.g. `from:ar` -> Tab/Right completes to `from:Arjun Rao`, mirroring Enter's mention
+    // handling. Must run before tab-cycling and the ArrowRight ticket-preview shortcut below,
+    // neither of which know about mention mode.
+    if ((e.key === 'Tab' || e.key === 'ArrowRight') && mentionSearchType !== null) {
+      e.preventDefault();
+      e.stopPropagation();
+      acceptHighlightedMention();
+      return;
     }
 
     // ── Tab / Shift+Tab: cycle filter tabs ──────────────────────────────
@@ -3108,16 +3223,6 @@ const ChannelCommandMenu = ({
       const currentIndex = Array.from(items).findIndex(
         item => item.getAttribute('aria-selected') === 'true',
       );
-
-      // First arrow (Up OR Down) from the resting row activates it IN PLACE (gray -> blue)
-      // instead of moving to an adjacent row; keeps ArrowUp from rest off the last row.
-      if (!hasNavigated && currentIndex >= 0) {
-        hasNavigatedRef.current = true;
-        markNavigated();
-        setSuppressHover(true);
-        syncEnterIntent();
-        return;
-      }
 
       // Calculate next index
       let nextIndex: number;
@@ -3287,108 +3392,9 @@ const ChannelCommandMenu = ({
 
     // If mention search is active, let the mention selection handle Enter
     if (mentionSearchType !== null) {
-      // Select the currently highlighted mention
       e.preventDefault();
       e.stopPropagation();
-
-      // Handle 'in:' trigger - Channels + DMs (NO Users)
-      if (channelTrigger === 'in:') {
-        const regularChannelCount = availableRegularChannels.length;
-
-        if (selectedMentionIndex < regularChannelCount) {
-          // Selecting a regular channel
-          const channelIndex = selectedMentionIndex;
-          if (availableRegularChannels[channelIndex]) {
-            const { channel, displayName } = availableRegularChannels[channelIndex];
-            void handleMentionSelect({
-              id: channel.id,
-              name: displayName,
-              type: MentionType.CHANNEL,
-            });
-          }
-        } else {
-          // Selecting a DM
-          const dmIndex = selectedMentionIndex - regularChannelCount;
-          if (availableDMs[dmIndex]) {
-            const { channel, displayName } = availableDMs[dmIndex];
-            void handleMentionSelect({
-              id: channel.id,
-              name: displayName,
-              type: MentionType.CHANNEL,
-            });
-          }
-        }
-        return;
-      }
-
-      // Handle 'in:#' trigger - Channels only (NO DMs)
-      if (channelTrigger === 'in:#') {
-        if (availableRegularChannels[selectedMentionIndex]) {
-          const { channel, displayName } = availableRegularChannels[selectedMentionIndex];
-          void handleMentionSelect({
-            id: channel.id,
-            name: displayName,
-            type: MentionType.CHANNEL,
-          });
-        }
-        return;
-      }
-
-      // Handle 'in:@' trigger - DMs only (NOT Users!)
-      if (channelTrigger === 'in:@') {
-        if (availableDMs[selectedMentionIndex]) {
-          const { channel, displayName } = availableDMs[selectedMentionIndex];
-          void handleMentionSelect({
-            id: channel.id,
-            name: displayName,
-            type: MentionType.CHANNEL,
-          });
-        }
-        return;
-      }
-
-      // Handle '#' trigger - only Channels (legacy combined list)
-      if (channelTrigger === '#' && availableChannels[selectedMentionIndex]) {
-        const { channel, displayName } = availableChannels[selectedMentionIndex];
-        void handleMentionSelect({
-          id: channel.id,
-          name: displayName,
-          type: MentionType.CHANNEL,
-        });
-        return;
-      }
-
-      // Handle priority value selection (closed enum, no backend)
-      if (mentionSearchType === MentionType.PRIORITY && availablePriorities[selectedMentionIndex]) {
-        const priority = availablePriorities[selectedMentionIndex];
-        void handleMentionSelect({
-          id: priority.id,
-          name: priority.name,
-          type: MentionType.PRIORITY,
-        });
-        return;
-      }
-
-      // Handle regular user mention search (@, from:, with:, assignee:)
-      if (mentionSearchType === MentionType.USER && availableUsers[selectedMentionIndex]) {
-        const user = availableUsers[selectedMentionIndex];
-        void handleMentionSelect({
-          id: user.id,
-          name: getUserDisplayName(user),
-          type: MentionType.USER,
-          ...(user.email ? { email: user.email } : {}),
-        });
-      } else if (
-        mentionSearchType === MentionType.CHANNEL &&
-        availableChannels[selectedMentionIndex]
-      ) {
-        const { channel, displayName } = availableChannels[selectedMentionIndex];
-        void handleMentionSelect({
-          id: channel.id,
-          name: displayName,
-          type: MentionType.CHANNEL,
-        });
-      }
+      acceptHighlightedMention();
       return;
     }
 

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -3971,11 +3971,7 @@ const ChannelCommandMenu = ({
                                     selectMention(index);
                                   }}
                                   className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                    index === selectedMentionIndex
-                                      ? hasNavigated
-                                        ? 'cmdk-active-row'
-                                        : 'bg-muted'
-                                      : ''
+                                    index === selectedMentionIndex ? 'cmdk-active-row' : ''
                                   } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
                                   style={{ WebkitTapHighlightColor: 'transparent' }}
                                 >
@@ -4017,11 +4013,7 @@ const ChannelCommandMenu = ({
                                     selectMention(adjustedIndex);
                                   }}
                                   className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                    adjustedIndex === selectedMentionIndex
-                                      ? hasNavigated
-                                        ? 'cmdk-active-row'
-                                        : 'bg-muted'
-                                      : ''
+                                    adjustedIndex === selectedMentionIndex ? 'cmdk-active-row' : ''
                                   } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
                                   style={{ WebkitTapHighlightColor: 'transparent' }}
                                 >
@@ -4076,11 +4068,7 @@ const ChannelCommandMenu = ({
                                       selectMention(index);
                                     }}
                                     className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                      index === selectedMentionIndex
-                                        ? hasNavigated
-                                          ? 'cmdk-active-row'
-                                          : 'bg-muted'
-                                        : ''
+                                      index === selectedMentionIndex ? 'cmdk-active-row' : ''
                                     } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
                                     style={{ WebkitTapHighlightColor: 'transparent' }}
                                   >
@@ -4146,11 +4134,7 @@ const ChannelCommandMenu = ({
                                     selectMention(index);
                                   }}
                                   className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                    index === selectedMentionIndex
-                                      ? hasNavigated
-                                        ? 'cmdk-active-row'
-                                        : 'bg-muted'
-                                      : ''
+                                    index === selectedMentionIndex ? 'cmdk-active-row' : ''
                                   } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
                                   style={{ WebkitTapHighlightColor: 'transparent' }}
                                 >
@@ -4197,11 +4181,7 @@ const ChannelCommandMenu = ({
                               selectMention(index);
                             }}
                             className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                              index === selectedMentionIndex
-                                ? hasNavigated
-                                  ? 'cmdk-active-row'
-                                  : 'bg-muted'
-                                : ''
+                              index === selectedMentionIndex ? 'cmdk-active-row' : ''
                             } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
                             style={{ WebkitTapHighlightColor: 'transparent' }}
                           >
@@ -4247,11 +4227,7 @@ const ChannelCommandMenu = ({
                                 selectMention(index);
                               }}
                               className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                index === selectedMentionIndex
-                                  ? hasNavigated
-                                    ? 'cmdk-active-row'
-                                    : 'bg-muted'
-                                  : ''
+                                index === selectedMentionIndex ? 'cmdk-active-row' : ''
                               } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
                               style={{ WebkitTapHighlightColor: 'transparent' }}
                             >
@@ -4306,11 +4282,7 @@ const ChannelCommandMenu = ({
                                   selectMention(index);
                                 }}
                                 className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                  index === selectedMentionIndex
-                                    ? hasNavigated
-                                      ? 'cmdk-active-row'
-                                      : 'bg-muted'
-                                    : ''
+                                  index === selectedMentionIndex ? 'cmdk-active-row' : ''
                                 } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
                                 style={{ WebkitTapHighlightColor: 'transparent' }}
                               >
@@ -4372,11 +4344,7 @@ const ChannelCommandMenu = ({
                                 selectMention(index);
                               }}
                               className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-all duration-150 mt-1.5 ${
-                                index === selectedMentionIndex
-                                  ? hasNavigated
-                                    ? 'cmdk-active-row'
-                                    : 'bg-muted'
-                                  : ''
+                                index === selectedMentionIndex ? 'cmdk-active-row' : ''
                               } ${!isMobile && 'active:bg-muted active:scale-[0.98]'}`}
                               style={{ WebkitTapHighlightColor: 'transparent' }}
                             >

--- a/apps/dashboard/src/components/Chat/ChatDirectory/MentionPlugin.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/MentionPlugin.tsx
@@ -334,12 +334,6 @@ export function MentionPlugin({
         if (currentItems.length === 0) {
           return true;
         }
-        // First ArrowDown activates the resting candidate (index 0) in place (gray -> blue +
-        // " - Select") instead of skipping to index 1.
-        if (!hasNavigated) {
-          onNavigate?.();
-          return true;
-        }
         setSelectedMentionIndex(prev => (prev + 1) % currentItems.length);
         onNavigate?.();
         return true;
@@ -352,12 +346,6 @@ export function MentionPlugin({
       event => {
         event?.preventDefault();
         if (currentItems.length === 0) {
-          return true;
-        }
-        // First ArrowUp activates the resting candidate (index 0) in place, same as ArrowDown,
-        // instead of wrapping to the last candidate.
-        if (!hasNavigated) {
-          onNavigate?.();
           return true;
         }
         setSelectedMentionIndex(prev => (prev - 1 + currentItems.length) % currentItems.length);

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -907,22 +907,22 @@
     --chip-fg: var(--mention-current-user-color, var(--mention-color));
   }
 
-  /* cmd+K "active" row tier (Slack-style): once the user engages a row (ArrowUp/Down or hover)
-     the selection turns blue; the resting auto-selection stays gray. Theme-tuned per data-theme.
+  /* cmd+K selected-row highlight: blue for the selected row from the moment it's selected,
+     resting or keyboard-engaged alike, matching the mention picker's .cmdk-active-row.
      Result rows carry aria-selected + an aria-selected:bg-accent utility, so !important is needed
      to win over the utilities layer; mention rows use the .cmdk-active-row class directly.
      When a mention typeahead is open (data-mention-active) selection is owned by the mention list's
      own .cmdk-active-row, so the aria-selected blue is suppressed to avoid a second highlighted row. */
-  [data-nav-active="true"]:not([data-mention-active="true"]) [cmdk-item][aria-selected="true"] {
-    background-color: hsl(var(--accent)) !important; /* gray, matches tabs/rows */
+  [cmdk-root]:not([data-mention-active="true"]) [cmdk-item][aria-selected="true"] {
+    background-color: rgb(219 234 254) !important; /* blue-100, matches .cmdk-active-row */
   }
   .cmdk-active-row {
     background-color: rgb(219 234 254); /* blue-100 */
   }
   [data-theme="midnight"]
-    [data-nav-active="true"]:not([data-mention-active="true"])
+    [cmdk-root]:not([data-mention-active="true"])
     [cmdk-item][aria-selected="true"] {
-    background-color: hsl(var(--accent)) !important; /* gray, matches tabs/rows */
+    background-color: rgb(30 58 138 / 0.4) !important; /* blue-900 @ 40%, matches .cmdk-active-row */
   }
   [data-theme="midnight"] .cmdk-active-row {
     background-color: rgb(30 58 138 / 0.4); /* blue-900 @ 40% */

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -907,25 +907,25 @@
     --chip-fg: var(--mention-current-user-color, var(--mention-color));
   }
 
-  /* cmd+K selected-row highlight: blue for the selected row from the moment it's selected,
+  /* cmd+K selected-row highlight: gray for the selected row from the moment it's selected,
      resting or keyboard-engaged alike, matching the mention picker's .cmdk-active-row.
      Result rows carry aria-selected + an aria-selected:bg-accent utility, so !important is needed
      to win over the utilities layer; mention rows use the .cmdk-active-row class directly.
      When a mention typeahead is open (data-mention-active) selection is owned by the mention list's
-     own .cmdk-active-row, so the aria-selected blue is suppressed to avoid a second highlighted row. */
+     own .cmdk-active-row, so the aria-selected gray is suppressed to avoid a second highlighted row. */
   [cmdk-root]:not([data-mention-active="true"]) [cmdk-item][aria-selected="true"] {
-    background-color: rgb(219 234 254) !important; /* blue-100, matches .cmdk-active-row */
+    background-color: hsl(var(--accent)) !important; /* gray, matches .cmdk-active-row */
   }
   .cmdk-active-row {
-    background-color: rgb(219 234 254); /* blue-100 */
+    background-color: hsl(var(--accent)); /* gray */
   }
   [data-theme="midnight"]
     [cmdk-root]:not([data-mention-active="true"])
     [cmdk-item][aria-selected="true"] {
-    background-color: rgb(30 58 138 / 0.4) !important; /* blue-900 @ 40%, matches .cmdk-active-row */
+    background-color: hsl(var(--accent)) !important; /* gray, matches .cmdk-active-row */
   }
   [data-theme="midnight"] .cmdk-active-row {
-    background-color: rgb(30 58 138 / 0.4); /* blue-900 @ 40% */
+    background-color: hsl(var(--accent)); /* gray */
   }
 
   /* Paragraph Adjacent Sibling */


### PR DESCRIPTION
POT: https://drive.google.com/file/d/1tdh23ZIXj7GnMLj__SBTKIRduE-BsLuP/view?usp=sharing

Fixes two keyboard-navigation bugs in the Cmd+K search palette (`ChannelCommandMenu.tsx`):

1. **ArrowDown/Up needed two presses to move.** The first press only "activated" the resting auto-selected row in place (gray → blue two-tier highlight) instead of moving to the next/previous row — removed that intermediate step.
2. **Tab/ArrowRight didn't accept an in-progress mention suggestion.** Typing `from:ar` and seeing "Arjun Rao" highlighted, then pressing Tab or → fell through to tab-cycling (Messages/People/Channels/…) or the ticket-preview shortcut instead of completing the mention. Extracted the mention-accept logic (previously inline only in the Enter handler) into a shared `acceptHighlightedMention()` and wired Tab/ArrowRight to call it, mirroring Enter's existing behavior.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-60286. Single-file change in `apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx`: removes the arrow-key "activate in place" step, and extracts + reuses the mention-select logic so Tab/ArrowRight accept a highlighted mention the same way Enter does.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Ran the full stack locally (`pnpm run dev:all`) and exercised the Cmd+K palette by hand: opened search, typed a query, pressed ArrowDown once from the resting row (moved to the next row immediately); typed `from:ar`, pressed Tab and separately →, confirmed each completes to the highlighted "Arjun Rao" mention instead of moving to the Messages tab / opening ticket preview.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — no existing test harness for this component's keyboard-nav; verified manually

### Manual

**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass — N/A, no backend files changed
- [x] Dashboard `typecheck` passes for this file (`pnpm run typecheck`, no errors introduced)
- [x] Formatting clean (`prettier --check` passes on the changed file)
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` — N/A, no new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed — N/A, no docs reference this behavior
- [x] No debug logging or commented-out code left behind

Note: `pnpm run lint:errors-only` currently fails on `main` with 85 pre-existing errors in unrelated files (`recordingService.ts`, `intent.worker.ts`, etc.) — none in the file touched by this PR.
