### PR TITLE
fix: always show Ask AI activity menu

### DIFF
--- a/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
@@ -2051,7 +2051,6 @@ const XyneAISidebar = ({
                 onShowHistory={() => setShowHistorySidebar(true)}
                 onShowUserActivity={() => setShowUserActivityPanel(true)}
                 isMobile={isMobile}
-                isCompact={isCompactSidebar}
                 isTight={isTightSidebar}
                 title={isFullscreen ? 'Xyne AI' : selectedAgentName || 'Ask AI'}
                 selectedAgent={selectedAgent}

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIHeader.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIHeader.tsx
@@ -54,7 +54,6 @@ export const XyneAIHeader = ({
   hideHistory = false,
   selectedAgent,
   onShowDebugger,
-  isCompact = false,
   isTight = false,
   hideClose = false,
   dense = false,
@@ -77,7 +76,7 @@ export const XyneAIHeader = ({
   // desktop and mobile render paths so they stay in sync.
   // `includeHistory` is false on desktop, where chat history has its own header
   // button; mobile has no such button, so it keeps the menu item.
-  const showMemoriesAndActivity = !hideMemoriesAndActivity && !isCompact;
+  const showMemoriesAndActivity = !hideMemoriesAndActivity;
   const buildOverflowMenuItems = (includeHistory: boolean): ReactNode => (
     <>
       {selectedAgent && (

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIHeader.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIHeader.tsx
@@ -36,7 +36,6 @@ interface XyneAIHeaderProps {
   hideHistory?: boolean;
   selectedAgent?: AccessibleClawAgent | null;
   onShowDebugger?: (() => void) | undefined;
-  isCompact?: boolean;
   isTight?: boolean;
   hideClose?: boolean;
   dense?: boolean;


### PR DESCRIPTION
POT:
<img width="449" height="1001" alt="image" src="https://github.com/user-attachments/assets/226f65f0-c071-460a-88bb-479b24410749" />
<img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/1d403800-14f7-422e-98cf-c2e59992bee8" />
<img width="841" height="162" alt="image" src="https://github.com/user-attachments/assets/29496045-8eae-46c5-9ee8-4ebc97250dac" />



1. Problem Description:
The Ask AI header More menu hid the `Your activity` option whenever the sidebar was under 760px wide. Because the Ask AI panel is capped at `maxSize='50%'` (`AppRoot.tsx`), that threshold needs a window wider than ~1520px, so on most screens the activity context picker was unreachable at any panel width.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Milind pointed out the width check in `XyneAIHeader.tsx`: `!hideMemoriesAndActivity && !isCompact`, with compact mode derived from sidebar width `< 760` in `XyneAISidebar.tsx`.

Tracing the history, the gate was introduced in `2da4af76a` (Bitbucket PR #7302, `feat: XYNE-15738 added debugger to ask ai`). That PR added a debugger icon button to the header's action row and, in the same commit, added a set of horizontal-overflow mitigations to that row: `flex-wrap justify-end`, `gap-1` instead of `gap-2` when compact, `shrink-0` on every button, and hiding the Memories and Your activity icons when compact. It was space management for an icon row, not a decision about the activity feature.

`4a8506f34` (Bitbucket PR #9268, `feat: XYNE-17769 ui revamp`) then replaced that entire icon row with a single overflow dropdown. It removed the compact spacing and both inline buttons but folded `!isCompact` forward into the new `showMemoriesAndActivity` constant. The items now live in a portaled Radix `DropdownMenuContent` with `min-w-[180px]`, whose width is independent of the sidebar, so the condition has protected nothing since that revamp — it has only been hiding the feature.

The rationale was never written down: the #7302 commit message does not mention compact/width/responsive/overflow, and there is no comment on the gate or on the bare `760`/`640` thresholds. Both PRs are on the decommissioned Bitbucket server, so the review discussion is not recoverable.

3. Explain the solution implemented in the PR:
- Removed `!isCompact` from the visibility condition so `Your activity` shows whenever memories/activity are not explicitly hidden.
- Removed `isCompact` entirely: the destructured param, the `isCompact?: boolean` interface member in `XyneAIHeader`, and the `isCompact={isCompactSidebar}` pass from `XyneAISidebar`. Leaving the prop declared and passed but ignored would recreate exactly the vestigial shape that caused this bug.

Deliberately left alone:
- `isCompactSidebar` in `XyneAISidebar.tsx` stays — it still drives `compactToolbar`.
- `isTight` / `isTightSidebar` stay — still used for header title sizing.
- The `isFullscreen` branch passing `hideMemoriesAndActivity: true` is untouched. No caller passes `variant='fullscreen'` (AppRoot passes no variant, `AutoDraftAgentChatPanel` passes `'sidebar'`), so that branch is unreachable today and changing it would be dead-code churn.

Edge cases checked:
- Mobile: the mobile drawer was always under 760px, so this menu item was never reachable there before. It is now. `UserActivityPanel` is already mobile-aware (`usePlatform`, mobile pill button styling, desktop-only close X, fluid `flex-1 h-full` layout with no fixed widths), so the newly-reachable surface renders correctly.
- Dropdown width: unaffected by sidebar width, the menu is portaled and content-sized.
- No unused-variable fallout — `isCompactSidebar` retains a consumer.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `pnpm exec eslint` on both changed files — 0 errors (28 pre-existing warnings, all `exhaustive-deps` / `explicit-function-return-type`, untouched by this change).
- `pnpm exec tsc --noEmit --project tsconfig.app.json` — clean, no errors. The ReactArtifact / onDeviceIntent failures noted in the earlier revision of this description were a sandbox artifact and do not reproduce.
- Full husky pre-commit suite passed, including `dashboard lint:errors-only` (0 errors) and `dashboard validate` (build, 1m50s).

9. Services to which this change is to be deployed:
Dashboard frontend

10. Main PR link (if this PR is raised against a release branch):
N/A
