### PR TITLE
fix: XYNE-60937 harden agent-auth against process spoofing and validate ask-ai d…

### DIFF
--- a/apps/electron/assets/agent-consent.html
+++ b/apps/electron/assets/agent-consent.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:;" />
+  <title>Agent Authorization</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --fg: #1a1a1e;
+      --muted: #6b7280;
+      --border: #e5e7eb;
+      --card: #f9fafb;
+      --accent: #4f46e5;
+      --accent-fg: #ffffff;
+      --danger: #dc2626;
+      --warn-bg: #fff7ed;
+      --warn-border: #fdba74;
+      --warn-fg: #9a3412;
+      --ok: #16a34a;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #1c1c20;
+        --fg: #f3f4f6;
+        --muted: #9ca3af;
+        --border: #2f2f36;
+        --card: #26262c;
+        --accent: #6366f1;
+        --warn-bg: #3a2a1a;
+        --warn-border: #92400e;
+        --warn-fg: #fcd9a8;
+      }
+    }
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: transparent;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      color: var(--fg);
+      -webkit-user-select: none;
+      user-select: none;
+    }
+    .card {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      overflow: hidden;
+      box-shadow: 0 12px 40px rgba(0,0,0,0.28);
+      width: 100%;
+    }
+    .head {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 18px 20px 12px;
+    }
+    .icon {
+      width: 40px; height: 40px;
+      flex: 0 0 40px;
+      border-radius: 10px;
+      background: var(--accent);
+      color: var(--accent-fg);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 20px; font-weight: 700;
+    }
+    .title { font-size: 15px; font-weight: 600; line-height: 1.2; }
+    .subtitle { font-size: 12.5px; color: var(--muted); margin-top: 2px; }
+    .badge {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: 11px; font-weight: 600;
+      padding: 2px 8px; border-radius: 999px; margin-left: auto;
+      white-space: nowrap;
+    }
+    .badge.trusted { background: rgba(22,163,74,0.12); color: var(--ok); }
+    .badge.unknown { background: rgba(220,38,38,0.12); color: var(--danger); }
+
+    .body { padding: 4px 20px 8px; }
+
+    .row {
+      display: flex; gap: 10px;
+      padding: 8px 0;
+      font-size: 12.5px;
+      border-top: 1px solid var(--border);
+    }
+    .row .k { color: var(--muted); flex: 0 0 92px; }
+    .row .v { color: var(--fg); word-break: break-all; }
+    .row .v.path { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+    .sig-unsigned { color: var(--danger); font-weight: 600; }
+    .sig-signed { color: var(--ok); font-weight: 600; }
+
+    .warn {
+      margin: 10px 0 4px;
+      padding: 10px 12px;
+      background: var(--warn-bg);
+      border: 1px solid var(--warn-border);
+      color: var(--warn-fg);
+      border-radius: 8px;
+      font-size: 12px;
+      line-height: 1.4;
+    }
+
+    .caps-title {
+      font-size: 12px; font-weight: 600; color: var(--muted);
+      text-transform: uppercase; letter-spacing: 0.04em;
+      margin: 14px 0 6px;
+    }
+    ul.caps {
+      list-style: none; margin: 0; padding: 0;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+    }
+    ul.caps li {
+      display: flex; align-items: flex-start; gap: 8px;
+      padding: 8px 12px; font-size: 12.5px;
+      border-top: 1px solid var(--border);
+    }
+    ul.caps li:first-child { border-top: none; }
+    ul.caps li::before {
+      content: "•"; color: var(--accent); font-weight: 700;
+      line-height: 1.3;
+    }
+
+    .duration { margin: 14px 0 4px; }
+    .duration-label { font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+    .seg {
+      display: flex; gap: 6px;
+    }
+    .seg label {
+      flex: 1;
+      text-align: center;
+      font-size: 12.5px;
+      padding: 8px 4px;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      cursor: pointer;
+      background: var(--card);
+    }
+    .seg input { display: none; }
+    .seg input:checked + span { font-weight: 600; }
+    .seg label:has(input:checked) {
+      border-color: var(--accent);
+      background: rgba(79,70,229,0.10);
+      color: var(--accent);
+    }
+
+    .actions {
+      display: flex; gap: 10px;
+      padding: 14px 20px 18px;
+    }
+    button {
+      flex: 1;
+      font-size: 13.5px; font-weight: 600;
+      padding: 11px 12px;
+      border-radius: 9px;
+      cursor: pointer;
+      border: 1px solid var(--border);
+    }
+    #deny { background: transparent; color: var(--fg); }
+    #deny:hover { background: rgba(0,0,0,0.05); }
+    #allow { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+    #allow:hover { filter: brightness(1.05); }
+  </style>
+</head>
+<body>
+  <div class="card" id="card">
+    <div class="head">
+      <div class="icon">⚡</div>
+      <div>
+        <div class="title">Agent authorization request</div>
+        <div class="subtitle">A local agent wants to connect</div>
+      </div>
+      <span class="badge unknown" id="badge">Unregistered</span>
+    </div>
+
+    <div class="body">
+      <div class="row"><span class="k">Name</span><span class="v" id="name"></span></div>
+      <div class="row" id="type-row"><span class="k">Type</span><span class="v" id="type"></span></div>
+      <div class="row"><span class="k">Requested by</span><span class="v path" id="requestedBy"></span></div>
+      <div class="row" id="desc-row"><span class="k">Description</span><span class="v" id="description"></span></div>
+
+      <div class="warn" id="warn">
+        This process is not a recognised Xyne agent. Only allow it if you started it and trust it.
+      </div>
+
+      <div class="caps-title">If allowed, this agent can</div>
+      <ul class="caps" id="caps"></ul>
+
+      <div class="duration">
+        <div class="duration-label">Grant access for</div>
+        <div class="seg">
+          <label><input type="radio" name="dur" value="5min" checked /><span>5 minutes</span></label>
+          <label><input type="radio" name="dur" value="1hour" /><span>1 hour</span></label>
+          <label><input type="radio" name="dur" value="session" /><span>Session</span></label>
+        </div>
+      </div>
+    </div>
+
+    <div class="actions">
+      <button id="deny">Deny</button>
+      <button id="allow">Allow</button>
+    </div>
+  </div>
+
+  <script>
+    const api = window.electronAPI?.agentConsent;
+    let responded = false;
+
+    function setText(id, value) {
+      document.getElementById(id).textContent = value ?? '';
+    }
+
+    function reportSize() {
+      const card = document.getElementById('card');
+      const rect = card.getBoundingClientRect();
+      window.electronAPI?.ipcSend?.('agent-consent:content-height', Math.ceil(rect.width), Math.ceil(rect.height));
+    }
+
+    function render(data) {
+      setText('name', data.agentName || 'Unnamed agent');
+      setText('requestedBy', data.requestedBy || 'unknown process');
+      setText('description', data.description || '—');
+
+      if (data.agentType) {
+        setText('type', data.agentType);
+      } else {
+        document.getElementById('type-row').style.display = 'none';
+      }
+
+      // signing suffix on the path
+      const rb = document.getElementById('requestedBy');
+      if (data.signed === false) {
+        const s = document.createElement('span');
+        s.className = 'sig-unsigned';
+        s.textContent = '  (unsigned)';
+        rb.appendChild(s);
+      } else if (data.signed === true) {
+        const s = document.createElement('span');
+        s.className = 'sig-signed';
+        s.textContent = '  (signed)';
+        rb.appendChild(s);
+      }
+
+      const badge = document.getElementById('badge');
+      if (data.isKnown) {
+        badge.className = 'badge trusted';
+        badge.textContent = 'Verified agent';
+        document.getElementById('warn').style.display = 'none';
+      } else {
+        badge.className = 'badge unknown';
+        badge.textContent = 'Unregistered';
+      }
+
+      const caps = document.getElementById('caps');
+      caps.innerHTML = '';
+      (data.capabilities || []).forEach((c) => {
+        const li = document.createElement('li');
+        const span = document.createElement('span');
+        span.textContent = c;
+        li.appendChild(span);
+        caps.appendChild(li);
+      });
+
+      requestAnimationFrame(reportSize);
+    }
+
+    function selectedDuration() {
+      const el = document.querySelector('input[name="dur"]:checked');
+      return el ? el.value : '5min';
+    }
+
+    function respond(result) {
+      if (responded) return;
+      responded = true;
+      api?.respond(result);
+    }
+
+    document.getElementById('allow').addEventListener('click', () => {
+      respond({ approved: true, duration: selectedDuration() });
+    });
+    document.getElementById('deny').addEventListener('click', () => {
+      respond({ approved: false, duration: 'none' });
+    });
+    // Esc = deny
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') respond({ approved: false, duration: 'none' });
+    });
+
+    if (api) api.onShow(render);
+    window.addEventListener('resize', reportSize);
+  </script>
+</body>
+</html>

