### PR TITLE
feat: XYNE-55834 fix selection of tickets

### DIFF
--- a/apps/backend/src/workers/stageEtaDeadlineWorker.ts
+++ b/apps/backend/src/workers/stageEtaDeadlineWorker.ts
@@ -1,7 +1,8 @@
 import { logger } from '@/utils/logger';
-import { db } from '@/database/client';
+import { db, readReplicaDb } from '@/database/client';
 import { stageEtaDeadlineQueue } from '@/queues/stageEtaDeadlineQueue';
 import { OPEN_STATUSES } from '@/utils/etaNotificationUtils';
+import { Prisma } from '@prisma/client';
 
 const BATCH_SIZE = parseInt(process.env.STAGE_ETA_DEADLINE_BATCH_SIZE || '15', 10);
 const BATCH_SLEEP_MS = parseInt(process.env.STAGE_ETA_DEADLINE_BATCH_SLEEP_MS || '1000', 10);
@@ -62,13 +63,13 @@ class StageEtaDeadlineWorker {
     if (overdueTicketIds.length === 0) return;
 
     for (let i = 0; i < overdueTicketIds.length; i += BATCH_SIZE) {
-      await db.ticket.updateMany({
-        where: {
-          id: { in: overdueTicketIds.slice(i, i + BATCH_SIZE) },
-          isStageOverdue: false,
-        } as any,
-        data: { isStageOverdue: true } as any,
-      });
+      const batchIds = overdueTicketIds.slice(i, i + BATCH_SIZE);
+      await db.$executeRaw`
+        UPDATE "tickets"
+        SET "isStageOverdue" = true
+        WHERE "id" IN (${Prisma.join(batchIds)})
+          AND ("isStageOverdue" = false OR "isStageOverdue" IS NULL)
+      `;
       if (i + BATCH_SIZE < overdueTicketIds.length) {
         await sleep(BATCH_SLEEP_MS);
       }
@@ -76,12 +77,13 @@ class StageEtaDeadlineWorker {
   }
 
   private async getOverdueTicketIds(now: Date): Promise<string[]> {
+    const readerDb = readReplicaDb ?? db;
     const allOverdueTicketIds: string[] = [];
     const QUERY_BATCH_SIZE = 10000;
     let cursor: string | undefined;
 
     while (true) {
-      const overdueEntries = await db.ticketStageEta.findMany({
+      const overdueEntries = await readerDb.ticketStageEta.findMany({
         where: {
           stageLeftAt: null,
           stageEta: { lte: now },

--- a/apps/backend/src/workers/stageEtaDeadlineWorker.ts
+++ b/apps/backend/src/workers/stageEtaDeadlineWorker.ts
@@ -87,7 +87,7 @@ class StageEtaDeadlineWorker {
           stageEta: { lte: now },
           // Ensure stage exists (filters out orphaned records with deleted stages)
           // ticket is implicitly checked via the statusV2 filter (JOIN filters out missing tickets)
-          stage: { isNot: null } as any,
+          stage: { id: { not: '' } },
           ticket: {
             statusV2: { in: OPEN_STATUSES },
             // Only fetch tickets not already marked as overdue


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
