### PR TITLE
feat: XYNE-60772 improve webhook payload guidance and draft deletion

### DIFF
--- a/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/AutomationBuilder.tsx
@@ -13,6 +13,7 @@ import {
   Power,
   Save as SaveIcon,
   Send,
+  Trash2,
   Undo2,
   X,
 } from 'lucide-react';
@@ -192,6 +193,7 @@ export function AutomationBuilder({
   const [editMode, setEditMode] = useState<boolean>(!automation);
   const [editConfirmOpen, setEditConfirmOpen] = useState(false);
   const [proposeChangeConfirmOpen, setProposeChangeConfirmOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   useEffect(() => {
     if (automation?.id) setSavedId(automation.id);
@@ -423,6 +425,22 @@ export function AutomationBuilder({
         message: String('[automations] save failed'),
         error: err,
       });
+      toast.error(message);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string): Promise<void> => {
+      zero.mutate(mutators.automations.delete({ id }));
+      return Promise.resolve();
+    },
+    onSuccess: () => {
+      toast.success('Automation deleted');
+      onBack();
+    },
+    onError: err => {
+      const message = err instanceof Error ? err.message : 'Delete failed';
+      setErrorMessage(message);
       toast.error(message);
     },
   });
@@ -850,6 +868,27 @@ export function AutomationBuilder({
               </button>
             </Tooltip>
           )}
+          {!editMode &&
+          !readOnlyPreview &&
+          savedId &&
+          savedStatus === AutomationStatusValues.DRAFT ? (
+            <Tooltip content='Delete draft' side='bottom'>
+              <button
+                type='button'
+                onClick={() => setDeleteDialogOpen(true)}
+                aria-label={`Delete draft automation ${name || 'Untitled automation'}`}
+                data-track-category='automation-builder'
+                data-track-name='header-delete-draft'
+                className={cn(
+                  'flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground',
+                  'hover:bg-red-500/10 hover:text-red-600',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/40',
+                )}
+              >
+                <Trash2 className='size-4' aria-hidden='true' />
+              </button>
+            </Tooltip>
+          ) : null}
 
           {readOnlyPreview ? null : editMode ? (
             <>
@@ -1279,6 +1318,45 @@ export function AutomationBuilder({
           errorMessage={errorMessage}
         />
       </div>
+
+      <Dialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        title='Delete draft automation?'
+        className='sm:max-w-md'
+      >
+        <div className='flex flex-col gap-4 px-5 py-4 text-sm text-foreground'>
+          <p>
+            Delete <strong>{name || 'this draft automation'}</strong>? This can&apos;t be undone.
+          </p>
+          <div className='flex justify-end gap-2 pt-2'>
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => setDeleteDialogOpen(false)}
+              data-track-category='automation-builder'
+              data-track-name='delete-draft-cancel'
+            >
+              Cancel
+            </Button>
+            <Button
+              variant='destructive'
+              size='sm'
+              disabled={deleteMutation.isPending}
+              loading={deleteMutation.isPending}
+              onClick={() => {
+                if (!savedId) return;
+                deleteMutation.mutate(savedId);
+                setDeleteDialogOpen(false);
+              }}
+              data-track-category='automation-builder'
+              data-track-name='delete-draft-confirm'
+            >
+              Delete draft
+            </Button>
+          </div>
+        </div>
+      </Dialog>
 
       <Dialog
         open={editConfirmOpen}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/TriggerCard/WebhookTriggerForm.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/TriggerCard/WebhookTriggerForm.tsx
@@ -43,14 +43,15 @@ export function WebhookTriggerForm({
   return (
     <div className='flex flex-col gap-5'>
       <Field
-        label='Request body'
-        description='JSON shape callers must POST. Declared keys are required on every call (extras allowed); a 400 is returned on mismatch. Downstream steps read these as {{trigger.body.*}}.'
+        label='Example payload'
+        description='Describe the JSON payload this webhook will receive. Use a field name and its type, for example { "ticketId": "string" }. Every field you add is required; requests that do not match return 400.'
         error={issuesAt.get('bodySchema')}
       >
         <SchemaJsonEditor
           value={bodySchema}
           onChange={next => setField('bodySchema', next)}
-          emptyHint='No body fields required — any JSON body is accepted.'
+          example={{ ticketId: 'string', event: 'string' }}
+          emptyHint='Add the fields your webhook expects, or leave this empty to accept any JSON payload.'
         />
       </Field>
 


### PR DESCRIPTION
Ticket: XYNE-60772

1. Problem Description:
The external webhook trigger form does not clearly tell administrators that they must provide a representative JSON payload/schema. Draft deletion is also only available from the automation list overflow menu, not from the main editor.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Identified from administrator feedback while configuring an external webhook automation.

3. Explain the solution implemented in the PR:
- Rename the webhook body field to "Example payload" and add clearer schema guidance.
- Add an "Insert example" action with a representative JSON payload.
- Add a trash icon to the main automation editor for saved DRAFT automations only.
- Require confirmation before deletion and retain the existing list overflow delete action.
- Preserve existing backend draft-only deletion and ACL enforcement.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Prettier passed.
- Focused ESLint passed with no errors (four pre-existing warnings remain in AutomationBuilder.tsx).
- Dashboard TypeScript typecheck passed.
- `git diff --check` passed.
- Manual browser POT verified Example payload guidance, saving a draft, the draft-only trash action, and the confirmation dialog. The POT video is attached in the originating Xyne Spaces thread.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A