### PR TITLE
fix: XYNE-60327: Fixed FCM priority to only tasks that show notificat…

### DIFF
--- a/apps/backend/src/services/fcmService.ts
+++ b/apps/backend/src/services/fcmService.ts
@@ -566,7 +566,7 @@ class FcmPushService {
         token,
         data: this.buildDataPayload(payload, isSilent),
         android: {
-          priority: 'high',
+          priority: isSilent ? 'normal' : 'high',
           ttl: '86400s',
         },
         ...(webpush ? { webpush } : {}),


### PR DESCRIPTION
…ions

Services-Requiring-Redeployment:
  - [x] backend

## Type of Change

- Bugfix

## Description
Changed the priority of notifications from always high to normal for silent notifications;
FCM android dictates that all priority notifications must show UI

## Areas Touched

- [x] `apps/backend` (API / worker)
---

## Zero (Sync) Changes

- No Zero changes

## Schema & Data Changes

- [x] No schema changes

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
