### PR TITLE
fix: XYNE-60618 reuse ServerBlockNoteEditor to stop jsdom memory leak

### DIFF
--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -13,7 +13,7 @@ import { CallOrigin, DEFAULT_SUMMARY_FIELDS, MessageType, CanvasRole, CanvasVisi
 import { logger } from '@/utils/logger';
 import { formatToISTLocaleString } from '@/utils/dateUtils';
 import type { Prisma, SummaryTemplate } from '@prisma/client';
-import { ServerBlockNoteEditor } from '@blocknote/server-util';
+import { withServerEditor } from '@/utils/serverBlockNoteEditor';
 import { getCanvasUrl, findExistingDetailedSummaryCanvas } from '@/services/canvasService';
 import { CanvasSideEffectHandler } from '@/zero/side-effects/tables/canvas-handler';
 import { vespaQueue } from '@/queues/vespaQueue';
@@ -624,8 +624,7 @@ async function convertMarkdownToBlockNote(
   citationCtx?: CitationContext,
 ): Promise<{ blocks: BlockNoteBlock[]; mentionedUserIds: string[] }> {
   try {
-    const editor = ServerBlockNoteEditor.create();
-    const parsed = await editor.tryParseMarkdownToBlocks(markdown);
+    const parsed = await withServerEditor((editor) => editor.tryParseMarkdownToBlocks(markdown));
 
     // Collect mentioned IDs during the mention-processing pass
     const mentionedIds = new Set<string>();

--- a/apps/backend/src/services/canvasService.ts
+++ b/apps/backend/src/services/canvasService.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DatabaseClient } from '@/database/client';
 import type { KnowledgeLearning } from '@/workflows/utils/knowledge-generator';
 import { logger } from '@/utils/logger';
-import { ServerBlockNoteEditor } from '@blocknote/server-util';
+import { withServerEditor } from '@/utils/serverBlockNoteEditor';
 import type { BlockNoteBlock } from '@/types/blockNoteTypes';
 import { vespaQueue } from '@/queues/vespaQueue';
 import { fileSchema, SubApp } from '@/vespa/src/types';
@@ -21,8 +21,7 @@ export const YSWEET_XML_FRAGMENT = 'document-store';
  */
 export async function convertMarkdownToBlockNote(markdown: string): Promise<BlockNoteBlock[]> {
   try {
-    const editor = ServerBlockNoteEditor.create();
-    const parsed = await editor.tryParseMarkdownToBlocks(markdown);
+    const parsed = await withServerEditor((editor) => editor.tryParseMarkdownToBlocks(markdown));
     return toJsonSafeValue(parsed) as BlockNoteBlock[];
   } catch (error) {
     logger.error('[CanvasService] Error converting markdown to BlockNote:', error);
@@ -382,13 +381,12 @@ function normalizeBlocksForMarkdown(blocks: LooseBlock[]): LooseBlock[] {
  */
 export async function convertBlockNoteToMarkdown(blocks: unknown[]): Promise<string> {
   try {
-    const editor = ServerBlockNoteEditor.create();
     // Strip custom inline nodes (e.g. mentions) the default server schema does
     // not know about, otherwise blocksToMarkdownLossy throws
     // "node type <x> not found in schema".
     const normalized = normalizeBlocksForMarkdown((blocks as LooseBlock[]) || []);
     // blocksToMarkdownLossy accepts the blocks array directly
-    const markdown = await editor.blocksToMarkdownLossy(normalized as any);
+    const markdown = await withServerEditor((editor) => editor.blocksToMarkdownLossy(normalized as any));
     return markdown;
   } catch (error) {
     logger.error('[CanvasService] Failed to convert BlockNote to Markdown:', error);

--- a/apps/backend/src/utils/serverBlockNoteEditor.ts
+++ b/apps/backend/src/utils/serverBlockNoteEditor.ts
@@ -1,0 +1,21 @@
+import { ServerBlockNoteEditor } from '@blocknote/server-util';
+type Editor = ReturnType<typeof ServerBlockNoteEditor.create>;
+
+let sharedEditor: Editor | null = null;
+let queue: Promise<unknown> = Promise.resolve();
+
+function getEditor(): Editor {
+  if (!sharedEditor) {
+    sharedEditor = ServerBlockNoteEditor.create();
+  }
+  return sharedEditor;
+}
+
+export function withServerEditor<T>(fn: (editor: Editor) => Promise<T>): Promise<T> {
+  const run = queue.then(() => fn(getEditor()));
+  queue = run.then(
+    () => undefined,
+    () => undefined
+  );
+  return run;
+}

--- a/apps/backend/src/utils/ysweetUtils.ts
+++ b/apps/backend/src/utils/ysweetUtils.ts
@@ -60,6 +60,19 @@ function createServerSchema() {
   });
 }
 
+function createServerEditor() {
+  return ServerBlockNoteEditor.create({ schema: createServerSchema() });
+}
+type ServerEditor = ReturnType<typeof createServerEditor>;
+
+let sharedServerEditor: ServerEditor | null = null;
+function getServerEditor(): ServerEditor {
+  if (!sharedServerEditor) {
+    sharedServerEditor = createServerEditor();
+  }
+  return sharedServerEditor;
+}
+
 /**
  * Y-Sweet XML fragment name used by the frontend collaborative editor
  */
@@ -198,7 +211,7 @@ export async function initializeYSweetDoc(
     logger.debug(`[YSweetUtils] Created/retrieved Y-Sweet document for canvas ${canvasId}`);
 
     // Step 2: Convert BlockNote blocks to Y.Doc format
-    const editor = ServerBlockNoteEditor.create({ schema: createServerSchema() });
+    const editor = getServerEditor();
     const ydoc = editor.blocksToYDoc(blocks as any, YSWEET_XML_FRAGMENT);
 
     // Step 3: Encode the state as an update
@@ -271,7 +284,7 @@ export async function syncToYSweet(canvasId: string, blocks: BlockNoteBlock[]): 
 
     // Use ServerBlockNoteEditor.blocksToYXmlFragment to directly populate the fragment
     // This is more efficient than creating an intermediate Y.Doc and cloning elements
-    const editor = ServerBlockNoteEditor.create({ schema: createServerSchema() });
+    const editor = getServerEditor();
     
     ydoc.transact(() => {
       // Clear existing content
@@ -330,7 +343,7 @@ export async function readFromYSweet(canvasId: string): Promise<BlockNoteBlock[]
     Y.applyUpdate(ydoc, existingUpdate);
 
     // Convert Y.Doc back to BlockNote blocks using ServerBlockNoteEditor
-    const editor = ServerBlockNoteEditor.create({ schema: createServerSchema() });
+    const editor = getServerEditor();
     const blocks = editor.yDocToBlocks(ydoc, YSWEET_XML_FRAGMENT);
 
     logger.info(`[YSweetUtils] Successfully read ${blocks.length} blocks from Y-Sweet for canvas ${canvasId}`);


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
