### PR TITLE
fix: silence superposition provider debug logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -315,6 +315,9 @@
       "ws@7": "7.5.13",
       "ws@8": "8.21.1",
       "xlsx": "npm:@e965/xlsx@0.20.3"
+    },
+    "patchedDependencies": {
+      "superposition-provider@0.97.4": "patches/superposition-provider@0.97.4.patch"
     }
   }
 }

--- a/patches/superposition-provider@0.97.4.patch
+++ b/patches/superposition-provider@0.97.4.patch
@@ -1,0 +1,156 @@
+diff --git a/dist/index.esm.js b/dist/index.esm.js
+index f48ef46050a4b4897b8913fbef249abd08128ca4..f46e433d59b9968c884152f38d1119e39160e95e 100644
+--- a/dist/index.esm.js
++++ b/dist/index.esm.js
+@@ -16568,17 +16568,6 @@ class NativeResolver {
+         const experimentationJson = experimentation
+             ? JSON.stringify(experimentation)
+             : null;
+-        console.log("🔧 Calling FFI with parameters:");
+-        console.log("  defaultConfigs:", defaultConfigs);
+-        console.log("  contexts length:", contextsJson.length);
+-        console.log("  overrides length:", overridesJson.length);
+-        console.log("  dimensions length:", dimensionsJson.length);
+-        console.log("  queryData :", queryDataJson);
+-        console.log("  mergeStrategy:", mergeStrategy);
+-        console.log("  filterPrefixes:", filterPrefixes);
+-        console.log("  experiment:", experimentation?.experiments?.length);
+-        console.log("  experiment groups:", experimentation?.experiment_groups?.length);
+-        console.log("  targetingKey:", experimentation?.targetingKey);
+         if (!defaultConfigsJson ||
+             defaultConfigsJson === "null" ||
+             defaultConfigsJson === "undefined") {
+@@ -16606,7 +16595,6 @@ class NativeResolver {
+         }
+         const ebuf = Buffer$1.alloc(256);
+         const result = this.lib.core_get_resolved_config(defaultConfigsJson, contextsJson, overridesJson, dimensionsJson, queryDataJson, mergeStrategy, filterPrefixesJson, experimentationJson, ebuf);
+-        console.log("🔧 FFI call completed, result:", result);
+         const err = ebuf.toString('utf8').split('\0')[0];
+         if (err.length !== 0) {
+             this.throwFFIError(err);
+@@ -16672,15 +16660,8 @@ class NativeResolver {
+         const userContextJson = JSON.stringify(userContext);
+         const dimensionsJson = JSON.stringify(dimensions);
+         const filterPrefixesJson = filterPrefixes.length > 0 ? JSON.stringify(filterPrefixes) : null;
+-        console.log("Calling FFI getApplicableVariants with parameters:");
+-        console.log("  experiments:", experiments.length);
+-        console.log("  experimentGroups:", experiment_groups.length);
+-        console.log("  userContext:", userContext);
+-        console.log("  identifier:", identifier);
+-        console.log("  filterPrefixes:", filterPrefixes);
+         const ebuf = Buffer$1.alloc(256);
+         const result = this.lib.core_get_applicable_variants(experimentsJson, experimentGroupsJson, dimensionsJson, userContextJson, identifier, filterPrefixesJson);
+-        console.log("FFI getApplicableVariants call completed, result:", result);
+         const err = ebuf.toString('utf8').split('\0')[0];
+         if (err.length !== 0) {
+             this.throwFFIError(err);
+@@ -16727,31 +16708,26 @@ class NativeResolver {
+         const dirname = path.dirname(fileURLToPath(import.meta.url));
+         const packageRootPath = path.resolve(dirname, "..", filename);
+         if (this.fileExists(packageRootPath)) {
+-            console.log(`Using native library from package root: ${packageRootPath}`);
+             return packageRootPath;
+         }
+         // 1. First try to load from package's native-lib directory (GitHub artifacts)
+         const packageNativeLibPath = path.resolve(dirname, "native-lib", filename);
+         if (this.fileExists(packageNativeLibPath)) {
+-            console.log(`Using native library from package: ${packageNativeLibPath}`);
+             return packageNativeLibPath;
+         }
+         const packageNative2LibPath = path.resolve(dirname, "..", "native-lib", filename);
+         if (this.fileExists(packageNative2LibPath)) {
+-            console.log(`Using native library from package: ${packageNative2LibPath}`);
+             return packageNative2LibPath;
+         }
+         // 2. Try platform-specific subdirectory in native-lib
+         const platformDir = `${platform}-${arch}`;
+         const platformSpecificPath = path.resolve(dirname, "..", "native-lib", platformDir, filename);
+         if (this.fileExists(platformSpecificPath)) {
+-            console.log(`Using platform-specific native library: ${platformSpecificPath}`);
+             return platformSpecificPath;
+         }
+         // 3. Fall back to local build (relative to repository root)
+         const localBuildPath = path.resolve(dirname, "..", "..", "..", "..", "target", "release", filename);
+         if (this.fileExists(localBuildPath)) {
+-            console.log(`Using local build: ${localBuildPath}`);
+             return localBuildPath;
+         }
+         // 4. Final fallback - assume it's in the system path
+diff --git a/dist/index.js b/dist/index.js
+index 7b368fea9d88776f6529da6c36a4bba3b89cb846..29aae72c1890dc6de7e8d2b6ffecf7c59e81c74e 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -16571,17 +16571,6 @@ class NativeResolver {
+         const experimentationJson = experimentation
+             ? JSON.stringify(experimentation)
+             : null;
+-        console.log("🔧 Calling FFI with parameters:");
+-        console.log("  defaultConfigs:", defaultConfigs);
+-        console.log("  contexts length:", contextsJson.length);
+-        console.log("  overrides length:", overridesJson.length);
+-        console.log("  dimensions length:", dimensionsJson.length);
+-        console.log("  queryData :", queryDataJson);
+-        console.log("  mergeStrategy:", mergeStrategy);
+-        console.log("  filterPrefixes:", filterPrefixes);
+-        console.log("  experiment:", experimentation?.experiments?.length);
+-        console.log("  experiment groups:", experimentation?.experiment_groups?.length);
+-        console.log("  targetingKey:", experimentation?.targetingKey);
+         if (!defaultConfigsJson ||
+             defaultConfigsJson === "null" ||
+             defaultConfigsJson === "undefined") {
+@@ -16609,7 +16598,6 @@ class NativeResolver {
+         }
+         const ebuf = buffer.Buffer.alloc(256);
+         const result = this.lib.core_get_resolved_config(defaultConfigsJson, contextsJson, overridesJson, dimensionsJson, queryDataJson, mergeStrategy, filterPrefixesJson, experimentationJson, ebuf);
+-        console.log("🔧 FFI call completed, result:", result);
+         const err = ebuf.toString('utf8').split('\0')[0];
+         if (err.length !== 0) {
+             this.throwFFIError(err);
+@@ -16675,15 +16663,8 @@ class NativeResolver {
+         const userContextJson = JSON.stringify(userContext);
+         const dimensionsJson = JSON.stringify(dimensions);
+         const filterPrefixesJson = filterPrefixes.length > 0 ? JSON.stringify(filterPrefixes) : null;
+-        console.log("Calling FFI getApplicableVariants with parameters:");
+-        console.log("  experiments:", experiments.length);
+-        console.log("  experimentGroups:", experiment_groups.length);
+-        console.log("  userContext:", userContext);
+-        console.log("  identifier:", identifier);
+-        console.log("  filterPrefixes:", filterPrefixes);
+         const ebuf = buffer.Buffer.alloc(256);
+         const result = this.lib.core_get_applicable_variants(experimentsJson, experimentGroupsJson, dimensionsJson, userContextJson, identifier, filterPrefixesJson);
+-        console.log("FFI getApplicableVariants call completed, result:", result);
+         const err = ebuf.toString('utf8').split('\0')[0];
+         if (err.length !== 0) {
+             this.throwFFIError(err);
+@@ -16730,31 +16711,26 @@ class NativeResolver {
+         const dirname = path.dirname(url.fileURLToPath((typeof document === 'undefined' ? require('u' + 'rl').pathToFileURL(__filename).href : (_documentCurrentScript && _documentCurrentScript.tagName.toUpperCase() === 'SCRIPT' && _documentCurrentScript.src || new URL('index.js', document.baseURI).href))));
+         const packageRootPath = path.resolve(dirname, "..", filename);
+         if (this.fileExists(packageRootPath)) {
+-            console.log(`Using native library from package root: ${packageRootPath}`);
+             return packageRootPath;
+         }
+         // 1. First try to load from package's native-lib directory (GitHub artifacts)
+         const packageNativeLibPath = path.resolve(dirname, "native-lib", filename);
+         if (this.fileExists(packageNativeLibPath)) {
+-            console.log(`Using native library from package: ${packageNativeLibPath}`);
+             return packageNativeLibPath;
+         }
+         const packageNative2LibPath = path.resolve(dirname, "..", "native-lib", filename);
+         if (this.fileExists(packageNative2LibPath)) {
+-            console.log(`Using native library from package: ${packageNative2LibPath}`);
+             return packageNative2LibPath;
+         }
+         // 2. Try platform-specific subdirectory in native-lib
+         const platformDir = `${platform}-${arch}`;
+         const platformSpecificPath = path.resolve(dirname, "..", "native-lib", platformDir, filename);
+         if (this.fileExists(platformSpecificPath)) {
+-            console.log(`Using platform-specific native library: ${platformSpecificPath}`);
+             return platformSpecificPath;
+         }
+         // 3. Fall back to local build (relative to repository root)
+         const localBuildPath = path.resolve(dirname, "..", "..", "..", "..", "target", "release", filename);
+         if (this.fileExists(localBuildPath)) {
+-            console.log(`Using local build: ${localBuildPath}`);
+             return localBuildPath;
+         }
+         // 4. Final fallback - assume it's in the system path

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-kYla/jBKu002rBl6Loamo/+kTzooiIs3F5TZy64LHO8=
 
+patchedDependencies:
+  superposition-provider@0.97.4:
+    hash: 7dbf5602c75be0e9ee2dc5557bf4d8d77d7343fffb981dd9fa158c71c8690507
+    path: patches/superposition-provider@0.97.4.patch
+
 importers:
 
   .:
@@ -461,7 +466,7 @@ importers:
         version: 1.1.1
       superposition-provider:
         specifier: ^0.97.0
-        version: 0.97.4(@openfeature/server-sdk@1.23.0(@openfeature/core@1.12.0))
+        version: 0.97.4(patch_hash=7dbf5602c75be0e9ee2dc5557bf4d8d77d7343fffb981dd9fa158c71c8690507)(@openfeature/server-sdk@1.23.0(@openfeature/core@1.12.0))
       undici:
         specifier: 7.29.0
         version: 7.29.0
@@ -40732,7 +40737,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  superposition-provider@0.97.4(@openfeature/server-sdk@1.23.0(@openfeature/core@1.12.0)):
+  superposition-provider@0.97.4(patch_hash=7dbf5602c75be0e9ee2dc5557bf4d8d77d7343fffb981dd9fa158c71c8690507)(@openfeature/server-sdk@1.23.0(@openfeature/core@1.12.0)):
     dependencies:
       '@openfeature/server-sdk': 1.23.0(@openfeature/core@1.12.0)
       koffi: 2.16.3


### PR DESCRIPTION
1. Problem Description:
`superposition-provider@0.97.4` emits high-volume debug `console.log` lines from its bundled FFI/native resolver path. These logs include repeated config-evaluation details such as `🔧 Calling FFI with parameters`, `queryData`, `targetingKey`, and `🔧 FFI call completed`, which are flooding Grafana/VictoriaLogs.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Investigated in sandbox. Xyne only instantiates `new SuperpositionProvider(...)` from `apps/backend/src/services/superpositionClient.ts`; the noisy log lines are inside the installed `superposition-provider` package, not Xyne logger code. The provider types do not expose a logger/log-level/silent option.

3. Explain the solution implemented in the PR:
Adds a pnpm `patchedDependencies` patch for `superposition-provider@0.97.4` that removes only the noisy SDK `console.log` lines from `dist/index.js` and `dist/index.esm.js`. It does not monkey-patch global console behavior and does not remove warning/error logs.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Ran `pnpm install --frozen-lockfile --offline --ignore-scripts` successfully.
- Verified the patched installed package no longer contains the targeted noisy debug strings in `apps/backend/node_modules/superposition-provider/dist/index.js` and `index.esm.js`.
- Note: a normal `pnpm install --frozen-lockfile --offline` was attempted but hung in workspace postinstall (`packages/xyne-claw-shared postinstall$ pnpm exec playwright install chromium`), so validation was rerun with `--ignore-scripts`.

9. Services to which this change is to be deployed:
Backend / services that install `apps/backend` dependencies and use `superposition-provider`.

10. Main PR link (if this PR is raised against a release branch):
N/A