### PR TITLE
feat: XYNE-60774 add humanized cron schedule display in v3

### DIFF
--- a/apps/xyne-claw-auth/frontend/package-lock.json
+++ b/apps/xyne-claw-auth/frontend/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "xyne-claw-auth-ui",
-  "license": "Apache-2.0",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
+  "license": "Apache-2.0",
   "packages": {
     "": {
       "name": "xyne-claw-auth-ui",
-  "license": "Apache-2.0",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@base-ui-components/react": "^1.0.0-rc.0",
         "@dagrejs/dagre": "^3.0.0",
@@ -23,6 +23,7 @@
         "@xyflow/react": "^12.10.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "cronstrue": "^3.24.0",
         "diff": "^7.0.0",
         "jszip": "^3.10.1",
         "lucide-react": "^0.460.0",
@@ -2784,6 +2785,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cronstrue": {
+      "version": "3.24.0",
+      "resolved": "http://verdaccio.xyne-apps.svc.cluster.local:4873/cronstrue/-/cronstrue-3.24.0.tgz",
+      "integrity": "sha512-t/Ji3Ur2c/pzhIAWNwC0ftl3JAE4dLfCjAdZoTZXmPDZwcispnS1PaMcMS4OmIIXyIVouAz+yw+mfQiE3hz5OQ==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
+      }
     },
     "node_modules/cssesc": {
       "version": "3.0.0",

--- a/apps/xyne-claw-auth/frontend/package.json
+++ b/apps/xyne-claw-auth/frontend/package.json
@@ -24,6 +24,7 @@
     "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "cronstrue": "^3.24.0",
     "diff": "^7.0.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.460.0",

--- a/apps/xyne-claw-auth/frontend/src/lib/humanizeCron.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/humanizeCron.ts
@@ -1,0 +1,21 @@
+import cronstrue from "cronstrue";
+
+/**
+ * Convert a 5-field cron expression into a plain-English sentence.
+ *
+ * Returns null for empty / invalid input so callers can fall back to the
+ * raw expression without showing an error to the user.
+ */
+export function humanizeCron(expr: string | null | undefined): string | null {
+  if (!expr || !expr.trim()) return null;
+
+  try {
+    const desc = cronstrue.toString(expr.trim(), {
+      throwExceptionOnParseError: true,
+      use24HourTimeFormat: false,
+    });
+    return desc || null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ScheduledJobsTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ScheduledJobsTab.tsx
@@ -22,6 +22,7 @@ import {
   listSpacesChannels,
 } from "../../../../lib/api";
 import { useSnackbar } from "../../ui/Snackbar";
+import { humanizeCron } from "../../../../lib/humanizeCron";
 
 interface Props {
   jobs: ScheduledJob[];
@@ -347,7 +348,9 @@ function JobCard({
   };
 
   const runMeta = [
-    job.type === "cron" && job.cronExpression ? job.cronExpression : null,
+    job.type === "cron" && job.cronExpression
+      ? humanizeCron(job.cronExpression) ?? job.cronExpression
+      : null,
     job.type === "once" && job.nextRunAt ? new Date(job.nextRunAt).toLocaleString() : null,
     job.maxRuns != null
       ? `runs: ${job.runCount}/${job.maxRuns}`
@@ -536,42 +539,52 @@ function JobCard({
         <div className="flex flex-wrap items-center gap-2 pl-11">
           <span className="text-[12px] text-xyne-fg-tertiary">schedule:</span>
           {editingCron ? (
-            <div className="flex items-center gap-1.5">
-              <input
-                autoFocus
-                type="text"
-                value={cronDraft}
-                onChange={(e) => setCronDraft(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") void handleSaveCron();
-                  if (e.key === "Escape") setEditingCron(false);
-                }}
-                placeholder="* * * * *"
-                className="w-36 rounded-lg border border-xyne-border-focus bg-xyne-surface px-2 py-1 font-mono text-[12px] text-xyne-fg-primary outline-none"
-              />
-              <button
-                type="button"
-                onClick={() => void handleSaveCron()}
-                disabled={savingCron}
-                title="Save schedule"
-                className="rounded-md p-1 text-xyne-success-fg hover:bg-xyne-success-bg disabled:opacity-40"
-              >
-                <CheckIcon size={14} />
-              </button>
-              <button
-                type="button"
-                onClick={() => setEditingCron(false)}
-                disabled={savingCron}
-                title="Cancel"
-                className="rounded-md p-1 text-xyne-fg-muted hover:bg-xyne-surface-subtle disabled:opacity-40"
-              >
-                <XIcon size={14} />
-              </button>
-            </div>
+            <>
+              <div className="flex items-center gap-1.5">
+                <input
+                  autoFocus
+                  type="text"
+                  value={cronDraft}
+                  onChange={(e) => setCronDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") void handleSaveCron();
+                    if (e.key === "Escape") setEditingCron(false);
+                  }}
+                  placeholder="* * * * *"
+                  className="w-36 rounded-lg border border-xyne-border-focus bg-xyne-surface px-2 py-1 font-mono text-[12px] text-xyne-fg-primary outline-none"
+                />
+                <button
+                  type="button"
+                  onClick={() => void handleSaveCron()}
+                  disabled={savingCron}
+                  title="Save schedule"
+                  className="rounded-md p-1 text-xyne-success-fg hover:bg-xyne-success-bg disabled:opacity-40"
+                >
+                  <CheckIcon size={14} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setEditingCron(false)}
+                  disabled={savingCron}
+                  title="Cancel"
+                  className="rounded-md p-1 text-xyne-fg-muted hover:bg-xyne-surface-subtle disabled:opacity-40"
+                >
+                  <XIcon size={14} />
+                </button>
+              </div>
+              {humanizeCron(cronDraft) && (
+                <span className="text-[11px] text-xyne-fg-tertiary">
+                  {humanizeCron(cronDraft)}
+                </span>
+              )}
+            </>
           ) : (
             <div className="flex items-center gap-1.5">
-              <span className="font-mono text-[12px] text-xyne-fg-secondary">
-                {job.cronExpression || "—"}
+              <span
+                className="text-[12px] text-xyne-fg-secondary"
+                title={job.cronExpression || undefined}
+              >
+                {humanizeCron(job.cronExpression) ?? job.cronExpression ?? "—"}
               </span>
               {isActive && (
                 <button


### PR DESCRIPTION
## What
Show plain-English schedule descriptions (e.g. \"At 01:00 AM, every 7 days in a month\") instead of raw cron expressions in the v3 agent detail page's scheduled-jobs tab.

## Why
Users shouldn't need to decode cron syntax to understand when an agent is scheduled to run.

## How
- **New utility** `apps/xyne-claw-auth/frontend/src/lib/humanizeCron.ts`: wraps `cronstrue.toString()` with `throwExceptionOnParseError: true` and `use24HourTimeFormat: false`. Returns `null` for empty/invalid input so callers gracefully fall back to the raw expression.
- **Integration** in `ScheduledJobsTab.tsx`:
  - runMeta badge shows humanized text (falls back to raw cron if unparseable)
  - Schedule display row uses plain text with `title` tooltip showing raw cron
  - Live preview while editing cron expression
- **Dependency**: `cronstrue@^3.24.0` added to frontend package.json

## Testing
- `tsc --noEmit` passes cleanly
- `humanizeCron` unit-verified against a battery of cron expressions:
  - `0 1 */7 * *` → \"At 01:00 AM, every 7 days in a month\"
  - `0 9 * * 1-5` → \"At 09:00 AM, Monday through Friday\"
  - `0 0 1 * *` → \"At 12:00 AM, on day 1 of the month\"
  - `*/5 * * * *` → \"Every 5 minutes\"
  - Empty/null/invalid → `null` (falls back to raw)

## Files changed
- `apps/xyne-claw-auth/frontend/package.json` (+cronstrue)
- `apps/xyne-claw-auth/frontend/src/lib/humanizeCron.ts` (new utility)
- `apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/ScheduledJobsTab.tsx` (3 integration points)