### PR TITLE
fix: XYNE-58300 clean up orphaned MCP tools and evict sessions on server deletion

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/servers.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/servers.ts
@@ -7,6 +7,7 @@ import { getCredentialFieldsByServerType } from "../mcp/connector-definitions.js
 import { getRequesterId, isClawAdmin, requireClawAdmin } from "../middleware/agent-acl.js";
 import { writeAuditLog } from "../lib/audit.js";
 import { isOAuthConnector } from "./oauth-token.js";
+import { evictSession } from "../mcp/runner.js";
 
 import { createLogger } from "../logger.js";
 const log = createLogger("servers");
@@ -768,7 +769,33 @@ router.delete("/:id", async (req: Request<{ id: string }>, res: Response) => {
       res.status(403).json({ success: false, error: "Only the connector owner or a CLAW_ADMIN can delete it" });
       return;
     }
+    // Evict cached MCP child processes for every user who has a connection to
+    // this server. Without this the runner keeps stale sessions alive until the
+    // 20-min idle eviction, and tools from the deleted server remain callable.
+    const connections = await prisma.userMcpConnection.findMany({
+      where: { mcpServerId: id },
+      select: { userId: true },
+    });
+    for (const c of connections) {
+      await evictSession(c.userId, existing.type).catch((err) => {
+        log.error(`[servers] evictSession failed for ${existing.type}:`, err);
+      });
+    }
+
     await prisma.mcpServer.delete({ where: { id } });
+
+    // Clean up orphaned tool catalog entries. The Tool model stores
+    // `source: "mcp:${serverType}"` as a plain string — NOT a foreign key —
+    // so Prisma's cascade delete does not reach the tools table. Without this
+    // the deleted server's tools persist in the agent config picker forever.
+    // AgentTool links cascade-delete automatically (onDelete: Cascade on Tool).
+    const deletedTools = await prisma.tool.deleteMany({
+      where: { source: `mcp:${existing.type}` },
+    });
+    if (deletedTools.count > 0) {
+      log.info(`[servers] Deleted ${deletedTools.count} orphaned tools for ${existing.type}`);
+    }
+
     await writeAuditLog({
       actorUserId: requesterId,
       eventType: "MCP_CONNECTOR_DELETED",
@@ -781,6 +808,7 @@ router.delete("/:id", async (req: Request<{ id: string }>, res: Response) => {
         launchConfigTemplate: existing.launchConfigTemplate,
         httpConfigTemplate: existing.httpConfigTemplate,
         credentialForm: existing.credentialForm,
+        deletedToolsCount: deletedTools.count,
       },
     });
     res.json({ success: true });


### PR DESCRIPTION
## Problem

When an MCP server (connector definition) is deleted via `DELETE /servers/:id`, the handler only removed the `McpServer` database row. Two issues resulted:

1. **Orphaned tools** — Tool catalog entries (`source: "mcp:<type>"`) persisted indefinitely because the `Tool` model stores the source as a plain string, not a foreign key to `McpServer`. Prisma's cascade delete never reached the `tools` table. These orphaned tools remained visible in the agent config picker even after the server was deleted.

2. **Stale cached sessions** — Cached MCP child processes lingered until the 20-min idle eviction, meaning tools from the deleted server remained callable.

## Root Cause

In `apps/xyne-claw-auth/backend/src/routes/servers.ts`, the `DELETE /:id` handler called `prisma.mcpServer.delete()` but did NOT:
- Call `evictSession()` to clean up cached MCP runner sessions (unlike `connections.ts` DELETE which does)
- Call `prisma.tool.deleteMany()` to remove tool catalog entries

The `reconcileServerCatalog()` function in `tool-sync.ts` can prune stale tools, but it only runs when the picker opens AND the MCP server is still reachable. Once the server is deleted, reconcile can't reach it.

## Fix

In the `DELETE /:id` handler, before deleting the `McpServer` row:
1. **Evict cached sessions** — Find all `UserMcpConnection` records for this server, call `evictSession(userId, serverType)` for each
2. **Delete orphaned tools** — After `prisma.mcpServer.delete()`, call `prisma.tool.deleteMany({ where: { source: "mcp:${existing.type}" } })`
3. **Audit trail** — Record `deletedToolsCount` in the audit log metadata

`AgentTool` links cascade-delete automatically (`onDelete: Cascade` on `Tool → AgentTool`), so no manual cleanup needed for agent-tool associations.

## Testing

- Typecheck passes (no new errors introduced; pre-existing Prisma client generation errors are sandbox-only)
- Code review verified the `Tool.source` field format matches the `mcp:${serverType}` pattern used by `syncToolsForServer()` in `tool-sync.ts`

## Files Changed

- `apps/xyne-claw-auth/backend/src/routes/servers.ts` — Added `evictSession` import, session eviction loop, tool cleanup, and audit metadata