### PR TITLE
feat: support guest invitation temp passwords

### DIFF
--- a/apps/backend/src/controllers/emailAuthController.ts
+++ b/apps/backend/src/controllers/emailAuthController.ts
@@ -24,6 +24,7 @@ import {
 import '../types/express';
 import { migrateLegacyIdentity } from '@/services/legacyIdentityMigrationHelper';
 import { logger } from '@/utils/logger';
+import { invitationService } from '@/services/invitationService';
 
 interface ResetCodePayload {
   code: string;
@@ -94,6 +95,19 @@ export class EmailAuthController {
       const normalizedEmail = email.toLowerCase().trim();
       const loginLockKey = `emaillogin:lock:${normalizedEmail}`;
       const loginAttemptKey = `emaillogin:attempts:${normalizedEmail}`;
+      const normalizedInvitationId = typeof invitationId === 'string'
+        ? invitationId.trim()
+        : '';
+      const pendingInvitation = normalizedInvitationId
+        ? await this.prisma.invitation.findFirst({
+          where: {
+            invitationId: normalizedInvitationId,
+            email: normalizedEmail,
+            acceptedAt: null,
+            expiredAt: { gt: new Date() },
+          },
+        })
+        : null;
 
       const existingLock = await redisService.get(loginLockKey);
       if (existingLock) {
@@ -114,25 +128,33 @@ export class EmailAuthController {
         where: { email: normalizedEmail },
       });
 
-      if (!orgMember || orgMember.leftAt) {
-        // Keep this response identical to the wrong-password response below.
-        res.status(401).json({
-          error: 'Invalid credentials',
-          message: 'Email or password is incorrect',
-        });
-        return;
+      let authenticatedWithGuestInvitationTempPassword = false;
+
+      if (!orgMember || orgMember.leftAt || !orgMember.passwordHash) {
+        if (pendingInvitation?.role === WorkspaceRole.GUEST) {
+          const guestTempPassword = await invitationService.verifyGuestInvitationTempPassword({
+            invitationId: pendingInvitation.invitationId ?? normalizedInvitationId,
+            email: normalizedEmail,
+            password,
+          });
+          authenticatedWithGuestInvitationTempPassword = Boolean(guestTempPassword);
+        }
+
+        if (!authenticatedWithGuestInvitationTempPassword) {
+          // Keep this response identical to the wrong-password path below.
+          res.status(401).json({
+            error: 'Invalid credentials',
+            message: 'Email or password is incorrect',
+          });
+          return;
+        }
       }
 
-      if (!orgMember.passwordHash) {
-        res.status(401).json({
-          error: 'Invalid credentials',
-          message: 'Email or password is incorrect',
-        });
-        return;
-      }
-
-      // 2. Verify password against orgMember.passwordHash
-      const isValid = await verifyEmailPassword(password, orgMember.passwordHash);
+      // 2. Verify password against orgMember.passwordHash, unless this is a
+      // first-time guest login using the Redis-backed invitation password.
+      const isValid = authenticatedWithGuestInvitationTempPassword
+        ? true
+        : await verifyEmailPassword(password, orgMember!.passwordHash!);
       if (!isValid) {
         const redis = redisService.getClient();
         const failedAttempts = await redis.incr(loginAttemptKey);
@@ -190,27 +212,10 @@ export class EmailAuthController {
 
       // 3. Find user's active workspace(s)
       const workspaceUsers = await this.prisma.user.findMany({
-        where: { orgMemberId: orgMember.memberId, leftAt: null },
+        where: { orgMemberId: orgMember?.memberId ?? '__pending_guest_invitation__', leftAt: null },
         orderBy: { createdAt: 'desc' },
         include: { workspace: true },
       });
-
-      // Invitation handling is keyed only by an explicit invitationId from the
-      // auth URL. Regular email login should not be diverted by unrelated
-      // pending invitations for the same email.
-      const normalizedInvitationId = typeof invitationId === 'string'
-        ? invitationId.trim()
-        : '';
-      const pendingInvitation = normalizedInvitationId
-        ? await this.prisma.invitation.findFirst({
-          where: {
-            invitationId: normalizedInvitationId,
-            email: normalizedEmail,
-            acceptedAt: null,
-            expiredAt: { gt: new Date() },
-          },
-        })
-        : null;
 
       if (workspaceUsers.length === 0 && !pendingInvitation) {
         // Check if user has approved community workspace join request(s).
@@ -472,8 +477,8 @@ export class EmailAuthController {
           name: workspaceUser.name,
           workspaceId: workspaceUser.workspaceId,
           role: workspaceUser.role,
-          orgRole: orgMember.role,
-          memberId: orgMember.memberId,
+          orgRole: orgMember!.role,
+          memberId: orgMember!.memberId,
           authProvider: AuthProvider.EMAIL,
         },
         workspaces,

--- a/apps/backend/src/controllers/invitationController.ts
+++ b/apps/backend/src/controllers/invitationController.ts
@@ -125,9 +125,17 @@ export class InvitationController {
       const existingWorkspaceUsers = await DatabaseClient.getInstance().user.count({
         where: { email: normalizedEmail, leftAt: null },
       });
+      const existingOrgMember = await withWorkspaceScope(() =>
+        DatabaseClient.getInstance().orgMember.findUnique({
+          where: { email: normalizedEmail },
+          select: { passwordHash: true, leftAt: true },
+        }),
+      );
 
       let tempPassword: string | null = null;
-      if (existingWorkspaceUsers === 0 && role !== 'GUEST') {
+      if (existingWorkspaceUsers === 0 && invitation.role === WorkspaceRole.GUEST && !existingOrgMember?.passwordHash) {
+        tempPassword = await invitationService.generateGuestInvitationTempPassword(invitation);
+      } else if (existingWorkspaceUsers === 0 && invitation.role !== WorkspaceRole.GUEST) {
         tempPassword = await invitationService.generateOrgMemberPassword(normalizedEmail);
       }
 

--- a/apps/backend/src/services/invitationService.ts
+++ b/apps/backend/src/services/invitationService.ts
@@ -18,7 +18,8 @@ import { logger } from '@/utils/logger';
 import { emailService } from './email/factory';
 import { grantPermissionsForRole } from './permissionMatrix';
 import crypto from 'crypto';
-import { hashPassword } from '../utils/passwordUtils';
+import { hashPassword, verifyEmailPassword } from '../utils/passwordUtils';
+import { redisService } from './redisService';
 import { organizationDomainService } from './organizationDomainService';
 import { ChannelUserStatusRepository } from '@/database/repositories/channelUserStatusRepository';
 import { aiProvisioningService } from './aiProvisioningService';
@@ -48,6 +49,13 @@ export interface InvitationWithDetails extends Invitation {
   } | null;
 }
 
+const GUEST_INVITATION_TEMP_PASSWORD_PREFIX = 'guestinvitation:temp-password';
+
+interface GuestInvitationTempPasswordPayload {
+  email: string;
+  passwordHash: string;
+}
+
 export class InvitationService {
   private prisma: PrismaClient;
   private channelUserStatusRepository: ChannelUserStatusRepository;
@@ -62,6 +70,55 @@ export class InvitationService {
     if (role === WorkspaceRole.ADMIN) return OrgRole.ADMIN;
     if (role === WorkspaceRole.COMMUNITY_MEMBER) return OrgRole.COMMUNITY_MEMBER;
     return OrgRole.MEMBER;
+  }
+
+  private getGuestInvitationTempPasswordKey(invitationId: string): string {
+    return `${GUEST_INVITATION_TEMP_PASSWORD_PREFIX}:${invitationId}`;
+  }
+
+  private async readGuestInvitationTempPassword(invitationId: string): Promise<GuestInvitationTempPasswordPayload | null> {
+    const raw = await redisService.get(this.getGuestInvitationTempPasswordKey(invitationId));
+    if (!raw) return null;
+
+    try {
+      const payload = JSON.parse(raw) as Partial<GuestInvitationTempPasswordPayload>;
+      if (typeof payload.email !== 'string' || typeof payload.passwordHash !== 'string') {
+        return null;
+      }
+      return { email: payload.email, passwordHash: payload.passwordHash };
+    } catch {
+      return null;
+    }
+  }
+
+  private async storeGuestInvitationTempPassword(params: {
+    invitationId: string;
+    email: string;
+    passwordHash: string;
+    expiredAt: Date | null;
+  }): Promise<void> {
+    const now = Date.now();
+    const ttlSeconds = params.expiredAt
+      ? Math.max(Math.ceil((params.expiredAt.getTime() - now) / 1000), 1)
+      : 15 * 24 * 60 * 60;
+
+    await redisService.set(
+      this.getGuestInvitationTempPasswordKey(params.invitationId),
+      JSON.stringify({ email: params.email, passwordHash: params.passwordHash }),
+      ttlSeconds,
+    );
+  }
+
+  async verifyGuestInvitationTempPassword(params: {
+    invitationId: string;
+    email: string;
+    password: string;
+  }): Promise<GuestInvitationTempPasswordPayload | null> {
+    const payload = await this.readGuestInvitationTempPassword(params.invitationId);
+    if (!payload || payload.email !== params.email.toLowerCase()) return null;
+
+    const valid = await verifyEmailPassword(params.password, payload.passwordHash);
+    return valid ? payload : null;
   }
 
   private async markInvitationAccepted(tx: TxClient, invitationId: string): Promise<void> {
@@ -235,7 +292,19 @@ export class InvitationService {
     });
 
     if (activeInvitation) {
-      throw new Error(`An invitation for ${email} already exists in this workspace`);
+      if (invitationRole === 'GUEST' && !existingUser) {
+        const activeTempPassword = await this.readGuestInvitationTempPassword(activeInvitation.invitationId ?? activeInvitation.id);
+        if (!activeTempPassword) {
+          await this.prisma.invitation.update({
+            where: { id: activeInvitation.id },
+            data: { expiredAt: new Date() },
+          });
+        } else {
+          throw new Error(`An invitation for ${email} already exists in this workspace`);
+        }
+      } else {
+        throw new Error(`An invitation for ${email} already exists in this workspace`);
+      }
     }
 
     // Calculate expiration date (15 days from now)
@@ -313,9 +382,12 @@ export class InvitationService {
    * Delete an invitation completely (used for cleanup on failure)
    */
   async deleteInvitation(id: string): Promise<void> {
-    await this.prisma.invitation.delete({
+    const deleted = await this.prisma.invitation.delete({
       where: { id },
+      select: { id: true, invitationId: true },
     });
+
+    await redisService.del(this.getGuestInvitationTempPasswordKey(deleted.invitationId ?? deleted.id));
 
     logger.info(`[InvitationService] Deleted invitation ${id}`);
   }
@@ -345,6 +417,24 @@ export class InvitationService {
 
       return tempPassword;
     });
+  }
+
+  /**
+   * Generate a first-login password for a guest invitation without writing an
+   * OrgMember yet. The hash lives only in Redis and expires with the invitation.
+   */
+  async generateGuestInvitationTempPassword(invitation: Pick<Invitation, 'invitationId' | 'id' | 'email' | 'expiredAt'>): Promise<string> {
+    const tempPassword = crypto.randomBytes(12).toString('base64url'); // ~16 chars
+    const passwordHash = await hashPassword(tempPassword);
+
+    await this.storeGuestInvitationTempPassword({
+      invitationId: invitation.invitationId ?? invitation.id,
+      email: invitation.email.toLowerCase(),
+      passwordHash,
+      expiredAt: invitation.expiredAt,
+    });
+
+    return tempPassword;
   }
 
   /**
@@ -592,6 +682,7 @@ export class InvitationService {
       name: string;
       providerUserId: string;
       authProvider: string;
+      passwordHash?: string;
     },
     tx: TxClient,
   ): Promise<{ user: User; redirectPath: string | null }> {
@@ -603,16 +694,26 @@ export class InvitationService {
       throw new Error(`Cannot accept invitation — ${userData.email} is no longer part of the organization`);
     }
 
+    if (userData.authProvider === AuthProvider.EMAIL && !orgMember?.passwordHash && !userData.passwordHash) {
+      throw new Error('Guest invitation password has expired. Please ask the sender to re-invite you.');
+    }
+
     const activeOrgMember = orgMember ?? await tx.orgMember.create({
       data: {
         orgId: invitation.orgId!,
         email: userData.email.toLowerCase(),
         role: OrgRole.GUEST,
+        ...(userData.passwordHash ? { passwordHash: userData.passwordHash } : {}),
       },
     });
 
     if (!orgMember) {
       logger.info(`[DEBUG] [handleGuestAcceptance] Created new orgMember with GUEST role id=${activeOrgMember.memberId}`);
+    } else if (!orgMember.passwordHash && userData.passwordHash) {
+      await tx.orgMember.update({
+        where: { memberId: activeOrgMember.memberId },
+        data: { passwordHash: userData.passwordHash, leftAt: null },
+      });
     }
 
     const newWorkspaceUser = await tx.user.create({
@@ -645,6 +746,7 @@ export class InvitationService {
       name: string;
       providerUserId: string;
       authProvider: string;
+      passwordHash?: string;
     };
   }): Promise<{ user: User; redirectPath: string | null }> {
     const { invitationId, userData } = params;
@@ -689,6 +791,13 @@ export class InvitationService {
 
     logger.info(`[DEBUG] [acceptInvitation] resolvedOrgId=${resolvedOrgId ?? 'null'} (from invitation.orgId=${invitation.orgId ?? 'null'})`);
 
+    const guestInvitationTempPassword = invitation.role === 'GUEST' && userData.authProvider === AuthProvider.EMAIL
+      ? await this.readGuestInvitationTempPassword(invitationId)
+      : null;
+    const guestUserData = guestInvitationTempPassword
+      ? { ...userData, passwordHash: guestInvitationTempPassword.passwordHash }
+      : userData;
+
     // Check if user already exists in this workspace (duplicate accept guard)
     const existingWorkspaceUser = await this.prisma.user.findFirst({
       where: {
@@ -709,7 +818,7 @@ export class InvitationService {
     if (!existingWorkspaceUser && invitation.role === 'GUEST') {
       const guestResult = await this.prisma.$transaction(async (tx) => {
         await this.markInvitationAccepted(tx, invitationId);
-        const result = await this.handleGuestAcceptance(invitation, userData, tx);
+        const result = await this.handleGuestAcceptance(invitation, guestUserData, tx);
         return result;
       });
       newWorkspaceUser = guestResult.user;
@@ -885,6 +994,10 @@ export class InvitationService {
         newWorkspaceUser.id,
         ChannelRole.MEMBER,
       );
+    }
+
+    if (guestInvitationTempPassword) {
+      await redisService.del(this.getGuestInvitationTempPasswordKey(invitationId));
     }
 
     return { user: newWorkspaceUser, redirectPath };


### PR DESCRIPTION
1. Problem Description:
Guest invitations are entity-scoped, so a guest can receive multiple active invitations for different channels/canvases. First-time guest invitees currently depend on email-password login, but that login expects an org_members passwordHash to already exist. This does not match the SSO invitation flow where login first establishes identity and accept invitation creates the org member/workspace user.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Verified in apps/backend/src/services/invitationService.ts that guest duplicate checks are scoped by entityId/entityType, and verified in apps/backend/src/controllers/emailAuthController.ts that email login previously required an existing orgMember.passwordHash before it could enter the pending-invitation path.

3. Explain the solution implemented in the PR:
- For first-time guest invitations, generate a temporary password and store only its hash in Redis under the invitation token until the invitation expires.
- Allow email login with a valid guest invitation token and Redis-backed temporary password even when org_members does not exist yet.
- On accept invitation, create or update the GUEST org member with that password hash, then create the workspace guest user and grant entity access.
- If the Redis temp credential is missing for an unaccepted first-time guest invite, allow a fresh re-invitation by expiring the stale active invite.
- Clean up the Redis temp credential when invitations are deleted or accepted.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- pnpm --filter xyne-spaces-backend typecheck
- pnpm --filter xyne-spaces-backend exec eslint src/services/invitationService.ts src/controllers/invitationController.ts src/controllers/emailAuthController.ts

9. Services to which this change is to be deployed:
backend

10. Main PR link (if this PR is raised against a release branch):
N/A