### PR TITLE
fix: persist ask ai composer drafts

### DIFF
--- a/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
@@ -31,6 +31,7 @@ import remarkBreaks from 'remark-breaks';
 import { Link } from 'react-router-dom';
 import { useXyneAIStream } from '../../hooks/useXyneAIStream';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
+import { useSelf } from '../../hooks/useUsers';
 import { useAskAIVersion } from '../../hooks/useAskAIVersion';
 import type {
   Message,
@@ -43,6 +44,7 @@ import { buildXyneAIStreamThreadId } from '../../utils/xyneAIStreamThreadId';
 import { cn } from '../../utils/classNames';
 import { AskAiRatingButtons } from './AskAiRatingButtons';
 import { AIComposer, type AIComposerAttachment, type AIComposerHandle } from './AIComposer';
+import { buildAskAIComposerDraftKey } from './askAIComposerDraftStorage';
 import { ReadonlyContextPills } from './ReadonlyContextPills';
 import { type ComposerContext, toStreamOverrides } from './composerContext';
 import { fetchV2ConversationMessages } from '../../services/XyneAI/XyneAISessionsV2Service';
@@ -1345,6 +1347,11 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
   ref,
 ): ReactElement {
   const composerRef = useRef<AIComposerHandle | null>(null);
+  const currentUser = useSelf();
+  const { selectedAgentSlug } = useSelectedAgent();
+  const { askAIVersion } = useAskAIVersion();
+  const isV2 = askAIVersion === 'v2';
+  const effectiveAgentSlug = isV2 ? selectedAgentSlug : null;
   const dropZoneRef = useRef<HTMLDivElement | null>(null);
   const dragCounterRef = useRef(0);
   const [isDragging, setIsDragging] = useState(false);
@@ -1428,6 +1435,17 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
   const [streamThreadKey, setStreamThreadKey] = useState<string>(
     () => sessionId ?? newStreamSlotKey(),
   );
+  const draftKey = useMemo(
+    () =>
+      buildAskAIComposerDraftKey({
+        workspaceId: currentUser?.workspaceId,
+        userId: currentUser?.id,
+        surface: 'ai-chat',
+        agentSlug: effectiveAgentSlug,
+        targetKey: conversationId || sessionId ? `session:${conversationId || sessionId}` : 'new',
+      }),
+    [currentUser?.workspaceId, currentUser?.id, effectiveAgentSlug, conversationId, sessionId],
+  );
   // True while this thread is on a draft (client-generated) stream slot — i.e. a
   // brand-new chat that hasn't acquired a server session yet. While draft, a
   // normal submit does NOT chain a parentId, so the first turn isn't linked as a
@@ -1496,11 +1514,6 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
   );
 
   void threadId; // Used by stream manager via useXyneAIStream internally
