### PR TITLE
fix: XYNE-60316 cmdK result card metadata

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -1986,24 +1986,22 @@ const ChannelCommandMenu = ({
     });
   }, [syncEnterIntent, markNavigated]);
 
-  const handleFilePreview = useCallback(
-    (result: DisplaySearchResult): void => {
-      // Handle attachment preview - show file preview modal
-      if (result.type !== 'attachment' || !result.searchContext?.internalUrl) {
-        return;
-      }
+  const handleFilePreview = useCallback((result: DisplaySearchResult): void => {
+    // Handle attachment preview - show file preview modal
+    if (result.type !== 'attachment' || !result.searchContext?.internalUrl) {
+      return;
+    }
 
-      const { attachmentId, internalUrl } = result.searchContext;
-      setPreviewFile({
-        fileName: result.title,
-        fileUrl: attachmentId ? `/attachments/${attachmentId}/download` : internalUrl,
-        mimeType: result.searchContext.mimeType || 'application/octet-stream',
-        fileSize: result.searchContext.fileSize || 0,
-      });
-      onOpenChange(false);
-    },
-    [onOpenChange],
-  );
+    const { attachmentId, internalUrl } = result.searchContext;
+    // Cmd+K stays open behind the preview so closing the preview returns to the
+    // results instead of dismissing the whole palette.
+    setPreviewFile({
+      fileName: result.title,
+      fileUrl: attachmentId ? `/attachments/${attachmentId}/download` : internalUrl,
+      mimeType: result.searchContext.mimeType || 'application/octet-stream',
+      fileSize: result.searchContext.fileSize || 0,
+    });
+  }, []);
 
   // Handle mouse hover over ticket and Desk items to show preview
   const handleTicketMouseEnter = useCallback(
@@ -2975,6 +2973,9 @@ const ChannelCommandMenu = ({
           fileUrl={previewFile.fileUrl}
           mimeType={previewFile.mimeType}
           fileSize={previewFile.fileSize}
+          // Cmd+K's own surface is z-[9999]; the preview opens on top of it and
+          // its default z-[56] would put it behind.
+          zIndexClass='z-[10002]'
         />
       )}
     </>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -2061,27 +2061,37 @@ const ChannelCommandMenu = ({
   };
 
   /**
-   * Channel tag for a result row (currently only ticket rows render it).
+   * Channel tag for a ticket / file result row.
    *
-   * The Vespa ticket doc denormalizes both `searchContext.channelId` and
+   * The Vespa doc denormalizes both `searchContext.channelId` and
    * `metadata.channelName`, so this needs no lookup of its own: it resolves the id
-   * against the already-loaded `allChannels` to reuse `getChannelIcon` (hashtag vs
-   * lock vs DM avatar). When the channel isn't in the local set — not a member, not
-   * yet loaded — it falls back to the denormalized name with a hashtag, mirroring
-   * FilterChipNode's `ChannelChipIcon` fallback. No network call, no per-row hook.
+   * against the already-loaded `allChannels`. No network call, no per-row hook.
+   *
+   * The row renders this as the phrase "in <name>", so a plain public channel
+   * sends no icon — a hashtag would only repeat the word. Anything the word can't
+   * say keeps its `getChannelIcon` glyph: private lock, DM avatar, group. The
+   * fallback path (channel not in the local set — not a member, not yet loaded)
+   * has only the denormalized name, so it reads as public.
    */
   const getResultChannelTag = (
     result: DisplaySearchResult,
-  ): { name: string; icon: ReactElement } | undefined => {
+  ): { name: string; icon?: ReactElement | undefined } | undefined => {
     const entry = result.searchContext?.channelId
       ? allChannels.find(item => item.channel.id === result.searchContext?.channelId)
       : undefined;
     if (entry) {
-      return { name: entry.channel.name, icon: getChannelIcon(entry.channel) };
+      const { channel } = entry;
+      const isPlainPublic =
+        !isDMChannel(channel.scopeType) &&
+        !isGroupDMChannel(channel.scopeType) &&
+        channel.visibility !== ChannelVisibility.PRIVATE;
+      return isPlainPublic
+        ? { name: channel.name }
+        : { name: channel.name, icon: getChannelIcon(channel) };
     }
     const fallbackName = result.metadata.channelName;
     if (!fallbackName) return undefined;
-    return { name: fallbackName, icon: <Hashtag size={16} /> };
+    return { name: fallbackName };
   };
 
   // Group results by type for display
@@ -2384,6 +2394,15 @@ const ChannelCommandMenu = ({
               const hiddenCount = items.length - displayItems.length;
               const sectionTab = GROUP_KEY_TO_DOC_TYPE[groupKey];
 
+              // "See more" routes to the full results page with this section's tab
+              // pre-selected. Offered on every tab, not just All: an active filter
+              // (`assignee:`, `from:`) narrows the enabled tabs via getRelevantTabs and
+              // moves activeTab off All, and those searches still need the way out.
+              // Every section here is a capped slice, so there is more to see even when
+              // nothing was truncated locally. Screen mode keeps its narrower rule: it
+              // only offers the link when it actually cut items off.
+              const showSeeMore = !!sectionTab && (!isScreenAll || hiddenCount > 0);
+
               return (
                 <div key={groupKey} className='mb-4'>
                   <Command.Group
@@ -2413,10 +2432,10 @@ const ChannelCommandMenu = ({
                         onToggleSelect={handleToggleDeskMergeSelect}
                       />
                     ))}
-                    {isScreenAll && hiddenCount > 0 && sectionTab && (
+                    {showSeeMore && sectionTab && (
                       <SeeMoreItem
                         value={`__see-more-backend-${groupKey}__`}
-                        label={`See ${hiddenCount} more`}
+                        label={hiddenCount > 0 ? `See ${hiddenCount} more` : 'See more'}
                         onSelect={() => handleSeeMoreNavigate(sectionTab)}
                         hoverable={!isMobile}
                         trackCategory='SEARCH'
@@ -2473,6 +2492,7 @@ const ChannelCommandMenu = ({
           const displayItems =
             isUserType && !isExpanded && hasMore ? items.slice(0, DISPLAY_LIMIT) : items;
           const hiddenCount = items.length - DISPLAY_LIMIT;
+          const sectionTab = GROUP_KEY_TO_DOC_TYPE[type];
 
           return (
             <div key={type} className='mb-4'>
@@ -2503,6 +2523,21 @@ const ChannelCommandMenu = ({
                     trackCategory='CHANNEL_SEARCH'
                     trackName='TOGGLE_BACKEND_USER_EXPANSION'
                     trackMetadata={JSON.stringify({ type, isExpanded })}
+                  />
+                )}
+                {/* Same routing link the search branch offers. This renderer runs when
+                    a filter chip is applied with no free-text query (`from:`,
+                    `assignee:`), so it needs the way out to the full results page too.
+                    Users are excluded — their row above expands in place instead. */}
+                {!isUserType && sectionTab && (
+                  <SeeMoreItem
+                    value={`__see-more-default-route-${type}__`}
+                    label='See more'
+                    onSelect={() => handleSeeMoreNavigate(sectionTab)}
+                    hoverable={!isMobile}
+                    trackCategory='SEARCH'
+                    trackName='SEE_MORE_SECTION'
+                    trackMetadata={JSON.stringify({ tab: sectionTab })}
                   />
                 )}
               </Command.Group>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -1993,9 +1993,10 @@ const ChannelCommandMenu = ({
         return;
       }
 
+      const { attachmentId, internalUrl } = result.searchContext;
       setPreviewFile({
         fileName: result.title,
-        fileUrl: result.searchContext.internalUrl,
+        fileUrl: attachmentId ? `/attachments/${attachmentId}/download` : internalUrl,
         mimeType: result.searchContext.mimeType || 'application/octet-stream',
         fileSize: result.searchContext.fileSize || 0,
       });

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
@@ -148,7 +148,10 @@ const ChannelSegment = ({
         {channelTag.icon}
       </span>
     )}
-    <span className='truncate'>{channelTag.name}</span>
+    {/* `ch` ≈ one "0" glyph, so this caps the name near 30 characters instead of
+        letting it take whatever the row has spare. It's a ceiling, not a width:
+        a narrow row still shrinks it further and truncates. */}
+    <span className='min-w-0 max-w-[30ch] truncate'>{channelTag.name}</span>
   </span>
 );
 
@@ -189,7 +192,7 @@ const TicketAssigneeSegment = ({
   const resolved = assignee ? getUserDisplayName(assignee) : '';
   const name = (resolved && resolved !== 'Unknown' ? resolved : assigneeName) || 'Unassigned';
 
-  return <span className='min-w-0 truncate'>{name}</span>;
+  return <span className='min-w-0 max-w-[30ch] truncate'>{name}</span>;
 };
 
 const AttachmentSearchResultItem = ({
@@ -229,8 +232,11 @@ const AttachmentSearchResultItem = ({
   if (shouldShowUploader) {
     // Reads the same as the file card on the full search screen.
     metaSegments.push(
-      <span key='uploader' className='min-w-0 truncate'>
-        Uploaded by {uploaderName}
+      // The prefix is held outside the cap so the 30ch applies to the name itself
+      // rather than being eaten by "Uploaded by ".
+      <span key='uploader' className='flex min-w-0 items-center gap-1'>
+        <span className='shrink-0'>Uploaded by</span>
+        <span className='min-w-0 max-w-[30ch] truncate'>{uploaderName}</span>
       </span>,
     );
   }

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
@@ -483,13 +483,19 @@ const SearchResultItem = ({
           <div className='flex items-center gap-1.5'>
             {result.avatar ? <UserAvatar userId={result.avatar} /> : getResultIcon(result)}
             <div className='flex-1 min-w-0'>
-              <div className='flex items-center gap-1.5 text-sm'>
-                <span className='font-medium text-foreground truncate'>
-                  {result.searchContext?.senderName}
+              {/* Sender / channel on the left, timestamp pinned right — same shape as
+                  the desk-mail row above and the ticket and file rows below. */}
+              <div className='flex items-center justify-between gap-2 text-sm'>
+                <span className='flex min-w-0 items-center gap-1.5'>
+                  <span className='font-medium text-foreground truncate'>
+                    {result.searchContext?.senderName}
+                  </span>
+                  <span className='shrink-0 text-xs text-muted-foreground'>{preposition}</span>
+                  <span className='text-xs font-medium text-foreground truncate'>
+                    {result.title}
+                  </span>
                 </span>
-                <span className='text-xs text-muted-foreground'>{preposition}</span>
-                <span className='text-xs font-medium text-foreground truncate'>{result.title}</span>
-                <span className='text-xs text-muted-foreground'>
+                <span className='shrink-0 whitespace-nowrap text-xs text-muted-foreground'>
                   {utcToIst(result.metadata.timestamp)}
                 </span>
               </div>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
@@ -181,11 +181,16 @@ const TicketAssigneeSegment = ({
 }: {
   assigneeId?: string | undefined;
   assigneeName?: string | undefined;
-}): ReactElement => (
-  <span className='min-w-0 truncate'>
-    {!assigneeId && !assigneeName ? 'Unassigned' : assigneeName || 'Unassigned'}
-  </span>
-);
+}): ReactElement => {
+  // Resolve through the user store so this reads the same as the file row's
+  // uploader — `searchContext.assigneeName` is the stored name, which ignores a
+  // user's displayName. Falls back to it when the id isn't in the store.
+  const assignee = useUser(assigneeId || '');
+  const resolved = assignee ? getUserDisplayName(assignee) : '';
+  const name = (resolved && resolved !== 'Unknown' ? resolved : assigneeName) || 'Unassigned';
+
+  return <span className='min-w-0 truncate'>{name}</span>;
+};
 
 const AttachmentSearchResultItem = ({
   result,
@@ -515,6 +520,11 @@ const SearchResultItem = ({
       // Only the title / channel / assignee truncate; every field reuses an
       // existing construct (no new icons).
       const ticketId = result.searchContext?.xyneId;
+      const idSegment = result.subtitle?.split(' | ')[0];
+      const ticketIdHtml =
+        ticketId && idSegment?.includes('<hi>') && idSegment.replace(/<\/?hi>/g, '') === ticketId
+          ? idSegment
+          : undefined;
       const rawTs = result.metadata.timestamp;
       const createdAt = rawTs && rawTs !== 'N/A' ? utcToIst(rawTs) : '';
       const status = result.searchContext?.ticketStatus;
@@ -556,7 +566,7 @@ const SearchResultItem = ({
               {ticketId && (
                 <>
                   <span className='shrink-0 whitespace-nowrap text-[15px] leading-[1.2] tracking-[-0.1px] text-muted-foreground'>
-                    {ticketId}
+                    {ticketIdHtml ? <RenderMessageWithHTML message={ticketIdHtml} /> : ticketId}
                   </span>
                   <span className='shrink-0 text-[14px] font-medium leading-[1.2] tracking-[-0.28px] text-muted-foreground'>
                     ·

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
@@ -152,7 +152,6 @@ const ChannelSegment = ({
   </span>
 );
 
-
 const asTicketPriority = (priority?: string): TicketPriority | null => {
   const normalized = priority?.toUpperCase();
   if (!normalized) return null;

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
@@ -190,6 +190,7 @@ const TicketAssigneeSegment = ({
 const AttachmentSearchResultItem = ({
   result,
   channelTag,
+  itemLabel,
   onSelect,
   onPreview,
   isSelected,
@@ -197,6 +198,8 @@ const AttachmentSearchResultItem = ({
 }: {
   result: DisplaySearchResult;
   channelTag?: { name: string; icon?: ReactElement | undefined } | undefined;
+  /** Title with highlight markup stripped, computed once by the parent. */
+  itemLabel: string;
   onSelect: (result: DisplaySearchResult) => Promise<void> | void;
   onPreview?: ((result: DisplaySearchResult) => void) | undefined;
   isSelected: boolean;
@@ -232,7 +235,7 @@ const AttachmentSearchResultItem = ({
       value={`backend-${result.type}-${result.id}`}
       data-result-id={result.id}
       data-result-type={result.type}
-      data-item-label={(result.title || '').replace(/<[^>]*>/g, '')}
+      data-item-label={itemLabel}
       onSelect={() => void onSelect(result)}
       onMouseDownCapture={handleMouseDown}
       className='flex w-full items-stretch gap-3 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
@@ -580,6 +583,7 @@ const SearchResultItem = ({
         <AttachmentSearchResultItem
           result={result}
           channelTag={channelTag}
+          itemLabel={itemLabel}
           onSelect={onSelect}
           onPreview={onPreview}
           isSelected={isSelected}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/SearchResultItem.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, MouseEvent as ReactMouseEvent } from 'react';
+import { ReactElement, Fragment, MouseEvent as ReactMouseEvent } from 'react';
 import { Command } from 'cmdk';
 import { Eye } from 'lucide-react';
 import {
@@ -18,19 +18,21 @@ import UserAvatar from '../../UserAvatar/UserAvatar';
 import Avatar from '../../ui/Avatar/Avatar';
 import { SearchSnippetRenderer } from '../RenderMessageWithHTML/searchSnippetRender';
 import { useUser } from '../../../hooks/useUsers';
-import { isUserDeactivated } from '../../../utils/userDisplayName';
+import { isUserDeactivated, getUserDisplayName } from '../../../utils/userDisplayName';
 import { StatusIndicator } from '../../ui/StatusIndicator';
+import { TicketPriority } from '@xyne/shared';
 
 interface SearchResultItemProps {
   result: DisplaySearchResult;
   channelDisplayName?: string | undefined;
   /**
    * Channel the result belongs to, resolved by the parent against its existing
-   * `allChannels` lookup (no per-row lookup here). `icon` is whatever the parent's
-   * shared `getChannelIcon` returns — hashtag / lock / DM avatar — so the tag
-   * follows the same public-vs-private logic as every other channel glyph.
+   * `allChannels` lookup (no per-row lookup here). The row leads this segment with
+   * the word "in", so the parent omits `icon` for plain public channels — a
+   * hashtag would only repeat the word — and sends one whenever the glyph still
+   * carries something the word cannot: private lock, DM avatar, group.
    */
-  channelTag?: { name: string; icon: ReactElement } | undefined;
+  channelTag?: { name: string; icon?: ReactElement | undefined } | undefined;
   onSelect: (result: DisplaySearchResult) => Promise<void> | void;
   onPreview?: (result: DisplaySearchResult) => void;
   isSelected?: boolean;
@@ -78,7 +80,10 @@ const getResultIcon = (result: DisplaySearchResult): ReactElement => {
 };
 
 const utcToIst = (utcString?: string): string => {
-  if (!utcString) return '';
+  // The backend writes the literal 'N/A' when a doc has no usable timestamp, so
+  // treat it as absent — otherwise it parses to an Invalid Date and every card
+  // that doesn't pre-guard renders the string "Invalid Date".
+  if (!utcString || utcString === 'N/A') return '';
 
   const dateUtc = new Date(`${utcString} UTC`);
 
@@ -98,6 +103,194 @@ const SelectedBadge = (): ReactElement => (
     <CheckTickSingle size={10} />
   </span>
 );
+
+// Second-line metadata row shared by ticket + file result cards. Renders a
+// muted, single-line list of pre-filtered segments separated by a middot. The
+// caller omits empty segments, so the separator never dangles. Uses only
+// existing text / avatar / channel-tag constructs — no new icons.
+//
+// `trailing` (the channel) closes the row without a middot in front of it: it
+// reads as a phrase — "in design" — and a separator would break that.
+const MetaLine = ({
+  segments,
+  trailing,
+}: {
+  segments: ReactElement[];
+  trailing?: ReactElement | undefined;
+}): ReactElement | null => {
+  if (segments.length === 0 && !trailing) return null;
+  return (
+    <div className='flex items-center gap-1.5 text-xs text-muted-foreground min-w-0 overflow-hidden'>
+      {segments.map((seg, i) => (
+        <Fragment key={i}>
+          {i > 0 && <span className='shrink-0 text-muted-foreground/70'>·</span>}
+          {seg}
+        </Fragment>
+      ))}
+      {trailing}
+    </div>
+  );
+};
+
+// Channel a result belongs to, on both ticket and file rows. Reads as a phrase —
+// "in design" — so it leads with the word rather than a hashtag glyph. Renders
+// whatever icon the parent sent (private lock, DM avatar, group); plain public
+// channels carry none, since the glyph would only repeat the word.
+const ChannelSegment = ({
+  channelTag,
+}: {
+  channelTag: { name: string; icon?: ReactElement | undefined };
+}): ReactElement => (
+  <span className='flex min-w-0 items-center gap-1'>
+    <span className='shrink-0'>in</span>
+    {channelTag.icon && (
+      <span className='flex h-3.5 w-3.5 shrink-0 items-center justify-center'>
+        {channelTag.icon}
+      </span>
+    )}
+    <span className='truncate'>{channelTag.name}</span>
+  </span>
+);
+
+
+const asTicketPriority = (priority?: string): TicketPriority | null => {
+  const normalized = priority?.toUpperCase();
+  if (!normalized) return null;
+  return (Object.values(TicketPriority) as string[]).includes(normalized)
+    ? (normalized as TicketPriority)
+    : null;
+};
+
+// The metadata row is text-only — no status dot, priority glyph or avatar. The
+// segments stay separate components so the row keeps its middot separators and
+// per-segment truncation rules.
+const TicketStatusSegment = ({ status }: { status?: string }): ReactElement | null => {
+  if (!status) return null;
+  return <span className='shrink-0 whitespace-nowrap'>{status}</span>;
+};
+
+const TicketPrioritySegment = ({ priority }: { priority?: string }): ReactElement | null => {
+  // Still gated on a known priority so an unrecognised value renders nothing
+  // rather than leaking a raw string into the row.
+  if (!asTicketPriority(priority)) return null;
+  return <span className='shrink-0 whitespace-nowrap'>{priority}</span>;
+};
+
+const TicketAssigneeSegment = ({
+  assigneeId,
+  assigneeName,
+}: {
+  assigneeId?: string | undefined;
+  assigneeName?: string | undefined;
+}): ReactElement => (
+  <span className='min-w-0 truncate'>
+    {!assigneeId && !assigneeName ? 'Unassigned' : assigneeName || 'Unassigned'}
+  </span>
+);
+
+const AttachmentSearchResultItem = ({
+  result,
+  channelTag,
+  onSelect,
+  onPreview,
+  isSelected,
+  onItemMouseDown,
+}: {
+  result: DisplaySearchResult;
+  channelTag?: { name: string; icon?: ReactElement | undefined } | undefined;
+  onSelect: (result: DisplaySearchResult) => Promise<void> | void;
+  onPreview?: ((result: DisplaySearchResult) => void) | undefined;
+  isSelected: boolean;
+  onItemMouseDown?: ((e: ReactMouseEvent, result: DisplaySearchResult) => void) | undefined;
+}): ReactElement => {
+  // `result.avatar` carries the file's ownerId (see transformFile in the backend
+  // resultTransform); resolve it to a display name via the same user store the
+  // rest of Cmd+K uses.
+  const uploaderId = result.avatar;
+  const uploader = useUser(uploaderId || '');
+  const handleMouseDown = onItemMouseDown
+    ? (e: ReactMouseEvent) => onItemMouseDown(e, result)
+    : undefined;
+
+  const rawTs = result.metadata.timestamp;
+  const createdAt = rawTs && rawTs !== 'N/A' ? utcToIst(rawTs) : '';
+
+  const uploaderName = uploader ? getUserDisplayName(uploader) : '';
+  const shouldShowUploader = !!uploaderId && !!uploader && uploaderName !== 'Unknown';
+
+  const metaSegments: ReactElement[] = [];
+  if (shouldShowUploader) {
+    // Reads the same as the file card on the full search screen.
+    metaSegments.push(
+      <span key='uploader' className='min-w-0 truncate'>
+        Uploaded by {uploaderName}
+      </span>,
+    );
+  }
+  return (
+    <Command.Item
+      key={result.id}
+      value={`backend-${result.type}-${result.id}`}
+      data-result-id={result.id}
+      data-result-type={result.type}
+      data-item-label={(result.title || '').replace(/<[^>]*>/g, '')}
+      onSelect={() => void onSelect(result)}
+      onMouseDownCapture={handleMouseDown}
+      className='flex w-full items-stretch gap-3 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
+    >
+      <span className='flex shrink-0 items-center'>{getResultIcon(result)}</span>
+      <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+        {/* `truncate` on the element that holds the text — `*:truncate` alone only
+            reaches direct element children, so a highlighted title (which renders
+            as several nodes) would overflow past the timestamp and eye instead. */}
+        <span className='block min-w-0 truncate *:truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
+          <RenderMessageWithHTML message={result.title} />
+        </span>
+        <MetaLine
+          segments={metaSegments}
+          trailing={channelTag ? <ChannelSegment channelTag={channelTag} /> : undefined}
+        />
+      </div>
+      {/* Right column mirrors the left one's two rows: the action lines up with
+          the title, the timestamp with the metadata line. The action keeps its
+          slot even when this row has no preview button (transcripts, selected
+          rows) so the timestamp stays put and every row's right edge matches. */}
+      <div className='flex shrink-0 flex-col items-end justify-between gap-0.5'>
+        <span className='flex h-[18px] w-7 items-center justify-center'>
+          {isSelected ? (
+            <SelectedBadge />
+          ) : (
+            onPreview &&
+            result.searchContext?.internalUrl &&
+            result.searchContext?.subApp?.toUpperCase() !== 'TRANSCRIPT' && (
+              <button
+                onClick={e => {
+                  e.stopPropagation();
+                  onPreview(result);
+                }}
+                className='p-1 text-muted-foreground hover:text-accent-foreground hover:bg-accent rounded transition-colors focus-visible:outline-none focus-visible:ring-0'
+                title='Preview file'
+                data-track-category='GLOBAL_SEARCH'
+                data-track-name='PREVIEW_SEARCH_RESULT'
+                data-track-metadata={JSON.stringify({
+                  resultId: result.id,
+                  resultType: result.type,
+                })}
+              >
+                <Eye size={14} />
+              </button>
+            )
+          )}
+        </span>
+        {createdAt && (
+          <span className='whitespace-nowrap text-xs leading-none text-muted-foreground'>
+            {createdAt}
+          </span>
+        )}
+      </div>
+    </Command.Item>
+  );
+};
 
 const UserSearchResultItem = ({
   result,
@@ -309,8 +502,33 @@ const SearchResultItem = ({
     }
 
     case 'ticket': {
-      // Single line: icon | ticketId | · | title | channel. Only the title truncates.
+      // Line 1: icon | ticketId | · | title. Line 2 (MetaLine): status · priority
+      // · assigned-to, closed by the channel as a trailing "in <name>" phrase.
+      // Only the title / channel / assignee truncate; every field reuses an
+      // existing construct (no new icons).
       const ticketId = result.searchContext?.xyneId;
+      const rawTs = result.metadata.timestamp;
+      const createdAt = rawTs && rawTs !== 'N/A' ? utcToIst(rawTs) : '';
+      const status = result.searchContext?.ticketStatus;
+      const priority = result.searchContext?.priority;
+      const assigneeId = result.searchContext?.assignedTo;
+      const assigneeName = result.searchContext?.assigneeName;
+
+      const metaSegments: ReactElement[] = [];
+      if (status) {
+        metaSegments.push(<TicketStatusSegment key='status' status={status} />);
+      }
+      if (priority) {
+        metaSegments.push(<TicketPrioritySegment key='priority' priority={priority} />);
+      }
+      metaSegments.push(
+        <TicketAssigneeSegment
+          key='assignee'
+          assigneeId={assigneeId}
+          assigneeName={assigneeName}
+        />,
+      );
+
       return (
         <Command.Item
           key={result.id}
@@ -322,85 +540,53 @@ const SearchResultItem = ({
           onMouseDownCapture={handleMouseDown}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
-          className='flex w-full items-center gap-3 h-10 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
+          className='flex w-full items-center gap-3 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
         >
           <span className='flex shrink-0 items-center'>{getResultIcon(result)}</span>
-          <div className='flex flex-1 items-center gap-1.5 min-w-0'>
-            {ticketId && (
-              <>
-                <span className='shrink-0 whitespace-nowrap text-[15px] leading-[1.2] tracking-[-0.1px] text-muted-foreground'>
-                  {ticketId}
-                </span>
-                <span className='shrink-0 text-[14px] font-medium leading-[1.2] tracking-[-0.28px] text-muted-foreground'>
-                  ·
-                </span>
-              </>
-            )}
-            <span className='min-w-0 *:truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
-              <RenderMessageWithHTML message={result.title} />
-            </span>
-            {/* The channel tag sits inside this group, not beside it: the design hugs it to
-                the truncated title (sharing the group's 6px gap) rather than flushing it to
-                the right edge of the row. */}
-            {channelTag && (
-              <span className='flex grow items-center gap-1 text-muted-foreground overflow-hidden'>
-                <span className='flex h-4 w-4 shrink-0 items-center justify-center'>
-                  {channelTag.icon}
-                </span>
-                <span className='text-[14px] font-medium leading-[1.2] tracking-[-0.28px] truncate'>
-                  {channelTag.name}
-                </span>
+          <div className='flex min-w-0 flex-1 flex-col gap-0.5'>
+            <div className='flex items-center gap-1.5 min-w-0'>
+              {ticketId && (
+                <>
+                  <span className='shrink-0 whitespace-nowrap text-[15px] leading-[1.2] tracking-[-0.1px] text-muted-foreground'>
+                    {ticketId}
+                  </span>
+                  <span className='shrink-0 text-[14px] font-medium leading-[1.2] tracking-[-0.28px] text-muted-foreground'>
+                    ·
+                  </span>
+                </>
+              )}
+              <span className='min-w-0 *:truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
+                <RenderMessageWithHTML message={result.title} />
               </span>
-            )}
+            </div>
+            <div className='flex min-w-0 items-center justify-between gap-2'>
+              <MetaLine
+                segments={metaSegments}
+                trailing={channelTag ? <ChannelSegment channelTag={channelTag} /> : undefined}
+              />
+              {createdAt && (
+                <span className='shrink-0 whitespace-nowrap text-xs text-muted-foreground'>
+                  {createdAt}
+                </span>
+              )}
+            </div>
           </div>
           {isSelected && <SelectedBadge />}
         </Command.Item>
       );
     }
 
-    case 'attachment': {
+    case 'attachment':
       return (
-        <Command.Item
-          key={result.id}
-          value={`backend-${result.type}-${result.id}`}
-          data-result-id={result.id}
-          data-result-type={result.type}
-          data-item-label={itemLabel}
-          onSelect={() => void onSelect(result)}
-          onMouseDownCapture={handleMouseDown}
-          className='flex w-full items-center gap-3 h-10 p-3 rounded-lg cursor-pointer hover:bg-accent aria-selected:bg-accent mt-1.5'
-        >
-          <span className='flex shrink-0 items-center'>{getResultIcon(result)}</span>
-          <div className='flex flex-1 items-center gap-1.5 min-w-0'>
-            <span className='min-w-0 *:truncate text-[15px] leading-[1.2] tracking-[-0.1px] text-foreground'>
-              <RenderMessageWithHTML message={result.title} />
-            </span>
-          </div>
-          {isSelected && <SelectedBadge />}
-          {!isSelected &&
-            onPreview &&
-            result.searchContext?.internalUrl &&
-            result.searchContext?.subApp?.toUpperCase() !== 'TRANSCRIPT' && (
-              <button
-                onClick={e => {
-                  e.stopPropagation();
-                  onPreview(result);
-                }}
-                className='p-1.5 text-muted-foreground hover:text-accent-foreground hover:bg-accent rounded transition-colors focus-visible:outline-none focus-visible:ring-0'
-                title='Preview file'
-                data-track-category='GLOBAL_SEARCH'
-                data-track-name='PREVIEW_SEARCH_RESULT'
-                data-track-metadata={JSON.stringify({
-                  resultId: result.id,
-                  resultType: result.type,
-                })}
-              >
-                <Eye size={14} />
-              </button>
-            )}
-        </Command.Item>
+        <AttachmentSearchResultItem
+          result={result}
+          channelTag={channelTag}
+          onSelect={onSelect}
+          onPreview={onPreview}
+          isSelected={isSelected}
+          onItemMouseDown={onItemMouseDown}
+        />
       );
-    }
 
     default:
       return (

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -54,7 +54,6 @@ import ConversationPanelV2 from '../ConversationPannel/ConversationPanelV2';
 import { useSearchMetrics } from '../../../hooks/useSearchMetrics';
 import { useUser, useUsers } from '../../../hooks/useUsers';
 import {
-  formatChannelLabel,
   getDMNames,
   isDMChannel,
   isGroupDMChannel,
@@ -1119,9 +1118,20 @@ function ResultsBody({
 }: ResultsBodyProps): ReactElement {
   const navigate = useNavigate();
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
+  // `searchableNames` is already the rendered form: getDMNames(...).display for DMs
+  // (participant names — `channel.name` is a participant id there) and [channel.name]
+  // for everything else. That is `formatChannelLabel` without its `#`, which rows
+  // supplying their own lead-in ("in design") don't want.
   const channelLabelsById = useMemo(
     () =>
-      new Map(searchableChannels.map(channel => [channel.channel.id, formatChannelLabel(channel)])),
+      new Map(
+        searchableChannels.map(channel => [
+          channel.channel.id,
+          (channel.searchableNames?.length ? channel.searchableNames : [channel.channel.name]).join(
+            ', ',
+          ),
+        ]),
+      ),
     [searchableChannels],
   );
 
@@ -1188,15 +1198,7 @@ function ResultsBody({
     if (result.type === 'attachment') {
       const icon = getAttachmentResultIcon(result);
       const channelId = result.searchContext?.channelId;
-      // `formatChannelLabel` renders the shared display form, `#name`. This row
-      // says "in <name>", which supplies its own preposition, so the hash would
-      // just repeat it — strip it here rather than change the shared helper,
-      // which pickers and mentions rely on. DM labels are participant names with
-      // no hash, so they pass through untouched.
-      const channelName = (channelId ? channelLabelsById.get(channelId) : undefined)?.replace(
-        /^#/,
-        '',
-      );
+      const channelName = channelId ? channelLabelsById.get(channelId) : undefined;
       const uploaderId = result.avatar;
       const uploader = uploaderId ? usersById.get(uploaderId) : undefined;
       const uploaderName = uploader ? getUserDisplayName(uploader) : '';

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -1197,9 +1197,7 @@ function ResultsBody({
       const metaLine = [shouldShowUploader ? `Uploaded by ${uploaderName}` : '', fileSizeLabel]
         .filter(Boolean)
         .join(' · ');
-      const infoLine = [metaLine, channelName ? `in ${channelName}` : '']
-        .filter(Boolean)
-        .join(' ');
+      const infoLine = [metaLine, channelName ? `in ${channelName}` : ''].filter(Boolean).join(' ');
 
       return (
         <button

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft } from '@xyne/icons';
+import { ArrowLeft, ArrowRight } from '@xyne/icons';
 import { ResizableGroup, Panel, Separator } from '../../ui/Resizable/Resizable';
 import {
   FileText,
@@ -794,6 +794,20 @@ const SearchResults = (): ReactElement => {
             data-track-name='GO_BACK'
           >
             <ArrowLeft size={16} />
+          </button>
+          {/* Paired with Back so a step backwards is undoable — refining a query pushes
+              history entries, and without this the only way forward is retyping. Mirrors
+              Back exactly, including staying enabled: forward past the end of the stack
+              is a harmless no-op. */}
+          <button
+            type='button'
+            aria-label='Forward'
+            onClick={() => void navigate(1)}
+            className='size-7 shrink-0 flex items-center justify-center rounded-[10px] border border-transparent transition-colors text-sidebar-secondary-foreground hover:text-sidebar-accent-foreground hover:bg-sidebar-accent'
+            data-track-category='SEARCH_RESULTS'
+            data-track-name='GO_FORWARD'
+          >
+            <ArrowRight size={16} />
           </button>
           <div className='flex-1 min-w-0'>
             <SearchQueryInput query={query} onSubmit={handleQuerySubmit} isSearching={isLoading} />

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -15,7 +15,10 @@ import {
 } from 'lucide-react';
 
 const utcToIst = (utcString?: string): string => {
-  if (!utcString) return '';
+  // The backend writes the literal 'N/A' when a doc has no usable timestamp, so
+  // treat it as absent — otherwise it parses to an Invalid Date and every card
+  // that doesn't pre-guard renders the string "Invalid Date".
+  if (!utcString || utcString === 'N/A') return '';
   const dateUtc = new Date(`${utcString} UTC`);
   return dateUtc.toLocaleString('en-IN', {
     timeZone: 'Asia/Kolkata',
@@ -58,6 +61,7 @@ import {
   groupChannelsByScope,
 } from '../ChatDirectory/ChatDirectory.utils';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
+import { formatFileSize } from '../MessageAttachment/utils';
 import {
   TabType,
   MentionType,
@@ -845,6 +849,7 @@ const SearchResults = (): ReactElement => {
             onSelectUser={handleSelectUser}
             channelData={allChannelsForNav}
             searchableChannels={allChannelsWithCategory}
+            usersById={usersById}
             compareMode={compareMode}
             isGrouped={isGrouped}
             selectedIds={selectedIds}
@@ -949,6 +954,7 @@ interface ResultsBodyProps {
     category: ChannelCategory;
     searchableNames?: string[];
   }>;
+  usersById: Map<string, Parameters<typeof getUserDisplayName>[0]>;
   compareMode: boolean;
   isGrouped: boolean;
   selectedIds: Set<string>;
@@ -1088,6 +1094,7 @@ function ResultsBody({
   onSelectUser,
   channelData,
   searchableChannels,
+  usersById,
   compareMode,
   isGrouped,
   selectedIds,
@@ -1167,8 +1174,33 @@ function ResultsBody({
     if (result.type === 'attachment') {
       const icon = getAttachmentResultIcon(result);
       const channelId = result.searchContext?.channelId;
-      const channelName = channelId ? channelLabelsById.get(channelId) : undefined;
-      const subtitle = channelName ? `File uploaded in ${channelName}` : result.subtitle;
+      // `formatChannelLabel` renders the shared display form, `#name`. This row
+      // says "in <name>", which supplies its own preposition, so the hash would
+      // just repeat it — strip it here rather than change the shared helper,
+      // which pickers and mentions rely on. DM labels are participant names with
+      // no hash, so they pass through untouched.
+      const channelName = (channelId ? channelLabelsById.get(channelId) : undefined)?.replace(
+        /^#/,
+        '',
+      );
+      const uploaderId = result.avatar;
+      const uploader = uploaderId ? usersById.get(uploaderId) : undefined;
+      const uploaderName = uploader ? getUserDisplayName(uploader) : '';
+      const shouldShowUploader = !!uploader && uploaderName !== 'Unknown';
+      const rawTs = result.metadata.timestamp;
+      const uploadedAt = rawTs && rawTs !== 'N/A' ? utcToIst(rawTs) : '';
+      const fileSize = result.searchContext?.fileSize;
+      const fileSizeLabel = typeof fileSize === 'number' ? formatFileSize(fileSize) : '';
+      // Same shape as every other card on this screen: metadata left, timestamp
+      // right. Segments are middot-separated, except the channel, which closes
+      // the line as a phrase ("in design") and so takes no separator in front.
+      const metaLine = [shouldShowUploader ? `Uploaded by ${uploaderName}` : '', fileSizeLabel]
+        .filter(Boolean)
+        .join(' · ');
+      const infoLine = [metaLine, channelName ? `in ${channelName}` : '']
+        .filter(Boolean)
+        .join(' ');
+
       return (
         <button
           key={key}
@@ -1181,21 +1213,22 @@ function ResultsBody({
             {icon}
           </div>
           <div className='min-w-0 flex-1'>
-            <p className='text-sm font-medium text-foreground truncate'>
-              <RenderMessageWithHTML message={result.title} />
-            </p>
-            <div className='flex items-center justify-between gap-2 text-xs text-muted-foreground'>
-              {subtitle && (
-                <span className='truncate'>
-                  {channelName ? subtitle : <RenderMessageWithHTML message={subtitle} />}
-                </span>
-              )}
-              {result.metadata.timestamp && (
-                <span className='shrink-0 whitespace-nowrap'>
-                  {utcToIst(result.metadata.timestamp)}
+            {/* Timestamp sits on the title row, matching the ticket and message
+                cards; the metadata line below carries only metadata. */}
+            <div className='flex items-baseline justify-between gap-2'>
+              <p className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>
+                <RenderMessageWithHTML message={result.title} />
+              </p>
+              {uploadedAt && (
+                <span className='shrink-0 whitespace-nowrap text-xs text-muted-foreground'>
+                  {uploadedAt}
                 </span>
               )}
             </div>
+            <span className='block min-w-0 truncate text-xs text-muted-foreground'>
+              {infoLine ||
+                (result.subtitle ? <RenderMessageWithHTML message={result.subtitle} /> : null)}
+            </span>
           </div>
         </button>
       );
@@ -1204,10 +1237,11 @@ function ResultsBody({
     // Conversation message card (type === 'conversation')
     // DESK mails navigate away; regular messages open in the side panel
     if (result.type === 'conversation' && result.searchContext?.subApp === 'DESK') {
-      // Mirrors cmdK's desk-mail row: subject, then sender + recipient count and
-      // timestamp, then the body snippet.
+      // Mirrors cmdK's desk-mail row: subject and timestamp, then sender +
+      // recipient count, then the body snippet.
       const senderName = result.searchContext?.senderName || result.subtitle || '';
       const recipientCount = result.searchContext?.recipientCount ?? 0;
+      const sentAt = utcToIst(result.metadata.timestamp);
       const deskTicketSubtitle = [
         result.subtitle || result.searchContext.xyneId,
         ...(result.searchContext.formFieldMatches ?? []).map(
@@ -1228,25 +1262,27 @@ function ResultsBody({
             <Mail className='size-4 text-muted-foreground' />
           </div>
           <div className='min-w-0 flex-1'>
-            <p className='text-sm font-medium text-foreground truncate'>
-              <RenderMessageWithHTML message={result.title} />
-            </p>
+            {/* Timestamp sits on the subject row, matching the ticket and message
+                cards; the metadata line below carries only metadata. */}
+            <div className='flex items-baseline justify-between gap-2'>
+              <p className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>
+                <RenderMessageWithHTML message={result.title} />
+              </p>
+              {sentAt && (
+                <span className='shrink-0 whitespace-nowrap text-xs text-muted-foreground'>
+                  {sentAt}
+                </span>
+              )}
+            </div>
             {deskTicketSubtitle && (
               <div className='text-xs text-foreground truncate'>
                 <RenderMessageWithHTML message={deskTicketSubtitle} />
               </div>
             )}
-            <div className='flex items-center justify-between gap-2 text-xs text-muted-foreground'>
-              <span className='min-w-0 truncate'>
-                {senderName}
-                {recipientCount > 0 && ` +${recipientCount} more`}
-              </span>
-              {result.metadata.timestamp && (
-                <span className='shrink-0 whitespace-nowrap'>
-                  {utcToIst(result.metadata.timestamp)}
-                </span>
-              )}
-            </div>
+            <span className='block min-w-0 truncate text-xs text-muted-foreground'>
+              {senderName}
+              {recipientCount > 0 && ` +${recipientCount} more`}
+            </span>
             {result.context && (
               <div className='mt-0.5 text-xs text-muted-foreground'>
                 <SearchSnippetRenderer message={result.context} wordLimit={40} />

--- a/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
+++ b/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
@@ -46,6 +46,12 @@ interface FilePreviewModalProps {
   files?: FileItem[];
   currentIndex?: number;
   onNavigate?: (index: number) => void;
+  /**
+   * Tailwind z-index class for the overlay and content. Raise it when the modal
+   * is opened from inside a higher-stacked surface — the Cmd+K palette sits at
+   * z-[9999], so the default would render the preview behind it.
+   */
+  zIndexClass?: string;
 }
 
 // Inline Loading Component
@@ -290,6 +296,7 @@ const FilePreviewModalInner: React.FC<FilePreviewModalProps> = ({
   files,
   currentIndex = 0,
   onNavigate,
+  zIndexClass = 'z-[56]',
 }) => {
   // Simple state - service handles all caching and complexity
   const [fileData, setFileData] = useState<File | null>(null);
@@ -774,9 +781,11 @@ const FilePreviewModalInner: React.FC<FilePreviewModalProps> = ({
       }}
     >
       <Dialog.Portal>
-        <Dialog.Overlay className='fixed inset-0 flex items-center justify-center bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 z-[56]' />
+        <Dialog.Overlay
+          className={`fixed inset-0 flex items-center justify-center bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 ${zIndexClass}`}
+        />
         <Dialog.Content
-          className={`fixed z-[56] bg-black focus:outline-none
+          className={`fixed ${zIndexClass} bg-black focus:outline-none
           data-[state=closed]:fade-out transition-all ease-in-out duration-300
           data-[state=open]:fade-in overflow-hidden
           ${


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->
POT: https://drive.google.com/file/d/1jsRnFbWAvw2t_wYdeyb-yGo-EvYz2fwJ/view?usp=sharing
  Cmd+K result rows (SearchResultItem.tsx)

  - Tickets now show status · priority · assignee, closing with the channel as a phrase — in design.
  - Files show Uploaded by <name> and the same trailing channel.
  - The channel segment reads as in <name> rather than # name: no hashtag, and no middot separator in front of it, since it's a phrase. Private / DM / group channels keep their lock, avatar or group glyph — only the redundant hashtag is dropped.
  - Metadata is text-only. Removed the status dot, priority glyph, assignee avatar and uploader avatar.
  - File rows: preview (eye) icon pinned top-right, timestamp bottom-right, and the title now truncates reliably so a long name can't run under either.

  Cmd+K sections (ChannelCommandMenu.tsx)

  - Each result section gets a "See more" link that opens the full results page with that section's tab pre-selected, carrying the active filters across. Wired into both render paths — free-text searches and filter-chip-only searches (from:,
  assignee:), the latter of which previously had no link at all.

  Full search screen (SearchResults.tsx)

  - File and desk-mail cards now match the ticket and message cards: timestamp on the title row, metadata on its own line beneath. Previously the timestamp was inline in the metadata and file size occupied the right slot.
  - Metadata segments are middot-separated; channel again reads in <name>.
  - Added a forward navigation button beside the existing back arrow.

  Fixes

  - File preview 404 — the eye icon passed internalUrl straight through, which for chat attachments is a raw storage key (attachments/CONVERSATION/temp/…), not a route. Now builds /attachments/<id>/download, matching every other attachment
  surface. Collection items keep their existing route.
  - "Invalid Date" — the backend writes the literal 'N/A' for missing timestamps; utcToIst now treats it as absent instead of rendering Invalid Date.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
