### PR TITLE
feat: show last updated date for skills

### DIFF
--- a/apps/dashboard/src/routes/AIScreen/library/skills/detail/ClawSkillDetailV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/skills/detail/ClawSkillDetailV2.tsx
@@ -13,11 +13,25 @@ import { resolveSkillTab, SKILL_DETAIL_TABS, type SkillDetailTabId } from './ski
 import { useSkillDetailActions } from './useSkillDetailActions';
 
 const DATE = new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+const DATE_TIME = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
 
 function formatCreated(value: string | undefined): string | null {
   if (!value) return null;
   const parsed = new Date(value);
   return Number.isNaN(parsed.getTime()) ? null : DATE.format(parsed);
+}
+
+function formatUpdated(value: string | undefined): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : DATE_TIME.format(parsed);
 }
 
 const ClawSkillDetailV2 = (): ReactElement => {
@@ -38,6 +52,7 @@ const ClawSkillDetailV2 = (): ReactElement => {
   };
 
   const created = formatCreated(skill?.createdAt);
+  const updated = formatUpdated(skill?.updatedAt);
   const author = skill?.owner?.name ?? skill?.owner?.email ?? null;
 
   return (
@@ -148,6 +163,12 @@ const ClawSkillDetailV2 = (): ReactElement => {
                     <>
                       <span aria-hidden>·</span>
                       <span>Created on {created}</span>
+                    </>
+                  )}
+                  {updated && (
+                    <>
+                      <span aria-hidden>·</span>
+                      <span>Last updated on: {updated}</span>
                     </>
                   )}
                 </div>

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawSkillDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawSkillDetailScreen.tsx
@@ -42,6 +42,19 @@ const formatDate = (iso: string): string => {
   return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
 };
 
+const formatDateTime = (iso: string): string => {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+};
+
 const formatNumber = (n: number): string => n.toLocaleString('en-US');
 
 const formatFileSize = (bytes: number): string => {
@@ -669,6 +682,7 @@ const ClawSkillDetailScreen = (): ReactElement => {
                         </DetailRow>
                       )}
                       <DetailRow label='Created'>{formatDate(skill.createdAt)}</DetailRow>
+                      <DetailRow label='Last updated'>{formatDateTime(skill.updatedAt)}</DetailRow>
                       <DetailRow label='Size'>
                         {formatNumber(contentValue.length)} characters
                       </DetailRow>


### PR DESCRIPTION
1. Problem Description:
The Xyne Claw skill detail view shows when a skill was created but not when it was last updated.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in the Xyne Spaces thread for the Claw Skills experience.

3. Explain the solution implemented in the PR:
Render the existing `updatedAt` value as a date and time in both the current AI Library skill detail view and the legacy Claw skill detail view. No API or schema change is required because the skill contract already includes `updatedAt`.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Focused ESLint passed for both changed files on the main-based branch.
- `git diff --check` passed.
- Browser POT verified the skill detail renders `Last updated on` with date and time using a mocked local skill API fixture; video and screenshot are attached in the originating Spaces thread.
- Full dashboard typecheck was attempted on the original branch and remains blocked by 14 unrelated pre-existing errors; neither changed file produced an error.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
This is the main PR. Companion Claw deployment-line PR: https://github.com/juspay/xyne-spaces/pull/1197