### PR TITLE
fix: scope nested ticket relations to reachable tickets in Zero read path

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -17,6 +17,7 @@ import {
   FormContextType,
   FormEntityType,
   LookupType,
+  reachableTicketsOnly,
   ShareableEntityType, SummaryTemplateVisibility, UserResponsibility } from '@xyne/shared';
 import { z } from 'zod';
 import {
@@ -1572,7 +1573,7 @@ export const queries: AnyQueryRegistry = defineQueries({
       return base
         .related('referencesIn', ref =>
           ref.where('relationType', TicketReferenceRelation.MERGED_INTO)
-            .related('sourceTicket'),
+            .related('sourceTicket', (t) => reachableTicketsOnly(t, ctx)),
         )
         .related('emailDrafts', q =>
           q.where(({ or, cmp }) =>
@@ -1593,14 +1594,14 @@ export const queries: AnyQueryRegistry = defineQueries({
       channelId: z.string(),
       isMember: z.boolean(),
     }),
-    ({ args: { id, xyneId, workspaceId } }) => {
+    ({ ctx, args: { id, xyneId, workspaceId } }) => {
       const base = id
         ? zql.tickets.where('id', id)
         : zql.tickets.where('xyneId', xyneId ?? '').where('workspaceId', workspaceId);
       return base
         .related('referencesIn', ref =>
           ref.where('relationType', TicketReferenceRelation.MERGED_INTO)
-            .related('sourceTicket'),
+            .related('sourceTicket', (t) => reachableTicketsOnly(t, ctx)),
         )
         .one();
     }
@@ -2070,14 +2071,14 @@ export const queries: AnyQueryRegistry = defineQueries({
   ),
 
   // @deprecated
-  ticketById: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
+  ticketById: defineQuery(z.object({ ticketId: z.string() }), ({ ctx, args: { ticketId } }) => {
     return zql.tickets
       .where('id', ticketId)
       .related('project')
       .related('tags')
       .related('assignments')
-      .related('referencesOut', (ref) => ref.related('targetTicket'))
-      .related('referencesIn', (ref) => ref.related('sourceTicket'))
+      .related('referencesOut', (ref) => ref.related('targetTicket', (t) => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', (ref) => ref.related('sourceTicket', (t) => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .related('stageEtaEntries')
@@ -2087,14 +2088,14 @@ export const queries: AnyQueryRegistry = defineQueries({
   ticketRowById: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
     return zql.tickets.where('id', ticketId).one();
   }),
-  ticketByIdV2: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
+  ticketByIdV2: defineQuery(z.object({ ticketId: z.string() }), ({ ctx, args: { ticketId } }) => {
     return zql.tickets
       .where('id', ticketId)
       .related('project')
       .related('tagMappings')
       .related('assignments', a => a.related('role'))
-      .related('referencesOut', (ref) => ref.related('targetTicket'))
-      .related('referencesIn', (ref) => ref.related('sourceTicket'))
+      .related('referencesOut', (ref) => ref.related('targetTicket', (t) => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', (ref) => ref.related('sourceTicket', (t) => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .related('stageEtaEntries')
@@ -2102,14 +2103,14 @@ export const queries: AnyQueryRegistry = defineQueries({
       .one();
   }),
   // @deprecated
-  ticketDetailsById: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
+  ticketDetailsById: defineQuery(z.object({ ticketId: z.string() }), ({ ctx, args: { ticketId } }) => {
     return zql.tickets
       .where('id', ticketId)
       .related('project')
       .related('tags')
       .related('assignments')
-      .related('referencesOut', (ref) => ref.related('targetTicket'))
-      .related('referencesIn', (ref) => ref.related('sourceTicket'))
+      .related('referencesOut', (ref) => ref.related('targetTicket', (t) => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', (ref) => ref.related('sourceTicket', (t) => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .related('stageEtaEntries')
@@ -2117,14 +2118,14 @@ export const queries: AnyQueryRegistry = defineQueries({
       .related('ticketStageRequests', a => a.related('form'))
       .one();
   }),
-  ticketDetailsByIdV2: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
+  ticketDetailsByIdV2: defineQuery(z.object({ ticketId: z.string() }), ({ ctx, args: { ticketId } }) => {
     return zql.tickets
       .where('id', ticketId)
       .related('project')
       .related('tagMappings')
       .related('assignments', a => a.related('role'))
-      .related('referencesOut', (ref) => ref.related('targetTicket'))
-      .related('referencesIn', (ref) => ref.related('sourceTicket'))
+      .related('referencesOut', (ref) => ref.related('targetTicket', (t) => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', (ref) => ref.related('sourceTicket', (t) => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .related('stageEtaEntries')
@@ -2133,38 +2134,38 @@ export const queries: AnyQueryRegistry = defineQueries({
       .one();
   }),
   // @deprecated
-  ticketByXyneId: defineQuery(z.object({ xyneId: z.string() }), ({ args: { xyneId } }) => {
+  ticketByXyneId: defineQuery(z.object({ xyneId: z.string() }), ({ ctx, args: { xyneId } }) => {
     return zql.tickets
       .where('xyneId', xyneId)
       .related('project')
       .related('tags')
-      .related('referencesOut', (ref) => ref.related('targetTicket'))
-      .related('referencesIn', (ref) => ref.related('sourceTicket'))
+      .related('referencesOut', (ref) => ref.related('targetTicket', (t) => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', (ref) => ref.related('sourceTicket', (t) => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .one();
   }),
   // @deprecated
-  ticketByXyneIdV2: defineQuery(z.object({ xyneId: z.string(), workspaceId: z.string() }), ({ args: { xyneId, workspaceId } }) => {
+  ticketByXyneIdV2: defineQuery(z.object({ xyneId: z.string(), workspaceId: z.string() }), ({ ctx, args: { xyneId, workspaceId } }) => {
     return zql.tickets
       .where('xyneId', xyneId)
       .where('workspaceId', workspaceId)
       .related('project')
       .related('tags')
-      .related('referencesOut', (ref) => ref.related('targetTicket'))
-      .related('referencesIn', (ref) => ref.related('sourceTicket'))
+      .related('referencesOut', (ref) => ref.related('targetTicket', (t) => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', (ref) => ref.related('sourceTicket', (t) => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .one();
   }),
-  ticketByXyneIdV3: defineQuery(z.object({ xyneId: z.string(), workspaceId: z.string() }), ({ args: { xyneId, workspaceId } }) => {
+  ticketByXyneIdV3: defineQuery(z.object({ xyneId: z.string(), workspaceId: z.string() }), ({ ctx, args: { xyneId, workspaceId } }) => {
     return zql.tickets
       .where('xyneId', xyneId)
       .where('workspaceId', workspaceId)
       .related('project')
       .related('tagMappings')
-      .related('referencesOut', (ref) => ref.related('targetTicket'))
-      .related('referencesIn', (ref) => ref.related('sourceTicket'))
+      .related('referencesOut', (ref) => ref.related('targetTicket', (t) => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', (ref) => ref.related('sourceTicket', (t) => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .one();
@@ -2200,21 +2201,21 @@ export const queries: AnyQueryRegistry = defineQueries({
       .where('workflowType', 'Automations')
       .one();
   }),
-  subTicketsForTicket: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
+  subTicketsForTicket: defineQuery(z.object({ ticketId: z.string() }), ({ ctx, args: { ticketId } }) => {
     return zql.ticket_sub_ticket_mappings
       .where('ticketId', ticketId)
       .related('subTicket', (subTicketQuery) =>
-        subTicketQuery.related('conversation').related('mappedTicket')
+        subTicketQuery.related('conversation').related('mappedTicket', (t) => reachableTicketsOnly(t, ctx))
       )
       .orderBy('id', 'asc');
   }),
   subTicketMappingsForTickets: defineQuery(
     z.object({ ticketIds: z.array(z.string()) }),
-    ({ args: { ticketIds } }) => {
+    ({ ctx, args: { ticketIds } }) => {
       return zql.ticket_sub_ticket_mappings
         .where(helpers => helpers.cmp('ticketId', 'IN', ticketIds))
         .related('subTicket', (subTicketQuery) =>
-          subTicketQuery.related('conversation').related('mappedTicket')
+          subTicketQuery.related('conversation').related('mappedTicket', (t) => reachableTicketsOnly(t, ctx))
         )
         .orderBy('id', 'asc');
     }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,6 @@
 // Barrel export - allows clean imports from @xyne/shared
 export * from './zero/schema';
-export { defineQuery } from './zero/acl';
+export { defineQuery, reachableTicketsOnly } from './zero/acl';
 export { encryptedFieldsConfig, type EncryptedTableConfig } from './zero/encrypted-fields';
 export { EncryptedFieldQueryError, validateQueryWhereClause, type Condition, type QueryAST } from './zero/client-transaction-wrapper';
 export * from './ai';

--- a/packages/shared/src/zero/acl/core/index.ts
+++ b/packages/shared/src/zero/acl/core/index.ts
@@ -1,3 +1,4 @@
 export { BaseQueryACL } from './base-acl';
 export { QueryACLFactory } from './query-acl-factory';
+export { reachableTicketsOnly } from './ticket-access-utils';
 export type {TableName, TableQuery } from './types';

--- a/packages/shared/src/zero/acl/core/ticket-access-utils.ts
+++ b/packages/shared/src/zero/acl/core/ticket-access-utils.ts
@@ -1,0 +1,28 @@
+import type { Query } from '@rocicorp/zero';
+import type { Context, Schema } from '../../schema';
+import { ChannelVisibility } from '../../schema';
+
+/**
+ * Scope a tickets-shaped query to the tickets the caller can reach: same workspace, and the
+ * ticket's channel is PUBLIC or one the caller participates in.
+ *
+ * This is the same predicate TicketsACL.canSelect applies to a root `tickets` query. It is
+ * exported because applyQueryACL only filters the ROOT table — a nested
+ * `.related('targetTicket' | 'sourceTicket' | 'mappedTicket')` hop resolves a ticket by id
+ * across channels with no ACL and no workspace backstop of its own, so those relations must
+ * apply it inline.
+ */
+export const reachableTicketsOnly = <TReturn>(
+  query: Query<'tickets', Schema, TReturn>,
+  ctx: Context,
+): Query<'tickets', Schema, TReturn> =>
+  (query as any)
+    .where('workspaceId', '=', ctx.workspaceId)
+    .whereExists('channel', (ch: any) =>
+      ch.where(({ or, cmp, exists }: any) =>
+        or(
+          cmp('visibility', ChannelVisibility.PUBLIC),
+          exists('participants', (p: any) => p.where('userId', ctx.userID)),
+        ),
+      ),
+    );

--- a/packages/shared/src/zero/acl/index.ts
+++ b/packages/shared/src/zero/acl/index.ts
@@ -1,6 +1,6 @@
 export { defineQuery } from './define-query';
 
-export { BaseQueryACL, QueryACLFactory } from './core';
+export { BaseQueryACL, QueryACLFactory, reachableTicketsOnly } from './core';
 export type {TableName, TableQuery } from './core';
 
 export {

--- a/packages/shared/src/zero/acl/tables/tickets-acl.ts
+++ b/packages/shared/src/zero/acl/tables/tickets-acl.ts
@@ -4,6 +4,7 @@ import { ChannelVisibility } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import type { SelectArgs } from '../core/types';
 import { guestTicketAccessWhere, isGuestContext } from '../core/guest-acl-utils';
+import { reachableTicketsOnly } from '../core/ticket-access-utils';
 
 export class TicketsACL extends BaseQueryACL<'tickets'> {
   constructor(ctx: Context) {
@@ -41,14 +42,7 @@ export class TicketsACL extends BaseQueryACL<'tickets'> {
       );
     }
 
-    return query.whereExists('channel', (ch) =>
-      ch.where(({ or, cmp, exists }) =>
-        or(
-          cmp('visibility', ChannelVisibility.PUBLIC),
-          exists('participants', (p) => p.where('userId', this.ctx.userID))
-        )
-      )
-    );
+    return reachableTicketsOnly(query, this.ctx);
   
   }
 }

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -2,6 +2,7 @@ import { createBuilder, defineQueries } from '@rocicorp/zero';
 import { BaseTicketType } from './types.js';
 import { flowStepVisibilitySchemaShape } from '../tickets/flow.js';
 import { defineQuery } from './acl/define-query.js';
+import { reachableTicketsOnly } from './acl/core/ticket-access-utils.js';
 import {
   AccessType,
   BoardType,
@@ -1316,7 +1317,7 @@ export const queries = defineQueries({
       return base
         .related('referencesIn', ref =>
           ref.where('relationType', TicketReferenceRelation.MERGED_INTO)
-            .related('sourceTicket'),
+            .related('sourceTicket', t => reachableTicketsOnly(t, ctx)),
         )
         .related('emailDrafts', q =>
           q.where(({ or, cmp }) =>
@@ -1337,14 +1338,14 @@ export const queries = defineQueries({
       channelId: z.string(),
       isMember: z.boolean(),
     }),
-    ({ args: { id, xyneId, workspaceId } }) => {
+    ({ ctx, args: { id, xyneId, workspaceId } }) => {
       const base = id
         ? zql.tickets.where('id', id)
         : zql.tickets.where('xyneId', xyneId ?? '').where('workspaceId', workspaceId);
       return base
         .related('referencesIn', ref =>
           ref.where('relationType', TicketReferenceRelation.MERGED_INTO)
-            .related('sourceTicket'),
+            .related('sourceTicket', t => reachableTicketsOnly(t, ctx)),
         )
         .one();
     },
@@ -1689,28 +1690,28 @@ export const queries = defineQueries({
   ticketRowById: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
     return zql.tickets.where('id', ticketId).one();
   }),
-  ticketByIdV2: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
+  ticketByIdV2: defineQuery(z.object({ ticketId: z.string() }), ({ ctx, args: { ticketId } }) => {
     return zql.tickets
       .where('id', ticketId)
       .related('project')
       .related('tagMappings')
       .related('assignments', a => a.related('role'))
-      .related('referencesOut', ref => ref.related('targetTicket'))
-      .related('referencesIn', ref => ref.related('sourceTicket'))
+      .related('referencesOut', ref => ref.related('targetTicket', t => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', ref => ref.related('sourceTicket', t => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .related('stageEtaEntries')
       .related('ticketStageRequests', a => a.related('form'))
       .one();
   }),
-  ticketDetailsByIdV2: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
+  ticketDetailsByIdV2: defineQuery(z.object({ ticketId: z.string() }), ({ ctx, args: { ticketId } }) => {
     return zql.tickets
       .where('id', ticketId)
       .related('project')
       .related('tagMappings')
       .related('assignments', a => a.related('role'))
-      .related('referencesOut', ref => ref.related('targetTicket'))
-      .related('referencesIn', ref => ref.related('sourceTicket'))
+      .related('referencesOut', ref => ref.related('targetTicket', t => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', ref => ref.related('sourceTicket', t => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .related('stageEtaEntries')
@@ -1718,14 +1719,14 @@ export const queries = defineQueries({
       .related('ticketStageRequests', a => a.related('form'))
       .one();
   }),
-  ticketByXyneIdV3: defineQuery(z.object({ xyneId: z.string(), workspaceId: z.string() }), ({ args: { xyneId, workspaceId } }) => {
+  ticketByXyneIdV3: defineQuery(z.object({ xyneId: z.string(), workspaceId: z.string() }), ({ ctx, args: { xyneId, workspaceId } }) => {
     return zql.tickets
       .where('xyneId', xyneId)
       .where('workspaceId', workspaceId)
       .related('project')
       .related('tagMappings')
-      .related('referencesOut', ref => ref.related('targetTicket'))
-      .related('referencesIn', ref => ref.related('sourceTicket'))
+      .related('referencesOut', ref => ref.related('targetTicket', t => reachableTicketsOnly(t, ctx)))
+      .related('referencesIn', ref => ref.related('sourceTicket', t => reachableTicketsOnly(t, ctx)))
       .related('entity')
       .related('conversation')
       .one();
@@ -1780,21 +1781,21 @@ export const queries = defineQueries({
         .orderBy('createdAt', 'asc');
     },
   ),
-  subTicketsForTicket: defineQuery(z.object({ ticketId: z.string() }), ({ args: { ticketId } }) => {
+  subTicketsForTicket: defineQuery(z.object({ ticketId: z.string() }), ({ ctx, args: { ticketId } }) => {
     return zql.ticket_sub_ticket_mappings
       .where('ticketId', ticketId)
       .related('subTicket', subTicketQuery =>
-        subTicketQuery.related('conversation').related('mappedTicket'),
+        subTicketQuery.related('conversation').related('mappedTicket', t => reachableTicketsOnly(t, ctx)),
       )
       .orderBy('id', 'asc');
   }),
   subTicketMappingsForTickets: defineQuery(
     z.object({ ticketIds: z.array(z.string()) }),
-    ({ args: { ticketIds } }) => {
+    ({ ctx, args: { ticketIds } }) => {
       return zql.ticket_sub_ticket_mappings
         .where(helpers => helpers.cmp('ticketId', 'IN', ticketIds))
         .related('subTicket', subTicketQuery =>
-          subTicketQuery.related('conversation').related('mappedTicket'),
+          subTicketQuery.related('conversation').related('mappedTicket', t => reachableTicketsOnly(t, ctx)),
         )
         .orderBy('id', 'asc');
     },


### PR DESCRIPTION
## What

`applyQueryACL` scopes the **root** table only. `getTableNameFromQuery` reads `query.ast.table`, `QueryACLFactory.getACL` is called exactly once in the whole Zero read-ACL layer, and the workspace backstop is applied to the root query too — its own comment says *"scope root rows"*. Nested `.related()` subqueries get no ACL and no tenant filter of their own. The code already logged this as `[related-acl]`.

`targetTicket`, `sourceTicket` and `mappedTicket` each resolve a ticket by id with no channel constraint, so **any workspace member could read tickets filed in channels they are not in** — title, description, metadata, classificationData — by opening a ticket that references one.

## Scope: read path only

The **write path is already covered** and needs no change here. The mutation ACL layer in `apps/backend/src/zero/acl` enforces `canInsert`/`canUpdate`/`canDelete` via `transaction-wrapper.ts`, and `TicketReferenceMappingsACL.canInsert` already verifies both the source and the target ticket. Verified: creating a reference to an unreachable ticket is rejected there with *"you do not have access to the target ticket"* and writes no row, while the same call against a readable ticket succeeds.

This is also **not** the same enforcement point as #1166. That hardens the Prisma read path (`apps/backend/src/database/acl`); this is the Zero read path, which #1166 leaves untouched — the two `TicketsACL` classes share a name and no code.

## Fix

`reachableTicketsOnly` is the single predicate: same workspace, and the ticket's channel is PUBLIC or one the caller participates in. `TicketsACL.canSelect` now calls it instead of inlining the same clause, so root and nested filtering cannot drift.

The `workspaceId` arm matters on its own: the root-only backstop does not reach a nested hop, so without it a PUBLIC channel in **another workspace** satisfied the visibility check. Reproduced across a second workspace before being closed.

Applied to both registries, 28 call sites — 18 in `apps/backend` (server-authoritative, resolved by name via `mustGetBackendQuery`) and 10 in `packages/shared` (imported by the dashboard), per the repo convention of keeping them in sync.

## Verification

Local canary — a ticket in a PRIVATE channel referenced from a PUBLIC one, queried as a plain MEMBER not in that channel:

| | before | after |
|---|---|---|
| direct read of the private ticket | empty (root ACL works) | empty |
| via `referencesOut.targetTicket` | **full row leaked** | empty |
| cross-**workspace** via the same hop | **full row leaked** | empty |
| root ticket itself | returned | returned |

Positive control: adding a `channel_participants` row made the reference return again, confirming the relation is filtered rather than broken. Covers `ticketById`, `ticketByIdV2`, `ticketDetailsById`, `ticketDetailsByIdV2`.

Backend `tsc --noEmit` clean, dashboard `tsc --noEmit` clean, backend eslint clean.

## Compatibility

No wire-contract change — every args schema is byte-identical and `ctx` is server-side only, so old clients need no coordinated deploy. All 45 consumer accesses of these relations already null-guard; an unreachable reference now returns empty, the same state as a reference to a deleted ticket.

Not verified: UI run, test suite, and how Zero invalidates rows a browser cached before deploy.