### PR TITLE
feat: PIE-14457 support RUN_AGENT inside conditions

### DIFF
--- a/apps/backend/src/automations/engine/automation-context-storage.ts
+++ b/apps/backend/src/automations/engine/automation-context-storage.ts
@@ -4,6 +4,8 @@ export interface AutomationContextStore {
   runId: string;
   automationId: string;
   chain: readonly string[];
+  /** Current persisted workflowStep key; set while a step executes. */
+  stepName?: string;
 }
 
 export const automationContextStorage = new AsyncLocalStorage<AutomationContextStore>();

--- a/apps/backend/src/automations/engine/automation-executor.test.ts
+++ b/apps/backend/src/automations/engine/automation-executor.test.ts
@@ -1,0 +1,226 @@
+import { z } from 'zod';
+
+jest.mock('@/database/repositories', () => ({
+  repositories: {
+    automationWorkflows: { getById: jest.fn() },
+  },
+}));
+
+jest.mock('@/database/repositories/workflowExecutionStateUtils', () => ({
+  persistAutomationPauseState: jest.fn(),
+  persistAutomationState: jest.fn(),
+  getAutomationPauseState: jest.fn(),
+}));
+
+jest.mock('./variable-resolver', () => ({
+  VariableResolver: class {
+    resolve(value: unknown): unknown {
+      return value;
+    }
+  },
+  stripNullForOptionalKeys: (value: unknown) => value,
+}));
+
+jest.mock('./condition-evaluator', () => ({
+  ConditionEvaluator: class {
+    evaluate(): boolean {
+      return true;
+    }
+  },
+}));
+
+jest.mock('../triggers/trigger-registry', () => ({
+  triggerRegistry: { has: jest.fn().mockReturnValue(false), get: jest.fn() },
+}));
+
+jest.mock('../types/workflow-adapter', () => ({
+  isExecutableAutomationWorkflowType: jest.fn().mockReturnValue(true),
+  mayDrainInFlight: jest.fn().mockReturnValue(false),
+  parseAutomationConfig: jest.fn(),
+  parseAutomationMetadata: jest.fn(),
+  readAutomationMeta: jest.fn().mockReturnValue({ error: null, chain: [] }),
+}));
+import type { PrismaClient } from '@prisma/client';
+import { AutomationExecutor, parseNestedStepIndex } from './automation-executor';
+import { PauseStep } from './pause-step';
+import { automationContextStorage } from './automation-context-storage';
+import { BaseActionStep } from '../steps/base-step';
+import { StepRegistry } from '../steps/step-registry';
+import { StepCategory } from '../types/categories';
+import type { AutomationContext } from '../types/context';
+import type { AutomationStepConfig } from '../types/automation-config';
+
+const EmptyConfig = z.object({});
+
+class RecordingStep extends BaseActionStep<typeof EmptyConfig, Record<string, unknown>> {
+  readonly type: string;
+  readonly configSchema = EmptyConfig;
+  readonly name = 'Recording step';
+  readonly description = 'Records executions for the test';
+  readonly outputSchema = z.record(z.unknown());
+  readonly category = StepCategory.EXTERNAL;
+
+  constructor(
+    type: string,
+    private readonly calls: string[]
+  ) {
+    super();
+    this.type = type;
+  }
+
+  async execute(): Promise<Record<string, unknown>> {
+    this.calls.push(this.type);
+    return { ok: true };
+  }
+}
+
+class PausingAgentStep extends BaseActionStep<typeof EmptyConfig, Record<string, unknown>> {
+  readonly type = 'RUN_AGENT';
+  readonly configSchema = EmptyConfig;
+  readonly name = 'Agent';
+  readonly description = 'Pauses until a callback arrives';
+  readonly outputSchema = z.record(z.unknown());
+  readonly category = StepCategory.AI;
+  executeCalls = 0;
+  resumeCalls = 0;
+
+  async execute(): Promise<Record<string, unknown>> {
+    this.executeCalls += 1;
+    const stepName = automationContextStorage.getStore()?.stepName;
+    throw new PauseStep('waiting for agent', {
+      externalRef: 'agent-run',
+      statePatch: { callbackStepName: stepName },
+    });
+  }
+
+  async onResume(rowData: Record<string, unknown>): Promise<Record<string, unknown>> {
+    this.resumeCalls += 1;
+    return {
+      result: rowData.agentRawResult,
+      resumedStepName: rowData.stepName,
+    };
+  }
+}
+
+type StepRow = { status: string; data: string | null };
+
+function createPrismaMock(rows: Map<string, StepRow>): PrismaClient {
+  return {
+    workflowExecution: {
+      findUnique: jest.fn().mockResolvedValue({ workspaceId: 'workspace-1' }),
+    },
+    workflowStep: {
+      upsert: jest.fn(async ({ where, create, update }) => {
+        const key = where.workflowExecutionId_stepName.stepName as string;
+        const previous = rows.get(key);
+        rows.set(key, {
+          status: (previous ? update.status : create.status) as string,
+          data:
+            ((previous ? update.data : create.data) as string | undefined) ??
+            previous?.data ??
+            null,
+        });
+      }),
+      update: jest.fn(async ({ where, data }) => {
+        const key = where.workflowExecutionId_stepName.stepName as string;
+        rows.set(key, {
+          status: data.status as string,
+          data: (data.data as string | undefined) ?? rows.get(key)?.data ?? null,
+        });
+      }),
+      findUnique: jest.fn(async ({ where }) => {
+        const key = where.workflowExecutionId_stepName.stepName as string;
+        const row = rows.get(key);
+        return row ? { data: row.data } : null;
+      }),
+    },
+  } as unknown as PrismaClient;
+}
+
+function buildContext(): AutomationContext {
+  return {
+    automation: { id: 'automation-1', workspaceId: 'workspace-1', createdById: 'user-1' },
+    trigger: {} as AutomationContext['trigger'],
+    steps: {},
+    __meta: { error: null, chain: [] },
+  };
+}
+
+describe('nested automation pause/resume', () => {
+  it('resumes the exact nested agent step without rerunning earlier side effects', async () => {
+    const rows = new Map<string, StepRow>();
+    const calls: string[] = [];
+    const agent = new PausingAgentStep();
+    const registry = new StepRegistry();
+    registry.register(new RecordingStep('BEFORE', calls));
+    registry.register(agent);
+    registry.register(new RecordingStep('AFTER', calls));
+
+    const executor = new AutomationExecutor(createPrismaMock(rows), registry);
+    const walkNested = (
+      executor as unknown as {
+        walkNestedBranch(
+          steps: AutomationStepConfig[],
+          context: AutomationContext,
+          runId: string,
+          pathPrefix: string,
+          resumeStepName?: string
+        ): Promise<void>;
+      }
+    ).walkNestedBranch.bind(executor);
+    const context = buildContext();
+    const steps = [
+      { id: 'before', type: 'BEFORE', config: {} },
+      { id: 'agent', type: 'RUN_AGENT', config: {} },
+      { id: 'after', type: 'AFTER', config: {} },
+    ] as AutomationStepConfig[];
+    const pathPrefix = 'step_0__if_true';
+    const agentStepName = `${pathPrefix}__step_1`;
+
+    await expect(
+      automationContextStorage.run(
+        { runId: 'run-1', automationId: 'automation-1', chain: [] },
+        () => walkNested(steps, context, 'run-1', pathPrefix)
+      )
+    ).rejects.toBeInstanceOf(PauseStep);
+
+    expect(calls).toEqual(['BEFORE']);
+    expect(agent.executeCalls).toBe(1);
+    expect(context.__meta?.resumeStepName).toBe(agentStepName);
+    expect(JSON.parse(rows.get(agentStepName)?.data ?? '{}')).toMatchObject({
+      callbackStepName: agentStepName,
+    });
+
+    const waitingData = JSON.parse(rows.get(agentStepName)?.data ?? '{}') as Record<
+      string,
+      unknown
+    >;
+    rows.set(agentStepName, {
+      status: 'EXTERNAL_WAIT',
+      data: JSON.stringify({ ...waitingData, agentRawResult: { answer: 'done' } }),
+    });
+
+    await automationContextStorage.run(
+      { runId: 'run-1', automationId: 'automation-1', chain: [] },
+      () => walkNested(steps, context, 'run-1', pathPrefix, agentStepName)
+    );
+
+    expect(calls).toEqual(['BEFORE', 'AFTER']);
+    expect(agent.executeCalls).toBe(1);
+    expect(agent.resumeCalls).toBe(1);
+    expect(context.steps.agent?.output).toEqual({
+      result: { answer: 'done' },
+      resumedStepName: agentStepName,
+    });
+    expect(context.__meta?.resumeStepName).toBeUndefined();
+    expect(rows.get(agentStepName)?.status).toBe('COMPLETED');
+  });
+
+  it('locates the direct child index for conditional and switch paths', () => {
+    expect(parseNestedStepIndex('step_3__if_true', 'step_3__if_true__step_2')).toBe(2);
+    expect(parseNestedStepIndex('step_1__case_0', 'step_1__case_0__step_4__if_false__step_1')).toBe(
+      4
+    );
+    expect(parseNestedStepIndex('step_1__default', 'step_1__case_0__step_0')).toBeNull();
+  });
+});