--- a/apps/electron/scripts/agent-auth-client.mjs
+++ b/apps/electron/scripts/agent-auth-client.mjs
@@ -39,7 +39,9 @@ function loadToken() {
 }
 
 function saveToken(data) {
-  writeFileSync(TOKEN_FILE, JSON.stringify(data, null, 2));
+  // 0o600: token is a bearer credential — keep it readable only by the owner so
+  // other users on a shared host cannot lift it from the world-readable temp dir.
+  writeFileSync(TOKEN_FILE, JSON.stringify(data, null, 2), { mode: 0o600 });
 }
 
 function parseFlags(argv) {

--- a/apps/electron/scripts/agent-auth-client.mjs
+++ b/apps/electron/scripts/agent-auth-client.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Reference client for the Xyne agent-auth loopback server (agent-auth.ts).
+ *
+ * Talks to http://127.0.0.1:49231. Demonstrates the full flow:
+ *   request  -> pops the native consent dialog, stores the granted token
+ *   whoami   -> prints the stored token/session
+ *   health   -> unauthenticated liveness probe
+ *   search   -> token-gated proxy call (needs a logged-in Electron session)
+ *   release  -> revokes the token
+ *
+ * Requires Node >= 18 (global fetch). No external deps.
+ *
+ * Usage:
+ *   node agent-auth-client.mjs request [--name NAME] [--type TYPE] [--desc TEXT]
+ *   node agent-auth-client.mjs health
+ *   node agent-auth-client.mjs search "my query"
+ *   node agent-auth-client.mjs release
+ *   node agent-auth-client.mjs whoami
+ *
+ * Token is cached at $TMPDIR/xyne-agent-auth-token.json so subsequent commands reuse it.
+ */
+
+import { readFileSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PORT = Number(process.env.XYNE_AGENT_AUTH_PORT || 49231);
+const BASE = `http://127.0.0.1:${PORT}`;
+const TOKEN_FILE = join(tmpdir(), 'xyne-agent-auth-token.json');
+
+function loadToken() {
+  if (!existsSync(TOKEN_FILE)) return null;
+  try {
+    return JSON.parse(readFileSync(TOKEN_FILE, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function saveToken(data) {
+  writeFileSync(TOKEN_FILE, JSON.stringify(data, null, 2));
+}
+
+function parseFlags(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i].startsWith('--')) {
+      out[argv[i].slice(2)] = argv[i + 1];
+      i++;
+    }
+  }
+  return out;
+}
+
+async function request(flags) {
+  const body = {
+    agentName: flags.name || 'Reference Client',
+    agentType: flags.type || 'cli',
+    description: flags.desc || 'Test agent-auth flow',
+  };
+  console.log('POST /auth/request — approve the native dialog that pops up...');
+  const res = await fetch(`${BASE}/auth/request`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => ({}));
+  console.log(`status ${res.status}:`, json);
+  if (res.status === 200 && json.accessToken) {
+    saveToken({ token: json.accessToken, expiresAt: json.expiresAt, agentName: body.agentName });
+    console.log(`\nToken cached at ${TOKEN_FILE}`);
+  }
+}
+
+async function health() {
+  const res = await fetch(`${BASE}/health`);
+  console.log(`status ${res.status}:`, await res.json().catch(() => ({})));
+}
+
+async function search(query) {
+  const t = loadToken();
+  if (!t?.token) return console.error('No cached token — run "request" first.');
+  const url = `${BASE}/search?${new URLSearchParams({ q: query ?? '', scope: 'my', limit: '5', offset: '0' })}`;
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${t.token}` } });
+  console.log(`status ${res.status}:`, await res.text());
+}
+
+async function release() {
+  const t = loadToken();
+  if (!t?.token) return console.error('No cached token.');
+  const res = await fetch(`${BASE}/auth/release`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${t.token}` },
+  });
+  console.log(`status ${res.status}:`, await res.json().catch(() => ({})));
+  rmSync(TOKEN_FILE, { force: true });
+}
+
+function whoami() {
+  const t = loadToken();
+  console.log(t ?? 'No cached token.');
+}
+
+const [cmd, ...rest] = process.argv.slice(2);
+const flags = parseFlags(rest);
+
+switch (cmd) {
+  case 'request': await request(flags); break;
+  case 'health': await health(); break;
+  case 'search': await search(rest.find((a) => !a.startsWith('--'))); break;
+  case 'release': await release(); break;
+  case 'whoami': whoami(); break;
+  default:
+    console.log('Commands: request | health | search "q" | release | whoami');
+}

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -290,6 +290,7 @@ const electronAPI = {
       'app:theme-changed',
       'call:state-changed',
       'meeting-popup:content-height',
+      'agent-consent:content-height',
       'recording-pill:recording-stopped',
       'recording:renderer-ready',
       'recording:set-minimized',
@@ -334,6 +335,27 @@ const electronAPI = {
     },
     dismiss: () => ipcRenderer.send('meeting-popup:dismiss'),
     startRecording: () => ipcRenderer.send('meeting-popup:start-recording'),
+  },
+
+  // Agent authorization consent modal (used by the consent window itself)
+  agentConsent: {
+    onShow: (
+      callback: (data: {
+        agentName: string;
+        agentType: string;
+        description: string;
+        requestedBy: string;
+        signed: boolean | null;
+        isKnown: boolean;
+        capabilities: string[];
+      }) => void,
+    ) => {
+      const listener = (_event: unknown, data: any) => callback(data);
+      ipcRenderer.on('agent-consent:show', listener);
+      return () => ipcRenderer.removeListener('agent-consent:show', listener);
+    },
+    respond: (result: { approved: boolean; duration: 'none' | '5min' | '1hour' | 'session' }) =>
+      ipcRenderer.send('agent-consent:respond', result),
   },
 
   // Screen Picker — in-app overlay instead of macOS native picker

--- a/apps/electron/src/services/agent-auth.ts
+++ b/apps/electron/src/services/agent-auth.ts
@@ -45,6 +45,11 @@ type DurationOption = '5min' | '1hour' | 'session';
 // dialog. Keyed by requester exe path (or 'unknown' when unresolved).
 const DENY_COOLDOWN_MS = 30 * 1000;
 
+// TTL for the per-socket peer cache used on the token re-check path. An established
+// socket's peer process cannot change within this window, so caching removes most of
+// the per-request shell-out cost without weakening the path binding.
+const PEER_RECHECK_CACHE_MS = 1500;
+
 // Registry of executables recognised as first-party agents. Anything not on the
 // list is shown in the consent dialog as an "Unregistered agent" alongside its
 // real path, so the user is not tricked by an attacker-controlled agentName.
