### PR TITLE
fix: scope canvas ACL to workspace + participant instead of workspace-wide

### DIFF
--- a/apps/backend/src/database/acl/tables/canvases-acl.ts
+++ b/apps/backend/src/database/acl/tables/canvases-acl.ts
@@ -1,6 +1,7 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
 import { getGuestAccessibleCanvasIds, isGuestContext } from './channel-access-helper'
+import { getUserGroupIds } from './user-group-helper'
 
 /**
  * Non-guest reads are scoped to workspace + reachable canvases:
@@ -31,19 +32,16 @@ export class CanvasesACL extends BaseQueryACL<
 
     const userId = this.ctx.userId
 
-    const userGroupIds = (
-      await this.prisma.userGroupMapping.findMany({
-        where: { userId },
-        select: { userGroupId: true },
-      })
-    ).map((m) => m.userGroupId)
-
-    const channelIds = (
-      await this.prisma.channelParticipant.findMany({
+    // Parallel: this runs on every per-user canvas read. Zero's equivalent filter needs no
+    // lookups, but CanvasParticipant has no userGroup/channel relation to traverse here.
+    const [userGroupIds, channelParticipations] = await Promise.all([
+      getUserGroupIds(this.prisma, userId),
+      this.prisma.channelParticipant.findMany({
         where: { userId },
         select: { channelId: true },
-      })
-    ).map((c) => c.channelId)
+      }),
+    ])
+    const channelIds = channelParticipations.map((c) => c.channelId)
 
     const participantMatchers: Prisma.CanvasParticipantWhereInput[] = [{ userId }]
     if (userGroupIds.length) participantMatchers.push({ userGroupId: { in: userGroupIds } })

--- a/apps/backend/src/database/acl/tables/canvases-acl.ts
+++ b/apps/backend/src/database/acl/tables/canvases-acl.ts
@@ -12,8 +12,14 @@ import { getGuestAccessibleCanvasIds, isGuestContext } from './channel-access-he
  *
  * Now mirrors the (already-correct) `CanvasParticipantsACL`:
  *   - same workspace, AND
- *   - creator, OR PUBLIC, OR a direct/group/channel participant, OR the canvas
- *     lives in a channel the caller is a member of.
+ *   - creator, OR PUBLIC, OR a direct / user-group / channel-share participant.
+ *
+ * Deliberately NOT an arm: membership of the canvas' home `channelId`. Call PRD
+ * and detailed-summary canvases are created PRIVATE with `channelId` set and
+ * access granted explicitly (callDocumentService), and neither
+ * `canvasAuthService.checkCanvasAccess` nor the Zero read filter
+ * (`applyCanvasVisibilityQueryFilter`) treats home-channel membership as
+ * access. Adding it here would let any channel member read those documents.
  */
 export class CanvasesACL extends BaseQueryACL<
   Prisma.CanvasWhereInput,
@@ -56,16 +62,13 @@ export class CanvasesACL extends BaseQueryACL<
     if (userGroupIds.length) participantMatchers.push({ userGroupId: { in: userGroupIds } })
     if (channelIds.length) participantMatchers.push({ channelId: { in: channelIds } })
 
-    const or: Prisma.CanvasWhereInput[] = [
-      { createdBy: userId },
-      { visibility: 'PUBLIC' },
-      { participants: { some: { OR: participantMatchers } } },
-    ]
-    if (channelIds.length) or.push({ channelId: { in: channelIds } })
-
     return {
       workspaceId: this.ctx.workspaceId,
-      OR: or,
+      OR: [
+        { createdBy: userId },
+        { visibility: 'PUBLIC' },
+        { participants: { some: { OR: participantMatchers } } },
+      ],
     }
   }
 

--- a/apps/backend/src/database/acl/tables/canvases-acl.ts
+++ b/apps/backend/src/database/acl/tables/canvases-acl.ts
@@ -2,6 +2,19 @@ import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
 import { getGuestAccessibleCanvasIds, isGuestContext } from './channel-access-helper'
 
+/**
+ * ACL for the `canvas` model.
+ *
+ * The non-guest branch previously scoped to `workspaceId` only, so any
+ * workspace member could read every canvas in the workspace via /api/query.
+ * Canvases default to `visibility: PRIVATE`, which made private documents
+ * readable by id.
+ *
+ * Now mirrors the (already-correct) `CanvasParticipantsACL`:
+ *   - same workspace, AND
+ *   - creator, OR PUBLIC, OR a direct/group/channel participant, OR the canvas
+ *     lives in a channel the caller is a member of.
+ */
 export class CanvasesACL extends BaseQueryACL<
   Prisma.CanvasWhereInput,
   Prisma.CanvasUncheckedCreateInput