--- a/apps/backend/src/automations/engine/automation-executor.ts
+++ b/apps/backend/src/automations/engine/automation-executor.ts
@@ -37,6 +37,7 @@ interface PreparedRun {
   startIndex: number;
   label: 'STARTED' | 'RESUMED';
   resumeAtIndex?: number;
+  resumeStepName?: string;
 }
 
 const EXTERNAL_WAIT_STATUS = 'EXTERNAL_WAIT';
@@ -54,6 +55,19 @@ function parseStepIndexFromName(name: string): number | null {
   if (!m) return null;
   const n = Number.parseInt(m[1] as string, 10);
   return Number.isInteger(n) ? n : null;
+}
+
+export function parseNestedStepIndex(
+  pathPrefix: string,
+  resumeStepName: string,
+): number | null {
+  const prefix = `${pathPrefix}__step_`;
+  if (!resumeStepName.startsWith(prefix)) return null;
+  const suffix = resumeStepName.slice(prefix.length);
+  const match = /^(\d+)(?:__|$)/.exec(suffix);
+  if (!match) return null;
+  const index = Number.parseInt(match[1] as string, 10);
+  return Number.isInteger(index) ? index : null;
 }
 
 export class AutomationExecutor {
@@ -131,7 +145,11 @@ export class AutomationExecutor {
     config: ReturnType<typeof parseAutomationConfig>,
     prep: PreparedRun,
   ): Promise<unknown> {
-    prep.ctx.__meta = { error: null, chain: prep.chain };
+    prep.ctx.__meta = {
+      error: null,
+      chain: prep.chain,
+      ...(prep.resumeStepName ? { resumeStepName: prep.resumeStepName } : {}),
+    };
     await this.prisma.workflowExecution.update({
       where: { id: executionId },
       data: { status: AutomationRunStatus.RUNNING },
@@ -147,6 +165,7 @@ export class AutomationExecutor {
       config.steps,
       prep.startIndex,
       prep.resumeAtIndex,
+      prep.resumeStepName,
     );
   }
 
@@ -218,12 +237,14 @@ export class AutomationExecutor {
         }
       }
       const pausedIndex = pauseState.currentStepIndex;
+      const resumeStepName = initialCtx.__meta?.resumeStepName ?? `step_${pausedIndex}`;
       return {
         ctx: initialCtx,
         chain,
         startIndex: pausedIndex,
         label: 'RESUMED',
         resumeAtIndex: pausedIndex,
+        resumeStepName,
       };
     }
 
@@ -281,10 +302,12 @@ export class AutomationExecutor {
       where: { workflowExecutionId_stepName: { workflowExecutionId: runId, stepName } },
       select: { data: true },
     });
