### PR TITLE
fix: XYNE-55539 add in-app browser header indicator for preference education, remove existing toast implementation

### DIFF
--- a/apps/dashboard/src/components/BrowserPanel/BrowserHintBar.tsx
+++ b/apps/dashboard/src/components/BrowserPanel/BrowserHintBar.tsx
@@ -1,0 +1,64 @@
+import { ReactElement } from 'react';
+import { X } from 'lucide-react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { useMeasure } from 'react-use';
+
+interface BrowserHintBarProps {
+  isMac: boolean;
+  onOpenPreferences: () => void;
+  onDismiss: () => void;
+}
+
+export function BrowserHintBar({
+  isMac,
+  onOpenPreferences,
+  onDismiss,
+}: BrowserHintBarProps): ReactElement {
+  const [containerRef, bounds] = useMeasure<HTMLDivElement>();
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <motion.div
+      className='overflow-hidden'
+      initial={{ height: 0, opacity: 0 }}
+      animate={bounds.height ? { height: bounds.height, opacity: 1 } : { opacity: 1 }}
+      exit={{ height: 0, opacity: 0 }}
+      transition={
+        shouldReduceMotion
+          ? { duration: 0.15 }
+          : {
+              height: { type: 'spring', duration: 0.2, bounce: 0 },
+              opacity: { duration: 0.12 },
+            }
+      }
+    >
+      <div ref={containerRef}>
+        <div className='flex items-start gap-2 bg-muted border-b border-border px-3 py-1'>
+          <p className='min-w-0 flex-1 text-[11px] leading-4 text-muted-foreground'>
+            {isMac ? '⌘' : 'Ctrl'}-click to open externally ·{' '}
+            <button
+              type='button'
+              onClick={onOpenPreferences}
+              className='underline underline-offset-2 transition-colors hover:text-foreground'
+              data-track-category='BROWSER'
+              data-track-name='OpenLinkPreferences'
+            >
+              change default in preferences
+            </button>
+          </p>
+          <button
+            type='button'
+            aria-label='Dismiss'
+            title='Dismiss'
+            onClick={onDismiss}
+            className='mt-px shrink-0 rounded-md p-0.5 text-muted-foreground transition-colors hover:bg-border hover:text-foreground'
+            data-track-category='BROWSER'
+            data-track-name='DismissLinkHint'
+          >
+            <X size={12} />
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/apps/dashboard/src/hooks/useLinkOpenHintDismissed.ts
+++ b/apps/dashboard/src/hooks/useLinkOpenHintDismissed.ts
@@ -1,0 +1,28 @@
+import { useSyncExternalStore } from 'react';
+
+export const LINK_OPEN_HINT_DISMISSED_KEY = 'xyne:link-open-hint-dismissed';
+
+const listeners = new Set<() => void>();
+
+const subscribe = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+};
+
+const getSnapshot = (): string => localStorage.getItem(LINK_OPEN_HINT_DISMISSED_KEY) ?? '';
+const getServerSnapshot = (): string => '';
+
+export const useLinkOpenHintDismissed = (): {
+  hintDismissed: boolean;
+  dismissHint: () => void;
+} => {
+  const raw = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  return {
+    hintDismissed: raw === 'true',
+    dismissHint: (): void => {
+      localStorage.setItem(LINK_OPEN_HINT_DISMISSED_KEY, 'true');
+      listeners.forEach(l => l());
+    },
+  };
+};

--- a/apps/dashboard/src/routes/BrowserTabsScreen/BrowserTabsScreen.tsx
+++ b/apps/dashboard/src/routes/BrowserTabsScreen/BrowserTabsScreen.tsx
@@ -16,6 +16,7 @@ import {
   Eye,
   EyeOff,
 } from 'lucide-react';
