### PR TITLE
fix: preserve canvas attachments and style links

### DIFF
--- a/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasScreen/CanvasScreen.tsx
@@ -196,7 +196,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
   );
 
   // Fetch message with attachments when editing a message
-  const [messageData] = useCachedQuery(
+  const [messageData, messageDetails] = useCachedQuery(
     queries.getMessageForActivityV2({ messageId: state?.messageId || '' }),
     { enabled: !!state?.messageId },
   );
@@ -467,6 +467,14 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
   useEffect(() => {
     if (canvasId === 'new') {
       setIsCreating(true);
+
+      // Editing a message starts with content from navigation state, but attachments
+      // arrive through Zero. Wait for that query before creating the canvas; otherwise
+      // the first render wins the race and permanently creates it without attachments.
+      if (isEditingMessage && state?.messageId && messageDetails.type !== 'complete') {
+        return;
+      }
+
       const createNewCanvas = async (): Promise<void> => {
         const newCanvasId = uuidv4();
         const now = Date.now();
@@ -570,6 +578,7 @@ const CanvasScreen: React.FC<CanvasScreenProps> = ({
     isCreatingMessage,
     state?.initialContent,
     messageData,
+    messageDetails.type,
     navigate,
     state,
     user?.id,

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2610,6 +2610,19 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
   color: hsl(var(--foreground));
 }
 
+/* Make ordinary canvas links visibly interactive in both light and midnight themes.
+   Repository source citations below intentionally override this base treatment. */
+.canvas-surface .bn-editor a[href] {
+  color: var(--link-color);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.canvas-surface .bn-editor a[href]:hover {
+  color: var(--link-hover-color);
+  text-decoration-thickness: 2px;
+}
+
 .canvas-surface .bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) {
   background-color: transparent;
 }


### PR DESCRIPTION
1. Problem Description:
Canvas hyperlinks rendered like plain text, and opening a message with attachments in Canvas could create the canvas before the attachment query completed, permanently omitting the attachments.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in a Spaces thread with screenshots showing a non-blue hyperlink and attachments disappearing in Canvas/ticket usage.

3. Explain the solution implemented in the PR:
Add theme-aware blue, underlined styling for ordinary Canvas links. Gate edit-message Canvas creation until the Zero message query is complete so attachment blocks are included deterministically.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Dashboard TypeScript typecheck passed.
- ESLint on CanvasScreen passed with 0 errors (2 pre-existing hook warnings).
- `git diff --check` passed.
- Browser computed-style check confirmed Canvas links render blue (`rgb(37, 99, 235)`) and underlined with a 2px underline offset.
- Full authenticated E2E was unavailable because the sandbox backend rejected the baked development LiveKit key at startup.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A