### PR TITLE
fix: open claw preview links externally

### DIFF
--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/internalLinkUtils.ts
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/internalLinkUtils.ts
@@ -40,6 +40,9 @@ const INTERNAL_XYNE_HOSTS = new Set([
 /** Paths that should be treated as external (no internal router handling) */
 const EXTERNAL_PATH_PREFIXES = ['/claw', '/claw-preview', '/changelog'];
 
+const isExternalPath = (pathname: string): boolean =>
+  EXTERNAL_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix));
+
 export const parseInternalXyneLink = (href: string): ParsedInternalXyneLink | null => {
   try {
     const url = new URL(href, window.location.origin);
@@ -50,7 +53,7 @@ export const parseInternalXyneLink = (href: string): ParsedInternalXyneLink | nu
     }
 
     // Treat certain paths as external - no internal routing exists
-    if (EXTERNAL_PATH_PREFIXES.some(prefix => url.pathname.startsWith(prefix))) {
+    if (isExternalPath(url.pathname)) {
       return null;
     }
 
@@ -144,7 +147,8 @@ const normalizeUrlForComparison = (value: string): string => value.trim().replac
 
 export const isExternalUrl = (url: string): boolean => {
   try {
-    return new URL(url, window.location.origin).origin !== window.location.origin;
+    const parsedUrl = new URL(url, window.location.origin);
+    return parsedUrl.origin !== window.location.origin || isExternalPath(parsedUrl.pathname);
   } catch {
     return true;
   }

--- a/apps/dashboard/src/utils/markdownComponents.tsx
+++ b/apps/dashboard/src/utils/markdownComponents.tsx
@@ -15,6 +15,7 @@ import { parseCiteGroupHref } from '../components/ui/TipTapExtensions/CitationMa
 import { InternalXyneLink } from '../components/Chat/RenderMessageWithHTML/RenderMessageWithHTML';
 import {
   getAnchorTargetProps,
+  isExternalUrl,
   parseInternalXyneLink,
 } from '../components/Chat/RenderMessageWithHTML/internalLinkUtils';
 import type { ToolInvocation } from '../components/Chat/XyneAISidebar/utils/XyneAITypes';
@@ -315,15 +316,7 @@ export const createMarkdownComponents = (
       );
     }
 
-    const isExternal = ((): boolean => {
-      if (!href) return false;
-      try {
-        const urlObj = new URL(href, window.location.origin);
-        return urlObj.origin !== window.location.origin;
-      } catch {
-        return true;
-      }
-    })();
+    const isExternal = href ? isExternalUrl(href) : false;
 
     if (isExternal) {
       const handleClick = (event: React.MouseEvent<HTMLAnchorElement>): void => {


### PR DESCRIPTION
1. Problem Description:
Claw/noVNC preview links posted in Spaces can share the Spaces host and use paths like `/claw-preview/...`. The message renderer already excludes these paths from internal semantic link parsing, but same-origin links were still classified as internal/non-external, so users could be routed through the Spaces app and hit the dashboard 404 page instead of opening the noVNC preview.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in Spaces thread `714775cb-c162-4315-9371-a563cd52301e`: clicking the Xyne Architect VNC link showed the Spaces fallback error page. Thread discussion concluded the link should open in the browser for now, before proper iframe integration.

3. Explain the solution implemented in the PR:
Centralized same-origin external-path detection in `internalLinkUtils.ts` and made `isExternalUrl` return true for `/claw`, `/claw-preview`, and `/changelog` paths. Reused `isExternalUrl` in Markdown link rendering so these links go through the external-link/open-browser path consistently across HTML and Markdown messages.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `pnpm --filter xyne-spaces-dashboard typecheck`
- `pnpm --filter xyne-spaces-dashboard exec eslint src/components/Chat/RenderMessageWithHTML/internalLinkUtils.ts src/utils/markdownComponents.tsx`

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A