-    const rowData: Record<string, unknown> =
-      row?.data && typeof row.data === 'string'
+    const rowData: Record<string, unknown> = {
+      ...(row?.data && typeof row.data === 'string'
         ? (safeParseJson(row.data) as Record<string, unknown> | undefined) ?? {}
-        : {};
+        : {}),
+      stepName,
+    };
 
     if (typeof actionImpl.onResume === 'function') {
       return actionImpl.onResume(rowData, resolvedInput, context);
@@ -338,12 +361,14 @@ export class AutomationExecutor {
     steps: AutomationStepConfig[],
     startIndex: number,
     resumeAtIndex?: number,
+    resumeStepName?: string,
   ): Promise<unknown> {
     const automationId = context.automation.id;
     try {
       const walkResult = await automationContextStorage.run<Promise<WalkResult>>(
         { runId, automationId, chain },
-        () => this.walkSteps(steps, context, runId, startIndex, resumeAtIndex),
+        () =>
+          this.walkSteps(steps, context, runId, startIndex, resumeAtIndex, resumeStepName),
       );
 
       if (walkResult.kind === 'paused') {
@@ -387,6 +412,7 @@ export class AutomationExecutor {
     runId: string,
     startIndex: number = 0,
     resumeAtIndex?: number,
+    resumeStepName?: string,
   ): Promise<WalkResult> {
     for (let i = startIndex; i < steps.length; i++) {
       const step = steps[i] as AutomationStepConfig;
@@ -398,13 +424,31 @@ export class AutomationExecutor {
       }
 
       try {
-        await this.executeStep(step, context, { runId, stepName, isResuming });
+        await this.executeStep(step, context, {
+          runId,
+          stepName,
+          isResuming: isResuming && resumeStepName === stepName,
+          resumeStepName,
+        });
 
         const stepCtxEntry = context.steps[step.id];
         await this.markStepCompleted(runId, stepName, stepCtxEntry);
+        if (isResuming && resumeStepName === stepName && context.__meta) {
+          delete context.__meta.resumeStepName;
+        }
       } catch (err) {
         if (PauseStep.is(err)) {
-          await this.markStepWaiting(runId, stepName, context.steps[step.id], err.statePatch);
+          const pausedStepName = context.__meta?.resumeStepName ?? stepName;
+          context.__meta = {
+            ...context.__meta,
+            resumeStepName: pausedStepName,
+          };
+          await this.markStepWaiting(
+            runId,
+            stepName,
+            context.steps[step.id],
+            pausedStepName === stepName ? err.statePatch : undefined,
+          );
           await persistAutomationPauseState(runId, {
             context: JSON.stringify(context),
             currentStepIndex: i,
@@ -426,19 +470,48 @@ export class AutomationExecutor {
   private async walkNestedBranch(
     steps: AutomationStepConfig[],
     context: AutomationContext,
+    runId: string,
+    pathPrefix: string,
+    resumeStepName?: string,
   ): Promise<void> {
-    for (const step of steps) {
+    const resumeIndex = resumeStepName
+      ? parseNestedStepIndex(pathPrefix, resumeStepName)
+      : null;
+    const startIndex = resumeIndex ?? 0;
+
+    for (let i = startIndex; i < steps.length; i++) {
+      const step = steps[i] as AutomationStepConfig;
+      const stepName = `${pathPrefix}__step_${i}`;
+      const isResumeTarget = resumeStepName === stepName;
+
+      if (!isResumeTarget) {
+        await this.upsertStepRow(runId, stepName, step, 'RUNNING', null);
+      }
+
       try {
         await this.executeStep(step, context, {
-          runId: '',
-          stepName: '',
-          isResuming: false,
+          runId,
+          stepName,
+          isResuming: isResumeTarget,
+          resumeStepName,
         });
+        await this.markStepCompleted(runId, stepName, context.steps[step.id]);
+        if (isResumeTarget && context.__meta) {
+          delete context.__meta.resumeStepName;
+        }
       } catch (err) {
         if (PauseStep.is(err)) {
-          throw new Error(
-            `Step "${step.id}" (${step.type}) tried to pause inside a control-flow branch. Pausing is only supported at the top level — restructure the automation so the waiting step is not nested.`,
+          const pausedStepName = context.__meta?.resumeStepName ?? stepName;
+          context.__meta = { ...context.__meta, resumeStepName: pausedStepName };
+          await this.markStepWaiting(
+            runId,
+            stepName,
+            context.steps[step.id],
+            pausedStepName === stepName ? err.statePatch : undefined,
           );
+        } else {
+          const message = err instanceof Error ? err.message : String(err);
+          await this.markStepFailed(runId, stepName, message, context.steps[step.id]);
         }
         throw err;
       }
@@ -536,7 +609,12 @@ export class AutomationExecutor {
   private async executeStep(
     step: AutomationStepConfig,
     context: AutomationContext,
-    callCtx: { runId: string; stepName: string; isResuming: boolean },
+    callCtx: {
+      runId: string;
+      stepName: string;
+      isResuming: boolean;
+      resumeStepName?: string;
+    },
   ): Promise<void> {
     const stepImpl = this.stepRegistry.get(step.type);
 
@@ -554,7 +632,24 @@ export class AutomationExecutor {
       const t0 = Date.now();
       logger.info(`[automations] step START id=${step.id} type=${step.type}`);
       const output = await controlImpl.execute(safeResult.data, context, {
-        walkBranch: (steps, ctx) => this.walkNestedBranch(steps, ctx),
+        walkBranch: (steps, ctx, branchKey) => {
+          const branchPrefix = `${callCtx.stepName}__${branchKey}`;
+          if (
+            callCtx.resumeStepName?.startsWith(`${callCtx.stepName}__`) &&
+            !callCtx.resumeStepName.startsWith(`${branchPrefix}__`)
+          ) {
+            throw new Error(
+              `Control-flow branch changed while resuming ${callCtx.resumeStepName}; selected ${branchKey}`,
+            );
+          }
+          return this.walkNestedBranch(
+            steps,
+            ctx,
+            callCtx.runId,
+            branchPrefix,
+            callCtx.resumeStepName,
+          );
+        },
       });
       context.steps[step.id] = { type: step.type, output };
       logger.info(
@@ -590,9 +685,17 @@ export class AutomationExecutor {
       `[automations] step ${callCtx.isResuming ? 'RESUME' : 'START'} id=${step.id} type=${step.type}`,
     );
     try {
-      const output = callCtx.isResuming
-        ? await this.invokeResume(actionImpl, callCtx.runId, callCtx.stepName, resolvedInput, context)
-        : await actionImpl.execute(resolvedInput, context);
+      const store = automationContextStorage.getStore();
+      const executeAction = async (): Promise<Record<string, unknown>> =>
+        callCtx.isResuming
+          ? this.invokeResume(actionImpl, callCtx.runId, callCtx.stepName, resolvedInput, context)
+          : actionImpl.execute(resolvedInput, context);
+      const output = store
+        ? await automationContextStorage.run(
+            { ...store, stepName: callCtx.stepName },
+            executeAction,
+          )
+        : await executeAction();
       context.steps[step.id] = { type: step.type, input: persistedInput, output };
       logger.info(
         `[automations] step OK    id=${step.id} type=${step.type} elapsedMs=${Date.now() - t0}`,

--- a/apps/backend/src/automations/routes/claw-callback.handler.test.ts
+++ b/apps/backend/src/automations/routes/claw-callback.handler.test.ts
@@ -1,0 +1,98 @@
+import type { Request, Response } from 'express';
+import { AutomationRunStatus } from '../types/status';
+
+const mockFindStep = jest.fn();
+const mockUpdateManySteps = jest.fn();
+const mockFindExecution = jest.fn();
+const mockEnqueueRun = jest.fn();
+
+jest.mock('@/database/client', () => ({
+  db: {
+    workflowStep: {
+      findUnique: (...args: unknown[]) => mockFindStep(...args),
+      updateMany: (...args: unknown[]) => mockUpdateManySteps(...args),
+    },
+    workflowExecution: {
+      findUniqueOrThrow: (...args: unknown[]) => mockFindExecution(...args),
+    },
+  },
+}));
+
+jest.mock('../queue/automation.queue', () => ({
+  automationQueue: {
+    enqueueRun: (...args: unknown[]) => mockEnqueueRun(...args),
+  },
+}));
+
+import { handleClawCallback } from './claw-callback.handler';
+
+function responseMock(): Response {
+  const response = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  response.status.mockReturnValue(response);
+  return response as unknown as Response;
+}
+
+function requestMock(
+  body: Record<string, unknown> = { answer: 'done' }
+): Request<{ executionId: string; stepName: string }> {
+  return {
+    params: { executionId: 'run-1', stepName: 'step_0__if_true__step_1' },
+    body,
+  } as unknown as Request<{ executionId: string; stepName: string }>;
+}
+
+describe('handleClawCallback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindExecution.mockResolvedValue({ status: AutomationRunStatus.EXTERNAL_WAIT });
+    mockUpdateManySteps.mockResolvedValue({ count: 1 });
+    mockEnqueueRun.mockResolvedValue(undefined);
+  });
+
+  it('stores and enqueues the first callback for a nested step', async () => {
+    mockFindStep.mockResolvedValue({ data: JSON.stringify({ input: { agentSlug: 'bot' } }) });
+    const res = responseMock();
+
+    await handleClawCallback(requestMock(), res);
+
+    expect(mockUpdateManySteps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          workflowExecutionId: 'run-1',
+          stepName: 'step_0__if_true__step_1',
+          data: JSON.stringify({ input: { agentSlug: 'bot' } }),
+        },
+      })
+    );
+    expect(mockEnqueueRun).toHaveBeenCalledWith({ executionId: 'run-1' });
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+  });
+
+  it('does not enqueue duplicate callbacks', async () => {
+    mockFindStep.mockResolvedValue({
+      data: JSON.stringify({ agentRawResult: { answer: 'first' } }),
+    });
+    const res = responseMock();
+
+    await handleClawCallback(requestMock({ answer: 'duplicate' }), res);
+
+    expect(mockUpdateManySteps).not.toHaveBeenCalled();
+    expect(mockEnqueueRun).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ success: true, duplicate: true });
+  });
+
+  it('ignores callbacks after the execution becomes terminal', async () => {
+    mockFindExecution.mockResolvedValue({ status: AutomationRunStatus.COMPLETED });
+    mockFindStep.mockResolvedValue({ data: '{}' });
+    const res = responseMock();
+
+    await handleClawCallback(requestMock(), res);
+
+    expect(mockUpdateManySteps).not.toHaveBeenCalled();
+    expect(mockEnqueueRun).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ success: true, ignored: 'execution_terminal' });
+  });
+});

--- a/apps/backend/src/automations/routes/claw-callback.handler.ts
+++ b/apps/backend/src/automations/routes/claw-callback.handler.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { automationQueue } from '../queue/automation.queue';
+import { AutomationRunStatus } from '../types/status';
 
 export async function handleClawCallback(
   req: Request<{ executionId: string; stepName: string }>,
@@ -18,32 +19,57 @@ export async function handleClawCallback(
       }),
       db.workflowExecution.findUniqueOrThrow({
         where: { id: executionId },
-        select: { workspaceId: true },
+        select: { status: true },
       }),
     ]);
-    if (!existingRow) {
+    if (
+      [
+        AutomationRunStatus.COMPLETED,
+        AutomationRunStatus.FAILED,
+        AutomationRunStatus.CANCELLED,
+        AutomationRunStatus.SKIPPED,
+      ].includes(workflowExecution.status as AutomationRunStatus)
+    ) {
       logger.warn(
-        `[automations] claw-callback: no workflow_step row for execution=${executionId} step=${stepName} — proceeding with empty existing data`,
+        `[automations] claw-callback: ignoring callback for execution=${executionId} status=${workflowExecution.status}`,
       );
+      res.json({ success: true, ignored: 'execution_terminal' });
+      return;
     }
 
-    const existing = parseRowData(existingRow?.data);
-    const merged = { ...existing, agentRawResult: payload };
+    if (!existingRow) {
+      logger.warn(
+        `[automations] claw-callback: ignoring unknown step execution=${executionId} step=${stepName}`,
+      );
+      res.json({ success: true, ignored: 'unknown_step' });
+      return;
+    }
 
-    await db.workflowStep.upsert({
-      where: { workflowExecutionId_stepName: { workflowExecutionId: executionId, stepName } },
-      create: {
+    const existing = parseRowData(existingRow.data);
+    if (existing.agentRawResult !== undefined) {
+      logger.info(
+        `[automations] claw-callback: duplicate ignored execution=${executionId} step=${stepName}`,
+      );
+      res.json({ success: true, duplicate: true });
+      return;
+    }
+
+    const merged = { ...existing, agentRawResult: payload };
+    const updated = await db.workflowStep.updateMany({
+      where: {
         workflowExecutionId: executionId,
         stepName,
-        stepExecutorType: 'RUN_AGENT',
-        status: 'EXTERNAL_WAIT',
-        data: JSON.stringify(merged),
-        workspaceId: workflowExecution.workspaceId,
+        data: existingRow.data,
       },
-      update: {
-        data: JSON.stringify(merged),
-      },
+      data: { data: JSON.stringify(merged) },
     });
+    if (updated.count === 0) {
+      logger.info(
+        `[automations] claw-callback: concurrent duplicate ignored execution=${executionId} step=${stepName}`,
+      );
+      res.json({ success: true, duplicate: true });
+      return;
+    }
 
     await automationQueue.enqueueRun({ executionId });
 

--- a/apps/backend/src/automations/steps/base-step.ts
+++ b/apps/backend/src/automations/steps/base-step.ts
@@ -5,7 +5,11 @@ import type { AutomationStepConfig } from '../types/automation-config';
 import { StepCategory } from '../types/categories';
 
 export interface ControlFlowExecutionContext {
-  walkBranch(steps: AutomationStepConfig[], context: AutomationContext): Promise<void>;
+  walkBranch(
+    steps: AutomationStepConfig[],
+    context: AutomationContext,
+    branchKey: string,
+  ): Promise<void>;
 }
 
 export enum StepKind {

--- a/apps/backend/src/automations/steps/conditional.step.ts
+++ b/apps/backend/src/automations/steps/conditional.step.ts
@@ -38,7 +38,7 @@ export class ConditionalStep extends BaseControlFlowStep<typeof ConditionalConfi
   ): Promise<ConditionalOutput> {
     const result = this.evaluator.evaluate(config.condition, context);
     const branch = (result ? config.if_true : (config.if_false ?? [])) as AutomationStepConfig[];
-    await ctx.walkBranch(branch, context);
+    await ctx.walkBranch(branch, context, result ? 'if_true' : 'if_false');
     return { result };
   }
 }

--- a/apps/backend/src/automations/steps/delay.step.ts
+++ b/apps/backend/src/automations/steps/delay.step.ts
@@ -96,7 +96,8 @@ export class DelayStep extends BaseActionStep<typeof DelayConfigSchema, DelayOut
 
     const stepCount = Object.keys(context.steps).length;
     const currentIndex = Math.max(0, stepCount - 1);
-    const jobId = `${store.runId}:delay:step_${currentIndex}`;
+    const stepName = store.stepName ?? `step_${currentIndex}`;
+    const jobId = `${store.runId}:delay:${stepName}`;
 
     logger.info(
       `[DELAY] scheduling wake-up — executionId=${store.runId} jobId=${jobId} amount=${amount} unit=${unit} delayedUntil=${delayedUntil}`,

--- a/apps/backend/src/automations/steps/run-agent.step.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.ts
@@ -66,8 +66,9 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     const stepCount = Object.keys(context.steps).length;
     const currentIndex = Math.max(0, stepCount - 1);
 
-    const sessionId = `${store.runId}:step_${currentIndex}`;
-    const callbackUrl = buildCallbackUrl(store.runId, `step_${currentIndex}`);
+    const stepName = store.stepName ?? `step_${currentIndex}`;
+    const sessionId = `${store.runId}:${stepName}`;
+    const callbackUrl = buildCallbackUrl(store.runId, stepName);
 
     const agentSlug = cfg.agentSlug as string;
     const prompt = cfg.prompt as string;
@@ -77,7 +78,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     const visibleContext = resolveVisibleConversationContext(context);
 
     logger.info(
-      `[RUN_AGENT] firing — executionId=${store.runId} stepIndex=${currentIndex} agentSlug=${agentSlug} sessionId=${sessionId} userId=${runUserId}`,
+      `[RUN_AGENT] firing — executionId=${store.runId} step=${stepName} agentSlug=${agentSlug} sessionId=${sessionId} userId=${runUserId}`,
     );
 
     try {

--- a/apps/backend/src/automations/steps/switch.step.ts
+++ b/apps/backend/src/automations/steps/switch.step.ts
@@ -45,12 +45,12 @@ export class SwitchStep extends BaseControlFlowStep<typeof SwitchConfigSchema, S
       const caseEntry = config.cases[i]!;
       const matched = this.evaluator.evaluate(caseEntry.condition, context);
       if (matched) {
-        await ctx.walkBranch(caseEntry.steps as AutomationStepConfig[], context);
+        await ctx.walkBranch(caseEntry.steps as AutomationStepConfig[], context, `case_${i}`);
         return { matchedIndex: i };
       }
     }
     // No case matched — run default branch
-    await ctx.walkBranch(config.default as AutomationStepConfig[], context);
+    await ctx.walkBranch(config.default as AutomationStepConfig[], context, 'default');
     return { matchedIndex: -1 };
   }
 }

--- a/apps/backend/src/automations/types/context.ts
+++ b/apps/backend/src/automations/types/context.ts
@@ -74,5 +74,7 @@ export interface AutomationContext {
   __meta?: {
     error?: string | null;
     chain?: readonly string[];
+    /** Exact workflowStep key to resume, including nested control-flow paths. */
+    resumeStepName?: string;
   };
 }


### PR DESCRIPTION
## Summary
- allow `RUN_AGENT` and other pausing steps inside `CONDITIONAL` and `SWITCH` branches
- persist an exact nested step path so resume continues at the waiting step without rerunning completed side effects
- make Claw callbacks idempotent and ignore callbacks for unknown steps or terminal executions

## Implementation
- record nested workflow-step rows with stable conditional/switch branch path segments
- propagate nested step identity to Claw callback/session IDs and delay job IDs
- validate that the selected control-flow branch has not changed during resume
- resume only the exact nested step and then continue the remaining branch

## Testing
- focused Jest tests: 2 suites, 5 tests passed
- `pnpm typecheck` passed for `apps/backend`
- focused ESLint passed with 0 errors (test files are excluded by the repo ignore rules)
- `git diff --check` passed