### PR TITLE
fix: XYNE-60420 dark mode table view colors

### DIFF
--- a/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
@@ -225,6 +225,14 @@ export const TicketTable: React.FC<TicketTableProps> = ({
   const userGroups = useUserGroups();
 
   const theme = themeQuartz.withParams({
+    // Keep AG Grid tied to Spaces theme tokens. Without these body-level params,
+    // Quartz keeps its default light row/pagination surfaces while the Support
+    // screen is in midnight mode.
+    backgroundColor: 'hsl(var(--background))',
+    foregroundColor: 'hsl(var(--foreground))',
+    chromeBackgroundColor: 'hsl(var(--card))',
+    oddRowBackgroundColor: 'hsl(var(--background))',
+    rowHoverColor: 'hsl(var(--accent))',
     headerBackgroundColor: 'hsl(var(--card))',
     headerTextColor: 'hsl(var(--muted-foreground))',
     headerFontWeight: '600',


### PR DESCRIPTION
1. Problem Description:
Support/ticket table view used AG Grid Quartz defaults for the grid body and pagination surfaces, so midnight/dark mode could keep light row surfaces while the surrounding Support screen was dark.

Ticket: XYNE-60420

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in a Spaces thread as a dark-mode issue in table view. Code inspection showed TicketTable only themed header/borders, not AG Grid body-level colors.

3. Explain the solution implemented in the PR:
Bind AG Grid's body-level theme params to Spaces CSS theme tokens: backgroundColor, foregroundColor, chromeBackgroundColor, oddRowBackgroundColor, and rowHoverColor. This keeps the grid rows, pagination/chrome, text, and hover state aligned with midnight mode without global CSS overrides.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
Ran `pnpm --filter xyne-spaces-dashboard exec tsc --noEmit --pretty false` successfully. Note: sandbox emitted an unrelated package engine warning for xyne-claw-mcp wanting Node >=22 while current Node is v20.20.2.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A