@@ -1510,23 +1515,47 @@ class AgentAuthService {
    * issued to (Payatu #2). Re-resolves the peer from the OS TCP table on every call and
    * rejects a path mismatch, so a token leaked to another local process is unusable.
    *
-   * Note: when the peer cannot be resolved right now (currentPath === null) but a path was
-   * bound at grant time, we log and allow rather than break a legitimate agent on a transient
-   * lookup failure — the null case is "unknown", not a proven mismatch.
+   * Fail closed on an unverified peer. Per the peer-process contract, a null result MUST be
+   * treated as "unverified" rather than "trusted", so both an unbound session (no path captured
+   * at grant time) and an unresolved re-lookup deny the request. The null case is reachable on
+   * demand — a process holding a leaked token can push lsof/ss/PowerShell past EXEC_TIMEOUT_MS
+   * under load, or run where the lookup tool is unavailable — so allowing it would reopen the
+   * exact token-replay hole the path binding exists to close.
    */
   private async validateTokenAndPeer(token: string, req: IncomingMessage): Promise<boolean> {
     if (!this.validateToken(token)) return false;
 
     const session = this.sessions.get(token);
     if (!session) return false;
-    if (!session.agentPath) return true; // nothing bound at grant time; cannot enforce
 
-    const peer = await resolvePeerProcess(req.socket.remotePort, process.pid);
+    // Nothing bound at grant time → the token was never tied to a process, so it is
+    // unverifiable. Treat as unverified and deny rather than trust it.
+    if (!session.agentPath) {
+      Logger.warn(ElectronEvent.AGENT_AUTH_PEER_MISMATCH, {
+        agentName: session.agentName,
+        expected: 'unbound-session',
+        actual: null,
+      }, 'AgentAuth');
+      return false;
+    }
+
+    // Re-check the signature only matters at grant time (consent dialog); here we compare
+    // execPath, so skip codesign. A short per-socket cache absorbs the per-request shell-out
+    // cost on the MCP ingest path without weakening the binding (an established socket's peer
+    // cannot change within the TTL).
+    const peer = await resolvePeerProcess(req.socket.remotePort, process.pid, {
+      verifySignature: false,
+      cacheTtlMs: PEER_RECHECK_CACHE_MS,
+    });
     const currentPath = peer?.execPath ?? null;
 
     if (currentPath === null) {
-      log.warn('[AgentAuth] Could not re-resolve peer for token-gated request; allowing bound session');
-      return true;
+      Logger.warn(ElectronEvent.AGENT_AUTH_PEER_MISMATCH, {
+        agentName: session.agentName,
+        expected: session.agentPath,
+        actual: 'unresolved-peer',
+      }, 'AgentAuth');
+      return false;
     }
 
     if (currentPath === session.agentPath) return true;
@@ -1541,7 +1570,7 @@ class AgentAuthService {
 
   private sanitizeDialogText(value: string | undefined, maxLen: number): string {
     if (typeof value !== 'string') return '';
-    const cleaned = value.replace(/[\u0000-\u001F\u007F]/g, ' ').replace(/\s+/g, ' ').trim();
+    const cleaned = value.replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200D\u2028\u2029\u202A-\u202E\u2066-\u2069\uFEFF]/g, ' ').replace(/\s+/g, ' ').trim();
     return cleaned.length > maxLen ? `${cleaned.slice(0, maxLen)}…` : cleaned;
   }
 

--- a/apps/electron/src/services/agent-auth.ts
+++ b/apps/electron/src/services/agent-auth.ts
@@ -7,6 +7,8 @@ import { Logger } from './logger/Logger';
 import ElectronEvent from './logger/electron-events';
 import * as fs from 'fs';
 import * as path from 'path';
+import { resolvePeerProcess, describePeer, PeerProcess } from './peer-process';
+import { showAgentConsentWindow } from './agent-consent-window';
 
 const DEFAULT_PORT = 49231;
 
@@ -22,6 +24,11 @@ interface AuthSession {
   description: string;
   expiresAt: number;
   createdAt: number;
+  // Absolute exe path of the process that was granted this token, resolved from
+  // the OS TCP table at grant time. Tokens are bound to this path: every
+  // token-gated request re-resolves the caller and must match. null = the peer
+  // could not be resolved at grant time, so path binding cannot be enforced.
+  agentPath: string | null;
 }
 
 interface AuthResponse {
@@ -34,12 +41,40 @@ interface AuthResponse {
 
 type DurationOption = '5min' | '1hour' | 'session';
 
+// Cool-down after a user Deny so a malicious process cannot hammer the consent
+// dialog. Keyed by requester exe path (or 'unknown' when unresolved).
+const DENY_COOLDOWN_MS = 30 * 1000;
+
+// Registry of executables recognised as first-party agents. Anything not on the
+// list is shown in the consent dialog as an "Unregistered agent" alongside its
+// real path, so the user is not tricked by an attacker-controlled agentName.
+// Populate with the absolute paths / basenames the team ships and trusts.
+const KNOWN_AGENT_EXECUTABLES: ReadonlySet<string> = new Set<string>([
+  // e.g. '/Applications/Xyne.app/Contents/MacOS/xyne-agent',
+]);
+
+// What an approved agent can do through this loopback server (all proxied to the
+// backend with the logged-in user's credentials). Shown in the consent modal so
+// the user understands the scope they are granting. Keep in step with the routes
+// handled in handleRequest().
+const AGENT_CAPABILITIES: readonly string[] = [
+  'Search your workspace data and memory',
+  'Read your conversations and messages',
+  'Download message attachments to your Desktop',
+  'Post messages in your chats',
+  'Create tickets and schedule calls',
+  'Read and write agent memory (facts & SOPs)',
+  'Send AI queries on your behalf',
+];
+
 class AgentAuthService {
   private server: ReturnType<typeof createServer> | null = null;
   private port: number = DEFAULT_PORT;
   private sessions: Map<string, AuthSession> = new Map();
   private cleanupInterval: NodeJS.Timeout | null = null;
   private consentDialogOpen = false;
+  // requester exe path (or 'unknown') -> epoch ms until which new requests are refused
+  private denyCooldowns: Map<string, number> = new Map();
 
   private getMcpBackendBaseUrl(): string {
     return config.BACKEND_URL.replace(/\/+$/, '');
@@ -132,11 +167,13 @@ class AgentAuthService {
 
     try {
       if (req.method === 'POST' && url.pathname === '/auth/request') {
-        // Real local agents are non-browser clients and send no Origin / Sec-Fetch-Site
-        // header; reject cross-site browser requests to the consent dialog.
-        if (this.isCrossSiteBrowserRequest(req)) {
-          log.warn('[AgentAuth] Rejected cross-site /auth/request (browser consent-dialog spam)');
-          this.sendJson(res, 403, { error: 'Forbidden', message: 'Cross-site request rejected' });
+        // Real local agents are non-browser clients and send NO Origin / Sec-Fetch-Site
+        // header. A browser always attaches Origin on a cross-origin POST, so the presence
+        // of an Origin header on the consent endpoint means the caller is a web page — kill
+        // the browser dialog-spam vector outright by rejecting any request that carries one.
+        if (req.headers['origin'] !== undefined || this.isCrossSiteBrowserRequest(req)) {
+          log.warn('[AgentAuth] Rejected /auth/request carrying Origin/fetch-metadata (browser consent-dialog spam)');
+          this.sendJson(res, 403, { error: 'Forbidden', message: 'Browser-originated request rejected' });
           return;
         }
         await this.handleAuthRequest(req, res);
@@ -197,16 +234,22 @@ class AgentAuthService {
   /**
    * Handle authorization request
    *
-   * ACCEPTED RISK (secops #367, MED): this loopback endpoint (127.0.0.1:49231) has no
-   * requesting-process binding and no out-of-band pairing, so ANY local process can POST an auth
-   * request and spawn a native consent dialog with attacker-controlled agentName/description text
-   * (and, on user approval, proxy authenticated backend calls). The declared pairing-code flow was
-   * never implemented; the team accepted this under a local-only (already-compromised-host) threat
-   * model. Implement the pairing-code echo before relying on this endpoint for anything sensitive.
+   * Hardening (Payatu #1/#2/#3): the loopback endpoint (127.0.0.1:49231) is reachable by any
+   * local process, so agentName/description in the body are attacker-controlled and cannot be
+   * trusted on their own. We now:
+   *   1. Resolve the REAL requesting process from the OS TCP table (client port -> PID -> exe
+   *      path) and surface it in the consent dialog, so the user sees the true binary rather
+   *      than only a self-declared name.
+   *   2. Bind the issued token to that exe path; every token-gated route re-resolves the caller
+   *      and rejects a path mismatch (see validateTokenAndPeer).
+   *   3. Apply a per-requester cool-down after a Deny so a rejected process cannot hammer the
+   *      dialog.
+   * This does not fully defend an already-compromised host (PID reuse / TOCTOU are inherent to
+   * a local IPC channel), but removes the trivial impersonation and dialog-spam vectors.
    */
   private async handleAuthRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     const body = await this.parseBody(req);
-    
+
     if (!body || typeof body !== 'object') {
       this.sendJson(res, 400, { error: 'Invalid request body' });
       return;
@@ -216,9 +259,21 @@ class AgentAuthService {
 
     // Validate required fields
     if (!authRequest.agentName || !authRequest.description) {
-      this.sendJson(res, 400, { 
-        error: 'Missing required fields: agentName, description' 
+      this.sendJson(res, 400, {
+        error: 'Missing required fields: agentName, description'
       });
+      return;
+    }
+
+    // Resolve the actual requesting process from the OS TCP table.
+    const peer = await resolvePeerProcess(req.socket.remotePort, process.pid);
+    const peerKey = peer?.execPath ?? 'unknown';
+
+    // Deny cool-down: refuse without re-prompting if this requester was recently denied.
+    const cooldownUntil = this.denyCooldowns.get(peerKey);
+    if (cooldownUntil && Date.now() < cooldownUntil) {
+      Logger.warn(ElectronEvent.AGENT_AUTH_COOLDOWN_BLOCKED, { agentName: authRequest.agentName, peer: peerKey }, 'AgentAuth');
+      this.sendJson(res, 429, { error: 'Request temporarily blocked', message: 'This process was recently denied' });
       return;
     }
 
@@ -228,20 +283,25 @@ class AgentAuthService {
     }
     this.consentDialogOpen = true;
     try {
-      Logger.info(ElectronEvent.AGENT_AUTH_REQUEST, { agentName: authRequest.agentName, agentType: authRequest.agentType }, 'AgentAuth');
+      Logger.info(ElectronEvent.AGENT_AUTH_REQUEST, { agentName: authRequest.agentName, agentType: authRequest.agentType, peer: peerKey }, 'AgentAuth');
 
-      // Show consent dialog to user
-      const approval = await this.showConsentDialog(authRequest);
+      // Show consent dialog to user, naming the real requesting process.
+      const approval = await this.showConsentDialog(authRequest, peer);
 
       if (!approval.approved) {
+        // Arm the cool-down so repeated prompts cannot be hammered after a Deny.
+        this.denyCooldowns.set(peerKey, Date.now() + DENY_COOLDOWN_MS);
         const response: AuthResponse = {
           status: 'denied',
           reason: 'User rejected the request'
         };
-        Logger.info(ElectronEvent.AGENT_AUTH_DENIED, { agentName: authRequest.agentName }, 'AgentAuth');
+        Logger.info(ElectronEvent.AGENT_AUTH_DENIED, { agentName: authRequest.agentName, peer: peerKey }, 'AgentAuth');
         this.sendJson(res, 403, response);
         return;
       }
+
+      // Clear any prior cool-down for this requester on approval.
+      this.denyCooldowns.delete(peerKey);
 
       // Generate access token
       const token = this.generateToken();
@@ -252,7 +312,8 @@ class AgentAuthService {
         agentName: authRequest.agentName,
         description: authRequest.description,
         expiresAt,
-        createdAt: Date.now()
+        createdAt: Date.now(),
+        agentPath: peer?.execPath ?? null,
       };
 
       this.sessions.set(token, session);
@@ -263,7 +324,7 @@ class AgentAuthService {
         expiresAt
       };
 
-      Logger.info(ElectronEvent.AGENT_AUTH_GRANTED, { agentName: authRequest.agentName, expiresAt, duration: approval.duration }, 'AgentAuth');
+      Logger.info(ElectronEvent.AGENT_AUTH_GRANTED, { agentName: authRequest.agentName, expiresAt, duration: approval.duration, peer: peerKey }, 'AgentAuth');
       this.sendJson(res, 200, response);
     } finally {
       this.consentDialogOpen = false;
@@ -297,7 +358,7 @@ class AgentAuthService {
   private async handleInteract(req: IncomingMessage, res: ServerResponse): Promise<void> {
     // Validate agent authorization token
     const agentToken = this.extractToken(req);
-    if (!agentToken || !this.validateToken(agentToken)) {
+    if (!agentToken || !(await this.validateTokenAndPeer(agentToken, req))) {
       this.sendJson(res, 401, { 
         error: 'Unauthorized',
         message: 'Invalid or missing agent authorization token' 
@@ -385,7 +446,7 @@ class AgentAuthService {
   private async handleSearch(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
     // Validate agent authorization token
     const agentToken = this.extractToken(req);
-    if (!agentToken || !this.validateToken(agentToken)) {
+    if (!agentToken || !(await this.validateTokenAndPeer(agentToken, req))) {
       this.sendJson(res, 401, { 
         error: 'Unauthorized',
         message: 'Invalid or missing agent authorization token' 
@@ -437,7 +498,7 @@ class AgentAuthService {
    */
   private async handleMcpSearch(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
     const agentToken = this.extractToken(req);
-    if (!agentToken || !this.validateToken(agentToken)) {
+    if (!agentToken || !(await this.validateTokenAndPeer(agentToken, req))) {
       this.sendJson(res, 401, {
         error: 'Unauthorized',
         message: 'Invalid or missing agent authorization token',
@@ -507,7 +568,7 @@ class AgentAuthService {
    */
   private async handleMcpIngestTurn(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
     const agentToken = this.extractToken(req);
-    if (!agentToken || !this.validateToken(agentToken)) {
+    if (!agentToken || !(await this.validateTokenAndPeer(agentToken, req))) {
       this.sendJson(res, 401, {
         error: 'Unauthorized',
         message: 'Invalid or missing agent authorization token',
@@ -577,7 +638,7 @@ class AgentAuthService {
    */
   private async handleMcpConversationIngestUpload(req: IncomingMessage, res: ServerResponse): Promise<void> {
     const agentToken = this.extractToken(req);
-    if (!agentToken || !this.validateToken(agentToken)) {
+    if (!agentToken || !(await this.validateTokenAndPeer(agentToken, req))) {
       this.sendJson(res, 401, {
         error: 'Unauthorized',
         message: 'Invalid or missing agent authorization token',
@@ -650,7 +711,7 @@ class AgentAuthService {
    * Handle POST /memory/search - Search documents
    */
   private async handleMemorySearch(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    if (!this.guardProxyRequest(req, res)) return;
+    if (!(await this.guardProxyRequest(req, res))) return;
 
     const body = await this.parseBody(req);
     log.info(`[AgentAuth] Memory search request: ${JSON.stringify(body)}`);
@@ -699,7 +760,7 @@ class AgentAuthService {
     * }
    */
   private async handleMemoryUpload(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    if (!this.guardProxyRequest(req, res)) return;
+    if (!(await this.guardProxyRequest(req, res))) return;
 
     const body = await this.parseBody(req);
     if (!body || typeof body !== 'object') {
@@ -744,7 +805,7 @@ class AgentAuthService {
    * }
    */
   private async handleSessionHistory(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
-    if (!this.guardProxyRequest(req, res)) return;
+    if (!(await this.guardProxyRequest(req, res))) return;
 
     const sessionId = url.searchParams.get('sessionId');
     if (!sessionId) {
@@ -792,7 +853,7 @@ class AgentAuthService {
    * }
    */
   private async handleMemoryUpdate(req: IncomingMessage, res: ServerResponse, url: URL): Promise<void> {
-    if (!this.guardProxyRequest(req, res)) return;
+    if (!(await this.guardProxyRequest(req, res))) return;
 
     const docId = url.pathname.replace('/memory/', '');
     if (!docId) {
@@ -848,7 +909,7 @@ class AgentAuthService {
    * }
    */
   private async handleMemoryReplaceSession(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    if (!this.guardProxyRequest(req, res)) return;
+    if (!(await this.guardProxyRequest(req, res))) return;
 
     const body = await this.parseBody(req);
     if (!body || typeof body !== 'object') {
@@ -900,7 +961,7 @@ class AgentAuthService {
   ): Promise<void> {
     // 1. Validate agent token
     const token = this.extractToken(req);
-    if (!token || !this.validateToken(token)) {
+    if (!token || !(await this.validateTokenAndPeer(token, req))) {
       this.sendJson(res, 401, { error: 'Unauthorized: invalid or missing agent token' });
       return;
     }
@@ -1039,7 +1100,7 @@ class AgentAuthService {
   ): Promise<void> {
     // 1. Validate agent token
     const token = this.extractToken(req);
-    if (!token || !this.validateToken(token)) {
+    if (!token || !(await this.validateTokenAndPeer(token, req))) {
       this.sendJson(res, 401, { error: 'Unauthorized: invalid or missing agent token' });
       return;
     }
@@ -1134,7 +1195,7 @@ class AgentAuthService {
   ): Promise<void> {
     // 1. Validate agent token
     const token = this.extractToken(req);
-    if (!token || !this.validateToken(token)) {
+    if (!token || !(await this.validateTokenAndPeer(token, req))) {
       this.sendJson(res, 401, { error: 'Unauthorized: invalid or missing agent token' });
       return;
     }
@@ -1436,6 +1497,48 @@ class AgentAuthService {
     return true;
   }
 
+  /** True when the resolved peer executable is a registered first-party agent. */
+  private isKnownAgent(peer: PeerProcess | null): boolean {
+    if (!peer?.execPath) return false;
+    if (KNOWN_AGENT_EXECUTABLES.has(peer.execPath)) return true;
+    const base = peer.execPath.split(/[/\\]/).pop() ?? '';
+    return base.length > 0 && KNOWN_AGENT_EXECUTABLES.has(base);
+  }
+
+  /**
+   * Validate a token AND enforce that the current caller is the same process the token was
+   * issued to (Payatu #2). Re-resolves the peer from the OS TCP table on every call and
+   * rejects a path mismatch, so a token leaked to another local process is unusable.
+   *
+   * Note: when the peer cannot be resolved right now (currentPath === null) but a path was
+   * bound at grant time, we log and allow rather than break a legitimate agent on a transient
+   * lookup failure — the null case is "unknown", not a proven mismatch.
+   */
+  private async validateTokenAndPeer(token: string, req: IncomingMessage): Promise<boolean> {
+    if (!this.validateToken(token)) return false;
+
+    const session = this.sessions.get(token);
+    if (!session) return false;
+    if (!session.agentPath) return true; // nothing bound at grant time; cannot enforce
+
+    const peer = await resolvePeerProcess(req.socket.remotePort, process.pid);
+    const currentPath = peer?.execPath ?? null;
+
+    if (currentPath === null) {
+      log.warn('[AgentAuth] Could not re-resolve peer for token-gated request; allowing bound session');
+      return true;
+    }
+
+    if (currentPath === session.agentPath) return true;
+
+    Logger.warn(ElectronEvent.AGENT_AUTH_PEER_MISMATCH, {
+      agentName: session.agentName,
+      expected: session.agentPath,
+      actual: currentPath,
+    }, 'AgentAuth');
+    return false;
+  }
+
   private sanitizeDialogText(value: string | undefined, maxLen: number): string {
     if (typeof value !== 'string') return '';
     const cleaned = value.replace(/[\u0000-\u001F\u007F]/g, ' ').replace(/\s+/g, ' ').trim();
@@ -1443,9 +1546,17 @@ class AgentAuthService {
   }
 
   /**
-   * Show consent dialog to user
+   * Show consent dialog to user.
+   *
+   * The dialog uses a fixed template driven by the RESOLVED requesting process, not just the
+   * self-declared agentName. An agent whose executable is not in KNOWN_AGENT_EXECUTABLES is
+   * labelled "Unregistered agent" and its real exe path (and code-signing status) are shown, so
+   * an attacker cannot masquerade as a trusted agent purely via the name field.
    */
-  private async showConsentDialog(authRequest: AuthRequest): Promise<{ approved: boolean; duration: DurationOption }> {
+  private async showConsentDialog(
+    authRequest: AuthRequest,
+    peer: PeerProcess | null,
+  ): Promise<{ approved: boolean; duration: DurationOption }> {
     const mainWindow = BrowserWindow.getAllWindows()[0];
 
     if (!mainWindow) {
@@ -1457,6 +1568,31 @@ class AgentAuthService {
     const type = this.sanitizeDialogText(authRequest.agentType, 32);
     const description = this.sanitizeDialogText(authRequest.description, 256);
 
+    const isKnown = this.isKnownAgent(peer);
+    const requestedBy = this.sanitizeDialogText(describePeer(peer), 256);
+    const requestedByPath = peer?.execPath ? this.sanitizeDialogText(peer.execPath, 256) : 'unknown process';
+
+    // Preferred UX: rich HTML consent modal showing requester, signing status, and the
+    // capabilities being granted. Fall back to the native message box if the modal fails.
+    try {
+      const modalResult = await showAgentConsentWindow(mainWindow, {
+        agentName: name,
+        agentType: type,
+        description,
+        requestedBy: requestedByPath,
+        signed: peer?.signed ?? null,
+        isKnown,
+        capabilities: [...AGENT_CAPABILITIES],
+      });
+      return {
+        approved: modalResult.approved,
+        duration: modalResult.duration === 'none' ? '5min' : modalResult.duration,
+      };
+    } catch (error) {
+      log.error('[AgentAuth] Consent modal failed, falling back to native dialog:', error);
+    }
+
+    const displayName = isKnown ? name : `${name || 'Unnamed'} — Unregistered agent`;
     const result = await dialog.showMessageBox(mainWindow, {
       type: 'question',
       buttons: ['Deny', 'Allow (5 min)', 'Allow (1 hour)', 'Allow (Session)'],
@@ -1464,9 +1600,13 @@ class AgentAuthService {
       cancelId: 0,
       title: 'Agent Authorization Request',
       message: `A local agent wants to connect`,
-      detail: `Name: ${name}\n` +
+      detail: `Name: ${displayName}\n` +
               `${type ? `Type: ${type}\n` : ''}` +
+              `Requested by: ${requestedBy}\n` +
               `Description: ${description}\n\n` +
+              `This agent will be able to:\n` +
+              AGENT_CAPABILITIES.map((c) => `  • ${c}`).join('\n') + '\n\n' +
+              `${isKnown ? '' : '⚠ This process is not a recognised Xyne agent. Only allow it if you trust it.\n\n'}` +
               `Do you want to allow this agent to access your application?`,
       normalizeAccessKeys: true
     });
@@ -1475,7 +1615,7 @@ class AgentAuthService {
       return { approved: false, duration: '5min' };
     }
 
-    const duration: DurationOption = result.response === 1 ? '5min' : 
+    const duration: DurationOption = result.response === 1 ? '5min' :
                                       result.response === 2 ? '1hour' : 'session';
 
     return { approved: true, duration };
@@ -1537,14 +1677,14 @@ class AgentAuthService {
     return false;
   }
 
-  private guardProxyRequest(req: IncomingMessage, res: ServerResponse): boolean {
+  private async guardProxyRequest(req: IncomingMessage, res: ServerResponse): Promise<boolean> {
     if (this.isCrossSiteBrowserRequest(req)) {
       log.warn('[AgentAuth] Rejected cross-site request to credential-forwarding endpoint');
       this.sendJson(res, 403, { error: 'Forbidden', message: 'Cross-site request rejected' });
       return false;
     }
     const agentToken = this.extractToken(req);
-    if (!agentToken || !this.validateToken(agentToken)) {
+    if (!agentToken || !(await this.validateTokenAndPeer(agentToken, req))) {
       this.sendJson(res, 401, {
         error: 'Unauthorized',
         message: 'Invalid or missing agent authorization token',

--- a/apps/electron/src/services/agent-consent-window.ts
+++ b/apps/electron/src/services/agent-consent-window.ts
@@ -1,0 +1,118 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import path from 'path';
+import log from 'electron-log/main';
+
+export type ConsentDuration = 'none' | '5min' | '1hour' | 'session';
+
+export interface AgentConsentPayload {
+  agentName: string;
+  agentType: string;
+  description: string;
+  requestedBy: string;
+  signed: boolean | null;
+  isKnown: boolean;
+  capabilities: string[];
+}
+
+export interface AgentConsentResult {
+  approved: boolean;
+  duration: ConsentDuration;
+}
+
+const DEFAULT_WIDTH = 440;
+const INITIAL_HEIGHT = 560;
+
+/**
+ * Show the custom agent-authorization consent modal and resolve with the user's choice.
+ *
+ * A framed, parented modal (HTML/CSS) replaces the cramped native message box: it renders the
+ * resolved requesting process, its signing status, a capability list, and a duration selector.
+ * All agent-supplied text is passed over IPC and rendered via textContent in the renderer, so it
+ * cannot inject markup. Falls back to a Deny result if no parent window is available.
+ */
+export function showAgentConsentWindow(
+  parent: BrowserWindow | null,
+  payload: AgentConsentPayload,
+): Promise<AgentConsentResult> {
+  return new Promise((resolve) => {
+    if (!parent || parent.isDestroyed()) {
+      log.error('[AgentConsent] No parent window available for consent modal');
+      resolve({ approved: false, duration: 'none' });
+      return;
+    }
+
+    const win = new BrowserWindow({
+      width: DEFAULT_WIDTH,
+      height: INITIAL_HEIGHT,
+      parent,
+      modal: true,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      frame: false,
+      transparent: true,
+      show: false,
+      title: 'Agent Authorization',
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        preload: path.join(__dirname, '..', 'preload.js'),
+      },
+    });
+
+    let settled = false;
+    const wcId = win.webContents.id;
+
+    const cleanup = () => {
+      ipcMain.removeListener('agent-consent:respond', onRespond);
+      ipcMain.removeListener('agent-consent:content-height', onSize);
+    };
+
+    const finish = (result: AgentConsentResult) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (!win.isDestroyed()) win.close();
+      resolve(result);
+    };
+
+    const onRespond = (event: Electron.IpcMainEvent, result: AgentConsentResult) => {
+      if (event.sender.id !== wcId) return; // ignore other windows
+      const duration: ConsentDuration =
+        result?.duration === '1hour' || result?.duration === 'session' || result?.duration === '5min'
+          ? result.duration
+          : '5min';
+      finish({ approved: !!result?.approved, duration: result?.approved ? duration : 'none' });
+    };
+
+    const onSize = (event: Electron.IpcMainEvent, width: number, height: number) => {
+      if (event.sender.id !== wcId || win.isDestroyed()) return;
+      const w = width ? Math.ceil(width) : DEFAULT_WIDTH;
+      const h = height ? Math.ceil(height) + 4 : INITIAL_HEIGHT;
+      win.setContentSize(w, h);
+      win.center();
+      if (!win.isVisible()) win.show();
+    };
+
+    ipcMain.on('agent-consent:respond', onRespond);
+    ipcMain.on('agent-consent:content-height', onSize);
+
+    win.webContents.once('did-finish-load', () => {
+      win.webContents.send('agent-consent:show', payload);
+      // Fallback reveal in case the size IPC is delayed.
+      setTimeout(() => {
+        if (!settled && !win.isDestroyed() && !win.isVisible()) win.show();
+      }, 400);
+    });
+
+    // Closing the window (e.g. via OS) without an explicit choice counts as Deny.
+    win.on('closed', () => finish({ approved: false, duration: 'none' }));
+
+    const consentHtml = path.join(__dirname, '..', '..', 'assets', 'agent-consent.html');
+    void win.loadFile(consentHtml).catch((err) => {
+      log.error('[AgentConsent] Failed to load consent modal:', err);
+      finish({ approved: false, duration: 'none' });
+    });
+  });
+}

--- a/apps/electron/src/services/deep-links.ts
+++ b/apps/electron/src/services/deep-links.ts
@@ -7,7 +7,12 @@ import log from 'electron-log/main';
 import { Logger } from './logger/Logger';
 import { EnrollmentEvent } from './logger/enrollment-events';
 import ElectronEvent from './logger/electron-events';
-import { isHexToken } from '../utils/validation';
+import {
+  isHexToken,
+  sanitizeAskAiText,
+  normalizeAskAiUrl,
+  normalizeAskAiDomain,
+} from '../utils/validation';
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -188,10 +193,29 @@ async function handleDeepLink(url: string): Promise<void> {
   if (url.startsWith(`${config.DEEP_LINK_PROTOCOL}://ask-ai`)) {
     try {
       const urlObj = new URL(url);
-      const text = urlObj.searchParams.get('text') || '';
-      const sourceUrl = urlObj.searchParams.get('url') || '';
-      const domain = urlObj.searchParams.get('domain') || '';
-      const title = urlObj.searchParams.get('title') || '';
+
+      // PY-JP-019: ask-ai params are attacker-controllable (any web page can invoke
+      // this protocol) and are forwarded verbatim to the privileged renderer, where
+      // they land in an AI prompt / DOM. Validate & sanitize every param against its
+      // expected format before forwarding; log and drop anything that fails.
+      const rawText = urlObj.searchParams.get('text') || '';
+      const rawUrl = urlObj.searchParams.get('url') || '';
+      const rawDomain = urlObj.searchParams.get('domain') || '';
+      const rawTitle = urlObj.searchParams.get('title') || '';
+
+      const text = sanitizeAskAiText(rawText, 8000);
+      const sourceUrl = normalizeAskAiUrl(rawUrl);
+      const domain = normalizeAskAiDomain(rawDomain);
+      const title = sanitizeAskAiText(rawTitle, 512);
+
+      if (rawUrl && !sourceUrl) {
+        Logger.error(ElectronEvent.DEEP_LINK_PARAM_REJECTED, { param: 'url', value: rawUrl.slice(0, 128) });
+        log.warn('[DeepLinks] Rejected invalid ask-ai url param');
+      }
+      if (rawDomain && !domain) {
+        Logger.error(ElectronEvent.DEEP_LINK_PARAM_REJECTED, { param: 'domain', value: rawDomain.slice(0, 128) });
+        log.warn('[DeepLinks] Rejected invalid ask-ai domain param');
+      }
 
       log.info('[DeepLinks] Ask AI context received:', { text: text.slice(0, 50), domain, title });
 

--- a/apps/electron/src/services/logger/electron-events.ts
+++ b/apps/electron/src/services/logger/electron-events.ts
@@ -57,6 +57,9 @@ const ElectronEvent = {
     // Security guard rail events
     OPEN_EXTERNAL_BLOCKED: 'open_external_blocked',
     DEEP_LINK_INVITATION_REJECTED: 'deep_link_invitation_rejected',
+    DEEP_LINK_PARAM_REJECTED: 'deep_link_param_rejected',
+    AGENT_AUTH_PEER_MISMATCH: 'agent_auth_peer_mismatch',
+    AGENT_AUTH_COOLDOWN_BLOCKED: 'agent_auth_cooldown_blocked',
     } as const;
 
 export type ElectronEventType = (typeof ElectronEvent)[keyof typeof ElectronEvent];

--- a/apps/electron/src/services/peer-process.ts
+++ b/apps/electron/src/services/peer-process.ts
@@ -1,0 +1,196 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import log from 'electron-log/main';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Identity of the local process on the other end of a loopback TCP connection.
+ *
+ * The agent-auth server listens on 127.0.0.1 and, until now, had no way to tell
+ * WHICH local process opened a given connection — so any process could POST an
+ * auth request pretending to be a trusted agent (Payatu #1/#2/#3). We resolve
+ * the peer from the OS TCP table (client ephemeral port -> PID -> exe path) so
+ * the consent dialog can name the real requester and tokens can be bound to the
+ * requesting executable path.
+ */
+export interface PeerProcess {
+  pid: number;
+  /** Absolute path to the peer's executable, or null when it could not be resolved. */
+  execPath: string | null;
+  /** macOS code-signing verdict for execPath: true=valid, false=unsigned/invalid, null=unknown. */
+  signed: boolean | null;
+}
+
+const EXEC_TIMEOUT_MS = 2000;
+
+/**
+ * Resolve the local process that owns `remotePort` — the client end of a
+ * loopback connection to our server. `selfPid` (our own pid) is excluded so we
+ * never mistake the server side of the socket for the client.
+ *
+ * Returns null when the peer cannot be determined; callers MUST treat null as
+ * "unverified" rather than "trusted". Caveats (documented, accepted): PID reuse
+ * and a TOCTOU window between connect and lookup — path binding on top of this
+ * mitigates the single-process spoof but not a fully compromised host.
+ */
+export async function resolvePeerProcess(
+  remotePort: number | undefined,
+  selfPid: number,
+): Promise<PeerProcess | null> {
+  if (!remotePort || !Number.isInteger(remotePort) || remotePort <= 0) {
+    return null;
+  }
+
+  try {
+    let pid: number | null = null;
+    if (process.platform === 'darwin') {
+      pid = await pidFromPortMac(remotePort, selfPid);
+    } else if (process.platform === 'win32') {
+      pid = await pidFromPortWin(remotePort);
+    } else {
+      pid = await pidFromPortLinux(remotePort);
+    }
+
+    if (pid === null || pid === selfPid) {
+      return null;
+    }
+
+    const execPath = await execPathFromPid(pid);
+    const signed = execPath && process.platform === 'darwin' ? await isSignedMac(execPath) : null;
+
+    return { pid, execPath, signed };
+  } catch (error) {
+    log.warn('[PeerProcess] Failed to resolve peer process:', error);
+    return null;
+  }
+}
+
+/**
+ * Human-readable label for a consent dialog / log line, e.g.
+ * "/usr/local/bin/python3 (unsigned)" or "unknown process".
+ */
+export function describePeer(peer: PeerProcess | null): string {
+  if (!peer || !peer.execPath) return 'unknown process';
+  if (peer.signed === false) return `${peer.execPath} (unsigned)`;
+  return peer.execPath;
+}
+
+// ---------------------------------------------------------------------------
+// macOS
+// ---------------------------------------------------------------------------
+
+// lsof -F field output groups by process: a `p<pid>` line followed by per-fd
+// `n<name>` lines (name = "127.0.0.1:<local>-><remote>"). The client is the
+// process whose LOCAL port equals remotePort.
+async function pidFromPortMac(remotePort: number, selfPid: number): Promise<number | null> {
+  const { stdout } = await execFileAsync(
+    'lsof',
+    ['-nP', `-iTCP:${remotePort}`, '-sTCP:ESTABLISHED', '-FpPn'],
+    { timeout: EXEC_TIMEOUT_MS },
+  );
+
+  let currentPid: number | null = null;
+  for (const line of stdout.split('\n')) {
+    if (line.length === 0) continue;
+    const tag = line[0];
+    const val = line.slice(1);
+    if (tag === 'p') {
+      currentPid = Number.parseInt(val, 10);
+    } else if (tag === 'n' && currentPid !== null && currentPid !== selfPid) {
+      const m = val.match(/:(\d+)->/); // local port precedes "->"
+      if (m && Number.parseInt(m[1], 10) === remotePort) {
+        return currentPid;
+      }
+    }
+  }
+  return null;
+}
+
+async function isSignedMac(execPath: string): Promise<boolean | null> {
+  try {
+    // Exit 0 = valid signature; non-zero throws => unsigned/invalid.
+    await execFileAsync('codesign', ['--verify', '--strict', execPath], { timeout: EXEC_TIMEOUT_MS });
+    return true;
+  } catch (error: any) {
+    // A real verification failure is a spawn exit code; a missing binary etc. is unknown.
+    if (typeof error?.code === 'number') return false;
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Windows
+// ---------------------------------------------------------------------------
+
+// The client socket's LocalPort is remotePort; Get-NetTCPConnection yields its
+// OwningProcess (PID).
+async function pidFromPortWin(remotePort: number): Promise<number | null> {
+  const { stdout } = await execFileAsync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      `(Get-NetTCPConnection -LocalPort ${remotePort} -State Established -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty OwningProcess)`,
+    ],
+    { timeout: EXEC_TIMEOUT_MS },
+  );
+  const pid = Number.parseInt(stdout.trim(), 10);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+// ---------------------------------------------------------------------------
+// Linux
+// ---------------------------------------------------------------------------
+
+// `ss` prints "users:(("proc",pid=1234,fd=5))" for the socket whose source
+// (local) port is remotePort.
+async function pidFromPortLinux(remotePort: number): Promise<number | null> {
+  const { stdout } = await execFileAsync(
+    'ss',
+    ['-tnpH', 'state', 'established', 'sport', '=', `:${remotePort}`],
+    { timeout: EXEC_TIMEOUT_MS },
+  );
+  const m = stdout.match(/pid=(\d+)/);
+  return m ? Number.parseInt(m[1], 10) : null;
+}
+
+// ---------------------------------------------------------------------------
+// PID -> executable path
+// ---------------------------------------------------------------------------
+
+async function execPathFromPid(pid: number): Promise<string | null> {
+  try {
+    if (process.platform === 'darwin') {
+      const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'comm='], {
+        timeout: EXEC_TIMEOUT_MS,
+      });
+      const p = stdout.trim();
+      return p.length > 0 ? p : null;
+    }
+    if (process.platform === 'win32') {
+      const { stdout } = await execFileAsync(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `(Get-Process -Id ${pid} -ErrorAction SilentlyContinue).Path`,
+        ],
+        { timeout: EXEC_TIMEOUT_MS },
+      );
+      const p = stdout.trim();
+      return p.length > 0 ? p : null;
+    }
+    // Linux
+    const { stdout } = await execFileAsync('readlink', ['-f', `/proc/${pid}/exe`], {
+      timeout: EXEC_TIMEOUT_MS,
+    });
+    const p = stdout.trim();
+    return p.length > 0 ? p : null;
+  } catch (error) {
+    log.warn(`[PeerProcess] Failed to resolve exe path for pid ${pid}:`, error);
+    return null;
+  }
+}

--- a/apps/electron/src/services/peer-process.ts
+++ b/apps/electron/src/services/peer-process.ts
@@ -24,6 +24,26 @@ export interface PeerProcess {
 
 const EXEC_TIMEOUT_MS = 2000;
 
+/** Options for {@link resolvePeerProcess}. */
+export interface ResolvePeerOptions {
+  /**
+   * Run the macOS `codesign` verification (populates `signed`). Only the grant-time
+   * consent dialog reads `signed`; the token re-check path compares `execPath` only, so
+   * it passes `false` to skip a per-request `codesign --verify` shell-out. Default true.
+   */
+  verifySignature?: boolean;
+  /**
+   * When > 0, cache a successful (non-null) resolution keyed on `remotePort` for this many
+   * ms. An established socket's peer process cannot change within the window, so this removes
+   * most of the repeated shell-out cost on hot paths without weakening the binding. Failures
+   * (null) are never cached, so a transient lookup error is not sticky. Default 0 (no cache).
+   */
+  cacheTtlMs?: number;
+}
+
+// Per-socket cache of successful resolutions, keyed on the client ephemeral port.
+const peerCache = new Map<number, { value: PeerProcess; expiresAt: number }>();
+
 /**
  * Resolve the local process that owns `remotePort` — the client end of a
  * loopback connection to our server. `selfPid` (our own pid) is excluded so we
@@ -37,11 +57,21 @@ const EXEC_TIMEOUT_MS = 2000;
 export async function resolvePeerProcess(
   remotePort: number | undefined,
   selfPid: number,
+  opts: ResolvePeerOptions = {},
 ): Promise<PeerProcess | null> {
+  const { verifySignature = true, cacheTtlMs = 0 } = opts;
+
   if (!remotePort || !Number.isInteger(remotePort) || remotePort <= 0) {
     return null;
   }
 
+  const now = Date.now();
+  if (cacheTtlMs > 0) {
+    const hit = peerCache.get(remotePort);
+    if (hit && hit.expiresAt > now) return hit.value;
+  }
+
+  let result: PeerProcess | null = null;
   try {
     let pid: number | null = null;
     if (process.platform === 'darwin') {
@@ -52,18 +82,29 @@ export async function resolvePeerProcess(
       pid = await pidFromPortLinux(remotePort);
     }
 
-    if (pid === null || pid === selfPid) {
-      return null;
+    if (pid !== null && pid !== selfPid) {
+      const execPath = await execPathFromPid(pid);
+      const signed =
+        verifySignature && execPath && process.platform === 'darwin'
+          ? await isSignedMac(execPath)
+          : null;
+      result = { pid, execPath, signed };
     }
-
-    const execPath = await execPathFromPid(pid);
-    const signed = execPath && process.platform === 'darwin' ? await isSignedMac(execPath) : null;
-
-    return { pid, execPath, signed };
   } catch (error) {
     log.warn('[PeerProcess] Failed to resolve peer process:', error);
-    return null;
+    result = null;
   }
+
+  // Cache successful resolutions only; never cache a null so transient failures are not sticky.
+  if (cacheTtlMs > 0 && result !== null) {
+    if (peerCache.size > 256) {
+      for (const [k, v] of peerCache) {
+        if (v.expiresAt <= now) peerCache.delete(k);
+      }
+    }
+    peerCache.set(remotePort, { value: result, expiresAt: now + cacheTtlMs });
+  }
+  return result;
 }
 
 /**

--- a/apps/electron/src/services/ui-updater.ts
+++ b/apps/electron/src/services/ui-updater.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, net } from 'electron';
 import { createWriteStream, existsSync, mkdirSync, rmSync, renameSync, readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
 import { pipeline } from 'stream/promises';
+import { createHash } from 'crypto';
 import path from 'path';
 import log from 'electron-log/main';
 import {config} from '../app/config';
@@ -329,6 +330,43 @@ export async function checkForUIUpdate(): Promise<UpdateCheckResult> {
 }
 
 /**
+ * Verify the extracted OTA bundle against the signed release manifest.
+ *
+ * The Airborne manifest pins a raw SHA-256 (hex) of the bundle's index file at
+ * `package.index.checksum` / `package.index.file_path`. We recompute it over the extracted
+ * file and reject on any mismatch — an unverifiable or tampered bundle must never be staged.
+ * Throws (aborting the update) on a missing checksum, missing/escaping index file, or mismatch.
+ */
+function verifyBundleChecksum(bundlePath: string, remoteConfig: ReleaseConfig): void {
+  const expected = remoteConfig.package.index.checksum?.trim().toLowerCase();
+  const indexRelPath = remoteConfig.package.index.file_path?.trim();
+
+  if (!expected || !indexRelPath) {
+    throw new Error('Release manifest is missing an index checksum/path; refusing unverifiable update');
+  }
+
+  // The file_path comes from a remote manifest — resolve it and confirm it stays inside the
+  // bundle so a crafted "../.." path cannot point the hash at an arbitrary file.
+  const bundleRoot = path.resolve(bundlePath);
+  const indexAbsPath = path.resolve(bundleRoot, indexRelPath);
+  if (indexAbsPath !== bundleRoot && !indexAbsPath.startsWith(bundleRoot + path.sep)) {
+    throw new Error(`Manifest index file_path escapes the bundle directory: ${indexRelPath}`);
+  }
+  if (!existsSync(indexAbsPath)) {
+    throw new Error(`UI bundle is missing its index file (${indexRelPath}); cannot verify integrity`);
+  }
+
+  const actual = createHash('sha256').update(readFileSync(indexAbsPath)).digest('hex');
+  if (actual !== expected) {
+    throw new Error(
+      `UI bundle checksum mismatch for ${indexRelPath}: expected ${expected}, got ${actual}`,
+    );
+  }
+
+  log.info('[UIUpdater] Bundle checksum verified:', indexRelPath);
+}
+
+/**
  * Download UI update to staging directory
  */
 export async function downloadUIUpdate(): Promise<boolean> {
@@ -421,6 +459,13 @@ export async function downloadUIUpdate(): Promise<boolean> {
       }
     }
     
+    // Integrity gate: verify the downloaded bundle against the signed release manifest
+    // BEFORE staging it. The manifest pins a SHA-256 of the bundle's index file
+    // (package.index.file_path, e.g. .vite/manifest.json). A mismatch means the bytes we
+    // fetched are not the release the manifest describes — tampered CDN, MITM, or a
+    // truncated download — so we refuse the update rather than run untrusted UI code.
+    verifyBundleChecksum(uiBundlePath, remoteConfig);
+
     // Move UI bundle to staging
     renameSync(uiBundlePath, stagingPath);
     

--- a/apps/electron/src/utils/validation.ts
+++ b/apps/electron/src/utils/validation.ts
@@ -74,7 +74,11 @@ export function callInvitePath(candidate: string): string | null {
 export function sanitizeAskAiText(value: unknown, maxLen: number): string {
   if (typeof value !== 'string') return '';
   const cleaned = value
-    .replace(/[\u0000-\u001F\u007F]/g, " ") // control chars
+    // Strip C0 + DEL + C1 controls, plus the invisible/format chars that survive a
+    // naive control-char filter but break prompt structure downstream: zero-width
+    // (200B-200D), line/paragraph separators (2028/2029), bidi overrides
+    // (202A-202E) and isolates (2066-2069), and the BOM/zero-width-no-break (FEFF).
+    .replace(/[\u0000-\u001F\u007F-\u009F\u200B-\u200D\u2028\u2029\u202A-\u202E\u2066-\u2069\uFEFF]/g, " ")
     .replace(/\s+/g, ' ')
     .trim();
   return cleaned.length > maxLen ? cleaned.slice(0, maxLen) : cleaned;

--- a/apps/electron/src/utils/validation.ts
+++ b/apps/electron/src/utils/validation.ts
@@ -58,3 +58,51 @@ export function callInvitePath(candidate: string): string | null {
     return null;
   }
 }
+// ---------------------------------------------------------------------------
+// Deep-link ask-ai parameter validation (PY-JP-019)
+//
+// A xyne-spaces://ask-ai deep link is externally triggerable (any web page can
+// set location.href). Its text/url/domain/title query params are forwarded
+// verbatim to the privileged renderer via the open-xyne-ai-with-context IPC and
+// end up in an AI prompt / DOM. Validate and sanitize each param at the main
+// process boundary before forwarding; callers should drop values that fail.
+// ---------------------------------------------------------------------------
+
+// Free-text params (ask-ai text/title). Strip control chars (including the
+// prompt-structure-breaking ones), collapse runs of whitespace, and cap length.
+// Never throws — returns a safe string ('' if input is unusable).
+export function sanitizeAskAiText(value: unknown, maxLen: number): string {
+  if (typeof value !== 'string') return '';
+  const cleaned = value
+    .replace(/[\u0000-\u001F\u007F]/g, " ") // control chars
+    .replace(/\s+/g, ' ')
+    .trim();
+  return cleaned.length > maxLen ? cleaned.slice(0, maxLen) : cleaned;
+}
+
+// URL param: parse with URL() and accept only http(s). Rejects javascript:,
+// data:, file:, protocol-relative, and malformed input. Returns the normalized
+// href, or '' when invalid.
+export function normalizeAskAiUrl(value: unknown): string {
+  if (typeof value !== 'string' || value.trim().length === 0) return '';
+  try {
+    const parsed = new URL(value.trim());
+    const protocol = parsed.protocol.toLowerCase();
+    if (protocol !== 'https:' && protocol !== 'http:') return '';
+    return parsed.href;
+  } catch {
+    return '';
+  }
+}
+
+// Hostname pattern (RFC-1123 labels, max 253 chars). Returns the lowercased
+// domain, or '' when it does not look like a hostname.
+const HOSTNAME_LABEL = '[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?';
+const HOSTNAME_RE = new RegExp(`^${HOSTNAME_LABEL}(?:\\.${HOSTNAME_LABEL})*$`, 'i');
+
+export function normalizeAskAiDomain(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed.length === 0 || trimmed.length > 253) return '';
+  return HOSTNAME_RE.test(trimmed) ? trimmed : '';
+}


### PR DESCRIPTION
…eep-link params

POT: https://drive.google.com/file/d/1vP85T3jUHF-zgo9IJyGMdT4RCm5y5dq0/view?usp=sharing

Bind agent-auth tokens to the requesting process and validate externally triggerable deep-link input (Payatu #1/#2/#3, PY-JP-019).

agent-auth:
- Resolve the real requesting process from the OS TCP table (client port -> PID -> exe path) via new peer-process module; surface it in the consent dialog so users see the true binary, not just a self-declared agentName.
- Bind issued tokens to that exe path; every token-gated route re-resolves the caller and rejects a path mismatch.
- Reject any /auth/request carrying an Origin header, killing the browser dialog-spam vector outright.
- Add a per-requester cool-down after a Deny.
- Replace the cramped native message box with a custom HTML consent modal showing requester, signing status, granted capabilities and a duration picker; native dialog kept as fallback. Agent text rendered via textContent.

deep-links: validate and sanitize ask-ai text/url/domain/title before forwarding to the privileged renderer; reject and log malformed url/domain.

Also adds a reference agent-auth client script for testing.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