+import { AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { isElectronApp } from '../../utils/electronApp';
 import { browserPanelActor, type BrowserTab } from '../../machines/browserPanelMachine';
@@ -24,6 +25,8 @@ import { useActivityTracking } from '../../hooks/useActivityTracking';
 import { logger, Event } from '../../utils/logger';
 import { xyneAIActor } from '../../machines/xyneAIMachine';
 import { BrowserSettingsMenu } from '../../components/BrowserPanel/BrowserSettingsMenu';
+import { BrowserHintBar } from '../../components/BrowserPanel/BrowserHintBar';
+import { useLinkOpenHintDismissed } from '../../hooks/useLinkOpenHintDismissed';
 import { usePlatform } from '../../hooks/usePlatform';
 
 // Define WebviewTag interface locally since Electron types may not be available in renderer
@@ -254,7 +257,8 @@ export function BrowserTabsScreen({
   const webviewRefs = useRef<Record<string, WebviewTag | null>>({});
   const findInputRef = useRef<HTMLInputElement>(null);
   const urlInputRef = useRef<HTMLInputElement>(null);
-  const { isMobile } = usePlatform();
+  const { isMobile, isMac } = usePlatform();
+  const { hintDismissed, dismissHint } = useLinkOpenHintDismissed();
   const { track } = useActivityTracking();
   const navigate = useNavigate();
 
@@ -831,6 +835,22 @@ export function BrowserTabsScreen({
           </form>
         </div>
       )}
+
+      <AnimatePresence>
+        {isElectronApp() && !hintDismissed && (
+          <BrowserHintBar
+            key='browser-hint-bar'
+            isMac={isMac}
+            onOpenPreferences={() => {
+              dismissHint();
+              window.dispatchEvent(
+                new CustomEvent('xyne-open-preferences', { detail: { section: 'messaging' } }),
+              );
+            }}
+            onDismiss={dismissHint}
+          />
+        )}
+      </AnimatePresence>
 
       {/* Browser Content Area - webview elements render as real DOM */}
       <div className='flex-1 bg-muted relative overflow-hidden'>

--- a/apps/dashboard/src/utils/openLink.ts
+++ b/apps/dashboard/src/utils/openLink.ts
@@ -1,11 +1,9 @@
-import { toast } from 'sonner';
 import { isElectronApp } from './electronApp';
 import { detectReactNativeWebView, reactNativeBridge } from './reactNativeBridge';
 import { browserPanelActor } from '../machines/browserPanelMachine';
 import { logger, Event } from './logger';
 
 const LINK_OPEN_EXTERNAL_KEY = 'xyne:link-open-external-default';
-const LINK_OPEN_HINT_DISMISSED_KEY = 'xyne:link-open-hint-dismissed';
 
 const listeners = new Set<() => void>();
 const notify = (): void => {
@@ -35,19 +33,10 @@ export const setLinkOpenExternalDefault = (value: boolean): void => {
   notify();
 };
 
-const getHintDismissed = (): boolean =>
-  localStorage.getItem(LINK_OPEN_HINT_DISMISSED_KEY) === 'true';
-
-const markHintDismissed = (): void => {
-  localStorage.setItem(LINK_OPEN_HINT_DISMISSED_KEY, 'true');
-  notify();
-};
-
 type MouseLike = Pick<MouseEvent, 'metaKey' | 'ctrlKey'>;
 
 export interface OpenLinkOpts {
   force?: 'in-app' | 'external';
-  silent?: boolean;
 }
 
 export const linkOpenPrefIsRelevant = (): boolean => isElectronApp() || detectReactNativeWebView();
@@ -80,7 +69,6 @@ export const openLink = (url: string, event?: MouseLike | null, opts?: OpenLinkO
     openExternal(url);
   } else {
     openInApp(url);
-    if (!opts?.silent) maybeShowHint();
   }
 };
 
@@ -106,24 +94,4 @@ const openInApp = (url: string): void => {
     return;
   }
   window.open(url, '_blank', 'noopener,noreferrer');
-};
-
-const maybeShowHint = (): void => {
-  if (!isElectronApp()) return;
-  if (getHintDismissed()) return;
-
-  toast.info('⌘/Ctrl-click for external browser', {
-    duration: Infinity,
-    style: { width: '360px', maxWidth: 'calc(100vw - 32px)' },
-    cancel: {
-      label: 'Open Preferences',
-      onClick: () => {
-        markHintDismissed();
-        window.dispatchEvent(
-          new CustomEvent('xyne-open-preferences', { detail: { section: 'messaging' } }),
-        );
-      },
-    },
-    onDismiss: markHintDismissed,
-  });
 };


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<img width="614" height="152" alt="image" src="https://github.com/user-attachments/assets/353a1fb1-e481-436b-a3cb-9c31ecd0c7fc" />

Users click a link, the in-app browser opens, and they have no idea the behaviour is configurable. There *was* education for this — a toast in `openLink.ts` saying `⌘/Ctrl-click for external browser` — but most users never saw it.

**Why the toast didn't reach people.** It was called from `openLink()`, which only runs for links that get a React `onClick`. Everything else leaves the renderer entirely, gets decided in the Electron main process, and re-enters over the `open-in-browser-panel` IPC channel — which had no hint call. That's 4 of 12 paths covered:

| Opens the panel | Toast fired? |
| --- | --- |
| Chat message links (markdown + composer-authored anchors), Links tab, recording Google-Docs | yes |
| Unfurl / link-preview cards | no |
| Email body links, AI sidebar links, draft cards, README viewer | no |
| Plain `<a href>` navigation, links clicked inside an open browser tab | no |
| Cmd-K search results | no |

The sharpest case: an unfurl card renders directly beneath a message whose link *did* toast, so clicking the card behaved differently from clicking the link above it.

**The fix.** Replace the toast with a persistent one-line indicator in the panel's own chrome. Because it renders from state rather than firing on an event, it's completely independent of which code path opened the panel — the reach problem disappears rather than being patched path by path. That's also why this deletes the toast and its trigger instead of rewiring them.

Details worth knowing while reviewing:

- **Placement** — last row of the header, below the tab strip. It deliberately sits *outside* the `areControlsVisible` gate, which defaults to `false`, so it stays visible when the Eye toggle collapses the rest of the chrome. One insertion point covers both the docked panel and the `/browser` fullscreen route.
- **Copy** — `⌘-click to open externally · change default in preferences`, with the second half underlined and opening Preferences → Messaging. `⌘` becomes `Ctrl` off macOS via `usePlatform()`. Sized to stay on one line at the panel's 35% default width and to wrap rather than truncate when narrower, so the link can't get cut off.
- **Dismissal** — reuses the existing `xyne:link-open-hint-dismissed` key, so anyone who already dismissed the old toast never sees the strip. Still once-per-device; no change to that behaviour in this PR.
- **Exit animation** — height collapses with a 200ms `bounce: 0` spring while the content fades over 120ms, so it reads as a dismissal rather than a clip. `prefers-reduced-motion` drops to a flat 150ms tween, matching the pattern in `TranscriptSidePanel.tsx:136`.

Net effect is smaller than what it replaces: the strip plus its dismissal hook cost less than the toast, its storage helpers, and the `sonner` import that came out of `openLink.ts`.

**Known limitation, pre-existing and not addressed here.** Three paths ignore `openLinksExternally` entirely — Cmd-K search results (`searchNavigation.ts`), links clicked inside an already-open browser tab (`main.ts`), and plain `<a href>` navigation (`manager.ts`, which also can't see ⌘-click because `will-navigate` carries no disposition). A user who sets "open externally" still gets the in-app panel from those. This PR doesn't change that routing, but it does make it more visible, since those paths now surface the indicator. Worth a follow-up.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

State is client-side only: the existing `xyne:link-open-hint-dismissed` localStorage key, read through a new `useSyncExternalStore` hook so the strip re-renders on dismiss.

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?

A fixture channel was seeded with one message per link-rendering branch so every path could be exercised side by side, plus a desk email with external anchors in its body.

Before the change, only the markdown and anchor fixtures produced the toast; the bare-URL and unfurl fixtures opened the panel silently. After it, the indicator is present regardless of which fixture opened the panel, since it no longer depends on the entry path.

Also checked: the Eye toggle collapsing the chrome leaves the strip visible; both the docked panel and `/browser` fullscreen; narrow panel widths wrap rather than truncate; the Preferences link lands on Messaging; dismissal survives tab switches and panel reopens; and a pre-set `xyne:link-open-hint-dismissed` suppresses the strip entirely (the migration path for existing users).

**Still outstanding** — needs a reviewer with a running desktop build:

- Frame-by-frame scrub of the dismissal to confirm the text clears before the gap closes.
- macOS Reduce Motion enabled.
- Frame rate with a heavy page loaded in the `<webview>`. The height collapse reflows the webview's separate renderer process each frame; if it janks, the right move is deleting the animation rather than tuning it, since it's seen at most once per device.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- presentational Electron-only component; no existing test harness renders the browser panel. Verified via typecheck, lint, and the manual matrix above. -->

### Manual

**Users**
- [x] Single user

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
- [x] Electron desktop

**Surface & data**
- [x] Electron desktop
- [x] Narrow viewport, dark + light theme

The strip is gated on `isElectronApp()`, so it does not render in the web build — no web-surface change to verify.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Dashboard `lint:errors-only` + `typecheck` pass
- [x] Formatting clean in the packages I touched
- [x] No new dependencies — `framer-motion` and `react-use` were already direct dashboard deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind
