### PR TITLE
fix: XYNE-60261 count SDLC channel tickets

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -4303,6 +4303,13 @@ dmChannelsLatestMessagesPaginated: defineQuery(
         )
         .related('pullRequests', pullRequest => pullRequest.orderBy('updatedAt', 'desc')),
   ),
+  sdlcChannelTickets: defineQuery(
+    z.object({ channelId: z.string(), isMember: z.boolean() }),
+    ({ args: { channelId } }) =>
+      zql.tickets
+        .where('channelId', channelId)
+        .where('isArchived', false),
+  ),
   sdlcDiscussionConversations: defineQuery(
     z.object({
       channelId: z.string(),

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -511,11 +511,24 @@ export default function SdlcScreen(): ReactElement {
   const [relatedTickets] = useCachedQuery(
     queries.sdlcTicketsByIds({ ticketIds: relatedTicketIds }),
   );
+  const isSdlcChannelMember = Boolean(
+    repo &&
+      !(repo instanceof Error) &&
+      repo.channel?.participants?.some(participant => participant.userId === auth.userID),
+  );
+  const [channelTickets] = useCachedQuery(
+    queries.sdlcChannelTickets({
+      channelId: repo && !(repo instanceof Error) ? (repo.channelId ?? '') : '',
+      isMember: isSdlcChannelMember,
+    }),
+    { enabled: Boolean(repo && !(repo instanceof Error) && repo.channelId) },
+  );
   const tickets = useMemo<readonly SdlcTicket[]>(
     () =>
       Array.isArray(relatedTickets) ? (relatedTickets as unknown as readonly SdlcTicket[]) : [],
     [relatedTickets],
   );
+  const channelTicketCount = Array.isArray(channelTickets) ? channelTickets.length : tickets.length;
   const selectedCanvasConversationLinkIds = useMemo(
     () =>
       selectedCanvas
@@ -1662,7 +1675,7 @@ export default function SdlcScreen(): ReactElement {
                       : item.id === 'baseline'
                         ? baseline.length
                         : item.id === 'tickets'
-                          ? tickets.length
+                          ? channelTicketCount
                           : item.id === 'tracks'
                             ? tracks.filter(track => track.status === 'ACTIVE').length
                             : ''}
@@ -2133,7 +2146,7 @@ export default function SdlcScreen(): ReactElement {
                         value={`${readyCount}/${SDLC_BASELINE_COUNT}`}
                         icon={ShieldCheck}
                       />
-                      <Metric label='Tickets' value={String(tickets.length)} icon={CircleDot} />
+                      <Metric label='Tickets' value={String(channelTicketCount)} icon={CircleDot} />
                     </div>
                     {repo.channelId ? (
                       <SdlcActivityPreview key={repo.channelId} channelId={repo.channelId} />

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -3701,6 +3701,13 @@ export const queries = defineQueries({
         )
         .related('pullRequests', pullRequest => pullRequest.orderBy('updatedAt', 'desc')),
   ),
+  sdlcChannelTickets: defineQuery(
+    z.object({ channelId: z.string(), isMember: z.boolean() }),
+    ({ args: { channelId } }) =>
+      zql.tickets
+        .where('channelId', channelId)
+        .where('isArchived', false),
+  ),
   sdlcDiscussionConversations: defineQuery(
     z.object({
       channelId: z.string(),


### PR DESCRIPTION
1. Problem Description:
SDLC Hub left panel and overview show `Tickets` as 0 when the repository channel has tickets that are not linked to SDLC artifacts/tracks.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
The #xyne-spaces-sdlc channel contains tickets, but `SdlcScreen` was rendering the count from the linked SDLC ticket list. That list is built from SDLC entity links, so unlinked channel tickets were excluded.

3. Explain the solution implemented in the PR:
Added an SDLC channel-scoped tickets query and changed the sidebar/overview ticket metric to use the channel ticket count. Existing linked-ticket logic is preserved for artifact/track context.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `pnpm --filter @xyne/shared exec tsc --noEmit --pretty false` passed.
- `pnpm --filter xyne-spaces-dashboard exec eslint src/routes/SdlcScreen/SdlcScreen.tsx` passed with pre-existing warnings only.
- `pnpm --filter @xyne/shared exec eslint src/zero/queries.ts` passed.
- `pnpm --filter xyne-spaces-dashboard run typecheck` was attempted but is blocked by existing unrelated missing dependency/type errors in ReactArtifact/onDeviceIntent files.

9. Services to which this change is to be deployed:
Dashboard, shared Zero query definitions, backend Zero query definitions.

10. Main PR link (if this PR is raised against a release branch):
N/A