### PR TITLE
fix: XYNE-17198 workspace thread-type vocabulary with admin tag review

### DIFF
--- a/apps/backend/prisma/migrations/20260825120000_thread_type_vocabulary/migration.sql
+++ b/apps/backend/prisma/migrations/20260825120000_thread_type_vocabulary/migration.sql
@@ -5,6 +5,7 @@ CREATE TABLE "non_zero"."thread_type_vocabulary" (
     "workspaceId" TEXT NOT NULL,
     "name" TEXT NOT NULL,
     "label" TEXT NOT NULL,
+    "summary" TEXT NOT NULL DEFAULT '',
     "color" TEXT NOT NULL,
     "description" TEXT NOT NULL,
     "status" TEXT NOT NULL DEFAULT 'APPROVED',

--- a/apps/backend/prisma/migrations/20260825120000_thread_type_vocabulary/migration.sql
+++ b/apps/backend/prisma/migrations/20260825120000_thread_type_vocabulary/migration.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "non_zero"."thread_type_vocabulary" (
+    "id" TEXT NOT NULL,
+    "scope" TEXT NOT NULL,
+    "scopeId" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "color" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'APPROVED',
+    "isDeleted" BOOLEAN NOT NULL DEFAULT false,
+    "createdBy" TEXT,
+    "updatedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "thread_type_vocabulary_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "thread_type_vocabulary_scope_scopeId_name_key" ON "non_zero"."thread_type_vocabulary"("scope", "scopeId", "name");
+
+CREATE INDEX "thread_type_vocabulary_workspaceId_scope_status_idx" ON "non_zero"."thread_type_vocabulary"("workspaceId", "scope", "status");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4530,6 +4530,7 @@ model ThreadTypeVocabulary {
   workspaceId String
   name        String
   label       String
+  summary     String   @default("")
   color       String
   description String
   status      String   @default("APPROVED")

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4523,6 +4523,28 @@ model TagsConfig {
   @@schema("non_zero")
 }
 
+model ThreadTypeVocabulary {
+  id          String   @id @default(cuid())
+  scope       String
+  scopeId     String
+  workspaceId String
+  name        String
+  label       String
+  color       String
+  description String
+  status      String   @default("APPROVED")
+  isDeleted   Boolean  @default(false)
+  createdBy   String?
+  updatedBy   String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([scope, scopeId, name])
+  @@index([workspaceId, scope, status])
+  @@map("thread_type_vocabulary")
+  @@schema("non_zero")
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Async OCR (Docling/LightOn) scheduler state machine
 // Ported from xyne-search. Two tables drive the splitter→submitter→result→

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -35,6 +35,7 @@ import userActivationRoutes from '@/routes/userActivation';
 import channelRoutes from '@/routes/channels';
 import microsoftDeskAuthRoutes from '@/integrations/routes/microsoft-desk-auth';
 import conversationRoutes from '@/routes/conversations';
+import threadTypeVocabularyRoutes from '@/routes/threadTypeVocabulary';
 import conversationLabelRoutes from '@/routes/conversationLabels';
 import radarExecutionRoutes from '@/routes/radarExecution';
 import organizationRoutes from '@/routes/organizations';
@@ -705,6 +706,7 @@ export class App {
     // New chat schema routes
     this.app.use('/api/channels', authMiddleware.authenticate, channelRoutes);
     this.app.use('/api/conversations', authMiddleware.authenticate, conversationRoutes);
+    this.app.use('/api/thread-type-vocabulary', authMiddleware.authenticate, threadTypeVocabularyRoutes);
     this.app.use('/api/organizations', authMiddleware.authenticate, organizationRoutes);
     this.app.use('/api/users', authMiddleware.authenticate, userRoutes);
     this.app.use('/api/user-groups', authMiddleware.authenticate, userGroupRoutes); // User groups (teams)

--- a/apps/backend/src/controllers/threadTypeVocabularyController.ts
+++ b/apps/backend/src/controllers/threadTypeVocabularyController.ts
@@ -1,0 +1,356 @@
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import { logger } from '@/utils/logger';
+import { threadCountsByTag } from '@/services/messageClassification/tagCounts';
+import {
+  getThreadTypeVocabulary,
+  listTagsCreatedBy,
+  listThreadTypeVocabulary,
+  patchThreadTypeVocabulary,
+  rejectVocabularyCandidates,
+  reconsiderVocabularyCandidates,
+  seedWorkspaceVocabulary,
+  setThreadTypeVocabulary,
+  MAX_ENTRIES,
+  MAX_NAME_LENGTH,
+  VOCABULARY_STATUSES,
+  type VocabularyStatus,
+} from '@/services/messageClassification/vocabulary';
+
+/**
+ * Names are the value stored in Vespa and echoed back to the model, so they are constrained
+ * to the shape the built-ins use: UPPER_SNAKE, deliberately unlike the lowercase-hyphenated
+ * shape people type for free-form thread tags, so the two stay distinguishable at a glance.
+ */
+const EntrySchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1)
+    .max(MAX_NAME_LENGTH)
+    .regex(/^[A-Z][A-Z0-9_]*$/, 'name must be UPPER_SNAKE, e.g. FEATURE_REQUEST'),
+  label: z.string().trim().min(1).max(60),
+  color: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'color must be a hex value, e.g. #0891b2'),
+  // Prompt copy, not a tooltip: this is what tells the model when the type applies, so a
+  // one-word description produces a classifier that guesses.
+  description: z.string().trim().min(20).max(1200),
+  // Promoting a candidate is just writing it back as APPROVED with a real label and
+  // description. Omitted means approved — nothing sent through the API is under review
+  // unless it says so.
+  status: z.enum(['APPROVED', 'UNDER_REVIEW']).optional(),
+});
+
+const NameSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(MAX_NAME_LENGTH)
+  .regex(/^[A-Z][A-Z0-9_]*$/, 'name must be UPPER_SNAKE, e.g. FEATURE_REQUEST');
+
+/**
+ * A candidate's name as the proposer typed it — lowercase-hyphenated, unlike the UPPER_SNAKE
+ * an approved entry must use. That difference is why promotion RENAMES rather than just
+ * flipping a status, and why decisions are keyed on this looser shape.
+ */
+const CandidateNameSchema = z.string().trim().min(1).max(MAX_NAME_LENGTH);
+
+const DecisionSchema = z.object({
+  names: z.array(CandidateNameSchema).min(1).max(MAX_ENTRIES),
+});
+
+/** Both lists optional so one curl can add without removing, or remove without adding. */
+const PatchSchema = z
+  .object({
+    add: z.array(EntrySchema).max(MAX_ENTRIES).optional(),
+    remove: z.array(NameSchema).max(MAX_ENTRIES).optional(),
+  })
+  .refine(patch => (patch.add?.length ?? 0) + (patch.remove?.length ?? 0) > 0, {
+    message: 'Send at least one entry under "add" or "remove"',
+  })
+  .refine(
+    patch => {
+      const removing = new Set(patch.remove ?? []);
+      return !(patch.add ?? []).some(entry => removing.has(entry.name));
+    },
+    { message: 'A name cannot appear in both "add" and "remove"' },
+  );
+
+const BodySchema = z.object({
+  // Order is meaningful — it is the picker's order, the chip sort order, and the order
+  // entries appear in the prompt.
+  entries: z
+    .array(EntrySchema)
+    .max(MAX_ENTRIES)
+    .superRefine((entries, ctx) => {
+      const seen = new Set<string>();
+      entries.forEach((entry, index) => {
+        if (seen.has(entry.name)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [index, 'name'],
+            message: `"${entry.name}" appears more than once`,
+          });
+        }
+        seen.add(entry.name);
+      });
+    }),
+});
+
+/**
+ * The workspace's thread-type vocabulary.
+ *
+ * Read by every member — the picker needs it. Written by admins only: an entry's
+ * description IS the classifier's instruction for that type, so an edit changes how every
+ * thread in the workspace gets classified from the next pass onward.
+ */
+export class ThreadTypeVocabularyController {
+  /**
+   * The approved vocabulary — what the picker offers and what chips are labelled from.
+   *
+   * Every member calls this, so it never widens to include candidates and never carries
+   * counts. Deciding their fate is `getReview`, which is admin-gated.
+   */
+  getVocabulary = async (req: Request, res: Response): Promise<void> => {
+    try {
+      res.status(200).json({
+        success: true,
+        entries: await getThreadTypeVocabulary(req.user!.workspaceId),
+      });
+    } catch (error) {
+      logger.error('[threadTypeVocabulary] read failed:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  /**
+   * The review queue: candidates, turned-down names, filters, option counts and thread usage.
+   *
+   * Admin-gated at the route, and it has to be. The thread counts are taken with the
+   * per-user permission filter deliberately OFF, so this endpoint reports usage across
+   * channels the caller is not a member of — fine for someone curating the workspace
+   * vocabulary, not something to hand to every member.
+   */
+  getReview = async (req: Request, res: Response): Promise<void> => {
+    try {
+      // ?status= narrows to one or more of APPROVED|UNDER_REVIEW|REJECTED. The review queue
+      // opens on UNDER_REVIEW alone; omitting it means all three.
+      const requested = String(req.query['status'] ?? '')
+        .split(',')
+        .map(value => value.trim().toUpperCase())
+        .filter((value): value is VocabularyStatus =>
+          (VOCABULARY_STATUSES as readonly string[]).includes(value),
+        );
+
+      // Candidates are unbounded, so this path is always paged — a workspace that has
+      // accumulated thousands of invented names must not ship all of them to a browser.
+      const csv = (key: string): string[] =>
+        String(req.query[key] ?? '')
+          .split(',')
+          .map(value => value.trim())
+          .filter(value => value.length > 0);
+
+      // The unattributed bucket travels as the literal 'BUILT_IN' because an empty string
+      // survives neither a query string nor a comma split.
+      const proposedBy = csv('proposedBy').map(value => (value === 'BUILT_IN' ? '' : value));
+      const page = await listThreadTypeVocabulary(req.user!.workspaceId, {
+        statuses: requested,
+        proposedBy,
+        limit: Number(req.query['limit']) || undefined,
+        offset: Number(req.query['offset']) || undefined,
+      });
+
+      // ?counts=true attaches thread counts. Opt-in: it costs a Vespa round trip, and a
+      // caller only listing names has no use for it.
+      if (req.query['counts'] !== 'true') {
+        res.status(200).json({ success: true, ...page, entries: page.rows });
+        return;
+      }
+
+      const { total, lastUsed, ok } = await threadCountsByTag(req.user!.workspaceId);
+
+      // Counting failed. Send the vocabulary without counts rather than a wall of zeros —
+      // the client renders an absent count as "unknown", and a zero as "nobody uses this".
+      if (!ok) {
+        res.status(200).json({ success: true, ...page, entries: page.rows });
+        return;
+      }
+
+      res.status(200).json({
+        success: true,
+        total: page.total,
+        facets: page.facets,
+        entries: page.rows.map(entry => ({
+          ...entry,
+          // Counted with the per-user permission filter deliberately off: a tag used widely
+          // in channels this admin is not in still deserves to look widely used.
+          threadCount: total.get(entry.name) ?? 0,
+          lastUsedAt: lastUsed.get(entry.name) ?? null,
+        })),
+      });
+    } catch (error) {
+      logger.error('[threadTypeVocabulary] read failed:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  /**
+   * Add or drop individual types. The form meant for a one-line curl — no need to GET the
+   * list, edit it and send it all back, and two people adding different types at the same
+   * time do not clobber each other.
+   */
+  /**
+   * Copy the starting vocabulary into this workspace.
+   *
+   * Explicit and admin-only: nothing seeds itself. A workspace that has pared its vocabulary
+   * down to three types must not get twelve back because someone opened a thread. Idempotent
+   * — re-running adds only the names that are missing, and `added` reports how many.
+   */
+  seedVocabulary = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { added } = await seedWorkspaceVocabulary(req.user!.workspaceId, req.user!.id);
+      res.status(200).json({ success: true, added });
+    } catch (error) {
+      logger.error('[threadTypeVocabulary] seed failed:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  patchVocabulary = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = PatchSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Invalid patch',
+          issues: parsed.error.issues.map(i => ({ path: i.path, message: i.message })),
+        });
+        return;
+      }
+
+      const result = await patchThreadTypeVocabulary(
+        req.user!.workspaceId,
+        parsed.data,
+        req.user!.id,
+      );
+      res.status(200).json({ success: true, ...result });
+    } catch (error) {
+      // The service throws this when a patch would empty the vocabulary; it is the caller's
+      // mistake, not a server fault.
+      if (error instanceof Error && error.message.includes('at least one thread type')) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      logger.error('[threadTypeVocabulary] patch failed:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  /**
+   * The names THIS person has proposed that are still undecided.
+   *
+   * Small and bounded — one person's inventions — which is what makes it cheap enough to
+   * hold for a session. It exists so the author's own chip can show as under review without
+   * denormalising a pending flag onto the applied tag (which would go stale the moment an
+   * admin decided it) and without pulling every candidate in the workspace into every client.
+   */
+  myPendingNames = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const mine = await listTagsCreatedBy(req.user!.id, req.user!.workspaceId);
+      res.status(200).json({
+        success: true,
+        names: mine.filter(entry => entry.status === 'UNDER_REVIEW').map(entry => entry.name),
+      });
+    } catch (error) {
+      logger.error('[threadTypeVocabulary] mine failed:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  /**
+   * Turn down one or more proposed names.
+   *
+   * Workspace-wide, mirroring promotion: candidates are per-proposer, so deciding only the
+   * row in front of you would leave an identical proposal from someone else in the queue.
+   *
+   * Nothing is removed from any thread. The tag stays where it was applied and stays
+   * searchable — this only stops the NAME being offered, assigned, or proposed again.
+   */
+  rejectCandidates = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = DecisionSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Invalid decision',
+          issues: parsed.error.issues.map(i => ({ path: i.path, message: i.message })),
+        });
+        return;
+      }
+
+      const decided = await rejectVocabularyCandidates(
+        req.user!.workspaceId,
+        parsed.data.names,
+        req.user!.id,
+      );
+      // `decided` counts rows, not names: one name can have several proposers. A zero means
+      // nothing was outstanding — already decided, or never proposed here.
+      res.status(200).json({ success: true, decided });
+    } catch (error) {
+      logger.error('[threadTypeVocabulary] reject failed:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  /** Put a turned-down name back in the queue, clearing the reason with it. */
+  reconsiderCandidates = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = DecisionSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Invalid decision',
+          issues: parsed.error.issues.map(i => ({ path: i.path, message: i.message })),
+        });
+        return;
+      }
+
+      const decided = await reconsiderVocabularyCandidates(
+        req.user!.workspaceId,
+        parsed.data.names,
+        req.user!.id,
+      );
+      res.status(200).json({ success: true, decided });
+    } catch (error) {
+      logger.error('[threadTypeVocabulary] reconsider failed:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+
+  updateVocabulary = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = BodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({
+          error: 'Invalid vocabulary',
+          issues: parsed.error.issues.map(i => ({ path: i.path, message: i.message })),
+        });
+        return;
+      }
+
+      // An empty vocabulary is not "no types" — it silently falls back to the built-ins on
+      // the next read, which is not what an admin who just cleared the list would expect.
+      // Refusing is the honest answer; removing the feature is a flag, not a config edit.
+      if (parsed.data.entries.length === 0) {
+        res.status(400).json({ error: 'A workspace must keep at least one thread type' });
+        return;
+      }
+
+      const entries = await setThreadTypeVocabulary(
+        req.user!.workspaceId,
+        parsed.data.entries,
+        req.user!.id,
+      );
+      res.status(200).json({ success: true, entries });
+    } catch (error) {
+      logger.error('[threadTypeVocabulary] write failed:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+}

--- a/apps/backend/src/controllers/threadTypeVocabularyController.ts
+++ b/apps/backend/src/controllers/threadTypeVocabularyController.ts
@@ -19,7 +19,7 @@ import {
 
 /**
  * Names are the value stored in Vespa and echoed back to the model, so they are constrained
- * to the shape the built-ins use: UPPER_SNAKE, deliberately unlike the lowercase-hyphenated
+ * to the shape the standard set uses: UPPER_SNAKE, deliberately unlike the lowercase-hyphenated
  * shape people type for free-form thread tags, so the two stay distinguishable at a glance.
  */
 const EntrySchema = z.object({
@@ -30,6 +30,10 @@ const EntrySchema = z.object({
     .max(MAX_NAME_LENGTH)
     .regex(/^[A-Z][A-Z0-9_]*$/, 'name must be UPPER_SNAKE, e.g. FEATURE_REQUEST'),
   label: z.string().trim().min(1).max(60),
+  // What a person reads on the chip's tooltip. Optional — an entry is usable without one,
+  // and forcing a second piece of prose at approval time is how the field ends up filled
+  // with a copy of the label.
+  summary: z.string().trim().max(160).optional().default(''),
   color: z.string().regex(/^#[0-9a-fA-F]{6}$/, 'color must be a hex value, e.g. #0891b2'),
   // Prompt copy, not a tooltip: this is what tells the model when the type applies, so a
   // one-word description produces a classifier that guesses.
@@ -334,9 +338,10 @@ export class ThreadTypeVocabularyController {
         return;
       }
 
-      // An empty vocabulary is not "no types" — it silently falls back to the built-ins on
-      // the next read, which is not what an admin who just cleared the list would expect.
-      // Refusing is the honest answer; removing the feature is a flag, not a config edit.
+      // An empty vocabulary really is no types: nothing falls back, so the picker empties and
+      // the classifier skips every thread in the workspace. That is a big enough switch that
+      // it should not be reachable by PUTting an empty array — turning the feature off is a
+      // flag, not a config edit.
       if (parsed.data.entries.length === 0) {
         res.status(400).json({ error: 'A workspace must keep at least one thread type' });
         return;

--- a/apps/backend/src/database/acl/acl-factory.ts
+++ b/apps/backend/src/database/acl/acl-factory.ts
@@ -469,6 +469,10 @@ export class ACLFactory {
       return new BaseQueryACL(ctx, prisma)
     case 'tagsConfig':
       return new BaseQueryACL(ctx, prisma)
+    // Workspace-scoped config, reached only through the thread-type-vocabulary API, which
+    // does its own admin check. Listed so the switch stays exhaustive over ModelName.
+    case 'threadTypeVocabulary':
+      return new BaseQueryACL(ctx, prisma)
     case 'teamIntelligenceIngestionBatchV2':
       return new UnscopedACL(ctx, prisma)
     case 'teamIntelligenceOrgSummaryV2':

--- a/apps/backend/src/queues/messageClassificationQueue.ts
+++ b/apps/backend/src/queues/messageClassificationQueue.ts
@@ -5,10 +5,17 @@ import { config } from '@/config/env';
 import { classifyAndTagThread } from '@/services/messageClassification';
 
 /**
- * Wait this long before classifying. Short enough to read as immediate, long enough that a
- * burst of replies collapses into one pass instead of one call per message.
+ * Wait for the thread to go QUIET this long before classifying.
+ *
+ * Ten minutes, not seconds. A thread judged 30s after its opening message is judged when it
+ * is one message long — and at that moment it cannot yet be a HOW_TO, a WHAT_HAPPENED, a
+ * WHY_DECISION or any other answer type, because the answer has not been written. Classifying
+ * that early does not just produce a stale tag, it makes over half the vocabulary unreachable.
+ *
+ * The delay is refreshed by every new message (see enqueueForMessage), so an active thread is
+ * read once after it settles rather than once per burst.
  */
-const DEBOUNCE_MS = Number(process.env['MESSAGE_CLASSIFICATION_DEBOUNCE_MS'] ?? 30_000);
+const DEBOUNCE_MS = Number(process.env['MESSAGE_CLASSIFICATION_DEBOUNCE_MS'] ?? 10 * 60_000);
 
 const QUEUE_NAME = 'message-classification';
 const JOB_NAME = 'classify-message';
@@ -111,8 +118,11 @@ class MessageClassificationQueue {
    * silently dropped every new thread while replies worked. All real gating (thread size,
    * already-classified, no project) happens in the consumer, which runs after commit.
    *
-   * The debounce collapses a burst of replies into one pass; the jobId is the thread, so
-   * Bull drops repeat adds while that job is still pending.
+   * The jobId is the thread, and Bull SILENTLY IGNORES an add whose jobId already exists —
+   * including a COMPLETED one, which it retains (removeOnComplete: 100). Adding blindly
+   * therefore does neither of the things this needs: a reply would not push the quiet window
+   * back, and a thread classified once could never be looked at again until its finished job
+   * aged out of the last hundred. Both are why an existing job is removed first.
    */
   async enqueueForMessage(conversationId: string): Promise<void> {
     if (!conversationId) return;
@@ -122,12 +132,20 @@ class MessageClassificationQueue {
       return;
     }
 
+    const jobId = `classify:${conversationId}`;
     try {
-      await this.queue.add(
-        JOB_NAME,
-        { conversationId },
-        { jobId: `classify:${conversationId}`, delay: DEBOUNCE_MS },
-      );
+      const existing = await this.queue.getJob(jobId);
+      if (existing) {
+        const state = await existing.getState();
+        // Leave a job that is already running: killing it mid-LLM-call would waste the call
+        // and the reply that triggered this will be picked up by the pass after it.
+        if (state === 'active') return;
+        // Delayed (still counting down), or finished from an earlier pass — either way it is
+        // replaced, which is what turns the delay into a rolling quiet window.
+        await existing.remove();
+      }
+
+      await this.queue.add(JOB_NAME, { conversationId }, { jobId, delay: DEBOUNCE_MS });
     } catch (error) {
       logger.error('[MessageClassificationQueue] Failed to enqueue', { conversationId, error });
     }

--- a/apps/backend/src/routes/threadTypeVocabulary.ts
+++ b/apps/backend/src/routes/threadTypeVocabulary.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express';
+import { authMiddleware } from '@/middleware/auth';
+import { ThreadTypeVocabularyController } from '@/controllers/threadTypeVocabularyController';
+
+const router = Router();
+const controller = new ThreadTypeVocabularyController();
+
+// Every member reads it — the thread-tag picker is built from it. Approved names only.
+router.get('/', controller.getVocabulary);
+
+// The review queue. Admin-gated, and not merely because the screen is: its thread counts are
+// taken with the per-user permission filter off, so it reports usage across channels the
+// caller cannot open.
+router.get('/review', authMiddleware.requireAdminOrOwner, controller.getReview);
+
+// The caller's own undecided proposals, so their chip can show as under review. Not admin
+// gated: it is their own list, and it is the only way the author learns the name is pending.
+router.get('/mine', controller.myPendingNames);
+
+// Admins only: an entry's description is the classifier's instruction for that type, so a
+// write changes how every thread in the workspace is classified from the next pass on.
+//
+// PATCH adds/removes individual types — the form to reach for from a script. PUT replaces
+// the whole list, for when the vocabulary is kept as a checked-in JSON file.
+router.patch('/', authMiddleware.requireAdminOrOwner, controller.patchVocabulary);
+
+// Deciding a proposal. Approval is a PATCH/PUT of the entry itself — four fields have to be
+// authored, so it cannot be a one-click verb. Turning one down needs no entry, only a reason.
+// Copies the starting vocabulary in. Nothing seeds implicitly, so a fresh workspace has no
+// types until an admin asks for them or authors their own.
+router.post('/seed', authMiddleware.requireAdminOrOwner, controller.seedVocabulary);
+
+router.post('/reject', authMiddleware.requireAdminOrOwner, controller.rejectCandidates);
+router.post('/reconsider', authMiddleware.requireAdminOrOwner, controller.reconsiderCandidates);
+router.put('/', authMiddleware.requireAdminOrOwner, controller.updateVocabulary);
+
+export default router;

--- a/apps/backend/src/services/messageClassification/index.ts
+++ b/apps/backend/src/services/messageClassification/index.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod';
 import {
-  MESSAGE_ACTS,
-  MESSAGE_ACT_NAMES,
-  NO_ACT,
-  THREAD_TYPES,
   OrgLLMServiceAccountPurpose,
+  isHumanApplied,
+  parseAppliedTags,
+  serializeAppliedTags,
+  type AppliedTag,
+  type ThreadTypeEntry,
 } from '@xyne/shared';
 import { config } from '@/config/env';
 import { db } from '@/database/client';
@@ -17,6 +18,7 @@ import {
 import { vespaQueue } from '@/queues/vespaQueue';
 import { messageSchema } from '@/vespa/src/types';
 import { buildClassifierPrompt } from './prompt';
+import { getThreadTypeVocabulary } from './vocabulary';
 
 const TAG = '[MessageClassification]';
 
@@ -49,12 +51,60 @@ export interface ClassifyThreadResult {
 }
 
 /**
- * Classify every message in a thread in one LLM call and apply the results.
+ * Has a person ruled on this thread's tags?
  *
- * Once per message: a message that already has acts is sent as context but never rewritten.
- * The vocabulary's dependencies all point backwards, so a later pass gets no better answer,
- * and the column has no provenance — a re-run would silently clobber hand-applied acts.
- * threadType is the exception, re-derived each pass and written only when it changes.
+ * A curated thread is never sent to the model again — not to protect cost, but because a
+ * re-run would argue with a decision someone already made. Three things count as a ruling:
+ *
+ *  - the column is non-null but holds no tags: the legacy '[]' a clear used to write
+ *  - any tag is tombstoned: someone removed it, and a removal is the one edit that leaves
+ *    no other trace, so re-deriving would hand it straight back
+ *  - any VOCABULARY tag was applied by hand: a person picked the type themselves
+ *
+ * A free-form tag deliberately does NOT count. Inventing "gateway-timeout" says nothing
+ * about whether ISSUE is right or whether HOW_TO should appear once the fix is posted — and
+ * the classifier can only ever emit vocabulary names, so it cannot touch the free-form one.
+ */
+const isCurated = (
+  raw: string | null,
+  tags: AppliedTag[],
+  vocabulary: readonly ThreadTypeEntry[],
+): boolean => {
+  if (raw === null) return false;
+  if (tags.length === 0) return true;
+
+  const known = new Set(vocabulary.map(entry => entry.name));
+  return tags.some(
+    tag => tag.removed === true || (isHumanApplied(tag) && known.has(tag.name)),
+  );
+};
+
+/**
+ * Enough has been said since the last pass to be worth another look.
+ *
+ * `max(at)` across the thread's tags IS the last-classification time, so no extra column is
+ * needed to remember it. The floor stops a one-word "thanks" buying a model call.
+ */
+const MIN_NEW_MESSAGES_TO_RECLASSIFY = Number(
+  process.env['MESSAGE_CLASSIFICATION_MIN_NEW_MESSAGES'] ?? 3,
+);
+
+const newMessagesSince = (tags: AppliedTag[], messages: { createdAt: Date }[]): number => {
+  const lastPass = Math.max(0, ...tags.map(tag => tag.at));
+  // A legacy tag carries at:0, which would make every message look new. Treating it as
+  // "never classified" is right: nothing is known about when it was tagged.
+  return messages.filter(message => message.createdAt.getTime() > lastPass).length;
+};
+
+/**
+ * Classify a thread in one LLM call and apply the results.
+ *
+ * The model returns thread types, each citing the messages that evidence it. Both halves are
+ * stored: the types land on the conversation, and every cited message gets the types it is
+ * the source for — so a chip on a thread can always be traced to the message that caused it.
+ *
+ * Everything the classifier writes is AI-applied and approved; a person's tags carry their
+ * own provenance and are never touched here.
  *
  * Writes go through Prisma (no client context in a worker); Zero replicates to clients.
  */
@@ -74,19 +124,32 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
     return { tagged: 0, skipped: 'conversation-not-found' };
   }
 
-  // Once a thread has a type — the classifier's or a person's, including '[]' for cleared —
-  // it is never sent to the model again. Nothing can then overwrite a hand-applied tag, and
-  // an active thread costs one call rather than one every few messages.
-  if (conversation.threadType !== null) {
-    return { tagged: 0, skipped: 'already-classified' };
-  }
-
   const channel = await db.channel.findUnique({
     where: { id: conversation.channelId },
     select: { id: true, workspaceId: true },
   });
   if (!channel) {
     return { tagged: 0, skipped: 'no-channel' };
+  }
+
+  // The vocabulary is per workspace and editable at runtime, so it is fetched once and
+  // threaded through everything below: the freeze check needs it to tell a vocabulary tag
+  // from a free-form one, and the same list generates the prompt AND validates what comes
+  // back. Building the prompt from one list and checking answers against another is how a
+  // workspace ends up with every model answer silently dropped.
+  const vocabulary = await getThreadTypeVocabulary(channel.workspaceId);
+
+  // A workspace whose vocabulary is empty has not set one up, or has removed everything.
+  // Bail rather than prompt the model with no types: it would either invent names that fail
+  // validation and get dropped, or return nothing, and either way every thread would cost an
+  // LLM call to achieve nothing.
+  if (vocabulary.length === 0) {
+    return { tagged: 0, skipped: 'no-vocabulary' };
+  }
+
+  const existingTags = parseAppliedTags(conversation.threadType);
+  if (isCurated(conversation.threadType, existingTags, vocabulary)) {
+    return { tagged: 0, skipped: 'curated-by-hand' };
   }
 
   // A ticket's title and description are usually the clearest statement of what the thread
@@ -109,7 +172,6 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
       messageId: true,
       content: true,
       createdAt: true,
-      messageActs: true,
       sender: { select: { name: true } },
     },
     // Newest first, reversed below: taking the oldest N would never reach a long thread's
@@ -120,28 +182,34 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
 
   messages.reverse(); // back to chronological — the model is told the thread is in order
 
+  // Every message is offered as context: the model is classifying the thread, and it needs
+  // the whole thing to pick which messages are the evidence for each type.
   const threadMessages: ClassifierMessage[] = messages
-    .map(m => {
-      const existing = parseActs(m.messageActs);
-      return {
-        id: m.messageId,
-        text: stripHtml(m.content ?? ''),
-        author_display_name: m.sender?.name ?? 'Unknown',
-        timestamp_iso: m.createdAt.toISOString(),
-        // Present at all => settled, empty included: [] is a deliberate clear, and
-        // re-tagging what someone just removed is worse than leaving it blank.
-        ...(m.messageActs !== null && { existing_acts: existing }),
-      };
-    })
+    .map(m => ({
+      id: m.messageId,
+      text: stripHtml(m.content ?? ''),
+      author_display_name: m.sender?.name ?? 'Unknown',
+      timestamp_iso: m.createdAt.toISOString(),
+    }))
     .filter(m => m.text.length > 0);
 
   if (threadMessages.length < MIN_THREAD_SIZE && !ticket) {
     return { tagged: 0, skipped: 'thread-too-short' };
   }
 
-  // Reached only when the thread has no type yet, so an empty list means there is nothing
-  // left to do at all.
-  const unclassified = threadMessages.filter(m => m.existing_acts === undefined);
+  // Already classified, and not curated. Worth re-reading only if the thread has actually
+  // moved on — otherwise a re-run pays for the same answer.
+  if (existingTags.length > 0) {
+    const fresh = newMessagesSince(existingTags, messages);
+    if (fresh < MIN_NEW_MESSAGES_TO_RECLASSIFY) {
+      return { tagged: 0, skipped: 'nothing-new' };
+    }
+    logger.info(`${TAG} Re-classifying a thread that has grown`, {
+      conversationId,
+      newMessages: fresh,
+      existing: existingTags.map(tag => tag.name),
+    });
+  }
 
   // Passed as a fact, not a rule — what it implies lives in the prompt, not in code.
   const rootMessage = await db.message.findUnique({
@@ -151,7 +219,7 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
   const rootIsBot = rootMessage?.msgType === 'BOT';
 
   const modelName = config.messageClassification.model;
-  const { acts, threadTypes } = await classifyThread(
+  const { threadTypes } = await classifyThread(
     {
       thread_messages: threadMessages,
       root_is_bot: rootIsBot,
@@ -165,39 +233,60 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
     null,
     channel.workspaceId,
     modelName,
+    vocabulary,
   );
 
+  const now = Date.now();
+
+  // Everything the model produced, merged onto what is already there. A tag with no cited
+  // message still counts for the thread — a type derived from the ticket has no message
+  // behind it.
+  //
+  // Additive, and existing entries are kept untouched. Two reasons: a tag that survives a
+  // re-run keeps its ORIGINAL timestamp and cited message, so the tooltip goes on meaning
+  // "first tagged" rather than silently becoming "last classified"; and a type the model
+  // happens not to repeat this time is not removed, so chips do not flicker with model
+  // variance between runs.
+  // No evidence pointer on the thread. The model's citations decide which MESSAGES get the
+  // tag, and that is the whole record: to see why a thread is an ISSUE you look at which of
+  // its messages carry ISSUE — messages the thread view has already loaded. A pointer here
+  // would duplicate that into a column replicated to every client, and nothing read it.
+  const byName = new Map(existingTags.map(tag => [tag.name, tag]));
+  for (const type of threadTypes) {
+    if (byName.has(type.name)) continue;
+    byName.set(type.name, { name: type.name, at: now });
+  }
+  const threadTags: AppliedTag[] = [...byName.values()];
+
+  // Inverted: messageId -> the types it is the evidence for. A message can justify several
+  // types, and a type can cite several messages, so this is many-to-many.
+  const byMessage = new Map<string, AppliedTag[]>();
+  for (const type of threadTypes) {
+    for (const messageId of type.sourceMessageIds) {
+      const tags = byMessage.get(messageId) ?? [];
+      // The tag alone: which messages evidence a type IS the record, so nothing points back.
+      // The model's citations decide which messages land here, and that is the whole trail —
+      // reading it back is a matter of asking which messages carry the name.
+      tags.push({ name: type.name, at: now });
+      byMessage.set(messageId, tags);
+    }
+  }
+
   let tagged = 0;
-  for (const [messageId, messageActs] of acts) {
-    await writeActs(messageId, messageActs);
+  for (const [messageId, tags] of byMessage) {
+    await writeMessageTags(messageId, tags);
     await refeedToVespa(messageId, conversation.workspaceId);
-    tagged += messageActs.length;
+    tagged += tags.length;
   }
 
-  // Anything the model skipped, or whose acts all failed validation, is marked attempted
-  // rather than left null. Without this it stays eligible forever, so `unclassified` is
-  // never empty and every future bucket pays a full-thread call that can only skip it
-  // again. No Vespa refeed — an empty act list changes nothing in the index.
-  const giveUps = unclassified.filter(m => !acts.has(m.id));
-  for (const message of giveUps) {
-    await writeActs(message.id, []);
-  }
-  if (giveUps.length > 0) {
-    logger.info(`${TAG} Messages judged to perform no act`, {
-      conversationId,
-      count: giveUps.length,
-    });
-  }
-
-  // threadType was null to get here, so this is the one and only write.
-  const nextThreadType = threadTypes.length > 0 ? JSON.stringify(threadTypes) : null;
+  const nextThreadType = threadTags.length > 0 ? serializeAppliedTags(threadTags) : null;
   if (nextThreadType) {
     await db.conversation.update({
       where: { conversationId },
       data: { threadType: nextThreadType },
     });
     // The root message doc is the one carrying the thread type, so it needs refeeding even
-    // if its own acts didn't change.
+    // if its own tags didn't change.
     await refeedToVespa(conversation.initialMessageId, conversation.workspaceId);
   }
 
@@ -224,20 +313,30 @@ async function refeedToVespa(messageId: string, workspaceId: string | null): Pro
   }
 }
 
-async function writeActs(messageId: string, acts: string[]): Promise<void> {
-  const valid = acts.filter(act => (MESSAGE_ACT_NAMES as readonly string[]).includes(act));
-  if (valid.length !== acts.length) {
-    logger.warn(`${TAG} Dropping acts outside the vocabulary`, {
-      messageId,
-      dropped: acts.filter(a => !valid.includes(a)),
-    });
+/**
+ * Add the classifier's tags to a message, keeping whatever is already there.
+ *
+ * A merge, not an overwrite: a person may have tagged this message by hand, and a later pass
+ * must not erase that. Existing names win — a tag someone deactivated stays deactivated
+ * rather than being re-applied by the next run.
+ */
+async function writeMessageTags(messageId: string, tags: AppliedTag[]): Promise<void> {
+  const message = await db.message.findUnique({
+    where: { messageId },
+    select: { messageActs: true },
+  });
+  if (!message) {
+    logger.warn(`${TAG} Model cited a message that no longer exists`, { messageId });
+    return;
   }
+
+  const existing = parseAppliedTags(message.messageActs);
+  const known = new Set(existing.map(tag => tag.name));
+  const merged = [...existing, ...tags.filter((tag: AppliedTag) => !known.has(tag.name))];
 
   await db.message.update({
     where: { messageId },
-    // '[]' rather than null, matching the picker: null means "never classified" and would
-    // make this message eligible again next pass, re-dropping the same acts every time.
-    data: { messageActs: valid.length > 0 ? JSON.stringify(valid) : '[]' },
+    data: { messageActs: serializeAppliedTags(merged) },
   });
 }
 
@@ -321,20 +420,7 @@ interface ClassifierMessage {
   text: string;
   author_display_name: string;
   timestamp_iso: string;
-  /** Acts already on this message; empty when cleared by hand. Absent => needs classifying. */
-  existing_acts?: string[];
 }
-
-/** messageActs is a stringified array; anything unparseable is treated as untagged. */
-const parseActs = (raw: string | null): string[] => {
-  if (!raw) return [];
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
-  } catch {
-    return [];
-  }
-};
 
 interface ClassifierInput {
   thread_messages: ClassifierMessage[];
@@ -344,34 +430,40 @@ interface ClassifierInput {
   ticket?: { title: string; description: string };
 }
 
-interface Classification {
-  /** messageId -> its message acts. Messages the model omitted or mis-tagged are absent. */
-  acts: Map<string, string[]>;
-  /** The thread as a whole — a thread can be several things at once. */
-  threadTypes: string[];
+/** One thread type the model returned, with the messages it says justify it. */
+export interface ClassifiedType {
+  name: string;
+  /** Always ids that were actually sent. Empty when the type came from the ticket. */
+  sourceMessageIds: string[];
 }
 
-const VALID_ACTS = new Set(MESSAGE_ACTS.map(entry => entry.name));
-/** Its own set so the sentinel gets the same spelling tolerance as a real act. */
-const NO_ACT_SET = new Set<string>([NO_ACT]);
-const VALID_THREAD_TYPES = new Set(THREAD_TYPES.map(entry => entry.name));
+interface Classification {
+  /** The thread as a whole — a thread can be several things at once. */
+  threadTypes: ClassifiedType[];
+}
 
-// Lenient on purpose: the model's raw shape is untrusted. Anything unrecognised becomes
-// null and is dropped rather than failing the whole job.
+/** No more than this many citations per type, matching what the prompt asks for. */
+const MAX_SOURCES_PER_TYPE = 3;
+
+// Lenient on purpose: the model's raw shape is untrusted. Anything unrecognised is dropped
+// rather than failing the whole job. Both the current object form and a bare list of names
+// are accepted — a smaller model asked for objects will sometimes answer with strings.
+const RawTypeSchema = z.union([
+  z.string(),
+  z.object({
+    name: z.string().nullish(),
+    // Tolerate a bare string as well as an array: models collapse single-element arrays
+    // even when the schema asks for one.
+    sourceMessageIds: z.union([z.string(), z.array(z.string())]).nullish(),
+  }),
+]);
+
 const RawOutputSchema = z.object({
-  // Tolerate a bare string as well as an array — the model collapses single-element arrays.
-  threadTypes: z.union([z.string(), z.array(z.string())]).nullish(),
-  classifications: z
-    .array(
-      z.object({
-        id: z.string(),
-        // Tolerate a bare string as well as an array — models collapse single-element
-        // arrays even when the schema asks for one.
-        messageActs: z.union([z.string(), z.array(z.string())]).nullish(),
-      }),
-    )
-    .default([]),
+  threadTypes: z.union([RawTypeSchema, z.array(RawTypeSchema)]).nullish(),
 });
+
+const asArray = <T,>(value: T | T[] | null | undefined): T[] =>
+  Array.isArray(value) ? value : value == null ? [] : [value];
 
 /**
  * Coerce onto the closed vocabulary. Near-misses (case, hyphens, whitespace) are worth
@@ -398,6 +490,7 @@ async function classifyThread(
   projectId: string | null,
   workspaceId: string,
   modelName: string,
+  vocabulary: readonly ThreadTypeEntry[],
 ): Promise<Classification> {
   const credential =
     dedicatedCredential() ??
@@ -415,7 +508,7 @@ async function classifyThread(
   }
 
   const output = await callLiteLLM(credential, modelName, [
-    { role: 'system', content: buildClassifierPrompt() },
+    { role: 'system', content: buildClassifierPrompt(vocabulary) },
     { role: 'user', content: JSON.stringify(input, null, 2) },
   ]);
 
@@ -425,57 +518,45 @@ async function classifyThread(
   const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
   const parsed = RawOutputSchema.parse(JSON.parse(jsonMatch ? jsonMatch[0] : cleaned));
 
-  // Sent AND still unclassified. Blocks both a hallucinated id and a model that ignores
-  // the prompt and re-classifies a settled message. The prompt asks; this guarantees.
-  const eligibleIds = new Set(
-    input.thread_messages.filter(m => m.existing_acts === undefined).map(m => m.id),
-  );
-  const acts = new Map<string, string[]>();
+  // Only ids that were actually sent. Blocks a hallucinated citation, which would otherwise
+  // become a Prisma update against a message that does not exist.
+  const sentIds = new Set(input.thread_messages.map(m => m.id));
+  const validThreadTypes = new Set(vocabulary.map(entry => entry.name));
 
-  for (const entry of parsed.classifications) {
-    if (!eligibleIds.has(entry.id)) {
-      logger.warn('[MessageClassifier] Model returned an unknown or already-tagged id; dropping', {
-        returned: entry.id,
-      });
+  const threadTypes: ClassifiedType[] = [];
+  const seen = new Set<string>();
+
+  for (const raw of asArray(parsed.threadTypes)) {
+    const rawName = typeof raw === 'string' ? raw : raw.name;
+    const name = coerce(rawName, validThreadTypes);
+    if (!name) {
+      logger.warn('[MessageClassifier] Unusable thread type; dropping', { returned: rawName });
       continue;
     }
-    const raw = Array.isArray(entry.messageActs)
-      ? entry.messageActs
-      : entry.messageActs
-        ? [entry.messageActs]
-        : [];
+    // A model asked for several types will sometimes repeat one; first citation wins.
+    if (seen.has(name)) continue;
+    seen.add(name);
 
-    // Dedupe: a model asked for several tags will sometimes repeat one.
-    const tagged = [...new Set(raw.map(value => coerce(value, VALID_ACTS)).filter(Boolean))] as string[];
-
-    // NO_ACT is the expected answer for chatter, not a failure — only warn when the model
-    // sent something that was meant to be a real act and failed to land on the vocabulary.
-    if (tagged.length === 0) {
-      const declaredNoAct = raw.some(value => coerce(value, NO_ACT_SET) !== null);
-      if (!declaredNoAct && raw.length > 0) {
-        logger.warn('[MessageClassifier] No usable message act returned; dropping', {
-          messageId: entry.id,
-          returned: entry.messageActs,
+    const cited = typeof raw === 'string' ? [] : asArray(raw.sourceMessageIds);
+    const sourceMessageIds = [...new Set(cited)]
+      .filter(id => {
+        if (sentIds.has(id)) return true;
+        logger.warn('[MessageClassifier] Type cited an unknown message id; dropping citation', {
+          type: name,
+          returned: id,
         });
-      }
-      continue;
-    }
-    acts.set(entry.id, tagged);
+        return false;
+      })
+      .slice(0, MAX_SOURCES_PER_TYPE);
+
+    threadTypes.push({ name, sourceMessageIds });
   }
 
-  const rawTypes = Array.isArray(parsed.threadTypes)
-    ? parsed.threadTypes
-    : parsed.threadTypes
-      ? [parsed.threadTypes]
-      : [];
-  const threadTypes = [
-    ...new Set(rawTypes.map(value => coerce(value, VALID_THREAD_TYPES)).filter(Boolean)),
-  ] as string[];
-  if (rawTypes.length > 0 && threadTypes.length === 0) {
-    logger.warn('[MessageClassifier] Model returned no usable thread type; dropping', {
+  if (threadTypes.length === 0) {
+    logger.warn('[MessageClassifier] Model returned no usable thread type', {
       returned: parsed.threadTypes,
     });
   }
 
-  return { acts, threadTypes };
+  return { threadTypes };
 }

--- a/apps/backend/src/services/messageClassification/index.ts
+++ b/apps/backend/src/services/messageClassification/index.ts
@@ -34,6 +34,21 @@ export const MIN_THREAD_SIZE = Number(
 /** Upper bound on messages sent to the model in one pass. */
 const MAX_THREAD_CONTEXT = 60;
 
+/**
+ * How many earlier messages from the same DM to send as background.
+ *
+ * People do not reply in threads in a DM — they just keep typing — so a DM "thread" is
+ * usually one message with nothing under it. Classifying that in isolation is guessing: "can
+ * you check this?" is a REQUEST or a QUESTION depending entirely on what came before it.
+ *
+ * Channels do not get this. There a thread is a real thread and its own replies are the
+ * context; pulling in unrelated channel chatter would add noise, not signal.
+ */
+const DM_CONTEXT_MESSAGES = Number(process.env['MESSAGE_CLASSIFICATION_DM_CONTEXT'] ?? 5);
+
+/** scopeType values that mean "no one uses threads here". */
+const DM_SCOPES = new Set(['DM', 'GROUP_DM']);
+
 /** A ticket description can be pages long; the opening is where the intent lives. */
 const TICKET_DESCRIPTION_LIMIT = 1000;
 
@@ -126,7 +141,7 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
 
   const channel = await db.channel.findUnique({
     where: { id: conversation.channelId },
-    select: { id: true, workspaceId: true },
+    select: { id: true, workspaceId: true, scopeType: true },
   });
   if (!channel) {
     return { tagged: 0, skipped: 'no-channel' };
@@ -182,6 +197,31 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
 
   messages.reverse(); // back to chronological — the model is told the thread is in order
 
+  // In a DM, everything before this message in the same conversation window is the context a
+  // reader would have had. Fetched from the CHANNEL rather than the conversation, because
+  // each top-level DM message opens a conversation of its own.
+  const precedingMessages =
+    DM_SCOPES.has(channel.scopeType) && DM_CONTEXT_MESSAGES > 0
+      ? await db.message.findMany({
+          where: {
+            // A message has no channel of its own — it reaches one through its conversation.
+            conversation: { channelId: channel.id },
+            conversationId: { not: conversationId },
+            isDeleted: false,
+            msgType: { not: 'SYSTEM' },
+            createdAt: { lt: messages[0]?.createdAt ?? conversation.createdAt },
+          },
+          select: {
+            content: true,
+            createdAt: true,
+            sender: { select: { name: true } },
+          },
+          orderBy: { createdAt: 'desc' },
+          take: DM_CONTEXT_MESSAGES,
+        })
+      : [];
+  precedingMessages.reverse();
+
   // Every message is offered as context: the model is classifying the thread, and it needs
   // the whole thing to pick which messages are the evidence for each type.
   const threadMessages: ClassifierMessage[] = messages
@@ -223,6 +263,18 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
     {
       thread_messages: threadMessages,
       root_is_bot: rootIsBot,
+      // Deliberately WITHOUT ids. These are not part of the thread and must never be cited
+      // as evidence — a citation is written back onto the message, and tagging someone
+      // else's unrelated DM line would be wrong and would surface as a stray evidence chip.
+      ...(precedingMessages.length > 0 && {
+        preceding_messages: precedingMessages
+          .map(m => ({
+            text: stripHtml(m.content ?? ''),
+            author_display_name: m.sender?.name ?? 'Unknown',
+            timestamp_iso: m.createdAt.toISOString(),
+          }))
+          .filter(m => m.text.length > 0),
+      }),
       ...(ticket && {
         ticket: {
           title: ticket.title,
@@ -242,21 +294,45 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
   // message still counts for the thread — a type derived from the ticket has no message
   // behind it.
   //
-  // Additive, and existing entries are kept untouched. Two reasons: a tag that survives a
-  // re-run keeps its ORIGINAL timestamp and cited message, so the tooltip goes on meaning
-  // "first tagged" rather than silently becoming "last classified"; and a type the model
-  // happens not to repeat this time is not removed, so chips do not flicker with model
-  // variance between runs.
+  // The classifier's answer REPLACES its own previous answer; anything a person touched is
+  // kept exactly as it is.
+  //
+  // Additive-only was wrong, and wrong in the direction that decays: a pass can misread a
+  // thread — "what is hydration here?" is a question, not an explanation — and under an
+  // additive merge that mistake was permanent, because nothing else ever removes a tag. Every
+  // re-read was another chance to add one and never a chance to correct one, so on a long
+  // thread precision could only fall. Superseding lets the model take a tag back when the
+  // thread turns out not to be that after all.
+  //
+  // A tag that survives a re-run keeps its ORIGINAL timestamp, so the tooltip goes on meaning
+  // "first tagged" rather than silently becoming "last classified".
+  //
+  // Dropped tags are DELETED rather than tombstoned. A tombstone means "a person took this
+  // off", which isCurated reads as "stop classifying this thread" — so tombstoning here would
+  // let the classifier freeze a thread by correcting itself.
+  //
   // No evidence pointer on the thread. The model's citations decide which MESSAGES get the
   // tag, and that is the whole record: to see why a thread is an ISSUE you look at which of
   // its messages carry ISSUE — messages the thread view has already loaded. A pointer here
   // would duplicate that into a column replicated to every client, and nothing read it.
-  const byName = new Map(existingTags.map(tag => [tag.name, tag]));
-  for (const type of threadTypes) {
-    if (byName.has(type.name)) continue;
-    byName.set(type.name, { name: type.name, at: now });
+  const returned = new Map(threadTypes.map(type => [type.name, type]));
+  const threadTags: AppliedTag[] = [];
+  for (const tag of existingTags) {
+    // Human decisions — an added tag, or a tombstone for one someone removed — outrank the
+    // model and are never superseded by it.
+    if (isHumanApplied(tag) || tag.removed) {
+      threadTags.push(tag);
+      continue;
+    }
+    // Its own earlier tag: kept only if it still stands this time, and kept with the
+    // timestamp it was first applied.
+    if (returned.has(tag.name)) threadTags.push(tag);
   }
-  const threadTags: AppliedTag[] = [...byName.values()];
+  const already = new Set(threadTags.map(tag => tag.name));
+  for (const type of threadTypes) {
+    if (already.has(type.name)) continue;
+    threadTags.push({ name: type.name, at: now });
+  }
 
   // Inverted: messageId -> the types it is the evidence for. A message can justify several
   // types, and a type can cite several messages, so this is many-to-many.
@@ -272,10 +348,17 @@ export async function classifyAndTagThread(conversationId: string): Promise<Clas
     }
   }
 
+  // Every message in the thread is reconciled, not only the newly cited ones. A message that
+  // was evidence last time and is not cited now must LOSE that tag, or clicking a thread's
+  // chip would still surface it — the thread would say it is not a WHAT_IS while one of its
+  // messages went on claiming to be the proof that it is.
   let tagged = 0;
-  for (const [messageId, tags] of byMessage) {
-    await writeMessageTags(messageId, tags);
-    await refeedToVespa(messageId, conversation.workspaceId);
+  for (const message of messages) {
+    const tags = byMessage.get(message.messageId) ?? [];
+    const changed = await writeMessageTags(message.messageId, tags);
+    // Only re-feed what actually moved: a thread of sixty messages would otherwise queue
+    // sixty Vespa writes on every pass to change two of them.
+    if (changed) await refeedToVespa(message.messageId, conversation.workspaceId);
     tagged += tags.length;
   }
 
@@ -314,30 +397,46 @@ async function refeedToVespa(messageId: string, workspaceId: string | null): Pro
 }
 
 /**
- * Add the classifier's tags to a message, keeping whatever is already there.
+ * Set the classifier's evidence tags on a message to `tags`, leaving human ones alone.
  *
- * A merge, not an overwrite: a person may have tagged this message by hand, and a later pass
- * must not erase that. Existing names win — a tag someone deactivated stays deactivated
- * rather than being re-applied by the next run.
+ * The same supersede rule the thread uses, for the same reason: the model's previous answer
+ * about this message is replaced by its current one, so a citation it no longer stands behind
+ * stops claiming to be evidence. What a PERSON put on the message — or took off it — outranks
+ * the model and survives untouched.
+ *
+ * `tags` may be empty, which is how a message that is no longer cited is cleared.
+ *
+ * Returns whether anything actually changed, so the caller can skip re-feeding Vespa for the
+ * messages this pass did not move.
  */
-async function writeMessageTags(messageId: string, tags: AppliedTag[]): Promise<void> {
+async function writeMessageTags(messageId: string, tags: AppliedTag[]): Promise<boolean> {
   const message = await db.message.findUnique({
     where: { messageId },
     select: { messageActs: true },
   });
   if (!message) {
     logger.warn(`${TAG} Model cited a message that no longer exists`, { messageId });
-    return;
+    return false;
   }
 
   const existing = parseAppliedTags(message.messageActs);
-  const known = new Set(existing.map(tag => tag.name));
-  const merged = [...existing, ...tags.filter((tag: AppliedTag) => !known.has(tag.name))];
+  // Nothing to do, and nothing was ever done: skip the write rather than rewrite '[]' onto
+  // every untagged message in the thread on every pass.
+  if (existing.length === 0 && tags.length === 0) return false;
+
+  const returned = new Set(tags.map(tag => tag.name));
+  const kept = existing.filter(tag => isHumanApplied(tag) || tag.removed || returned.has(tag.name));
+  const already = new Set(kept.map(tag => tag.name));
+  const merged = [...kept, ...tags.filter(tag => !already.has(tag.name))];
+
+  const next = serializeAppliedTags(merged);
+  if (next === serializeAppliedTags(existing)) return false;
 
   await db.message.update({
     where: { messageId },
-    data: { messageActs: serializeAppliedTags(merged) },
+    data: { messageActs: next },
   });
+  return true;
 }
 
 // ─── LLM invocation ──────────────────────────────────────────────────────────────
@@ -426,6 +525,11 @@ interface ClassifierInput {
   thread_messages: ClassifierMessage[];
   /** True when a bot or automated system opened the thread. Gates the ALERT type. */
   root_is_bot: boolean;
+  /**
+   * Earlier DM messages, for context only. No ids, so they cannot be cited — see where this
+   * is built. Absent for channel threads.
+   */
+  preceding_messages?: Omit<ClassifierMessage, 'id'>[];
   /** Present when the thread was turned into a ticket. */
   ticket?: { title: string; description: string };
 }

--- a/apps/backend/src/services/messageClassification/prompt.ts
+++ b/apps/backend/src/services/messageClassification/prompt.ts
@@ -1,131 +1,92 @@
-import { MESSAGE_ACTS, NO_ACT, THREAD_TYPES } from '@xyne/shared';
+import type { ThreadTypeEntry } from '@xyne/shared';
 
 /**
- * The classifier prompt is GENERATED from the vocabularies rather than written out by hand,
- * so adding or editing a tag in packages/shared/src/tags/vocabularies.ts updates the prompt
- * automatically. A hand-copied list is the classic way for a prompt to drift out of sync
- * with the values the mutator will actually accept.
+ * The classifier prompt is GENERATED from the workspace's vocabulary rather than written out
+ * by hand. Nothing here names a thread type — a hand-copied list is the classic way for a
+ * prompt to drift out of sync with the values that will actually be accepted.
+ *
+ * Thread types are the only vocabulary; the message-act list that used to sit alongside them
+ * is gone. Instead the model must cite, for each type it returns, the messages that evidence
+ * it. That citation is what lets a chip on a thread be traced back to the message it came
+ * from, and it is what gets stored on those messages.
  *
  * The prompt is a hint, not a guarantee — models return near-misses ("Billing" for
- * "billing", "bug-report" for "bug"). Output is filtered against the seeded catalog before
- * anything is written, and the mutator rejects unknown names as a final backstop.
+ * "billing", "bug-report" for "bug"). Output is coerced onto the same vocabulary this prompt
+ * was built from, and anything unrecognised is dropped rather than stored.
  */
 
-const numbered = (entries: readonly { name: string; description: string }[]): string =>
+const numbered = (entries: readonly ThreadTypeEntry[]): string =>
   entries.map((entry, i) => `${i + 1}. ${entry.name} — ${entry.description}`).join('\n');
 
-const ACT_NAMES = MESSAGE_ACTS.map(entry => entry.name);
-const THREAD_TYPE_CHOICES = THREAD_TYPES;
+const names = (entries: readonly ThreadTypeEntry[]): string =>
+  entries.map(entry => entry.name).join(', ');
 
-export const buildClassifierPrompt = (): string => `You classify workplace chat messages.
+/**
+ * @param threadTypes the workspace's vocabulary, in display order. Both the list and the
+ *        output enum are generated from it, so a workspace that adds a type gets it offered
+ *        to the model without any change here.
+ */
+export const buildClassifierPrompt = (threadTypes: readonly ThreadTypeEntry[]): string => {
+  return `You classify workplace chat threads.
 
 Output STRICT JSON only. No markdown, no commentary, no explanation.
 
 You will receive a JSON object with:
-- thread_messages: [{ id, text, author_display_name, timestamp_iso, existing_acts? }] — the
-  ENTIRE thread in chronological order, starting with the message that opened it.
-  existing_acts, when present, is the tags that message was already given — an empty
-  array means someone deliberately cleared it and it must stay untagged.
+- thread_messages: [{ id, text, author_display_name, timestamp_iso }] — the ENTIRE thread
+  in chronological order, starting with the message that opened it.
 - root_is_bot: boolean — true when a bot or automated system posted the opening message.
 - ticket: optional — { title, description } when this thread was turned into a ticket.
   Someone wrote these deliberately, so they state the thread's purpose more reliably than
-  the conversation does. Weigh them heavily for threadTypes; they say nothing about what
-  any individual message does. thread_messages may be EMPTY when a thread was opened from a
-  ticket and nobody has replied — classify threadTypes from the ticket alone and return an
-  empty classifications array.
+  the conversation does, so weigh them heavily. thread_messages may be EMPTY when a thread
+  was opened from a ticket and nobody has replied — classify from the ticket alone and
+  return an empty sourceMessageIds for each type.
 
-## Task — classify ONLY the messages that have no existing_acts
+## Task — tag the thread
 
-Messages that already carry existing_acts are settled. They are given to you as context so
-you can judge the new ones — do NOT return entries for them, and do not revise them.
+${numbered(threadTypes)}
 
-Return the tags for each remaining message. A message usually performs ONE act, but it may
-perform several — "I'll patch this by 4pm, but which gateway should I point it at?" is both
-a COMMITMENT and a QUESTION. Return every act a message genuinely performs.
+Add every type that genuinely applies, and nothing else. Most threads take one; some take
+two or three; none take all of them.
 
-Be conservative: most messages do exactly one thing. Only return more than one tag when the
-message clearly performs distinct acts, not when you are unsure which single tag fits.
+Each definition states what it covers and, after "NOT", the near-misses it excludes. Read the
+NOT clauses before tagging — they are where this task goes wrong.
 
-You see the whole thread at once, so use it. A message's act depends on what is already open
-above it — read the earlier messages and their existing_acts before judging a new one.
+Two tests, and a type must pass the one its definition is written in terms of:
 
-Classify each message by WHAT IT CREATES GOING FORWARD:
+- Definitions phrased as "done = …" are about the thread as a piece of WORK. Ask what would
+  have to happen for this thread to be finished.
+- The rest are about the thread as a DOCUMENT. Ask whether someone who was never in this
+  thread could get their question answered by THIS THREAD ALONE. The bar is high and most
+  threads clear none of them. Tag what the thread ANSWERS, not what it discusses — a thread
+  full of debugging that never lands on an answer gets none of these. Not reaching for one is
+  the normal, correct result; do not add one to look thorough.
 
-${numbered(MESSAGE_ACTS)}
+## Evidence — required for every type
 
-When you do return several tags for one message, list them strongest-first using this
-precedence: ${ACT_NAMES.join(' > ')}.
+For each type you return, cite the messages that make it true, by id, in sourceMessageIds.
 
-Critical: ANSWER and RESOLUTION are not intrinsic to the message — they depend on what is
-open earlier in the thread. Only use ANSWER when an earlier message actually asked a
-question. Only use RESOLUTION when an earlier message opened an issue or commitment.
+Cite the message that CAUSED the tag, not every message that mentions the topic. When the
+type describes what the thread is for, that is usually the message that opened it or first
+stated the problem; when the type describes what the thread teaches, it is the message that
+actually contains the answer — the one with the steps, the narrative, the decision and its
+reasoning, the values. One or two ids is normal. Never cite more than three.
 
-Return exactly ["${NO_ACT}"] when the message genuinely performs no act — acknowledgements
-("ok", "thanks", "+1"), greetings, one-word fragments, thinking aloud. Do not stretch a tag
-to fit.
+Only ever cite ids that appear in thread_messages. If the type comes from the ticket rather
+than any message, return an empty list rather than guessing at an id.
 
-${NO_ACT} is not a way to avoid judging. A message that reports the state of work, assigns
-or accepts it, asks something, decides something or raises urgency DOES perform an act —
-including when it is long, list-shaped, or covers many items at once. A list of workstreams
-with owners is a STATUS_UPDATE; an agenda someone commits to is a COMMITMENT. Tag the
-dominant act.
-
-## Second task — the thread as a whole
-
-Also classify the ENTIRE thread, on TWO independent axes.
-
-${numbered(THREAD_TYPE_CHOICES)}
-
-### Axis 1 — outcome (one, rarely two)
-
-Pick ONE of ISSUE, ALERT, QUESTION, REQUEST, FEATURE_REQUEST, DISCUSSION, ANNOUNCEMENT by
-what "done" would mean for the thread. Return a second one only when the thread genuinely
-is two things at once (a bug report that also requests a feature) — never more than two.
-
-Decide by what would have to happen for this thread to be finished:
-- fixed AND verified → ISSUE
-- answered → QUESTION
-- an action performed with existing tools → REQUEST
-- accepted or declined for the roadmap → FEATURE_REQUEST
-- nothing owed by anyone → ANNOUNCEMENT
-- no done state at all → DISCUSSION
-
-REQUEST vs FEATURE_REQUEST: could someone with the right permissions do this TODAY with
-tools that already exist? Yes → REQUEST. Needs something built → FEATURE_REQUEST.
-
-When no other type fits, DISCUSSION.
-
-### Axis 2 — answer types (usually NONE)
-
-Then add any of HOW_TO, WHAT_HAPPENED, WHY_DECISION, WHAT_IS, KNOWN_ISSUE, REFERENCE,
-EXAMPLE, POLICY_LIMIT that apply. These are independent of the outcome — an ISSUE whose
-resolution spells out the fix is both ISSUE and HOW_TO.
-
-The bar is high and most threads clear none of it: add one ONLY if someone who was never in
-this thread could get their question answered by THIS THREAD ALONE. Tag what the thread
-ANSWERS, not what it discusses. A thread full of debugging that never lands on an answer
-gets none of these. Returning no answer types is the normal, correct outcome — do not reach
-for one to look thorough.
-
-Read each definition's "NOT" clauses before tagging: asking how to do something is not
-HOW_TO, mid-incident chatter is not WHAT_HAPPENED, a choice with no reasoning is not
-WHY_DECISION, and a value someone is unsure about is not POLICY_LIMIT.
-
-ANNOUNCEMENT is an outcome, not an answer type — a release note is ANNOUNCEMENT alone.
+If you cannot point at a message that justifies a type, that is a sign the type does not
+apply — drop it rather than citing something loosely related.
 
 ## Output
 
 {
-  "threadTypes": [the outcome type first, then any answer types — from ${THREAD_TYPE_CHOICES.map(e => e.name).join(', ')}],
-  "classifications": [
-    { "id": "<message id from thread_messages>", "messageActs": [one or more of ${ACT_NAMES.join(', ')}, or exactly ["${NO_ACT}"]] }
+  "threadTypes": [
+    { "name": "<one of ${names(threadTypes)}>", "sourceMessageIds": ["<id from thread_messages>"] }
   ]
 }
 
-One classifications entry per message WITHOUT existing_acts, using the exact ids given —
-including the ones that perform no act, as ["${NO_ACT}"]. Messages that already have
-existing_acts must not appear in classifications at all. messageActs must always have at
-least one value. Use the exact strings above — no other spelling, casing or punctuation.
-
-threadTypes covers the whole thread and is always required, even when every message was
-already classified.`;
+Most-important type first. Use the exact strings above — no other spelling, casing or
+punctuation. threadTypes is always required and must never be empty; every entry must have a
+name and a sourceMessageIds array, which may be empty only when the type comes from the
+ticket.`;
+};

--- a/apps/backend/src/services/messageClassification/prompt.ts
+++ b/apps/backend/src/services/messageClassification/prompt.ts
@@ -35,6 +35,13 @@ You will receive a JSON object with:
 - thread_messages: [{ id, text, author_display_name, timestamp_iso }] — the ENTIRE thread
   in chronological order, starting with the message that opened it.
 - root_is_bot: boolean — true when a bot or automated system posted the opening message.
+- preceding_messages: optional — [{ text, author_display_name, timestamp_iso }] — earlier
+  messages from the same direct message conversation, in chronological order, ending just
+  before thread_messages begins. Present only for DMs, where people rarely reply in threads
+  and a message therefore arrives with no visible thread around it. Read them to understand
+  what thread_messages is about — "can you check this?" means nothing on its own. They have
+  NO ids and are NOT part of the thread: never cite them, and never classify them. Classify
+  thread_messages, using these only to understand it.
 - ticket: optional — { title, description } when this thread was turned into a ticket.
   Someone wrote these deliberately, so they state the thread's purpose more reliably than
   the conversation does, so weigh them heavily. thread_messages may be EMPTY when a thread

--- a/apps/backend/src/services/messageClassification/tagCounts.ts
+++ b/apps/backend/src/services/messageClassification/tagCounts.ts
@@ -1,0 +1,103 @@
+/**
+ * How many threads carry each tag.
+ *
+ * One grouped Vespa query for the whole vocabulary, not a query per name: the review table
+ * lists every candidate at once, so per-name counting would be a round trip per row.
+ *
+ * `threadType` is written only onto a thread's ROOT message
+ * (zero/vespa-injection/core/mapper.ts), so a group's count is a THREAD count — no dedupe.
+ * Free-form names are indexed before approval, so a candidate has a count from the moment
+ * someone applies it.
+ */
+import { vespaClient } from '@/services/vespaSearch';
+import { messageSchema } from '@/vespa/src/types';
+import { escapeYqlString } from '@/utils/yqlEscape';
+import { logger } from '@/utils/logger';
+
+const TAG = '[TagCounts]';
+
+/** Ceiling on distinct tag names returned. Comfortably above MAX_ENTRIES plus candidates. */
+const MAX_TAG_GROUPS = 500;
+
+export interface TagThreadCounts {
+  /** name -> threads carrying it, across the whole workspace. */
+  total: Map<string, number>;
+  /** name -> epoch ms of the newest thread carrying it. Free, from the same grouping. */
+  lastUsed: Map<string, number>;
+  /**
+   * False when the query failed — Vespa down, or the schema missing `threadType`.
+   *
+   * Without this an empty map is indistinguishable from "every tag is on zero threads", and
+   * the review screen would tell an admin a widely-used tag is unused. The caller must omit
+   * the counts entirely rather than send zeros.
+   */
+  ok: boolean;
+}
+
+/**
+ * Raw YQL rather than searchService, deliberately.
+ *
+ * Every path through YqlBuilder ANDs in `permissions contains <userId>`, which is right for
+ * search and wrong for this: an admin deciding whether a tag earns a place in the vocabulary
+ * needs to know it is used on 41 threads, not on the 12 they happen to be a member of. A
+ * count that silently reads 0 because the reviewer is not in the channel is worse than no
+ * count at all.
+ *
+ * What that discloses is a tag name and a number — never a message, a thread, or a channel,
+ * and no list is ever opened from it.
+ */
+const groupedCounts = async (
+  workspaceId: string,
+): Promise<{ counts: Map<string, number>; lastUsed: Map<string, number>; ok: boolean }> => {
+  const counts = new Map<string, number>();
+  const lastUsed = new Map<string, number>();
+  let ok = true;
+
+  const where = [
+    `docType contains "message"`,
+    `workspaceId contains "${escapeYqlString(workspaceId)}"`,
+  ].join(' and ');
+
+  try {
+    const response = await vespaClient.search<{
+      root?: { children?: unknown[] };
+    }>({
+      yql:
+        `select * from sources ${messageSchema} where ${where} ` +
+        `| all(group(threadType) max(${MAX_TAG_GROUPS}) each(output(count(), max(createdAtTimestamp))))`,
+      // Grouping only — the hit list is not wanted and would be pure transfer cost.
+      hits: 0,
+      'ranking.profile': 'unranked',
+    });
+
+    // Vespa nests grouplists arbitrarily deep depending on the query shape, so walk rather
+    // than index into a fixed path.
+    const walk = (node: unknown): void => {
+      if (!node || typeof node !== 'object') return;
+      const record = node as Record<string, unknown>;
+      const value = record['value'];
+      const fields = record['fields'] as Record<string, unknown> | undefined;
+      const count = fields?.['count()'];
+      if (typeof value === 'string' && typeof count === 'number') {
+        counts.set(value, count);
+        // Already epoch ms — the mapper writes Date.getTime() into it (mapper.ts toTimestamp).
+        const newest = fields?.['max(createdAtTimestamp)'];
+        if (typeof newest === 'number' && newest > 0) lastUsed.set(value, newest);
+      }
+      for (const child of (record['children'] as unknown[] | undefined) ?? []) walk(child);
+    };
+    for (const child of response.root?.children ?? []) walk(child);
+  } catch (error) {
+    // A missing count renders as an em dash; it must never take the review screen down.
+    ok = false;
+    logger.error(`${TAG} Grouped count failed`, { workspaceId, error });
+  }
+
+  return { counts, lastUsed, ok };
+};
+
+/** One grouped query for the whole vocabulary. */
+export async function threadCountsByTag(workspaceId: string): Promise<TagThreadCounts> {
+  const { counts, lastUsed, ok } = await groupedCounts(workspaceId);
+  return { total: counts, lastUsed, ok };
+}

--- a/apps/backend/src/services/messageClassification/vocabulary.ts
+++ b/apps/backend/src/services/messageClassification/vocabulary.ts
@@ -4,12 +4,15 @@
  * One source for three things that must never disagree: the classifier prompt, the
  * validation that filters the model's output, and the picker the dashboard renders.
  *
- * Layered. The built-ins in packages/shared/src/tags/vocabularies.ts ship with the product
- * and are the base; table rows override or extend them at a narrower scope, most specific
- * winning by name. ORG and USER scopes are not resolved yet but need no schema change to
- * slot in — that is what `scope` is for.
+ * The table is the whole truth. A workspace's vocabulary is its rows in
+ * non_zero.thread_type_vocabulary — there is no fallback to code, so a workspace with no
+ * rows has no types and classification skips it until an admin installs some. THREAD_TYPES
+ * is a template `seedWorkspaceVocabulary` copies in on request; nothing else reads it.
+ *
+ * ORG and USER scopes are not resolved yet but need no schema change to slot in — that is
+ * what `scope` is for.
  */
-import { THREAD_TYPES, type ThreadTypeEntry } from '@xyne/shared';
+import { normalizeThreadTypeName, THREAD_TYPES, type ThreadTypeEntry } from '@xyne/shared';
 import { db } from '@/database/client';
 import { logger } from '@/utils/logger';
 
@@ -34,8 +37,8 @@ export type VocabularyScope = (typeof VOCABULARY_SCOPES)[number];
  * them. UNDER_REVIEW is a free-form tag someone invented — recorded so an admin can promote
  * it, but withheld from both until they do. REJECTED is one an admin turned down.
  *
- * Rejection is a status, not `isDeleted`: on this table that flag already means "suppress the
- * built-in of this name", and a boolean has nowhere to record WHY a name was turned down.
+ * Rejection is a status, not `isDeleted`: that flag already means "this workspace removed
+ * this type", and a boolean has nowhere to record WHY a name was turned down.
  *
  * A rejected name keeps everything it already had — the tag stays on its threads and stays
  * searchable. All the status governs is whether the NAME spreads: whether the picker offers
@@ -75,22 +78,33 @@ const inDisplayOrder = (entries: ThreadTypeEntry[]): ThreadTypeEntry[] =>
 const toEntry = (row: {
   name: string;
   label: string;
+  summary: string;
   color: string;
   description: string;
 }): ThreadTypeEntry => ({
   name: row.name,
   label: row.label,
+  summary: row.summary,
   color: row.color,
   description: row.description,
 });
 
 /**
- * The name a candidate would take once approved: UPPER_SNAKE, which is what EntrySchema
- * requires. Shared by the retire match and by the rename preview an admin is shown, so the
- * two can never disagree about which proposal an approval answers.
+ * The approved names, read straight from the database.
+ *
+ * `getThreadTypeVocabulary` is fine to serve a minute-old answer to a prompt or a picker. It
+ * is NOT fine to diff a destructive write against: the cache is per process, so on a second
+ * instance a PUT can compute "this type is already gone" from a stale list and skip the
+ * removal, and the must-keep-one guard can pass on a vocabulary that is no longer there.
+ * Taken inside the caller's transaction so the decision and the write see the same rows.
  */
-export const promotedForm = (name: string): string =>
-  name.trim().toUpperCase().replace(/[\s-]+/g, '_');
+const approvedNames = async (tx: Tx, workspaceId: string): Promise<Set<string>> => {
+  const rows = await tx.threadTypeVocabulary.findMany({
+    where: { ...scopeKey(workspaceId), status: 'APPROVED', isDeleted: false },
+    select: { name: true },
+  });
+  return new Set(rows.map(row => row.name));
+};
 
 const scopeKey = (workspaceId: string): { scope: string; scopeId: string } => ({
   scope: 'WORKSPACE',
@@ -119,25 +133,62 @@ export const seedWorkspaceVocabulary = async (
   workspaceId: string,
   userId: string,
 ): Promise<{ added: number }> => {
-  const result = await db.threadTypeVocabulary.createMany({
-    data: THREAD_TYPES.map(entry => ({
-      ...scopeKey(workspaceId),
-      workspaceId,
-      name: entry.name,
-      label: entry.label,
-      color: entry.color,
-      description: entry.description,
-      status: 'APPROVED',
-      // The admin who ran the seed. They chose to add these, so they own them like any other
-      // entry — there is no "built in" author, because nothing is built in any more.
-      createdBy: userId,
-      updatedBy: userId,
-    })),
-    skipDuplicates: true,
-  });
+  const key = scopeKey(workspaceId);
+  let added = 0;
+
+  for (const entry of THREAD_TYPES) {
+    const existing = await db.threadTypeVocabulary.findUnique({
+      where: { scope_scopeId_name: { ...key, name: entry.name } },
+      select: { id: true, isDeleted: true },
+    });
+
+    // Already live: left exactly as it is. An admin may have renamed it, recoloured it or
+    // rewritten its instruction, and "add the standard types" must not quietly undo that.
+    if (existing && !existing.isDeleted) continue;
+
+    if (existing) {
+      // Suppressed. Reviving is the whole point of running this again — skipping it (which is
+      // what createMany's skipDuplicates did) left a workspace that had removed the standard
+      // types unable to ever get them back, because the tombstone still holds the unique key.
+      await db.threadTypeVocabulary.update({
+        where: { id: existing.id },
+        data: {
+          label: entry.label,
+          summary: entry.summary,
+          color: entry.color,
+          description: entry.description,
+          status: 'APPROVED',
+          isDeleted: false,
+          updatedBy: userId,
+          updatedAt: new Date(),
+        },
+      });
+      added += 1;
+      continue;
+    }
+
+    await db.threadTypeVocabulary.create({
+      data: {
+        ...key,
+        workspaceId,
+        name: entry.name,
+        label: entry.label,
+        summary: entry.summary,
+        color: entry.color,
+        description: entry.description,
+        status: 'APPROVED',
+        // The admin who installed the set. They own these like any other entry: there is no
+        // authorless row, so "Proposed by" never has to show a bucket for nobody.
+        createdBy: userId,
+        updatedBy: userId,
+      },
+    });
+    added += 1;
+  }
+
   clearVocabularyCache(workspaceId);
-  logger.info(`${TAG} Seeded starting vocabulary`, { workspaceId, added: result.count });
-  return { added: result.count };
+  logger.info(`${TAG} Installed standard vocabulary`, { workspaceId, added, userId });
+  return { added };
 };
 
 /**
@@ -187,14 +238,16 @@ export async function setThreadTypeVocabulary(
   const now = new Date();
   const key = scopeKey(workspaceId);
   const keep = new Set(entries.map(entry => entry.name));
-  const current = await getThreadTypeVocabulary(workspaceId);
 
   await db.$transaction(async tx => {
-    for (const entry of current) {
-      if (keep.has(entry.name)) continue;
+    // Read inside the transaction: what is removed is everything currently approved that the
+    // caller did not resend, and that set has to be the one this write is about to act on.
+    const current = await approvedNames(tx, workspaceId);
+    for (const name of current) {
+      if (keep.has(name)) continue;
       await tx.threadTypeVocabulary.upsert({
-        where: { scope_scopeId_name: { ...key, name: entry.name } },
-        create: { ...key, workspaceId, ...suppression(entry.name), createdBy: userId, updatedBy: userId },
+        where: { scope_scopeId_name: { ...key, name } },
+        create: { ...key, workspaceId, ...suppression(name), createdBy: userId, updatedBy: userId },
         update: { isDeleted: true, updatedBy: userId, updatedAt: now },
       });
     }
@@ -235,6 +288,7 @@ export async function setThreadTypeVocabulary(
 const suppression = (name: string) => ({
   name,
   label: name,
+  summary: '',
   color: '#6b7280',
   description: '',
   isDeleted: true,
@@ -264,22 +318,28 @@ export async function patchThreadTypeVocabulary(
   const remove = patch.remove ?? [];
   const now = new Date();
   const key = scopeKey(workspaceId);
-  const effective = new Set((await getThreadTypeVocabulary(workspaceId)).map(entry => entry.name));
-
-  // Refuse to empty the vocabulary: a workspace with nothing to pick from cannot classify.
-  const surviving = new Set(effective);
-  for (const name of remove) surviving.delete(name);
-  for (const entry of add) surviving.add(entry.name);
-  if (surviving.size === 0) {
-    throw new Error('A workspace must keep at least one thread type');
-  }
-
-  const removed = remove.filter(name => effective.has(name));
-  const ignored = remove.filter(name => !effective.has(name));
   const added: string[] = [];
   const updated: string[] = [];
+  let removed: string[] = [];
+  let ignored: string[] = [];
 
   await db.$transaction(async tx => {
+    // Read inside the transaction rather than through the cache. Both the guard below and the
+    // removed/ignored split are DECISIONS taken on this list, and a per-process cache means a
+    // second instance can decide them on a vocabulary that no longer exists.
+    const effective = await approvedNames(tx, workspaceId);
+
+    // Refuse to empty the vocabulary: a workspace with nothing to pick from cannot classify.
+    const surviving = new Set(effective);
+    for (const name of remove) surviving.delete(name);
+    for (const entry of add) surviving.add(entry.name);
+    if (surviving.size === 0) {
+      throw new Error('A workspace must keep at least one thread type');
+    }
+
+    removed = remove.filter(name => effective.has(name));
+    ignored = remove.filter(name => !effective.has(name));
+
     for (const name of removed) {
       await tx.threadTypeVocabulary.upsert({
         where: { scope_scopeId_name: { ...key, name } },
@@ -321,11 +381,19 @@ export async function patchThreadTypeVocabulary(
 
 /** A vocabulary row as an admin sees it — including the ones awaiting a decision. */
 export interface VocabularyRow extends ThreadTypeEntry {
+  /**
+   * The row id, and the only unique thing about a row.
+   *
+   * `name` is NOT unique here: candidates are USER-scoped, so two people inventing `p0`
+   * produce two rows with the same name, both in this list. Anything keying on name — a
+   * React key, a selection — collides and makes the second proposer's row unreachable.
+   */
+  id: string;
   scope: VocabularyScope;
   status: VocabularyStatus;
-  /** Who invented it. Null for entries resolved from the built-ins. */
+  /** Who invented it, or who installed it with the standard set. */
   createdBy: string | null;
-  /** When it was proposed, epoch ms. Null for entries resolved from the built-ins. */
+  /** When the row was written, epoch ms. */
   proposedAt: number | null;
 }
 
@@ -341,7 +409,7 @@ export interface VocabularyRow extends ThreadTypeEntry {
  */
 export interface VocabularyQuery {
   statuses?: readonly VocabularyStatus[];
-  /** User ids. The empty string selects the built-ins, which nobody proposed. */
+  /** User ids. The empty string selects rows with no recorded author. */
   proposedBy?: readonly string[];
   limit?: number;
   offset?: number;
@@ -424,6 +492,7 @@ export async function listThreadTypeVocabulary(
   return {
     rows: rows.map(row => ({
       ...toEntry(row),
+      id: row.id,
       scope: isScope(row.scope) ? row.scope : ('USER' as VocabularyScope),
       status: isStatus(row.status) ? row.status : ('UNDER_REVIEW' as VocabularyStatus),
       createdBy: row.createdBy,
@@ -511,6 +580,7 @@ export async function listTagsCreatedBy(
   });
   return rows.map(row => ({
     ...toEntry(row),
+    id: row.id,
     scope: isScope(row.scope) ? row.scope : ('USER' as VocabularyScope),
     // Read the stored value rather than collapsing "not under review" to approved — that
     // would report a name this person proposed and had turned down as though it had been
@@ -634,18 +704,17 @@ export async function reconsiderVocabularyCandidates(
 const retireCandidates = async (tx: Tx, workspaceId: string, names: string[]): Promise<void> => {
   if (names.length === 0) return;
 
-  // Match on the PROMOTED form, not on an identical string. An approved name must be
-  // UPPER_SNAKE and a candidate is whatever the proposer typed, so promoting one always
-  // renames it — `vespa-latency` becomes `VESPA_LATENCY`. Comparing raw names would retire
-  // nothing on the only path that actually happens, and the queue would keep offering a
-  // proposal that had already been accepted.
-  const promoted = new Set(names.map(promotedForm));
+  // Names are normalised where they are INVENTED, so a proposal and the entry that approves
+  // it are already the same string and this is an exact match. It is still routed through
+  // normalizeThreadTypeName rather than compared raw, so that rows written before that rule
+  // existed still retire instead of sitting in the queue forever.
+  const promoted = new Set(names.map(normalizeThreadTypeName));
   const outstanding = await tx.threadTypeVocabulary.findMany({
     where: { workspaceId, scope: 'USER', status: 'UNDER_REVIEW' },
     select: { id: true, name: true },
   });
   const resolved = outstanding
-    .filter(row => promoted.has(promotedForm(row.name)))
+    .filter(row => promoted.has(normalizeThreadTypeName(row.name)))
     .map(row => row.id);
   if (resolved.length === 0) return;
 

--- a/apps/backend/src/services/messageClassification/vocabulary.ts
+++ b/apps/backend/src/services/messageClassification/vocabulary.ts
@@ -1,0 +1,659 @@
+/**
+ * The thread-type vocabulary a workspace classifies against.
+ *
+ * One source for three things that must never disagree: the classifier prompt, the
+ * validation that filters the model's output, and the picker the dashboard renders.
+ *
+ * Layered. The built-ins in packages/shared/src/tags/vocabularies.ts ship with the product
+ * and are the base; table rows override or extend them at a narrower scope, most specific
+ * winning by name. ORG and USER scopes are not resolved yet but need no schema change to
+ * slot in — that is what `scope` is for.
+ */
+import { THREAD_TYPES, type ThreadTypeEntry } from '@xyne/shared';
+import { db } from '@/database/client';
+import { logger } from '@/utils/logger';
+
+const TAG = '[ThreadTypeVocabulary]';
+
+/** Matches the picker's cap and the stored-value cap in threadTypes.ts. */
+export const MAX_NAME_LENGTH = 40;
+
+/** A vocabulary bigger than this stops fitting in one prompt, and in one menu. */
+export const MAX_ENTRIES = 40;
+
+/**
+ * Who owns an entry. `scopeId` says which one: '' for GLOBAL, the org/workspace/user id
+ * otherwise. Resolution runs broadest to narrowest, so a narrower entry with the same name
+ * replaces a wider one, and a narrower deleted row suppresses it.
+ */
+export const VOCABULARY_SCOPES = ['GLOBAL', 'ORG', 'WORKSPACE', 'USER'] as const;
+export type VocabularyScope = (typeof VOCABULARY_SCOPES)[number];
+
+/**
+ * APPROVED entries are the vocabulary: the picker offers them and the classifier is given
+ * them. UNDER_REVIEW is a free-form tag someone invented — recorded so an admin can promote
+ * it, but withheld from both until they do. REJECTED is one an admin turned down.
+ *
+ * Rejection is a status, not `isDeleted`: on this table that flag already means "suppress the
+ * built-in of this name", and a boolean has nowhere to record WHY a name was turned down.
+ *
+ * A rejected name keeps everything it already had — the tag stays on its threads and stays
+ * searchable. All the status governs is whether the NAME spreads: whether the picker offers
+ * it, whether the classifier may assign it, and whether it can be proposed again.
+ */
+export const VOCABULARY_STATUSES = ['APPROVED', 'UNDER_REVIEW', 'REJECTED'] as const;
+export type VocabularyStatus = (typeof VOCABULARY_STATUSES)[number];
+
+const isStatus = (value: string): value is VocabularyStatus =>
+  (VOCABULARY_STATUSES as readonly string[]).includes(value);
+
+const isScope = (value: string): value is VocabularyScope =>
+  (VOCABULARY_SCOPES as readonly string[]).includes(value);
+
+
+/**
+ * Short TTL rather than explicit invalidation: the classifier reads this once per thread and
+ * the picker once per open, so a stale minute costs nothing, and API and worker are separate
+ * processes — an in-process bust would only ever fix one of them.
+ */
+const CACHE_TTL_MS = 60_000;
+
+const cache = new Map<string, { entries: ThreadTypeEntry[]; expiresAt: number }>();
+
+export const clearVocabularyCache = (workspaceId?: string): void => {
+  if (workspaceId) cache.delete(workspaceId);
+  else cache.clear();
+};
+
+/** Outcome types before answer types, alphabetical within each — stable across layers. */
+const inDisplayOrder = (entries: ThreadTypeEntry[]): ThreadTypeEntry[] =>
+  [...entries].sort(
+    (a, b) =>
+      a.name.localeCompare(b.name),
+  );
+
+const toEntry = (row: {
+  name: string;
+  label: string;
+  color: string;
+  description: string;
+}): ThreadTypeEntry => ({
+  name: row.name,
+  label: row.label,
+  color: row.color,
+  description: row.description,
+});
+
+/**
+ * The name a candidate would take once approved: UPPER_SNAKE, which is what EntrySchema
+ * requires. Shared by the retire match and by the rename preview an admin is shown, so the
+ * two can never disagree about which proposal an approval answers.
+ */
+export const promotedForm = (name: string): string =>
+  name.trim().toUpperCase().replace(/[\s-]+/g, '_');
+
+const scopeKey = (workspaceId: string): { scope: string; scopeId: string } => ({
+  scope: 'WORKSPACE',
+  scopeId: workspaceId,
+});
+
+/** A candidate belongs to the person who invented it, not to the workspace — see below. */
+const userKey = (userId: string): { scope: string; scopeId: string } => ({
+  scope: 'USER',
+  scopeId: userId,
+});
+
+/**
+ * Copy the starting vocabulary into a workspace.
+ *
+ * The list in code is a TEMPLATE, not the live vocabulary — a workspace gets its own rows so
+ * the table alone answers "what can this workspace tag with". Nothing reads the template at
+ * runtime.
+ *
+ * Explicitly invoked by an admin, never on a read: a workspace that has deliberately pared
+ * its vocabulary down, or has not chosen one yet, must not have fifteen types appear because
+ * somebody happened to open a thread. `skipDuplicates` makes it idempotent, so running it
+ * twice adds only what is missing.
+ */
+export const seedWorkspaceVocabulary = async (
+  workspaceId: string,
+  userId: string,
+): Promise<{ added: number }> => {
+  const result = await db.threadTypeVocabulary.createMany({
+    data: THREAD_TYPES.map(entry => ({
+      ...scopeKey(workspaceId),
+      workspaceId,
+      name: entry.name,
+      label: entry.label,
+      color: entry.color,
+      description: entry.description,
+      status: 'APPROVED',
+      // The admin who ran the seed. They chose to add these, so they own them like any other
+      // entry — there is no "built in" author, because nothing is built in any more.
+      createdBy: userId,
+      updatedBy: userId,
+    })),
+    skipDuplicates: true,
+  });
+  clearVocabularyCache(workspaceId);
+  logger.info(`${TAG} Seeded starting vocabulary`, { workspaceId, added: result.count });
+  return { added: result.count };
+};
+
+/**
+ * The APPROVED vocabulary a workspace classifies and picks from.
+ *
+ * Read entirely from the table, and the table is taken at its word — including when it is
+ * empty. Falling back to the list in code would resurrect types an admin deleted and would
+ * give a workspace that has not chosen a vocabulary one it never asked for.
+ */
+export async function getThreadTypeVocabulary(workspaceId: string): Promise<ThreadTypeEntry[]> {
+  const cached = cache.get(workspaceId);
+  if (cached && cached.expiresAt > Date.now()) return cached.entries;
+
+  const key = scopeKey(workspaceId);
+  const rows = await db.threadTypeVocabulary.findMany({
+    // UNDER_REVIEW is excluded here and only here: this call feeds both the classifier
+    // prompt and the picker, so a candidate must reach neither.
+    where: { ...key, status: 'APPROVED', isDeleted: false },
+  });
+
+  const entries = inDisplayOrder(rows.map(toEntry));
+  cache.set(workspaceId, { entries, expiresAt: Date.now() + CACHE_TTL_MS });
+  return entries;
+}
+
+export interface VocabularyInput {
+  name: string;
+  label: string;
+  color: string;
+  description: string;
+  /** Omitted means APPROVED — writing an entry through the API is how a candidate is promoted. */
+  status?: VocabularyStatus;
+}
+
+/**
+ * Replace the workspace's overrides with exactly this list.
+ *
+ * The declarative form: GET the vocabulary, edit the JSON, PUT it back. Names dropped from
+ * the list are suppressed. For adding or dropping one type prefer patchThreadTypeVocabulary
+ * — a full replace makes two concurrent edits clobber each other.
+ */
+export async function setThreadTypeVocabulary(
+  workspaceId: string,
+  entries: VocabularyInput[],
+  userId: string,
+): Promise<ThreadTypeEntry[]> {
+  const now = new Date();
+  const key = scopeKey(workspaceId);
+  const keep = new Set(entries.map(entry => entry.name));
+  const current = await getThreadTypeVocabulary(workspaceId);
+
+  await db.$transaction(async tx => {
+    for (const entry of current) {
+      if (keep.has(entry.name)) continue;
+      await tx.threadTypeVocabulary.upsert({
+        where: { scope_scopeId_name: { ...key, name: entry.name } },
+        create: { ...key, workspaceId, ...suppression(entry.name), createdBy: userId, updatedBy: userId },
+        update: { isDeleted: true, updatedBy: userId, updatedAt: now },
+      });
+    }
+
+    for (const entry of entries) {
+      // Upsert on (scope, scopeId, name) so re-adding a suppressed entry revives that row
+      // rather than colliding with it on the unique index.
+      await tx.threadTypeVocabulary.upsert({
+        where: { scope_scopeId_name: { ...key, name: entry.name } },
+        create: {
+          ...key,
+          workspaceId,
+          ...entry,
+          status: entry.status ?? 'APPROVED',
+          createdBy: userId,
+          updatedBy: userId,
+        },
+        update: {
+          ...entry,
+          status: entry.status ?? 'APPROVED',
+          isDeleted: false,
+          updatedBy: userId,
+          updatedAt: now,
+        },
+      });
+    }
+
+    await retireCandidates(tx, workspaceId, entries.map(entry => entry.name));
+  });
+
+  clearVocabularyCache(workspaceId);
+  logger.info(`${TAG} Vocabulary replaced`, { workspaceId, entries: entries.length, userId });
+
+  return getThreadTypeVocabulary(workspaceId);
+}
+
+/** A row that exists only to hide a name. Nothing renders from these fields. */
+const suppression = (name: string) => ({
+  name,
+  label: name,
+  color: '#6b7280',
+  description: '',
+  isDeleted: true,
+});
+
+export interface VocabularyPatchResult {
+  entries: ThreadTypeEntry[];
+  added: string[];
+  updated: string[];
+  removed: string[];
+  /** Names in `remove` the workspace did not have. Reported, not an error. */
+  ignored: string[];
+}
+
+/**
+ * Add or drop individual types without resending the whole list.
+ *
+ * Idempotent both ways so a script can be re-run: adding a name that already exists updates
+ * it in place, and removing one that isn't there is reported under `ignored`.
+ */
+export async function patchThreadTypeVocabulary(
+  workspaceId: string,
+  patch: { add?: VocabularyInput[]; remove?: string[] },
+  userId: string,
+): Promise<VocabularyPatchResult> {
+  const add = patch.add ?? [];
+  const remove = patch.remove ?? [];
+  const now = new Date();
+  const key = scopeKey(workspaceId);
+  const effective = new Set((await getThreadTypeVocabulary(workspaceId)).map(entry => entry.name));
+
+  // Refuse to empty the vocabulary: a workspace with nothing to pick from cannot classify.
+  const surviving = new Set(effective);
+  for (const name of remove) surviving.delete(name);
+  for (const entry of add) surviving.add(entry.name);
+  if (surviving.size === 0) {
+    throw new Error('A workspace must keep at least one thread type');
+  }
+
+  const removed = remove.filter(name => effective.has(name));
+  const ignored = remove.filter(name => !effective.has(name));
+  const added: string[] = [];
+  const updated: string[] = [];
+
+  await db.$transaction(async tx => {
+    for (const name of removed) {
+      await tx.threadTypeVocabulary.upsert({
+        where: { scope_scopeId_name: { ...key, name } },
+        create: { ...key, workspaceId, ...suppression(name), createdBy: userId, updatedBy: userId },
+        update: { isDeleted: true, updatedBy: userId, updatedAt: now },
+      });
+    }
+
+    for (const entry of add) {
+      (effective.has(entry.name) ? updated : added).push(entry.name);
+      await tx.threadTypeVocabulary.upsert({
+        where: { scope_scopeId_name: { ...key, name: entry.name } },
+        create: {
+          ...key,
+          workspaceId,
+          ...entry,
+          status: entry.status ?? 'APPROVED',
+          createdBy: userId,
+          updatedBy: userId,
+        },
+        update: {
+          ...entry,
+          status: entry.status ?? 'APPROVED',
+          isDeleted: false,
+          updatedBy: userId,
+          updatedAt: now,
+        },
+      });
+    }
+
+    await retireCandidates(tx, workspaceId, add.map(entry => entry.name));
+  });
+
+  clearVocabularyCache(workspaceId);
+  logger.info(`${TAG} Vocabulary patched`, { workspaceId, userId, added, updated, removed, ignored });
+
+  return { entries: await getThreadTypeVocabulary(workspaceId), added, updated, removed, ignored };
+}
+
+/** A vocabulary row as an admin sees it — including the ones awaiting a decision. */
+export interface VocabularyRow extends ThreadTypeEntry {
+  scope: VocabularyScope;
+  status: VocabularyStatus;
+  /** Who invented it. Null for entries resolved from the built-ins. */
+  createdBy: string | null;
+  /** When it was proposed, epoch ms. Null for entries resolved from the built-ins. */
+  proposedAt: number | null;
+}
+
+/**
+ * Everything this workspace can see, approved and under review alike.
+ *
+ * Separate from getThreadTypeVocabulary on purpose: that one is wired to the classifier and
+ * the picker and must never widen to include candidates.
+ *
+ * Paged, because candidates are UNBOUNDED — anyone can invent a name on any thread, and a
+ * busy workspace accumulates them without limit. The approved vocabulary is capped at
+ * MAX_ENTRIES and so is resolved whole; only the candidate half is paged in the database.
+ */
+export interface VocabularyQuery {
+  statuses?: readonly VocabularyStatus[];
+  /** User ids. The empty string selects the built-ins, which nobody proposed. */
+  proposedBy?: readonly string[];
+  limit?: number;
+  offset?: number;
+}
+
+/** One option in a filter, already labelled — the client should not need a user lookup. */
+export interface VocabularyFacet {
+  value: string;
+  label: string;
+  /** Only set for proposers. What the "Proposed by" search matches on. */
+  email?: string;
+  count: number;
+}
+
+export interface VocabularyPage {
+  rows: VocabularyRow[];
+  /** Rows matching the filters, ignoring the page window. */
+  total: number;
+  facets: {
+    proposedBy: VocabularyFacet[];
+    status: VocabularyFacet[];
+  };
+}
+
+export const DEFAULT_PAGE_SIZE = 20;
+export const MAX_PAGE_SIZE = 200;
+
+const STATUS_LABEL: Record<string, string> = {
+  APPROVED: 'Approved',
+  UNDER_REVIEW: 'Under review',
+  REJECTED: 'Turned down',
+};
+
+export async function listThreadTypeVocabulary(
+  workspaceId: string,
+  query: VocabularyQuery = {},
+): Promise<VocabularyPage> {
+  const statuses = query.statuses?.length ? query.statuses : VOCABULARY_STATUSES;
+  const limit = Math.min(Math.max(query.limit ?? DEFAULT_PAGE_SIZE, 1), MAX_PAGE_SIZE);
+  const offset = Math.max(query.offset ?? 0, 0);
+
+  const people = query.proposedBy ?? [];
+  // '' is the unattributed bucket — rows written before seeding named its author.
+  const wantsBuiltIn = people.includes('');
+  const personIds = people.filter(Boolean);
+
+  const proposedByWhere = (): Record<string, unknown> => {
+    if (people.length === 0) return {};
+    if (wantsBuiltIn && personIds.length > 0) {
+      return { OR: [{ createdBy: null }, { createdBy: { in: personIds } }] };
+    }
+    return wantsBuiltIn ? { createdBy: null } : { createdBy: { in: personIds } };
+  };
+
+  // Each facet group is counted with every OTHER group's filter applied but not its own, so
+  // `ignore` drops exactly one clause.
+  const whereFor = (ignore?: 'proposedBy' | 'status'): Record<string, unknown> => ({
+    workspaceId,
+    // Suppressed types are gone from the workspace's point of view; the row survives only so
+    // the removal is not silently undone.
+    isDeleted: false,
+    ...(ignore === 'status' ? {} : { status: { in: [...statuses] } }),
+    ...(ignore === 'proposedBy' ? {} : proposedByWhere()),
+  });
+
+  const where = whereFor();
+  const [total, rows] = await Promise.all([
+    db.threadTypeVocabulary.count({ where }),
+    db.threadTypeVocabulary.findMany({
+      where,
+      // Newest first: the sort the UI would prefer — most-used — lives in Vespa, and ordering
+      // a database page by a column the database does not have would sort only within the
+      // page, which is worse than not sorting.
+      orderBy: [{ createdAt: 'desc' }, { name: 'asc' }],
+      skip: offset,
+      take: limit,
+    }),
+  ]);
+
+  return {
+    rows: rows.map(row => ({
+      ...toEntry(row),
+      scope: isScope(row.scope) ? row.scope : ('USER' as VocabularyScope),
+      status: isStatus(row.status) ? row.status : ('UNDER_REVIEW' as VocabularyStatus),
+      createdBy: row.createdBy,
+      proposedAt: row.createdAt.getTime(),
+    })),
+    total,
+    facets: await buildFacets(whereFor),
+  };
+}
+
+/**
+ * Option counts for the toolbar.
+ *
+ * Each group is counted with every OTHER group's filter applied but not its own — otherwise
+ * selecting one proposer would zero out every other proposer, and the filter could never be
+ * widened again. Server-side because the client only holds one page and cannot count what it
+ * has not been sent.
+ */
+async function buildFacets(
+  whereFor: (ignore?: 'proposedBy' | 'status') => Record<string, unknown>,
+): Promise<VocabularyPage['facets']> {
+  const [byPerson, byStatus] = await Promise.all([
+    db.threadTypeVocabulary.groupBy({
+      by: ['createdBy'],
+      where: whereFor('proposedBy') as never,
+      _count: { _all: true },
+    }),
+    db.threadTypeVocabulary.groupBy({
+      by: ['status'],
+      where: whereFor('status') as never,
+      _count: { _all: true },
+    }),
+  ]);
+
+  // Names and emails come from here rather than from the client's user map: a proposer who
+  // has left, or whom the client has not synced, would otherwise render as "Someone" and be
+  // unsearchable by email — which is the whole point of the search.
+  const ids = byPerson.map(group => group.createdBy).filter((id): id is string => Boolean(id));
+  const users = ids.length
+    ? await db.user.findMany({
+        where: { id: { in: ids } },
+        select: { id: true, name: true, email: true },
+      })
+    : [];
+  const userById = new Map(users.map(user => [user.id, user]));
+
+  const byCount = (a: VocabularyFacet, b: VocabularyFacet): number =>
+    b.count - a.count || a.label.localeCompare(b.label);
+
+  return {
+    proposedBy: byPerson
+      .map(group => {
+        // Nothing writes a null proposer any more; rows predating that read as System rather
+        // than being dropped, which would make them unfilterable.
+        if (!group.createdBy) {
+          return { value: '', label: 'System', count: group._count._all };
+        }
+        const user = userById.get(group.createdBy);
+        return {
+          value: group.createdBy,
+          label: user?.name ?? 'Someone',
+          email: user?.email ?? '',
+          count: group._count._all,
+        };
+      })
+      .sort(byCount),
+    status: byStatus
+      .map(group => ({
+        value: group.status,
+        label: STATUS_LABEL[group.status] ?? group.status,
+        count: group._count._all,
+      }))
+      .sort(byCount),
+  };
+}
+
+/** Every tag this person has invented, across the workspaces they work in. */
+export async function listTagsCreatedBy(
+  userId: string,
+  workspaceId?: string,
+): Promise<VocabularyRow[]> {
+  const rows = await db.threadTypeVocabulary.findMany({
+    where: { ...userKey(userId), isDeleted: false, ...(workspaceId ? { workspaceId } : {}) },
+    orderBy: { createdAt: 'desc' },
+  });
+  return rows.map(row => ({
+    ...toEntry(row),
+    scope: isScope(row.scope) ? row.scope : ('USER' as VocabularyScope),
+    // Read the stored value rather than collapsing "not under review" to approved — that
+    // would report a name this person proposed and had turned down as though it had been
+    // accepted into the vocabulary.
+    status: isStatus(row.status) ? row.status : ('UNDER_REVIEW' as VocabularyStatus),
+    createdBy: row.createdBy,
+    proposedAt: row.createdAt.getTime(),
+  }));
+}
+
+/**
+ * Record a free-form tag as a candidate for the vocabulary.
+ *
+ * Written at USER scope, not WORKSPACE. A candidate is one person's suggestion — workspace
+ * scope is what approval CONFERS, not where a proposal starts. Scoping it to the inventor is
+ * also the only way "which tags has Arun created" is answerable: at workspace scope, two
+ * people inventing the same name collapse into one row and the second creation is lost.
+ *
+ * The tag still lands on the thread regardless. This only governs whether the NAME becomes
+ * something the picker offers and the classifier may assign.
+ */
+export async function recordVocabularyCandidate(
+  workspaceId: string,
+  name: string,
+  userId: string,
+  description = '',
+): Promise<void> {
+  try {
+    // A name someone has already turned down does not come back. The upsert below is keyed on
+    // (scope, scopeId, name), so re-typing your OWN rejected tag is a no-op anyway — but a
+    // DIFFERENT person typing it would open a fresh candidate, and the queue would refill with
+    // a decision that has already been made.
+    const turnedDown = await db.threadTypeVocabulary.findFirst({
+      where: { workspaceId, name, status: 'REJECTED' },
+      select: { id: true },
+    });
+    if (turnedDown) {
+      logger.info(`${TAG} Skipping candidate for a name already turned down`, {
+        workspaceId,
+        name,
+        userId,
+      });
+      return;
+    }
+
+    await db.threadTypeVocabulary.upsert({
+      where: { scope_scopeId_name: { ...userKey(userId), name } },
+      create: {
+        ...userKey(userId),
+        // Kept alongside the scope so tenant filtering and cleanup still run off a real
+        // column — scopeId is polymorphic and cannot carry a foreign key.
+        workspaceId,
+        name,
+        // Placeholders an admin edits on approval. The label is the raw name so the review
+        // screen shows what was actually typed.
+        label: name,
+        color: '#6b7280',
+        // The note the inventor typed, if they gave one. It belongs here rather than on the
+        // thread: it explains what the TAG means, so it is written once and every chip of
+        // that name renders it — and it gives an admin something to judge on promotion.
+        description,
+        status: 'UNDER_REVIEW',
+        createdBy: userId,
+        updatedBy: userId,
+      },
+      // Re-using their own tag changes nothing, except that a note fills in a description
+      // they did not give the first time.
+      update: description ? { description, updatedBy: userId } : {},
+    });
+    logger.info(`${TAG} Recorded free-form tag as a candidate`, { workspaceId, name, userId });
+  } catch (error) {
+    // Never fail the tag write for this — the label is on the thread either way.
+    logger.error(`${TAG} Failed to record vocabulary candidate`, { workspaceId, name, error });
+  }
+}
+
+/**
+ * Turn down every outstanding proposal of these names.
+ *
+ * Workspace-wide, mirroring promotion: candidates are USER-scoped, so rejecting only the row
+ * you were looking at would leave an identical proposal from someone else sitting in the
+ * queue. A decision is about the NAME, not about who happened to type it first.
+ *
+ * Nothing is deleted. The tag stays on its threads and stays searchable — see VocabularyStatus.
+ */
+export async function rejectVocabularyCandidates(
+  workspaceId: string,
+  names: string[],
+  userId: string,
+): Promise<number> {
+  if (names.length === 0) return 0;
+  const { count } = await db.threadTypeVocabulary.updateMany({
+    where: { workspaceId, status: 'UNDER_REVIEW', name: { in: names } },
+    data: { status: 'REJECTED', updatedBy: userId, updatedAt: new Date() },
+  });
+  clearVocabularyCache(workspaceId);
+  logger.info(`${TAG} Candidates turned down`, { workspaceId, names, count, userId });
+  return count;
+}
+
+/** Put a turned-down name back in the queue. */
+export async function reconsiderVocabularyCandidates(
+  workspaceId: string,
+  names: string[],
+  userId: string,
+): Promise<number> {
+  if (names.length === 0) return 0;
+  const { count } = await db.threadTypeVocabulary.updateMany({
+    where: { workspaceId, status: 'REJECTED', name: { in: names } },
+    data: { status: 'UNDER_REVIEW', updatedBy: userId, updatedAt: new Date() },
+  });
+  clearVocabularyCache(workspaceId);
+  logger.info(`${TAG} Candidates reopened`, { workspaceId, names, count, userId });
+  return count;
+}
+
+/**
+ * Promoting a name to the workspace retires every user's candidate for it — the suggestion
+ * has been answered, and leaving them would keep the name in the review queue forever.
+ */
+const retireCandidates = async (tx: Tx, workspaceId: string, names: string[]): Promise<void> => {
+  if (names.length === 0) return;
+
+  // Match on the PROMOTED form, not on an identical string. An approved name must be
+  // UPPER_SNAKE and a candidate is whatever the proposer typed, so promoting one always
+  // renames it — `vespa-latency` becomes `VESPA_LATENCY`. Comparing raw names would retire
+  // nothing on the only path that actually happens, and the queue would keep offering a
+  // proposal that had already been accepted.
+  const promoted = new Set(names.map(promotedForm));
+  const outstanding = await tx.threadTypeVocabulary.findMany({
+    where: { workspaceId, scope: 'USER', status: 'UNDER_REVIEW' },
+    select: { id: true, name: true },
+  });
+  const resolved = outstanding
+    .filter(row => promoted.has(promotedForm(row.name)))
+    .map(row => row.id);
+  if (resolved.length === 0) return;
+
+  await tx.threadTypeVocabulary.updateMany({
+    where: { id: { in: resolved } },
+    data: { status: 'APPROVED', updatedAt: new Date() },
+  });
+};
+
+/** Prisma's transaction client, so the helper above composes inside one. */
+type Tx = Parameters<Parameters<typeof db.$transaction>[0]>[0];

--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -214,7 +214,9 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       priority,    // Priority (HIGH, MEDIUM, LOW) - comma-separated
       searchId,
       board,       // Board name/ID
-      tags,        // Comma-separated tags
+      tags,        // Comma-separated tags (ticket Tag framework — NOT thread types)
+      threadType,  // Thread classification type(s) - comma-separated; matches thread roots
+      messageActs, // Thread type(s) a message was cited as evidence for - comma-separated
       dynamicFieldValues, // Dynamic field filters
       dynamicFieldDateRanges, // JSON string of fieldId -> { start, end }
       before,      // Created before date (multiple formats)
@@ -775,6 +777,16 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
     }
     if (channelMentions) {
       options.slack.mentionedChannelIds = channelMentions;
+    }
+    // Thread classification. threadType matches a thread's ROOT message, so it returns one
+    // hit per thread; messageActs matches the individual messages the classifier cited as
+    // evidence. Sent together they AND, which is how you ask for "the message that made this
+    // an ISSUE" rather than either on its own.
+    if (threadType) {
+      options.slack.threadType = toFilterValues(threadType, 'threadType');
+    }
+    if (messageActs) {
+      options.slack.messageActs = toFilterValues(messageActs, 'messageActs');
     }
     // Highlight-only: exact display names to bold in result snippets (kept out of the YQL filter).
     if (mentionHighlights) {

--- a/apps/backend/src/validators/vespaSearchValidator.ts
+++ b/apps/backend/src/validators/vespaSearchValidator.ts
@@ -209,6 +209,16 @@ export const vespaSearchQuerySchema = Joi.object({
     'string.base': 'Tags must be a comma-separated string'
   }),
 
+  // Thread classification. threadType matches a thread's ROOT message (one hit per thread);
+  // messageActs matches the individual messages cited as evidence for a type.
+  threadType: Joi.string().optional().messages({
+    'string.base': 'threadType must be a comma-separated string'
+  }),
+
+  messageActs: Joi.string().optional().messages({
+    'string.base': 'messageActs must be a comma-separated string'
+  }),
+
   dynamicFieldValues: Joi.alternatives()
     .try(
       Joi.array().items(Joi.string()),

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -51,6 +51,12 @@ export interface SlackFilters {
   // or reference a channel (channelMentions field). Both are exact attribute membership filters.
   mentionedUserIds?: string[];
   mentionedChannelIds?: string[];
+  // Thread classification. threadType lives ONLY on a thread's root message, so filtering it
+  // yields one hit per matching thread — "show me the ISSUE threads". messageActs lives on
+  // each message the classifier cited as evidence, so filtering that yields the individual
+  // messages that justified a tag. Different questions; both exact attribute filters.
+  threadType?: string[];
+  messageActs?: string[];
   // Date filters
   createdBefore?: string; // Created before date (multiple formats)
   createdAfter?: string; // Created after date (multiple formats)
@@ -794,6 +800,24 @@ export class YqlBuilder {
       conditions.push(`(${mentionedChannels})`);
     }
 
+    // Thread-type filter - the root messages of threads carrying these types.
+    if (filters.threadType && filters.threadType.length > 0) {
+      const threadTypes = filters.threadType
+        .map((type) => `threadType contains ${params.bind('threadType', type.trim())}`)
+        .join(' or ');
+      conditions.push(`(${threadTypes})`);
+    }
+
+    // Message-act filter - the individual messages the classifier cited as evidence for
+    // these types. Separate from threadType on purpose: OR-ing the two would return a
+    // thread's root AND its evidence messages as if they were unrelated hits.
+    if (filters.messageActs && filters.messageActs.length > 0) {
+      const acts = filters.messageActs
+        .map((act) => `messageActs contains ${params.bind('messageActs', act.trim())}`)
+        .join(' or ');
+      conditions.push(`(${acts})`);
+    }
+
     if (filters.createdBefore) {
       const timestamp = parseDateToTimestamp(filters.createdBefore, 'start');
       if (timestamp) conditions.push(`createdAtTimestamp < ${timestamp}`);
@@ -1349,12 +1373,16 @@ export class YqlBuilder {
    *                                    (imported as channelRef.docId)
    *   docType           -> docType   : every schema ('all')
    *   date / hour       -> createdAt : every schema except mail (mail uses `timestamp`)
+   *   threadType        -> threadType: chat_message only, and only on a thread's ROOT
+   *                                    message — so one group entry is one thread, with no
+   *                                    dedupe needed
    */
   private static readonly GROUP_FIELD_SCHEMAS: Record<string, VespaSchema[] | 'all'> = {
     senderId: [messageSchema, attachmentSchema],
     userId: [messageSchema, attachmentSchema],
     channelId: [messageSchema, attachmentSchema, ticketSchema, fileSchema, mailSchema],
     docType: 'all',
+    threadType: [messageSchema],
     date: [messageSchema, channelSchema, attachmentSchema, ticketSchema, fileSchema, userSchema],
     hour: [messageSchema, channelSchema, attachmentSchema, ticketSchema, fileSchema, userSchema],
   };
@@ -1414,6 +1442,15 @@ export class YqlBuilder {
       case 'hour':
         // Group by hour
         return `all(group(time.hourofday(createdAt)) max(24) each(max(10) each(output(summary()))))`;
+
+      case 'threadType':
+        // Counts only — no `each(...)` emitting summaries. This answers "how many threads
+        // carry each tag" for the whole vocabulary in ONE round trip; asking per name would
+        // be a query per candidate on a page that lists them all.
+        //
+        // threadType lives only on a thread's root message, so a group's count IS a thread
+        // count with no dedupe.
+        return `all(group(threadType) max(${maxGroups}) each(output(count(), max(createdAtTimestamp))))`;
 
       default:
         // Unknown groupBy field — return empty to avoid injecting arbitrary field names

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -98,6 +98,7 @@ import {
   sdlcDiscussionSchema,
 } from '@xyne/shared';
 import {
+  normalizeThreadTypeName,
   parseAppliedTags,
   serializeAppliedTags,
   type AppliedTag,
@@ -12259,9 +12260,24 @@ export function createMutators(
           );
           if (!conversation) throw new Error('Conversation not found');
 
-          const desired = [...new Set(types.map(t => t.trim()).filter(Boolean))];
           const existing = parseAppliedTags(conversation.threadType);
           const byName = new Map(existing.map(tag => [tag.name, tag]));
+
+          // Normalise the names being ADDED, and only those. A name already on this thread is
+          // passed through untouched: the caller resends the full set on every edit, so
+          // normalising indiscriminately would silently rewrite tags applied long ago, on an
+          // edit that had nothing to do with them, leaving the same tag spelled two ways
+          // across the workspace.
+          const desired = [
+            ...new Set(
+              types
+                .map(raw => {
+                  const trimmed = raw.trim();
+                  return byName.has(trimmed) ? trimmed : normalizeThreadTypeName(trimmed);
+                })
+                .filter(Boolean),
+            ),
+          ];
 
           // A merge, never a replace. The caller sends the full desired set, but each tag
           // already there keeps its own provenance — who applied it and when. Rewriting them all

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -97,7 +97,15 @@ import {
   createSdlcLinkSchema,
   sdlcDiscussionSchema,
 } from '@xyne/shared';
-import { THREAD_TYPE_NAMES } from '@xyne/shared';
+import {
+  parseAppliedTags,
+  serializeAppliedTags,
+  type AppliedTag,
+} from '@xyne/shared';
+import {
+  getThreadTypeVocabulary,
+  recordVocabularyCandidate,
+} from '@/services/messageClassification/vocabulary';
 import {
   MessageArtifactStatus,
   parseSlashCommandArtifactMessage,
@@ -12235,33 +12243,77 @@ export function createMutators(
       setTypes: defineMutator(
         z.object({
           conversationId: z.string(),
-          // Free-form, not z.enum: the built-in vocabulary is a starting point, and projects
-          // add their own. Length-capped so a tag stays a label rather than a paragraph.
+          // Free-form, not z.enum: the workspace vocabulary is a starting point, and people
+          // type their own. Length-capped so a tag stays a label rather than a paragraph.
           types: z.array(z.string().trim().min(1).max(40)),
+          /**
+           * What a newly invented tag means. Stored as the vocabulary candidate's
+           * description, not on the thread — see the candidate write below.
+           */
+          note: z.string().trim().max(280).optional(),
+          timestamp: z.number(),
         }),
-        async ({ tx, ctx, args: { conversationId, types } }) => {
+        async ({ tx, ctx, args: { conversationId, types, note, timestamp } }) => {
           const conversation = await tx.run(
             zql.conversations.where('conversationId', conversationId).one(),
           );
           if (!conversation) throw new Error('Conversation not found');
 
-          // Built-in types first in vocabulary order, then custom ones alphabetically, so
-          // chips render in a stable order regardless of the order they were picked.
-          const rank = (name: string): number => {
-            const i = (THREAD_TYPE_NAMES as readonly string[]).indexOf(name);
-            return i === -1 ? THREAD_TYPE_NAMES.length : i;
-          };
-          const unique = [...new Set(types.map(t => t.trim()).filter(Boolean))].sort(
-            (a, b) => rank(a) - rank(b) || a.localeCompare(b),
-          );
+          const desired = [...new Set(types.map(t => t.trim()).filter(Boolean))];
+          const existing = parseAppliedTags(conversation.threadType);
+          const byName = new Map(existing.map(tag => [tag.name, tag]));
 
+          // A merge, never a replace. The caller sends the full desired set, but each tag
+          // already there keeps its own provenance — who applied it and when. Rewriting them all
+          // as freshly hand-applied would erase exactly the trail the tooltip exists to show.
+          const next: AppliedTag[] = [];
+          // Names THIS call applied fresh. Not the same as "every human tag on the thread":
+          // a tag someone else added survives the merge with their `by` intact, and sweeping
+          // those up would file a candidate crediting the wrong person every time anyone
+          // touched the thread's tags.
+          const addedNames: string[] = [];
+          for (const name of desired) {
+            const prior = byName.get(name);
+            if (prior && !prior.removed) {
+              next.push(prior);
+              continue;
+            }
+            next.push({ name, at: timestamp, by: ctx.userID });
+            addedNames.push(name);
+          }
 
-          // '[]' rather than null when cleared: null means "never classified" and the
-          // classifier would re-derive it on its next pass.
+          // Dropped tags are tombstoned, not deleted: removal has to stay auditable, and a
+          // deleted tag would look unclassified to the classifier and come straight back.
+          const kept = new Set(desired);
+          for (const tag of existing) {
+            if (kept.has(tag.name)) continue;
+            next.push(
+              tag.removed ? tag : { ...tag, removed: true, at: timestamp, by: ctx.userID },
+            );
+          }
+
           await tx.mutate.conversations.update({
             conversationId,
-            threadType: unique.length > 0 ? JSON.stringify(unique) : '[]',
+            threadType: serializeAppliedTags(next),
           });
+
+          // Backend copy only, like the refeed below: a free-form tag someone invented is
+          // recorded as a vocabulary candidate for an admin to promote or drop. The tag is
+          // already on the thread — this only governs whether the NAME becomes something the
+          // picker offers and the classifier may assign.
+          const workspaceIdForVocab = conversation.workspaceId;
+          if (workspaceIdForVocab && addedNames.length > 0) {
+            asyncTasks.push(async () => {
+              const vocabulary = await getThreadTypeVocabulary(workspaceIdForVocab);
+              const known = new Set(vocabulary.map(entry => entry.name));
+              for (const name of addedNames) {
+                if (known.has(name)) continue;
+                // The note describes the tag, so it lands on the candidate as its
+                // description — not copied onto every thread that carries the name.
+                await recordVocabularyCandidate(workspaceIdForVocab, name, ctx.userID, note);
+              }
+            });
+          }
 
           // Backend copy only. Zero collects no side-effect job for conversation updates
           // (SIDE_EFFECT_OPERATION_CONFIG lists insert/delete), and a thread's tags live on

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -14,6 +14,7 @@ import {
   VespaOperationType as VespaOpType,
 } from '@xyne/shared';
 import { FormFieldType } from '@xyne/shared';
+import { indexableTagNames, parseAppliedTags } from '@xyne/shared';
 import { VespaJobType, VespaPayload } from './types';
 import { db } from '@/database/client';
 import {
@@ -458,36 +459,14 @@ export const mapMessage = async (
 
   const threadInfo = await mapAndUpdatePreviousMessagesMentions(args.messageId, args.conversationId);
 
-  // Message acts, denormalized onto the doc so search can filter on them. Stored as a
-  // stringified JSON array; parsed defensively because it is plain TEXT with no DB-level
-  // guarantee of shape.
-  let messageActs: string[] = [];
-  if (args.messageActs) {
-    try {
-      const parsed: unknown = JSON.parse(args.messageActs);
-      if (Array.isArray(parsed)) {
-        messageActs = parsed.filter((v): v is string => typeof v === 'string');
-      }
-    } catch {
-      logger.warn('[VESPA] Ignoring malformed messageActs', { messageId: args.messageId });
-    }
-  }
-
-  // Thread types, same stringified-array shape as messageActs.
-  let threadType: string[] = [];
-  if (conversation.threadType) {
-    try {
-      const parsed: unknown = JSON.parse(conversation.threadType);
-      threadType = Array.isArray(parsed)
-        ? parsed.filter((v): v is string => typeof v === 'string')
-        : typeof parsed === 'string'
-          ? [parsed]
-          : [];
-    } catch {
-      // Rows written before the column held an array stored a bare name.
-      threadType = [conversation.threadType];
-    }
-  }
+  // Tag names, denormalized onto the doc so search can filter on them. Everything on the
+  // thread is indexed as soon as it lands — classifier or person, vocabulary or free-form —
+  // minus anything removed.
+  //
+  // messageActs holds the thread types this message is the EVIDENCE for: the classifier
+  // cites a message per type, and that citation is stored on both sides.
+  const messageActs = indexableTagNames(parseAppliedTags(args.messageActs));
+  const threadType = indexableTagNames(parseAppliedTags(conversation.threadType));
 
   // Update parent ticket thread fields if this is a ticket conversation
   await updateTicketThreadFields(args.conversationId);

--- a/apps/dashboard/src/api/threadTypeVocabularyApi.ts
+++ b/apps/dashboard/src/api/threadTypeVocabularyApi.ts
@@ -1,0 +1,139 @@
+import type { ThreadTypeEntry } from '@xyne/shared';
+import { apiInstance } from '../services/clients/apiClient';
+
+export type VocabularyStatus = 'APPROVED' | 'UNDER_REVIEW' | 'REJECTED';
+
+export interface VocabularyEntry extends ThreadTypeEntry {
+  /** Only APPROVED entries are offered in the picker or given to the classifier. */
+  status?: VocabularyStatus;
+  /** Who proposed it. Null for entries resolved from the built-in list. */
+  createdBy?: string | null;
+  /** Threads carrying it across the whole workspace. Only present with counts. */
+  threadCount?: number;
+  /** When it was proposed, epoch ms. Null for built-ins, which nobody proposed. */
+  proposedAt?: number | null;
+  /** Newest thread carrying it, epoch ms. Null when unused. */
+  lastUsedAt?: number | null;
+}
+
+/** One filter option, labelled by the server so the client needs no user lookup. */
+export interface VocabularyFacet {
+  value: string;
+  label: string;
+  /** Only present for proposers. What the "Proposed by" search matches on. */
+  email?: string;
+  count: number;
+}
+
+export interface VocabularyPage {
+  entries: VocabularyEntry[];
+  /** Rows matching the filters, ignoring the page window. */
+  total: number;
+  facets: {
+    proposedBy: VocabularyFacet[];
+    status: VocabularyFacet[];
+  };
+}
+
+/**
+ * The workspace's thread-type vocabulary — what the picker offers and how a chip is
+ * labelled and coloured. Editable at runtime by admins, so it is fetched rather than
+ * bundled.
+ */
+export const threadTypeVocabularyApi = {
+  /**
+   * The approved vocabulary. Bounded, so it is safe to hold for a session.
+   *
+   * Candidates are NOT fetched here. There is no limit on how many free-form tags a
+   * workspace accumulates, and pulling all of them into every client to resolve a handful of
+   * chips does not scale — `include=all` exists for the admin review queue, which can
+   * paginate.
+   */
+  get: async (): Promise<VocabularyEntry[]> => {
+    const res = await apiInstance.get<{ entries: VocabularyEntry[] }>('/thread-type-vocabulary');
+    return res.data.entries ?? [];
+  },
+
+  /**
+   * The review queue. Always paged — candidates are unbounded, so the full set is not
+   * something a browser should ever hold. Filters and option counts are the server's job for
+   * the same reason: one page cannot be counted to produce totals for the whole set.
+   *
+   * `counts` costs two extra Vespa round trips, so it is opt-in and only the review screen
+   * asks for it — the picker has no use for thread counts.
+   */
+  review: async (params: {
+    statuses: VocabularyStatus[];
+    proposedBy?: string[];
+    limit: number;
+    offset: number;
+    withCounts?: boolean;
+  }): Promise<VocabularyPage> => {
+    const res = await apiInstance.get<VocabularyPage>('/thread-type-vocabulary/review', {
+      params: {
+        status: params.statuses.join(','),
+        // '' means the built-ins, and an empty string survives neither a query string nor the
+        // comma split on the other end.
+        ...(params.proposedBy?.length
+          ? { proposedBy: params.proposedBy.map(value => value || 'BUILT_IN').join(',') }
+          : {}),
+        limit: params.limit,
+        offset: params.offset,
+        ...(params.withCounts === false ? {} : { counts: 'true' }),
+      },
+    });
+    return {
+      entries: res.data.entries ?? [],
+      total: res.data.total ?? 0,
+      facets: res.data.facets ?? { proposedBy: [], status: [] },
+    };
+  },
+
+  /**
+   * Copy the starting vocabulary into this workspace. Admin-only, idempotent — returns how
+   * many names it actually added.
+   */
+  seed: async (): Promise<number> => {
+    const res = await apiInstance.post<{ added: number }>('/thread-type-vocabulary/seed');
+    return res.data.added ?? 0;
+  },
+
+  /** Turn down proposals, workspace-wide for each name. Admin-only. */
+  reject: async (names: string[]): Promise<number> => {
+    const res = await apiInstance.post<{ decided: number }>('/thread-type-vocabulary/reject', {
+      names,
+    });
+    return res.data.decided ?? 0;
+  },
+
+  /** Put turned-down names back in the queue. Admin-only. */
+  reconsider: async (names: string[]): Promise<number> => {
+    const res = await apiInstance.post<{ decided: number }>('/thread-type-vocabulary/reconsider', {
+      names,
+    });
+    return res.data.decided ?? 0;
+  },
+
+  /** Names the caller proposed that are still undecided — drives the author's pending chip. */
+  mine: async (): Promise<string[]> => {
+    const res = await apiInstance.get<{ names: string[] }>('/thread-type-vocabulary/mine');
+    return res.data.names ?? [];
+  },
+
+  /**
+   * Add or drop individual entries. Approving a proposal is an `add` of the promoted entry —
+   * there is no approve verb, because approval IS authoring the four fields the classifier
+   * needs, and the server retires everyone's proposal for that name as a side effect.
+   */
+  patch: async (payload: { add?: ThreadTypeEntry[]; remove?: string[] }): Promise<void> => {
+    await apiInstance.patch('/thread-type-vocabulary', payload);
+  },
+
+  /** Sends the FULL list; order is meaningful. Admin-only server side. */
+  set: async (entries: ThreadTypeEntry[]): Promise<VocabularyEntry[]> => {
+    const res = await apiInstance.put<{ entries: VocabularyEntry[] }>('/thread-type-vocabulary', {
+      entries,
+    });
+    return res.data.entries ?? [];
+  },
+};

--- a/apps/dashboard/src/api/threadTypeVocabularyApi.ts
+++ b/apps/dashboard/src/api/threadTypeVocabularyApi.ts
@@ -4,6 +4,13 @@ import { apiInstance } from '../services/clients/apiClient';
 export type VocabularyStatus = 'APPROVED' | 'UNDER_REVIEW' | 'REJECTED';
 
 export interface VocabularyEntry extends ThreadTypeEntry {
+  /**
+   * Row id. Absent from the picker's read, present on every review row.
+   *
+   * `name` is not unique in the review queue — two people can propose the same one — so this
+   * is what a key or a selection has to use.
+   */
+  id?: string;
   /** Only APPROVED entries are offered in the picker or given to the classifier. */
   status?: VocabularyStatus;
   /** Who proposed it. Null for entries resolved from the built-in list. */

--- a/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
+++ b/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
@@ -30,6 +30,7 @@ import {
   Bot,
   RocketShip,
   type PikaIconProps,
+  Tag,
 } from '@xyne/icons';
 import { AudioLines } from 'lucide-react';
 
@@ -105,6 +106,7 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
   },
   { path: '/roles', label: 'Roles', icon: ShieldCheck, iconSize: 18, popout: true },
   { path: '/workspace-management', label: 'Workspace Management', icon: Settings01, popout: true },
+  { path: '/tag-review', label: 'Tag Review', icon: Tag, iconSize: 18, popout: true },
   { path: '/organisations', label: 'Organisations', icon: BuildingApartmentTwo, popout: true },
   { path: '/analytics', label: 'Analytics', icon: GraphTrendLine, popout: true },
   { path: '/forms', label: 'Forms', icon: ClipboardDefault, popout: true },

--- a/apps/dashboard/src/components/AppSidebar/utils/resourceMapping.ts
+++ b/apps/dashboard/src/components/AppSidebar/utils/resourceMapping.ts
@@ -18,6 +18,7 @@ export const PATH_TO_RESOURCE: Record<string, string> = {
   '/product-insights': 'PRODUCT-INSIGHTS',
   '/projects': 'PROJECTS',
   '/workspace-management': 'WORKSPACE',
+  '/tag-review': 'WORKSPACE',
   '/organisations': 'ORGANIZATIONS',
   '/team-intelligence': 'TEAM-INTELLIGENCE-DASHBOARD',
 };

--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -31,6 +31,7 @@ import {
   isDeskChannelType,
 } from '@xyne/shared';
 import { mutators } from '../../../zero/mutators';
+import { MessageTags } from '../../tags/MessageTags';
 // import { useIntersectionObserver } from '../../../hooks/useIntersectionObserver';
 import { convertHtmlToBlocks } from './ChatBubble.utils';
 import { sanitizeHtmlString } from '../../../utils/sanitizer';
@@ -136,6 +137,8 @@ interface ChatBubbleProps {
   linkedConversationId?: string | null;
   /** Message ID to highlight when this bubble is rendered in a thread context (e.g. search screen sidebar). */
   highlightMessageId?: string | null;
+  /** Tag being inspected from the thread header; messages carrying it show a chip. */
+  inspectedTag?: string | null;
   afterTextContent?: React.ReactNode;
   isThreadTicketSubTicket?: boolean;
 }
@@ -165,6 +168,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   isNextActivity = false,
   linkedConversationId,
   highlightMessageId,
+  inspectedTag = null,
   afterTextContent,
   isThreadTicketSubTicket = false,
 }) => {
@@ -964,12 +968,27 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   // the overlay can derive them at show time. Hover never sets state here.
 
   const hoverToolbarKey = useId();
+
   const appliedThreadTypes = useMemo(
     () => parseThreadTypes(conversation?.threadType),
     [conversation?.threadType],
   );
   const setThreadTypes = useSetThreadTypes(conversation?.conversationId);
   const { showThreadTags } = useShowThreadTags();
+  // The thread types this message was cited as evidence for. Composed onto afterTextContent
+  // rather than the header slot: the header only renders for the first message in a group,
+  // and the second and third messages of a burst are exactly the ones you need to see marked.
+  const messageTags =
+    showThreadTags && context === 'thread' && !isSystemMessage && !isMessageDeleted ? (
+      <MessageTags messageActs={message.messageActs} inspectedTag={inspectedTag} />
+    ) : null;
+  const textTrailer =
+    afterTextContent !== undefined || messageTags ? (
+      <>
+        {afterTextContent}
+        {messageTags}
+      </>
+    ) : undefined;
 
   const canShowHoverToolbar =
     !isMobile &&
@@ -1287,7 +1306,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
             {...(onUserClick && { onUserClick })}
             {...(allThreadAttachments && { allThreadAttachments })}
             workflowNumber={workflowNumber}
-            {...(afterTextContent !== undefined && { afterTextContent })}
+            {...(textTrailer !== undefined && { afterTextContent: textTrailer })}
             {...(context === 'channel' &&
               !isSystemMessage &&
               !isMessageDeleted && {

--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -40,6 +40,8 @@ type ThreadListProps = {
   conversationParticipant?: { lastReadAt?: number | null };
   /** Scroll to and highlight this specific message on mount. Overrides URL-hash-based scroll. */
   matchedMessageId?: string | null;
+  /** Tag being inspected from the thread header. Passed straight through to the bubbles. */
+  inspectedTag?: string | null;
   /** Overrides the bubbles' default profile navigation (pass a noop to disable it, e.g. SDLC panels). */
   onUserClick?: ((userId: string) => void) | undefined;
 };
@@ -68,6 +70,7 @@ const ThreadList = ({
   isMessagesLoaded = true,
   conversationParticipant,
   matchedMessageId,
+  inspectedTag = null,
   onUserClick,
 }: ThreadListProps): ReactElement => {
   const { user } = useAuthContext();
@@ -513,6 +516,7 @@ const ThreadList = ({
                       {...(disableAskAI !== undefined && { disableAskAI })}
                       {...(conversation && { conversation })}
                       highlightMessageId={matchedMessageId ?? null}
+                      inspectedTag={inspectedTag}
                     />
                   </div>
                   {messageIndex === 0 && threadMessages.length > 1 && (
@@ -611,6 +615,7 @@ const ThreadList = ({
                     {...(disableAskAI !== undefined && { disableAskAI })}
                     {...(conversation && { conversation })}
                     highlightMessageId={matchedMessageId ?? null}
+                    inspectedTag={inspectedTag}
                   />
                 </div>
                 {!enableCollapsing &&

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -697,6 +697,10 @@ export const ThreadMessages = ({
   const initialMessageSender = useUser(initialMessage?.senderId || '');
   const setThreadTypes = useSetThreadTypes(derivedConversationId);
   const { showThreadTags } = useShowThreadTags();
+  // Which tag's evidence is on screen. Owned here because this component renders both the
+  // chips and the message list; cleared on thread change so it never leaks across threads.
+  const [inspectedTag, setInspectedTag] = useState<string | null>(null);
+  useEffect(() => setInspectedTag(null), [derivedConversationId]);
 
   const threadInfo: ThreadInfo | null = useMemo(() => {
     if (!derivedConversationId || !initialMessage) return null;
@@ -1094,6 +1098,7 @@ export const ThreadMessages = ({
             className='flex-1 flex flex-col overflow-hidden data-[state=inactive]:hidden'
           >
             <ThreadList
+              inspectedTag={inspectedTag}
               channelId={derivedChannelId || ''}
               conversationId={derivedConversationId || ''}
               threadMessages={messages}
@@ -1471,6 +1476,7 @@ export const ThreadMessages = ({
               ) : (
                 <>
                   <ThreadList
+                    inspectedTag={inspectedTag}
                     channelId={derivedChannelId || ''}
                     conversationId={derivedConversationId || ''}
                     threadMessages={messages}
@@ -1603,6 +1609,8 @@ export const ThreadMessages = ({
                       conversationId={derivedConversationId}
                       threadType={conversation?.threadType}
                       canEdit
+                      inspectedTag={inspectedTag}
+                      onInspect={setInspectedTag}
                     />
                   )}
                   {!simpleView && focusedChannelBreadcrumb}
@@ -1793,6 +1801,7 @@ export const ThreadMessages = ({
             ) : (
               <>
                 <ThreadList
+                  inspectedTag={inspectedTag}
                   channelId={derivedChannelId || ''}
                   conversationId={derivedConversationId || ''}
                   threadMessages={messages}

--- a/apps/dashboard/src/components/tags/MessageTags.tsx
+++ b/apps/dashboard/src/components/tags/MessageTags.tsx
@@ -1,0 +1,65 @@
+import { JSX, useMemo } from 'react';
+import { parseAppliedTags, visibleTags } from '@xyne/shared';
+import { useThreadTypeVocabulary } from '../../hooks/useThreadTypeVocabulary';
+import { colorForTagName } from './tagColors';
+
+interface MessageTagsProps {
+  /** `messages.messageActs` — the thread types this message was cited as evidence for. */
+  messageActs: string | null | undefined;
+  /**
+   * The tag being inspected from the thread header. Only that one renders, and only on the
+   * messages that carry it — so clicking a header chip answers "which messages made this an
+   * ISSUE" without marking up every message that happens to carry some other tag.
+   */
+  inspectedTag: string | null;
+}
+
+/**
+ * Marks this message as evidence for the tag being inspected.
+ *
+ * The classifier cites the messages behind each type it returns, and that citation is stored
+ * on the messages themselves — so clicking a chip in the thread header and seeing which
+ * messages sprout one is the answer to "why is this thread an ISSUE".
+ *
+ * Renders nothing unless a tag is being inspected: a chip on every classified message, all
+ * the time, is noise on the threads that need reading most.
+ *
+ * Read-only. A thread's tags are edited from the header, not per message — the tag belongs
+ * to the thread, and this only shows where it came from.
+ */
+export const MessageTags = ({
+  messageActs,
+  inspectedTag,
+}: MessageTagsProps): JSX.Element | null => {
+  const { entry: vocabularyEntry } = useThreadTypeVocabulary();
+  const tags = useMemo(
+    () =>
+      inspectedTag
+        ? visibleTags(parseAppliedTags(messageActs)).filter(tag => tag.name === inspectedTag)
+        : [],
+    [messageActs, inspectedTag],
+  );
+
+  if (tags.length === 0) return null;
+
+  return (
+    <span className='inline-flex flex-wrap items-center gap-1 align-middle ml-1'>
+      {tags.map(tag => {
+        // Undefined for a free-form tag, or a name from a vocabulary that has since changed
+        // — both keep rendering from the stored name rather than disappearing.
+        const entry = vocabularyEntry(tag.name);
+        const color = entry?.color ?? colorForTagName(tag.name);
+        return (
+          <span
+            key={tag.name}
+            title={entry?.description ?? tag.name}
+            className='inline-flex items-center rounded-full px-1.5 text-[10px] font-medium leading-[15px] whitespace-nowrap align-middle'
+            style={{ backgroundColor: `${color}1f`, color }}
+          >
+            {entry?.label ?? tag.name}
+          </span>
+        );
+      })}
+    </span>
+  );
+};

--- a/apps/dashboard/src/components/tags/TagReview/TagDecisionPane.tsx
+++ b/apps/dashboard/src/components/tags/TagReview/TagDecisionPane.tsx
@@ -7,7 +7,7 @@
  */
 import { JSX, useEffect, useMemo, useState } from 'react';
 import { Check, RotateCcw, Trash2, X } from 'lucide-react';
-import type { ThreadTypeEntry } from '@xyne/shared';
+import { normalizeThreadTypeName, type ThreadTypeEntry } from '@xyne/shared';
 import type { VocabularyEntry } from '../../../api/threadTypeVocabularyApi';
 import { useUser } from '../../../hooks/useUsers';
 import { Button } from '../../ui/Button/Button';
@@ -18,19 +18,6 @@ import { colorForTagName } from '../tagColors';
 /** The API's floor. It is a prompt, not a tooltip: under twenty characters cannot define a type. */
 const MIN_DESCRIPTION = 20;
 const MAX_DESCRIPTION = 1200;
-
-/**
- * Must match `promotedForm` in the backend's vocabulary service exactly.
- *
- * Approving under a name the server does not derive the same way leaves every proposal for
- * the original name sitting in the queue forever, because retirement matches on this. That is
- * also why the field is shown and not edited.
- */
-const promotedForm = (name: string): string =>
-  name
-    .trim()
-    .toUpperCase()
-    .replace(/[\s-]+/g, '_');
 
 const VALID_NAME = /^[A-Z][A-Z0-9_]*$/;
 
@@ -99,9 +86,13 @@ export const TagDecisionPane = ({
   const isRejected = status === 'REJECTED';
   const proposer = useUser(entry.createdBy ?? '');
 
-  const promoted = useMemo(() => promotedForm(entry.name), [entry.name]);
+  // Normally identical to entry.name: names are normalised where they are invented, so
+  // approval renames nothing. It differs only for rows written before that rule existed,
+  // which is exactly when the reader needs to be shown the rename.
+  const promoted = useMemo(() => normalizeThreadTypeName(entry.name), [entry.name]);
 
   const [label, setLabel] = useState('');
+  const [summary, setSummary] = useState('');
   const [color, setColor] = useState('#0891b2');
   const [description, setDescription] = useState('');
 
@@ -113,11 +104,12 @@ export const TagDecisionPane = ({
         // A proposal has no authored label; the name is the only thing the proposer gave.
         entry.name.replace(/[-_]+/g, ' ').replace(/\b\w/g, character => character.toUpperCase()),
     );
+    setSummary(entry.summary ?? '');
     setColor(entry.color || colorForTagName(entry.name));
     // For a proposal this is the note its author typed — the only thing to judge on, and the
     // right starting point for the prompt copy.
     setDescription(entry.description ?? '');
-  }, [entry.name, entry.label, entry.color, entry.description]);
+  }, [entry.name, entry.label, entry.summary, entry.color, entry.description]);
 
   const targetName = isProposal ? promoted : entry.name;
   const nameValid = VALID_NAME.test(targetName);
@@ -136,7 +128,7 @@ export const TagDecisionPane = ({
     : !label.trim()
       ? 'Give it a label.'
       : trimmed.length < MIN_DESCRIPTION
-        ? `The definition needs ${MIN_DESCRIPTION - trimmed.length} more character${
+        ? `The classifier instruction needs ${MIN_DESCRIPTION - trimmed.length} more character${
             MIN_DESCRIPTION - trimmed.length === 1 ? '' : 's'
           } — it is what the classifier is told about this type.`
         : null;
@@ -145,7 +137,16 @@ export const TagDecisionPane = ({
   const counted = typeof total === 'number';
 
   const save = (): void =>
-    onSave({ name: targetName, label: label.trim(), color, description: trimmed }, isProposal);
+    onSave(
+      {
+        name: targetName,
+        label: label.trim(),
+        summary: summary.trim(),
+        color,
+        description: trimmed,
+      },
+      isProposal,
+    );
 
   return (
     <aside className='flex w-[420px] shrink-0 flex-col border-l border-border bg-background'>
@@ -209,7 +210,7 @@ export const TagDecisionPane = ({
           </div>
         ) : (
           <div className='flex flex-col gap-4'>
-            {isProposal && (
+            {isProposal && promoted !== entry.name && (
               <Field label='Will be stored as'>
                 <div className='flex items-center gap-2 text-sm'>
                   <span className='font-mono text-muted-foreground'>{entry.name}</span>
@@ -232,6 +233,16 @@ export const TagDecisionPane = ({
                 maxLength={60}
                 onChange={event => setLabel(event.target.value)}
                 placeholder='Feature request'
+              />
+            </Field>
+
+            <Field label='Summary' hint='One line, shown on the chip'>
+              <Input
+                variant='flat'
+                value={summary}
+                maxLength={160}
+                onChange={event => setSummary(event.target.value)}
+                placeholder='Something is broken. Done when it is fixed and verified.'
               />
             </Field>
 
@@ -258,7 +269,7 @@ export const TagDecisionPane = ({
             </Field>
 
             <Field
-              label='Definition'
+              label='Classifier instruction'
               hint={
                 trimmed.length < MIN_DESCRIPTION ? (
                   <span className='text-destructive'>
@@ -286,10 +297,11 @@ export const TagDecisionPane = ({
                 )}
               />
             </Field>
-            {/* Not a tooltip. Saying so where the field is stops descriptions being written as
-                one, which is how a classifier ends up guessing. */}
+            {/* Saying whose it is, where the field is. This one is read by the model and by
+                nobody else — the human-facing line is Summary, above. */}
             <p className='-mt-2 text-[11px] text-muted-foreground'>
-              This is the instruction the classifier is given for this type.
+              Given to the model, not shown to anyone. Say what it covers AND what it does not —
+              near-misses are what gets mistagged.
             </p>
 
             <Field label='Preview'>

--- a/apps/dashboard/src/components/tags/TagReview/TagDecisionPane.tsx
+++ b/apps/dashboard/src/components/tags/TagReview/TagDecisionPane.tsx
@@ -1,0 +1,336 @@
+/**
+ * The decision pane — one tag, three shapes depending on where it is in its life.
+ *
+ * Approval is not a button. An approved entry's description is the classifier's instruction
+ * for that type, so promoting a proposal means authoring four fields the proposer never
+ * supplied; the pane exists because that does not fit in a row.
+ */
+import { JSX, useEffect, useMemo, useState } from 'react';
+import { Check, RotateCcw, Trash2, X } from 'lucide-react';
+import type { ThreadTypeEntry } from '@xyne/shared';
+import type { VocabularyEntry } from '../../../api/threadTypeVocabularyApi';
+import { useUser } from '../../../hooks/useUsers';
+import { Button } from '../../ui/Button/Button';
+import { Input } from '../../ui/Input';
+import { cn } from '../../../utils/classNames';
+import { colorForTagName } from '../tagColors';
+
+/** The API's floor. It is a prompt, not a tooltip: under twenty characters cannot define a type. */
+const MIN_DESCRIPTION = 20;
+const MAX_DESCRIPTION = 1200;
+
+/**
+ * Must match `promotedForm` in the backend's vocabulary service exactly.
+ *
+ * Approving under a name the server does not derive the same way leaves every proposal for
+ * the original name sitting in the queue forever, because retirement matches on this. That is
+ * also why the field is shown and not edited.
+ */
+const promotedForm = (name: string): string =>
+  name
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, '_');
+
+const VALID_NAME = /^[A-Z][A-Z0-9_]*$/;
+
+/** A spread wide enough to tell chips apart at a glance, dark enough to read on both themes. */
+const PALETTE = [
+  '#0891b2',
+  '#7c3aed',
+  '#db2777',
+  '#dc2626',
+  '#ea580c',
+  '#ca8a04',
+  '#16a34a',
+  '#0d9488',
+  '#2563eb',
+  '#64748b',
+];
+
+const formatWhen = (at: number | null | undefined): string =>
+  at
+    ? new Date(at).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : 'an unknown date';
+
+interface TagDecisionPaneProps {
+  entry: VocabularyEntry;
+  onClose: () => void;
+  onReject: () => void;
+  onReconsider: () => void;
+  onSave: (entry: ThreadTypeEntry, wasProposal: boolean) => void;
+  onRemove: () => void;
+  isDeciding: boolean;
+}
+
+const Field = ({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: JSX.Element | string;
+  children: JSX.Element;
+}): JSX.Element => (
+  <div className='flex flex-col gap-1.5'>
+    <div className='flex items-baseline justify-between gap-2'>
+      <span className='text-xs font-medium text-foreground'>{label}</span>
+      {hint && <span className='text-[11px] text-muted-foreground'>{hint}</span>}
+    </div>
+    {children}
+  </div>
+);
+
+export const TagDecisionPane = ({
+  entry,
+  onClose,
+  onReject,
+  onReconsider,
+  onSave,
+  onRemove,
+  isDeciding,
+}: TagDecisionPaneProps): JSX.Element => {
+  const status = entry.status ?? 'APPROVED';
+  const isProposal = status === 'UNDER_REVIEW';
+  const isRejected = status === 'REJECTED';
+  const proposer = useUser(entry.createdBy ?? '');
+
+  const promoted = useMemo(() => promotedForm(entry.name), [entry.name]);
+
+  const [label, setLabel] = useState('');
+  const [color, setColor] = useState('#0891b2');
+  const [description, setDescription] = useState('');
+
+  // Keyed on the name so switching rows reloads the form rather than carrying half-typed copy
+  // from the previous tag into the next one's approval.
+  useEffect(() => {
+    setLabel(
+      entry.label ||
+        // A proposal has no authored label; the name is the only thing the proposer gave.
+        entry.name.replace(/[-_]+/g, ' ').replace(/\b\w/g, character => character.toUpperCase()),
+    );
+    setColor(entry.color || colorForTagName(entry.name));
+    // For a proposal this is the note its author typed — the only thing to judge on, and the
+    // right starting point for the prompt copy.
+    setDescription(entry.description ?? '');
+  }, [entry.name, entry.label, entry.color, entry.description]);
+
+  const targetName = isProposal ? promoted : entry.name;
+  const nameValid = VALID_NAME.test(targetName);
+  const trimmed = description.trim();
+  const canSave =
+    nameValid &&
+    label.trim().length > 0 &&
+    label.trim().length <= 60 &&
+    trimmed.length >= MIN_DESCRIPTION &&
+    trimmed.length <= MAX_DESCRIPTION;
+
+  // Named so the footer can say WHY Approve is off. A disabled button with a red counter
+  // somewhere above it makes the reader hunt for the connection.
+  const blocker = !nameValid
+    ? 'That name cannot be stored — turn it down and ask for a rename.'
+    : !label.trim()
+      ? 'Give it a label.'
+      : trimmed.length < MIN_DESCRIPTION
+        ? `The definition needs ${MIN_DESCRIPTION - trimmed.length} more character${
+            MIN_DESCRIPTION - trimmed.length === 1 ? '' : 's'
+          } — it is what the classifier is told about this type.`
+        : null;
+
+  const total = entry.threadCount;
+  const counted = typeof total === 'number';
+
+  const save = (): void =>
+    onSave({ name: targetName, label: label.trim(), color, description: trimmed }, isProposal);
+
+  return (
+    <aside className='flex w-[420px] shrink-0 flex-col border-l border-border bg-background'>
+      <div className='flex shrink-0 items-start justify-between gap-2 px-5 pt-5'>
+        <div className='min-w-0'>
+          <div className='font-mono text-sm text-foreground'>{entry.name}</div>
+          <div className='mt-0.5 text-xs text-muted-foreground'>
+            {entry.createdBy
+              ? `Proposed by ${proposer?.name ?? 'someone'} on ${formatWhen(entry.proposedAt)}`
+              : 'Added with the standard set'}
+          </div>
+        </div>
+        <Button variant='ghost' size='iconSm' onClick={onClose} aria-label='Close'>
+          <X className='size-4' />
+        </Button>
+      </div>
+
+      <div className='min-h-0 flex-1 overflow-y-auto px-5 py-4'>
+        {/* What the tag is actually doing in the workspace. It is the whole case for or
+            against approving it, so it sits above the form rather than under it. */}
+        <div className='mb-4 rounded-lg border border-border px-3 py-2.5 text-xs'>
+          {!counted ? (
+            // Never say "0 threads" when the count simply failed — that is the difference
+            // between "nobody wants this tag" and "we could not check", and an admin is about
+            // to make a decision on it.
+            <span className='text-muted-foreground'>Thread counts are unavailable right now</span>
+          ) : (
+            <>
+              <span className='text-foreground'>
+                On {total} {total === 1 ? 'thread' : 'threads'}
+              </span>
+              {total === 0 && (
+                <span className='text-muted-foreground'> · nobody has used it yet</span>
+              )}
+            </>
+          )}
+        </div>
+
+        {isRejected ? (
+          <div className='flex flex-col gap-3 text-sm'>
+            <div className='rounded-lg border border-border px-3 py-2.5'>
+              <div className='text-xs font-medium text-foreground'>Turned down</div>
+              {/* Turning a name down decides whether it joins the vocabulary — not whether it
+                  stays on the threads people put it on. Saying so here stops the obvious
+                  misreading that rejecting deletes someone's work. */}
+              <p className='mt-1 text-xs text-muted-foreground'>
+                Still on the threads that carry it and still findable by search — only kept out of
+                the picker and away from the classifier.
+              </p>
+            </div>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={onReconsider}
+              loading={isDeciding}
+              className='self-start'
+            >
+              <RotateCcw className='size-3.5' />
+              Reconsider
+            </Button>
+          </div>
+        ) : (
+          <div className='flex flex-col gap-4'>
+            {isProposal && (
+              <Field label='Will be stored as'>
+                <div className='flex items-center gap-2 text-sm'>
+                  <span className='font-mono text-muted-foreground'>{entry.name}</span>
+                  <span className='text-muted-foreground'>→</span>
+                  <span className='font-mono text-foreground'>{promoted}</span>
+                </div>
+              </Field>
+            )}
+            {isProposal && !nameValid && (
+              <p className='text-xs text-destructive'>
+                “{promoted}” is not a usable name — it must start with a letter and contain only
+                letters, digits and underscores. Turn this one down and ask for a rename.
+              </p>
+            )}
+
+            <Field label='Label' hint='What people see on the chip'>
+              <Input
+                variant='flat'
+                value={label}
+                maxLength={60}
+                onChange={event => setLabel(event.target.value)}
+                placeholder='Feature request'
+              />
+            </Field>
+
+            <Field label='Colour'>
+              <div className='flex flex-wrap gap-1.5'>
+                {PALETTE.map(swatch => (
+                  <button
+                    key={swatch}
+                    type='button'
+                    aria-label={swatch}
+                    onClick={() => setColor(swatch)}
+                    data-track-category='TagReview'
+                    data-track-name='SetColour'
+                    className={cn(
+                      'size-6 rounded-full transition-transform',
+                      color.toLowerCase() === swatch
+                        ? 'scale-110 ring-2 ring-offset-1 ring-ring'
+                        : '',
+                    )}
+                    style={{ backgroundColor: swatch }}
+                  />
+                ))}
+              </div>
+            </Field>
+
+            <Field
+              label='Definition'
+              hint={
+                trimmed.length < MIN_DESCRIPTION ? (
+                  <span className='text-destructive'>
+                    {MIN_DESCRIPTION - trimmed.length} more to go
+                  </span>
+                ) : (
+                  <span>
+                    {trimmed.length} / {MAX_DESCRIPTION}
+                  </span>
+                )
+              }
+            >
+              <textarea
+                value={description}
+                maxLength={MAX_DESCRIPTION}
+                onChange={event => setDescription(event.target.value)}
+                data-track-category='TagReview'
+                data-track-name='EditDefinition'
+                rows={5}
+                placeholder='Describe when this type applies, as if instructing someone who has never seen the thread.'
+                className={cn(
+                  'w-full resize-y rounded-[10px] border border-border bg-background px-3 py-2',
+                  'text-sm text-foreground outline-none placeholder:text-muted-foreground',
+                  'focus-visible:border-ring focus-visible:ring-ring/10 focus-visible:ring-[2px]',
+                )}
+              />
+            </Field>
+            {/* Not a tooltip. Saying so where the field is stops descriptions being written as
+                one, which is how a classifier ends up guessing. */}
+            <p className='-mt-2 text-[11px] text-muted-foreground'>
+              This is the instruction the classifier is given for this type.
+            </p>
+
+            <Field label='Preview'>
+              <span
+                className='inline-flex w-fit items-center rounded-full px-1.5 py-[1px] text-[11px] font-medium leading-[16px]'
+                style={{ backgroundColor: `${color}1f`, color }}
+              >
+                {label.trim() || promoted}
+              </span>
+            </Field>
+          </div>
+        )}
+      </div>
+
+      {!isRejected && (
+        <div className='shrink-0 border-t border-border px-5 py-3'>
+          {blocker && <p className='mb-2 text-[11px] text-muted-foreground'>{blocker}</p>}
+          <div className='flex items-center gap-2'>
+            <Button size='sm' disabled={!canSave} loading={isDeciding} onClick={save}>
+              <Check className='size-3.5' />
+              {isProposal ? 'Approve' : 'Save changes'}
+            </Button>
+            {isProposal ? (
+              <Button variant='outline' size='sm' loading={isDeciding} onClick={onReject}>
+                Turn down
+              </Button>
+            ) : (
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={onRemove}
+                loading={isDeciding}
+                className='text-muted-foreground'
+              >
+                <Trash2 className='size-3.5' />
+                Remove
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+};

--- a/apps/dashboard/src/components/tags/TagReview/TagReviewFilters.tsx
+++ b/apps/dashboard/src/components/tags/TagReview/TagReviewFilters.tsx
@@ -1,0 +1,173 @@
+/**
+ * The toolbar's filter pills.
+ *
+ * Multi-select within a group, AND across groups — the same contract as the ticket list's
+ * filters, so a reviewer who has used one already knows this one.
+ *
+ * Options and their counts come from the SERVER. The client holds one page, and a page
+ * cannot be counted to produce totals for the whole set; it also cannot know about a proposer
+ * whose tags all sit on some other page. Each count is taken with every other group's filter
+ * applied but not its own, so selecting one option never zeroes out its siblings.
+ */
+import { JSX, useMemo, useState } from 'react';
+import { Check, ChevronDown, Search, X } from 'lucide-react';
+import type { VocabularyFacet } from '../../../api/threadTypeVocabularyApi';
+import { Button } from '../../ui/Button/Button';
+import { Popover } from '../../ui/Popover/Popover';
+import { cn } from '../../../utils/classNames';
+
+interface TagReviewFilterProps {
+  label: string;
+  options: VocabularyFacet[];
+  selected: string[];
+  onChange: (next: string[]) => void;
+  /**
+   * Adds a search box. For proposers, where a workspace can have hundreds and picking one out
+   * of a scroll list is hopeless — and where the thing a reviewer actually knows is an email
+   * address, not a display name.
+   */
+  searchable?: boolean;
+  searchPlaceholder?: string;
+}
+
+export const TagReviewFilter = ({
+  label,
+  options,
+  selected,
+  onChange,
+  searchable = false,
+  searchPlaceholder = 'Search',
+}: TagReviewFilterProps): JSX.Element => {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+
+  const visible = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return options;
+    return options.filter(
+      option =>
+        option.label.toLowerCase().includes(query) ||
+        (option.email ?? '').toLowerCase().includes(query),
+    );
+  }, [options, search]);
+
+  const toggle = (value: string): void => {
+    onChange(
+      selected.includes(value) ? selected.filter(item => item !== value) : [...selected, value],
+    );
+  };
+
+  const active = selected.length > 0;
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={next => {
+        setOpen(next);
+        if (!next) setSearch('');
+      }}
+      align='start'
+      className='w-64 p-1'
+      trigger={
+        <Button
+          variant='outline'
+          size='sm'
+          className={cn(
+            'rounded-[10px] border-border hover:bg-muted text-muted-foreground',
+            active && 'text-foreground border-primary/40 bg-primary/5',
+          )}
+        >
+          {label}
+          {active && (
+            <span className='rounded bg-primary/15 px-1 text-[11px] font-medium text-primary'>
+              {selected.length}
+            </span>
+          )}
+          <ChevronDown className='size-3 opacity-60' />
+        </Button>
+      }
+    >
+      {searchable && (
+        <div className='flex items-center gap-1.5 border-b border-border px-2 pb-1.5'>
+          <Search className='size-3.5 shrink-0 text-muted-foreground' />
+          <input
+            autoFocus
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            placeholder={searchPlaceholder}
+            aria-label={searchPlaceholder}
+            data-track-category='TagReview'
+            data-track-name='SearchFilter'
+            className='w-full bg-transparent py-1 text-sm outline-none placeholder:text-muted-foreground'
+          />
+        </div>
+      )}
+
+      <div className='max-h-72 overflow-y-auto'>
+        {visible.length === 0 ? (
+          <div className='px-2 py-3 text-center text-xs text-muted-foreground'>
+            {search ? 'Nobody matches that' : 'Nothing to filter'}
+          </div>
+        ) : (
+          visible.map(option => {
+            const checked = selected.includes(option.value);
+            return (
+              <button
+                key={option.value}
+                type='button'
+                onClick={() => toggle(option.value)}
+                data-track-category='TagReview'
+                data-track-name='ToggleFilter'
+                className='flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted'
+              >
+                <span
+                  className={cn(
+                    'flex size-4 shrink-0 items-center justify-center rounded border',
+                    checked ? 'border-primary bg-primary text-primary-foreground' : 'border-border',
+                  )}
+                >
+                  {checked && <Check className='size-3' />}
+                </span>
+                <span className='flex min-w-0 flex-1 flex-col'>
+                  <span className='min-w-0 truncate'>{option.label}</span>
+                  {/* The email is the identifier a reviewer actually recognises — two people
+                      can share a display name, and nobody shares an address. */}
+                  {option.email ? (
+                    <span className='min-w-0 truncate text-[11px] text-muted-foreground'>
+                      {option.email}
+                    </span>
+                  ) : null}
+                </span>
+                {/* Dimmed at zero rather than hidden: a reviewer looking for a name they know
+                    exists should see it is filtered out, not wonder where it went. */}
+                <span
+                  className={cn(
+                    'shrink-0 text-xs tabular-nums',
+                    option.count === 0 ? 'text-muted-foreground/40' : 'text-muted-foreground',
+                  )}
+                >
+                  {option.count}
+                </span>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </Popover>
+  );
+};
+
+/** Shown only when something is filtered, so the toolbar is quiet at rest. */
+export const ClearFiltersPill = ({ onClear }: { onClear: () => void }): JSX.Element => (
+  <Button
+    variant='ghost'
+    size='sm'
+    onClick={onClear}
+    data-track-category='TagReview'
+    data-track-name='ClearFilters'
+    className='rounded-[10px] text-muted-foreground hover:bg-muted'
+  >
+    <X className='size-3' />
+    Clear
+  </Button>
+);

--- a/apps/dashboard/src/components/tags/TagReview/TagReviewRow.tsx
+++ b/apps/dashboard/src/components/tags/TagReview/TagReviewRow.tsx
@@ -8,7 +8,8 @@ import { tagReviewAlignClass, tagReviewGridTemplate } from './tagReviewColumns';
 interface TagReviewRowProps {
   entry: VocabularyEntry;
   isSelected: boolean;
-  onSelect: (name: string) => void;
+  /** Receives the ROW id — names collide when two people propose the same one. */
+  onSelect: (id: string) => void;
 }
 
 const STATUS_LABEL: Record<string, string> = {
@@ -47,11 +48,11 @@ export const TagReviewRow = ({ entry, isSelected, onSelect }: TagReviewRowProps)
     <div
       role='row'
       tabIndex={0}
-      onClick={() => onSelect(entry.name)}
+      onClick={() => onSelect(entry.id ?? entry.name)}
       onKeyDown={event => {
         if (event.key !== 'Enter' && event.key !== ' ') return;
         event.preventDefault();
-        onSelect(entry.name);
+        onSelect(entry.id ?? entry.name);
       }}
       data-track-category='TagReview'
       data-track-name='SelectTag'
@@ -71,14 +72,15 @@ export const TagReviewRow = ({ entry, isSelected, onSelect }: TagReviewRowProps)
               {entry.name}
             </span>
           </div>
-          {/* The proposer's note. It is the only thing an admin has to judge on, so it gets a
-              line of its own rather than a tooltip. */}
-          {entry.description ? (
+          {/* The human-facing line, falling back to the classifier instruction for entries
+              written before the two were separated. A proposal has neither until it is
+              approved — nobody writes prose to invent a tag. */}
+          {entry.summary || entry.description ? (
             <span className='min-w-0 truncate text-xs text-muted-foreground'>
-              {entry.description}
+              {entry.summary || entry.description}
             </span>
           ) : (
-            <span className='text-xs italic text-muted-foreground/60'>No note given</span>
+            <span className='text-xs italic text-muted-foreground/60'>No summary yet</span>
           )}
         </div>,
       )}

--- a/apps/dashboard/src/components/tags/TagReview/TagReviewRow.tsx
+++ b/apps/dashboard/src/components/tags/TagReview/TagReviewRow.tsx
@@ -1,0 +1,122 @@
+import { JSX } from 'react';
+import { UserPlus } from 'lucide-react';
+import type { VocabularyEntry } from '../../../api/threadTypeVocabularyApi';
+import { useUser } from '../../../hooks/useUsers';
+import { cn } from '../../../utils/classNames';
+import { tagReviewAlignClass, tagReviewGridTemplate } from './tagReviewColumns';
+
+interface TagReviewRowProps {
+  entry: VocabularyEntry;
+  isSelected: boolean;
+  onSelect: (name: string) => void;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  UNDER_REVIEW: 'Under review',
+  APPROVED: 'Approved',
+  REJECTED: 'Turned down',
+};
+
+const relative = (at: number | null | undefined): string => {
+  if (!at) return '—';
+  const days = Math.floor((Date.now() - at) / 86_400_000);
+  if (days <= 0) return 'Today';
+  if (days === 1) return 'Yesterday';
+  if (days < 30) return `${days}d ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+};
+
+export const TagReviewRow = ({ entry, isSelected, onSelect }: TagReviewRowProps): JSX.Element => {
+  const proposer = useUser(entry.createdBy ?? '');
+  // Undefined means counting FAILED, which is not the same as zero — the server omits the
+  // field entirely rather than send zeros it does not believe.
+  const total = entry.threadCount;
+  const counted = typeof total === 'number';
+
+  const cell = (key: string, children: JSX.Element | string): JSX.Element => (
+    <div key={key} className={cn('flex min-w-0 items-center', tagReviewAlignClass(key as never))}>
+      {typeof children === 'string' ? (
+        <span className='min-w-0 truncate'>{children}</span>
+      ) : (
+        children
+      )}
+    </div>
+  );
+
+  return (
+    <div
+      role='row'
+      tabIndex={0}
+      onClick={() => onSelect(entry.name)}
+      onKeyDown={event => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        onSelect(entry.name);
+      }}
+      data-track-category='TagReview'
+      data-track-name='SelectTag'
+      className={cn(
+        'grid items-center gap-x-3 px-6 py-3 border-b border-border last:border-b-0 w-full',
+        'cursor-pointer transition-colors text-sm',
+        isSelected ? 'bg-primary/10' : 'hover:bg-muted/50',
+      )}
+      style={{ gridTemplateColumns: tagReviewGridTemplate(false) }}
+    >
+      {cell(
+        'tag',
+        <div className='flex min-w-0 flex-col gap-0.5'>
+          <div className='flex min-w-0 items-center gap-2'>
+            {/* Mono because the name is an identifier the admin is about to rename, not prose. */}
+            <span className='min-w-0 truncate font-mono text-[13px] text-foreground'>
+              {entry.name}
+            </span>
+          </div>
+          {/* The proposer's note. It is the only thing an admin has to judge on, so it gets a
+              line of its own rather than a tooltip. */}
+          {entry.description ? (
+            <span className='min-w-0 truncate text-xs text-muted-foreground'>
+              {entry.description}
+            </span>
+          ) : (
+            <span className='text-xs italic text-muted-foreground/60'>No note given</span>
+          )}
+        </div>,
+      )}
+
+      {cell(
+        'threads',
+        counted ? (
+          <span className='rounded-full bg-muted px-2 py-px text-xs text-muted-foreground'>
+            {total}
+          </span>
+        ) : (
+          <span className='text-xs text-muted-foreground/60' title='Thread counts are unavailable'>
+            —
+          </span>
+        ),
+      )}
+
+      {cell('proposedBy', proposer?.name ?? (entry.createdBy ? 'Someone' : '—'))}
+      {cell(
+        'status',
+        <span className='text-xs text-muted-foreground'>
+          {STATUS_LABEL[entry.status ?? 'APPROVED'] ?? entry.status}
+        </span>,
+      )}
+      {cell('proposed', relative(entry.proposedAt))}
+      {cell(
+        'lastUsed',
+        !counted ? (
+          <span className='text-xs text-muted-foreground/60'>—</span>
+        ) : total === 0 ? (
+          <span className='flex items-center gap-1 text-xs text-muted-foreground/60'>
+            <UserPlus className='size-3' />
+            Unused
+          </span>
+        ) : (
+          <span className='text-xs text-muted-foreground'>{relative(entry.lastUsedAt)}</span>
+        ),
+      )}
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/tags/TagReview/TagReviewView.tsx
+++ b/apps/dashboard/src/components/tags/TagReview/TagReviewView.tsx
@@ -1,0 +1,254 @@
+/**
+ * The tag review queue.
+ *
+ * Free-form tags people invent on threads land here as proposals. An admin decides whether a
+ * name earns a place in the workspace vocabulary — which is what the picker offers and what
+ * the classifier is allowed to apply — or is turned down.
+ *
+ * List plus a right-hand reading pane, the shape Desk already uses: deciding a tag needs four
+ * authored fields, so it cannot be a click in the row, and a modal would lose the queue.
+ *
+ * Filtering, counting and paging all happen on the server. Candidates are unbounded — anyone
+ * can invent a name on any thread — so the client never holds the full set and therefore
+ * cannot derive any of the three for itself.
+ */
+import { JSX, useEffect, useMemo, useState } from 'react';
+import { ChevronLeft, ChevronRight, Tags } from 'lucide-react';
+import { useTagReview, type TagReviewFilters } from '../../../hooks/useTagReview';
+import { Button } from '../../ui/Button/Button';
+import { Skeleton } from '../../ui/Skeleton';
+import { cn } from '../../../utils/classNames';
+import { TagReviewRow } from './TagReviewRow';
+import { TagDecisionPane } from './TagDecisionPane';
+import { ClearFiltersPill, TagReviewFilter } from './TagReviewFilters';
+import { TAG_REVIEW_COLUMNS, tagReviewAlignClass, tagReviewGridTemplate } from './tagReviewColumns';
+
+const PAGE_SIZE = 20;
+
+type GroupKey = keyof TagReviewFilters;
+
+const GROUPS: GroupKey[] = ['proposedBy', 'status'];
+
+const GROUP_LABEL: Record<GroupKey, string> = {
+  proposedBy: 'Proposed by',
+  status: 'Status',
+};
+
+// Opens on the only thing a reviewer has to act on. Everything else is history.
+const initialFilters = (): TagReviewFilters => ({
+  proposedBy: [],
+  status: ['UNDER_REVIEW'],
+});
+
+const isDefault = (filters: TagReviewFilters): boolean =>
+  filters.proposedBy.length === 0 &&
+  filters.status.length === 1 &&
+  filters.status[0] === 'UNDER_REVIEW';
+
+export const TagReviewView = (): JSX.Element => {
+  const [filters, setFilters] = useState<TagReviewFilters>(initialFilters);
+  const [offset, setOffset] = useState(0);
+  const [selectedName, setSelectedName] = useState<string | null>(null);
+
+  const {
+    entries,
+    total,
+    facets,
+    isLoading,
+    isFetching,
+    reject,
+    reconsider,
+    save,
+    remove,
+    seed,
+    isDeciding,
+  } = useTagReview(filters, offset, PAGE_SIZE);
+
+  // Facet counts ignore the status filter, so an absent APPROVED bucket means the workspace
+  // has no approved types AT ALL — not merely that the current filter hides them. Nothing
+  // seeds implicitly any more, so that is a state an admin has to be offered a way out of.
+  const hasApproved = facets.status.some(option => option.value === 'APPROVED');
+
+  // Page 4 of one filter almost never exists under the next, and landing on an empty page
+  // reads as "no results" rather than "you are past the end".
+  const setGroup =
+    (group: GroupKey) =>
+    (next: string[]): void => {
+      setFilters(current => ({ ...current, [group]: next }));
+      setOffset(0);
+    };
+
+  const clear = (): void => {
+    setFilters(initialFilters());
+    setOffset(0);
+  };
+
+  // The pane is keyed by name, and a name that is no longer on this page has nothing to show.
+  useEffect(() => {
+    if (selectedName && !entries.some(entry => entry.name === selectedName)) setSelectedName(null);
+  }, [entries, selectedName]);
+
+  const selected = useMemo(
+    () => entries.find(entry => entry.name === selectedName) ?? null,
+    [entries, selectedName],
+  );
+
+  const filtered = !isDefault(filters);
+  const from = total === 0 ? 0 : offset + 1;
+  const to = Math.min(offset + entries.length, total);
+  const hasPrev = offset > 0;
+  const hasNext = offset + entries.length < total;
+
+  return (
+    <div className='flex h-full min-h-0 w-full'>
+      <div className='flex min-w-0 flex-1 flex-col'>
+        <div className='shrink-0 px-6 pt-5'>
+          <h1 className='text-lg font-semibold text-foreground'>Tag review</h1>
+          <p className='mt-0.5 text-sm text-muted-foreground'>
+            Names people invented on threads. Approving one adds it to the picker and lets the
+            classifier apply it; turning it down leaves it on the threads that already carry it.
+          </p>
+        </div>
+
+        {/* Sits above the toolbar rather than inside the empty list: the list is empty on
+            the default filter for an ordinary reason (nothing to review), and this is a
+            different, rarer condition that must not be confused with it. */}
+        {!isLoading && !hasApproved && (
+          <div className='mx-6 mt-3 flex items-center gap-3 rounded-lg border border-border px-4 py-3'>
+            <div className='min-w-0 flex-1'>
+              <p className='text-sm font-medium text-foreground'>No thread types yet</p>
+              <p className='mt-0.5 text-xs text-muted-foreground'>
+                Nothing can be tagged and the classifier is skipping every thread until this
+                workspace has at least one type. Start from the standard set, or approve a proposal
+                below to author your own.
+              </p>
+            </div>
+            <Button
+              size='sm'
+              onClick={seed}
+              loading={isDeciding}
+              data-track-category='TagReview'
+              data-track-name='SeedVocabulary'
+            >
+              Add the standard types
+            </Button>
+          </div>
+        )}
+
+        <div className='flex shrink-0 flex-wrap items-center gap-2 px-6 py-3'>
+          {GROUPS.map(group => (
+            <TagReviewFilter
+              key={group}
+              label={GROUP_LABEL[group]}
+              options={facets[group]}
+              selected={filters[group]}
+              onChange={setGroup(group)}
+              searchable={group === 'proposedBy'}
+              searchPlaceholder='Search name or email'
+            />
+          ))}
+          {filtered && <ClearFiltersPill onClear={clear} />}
+          <span className='ml-auto text-xs tabular-nums text-muted-foreground'>
+            {total === 0 ? '0 tags' : `${from}–${to} of ${total}`}
+          </span>
+        </div>
+
+        <div
+          className='grid shrink-0 items-center gap-x-3 px-6 pb-1.5'
+          style={{ gridTemplateColumns: tagReviewGridTemplate(false) }}
+        >
+          {TAG_REVIEW_COLUMNS.map(column => (
+            <div
+              key={column.key}
+              className={cn(
+                'flex h-6 min-w-0 items-center text-[10px] font-medium uppercase tracking-wide text-muted-foreground',
+                tagReviewAlignClass(column.key),
+              )}
+            >
+              <span className='min-w-0 truncate'>{column.label}</span>
+            </div>
+          ))}
+        </div>
+
+        <div
+          className={cn(
+            'min-h-0 flex-1 overflow-y-auto border-t border-border transition-opacity',
+            // The previous page stays on screen while the next loads, dimmed so the click
+            // registers as having done something.
+            isFetching && !isLoading && 'opacity-60',
+          )}
+        >
+          {isLoading ? (
+            <div className='space-y-2 px-6 py-4'>
+              {Array.from({ length: 8 }).map((_, index) => (
+                <Skeleton key={index} className='h-10 w-full' />
+              ))}
+            </div>
+          ) : entries.length === 0 ? (
+            <div className='flex flex-col items-center gap-2 py-20 text-center'>
+              <Tags className='size-6 text-muted-foreground/50' />
+              <p className='text-sm text-muted-foreground'>
+                {filtered ? 'No tags match these filters' : 'Nothing waiting to be reviewed'}
+              </p>
+            </div>
+          ) : (
+            entries.map(entry => (
+              <TagReviewRow
+                key={entry.name}
+                entry={entry}
+                isSelected={entry.name === selectedName}
+                onSelect={name => setSelectedName(current => (current === name ? null : name))}
+              />
+            ))
+          )}
+        </div>
+
+        {/* Offset paging, not infinite scroll: a reviewer works a queue and needs to know how
+            much is left, which a scroll position cannot tell them. */}
+        {total > PAGE_SIZE && (
+          <div className='flex shrink-0 items-center justify-end gap-2 border-t border-border px-6 py-2'>
+            <span className='mr-auto text-xs tabular-nums text-muted-foreground'>
+              {from}–{to} of {total}
+            </span>
+            <Button
+              variant='outline'
+              size='sm'
+              disabled={!hasPrev || isFetching}
+              onClick={() => setOffset(current => Math.max(current - PAGE_SIZE, 0))}
+              data-track-category='TagReview'
+              data-track-name='PrevPage'
+            >
+              <ChevronLeft className='size-3.5' />
+              Previous
+            </Button>
+            <Button
+              variant='outline'
+              size='sm'
+              disabled={!hasNext || isFetching}
+              onClick={() => setOffset(current => current + PAGE_SIZE)}
+              data-track-category='TagReview'
+              data-track-name='NextPage'
+            >
+              Next
+              <ChevronRight className='size-3.5' />
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {selected && (
+        <TagDecisionPane
+          entry={selected}
+          onClose={() => setSelectedName(null)}
+          onReject={() => reject([selected.name])}
+          onReconsider={() => reconsider([selected.name])}
+          onSave={save}
+          onRemove={() => remove(selected.name)}
+          isDeciding={isDeciding}
+        />
+      )}
+    </div>
+  );
+};
+
+export default TagReviewView;

--- a/apps/dashboard/src/components/tags/TagReview/TagReviewView.tsx
+++ b/apps/dashboard/src/components/tags/TagReview/TagReviewView.tsx
@@ -48,7 +48,9 @@ const isDefault = (filters: TagReviewFilters): boolean =>
 export const TagReviewView = (): JSX.Element => {
   const [filters, setFilters] = useState<TagReviewFilters>(initialFilters);
   const [offset, setOffset] = useState(0);
-  const [selectedName, setSelectedName] = useState<string | null>(null);
+  // Held by ROW ID, not by name: two people proposing the same name give two rows, and
+  // selecting by name would open the first and leave the second unreachable.
+  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const {
     entries,
@@ -83,14 +85,14 @@ export const TagReviewView = (): JSX.Element => {
     setOffset(0);
   };
 
-  // The pane is keyed by name, and a name that is no longer on this page has nothing to show.
+  // A row that has left this page has nothing to show in the pane.
   useEffect(() => {
-    if (selectedName && !entries.some(entry => entry.name === selectedName)) setSelectedName(null);
-  }, [entries, selectedName]);
+    if (selectedId && !entries.some(entry => entry.id === selectedId)) setSelectedId(null);
+  }, [entries, selectedId]);
 
   const selected = useMemo(
-    () => entries.find(entry => entry.name === selectedName) ?? null,
-    [entries, selectedName],
+    () => entries.find(entry => entry.id === selectedId) ?? null,
+    [entries, selectedId],
   );
 
   const filtered = !isDefault(filters);
@@ -194,10 +196,10 @@ export const TagReviewView = (): JSX.Element => {
           ) : (
             entries.map(entry => (
               <TagReviewRow
-                key={entry.name}
+                key={entry.id ?? entry.name}
                 entry={entry}
-                isSelected={entry.name === selectedName}
-                onSelect={name => setSelectedName(current => (current === name ? null : name))}
+                isSelected={entry.id === selectedId}
+                onSelect={id => setSelectedId(current => (current === id ? null : id))}
               />
             ))
           )}
@@ -239,7 +241,7 @@ export const TagReviewView = (): JSX.Element => {
       {selected && (
         <TagDecisionPane
           entry={selected}
-          onClose={() => setSelectedName(null)}
+          onClose={() => setSelectedId(null)}
           onReject={() => reject([selected.name])}
           onReconsider={() => reconsider([selected.name])}
           onSave={save}

--- a/apps/dashboard/src/components/tags/TagReview/tagReviewColumns.ts
+++ b/apps/dashboard/src/components/tags/TagReview/tagReviewColumns.ts
@@ -1,0 +1,48 @@
+/**
+ * Column definitions for the tag review table.
+ *
+ * Deliberately the same shape as ticketListColumns.ts — a CSS grid of `minmax(0, Nfr)` tracks
+ * with a literal selection column — so the two tables line up visually and one recipe governs
+ * both. Column keys map onto the ticket list's: Tag sits where Subject does, and so on down
+ * the row.
+ */
+export type TagReviewColumnKey =
+  | 'tag'
+  | 'threads'
+  | 'proposedBy'
+  | 'status'
+  | 'proposed'
+  | 'lastUsed';
+
+export interface TagReviewColumnDefinition {
+  key: TagReviewColumnKey;
+  label: string;
+  width: number;
+  align: 'left' | 'right' | 'center';
+}
+
+export const TAG_REVIEW_SELECTION_COLUMN_WIDTH = 28;
+export const TAG_REVIEW_COLUMN_PADDING_X = 24;
+
+export const TAG_REVIEW_COLUMNS: readonly TagReviewColumnDefinition[] = [
+  { key: 'tag', label: 'Tag', width: 420, align: 'left' },
+  { key: 'threads', label: 'Threads', width: 80, align: 'right' },
+  { key: 'proposedBy', label: 'Proposed by', width: 150, align: 'left' },
+  { key: 'status', label: 'Status', width: 130, align: 'left' },
+  { key: 'proposed', label: 'Proposed', width: 110, align: 'left' },
+  { key: 'lastUsed', label: 'Last used', width: 110, align: 'left' },
+];
+
+/** One `minmax(0, Nfr)` track per column, so every cell can truncate rather than overflow. */
+export const tagReviewGridTemplate = (showSelection: boolean): string =>
+  [
+    ...(showSelection ? [`${TAG_REVIEW_SELECTION_COLUMN_WIDTH}px`] : []),
+    ...TAG_REVIEW_COLUMNS.map(column => `minmax(0, ${column.width}fr)`),
+  ].join(' ');
+
+export const tagReviewAlignClass = (key: TagReviewColumnKey): string => {
+  const column = TAG_REVIEW_COLUMNS.find(entry => entry.key === key);
+  if (column?.align === 'right') return 'justify-end text-right';
+  if (column?.align === 'center') return 'justify-center text-center';
+  return 'justify-start text-left';
+};

--- a/apps/dashboard/src/components/tags/ThreadTagMenuItems.tsx
+++ b/apps/dashboard/src/components/tags/ThreadTagMenuItems.tsx
@@ -1,9 +1,9 @@
 import { JSX, useMemo, useState } from 'react';
 import { Check, Plus } from 'lucide-react';
-import { THREAD_TYPES } from '@xyne/shared';
 import { DropdownMenuItem, DropdownMenuSeparator } from '../ui/dropdown-menu';
+import { useThreadTypeVocabulary } from '../../hooks/useThreadTypeVocabulary';
 
-/** Matches the mutator's cap, so the UI cannot offer something the server will reject. */
+/** Matches the server's cap, so the UI cannot offer something the API will reject. */
 const MAX_TAG_LENGTH = 40;
 
 interface ThreadTagMenuItemsProps {
@@ -14,35 +14,41 @@ interface ThreadTagMenuItemsProps {
 const normalize = (value: string): string => value.trim().toLowerCase();
 
 /**
- * The body of the "Thread tags" submenu, shared by the message hover toolbar and the
- * thread panel header so the two stay identical.
+ * The body of the "Thread tags" submenu, used by the thread panel header.
  *
- * The listed choices are deliberately just the built-in vocabulary plus whatever this
- * thread already carries — a menu that grows with every tag anyone ever invented stops
- * being scannable. Anything else is reached by typing it.
+ * The listed choices are the workspace's vocabulary plus whatever this thread already
+ * carries — a menu that grows with every tag anyone ever invented stops being scannable.
+ * Anything else is reached by typing it.
  */
 export const ThreadTagMenuItems = ({ applied, onToggle }: ThreadTagMenuItemsProps): JSX.Element => {
   const [search, setSearch] = useState('');
   const query = normalize(search);
+  const { entries } = useThreadTypeVocabulary();
 
-  const builtIn = useMemo(
-    () => THREAD_TYPES.filter(entry => !query || normalize(entry.label).includes(query)),
-    [query],
+  const vocabulary = useMemo(
+    () => entries.filter(entry => !query || normalize(entry.label).includes(query)),
+    [entries, query],
   );
 
-  // Custom tags already on this thread, so they can be unticked from the same list.
+  // Tags on this thread that the vocabulary doesn't cover — free-form ones, and entries an
+  // admin has since removed — so they can be unticked from the same list.
   const custom = useMemo(() => {
-    const builtInNames = new Set(THREAD_TYPES.map(entry => normalize(entry.name)));
+    const known = new Set(entries.map(entry => normalize(entry.name)));
     return applied
-      .filter(name => !builtInNames.has(normalize(name)))
+      .filter(name => !known.has(normalize(name)))
       .filter(name => !query || normalize(name).includes(query));
-  }, [applied, query]);
+  }, [applied, entries, query]);
 
   const trimmed = search.trim().slice(0, MAX_TAG_LENGTH);
-  const alreadyExists = [...THREAD_TYPES.map(e => e.name), ...applied].some(
+  const alreadyExists = [...entries.map(e => e.name), ...applied].some(
     name => normalize(name) === query,
   );
   const canCreate = trimmed.length > 0 && !alreadyExists;
+
+  const create = (): void => {
+    onToggle(trimmed);
+    setSearch('');
+  };
 
   const row = (name: string, label: string, color: string | undefined): JSX.Element => (
     <DropdownMenuItem
@@ -78,8 +84,7 @@ export const ThreadTagMenuItems = ({ applied, onToggle }: ThreadTagMenuItemsProp
           event.stopPropagation();
           if (event.key === 'Enter' && canCreate) {
             event.preventDefault();
-            onToggle(trimmed);
-            setSearch('');
+            create();
           }
         }}
         maxLength={MAX_TAG_LENGTH}
@@ -90,19 +95,18 @@ export const ThreadTagMenuItems = ({ applied, onToggle }: ThreadTagMenuItemsProp
         className='w-full px-2 py-1.5 mb-1 text-sm bg-transparent border-b border-border outline-none placeholder:text-muted-foreground'
       />
 
-      {builtIn.map(entry => row(entry.name, entry.label, entry.color))}
-      {custom.length > 0 && builtIn.length > 0 && <DropdownMenuSeparator />}
+      {vocabulary.map(entry => row(entry.name, entry.label, entry.color))}
+      {custom.length > 0 && vocabulary.length > 0 && <DropdownMenuSeparator />}
       {custom.map(name => row(name, name, undefined))}
 
       {canCreate && (
         <>
-          {(builtIn.length > 0 || custom.length > 0) && <DropdownMenuSeparator />}
+          {(vocabulary.length > 0 || custom.length > 0) && <DropdownMenuSeparator />}
           <DropdownMenuItem
             className='gap-2'
             onSelect={event => {
               event.preventDefault();
-              onToggle(trimmed);
-              setSearch('');
+              create();
             }}
             data-track-category='Tags'
             data-track-name='CreateThreadTag'

--- a/apps/dashboard/src/components/tags/ThreadTagMenuItems.tsx
+++ b/apps/dashboard/src/components/tags/ThreadTagMenuItems.tsx
@@ -1,6 +1,7 @@
 import { JSX, useMemo, useState } from 'react';
 import { Check, Plus } from 'lucide-react';
 import { DropdownMenuItem, DropdownMenuSeparator } from '../ui/dropdown-menu';
+import { normalizeThreadTypeName } from '@xyne/shared';
 import { useThreadTypeVocabulary } from '../../hooks/useThreadTypeVocabulary';
 
 /** Matches the server's cap, so the UI cannot offer something the API will reject. */
@@ -39,14 +40,19 @@ export const ThreadTagMenuItems = ({ applied, onToggle }: ThreadTagMenuItemsProp
       .filter(name => !query || normalize(name).includes(query));
   }, [applied, entries, query]);
 
-  const trimmed = search.trim().slice(0, MAX_TAG_LENGTH);
+  // What typing this would actually create. Shown rather than applied to the input itself,
+  // because the same box is the SEARCH box — forcing the field to uppercase would fight
+  // someone typing "feature" to find "Feature request".
+  const proposed = normalizeThreadTypeName(search).slice(0, MAX_TAG_LENGTH);
+  // Compared in normalised form, so "vespa latency" does not offer to create a second tag
+  // when VESPA_LATENCY already exists.
   const alreadyExists = [...entries.map(e => e.name), ...applied].some(
-    name => normalize(name) === query,
+    name => normalizeThreadTypeName(name) === proposed,
   );
-  const canCreate = trimmed.length > 0 && !alreadyExists;
+  const canCreate = proposed.length > 0 && !alreadyExists;
 
   const create = (): void => {
-    onToggle(trimmed);
+    onToggle(proposed);
     setSearch('');
   };
 
@@ -112,7 +118,12 @@ export const ThreadTagMenuItems = ({ applied, onToggle }: ThreadTagMenuItemsProp
             data-track-name='CreateThreadTag'
           >
             <Plus size={14} className='shrink-0 text-muted-foreground' />
-            <span className='flex-1 truncate'>Add “{trimmed}”</span>
+            {/* The NORMALISED name, not what was typed: this is the string that lands on the
+                thread, gets indexed, and goes into the review queue, so it is the string to
+                show before anyone commits to it. */}
+            <span className='flex-1 truncate'>
+              Add <span className='font-mono'>{proposed}</span>
+            </span>
           </DropdownMenuItem>
         </>
       )}

--- a/apps/dashboard/src/components/tags/ThreadTags.tsx
+++ b/apps/dashboard/src/components/tags/ThreadTags.tsx
@@ -1,49 +1,57 @@
-import { JSX, useCallback, useMemo } from 'react';
+import { JSX, useCallback, useEffect, useMemo, type KeyboardEvent, type MouseEvent } from 'react';
 import { X } from 'lucide-react';
 import { toast } from 'sonner';
-import { threadTypeEntry } from '@xyne/shared';
+import { parseAppliedTags, visibleTags, type AppliedTag, type ThreadTypeEntry } from '@xyne/shared';
 import { useZero } from '../../hooks/useZero';
+import { useUser } from '../../hooks/useUsers';
 import { useShowThreadTags } from '../../hooks/useShowThreadTags';
+import { useThreadTypeVocabulary } from '../../hooks/useThreadTypeVocabulary';
+import { useMyPendingTags } from '../../hooks/useTagReview';
 import { mutators } from '../../zero/mutators';
+import { Tooltip } from '../ui/Tooltip/Tooltip';
 import { cn } from '../../utils/classNames';
 import { colorForTagName } from './tagColors';
 
 interface ThreadTagsProps {
   conversationId: string | undefined;
-  /** `conversations.threadType` — a stringified JSON array, or null when unclassified. */
+  /** `conversations.threadType` — a JSON array of applied tags, or null when unclassified. */
   threadType: string | null | undefined;
   /** Without this the chips render read-only, with no remove control. */
   canEdit?: boolean;
+  /** The tag currently being inspected — that chip renders pressed. */
+  inspectedTag?: string | null;
+  /** Clicking a chip inspects it; clicking the active one clears. Omit to disable. */
+  onInspect?: (name: string | null) => void;
 }
 
-/** Plain TEXT in the database, so parse defensively — nothing guarantees the shape. */
-export const parseThreadTypes = (raw: string | null | undefined): string[] => {
-  if (!raw) return [];
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    // Any non-empty string is valid — tags are free-form beyond the built-in vocabulary.
-    if (!Array.isArray(parsed)) return typeof parsed === 'string' && parsed ? [parsed] : [];
-    return parsed.filter((v): v is string => typeof v === 'string' && v.length > 0);
-  } catch {
-    // Rows written before the column held an array stored a bare name rather than JSON.
-    return raw.trim() ? [raw] : [];
-  }
-};
+/**
+ * The tag names on a thread, for callers that only need names — the picker's tick marks and
+ * its toggle handlers. Deactivated tags are excluded: they were removed, and offering them
+ * back as already-applied would make the menu lie.
+ */
+export const parseThreadTypes = (raw: string | null | undefined): string[] =>
+  visibleTags(parseAppliedTags(raw)).map(tag => tag.name);
 
 /**
  * Writes the FULL desired set — the column is one value, so a partial add/remove would be
- * a read-modify-write race between two clients.
+ * a read-modify-write race between two clients. The mutator merges rather than replaces, so
+ * a tag already there keeps the provenance it was applied with.
  */
 export const useSetThreadTypes = (
   conversationId: string | undefined,
-): ((types: string[]) => Promise<void>) => {
+): ((types: string[], note?: string) => Promise<void>) => {
   const zero = useZero();
   return useCallback(
-    async (types: string[]): Promise<void> => {
+    async (types: string[], note?: string): Promise<void> => {
       if (!conversationId) return;
       try {
         const result = await zero.mutate(
-          mutators.threadTag.setTypes({ conversationId, types: types as never }),
+          mutators.threadTag.setTypes({
+            conversationId,
+            types: types as never,
+            timestamp: Date.now(),
+            ...(note ? { note } : {}),
+          }),
         ).server;
         if (result.type === 'error') {
           throw new Error(result.error.message || 'Failed to update thread tags');
@@ -56,62 +64,171 @@ export const useSetThreadTypes = (
   );
 };
 
+// 0 is the sentinel for a legacy row that carried no timestamp — show nothing rather than
+// 1970.
+const appliedAt = (at: number): string =>
+  at === 0
+    ? ''
+    : new Date(at).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+
+/** The tooltip body: definition, then who applied it and when. */
+const TagTooltip = ({
+  tag,
+  entry,
+  pending,
+}: {
+  tag: AppliedTag;
+  entry: ThreadTypeEntry | undefined;
+  pending: boolean;
+}): JSX.Element => {
+  // `by` is set only when a person acts on a tag, so its absence means the classifier did.
+  // Empty string is a deliberate no-op lookup for classifier tags.
+  const author = useUser(tag.by ?? '');
+  const who = tag.by ? `Added by ${author?.name ?? 'someone'}` : 'Tagged by AI';
+  const when = appliedAt(tag.at);
+
+  return (
+    <span className='block max-w-[260px] text-left'>
+      <span className='block font-medium'>{entry?.label ?? tag.name}</span>
+      {/* Straight from the vocabulary, so an admin's edit lands here immediately. A
+          free-form tag resolves to its candidate entry, whose description is the note its
+          inventor typed — which is why nothing carries a definition on the thread itself. */}
+      {entry?.description ? (
+        <span className='block mt-0.5 opacity-80'>{entry.description}</span>
+      ) : null}
+      <span className='block mt-1 opacity-70'>
+        {who}
+        {when && ` · ${when}`}
+      </span>
+      {/* Only the author of a name sees this, and only until an admin decides it. The tag is
+          on the thread for everyone either way — what is pending is whether the NAME joins
+          the picker. */}
+      {pending && (
+        <span className='block mt-1 opacity-70'>Name under review — not in the picker yet</span>
+      )}
+    </span>
+  );
+};
+
 /**
  * What kind of thread this is. A thread can be several things at once, so this is a set.
  *
- * Display plus a remove control — adding lives in the message overflow menu, since
+ * Display plus a remove control — adding lives in the thread panel's overflow menu, since
  * classifying a thread is rare next to reading one.
  */
 export const ThreadTags = ({
   conversationId,
   threadType,
   canEdit = false,
+  inspectedTag = null,
+  onInspect,
 }: ThreadTagsProps): JSX.Element | null => {
-  const applied = useMemo(() => parseThreadTypes(threadType), [threadType]);
   const setTypes = useSetThreadTypes(conversationId);
   const { showThreadTags } = useShowThreadTags();
+  // Labels, colours, definitions and chip order all come from the workspace's vocabulary —
+  // an admin can rename, recolour, redefine or reorder a type and chips follow immediately.
+  const { entry: vocabularyEntry, sort } = useThreadTypeVocabulary();
+  // Their own undecided proposals, nobody else's: a name pending for someone else is not this
+  // reader's business, and it would be a request per client for a list they cannot act on.
+  const isPending = useMyPendingTags(showThreadTags);
+
+  const applied = useMemo(() => {
+    const tags = visibleTags(parseAppliedTags(threadType));
+    const byName = new Map(tags.map(tag => [tag.name, tag]));
+    return sort([...byName.keys()])
+      .map(name => byName.get(name))
+      .filter((tag): tag is AppliedTag => Boolean(tag));
+  }, [threadType, sort]);
+
+  // A tag that is no longer on the thread cannot stay inspected, or its evidence chips hang
+  // around after the chip that summoned them is gone. Keyed on the applied set rather than on
+  // the remove button, so unticking from the overflow menu — or any future path that drops a
+  // tag — is covered by the same guard.
+  const appliedNames = applied.map(tag => tag.name).join('\u0000');
+  useEffect(() => {
+    if (!inspectedTag || !onInspect) return;
+    if (!appliedNames.split('\u0000').includes(inspectedTag)) onInspect(null);
+  }, [appliedNames, inspectedTag, onInspect]);
 
   // Opt-in per user: the classifier tags every thread, so rendering by default would put a
-  // chip on every row for people who never asked for them.
+  // chip on every thread for people who never asked for them.
   if (!showThreadTags || applied.length === 0) {
     return null;
   }
 
   return (
     <span className='inline-flex items-center gap-1 align-middle'>
-      {applied.map(name => {
-        const entry = threadTypeEntry(name);
-        const color = entry?.color ?? colorForTagName(name);
+      {applied.map(tag => {
+        // Undefined for a free-form tag, or one an admin has since removed — both keep
+        // rendering from the stored name rather than disappearing.
+        const entry = vocabularyEntry(tag.name);
+        const color = entry?.color ?? colorForTagName(tag.name);
+        const inspecting = inspectedTag === tag.name;
+        // An entry means the name is already in the vocabulary, so nothing is pending on it.
+        const pending = !entry && isPending(tag.name);
+        const inspect = (): void => onInspect?.(inspecting ? null : tag.name);
         return (
-          <span
-            key={name}
-            className={cn(
-              'group/chip inline-flex items-center gap-0.5 rounded-full text-[11px] font-medium',
-              'leading-[16px] whitespace-nowrap align-middle py-[1px]',
-              canEdit ? 'pl-1.5 pr-1' : 'px-1.5',
-            )}
-            style={{ backgroundColor: `${color}1f`, color }}
-            title={entry?.description ?? name}
+          <Tooltip
+            key={tag.name}
+            content={<TagTooltip tag={tag} entry={entry} pending={pending} />}
           >
-            {entry?.label ?? name}
-            {canEdit && (
-              <button
-                type='button'
-                aria-label={`Remove ${entry?.label ?? name}`}
-                // Width reserved, only opacity changes, so the chip does not resize under
-                // the cursor. stopPropagation because the row opens the thread on click.
-                onClick={event => {
+            <span
+              {...(onInspect && {
+                role: 'button',
+                tabIndex: 0,
+                'aria-pressed': inspecting,
+                onClick: (event: MouseEvent): void => {
                   event.stopPropagation();
-                  void setTypes(applied.filter(value => value !== name));
-                }}
-                className='opacity-0 group-hover/chip:opacity-100 focus-visible:opacity-100 transition-opacity rounded-full'
-                data-track-category='Tags'
-                data-track-name='RemoveThreadTag'
-              >
-                <X className='size-2.5' />
-              </button>
-            )}
-          </span>
+                  inspect();
+                },
+                onKeyDown: (event: KeyboardEvent): void => {
+                  if (event.key !== 'Enter' && event.key !== ' ') return;
+                  event.preventDefault();
+                  event.stopPropagation();
+                  inspect();
+                },
+              })}
+              className={cn(
+                'group/chip inline-flex items-center gap-0.5 rounded-full text-[11px] font-medium',
+                'leading-[16px] whitespace-nowrap align-middle py-[1px]',
+                canEdit ? 'pl-1.5 pr-1' : 'px-1.5',
+                onInspect && 'cursor-pointer',
+                // Dashed, not a second badge: it reads as provisional without adding anything
+                // to the chip, which is in an already tight row.
+                pending && 'border border-dashed',
+              )}
+              style={{
+                backgroundColor: `${color}${inspecting ? '33' : pending ? '12' : '1f'}`,
+                color,
+                ...(pending ? { borderColor: `${color}80` } : {}),
+                ...(inspecting ? { boxShadow: `inset 0 0 0 1px ${color}` } : {}),
+              }}
+            >
+              {entry?.label ?? tag.name}
+              {canEdit && (
+                <button
+                  type='button'
+                  aria-label={`Remove ${entry?.label ?? tag.name}`}
+                  // Width reserved, only opacity changes, so the chip does not resize under
+                  // the cursor. stopPropagation because the row opens the thread on click.
+                  onClick={event => {
+                    event.stopPropagation();
+                    void setTypes(applied.filter(t => t.name !== tag.name).map(t => t.name));
+                  }}
+                  className='opacity-0 group-hover/chip:opacity-100 focus-visible:opacity-100 transition-opacity rounded-full'
+                  data-track-category='Tags'
+                  data-track-name='RemoveThreadTag'
+                >
+                  <X className='size-2.5' />
+                </button>
+              )}
+            </span>
+          </Tooltip>
         );
       })}
     </span>

--- a/apps/dashboard/src/components/tags/ThreadTags.tsx
+++ b/apps/dashboard/src/components/tags/ThreadTags.tsx
@@ -95,12 +95,10 @@ const TagTooltip = ({
   return (
     <span className='block max-w-[260px] text-left'>
       <span className='block font-medium'>{entry?.label ?? tag.name}</span>
-      {/* Straight from the vocabulary, so an admin's edit lands here immediately. A
-          free-form tag resolves to its candidate entry, whose description is the note its
-          inventor typed — which is why nothing carries a definition on the thread itself. */}
-      {entry?.description ? (
-        <span className='block mt-0.5 opacity-80'>{entry.description}</span>
-      ) : null}
+      {/* The SUMMARY, not the description. The description is the classifier's instruction —
+          long, and mostly "NOT" clauses that exist to stop the model on near-misses. Every
+          one of them is noise to someone hovering a chip. */}
+      {entry?.summary ? <span className='block mt-0.5 opacity-80'>{entry.summary}</span> : null}
       <span className='block mt-1 opacity-70'>
         {who}
         {when && ` · ${when}`}
@@ -108,9 +106,7 @@ const TagTooltip = ({
       {/* Only the author of a name sees this, and only until an admin decides it. The tag is
           on the thread for everyone either way — what is pending is whether the NAME joins
           the picker. */}
-      {pending && (
-        <span className='block mt-1 opacity-70'>Name under review — not in the picker yet</span>
-      )}
+      {pending && <span className='block mt-1 opacity-70'>Under review</span>}
     </span>
   );
 };

--- a/apps/dashboard/src/hooks/useTagReview.ts
+++ b/apps/dashboard/src/hooks/useTagReview.ts
@@ -1,0 +1,175 @@
+import { useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import type { ThreadTypeEntry } from '@xyne/shared';
+import {
+  threadTypeVocabularyApi,
+  type VocabularyEntry,
+  type VocabularyPage,
+  type VocabularyStatus,
+} from '../api/threadTypeVocabularyApi';
+import { THREAD_TYPE_VOCABULARY_KEY } from './useThreadTypeVocabulary';
+
+export const TAG_REVIEW_KEY = ['tag-review'];
+export const MY_PENDING_TAGS_KEY = ['tag-review', 'mine'];
+
+/**
+ * The whole vocabulary as a reviewer sees it — proposals, approved entries and turned-down
+ * names alike, each with how many threads carry it.
+ *
+ * One request for everything rather than one per status: the toolbar filters across all three
+ * and shows a count beside each option, which needs the full set in hand anyway.
+ */
+export interface TagReviewFilters {
+  proposedBy: string[];
+  status: string[];
+}
+
+export const useTagReview = (
+  filters: TagReviewFilters,
+  offset: number,
+  limit: number,
+): {
+  entries: VocabularyEntry[];
+  total: number;
+  facets: VocabularyPage['facets'];
+  isLoading: boolean;
+  isFetching: boolean;
+  reject: (names: string[]) => void;
+  reconsider: (names: string[]) => void;
+  save: (entry: ThreadTypeEntry, wasProposal: boolean) => void;
+  remove: (name: string) => void;
+  seed: () => void;
+  isDeciding: boolean;
+} => {
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, isFetching } = useQuery({
+    // The window and the filters are part of the identity of the result — two pages of the
+    // same query are different data, not the same data refetched.
+    queryKey: [...TAG_REVIEW_KEY, filters, offset, limit],
+    queryFn: () =>
+      threadTypeVocabularyApi.review({
+        statuses: (filters.status.length
+          ? filters.status
+          : ['UNDER_REVIEW', 'APPROVED', 'REJECTED']) as VocabularyStatus[],
+        proposedBy: filters.proposedBy,
+        limit,
+        offset,
+      }),
+    // Holding the previous page while the next one loads keeps the table from collapsing to
+    // an empty state and back on every click of Next.
+    placeholderData: previous => previous,
+    // Short: a reviewer works through a queue and expects their own decisions to stick, but
+    // someone else deciding in parallel should surface without a reload.
+    staleTime: 30_000,
+  });
+
+  // A decision changes what the picker and classifier may use, so the vocabulary the rest of
+  // the app holds is stale the moment one lands.
+  const invalidate = (): void => {
+    void queryClient.invalidateQueries({ queryKey: TAG_REVIEW_KEY });
+    void queryClient.invalidateQueries({ queryKey: THREAD_TYPE_VOCABULARY_KEY });
+    void queryClient.invalidateQueries({ queryKey: MY_PENDING_TAGS_KEY });
+  };
+
+  const rejectMutation = useMutation({
+    mutationFn: (names: string[]) => threadTypeVocabularyApi.reject(names),
+    onSuccess: (decided, names) => {
+      invalidate();
+      // Rows, not names — one name can have several proposers, and all of them are answered.
+      toast.success(
+        names.length === 1
+          ? `Turned down "${names[0]}"${decided > 1 ? ` (${decided} proposals)` : ''}`
+          : `Turned down ${names.length} tags`,
+      );
+    },
+    onError: (error: unknown) =>
+      toast.error(error instanceof Error ? error.message : 'Could not turn that down'),
+  });
+
+  const reconsiderMutation = useMutation({
+    mutationFn: (names: string[]) => threadTypeVocabularyApi.reconsider(names),
+    onSuccess: (_decided, names) => {
+      invalidate();
+      toast.success(
+        names.length === 1 ? `Reopened "${names[0]}"` : `Reopened ${names.length} tags`,
+      );
+    },
+    onError: (error: unknown) =>
+      toast.error(error instanceof Error ? error.message : 'Could not reopen that'),
+  });
+
+  // Approving and editing are the same write: an entry with its four fields, sent as an add.
+  // The server upserts on name, and promoting a proposal retires it in the same transaction.
+  const saveMutation = useMutation({
+    mutationFn: ({ entry }: { entry: ThreadTypeEntry; wasProposal: boolean }) =>
+      threadTypeVocabularyApi.patch({ add: [entry] }),
+    onSuccess: (_result, { entry, wasProposal }) => {
+      invalidate();
+      toast.success(wasProposal ? `Approved as ${entry.name}` : `Saved ${entry.label}`);
+    },
+    onError: (error: unknown) =>
+      toast.error(error instanceof Error ? error.message : 'Could not save that'),
+  });
+
+  const removeMutation = useMutation({
+    mutationFn: (name: string) => threadTypeVocabularyApi.patch({ remove: [name] }),
+    onSuccess: (_result, name) => {
+      invalidate();
+      toast.success(`Removed ${name} from the vocabulary`);
+    },
+    onError: (error: unknown) =>
+      toast.error(error instanceof Error ? error.message : 'Could not remove that'),
+  });
+
+  const seedMutation = useMutation({
+    mutationFn: () => threadTypeVocabularyApi.seed(),
+    onSuccess: added => {
+      invalidate();
+      toast.success(
+        added === 0 ? 'Every starting type is already here' : `Added ${added} starting types`,
+      );
+    },
+    onError: (error: unknown) =>
+      toast.error(error instanceof Error ? error.message : 'Could not add the starting types'),
+  });
+
+  return {
+    entries: data?.entries ?? [],
+    total: data?.total ?? 0,
+    facets: data?.facets ?? { proposedBy: [], status: [] },
+    isLoading,
+    isFetching,
+    reject: names => rejectMutation.mutate(names),
+    reconsider: names => reconsiderMutation.mutate(names),
+    save: (entry, wasProposal) => saveMutation.mutate({ entry, wasProposal }),
+    remove: name => removeMutation.mutate(name),
+    seed: () => seedMutation.mutate(),
+    isDeciding:
+      rejectMutation.isPending ||
+      reconsiderMutation.isPending ||
+      saveMutation.isPending ||
+      removeMutation.isPending ||
+      seedMutation.isPending,
+  };
+};
+
+/**
+ * Names the current user proposed that are still undecided.
+ *
+ * Drives the dashed "under review" chip on the author's own threads. Deliberately their list
+ * and no one else's: a pending flag on the applied tag would go stale the moment an admin
+ * decided it, and fetching every candidate in the workspace into every client does not scale.
+ */
+export const useMyPendingTags = (enabled: boolean): ((name: string) => boolean) => {
+  const { data } = useQuery({
+    queryKey: MY_PENDING_TAGS_KEY,
+    enabled,
+    queryFn: () => threadTypeVocabularyApi.mine(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const pending = useMemo(() => new Set(data ?? []), [data]);
+  return (name: string) => pending.has(name);
+};

--- a/apps/dashboard/src/hooks/useThreadTypeVocabulary.ts
+++ b/apps/dashboard/src/hooks/useThreadTypeVocabulary.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { THREAD_TYPES, type ThreadTypeEntry } from '@xyne/shared';
+import { type ThreadTypeEntry } from '@xyne/shared';
 import { threadTypeVocabularyApi, type VocabularyEntry } from '../api/threadTypeVocabularyApi';
 import { useShowThreadTags } from './useShowThreadTags';
 
@@ -13,14 +13,14 @@ export const THREAD_TYPE_VOCABULARY_KEY = ['thread-type-vocabulary'];
  * One request per session, shared by every picker and chip: it changes only when an admin
  * edits it, so a long staleTime is right and refetching per thread would be waste.
  *
- * Falls back to the built-ins whenever the fetch has not landed — still loading, request
- * failed, or the endpoint is not there at all. That last case is the one that matters: a
- * dashboard deployed ahead of its backend would 404 and, without this, offer an empty picker
- * for as long as the skew lasts. The built-ins are what the server would have returned for an
- * uncustomised workspace anyway, so degrading to them is degrading to the truth.
+ * There is NO fallback to the list in code, and there must not be. A workspace's vocabulary
+ * is its rows and nothing else, so an empty answer is a real answer: it means an admin has
+ * not installed any types yet. Filling the picker from code would offer types the workspace
+ * does not have — and picking one would send a name the server has never heard of, which
+ * lands as a free-form PROPOSAL for a type nobody chose to install.
  *
- * The cost is a workspace that RENAMED a type sees the built-in label for the few hundred ms
- * before the real vocabulary arrives. A brief wrong label is the cheaper failure.
+ * While the request is in flight the picker is briefly empty and chips render from their
+ * stored name without label or colour. That is the honest reading of "we do not know yet".
  */
 export const useThreadTypeVocabulary = (): {
   entries: ThreadTypeEntry[];
@@ -40,7 +40,7 @@ export const useThreadTypeVocabulary = (): {
     staleTime: 15 * 60 * 1000,
   });
 
-  const entries = useMemo<VocabularyEntry[]>(() => data ?? [...THREAD_TYPES], [data]);
+  const entries = useMemo<VocabularyEntry[]>(() => data ?? [], [data]);
 
   const rank = useMemo(() => {
     const order = new Map(entries.map((entry, index) => [entry.name, index]));

--- a/apps/dashboard/src/hooks/useThreadTypeVocabulary.ts
+++ b/apps/dashboard/src/hooks/useThreadTypeVocabulary.ts
@@ -1,0 +1,66 @@
+import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { THREAD_TYPES, type ThreadTypeEntry } from '@xyne/shared';
+import { threadTypeVocabularyApi, type VocabularyEntry } from '../api/threadTypeVocabularyApi';
+import { useShowThreadTags } from './useShowThreadTags';
+
+export const THREAD_TYPE_VOCABULARY_KEY = ['thread-type-vocabulary'];
+
+/**
+ * The workspace's thread-type vocabulary — the list the picker offers, and the labels,
+ * colours and order every chip renders with.
+ *
+ * One request per session, shared by every picker and chip: it changes only when an admin
+ * edits it, so a long staleTime is right and refetching per thread would be waste.
+ *
+ * Falls back to the built-ins whenever the fetch has not landed — still loading, request
+ * failed, or the endpoint is not there at all. That last case is the one that matters: a
+ * dashboard deployed ahead of its backend would 404 and, without this, offer an empty picker
+ * for as long as the skew lasts. The built-ins are what the server would have returned for an
+ * uncustomised workspace anyway, so degrading to them is degrading to the truth.
+ *
+ * The cost is a workspace that RENAMED a type sees the built-in label for the few hundred ms
+ * before the real vocabulary arrives. A brief wrong label is the cheaper failure.
+ */
+export const useThreadTypeVocabulary = (): {
+  entries: ThreadTypeEntry[];
+  entry: (name: string) => ThreadTypeEntry | undefined;
+  /** Vocabulary order first, then anything unknown alphabetically. */
+  sort: (names: string[]) => string[];
+} => {
+  const { showThreadTags } = useShowThreadTags();
+
+  const { data } = useQuery({
+    queryKey: THREAD_TYPE_VOCABULARY_KEY,
+    enabled: showThreadTags,
+    // Approved entries only, and deliberately so: candidates are unbounded — anyone can
+    // invent a free-form tag — and pulling all of them into every client to resolve the two
+    // or three on screen does not scale. A free-form chip renders from its stored name.
+    queryFn: () => threadTypeVocabularyApi.get(),
+    staleTime: 15 * 60 * 1000,
+  });
+
+  const entries = useMemo<VocabularyEntry[]>(() => data ?? [...THREAD_TYPES], [data]);
+
+  const rank = useMemo(() => {
+    const order = new Map(entries.map((entry, index) => [entry.name, index]));
+    // Free-form tags and entries an admin has removed have no rank, so they trail the
+    // vocabulary in alphabetical order rather than jumping around between renders.
+    return (name: string): number => order.get(name) ?? entries.length;
+  }, [entries]);
+
+  // Undefined for a free-form tag: it has no approved entry, so the chip falls back to its
+  // stored name and the tooltip simply omits the definition line.
+  const entry = useCallback(
+    (name: string) => entries.find(candidate => candidate.name === name),
+    [entries],
+  );
+
+  const sort = useCallback(
+    (names: string[]): string[] =>
+      [...names].sort((a, b) => rank(a) - rank(b) || a.localeCompare(b)),
+    [rank],
+  );
+
+  return { entries, entry, sort };
+};

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -208,6 +208,7 @@ import { TranscriptCitationModal } from '../components/Chat/TranscriptCitationMo
 import { sharedChatRoutes } from './SharedChatRoutes';
 import { ResourceAccessScreen } from './ResourceAccessScreen/ResourceAccessScreen';
 import { RoleManagementScreen } from './RoleManagementScreen';
+import { TagReviewView } from '../components/tags/TagReview/TagReviewView';
 import { ResourceProtectedRoute } from '../components/Auth/ResourceProtectedRoute';
 import { GuestBlockedRoute } from '../components/Auth/GuestBlockedRoute';
 import { ToolbarProtectedRoute } from '../components/Auth/ToolbarProtectedRoute';
@@ -1841,6 +1842,14 @@ export const router = createBrowserRouter(
                   element: (
                     <ResourceProtectedRoute resourceName='ROLES'>
                       <RoleManagementScreen />
+                    </ResourceProtectedRoute>
+                  ),
+                },
+                {
+                  path: 'tag-review',
+                  element: (
+                    <ResourceProtectedRoute resourceName='WORKSPACE'>
+                      <TagReviewView />
                     </ResourceProtectedRoute>
                   ),
                 },

--- a/packages/shared/src/tags/appliedTags.ts
+++ b/packages/shared/src/tags/appliedTags.ts
@@ -134,3 +134,32 @@ export const indexableTagNames = (tags: AppliedTag[]): string[] =>
  * has been curated and should no longer be re-classified.
  */
 export const isHumanApplied = (tag: AppliedTag): boolean => Boolean(tag.by);
+
+/**
+ * The stored form of a tag name, applied the moment someone invents one.
+ *
+ * Normalising at CREATION rather than at approval is what keeps a tag matching itself. If a
+ * name were rewritten later, the threads already carrying it would keep the old spelling: the
+ * chips would stop resolving to the vocabulary entry, the usage count would read zero, and a
+ * search for the approved name would find none of them.
+ *
+ * There is exactly one copy of this rule and every writer imports it — the two Zero mutator
+ * copies, the picker, and the promotion path. Two copies of it either side of a network
+ * boundary is how a proposal ends up approved under a name the server never retires.
+ *
+ * Returns '' when nothing usable survives (punctuation only); callers refuse rather than
+ * store a blank.
+ *
+ * NOT to be confused with `normalizeTagName` in this package's index, which is the Desk tag
+ * system's rule and produces the opposite shape — lowercase, hyphen-separated.
+ */
+export const normalizeThreadTypeName = (raw: string): string =>
+  raw
+    .trim()
+    .toUpperCase()
+    // Every RUN of non-alphanumerics becomes one underscore, so "vespa latency",
+    // "vespa-latency" and "Vespa/Latency" are one tag rather than three near-duplicates.
+    // Underscore is itself non-alphanumeric, so existing ones are absorbed by the same run:
+    // "VESPA__LATENCY" collapses here too, and nothing downstream can see a doubled one.
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_|_$/g, '');

--- a/packages/shared/src/tags/appliedTags.ts
+++ b/packages/shared/src/tags/appliedTags.ts
@@ -1,0 +1,136 @@
+/**
+ * An applied tag, and the one place that reads and writes the stored form.
+ *
+ * `conversations.threadType` and `messages.messageActs` are plain TEXT columns holding a
+ * JSON array of these. They used to hold a bare array of names; the parser still accepts that
+ * shape so pre-existing rows keep rendering, as a classifier-applied tag with no known
+ * timestamp.
+ *
+ * Which messages evidence a thread's tag is not recorded on the tag — it is expressed by
+ * which MESSAGES carry that tag, which the thread view already has in hand.
+ *
+ * Everything that touches those columns — classifier, mutators, Vespa mapper, UI — goes
+ * through here, because a hand-rolled JSON.parse is how the two shapes start disagreeing.
+ */
+
+export interface AppliedTag {
+  /** Vocabulary entry name, or a free-form tag someone typed. */
+  name: string;
+  /**
+   * Someone took this tag off the thread.
+   *
+   * A tombstone rather than a delete. Deletion is the only edit that destroys its own
+   * evidence — a removed tag and a tag that was never suggested look identical — so without
+   * this the classifier would hand it straight back on its next pass.
+   *
+   * There is no approval state here. Whether a NAME belongs in the vocabulary is decided
+   * once, on the vocabulary row; whether a tag belongs on a thread is decided by the person
+   * who put it there.
+   */
+  removed?: boolean;
+  /** Epoch ms. 0 for a legacy row, which carried no timestamp — render as unknown. */
+  at: number;
+  /**
+   * The person who last acted on this tag — set when someone adds it, and when someone
+   * removes it. The classifier never sets it, so its presence IS "a human touched this":
+   * there is no separate method field, because a second field could only ever disagree.
+   */
+  by?: string | null;
+}
+
+/** Legacy rows carried no timestamp; 0 is the sentinel for "applied, time unknown". */
+export const UNKNOWN_APPLIED_AT = 0;
+
+/** A bare name from a legacy row: the classifier wrote it, and nothing gated it. */
+const fromLegacyName = (name: string): AppliedTag => ({
+  name,
+  at: UNKNOWN_APPLIED_AT,
+});
+
+const fromObject = (value: Record<string, unknown>): AppliedTag | null => {
+  const name = typeof value['name'] === 'string' ? value['name'].trim() : '';
+  if (!name) return null;
+
+  return {
+    name,
+    // 'DEACTIVATED' is the old spelling of removed. The other old values — PENDING,
+    // APPROVED — both meant the tag was on the thread, so they read as not removed.
+    removed: value['removed'] === true || value['status'] === 'DEACTIVATED',
+    at: typeof value['at'] === 'number' && Number.isFinite(value['at']) ? value['at'] : UNKNOWN_APPLIED_AT,
+    by: typeof value['by'] === 'string' ? value['by'] : null,
+  };
+};
+
+/**
+ * Parse a stored column into applied tags. Never throws: the column is plain TEXT with no
+ * database-level guarantee of shape, and an unreadable value means "no tags", never a crash
+ * in a chat row.
+ *
+ * Accepts all four shapes that exist in the wild: null/empty, `'[]'`, a legacy array of
+ * names, a legacy bare name, and the current array of objects. Duplicates by name are
+ * collapsed, last write winning, so a merge bug can't render the same chip twice.
+ */
+export const parseAppliedTags = (raw: string | null | undefined): AppliedTag[] => {
+  if (!raw || !raw.trim()) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Rows written before the column held JSON stored a bare name.
+    return raw.trim() ? [fromLegacyName(raw.trim())] : [];
+  }
+
+  const list = Array.isArray(parsed) ? parsed : [parsed];
+  const byName = new Map<string, AppliedTag>();
+
+  for (const item of list) {
+    let tag: AppliedTag | null = null;
+    if (typeof item === 'string' && item.trim()) {
+      tag = fromLegacyName(item.trim());
+    } else if (item && typeof item === 'object') {
+      tag = fromObject(item as Record<string, unknown>);
+    }
+    if (tag) byName.set(tag.name, tag);
+  }
+
+  return [...byName.values()];
+};
+
+/**
+ * Serialize for storage. Always an array, always a string — `'[]'` rather than null when
+ * empty, because null means "never classified" and would make the thread eligible again on
+ * the classifier's next pass.
+ */
+export const serializeAppliedTags = (tags: AppliedTag[]): string =>
+  JSON.stringify(
+    tags.map(tag => ({
+      name: tag.name,
+      at: tag.at,
+      // Only fields that DEVIATE from the norm are written; the parser fills the rest back
+      // in. Anything present in a stored tag is therefore something that happened to it, and
+      // these columns replicate to every client through Zero.
+      ...(tag.removed ? { removed: true } : {}),
+      ...(tag.by ? { by: tag.by } : {}),
+    })),
+  );
+
+/** Tags a reader should see — everything still on the thread. */
+export const visibleTags = (tags: AppliedTag[]): AppliedTag[] =>
+  tags.filter(tag => !tag.removed);
+
+/**
+ * Names for search. Everything on the thread is indexed the moment it lands, whether the
+ * classifier or a person put it there, and whether or not the name is in the vocabulary —
+ * a tag you can see on a thread and cannot find by searching for it is just broken.
+ */
+export const indexableTagNames = (tags: AppliedTag[]): string[] =>
+  visibleTags(tags).map(tag => tag.name);
+
+/**
+ * Whether a person has acted on this tag — added it, or removed it.
+ *
+ * The classifier never writes `by`, so this is the whole test. Used to decide that a thread
+ * has been curated and should no longer be re-classified.
+ */
+export const isHumanApplied = (tag: AppliedTag): boolean => Boolean(tag.by);

--- a/packages/shared/src/tags/index.ts
+++ b/packages/shared/src/tags/index.ts
@@ -52,5 +52,7 @@ export const findDuplicateTags = (list: string[] | undefined): DuplicateTag[] =>
   return duplicates;
 };
 
-// Controlled classification vocabularies (message acts / thread types).
+// Controlled classification vocabulary (thread types).
 export * from './vocabularies';
+// The applied-tag record and the one parser/serializer for the stored columns.
+export * from './appliedTags';

--- a/packages/shared/src/tags/vocabularies.ts
+++ b/packages/shared/src/tags/vocabularies.ts
@@ -1,80 +1,46 @@
 /**
- * Controlled tag vocabularies for the classifier.
+ * The built-in thread-type vocabulary — the BASE layer.
+ *
+ * Thread types are the only tag kind; the message-act vocabulary that used to sit alongside
+ * them is gone. A message now carries the thread types it is evidence for, which is how a
+ * thread's tag is traced back to what caused it.
+ *
+ * These entries are not seeded into any table. They are the base of the layered resolution
+ * in services/messageClassification/vocabulary.ts: rows in non_zero.thread_type_vocabulary
+ * override or suppress them per workspace, and a workspace with no rows sees exactly this.
+ * Editing a name here changes it for every workspace that has not overridden it.
+ *
+ * Do NOT look an entry up from this list to render a chip — use the resolved workspace
+ * vocabulary, or a workspace that renamed a type will still show the built-in label.
  *
  * Values are UPPER_SNAKE, deliberately unlike the lowercase-hyphenated shape people type
  * for free-form thread tags, so built-in and custom are distinguishable at a glance.
  */
 
-/** Message acts are never rendered — the classifier writes them, nothing displays them. */
-export interface ActEntry {
+/** One entry in the workspace's thread-type vocabulary. */
+export interface ThreadTypeEntry {
   name: string;
-  /** One-line definition, used to generate the classifier prompt. */
+  label: string;
+  color: string;
+  /** One-line definition. Generates the classifier prompt AND the chip's hover tooltip. */
   description: string;
 }
 
-export interface VocabularyEntry extends ActEntry {
-  label: string;
-  color: string;
-}
-
 /**
- * What a message creates going forward. A message carries exactly one of these — when it
- * performs several acts, the strongest wins. Order here IS the precedence, strongest first.
- */
-export const MESSAGE_ACTS: readonly ActEntry[] = [
-  {
-    name: 'DECISION',
-    description:
-      'A choice among alternatives is made or announced by someone with authority to make it, binding what happens next.',
-  },
-  {
-    name: 'COMMITMENT',
-    description:
-      'A specific person takes on a specific obligation, optionally with a deadline.',
-  },
-  {
-    name: 'ESCALATION',
-    description:
-      'Raises urgency, severity or visibility: pulls in more senior people, or flags that something is stuck and needs intervention.',
-  },
-  {
-    name: 'QUESTION',
-    description:
-      'The sender wants information or a response. Creates an open expectation: someone now owes an answer.',
-  },
-  {
-    name: 'RESOLUTION',
-    description:
-      'Declares a piece of work finished or a problem no longer present. The claim of doneness, not the proof.',
-  },
-  {
-    name: 'STATUS_UPDATE',
-    description:
-      'Reports progress or state of ongoing work without completing it or creating anything new.',
-  },
-  {
-    name: 'ANSWER',
-    description:
-      'Supplies the information an earlier question asked for, and creates nothing new.',
-  },
-];
-
-/**
- * How a thread is classified, on two independent axes that share this one vocabulary.
+ * The thread types, in display order.
  *
- * The first seven are OUTCOME types — what "done" would mean for the thread. A thread
- * carries exactly one.
+ * One flat vocabulary: a thread carries every type that genuinely applies and nothing else —
+ * usually one, sometimes two or three. There is no partition and no per-thread cap.
  *
- * The rest are ANSWER types — what question the thread's content answers for someone who
- * was never in it. A thread carries any number, and most carry none: the bar is that a
- * reader could get their question answered by this thread alone, so tag what it answers,
- * not what it discusses.
+ * Two kinds of definition live here, distinguished by how they are phrased rather than by a
+ * field. A "done = …" definition describes the thread as a piece of WORK; the rest describe
+ * what a reader who was never in the thread could learn from it, and their bar is high —
+ * most threads clear none of them.
  *
- * The two are independent — a thread can be an ISSUE whose resolution is also a HOW_TO.
  * Descriptions are prompt copy, so the "not" clauses matter as much as the definitions:
  * near-misses are what the classifier gets wrong, and each one here is load-bearing.
  */
-export const THREAD_TYPES: readonly VocabularyEntry[] = [
+export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'ISSUE',
     label: 'Issue',
@@ -128,7 +94,6 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
       'intention without commitment ("we should ship this next week").',
   },
 
-  // ─── Answer types — what a reader could learn from this thread ──────────────
   {
     name: 'HOW_TO',
     label: 'How-to',
@@ -215,52 +180,3 @@ export const THREAD_TYPES: readonly VocabularyEntry[] = [
       'being breached during an incident (that is WHAT_HAPPENED).',
   },
 ];
-
-/**
- * Sentinel the classifier may return for a message that performs no act. Deliberately NOT
- * in MESSAGE_ACTS: it is never stored and never rendered, it is mapped to an empty act
- * list. Asking the model to name a value is more reliable than asking it for [].
- */
-export const NO_ACT = 'NONE';
-
-/**
- * Tag names as a const tuple, strongest act first. Exported separately from MESSAGE_ACTS
- * because Zod's z.enum needs a literal tuple, and because precedence ordering is derived
- * from this array's order rather than stored on each entry.
- */
-export const MESSAGE_ACT_NAMES = [
-  'DECISION',
-  'COMMITMENT',
-  'ESCALATION',
-  'QUESTION',
-  'RESOLUTION',
-  'STATUS_UPDATE',
-  'ANSWER',
-] as const;
-
-/**
- * Thread types as a const tuple — z.enum needs a literal tuple. Order is display order, and
- * it is also the chip sort order via `rank()` in both mutator copies, so outcome types stay
- * first and answer types trail them.
- */
-export const THREAD_TYPE_NAMES = [
-  'ISSUE',
-  'ALERT',
-  'QUESTION',
-  'REQUEST',
-  'FEATURE_REQUEST',
-  'DISCUSSION',
-  'ANNOUNCEMENT',
-  'HOW_TO',
-  'WHAT_HAPPENED',
-  'WHY_DECISION',
-  'WHAT_IS',
-  'KNOWN_ISSUE',
-  'REFERENCE',
-  'EXAMPLE',
-  'POLICY_LIMIT',
-] as const;
-
-/** Built-in thread type by name; undefined for a free-form tag. */
-export const threadTypeEntry = (name: string): VocabularyEntry | undefined =>
-  THREAD_TYPES.find(entry => entry.name === name);

--- a/packages/shared/src/tags/vocabularies.ts
+++ b/packages/shared/src/tags/vocabularies.ts
@@ -22,7 +22,20 @@ export interface ThreadTypeEntry {
   name: string;
   label: string;
   color: string;
-  /** One-line definition. Generates the classifier prompt AND the chip's hover tooltip. */
+  /**
+   * One line, for people. The chip's tooltip and the review row.
+   *
+   * Separate from `description` because the two are written for different readers and pull in
+   * opposite directions: prompt copy earns its length from the "NOT" clauses that stop the
+   * model on near-misses, and every one of those is noise to someone hovering a chip.
+   */
+  summary: string;
+  /**
+   * The classifier's instruction for this type — prompt copy, not a tooltip.
+   *
+   * Long on purpose. The NOT clauses matter as much as the definition: near-misses are what
+   * the model gets wrong, and each one is there because something was mistagged without it.
+   */
   description: string;
 }
 
@@ -44,6 +57,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'ISSUE',
     label: 'Issue',
+    summary: 'Something is broken. Done when it is fixed and verified.',
     color: '#ef4444',
     description:
       'Something that should work is broken or degraded. Done = fixed and verified.',
@@ -51,6 +65,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'ALERT',
     label: 'Alert',
+    summary: 'A bot or monitoring check reported a problem.',
     color: '#f59e0b',
     description:
       'A bot or automated check (monitoring, QA, CI) opened the thread to report a problem. Done = acknowledged and resolved or deliberately suppressed.',
@@ -58,6 +73,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'QUESTION',
     label: 'Question',
+    summary: 'Someone wants information. Done when it is answered.',
     color: '#f97316',
     description:
       'The thread exists to get information; no defect, no action on a system. Done = answered.',
@@ -65,6 +81,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'REQUEST',
     label: 'Request',
+    summary: 'Asks someone to do something the system already supports.',
     color: '#3b82f6',
     description:
       'Asks someone to perform an action the system already supports. Done = action performed and confirmed.',
@@ -72,6 +89,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'FEATURE_REQUEST',
     label: 'Feature request',
+    summary: 'Asks for something that does not exist yet.',
     color: '#8b5cf6',
     description:
       'Asks for capability that does not exist; requires product evaluation. Done = accepted onto the roadmap or declined with reason.',
@@ -79,6 +97,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'DISCUSSION',
     label: 'Discussion',
+    summary: 'An open-ended exchange with no finish line.',
     color: '#6b7280',
     description:
       'Open-ended exchange with no inherent done state. The default when no other type fits.',
@@ -86,6 +105,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'ANNOUNCEMENT',
     label: 'Announcement',
+    summary: 'A broadcast — a release, deprecation or planned maintenance.',
     color: '#14b8a6',
     description:
       'One-to-many broadcast; nothing is owed by anyone. No done state. Covers dated ' +
@@ -97,6 +117,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'HOW_TO',
     label: 'How-to',
+    summary: 'Explains how to do something, completely enough to follow.',
     color: '#0891b2',
     description:
       'Contains an actionable procedure — ordered steps, or a complete instruction a reader ' +
@@ -109,6 +130,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'WHAT_HAPPENED',
     label: 'What happened',
+    summary: 'An account of a specific past event, such as an incident.',
     color: '#b45309',
     description:
       'A narrative of a specific past event — incident recap, sequence of events, impact, ' +
@@ -120,6 +142,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'WHY_DECISION',
     label: 'Why (decision)',
+    summary: 'A decision and the reasoning behind it.',
     color: '#4f46e5',
     description:
       'States a decision AND the reasoning behind it. Fires on "we chose X over Y because…", ' +
@@ -130,17 +153,21 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'WHAT_IS',
     label: 'What is',
+    summary: 'Explains what something is — a term, feature or system.',
     color: '#059669',
     description:
       'Explains a concept, term, feature or system — a definition or explainer a newcomer ' +
       'could learn from. Answers a vocabulary question, not a task question. Fires on "X is…", ' +
       '"X means…", capability descriptions, jargon explanations, architecture explainers. NOT ' +
-      'when the term is merely USED rather than explained, NOT a one-word or purely contextual ' +
-      'reply.',
+      'when someone ASKS what something is and no one answers — a question is not an answer, ' +
+      'and an unanswered "what is X?" is the clearest case of what this must never fire on. ' +
+      'NOT when the term is merely USED rather than explained, NOT a one-word or purely ' +
+      'contextual reply.',
   },
   {
     name: 'KNOWN_ISSUE',
     label: 'Known issue',
+    summary: 'An acknowledged bug or limitation, and any workaround.',
     color: '#be123c',
     description:
       'An acknowledged bug or limitation, its status, and any workaround. Fires when the ' +
@@ -151,6 +178,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'REFERENCE',
     label: 'Reference',
+    summary: 'Exact values to look up: fields, error codes, formats.',
     color: '#334155',
     description:
       'Exact technical facts meant to be looked up: field lists, parameter names and types, ' +
@@ -162,6 +190,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'EXAMPLE',
     label: 'Example',
+    summary: 'A concrete, working instance you could copy and use.',
     color: '#65a30d',
     description:
       'A concrete, complete instance whose value is that it can be copied and used: a working ' +
@@ -172,6 +201,7 @@ export const THREAD_TYPES: readonly ThreadTypeEntry[] = [
   {
     name: 'POLICY_LIMIT',
     label: 'Policy / limit',
+    summary: 'A rule or limit, stated with its actual value.',
     color: '#c026d3',
     description:
       'States an operative constraint together with its value: transaction limits, SLA ' +

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -76,6 +76,7 @@ import {
   serializeParentMessageMd,
 } from '../utils/activityMetadataParser.js';
 import {
+  normalizeThreadTypeName,
   parseAppliedTags,
   serializeAppliedTags,
   type AppliedTag,
@@ -9267,9 +9268,24 @@ export const mutators = defineMutators({
         );
         if (!conversation) throw new Error('Conversation not found');
 
-        const desired = [...new Set(types.map(t => t.trim()).filter(Boolean))];
         const existing = parseAppliedTags(conversation.threadType);
         const byName = new Map(existing.map(tag => [tag.name, tag]));
+
+        // Normalise the names being ADDED, and only those. A name already on this thread is
+        // passed through untouched: the caller resends the full set on every edit, so
+        // normalising indiscriminately would silently rewrite tags applied long ago, on an
+        // edit that had nothing to do with them, leaving the same tag spelled two ways
+        // across the workspace.
+        const desired = [
+          ...new Set(
+            types
+              .map(raw => {
+                const trimmed = raw.trim();
+                return byName.has(trimmed) ? trimmed : normalizeThreadTypeName(trimmed);
+              })
+              .filter(Boolean),
+          ),
+        ];
 
         // A merge, never a replace. The caller sends the full desired set, but each tag
         // already there keeps its own provenance — who applied it and when. Rewriting them all

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -75,7 +75,11 @@ import {
   serializeInitialMessageMd,
   serializeParentMessageMd,
 } from '../utils/activityMetadataParser.js';
-import { THREAD_TYPE_NAMES } from '../tags/vocabularies.js';
+import {
+  parseAppliedTags,
+  serializeAppliedTags,
+  type AppliedTag,
+} from '../tags/appliedTags.js';
 import { assertCanvasDestinationAccess } from '../utils/canvasDestinationAccess.js';
 import {
   getCanvasFolderNameConflictMessage,
@@ -9243,32 +9247,58 @@ export const mutators = defineMutators({
     setTypes: defineMutator(
       z.object({
         conversationId: z.string(),
-        // Free-form, not z.enum: the built-in vocabulary is a starting point, and projects
-        // add their own. Length-capped so a tag stays a label rather than a paragraph.
+        // Free-form, not z.enum: the workspace vocabulary is a starting point, and people
+        // type their own. Length-capped so a tag stays a label rather than a paragraph.
         types: z.array(z.string().trim().min(1).max(40)),
+        /**
+         * What a newly invented tag means. Stored on the vocabulary candidate as its
+         * description — backend side only, since the vocabulary is not a Zero table — so it
+         * is written once per tag rather than copied onto every thread carrying it.
+         */
+        note: z.string().trim().max(280).optional(),
+        timestamp: z.number(),
       }),
-      async ({ tx, args: { conversationId, types } }) => {
+      // `note` is accepted but deliberately unread here. It describes the TAG, not the
+      // thread, so it is stored on the vocabulary candidate — a non-Zero table this client
+      // copy cannot reach. The backend copy picks it up; see recordVocabularyCandidate.
+      async ({ tx, ctx, args: { conversationId, types, timestamp } }) => {
         const conversation = await tx.run(
           zql.conversations.where('conversationId', conversationId).one(),
         );
         if (!conversation) throw new Error('Conversation not found');
 
-        // Built-in types first in vocabulary order, then custom ones alphabetically, so
-        // chips render in a stable order regardless of the order they were picked.
-        const rank = (name: string): number => {
-          const i = (THREAD_TYPE_NAMES as readonly string[]).indexOf(name);
-          return i === -1 ? THREAD_TYPE_NAMES.length : i;
-        };
-        const unique = [...new Set(types.map(t => t.trim()).filter(Boolean))].sort(
-          (a, b) => rank(a) - rank(b) || a.localeCompare(b),
-        );
+        const desired = [...new Set(types.map(t => t.trim()).filter(Boolean))];
+        const existing = parseAppliedTags(conversation.threadType);
+        const byName = new Map(existing.map(tag => [tag.name, tag]));
 
+        // A merge, never a replace. The caller sends the full desired set, but each tag
+        // already there keeps its own provenance — who applied it and when. Rewriting them all
+        // as freshly hand-applied would erase exactly the trail the tooltip exists to show.
+        const next: AppliedTag[] = [];
+        for (const name of desired) {
+          const prior = byName.get(name);
+          if (prior && !prior.removed) {
+            next.push(prior);
+            continue;
+          }
+          // New, or being re-applied after removal: this is the caller's doing either way.
+          next.push({ name, at: timestamp, by: ctx.userID });
+        }
 
-        // '[]' rather than null when cleared: null means "never classified" and the
-        // classifier would re-derive it on its next pass.
+        // Dropped tags are tombstoned, not deleted: removal has to stay auditable, and a
+        // deleted tag would look unclassified to the classifier and come straight back.
+        const kept = new Set(desired);
+        for (const tag of existing) {
+          if (kept.has(tag.name)) continue;
+          next.push(
+            tag.removed ? tag : { ...tag, removed: true, at: timestamp, by: ctx.userID },
+          );
+        }
+
         await tx.mutate.conversations.update({
           conversationId,
-          threadType: unique.length > 0 ? JSON.stringify(unique) : '[]',
+          // Never null: null means "never classified" and the classifier would re-derive it.
+          threadType: serializeAppliedTags(next),
         });
       },
     ),


### PR DESCRIPTION
Migration-Changes:
  - added a new table to store tags vocab

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
