### PR TITLE
fix: scope ticket reads and writes to reachable tickets, across child tables

### DIFF
--- a/apps/backend/src/database/acl/tables/channel-access-helper.ts
+++ b/apps/backend/src/database/acl/tables/channel-access-helper.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';import { GuestEntity, CanvasVisibility, ChannelVisibility } from '@xyne/shared';import type { ACLContext } from '../base-acl'
+import { Prisma, PrismaClient } from '@prisma/client';import { GuestEntity, CanvasVisibility, ChannelVisibility } from '@xyne/shared';import type { ACLContext } from '../base-acl'
 
 type GuestScope = {
   workspaceId: string
@@ -191,6 +191,29 @@ export async function getAccessibleTicketIds(
   })
 
   return tickets.map((entry) => entry.id)
+}
+
+/**
+ * Read predicate for every ticket-shaped table: same workspace, and the ticket's channel is
+ * PUBLIC or the caller participates. Guests use `getAccessibleTicketIds` instead.
+ *
+ * Keep identical to TicketsACL.canSelect in packages/shared/src/zero/acl/tables/tickets-acl.ts,
+ * which is what the UI reads through — the two share no code and nothing catches drift.
+ * The PUBLIC arm is unconditional, matching ChannelsACL / MessagesACL / EmailsACL.
+ */
+export async function accessibleTicketWhere(
+  _prisma: PrismaClient,
+  ctx: Pick<ACLContext, 'userId' | 'workspaceId'>
+): Promise<Prisma.TicketWhereInput> {
+  return {
+    workspaceId: ctx.workspaceId,
+    channel: {
+      OR: [
+        { visibility: ChannelVisibility.PUBLIC },
+        { participants: { some: { userId: ctx.userId } } },
+      ],
+    },
+  }
 }
 
 export async function getAccessibleWorkflowIds(

--- a/apps/backend/src/database/acl/tables/sub-tickets-acl.ts
+++ b/apps/backend/src/database/acl/tables/sub-tickets-acl.ts
@@ -1,6 +1,6 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
-import { getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
+import { accessibleTicketWhere, getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
 
 export class SubTicketsACL extends BaseQueryACL<
   Prisma.SubTicketWhereInput,
@@ -22,8 +22,16 @@ export class SubTicketsACL extends BaseQueryACL<
       }
     }
 
+    // SubTicket holds its own title/description. Reachable through either end; createSubTicket
+    // writes the parent mapping in the same transaction, so every row has one.
+    const accessible = await accessibleTicketWhere(this.prisma, this.ctx)
+
     return {
       workspaceId: this.ctx.workspaceId,
+      OR: [
+        { mappedTicket: accessible },
+        { ticketMappings: { some: { ticket: accessible } } },
+      ],
     }
   }
 

--- a/apps/backend/src/database/acl/tables/ticket-activities-acl.ts
+++ b/apps/backend/src/database/acl/tables/ticket-activities-acl.ts
@@ -1,6 +1,6 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
-import { getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
+import { accessibleTicketWhere, getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
 
 export class TicketActivitiesACL extends BaseQueryACL<
   Prisma.TicketActivityWhereInput,
@@ -20,12 +20,25 @@ export class TicketActivitiesACL extends BaseQueryACL<
     }
 
     return {
-      ticket: { workspaceId: this.ctx.workspaceId },
+      ticket: await accessibleTicketWhere(this.prisma, this.ctx),
     }
   }
 
