### PR TITLE
feat: show last updated date in Claw v3 skills

### DIFF
--- a/apps/xyne-claw-auth/frontend/src/v3/components/skills/SkillSlideOver.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/skills/SkillSlideOver.tsx
@@ -407,6 +407,10 @@ export function SkillSlideOver({
               <span className="text-xyne-fg-primary">{formatDate(skill.createdAt)}</span>
             </div>
             <div className="flex items-center justify-between py-[8px]">
+              <span className="text-xyne-fg-tertiary">Last updated</span>
+              <span className="text-xyne-fg-primary">{formatDate(skill.updatedAt)}</span>
+            </div>
+            <div className="flex items-center justify-between py-[8px]">
               <span className="text-xyne-fg-tertiary">Size</span>
               <span className="text-xyne-fg-primary">{formatNumber(skill.content?.length ?? 0)} characters</span>
             </div>


### PR DESCRIPTION
1. Problem Description:
The Xyne Claw Auth v3 skill details panel shows when a skill was created but not when it was last updated.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in the Xyne Spaces thread while reviewing the Claw Skills experience.

3. Explain the solution implemented in the PR:
Add a `Last updated` row directly below `Created` in the v3 skill Details panel. It formats the existing `skill.updatedAt` value using the screen's current date formatter. No backend or schema change is required because the API contract already provides `updatedAt`.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `pnpm --dir apps/xyne-claw-auth/frontend typecheck` passed.
- `git diff --check` passed.

9. Services to which this change is to be deployed:
Claw Auth frontend

10. Main PR link (if this PR is raised against a release branch):
To be raised separately if required.