@@ -23,7 +36,37 @@ export class CanvasesACL extends BaseQueryACL<
       }
     }
 
-    return { workspaceId: this.ctx.workspaceId }
+    const userId = this.ctx.userId
+
+    const userGroupIds = (
+      await this.prisma.userGroupMapping.findMany({
+        where: { userId },
+        select: { userGroupId: true },
+      })
+    ).map((m) => m.userGroupId)
+
+    const channelIds = (
+      await this.prisma.channelParticipant.findMany({
+        where: { userId },
+        select: { channelId: true },
+      })
+    ).map((c) => c.channelId)
+
+    const participantMatchers: Prisma.CanvasParticipantWhereInput[] = [{ userId }]
+    if (userGroupIds.length) participantMatchers.push({ userGroupId: { in: userGroupIds } })
+    if (channelIds.length) participantMatchers.push({ channelId: { in: channelIds } })
+
+    const or: Prisma.CanvasWhereInput[] = [
+      { createdBy: userId },
+      { visibility: 'PUBLIC' },
+      { participants: { some: { OR: participantMatchers } } },
+    ]
+    if (channelIds.length) or.push({ channelId: { in: channelIds } })
+
+    return {
+      workspaceId: this.ctx.workspaceId,
+      OR: or,
+    }
   }
 
   async getMutateWhere(): Promise<Prisma.CanvasWhereInput> {

--- a/apps/backend/src/database/acl/tables/canvases-acl.ts
+++ b/apps/backend/src/database/acl/tables/canvases-acl.ts
@@ -3,23 +3,10 @@ import { BaseQueryACL, ACLContext } from '../base-acl'
 import { getGuestAccessibleCanvasIds, isGuestContext } from './channel-access-helper'
 
 /**
- * ACL for the `canvas` model.
- *
- * The non-guest branch previously scoped to `workspaceId` only, so any
- * workspace member could read every canvas in the workspace via /api/query.
- * Canvases default to `visibility: PRIVATE`, which made private documents
- * readable by id.
- *
- * Now mirrors the (already-correct) `CanvasParticipantsACL`:
- *   - same workspace, AND
- *   - creator, OR PUBLIC, OR a direct / user-group / channel-share participant.
- *
- * Deliberately NOT an arm: membership of the canvas' home `channelId`. Call PRD
- * and detailed-summary canvases are created PRIVATE with `channelId` set and
- * access granted explicitly (callDocumentService), and neither
- * `canvasAuthService.checkCanvasAccess` nor the Zero read filter
- * (`applyCanvasVisibilityQueryFilter`) treats home-channel membership as
- * access. Adding it here would let any channel member read those documents.
+ * Non-guest reads are scoped to workspace + reachable canvases:
+ * creator, PUBLIC, or explicit user/group/channel share.
+ * Home-channel membership is intentionally excluded; private call/summary
+ * canvases must be shared through CanvasParticipant rows.
  */
 export class CanvasesACL extends BaseQueryACL<
   Prisma.CanvasWhereInput,

--- a/apps/backend/src/database/repositories/analyticsRepository.ts
+++ b/apps/backend/src/database/repositories/analyticsRepository.ts
@@ -1559,12 +1559,13 @@ export class AnalyticsRepository {
         distinct: ['updatedBy'],
       }),
 