-
-  const { selectedAgentSlug } = useSelectedAgent();
-  const { askAIVersion } = useAskAIVersion();
-  const isV2 = askAIVersion === 'v2';
-  const effectiveAgentSlug = isV2 ? selectedAgentSlug : null;
 
   const { submitQuery, abortCurrentRequest } = useXyneAIStream({
     channelIds: [],
@@ -2257,6 +2270,7 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
               pending={isAnyMessageStreaming}
               onStop={handleStop}
               placeholder='Write a message...'
+              draftKey={draftKey}
             />
           </div>
         </div>

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -47,6 +47,11 @@ import {
   type AttachedContextItem,
 } from '../Chat/XyneAISidebar/components/ContextPickerPanel';
 import { EMPTY_COMPOSER_CONTEXT, type ComposerContext } from './composerContext';
+import {
+  readAskAIComposerDraft,
+  removeAskAIComposerDraft,
+  writeAskAIComposerDraft,
+} from './askAIComposerDraftStorage';
 import { fetchAccessibleClawAgents } from '../../services/clawAgentListService';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
 
@@ -98,6 +103,8 @@ interface AIComposerProps {
    *  the latest snapshot so selections survive switching to a recent chat,
    *  matching XyneAISidebar (where composer state lives in the parent). */
   onContextChange?: ((context: ComposerContext) => void) | undefined;
+  /** Stable localStorage key for unsent Ask AI text/context drafts. */
+  draftKey?: string | null | undefined;
 }
 
 interface XyneAIConfigResponse {
@@ -221,10 +228,13 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
     showAgentSelector = true,
     initialExtras,
     onContextChange,
+    draftKey,
   },
   ref,
 ): ReactElement {
   const [value, setValue] = useState('');
+  const hydratedDraftKeyRef = useRef<string | null>(null);
+  const skipNextDraftWriteRef = useRef(false);
   const [attachments, setAttachments] = useState<AIComposerAttachment[]>([]);
   const [isVoiceRecording, setIsVoiceRecording] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -302,6 +312,37 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
 
   const modelPinProvider = agentModelsData?.pinProvider ?? 'litellm';
 
+  useEffect((): void => {
+    if (!draftKey) {
+      hydratedDraftKeyRef.current = null;
+      return;
+    }
+
+    hydratedDraftKeyRef.current = draftKey;
+    const draft = readAskAIComposerDraft(draftKey);
+    skipNextDraftWriteRef.current = !!draft?.text;
+    if (draft?.text) {
+      setValue(draft.text);
+    }
+    if (draft?.context) {
+      setSelections({
+        channels: draft.context.channels,
+        tickets: draft.context.tickets,
+        canvases: draft.context.canvases,
+        transcripts: draft.context.transcripts,
+        recordings: draft.context.recordings,
+      });
+      setCollections(draft.context.collections);
+      setFileScopes(draft.context.fileScopes);
+      setFolderScopes(draft.context.folderScopes);
+      setWebSearchEnabled(draft.context.webSearchEnabled);
+      setDeepResearchEnabled(draft.context.deepResearchEnabled);
+      setCreateCanvasEnabled(draft.context.createCanvasEnabled);
+      setSelectedModel(draft.context.model);
+      setThinkingLevel(draft.context.thinkingLevel);
+    }
+  }, [draftKey]);
+
   const buildContext = useCallback(
     (): ComposerContext => ({
       channels: selections.channels,
@@ -337,6 +378,15 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       deepResearchAccessible,
     ],
   );
+
+  useEffect((): void => {
+    if (!draftKey || hydratedDraftKeyRef.current !== draftKey) return;
+    if (skipNextDraftWriteRef.current) {
+      skipNextDraftWriteRef.current = false;
+      return;
+    }
+    writeAskAIComposerDraft(draftKey, { text: value, context: buildContext() });
+  }, [draftKey, value, buildContext]);
 
   // Report the latest context up to the parent (via a ref so an inline
   // onContextChange doesn't refire this every render). Lets AIScreen preserve
@@ -472,6 +522,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       clearContent: (): void => {
         setValue('');
         setAttachments([]);
+        removeAskAIComposerDraft(draftKey);
       },
       focus: (): void => {
         textareaRef.current?.focus();
@@ -494,7 +545,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
         setFolderScopes(next.folderScopes);
       },
     }),
-    [handleFilesAdded],
+    [draftKey, handleFilesAdded],
   );
 
   const submit = (): void => {
@@ -502,6 +553,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
     const trimmed = value.trim();
     if (!trimmed) return;
     onSubmit?.(trimmed, attachments.length > 0 ? attachments : undefined, buildContext());
+    removeAskAIComposerDraft(draftKey);
     setValue('');
     setAttachments([]);
     // Toggles/context persist across turns (mirrors the sidebar), so they are

--- a/apps/dashboard/src/components/AIScreen/askAIComposerDraftStorage.ts
+++ b/apps/dashboard/src/components/AIScreen/askAIComposerDraftStorage.ts
@@ -1,0 +1,92 @@
+import type { ComposerContext } from './composerContext';
+
+const ASK_AI_DRAFT_PREFIX = 'ask-ai-draft:v1';
+
+export interface AskAIComposerDraftKeyParts {
+  workspaceId?: string | null | undefined;
+  userId?: string | null | undefined;
+  surface: 'sidebar' | 'ai-chat';
+  agentSlug?: string | null | undefined;
+  targetKey: string;
+}
+
+export interface AskAIComposerDraft {
+  text: string;
+  context?: ComposerContext | undefined;
+  updatedAt: number;
+}
+
+const safePart = (value: string): string => encodeURIComponent(value);
+
+export function buildAskAIComposerDraftKey({
+  workspaceId,
+  userId,
+  surface,
+  agentSlug,
+  targetKey,
+}: AskAIComposerDraftKeyParts): string | null {
+  if (!workspaceId || !userId || !targetKey) return null;
+
+  return [
+    ASK_AI_DRAFT_PREFIX,
+    safePart(workspaceId),
+    safePart(userId),
+    surface,
+    safePart(agentSlug || 'ask-ai'),
+    safePart(targetKey),
+  ].join(':');
+}
+
+export function readAskAIComposerDraft(key: string | null | undefined): AskAIComposerDraft | null {
+  if (!key || typeof window === 'undefined') return null;
+
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as Partial<AskAIComposerDraft>;
+    return {
+      text: typeof parsed.text === 'string' ? parsed.text : '',
+      ...(parsed.context ? { context: parsed.context } : {}),
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeAskAIComposerDraft(
+  key: string | null | undefined,
+  draft: Pick<AskAIComposerDraft, 'text'> & Partial<Pick<AskAIComposerDraft, 'context'>>,
+): void {
+  if (!key || typeof window === 'undefined') return;
+
+  try {
+    const normalizedText = draft.text.trim();
+    if (!normalizedText) {
+      window.localStorage.removeItem(key);
+      return;
+    }
+
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        text: draft.text,
+        ...(draft.context ? { context: draft.context } : {}),
+        updatedAt: Date.now(),
+      } satisfies AskAIComposerDraft),
+    );
+  } catch {
+    // Draft persistence is best-effort; never block the composer.
+  }
+}
+
+export function removeAskAIComposerDraft(key: string | null | undefined): void {
+  if (!key || typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Ignore storage failures.
+  }
+}

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
@@ -93,6 +93,12 @@ import {
   buildXyneAIStreamThreadId,
   getChannelIdFromStreamThreadId,
 } from '../../../utils/xyneAIStreamThreadId';
