### PR TITLE
feat: clarify automation schema fields

### DIFF
--- a/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/RunAgentStepForm.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/RunAgentStepForm.tsx
@@ -8,6 +8,12 @@ import type { VariablePickerSource } from '../VariablePicker/VariablePicker.type
 import type { ValidationIssue } from '../../Automation.types';
 import { fetchClawAgents, type ClawAgent } from '../../../../api/automationsApi';
 
+const AGENT_OUTPUT_SCHEMA_EXAMPLE: SchemaTree = {
+  summary: 'string',
+  priority: 'string',
+  needsFollowUp: 'boolean',
+};
+
 interface RunAgentConfigShape {
   agentSlug?: string;
   prompt?: string;
@@ -186,14 +192,15 @@ export function RunAgentStepForm({
 
       {/* Output schema — JSON editor with nesting support */}
       <FieldRow
-        label='Expected output'
-        description='JSON shape the agent will return. Leaves are type strings ("string" | "number" | "boolean" | "object" | "array"); use a nested object for nested fields. Downstream steps see top-level keys as variables before this step runs.'
+        label='Expected agent output schema'
+        description='Declare each variable the agent must return and its type, for example { result: "string" }. The default { result: "string" } is kept for new agent steps so downstream steps always have a usable variable.'
         error={issuesAt.get('outputSchema')}
       >
         <SchemaJsonEditor
           value={outputSchema}
           onChange={next => setField('outputSchema', next)}
           readOnly={readOnly}
+          example={AGENT_OUTPUT_SCHEMA_EXAMPLE}
           emptyHint='Empty schema — downstream steps will see no variables.'
         />
       </FieldRow>

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/WebhookStepForm.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/WebhookStepForm.tsx
@@ -30,6 +30,14 @@ const JSON_BODY_PLACEHOLDER = `{
   "key": "value"
 }`;
 
+const RESPONSE_SCHEMA_EXAMPLE: SchemaTree = {
+  id: 'string',
+  success: 'boolean',
+  data: {
+    status: 'string',
+  },
+};
+
 const AUTH_TYPES = ['none', 'basic', 'bearer'] as const;
 type AuthType = (typeof AUTH_TYPES)[number];
 
@@ -301,8 +309,8 @@ export function WebhookStepForm({
       )}
 
       <FieldGroup
-        label='Expected response body'
-        description='Declare the JSON shape of the response body so downstream steps can drill into it. This shape becomes responseJson inside the full step output: { status, ok, responseBody, responseJson: <your shape> }. Open the Input / output peek above this form to see the complete output. Leaves are type strings ("string" | "number" | "boolean" | "object" | "array"); nest objects for nested fields.'
+        label='Expected response body schema'
+        description='This is not a sample response body. Declare each responseJson variable name and its type, for example { id: "string", success: "boolean" }. The full webhook output remains { status, ok, responseBody, responseJson: <this schema> }.'
       >
         <SchemaJsonEditor
           value={responseSchema}
@@ -313,6 +321,7 @@ export function WebhookStepForm({
             onChange(cleaned);
           }}
           readOnly={readOnly}
+          example={RESPONSE_SCHEMA_EXAMPLE}
           emptyHint='Empty schema — downstream steps see responseJson as an opaque blob.'
         />
       </FieldGroup>

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/TriggerCard/WebhookTriggerForm.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/TriggerCard/WebhookTriggerForm.tsx
@@ -2,6 +2,19 @@ import { useMemo } from 'react';
 import { SchemaJsonEditor, type SchemaTree } from '../SchemaForm/SchemaJsonEditor';
 import type { ValidationIssue } from '../../Automation.types';
 
+const BODY_SCHEMA_EXAMPLE: SchemaTree = {
+  customerId: 'string',
+  amount: 'number',
+  metadata: {
+    source: 'string',
+  },
+};
+
+const HEADER_SCHEMA_EXAMPLE: SchemaTree = {
+  'x-signature': 'secret',
+  'x-api-version': 'string',
+};
+
 interface WebhookTriggerConfigShape {
   bodySchema?: SchemaTree;
   headerSchema?: SchemaTree;
@@ -43,26 +56,28 @@ export function WebhookTriggerForm({
   return (
     <div className='flex flex-col gap-5'>
       <Field
-        label='Request body'
-        description='JSON shape callers must POST. Declared keys are required on every call (extras allowed); a 400 is returned on mismatch. Downstream steps read these as {{trigger.body.*}}.'
+        label='Request body schema'
+        description='This is not a sample request body. Declare each variable name and its type, for example { customerId: "string" }. Callers must POST those fields; downstream steps read them as {{trigger.body.customerId}}.'
         error={issuesAt.get('bodySchema')}
       >
         <SchemaJsonEditor
           value={bodySchema}
           onChange={next => setField('bodySchema', next)}
+          example={BODY_SCHEMA_EXAMPLE}
           emptyHint='No body fields required — any JSON body is accepted.'
         />
       </Field>
 
       <Field
-        label='Request headers'
-        description='Header names callers must send. Declared headers are required (extras allowed). Mark a header sensitive by giving it the "secret" type — its value is redacted before the request is stored. Downstream steps read these as {{trigger.headers.*}}.'
+        label='Request header schema'
+        description='Declare required header variable names and their types. Mark a sensitive header as "secret" so its value is redacted before storage. Downstream steps read them as {{trigger.headers.x-signature}}.'
         error={issuesAt.get('headerSchema')}
       >
         <SchemaJsonEditor
           value={headerSchema}
           onChange={next => setField('headerSchema', next)}
           allowSecret
+          example={HEADER_SCHEMA_EXAMPLE}
           emptyHint='No required headers.'
         />
       </Field>


### PR DESCRIPTION
1. Problem Description:
Automation users were confusing request/response body schema editors with literal JSON bodies, especially webhook trigger/action schemas. Agent output schema also did not explicitly say that each key becomes a variable name with a declared type.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
User feedback in Spaces thread: webhook request body and response body fields are schemas, not true bodies, and need clearer wording plus examples.

3. Explain the solution implemented in the PR:
- Relabel webhook trigger request body/header fields as schemas.
- Relabel webhook action expected response body as a response body schema.
- Add concrete Insert example payloads for webhook body, webhook headers, and webhook response schema editors.
- Clarify agent output schema wording while preserving the existing default { result: "string" } behavior for new agent steps.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- pnpm --dir apps/dashboard format:check
- pnpm --dir apps/dashboard exec eslint --quiet src/components/Automation/AutomationBuilder/TriggerCard/WebhookTriggerForm.tsx src/components/Automation/AutomationBuilder/StepCard/WebhookStepForm.tsx src/components/Automation/AutomationBuilder/StepCard/RunAgentStepForm.tsx
- pnpm --dir apps/dashboard typecheck was attempted, but the repo currently fails on unrelated missing deps/types in ReactArtifact and onDeviceIntent files.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A