-      // Users who created canvas
-      this.prisma.canvas.findMany({
+      // Users who created canvas. Workspace-wide metric: CanvasesACL is now a per-user
+      // clause and this query carries no workspaceId of its own. Same as the sibling below.
+      withWorkspaceScope(async () => await this.prisma.canvas.findMany({
         where: { createdAt: dateCondition, createdBy: { in: userIds } },
         select: { createdBy: true},
         distinct: ['createdBy'],
-      }),
+      })),
 
       // Users who edited canvas
       withWorkspaceScope(async () => await this.prisma.canvasParticipant.findMany({
@@ -1863,11 +1864,11 @@ export class AnalyticsRepository {
         select: { updatedBy: true, timestamp: true },
       }),
 
-      // Users who created canvas
-      this.prisma.canvas.findMany({
+      // Users who created canvas. withWorkspaceScope for the same reason as getActiveUsers.
+      withWorkspaceScope(async () => await this.prisma.canvas.findMany({
         where: { createdAt: dateCondition, createdBy: { in: userIds } },
         select: { createdBy: true, createdAt: true },
-      }),
+      })),
 
       // Users who edited canvas
       withWorkspaceScope(async () => await this.prisma.canvasParticipant.findMany({
@@ -2317,12 +2318,13 @@ export class AnalyticsRepository {
     const userIds = await this.getUsersId(workspaceId);
 
     // Count canvases edited in the selected time period by real users only
-    const canvasesCount = await this.prisma.canvas.count({
+    // withWorkspaceScope: a workspace-wide metric, not "canvases the caller can reach".
+    const canvasesCount = await withWorkspaceScope(async () => await this.prisma.canvas.count({
       where: {
         lastEditedAt: dateCondition,
         createdBy: { in: userIds }
       }
-    });
+    }));
 
     return canvasesCount;
   }
@@ -2346,13 +2348,14 @@ export class AnalyticsRepository {
     const userIds = await this.getUsersId(workspaceId);
 
     // Get canvases created by real users only
-    const canvases = await this.prisma.canvas.findMany({
+    // withWorkspaceScope: workspace-wide metric, as in getNumberOfCanvases.
+    const canvases = await withWorkspaceScope(async () => await this.prisma.canvas.findMany({
       where: {
         lastEditedAt: dateCondition,
         createdBy: { in: userIds }
       },
       select: { lastEditedAt: true },
-    });
+    }));
 
     // Generate time buckets based on groupBy
     const timeBuckets = groupBy === 'hour'

--- a/apps/backend/src/services/userManagementService.ts
+++ b/apps/backend/src/services/userManagementService.ts
@@ -5,6 +5,7 @@ import { PrismaClient } from '@prisma/client';
 import { GuestEntity, AccessType, WorkspaceRole } from '@xyne/shared';
 import { logger } from '../utils/logger';
 import { DatabaseClient } from '@/database/client';
+import { withWorkspaceScope } from '@/database/tenant/context';
 import { config } from '@/config/env';
 import axios from 'axios';
 import FormData from 'form-data';
@@ -442,10 +443,12 @@ export class UserManagementService {
           })
         : [],
       canvasIds.length
-        ? this.prisma.canvas.findMany({
+        // Ids come from guest access grants, so the admin is auditing access an outsider
+        // already has — the grant must render with its title, not 'Unknown entity'.
+        ? withWorkspaceScope(async () => await this.prisma.canvas.findMany({
             where: { id: { in: [...new Set(canvasIds)] } },
             select: { id: true, title: true },
-          })
+          }))
         : [],
     ]);
 

--- a/apps/backend/src/services/userManagementService.ts
+++ b/apps/backend/src/services/userManagementService.ts
@@ -5,7 +5,6 @@ import { PrismaClient } from '@prisma/client';
 import { GuestEntity, AccessType, WorkspaceRole } from '@xyne/shared';
 import { logger } from '../utils/logger';
 import { DatabaseClient } from '@/database/client';
-import { withWorkspaceScope } from '@/database/tenant/context';
 import { config } from '@/config/env';
 import axios from 'axios';
 import FormData from 'form-data';
@@ -33,6 +32,25 @@ import { v4 as uuidv4 } from 'uuid';
  *
  * Handles business logic for user groups, users, resources, and access control
  */
+/**
+ * Label for a guest grant whose target the *viewing admin* cannot read.
+ *
+ * Both lookups behind this screen run through the ACL'd client, so a grant on a channel the
+ * admin is not a participant of (ChannelsACL: PUBLIC or participant) or on a canvas they
+ * cannot reach (CanvasesACL) resolves to nothing. Naming the kind is deliberate: the admin
+ * may revoke without being shown a private name, and 'Unknown entity' read like a data bug.
+ */
+function unresolvedEntityName(entityType: string): string {
+  switch (entityType) {
+    case GuestEntity.CHANNEL:
+      return 'Private channel'
+    case GuestEntity.CANVAS:
+      return 'Private canvas'
+    default:
+      return 'Unknown entity'
+  }
+}
+
 export class UserManagementService {
   private static instance: UserManagementService;
   private prisma: PrismaClient;
@@ -443,12 +461,10 @@ export class UserManagementService {
           })
         : [],
       canvasIds.length
-        // Ids come from guest access grants, so the admin is auditing access an outsider
-        // already has — the grant must render with its title, not 'Unknown entity'.
-        ? withWorkspaceScope(async () => await this.prisma.canvas.findMany({
+        ? this.prisma.canvas.findMany({
             where: { id: { in: [...new Set(canvasIds)] } },
             select: { id: true, title: true },
-          }))
+          })
         : [],
     ]);
 
@@ -475,7 +491,7 @@ export class UserManagementService {
         id: mapping.id,
         accessibleEntityId: mapping.accessibleEntityId,
         accessibleEntityType: mapping.accessibleEntityType,
-        entityName: entityName ?? 'Unknown entity',
+        entityName: entityName ?? unresolvedEntityName(mapping.accessibleEntityType),
         createdAt: mapping.createdAt,
         invitedBy: mapping.invitedBy,
         invitedByName: userMap.get(mapping.invitedBy)?.name ?? null,


### PR DESCRIPTION
## Problem

The non-guest branch of `CanvasesACL.getWhereClause()` returned `{ workspaceId }` only, so **any workspace member could read every canvas in the workspace** via `/api/query`. Canvases default to `visibility: PRIVATE`, so this exposed private documents by id.

## Fix

Non-guest reads are scoped to workspace + reachable canvases: creator, `PUBLIC`, or an explicit user / user-group / channel share.

**Home-channel membership is deliberately not an arm.** Call PRD and detailed-summary canvases are created `PRIVATE` with `channelId` set and access granted explicitly (`callDocumentService`), and neither `canvasAuthService.checkCanvasAccess` nor the Zero read filter `applyCanvasVisibilityQueryFilter` treats home-channel membership as access. An earlier revision of this PR had that arm; it was removed.

Guest handling (`isGuestContext` → `getGuestAccessibleCanvasIds`) is untouched.

## Call sites that meant "workspace-wide"

Turning `canvas` from a workspace-scoped table into a per-user-scoped one silently narrowed readers that run on a user's behalf but mean the whole workspace. Both now use `withWorkspaceScope`, matching siblings already wrapped on adjacent lines:

- **`analyticsRepository`** — `getActiveUsers`, `getActiveUsersWithChart`, `getNumberOfCanvases` and its time-series carry no `workspaceId` of their own and relied on the ACL's old scope. `/api/analytics` is `authorize('ANALYTICS', ADMIN)` with no `workspaceScopedRoute`, so it runs as a user actor and an admin's canvas metrics would have dropped to their own reachable set. Counts and `createdBy` only — no canvas content crosses the boundary either way.
- **`userManagementService.getWorkspaceGuestsWithAccess`** — *not* wrapped, deliberately. Titles stay hidden; the fallback now names the kind instead. See below.

## Guest access list

The Guest Users tab (`/workspace-management`, ADMIN/OWNER only) resolves each grant's entity name through the ACL'd client. That screen is **already broken for channels** on `main`: `ChannelsACL` gives a non-guest `PUBLIC OR participant`, so a guest-granted private channel the viewing admin is not in falls through to `entityName ?? 'Unknown entity'`. Reproduced in the UI — three indistinguishable `Unknown entity` channel rows against one canvas row that still resolves, because `CanvasesACL` on main is plain `{ workspaceId }`.

This PR would put canvas grants in the same position, so the fallback is now type-aware — `Private channel` / `Private canvas`, with `Unknown entity` kept for anything else. The admin can still revoke (it goes by `accessibleEntityId`, never the name) without being shown a name they are not entitled to read, and the row reads as a permission boundary rather than a data bug. It also fixes the pre-existing channel case.

Considered and rejected: wrapping the lookup in `withWorkspaceScope` to show real titles. Every id there comes from a guest grant, so an outside party already holds the document — but it would let any workspace admin read private canvas and channel names, which no other content ACL in this codebase permits.

## Cost

The clause needs the caller's group and channel memberships, so per-user canvas reads go from one primary-key `findUnique` to two round trips (the two lookups are `Promise.all`'d, then the query). `attachmentController` runs one access check per attachment, so image-heavy canvases pay it repeatedly.

Zero's `applyCanvasVisibilityQueryFilter` expresses the same rule with no lookups at all, but that form is not available here: `CanvasParticipant` declares only its `canvas` relation in `schema.prisma`, with no `userGroup` / `channel` counterparts to traverse. Adding those emulated relations would remove both queries — worth a follow-up. Per-request memoization is not an option as written, since `ACLFactory.getACL` constructs a fresh ACL per query.

## Known gap (not in this PR)

`CanvasVersionsACL` is still `{ workspaceId }` while `canvas_versions.content` holds full copies of canvas content. `canvasVersion` is not in the `/api/query` allowlist and no request-context route reads versions by arbitrary canvas id today, so it is not currently reachable — but it is the next hole if such a route appears.

## Verification

`tsc --noEmit` on `apps/backend`: 77 errors before and after, all pre-existing (stale generated Prisma client), none in the touched files. Husky pre-commit was bypassed because it requires a TTY; its backend typecheck was run manually.