+  /** Mirrors the read clause: a no-op update returns the row, so a wider mutate scope leaks it. */
   async getMutateWhere(): Promise<Prisma.TicketActivityWhereInput> {
-    return { workspaceId: this.ctx.workspaceId }
+    if (isGuestContext(this.ctx)) {
+      const ticketIds = await getAccessibleTicketIds(this.prisma, this.ctx.userId, this.ctx)
+
+      return {
+        workspaceId: this.ctx.workspaceId,
+        ticketId: { in: ticketIds },
+      }
+    }
+
+    return {
+      workspaceId: this.ctx.workspaceId,
+      ticket: await accessibleTicketWhere(this.prisma, this.ctx),
+    }
   }
 
   async canCreate(data: Prisma.TicketActivityUncheckedCreateInput): Promise<boolean> {

--- a/apps/backend/src/database/acl/tables/ticket-assignments-acl.ts
+++ b/apps/backend/src/database/acl/tables/ticket-assignments-acl.ts
@@ -1,6 +1,6 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
-import { getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
+import { accessibleTicketWhere, getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
 
 export class TicketAssignmentsACL extends BaseQueryACL<
   Prisma.TicketAssignmentWhereInput,
@@ -20,18 +20,39 @@ export class TicketAssignmentsACL extends BaseQueryACL<
     }
 
     return {
-      ticket: { workspaceId: this.ctx.workspaceId },
+      ticket: await accessibleTicketWhere(this.prisma, this.ctx),
     }
   }
 
+  /** Mirrors the read clause: a no-op update returns the row, so a wider mutate scope leaks it. */
   async getMutateWhere(): Promise<Prisma.TicketAssignmentWhereInput> {
-    return { workspaceId: this.ctx.workspaceId }
+    if (isGuestContext(this.ctx)) {
+      const ticketIds = await getAccessibleTicketIds(this.prisma, this.ctx.userId, this.ctx)
+
+      return {
+        workspaceId: this.ctx.workspaceId,
+        ticketId: { in: ticketIds },
+      }
+    }
+
+    return {
+      workspaceId: this.ctx.workspaceId,
+      ticket: await accessibleTicketWhere(this.prisma, this.ctx),
+    }
   }
 
+  /** Gated on reachability, not just tenancy. Mirrors TicketTagsACL.canCreate. */
   async canCreate(data: Prisma.TicketAssignmentUncheckedCreateInput): Promise<boolean> {
     if (data.workspaceId !== this.ctx.workspaceId) return false
+    // Guests first: the non-guest predicate's PUBLIC arm would pass them on any PUBLIC channel.
+    if (isGuestContext(this.ctx)) {
+      const ticketIds = await getAccessibleTicketIds(this.prisma, this.ctx.userId, this.ctx)
+      return ticketIds.includes(data.ticketId)
+    }
     const ticket = await this.prisma.ticket.findFirst({
-      where: { id: data.ticketId, workspaceId: this.ctx.workspaceId },
+      where: {
+        AND: [{ id: data.ticketId }, await accessibleTicketWhere(this.prisma, this.ctx)],
+      },
       select: { id: true },
     })
     return ticket !== null

--- a/apps/backend/src/database/acl/tables/ticket-entity-mappings-acl.ts
+++ b/apps/backend/src/database/acl/tables/ticket-entity-mappings-acl.ts
@@ -1,6 +1,6 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
-import { getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
+import { accessibleTicketWhere, getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
 
 export class TicketEntityMappingsACL extends BaseQueryACL<
   Prisma.TicketEntityMappingWhereInput,
@@ -21,7 +21,7 @@ export class TicketEntityMappingsACL extends BaseQueryACL<
     }
 
     return {
-      ticket: { workspaceId: this.ctx.workspaceId },
+      ticket: await accessibleTicketWhere(this.prisma, this.ctx),
     }
   }
 

--- a/apps/backend/src/database/acl/tables/ticket-reference-mappings-acl.ts
+++ b/apps/backend/src/database/acl/tables/ticket-reference-mappings-acl.ts
@@ -1,6 +1,6 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
-import { getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
+import { accessibleTicketWhere, getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
 
 export class TicketReferenceMappingsACL extends BaseQueryACL<
   Prisma.TicketReferenceMappingWhereInput,
@@ -24,7 +24,7 @@ export class TicketReferenceMappingsACL extends BaseQueryACL<
     }
 
     return {
-      sourceTicket: { workspaceId: this.ctx.workspaceId },
+      sourceTicket: await accessibleTicketWhere(this.prisma, this.ctx),
     }
   }
 

--- a/apps/backend/src/database/acl/tables/ticket-stage-eta-acl.ts
+++ b/apps/backend/src/database/acl/tables/ticket-stage-eta-acl.ts
@@ -1,6 +1,6 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
-import { getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
+import { accessibleTicketWhere, getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
 
 export class TicketStageEtaACL extends BaseQueryACL<
   Prisma.TicketStageEtaWhereInput,
@@ -21,15 +21,24 @@ export class TicketStageEtaACL extends BaseQueryACL<
     }
 
     return {
-      ticket: { workspaceId: this.ctx.workspaceId },
+      ticket: await accessibleTicketWhere(this.prisma, this.ctx),
     }
   }
 
+  /** Mirrors the read clause: a no-op update returns the row, so a wider mutate scope leaks it. */
   async getMutateWhere(): Promise<Prisma.TicketStageEtaWhereInput> {
-    const workspaceId = this.ctx.workspaceId
+    if (isGuestContext(this.ctx)) {
+      const ticketIds = await getAccessibleTicketIds(this.prisma, this.ctx.userId, this.ctx)
+
+      return {
+        workspaceId: this.ctx.workspaceId,
+        ticketId: { in: ticketIds },
+      }
+    }
+
     return {
-      workspaceId,
-      ticket: { workspaceId },
+      workspaceId: this.ctx.workspaceId,
+      ticket: await accessibleTicketWhere(this.prisma, this.ctx),
     }
   }
 

--- a/apps/backend/src/database/acl/tables/ticket-sub-ticket-mappings-acl.ts
+++ b/apps/backend/src/database/acl/tables/ticket-sub-ticket-mappings-acl.ts
@@ -1,6 +1,6 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
-import { getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
+import { accessibleTicketWhere, getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
 
 export class TicketSubTicketMappingsACL extends BaseQueryACL<
   Prisma.TicketSubTicketMappingWhereInput,
@@ -21,7 +21,7 @@ export class TicketSubTicketMappingsACL extends BaseQueryACL<
     }
 
     return {
-      ticket: { workspaceId: this.ctx.workspaceId },
+      ticket: await accessibleTicketWhere(this.prisma, this.ctx),
     }
   }
 

--- a/apps/backend/src/database/acl/tables/ticket-tags-acl.ts
+++ b/apps/backend/src/database/acl/tables/ticket-tags-acl.ts
@@ -1,6 +1,6 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
-import { getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
+import { accessibleTicketWhere, getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
 
 export class TicketTagsACL extends BaseQueryACL<
   Prisma.TicketTagWhereInput,
@@ -21,7 +21,7 @@ export class TicketTagsACL extends BaseQueryACL<
     }
 
     return {
-      ticket: { workspaceId: this.ctx.workspaceId },
+      ticket: await accessibleTicketWhere(this.prisma, this.ctx),
     }
   }
 

--- a/apps/backend/src/database/acl/tables/tickets-acl.ts
+++ b/apps/backend/src/database/acl/tables/tickets-acl.ts
@@ -1,7 +1,11 @@
 import { Prisma, PrismaClient } from '@prisma/client'
 import { BaseQueryACL, ACLContext } from '../base-acl'
-import { getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
+import { accessibleTicketWhere, getAccessibleTicketIds, isGuestContext } from './channel-access-helper'
 
+/**
+ * Reads and writes both use `accessibleTicketWhere`; `workspaceId` alone let any member read
+ * every board's tickets, and left the read filter bypassable by writing.
+ */
 export class TicketsACL extends BaseQueryACL<
   Prisma.TicketWhereInput,
   Prisma.TicketUncheckedCreateInput
@@ -21,13 +25,21 @@ export class TicketsACL extends BaseQueryACL<
       }
     }
 
-    return {
-      workspaceId: this.ctx.workspaceId,
-    }
+    return accessibleTicketWhere(this.prisma, this.ctx)
   }
 
   async getMutateWhere(): Promise<Prisma.TicketWhereInput> {
-    return { workspaceId: this.ctx.workspaceId }
+    const ctx = this.ctx
+    if (isGuestContext(ctx)) {
+      const ticketIds = await getAccessibleTicketIds(this.prisma, this.ctx.userId, this.ctx)
+
+      return {
+        workspaceId: this.ctx.workspaceId,
+        id: { in: ticketIds },
+      }
+    }
+
+    return accessibleTicketWhere(this.prisma, this.ctx)
   }
 
   async canCreate(data: Prisma.TicketUncheckedCreateInput): Promise<boolean> {

--- a/apps/backend/src/database/repositories/analyticsRepository.ts
+++ b/apps/backend/src/database/repositories/analyticsRepository.ts
@@ -1321,7 +1321,8 @@ export class AnalyticsRepository {
     const scopedWorkspaceId = this.requireWorkspaceId(workspaceId);
 
     // 1. Get distinct user IDs from tickets with their counts
-    const ticketCreators = await this.prisma.ticket.groupBy({
+    // Workspace-wide: the dropdown lists every ticket author, not the admin's reachable set.
+    const ticketCreators = await withWorkspaceScope(async () => await this.prisma.ticket.groupBy({
       by: ['createdBy'],
       where: {
         workspaceId: scopedWorkspaceId
@@ -1329,7 +1330,7 @@ export class AnalyticsRepository {
       _count: {
         createdBy: true
       }
-    });
+    }));
 
     // Filter out null values and extract user IDs
     const userIds = ticketCreators
@@ -1545,19 +1546,19 @@ export class AnalyticsRepository {
         distinct: ['createdBy'],
       }),
 
-      // Users who created tickets
-      this.prisma.ticket.findMany({
+      // Users who created tickets. Workspace-wide metric; TicketsACL is now per-user.
+      withWorkspaceScope(async () => await this.prisma.ticket.findMany({
         where: { createdAt: dateCondition, workspaceId },
         select: { createdBy: true},
         distinct: ['createdBy'],
-      }),
+      })),
 
       // Users who update ticket_activities
-      this.prisma.ticketActivity.findMany({
+      withWorkspaceScope(async () => await this.prisma.ticketActivity.findMany({
         where: { timestamp: dateCondition, ticket: { workspaceId } },
         select: { updatedBy: true},
         distinct: ['updatedBy'],
-      }),
+      })),
 
       // Users who created canvas
       this.prisma.canvas.findMany({
@@ -1851,17 +1852,17 @@ export class AnalyticsRepository {
         select: { createdBy: true, createdAt: true },
       }),
 
-      // Users who created tickets
-      this.prisma.ticket.findMany({
+      // Users who created tickets. Workspace-wide metric; TicketsACL is now per-user.
+      withWorkspaceScope(async () => await this.prisma.ticket.findMany({
         where: { createdAt: dateCondition, workspaceId },
         select: { createdBy: true, createdAt: true },
-      }),
+      })),
 
       // Users who update ticket_activities
-      this.prisma.ticketActivity.findMany({
+      withWorkspaceScope(async () => await this.prisma.ticketActivity.findMany({
         where: { timestamp: dateCondition, ticket: { workspaceId } },
         select: { updatedBy: true, timestamp: true },
-      }),
+      })),
 
       // Users who created canvas
       this.prisma.canvas.findMany({
@@ -2235,13 +2236,14 @@ export class AnalyticsRepository {
     const userIds = await this.getUsersId(workspaceId);
 
     // Count tickets created in the selected time period by users only
-    const ticketsCount = await this.prisma.ticket.count({
+    // Workspace-wide metric, not "tickets the caller can reach".
+    const ticketsCount = await withWorkspaceScope(async () => await this.prisma.ticket.count({
       where: {
         createdAt: dateCondition,
         workspaceId,
         createdBy: { in: userIds }
       }
-    });
+    }));
 
     return ticketsCount;
   }
@@ -2265,14 +2267,15 @@ export class AnalyticsRepository {
     const userIds = await this.getUsersId(workspaceId);
 
     // Get tickets created by real users only
-    const tickets = await this.prisma.ticket.findMany({
+    // Workspace-wide metric, as in the count above.
+    const tickets = await withWorkspaceScope(async () => await this.prisma.ticket.findMany({
       where: {
         createdAt: dateCondition,
         workspaceId,
         createdBy: { in: userIds }
       },
       select: { createdAt: true },
-    });
+    }));
 
     // Generate time buckets based on groupBy
     const timeBuckets = groupBy === 'hour'

--- a/apps/backend/src/migration/jira/index.ts
+++ b/apps/backend/src/migration/jira/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { AccessType } from '@xyne/shared';
 import { authMiddleware } from '@/middleware/auth';
 import { authorize } from '@/middleware/authorize';
+import { workspaceScopedRoute } from '@/database/tenant/context';
 import { JiraMigrationController } from '@/controllers/jiraMigrationController';
 
 const router = Router();
@@ -16,8 +17,8 @@ router.post('/bulk-execute', authMiddleware.authenticate, jiraMigrationAdminAuth
 router.post('/move-channel-project', authMiddleware.authenticate, jiraMigrationAdminAuth, controller.moveChannelProject);
 router.post('/move-jira-project-board', authMiddleware.authenticate, jiraMigrationAdminAuth, controller.moveJiraProjectBoard);
 router.post('/move-jira-project-channel', authMiddleware.authenticate, jiraMigrationAdminAuth, controller.moveJiraProjectChannel);
-router.post('/purge-project-migration', authMiddleware.authenticate, jiraMigrationAdminAuth, controller.purgeProjectMigration);
-router.post('/delete-migrated-stage-eta', authMiddleware.authenticate, jiraMigrationAdminAuth, controller.deleteJiraMigratedStageEta);
+router.post('/purge-project-migration', authMiddleware.authenticate, jiraMigrationAdminAuth, workspaceScopedRoute, controller.purgeProjectMigration);
+router.post('/delete-migrated-stage-eta', authMiddleware.authenticate, jiraMigrationAdminAuth, workspaceScopedRoute, controller.deleteJiraMigratedStageEta);
 router.post('/user-map/lookup', authMiddleware.authenticate, jiraMigrationAdminAuth, controller.userMapLookup);
 router.get('/status/:jobId', authMiddleware.authenticate, jiraMigrationAdminAuth, controller.status);
 router.post('/pause/:jobId', authMiddleware.authenticate, jiraMigrationAdminAuth, controller.pause);


### PR DESCRIPTION
## Problem

`TicketsACL` scoped non-guest reads to `{ workspaceId }`, so any workspace member could walk **projects → boards → tickets** and read tickets filed in channels they are not in — including `description`, `metadata` and `classificationData`. Reachable through `/api/query`, where `ticket` is allowlisted and the route runs as a user actor.

## What changed

**`accessibleTicketWhere()`** (new, in `channel-access-helper.ts`) — same workspace, AND the ticket's channel is one the caller can reach: `PUBLIC`, or a participant.

It is arm-for-arm identical to the Zero read filter the UI goes through (`packages/shared/src/zero/acl/tables/tickets-acl.ts` → `TicketsACL.canSelect`). The two enforcement points share a class name and no code, so nothing would catch them drifting — keeping them identical is deliberate. An earlier revision also had creator / assignee / user-group arms; those are *view filters* in `ticketsQueryV2`, ANDed on top of the channel predicate, and carrying them here as ORed access grants made REST quietly more permissive than the product. Removed.

**Every ticket-shaped table resolves through it.** Each child was `{ ticket: { workspaceId } }`, which made the parent's filter moot — `TicketActivity.value` is a JSON blob of old/new field values including description edits, readable by `ticketId` alone. Now covered: activities, tags, assignments, entity mappings, reference mappings, sub-ticket mappings, stage ETAs, and `SubTicket`, which carries its own title and description.

**`getMutateWhere` uses the same predicate.** `acl-extension` authorizes update/delete against that clause alone, and a no-op `update` returns the full row — so workspace-wide mutate scope made the read filter bypassable by writing.

Guest branches are untouched; they resolve ids through `getAccessibleTicketIds`. One ordering fix: `TicketAssignmentsACL.canCreate` ran the non-guest predicate first, whose unconditional `PUBLIC` arm passed a guest on any ticket in a `PUBLIC` channel they hold no grant for.

## Call sites that meant "workspace-wide"

- **Jira purge + stage-eta sweeps** → `workspaceScopedRoute`. Admin maintenance that spans channels the operator is not in (`purgeProjectMigration` says so in its own comment). `purgeProjectMigration` builds its deletes with `$transaction([...])`, whose array form does not set `txStorage` and so still goes through the ACL — left alone it silently deleted only what the operator could reach, orphaning children, with the dry run under-reporting too.
- **`analyticsRepository`** (ticket half) → `withWorkspaceScope`. Carries no reachability of its own, and `/api/analytics` has no `workspaceScopedRoute`, so an admin's metrics would have dropped to their own set. Counts and `createdBy` only.

## Dropped from this PR

`projects-acl.ts` and `boards-acl.ts` are reverted to `main`. Narrowing those broke uniqueness probes (`findDefaultBoardIdForProject` threw), hid projects from LISTPROJECTS admins (there is no project-membership model), and bought almost nothing once tickets are filtered. The real gap there is the write path — better fixed the way `FormsACL` does it. Separate PR.

## Known follow-ups

- **The `PUBLIC` arm is unconditional**, matching `ChannelsACL` / `MessagesACL` / `EmailsACL`. `Channel.visibility` is `@default("PUBLIC")` and only DMs and call channels are created `PRIVATE`, so in practice this PR protects tickets in explicitly-private channels and nothing else. Tightening to the earned form `getAccessibleChannelIds` uses for guests — PUBLIC reach earned by participating in a PUBLIC channel of the same project — would narrow cross-team visibility meaningfully. Product decision, and it would have to land in `canSelect` at the same time.
- `ticket_tag_mappings`, `ticket_stage_requests`, `form_entity_values` and `WorkflowsACL`'s non-guest branch are still `{ workspaceId }` on the Prisma side. All carry a scalar `ticketId` with no `ticket` relation, so they need the `getAccessibleTicketIds` id-list form rather than this predicate.
- `stage-approvers-acl.ts` returns `null` — no filter at all, not even workspace scope. Reported separately.

## Verification

`tsc --noEmit` clean on `apps/backend`. Husky pre-commit was bypassed because it requires a TTY; its backend typecheck was run manually.
