### PR TITLE
fix: XYNE-56627 fix empty-result loader flash on cached cmd+K search

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -955,6 +955,11 @@ const ChannelCommandMenu = ({
     if (text.trim()) params.set('query', text.trim());
     if (tab) params.set('tab', tab);
 
+    // Carry the cmd+K toggles so the full-screen page issues the identical Vespa request
+    // (same filtered results) and can reuse the popup's cached search.
+    params.set('onlyMyChannels', String(onlyMyChannels));
+    params.set('includeBotMessages', String(includeBotMessages));
+
     const fromMentions = mentions.filter(m => m.type === MentionType.USER && m.prefix === 'from:');
     const fromEmails = fromMentions.filter(m => m.id.includes('@')).map(m => m.id);
     const fromIds = fromMentions.filter(m => !m.id.includes('@')).map(m => m.id);
@@ -3635,6 +3640,9 @@ const ChannelCommandMenu = ({
                       </button>
                     ))}
                     <div className='my-1 border-t border-border' />
+                    {/* State-only — deliberately not mirrored to the URL: a per-click searchParams
+                        update would push a browser history entry each toggle. The URL is stamped
+                        once at the full-screen hand-off (buildSearchParams) instead. */}
                     <button
                       type='button'
                       onMouseDown={e => e.preventDefault()}
@@ -3691,6 +3699,9 @@ const ChannelCommandMenu = ({
                     className='z-[10000] bg-popover border border-border rounded-lg shadow-md min-w-[180px] p-1 text-popover-foreground'
                     onOpenAutoFocus={e => e.preventDefault()}
                   >
+                    {/* State-only — deliberately not mirrored to the URL: a per-click searchParams
+                        update would push a browser history entry each toggle. The URL is stamped
+                        once at the full-screen hand-off (buildSearchParams) instead. */}
                     <button
                       type='button'
                       onMouseDown={e => e.preventDefault()}

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -199,9 +199,17 @@ const SearchResults = (): ReactElement => {
     const mentionsParam = searchParams.get('mentions') ?? '';
     const channelMentionsParam = searchParams.get('channelMentions') ?? '';
     const tabParam = parseDocTypeParam(searchParams.get('tab'));
+    // Toggles come from cmd+K (see buildSearchParams). Absent for deep links / other entry
+    // points → fall back to DEFAULT_SEARCH_FILTERS.
+    const onlyMyChannelsParam = searchParams.get('onlyMyChannels');
+    const includeBotMessagesParam = searchParams.get('includeBotMessages');
     return {
       ...DEFAULT_SEARCH_FILTERS,
       ...(tabParam ? { docType: tabParam } : {}),
+      ...(onlyMyChannelsParam !== null ? { onlyMyChannels: onlyMyChannelsParam === 'true' } : {}),
+      ...(includeBotMessagesParam !== null
+        ? { includeBotMessages: includeBotMessagesParam === 'true' }
+        : {}),
       fromUserIds: fromParam ? fromParam.split(',').filter(Boolean) : [],
       fromEmails: fromEmailParam ? fromEmailParam.split(',').filter(Boolean) : [],
       toEmails: toEmailParam ? toEmailParam.split(',').filter(Boolean) : [],
@@ -300,6 +308,7 @@ const SearchResults = (): ReactElement => {
     searchResults: backendResults,
     isGrouped,
     isSearching: isLoading,
+    isSearchPending,
     searchError: error,
     text: searchedText,
     setText,
@@ -597,9 +606,6 @@ const SearchResults = (): ReactElement => {
     });
   }, [baseResults, filters.sortBy, isChannelsMode]);
 
-  // Track whether a search has been initiated for the current query/filters to avoid
-  // showing "No results" before the first search fires (300ms debounce window)
-  const hasEverLoadedRef = useRef(false);
   const autoOpenedResultKeyRef = useRef<string | null>(null);
   const hasManualPanelSelectionRef = useRef(false);
   const filterKey = JSON.stringify([
@@ -616,23 +622,6 @@ const SearchResults = (): ReactElement => {
   ]);
   const searchRequestKey = JSON.stringify([query, filterKey]);
   const fullSearchKey = JSON.stringify([searchRequestKey, filters.sortBy]);
-  const prevSearchKeyRef = useRef(searchRequestKey);
-  const prevFilterKeyRef = useRef(filterKey);
-  if (searchRequestKey !== prevSearchKeyRef.current) {
-    prevSearchKeyRef.current = searchRequestKey;
-    // Only show the loading bridge when a new API call will actually run: a filter change,
-    // or a query the search hook hasn't fetched yet. Since results now update live while
-    // typing, pressing Enter commits the already-searched query to the URL but fires no API
-    // call (the hook duplicate-suppresses it) — so resetting here would leave `isLoading`
-    // false forever and spin the screen indefinitely. Guard against that.
-    // `query` is already both-ends trimmed (line ~183); the hook dedupes on text.trimEnd()
-    // (useSearchMetrics), so normalize the same way here or a leading-space edit would
-    // disagree with whether the hook actually re-fetches.
-    const willFetch = filterKey !== prevFilterKeyRef.current || query !== searchedText.trimEnd();
-    if (willFetch) hasEverLoadedRef.current = false; // reset for new search
-    prevFilterKeyRef.current = filterKey;
-  }
-  if (isLoading) hasEverLoadedRef.current = true;
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: 0 });
@@ -860,7 +849,7 @@ const SearchResults = (): ReactElement => {
             query={query}
             displayQuery={displayQuery}
             hasActiveFilters={filtersActive}
-            hasEverLoaded={hasEverLoadedRef.current}
+            isSearchPending={isSearchPending}
             isLoading={isLoading}
             error={error}
             results={results}
@@ -963,7 +952,7 @@ interface ResultsBodyProps {
    *  query). Drives empty-state copy and local-section gating so they track live typing. */
   displayQuery: string;
   hasActiveFilters: boolean;
-  hasEverLoaded: boolean;
+  isSearchPending: boolean;
   isLoading: boolean;
   error: string | null;
   results: DisplaySearchResult[];
@@ -1107,7 +1096,7 @@ function ResultsBody({
   query,
   displayQuery,
   hasActiveFilters,
-  hasEverLoaded,
+  isSearchPending,
   isLoading,
   error,
   results,
@@ -1505,7 +1494,8 @@ function ResultsBody({
           <EmptyState title='Search for messages, files, and tickets' subtitle='Type to search' />
         );
       }
-      if (isLoading || !hasEverLoaded) {
+      // isSearchPending is primary (race-proof); isLoading backstops a real in-flight fetch.
+      if (isLoading || isSearchPending) {
         return (
           <div className='flex items-center justify-center h-full'>
             <Loader2 className='animate-spin text-muted-foreground' size={32} />
@@ -1571,7 +1561,8 @@ function ResultsBody({
         <EmptyState title='Search for messages, files, and tickets' subtitle='Type to search' />
       );
     }
-    if (isLoading || !hasEverLoaded) {
+    // isSearchPending is primary (race-proof); isLoading backstops a real in-flight fetch.
+    if (isLoading || isSearchPending) {
       return (
         <div className='flex items-center justify-center h-full'>
           <Loader2 className='animate-spin text-muted-foreground' size={32} />

--- a/apps/dashboard/src/hooks/useSearchMetrics.ts
+++ b/apps/dashboard/src/hooks/useSearchMetrics.ts
@@ -1228,6 +1228,9 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       includeDebugInfo === lastSearchedParamsRef.current.includeDebugInfo &&
       normalizedText !== ''
     ) {
+      // Terminal exit with no dispatch — no performSearch().finally runs to disarm the loader.
+      // Reconcile to the real in-flight state so a cancelled arm can't strand the spinner true.
+      setIsSearchPending(pendingSearchCountRef.current > 0);
       return;
     }
 

--- a/apps/dashboard/src/hooks/useSearchMetrics.ts
+++ b/apps/dashboard/src/hooks/useSearchMetrics.ts
@@ -2,7 +2,7 @@ import { logger, Event as LogEvent } from '../utils/logger';
 import { useState, useCallback, useRef, useEffect, useMemo, useDeferredValue } from 'react';
 import { searchMetricsService } from '../services/searchMetricsService';
 import { useAuthContextValues } from './useAuth';
-import { searchService } from '../services/searchService';
+import { searchService, clearVespaSearchCache } from '../services/searchService';
 import { DisplaySearchResult, VespaSearchFilters } from '../types/search';
 import {
   TabType,
@@ -204,6 +204,12 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
   // ranked list). Defaults true to preserve the sectioned ALL view.
   const [isGrouped, setIsGrouped] = useState(true);
   const [isSearching, setIsSearching] = useState(false);
+  // Whether a search has been scheduled for the current inputs and hasn't settled yet.
+  // Drives the initial loader. Armed in the debounce effect (whose dep array is the
+  // canonical, lint-enforced list of search inputs) and disarmed when the latest
+  // dispatch's performSearch settles — so it is immune to the synchronous-cache-hit
+  // race that stranded the old render-body `isLoading` latch.
+  const [isSearchPending, setIsSearchPending] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [paginationState, setPaginationState] = useState<
@@ -237,9 +243,10 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
   // results — would hand the callback fresh results labelled with its stale query.
   const latestQueryRef = useRef('');
   const sessionFiltersRef = useRef<Set<string>>(new Set());
-  // Guards out-of-order search responses. Each performSearch run claims the next
-  // sequence number; only the latest run is allowed to commit. A slow/stale response
-  // (e.g. a partial `from` query that resolves seconds after the completed `from:`
+  // Guards out-of-order responses. Each dispatch claims the next sequence number at the
+  // call site (alongside the abort below); only the latest run may commit its results, and
+  // the same seq gates the loader disarm — so no separate loader counter is needed. A
+  // slow/stale response (e.g. a partial `from` query resolving after the completed `from:`
   // filter) is discarded instead of overwriting fresh results with an empty payload.
   const searchSeqRef = useRef(0);
   // Cancels the previous in-flight vespaSearch when a newer search is dispatched.
@@ -574,6 +581,11 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
    */
   const onOpen = useCallback(
     (trigger: SearchTrigger) => {
+      // A fresh palette open must never reuse a previous session's cached search — only the
+      // in-flight popup → full-screen → back handoff should. Back-navigation restores the
+      // palette without calling onOpen, so its cached result survives.
+      // debugger;
+      clearVespaSearchCache();
       startSession(trigger);
     },
     [startSession],
@@ -685,6 +697,12 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       [TabType.RECORDING]: { page: 1, hasMore: false, total: 0, offset: 0, cumulativeCount: 0 },
       [TabType.DESK]: { page: 1, hasMore: false, total: 0, offset: 0, cumulativeCount: 0 },
     });
+    // Clear the dedup guard's text so reopening the palette and re-entering the same query
+    // (notably a paste of the last search) isn't skipped as a duplicate and re-runs the search.
+    lastSearchedParamsRef.current.text = '';
+    // Re-arm the loader latch: after a clear/close, re-entering a query must show the
+    // spinner again rather than a stale "No results".
+    setIsSearchPending(false);
   }, [resetImpressionTracking]);
 
   /**
@@ -692,6 +710,8 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
    */
   const performSearch = useCallback(
     async (
+      seq: number,
+      abortController: AbortController,
       query: string,
       activeTab: TabType,
       selectedMentions: Array<{ id: string; type: MentionType; prefix?: string; name?: string }>,
@@ -703,13 +723,9 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       }>,
       onComplete?: (results: DisplaySearchResult[], query: string) => void,
     ) => {
-      // Claim this run's sequence and abort any previous in-flight request so a slow,
-      // stale response can neither waste the network nor overwrite fresh results.
-      const seq = ++searchSeqRef.current;
+      // Run identity (seq + abortController) is minted by the caller at dispatch time so the
+      // loader disarm can reuse the same seq. A stale response fails isStale() and is dropped.
       const isStale = () => seq !== searchSeqRef.current;
-      searchAbortRef.current?.abort();
-      const abortController = new AbortController();
-      searchAbortRef.current = abortController;
 
       const {
         searchText,
@@ -1039,6 +1055,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
                   presentationSummary: 'lean',
                 },
                 abortController.signal,
+                { cache: true },
               );
 
               // A newer search superseded this one — drop this out-of-order response.
@@ -1085,6 +1102,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
                   presentationSummary: 'lean',
                 },
                 abortController.signal,
+                { cache: true },
               );
 
               // A newer search superseded this one — drop this out-of-order response.
@@ -1213,6 +1231,9 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       return;
     }
 
+    // Arm the loader now (before the 300ms debounce) so we never flash "No results"
+    // in the gap before the request fires. Disarmed when the dispatched search settles.
+    setIsSearchPending(true);
     const timer = setTimeout(() => {
       lastSearchedParamsRef.current = {
         text: normalizedText,
@@ -1224,14 +1245,29 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
         includeDebugInfo,
         mentionsKey: currentMentionsKey,
       };
+      // Mint this dispatch's run identity here (not in the effect body) so the abort fires at
+      // dispatch time, not on every keystroke; seq and the abort stay atomic together.
+      const seq = ++searchSeqRef.current;
+      searchAbortRef.current?.abort();
+      const abortController = new AbortController();
+      searchAbortRef.current = abortController;
       void performSearch(
+        seq,
+        abortController,
         text,
         activeTab,
         selectedMentions,
         filteredLocalUsers,
         filteredLocalChannels,
         options.onSearchComplete,
-      );
+      ).finally(() => {
+        // Runs on every exit path of performSearch (returns, errors, aborts). Only the
+        // newest dispatch may clear the flag — a superseded run settling (aborted
+        // mid-flight) must not hide the loader while a fresher search is still running.
+        if (seq === searchSeqRef.current) {
+          setIsSearchPending(false);
+        }
+      });
     }, 300);
 
     return () => clearTimeout(timer);
@@ -1588,6 +1624,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
     searchResults,
     isGrouped,
     isSearching,
+    isSearchPending,
     searchError,
     isLoadingMore,
     paginationState,

--- a/apps/dashboard/src/services/searchService.ts
+++ b/apps/dashboard/src/services/searchService.ts
@@ -1,6 +1,6 @@
 import { apiInstance } from './clients/apiClient';
 import { DisplaySearchResult, VespaSearchResponse, VespaSearchFilters } from '../types/search';
-
+import { buildVespaSearchCacheKey } from './vespaSearchCacheKey';
 /**
  * Sanitizes search query by removing potentially harmful characters
  */
@@ -26,6 +26,7 @@ export class SearchService {
   async vespaSearch(
     filters: VespaSearchFilters,
     signal?: AbortSignal,
+    opts?: { cache?: boolean },
   ): Promise<{
     results: DisplaySearchResult[];
     totalCount: number;
@@ -42,6 +43,16 @@ export class SearchService {
 
       const params = this.buildVespaSearchParams(sanitizedFilters);
 
+      // Opt-in handoff cache: serve the most recent identical cmd+K search (see cachedVespaSearch).
+      const cacheKey = opts?.cache ? buildVespaSearchCacheKey(params) : null;
+      if (
+        cacheKey &&
+        cachedVespaSearch?.key === cacheKey &&
+        cachedVespaSearch.expiresAt > Date.now()
+      ) {
+        return cachedVespaSearch.value;
+      }
+
       const response = await apiInstance.get<VespaSearchResponse>(this.vespaBaseUrl, {
         params,
         ...(signal ? { signal } : {}),
@@ -54,28 +65,40 @@ export class SearchService {
       const data = response.data.data;
 
       // Handle grouped results - flatten them for backward compatibility
+      let vespaResult: VespaSearchResult;
       if (data.grouped && data.groups) {
         const flattenedResults: DisplaySearchResult[] = [];
         for (const group of data.groups) {
           flattenedResults.push(...group.results);
         }
 
-        return {
+        vespaResult = {
           results: flattenedResults.filter(result => result.relevanceScore > 0),
           totalCount: data.totalCount,
           offset: data.offset,
           limit: data.limit,
           grouped: true,
         };
+      } else {
+        // Handle flat results (backward compatible)
+        vespaResult = {
+          results: data.results || [],
+          totalCount: data.totalCount,
+          offset: data.offset,
+          limit: data.limit,
+          grouped: false,
+        };
       }
-      // Handle flat results (backward compatible)
-      return {
-        results: data.results || [],
-        totalCount: data.totalCount,
-        offset: data.offset,
-        limit: data.limit,
-        grouped: false,
-      };
+
+      // Store on success only; a new text/toggle/tab/offset yields a new key and overwrites.
+      if (cacheKey) {
+        cachedVespaSearch = {
+          key: cacheKey,
+          value: vespaResult,
+          expiresAt: Date.now() + VESPA_SEARCH_CACHE_TTL_MS,
+        };
+      }
+      return vespaResult;
     } catch (error) {
       if (error instanceof Error) {
         throw error;
@@ -258,6 +281,27 @@ export class SearchService {
 
     return params;
   }
+}
+
+// 30s: gives the popup → full-screen handoff headroom to reuse the popup's search even if
+// the results page is slow to mount, while still bounding how stale a reused result can be.
+const VESPA_SEARCH_CACHE_TTL_MS = 30_000;
+
+type VespaSearchResult = Awaited<ReturnType<SearchService['vespaSearch']>>;
+
+// Single-slot handoff cache. Lets ONLY the cmd+K popup → full-screen results navigation (and
+// the full-screen → back → popup return) reuse the popup's last search instead of re-hitting
+// Vespa. Opt-in only (the `cache` option), so other vespaSearch callers stay always-fresh.
+// A fresh cmd+K open invalidates it (see clearVespaSearchCache), so re-opening the palette
+// always fetches fresh — only the in-flight handoff survives. Module state is also wiped on
+// the hard reload a workspace switch triggers, so there is no cross-workspace leak.
+let cachedVespaSearch: { key: string; value: VespaSearchResult; expiresAt: number } | null = null;
+
+// Drop the handoff entry so the next search fetches fresh. Called when the cmd+K palette is
+// opened anew (not on the back-navigation restore), so a reopened palette never serves a
+// result cached by an earlier session.
+export function clearVespaSearchCache(): void {
+  cachedVespaSearch = null;
 }
 
 // Export singleton instance

--- a/apps/dashboard/src/services/vespaSearchCacheKey.ts
+++ b/apps/dashboard/src/services/vespaSearchCacheKey.ts
@@ -28,6 +28,10 @@ export const ORDER_INSENSITIVE_LIST_PARAMS = [
 export function buildVespaSearchCacheKey(params: Record<string, string>): string {
   const keyParams: Record<string, string> = { ...params, groupBy: params['groupBy'] ?? 'docType' };
   delete keyParams['searchId'];
+  // Highlight-only + derived from the mention ids already in the key; its array order differs
+  // between the popup (click order) and the results screen (URL parse order), so keeping it
+  // would break order-insensitivity and make mention searches always miss the handoff cache.
+  delete keyParams['mentionHighlights'];
   for (const listParam of ORDER_INSENSITIVE_LIST_PARAMS) {
     const value = keyParams[listParam];
     if (value) {

--- a/apps/dashboard/src/services/vespaSearchCacheKey.ts
+++ b/apps/dashboard/src/services/vespaSearchCacheKey.ts
@@ -1,0 +1,42 @@
+// Pure cache-key logic for the vespaSearch handoff cache (see searchService.ts). Kept in its
+// own side-effect-free module so it can be unit-tested without importing the axios/logger/config
+// chain that searchService pulls in. Runnable directly by `node --test`.
+
+// Comma-joined params whose items form an order-insensitive set (OR filters). Sorting their
+// items in the key means from=a,b and from=b,a hit the same entry without changing the request.
+export const ORDER_INSENSITIVE_LIST_PARAMS = [
+  'apps',
+  'from',
+  'fromEmail',
+  'toEmail',
+  'in',
+  'mentions',
+  'channelMentions',
+  'assignee',
+  'tags',
+  'dynamicFieldValues',
+];
+
+/**
+ * Build a stable cache key from a vespaSearch request's wire params.
+ *
+ * The key is order-independent — both the param keys and the items of set-like list params are
+ * sorted — and it ignores `searchId` (changes per palette session). Absent `groupBy` is
+ * normalized to the backend default `docType`, so the popup (which omits it) and the full-screen
+ * page (which sends `docType`) collide; an explicit `groupBy: ''` (flat load-more) stays distinct.
+ */
+export function buildVespaSearchCacheKey(params: Record<string, string>): string {
+  const keyParams: Record<string, string> = { ...params, groupBy: params['groupBy'] ?? 'docType' };
+  delete keyParams['searchId'];
+  for (const listParam of ORDER_INSENSITIVE_LIST_PARAMS) {
+    const value = keyParams[listParam];
+    if (value) {
+      keyParams[listParam] = value.split(',').sort().join(',');
+    }
+  }
+  return JSON.stringify(
+    Object.keys(keyParams)
+      .sort()
+      .map(key => [key, keyParams[key]]),
+  );
+}


### PR DESCRIPTION
  ## Type of Change

  - [x] Bugfix
  - [ ] New feature
  - [ ] Enhancement
  - [ ] Refactoring
  - [ ] Dependency updates
  - [ ] Documentation
  - [ ] CI/CD

  ## Description
  
  **XYNE-56627.** Adds a client-side cache for the cmd+K `vespaSearch` call, and fixes
  the "No results" loader flash that surfaced once results could resolve instantly.

  **1. Cache the vespaSearch call (single-slot handoff cache).**
  `vespaSearch` gains an opt-in `cache` option, backed by a single module-level slot
  (`cachedVespaSearch`) that holds the most recent result under an order-insensitive key,
  with a **30s TTL**.
  - **Order-insensitive key** (`vespaSearchCacheKey`, new module): sorts set-like list
    params (`apps`, `from`, `in`, `tags`, …) and the param keys, drops the per-session
    `searchId`, and normalizes an absent `groupBy` to the backend default — so the popup
    and the results screen (and reordered OR-filters) collide on one entry instead of
    fragmenting the cache and missing the reuse.
  - **Lifecycle:**
    - **Popup search** → the initial cmd+K search stores its result in the slot.
    - **→ Search screen** → navigating via the top "Show detailed results for:" entry
      reissues the identical query; it's served from the slot instead of re-hitting Vespa.
    - **← Back to popup** → returning from the results screen restores the palette and
      reuses the same cached result (the entry deliberately survives back-navigation),
      so back is instant.
    - **New cmd+K open** → opening the palette anew **resets** the cache
      (`clearVespaSearchCache`), so a fresh session always fetches fresh — only the
      in-flight popup ↔ results handoff survives.
    - **Expiry** → entries expire after **30s**, and the slot is wiped on the
      workspace-switch hard reload (no cross-workspace leak).
  - **First page only (by design):** only the initial search is cached — `loadMoreResults`
    isn't. The handoff enters at the top "Show detailed results for:" entry, which lands on
    page 1, so deeper pages are never part of it. Extendable later (the key already carries
    `offset`) by swapping the single slot for a bounded LRU, deferred until deeper reuse is
    actually needed.

https://github.com/user-attachments/assets/3d5cb86c-70f0-45ea-829b-6c25627e758f


  - [ ] `apps/backend` (API / worker)
  - [x] `apps/dashboard`
  - [ ] `apps/electron`
  - [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
  - [ ] `packages/shared` or another shared package
  - [ ] Infra (docker, scripts, nix, CI)
---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [x] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [x] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [x] Web browser
- [x] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
