### PR TITLE
feat: support thread replies in message automations

### DIFF
--- a/apps/backend/src/automations/engine/event-router.ts
+++ b/apps/backend/src/automations/engine/event-router.ts
@@ -6,6 +6,7 @@ import { currentUpstreamChain } from './automation-context-storage';
 import {
   AUTOMATION_WORKFLOW_TYPE,
   DESK_AUTOMATION_WORKFLOW_TYPE,
+  parseAutomationConfig,
   parseAutomationMetadata,
   triggerTypeToEventType,
 } from '../types/workflow-adapter';
@@ -13,6 +14,11 @@ import { AutomationStatus, AutomationRunStatus } from '../types/status';
 import { automationQueue } from '../queue/automation.queue';
 import type { AutomationEvent } from '../types/automation-events';
 import { EMAIL_RECEIVED_EVENT } from '../triggers/email-received.trigger';
+import {
+  MESSAGE_RECEIVED_EVENT,
+  MessageLocation,
+  messageLocationMatches,
+} from '../types/message-received-event';
 
 class EventRouter {
   async emit(event: AutomationEvent, workspaceId: string): Promise<void> {
@@ -94,12 +100,30 @@ class EventRouter {
     };
 
     if (event.type !== EMAIL_RECEIVED_EVENT || typeof event.payload.channelId !== 'string') {
-      return db.workflow.findMany({
+      const workflows = await db.workflow.findMany({
         where: {
           workflowType: AUTOMATION_WORKFLOW_TYPE,
           ...baseWhere,
         },
       });
+
+      // Thread replies are much more frequent than new channel conversations.
+      // Drop automations that cannot match before creating execution rows and
+      // queue jobs; legacy configurations remain new-conversation-only.
+      if (
+        event.type === MESSAGE_RECEIVED_EVENT &&
+        event.payload.messageLocation === MessageLocation.THREAD_REPLY
+      ) {
+        return workflows.filter(workflow => {
+          const config = parseAutomationConfig(workflow.context);
+          return messageLocationMatches(
+            config.trigger.config.messageLocation,
+            event.payload.messageLocation,
+          );
+        });
+      }
+
+      return workflows;
     }
 
     const [generalAutomations, deskRules] = await Promise.all([

--- a/apps/backend/src/automations/triggers/message-received.trigger.test.ts
+++ b/apps/backend/src/automations/triggers/message-received.trigger.test.ts
@@ -1,0 +1,141 @@
+jest.mock('@/database/repositories', () => ({ repositories: {} }));
+jest.mock('@/database/client', () => ({ db: {} }));
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), debug: jest.fn(), warn: jest.fn() },
+}));
+jest.mock('@/utils/mentionParser', () => ({
+  extractUserMentions: jest.fn(() => []),
+  extractGroupMentions: jest.fn(() => []),
+}));
+jest.mock('../engine/event-router', () => ({
+  eventRouter: { emit: jest.fn() },
+}));
+jest.mock('@xyne/shared', () => ({
+  MessageType: {
+    USER: 'USER',
+    BOT: 'BOT',
+    SYSTEM: 'SYSTEM',
+    FORWARDED: 'FORWARDED',
+  },
+}));
+
+import { MessageType } from '@xyne/shared';
+import {
+  MessageLocation,
+  messageReceivedTrigger,
+} from './message-received.trigger';
+
+function payload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    message: {
+      id: 'message-1',
+      content: 'Please start the incident call',
+      conversationId: 'conversation-1',
+      channelId: 'channel-1',
+      createdAt: new Date('2026-08-29T00:00:00.000Z'),
+    },
+    author: null,
+    authorId: 'user-1',
+    channelId: 'channel-1',
+    conversationId: 'conversation-1',
+    messageLocation: MessageLocation.NEW_CONVERSATION,
+    msgType: MessageType.USER,
+    deleted: false,
+    ...overrides,
+  };
+}
+
+describe('MessageReceivedTrigger thread reply filters', () => {
+  it('keeps legacy configurations limited to new conversations', () => {
+    expect(messageReceivedTrigger.matchFilters({}, payload())).toBe(true);
+    expect(
+      messageReceivedTrigger.matchFilters(
+        {},
+        payload({ messageLocation: MessageLocation.THREAD_REPLY }),
+      ),
+    ).toBe(false);
+  });
+
+  it('matches thread replies when explicitly configured', () => {
+    const config = { messageLocation: MessageLocation.THREAD_REPLY };
+
+    expect(
+      messageReceivedTrigger.matchFilters(
+        config,
+        payload({ messageLocation: MessageLocation.THREAD_REPLY }),
+      ),
+    ).toBe(true);
+    expect(messageReceivedTrigger.matchFilters(config, payload())).toBe(false);
+  });
+
+  it('matches both locations when configured for any message', () => {
+    const config = { messageLocation: MessageLocation.ANY };
+
+    expect(messageReceivedTrigger.matchFilters(config, payload())).toBe(true);
+    expect(
+      messageReceivedTrigger.matchFilters(
+        config,
+        payload({ messageLocation: MessageLocation.THREAD_REPLY }),
+      ),
+    ).toBe(true);
+  });
+
+  it('limits thread replies to configured conversations', () => {
+    const config = {
+      messageLocation: MessageLocation.THREAD_REPLY,
+      conversationIds: ['conversation-1'],
+    };
+
+    expect(
+      messageReceivedTrigger.matchFilters(
+        config,
+        payload({ messageLocation: MessageLocation.THREAD_REPLY }),
+      ),
+    ).toBe(true);
+    expect(
+      messageReceivedTrigger.matchFilters(
+        config,
+        payload({
+          conversationId: 'conversation-2',
+          messageLocation: MessageLocation.THREAD_REPLY,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('applies existing text matching to thread replies', () => {
+    const config = {
+      messageLocation: MessageLocation.THREAD_REPLY,
+      contentContains: 'INCIDENT CALL',
+    };
+
+    expect(
+      messageReceivedTrigger.matchFilters(
+        config,
+        payload({ messageLocation: MessageLocation.THREAD_REPLY }),
+      ),
+    ).toBe(true);
+    expect(
+      messageReceivedTrigger.matchFilters(
+        config,
+        payload({
+          messageLocation: MessageLocation.THREAD_REPLY,
+          message: {
+            id: 'message-2',
+            content: 'No alert required',
+            conversationId: 'conversation-1',
+            channelId: 'channel-1',
+            createdAt: new Date('2026-08-29T00:01:00.000Z'),
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('defaults new trigger configurations to new conversations', () => {
+    const parsed = messageReceivedTrigger.validate({});
+
+    expect(parsed.messageLocation).toBe(MessageLocation.NEW_CONVERSATION);
+    expect(parsed.messageTypes).toEqual([MessageType.USER]);
+  });
+});

--- a/apps/backend/src/automations/triggers/message-received.trigger.ts
+++ b/apps/backend/src/automations/triggers/message-received.trigger.ts
@@ -9,7 +9,23 @@ import { db } from '@/database/client';
 import { extractGroupMentions, extractUserMentions } from '@/utils/mentionParser';
 import type { MessageReceivedEventPayload } from '../types/automation-events';
 
-export const MESSAGE_RECEIVED_EVENT = 'MESSAGE_RECEIVED';
+import {
+  MESSAGE_RECEIVED_EVENT,
+  MessageLocation,
+  messageLocationMatches,
+  type MessageEventLocation,
+} from '../types/message-received-event';
+
+export {
+  MESSAGE_RECEIVED_EVENT,
+  MessageLocation,
+  type MessageEventLocation,
+} from '../types/message-received-event';
+
+const MessageEventLocationSchema = z.enum([
+  MessageLocation.NEW_CONVERSATION,
+  MessageLocation.THREAD_REPLY,
+]);
 
 const MessageReceivedConfigSchema = z.object({
   channelIds: z
@@ -20,6 +36,14 @@ const MessageReceivedConfigSchema = z.object({
     .array(z.string())
     .optional()
     .describe('Only fire when the sender is one of these users. Empty matches anyone.'),
+  conversationIds: z
+    .array(z.string())
+    .optional()
+    .describe('Limit to messages in these conversations. Empty matches every conversation.'),
+  messageLocation: z
+    .nativeEnum(MessageLocation)
+    .default(MessageLocation.NEW_CONVERSATION)
+    .describe('Choose whether to fire for new channel conversations, replies inside threads, or both.'),
   contentContains: z
     .string()
     .optional()
@@ -58,6 +82,7 @@ export const MessageReceivedOutputSchema = z.object({
   authorId: z.string(),
   channelId: z.string(),
   conversationId: z.string(),
+  messageLocation: MessageEventLocationSchema,
   msgType: z.nativeEnum(MessageType),
   deleted: z.boolean(),
   mentionedUsers: z
@@ -95,10 +120,10 @@ export class MessageReceivedTrigger extends BaseTrigger<typeof MessageReceivedCo
   readonly outputSchema = MessageReceivedOutputSchema;
   readonly name = 'When a message is received in a channel';
   readonly description =
-    'Fires when a person starts a new message in a channel (not replies within an existing conversation). Scope by channel or sender; optionally refine by message kind or text.';
+    'Fires when a message starts a channel conversation or is added as a thread reply. Scope by location, channel, conversation, or sender; optionally refine by message kind or text.';
   readonly category = TriggerCategory.EVENT;
   readonly icon = 'MessageSquare';
-  readonly scopeFilterFields = ['channelIds', 'fromUserIds'] as const;
+  readonly scopeFilterFields = ['channelIds', 'conversationIds', 'fromUserIds'] as const;
 
   async hydratePayload(payload: Record<string, unknown>): Promise<Record<string, unknown>> {
     return hydrateMessageReceivedPayload(payload as unknown as MessageReceivedEventPayload);
@@ -113,17 +138,27 @@ export class MessageReceivedTrigger extends BaseTrigger<typeof MessageReceivedCo
 
     // The message was deleted before we got to run — nothing to act on.
     if (p.deleted) return false;
+
+    // Configurations saved before thread replies were supported retain the old
+    // top-level-only behaviour. The same fallback handles executions queued
+    // before the event payload gained messageLocation during a rolling deploy.
+    if (!messageLocationMatches(cfg.messageLocation, p.messageLocation)) return false;
+
     if (cfg.messageTypes && cfg.messageTypes.length > 0) {
       if (!cfg.messageTypes.includes(p.msgType)) return false;
     }
 
     const channelIds = (cfg.channelIds ?? []).map(id => id?.trim()).filter((id): id is string => !!id);
     const fromUserIds = (cfg.fromUserIds ?? []).map(id => id?.trim()).filter((id): id is string => !!id);
+    const conversationIds = (cfg.conversationIds ?? []).map(id => id?.trim()).filter((id): id is string => !!id);
     if (channelIds.length > 0) {
       if (!channelIds.includes(p.channelId)) return false;
     }
     if (fromUserIds.length > 0) {
       if (!fromUserIds.includes(p.authorId)) return false;
+    }
+    if (conversationIds.length > 0) {
+      if (!conversationIds.includes(p.conversationId)) return false;
     }
     // Match filters: contentContains, user mentions, group mentions.
     // These combine with OR logic when multiple are configured:
@@ -193,6 +228,7 @@ interface ReceivedMessage {
   channelId: string;
   msgType?: MessageType | undefined;
   userId: string;
+  messageLocation: MessageEventLocation;
 }
 
 /**
@@ -217,6 +253,7 @@ export async function emitMessageReceived(message: ReceivedMessage): Promise<voi
           conversationId: message.conversationId,
           channelId: message.channelId,
           authorId: message.userId,
+          messageLocation: message.messageLocation,
           msgType: message.msgType ?? MessageType.USER,
         },
       },
@@ -309,6 +346,7 @@ async function hydrateMessageReceivedPayload(
     authorId,
     channelId,
     conversationId,
+    messageLocation: payload.messageLocation ?? MessageLocation.NEW_CONVERSATION,
     msgType: payload.msgType,
     deleted: !messageRow,
     mentionedUsers: mentionedUsers.length > 0 ? mentionedUsers : undefined,

--- a/apps/backend/src/automations/types/automation-events.ts
+++ b/apps/backend/src/automations/types/automation-events.ts
@@ -8,7 +8,10 @@ import {
   type TicketChanges,
   type FormFieldChanges,
 } from '../triggers/ticket-updated.trigger';
-import { MESSAGE_RECEIVED_EVENT } from '../triggers/message-received.trigger';
+import {
+  MESSAGE_RECEIVED_EVENT,
+  type MessageEventLocation,
+} from './message-received-event';
 import { CALL_EVENT, CALL_STARTED, CALL_ENDED } from '../triggers/call.trigger';
 import { TAG_GENERATED_EVENT } from '../triggers/tag-generated.trigger';
 
@@ -44,6 +47,8 @@ export interface MessageReceivedEventPayload {
   channelId: string;
   authorId: string;
   msgType: MessageType;
+  /** Optional only for executions queued before thread-reply support was deployed. */
+  messageLocation?: MessageEventLocation;
 }
 
 export interface CallEventPayload {

--- a/apps/backend/src/automations/types/message-received-event.ts
+++ b/apps/backend/src/automations/types/message-received-event.ts
@@ -1,0 +1,21 @@
+export const MESSAGE_RECEIVED_EVENT = 'MESSAGE_RECEIVED';
+
+export const MessageLocation = {
+  NEW_CONVERSATION: 'New conversation',
+  THREAD_REPLY: 'Thread reply',
+  ANY: 'Any message',
+} as const;
+
+export type MessageLocation = (typeof MessageLocation)[keyof typeof MessageLocation];
+export type MessageEventLocation = Exclude<MessageLocation, typeof MessageLocation.ANY>;
+
+export function messageLocationMatches(
+  configuredLocation: unknown,
+  eventLocation: MessageEventLocation | undefined,
+): boolean {
+  const configured = Object.values(MessageLocation).includes(configuredLocation as MessageLocation)
+    ? (configuredLocation as MessageLocation)
+    : MessageLocation.NEW_CONVERSATION;
+  const event = eventLocation ?? MessageLocation.NEW_CONVERSATION;
+  return configured === MessageLocation.ANY || configured === event;
+}

--- a/apps/backend/src/services/conversationService.ts
+++ b/apps/backend/src/services/conversationService.ts
@@ -34,7 +34,10 @@ import { messageMetadataService } from '@/services/messageMetadataService';
 import { replaceCustomEmojiShortcodesWithImg } from '@/utils/customEmojiUtils';
 import { isSupportedMimeType } from '@/services/fileProcessor';
 import { emitTicketCommented } from '@/automations/triggers/ticket-commented.trigger';
-import { emitMessageReceived } from '@/automations/triggers/message-received.trigger';
+import {
+  emitMessageReceived,
+  MessageLocation,
+} from '@/automations/triggers/message-received.trigger';
 import { processMeetLinksFromChatMessage } from '@/services/meetLinkService';
 
 interface UserInfo {
@@ -540,6 +543,7 @@ export class ConversationService {
       channelId,
       msgType: message.msgType as MessageType,
       userId,
+      messageLocation: MessageLocation.NEW_CONVERSATION,
     });
 
     return {
@@ -800,6 +804,18 @@ export class ConversationService {
 
     // Also broadcast via Redis for horizontal scaling (using session method for now)
     // await redisService.broadcastMessageToSession(conversationId, chatMessage);
+
+    // Fan out the automation `MESSAGE_RECEIVED` event for replies. Matching by
+    // location, conversation, sender, message kind, and text happens in the
+    // automation worker. Failures must not fail the message write.
+    void emitMessageReceived({
+      messageId: message.messageId,
+      conversationId,
+      channelId: conversation.channelId,
+      msgType: message.msgType as MessageType,
+      userId,
+      messageLocation: MessageLocation.THREAD_REPLY,
+    });
 
     // Fan out the automation `TICKET_COMMENTED` event. Fire-and-forget; the
     // helper itself filters out bot/system messages and conversations not

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -19,7 +19,10 @@ import {
 } from '@/utils/mentionUtils';
 import { userActivityTrackingService } from '@/services/userActivityTrackingService';
 import { logger } from '@/utils/logger';
-import { emitMessageReceived } from '@/automations/triggers/message-received.trigger';
+import {
+  emitMessageReceived,
+  MessageLocation,
+} from '@/automations/triggers/message-received.trigger';
 import { activityTrackingService } from '@/services/activityTrackingService';
 import { Platform,
   serializeMessagePreviewMd,
@@ -394,15 +397,17 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
     const { senderId, content, conversationId } = message;
     const { channelId } = conversation;
 
-    if (conversation.initialMessageId === message.messageId) {
-      void emitMessageReceived({
-        messageId: message.messageId,
-        conversationId,
-        channelId,
-        msgType: message.msgType as MessageType,
-        userId: senderId,
-      });
-    }
+    void emitMessageReceived({
+      messageId: message.messageId,
+      conversationId,
+      channelId,
+      msgType: message.msgType as MessageType,
+      userId: senderId,
+      messageLocation:
+        conversation.initialMessageId === message.messageId
+          ? MessageLocation.NEW_CONVERSATION
+          : MessageLocation.THREAD_REPLY,
+    });
 
     const [channel, sender, channelParticipantsRaw, userPreference] = await Promise.all([
       db.channel.findUnique({


### PR DESCRIPTION
1. Problem Description:
The `MESSAGE_RECEIVED` automation trigger only emitted for messages that started a channel conversation, so a matching reply inside an existing thread could not trigger actions such as a call alert. No XYNE ticket key was supplied for this change.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
The backend emitted `MESSAGE_RECEIVED` only when `conversation.initialMessageId === message.messageId`; both the service write path and Zero side-effect path excluded thread replies.

3. Explain the solution implemented in the PR:
- Add `New conversation`, `Thread reply`, and `Any message` location choices to the existing trigger.
- Add optional `conversationIds` filtering for targeting specific threads.
- Emit location-aware events from both ConversationService and Zero message side effects.
- Preserve existing automation behavior by defaulting missing configuration and older queued payloads to `New conversation`.
- Pre-filter thread-reply candidates in the event router so legacy automations do not create skipped execution rows or queue jobs for every reply.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Focused Jest suite: 6 tests passed (`message-received.trigger.test.ts`).
- Backend TypeScript check: `pnpm typecheck` passed.
- `git diff --check` passed.
- Targeted ESLint found only pre-existing errors outside changed lines in `conversationService.ts` and `messages-handler.ts`; the new automation files passed.

9. Services to which this change is to be deployed:
Backend and Zero side-effect worker processes that consume the backend codebase.

10. Main PR link (if this PR is raised against a release branch):
N/A