### PR TITLE
feat: add canvas edit access request

### DIFF
--- a/apps/backend/src/controllers/canvasController.ts
+++ b/apps/backend/src/controllers/canvasController.ts
@@ -1,5 +1,10 @@
 import { Request, Response } from 'express';
-import { AttachmentEntityType, ActivityClassification, CanvasRole } from '@xyne/shared';
+import {
+  AttachmentEntityType,
+  ActivityClassification,
+  CanvasRole,
+  NotificationType,
+} from '@xyne/shared';
 import { z } from 'zod';
 import { uploadFiles } from '../services/fileUploadService.js';
 import { MessageAttachmentRepository } from '../database/repositories/messageAttachmentRepository.js';
@@ -14,8 +19,13 @@ import { getGroupMembersForNotification } from '../utils/mentionUtils.js';
 import { getSlackRecipientEmails } from '../utils/notificationHelper.js';
 import { cleanupProxiedFile } from '../utils/attachmentUtils';
 import { v4 as uuidv4 } from 'uuid';
-import {initializeYSweetDoc, syncToYSweet} from '../utils/ysweetUtils.js';
-import { convertMarkdownToBlockNote, convertBlockNoteToMarkdown, getCanvasUrl, getCanvasById } from '../services/canvasService.js';
+import { initializeYSweetDoc, syncToYSweet } from '../utils/ysweetUtils.js';
+import {
+  convertMarkdownToBlockNote,
+  convertBlockNoteToMarkdown,
+  getCanvasUrl,
+  getCanvasById,
+} from '../services/canvasService.js';
 
 export class CanvasController {
   private messageAttachmentRepository: MessageAttachmentRepository;
@@ -24,7 +34,7 @@ export class CanvasController {
     this.messageAttachmentRepository = messageAttachmentRepository;
   }
 
-    createCanvas = async (req: Request, res: Response): Promise<void> => {
+  createCanvas = async (req: Request, res: Response): Promise<void> => {
     try {
       const userId = req.user?.id;
       if (!userId) {
@@ -55,8 +65,8 @@ export class CanvasController {
             title,
             content: [],
             workspaceId: req.user!.workspaceId!,
-            createdBy: creatorId,  // <-- AUTHENTICATED USER
-            channelId: channelId || null,  // <-- ASSOCIATE WITH CHANNEL IF PROVIDED
+            createdBy: creatorId, // <-- AUTHENTICATED USER
+            channelId: channelId || null, // <-- ASSOCIATE WITH CHANNEL IF PROVIDED
             visibility: visibility === 'PUBLIC' ? 'PUBLIC' : 'PRIVATE',
             isTemplate: false,
             isCollaborative: true,
@@ -71,7 +81,7 @@ export class CanvasController {
             id: participantId,
             canvasId,
             workspaceId: req.user!.workspaceId!,
-            userId: creatorId,  // <-- AUTHENTICATED USER IS OWNER
+            userId: creatorId, // <-- AUTHENTICATED USER IS OWNER
             role: CanvasRole.OWNER,
             joinedAt: now,
             updatedAt: now,
@@ -100,6 +110,141 @@ export class CanvasController {
     }
   };
 
+  /**
+   * POST /api/canvas/:canvasId/request-edit-access
+   * Lets a viewer ask the direct canvas owner(s) for edit access.
+   */
+  requestEditAccess = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = req.user?.id;
+      const workspaceId = req.user?.workspaceId;
+      const { canvasId } = req.params;
+
+      if (!userId || !workspaceId) {
+        res.status(403).json({ error: 'Unauthorized - user not authenticated' });
+        return;
+      }
+
+      if (!canvasId) {
+        res.status(400).json({ error: 'Canvas ID is required' });
+        return;
+      }
+
+      const access = await canvasAuthService.checkCanvasAccess(canvasId, userId);
+      if (!access.hasAccess || !access.canView) {
+        res.status(403).json({ error: 'Permission denied' });
+        return;
+      }
+
+      if (access.canEdit) {
+        res.status(200).json({ success: true, alreadyHasEditAccess: true, requested: 0 });
+        return;
+      }
+
+      const db = DatabaseClient.getInstance();
+      const canonicalCanvasId = access.canvas?.id ?? canvasId;
+      const [canvas, requester] = await Promise.all([
+        db.canvas.findUnique({
+          where: { id: canonicalCanvasId },
+          select: {
+            id: true,
+            title: true,
+            createdBy: true,
+            channelId: true,
+            workspaceId: true,
+            participants: {
+              where: { role: CanvasRole.OWNER, userId: { not: null } },
+              select: { userId: true },
+            },
+          },
+        }),
+        db.user.findUnique({ where: { id: userId }, select: { name: true, displayName: true } }),
+      ]);
+
+      if (!canvas || canvas.workspaceId !== workspaceId) {
+        res.status(404).json({ error: 'Canvas not found' });
+        return;
+      }
+
+      const ownerIds = Array.from(
+        new Set(
+          [canvas.createdBy, ...canvas.participants.map((p) => p.userId)].filter(
+            Boolean
+          ) as string[]
+        )
+      ).filter((ownerId) => ownerId !== userId);
+
+      if (ownerIds.length === 0) {
+        res.status(404).json({ error: 'No owner available to request edit access from' });
+        return;
+      }
+
+      const existingRequests = await db.activity.findMany({
+        where: {
+          userId: { in: ownerIds },
+          actorId: userId,
+          actorAction: 'canvas_edit_access_requested',
+          canvasId: canvas.id,
+          isRead: false,
+        },
+        select: { userId: true },
+      });
+      const existingOwnerIds = new Set(existingRequests.map((request) => request.userId));
+      const ownersToNotify = ownerIds.filter((ownerId) => !existingOwnerIds.has(ownerId));
+
+      if (ownersToNotify.length > 0) {
+        await activityService.createActivities(
+          ownersToNotify.map((ownerId) => ({
+            id: uuidv4(),
+            userId: ownerId,
+            workspaceId,
+            actorId: userId,
+            actorAction: 'canvas_edit_access_requested',
+            actionSource: 'canvas',
+            actionSourceId: canvas.id,
+            channelId: canvas.channelId ?? undefined,
+            canvasId: canvas.id,
+            classification: ActivityClassification.ACTIONABLE,
+          }))
+        );
+
+        const requesterName = requester?.displayName || requester?.name || 'Someone';
+        const actionUrl = `/${workspaceId}/chat/canvas/${canvas.id}`;
+        await Promise.allSettled(
+          ownersToNotify.map((ownerId) =>
+            notificationService.createNotification(ownerId, {
+              title: `${requesterName} requested edit access`,
+              message: `${requesterName} requested edit access to "${canvas.title || 'Untitled Canvas'}"`,
+              type: NotificationType.CANVAS_SHARED,
+              relatedEntityType: 'canvas',
+              relatedEntityId: canvas.id,
+              actionUrl,
+              workspaceId,
+              metadata: {
+                canvasId: canvas.id,
+                requesterId: userId,
+                requesterName,
+                actorAction: 'canvas_edit_access_requested',
+              },
+            })
+          )
+        );
+      }
+
+      res.status(200).json({
+        success: true,
+        requested: ownersToNotify.length,
+        alreadyRequested: ownerIds.length - ownersToNotify.length,
+      });
+    } catch (error) {
+      logger.error('[CANVAS-REQUEST-EDIT-ACCESS] Error:', error);
+      res.status(500).json({
+        error: 'Failed to request edit access',
+        message: 'An unexpected error occurred.',
+      });
+    }
+  };
+
   uploadFile = async (req: Request, res: Response): Promise<void> => {
     try {
       const { canvasId, width, height } = req.body;
@@ -123,7 +268,7 @@ export class CanvasController {
         await canvasAuthService.requireEditAccess(canvasId, userId);
       } catch (error) {
         logger.warn(`[CANVAS-UPLOAD] Permission denied for user ${userId} on canvas ${canvasId}`, {
-          error: error instanceof Error ? error.message : 'Unknown error'
+          error: error instanceof Error ? error.message : 'Unknown error',
         });
         await cleanupProxiedFile(file, { logPrefix: 'CANVAS-UPLOAD' });
         res.status(403).json({ error: 'Permission denied' });
@@ -151,7 +296,10 @@ export class CanvasController {
       const uploadResults = await uploadFiles([file]);
 
       if (!uploadResults || uploadResults.length === 0) {
-        logger.error('[CANVAS-UPLOAD] The file upload service did not return a valid result for file:', { fileName: file.originalname });
+        logger.error(
+          '[CANVAS-UPLOAD] The file upload service did not return a valid result for file:',
+          { fileName: file.originalname }
+        );
         await cleanupProxiedFile(file, { logPrefix: 'CANVAS-UPLOAD' });
         res.status(500).json({ error: 'Failed to process the uploaded file.' });
         return;
@@ -242,8 +390,15 @@ export class CanvasController {
         return;
       }
 
-      const { mentionType, mentionId, blockId, commentThreadId, canvasTitle, mentionContext, slackUrl } =
-        validatedBody.data;
+      const {
+        mentionType,
+        mentionId,
+        blockId,
+        commentThreadId,
+        canvasTitle,
+        mentionContext,
+        slackUrl,
+      } = validatedBody.data;
       const userId = req.user?.id;
 
       if (!userId) {
@@ -283,7 +438,7 @@ export class CanvasController {
 
       // Resolve mentioned users
       const mentionedUsers: { userId: string; mentionSource: 'direct' | 'group' }[] = [];
-      
+
       if (mentionType === 'user' && mentionId !== userId) {
         mentionedUsers.push({ userId: mentionId, mentionSource: 'direct' });
       } else if (mentionType === 'group') {
@@ -301,8 +456,8 @@ export class CanvasController {
       }
 
       // Batch check canvas access for all mentioned users in a single query
-      const uniqueUserIds = [...new Set(mentionedUsers.map(u => u.userId))];
-      
+      const uniqueUserIds = [...new Set(mentionedUsers.map((u) => u.userId))];
+
       // Fetch canvas details, canvas participants, sender name, and mentioned users' emails in one batch
       const [canvas, canvasParticipants, sender, mentionedUserRecords] = await Promise.all([
         db.canvas.findUnique({
@@ -322,12 +477,11 @@ export class CanvasController {
           select: { id: true, email: true },
         }),
       ]);
-      
+
       // Determine which users have access (canvas creator or canvas participant)
-      const canvasParticipantIds = new Set(canvasParticipants.map(p => p.userId));
-      const usersWithAccessIds = uniqueUserIds.filter(uid => 
-        uid === canvas?.createdBy || 
-        canvasParticipantIds.has(uid)
+      const canvasParticipantIds = new Set(canvasParticipants.map((p) => p.userId));
+      const usersWithAccessIds = uniqueUserIds.filter(
+        (uid) => uid === canvas?.createdBy || canvasParticipantIds.has(uid)
       );
 
       if (usersWithAccessIds.length === 0) {
@@ -336,14 +490,17 @@ export class CanvasController {
       }
 
       // Filter to users with access and create activities
-      const mentionedUsersWithAccess = mentionedUsers.filter(u => usersWithAccessIds.includes(u.userId));
-      const activities = mentionedUsersWithAccess.map(u => ({
+      const mentionedUsersWithAccess = mentionedUsers.filter((u) =>
+        usersWithAccessIds.includes(u.userId)
+      );
+      const activities = mentionedUsersWithAccess.map((u) => ({
         id: uuidv4(),
         userId: u.userId,
         actorId: userId,
         actorAction: u.mentionSource === 'direct' ? 'mentioned_user' : 'group_mention',
         actionSource: mentionContext === 'comment' ? 'canvas_comment' : 'canvas',
-        actionSourceId: mentionContext === 'comment' && commentThreadId ? commentThreadId : canvasId,
+        actionSourceId:
+          mentionContext === 'comment' && commentThreadId ? commentThreadId : canvasId,
         channelId: canvasChannelId ?? undefined,
         canvasId: canvasId,
         blockId: blockId ?? undefined,
@@ -355,8 +512,8 @@ export class CanvasController {
       const usersWithAccessSet = new Set(usersWithAccessIds);
       const userEmailMap = new Map(
         mentionedUserRecords
-          .filter(u => u.email && usersWithAccessSet.has(u.id))
-          .map(u => [u.id, u.email!])
+          .filter((u) => u.email && usersWithAccessSet.has(u.id))
+          .map((u) => [u.id, u.email!])
       );
       const mentionedEmails = Array.from(userEmailMap.values());
 
@@ -378,12 +535,19 @@ export class CanvasController {
           blockId,
           commentThreadId,
           canvasChannelId ?? undefined,
-          mentionContext,
+          mentionContext
         );
 
-        slackRecipientEmails = getSlackRecipientEmails(mentionedEmails, deliveredUserIds, userEmailMap);
+        slackRecipientEmails = getSlackRecipientEmails(
+          mentionedEmails,
+          deliveredUserIds,
+          userEmailMap
+        );
       } catch (error) {
-        logger.error('[CANVAS-MENTIONS] Spaces notification failed — sending Slack to all recipients', { error });
+        logger.error(
+          '[CANVAS-MENTIONS] Spaces notification failed — sending Slack to all recipients',
+          { error }
+        );
       }
 
       // Step 3: Send Slack notifications only to users who didn't receive app notification
@@ -391,7 +555,7 @@ export class CanvasController {
         slackRecipientEmails,
         senderName,
         canvasTitle ?? 'Canvas',
-        slackUrl!,
+        slackUrl!
       );
 
       res.status(200).json({

--- a/apps/backend/src/routes/canvas.ts
+++ b/apps/backend/src/routes/canvas.ts
@@ -7,16 +7,11 @@ const router = express.Router();
 const messageAttachmentRepository = new MessageAttachmentRepository();
 const canvasController = new CanvasController(messageAttachmentRepository);
 
-router.post(
-  '/upload',
-  uploadSingle(),
-  canvasController.uploadFile
-);
+router.post('/upload', uploadSingle(), canvasController.uploadFile);
 
-router.post(
-  '/:canvasId/mentions',
-  canvasController.handleMentions
-);
+router.post('/:canvasId/mentions', canvasController.handleMentions);
+
+router.post('/:canvasId/request-edit-access', canvasController.requestEditAccess);
 
 router.post('/create', canvasController.createCanvas);
 

--- a/apps/dashboard/src/components/Activity/ActivityItem.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItem.tsx
@@ -121,6 +121,7 @@ export const ActivityItem = memo(function ActivityItem({
     case 'canvas_shared':
     case 'canvas_role_changed':
     case 'canvas_access_revoked':
+    case 'canvas_edit_access_requested':
       return <CanvasSharedActivity activity={activity} isExpanded={isExpanded} />;
 
     case 'recording_shared':

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -185,6 +185,7 @@ const TABS: TabConfig[] = [
       activity.actorAction === 'canvas_shared' ||
       activity.actorAction === 'canvas_role_changed' ||
       activity.actorAction === 'canvas_access_revoked' ||
+      activity.actorAction === 'canvas_edit_access_requested' ||
       (activity.actorAction === 'mentioned_user' && !!activity.canvasId),
   },
   {
@@ -721,6 +722,12 @@ const ActivityListView = (): ReactElement => {
       void zero.mutate(
         mutators.activities.markAsReadByFilter({ actorAction: 'canvas_access_revoked', timestamp }),
       );
+      void zero.mutate(
+        mutators.activities.markAsReadByFilter({
+          actorAction: 'canvas_edit_access_requested',
+          timestamp,
+        }),
+      );
       return;
     } else if (activeTab === 'calls') {
       const timestamp = Date.now();
@@ -785,6 +792,7 @@ const ActivityListView = (): ReactElement => {
         activity.actorAction === 'canvas_shared' ||
         activity.actorAction === 'canvas_role_changed' ||
         activity.actorAction === 'canvas_access_revoked' ||
+        activity.actorAction === 'canvas_edit_access_requested' ||
         (activity.actorAction === 'mentioned_user' && activity.canvasId)
       ) {
         counts.canvas++;

--- a/apps/dashboard/src/components/Activity/CanvasSharedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/CanvasSharedActivity.tsx
@@ -11,6 +11,7 @@ import { useRouteContext } from '../../hooks/useRouteContext';
  * - canvas_shared: "X shared 'Canvas Name' with you"
  * - canvas_role_changed: "X changed your role on 'Canvas Name'"
  * - canvas_access_revoked: "X revoked your access to 'Canvas Name'"
+ * - canvas_edit_access_requested: "X requested edit access to 'Canvas Name'"
  *
  * Note: The specific role (Editor/Viewer/Owner) is not stored on the Activity record.
  * The push notification (via NotificationService) includes role text in its metadata,
@@ -35,11 +36,14 @@ export const CanvasSharedActivity = ({
 
   const isShare = activity.actorAction === 'canvas_shared';
   const isAccessRevoked = activity.actorAction === 'canvas_access_revoked';
-  const descriptionText = isAccessRevoked
-    ? 'revoked your access to'
-    : isShare
-      ? 'shared a canvas with you'
-      : 'changed your role on';
+  const isEditAccessRequest = activity.actorAction === 'canvas_edit_access_requested';
+  const descriptionText = isEditAccessRequest
+    ? 'requested edit access to'
+    : isAccessRevoked
+      ? 'revoked your access to'
+      : isShare
+        ? 'shared a canvas with you'
+        : 'changed your role on';
 
   return (
     <ActivityItemCard
@@ -56,9 +60,11 @@ export const CanvasSharedActivity = ({
       unresolvedChannelLabel='Private channel'
     >
       <div className='text-muted-foreground text-sm'>
-        {isExpanded
-          ? `Canvas: ${canvas.title ?? 'Untitled'}`
-          : `View canvas: ${canvas.title ?? 'Untitled'}`}
+        {isEditAccessRequest
+          ? `Open share settings for: ${canvas.title ?? 'Untitled'}`
+          : isExpanded
+            ? `Canvas: ${canvas.title ?? 'Untitled'}`
+            : `View canvas: ${canvas.title ?? 'Untitled'}`}
       </div>
     </ActivityItemCard>
   );

--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -214,6 +214,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
   const [showShareModal, setShowShareModal] = useState(false);
   const [isApproving, setIsApproving] = useState(false);
   const [isApproved, setIsApproved] = useState(false);
+  const [isRequestingEditAccess, setIsRequestingEditAccess] = useState(false);
   const [selectedTheme, setSelectedTheme] = useState('white');
   const [collaborators, setCollaborators] = useState<CollaboratorInfo[]>([]);
   const {
@@ -693,6 +694,32 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
     canvas: selectedCanvas,
     onCreated: handleVersionCopyCreated,
   });
+
+  const handleRequestEditAccess = useCallback(async (): Promise<void> => {
+    if (!selectedCanvas?.id || isRequestingEditAccess) return;
+
+    setIsRequestingEditAccess(true);
+    try {
+      const response = await canvasService.requestCanvasEditAccess(selectedCanvas.id);
+      if (response.alreadyHasEditAccess) {
+        toast.info('You already have edit access to this canvas.');
+      } else if (response.requested > 0) {
+        toast.success('Requested edit access from the canvas owner.');
+      } else {
+        toast.info('You have already requested edit access.');
+      }
+    } catch (error) {
+      logger.error(Event.CANVAS_REQUEST_EDIT_ACCESS_FAILED, {
+        canvasId: selectedCanvas.id,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      toast.error('Could not request edit access', {
+        description: 'Please try again later.',
+      });
+    } finally {
+      setIsRequestingEditAccess(false);
+    }
+  }, [isRequestingEditAccess, selectedCanvas?.id]);
 
   const handleArchivedStateChange = useCallback((canvasId: string, isArchived: boolean): void => {
     setSelectedCanvas(current => (current?.id === canvasId ? { ...current, isArchived } : current));
@@ -1445,6 +1472,29 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
                                 <ReminderClockwise size={16} className='shrink-0' />
                                 <span className='flex-1'>Version history</span>
                               </DropdownMenuItem>
+
+                              {!canEdit && !selectedCanvas.isArchived && (
+                                <DropdownMenuItem
+                                  className='gap-2'
+                                  disabled={isRequestingEditAccess}
+                                  onClick={() => {
+                                    void handleRequestEditAccess();
+                                  }}
+                                  data-testid='canvas-request-edit-access-item'
+                                  data-track-category='CANVAS'
+                                  data-track-name='REQUEST_CANVAS_EDIT_ACCESS'
+                                  data-track-metadata={JSON.stringify({
+                                    canvasId: selectedCanvas.id,
+                                  })}
+                                >
+                                  {isRequestingEditAccess ? (
+                                    <Loader2 size={16} className='shrink-0 animate-spin' />
+                                  ) : (
+                                    <Share01 size={16} className='shrink-0' />
+                                  )}
+                                  <span className='flex-1'>Request edit access</span>
+                                </DropdownMenuItem>
+                              )}
 
                               <DropdownMenuSub>
                                 <DropdownMenuSubTrigger

--- a/apps/dashboard/src/services/Canvas/canvasService.ts
+++ b/apps/dashboard/src/services/Canvas/canvasService.ts
@@ -36,6 +36,13 @@ export interface CanvasFileUploadResponse {
   thumbnailUrl?: string;
 }
 
+export interface CanvasEditAccessRequestResponse {
+  success: boolean;
+  requested: number;
+  alreadyRequested?: number;
+  alreadyHasEditAccess?: boolean;
+}
+
 // Cache for prefetched canvas data
 const prefetchedCanvases = new Map<string, { token: YSweetAuthToken; timestamp: number }>();
 const PREFETCH_CACHE_TTL = 1000 * 60 * 50; // 50 minutes (same as staleTime)
@@ -84,6 +91,13 @@ export class CanvasService {
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }
+  }
+
+  async requestCanvasEditAccess(canvasId: string): Promise<CanvasEditAccessRequestResponse> {
+    const response = await apiInstance.post<CanvasEditAccessRequestResponse>(
+      `/canvas/${canvasId}/request-edit-access`,
+    );
+    return response.data;
   }
 
   async uploadCanvasFile(canvasId: string, file: File): Promise<string> {

--- a/apps/dashboard/src/utils/logger.ts
+++ b/apps/dashboard/src/utils/logger.ts
@@ -209,6 +209,7 @@ export const Event = {
   CANVAS_SAVE_STARTED: 'canvas_save_started',
   CANVAS_SAVE_COMPLETE: 'canvas_save_complete',
   CANVAS_SAVE_FAILED: 'canvas_save_failed',
+  CANVAS_REQUEST_EDIT_ACCESS_FAILED: 'canvas_request_edit_access_failed',
   CANVAS_SAVE_SLOW: 'canvas_save_slow',
   CANVAS_SAVE_RERUN_QUEUED: 'canvas_save_rerun_queued',
   CANVAS_AUTOSAVE_TRIGGERED: 'canvas_autosave_triggered',


### PR DESCRIPTION
## Summary
- Add a viewer-only "Request edit access" item to the canvas three-dot menu.
- Add an authenticated backend endpoint that verifies the requester can view the canvas, resolves direct canvas owners, creates actionable owner activities, and sends canvas notifications.
- Render edit-access requests in the Canvas activity feed and include them in Canvas tab counts / mark-read handling.

## Validation
- pnpm --filter xyne-spaces-dashboard typecheck
- pnpm --filter xyne-spaces-backend typecheck
- cd apps/dashboard && pnpm exec eslint src/services/Canvas/canvasService.ts src/components/Canvas/CanvasScreen/CanvasScreen.tsx src/components/Activity/ActivityItem.tsx src/components/Activity/CanvasSharedActivity.tsx src/components/Activity/ActivityListView/ActivityListView.tsx src/utils/logger.ts --quiet
- cd apps/backend && pnpm exec eslint src/controllers/canvasController.ts src/routes/canvas.ts --quiet