+import {
+  buildAskAIComposerDraftKey,
+  readAskAIComposerDraft,
+  removeAskAIComposerDraft,
+  writeAskAIComposerDraft,
+} from '../../AIScreen/askAIComposerDraftStorage';
 
 function newStreamSlotKey(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -694,6 +700,57 @@ const XyneAISidebar = ({
   // Ask AI v1 has been removed; everything runs on v2 (xyne-claw) now.
   const isV2 = true;
   const effectiveAgentSlug = selectedAgentSlug;
+  const askAIDraftTargetKey = useMemo(() => {
+    if (conversationId) return `session:${conversationId}`;
+    if (threadInfo?.conversationId) return `thread:${threadInfo.conversationId}`;
+    if (canvasInfo?.canvasId) return `canvas:${canvasInfo.canvasId}`;
+    if (kbDocIdProp) return `kb-file:${kbDocIdProp}`;
+    if (kbFolderIdProp) return `kb-folder:${kbFolderIdProp}`;
+    if (kbCollectionIdProp) return `kb-collection:${kbCollectionIdProp}`;
+    if (channelId) return `channel:${channelId}`;
+    return 'global';
+  }, [
+    conversationId,
+    threadInfo?.conversationId,
+    canvasInfo?.canvasId,
+    kbDocIdProp,
+    kbFolderIdProp,
+    kbCollectionIdProp,
+    channelId,
+  ]);
+  const askAIDraftKey = useMemo(
+    () =>
+      buildAskAIComposerDraftKey({
+        workspaceId: currentUser?.workspaceId,
+        userId: currentUser?.id,
+        surface: 'sidebar',
+        agentSlug: effectiveAgentSlug,
+        targetKey: askAIDraftTargetKey,
+      }),
+    [currentUser?.workspaceId, currentUser?.id, effectiveAgentSlug, askAIDraftTargetKey],
+  );
+  const hydratedDraftKeyRef = useRef<string | null>(null);
+  const skipNextDraftWriteRef = useRef(false);
+  useEffect(() => {
+    if (!askAIDraftKey) {
+      hydratedDraftKeyRef.current = null;
+      return;
+    }
+    hydratedDraftKeyRef.current = askAIDraftKey;
+    const draft = readAskAIComposerDraft(askAIDraftKey);
+    skipNextDraftWriteRef.current = !!draft?.text;
+    if (draft?.text) {
+      setInputValue(draft.text);
+    }
+  }, [askAIDraftKey]);
+  useEffect(() => {
+    if (!askAIDraftKey || hydratedDraftKeyRef.current !== askAIDraftKey) return;
+    if (skipNextDraftWriteRef.current) {
+      skipNextDraftWriteRef.current = false;
+      return;
+    }
+    writeAskAIComposerDraft(askAIDraftKey, { text: inputValue });
+  }, [askAIDraftKey, inputValue]);
   // Per-run model pin. The model list is scoped to the AGENT's LiteLLM key, so
   // it refetches per agent and the pin resets on agent change — a model from
   // the previous agent's key may not exist on the new one.
@@ -1216,6 +1273,7 @@ const XyneAISidebar = ({
     setDebugEvents([]);
     setDebugArtifactsReadyVersion(0);
     setShowDebugger(false);
+    removeAskAIComposerDraft(askAIDraftKey);
     setInputValue('');
     setAttachments([]);
     setSelectedActivities([]);
@@ -1225,7 +1283,7 @@ const XyneAISidebar = ({
     setShowUserActivityPanel(false);
 
     processedSelectionKeysRef.current.clear();
-  }, []);
+  }, [askAIDraftKey]);
 
   // When user selects a different agent from the global selector,
   // reset to a fresh conversation scoped to that agent.
@@ -1804,6 +1862,7 @@ const XyneAISidebar = ({
       }
     }
 
+    removeAskAIComposerDraft(askAIDraftKey);
     setInputValue('');
     setAttachments([]);
     setSelectedActivities([]);
@@ -1855,6 +1914,7 @@ const XyneAISidebar = ({
     abortCurrentRequest,
     isLegacyConversation,
     kbCollectionIdProp,
+    askAIDraftKey,
   ]);
 
   // Submits once the auto-send seed effect above has landed in inputValue (handleSubmit closes over it).

--- a/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
+++ b/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useState, useCallback, useEffect, useRef } from 'react';
+import { type ReactElement, useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Upload } from 'lucide-react';
 import { AIShell } from '../../components/AIScreen/AIShell';
@@ -16,6 +16,8 @@ import { xyneAIStreamManager } from '../../services/XyneAI/XyneAIStreamManager';
 import { useV2SessionInvalidator } from '../../hooks/useAskAISessionsV2';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
 import { AI_ACTIVE_SESSION_KEY, AI_SHOW_CHAT_VIEW_KEY } from './aiSessionStorage';
+import { useSelf } from '../../hooks/useUsers';
+import { buildAskAIComposerDraftKey } from '../../components/AIScreen/askAIComposerDraftStorage';
 
 const AIScreen = (): ReactElement => {
   const [activeSessionId, setActiveSessionId] = useState(
@@ -43,8 +45,20 @@ const AIScreen = (): ReactElement => {
   const lastContextRef = useRef<ComposerContext | undefined>(undefined);
   const navigate = useNavigate();
   const { selectedAgentSlug } = useSelectedAgent();
+  const currentUser = useSelf();
   const isV2 = true;
   const effectiveAgentSlug = selectedAgentSlug;
+  const landingDraftKey = useMemo(
+    () =>
+      buildAskAIComposerDraftKey({
+        workspaceId: currentUser?.workspaceId,
+        userId: currentUser?.id,
+        surface: 'ai-chat',
+        agentSlug: effectiveAgentSlug,
+        targetKey: 'new',
+      }),
+    [currentUser?.workspaceId, currentUser?.id, effectiveAgentSlug],
+  );
   const { invalidateSessions: invalidateV2Sessions } = useV2SessionInvalidator();
 
   useEffect(() => {
@@ -271,6 +285,7 @@ const AIScreen = (): ReactElement => {
                   showAgentSelector={isV2}
                   onContextChange={handleContextChange}
                   hideDisclaimer
+                  draftKey={landingDraftKey}
                 />
               </div>
             </div>


### PR DESCRIPTION
1. Problem Description:
Ask AI composer text was stored only in React state. If a user typed into the Ask AI sidebar or /ai/chat composer and switched tabs/routes before submitting, the unsent text disappeared.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in Spaces thread: Ask AI draft text is lost when switching away and returning.

3. Explain the solution implemented in the PR:
Added a local Ask AI composer draft store keyed by workspace, user, surface, selected agent, and deterministic target context. The shared /ai composer now restores and persists unsent text plus lightweight composer context. The global Ask AI sidebar persists unsent text for channel/thread/canvas/KB/global contexts and clears the draft on submit or starting a new chat.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- pnpm exec eslint src/components/AIScreen/AIComposer.tsx src/components/AIScreen/AIChatThread.tsx src/routes/AIScreen/AIScreen.tsx src/components/Chat/XyneAISidebar/XyneAISidebar.tsx src/components/AIScreen/askAIComposerDraftStorage.ts --quiet
- pnpm run typecheck (apps/dashboard)

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A