### PR TITLE
feat: XYNE-60825 add PPTX viewer, KB UI polish, and workspace toolbar admin control

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     ca-certificates \
     libjemalloc2 \
+    libreoffice \
     && ln -sf "$(find /usr/lib -name 'libjemalloc.so.2' | head -1)" /usr/local/lib/libjemalloc.so.2 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -2252,6 +2252,7 @@ export const collectionPermissionTable = table("collection_permissions")
     collectionId: string(),
     userId: string().optional(),
     userGroupId: string().optional(),
+    channelId: string().optional(),
     role: string(),
     canShare: boolean(),
     grantedBy: string().optional(),
@@ -4050,6 +4051,11 @@ export const channelTableRelationships = relationships(channelTable, ({ one, man
     sourceField: ["id"],
     destField: ["channelId"],
     destSchema: repoTable,
+  }),
+  collectionPermissions: many({
+    sourceField: ["id"],
+    destField: ["channelId"],
+    destSchema: collectionPermissionTable,
   })
 }));
 
@@ -4581,6 +4587,11 @@ export const collectionPermissionTableRelationships = relationships(collectionPe
     sourceField: ["userGroupId"],
     destField: ["id"],
     destSchema: userGroupTable,
+  }),
+  channel: one({
+    sourceField: ["channelId"],
+    destField: ["id"],
+    destSchema: channelTable,
   })
 }));
 

--- a/apps/backend/prisma/migrations/20260821190000_add_channel_id_to_collection_permissions/migration.sql
+++ b/apps/backend/prisma/migrations/20260821190000_add_channel_id_to_collection_permissions/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "public"."collection_permissions" ADD COLUMN     "channelId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "collection_permissions_channelId_idx" ON "public"."collection_permissions"("channelId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "collection_permissions_collectionId_channelId_key" ON "public"."collection_permissions"("collectionId", "channelId");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1783,6 +1783,7 @@ model Channel {
   emails             Email[]
   boardMappings      ChannelBoardMapping[]
   sdlcRepos          Repo[] @relation("RepoSdlcChannel")
+  collectionPermissions CollectionPermission[]
 
   @@index([projectId])
   @@index([workspaceId, visibility, id]) // ACL workspace filtering + visibility
@@ -3628,6 +3629,10 @@ model CollectionPermission {
   collectionId String
   userId       String?
   userGroupId  String?
+  // Grants every current+future member of this channel access — always
+  // VIEWER (enforced in the grantPermission mutator), and only offered for
+  // workspace-scoped collections (no home channel of their own) in the UI.
+  channelId    String?
   role         String
   canShare     Boolean        @default(false)
   grantedBy    String?
@@ -3637,10 +3642,13 @@ model CollectionPermission {
   collection Collection  @relation(fields: [collectionId], references: [id], onDelete: Cascade)
   user       User?       @relation(fields: [userId], references: [id], onDelete: Cascade)
   userGroup  UserGroup?  @relation(fields: [userGroupId], references: [id], onDelete: Cascade)
+  channel    Channel?    @relation(fields: [channelId], references: [id], onDelete: Cascade)
 
   @@unique([collectionId, userId])
   @@unique([collectionId, userGroupId])
+  @@unique([collectionId, channelId])
   @@index([userGroupId])
+  @@index([channelId])
   @@index([collectionId, userId, id], map: "idx_collection_permissions_collection_user_id")
   @@map("collection_permissions")
   @@schema("public")

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -189,6 +189,7 @@ import userMigrationRoutes from '@/routes/userMigration';
 import { decryptRequestBodyMiddleware, encryptResponseBodyMiddleware } from './middleware/decryptionMiddleware';
 import internalRoutes from '@/routes/internal';
 import collectionsRoutes from '@/routes/collections';
+import officeConversionRoutes from '@/routes/officeConversion';
 import sdlcRoutes from '@/routes/sdlc';
 import sdlcClawRoutes from '@/routes/sdlcClaw';
 import sdlcVcsInternalRoutes from '@/routes/sdlcVcsInternal';
@@ -679,6 +680,10 @@ export class App {
 
     // Collections routes
     this.app.use('/api/collections', authMiddleware.authenticate, collectionsRoutes);
+
+    // Office document (pptx, docx, ...) -> PDF conversion, via LibreOffice.
+    // Stateless: takes uploaded bytes, returns converted bytes, touches no stored data.
+    this.app.use('/api/office-conversion', authMiddleware.authenticate, officeConversionRoutes);
 
     // Activity logging routes (auth required)
     this.app.use('/api/activity', authMiddleware.authenticate, activityLogRoutes);

--- a/apps/backend/src/controllers/cacConfigController.ts
+++ b/apps/backend/src/controllers/cacConfigController.ts
@@ -10,10 +10,12 @@ export class CacConfigController {
     }
 
     const userEmail = req.user?.email?.trim();
+    const workspaceId = req.user?.workspaceId;
     const isPlayground = req.get('x-route-env')?.trim().toLowerCase() === 'playground';
-    const context = userEmail || isPlayground
+    const context = userEmail || workspaceId || isPlayground
       ? {
           ...(userEmail ? { email: userEmail } : {}),
+          ...(workspaceId ? { workspaceId } : {}),
           ...(isPlayground ? { environment: 'playground' } : {}),
         }
       : undefined;

--- a/apps/backend/src/controllers/officeConversionController.ts
+++ b/apps/backend/src/controllers/officeConversionController.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from "express"
+import { logger } from "@/utils/logger"
+import { convertToPdf, OfficeConversionError } from "@/services/officeConversionService"
+
+/**
+ * Stateless office-document-to-PDF conversion. Deliberately not scoped to a
+ * collection/attachment/item — every viewer that needs this (KB file viewer,
+ * chat attachment gallery, citation previews) already has the raw file
+ * bytes client-side (the same `source: File` contract every FileViewer uses),
+ * so there's no reason to require a stored resource's ID or duplicate
+ * per-context ACL checks for what is purely a transform, not a data access.
+ */
+export class OfficeConversionController {
+    convertToPdf = async (req: Request, res: Response): Promise<void> => {
+        const file = req.file
+        if (!file) {
+            res.status(400).json({ error: "A file is required", code: "MISSING_FILE" })
+            return
+        }
+
+        try {
+            const pdfBuffer = await convertToPdf(file.buffer, file.originalname)
+            res.setHeader("Content-Type", "application/pdf")
+            res.setHeader("Content-Length", pdfBuffer.length)
+            res.send(pdfBuffer)
+        } catch (error) {
+            if (error instanceof OfficeConversionError && error.code === "SOFFICE_NOT_FOUND") {
+                logger.error("[OfficeConversion] LibreOffice not installed on this host", error)
+                res.status(503).json({
+                    error: "PDF conversion is not available on this server",
+                    code: "CONVERTER_UNAVAILABLE",
+                })
+                return
+            }
+            if (error instanceof OfficeConversionError && error.code === "TIMEOUT") {
+                res.status(504).json({ error: "Conversion timed out", code: "TIMEOUT" })
+                return
+            }
+            logger.error("[OfficeConversion] Conversion failed", error)
+            res.status(500).json({ error: "Failed to convert file", code: "CONVERSION_FAILED" })
+        }
+    }
+}

--- a/apps/backend/src/controllers/xyneAIControllerV2.ts
+++ b/apps/backend/src/controllers/xyneAIControllerV2.ts
@@ -174,6 +174,13 @@ const XyneAIRequestSchemaV2 = z.object({
   collection_ids: z.array(z.string().min(1)).optional(),
   fileIds: z.array(z.string().min(1)).optional(),
   file_ids: z.array(z.string().min(1)).optional(),
+  // A folder scope from the composer picker. Forwarded to claw-auth as a
+  // single 'folder' attached_context pointer (like collectionIds is) — NOT
+  // expanded to individual file ids here. claw-auth resolves it to files
+  // itself at Vespa-query time; expanding it here could blow up to
+  // thousands of ids for one folder.
+  folderIds: z.array(z.string().min(1)).optional(),
+  folder_ids: z.array(z.string().min(1)).optional(),
   attachedContext: AttachedContextSchema,
   attached_context: AttachedContextSchema,
   displayQuery: z.string().optional(),
@@ -278,6 +285,8 @@ export class XyneAIControllerV2 {
       collection_ids,
       fileIds,
       file_ids,
+      folderIds,
+      folder_ids,
       attachedContext,
       attached_context,
       draftMode,
@@ -306,6 +315,7 @@ export class XyneAIControllerV2 {
     const effectiveCallIds = callIds?.length ? callIds : call_ids;
     const effectiveCollectionIds = collectionIds?.length ? collectionIds : collection_ids;
     const effectiveFileIds = fileIds?.length ? fileIds : file_ids;
+    const effectiveFolderIds = folderIds?.length ? folderIds : folder_ids;
     // Same snake-case fallback rationale for branching params — the worker
     // sends snake_case; HTTP callers may use either.
     const effectiveParentMessageId = parentMessageIdCC || parentMessageIdSC;
@@ -482,16 +492,23 @@ export class XyneAIControllerV2 {
         agentSlug,
       });
 
-      // Resolve KB context (collections + files) → attached_context items so
-      // claw-auth's existing prompt-prefix mechanism surfaces them in the
-      // agent's prompt. We translate:
+      // Resolve KB context (collections + folders + files) → attached_context
+      // items so claw-auth's existing prompt-prefix mechanism surfaces them
+      // in the agent's prompt. We translate:
       //   • Collection.id (cuid)         → 'collection' attached_context item
+      //   • Collection.id (cuid, folder) → 'folder' attached_context item
       //   • CollectionItem.fileId (UUID) → CollectionItem.id (cuid) +
       //                                    'file' attached_context item
       // The cuid is what the agent's kb-* tools expect as fileId — see the
       // KB-tools handlers and the validateKbGrants files-set in claw-auth.
+      // A folder is deliberately sent as ONE pointer, not expanded to its
+      // (potentially thousands of) files here — attachedContext is a small,
+      // model-facing prompt list (claw-auth caps it at 20 items total), not a
+      // bulk id manifest. claw-auth resolves the folder to files itself, at
+      // Vespa-query time (buildVespaScope in kb-handlers.ts), from the KB
+      // tree it already fetches for permission checks.
       const kbAttachedContextItems: Array<{
-        type: 'collection' | 'file';
+        type: 'collection' | 'folder' | 'file';
         id: string;
         title: string;
       }> = [];
@@ -502,6 +519,15 @@ export class XyneAIControllerV2 {
         });
         for (const row of rows) {
           kbAttachedContextItems.push({ type: 'collection', id: row.id, title: row.name });
+        }
+      }
+      if (effectiveFolderIds && effectiveFolderIds.length > 0) {
+        const rows = await db.collection.findMany({
+          where: { id: { in: effectiveFolderIds }, deletedAt: null },
+          select: { id: true, name: true },
+        });
+        for (const row of rows) {
+          kbAttachedContextItems.push({ type: 'folder', id: row.id, title: row.name });
         }
       }
       if (effectiveFileIds && effectiveFileIds.length > 0) {

--- a/apps/backend/src/middleware/upload.ts
+++ b/apps/backend/src/middleware/upload.ts
@@ -208,6 +208,14 @@ export const versionUpload = multer({
   limits: { fileSize: 100 * 1024 * 1024 },
 });
 
+// In-memory (not GCS-streamed): the file is transient input to a conversion,
+// never stored.
+export const officeConversionUpload = multer({
+  storage: multer.memoryStorage(),
+  fileFilter: uploadFileFilter,
+  limits: { fileSize: 100 * 1024 * 1024, files: 1 },
+});
+
 const createUploadStreamConfig = (fileSizeBytes: number, maxFiles: number) =>
   multer({
     storage: streamingStorage,

--- a/apps/backend/src/routes/officeConversion.ts
+++ b/apps/backend/src/routes/officeConversion.ts
@@ -1,0 +1,15 @@
+import express from "express"
+import { OfficeConversionController } from "../controllers/officeConversionController"
+import { officeConversionUpload } from "../middleware/upload"
+
+const router = express.Router()
+const officeConversionController = new OfficeConversionController()
+
+// Converts an uploaded office document (pptx, docx, ...) to PDF via LibreOffice.
+router.post(
+    "/pdf",
+    officeConversionUpload.single("file"),
+    officeConversionController.convertToPdf,
+)
+
+export default router

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -51,10 +51,21 @@ export interface ClawRunRequest {
   // attached context; separate from `canvasIds` (picker canvases, keyed by cuid).
   canvasId?: string;
   attachedContext?: Array<{
-    // 'collection' + 'file' carry KB picks from the ask-ai v2 picker.
-    // claw-auth's resolveSection emits a prompt block that points the agent
-    // at kb-list-files / kb-read-file with the right id.
-    type: 'channel' | 'ticket' | 'canvas' | 'call' | 'activity' | 'collection' | 'file' | string;
+    // 'collection' / 'folder' / 'file' carry KB picks from the ask-ai v2
+    // picker. claw-auth's resolveSection emits a prompt block that points
+    // the agent at kb-list-files / kb-search / kb-read-file with the right
+    // id — a 'folder' id is NOT pre-expanded to its files here, claw-auth
+    // resolves it itself at Vespa-query time.
+    type:
+      | 'channel'
+      | 'ticket'
+      | 'canvas'
+      | 'call'
+      | 'activity'
+      | 'collection'
+      | 'folder'
+      | 'file'
+      | string;
     id: string;
     title: string;
     threadId?: string;

--- a/apps/backend/src/services/collectionAccess.ts
+++ b/apps/backend/src/services/collectionAccess.ts
@@ -66,6 +66,14 @@ async function getUserGroupIds(db: PrismaClient, userId: string): Promise<string
     return rows.map(r => r.userGroupId);
 }
 
+async function getUserChannelIds(db: PrismaClient, userId: string): Promise<string[]> {
+    const rows = await db.channelParticipant.findMany({
+        where: { userId },
+        select: { channelId: true },
+    });
+    return rows.map(r => r.channelId);
+}
+
 /**
  * Resolve the effective role for a user on a single (already-loaded) collection.
  * Caller must pre-load permissions if they want the same single-query path the
@@ -75,9 +83,9 @@ async function getUserGroupIds(db: PrismaClient, userId: string): Promise<string
 export async function resolveCollectionAccess(
     userId: string,
     collection: Pick<Collection, 'ownerId' | 'isPrivate'> & {
-        permissions?: Array<{ userId: string | null; userGroupId: string | null; role: CollectionRole }>;
+        permissions?: Array<{ userId: string | null; userGroupId: string | null; channelId?: string | null; role: CollectionRole }>;
     },
-    options?: { userGroupIds?: string[] }
+    options?: { userGroupIds?: string[]; userChannelIds?: string[] }
 ): Promise<ResolvedRoleResult> {
     if (collection.ownerId === userId) {
         return { role: CollectionRole.OWNER };
@@ -86,18 +94,24 @@ export async function resolveCollectionAccess(
     const db = DatabaseClient.getInstance();
     const userGroupIds = options?.userGroupIds ?? (await getUserGroupIds(db, userId));
     const groupSet = new Set(userGroupIds);
+    const userChannelIds = options?.userChannelIds ?? (await getUserChannelIds(db, userId));
+    const channelSet = new Set(userChannelIds);
 
     let role: CollectionRole | null = null;
     for (const p of collection.permissions ?? []) {
         if (p.userId === userId) role = maxRole(role, p.role);
         if (p.userGroupId && groupSet.has(p.userGroupId)) role = maxRole(role, p.role);
+        // Channel grants are always stored as VIEWER (enforced in
+        // grantPermission), so this can never elevate anyone above VIEWER.
+        if (p.channelId && channelSet.has(p.channelId)) role = maxRole(role, p.role);
     }
 
     if (!role && !collection.isPrivate) {
-        // Public collections grant implicit EDITOR — mirrors prior behaviour at
-        // collectionController.ts:191-193. Kept here so the legacy controller's
-        // upload/edit paths still permit non-private collections.
-        role = CollectionRole.EDITOR;
+        // Public collections grant implicit VIEWER (read-only) — write access
+        // requires being the owner or an explicit collaborator (EDITOR/OWNER
+        // CollectionPermission row). See zero/mutators.ts's matching write-path
+        // checks for the enforcement side of this.
+        role = CollectionRole.VIEWER;
     }
 
     return { role };
@@ -116,6 +130,7 @@ export async function listAccessibleRootCollections(
 ): Promise<Array<AccessibleCollectionNode>> {
     const db = DatabaseClient.getInstance();
     const userGroupIds = await getUserGroupIds(db, userId);
+    const userChannelIds = await getUserChannelIds(db, userId);
 
     const rows = await db.collection.findMany({
         where: {
@@ -131,6 +146,9 @@ export async function listAccessibleRootCollections(
                 ...(userGroupIds.length > 0
                     ? [{ permissions: { some: { userGroupId: { in: userGroupIds } } } }]
                     : []),
+                ...(userChannelIds.length > 0
+                    ? [{ permissions: { some: { channelId: { in: userChannelIds } } } }]
+                    : []),
             ],
         },
         include: {
@@ -139,9 +157,10 @@ export async function listAccessibleRootCollections(
                     OR: [
                         { userId },
                         ...(userGroupIds.length > 0 ? [{ userGroupId: { in: userGroupIds } }] : []),
+                        ...(userChannelIds.length > 0 ? [{ channelId: { in: userChannelIds } }] : []),
                     ],
                 },
-                select: { userId: true, userGroupId: true, role: true },
+                select: { userId: true, userGroupId: true, channelId: true, role: true },
             },
         },
         orderBy: { createdAt: 'desc' },
@@ -199,8 +218,8 @@ export async function listAccessibleRootCollections(
     for (const row of rows) {
         const { role } = await resolveCollectionAccess(
             userId,
-            { ownerId: row.ownerId, isPrivate: row.isPrivate, permissions: row.permissions as Array<{ userId: string | null; userGroupId: string | null; role: CollectionRole }> },
-            { userGroupIds }
+            { ownerId: row.ownerId, isPrivate: row.isPrivate, permissions: row.permissions as Array<{ userId: string | null; userGroupId: string | null; channelId: string | null; role: CollectionRole }> },
+            { userGroupIds, userChannelIds }
         );
         if (!role) continue;
         const meta = row.scopeType === 'CHANNEL' ? channelMeta.get(row.scopeId) : undefined;

--- a/apps/backend/src/services/driveImport/driveImportWorker.ts
+++ b/apps/backend/src/services/driveImport/driveImportWorker.ts
@@ -281,7 +281,9 @@ export async function processDriveImportJob(data: DriveImportJobData): Promise<v
         if (err instanceof DriveUnauthorizedError) progress.needsDriveAuth = true;
         progress.processed += 1;
         await writeDriveImportProgress(sessionId, progress);
-        logger.error(`[DRIVE_IMPORT] Failed to import ${df.name}:`, err);
+        // df.name is an untrusted Drive file name — pass it as a structured field
+        // rather than interpolating into the message (CodeQL js/log-injection).
+        logger.error('[DRIVE_IMPORT] Failed to import file', { fileName: df.name, error: err });
       }
     }
   } finally {

--- a/apps/backend/src/services/fileProcessor/DoclingService.ts
+++ b/apps/backend/src/services/fileProcessor/DoclingService.ts
@@ -225,7 +225,7 @@ export class DoclingService {
    * @returns True if page info should be appended
    */
   private shouldAppendPageInfo(extension: string): boolean {
-    const supportedExtensions = ["pdf", "docx"];
+    const supportedExtensions = ["pdf", "docx", "pptx", "ppt"];
     return supportedExtensions.includes(extension);
   }
 

--- a/apps/backend/src/services/fileProcessor/FileProcessor.ts
+++ b/apps/backend/src/services/fileProcessor/FileProcessor.ts
@@ -6,6 +6,7 @@ import { BaseStrategy } from "./strategies/BaseStrategy"
 import { TextStrategy } from "./strategies/TextStrategy"
 import { PdfJsStrategy } from "./strategies/PdfJsStrategy"
 import { DocxStrategy } from "./strategies/DocxStrategy"
+import { PptxStrategy } from "./strategies/PptxStrategy"
 import { ImageDescriptionStrategy } from "./strategies/ImageStrategy"
 import { SpreadsheetStrategy } from "./strategies/SpreadsheetStrategy"
 import { PdfFallbackProcessor } from "./PdfFallbackProcessor"
@@ -241,6 +242,9 @@ export class FileProcessor {
                 return new PdfJsStrategy(config)
             case "docx":
                 return new DocxStrategy(config)
+            case "pptx":
+            case "ppt":
+                return new PptxStrategy(config)
             case "xls":
             case "xlsx":
                 return new SpreadsheetStrategy(config)
@@ -275,6 +279,9 @@ export class FileProcessor {
                 return new PdfJsStrategy(config)
             case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
                 return new DocxStrategy(config)
+            case "application/vnd.ms-powerpoint":
+            case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+                return new PptxStrategy(config)
             case "application/vnd.ms-excel":
             case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
                 return new SpreadsheetStrategy(config)

--- a/apps/backend/src/services/fileProcessor/pptxSlideParser.ts
+++ b/apps/backend/src/services/fileProcessor/pptxSlideParser.ts
@@ -1,0 +1,315 @@
+import JSZip from "jszip"
+import { XMLParser } from "fast-xml-parser"
+
+/**
+ * Low-level PPTX (OOXML) parser shared by PptxStrategy (text extraction for
+ * Vespa ingestion) and collectionController's slide-viewer endpoint (visual
+ * rendering). PPTX is a ZIP of XML, same family as DOCX — this mirrors
+ * DocxStrategy's JSZip + fast-xml-parser approach, just walking
+ * ppt/slides/slideN.xml's DrawingML shape tree instead of
+ * word/document.xml's WordprocessingML paragraph tree.
+ *
+ * Positions/sizes are returned in raw EMU (English Metric Units, OOXML's
+ * native unit — 914400 EMU per inch) alongside the slide's own EMU
+ * dimensions, so callers can convert to whatever target canvas they need
+ * rather than baking in an assumption here.
+ */
+
+const EMU_PER_INCH = 914400
+
+export interface ParsedTextRun {
+    text: string
+    bold?: boolean
+    italic?: boolean
+    /** 6-hex-digit RGB, no '#' prefix (matches OOXML's <a:srgbClr val="RRGGBB"/> directly) */
+    color?: string
+    /** Points */
+    fontSize?: number
+    bullet?: boolean
+}
+
+export interface ParsedShape {
+    kind: "text" | "image"
+    /** OOXML placeholder type, e.g. "title" | "ctrTitle" | "subTitle" | "body" — absent for non-placeholder shapes */
+    placeholderType?: string
+    /** One entry per paragraph in the shape's text body */
+    runs?: ParsedTextRun[]
+    /** EMU */
+    x?: number
+    y?: number
+    w?: number
+    h?: number
+    /** 6-hex-digit RGB, no '#' prefix */
+    fillColor?: string
+    image?: { base64: string; mimeType: string }
+}
+
+export interface ParsedSlide {
+    /** 1-based, in presentation (display) order */
+    index: number
+    shapes: ParsedShape[]
+}
+
+export interface ParsedPptx {
+    /** EMU */
+    slideWidthEmu: number
+    /** EMU */
+    slideHeightEmu: number
+    slides: ParsedSlide[]
+}
+
+const xmlParser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+    preserveOrder: false,
+    removeNSPrefix: true,
+    processEntities: {
+        maxTotalExpansions: 10000,
+        maxEntityCount: 1000,
+    },
+})
+
+// A second parser WITHOUT namespace stripping, used only for
+// ppt/presentation.xml's <p:sldId id="256" r:id="rId2"/> — its plain `id`
+// (the slide's own numeric id) and namespaced `r:id` (the relationship id
+// we actually need) would otherwise collide onto the same `@_id` key once
+// prefixes are stripped, silently picking whichever happened to parse last.
+const nsAwareXmlParser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+    preserveOrder: false,
+    removeNSPrefix: false,
+    processEntities: {
+        maxTotalExpansions: 10000,
+        maxEntityCount: 1000,
+    },
+})
+
+function asArray<T>(value: T | T[] | undefined): T[] {
+    if (value == null) return []
+    return Array.isArray(value) ? value : [value]
+}
+
+const IMAGE_EXT_TO_MIME: Record<string, string> = {
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    bmp: "image/bmp",
+    webp: "image/webp",
+    tiff: "image/tiff",
+    emf: "image/x-emf",
+    wmf: "image/x-wmf",
+}
+
+/**
+ * Resolve r:id -> target path for a part, from its sibling _rels/*.rels file.
+ */
+async function readRels(zip: JSZip, relsPath: string): Promise<Map<string, string>> {
+    const map = new Map<string, string>()
+    const relsFile = zip.file(relsPath)
+    if (!relsFile) return map
+    const xml = await relsFile.async("text")
+    const parsed = xmlParser.parse(xml)
+    const relationships = asArray(parsed?.Relationships?.Relationship)
+    for (const rel of relationships) {
+        const id = rel?.["@_Id"]
+        const target = rel?.["@_Target"]
+        if (id && target) map.set(id, target)
+    }
+    return map
+}
+
+/** Resolve a relationship target (possibly relative, e.g. "../media/image1.png") against its part's directory. */
+function resolveRelTarget(partDir: string, target: string): string {
+    if (target.startsWith("/")) return target.slice(1)
+    const parts = `${partDir}/${target}`.split("/")
+    const resolved: string[] = []
+    for (const part of parts) {
+        if (part === "." || part === "") continue
+        if (part === "..") resolved.pop()
+        else resolved.push(part)
+    }
+    return resolved.join("/")
+}
+
+function extractRunsFromTxBody(txBody: any): ParsedTextRun[] {
+    const runs: ParsedTextRun[] = []
+    const paragraphs = asArray(txBody?.p)
+    for (const p of paragraphs) {
+        const rNodes = asArray(p?.r)
+        const bullet = p?.pPr?.buChar != null || p?.pPr?.buAutoNum != null
+        let text = ""
+        let bold: boolean | undefined
+        let italic: boolean | undefined
+        let color: string | undefined
+        let fontSize: number | undefined
+        for (const r of rNodes) {
+            const t = r?.t
+            const runText = typeof t === "string" ? t : (t?.["#text"] ?? "")
+            text += runText
+            const rPr = r?.rPr
+            if (rPr) {
+                if (rPr["@_b"] === "1" || rPr["@_b"] === 1 || rPr["@_b"] === true) bold = true
+                if (rPr["@_i"] === "1" || rPr["@_i"] === 1 || rPr["@_i"] === true) italic = true
+                const sz = rPr["@_sz"]
+                if (sz != null) fontSize = Number(sz) / 100 // OOXML sz is in hundredths of a point
+                const srgb = rPr?.solidFill?.srgbClr?.["@_val"]
+                if (srgb) color = String(srgb)
+            }
+        }
+        if (text.trim().length > 0) {
+            runs.push({
+                text,
+                ...(bold !== undefined && { bold }),
+                ...(italic !== undefined && { italic }),
+                ...(color !== undefined && { color }),
+                ...(fontSize !== undefined && { fontSize }),
+                ...(bullet && { bullet: true }),
+            })
+        }
+    }
+    return runs
+}
+
+function extractXfrm(spPr: any): { x?: number; y?: number; w?: number; h?: number } {
+    const xfrm = spPr?.xfrm
+    if (!xfrm) return {}
+    const off = xfrm.off
+    const ext = xfrm.ext
+    return {
+        ...(off?.["@_x"] != null && { x: Number(off["@_x"]) }),
+        ...(off?.["@_y"] != null && { y: Number(off["@_y"]) }),
+        ...(ext?.["@_cx"] != null && { w: Number(ext["@_cx"]) }),
+        ...(ext?.["@_cy"] != null && { h: Number(ext["@_cy"]) }),
+    }
+}
+
+function extractFillColor(spPr: any): string | undefined {
+    const srgb = spPr?.solidFill?.srgbClr?.["@_val"]
+    return srgb ? String(srgb) : undefined
+}
+
+async function parseSlideXml(
+    zip: JSZip,
+    slideXmlPath: string,
+    slideIndex: number,
+): Promise<ParsedSlide> {
+    const xmlFile = zip.file(slideXmlPath)
+    if (!xmlFile) return { index: slideIndex, shapes: [] }
+    const xml = await xmlFile.async("text")
+    const parsed = xmlParser.parse(xml)
+
+    const relsPath = slideXmlPath.replace(/^(.*)\/([^/]+)$/, "$1/_rels/$2.rels")
+    const rels = await readRels(zip, relsPath)
+    const partDir = slideXmlPath.split("/").slice(0, -1).join("/")
+
+    const spTree = parsed?.sld?.cSld?.spTree
+    const shapes: ParsedShape[] = []
+
+    for (const sp of asArray(spTree?.sp)) {
+        const placeholderType: string | undefined = sp?.nvSpPr?.nvPr?.ph?.["@_type"]
+        const runs = extractRunsFromTxBody(sp?.txBody)
+        const { x, y, w, h } = extractXfrm(sp?.spPr)
+        const fillColor = extractFillColor(sp?.spPr)
+        if (runs.length > 0 || x !== undefined) {
+            shapes.push({
+                kind: "text",
+                ...(placeholderType && { placeholderType }),
+                runs,
+                x,
+                y,
+                w,
+                h,
+                ...(fillColor && { fillColor }),
+            })
+        }
+    }
+
+    for (const pic of asArray(spTree?.pic)) {
+        const embedId: string | undefined = pic?.blipFill?.blip?.["@_embed"]
+        const { x, y, w, h } = extractXfrm(pic?.spPr)
+        if (!embedId) continue
+        const target = rels.get(embedId)
+        if (!target) continue
+        const mediaPath = resolveRelTarget(partDir, target)
+        const mediaFile = zip.file(mediaPath)
+        if (!mediaFile) continue
+        const ext = mediaPath.split(".").pop()?.toLowerCase() ?? ""
+        const mimeType = IMAGE_EXT_TO_MIME[ext]
+        // Skip formats browsers can't render inline (EMF/WMF vector metafiles) —
+        // they'd need their own conversion step; leaving the shape out entirely
+        // is better than embedding a data URI the <img> tag can't decode.
+        if (!mimeType || mimeType.startsWith("image/x-")) continue
+        const base64 = await mediaFile.async("base64")
+        shapes.push({ kind: "image", x, y, w, h, image: { base64, mimeType } })
+    }
+
+    return { index: slideIndex, shapes }
+}
+
+/**
+ * Parse a PPTX buffer into per-slide shape data, in presentation (display)
+ * order — resolved via ppt/presentation.xml's slide id list and its
+ * relationship file, not by filename sort, since slideN.xml numbering isn't
+ * guaranteed to match display order after slides are reordered.
+ */
+export async function parsePptxSlides(buffer: Buffer): Promise<ParsedPptx> {
+    const zip = await JSZip.loadAsync(buffer)
+
+    const presentationFile = zip.file("ppt/presentation.xml")
+    if (!presentationFile) {
+        throw new Error("ppt/presentation.xml not found in PPTX archive")
+    }
+    const presentationXml = await presentationFile.async("text")
+    const presentation = xmlParser.parse(presentationXml)
+
+    const sldSz = presentation?.presentation?.sldSz
+    const slideWidthEmu = sldSz?.["@_cx"] != null ? Number(sldSz["@_cx"]) : 9144000 // 10in default
+    const slideHeightEmu = sldSz?.["@_cy"] != null ? Number(sldSz["@_cy"]) : 6858000 // 7.5in default (4:3)
+
+    // Namespace-preserved re-parse just for the slide id list: <p:sldId
+    // id="256" r:id="rId2"/> has both a plain `id` (the slide's own numeric
+    // id, unrelated) and a namespaced `r:id` (the relationship id we need) —
+    // removeNSPrefix would collide them onto one `@_id` key.
+    const presentationNsAware = nsAwareXmlParser.parse(presentationXml)
+    const sldIds = asArray(presentationNsAware?.["p:presentation"]?.["p:sldIdLst"]?.["p:sldId"])
+
+    const presentationRels = await readRels(zip, "ppt/_rels/presentation.xml.rels")
+
+    const slides: ParsedSlide[] = []
+    let index = 1
+    for (const sldId of sldIds) {
+        const relId: string | undefined = sldId?.["@_r:id"]
+        const target = relId ? presentationRels.get(relId) : undefined
+        if (!target) {
+            index++
+            continue
+        }
+        const slideXmlPath = resolveRelTarget("ppt", target)
+        slides.push(await parseSlideXml(zip, slideXmlPath, index))
+        index++
+    }
+
+    // Fallback: if the presentation.xml relationship walk found nothing
+    // (unexpected structure), enumerate ppt/slides/slideN.xml directly —
+    // correct in the common case, just not reorder-safe.
+    if (slides.length === 0) {
+        const slideFiles = Object.keys(zip.files)
+            .filter(name => /^ppt\/slides\/slide\d+\.xml$/.test(name))
+            .sort((a, b) => {
+                const numA = Number(a.match(/slide(\d+)\.xml$/)?.[1] ?? 0)
+                const numB = Number(b.match(/slide(\d+)\.xml$/)?.[1] ?? 0)
+                return numA - numB
+            })
+        let fallbackIndex = 1
+        for (const path of slideFiles) {
+            slides.push(await parseSlideXml(zip, path, fallbackIndex))
+            fallbackIndex++
+        }
+    }
+
+    return { slideWidthEmu, slideHeightEmu, slides }
+}
+
+export { EMU_PER_INCH }

--- a/apps/backend/src/services/fileProcessor/strategies/PptxStrategy.ts
+++ b/apps/backend/src/services/fileProcessor/strategies/PptxStrategy.ts
@@ -1,0 +1,140 @@
+import { BaseStrategy } from "./BaseStrategy"
+import type { ProcessingResult, StrategyConfig, ChunkMetadata } from "../types"
+import { parsePptxSlides } from "../pptxSlideParser"
+
+const TITLE_PLACEHOLDER_TYPES = new Set(["title", "ctrTitle", "subTitle"])
+
+/**
+ * PPTX parsing strategy — native text extraction for uploaded .ppt/.pptx
+ * files, used as the fallback when Docling is disabled/unavailable/fails
+ * (see FileProcessor.processBufferWithFallback). Docling remains the OCR
+ * path for text baked into slide images/screenshots; this strategy covers
+ * the common case of native, machine-readable slide text reliably and
+ * without any external dependency.
+ *
+ * PPTX files are ZIP archives containing XML, same family as DOCX — this
+ * mirrors DocxStrategy's structure (JSZip + fast-xml-parser, paragraph-style
+ * chunking with page/label metadata), reading ppt/slides/slideN.xml via the
+ * shared pptxSlideParser instead of DocxStrategy's word/document.xml walk.
+ * A slide stands in for a "page"; the placeholder type (title vs body)
+ * stands in for heading level.
+ */
+export class PptxStrategy extends BaseStrategy {
+    private config: Required<Pick<StrategyConfig, "chunkSize" | "chunkOverlap">>
+
+    constructor(config?: StrategyConfig) {
+        super()
+        this.config = {
+            chunkSize: config?.chunkSize ?? 1000,
+            chunkOverlap: config?.chunkOverlap ?? 200,
+        }
+    }
+
+    async parse(buffer: Buffer, vespaDocId: string): Promise<ProcessingResult> {
+        try {
+            const { slides } = await parsePptxSlides(buffer)
+
+            const paragraphs = this.extractParagraphsWithMeta(slides)
+            const { chunks, chunks_map } = this.chunkByParagraphsWithMeta(paragraphs)
+
+            const documentOutline = await this.buildDocumentOutline(chunks, chunks_map, vespaDocId)
+
+            return {
+                chunks,
+                chunks_map,
+                documentOutline,
+                processingMethod: this.getName(),
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            throw new Error(`PPTX parsing failed: ${message}`)
+        }
+    }
+
+    /**
+     * Flatten parsed slides into paragraph-like entries — one per shape's
+     * text-body paragraph, tagged with its slide number (standing in for
+     * page) and a "title"/"text" label derived from the shape's placeholder
+     * type — so the same greedy chunker DocxStrategy uses can run unchanged.
+     */
+    private extractParagraphsWithMeta(
+        slides: Awaited<ReturnType<typeof parsePptxSlides>>["slides"],
+    ): Array<{ text: string; page: number; blockLabel: string }> {
+        const results: Array<{ text: string; page: number; blockLabel: string }> = []
+
+        for (const slide of slides) {
+            for (const shape of slide.shapes) {
+                if (shape.kind !== "text" || !shape.runs) continue
+                const blockLabel =
+                    shape.placeholderType && TITLE_PLACEHOLDER_TYPES.has(shape.placeholderType)
+                        ? "title"
+                        : "text"
+                for (const run of shape.runs) {
+                    const text = run.text.trim()
+                    if (text.length > 0) {
+                        results.push({ text, page: slide.index, blockLabel })
+                    }
+                }
+            }
+        }
+
+        return results
+    }
+
+    /**
+     * Chunk paragraphs while building chunks_map with real slide numbers and
+     * placeholder-derived block labels. Identical shape to DocxStrategy's
+     * chunkByParagraphsWithMeta — [Slide N] instead of [Page N].
+     */
+    private chunkByParagraphsWithMeta(
+        paragraphs: Array<{ text: string; page: number; blockLabel: string }>,
+    ): { chunks: string[]; chunks_map: ChunkMetadata[] } {
+        const chunks: string[] = []
+        const chunks_map: ChunkMetadata[] = []
+
+        let currentChunk = ""
+        let currentPages = new Set<number>()
+        let currentLabels = new Set<string>()
+        let chunkIndex = 0
+        const { chunkSize } = this.config
+
+        const flush = () => {
+            if (currentChunk.trim().length === 0) return
+            const pages = Array.from(currentPages).sort((a, b) => a - b)
+            const pageLabel = pages.length === 1 ? `[Slide ${pages[0]}]` : `[Slides ${pages.join(", ")}]`
+            chunks.push(`${pageLabel}\n${currentChunk.trim()}`)
+            chunks_map.push({
+                chunk_index: chunkIndex++,
+                page_numbers: pages,
+                block_labels: Array.from(currentLabels),
+            })
+            currentChunk = ""
+            currentPages = new Set()
+            currentLabels = new Set()
+        }
+
+        for (const { text, page, blockLabel } of paragraphs) {
+            // A slide boundary always starts a fresh chunk — unlike DOCX,
+            // where an unbroken multi-page paragraph flow is common, PPTX
+            // slides are naturally discrete units and mixing two slides'
+            // text into one chunk (just because both are small) muddies the
+            // per-slide citation this is meant to preserve.
+            if (currentPages.size > 0 && !currentPages.has(page)) {
+                flush()
+            } else if (currentChunk.length + text.length + 2 > chunkSize && currentChunk.length > 0) {
+                flush()
+            }
+            currentChunk += (currentChunk ? "\n\n" : "") + text
+            currentPages.add(page)
+            currentLabels.add(blockLabel)
+        }
+
+        flush()
+
+        return { chunks, chunks_map }
+    }
+
+    getName(): string {
+        return "pptx-xml-parser"
+    }
+}

--- a/apps/backend/src/services/officeConversionService.ts
+++ b/apps/backend/src/services/officeConversionService.ts
@@ -1,0 +1,207 @@
+import { spawn } from "child_process"
+import { createHash } from "crypto"
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import { logger } from "@/utils/logger"
+import { storageService } from "@/services/storage"
+import { isPreconditionFailed } from "@xyne/storage"
+
+/**
+ * Converts an office document (pptx, docx, xlsx, ...) to PDF via LibreOffice's
+ * headless CLI — the same approach Google Drive/Slack/Notion previews use.
+ * Reimplementing OOXML rendering in the browser (the prior approach for the
+ * PPTX viewer) can never be "exact": OOXML is too large a spec, and every
+ * fixed gap (theme colors, placeholder inheritance, custom geometry, picture
+ * effects) just reveals the next one. Shelling out to a real office engine
+ * sidesteps that entirely by letting it do the rendering.
+ *
+ * `-env:UserInstallation` gives each conversion its own LibreOffice profile
+ * directory — soffice locks its profile against concurrent use, so sharing
+ * the default profile across concurrent requests causes conversions to hang
+ * or fail outright.
+ */
+
+const SOFFICE_BINARY = process.env.SOFFICE_PATH || "soffice"
+const CONVERSION_TIMEOUT_MS = 60_000
+
+// Two-tier cache, both keyed on the content hash (this endpoint is
+// stateless — no file/collection id, just bytes, so content is the only key
+// available):
+//   1. Local disk — near-zero latency, but wiped on pod restart and not
+//      shared across replicas.
+//   2. GCS (the same bucket every other upload in this app already uses) —
+//      survives restarts and is shared across every backend replica, at the
+//      cost of a network round trip instead of a local read.
+// A hit on tier 2 backfills tier 1, so a given pod only pays the GCS latency
+// once per content hash.
+const CACHE_DIR = path.join(tmpdir(), "office-conversion-cache")
+const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000
+const GCS_CACHE_PREFIX = "office-conversion-cache"
+
+export class OfficeConversionError extends Error {
+    constructor(
+        message: string,
+        public readonly code: "SOFFICE_NOT_FOUND" | "TIMEOUT" | "CONVERSION_FAILED",
+    ) {
+        super(message)
+        this.name = "OfficeConversionError"
+    }
+}
+
+async function readLocalCache(cachePath: string): Promise<Buffer | null> {
+    try {
+        const stats = await stat(cachePath)
+        if (Date.now() - stats.mtimeMs > CACHE_MAX_AGE_MS) return null
+        return await readFile(cachePath)
+    } catch {
+        return null
+    }
+}
+
+async function writeLocalCache(cachePath: string, buffer: Buffer, contentHash: string): Promise<void> {
+    await mkdir(CACHE_DIR, { recursive: true })
+        .then(() => writeFile(cachePath, buffer))
+        .catch(err => {
+            logger.warn("[OfficeConversion] Failed to write local cache entry", {
+                contentHash,
+                error: err instanceof Error ? err.message : String(err),
+            })
+        })
+}
+
+async function readGcsCache(gcsPath: string): Promise<Buffer | null> {
+    try {
+        // getFileBuffer retries with backoff on a missing file (it's built
+        // for "should exist, might not be finalized yet" reads) — pointless
+        // delay on a genuine cache miss, so check existence first.
+        const exists = await storageService.fileExists(gcsPath)
+        if (!exists) return null
+        return await storageService.getFileBuffer(gcsPath)
+    } catch {
+        return null
+    }
+}
+
+async function writeGcsCache(gcsPath: string, buffer: Buffer, contentHash: string): Promise<void> {
+    try {
+        // Content-addressed, so a collision means another replica already
+        // cached the identical bytes concurrently — not an error.
+        await storageService.uploadFileV2(buffer, {
+            path: gcsPath,
+            contentType: "application/pdf",
+            ifNotExists: true,
+        })
+    } catch (err) {
+        if (isPreconditionFailed(err)) return
+        logger.warn("[OfficeConversion] Failed to write GCS cache entry", {
+            contentHash,
+            error: err instanceof Error ? err.message : String(err),
+        })
+    }
+}
+
+export async function convertToPdf(buffer: Buffer, originalFilename: string): Promise<Buffer> {
+    const contentHash = createHash("sha256").update(buffer).digest("hex")
+    const cachePath = path.join(CACHE_DIR, `${contentHash}.pdf`)
+    const gcsPath = `${GCS_CACHE_PREFIX}/${contentHash}.pdf`
+
+    const localHit = await readLocalCache(cachePath)
+    if (localHit) {
+        logger.info("[OfficeConversion] Local cache hit", { contentHash })
+        return localHit
+    }
+
+    const gcsHit = await readGcsCache(gcsPath)
+    if (gcsHit) {
+        logger.info("[OfficeConversion] GCS cache hit", { contentHash })
+        await writeLocalCache(cachePath, gcsHit, contentHash)
+        return gcsHit
+    }
+
+    const workDir = await mkdtemp(path.join(tmpdir(), "office-convert-"))
+    const profileDir = path.join(workDir, "profile")
+    const ext = path.extname(originalFilename) || ".bin"
+    const inputPath = path.join(workDir, `input${ext}`)
+    const outputPath = path.join(workDir, "input.pdf")
+
+    try {
+        await writeFile(inputPath, buffer)
+
+        await new Promise<void>((resolve, reject) => {
+            const args = [
+                "--headless",
+                "--norestore",
+                `-env:UserInstallation=file://${profileDir}`,
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                workDir,
+                inputPath,
+            ]
+            const proc = spawn(SOFFICE_BINARY, args)
+
+            let stderr = ""
+            let stdout = ""
+            const timer = setTimeout(() => {
+                proc.kill("SIGKILL")
+                reject(new OfficeConversionError("LibreOffice conversion timed out", "TIMEOUT"))
+            }, CONVERSION_TIMEOUT_MS)
+
+            proc.stderr.on("data", chunk => {
+                stderr += chunk.toString()
+            })
+            proc.stdout.on("data", chunk => {
+                stdout += chunk.toString()
+            })
+            proc.on("error", err => {
+                clearTimeout(timer)
+                if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+                    reject(
+                        new OfficeConversionError(
+                            `LibreOffice binary not found (looked for "${SOFFICE_BINARY}")`,
+                            "SOFFICE_NOT_FOUND",
+                        ),
+                    )
+                    return
+                }
+                reject(new OfficeConversionError(err.message, "CONVERSION_FAILED"))
+            })
+            proc.on("close", code => {
+                clearTimeout(timer)
+                if (code === 0) {
+                    resolve()
+                } else {
+                    logger.error("[OfficeConversion] soffice exited non-zero", {
+                        code,
+                        stderr: stderr.slice(-2000),
+                        stdout: stdout.slice(-2000),
+                    })
+                    reject(
+                        new OfficeConversionError(
+                            `LibreOffice exited with code ${code}`,
+                            "CONVERSION_FAILED",
+                        ),
+                    )
+                }
+            })
+        })
+
+        const result = await readFile(outputPath)
+
+        await Promise.all([
+            writeLocalCache(cachePath, result, contentHash),
+            writeGcsCache(gcsPath, result, contentHash),
+        ])
+
+        return result
+    } finally {
+        await rm(workDir, { recursive: true, force: true }).catch(err => {
+            logger.warn("[OfficeConversion] Failed to clean up temp dir", {
+                workDir,
+                error: err instanceof Error ? err.message : String(err),
+            })
+        })
+    }
+}
+

--- a/apps/backend/src/services/pythonQuery/validator.ts
+++ b/apps/backend/src/services/pythonQuery/validator.ts
@@ -22,6 +22,7 @@ export const ALLOWED_MODELS = new Set([
   'notification',
   'call',
   'canvas',
+  'collectionItem',
   'organization',
   'form',
   'formEntityValues',

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -433,6 +433,50 @@ async function reopenClosedDmParticipants(
   }
 }
 
+const COLLECTION_ROLE_RANK: Record<CollectionRole, number> = {
+  [CollectionRole.VIEWER]: 1,
+  [CollectionRole.EDITOR]: 2,
+  [CollectionRole.OWNER]: 3,
+};
+
+/**
+ * Resolve a user's CollectionRole on a collection from its collection_permissions
+ * rows, considering a direct grant (userId), a grant made to a group they
+ * belong to (userGroupId), or a grant made to a channel they participate in
+ * (channelId — always VIEWER, enforced at grant time, but still needs to be
+ * visible here so a channel-only Viewer can exercise "any role can share").
+ * Mirrors collectionAccess.ts's resolveCollectionAccess read-side resolution,
+ * via Zero's tx instead of Prisma so mutators see the transaction's own
+ * consistent view. Membership is resolved at check-time, not fanned out into
+ * per-member rows — one group/channel-scoped row keeps covering every
+ * current+future member.
+ */
+async function resolveCollectionPermissionRole(
+  tx: Transaction<Schema>,
+  collectionId: string,
+  userId: string,
+): Promise<CollectionRole | null> {
+  const permissions = await tx.run(zql.collection_permissions.where('collectionId', collectionId));
+  const groupIds = new Set(
+    (await tx.run(zql.user_group_mappings.where('userId', userId))).map(m => m.userGroupId),
+  );
+  const channelIds = new Set(
+    (await tx.run(zql.channel_participants.where('userId', userId))).map(cp => cp.channelId),
+  );
+
+  let role: CollectionRole | null = null;
+  for (const p of permissions) {
+    const matches =
+      p.userId === userId ||
+      (p.userGroupId !== null && groupIds.has(p.userGroupId)) ||
+      (p.channelId !== null && channelIds.has(p.channelId));
+    if (!matches) continue;
+    const candidate = p.role as CollectionRole;
+    if (!role || COLLECTION_ROLE_RANK[candidate] > COLLECTION_ROLE_RANK[role]) role = candidate;
+  }
+  return role;
+}
+
 async function resolveMentionParticipantUserIds(
   tx: Transaction<Schema>,
   mentionedUserIds: string[],
@@ -15414,33 +15458,32 @@ export function createMutators(
             throw new Error('Collection not found');
           }
 
-          const isOwner = collection.ownerId === authData.sub;
+          // OWNER is a real, multi-holder role — the creator (ownerId) is a
+          // separate, permanent label, not the sole authority. Either grants
+          // full owner privilege here.
+          const isCreator = collection.ownerId === authData.sub;
+          const permissionRole = isCreator
+            ? null
+            : await resolveCollectionPermissionRole(tx, id, authData.sub);
+          const canActAsOwner = isCreator || permissionRole === CollectionRole.OWNER;
 
           // Visibility is owner-only: flipping isPrivate changes who can see
           // the collection at all, so EDITOR permissions are not enough.
-          if (isPrivate !== undefined && !isOwner) {
-            throw new Error('Collection update failed: only the owner can change visibility');
+          if (isPrivate !== undefined && !canActAsOwner) {
+            throw new Error('Collection update failed: only an owner can change visibility');
           }
 
           // Rename is owner-only too: collection names are surfaced wherever
           // the collection is referenced (sidebar, breadcrumbs, share UI),
           // so we treat the title the same as visibility — a property only
-          // the owner is allowed to change.
-          if (name !== undefined && !isOwner) {
-            throw new Error('Collection update failed: only the owner can rename the collection');
+          // owners are allowed to change.
+          if (name !== undefined && !canActAsOwner) {
+            throw new Error('Collection update failed: only an owner can rename the collection');
           }
 
           // Verify OWNER or EDITOR permission for name/description edits
-          if (!isOwner && collection.isPrivate) {
-            const permission = await tx.run(
-              zql.collection_permissions
-                .where('collectionId', id)
-                .where('userId', authData.sub)
-                .one(),
-            );
-            if (!permission || permission.role === CollectionRole.VIEWER) {
-              throw new Error('Collection update failed: requires EDITOR or OWNER permission');
-            }
+          if (!canActAsOwner && (!permissionRole || permissionRole === CollectionRole.VIEWER)) {
+            throw new Error('Collection update failed: requires EDITOR or OWNER permission');
           }
 
           await tx.mutate.collections.update({
@@ -15464,7 +15507,10 @@ export function createMutators(
             throw new Error('Collection not found');
           }
           if (collection.ownerId !== authData.sub) {
-            throw new Error('Collection deletion failed: only the owner can delete a collection');
+            const permissionRole = await resolveCollectionPermissionRole(tx, id, authData.sub);
+            if (permissionRole !== CollectionRole.OWNER) {
+              throw new Error('Collection deletion failed: only an owner can delete a collection');
+            }
           }
 
           await tx.mutate.collections.update({
@@ -15519,14 +15565,9 @@ export function createMutators(
           // Verify EDITOR+ permission against the root collection (permissions only exist on root collections)
           const rootCollectionId = parentCollection.rootCollectionId ?? parentId;
           const isOwner = parentCollection.ownerId === authData.sub;
-          if (!isOwner && parentCollection.isPrivate) {
-            const permission = await tx.run(
-              zql.collection_permissions
-                .where('collectionId', rootCollectionId)
-                .where('userId', authData.sub)
-                .one(),
-            );
-            if (!permission || permission.role === CollectionRole.VIEWER) {
+          if (!isOwner) {
+            const permissionRole = await resolveCollectionPermissionRole(tx, rootCollectionId, authData.sub);
+            if (!permissionRole || permissionRole === CollectionRole.VIEWER) {
               throw new Error('Folder creation failed: requires EDITOR or OWNER permission');
             }
           }
@@ -15562,14 +15603,9 @@ export function createMutators(
           // Verify EDITOR+ permission against the root collection (permissions only exist on root collections)
           const rootCollectionId = collection.rootCollectionId ?? collectionId;
           const isOwner = collection.ownerId === authData.sub;
-          if (!isOwner && collection.isPrivate) {
-            const permission = await tx.run(
-              zql.collection_permissions
-                .where('collectionId', rootCollectionId)
-                .where('userId', authData.sub)
-                .one(),
-            );
-            if (!permission || permission.role === CollectionRole.VIEWER) {
+          if (!isOwner) {
+            const permissionRole = await resolveCollectionPermissionRole(tx, rootCollectionId, authData.sub);
+            if (!permissionRole || permissionRole === CollectionRole.VIEWER) {
               throw new Error('Item deletion failed: requires EDITOR or OWNER permission');
             }
           }
@@ -15633,14 +15669,9 @@ export function createMutators(
           // Verify EDITOR+ permission against the root collection (permissions only exist on root collections)
           const rootCollectionId = collection.rootCollectionId ?? collectionId;
           const isOwner = collection.ownerId === authData.sub;
-          if (!isOwner && collection.isPrivate) {
-            const permission = await tx.run(
-              zql.collection_permissions
-                .where('collectionId', rootCollectionId)
-                .where('userId', authData.sub)
-                .one(),
-            );
-            if (!permission || permission.role === CollectionRole.VIEWER) {
+          if (!isOwner) {
+            const permissionRole = await resolveCollectionPermissionRole(tx, rootCollectionId, authData.sub);
+            if (!permissionRole || permissionRole === CollectionRole.VIEWER) {
               throw new Error('Item rename failed: requires EDITOR or OWNER permission');
             }
           }
@@ -15661,44 +15692,52 @@ export function createMutators(
           collectionId: z.string(),
           userId: z.string().optional(),
           userGroupId: z.string().optional(),
+          channelId: z.string().optional(),
           role: z.nativeEnum(CollectionRole),
-          canShare: z.boolean(),
           timestamp: z.number(),
         }),
-        async ({ tx, args: { id, collectionId, userId, userGroupId, role, canShare, timestamp } }) => {
+        async ({ tx, args: { id, collectionId, userId, userGroupId, channelId, role, timestamp } }) => {
           const collection = await tx.run(zql.collections.where('id', collectionId).one());
           if (!collection) {
             throw new Error('Collection not found');
           }
-    if (collection.ownerId !== authData.sub) {
-      const rootCollectionId = collection.rootCollectionId ?? collectionId;
-      const granterPermission = await tx.run(
-        zql.collection_permissions
-          .where('collectionId', rootCollectionId)
-          .where('userId', authData.sub)
-          .one(),
-      );
-      if (!granterPermission || !granterPermission.canShare) {
-        throw new Error('Permission grant failed: only owners or users with canShare can grant permissions');
-      }
+    // OWNER is a real, multi-holder role (like EDITOR/VIEWER) — the creator
+    // (collection.ownerId) is a separate, permanent, never-reassigned label,
+    // not the sole authority. Anyone holding an OWNER permission row gets the
+    // same full privilege as the creator here.
+    const isCreator = collection.ownerId === authData.sub;
+    const rootCollectionId = collection.rootCollectionId ?? collectionId;
+    const granterRole = isCreator
+      ? null
+      : await resolveCollectionPermissionRole(tx, rootCollectionId, authData.sub);
+    const granterIsOwner = isCreator || granterRole === CollectionRole.OWNER;
 
-      // Prevent role escalation: non-owners cannot grant a role higher than their own
-      const granterRole = granterPermission.role;
+    // Anyone with an explicit role (Viewer/Editor/Owner) can share — there's
+    // no separate delegated "canShare" permission. The only real limit is
+    // role escalation: you can't grant a role higher than your own.
+    if (!granterIsOwner) {
+      if (!granterRole) {
+        throw new Error('Permission grant failed: you do not have access to this collection');
+      }
       if (role === CollectionRole.OWNER) {
-        throw new Error('Permission grant failed: only the owner can grant OWNER role');
+        throw new Error('Permission grant failed: only an owner can grant OWNER role');
       }
       if (granterRole === CollectionRole.VIEWER && role !== CollectionRole.VIEWER) {
         throw new Error('Permission grant failed: VIEWERs can only grant VIEWER role');
-      }
-      // Prevent granting canShare if the granter doesn't have it (already checked above, but also block passing it through)
-      if (canShare && !granterPermission.canShare) {
-        throw new Error('Permission grant failed: you do not have permission to grant share access');
       }
     }
 
     // Prevent sharing with the collection owner
     if (userId && userId === collection.ownerId) {
       throw new Error('Cannot share collection with its owner');
+    }
+
+    // A channel grant is always read-only — a channel can have many members,
+    // so defaulting all of them to write access is a bigger blast radius
+    // than a person or a curated group. Enforced server-side regardless of
+    // what the UI sends.
+    if (channelId && role !== CollectionRole.VIEWER) {
+      throw new Error('Permission grant failed: channel grants are read-only (Viewer)');
     }
 
     const existing = userId
@@ -15708,13 +15747,31 @@ export function createMutators(
                   .where('userId', userId)
                   .one(),
               )
-            : null;
+            : userGroupId
+              ? await tx.run(
+                  zql.collection_permissions
+                    .where('collectionId', collectionId)
+                    .where('userGroupId', userGroupId)
+                    .one(),
+                )
+              : channelId
+                ? await tx.run(
+                    zql.collection_permissions
+                      .where('collectionId', collectionId)
+                      .where('channelId', channelId)
+                      .one(),
+                  )
+                : null;
 
           if (existing) {
             await tx.mutate.collection_permissions.update({
               id: existing.id,
               role,
-              canShare,
+              // Dead field — nothing reads canShare anymore (sharing is
+              // purely role-based, see the escalation check above). Kept at
+              // the Prisma column default since it's still NOT NULL; not
+              // threaded through as a caller-supplied argument.
+              canShare: false,
               updatedAt: timestamp,
             });
           } else {
@@ -15724,8 +15781,9 @@ export function createMutators(
               collectionId,
               userId,
               userGroupId,
+              channelId,
               role,
-              canShare,
+              canShare: false,
               grantedBy: authData.sub,
               createdAt: timestamp,
               updatedAt: timestamp,
@@ -15811,7 +15869,10 @@ export function createMutators(
             throw new Error('Collection not found');
           }
           if (collection.ownerId !== authData.sub) {
-            throw new Error('Permission revoke failed: only the owner can revoke permissions');
+            const granterRole = await resolveCollectionPermissionRole(tx, collectionId, authData.sub);
+            if (granterRole !== CollectionRole.OWNER) {
+              throw new Error('Permission revoke failed: only an owner can revoke permissions');
+            }
           }
 
           await tx.mutate.collection_permissions.delete({ id });

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -4830,7 +4830,20 @@ dmChannelsLatestMessagesPaginated: defineQuery(
       const scoped =
         scopeType && scopeId ? base.where('scopeType', scopeType).where('scopeId', scopeId) : base;
       return scoped
-        .related('permissions', p => p.where('userId', ctx.userID))
+        .related('permissions', p =>
+          // Direct grant, OR a grant on a group/channel this user belongs to —
+          // otherwise a group/channel-only grant never resolves a role here
+          // (same fix as scopedCollectionsWithItems below).
+          p.where(({ or, cmp, exists }) =>
+            or(
+              cmp('userId', '=', ctx.userID),
+              exists('userGroup', ug =>
+                ug.whereExists('userGroupMappings', m => m.where('userId', ctx.userID)),
+              ),
+              exists('channel', ch => ch.whereExists('participants', cp => cp.where('userId', ctx.userID))),
+            ),
+          ),
+        )
         .orderBy('createdAt', 'asc');
     },
   ),
@@ -4847,9 +4860,36 @@ dmChannelsLatestMessagesPaginated: defineQuery(
       const scoped =
         scopeType && scopeId ? base.where('scopeType', scopeType).where('scopeId', scopeId) : base;
       return scoped
-        .related('permissions', p => p.where('userId', ctx.userID))
+        .related('permissions', p =>
+          // Direct grant, OR a grant on a group/channel this user belongs to —
+          // otherwise a group/channel-only grant never reaches the client at
+          // all, and useGlobalCollections falls back to the VIEWER default
+          // even though the server mutators would allow the write.
+          p.where(({ or, cmp, exists }) =>
+            or(
+              cmp('userId', '=', ctx.userID),
+              exists('userGroup', ug =>
+                ug.whereExists('userGroupMappings', m => m.where('userId', ctx.userID)),
+              ),
+              exists('channel', ch => ch.whereExists('participants', cp => cp.where('userId', ctx.userID))),
+            ),
+          ),
+        )
         .related('allItems', i => i.where('isLatest', true).where('deletedAt', 'IS', null))
         .orderBy('createdAt', 'asc');
+    },
+  ),
+
+  // Every explicit grant (per-user or per-group) on a root collection — the
+  // "Who has access" list in ShareCollectionModal.
+  collectionPermissions: defineQuery(
+    z.object({ collectionId: z.string() }),
+    ({ args: { collectionId } }) => {
+      return zql.collection_permissions
+        .where('collectionId', collectionId)
+        .related('user')
+        .related('userGroup')
+        .related('channel');
     },
   ),
 

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -199,6 +199,7 @@
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
+    "rehype-slug": "^6.0.0",
     "rehype-stringify": "10.0.1",
     "remark-breaks": "^4.0.0",
     "remark-frontmatter": "^5.0.0",

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -21,6 +21,7 @@ import {
   Globe,
   Microscope,
   File as FileIcon,
+  Folder,
   BookOpen,
   Ticket,
   Phone,
@@ -134,7 +135,7 @@ function ContextPill({
       <span
         className={cn(
           'max-w-[140px] truncate text-[12.5px] font-medium',
-          accent ? 'text-[#7C3AED]' : 'text-foreground',
+          accent ? 'text-claw-ai-fg' : 'text-foreground',
         )}
       >
         {label}
@@ -235,6 +236,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
   }));
   const [collections, setCollections] = useState(() => seed.collections);
   const [fileScopes, setFileScopes] = useState(() => seed.fileScopes);
+  const [folderScopes, setFolderScopes] = useState(() => seed.folderScopes);
   const [webSearchEnabled, setWebSearchEnabled] = useState(() => seed.webSearchEnabled);
   const [deepResearchEnabled, setDeepResearchEnabled] = useState(() => seed.deepResearchEnabled);
   const [createCanvasEnabled, setCreateCanvasEnabled] = useState(() => seed.createCanvasEnabled);
@@ -303,6 +305,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       recordings: selections.recordings,
       collections,
       fileScopes,
+      folderScopes,
       research: null,
       webSearchEnabled: webSearchAccessible ? webSearchEnabled : false,
       deepResearchEnabled: deepResearchAccessible ? deepResearchEnabled : false,
@@ -316,6 +319,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       selections,
       collections,
       fileScopes,
+      folderScopes,
       webSearchEnabled,
       deepResearchEnabled,
       createCanvasEnabled,
@@ -578,8 +582,9 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
       selections.transcripts.length > 0 ||
       selections.recordings.length > 0 ||
       collections.length > 0 ||
-      fileScopes.length > 0,
-    [attachments, selections, collections, fileScopes],
+      fileScopes.length > 0 ||
+      folderScopes.length > 0,
+    [attachments, selections, collections, fileScopes, folderScopes],
   );
 
   const canSend = value.trim().length > 0;
@@ -687,7 +692,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
               {collections.map(collection => (
                 <ContextPill
                   key={`co-${collection.id}`}
-                  icon={<BookOpen className='h-3.5 w-3.5 shrink-0 text-[#7C3AED]' aria-hidden />}
+                  icon={<BookOpen className='h-3.5 w-3.5 shrink-0 text-claw-ai-fg' aria-hidden />}
                   label={collection.name}
                   accent
                   onRemove={() => setCollections(prev => prev.filter(c => c.id !== collection.id))}
@@ -696,10 +701,19 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
               {fileScopes.map(fs => (
                 <ContextPill
                   key={`fs-${fs.id}`}
-                  icon={<FileText className='h-3.5 w-3.5 shrink-0 text-[#7C3AED]' aria-hidden />}
+                  icon={<FileText className='h-3.5 w-3.5 shrink-0 text-claw-ai-fg' aria-hidden />}
                   label={fs.name}
                   accent
                   onRemove={() => setFileScopes(prev => prev.filter(f => f.id !== fs.id))}
+                />
+              ))}
+              {folderScopes.map(folder => (
+                <ContextPill
+                  key={`fo-${folder.id}`}
+                  icon={<Folder className='h-3.5 w-3.5 shrink-0 text-claw-ai-fg' aria-hidden />}
+                  label={folder.name}
+                  accent
+                  onRemove={() => setFolderScopes(prev => prev.filter(f => f.id !== folder.id))}
                 />
               ))}
               {attachments.map(attachment => (
@@ -769,8 +783,10 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
               <ComposerCollectionPicker
                 collections={collections}
                 fileScopes={fileScopes}
+                folderScopes={folderScopes}
                 onCollectionsChange={setCollections}
                 onFileScopesChange={setFileScopes}
+                onFolderScopesChange={setFolderScopes}
               />
               <div className='mx-0.5 h-4 w-px bg-border' />
 

--- a/apps/dashboard/src/components/AIScreen/AIShell.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIShell.tsx
@@ -1,4 +1,5 @@
 import { useRef, type ReactElement, type ReactNode, type RefObject } from 'react';
+import { cn } from '../../utils/classNames';
 import { AISidebar } from './AISidebar';
 import {
   ResizableGroup,
@@ -21,6 +22,10 @@ interface AIShellProps {
   mobileOpen?: boolean | undefined;
   onMobileOpenChange?: ((open: boolean) => void) | undefined;
   mainRef?: RefObject<HTMLDivElement | null> | undefined;
+  /** Overrides the main panel's background token (defaults to
+   *  `bg-background`) — e.g. `ai-page-bg` for screens (like /ai/knowledge)
+   *  that need to match a different surface elsewhere in the app. */
+  mainClassName?: string | undefined;
   children: ReactNode;
 }
 
@@ -32,6 +37,7 @@ export function AIShell({
   mobileOpen,
   onMobileOpenChange,
   mainRef,
+  mainClassName,
   children,
 }: AIShellProps): ReactElement {
   const sidebarPanelRef = useRef<PanelImperativeHandle>(null);
@@ -75,7 +81,10 @@ export function AIShell({
       <Panel id='ai-main' minSize='30%'>
         <div
           ref={mainRef}
-          className='bg-background relative flex h-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl'
+          className={cn(
+            'relative flex h-full min-w-0 flex-1 flex-col overflow-hidden rounded-2xl',
+            mainClassName ?? 'bg-background',
+          )}
         >
           {children}
         </div>

--- a/apps/dashboard/src/components/AIScreen/CitationDocsPanel.tsx
+++ b/apps/dashboard/src/components/AIScreen/CitationDocsPanel.tsx
@@ -1,25 +1,30 @@
 import { useEffect, useState, type ReactElement, type ReactNode } from 'react';
-import { Panel, ResizableGroup, Separator } from '../ui/Resizable/Resizable';
-import { X } from 'lucide-react';
+import { Panel, ResizableGroup, Separator, usePanelRef } from '../ui/Resizable/Resizable';
+import { ChevronDown, FileText, PanelRightClose, PanelRightOpen, X } from 'lucide-react';
 import { cn } from '../../utils/classNames';
 import PdfViewer from '../FileViewer/PdfViewer';
+import ReadmeViewer from '../FileViewer/ReadmeViewer';
+import { detectFileType } from '../FileViewer/utils';
 import { fetchFile } from '../../services/clients/fileFetchService';
 import { apiInstance } from '../../services/clients/apiClient';
 import { useCitationDocs, type CitationDoc } from './citationDocs';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
 
-/**
- * One open citation document: fetches the PDF bytes + the cited chunk's
- * highlight snippet, then renders the shared pdf.js viewer. Self-contained
- * (props only, no route/collection-tree coupling) so it works on the /ai page.
- * Chrome (name / close) lives in the panel's tab strip, not here.
- */
-function CitationDocView({ doc }: { doc: CitationDoc }): ReactElement {
+/** Fetches a KB file's bytes once per fileId/mimeType. Shared by both the PDF
+ *  and markdown branches below — only what's rendered on top differs. */
+function useCitationFile(
+  doc: Pick<CitationDoc, 'fileId' | 'name' | 'mimeType'>,
+  fallbackMimeType: string,
+): { file: File | null; loading: boolean; error: string | null } {
   const [file, setFile] = useState<File | null>(null);
-  const [highlightQuery, setHighlightQuery] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Fetch the file bytes once per file.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -28,7 +33,7 @@ function CitationDocView({ doc }: { doc: CitationDoc }): ReactElement {
     void fetchFile(
       `/collections/items/${doc.fileId}/download`,
       doc.name,
-      doc.mimeType ?? 'application/pdf',
+      doc.mimeType ?? fallbackMimeType,
     )
       .then(f => {
         if (!cancelled) setFile(f);
@@ -42,7 +47,16 @@ function CitationDocView({ doc }: { doc: CitationDoc }): ReactElement {
     return () => {
       cancelled = true;
     };
-  }, [doc.fileId, doc.name, doc.mimeType]);
+  }, [doc.fileId, doc.name, doc.mimeType, fallbackMimeType]);
+
+  return { file, loading, error };
+}
+
+/** PDF branch: adds the cited chunk's highlight snippet on top of the shared
+ *  file fetch, then renders the shared pdf.js viewer. */
+function CitationPdfView({ doc }: { doc: CitationDoc }): ReactElement {
+  const { file, loading, error } = useCitationFile(doc, 'application/pdf');
+  const [highlightQuery, setHighlightQuery] = useState<string | undefined>(undefined);
 
   // Resolve the cited chunk's highlight snippet. Re-runs on navSeq (re-click) so
   // a re-clicked citation re-highlights. Best-effort.
@@ -95,6 +109,145 @@ function CitationDocView({ doc }: { doc: CitationDoc }): ReactElement {
   );
 }
 
+/** Markdown branch: a compact filename + Raw/Preview header (mirrors the
+ *  reference design) over either the rendered doc (ReadmeViewer, reused from
+ *  the KB file viewer) or the raw source text. No chunk-highlight support —
+ *  ReadmeViewer doesn't have a find-and-scroll path like pdf.js does. */
+function CitationMarkdownView({ doc }: { doc: CitationDoc }): ReactElement {
+  const { file, loading, error } = useCitationFile(doc, 'text/markdown');
+  const [mode, setMode] = useState<'raw' | 'preview'>('preview');
+  const [rawText, setRawText] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRawText(null);
+    if (!file) return;
+    let cancelled = false;
+    void file
+      .text()
+      .then(text => {
+        if (!cancelled) setRawText(text);
+      })
+      .catch(() => {
+        if (!cancelled) setRawText('Failed to read file.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [file]);
+
+  return (
+    <div className='flex h-full w-full flex-col bg-background'>
+      <div className='flex h-10 flex-shrink-0 items-center justify-between gap-3 border-b border-border px-3'>
+        <span className='min-w-0 truncate text-sm font-medium text-foreground' title={doc.name}>
+          {doc.name}
+        </span>
+        <div className='flex flex-shrink-0 items-center gap-1 rounded-md bg-muted p-0.5'>
+          <button
+            type='button'
+            onClick={() => setMode('raw')}
+            aria-pressed={mode === 'raw'}
+            className={cn(
+              'rounded px-2.5 py-1 text-xs font-medium transition-colors',
+              mode === 'raw'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+            data-track-category='ask-ai'
+            data-track-name='citation-doc-raw'
+          >
+            Raw
+          </button>
+          <button
+            type='button'
+            onClick={() => setMode('preview')}
+            aria-pressed={mode === 'preview'}
+            className={cn(
+              'rounded px-2.5 py-1 text-xs font-medium transition-colors',
+              mode === 'preview'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+            data-track-category='ask-ai'
+            data-track-name='citation-doc-preview'
+          >
+            Preview
+          </button>
+        </div>
+      </div>
+      <div className='relative min-h-0 flex-1'>
+        {loading ? (
+          <div className='flex h-full items-center justify-center'>
+            <div className='h-8 w-8 animate-spin rounded-full border-b-2 border-ring' />
+          </div>
+        ) : error ? (
+          <div className='flex h-full items-center justify-center px-4 text-center text-sm text-destructive'>
+            {error}
+          </div>
+        ) : mode === 'preview' ? (
+          <div className='h-full min-h-0'>
+            <ReadmeViewer source={file} fileName={doc.name} />
+          </div>
+        ) : (
+          <pre className='h-full overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-sm text-foreground'>
+            {rawText ?? ''}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Everything else the KB file viewer already knows how to render — docx,
+ *  csv, excel, images, video, non-md code, html, txt — via the same
+ *  `FILE_TYPE_CONFIG` lookup `FileViewerPanel` uses, just with a plain
+ *  filename header (no Raw/Preview — that's a markdown-only concept, these
+ *  viewers already render "the preview"). No chunk-highlight: only pdf.js
+ *  (via PdfViewer) actually consumes `highlightQuery`. */
+function CitationGenericView({ doc }: { doc: CitationDoc }): ReactElement {
+  const fileType = detectFileType(doc.mimeType ?? '', doc.name);
+  const { file, loading, error } = useCitationFile(doc, doc.mimeType ?? 'application/octet-stream');
+  const ViewerComponent = fileType?.component;
+
+  return (
+    <div className='flex h-full w-full flex-col bg-background'>
+      <div className='flex h-10 flex-shrink-0 items-center border-b border-border px-3'>
+        <span className='truncate text-sm font-medium text-foreground' title={doc.name}>
+          {doc.name}
+        </span>
+      </div>
+      <div className='relative min-h-0 flex-1'>
+        {loading ? (
+          <div className='flex h-full items-center justify-center'>
+            <div className='h-8 w-8 animate-spin rounded-full border-b-2 border-ring' />
+          </div>
+        ) : error ? (
+          <div className='flex h-full items-center justify-center px-4 text-center text-sm text-destructive'>
+            {error}
+          </div>
+        ) : file && ViewerComponent ? (
+          <div className={cn(fileType.wrapperClass, 'bg-background max-w-full max-h-full')}>
+            <ViewerComponent
+              source={file}
+              fileName={doc.name}
+              {...(doc.page ? { initialPage: doc.page } : {})}
+            />
+          </div>
+        ) : (
+          <div className='flex h-full items-center justify-center px-4 text-center text-sm text-muted-foreground'>
+            Preview not available for this file type
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CitationDocView({ doc }: { doc: CitationDoc }): ReactElement {
+  if (doc.kind === 'markdown') return <CitationMarkdownView doc={doc} />;
+  if (doc.kind === 'pdf') return <CitationPdfView doc={doc} />;
+  return <CitationGenericView doc={doc} />;
+}
+
 /**
  * Right-side panel on the /ai page. Shows one open citation doc at a time, with a
  * tab strip to switch between them. All open docs stay mounted (inactive ones
@@ -104,50 +257,133 @@ function CitationDocView({ doc }: { doc: CitationDoc }): ReactElement {
 export function CitationDocsPanel(): ReactElement | null {
   const ctx = useCitationDocs();
   if (!ctx || ctx.docs.length === 0) return null;
-  const { docs, activeFileId, setActive, closeDoc } = ctx;
+  const { docs, activeFileId, setActive, closeDoc, closeAll, collapsed, setCollapsed } = ctx;
   const active = activeFileId ?? docs[docs.length - 1]?.fileId ?? null;
+
+  // Collapsed: a thin re-open rail instead of the tab strip + viewer — the
+  // open docs stay in state, just not rendered, so re-expanding restores them.
+  if (collapsed) {
+    return (
+      <div className='flex h-full w-full flex-col items-center border-l border-border bg-background pt-2'>
+        <button
+          type='button'
+          onClick={() => setCollapsed(false)}
+          aria-label='Expand documents panel'
+          title='Expand'
+          className='grid h-7 w-7 flex-shrink-0 place-items-center rounded text-muted-foreground hover:bg-secondary/60 hover:text-foreground'
+          data-track-category='ask-ai'
+          data-track-name='citation-docs-expand'
+        >
+          <PanelRightOpen className='h-4 w-4' />
+        </button>
+        <span className='mt-1.5 text-[11px] font-medium text-muted-foreground'>{docs.length}</span>
+      </div>
+    );
+  }
 
   return (
     <div className='flex h-full w-full flex-col border-l border-border bg-background'>
-      {/* Tab strip — one tab per open doc; click to switch, ✕ to close. */}
-      <div className='flex h-9 flex-shrink-0 items-center gap-1 overflow-x-auto border-b border-border px-2'>
-        {docs.map(doc => {
-          const isActive = doc.fileId === active;
-          return (
-            <div
-              key={doc.fileId}
-              className={cn(
-                'flex h-7 max-w-[220px] flex-shrink-0 items-center rounded pr-1 transition-colors',
-                isActive ? 'bg-secondary' : 'hover:bg-secondary/60',
-              )}
+      {/* Header — open-doc count dropdown, the tab strip, then collapse / close-all. */}
+      <div className='flex h-9 flex-shrink-0 items-center gap-1 border-b border-border pl-2 pr-1'>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type='button'
+              className='flex h-7 flex-shrink-0 items-center gap-0.5 rounded px-1.5 text-[12px] font-medium text-foreground hover:bg-secondary/60'
+              aria-label='List open documents'
+              data-track-category='ask-ai'
+              data-track-name='citation-docs-list-open'
             >
-              <button
-                type='button'
-                aria-pressed={isActive}
-                title={doc.name}
+              {docs.length}
+              <ChevronDown className='h-3.5 w-3.5 text-muted-foreground' />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align='start' className='w-64'>
+            {docs.map(doc => (
+              <DropdownMenuItem
+                key={doc.fileId}
                 onClick={() => setActive(doc.fileId)}
-                className={cn(
-                  'flex h-7 min-w-0 items-center pl-2 pr-1 text-[12px]',
-                  isActive ? 'text-foreground' : 'text-muted-foreground',
+                className='flex items-center justify-between gap-2 cursor-pointer'
+              >
+                <span className='flex min-w-0 items-center gap-2'>
+                  <FileText className='h-3.5 w-3.5 flex-shrink-0 text-muted-foreground' />
+                  <span className='truncate'>{doc.name}</span>
+                </span>
+                {typeof doc.chunkIndex === 'number' && (
+                  <span className='flex-shrink-0 text-xs text-muted-foreground'>
+                    ch {doc.chunkIndex}
+                  </span>
                 )}
-                data-track-category='ask-ai'
-                data-track-name='citation-doc-tab-select'
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <div className='flex h-full min-w-0 flex-1 items-center gap-1 overflow-x-auto'>
+          {docs.map(doc => {
+            const isActive = doc.fileId === active;
+            return (
+              <div
+                key={doc.fileId}
+                className={cn(
+                  'flex h-7 max-w-[220px] flex-shrink-0 items-center rounded pr-1 transition-colors',
+                  isActive ? 'bg-secondary' : 'hover:bg-secondary/60',
+                )}
               >
-                <span className='truncate'>{doc.name}</span>
-              </button>
-              <button
-                type='button'
-                aria-label={`Close ${doc.name}`}
-                onClick={() => closeDoc(doc.fileId)}
-                className='grid h-4 w-4 flex-shrink-0 place-items-center rounded text-muted-foreground hover:bg-foreground/10'
-                data-track-category='ask-ai'
-                data-track-name='citation-doc-tab-close'
-              >
-                <X className='h-3 w-3' strokeWidth={2} />
-              </button>
-            </div>
-          );
-        })}
+                <button
+                  type='button'
+                  aria-pressed={isActive}
+                  title={doc.name}
+                  onClick={() => setActive(doc.fileId)}
+                  className={cn(
+                    'flex h-7 min-w-0 items-center gap-1.5 pl-2 pr-1 text-[12px]',
+                    isActive ? 'text-foreground' : 'text-muted-foreground',
+                  )}
+                  data-track-category='ask-ai'
+                  data-track-name='citation-doc-tab-select'
+                >
+                  <FileText className='h-3.5 w-3.5 flex-shrink-0' />
+                  <span className='truncate'>{doc.name}</span>
+                </button>
+                <button
+                  type='button'
+                  aria-label={`Close ${doc.name}`}
+                  onClick={() => closeDoc(doc.fileId)}
+                  className='grid h-4 w-4 flex-shrink-0 place-items-center rounded text-muted-foreground hover:bg-foreground/10'
+                  data-track-category='ask-ai'
+                  data-track-name='citation-doc-tab-close'
+                >
+                  <X className='h-3 w-3' strokeWidth={2} />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className='flex flex-shrink-0 items-center gap-0.5 pl-1'>
+          <button
+            type='button'
+            onClick={() => setCollapsed(true)}
+            aria-label='Collapse panel'
+            title='Collapse'
+            className='grid h-7 w-7 flex-shrink-0 place-items-center rounded text-muted-foreground hover:bg-secondary/60 hover:text-foreground'
+            data-track-category='ask-ai'
+            data-track-name='citation-docs-collapse'
+          >
+            <PanelRightClose className='h-4 w-4' />
+          </button>
+          <button
+            type='button'
+            onClick={closeAll}
+            aria-label='Close all documents'
+            title='Close all'
+            className='grid h-7 w-7 flex-shrink-0 place-items-center rounded text-muted-foreground hover:bg-secondary/60 hover:text-foreground'
+            data-track-category='ask-ai'
+            data-track-name='citation-docs-close-all'
+          >
+            <X className='h-4 w-4' />
+          </button>
+        </div>
       </div>
 
       {/* Stacked viewers — only the active one is visible; the rest stay mounted
@@ -190,6 +426,30 @@ export function CitationDocsPanel(): ReactElement | null {
 export function ChatWithCitationDocs({ children }: { children: ReactNode }): ReactElement {
   const ctx = useCitationDocs();
   const hasDocs = !!ctx && ctx.docs.length > 0;
+  const collapsed = !!ctx?.collapsed;
+  const docsPanelRef = usePanelRef();
+
+  // Drive the Panel's own collapse/expand via its imperative handle, keyed off
+  // the collapse button's state in context — the Panel stays mounted (rail UI
+  // renders inside it at collapsedSize) so the group's saved layout survives.
+  //
+  // The ref callback fires as soon as the Panel mounts, but the group doesn't
+  // register its layout constraints (measured via ResizeObserver) until a
+  // moment later — calling isCollapsed()/collapse()/expand() in that window
+  // throws "Panel constraints not found". That window only exists right on
+  // mount; by the time a user can actually click the collapse button the
+  // panel is long since registered, so best-effort + swallow is safe here.
+  useEffect(() => {
+    const handle = docsPanelRef.current;
+    if (!handle || !hasDocs) return;
+    try {
+      if (collapsed && !handle.isCollapsed()) handle.collapse();
+      else if (!collapsed && handle.isCollapsed()) handle.expand();
+    } catch {
+      /* constraints not registered yet — nothing to sync on this pass */
+    }
+  }, [collapsed, hasDocs, docsPanelRef]);
+
   return (
     <ResizableGroup
       orientation='horizontal'
@@ -210,7 +470,15 @@ export function ChatWithCitationDocs({ children }: { children: ReactNode }): Rea
       {hasDocs && (
         <>
           <Separator className='w-px bg-border transition-colors hover:bg-primary/40 active:bg-primary/60' />
-          <Panel id='ai-citation-docs' defaultSize='45%' minSize='25%' className='min-w-0'>
+          <Panel
+            id='ai-citation-docs'
+            defaultSize='45%'
+            minSize='25%'
+            collapsible
+            collapsedSize={40}
+            panelRef={docsPanelRef}
+            className='min-w-0'
+          >
             <CitationDocsPanel />
           </Panel>
         </>

--- a/apps/dashboard/src/components/AIScreen/ComposerCollectionPicker.tsx
+++ b/apps/dashboard/src/components/AIScreen/ComposerCollectionPicker.tsx
@@ -14,12 +14,23 @@ interface FileScope {
   id: string;
   name: string;
 }
+/** A folder scope. Sent to claw-auth as a single 'folder' attached_context
+ *  pointer — NOT expanded to a recursive file list here (xyneAIControllerV2.ts
+ *  doesn't do that); claw-auth resolves it itself, at Vespa-query time, since
+ *  Vespa's collectionId filter only ever matches a doc's ROOT collection.
+ *  The picker just tracks the id. */
+interface FolderScope {
+  id: string;
+  name: string;
+}
 
 interface ComposerCollectionPickerProps {
   collections: SelectedCollection[];
   fileScopes: FileScope[];
+  folderScopes: FolderScope[];
   onCollectionsChange: (collections: SelectedCollection[]) => void;
   onFileScopesChange: (fileScopes: FileScope[]) => void;
+  onFolderScopesChange: (folderScopes: FolderScope[]) => void;
 }
 
 /**
@@ -32,8 +43,10 @@ interface ComposerCollectionPickerProps {
 export function ComposerCollectionPicker({
   collections,
   fileScopes,
+  folderScopes,
   onCollectionsChange,
   onFileScopesChange,
+  onFolderScopesChange,
 }: ComposerCollectionPickerProps): ReactElement {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
@@ -160,6 +173,28 @@ export function ComposerCollectionPicker({
     [fileScopes, collections, navStack, onFileScopesChange, onCollectionsChange],
   );
 
+  const handleFolderSingleClick = useCallback(
+    (folder: { id: string; name: string }) => {
+      if (clickTimer.current) return; // a double-click is in progress
+      clickTimer.current = setTimeout(() => {
+        clickTimer.current = null;
+        const isSelected = folderScopes.some(f => f.id === folder.id);
+        onFolderScopesChange(
+          isSelected
+            ? folderScopes.filter(f => f.id !== folder.id)
+            : [...folderScopes, { id: folder.id, name: folder.name }],
+        );
+        // Keep the folder's root collection in scope too, same as file picks —
+        // the backend resolves a folder id against its root collection.
+        const root = navStack[0];
+        if (!isSelected && root && !collections.some(c => c.id === root.id)) {
+          onCollectionsChange([...collections, root]);
+        }
+      }, 220);
+    },
+    [folderScopes, collections, navStack, onFolderScopesChange, onCollectionsChange],
+  );
+
   return (
     <div ref={containerRef} className='relative'>
       <button
@@ -172,8 +207,8 @@ export function ComposerCollectionPicker({
           // Accent only while something is actually scoped — idle matches the
           // neighbouring ToolbarButtons so the row reads as one set. Files count
           // as a selection too: this picker sets both.
-          collections.length > 0 || fileScopes.length > 0
-            ? 'bg-secondary text-[#7C3AED]'
+          collections.length > 0 || fileScopes.length > 0 || folderScopes.length > 0
+            ? 'bg-secondary text-claw-ai-fg'
             : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
         )}
         data-track-category='XyneAI'
@@ -222,21 +257,29 @@ export function ComposerCollectionPicker({
                 </div>
               ) : (
                 <div className='py-1'>
-                  {currentSubfolders.map(folder => (
-                    <button
-                      key={folder.id}
-                      type='button'
-                      onDoubleClick={() => openNode(folder)}
-                      className='flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent'
-                      title='Double-click to open'
-                      data-track-category='XyneAI'
-                      data-track-name='OPEN_KB_FOLDER'
-                    >
-                      <Folder className='h-4 w-4 flex-shrink-0 text-[#7C3AED]' />
-                      <span className='flex-1 truncate'>{folder.name}</span>
-                      <ChevronRight className='h-4 w-4 flex-shrink-0 text-muted-foreground' />
-                    </button>
-                  ))}
+                  {currentSubfolders.map(folder => {
+                    const isSelected = folderScopes.some(f => f.id === folder.id);
+                    return (
+                      <button
+                        key={folder.id}
+                        type='button'
+                        onClick={() => handleFolderSingleClick(folder)}
+                        onDoubleClick={() => openNode(folder)}
+                        className={cn(
+                          'flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent',
+                          isSelected && 'bg-accent',
+                        )}
+                        title='Click to select · double-click to open'
+                        data-track-category='XyneAI'
+                        data-track-name='SELECT_KB_FOLDER'
+                      >
+                        <Folder className='h-4 w-4 flex-shrink-0 text-claw-ai-fg' />
+                        <span className='flex-1 truncate'>{folder.name}</span>
+                        {isSelected && <span className='text-xs text-claw-ai-fg'>Selected</span>}
+                        <ChevronRight className='h-4 w-4 flex-shrink-0 text-muted-foreground' />
+                      </button>
+                    );
+                  })}
                   {currentFiles.map(file => {
                     const isSelected = fileScopes.some(f => f.id === file.fileId);
                     return (
@@ -251,9 +294,9 @@ export function ComposerCollectionPicker({
                         data-track-category='XyneAI'
                         data-track-name='SELECT_FILE_SCOPE'
                       >
-                        <FileText className='h-4 w-4 flex-shrink-0 text-[#7C3AED]' />
+                        <FileText className='h-4 w-4 flex-shrink-0 text-claw-ai-fg' />
                         <span className='flex-1 truncate'>{file.name}</span>
-                        {isSelected && <span className='text-xs text-[#7C3AED]'>Selected</span>}
+                        {isSelected && <span className='text-xs text-claw-ai-fg'>Selected</span>}
                       </button>
                     );
                   })}
@@ -286,9 +329,9 @@ export function ComposerCollectionPicker({
                       data-track-category='XyneAI'
                       data-track-name='SELECT_COLLECTION'
                     >
-                      <BookOpen className='h-4 w-4 flex-shrink-0 text-[#7C3AED]' />
+                      <BookOpen className='h-4 w-4 flex-shrink-0 text-claw-ai-fg' />
                       <span className='flex-1 truncate'>{collection.name}</span>
-                      {isSelected && <span className='text-xs text-[#7C3AED]'>Selected</span>}
+                      {isSelected && <span className='text-xs text-claw-ai-fg'>Selected</span>}
                       <ChevronRight className='h-4 w-4 flex-shrink-0 text-muted-foreground' />
                     </button>
                   );

--- a/apps/dashboard/src/components/AIScreen/citationDocs.tsx
+++ b/apps/dashboard/src/components/AIScreen/citationDocs.tsx
@@ -7,6 +7,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react';
+import { detectFileType } from '../FileViewer/utils';
 
 /**
  * A KB document opened in the /ai page's right-side citation panel. Mirrors
@@ -18,10 +19,16 @@ import {
 export interface CitationDoc {
   fileId: string;
   name: string;
+  /** Which viewer the panel renders — pdf gets the pdf.js viewer + chunk
+   *  highlight; markdown gets a Raw/Preview toggle (no highlight support);
+   *  everything else the KB file viewer already knows how to render (docx,
+   *  csv, excel, images, video, non-md code, html, txt) gets that same
+   *  viewer with just a filename header. */
+  kind: 'pdf' | 'markdown' | 'other';
   mimeType?: string;
-  /** 1-based page to open on. */
+  /** 1-based page to open on. PDF only. */
   page?: number;
-  /** 0-based chunk index → resolves the highlight snippet. */
+  /** 0-based chunk index → resolves the highlight snippet. PDF only. */
   chunkIndex?: number;
   navSeq: number;
 }
@@ -38,9 +45,13 @@ interface PanelCitationInput {
 }
 
 /**
- * Returns the `openDoc` payload for a citation IF it's a KB PDF file (the only
- * thing the panel can render), else `null` so the caller falls back to normal
- * navigation. `page` is lifted off the citation's deep-link `?page=`.
+ * Returns the `openDoc` payload for a citation IF it's a KB file kind the
+ * panel knows how to render, else `null` so the caller falls back to normal
+ * navigation. Renderability is decided the same way the KB file viewer
+ * decides it (`detectFileType`, extension-only here since citations don't
+ * carry a mime type) — anything with no matching viewer (e.g. a zip) still
+ * falls back to navigation. `page` is lifted off the citation's deep-link
+ * `?page=`.
  */
 export function panelDocFromCitation(
   citation: PanelCitationInput | null | undefined,
@@ -49,11 +60,16 @@ export function panelDocFromCitation(
   if (!citation || citation.kind !== 'collection-item') return null;
   const fileId = citation.collectionItemId;
   const name = citation.fileName;
-  if (!fileId || !name || !/\.pdf$/i.test(name)) return null;
+  if (!fileId || !name) return null;
+  const fileType = detectFileType('', name);
+  if (!fileType) return null;
+  const kind: CitationDoc['kind'] =
+    fileType.type === 'pdf' ? 'pdf' : /\.(md|markdown)$/i.test(name) ? 'markdown' : 'other';
   const pageMatch = url ? /[?&]page=(\d+)/.exec(url) : null;
   return {
     fileId,
     name,
+    kind,
     ...(pageMatch ? { page: Number(pageMatch[1]) } : {}),
     ...(typeof citation.chunkIndex === 'number' ? { chunkIndex: citation.chunkIndex } : {}),
   };
@@ -67,6 +83,10 @@ interface CitationDocsContextValue {
   setActive: (fileId: string) => void;
   closeDoc: (fileId: string) => void;
   closeAll: () => void;
+  /** Panel shrunk to a re-open rail without losing the open docs — distinct
+   *  from closeAll, which drops them. */
+  collapsed: boolean;
+  setCollapsed: (collapsed: boolean) => void;
 }
 
 const CitationDocsContext = createContext<CitationDocsContextValue | null>(null);
@@ -86,9 +106,11 @@ export function useCitationDocs(): CitationDocsContextValue | null {
 export function CitationDocsProvider({ children }: { children: ReactNode }): ReactElement {
   const [docs, setDocs] = useState<CitationDoc[]>([]);
   const [activeFileId, setActiveFileId] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
 
   const openDoc = useCallback((doc: OpenDocInput): void => {
     setActiveFileId(doc.fileId); // opening/clicking a citation focuses that doc
+    setCollapsed(false); // ...and always re-expands a collapsed panel
     setDocs(prev => {
       const existing = prev.find(d => d.fileId === doc.fileId);
       if (existing) {
@@ -121,11 +143,21 @@ export function CitationDocsProvider({ children }: { children: ReactNode }): Rea
   const closeAll = useCallback((): void => {
     setDocs([]);
     setActiveFileId(null);
+    setCollapsed(false);
   }, []);
 
   const value = useMemo(
-    () => ({ docs, activeFileId, openDoc, setActive, closeDoc, closeAll }),
-    [docs, activeFileId, openDoc, setActive, closeDoc, closeAll],
+    () => ({
+      docs,
+      activeFileId,
+      openDoc,
+      setActive,
+      closeDoc,
+      closeAll,
+      collapsed,
+      setCollapsed,
+    }),
+    [docs, activeFileId, openDoc, setActive, closeDoc, closeAll, collapsed],
   );
 
   return <CitationDocsContext.Provider value={value}>{children}</CitationDocsContext.Provider>;

--- a/apps/dashboard/src/components/AIScreen/composerContext.ts
+++ b/apps/dashboard/src/components/AIScreen/composerContext.ts
@@ -28,6 +28,13 @@ export interface ComposerContext {
   recordings: SelectedRecording[];
   collections: { id: string; name: string }[];
   fileScopes: { id: string; name: string }[];
+  /** A specific folder scoped in (not the whole collection, not one file).
+   *  Sent to claw-auth as a single 'folder' attached_context pointer — NOT
+   *  expanded to a recursive file list here (xyneAIControllerV2.ts doesn't
+   *  do that); claw-auth resolves it itself, at Vespa-query time, since
+   *  Vespa's collectionId filter only ever matches a doc's ROOT collection
+   *  and can't filter on a folder id directly. */
+  folderScopes: { id: string; name: string }[];
   research: ResearchContext | null;
   webSearchEnabled: boolean;
   deepResearchEnabled: boolean;
@@ -56,6 +63,7 @@ export const EMPTY_COMPOSER_CONTEXT: ComposerContext = {
   recordings: [],
   collections: [],
   fileScopes: [],
+  folderScopes: [],
   research: null,
   webSearchEnabled: false,
   deepResearchEnabled: false,
@@ -76,6 +84,7 @@ export function hasComposerContext(ctx: ComposerContext): boolean {
     ctx.recordings.length > 0 ||
     ctx.collections.length > 0 ||
     ctx.fileScopes.length > 0 ||
+    ctx.folderScopes.length > 0 ||
     ctx.research !== null ||
     ctx.webSearchEnabled ||
     ctx.deepResearchEnabled ||
@@ -97,6 +106,7 @@ export function toStreamOverrides(ctx: ComposerContext): StreamOverrides {
     channelIds: ctx.channels.map(c => c.id),
     collectionIds: ctx.collections.map(c => c.id),
     fileIds: ctx.fileScopes.map(f => f.id),
+    folderIds: ctx.folderScopes.map(f => f.id),
     ticketIds: ctx.tickets.map(t => t.id),
     canvasIds: ctx.canvases.map(c => c.id),
     callIds: [...ctx.transcripts.map(t => t.id), ...ctx.recordings.map(r => r.id)],

--- a/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
@@ -56,8 +56,6 @@ import {
   railShortcutsAvailable,
 } from './navigationConfig';
 import { useKeyboard } from '../../contexts/KeyboardContext';
-import { useAILandingDefault } from '../../hooks/useAILandingDefault';
-import XyneAISidebarIcon from '../icons/xyne-ai/XyneAISidebarIcon';
 import { cn } from '../../utils/classNames';
 import { APP_DRAG_STYLE, isElectronApp } from '../../utils/electronApp';
 import { ErrorReportModal } from '../ErrorReportModal/ErrorReportModal';
@@ -156,7 +154,6 @@ const AppSidebar = (): ReactElement => {
   const { workspaceId } = useParams<{ workspaceId?: string }>();
   const prefixWs = (path: string): string => (workspaceId ? `/${workspaceId}${path}` : path);
   const { user } = useAuth();
-  const { aiLandingDefault } = useAILandingDefault();
   const currentUser = useSelf();
   const visibleNavigationItems = useVisibleNavigationItems();
   const { toolbarPaths } = useToolbarItems();
@@ -371,30 +368,6 @@ const AppSidebar = (): ReactElement => {
           ) : (
             <nav>
               <ul className='relative flex flex-col gap-4'>
-                {/* Xyne AI nav item — only visible when "Open AI on launch" is enabled */}
-                {aiLandingDefault && (
-                  <li key='/ai' className='relative'>
-                    <Tooltip content='Xyne AI' side='right' delayDuration={0}>
-                      <Link
-                        to={prefixWs('/ai')}
-                        onClick={() => handleNavigationClick('Xyne AI')}
-                        data-testid='nav-xyne-ai'
-                        data-track-category='App_Sidebar'
-                        data-track-name='Sidebar_Nav_Item'
-                        data-track-metadata={JSON.stringify({ path: '/ai', label: 'Xyne AI' })}
-                        className={cn(
-                          'size-8 flex items-center justify-center rounded-lg cursor-pointer border border-transparent transition-colors',
-                          activeRoute === '/ai'
-                            ? 'bg-sidebar-accent border-sidebar-border text-sidebar-accent-foreground'
-                            : 'bg-transparent text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-                        )}
-                      >
-                        <XyneAISidebarIcon size={16} />
-                      </Link>
-                    </Tooltip>
-                  </li>
-                )}
-
                 {toolbarItems.map((item, index) => {
                   const shortcutIndex =
                     railShortcuts && index < RAIL_SHORTCUT_LIMIT ? index + 1 : null;

--- a/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
+++ b/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
@@ -37,6 +37,7 @@ import { PATH_TO_RESOURCE } from './utils/resourceMapping';
 import { isElectronApp } from '../../utils/electronApp';
 import type { usePermissions } from '../../hooks/usePermissions';
 import { AccessType } from '@xyne/shared';
+import { XyneAISidebarIcon } from '../icons/xyne-ai';
 
 /** A themeable pika-icon component (accepts size, color, variant, strokeWidth, className). */
 export type PikaIcon = ComponentType<PikaIconProps>;
@@ -63,10 +64,25 @@ export interface NavigationItem {
   iconSize?: number;
 }
 
+// Adapts XyneAISidebarIcon — a plain {color?, size?: number} SVG component,
+// not a pika-icon — to the PikaIcon shape NavigationItem.icon requires.
+// PikaIconProps.size is `number | string`, so it's coerced rather than
+// widening XyneAISidebarIcon's own signature. Pika-only props (variant/
+// strokeWidth/...) are dropped: this glyph has no stroke/variant concept and
+// renders identically regardless of active state, unlike every other item.
+const XyneAINavIcon: PikaIcon = ({ size, color }) =>
+  createElement(XyneAISidebarIcon, {
+    // exactOptionalPropertyTypes rejects an explicit `undefined` for an
+    // optional prop — omit the key entirely instead of assigning it.
+    ...(typeof size === 'number' ? { size } : {}),
+    ...(color !== undefined ? { color } : {}),
+  });
+
 // Items are listed toolbar-first: the default toolbar paths come first in the
 // order they should appear in the rail, followed by everything that lives in
 // the "More" menu by default. Toggling is handled per-path by useToolbarItems.
 export const NAVIGATION_ITEMS: NavigationItem[] = [
+  { path: '/ai', label: 'Xyne AI', icon: XyneAINavIcon },
   { path: '/chat/dir', label: 'Chat', icon: Hashtag },
   { path: '/chat/dm', label: 'DMs', icon: ChatDefault },
   { path: '/chat/activity', label: 'Activity', icon: NotificationBellOn },
@@ -128,6 +144,29 @@ export const DEFAULT_TOOLBAR_PATHS: string[] = [...REQUIRED_TOOLBAR_PATHS];
 // Whether a path is locked into the toolbar (cannot be toggled off).
 export const isRequiredToolbarPath = (path: string): boolean =>
   REQUIRED_TOOLBAR_PATHS.includes(path);
+
+// One-line description per toolbar-manageable path, shown under the label in
+// the workspace admin's Toolbar tab — same { name, description } shape as
+// the RESOURCES registry backing the Roles access grid (seed-acl.ts), so an
+// admin sees what they're hiding, not just a bare label.
+export const TOOLBAR_ITEM_DESCRIPTIONS: Record<string, string> = {
+  '/ai': 'AI chat assistant panel',
+  '/chat/dir': 'Channel-based team chat',
+  '/chat/dm': 'Direct messages between users',
+  '/chat/activity': 'Mentions and notification activity feed',
+  '/calls': 'Voice and video calling',
+  '/recordings': 'Call and meeting recordings',
+  '/chat/canvas': 'Personal canvas documents',
+  '/automations': 'Workflow automation triggers and actions',
+  '/scheduled-messages': 'Messages scheduled for later delivery',
+  '/browser': 'In-app browser tabs (desktop app only)',
+  '/apps': 'Installed app integrations',
+  '/guide': 'Product documentation and onboarding guide',
+  '/knowledge-base': 'File and folder knowledge base for Ask AI',
+  '/memory': 'Saved context and memory for AI',
+  '/releaseManager': 'Release and deployment tracking',
+  '/claw-agents': 'Claw AI agents dashboard',
+};
 
 type Permissions = ReturnType<typeof usePermissions>;
 

--- a/apps/dashboard/src/components/AppSidebar/toolbarCacConfig.ts
+++ b/apps/dashboard/src/components/AppSidebar/toolbarCacConfig.ts
@@ -1,0 +1,28 @@
+/**
+ * CAC key: "disabled_toolbar_paths"
+ *
+ * One global key shared by all of xyne-spaces — the upstream Superposition
+ * instance is provisioned as a single org/workspace for all of xyne-spaces
+ * in prod, so per-internal-workspace Superposition dimension targeting
+ * isn't something we can provision there (that would require the team
+ * owning that shared instance to configure a rule per xyne-spaces tenant).
+ * Instead, the per-workspace split lives in the VALUE: it's a map from
+ * xyne-spaces workspaceId to that workspace's list of NAVIGATION_ITEMS
+ * paths hidden from the sidebar and blocked at the route level (see
+ * ToolbarProtectedRoute). useDisabledToolbarPaths indexes into it with the
+ * current user's own workspaceId.
+ *
+ * Toggle from Superposition CAC:
+ *   key:   disabled_toolbar_paths
+ *   value: {
+ *     "<workspaceId-a>": ["/calls", "/support"],
+ *     "<workspaceId-b>": ["/browser"]
+ *   }
+ * A workspaceId with no entry (or the whole key unset) ⇒ nothing hidden.
+ */
+
+export const DISABLED_TOOLBAR_PATHS_CAC_KEY = 'disabled_toolbar_paths';
+
+export type DisabledToolbarPathsCacConfig = Record<string, string[]>;
+
+export const DEFAULT_DISABLED_TOOLBAR_PATHS_CAC_CONFIG: DisabledToolbarPathsCacConfig = {};

--- a/apps/dashboard/src/components/Auth/ToolbarProtectedRoute.tsx
+++ b/apps/dashboard/src/components/Auth/ToolbarProtectedRoute.tsx
@@ -1,0 +1,30 @@
+import { ReactElement } from 'react';
+import { useDisabledToolbarPaths } from '../../hooks/useDisabledToolbarPaths';
+import NotFoundScreen from '../../routes/NotFoundScreen/NotFoundScreen';
+
+interface ToolbarProtectedRouteProps {
+  path: string;
+  children: ReactElement;
+}
+
+/**
+ * Route guard mirroring ResourceProtectedRoute, but for per-workspace
+ * toolbar-disabled paths (Superposition CAC key disabled_toolbar_paths,
+ * targeted by workspaceId) instead of an RBAC resource. A disabled path
+ * renders the same 404 as a URL that doesn't match any route — from the
+ * requester's side, a workspace-disabled item and a nonexistent one should
+ * look identical, not tip off that it exists but is merely off-limits
+ * (that's what ResourceProtectedRoute's home-redirect would imply instead).
+ */
+export const ToolbarProtectedRoute = ({
+  path,
+  children,
+}: ToolbarProtectedRouteProps): ReactElement => {
+  const disabledToolbarPaths = useDisabledToolbarPaths();
+
+  if (disabledToolbarPaths.has(path)) {
+    return <NotFoundScreen />;
+  }
+
+  return children;
+};

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/XyneAISidebar.tsx
@@ -130,6 +130,8 @@ interface XyneAISidebarProps {
   kbChannelId?: string;
   kbDocId?: string;
   kbDocName?: string;
+  kbFolderId?: string;
+  kbFolderName?: string;
   // Bumped by xyneAIMachine each time OPEN is dispatched with a kbCollectionId.
   // The input box re-attaches the KB collection chip on every bump.
   kbOpenNonce?: number;
@@ -165,6 +167,8 @@ const XyneAISidebar = ({
   kbCollectionId: kbCollectionIdProp,
   kbDocId: kbDocIdProp,
   kbDocName: kbDocNameProp,
+  kbFolderId: kbFolderIdProp,
+  kbFolderName: kbFolderNameProp,
   kbOpenNonce,
   visible = true,
   forcedAgentSlug,
@@ -257,6 +261,24 @@ const XyneAISidebar = ({
   useEffect(() => {
     setFileScopes(kbDocIdProp ? [{ id: kbDocIdProp, name: kbDocNameProp || 'this file' }] : []);
   }, [kbDocIdProp, kbDocNameProp, kbOpenNonce]);
+  // Folder scope(s) — multi-select, from the collection picker. Sent to
+  // claw-auth as a single 'folder' attached_context pointer per id — NOT
+  // expanded to a recursive file list here (xyneAIControllerV2.ts doesn't do
+  // that); claw-auth resolves it itself, at Vespa-query time, since Vespa's
+  // collectionId filter only ever matches a doc's ROOT collection and can't
+  // filter on a folder id directly.
+  // Seeded with the folder Ask AI was opened from (browsing inside a
+  // sub-folder in the KB screen, not its root); re-synced below like
+  // fileScopes so re-opening Ask AI from a folder re-attaches the chip even
+  // after it was manually removed.
+  const [folderScopes, setFolderScopes] = useState<{ id: string; name: string }[]>(
+    kbFolderIdProp ? [{ id: kbFolderIdProp, name: kbFolderNameProp || 'this folder' }] : [],
+  );
+  useEffect(() => {
+    setFolderScopes(
+      kbFolderIdProp ? [{ id: kbFolderIdProp, name: kbFolderNameProp || 'this folder' }] : [],
+    );
+  }, [kbFolderIdProp, kbFolderNameProp, kbOpenNonce]);
   // Bumping autoSendNonce seeds inputValue from initialQuery; submitted once seeded (see effect near handleSubmit).
   const autoSendPendingQueryRef = useRef<string | null>(null);
   const lastAutoSendNonceRef = useRef<number | undefined>(undefined);
@@ -739,6 +761,7 @@ const XyneAISidebar = ({
     activities: selectedActivities,
     collectionIds: selectedCollectionIds ?? [],
     fileIds: fileScopes.map(f => f.id),
+    folderIds: folderScopes.map(f => f.id),
     conversationId,
     streamSessionKey: streamThreadKey,
     threadConversationId: activeThreadInfo?.conversationId,
@@ -1879,6 +1902,8 @@ const XyneAISidebar = ({
       : {}),
     fileScopes,
     onFileScopesChange: setFileScopes,
+    folderScopes,
+    onFolderScopesChange: setFolderScopes,
     onOpenContextModal: handleOpenContextModal,
     selectedTickets,
     onRemoveTicket: handleRemoveTicket,

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPillRow.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPillRow.tsx
@@ -13,6 +13,7 @@ import {
   ChevronBigDown,
   ChevronBigUp,
   FileText,
+  FolderDefault,
   Globe,
   Hashtag,
   LockClose,
@@ -118,6 +119,7 @@ const DEBUG_PILLS: {
   recordings: SelectedRecording[];
   collections: NamedItem[];
   fileScopes: NamedItem[];
+  folderScopes: NamedItem[];
 } = {
   channels: [
     { id: 'dbg-ch-public', name: 'general', isPrivate: false },
@@ -130,6 +132,7 @@ const DEBUG_PILLS: {
   recordings: [{ id: 'dbg-recording', title: 'Design review' }],
   collections: [{ id: 'dbg-collection', name: 'Engineering Handbook' }],
   fileScopes: [{ id: 'dbg-filescope', name: 'architecture-overview.md' }],
+  folderScopes: [{ id: 'dbg-folderscope', name: 'design-docs' }],
 };
 
 type DebugPillKind = keyof typeof DEBUG_PILLS;
@@ -169,6 +172,9 @@ export interface ContextPillRowProps {
 
   fileScopes: NamedItem[];
   onFileScopesChange?: (fileScopes: NamedItem[]) => void;
+
+  folderScopes?: NamedItem[];
+  onFolderScopesChange?: (folderScopes: NamedItem[]) => void;
 
   collections: NamedItem[];
   onRemoveCollection: (id: string) => void;
@@ -242,6 +248,8 @@ export const ContextPillRow = ({
   onRemoveChannel,
   fileScopes,
   onFileScopesChange,
+  folderScopes = [],
+  onFolderScopesChange,
   collections,
   onRemoveCollection,
   attachments,
@@ -283,6 +291,7 @@ export const ContextPillRow = ({
   const rowRecordings = DEBUG_CONTEXT_PILLS ? debugPills.recordings : recordings;
   const rowCollections = DEBUG_CONTEXT_PILLS ? debugPills.collections : collections;
   const rowFileScopes = DEBUG_CONTEXT_PILLS ? debugPills.fileScopes : fileScopes;
+  const rowFolderScopes = DEBUG_CONTEXT_PILLS ? debugPills.folderScopes : folderScopes;
 
   // Flattened so the row can slice by "how many fit" without caring which kind
   // each pill is. Order is the display order.
@@ -507,6 +516,36 @@ export const ContextPillRow = ({
               aria-label={`Remove file scope ${fs.name}`}
               data-track-category='XyneAI'
               data-track-name='REMOVE_FILE_SCOPE'
+            >
+              <MultipleCrossCancelDefault className='w-3 h-3' />
+            </button>
+          )}
+        </div>
+      ),
+    });
+  });
+
+  rowFolderScopes.forEach(fo => {
+    pills.push({
+      key: `fo-${fo.id}`,
+      node: (
+        <div className={CONTEXT_PILL_CLASS}>
+          <div className='flex items-center gap-1.5'>
+            <div className='flex-shrink-0'>
+              <FolderDefault className={CONTEXT_PILL_ICON_CLASS} />
+            </div>
+            <span className={`${CONTEXT_PILL_LABEL_CLASS} max-w-[160px] truncate`}>{fo.name}</span>
+          </div>
+          {(DEBUG_CONTEXT_PILLS || onFolderScopesChange) && (
+            <button
+              onClick={() => {
+                removeDebugPill('folderScopes', fo.id);
+                onFolderScopesChange?.(folderScopes.filter(f => f.id !== fo.id));
+              }}
+              className={CONTEXT_PILL_REMOVE_CLASS}
+              aria-label={`Remove folder scope ${fo.name}`}
+              data-track-category='XyneAI'
+              data-track-name='REMOVE_FOLDER_SCOPE'
             >
               <MultipleCrossCancelDefault className='w-3 h-3' />
             </button>

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
@@ -190,6 +190,14 @@ export interface XyneAIInputBoxProps {
   fileScopes?: { id: string; name: string }[];
   /** Replace the selected file set (id = each file's Vespa docId / fileId UUID). */
   onFileScopesChange?: (fileScopes: { id: string; name: string }[]) => void;
+  /** Folders scoped in from the collection picker. Sent to claw-auth as a
+   *  single 'folder' attached_context pointer per id — NOT expanded to a
+   *  recursive file list here (xyneAIControllerV2.ts doesn't do that);
+   *  claw-auth resolves it itself, at Vespa-query time, since Vespa's
+   *  collectionId filter only ever matches a doc's ROOT collection and
+   *  can't filter on a folder id directly. */
+  folderScopes?: { id: string; name: string }[];
+  onFolderScopesChange?: (folderScopes: { id: string; name: string }[]) => void;
   compactToolbar?: boolean;
 }
 
@@ -263,6 +271,8 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
       kbOpenNonce,
       fileScopes = [],
       onFileScopesChange,
+      folderScopes = [],
+      onFolderScopesChange,
       onUserTagsChange,
       isOnboarding = false,
       selectedAgentSlug = null,
@@ -358,11 +368,18 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
     useEffect(() => {
       if (kbOpenNonce === undefined) return;
       if (kbOpenNonce === lastSeenOpenNonce.current) return;
-      lastSeenOpenNonce.current = kbOpenNonce;
-      if (!kbCollectionId) return;
-      autoAddedCollectionRemoved.current = false;
+      if (!kbCollectionId) {
+        lastSeenOpenNonce.current = kbOpenNonce;
+        return;
+      }
+      // collectionsList (Zero query) can still be hydrating on a fresh
+      // sidebar mount — don't mark this nonce as handled until the
+      // collection is actually found, so this effect retries on the next
+      // collectionsList update instead of silently dropping the chip.
       const collection = collectionsList.find(c => c.id === kbCollectionId);
       if (!collection) return;
+      lastSeenOpenNonce.current = kbOpenNonce;
+      autoAddedCollectionRemoved.current = false;
       const newCollection = [{ id: collection.id, name: collection.name }];
       setSelectedCollections(newCollection);
       onSelectedCollectionsChange?.(newCollection.map(c => c.id));
@@ -607,6 +624,35 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
         }
       },
       [fileScopes, onFileScopesChange, navStack, onSelectedCollectionsChange],
+    );
+
+    const handleFolderSingleClick = useCallback(
+      (folder: { id: string; name: string }) => {
+        if (collectionClickTimer.current) return; // a double-click is in progress
+        collectionClickTimer.current = setTimeout(() => {
+          collectionClickTimer.current = null;
+          const isSelected = folderScopes.some(f => f.id === folder.id);
+          onFolderScopesChange?.(
+            isSelected
+              ? folderScopes.filter(f => f.id !== folder.id)
+              : [...folderScopes, { id: folder.id, name: folder.name }],
+          );
+          if (!isSelected) {
+            // Same rationale as handleToggleFile: keep the folder's root
+            // collection in scope so the backend can resolve the folder id.
+            const col = navStack[0];
+            if (col) {
+              setSelectedCollections(prev => {
+                if (prev.some(c => c.id === col.id)) return prev;
+                const updated = [...prev, col];
+                onSelectedCollectionsChange?.(updated.map(c => c.id));
+                return updated;
+              });
+            }
+          }
+        }, 220);
+      },
+      [folderScopes, navStack, onFolderScopesChange, onSelectedCollectionsChange],
     );
 
     // Thread info state - track if user has removed it
@@ -1701,6 +1747,8 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
           {...(onRemoveChannel && { onRemoveChannel })}
           fileScopes={fileScopes}
           {...(onFileScopesChange && { onFileScopesChange })}
+          folderScopes={folderScopes}
+          {...(onFolderScopesChange && { onFolderScopesChange })}
           collections={selectedCollections}
           onRemoveCollection={handleRemoveCollection}
           attachments={selectedAttachments}
@@ -1967,21 +2015,28 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
                   </div>
                 ) : (
                   <div className='py-1'>
-                    {currentSubfolders.map(folder => (
-                      <button
-                        key={folder.id}
-                        type='button'
-                        onDoubleClick={() => openNode(folder)}
-                        className='w-full px-3 py-2 text-left text-sm flex items-center gap-2 hover:bg-accent'
-                        title='Double-click to open'
-                        data-track-category='XyneAI'
-                        data-track-name='OPEN_KB_FOLDER'
-                      >
-                        <FolderDefault className='w-4 h-4 text-[#7C3AED] flex-shrink-0' />
-                        <span className='flex-1 truncate'>{folder.name}</span>
-                        <ChevronRight className='w-4 h-4 text-muted-foreground flex-shrink-0' />
-                      </button>
-                    ))}
+                    {currentSubfolders.map(folder => {
+                      const isSelected = folderScopes.some(f => f.id === folder.id);
+                      return (
+                        <button
+                          key={folder.id}
+                          type='button'
+                          onClick={() => handleFolderSingleClick(folder)}
+                          onDoubleClick={() => openNode(folder)}
+                          className={`w-full px-3 py-2 text-left text-sm flex items-center gap-2 hover:bg-accent ${
+                            isSelected ? 'bg-accent' : ''
+                          }`}
+                          title='Click to select · double-click to open'
+                          data-track-category='XyneAI'
+                          data-track-name='SELECT_KB_FOLDER'
+                        >
+                          <FolderDefault className='w-4 h-4 text-claw-ai-fg flex-shrink-0' />
+                          <span className='flex-1 truncate'>{folder.name}</span>
+                          {isSelected && <span className='text-xs text-claw-ai-fg'>Selected</span>}
+                          <ChevronRight className='w-4 h-4 text-muted-foreground flex-shrink-0' />
+                        </button>
+                      );
+                    })}
                     {currentFiles.map(file => {
                       const isSelected = fileScopes.some(f => f.id === file.fileId);
                       return (
@@ -1996,9 +2051,9 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
                           data-track-name='SELECT_FILE_SCOPE'
                           data-track-metadata={JSON.stringify({ fileId: file.fileId })}
                         >
-                          <FileText className='w-4 h-4 text-[#7C3AED] flex-shrink-0' />
+                          <FileText className='w-4 h-4 text-claw-ai-fg flex-shrink-0' />
                           <span className='flex-1 truncate'>{file.name}</span>
-                          {isSelected && <span className='text-xs text-[#7C3AED]'>Selected</span>}
+                          {isSelected && <span className='text-xs text-claw-ai-fg'>Selected</span>}
                         </button>
                       );
                     })}
@@ -2034,9 +2089,9 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
                         data-track-name='SELECT_COLLECTION'
                         data-track-metadata={JSON.stringify({ collectionId: collection.id })}
                       >
-                        <Notebook className='w-4 h-4 text-[#7C3AED] flex-shrink-0' />
+                        <Notebook className='w-4 h-4 text-claw-ai-fg flex-shrink-0' />
                         <span className='flex-1 truncate'>{collection.name}</span>
-                        {isSelected && <span className='text-xs text-[#7C3AED]'>Selected</span>}
+                        {isSelected && <span className='text-xs text-claw-ai-fg'>Selected</span>}
                         <ChevronRight className='w-4 h-4 text-muted-foreground flex-shrink-0' />
                       </button>
                     );

--- a/apps/dashboard/src/components/FileViewer/AttachmentCitationPreview.tsx
+++ b/apps/dashboard/src/components/FileViewer/AttachmentCitationPreview.tsx
@@ -23,6 +23,7 @@ import ReadmeViewer from './ReadmeViewer';
 import TxtViewer from './TxtViewer';
 import HtmlViewer from './HtmlViewer';
 import ImageViewer from './ImageViewer';
+import PptxFileViewer from './PptxFileViewer';
 import { DocumentOperationsProvider } from '../../contexts/DocumentOperationsContext';
 import type { DocumentOperations } from '../../contexts/DocumentOperationsContext';
 import { useScopedFind } from '../../hooks/useScopedFind';
@@ -111,6 +112,9 @@ function getExtension(mimeType: string, fileName: string): string {
     return 'xlsx';
   if (mimeType === 'text/csv') return 'csv';
   if (mimeType === 'text/tsv') return 'tsv';
+  if (mimeType === 'application/vnd.ms-powerpoint') return 'ppt';
+  if (mimeType === 'application/vnd.openxmlformats-officedocument.presentationml.presentation')
+    return 'pptx';
   if (mimeType.startsWith('image/')) return 'image';
   // fall back to filename extension
   return fileName.toLowerCase().split('.').pop() ?? '';
@@ -137,6 +141,10 @@ function getDefaultMimeType(ext: string): string {
       return 'application/vnd.ms-excel';
     case 'csv':
       return 'text/csv';
+    case 'pptx':
+      return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+    case 'ppt':
+      return 'application/vnd.ms-powerpoint';
     default:
       return 'application/octet-stream';
   }
@@ -259,6 +267,9 @@ const AttachmentCitationPreviewInner: React.FC = () => {
       case 'csv':
       case 'tsv':
         return <CsvViewer source={fileWithType} />;
+      case 'pptx':
+      case 'ppt':
+        return <PptxFileViewer source={fileWithType} />;
       case 'txt':
       case 'text':
         return <TxtViewer source={fileWithType} />;

--- a/apps/dashboard/src/components/FileViewer/CodeViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/CodeViewer.tsx
@@ -106,7 +106,9 @@ const CodeViewer: React.FC<BaseViewerProps> = memo(({ source, fileName, searchab
     ? fileName.toLowerCase().endsWith('.md') || fileName.toLowerCase().endsWith('.markdown')
     : false;
 
-  const [markdownMode, setMarkdownMode] = useState<'raw' | 'rendered'>('raw');
+  const [markdownMode, setMarkdownMode] = useState<'raw' | 'rendered'>(
+    isMarkdown ? 'rendered' : 'raw',
+  );
 
   const fileSizeMB = useMemo(() => {
     return source ? source.size / (1024 * 1024) : 0;

--- a/apps/dashboard/src/components/FileViewer/PptxFileViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/PptxFileViewer.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Presentation, Download } from 'lucide-react';
+import type { BaseViewerProps } from './utils';
+import PdfViewer from './PdfViewer';
+import { apiInstance } from '../../services/clients/apiClient';
+import { logger, Event as LogEvent } from '../../utils/logger';
+
+/**
+ * .ppt/.pptx viewer for the shared FileViewer registry — converts the
+ * already-fetched raw file to PDF server-side (LibreOffice, via the backend's
+ * /api/office-conversion/pdf endpoint) and hands the result to the existing
+ * PdfViewer.
+ *
+ * Why not parse the OOXML client-side and render it directly (the prior
+ * approach): that means reimplementing pieces of PowerPoint's own layout
+ * engine — placeholder inheritance, theme colors, custom freeform geometry,
+ * picture recolor/crop effects — one gap at a time, and OOXML is too large a
+ * spec to ever get pixel-exact that way. LibreOffice already implements the
+ * full spec, so shelling out to it for the actual rendering (the same
+ * approach Drive/Slack/Notion previews use) gets genuine fidelity instead of
+ * an ever-growing list of approximations.
+ */
+const PptxFileViewer: React.FC<BaseViewerProps> = props => {
+  const { source, fileName } = props;
+  const [pdfFile, setPdfFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const objectUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setPdfFile(null);
+    setStatus('loading');
+    if (!source) return;
+
+    let cancelled = false;
+    const formData = new FormData();
+    formData.append('file', source, source.name);
+
+    apiInstance
+      .post('/office-conversion/pdf', formData, { responseType: 'blob' })
+      .then(response => {
+        if (cancelled) return;
+        const blob = response.data as Blob;
+        const displayName = (fileName ?? source.name).replace(/\.(pptx|ppt)$/i, '.pdf');
+        setPdfFile(new File([blob], displayName, { type: 'application/pdf' }));
+        setStatus('ready');
+      })
+      .catch(error => {
+        if (cancelled) return;
+        logger.warn(LogEvent.FRONTEND_ERROR, {
+          type: 'migrated_console_warn',
+          message: String('[PptxFileViewer] Failed to convert .pptx file to PDF:'),
+          error,
+        });
+        setStatus('error');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, fileName]);
+
+  useEffect(() => {
+    if (!source) return;
+    const url = URL.createObjectURL(source);
+    objectUrlRef.current = url;
+    return () => {
+      URL.revokeObjectURL(url);
+      objectUrlRef.current = null;
+    };
+  }, [source]);
+
+  const displayName = fileName ?? 'Presentation';
+
+  if (status === 'loading') {
+    return (
+      <div className='flex h-full w-full items-center justify-center'>
+        <div className='text-center'>
+          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary mx-auto mb-3' />
+          <p className='text-muted-foreground dark:text-muted text-sm'>Loading presentation...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'error' || !pdfFile) {
+    return (
+      <div className='flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center'>
+        <div className='flex h-20 w-20 items-center justify-center rounded-lg bg-orange-500 shadow-lg'>
+          <Presentation size={40} className='text-white' />
+        </div>
+        <div>
+          <h3 className='text-base font-semibold text-foreground'>PowerPoint Presentation</h3>
+          <p className='mt-2 max-w-md text-sm text-muted-foreground'>
+            Preview is not available for this file.
+            <br />
+            Download the file to view it.
+          </p>
+        </div>
+        {objectUrlRef.current && (
+          <a
+            href={objectUrlRef.current}
+            download={displayName}
+            className='inline-flex items-center gap-2 rounded-lg bg-orange-600 px-4 py-2 text-sm font-medium text-white hover:bg-orange-700'
+          >
+            <Download size={16} />
+            Download Presentation
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  return <PdfViewer {...props} source={pdfFile} fileName={displayName} />;
+};
+
+export default PptxFileViewer;

--- a/apps/dashboard/src/components/FileViewer/ReadmeViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/ReadmeViewer.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect, useState, useMemo, memo } from 'react';
+import React, { useEffect, useState, useMemo, useRef, useCallback, memo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import rehypeSlug from 'rehype-slug';
 import type { Components } from 'react-markdown';
 import { BaseViewerProps } from './utils';
+import { TableOfContents } from '../Canvas/TableOfContents';
+import type { TocHeading } from '../Canvas/TableOfContents';
 
 // Sanitize schema for file-provided markdown. Starts from rehype-sanitize's
 // safe defaults (scripts / event handlers stripped; img `src` and anchor
@@ -44,6 +47,8 @@ export const ReadmeViewer: React.FC<BaseViewerProps> = memo(({ source }) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [markdownContent, setMarkdownContent] = useState<string>('');
+  const [tocHeadings, setTocHeadings] = useState<TocHeading[]>([]);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   // ----- Stable key (always runs) -----
   const sourceKey = useMemo(() => {
@@ -97,6 +102,38 @@ export const ReadmeViewer: React.FC<BaseViewerProps> = memo(({ source }) => {
     };
   }, [sourceKey, source]);
 
+  // ----- Table of contents (always runs) -----
+  // Read headings back from the rendered DOM rather than re-parsing the
+  // markdown: rehype-slug already assigned each h1-h3 a real `id` (surfaced
+  // to us via the id prop wired into the heading components below), so this
+  // guarantees the TOC always matches exactly what's actually scrollable —
+  // no separate parser to drift out of sync with rehype-sanitize's
+  // clobber-prefixing or slug de-duplication. Mirrors Canvas's TOC, which
+  // reads live BlockNote blocks instead of a parallel source of truth.
+  useEffect(() => {
+    if (loading || error || !markdownContent) {
+      setTocHeadings([]);
+      return;
+    }
+    const container = contentRef.current;
+    if (!container) return;
+    const headings = Array.from(container.querySelectorAll<HTMLHeadingElement>('h1, h2, h3'))
+      .map(el => ({
+        id: el.id,
+        text: el.textContent?.trim() ?? '',
+        level: Number(el.tagName.charAt(1)),
+      }))
+      .filter(h => h.id && h.text);
+    setTocHeadings(headings);
+  }, [loading, error, markdownContent]);
+
+  const handleHeadingClick = useCallback((id: string) => {
+    contentRef.current?.querySelector(`#${CSS.escape(id)}`)?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
+  }, []);
+
   // ----- Markdown components (always runs) -----
   // NOTE: Colors here use CSS-variable design tokens (text-foreground,
   // text-muted-foreground, border-border, bg-muted). These flip with the
@@ -108,27 +145,41 @@ export const ReadmeViewer: React.FC<BaseViewerProps> = memo(({ source }) => {
   // ambient color.
   const markdownComponents: Components = useMemo(
     () => ({
-      h1: ({ children }) => (
-        <h1 className='text-4xl font-bold text-foreground mb-6 pb-2 border-b border-border'>
+      h1: ({ id, children }) => (
+        <h1
+          id={id}
+          className='text-4xl font-bold text-foreground mb-6 pb-2 border-b border-border scroll-mt-10'
+        >
           {children}
         </h1>
       ),
-      h2: ({ children }) => (
-        <h2 className='text-3xl font-semibold text-foreground mb-5 mt-8 pb-2 border-b border-border'>
+      h2: ({ id, children }) => (
+        <h2
+          id={id}
+          className='text-3xl font-semibold text-foreground mb-5 mt-8 pb-2 border-b border-border scroll-mt-10'
+        >
           {children}
         </h2>
       ),
-      h3: ({ children }) => (
-        <h3 className='text-2xl font-semibold text-foreground mb-4 mt-6'>{children}</h3>
+      h3: ({ id, children }) => (
+        <h3 id={id} className='text-2xl font-semibold text-foreground mb-4 mt-6 scroll-mt-10'>
+          {children}
+        </h3>
       ),
-      h4: ({ children }) => (
-        <h4 className='text-xl font-semibold text-foreground mb-3 mt-5'>{children}</h4>
+      h4: ({ id, children }) => (
+        <h4 id={id} className='text-xl font-semibold text-foreground mb-3 mt-5'>
+          {children}
+        </h4>
       ),
-      h5: ({ children }) => (
-        <h5 className='text-lg font-semibold text-foreground mb-2 mt-4'>{children}</h5>
+      h5: ({ id, children }) => (
+        <h5 id={id} className='text-lg font-semibold text-foreground mb-2 mt-4'>
+          {children}
+        </h5>
       ),
-      h6: ({ children }) => (
-        <h6 className='text-base font-semibold text-muted-foreground mb-2 mt-4'>{children}</h6>
+      h6: ({ id, children }) => (
+        <h6 id={id} className='text-base font-semibold text-muted-foreground mb-2 mt-4'>
+          {children}
+        </h6>
       ),
       p: ({ children }) => <p className='text-foreground leading-relaxed mb-4'>{children}</p>,
       a: ({ href, children }) => (
@@ -204,23 +255,42 @@ export const ReadmeViewer: React.FC<BaseViewerProps> = memo(({ source }) => {
   // ----- Rendering (safe conditional) -----
   // `text-foreground` on the root guarantees a theme-correct base color for any
   // element the component map does not explicitly cover.
+  //
+  // The root is a BOUNDED, non-scrolling box (`h-full`, no overflow of its
+  // own) — it's the containing block the TOC is positioned against. Scrolling
+  // happens one level down, on `contentRef`. Nesting the TOC inside the
+  // scrolling div (like the markdown content) would make it a normal-flow
+  // sibling of the scrolled content, so its `top: 50%` would resolve against
+  // the full document height and drift with scroll instead of staying pinned
+  // to the viewport — mirrors Canvas's `containerRef` (non-scrolling) vs. its
+  // inner `overflow-auto` editor pane in CollaborativeCanvasEditor.
   return (
-    <div className='relative min-h-full bg-background text-foreground font-sans'>
+    <div className='relative h-full bg-background text-foreground font-sans'>
       {loading && <LoadingSpinner />}
       {error && !loading && <ErrorDisplay error={error} />}
 
       {!loading && !error && markdownContent && (
-        <div className='min-h-screen px-10 py-10 md:px-15 lg:px-20'>
-          <div className='max-w-4xl mx-auto'>
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeRaw, [rehypeSanitize, markdownSanitizeSchema], rehypeHighlight]}
-              components={markdownComponents}
-            >
-              {markdownContent}
-            </ReactMarkdown>
+        <>
+          <TableOfContents headings={tocHeadings} onHeadingClick={handleHeadingClick} />
+          <div className='h-full overflow-y-auto' ref={contentRef}>
+            <div className='px-10 py-10 md:px-15 lg:px-20'>
+              <div className='max-w-4xl mx-auto'>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[
+                    rehypeRaw,
+                    rehypeSlug,
+                    [rehypeSanitize, markdownSanitizeSchema],
+                    rehypeHighlight,
+                  ]}
+                  components={markdownComponents}
+                >
+                  {markdownContent}
+                </ReactMarkdown>
+              </div>
+            </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/apps/dashboard/src/components/FileViewer/utils.ts
+++ b/apps/dashboard/src/components/FileViewer/utils.ts
@@ -7,6 +7,7 @@ import PdfViewer from './PdfViewer';
 import VideoViewer from './VideoViewer';
 import CodeViewer from './CodeViewer';
 import HtmlViewer from './HtmlViewer';
+import PptxFileViewer from './PptxFileViewer';
 
 export interface ZoomState {
   scale: number;
@@ -87,6 +88,16 @@ export const FILE_TYPE_CONFIG: Record<string, FileTypeConfig<BaseViewerProps>> =
     component: DocxViewer,
     wrapperClass: 'h-full w-full overflow-auto',
     displayName: 'Word Document',
+  },
+  pptx: {
+    mimeTypes: [
+      'application/vnd.ms-powerpoint',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    ],
+    extensions: ['.pptx', '.ppt'],
+    component: PptxFileViewer,
+    wrapperClass: 'h-full w-full overflow-auto',
+    displayName: 'PowerPoint Presentation',
   },
   code: {
     mimeTypes: [

--- a/apps/dashboard/src/components/icons/xyne-ai/index.ts
+++ b/apps/dashboard/src/components/icons/xyne-ai/index.ts
@@ -1,5 +1,6 @@
 export { default as ChatHistory } from './ChatHistory';
 export { default as GlassStar } from './GlassStar';
+export { default as XyneAISidebarIcon } from './XyneAISidebarIcon';
 export { default as XyneAIStar } from './XyneAIStar';
 export { default as XyneDelete } from './XyneDelete';
 export { default as XyneRename } from './XyneRename';

--- a/apps/dashboard/src/components/knowledgeBase/hooks/useProjectCollections.ts
+++ b/apps/dashboard/src/components/knowledgeBase/hooks/useProjectCollections.ts
@@ -37,6 +37,10 @@ export const setCurrentFolderId = (
   knowledgeBaseActor.send({ type: 'SET_CURRENT_FOLDER_ID', id: next });
 };
 
+export const setCurrentFileId = (id: string | null): void => {
+  knowledgeBaseActor.send({ type: 'SET_CURRENT_FILE_ID', id });
+};
+
 export const setViewMode = (mode: ViewMode): void => {
   knowledgeBaseActor.send({ type: 'SET_VIEW_MODE', mode });
 };
@@ -79,6 +83,8 @@ export interface ProjectCollectionsValue {
   setActiveCollection: typeof setActiveCollection;
   currentFolderId: string | null;
   setCurrentFolderId: typeof setCurrentFolderId;
+  currentFileId: string | null;
+  setCurrentFileId: typeof setCurrentFileId;
   viewMode: ViewMode;
   setViewMode: typeof setViewMode;
   expansionState: Record<string, boolean>;
@@ -99,6 +105,7 @@ export function useProjectCollections(): ProjectCollectionsValue {
   const channelId = useSelector(knowledgeBaseActor, s => s.context.channelId);
   const activeCollection = useSelector(knowledgeBaseActor, s => s.context.activeCollection);
   const currentFolderId = useSelector(knowledgeBaseActor, s => s.context.currentFolderId);
+  const currentFileId = useSelector(knowledgeBaseActor, s => s.context.currentFileId);
   const viewMode = useSelector(knowledgeBaseActor, s => s.context.viewMode);
   const expansionState = useSelector(knowledgeBaseActor, s => s.context.expansionState);
   const nodes = useSelector(knowledgeBaseActor, s => s.context.nodes);
@@ -115,6 +122,8 @@ export function useProjectCollections(): ProjectCollectionsValue {
     setActiveCollection,
     currentFolderId,
     setCurrentFolderId,
+    currentFileId,
+    setCurrentFileId,
     viewMode,
     setViewMode,
     expansionState,

--- a/apps/dashboard/src/components/knowledgeBase/layout/FileViewerLayout.tsx
+++ b/apps/dashboard/src/components/knowledgeBase/layout/FileViewerLayout.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { FileViewerPanel } from '../viewer/FileViewerPanel';
+import { resolveKbBasePath } from '../../knowledgeBaseV2/utils/kbRoutePaths';
 import { xyneAIActor } from '../../../machines/xyneAIMachine';
 import {
   useProjectCollections,
@@ -8,6 +9,7 @@ import {
   setChannelId,
   setActiveCollection,
   setCurrentFolderId,
+  setCurrentFileId,
 } from '../hooks/useProjectCollections';
 
 // Minimal layout above FileViewerPanel's thin toolbar. The toolbar exposes an
@@ -15,6 +17,7 @@ import {
 // the Vespa fileId, not the route cuid).
 export const FileViewerLayout: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { projectId, channelId, collectionId, folderId, fileId } = useParams<{
     projectId: string;
     channelId: string;
@@ -49,6 +52,7 @@ export const FileViewerLayout: React.FC = () => {
   const {
     activeCollection,
     currentFolderId,
+    currentFileId,
     projectId: machineProjectId,
     channelId: machineChannelId,
   } = useProjectCollections();
@@ -71,19 +75,36 @@ export const FileViewerLayout: React.FC = () => {
     if (resolvedFolderId !== currentFolderId) setCurrentFolderId(resolvedFolderId);
   }, [resolvedFolderId, currentFolderId]);
 
+  // Lets the Contents panel highlight whichever file is currently open, the
+  // same way it highlights the active folder. Cleared on unmount so leaving
+  // the viewer (back to the folder browser) doesn't leave a stale file
+  // highlighted.
+  useEffect(() => {
+    if (fileId && fileId !== currentFileId) setCurrentFileId(fileId);
+  }, [fileId, currentFileId]);
+
+  useEffect(() => {
+    return () => setCurrentFileId(null);
+  }, []);
+
+  // This viewer is reachable both under /knowledge-base and /ai/knowledge —
+  // Back must return to whichever of those it was opened from, not always
+  // the standalone browser.
+  const basePath = resolveKbBasePath(location.pathname);
+
   const getBackNavigationPath = (): string => {
     if (!collectionId) {
-      return '/knowledge-base';
+      return basePath;
     }
-    // The listing screen lives at /knowledge-base?cl=&parent=, not under the
-    // old path-param scheme. Build the search-params URL so Back returns the
+    // The listing screen lives at <basePath>?cl=&parent=, not under the old
+    // path-param scheme. Build the search-params URL so Back returns the
     // user to the folder they came from instead of 404ing.
     const sp = new URLSearchParams();
     sp.set('cl', collectionId);
     if (resolvedFolderId) {
       sp.set('parent', resolvedFolderId);
     }
-    return `/knowledge-base?${sp.toString()}`;
+    return `${basePath}?${sp.toString()}`;
   };
 
   const handleBack = (): void => {

--- a/apps/dashboard/src/components/knowledgeBase/upload/CreateCollectionModal.tsx
+++ b/apps/dashboard/src/components/knowledgeBase/upload/CreateCollectionModal.tsx
@@ -72,10 +72,6 @@ const CreateCollectionModal = ({
   const handleCreateCollection = useCallback(async () => {
     const finalTitle = title.trim();
     if (!finalTitle) return;
-    if (!effectiveScopeId) {
-      toast.error('Please select a channel');
-      return;
-    }
     if (!user) {
       toast.error('You must be logged in to create a collection');
       return;
@@ -86,11 +82,16 @@ const CreateCollectionModal = ({
     try {
       const id = crypto.randomUUID();
       const timestamp = Date.now();
+      // No channel selected — the collection belongs to the whole workspace
+      // instead of a single channel. 'WORKSPACE' is just another value for
+      // the existing (non-nullable) scopeType/scopeId columns, not a schema
+      // change; visibility then follows `isPrivate` same as channel-scoped
+      // collections.
       const serverRes = await zero.mutate(
         mutators.collection.createCollection({
           id,
-          scopeType,
-          scopeId: effectiveScopeId,
+          scopeType: effectiveScopeId ? scopeType : 'WORKSPACE',
+          scopeId: effectiveScopeId ?? user.workspaceId,
           name: finalTitle,
           description: null,
           isPrivate,
@@ -133,7 +134,7 @@ const CreateCollectionModal = ({
     }
   }, [zero, title, scopeType, effectiveScopeId, isPrivate, user, onSuccess, onClose, resetForm]);
 
-  const canSubmit = title.trim().length > 0 && !!effectiveScopeId && !isCreating;
+  const canSubmit = title.trim().length > 0 && !isCreating;
 
   const channelOptions = useMemo(
     () =>
@@ -180,18 +181,22 @@ const CreateCollectionModal = ({
             />
           </div>
 
-          {/* Channel selector (only if no initialScopeId provided) */}
+          {/* Channel selector (only if no initialScopeId provided). Optional —
+              leaving it unset scopes the collection to the whole workspace
+              instead of a single channel. */}
           {!initialScopeId && (
             <div>
-              <div className='block text-sm font-medium text-foreground mb-1'>Channel</div>
+              <div className='block text-sm font-medium text-foreground mb-1'>
+                Channel <span className='text-muted-foreground font-normal'>(optional)</span>
+              </div>
               <EntitySelector
                 options={channelOptions}
                 selectedValue={selectedChannelId}
                 onSelect={setSelectedChannelId}
-                placeholder='Select a channel...'
+                placeholder='No channel — visible to the whole workspace'
                 searchPlaceholder='Search channels...'
                 width='100%'
-                showClearButton={false}
+                showClearButton
               />
             </div>
           )}
@@ -203,7 +208,10 @@ const CreateCollectionModal = ({
             onChange={value => setIsPrivate(value === 'private')}
             disabled={isCreating}
           >
-            <Radio value='public' subtext='Anyone can upload and view'>
+            <Radio
+              value='public'
+              subtext='Anyone in the workspace can view — editing requires an invite'
+            >
               Public
             </Radio>
             <Radio value='private' subtext='Invite only'>

--- a/apps/dashboard/src/components/knowledgeBase/upload/ShareCollectionModal.tsx
+++ b/apps/dashboard/src/components/knowledgeBase/upload/ShareCollectionModal.tsx
@@ -1,11 +1,25 @@
 import { ReactElement, useState, useCallback, useMemo, useEffect } from 'react';
 import { toast } from 'sonner';
-import { ChevronDown, Check, Globe, Lock, Share2, X } from 'lucide-react';
+import {
+  ChevronDown,
+  Check,
+  Crown,
+  Globe,
+  Hash,
+  Link2,
+  Lock,
+  Search,
+  Share2,
+  UsersRound,
+  X,
+} from 'lucide-react';
 import Dialog from '../../ui/Dialog';
 import { Button } from '../../ui/Button/Button';
-import { SearchUser } from '../../ui/SearchUser/SearchUser';
+import Avatar from '../../ui/Avatar/Avatar';
 import { User } from '@xyne/shared';
 import { useAuth } from '../../../hooks/useAuth';
+import { useActiveUserSearch } from '../../../hooks/useUsers';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { CollectionRole } from '../../../services/Knowledge/collectionService';
 import { CollectionRole as CollectionRoleEnum } from '@xyne/shared';
 import { useZero } from '../../../hooks/useZero';
@@ -14,12 +28,31 @@ import { useProjectCollections } from '../hooks/useProjectCollections';
 import { useProjectCollectionMutations } from '../hooks/useProjectCollectionMutations';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { queries } from '../../../zero/queries';
+import { useUserGroups } from '../../../hooks/useUserGroup';
+import { useAllVisibleChannels } from '../../../hooks/useChannels';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '../../ui/dropdown-menu';
+
+type UserGroupLike = ReturnType<typeof useUserGroups>[number];
+type VisibleChannelLike = ReturnType<typeof useAllVisibleChannels>[number];
+
+// Combined search result kind — mirrors Canvas's own share dialog
+// (CanvasShareModal's AddKind/AddCandidate), which searches people, groups,
+// and channels from a single input instead of three separate pickers.
+type AddKind = 'user' | 'group' | 'channel';
+interface AddCandidate {
+  kind: AddKind;
+  id: string;
+  name: string;
+  sub: string;
+  user?: User;
+  group?: UserGroupLike;
+  channel?: VisibleChannelLike;
+}
 
 interface ShareCollectionModalProps {
   isOpen: boolean;
@@ -36,6 +69,9 @@ interface ShareCollectionModalProps {
    *  enforces this too, but hiding the control for non-owners avoids a wasted
    *  round-trip + error toast. */
   canEditVisibility?: boolean;
+  /** Deep link to the collection. Renders a "Copy link" row in the footer
+   *  when present; omitted entirely otherwise. */
+  link?: string;
 }
 
 export const ShareCollectionModal = ({
@@ -46,16 +82,32 @@ export const ShareCollectionModal = ({
   channelId,
   isPrivate: isPrivateProp,
   canEditVisibility = false,
+  link,
 }: ShareCollectionModalProps): ReactElement => {
   const { user } = useAuth();
   const zero = useZero();
   const { activeCollection } = useProjectCollections();
   const { setCollectionVisibility } = useProjectCollectionMutations();
   const collectionRole = activeCollection?.role;
-  const collectionCanShare = activeCollection?.canShare;
+  // Only owners get the management UI (search/invite, add group, edit
+  // others' roles, remove access, change visibility). Viewer/Editor get a
+  // read-only view — Who has access + General access, Copy link + Done —
+  // matching the simpler ShareLinkModal pattern used for folders/files.
+  const isManager = collectionRole === 'OWNER';
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
   const [userPermissions, setUserPermissions] = useState<Record<string, CollectionRole>>({});
-  const [userCanShare, setUserCanShare] = useState<Record<string, boolean>>({});
+  const [selectedGroups, setSelectedGroups] = useState<UserGroupLike[]>([]);
+  const [groupPermissions, setGroupPermissions] = useState<Record<string, CollectionRole>>({});
+  const allUserGroups = useUserGroups();
+  // Channel grants — Viewer-only, only offered for workspace-scoped
+  // collections (channelId prop is null). A channel-scoped collection
+  // already restricts its own invite search to that channel's members, so
+  // it doesn't need this.
+  const [selectedChannels, setSelectedChannels] = useState<VisibleChannelLike[]>([]);
+  const allVisibleChannels = useAllVisibleChannels();
+  // Combined "Add people, groups, or channels" search — one input searching
+  // all three kinds at once, mirroring Canvas's share dialog.
+  const [query, setQuery] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   // Local-only mirror of the visibility — we don't fire the mutator until the
   // user clicks Share Collection. Re-syncs to the prop whenever the modal
@@ -88,72 +140,145 @@ export const ShareCollectionModal = ({
     [channelId, channelParticipants],
   );
 
-  // Determine what roles and permissions the current user can assign
-  const allowedRoles = useMemo(() => {
-    if (!collectionRole) return [];
+  // Existing collaborators — "Who has access". Includes the owner's own
+  // OWNER row (createCollection inserts one at creation time).
+  const [accessList] = useCachedQuery(queries.collectionPermissions({ collectionId }), {
+    enabled: isOpen,
+  });
+  // Role edits on existing rows are staged (not applied) until
+  // "Share Collection" is clicked — mirrors Canvas's share dialog ("Unsaved
+  // changes" next to Done). Remove stays immediate, matching Canvas's own
+  // precedent there. Keyed by permission row id.
+  const [pendingAccessRoles, setPendingAccessRoles] = useState<Record<string, CollectionRole>>({});
+  const hasPendingAccessChanges = Object.keys(pendingAccessRoles).length > 0;
+  // People who already have explicit access — excluded from the search below
+  // so they can't be "re-added" there; their role is managed via the Viewer/
+  // Editor toggle on their row above instead.
+  const existingAccessUserIds = useMemo(
+    () => accessList.map(row => row.userId).filter((id): id is string => !!id),
+    [accessList],
+  );
+  // Same, for groups — excluded from the "Add a group" picker below.
+  const existingAccessGroupIds = useMemo(
+    () => accessList.map(row => row.userGroupId).filter((id): id is string => !!id),
+    [accessList],
+  );
+  const availableGroups = useMemo(
+    () =>
+      allUserGroups.filter(
+        g => !existingAccessGroupIds.includes(g.id) && !selectedGroups.some(sg => sg.id === g.id),
+      ),
+    [allUserGroups, existingAccessGroupIds, selectedGroups],
+  );
+  // Same, for channels — excluded from the "Add a channel" picker below.
+  const existingAccessChannelIds = useMemo(
+    () => accessList.map(row => row.channelId).filter((id): id is string => !!id),
+    [accessList],
+  );
+  const availableChannels = useMemo(
+    () =>
+      allVisibleChannels.filter(
+        ch =>
+          !existingAccessChannelIds.includes(ch.id) &&
+          !selectedChannels.some(sc => sc.id === ch.id),
+      ),
+    [allVisibleChannels, existingAccessChannelIds, selectedChannels],
+  );
 
-    // OWNER can assign all roles
-    if (collectionRole === 'OWNER') {
-      return ['VIEWER', 'EDITOR'] as CollectionRole[];
-    }
+  // Stages a role change — applied on "Share Collection", not immediately.
+  const handleAccessRoleChange = useCallback(
+    (
+      row: { id: string; userId: string | null; userGroupId: string | null },
+      role: CollectionRole,
+    ) => {
+      if (!row.userId && !row.userGroupId) return;
+      setPendingAccessRoles(prev => ({ ...prev, [row.id]: role }));
+    },
+    [],
+  );
 
-    // EDITOR can assign VIEWER and EDITOR
-    if (collectionRole === 'EDITOR') {
-      return ['VIEWER', 'EDITOR'] as CollectionRole[];
-    }
+  const handleRemoveAccess = useCallback(
+    (row: { id: string }) => {
+      void zero
+        .mutate(mutators.collection.revokePermission({ id: row.id, collectionId }))
+        .server.then(res => {
+          if (res.type === 'error') {
+            toast.error(res.error.message || 'Failed to remove access');
+          }
+        });
+    },
+    [zero, collectionId],
+  );
 
-    // VIEWER can only assign VIEWER
-    if (collectionRole === 'VIEWER') {
-      return ['VIEWER'] as CollectionRole[];
-    }
-
-    return [];
-  }, [collectionRole]);
-
-  // Whether the current user can grant canShare permission
-  const canGrantCanShare = useMemo(() => {
-    return collectionCanShare === true;
-  }, [collectionCanShare]);
+  // Determine what roles the current user can assign. The backend
+  // (grantPermission) actually allows any explicit role to share, capped by
+  // escalation — but the invite/role-change UI below is gated to `isManager`
+  // (collectionRole === 'OWNER') only, so an EDITOR or VIEWER can never
+  // reach a point where this value is used. Reflects that reality directly
+  // instead of computing EDITOR/VIEWER cases that are dead code here.
+  const allowedRoles = useMemo(
+    () => (collectionRole === 'OWNER' ? (['VIEWER', 'EDITOR', 'OWNER'] as CollectionRole[]) : []),
+    [collectionRole],
+  );
 
   const handleClose = useCallback(() => {
     if (!isLoading) {
       setSelectedUsers([]);
       setUserPermissions({});
-      setUserCanShare({});
+      setSelectedGroups([]);
+      setGroupPermissions({});
+      setSelectedChannels([]);
+      setQuery('');
+      // Discard any staged "Who has access" edits — nothing was ever sent.
+      setPendingAccessRoles({});
       onClose();
     }
   }, [isLoading, onClose]);
 
-  // Update permissions when users are added/removed
-  const handleUsersChange = useCallback(
-    (users: User[]) => {
-      setSelectedUsers(users);
-      // Set default permission (viewer) for new users
-      const newPermissions: Record<string, CollectionRole> = { ...userPermissions };
-      const newCanShare: Record<string, boolean> = { ...userCanShare };
-      users.forEach(user => {
-        if (
-          !newPermissions[user.id] ||
-          !allowedRoles.includes(newPermissions[user.id] as CollectionRole)
-        ) {
-          newPermissions[user.id] = 'VIEWER';
-        }
-        if (!newCanShare[user.id] || !canGrantCanShare) {
-          newCanShare[user.id] = false;
-        }
-      });
-      // Remove permissions for users that are no longer selected
-      Object.keys(newPermissions).forEach(userId => {
-        if (!users.some(u => u.id === userId)) {
-          delete newPermissions[userId];
-          delete newCanShare[userId];
-        }
-      });
-      setUserPermissions(newPermissions);
-      setUserCanShare(newCanShare);
+  const addUser = useCallback((u: User) => {
+    setSelectedUsers(prev => [...prev, u]);
+    setUserPermissions(prev => ({ ...prev, [u.id]: 'VIEWER' }));
+  }, []);
+
+  const removeUser = useCallback((userId: string) => {
+    setSelectedUsers(prev => prev.filter(u => u.id !== userId));
+    setUserPermissions(prev => {
+      const next = { ...prev };
+      delete next[userId];
+      return next;
+    });
+  }, []);
+
+  const addGroup = useCallback((group: UserGroupLike) => {
+    setSelectedGroups(prev => [...prev, group]);
+    setGroupPermissions(prev => ({ ...prev, [group.id]: 'VIEWER' }));
+  }, []);
+
+  const removeGroup = useCallback((groupId: string) => {
+    setSelectedGroups(prev => prev.filter(g => g.id !== groupId));
+    setGroupPermissions(prev => {
+      const next = { ...prev };
+      delete next[groupId];
+      return next;
+    });
+  }, []);
+
+  const handleGroupPermissionChange = useCallback(
+    (groupId: string, permission: CollectionRole) => {
+      if (!allowedRoles.includes(permission)) return;
+      setGroupPermissions(prev => ({ ...prev, [groupId]: permission }));
     },
-    [userPermissions, userCanShare, allowedRoles, canGrantCanShare],
+    [allowedRoles],
   );
+
+  // Channel grants are always Viewer — no permission picker, just add/remove.
+  const addChannel = useCallback((channel: VisibleChannelLike) => {
+    setSelectedChannels(prev => [...prev, channel]);
+  }, []);
+
+  const removeChannel = useCallback((channelId: string) => {
+    setSelectedChannels(prev => prev.filter(c => c.id !== channelId));
+  }, []);
 
   const handlePermissionChange = useCallback(
     (userId: string, permission: CollectionRole) => {
@@ -169,19 +294,73 @@ export const ShareCollectionModal = ({
     [allowedRoles],
   );
 
-  const handleCanShareChange = useCallback(
-    (userId: string, canShare: boolean) => {
-      // Only allow setting canShare if the current user can grant it
-      if (!canGrantCanShare) {
-        return;
-      }
-      setUserCanShare(prev => ({
-        ...prev,
-        [userId]: canShare,
+  // Combined search across people / groups / channels — one input, like
+  // Canvas's share dialog. Channels are only candidates for workspace-scoped
+  // collections (channelId prop null); a channel-scoped collection already
+  // restricts its own people search to that channel's participants.
+  const userSearchResults = useActiveUserSearch(query, 6);
+  const results = useMemo((): AddCandidate[] => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+
+    const excludedUserIds = new Set([
+      user?.id || '',
+      activeCollection?.ownerId || '',
+      ...existingAccessUserIds,
+      ...selectedUsers.map(u => u.id),
+    ]);
+    const users: AddCandidate[] = userSearchResults
+      .filter(u => !excludedUserIds.has(u.id) && (!allowedUserIds || allowedUserIds.has(u.id)))
+      .map(u => ({
+        kind: 'user',
+        id: u.id,
+        name: getUserDisplayName(u),
+        sub: u.email ?? '',
+        user: u,
       }));
+
+    const groups: AddCandidate[] = availableGroups
+      .filter(g => g.name.toLowerCase().includes(q))
+      .slice(0, 4)
+      .map(g => ({ kind: 'group', id: g.id, name: g.name, sub: 'Group', group: g }));
+
+    const channels: AddCandidate[] = channelId
+      ? []
+      : availableChannels
+          .filter(ch => ch.name.toLowerCase().includes(q))
+          .slice(0, 4)
+          .map(ch => ({ kind: 'channel', id: ch.id, name: ch.name, sub: 'Channel', channel: ch }));
+
+    return [...users, ...groups, ...channels];
+  }, [
+    query,
+    userSearchResults,
+    user?.id,
+    activeCollection?.ownerId,
+    existingAccessUserIds,
+    selectedUsers,
+    allowedUserIds,
+    availableGroups,
+    availableChannels,
+    channelId,
+  ]);
+
+  const addCandidate = useCallback(
+    (c: AddCandidate) => {
+      if (c.kind === 'user' && c.user) addUser(c.user);
+      else if (c.kind === 'group' && c.group) addGroup(c.group);
+      else if (c.kind === 'channel' && c.channel) addChannel(c.channel);
+      setQuery('');
     },
-    [canGrantCanShare],
+    [addUser, addGroup, addChannel],
   );
+
+  const searchCandidateIcon = (kind: AddKind): ReactElement =>
+    kind === 'group' ? (
+      <UsersRound size={16} className='text-muted-foreground' />
+    ) : (
+      <Hash size={16} className='text-muted-foreground' />
+    );
 
   const visibilityChanged =
     isPrivateProp !== undefined && (visibility === 'private') !== isPrivateProp;
@@ -192,12 +371,15 @@ export const ShareCollectionModal = ({
       return;
     }
 
-    // Allow submitting the dialog if the user has either picked someone to
-    // share with OR flipped the visibility. Both branches can apply in the
-    // same click — visibility is persisted first so the new permissions are
-    // evaluated against the correct visibility.
-    if (selectedUsers.length === 0 && !visibilityChanged) {
-      toast.error('Pick a user to share with, or change visibility');
+    // Allow submitting the dialog if the user has either picked someone (or a
+    // group) to share with, changed an existing collaborator's role, OR
+    // flipped the visibility. Visibility is persisted first so the new
+    // permissions are evaluated against the correct visibility.
+    const hasNewInvites =
+      selectedUsers.length > 0 || selectedGroups.length > 0 || selectedChannels.length > 0;
+    const hasPending = hasNewInvites || hasPendingAccessChanges;
+    if (!hasPending && !visibilityChanged) {
+      toast.error('Pick a user or group to share with, or change visibility');
       return;
     }
 
@@ -208,10 +390,11 @@ export const ShareCollectionModal = ({
         await setCollectionVisibility(collectionId, visibility === 'private');
       }
 
-      if (selectedUsers.length > 0) {
+      if (hasPending) {
         const timestamp = Date.now();
-        await Promise.all(
-          selectedUsers.map(
+        const changedAccessRows = accessList.filter(row => row.id in pendingAccessRoles);
+        await Promise.all([
+          ...selectedUsers.map(
             selectedUser =>
               zero.mutate(
                 mutators.collection.grantPermission({
@@ -219,12 +402,47 @@ export const ShareCollectionModal = ({
                   collectionId,
                   userId: selectedUser.id,
                   role: (userPermissions[selectedUser.id] ?? 'VIEWER') as CollectionRoleEnum,
-                  canShare: userCanShare[selectedUser.id] ?? false,
                   timestamp,
                 }),
               ).server,
           ),
-        );
+          ...selectedGroups.map(
+            selectedGroup =>
+              zero.mutate(
+                mutators.collection.grantPermission({
+                  id: crypto.randomUUID(),
+                  collectionId,
+                  userGroupId: selectedGroup.id,
+                  role: (groupPermissions[selectedGroup.id] ?? 'VIEWER') as CollectionRoleEnum,
+                  timestamp,
+                }),
+              ).server,
+          ),
+          ...selectedChannels.map(
+            selectedChannel =>
+              zero.mutate(
+                mutators.collection.grantPermission({
+                  id: crypto.randomUUID(),
+                  collectionId,
+                  channelId: selectedChannel.id,
+                  role: 'VIEWER' as CollectionRoleEnum,
+                  timestamp,
+                }),
+              ).server,
+          ),
+          ...changedAccessRows.map(
+            row =>
+              zero.mutate(
+                mutators.collection.grantPermission({
+                  id: row.id,
+                  collectionId,
+                  ...(row.userId ? { userId: row.userId } : { userGroupId: row.userGroupId! }),
+                  role: (pendingAccessRoles[row.id] ?? row.role) as CollectionRoleEnum,
+                  timestamp,
+                }),
+              ).server,
+          ),
+        ]);
         toast.success('Collection shared successfully');
       } else if (visibilityChanged) {
         toast.success(`"${collectionName}" is now ${visibility}`);
@@ -238,7 +456,21 @@ export const ShareCollectionModal = ({
     }
   };
 
-  const canSubmit = (selectedUsers.length > 0 || visibilityChanged) && !isLoading;
+  const hasUnsavedChanges =
+    selectedUsers.length > 0 ||
+    selectedGroups.length > 0 ||
+    selectedChannels.length > 0 ||
+    visibilityChanged ||
+    hasPendingAccessChanges;
+  const canSubmit = hasUnsavedChanges && !isLoading;
+
+  const handleCopyLink = (): void => {
+    if (!link) return;
+    void navigator.clipboard.writeText(link).then(
+      () => toast.success('Link copied'),
+      () => toast.error('Could not copy link'),
+    );
+  };
 
   return (
     <Dialog
@@ -248,7 +480,7 @@ export const ShareCollectionModal = ({
       }}
       title='Share Collection'
       description={`Share "${collectionName}" with other users`}
-      className='max-w-md bg-secondary border border-border'
+      className='max-w-md max-h-[85vh] overflow-y-auto bg-popover border border-border'
     >
       <div className='p-6'>
         {/* Header */}
@@ -270,12 +502,485 @@ export const ShareCollectionModal = ({
           <p className='text-sm text-muted-foreground mb-2'>
             Collection: <span className='font-medium text-foreground'>{collectionName}</span>
           </p>
-          <p className='text-xs text-muted-foreground'>
-            {channelId
-              ? 'Only users in this channel can be shared with. Choose viewer or editor permission for each user.'
-              : 'Search and select users from your workspace. Choose viewer or editor permission for each user.'}
-          </p>
+          {isManager && (
+            <p className='text-xs text-muted-foreground'>
+              {channelId
+                ? 'Only users in this channel can be shared with. Choose viewer or editor permission for each user.'
+                : 'Search and select users from your workspace. Choose viewer or editor permission for each user.'}
+            </p>
+          )}
         </div>
+
+        {/* Search/invite, "Add a group", and "Set Permissions" are
+            owner-only — Viewer/Editor get a read-only view (Who has access +
+            General access) below instead. */}
+        {isManager && (
+          <>
+            {/* Combined search — one input for people, groups, and channels,
+            mirroring Canvas's share dialog (CanvasShareModal) instead of
+            three separate pickers. Channel results only appear for
+            workspace-scoped collections (channelId prop null). */}
+            <div className='mb-4 relative'>
+              <label
+                htmlFor='share-search'
+                className='block text-sm font-medium text-foreground mb-2'
+              >
+                Select Users
+              </label>
+              <div className='relative'>
+                <Search
+                  size={16}
+                  className='absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none'
+                />
+                <input
+                  id='share-search'
+                  type='text'
+                  value={query}
+                  onChange={e => setQuery(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' && results[0]) {
+                      e.preventDefault();
+                      addCandidate(results[0]);
+                    } else if (e.key === 'Escape') {
+                      setQuery('');
+                    }
+                  }}
+                  disabled={isLoading}
+                  placeholder={
+                    channelId ? 'Add people or groups...' : 'Add people, groups, or channels...'
+                  }
+                  data-track-category='knowledge-base'
+                  data-track-name='share-collection-search-input'
+                  className='w-full rounded-md border border-border bg-background pl-9 pr-3 py-2 text-sm text-foreground outline-none focus:border-ring focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50'
+                />
+              </div>
+              {query.trim() && (
+                <div className='absolute left-0 right-0 top-[calc(100%+4px)] z-[60] max-h-64 overflow-y-auto rounded-md border border-border bg-popover shadow-md p-1'>
+                  {results.length > 0 ? (
+                    results.map(c => (
+                      <button
+                        key={`${c.kind}:${c.id}`}
+                        type='button'
+                        onMouseDown={e => {
+                          e.preventDefault();
+                          addCandidate(c);
+                        }}
+                        data-track-category='knowledge-base'
+                        data-track-name='share-collection-add-candidate'
+                        className='w-full flex items-center gap-3 px-2 py-1.5 rounded-md text-left hover:bg-muted'
+                      >
+                        {c.kind === 'user' ? (
+                          <Avatar userId={c.id} size='sm' />
+                        ) : (
+                          <span className='flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-muted'>
+                            {searchCandidateIcon(c.kind)}
+                          </span>
+                        )}
+                        <span className='min-w-0 flex-1'>
+                          <span className='block text-sm font-medium text-foreground truncate'>
+                            {c.name}
+                          </span>
+                          <span className='block text-xs text-muted-foreground truncate'>
+                            {c.sub}
+                          </span>
+                        </span>
+                      </button>
+                    ))
+                  ) : (
+                    <div className='px-3 py-2.5 text-sm text-muted-foreground'>
+                      {channelId
+                        ? 'No people or groups found'
+                        : 'No people, groups, or channels found'}
+                    </div>
+                  )}
+                </div>
+              )}
+              {channelId && (
+                <p className='mt-1.5 text-xs text-muted-foreground'>
+                  Only users in this channel can be selected.
+                </p>
+              )}
+            </div>
+
+            {/* Permission Selection for Selected Users + Groups + Channels */}
+            {(selectedUsers.length > 0 ||
+              selectedGroups.length > 0 ||
+              selectedChannels.length > 0) && (
+              <div className='mb-6'>
+                <div className='block text-sm font-medium text-foreground mb-3'>
+                  Set Permissions
+                </div>
+                <div className='max-h-64 overflow-y-auto space-y-3 pr-2'>
+                  {selectedUsers.map(user => (
+                    <div
+                      key={user.id}
+                      className='flex items-center justify-between p-3 gap-3 border border-border rounded-md bg-muted/40'
+                    >
+                      <div className='flex items-center gap-3 flex-1 min-w-0'>
+                        <div className='flex-shrink-0'>
+                          <div className='w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-500/20 flex items-center justify-center text-blue-600 dark:text-blue-300 font-medium text-sm'>
+                            {user.name?.[0]?.toUpperCase() || user.email?.[0]?.toUpperCase() || '?'}
+                          </div>
+                        </div>
+                        <div className='flex-1 min-w-0'>
+                          <div className='text-sm font-medium text-foreground truncate'>
+                            {user.name || 'Unnamed User'}
+                          </div>
+                          <div className='text-xs text-muted-foreground truncate'>{user.email}</div>
+                        </div>
+                      </div>
+                      <div className='flex items-center gap-2 flex-shrink-0'>
+                        {allowedRoles.includes('VIEWER') && (
+                          <button
+                            type='button'
+                            onClick={() => handlePermissionChange(user.id, 'VIEWER')}
+                            disabled={isLoading}
+                            data-track-category='knowledge-base'
+                            data-track-name='set-viewer-permission'
+                            className={`
+                          px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+                          ${
+                            (userPermissions[user.id] || 'VIEWER') === 'VIEWER'
+                              ? 'bg-muted-foreground text-background'
+                              : 'bg-background text-foreground border border-border hover:bg-muted'
+                          }
+                          disabled:opacity-50 disabled:cursor-not-allowed
+                        `}
+                          >
+                            Viewer
+                          </button>
+                        )}
+                        {allowedRoles.includes('EDITOR') && (
+                          <button
+                            type='button'
+                            onClick={() => handlePermissionChange(user.id, 'EDITOR')}
+                            disabled={isLoading}
+                            data-track-category='knowledge-base'
+                            data-track-name='set-editor-permission'
+                            className={`
+                          px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+                          ${
+                            userPermissions[user.id] === 'EDITOR'
+                              ? 'bg-muted-foreground text-background'
+                              : 'bg-background text-foreground border border-border hover:bg-muted'
+                          }
+                          disabled:opacity-50 disabled:cursor-not-allowed
+                        `}
+                          >
+                            Editor
+                          </button>
+                        )}
+                        {allowedRoles.includes('OWNER') && (
+                          <button
+                            type='button'
+                            onClick={() => handlePermissionChange(user.id, 'OWNER')}
+                            disabled={isLoading}
+                            data-track-category='knowledge-base'
+                            data-track-name='set-owner-permission'
+                            className={`
+                          px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+                          ${
+                            userPermissions[user.id] === 'OWNER'
+                              ? 'bg-muted-foreground text-background'
+                              : 'bg-background text-foreground border border-border hover:bg-muted'
+                          }
+                          disabled:opacity-50 disabled:cursor-not-allowed
+                        `}
+                          >
+                            Owner
+                          </button>
+                        )}
+                        <button
+                          type='button'
+                          onClick={() => removeUser(user.id)}
+                          disabled={isLoading}
+                          aria-label={`Remove ${user.name || user.email || 'user'}`}
+                          data-track-category='knowledge-base'
+                          data-track-name='remove-pending-user'
+                          className='p-1 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+                        >
+                          <X size={14} />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                  {selectedGroups.map(group => (
+                    <div
+                      key={group.id}
+                      className='flex items-center justify-between p-3 gap-3 border border-border rounded-md bg-muted/40'
+                    >
+                      <div className='flex items-center gap-3 flex-1 min-w-0'>
+                        <div className='flex-shrink-0'>
+                          <div className='w-8 h-8 rounded-full bg-muted flex items-center justify-center text-muted-foreground'>
+                            <UsersRound size={16} />
+                          </div>
+                        </div>
+                        <div className='flex-1 min-w-0'>
+                          <div className='text-sm font-medium text-foreground truncate'>
+                            {group.name}
+                          </div>
+                          <div className='text-xs text-muted-foreground truncate'>Group</div>
+                        </div>
+                      </div>
+                      <div className='flex items-center gap-2 flex-shrink-0'>
+                        {allowedRoles.includes('VIEWER') && (
+                          <button
+                            type='button'
+                            onClick={() => handleGroupPermissionChange(group.id, 'VIEWER')}
+                            disabled={isLoading}
+                            data-track-category='knowledge-base'
+                            data-track-name='set-group-viewer-permission'
+                            className={`
+                          px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+                          ${
+                            (groupPermissions[group.id] || 'VIEWER') === 'VIEWER'
+                              ? 'bg-muted-foreground text-background'
+                              : 'bg-background text-foreground border border-border hover:bg-muted'
+                          }
+                          disabled:opacity-50 disabled:cursor-not-allowed
+                        `}
+                          >
+                            Viewer
+                          </button>
+                        )}
+                        {allowedRoles.includes('EDITOR') && (
+                          <button
+                            type='button'
+                            onClick={() => handleGroupPermissionChange(group.id, 'EDITOR')}
+                            disabled={isLoading}
+                            data-track-category='knowledge-base'
+                            data-track-name='set-group-editor-permission'
+                            className={`
+                          px-3 py-1.5 text-xs font-medium rounded-md transition-colors
+                          ${
+                            groupPermissions[group.id] === 'EDITOR'
+                              ? 'bg-muted-foreground text-background'
+                              : 'bg-background text-foreground border border-border hover:bg-muted'
+                          }
+                          disabled:opacity-50 disabled:cursor-not-allowed
+                        `}
+                          >
+                            Editor
+                          </button>
+                        )}
+                        <button
+                          type='button'
+                          onClick={() => removeGroup(group.id)}
+                          disabled={isLoading}
+                          aria-label={`Remove ${group.name}`}
+                          data-track-category='knowledge-base'
+                          data-track-name='remove-pending-group'
+                          className='p-1 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+                        >
+                          <X size={14} />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                  {selectedChannels.map(channel => (
+                    <div
+                      key={channel.id}
+                      className='flex items-center justify-between p-3 gap-3 border border-border rounded-md bg-muted/40'
+                    >
+                      <div className='flex items-center gap-3 flex-1 min-w-0'>
+                        <div className='flex-shrink-0'>
+                          <div className='w-8 h-8 rounded-full bg-muted flex items-center justify-center text-muted-foreground'>
+                            <Hash size={16} />
+                          </div>
+                        </div>
+                        <div className='flex-1 min-w-0'>
+                          <div className='text-sm font-medium text-foreground truncate'>
+                            {channel.name}
+                          </div>
+                          <div className='text-xs text-muted-foreground truncate'>Channel</div>
+                        </div>
+                      </div>
+                      <div className='flex items-center gap-2 flex-shrink-0'>
+                        <span className='px-3 py-1.5 text-xs font-medium text-muted-foreground'>
+                          Viewer
+                        </span>
+                        <button
+                          type='button'
+                          onClick={() => removeChannel(channel.id)}
+                          disabled={isLoading}
+                          aria-label={`Remove ${channel.name}`}
+                          data-track-category='knowledge-base'
+                          data-track-name='remove-pending-channel'
+                          className='p-1 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
+                        >
+                          <X size={14} />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {/* Who has access — existing collaborators. OWNER is a real,
+            multi-holder role here (like EDITOR/VIEWER) — the creator
+            (activeCollection.ownerId) is a separate, permanent label shown
+            on their row only, always first and locked. Everyone else
+            (including other OWNER-role holders) gets a single role dropdown
+            (Viewer/Editor/Owner + Remove access) mirroring Canvas's
+            share-dialog RoleSelect. Anyone with an explicit role can share —
+            there's no separate delegated "canShare" permission anymore. */}
+        {accessList.length > 0 && (
+          <div className='mb-6'>
+            <div className='block text-sm font-medium text-foreground mb-2'>Who has access</div>
+            <div className='max-h-56 overflow-y-auto -mx-1 space-y-1 pr-0.5'>
+              {[...accessList]
+                .sort((a, b) => {
+                  const aIsCreator = a.userId === activeCollection?.ownerId;
+                  const bIsCreator = b.userId === activeCollection?.ownerId;
+                  if (aIsCreator !== bIsCreator) return aIsCreator ? -1 : 1;
+                  const rank = { OWNER: 0, EDITOR: 1, VIEWER: 2 } as const;
+                  return (
+                    (rank[a.role as keyof typeof rank] ?? 3) -
+                    (rank[b.role as keyof typeof rank] ?? 3)
+                  );
+                })
+                .map(row => {
+                  const isCreatorRow = !!row.userId && row.userId === activeCollection?.ownerId;
+                  // Your own row is always locked too — matches Canvas's
+                  // share dialog (isYou locks the same as isCreator), so you
+                  // can't change or remove your own access from this list.
+                  const isOwnRow = !!row.userId && row.userId === user?.id;
+                  const locked = isCreatorRow || isOwnRow || !isManager;
+                  // Reflect staged edits, if any, rather than the synced value.
+                  const displayRole = (pendingAccessRoles[row.id] ?? row.role) as CollectionRole;
+                  const roleLabel =
+                    displayRole === 'OWNER'
+                      ? 'Owner'
+                      : displayRole === 'EDITOR'
+                        ? 'Editor'
+                        : 'Viewer';
+                  return (
+                    <div
+                      key={row.id}
+                      className='flex items-center gap-3 px-1 py-1.5 rounded-lg hover:bg-muted/60'
+                    >
+                      {row.channelId ? (
+                        <div className='flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground'>
+                          <Hash size={16} />
+                        </div>
+                      ) : row.userGroupId ? (
+                        <div className='flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground'>
+                          <UsersRound size={16} />
+                        </div>
+                      ) : (
+                        <Avatar userId={row.userId} size='sm' />
+                      )}
+                      <div className='min-w-0 flex-1'>
+                        <p className='text-sm font-medium text-foreground truncate'>
+                          {row.channelId
+                            ? row.channel?.name || 'Unknown channel'
+                            : row.userGroupId
+                              ? row.userGroup?.name || 'Unknown group'
+                              : row.user?.name || row.user?.email || 'Unknown user'}
+                          {row.userId === user?.id ? (
+                            <span className='ml-1.5 text-xs text-muted-foreground'>You</span>
+                          ) : null}
+                        </p>
+                      </div>
+                      {row.channelId ? (
+                        // Channel grants are always Viewer — no role dropdown,
+                        // just a fixed label and a standalone remove button.
+                        <div className='flex items-center gap-1 pr-1'>
+                          <span className='text-xs text-muted-foreground'>Viewer</span>
+                          {collectionRole === 'OWNER' && (
+                            <button
+                              type='button'
+                              onClick={() => handleRemoveAccess(row)}
+                              aria-label={`Remove ${row.channel?.name || 'channel'} access`}
+                              data-track-category='knowledge-base'
+                              data-track-name='access-remove-channel'
+                              className='p-1 rounded-md text-muted-foreground hover:bg-muted hover:text-red-600'
+                            >
+                              <X size={14} />
+                            </button>
+                          )}
+                        </div>
+                      ) : locked ? (
+                        isCreatorRow ? (
+                          <span className='flex items-center gap-1.5 text-sm text-muted-foreground pr-1'>
+                            <Crown size={14} className='text-amber-500' />
+                            Owner
+                            <span className='text-xs'>(Creator)</span>
+                          </span>
+                        ) : (
+                          <span className='text-xs text-muted-foreground pr-1'>{roleLabel}</span>
+                        )
+                      ) : (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type='button'
+                              aria-label={`Change role for ${row.userGroupId ? row.userGroup?.name || 'group' : row.user?.name || 'user'}`}
+                              data-track-category='knowledge-base'
+                              data-track-name='access-change-role'
+                              className='inline-flex items-center gap-1 rounded-md px-2 py-1 text-sm font-medium text-foreground transition hover:bg-muted'
+                            >
+                              {roleLabel}
+                              <ChevronDown size={14} className='text-muted-foreground' />
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align='end' className='w-40'>
+                            <DropdownMenuItem
+                              onClick={() => handleAccessRoleChange(row, 'VIEWER')}
+                              className='flex items-center justify-between cursor-pointer'
+                            >
+                              Viewer
+                              {displayRole === 'VIEWER' && (
+                                <Check size={14} className='text-blue-600' />
+                              )}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() => handleAccessRoleChange(row, 'EDITOR')}
+                              className='flex items-center justify-between cursor-pointer'
+                            >
+                              Editor
+                              {displayRole === 'EDITOR' && (
+                                <Check size={14} className='text-blue-600' />
+                              )}
+                            </DropdownMenuItem>
+                            {collectionRole === 'OWNER' && row.userId && (
+                              <DropdownMenuItem
+                                onClick={() => handleAccessRoleChange(row, 'OWNER')}
+                                className='flex items-center justify-between cursor-pointer'
+                              >
+                                Owner
+                                {displayRole === 'OWNER' && (
+                                  <Check size={14} className='text-blue-600' />
+                                )}
+                              </DropdownMenuItem>
+                            )}
+                            {collectionRole === 'OWNER' && (
+                              <>
+                                <div
+                                  className='h-px bg-border my-1'
+                                  role='separator'
+                                  aria-hidden='true'
+                                />
+                                <DropdownMenuItem
+                                  onClick={() => handleRemoveAccess(row)}
+                                  className='cursor-pointer text-red-600 focus:text-red-600'
+                                >
+                                  Remove access
+                                </DropdownMenuItem>
+                              </>
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </div>
+                  );
+                })}
+            </div>
+          </div>
+        )}
 
         {/* General access — Google Drive style: pick Public or Private. The
             choice is only persisted when the user clicks Share Collection,
@@ -364,138 +1069,44 @@ export const ShareCollectionModal = ({
           </div>
         )}
 
-        {/* User Search */}
-        <div className='mb-4'>
-          <label htmlFor='user-search' className='block text-sm font-medium text-foreground mb-2'>
-            Select Users
-          </label>
-          <SearchUser
-            excludeUserIds={[user?.id || '', activeCollection?.ownerId || '']}
-            selectedUsers={selectedUsers}
-            onUsersChange={handleUsersChange}
-            placeholder='Search users by name or email...'
-            label=''
-            hintText={
-              channelId
-                ? 'Only users in this channel can be selected. Search by name or email.'
-                : ''
-            }
-            disabled={{ value: isLoading }}
-            allowedUserIds={allowedUserIds}
-          />
-        </div>
-
-        {/* Permission Selection for Selected Users */}
-        {selectedUsers.length > 0 && (
-          <div className='mb-6'>
-            <div className='block text-sm font-medium text-foreground mb-3'>Set Permissions</div>
-            <div className='max-h-64 overflow-y-auto space-y-3 pr-2'>
-              {selectedUsers.map(user => (
-                <div
-                  key={user.id}
-                  className='flex items-center justify-between p-3 g-3 border border-border rounded-md bg-muted/40'
-                >
-                  <div className='flex items-center gap-3 flex-1 min-w-0'>
-                    <div className='flex-shrink-0'>
-                      <div className='w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-500/20 flex items-center justify-center text-blue-600 dark:text-blue-300 font-medium text-sm'>
-                        {user.name?.[0]?.toUpperCase() || user.email?.[0]?.toUpperCase() || '?'}
-                      </div>
-                    </div>
-                    <div className='flex-1 min-w-0'>
-                      <div className='text-sm font-medium text-foreground truncate'>
-                        {user.name || 'Unnamed User'}
-                      </div>
-                      <div className='text-xs text-muted-foreground truncate'>{user.email}</div>
-                    </div>
-                  </div>
-                  <div className='flex flex-col gap-2 flex-shrink-0'>
-                    <div className='flex items-center gap-2'>
-                      {allowedRoles.includes('VIEWER') && (
-                        <button
-                          type='button'
-                          onClick={() => handlePermissionChange(user.id, 'VIEWER')}
-                          disabled={isLoading}
-                          data-track-category='knowledge-base'
-                          data-track-name='set-viewer-permission'
-                          className={`
-                            px-3 py-1.5 text-xs font-medium rounded-md transition-colors
-                            ${
-                              (userPermissions[user.id] || 'VIEWER') === 'VIEWER'
-                                ? 'bg-muted-foreground text-background'
-                                : 'bg-background text-foreground border border-border hover:bg-muted'
-                            }
-                            disabled:opacity-50 disabled:cursor-not-allowed
-                          `}
-                        >
-                          Viewer
-                        </button>
-                      )}
-                      {allowedRoles.includes('EDITOR') && (
-                        <button
-                          type='button'
-                          onClick={() => handlePermissionChange(user.id, 'EDITOR')}
-                          disabled={isLoading}
-                          data-track-category='knowledge-base'
-                          data-track-name='set-editor-permission'
-                          className={`
-                            px-3 py-1.5 text-xs font-medium rounded-md transition-colors
-                            ${
-                              userPermissions[user.id] === 'EDITOR'
-                                ? 'bg-muted-foreground text-background'
-                                : 'bg-background text-foreground border border-border hover:bg-muted'
-                            }
-                            disabled:opacity-50 disabled:cursor-not-allowed
-                          `}
-                        >
-                          Editor
-                        </button>
-                      )}
-                    </div>
-                    {canGrantCanShare && (
-                      <label className='flex justify-center items-center gap-2 text-xs text-muted-foreground cursor-pointer'>
-                        <input
-                          type='checkbox'
-                          checked={userCanShare[user.id] || false}
-                          onChange={e => handleCanShareChange(user.id, e.target.checked)}
-                          disabled={isLoading}
-                          data-track-category='knowledge-base'
-                          data-track-name='toggle-can-share'
-                          className='w-4 h-4 text-blue-600 border-border rounded focus:ring-blue-500'
-                        />
-                        <span>Can share</span>
-                      </label>
-                    )}
-                  </div>
-                </div>
-              ))}
+        {/* Footer — Copy link (left) alongside Share Collection (right) for
+            owners; the X at the top already covers "cancel". Viewer/Editor
+            get just Copy link + Done — there's nothing for them to submit. */}
+        <div className='flex items-center justify-between gap-3 border-t border-border pt-4'>
+          {link ? (
+            <button
+              type='button'
+              onClick={handleCopyLink}
+              data-track-category='knowledge-base'
+              data-track-name='share-collection-copy-link'
+              className='inline-flex items-center gap-2 rounded-md px-2.5 py-1.5 -ml-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-primary'
+            >
+              <Link2 size={16} />
+              Copy link
+            </button>
+          ) : (
+            <span />
+          )}
+          {isManager ? (
+            <div className='flex items-center justify-end gap-3'>
+              {hasUnsavedChanges && !isLoading ? (
+                <span className='text-xs italic text-muted-foreground'>Unsaved changes</span>
+              ) : null}
+              <Button
+                disabled={!canSubmit}
+                loading={isLoading}
+                onClick={() => {
+                  void handleShare();
+                }}
+                className='px-4 py-2 bg-muted-foreground text-background rounded-lg hover:bg-muted-foreground/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors'
+              >
+                <Share2 size={16} />
+                Share Collection
+              </Button>
             </div>
-          </div>
-        )}
-
-        {/* Submit Button */}
-        <div className='flex justify-end gap-2'>
-          <Button
-            variant='outline'
-            onClick={handleClose}
-            disabled={isLoading}
-            data-track-category='knowledge-base'
-            data-track-name='CANCEL_SHARE_COLLECTION'
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={!canSubmit}
-            loading={isLoading}
-            onClick={() => {
-              void handleShare();
-            }}
-            data-track-category='knowledge-base'
-            data-track-name='SHARE_COLLECTION'
-            className='px-4 py-2 bg-muted-foreground text-background rounded-lg hover:bg-muted-foreground/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors'
-          >
-            <Share2 size={16} />
-            Share Collection
-          </Button>
+          ) : (
+            <Button onClick={handleClose}>Done</Button>
+          )}
         </div>
       </div>
     </Dialog>

--- a/apps/dashboard/src/components/knowledgeBase/viewer/FileViewerPanel.tsx
+++ b/apps/dashboard/src/components/knowledgeBase/viewer/FileViewerPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
-import { ArrowLeft, Database, Download, X } from 'lucide-react';
+import { ArrowLeft, Database, Download, Share2, X } from 'lucide-react';
 import { Button } from '../../ui/Button';
 import Tooltip from '../../ui/Tooltip';
 import { XyneAIStar } from '../../icons/xyne-ai';
@@ -11,6 +11,7 @@ import { KbCodeViewer } from './KbCodeViewer';
 import { KbTxtViewer } from './KbTxtViewer';
 import { KbPdfViewer } from './KbPdfViewer';
 import { VespaDocView } from './VespaDocView';
+import { ShareLinkModal } from '../../knowledgeBaseV2/components/ShareLinkModal';
 
 // KB-local override map. Substitutes the shared viewers with the thin
 // wrappers under `./Kb*Viewer.tsx`, which supply the full-size shell the KB
@@ -66,6 +67,7 @@ export const FileViewerPanel: React.FC<{
   const [containerWidth, setContainerWidth] = useState<number | undefined>(undefined);
   const [highlightQuery, setHighlightQuery] = useState<string | undefined>(undefined);
   const [vespaInspectorOpen, setVespaInspectorOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
   const fileIdRef = useRef<string | undefined>(fileId);
   fileIdRef.current = fileId;
@@ -321,41 +323,21 @@ export const FileViewerPanel: React.FC<{
     // `bg-background` is the shared page surface, so the file panel sits on
     // the same colour as the listing it came from.
     <div className='h-full w-full flex flex-col bg-background' ref={contentRef}>
-      {/* Slim toolbar — back / filename · meta / download. Mirrors
-          xyne-search's PdfViewer top bar; no gradient, no Ask-AI. */}
-      <div className='flex h-12 flex-shrink-0 items-center gap-3 border-b border-border bg-background px-3'>
-        <button
-          type='button'
-          onClick={handleBackNavigation}
-          aria-label='Back'
-          title='Back'
-          className='grid h-8 w-8 place-items-center rounded-md text-muted-foreground transition hover:bg-secondary hover:text-foreground'
-          data-track-category='knowledge-base'
-          data-track-name='file-viewer-back'
-        >
-          <ArrowLeft className='h-4 w-4' strokeWidth={1.75} />
-        </button>
-
-        <div className='min-w-0 flex flex-1 items-baseline gap-2'>
-          <span className='truncate text-[13.5px] font-medium text-foreground' title={file.name}>
-            {file.name}
-          </span>
-          <span className='flex-shrink-0 text-[12px] text-muted-foreground'>
-            {extLabel(file.name)} · {formatBytes(file.size)}
-          </span>
-        </div>
-
+      {/* Two-row toolbar, mirroring KnowledgeBaseV2Screen's header/breadcrumbRow
+          split: an actions row (Ask AI / Vespa / Share / Download) with the
+          divider, then a nav row below it (back / filename · meta). */}
+      <div className='flex flex-shrink-0 items-center justify-end gap-2 border-b border-border bg-background px-5 py-2.5'>
         {onOpenChat && (
           <Tooltip content='Ask AI about this file' side='bottom'>
             <button
               type='button'
               onClick={() => onOpenChat(file.fileId, file.name)}
+              aria-label='Ask AI'
               data-track-category='knowledge-base'
               data-track-name='file-viewer-open-ai-chat'
-              className='inline-flex h-8 items-center gap-1.5 rounded-md px-2.5 text-[12.5px] font-medium text-muted-foreground transition hover:bg-secondary hover:text-foreground'
+              className='inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-sm transition hover:bg-muted'
             >
-              <XyneAIStar size={14} />
-              <span>Ask AI</span>
+              <XyneAIStar size={22} />
             </button>
           </Tooltip>
         )}
@@ -378,6 +360,19 @@ export const FileViewerPanel: React.FC<{
           </button>
         </Tooltip>
 
+        <Tooltip content='Share' side='bottom'>
+          <button
+            type='button'
+            onClick={() => setShareOpen(true)}
+            aria-label='Share'
+            data-track-category='knowledge-base'
+            data-track-name='file-viewer-share'
+            className='grid h-8 w-8 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-secondary hover:text-primary'
+          >
+            <Share2 className='h-4 w-4' strokeWidth={1.75} />
+          </button>
+        </Tooltip>
+
         <button
           type='button'
           onClick={() => {
@@ -391,6 +386,29 @@ export const FileViewerPanel: React.FC<{
         >
           <Download className='h-4 w-4' strokeWidth={1.75} />
         </button>
+      </div>
+
+      <div className='flex min-w-0 items-center gap-2 px-5 py-2.5'>
+        <button
+          type='button'
+          onClick={handleBackNavigation}
+          aria-label='Back'
+          title='Back'
+          className='grid h-7 w-7 flex-shrink-0 place-items-center rounded-md text-muted-foreground transition hover:bg-secondary hover:text-foreground'
+          data-track-category='knowledge-base'
+          data-track-name='file-viewer-back'
+        >
+          <ArrowLeft className='h-3.5 w-3.5' strokeWidth={1.75} />
+        </button>
+
+        <div className='min-w-0 flex flex-1 items-baseline gap-2'>
+          <span className='truncate text-[13.5px] font-medium text-foreground' title={file.name}>
+            {file.name}
+          </span>
+          <span className='flex-shrink-0 text-[12px] text-muted-foreground'>
+            {extLabel(file.name)} · {formatBytes(file.size)}
+          </span>
+        </div>
       </div>
 
       <div className='flex min-h-0 flex-1 bg-background'>
@@ -423,6 +441,15 @@ export const FileViewerPanel: React.FC<{
           </aside>
         )}
       </div>
+
+      {shareOpen && (
+        <ShareLinkModal
+          isOpen
+          onClose={() => setShareOpen(false)}
+          title={file.name}
+          link={`${window.location.origin}${window.location.pathname}`}
+        />
+      )}
     </div>
   );
 };

--- a/apps/dashboard/src/components/knowledgeBaseV2/KbContentsShell.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/KbContentsShell.tsx
@@ -1,0 +1,246 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { CollectionTreeDataSync } from '../../components/knowledgeBase/hooks/CollectionTreeDataSync';
+import { useProjectCollections } from '../../components/knowledgeBase/hooks/useProjectCollections';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { queries } from '../../zero/queries';
+import { GlobalCollectionsProvider, useGlobalCollections } from './hooks/useGlobalCollections';
+import { KbContentsPanel, type KbContentsFile } from './components/KbContentsPanel';
+import { resolveKbBasePath } from './utils/kbRoutePaths';
+import { cn } from '../../utils/classNames';
+import {
+  ResizableGroup,
+  Panel,
+  Separator,
+  type PanelImperativeHandle,
+} from '../ui/Resizable/Resizable';
+
+const KB_CONTENTS_DEFAULT_WIDTH = 240;
+const KB_CONTENTS_MIN_WIDTH = 180;
+const KB_CONTENTS_MAX_WIDTH = 600;
+const KB_CONTENTS_COLLAPSED_WIDTH = 40;
+
+interface KbContentsShellProps {
+  children: React.ReactNode;
+}
+
+// The Google-Drive/wiki-style left Contents panel, shared by every place the
+// KB folder browser or file viewer can be reached from — the standalone
+// /knowledge-base route (KnowledgeBaseV2Layout) and the embedded /ai/knowledge
+// screen (AIKnowledgeScreen) both render this exact component around their
+// own content, rather than each keeping their own copy of this data-fetching
+// and panel-wiring logic. `children` is whatever that caller's own main
+// content is (an <Outlet/> for a nested-route layout, or a screen element
+// directly for a leaf route) — this shell only owns the Contents panel
+// itself and the resizable split next to it.
+const KbContentsShellInner: React.FC<KbContentsShellProps> = ({ children }) => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const globalCollections = useGlobalCollections();
+  const { activeCollection, currentFolderId, currentFileId, nodes, rootChildrenIds } =
+    useProjectCollections();
+
+  const contentsPanelRef = useRef<PanelImperativeHandle>(null);
+  const [isContentsCollapsed, setIsContentsCollapsed] = useState(false);
+
+  useEffect(() => {
+    const panel = contentsPanelRef.current;
+    if (!panel) return;
+    if (isContentsCollapsed) {
+      if (!panel.isCollapsed()) panel.collapse();
+    } else if (panel.isCollapsed()) {
+      panel.expand();
+    }
+  }, [isContentsCollapsed]);
+
+  const collectionId = activeCollection?.id ?? null;
+
+  const collectionName =
+    activeCollection?.name ??
+    (collectionId ? globalCollections.byId(collectionId)?.name : undefined) ??
+    'Collection';
+
+  // The tree loads a folder's files lazily (only the root + whichever
+  // folder is currently open), which can't show every expanded folder's
+  // files at once — only ever the active one. `collectionFilesByRoot` pulls
+  // every file in the whole collection in one query (already used elsewhere
+  // for the root's rolled-up ingestion badges), so every folder in the tree
+  // can show its own files as soon as it's expanded, independent of which
+  // one is currently active — matching how Canvas's folders each show their
+  // own canvases regardless of which is selected.
+  const [allCollectionFiles] = useCachedQuery(
+    queries.collectionFilesByRoot({ rootCollectionId: collectionId ?? '' }),
+    !!collectionId,
+  );
+
+  const filesByFolder = useMemo(() => {
+    const map = new Map<string, KbContentsFile[]>();
+    for (const f of allCollectionFiles ?? []) {
+      const list = map.get(f.collectionId);
+      const entry = { id: f.id, name: f.name };
+      if (list) list.push(entry);
+      else map.set(f.collectionId, [entry]);
+    }
+    return map;
+  }, [allCollectionFiles]);
+
+  // The active folder and all of its ancestors default open, so wherever
+  // you are — reached by browsing the tree, a grid click, a citation link,
+  // anything — is always visible fully expanded, not just the path down to
+  // it. (An earlier version left the active folder's own row collapsed by
+  // default, on the theory that its contents already show in the main pane
+  // so the tree didn't need to also reveal them — but that meant a folder
+  // full of only subfolders showed nothing in the tree until you clicked
+  // its chevron yourself, and a file stayed invisible under its own
+  // collapsed parent. Always-open is simpler and matches how every other
+  // file explorer actually behaves.)
+  const activePath = useMemo(() => {
+    const path = new Set<string>();
+    let curr = currentFolderId ? nodes[currentFolderId] : undefined;
+    while (curr) {
+      path.add(curr.id);
+      curr = curr.parentId ? nodes[curr.parentId] : undefined;
+    }
+    return path;
+  }, [currentFolderId, nodes]);
+
+  // Folder/file navigation stays on whichever browse screen you're already
+  // on — /ai/knowledge if that's embedding this shell, /knowledge-base
+  // otherwise — instead of always hopping to the standalone route. Both
+  // routes now have their own nested file-viewer path.
+  const browseBasePath = useMemo(() => resolveKbBasePath(location.pathname), [location.pathname]);
+
+  const onNavigate = useCallback(
+    (folderId: string | null): void => {
+      if (!collectionId) return;
+      const sp = new URLSearchParams();
+      sp.set('cl', collectionId);
+      if (folderId) sp.set('parent', folderId);
+      void navigate(`${browseBasePath}?${sp.toString()}`);
+    },
+    [collectionId, navigate, browseBasePath],
+  );
+
+  // KB root (no collection open yet) — same navigation shape as `onNavigate`
+  // above but targets a collection id instead of a folder within one.
+  const onNavigateCollection = useCallback(
+    (id: string): void => {
+      const sp = new URLSearchParams();
+      sp.set('cl', id);
+      void navigate(`${browseBasePath}?${sp.toString()}`);
+    },
+    [navigate, browseBasePath],
+  );
+
+  // `folderId` is the file's *actual* parent folder (or null for a root
+  // file), passed by the caller — not necessarily `currentFolderId`. With
+  // every folder's files preloaded (`filesByFolder` above), you can open a
+  // file from a folder you're not currently browsing; using the active
+  // folder here would point the URL — and so `nodes[fileId]` resolution in
+  // FileViewerPanel — at the wrong folder and show "No file selected".
+  const onOpenFile = useCallback(
+    (fileId: string, folderId: string | null): void => {
+      if (!collectionId) return;
+      const owning = globalCollections.byId(collectionId);
+      const projectId = owning?.projectId;
+      const channelId = owning?.scopeId;
+      if (projectId && channelId) {
+        void navigate(
+          `${browseBasePath}/${projectId}/${channelId}/${collectionId}/${folderId ?? '_'}/${fileId}`,
+        );
+      } else {
+        toast.error('Could not resolve collection scope');
+      }
+    },
+    [collectionId, globalCollections, navigate, browseBasePath],
+  );
+
+  // Root mode: no collection is open, so the panel lists every top-level
+  // collection flat instead of one collection's folder tree — kept present
+  // here (rather than only showing `children` unwrapped) so the KB root
+  // screen doesn't feel inconsistent with every other screen this shell
+  // wraps, which always has the Contents panel on the left.
+  const rootCollections = useMemo(
+    () => globalCollections.collections.map(c => ({ id: c.id, name: c.name })),
+    [globalCollections.collections],
+  );
+
+  return (
+    <div className='relative h-full w-full'>
+      <ResizableGroup
+        orientation='horizontal'
+        className='flex h-full min-h-0'
+        autoSaveId='kb-contents-resize'
+      >
+        <Panel
+          id='kb-contents-panel'
+          panelRef={contentsPanelRef}
+          defaultSize={KB_CONTENTS_DEFAULT_WIDTH}
+          minSize={KB_CONTENTS_MIN_WIDTH}
+          maxSize={KB_CONTENTS_MAX_WIDTH}
+          groupResizeBehavior='preserve-pixel-size'
+          collapsible
+          collapsedSize={KB_CONTENTS_COLLAPSED_WIDTH}
+        >
+          {activeCollection ? (
+            <KbContentsPanel
+              collectionName={collectionName}
+              collectionId={collectionId ?? ''}
+              activeFolderId={currentFolderId}
+              activeFileId={currentFileId}
+              nodes={nodes}
+              rootChildrenIds={rootChildrenIds}
+              filesByFolder={filesByFolder}
+              activePath={activePath}
+              collapsed={isContentsCollapsed}
+              onNavigate={onNavigate}
+              onOpenFile={onOpenFile}
+              onToggleCollapsed={() => setIsContentsCollapsed(c => !c)}
+            />
+          ) : (
+            <KbContentsPanel
+              collectionName=''
+              collectionId=''
+              activeFolderId={null}
+              activeFileId={null}
+              nodes={{}}
+              rootChildrenIds={[]}
+              filesByFolder={new Map()}
+              activePath={new Set()}
+              collapsed={isContentsCollapsed}
+              onNavigate={() => {}}
+              onOpenFile={() => {}}
+              onToggleCollapsed={() => setIsContentsCollapsed(c => !c)}
+              rootCollections={rootCollections}
+              onNavigateCollection={onNavigateCollection}
+            />
+          )}
+        </Panel>
+        <Separator
+          className={cn(
+            'group flex w-[2px] cursor-col-resize items-center justify-center transition-colors',
+            isContentsCollapsed && 'hidden',
+          )}
+        >
+          <div className='h-full w-px bg-sidebar-border-muted group-hover:bg-primary group-active:bg-primary' />
+        </Separator>
+        <Panel id='kb-main-panel' minSize='50%'>
+          {children}
+        </Panel>
+      </ResizableGroup>
+    </div>
+  );
+};
+
+export const KbContentsShell: React.FC<KbContentsShellProps> = ({ children }) => {
+  return (
+    <GlobalCollectionsProvider>
+      <CollectionTreeDataSync>
+        <KbContentsShellInner>{children}</KbContentsShellInner>
+      </CollectionTreeDataSync>
+    </GlobalCollectionsProvider>
+  );
+};
+
+export default KbContentsShell;

--- a/apps/dashboard/src/components/knowledgeBaseV2/KnowledgeBaseV2Layout.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/KnowledgeBaseV2Layout.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
-import { CollectionTreeDataSync } from '../../components/knowledgeBase/hooks/CollectionTreeDataSync';
-import { GlobalCollectionsProvider } from './hooks/useGlobalCollections';
+import { KbContentsShell } from './KbContentsShell';
 
+// Wraps both the folder/collection browser (KnowledgeBaseV2Screen) and the
+// file viewer (FileViewerLayout) — both are children of this layout's
+// <Outlet/>, and both already keep `activeCollection`/`currentFolderId` in
+// the shared knowledgeBaseMachine in sync with their own URLs. The actual
+// Contents panel lives in KbContentsShell, shared with the /ai/knowledge
+// embedding (AIKnowledgeScreen) so both keep the exact same panel, data
+// fetching, and navigation behavior instead of two copies drifting apart.
 export const KnowledgeBaseV2Layout: React.FC = () => {
   return (
-    <GlobalCollectionsProvider>
-      <CollectionTreeDataSync>
-        <Outlet />
-      </CollectionTreeDataSync>
-    </GlobalCollectionsProvider>
+    <KbContentsShell>
+      <Outlet />
+    </KbContentsShell>
   );
 };

--- a/apps/dashboard/src/components/knowledgeBaseV2/KnowledgeBaseV2Screen.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/KnowledgeBaseV2Screen.tsx
@@ -1,15 +1,19 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { cn } from '../../utils/classNames';
 import {
+  AlertCircle,
   ArrowLeft,
+  CheckCircle2,
   ChevronDown,
   File,
+  Folder,
   FolderOpen,
   FolderPlus,
   Link2,
   Loader2,
   Plus,
-  Upload,
+  X,
 } from 'lucide-react';
 import { useProjectCollections } from '../../components/knowledgeBase/hooks/useProjectCollections';
 import { useProjectCollectionMutations } from '../../components/knowledgeBase/hooks/useProjectCollectionMutations';
@@ -20,11 +24,11 @@ import {
   CollectionChild,
   CollectionSummary,
   NodeType,
-  searchCollectionItems,
   uploadFilesInBatches,
 } from '../../services/Knowledge/collectionService';
 import CreateCollectionModal from '../../components/knowledgeBase/upload/CreateCollectionModal';
 import { ShareCollectionModal } from '../../components/knowledgeBase/upload/ShareCollectionModal';
+import { ShareLinkModal } from '../../components/knowledgeBaseV2/components/ShareLinkModal';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -51,11 +55,11 @@ import {
   runDriveImport,
   takePendingDriveImport,
 } from '../../components/knowledgeBaseV2/utils/driveImport';
-import { SearchFieldV2 } from '../../components/knowledgeBaseV2/components/SearchFieldV2';
 import { ViewToggleV2, ViewMode } from '../../components/knowledgeBaseV2/components/ViewToggleV2';
 import { EmptyPaneV2 } from '../../components/knowledgeBaseV2/components/EmptyPaneV2';
+import { StatusBadgeV2 } from '../../components/knowledgeBaseV2/components/StatusBadgeV2';
 import { CrumbsV2 } from '../../components/knowledgeBaseV2/components/CrumbsV2';
-import { SearchResultsV2 } from '../../components/knowledgeBaseV2/components/SearchResultsV2';
+import { resolveKbBasePath } from './utils/kbRoutePaths';
 import { NameDialogV2 } from '../../components/knowledgeBaseV2/components/NameDialogV2';
 import { toast } from 'sonner';
 import { useGlobalCollections } from './hooks/useGlobalCollections';
@@ -64,7 +68,6 @@ import { XyneAIStar } from '../../components/icons/xyne-ai';
 import Tooltip from '../../components/ui/Tooltip';
 
 const KB_COLUMNS: ReadonlyArray<ColumnDef> = [
-  { key: 'kind', header: 'Kind', width: '120px' },
   { key: 'size', header: 'Size', width: '120px' },
   { key: 'updated', header: 'Updated', width: '140px' },
 ];
@@ -77,12 +80,70 @@ const KB_ROOT_COLUMNS: ReadonlyArray<ColumnDef> = [
   { key: 'updated', header: 'Updated', width: '140px' },
 ];
 
-// Mirrors xyne-search /kb: collection id, optional folder id, and free-text
-// search live in the URL as search params so back/forward and deep links
-// behave the same as in xyne-search.
+type StatusFilterValue = 'ALL' | 'PENDING' | 'PROCESSING' | 'FAILED' | 'COMPLETED';
+
+// Collapses a raw ingestionStatus (null/NONE/COMPLETED all mean "nothing left
+// to do") down to the four buckets the filter dropdown offers.
+function normalizeStatusFilter(
+  status: IngestionStatus | string | null | undefined,
+): StatusFilterValue {
+  const s = (status ?? '').toUpperCase();
+  if (s === 'PENDING' || s === 'PROCESSING' || s === 'FAILED') return s;
+  return 'COMPLETED';
+}
+
+const STATUS_FILTER_OPTIONS: ReadonlyArray<{ value: StatusFilterValue; label: string }> = [
+  { value: 'PROCESSING', label: 'Processing' },
+  { value: 'PENDING', label: 'Pending' },
+  { value: 'FAILED', label: 'Failed' },
+  { value: 'COMPLETED', label: 'Ready' },
+];
+
+// Same icon language as CollectionStatusBadgeV2 / FileFailedBadgeV2, just
+// inline-sized for a dropdown row instead of a circular overlay badge.
+function statusFilterIcon(value: StatusFilterValue): React.ReactElement {
+  switch (value) {
+    case 'PROCESSING':
+      return (
+        <Loader2 className='h-3.5 w-3.5 shrink-0 animate-spin text-amber-500' strokeWidth={2} />
+      );
+    case 'PENDING':
+      return (
+        <Loader2 className='h-3.5 w-3.5 shrink-0 animate-spin text-gray-400' strokeWidth={2} />
+      );
+    case 'FAILED':
+      return <AlertCircle className='h-3.5 w-3.5 shrink-0 text-red-500' strokeWidth={2} />;
+    default:
+      return <CheckCircle2 className='h-3.5 w-3.5 shrink-0 text-green-600' strokeWidth={2} />;
+  }
+}
+
+// 'FOLDER' for folders, else the uppercased file extension (e.g. 'MD', 'PDF') —
+// same bucketing EntryListV2's Kind column already uses for files.
+function typeFilterValueFor(entry: CollectionChild): string {
+  if (entry.type === 'FOLDER') return 'FOLDER';
+  const ext = entry.name.split('.').pop()?.toUpperCase();
+  return ext || 'FILE';
+}
+
+function typeFilterLabelFor(value: string): string {
+  return value === 'FOLDER' ? 'Folders' : value;
+}
+
+// Same file-type color language as the grid/list icons (StatusBadgeV2) —
+// `file.<ext>` is a throwaway name, only its extension is ever read.
+function typeFilterIcon(value: string): React.ReactElement {
+  if (value === 'FOLDER') {
+    return <Folder className='h-4 w-4 shrink-0 text-muted-foreground' strokeWidth={1.75} />;
+  }
+  return <StatusBadgeV2 name={`file.${value.toLowerCase()}`} size='sm' />;
+}
+
+// Mirrors xyne-search /kb: collection id and optional folder id live in the
+// URL as search params so back/forward and deep links behave the same as in
+// xyne-search.
 const SP_COLLECTION = 'cl';
 const SP_PARENT = 'parent';
-const SP_QUERY = 'q';
 
 /** A folder id + all descendant folder ids (used to scope a file listing to a subtree). */
 function collectSubtreeFolderIds(
@@ -106,12 +167,16 @@ function collectSubtreeFolderIds(
 
 export const KnowledgeBaseV2Screen: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  // This screen is a leaf under both /knowledge-base and /ai/knowledge; the
+  // file viewer route it navigates to lives at the same prefix as whichever
+  // of the two it's currently mounted under.
+  const browseBasePath = useMemo(() => resolveKbBasePath(location.pathname), [location.pathname]);
   const { workspaceId } = useParams<{ workspaceId?: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
 
   const spCollectionId = searchParams.get(SP_COLLECTION);
   const spParentId = searchParams.get(SP_PARENT);
-  const spQuery = searchParams.get(SP_QUERY) ?? '';
 
   // Resume a Drive import after the full-page "Connect Google Drive" OAuth redirect.
   // The backend returns us to this KB URL with ?driveOAuth=success|driveOAuthError;
@@ -177,8 +242,7 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
     s => s.currentUpload?.isUploading === true && s.currentUpload.collectionId === spCollectionId,
   );
 
-  const [view, setView] = useState<ViewMode>('grid');
-  const [query, setQueryState] = useState(spQuery);
+  const [view, setView] = useState<ViewMode>('list');
   const [dragging, setDragging] = useState(false);
   const [dialog, setDialog] = useState<'folder' | null>(null);
   // Open rename target. Holds the original entry so the dialog can both
@@ -189,6 +253,10 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
   // `activeCollection` machine slot, so opening the modal also seeds that
   // slot from the chosen card and we restore it on close.
   const [shareTarget, setShareTarget] = useState<CollectionChild | null>(null);
+  // Open share target for a regular folder/file (copy-link-only dialog —
+  // no ACL of its own, see ShareLinkModal). Distinct from `shareTarget`
+  // (collections), which drives the full access-management dialog.
+  const [linkShareTarget, setLinkShareTarget] = useState<CollectionChild | null>(null);
   // Collection whose ingestion status drawer is open (root view only).
   const [statusFor, setStatusFor] = useState<StatusDrawerTarget | null>(null);
   // "Add from Google Drive link" modal (inside a collection).
@@ -208,14 +276,6 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
       el.setAttribute('directory', '');
     }
   }, []);
-
-  // Search
-  const [searchHits, setSearchHits] = useState<CollectionChild[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
-  const [searchError, setSearchError] = useState<string | null>(null);
-  const searchTokenRef = useRef(0);
-  const trimmedQuery = query.trim();
-  const searching = trimmedQuery.length > 0;
 
   // No local upload state — V1's `useUploadHandler` registers each upload in
   // a global zustand store and `GlobalUploadProgress` (rendered by AppRoot)
@@ -245,12 +305,6 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [spParentId]);
 
-  // Keep the local search input in sync with the URL when the URL changes
-  // (e.g. browser back/forward).
-  useEffect(() => {
-    setQueryState(spQuery);
-  }, [spQuery]);
-
   // Once the active collection's data has loaded, fill in its name on the
   // breadcrumb. Falls back to the global collections cache for the deep-link
   // case where the user lands straight on ?cl=<id>.
@@ -273,6 +327,11 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
   const collectionId = spCollectionId;
   const isAtRoot = !collectionId;
   const isAtCollectionRoot = !!collectionId && !spParentId;
+  // Write access to an open collection's contents (upload, new folder,
+  // rename, delete) requires being a collaborator — owner or explicit
+  // EDITOR grant. Public collections are read-only by default; sub-folders
+  // have no ACL of their own, so this is depth-independent.
+  const canEdit = activeCollection?.role === 'EDITOR' || activeCollection?.role === 'OWNER';
 
   // Inside a collection, load ALL its files so each subfolder can show the same
   // rolled-up ingestion badge the root collections do. (The tree loads files
@@ -373,8 +432,52 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
     subfolderRollup,
   ]);
 
-  const folderCount = entries.filter(e => e.type === 'FOLDER').length;
-  const fileCount = entries.filter(e => e.type === 'FILE').length;
+  // Status filter — works the same at every level (root collections list or
+  // any folder), since every CollectionChild (collection, folder, or file)
+  // already carries a rolled-up `ingestionStatus`. Options are the fixed
+  // full list (like Type's "Folders"), not limited to whatever's present —
+  // picking one with no matches just shows an empty result.
+  const [statusFilter, setStatusFilter] = useState<StatusFilterValue>('ALL');
+  // Type filter — same idea as status, but bucketed by "Folders" vs. each
+  // file extension actually present (mirrors EntryListV2's own Kind column
+  // logic) instead of a fixed list.
+  const [typeFilter, setTypeFilter] = useState<string>('ALL');
+  const availableTypeFilters = useMemo(() => {
+    // 'Folders' is always offered (mirrors Drive's Type menu, which always
+    // lists Folders as a category) even when the current view has none —
+    // picking it then just filters down to nothing, same as any other type
+    // with zero matches.
+    const seen = new Map<string, string>([['FOLDER', 'Folders']]);
+    for (const e of entries) {
+      const value = typeFilterValueFor(e);
+      if (!seen.has(value)) seen.set(value, typeFilterLabelFor(value));
+    }
+    return [...seen.entries()]
+      .map(([value, label]) => ({ value, label }))
+      .sort((a, b) =>
+        a.value === 'FOLDER' ? -1 : b.value === 'FOLDER' ? 1 : a.label.localeCompare(b.label),
+      );
+  }, [entries]);
+  useEffect(() => {
+    if (typeFilter !== 'ALL' && !availableTypeFilters.some(o => o.value === typeFilter)) {
+      setTypeFilter('ALL');
+    }
+  }, [availableTypeFilters, typeFilter]);
+
+  const filteredEntries = useMemo(
+    () =>
+      entries.filter(e => {
+        if (statusFilter !== 'ALL' && normalizeStatusFilter(e.ingestionStatus) !== statusFilter) {
+          return false;
+        }
+        if (typeFilter !== 'ALL' && typeFilterValueFor(e) !== typeFilter) return false;
+        return true;
+      }),
+    [entries, statusFilter, typeFilter],
+  );
+
+  const folderCount = filteredEntries.filter(e => e.type === 'FOLDER').length;
+  const fileCount = filteredEntries.filter(e => e.type === 'FILE').length;
 
   // ── Breadcrumb chain ─────────────────────────────────────────────────
   const chain = useMemo(() => {
@@ -389,69 +492,9 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
     return result;
   }, [collectionId, spParentId, nodes]);
 
-  // ── Search ───────────────────────────────────────────────────────────
-  // Two regimes:
-  //   • Root (`/knowledge-base`, no `cl`): no dedicated KB-wide endpoint, so
-  //     we filter the already-loaded collections list client-side by name.
-  //   • Inside a collection: hit `searchCollectionItems` for full-text search
-  //     across files in that collection.
-  useEffect((): (() => void) | undefined => {
-    if (!searching) {
-      setSearchHits([]);
-      setSearchLoading(false);
-      setSearchError(null);
-      return undefined;
-    }
-    if (!collectionId) {
-      // Client-side filter on the root collections list.
-      const q = trimmedQuery.toLowerCase();
-      const hits: CollectionChild[] = globalCollections.collections
-        .filter(c => c.name.toLowerCase().includes(q))
-        .map(c => ({
-          id: c.id,
-          name: c.name,
-          type: 'FOLDER' as NodeType,
-          size: 0,
-          updatedAt: new Date().toISOString(),
-          ingestionStatus: null,
-          mimeType: '',
-          parentId: null,
-        }));
-      setSearchHits(hits);
-      setSearchLoading(false);
-      setSearchError(null);
-      return undefined;
-    }
-    setSearchLoading(true);
-    setSearchError(null);
-    const myToken = ++searchTokenRef.current;
-    const runSearch = async (): Promise<void> => {
-      try {
-        const results = await searchCollectionItems(collectionId, trimmedQuery);
-        if (myToken !== searchTokenRef.current) return;
-        setSearchHits(results);
-      } catch (err: unknown) {
-        if (myToken !== searchTokenRef.current) return;
-        const msg = err instanceof Error ? err.message : 'Search failed';
-        setSearchError(msg);
-        setSearchHits([]);
-      } finally {
-        if (myToken === searchTokenRef.current) {
-          setSearchLoading(false);
-        }
-      }
-    };
-    const handle = window.setTimeout((): void => {
-      void runSearch();
-    }, 160);
-    return (): void => {
-      window.clearTimeout(handle);
-    };
-  }, [searching, trimmedQuery, collectionId, globalCollections.collections]);
-
   // ── URL writers ─────────────────────────────────────────────────────
   const updateParams = useCallback(
-    (next: { cl?: string | null; parent?: string | null; q?: string | null }, replace = false) => {
+    (next: { cl?: string | null; parent?: string | null }, replace = false) => {
       const sp = new URLSearchParams(searchParams);
       const apply = (key: string, val: string | null | undefined): void => {
         if (val === undefined) return;
@@ -460,7 +503,6 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
       };
       apply(SP_COLLECTION, next.cl);
       apply(SP_PARENT, next.parent);
-      apply(SP_QUERY, next.q);
       setSearchParams(sp, { replace });
     },
     [searchParams, setSearchParams],
@@ -468,12 +510,12 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
 
   // ── Navigation helpers ───────────────────────────────────────────────
   const goToCollections = useCallback((): void => {
-    updateParams({ cl: null, parent: null, q: null });
+    updateParams({ cl: null, parent: null });
   }, [updateParams]);
 
   const goToCollection = useCallback(
     (clId: string): void => {
-      updateParams({ cl: clId, parent: null, q: null });
+      updateParams({ cl: clId, parent: null });
     },
     [updateParams],
   );
@@ -481,7 +523,7 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
   const goToFolder = useCallback(
     (folderId: string): void => {
       if (!collectionId) return;
-      updateParams({ cl: collectionId, parent: folderId, q: null });
+      updateParams({ cl: collectionId, parent: folderId });
     },
     [collectionId, updateParams],
   );
@@ -489,7 +531,7 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
   const goToParent = useCallback(
     (parentId: string | null): void => {
       if (!collectionId) return;
-      updateParams({ cl: collectionId, parent: parentId, q: null });
+      updateParams({ cl: collectionId, parent: parentId });
     },
     [collectionId, updateParams],
   );
@@ -533,6 +575,7 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
     (entry: CollectionChild): string => {
       const owning = globalCollections.byId(entry.id);
       if (!owning) return 'Collection';
+      if (owning.scopeType === 'WORKSPACE') return 'Workspace';
       const channelName = channelNameById.get(owning.scopeId);
       const projectName = owning.projectId ? projectNameById.get(owning.projectId) : undefined;
       if (channelName && projectName) return `#${channelName} · ${projectName}`;
@@ -580,21 +623,37 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
       if (!collectionId) return;
       // File viewer still reads projectId/channelId from URL path params, so
       // look up the owning channel via the global collections cache and route
-      // to the existing nested viewer URL.
+      // to the existing nested viewer URL. Use the entry's own `parentId`,
+      // not `spParentId` (the currently-browsed folder) — search results can
+      // come from anywhere in the collection, so a match outside the folder
+      // you're currently viewing would otherwise point the URL, and so
+      // `nodes[fileId]` resolution in FileViewerPanel, at the wrong folder
+      // and show "No file selected".
       const found = globalCollections.byId(collectionId);
-      const projectId = found?.projectId;
       const channelId = found?.scopeId;
-      if (projectId && channelId) {
+      if (channelId) {
+        // `projectId` is only known for CHANNEL-scoped collections whose
+        // channel is in our visible-channel list — '_' for workspace-scoped
+        // (or unresolvable) collections, same sentinel as the folder segment.
+        const projectId = found?.projectId ?? '_';
         void navigate(
-          `/knowledge-base/${projectId}/${channelId}/${collectionId}/${
-            spParentId ?? '_'
+          `${browseBasePath}/${projectId}/${channelId}/${collectionId}/${
+            entry.parentId ?? '_'
           }/${entry.id}`,
         );
       } else {
         toast.error('Could not resolve collection scope');
       }
     },
-    [isAtRoot, goToCollection, goToFolder, navigate, collectionId, spParentId, globalCollections],
+    [
+      isAtRoot,
+      goToCollection,
+      goToFolder,
+      navigate,
+      collectionId,
+      globalCollections,
+      browseBasePath,
+    ],
   );
 
   // ── Mutations ─────────────────────────────────────────────────────────
@@ -602,6 +661,10 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
     if (!collectionId) return;
     if (!user) {
       toast.error('You must be logged in');
+      return;
+    }
+    if (!canEdit) {
+      toast.error("You don't have permission to add to this collection");
       return;
     }
     try {
@@ -642,6 +705,10 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
         toast.error('Open a collection before uploading');
         return;
       }
+      if (!canEdit) {
+        toast.error("You don't have permission to add to this collection");
+        return;
+      }
       const files = Array.from(fileList);
       if (files.length === 0) return;
 
@@ -674,6 +741,7 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
     },
     [
       collectionId,
+      canEdit,
       spParentId,
       activeCollection?.name,
       globalCollections,
@@ -730,6 +798,10 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
       return;
     }
     if (!collectionId) return;
+    if (!canEdit) {
+      toast.error("You don't have permission to delete from this collection");
+      return;
+    }
     const what = entry.type === 'FOLDER' ? 'folder' : 'file';
     const ok = window.confirm(`Delete ${what} "${entry.name}"?`);
     if (!ok) return;
@@ -760,6 +832,9 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
         toast.error('Only the collection owner can rename');
         return;
       }
+    } else if (!canEdit) {
+      toast.error("You don't have permission to rename items in this collection");
+      return;
     }
     setRenameTarget(entry);
   };
@@ -794,6 +869,11 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
             setRenameTarget(null);
             return;
           }
+          if (!canEdit) {
+            toast.error("You don't have permission to rename items in this collection");
+            setRenameTarget(null);
+            return;
+          }
           await renameNode(entry.id, trimmed);
         }
         toast.success(`Renamed to "${trimmed}"`);
@@ -804,23 +884,67 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
         setRenameTarget(null);
       }
     },
-    [user, isAtRoot, collectionId, renameCollection, renameNode, globalCollections],
+    [user, isAtRoot, collectionId, canEdit, renameCollection, renameNode, globalCollections],
   );
 
-  // ── Share (root-only) ────────────────────────────────────────────────
-  // Matches V1's TreeSidebar gate (`canShare = perm?.canShare ?? isOwner`).
-  // The modal validates against `activeCollection.role/canShare` internally,
-  // so we seed those on the machine before opening — the URL→machine sync
-  // effect only re-runs when spCollectionId changes, so our seed sticks for
-  // the lifetime of the modal.
+  // ── Entry deep link ──────────────────────────────────────────────────
+  // Same URL shape onOpenEntry navigates to. There's no separate ACL for
+  // this: whoever opens it needs access to the owning collection already
+  // (or gets Shared it separately), matching how every other "copy link"
+  // button in the app works (Canvas, messages). Used by onShare below to
+  // seed both the collection dialog's link and the folder/file dialog's link.
+  const buildEntryLink = useCallback(
+    (entry: CollectionChild): string | null => {
+      const base = window.location.origin + browseBasePath;
+      if (entry.type === 'FOLDER') {
+        if (isAtRoot) return `${base}?cl=${entry.id}`;
+        if (!collectionId) return null;
+        return `${base}?cl=${collectionId}&parent=${entry.id}`;
+      }
+      if (!collectionId) return null;
+      const owning = globalCollections.byId(collectionId);
+      const channelId = owning?.scopeId;
+      if (!channelId) return null;
+      // `projectId` is only known for CHANNEL-scoped collections whose channel
+      // is in our visible-channel list; '_' mirrors the existing "no folder"
+      // sentinel below — the file-viewer route only needs a 5-segment URL,
+      // it doesn't require projectId/channelId to resolve to real entities.
+      const projectId = owning?.projectId ?? '_';
+      return `${base}/${projectId}/${channelId}/${collectionId}/${entry.parentId ?? '_'}/${entry.id}`;
+    },
+    [browseBasePath, isAtRoot, collectionId, globalCollections],
+  );
+
+  // ── Share ─────────────────────────────────────────────────────────────
+  // One entry point for every "Share" button in the screen — it routes to
+  // one of two dialogs depending on what's being shared:
+  //   - At root (collection cards): the full access-management dialog
+  //     (ShareCollectionModal — per-user roles, public/private visibility).
+  //     Open to anyone with a resolved role; the dialog itself bounds what
+  //     each role can actually do.
+  //   - Inside a collection (a regular folder/file): those have no ACL of
+  //     their own — access is entirely inherited from the owning collection
+  //     — so there's nothing to grant, just a copy-link-only dialog
+  //     (ShareLinkModal).
   const onShare = (entry: CollectionChild): void => {
+    if (!isAtRoot) {
+      const link = buildEntryLink(entry);
+      if (!link) {
+        toast.error('Could not build a link for this item');
+        return;
+      }
+      setLinkShareTarget(entry);
+      return;
+    }
+    // The modal validates against `activeCollection.role` internally, so we
+    // seed it on the machine before opening — the URL→machine sync effect
+    // only re-runs when spCollectionId changes, so our seed sticks for the
+    // lifetime of the modal. Anyone with a resolved role (Viewer/Editor/
+    // Owner) can open the dialog — there's no separate "canShare" gate;
+    // what they can actually do inside it is bounded by role escalation.
     const owning = globalCollections.byId(entry.id);
     if (!owning) {
       toast.error('Could not resolve collection');
-      return;
-    }
-    if (!owning.canShare) {
-      toast.error("You don't have permission to share this collection");
       return;
     }
     setActiveCollection({
@@ -843,26 +967,78 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
     }
   };
 
-  // ── Search field writer ─────────────────────────────────────────────
-  const setQuery = (next: string): void => {
-    setQueryState(next);
-    updateParams({ q: next === '' ? null : next }, /* replace */ true);
-  };
-
   // ── Ask AI ──────────────────────────────────────────────────────────
-  // Only rendered when `!isAtRoot` (i.e. a collection is open), so we always
-  // have a real collectionId to scope to. The channelId comes from the global
-  // collections cache because V2 doesn't carry it in the URL.
+  // Rendered at every level, including the root Knowledge listing (isAtRoot,
+  // no collectionId) — the tooltip has dedicated copy for that case. At root
+  // there's nothing to scope to, so just open a fresh, unscoped chat instead
+  // of silently no-oping. The channelId comes from the global collections
+  // cache because V2 doesn't carry it in the URL.
+  //
+  // Inside a sub-folder (spParentId set), attach BOTH chips — the folder
+  // (for scope) and its collection (for context) — same "harmless overlap"
+  // the composer's own picker already allows when you select a collection
+  // and one of its folders together. At the collection root there's no
+  // folder to add, so just the collection chip shows, as before.
   const handleOpenAI = useCallback((): void => {
-    if (!collectionId) return;
+    if (!collectionId) {
+      xyneAIActor.send({ type: 'OPEN', startFreshChat: true });
+      return;
+    }
     const owning = globalCollections.byId(collectionId);
+    const currentFolder = spParentId ? nodes[spParentId] : undefined;
     xyneAIActor.send({
       type: 'OPEN',
       startFreshChat: true,
       kbCollectionId: collectionId,
       kbChannelId: owning?.scopeId ?? null,
+      ...(currentFolder && { kbFolderId: currentFolder.id, kbFolderName: currentFolder.name }),
     });
-  }, [collectionId, globalCollections]);
+  }, [collectionId, globalCollections, spParentId, nodes]);
+
+  // Per-row Ask AI (hover action on every folder/file, next to Share). A
+  // file gets precise scoping via kbDocId/kbDocName — the machine already
+  // supports asking about one specific document (same path FileViewerLayout
+  // uses from inside the viewer). A folder row attaches BOTH itself
+  // (kbFolderId) and its collection (kbCollectionId) when it's a genuine
+  // sub-folder inside an open collection — same "harmless overlap" as
+  // handleOpenAI; at root, `entry` IS a root collection (isAtRoot only
+  // lists root collections), so it scopes as just a collection instead.
+  const onAskAIAboutEntry = useCallback(
+    (entry: CollectionChild): void => {
+      if (entry.type === 'FILE') {
+        const owning = collectionId ? globalCollections.byId(collectionId) : null;
+        xyneAIActor.send({
+          type: 'OPEN',
+          startFreshChat: true,
+          kbCollectionId: collectionId ?? null,
+          kbChannelId: owning?.scopeId ?? null,
+          kbDocId: entry.id,
+          kbDocName: entry.name,
+        });
+        return;
+      }
+      if (isAtRoot) {
+        const owning = globalCollections.byId(entry.id);
+        xyneAIActor.send({
+          type: 'OPEN',
+          startFreshChat: true,
+          kbCollectionId: entry.id,
+          kbChannelId: owning?.scopeId ?? null,
+        });
+        return;
+      }
+      const owning = collectionId ? globalCollections.byId(collectionId) : null;
+      xyneAIActor.send({
+        type: 'OPEN',
+        startFreshChat: true,
+        kbCollectionId: collectionId ?? null,
+        kbChannelId: owning?.scopeId ?? null,
+        kbFolderId: entry.id,
+        kbFolderName: entry.name,
+      });
+    },
+    [collectionId, globalCollections, isAtRoot],
+  );
 
   // ── Header label ─────────────────────────────────────────────────────
   const rootLabel = isAtRoot
@@ -871,12 +1047,370 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
 
   const loading = isInitialLoading || (isAtRoot && globalCollections.isLoading);
 
+  const header = (
+    <div className='flex flex-wrap items-center justify-end gap-2 border-b border-border ai-page-bg px-5 py-2.5'>
+      <Tooltip
+        content={isAtRoot ? 'Ask AI' : `Ask AI about this ${spParentId ? 'folder' : 'collection'}`}
+        side='bottom'
+      >
+        <button
+          type='button'
+          onClick={handleOpenAI}
+          aria-label='Ask AI'
+          data-track-category='knowledge-base'
+          data-track-name='kb-open-ai-chat'
+          className='inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-background text-foreground shadow-sm transition hover:bg-muted'
+        >
+          <XyneAIStar size={22} />
+        </button>
+      </Tooltip>
+      {isAtRoot ? (
+        // Collections are channel-scoped, so creation must go through the
+        // CreateCollectionModal (it owns the channel picker + name step).
+        // The single-field NameDialog can't capture scope, so we wire
+        // root creation through the scoped modal.
+        <button
+          type='button'
+          onClick={() => setIsCreateModalOpen(true)}
+          className='inline-flex h-10 items-center gap-1.5 rounded-full border border-border bg-background px-4 text-[13px] font-medium text-foreground shadow-sm transition hover:bg-muted'
+          data-track-category='knowledge-base'
+          data-track-name='new-collection'
+        >
+          <Plus className='h-4 w-4' strokeWidth={1.75} />
+          New collection
+        </button>
+      ) : canEdit ? (
+        <>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type='button'
+                className='inline-flex h-10 items-center gap-1.5 rounded-full border border-border bg-background px-4 text-[13px] font-medium text-foreground shadow-sm transition hover:bg-muted'
+                data-track-category='knowledge-base'
+                data-track-name='open-new-menu'
+              >
+                {isUploadingForThisCollection ? (
+                  <Loader2 className='h-4 w-4 animate-spin' strokeWidth={1.75} />
+                ) : (
+                  <Plus className='h-4 w-4' strokeWidth={1.75} />
+                )}
+                New
+                <ChevronDown className='h-3.5 w-3.5' strokeWidth={1.75} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+              <DropdownMenuItem onClick={() => setDialog('folder')}>
+                <FolderPlus className='h-4 w-4' strokeWidth={1.75} />
+                New folder
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={onPickFiles}>
+                <File className='h-4 w-4' strokeWidth={1.75} />
+                Upload files
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => folderInputRef.current?.click()}>
+                <FolderOpen className='h-4 w-4' strokeWidth={1.75} />
+                Upload folder
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setDriveLinkOpen(true)}>
+                <Link2 className='h-4 w-4' strokeWidth={1.75} />
+                Add from Drive
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <input
+            ref={fileInputRef}
+            type='file'
+            multiple
+            className='sr-only'
+            onChange={onFileInputChange}
+          />
+          <input
+            ref={setFolderInputRef}
+            type='file'
+            multiple
+            className='sr-only'
+            onChange={onFileInputChange}
+          />
+        </>
+      ) : null}
+      <ViewToggleV2 value={view} onChange={setView} />
+    </div>
+  );
+
+  const breadcrumbRow = (
+    <div className='flex min-w-0 items-center gap-2 px-5 py-2.5'>
+      <button
+        type='button'
+        aria-label={
+          isAtRoot ? 'Back to Ask AI' : isAtCollectionRoot ? 'Back to collections' : 'Up one level'
+        }
+        onClick={() => {
+          if (isAtRoot) {
+            void navigate(workspaceId ? `/${workspaceId}/ai` : '/ai');
+          } else if (collectionId && !spParentId) {
+            goToCollections();
+          } else {
+            goUp();
+          }
+        }}
+        className='grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition hover:bg-secondary hover:text-foreground'
+        title={isAtRoot ? 'Back to Ask AI' : isAtCollectionRoot ? 'Back to collections' : 'Up'}
+        data-track-category='knowledge-base'
+        data-track-name='navigate-up'
+      >
+        <ArrowLeft className='h-3.5 w-3.5' aria-hidden strokeWidth={1.75} />
+      </button>
+
+      {isAtRoot ? (
+        <span className='text-[13px] font-medium text-foreground'>Knowledge</span>
+      ) : (
+        <CrumbsV2
+          currentCollectionId={collectionId}
+          currentFolderId={spParentId}
+          collectionName={rootLabel}
+          chain={chain}
+          onGoToCollections={goToCollections}
+          onGoToParent={parentId => {
+            goToParent(parentId);
+          }}
+          isAtRoot={isAtRoot}
+        />
+      )}
+    </div>
+  );
+
+  // A second, labeled Ask AI entry point sitting inline with the folder/file
+  // count, directly above the list — mirrors Drive's "Ask Gemini" pill,
+  // which sits in the same spot relative to its file table. The header's
+  // circular icon is the primary action; this is a secondary, more
+  // discoverable prompt right where you're about to look for it while
+  // browsing.
+  const askAiPill = (
+    <button
+      type='button'
+      onClick={handleOpenAI}
+      data-track-category='knowledge-base'
+      data-track-name='kb-open-ai-chat-pill'
+      className='inline-flex h-8 items-center gap-1.5 rounded-full bg-primary/10 px-3 text-[12.5px] font-medium text-foreground transition hover:bg-primary/15'
+    >
+      <XyneAIStar size={14} />
+      Ask AI
+    </button>
+  );
+
+  const mainContent = (
+    <main ref={mainRef} className='relative flex-1 overflow-auto px-5 py-5'>
+      {dragging ? (
+        <div className='pointer-events-none absolute inset-3 z-10 flex items-center justify-center rounded-2xl border-2 border-dashed border-primary/60 bg-background/80 text-[14px] font-medium text-foreground'>
+          Drop files to upload
+        </div>
+      ) : null}
+      <div className='mx-auto w-full max-w-7xl'>
+        <div className='mb-3 flex items-center gap-3'>
+          {askAiPill}
+          <p className='text-[12px] text-muted-foreground'>
+            {loading
+              ? 'Loading...'
+              : isAtRoot
+                ? filteredEntries.length === 0
+                  ? 'No collections yet'
+                  : `${String(filteredEntries.length)} collection${filteredEntries.length === 1 ? '' : 's'}`
+                : filteredEntries.length === 0
+                  ? 'This folder is empty'
+                  : [
+                      folderCount > 0
+                        ? `${String(folderCount)} folder${folderCount === 1 ? '' : 's'}`
+                        : null,
+                      fileCount > 0
+                        ? `${String(fileCount)} file${fileCount === 1 ? '' : 's'}`
+                        : null,
+                    ]
+                      .filter(Boolean)
+                      .join(' · ')}
+          </p>
+
+          {/* Type / Status filters — Drive-style pill buttons, always present
+              at every level (root or any folder), not just when more than
+              one option happens to be available right now. */}
+          <div className='ml-auto flex items-center gap-2'>
+            <div className='inline-flex items-center gap-1'>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type='button'
+                    className={cn(
+                      'inline-flex h-8 items-center gap-1.5 rounded-full border px-3 text-[12.5px] font-medium shadow-sm transition',
+                      typeFilter === 'ALL'
+                        ? 'border-border bg-background text-foreground hover:bg-muted'
+                        : 'border-primary/20 bg-primary/10 text-foreground hover:bg-primary/15',
+                    )}
+                    data-track-category='knowledge-base'
+                    data-track-name='kb-type-filter'
+                  >
+                    {typeFilter === 'ALL'
+                      ? 'Type'
+                      : (availableTypeFilters.find(o => o.value === typeFilter)?.label ?? 'Type')}
+                    <ChevronDown
+                      className={cn(
+                        'h-3.5 w-3.5',
+                        typeFilter === 'ALL' ? 'text-muted-foreground' : 'text-foreground',
+                      )}
+                      strokeWidth={1.75}
+                    />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end'>
+                  <DropdownMenuItem onClick={() => setTypeFilter('ALL')}>All</DropdownMenuItem>
+                  {availableTypeFilters.map(opt => (
+                    <DropdownMenuItem key={opt.value} onClick={() => setTypeFilter(opt.value)}>
+                      <span className='flex items-center gap-2'>
+                        {typeFilterIcon(opt.value)}
+                        {opt.label}
+                      </span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+              {typeFilter !== 'ALL' ? (
+                <button
+                  type='button'
+                  onClick={() => setTypeFilter('ALL')}
+                  aria-label='Clear type filter'
+                  title='Clear type filter'
+                  className='grid h-8 w-8 place-items-center rounded-full border border-primary/20 bg-primary/10 text-foreground transition hover:bg-primary/15'
+                  data-track-category='knowledge-base'
+                  data-track-name='kb-type-filter-clear'
+                >
+                  <X className='h-3.5 w-3.5' strokeWidth={1.75} />
+                </button>
+              ) : null}
+            </div>
+            <div className='inline-flex items-center gap-1'>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type='button'
+                    className={cn(
+                      'inline-flex h-8 items-center gap-1.5 rounded-full border px-3 text-[12.5px] font-medium shadow-sm transition',
+                      statusFilter === 'ALL'
+                        ? 'border-border bg-background text-foreground hover:bg-muted'
+                        : 'border-primary/20 bg-primary/10 text-foreground hover:bg-primary/15',
+                    )}
+                    data-track-category='knowledge-base'
+                    data-track-name='kb-status-filter'
+                  >
+                    {statusFilter === 'ALL'
+                      ? 'Status'
+                      : (STATUS_FILTER_OPTIONS.find(o => o.value === statusFilter)?.label ??
+                        'Status')}
+                    <ChevronDown
+                      className={cn(
+                        'h-3.5 w-3.5',
+                        statusFilter === 'ALL' ? 'text-muted-foreground' : 'text-foreground',
+                      )}
+                      strokeWidth={1.75}
+                    />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align='end'>
+                  <DropdownMenuItem onClick={() => setStatusFilter('ALL')}>All</DropdownMenuItem>
+                  {STATUS_FILTER_OPTIONS.map(opt => (
+                    <DropdownMenuItem key={opt.value} onClick={() => setStatusFilter(opt.value)}>
+                      <span className='flex items-center gap-2'>
+                        {statusFilterIcon(opt.value)}
+                        {opt.label}
+                      </span>
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+              {statusFilter !== 'ALL' ? (
+                <button
+                  type='button'
+                  onClick={() => setStatusFilter('ALL')}
+                  aria-label='Clear status filter'
+                  title='Clear status filter'
+                  className='grid h-8 w-8 place-items-center rounded-full border border-primary/20 bg-primary/10 text-foreground transition hover:bg-primary/15'
+                  data-track-category='knowledge-base'
+                  data-track-name='kb-status-filter-clear'
+                >
+                  <X className='h-3.5 w-3.5' strokeWidth={1.75} />
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        {filteredEntries.length === 0 && !loading && !isUploadingForThisCollection ? (
+          entries.length > 0 ? (
+            <div className='mx-auto flex max-w-md flex-col items-center justify-center gap-2 py-24 text-center'>
+              <p className='text-[14px] font-medium text-foreground'>No items match this filter</p>
+              <p className='max-w-xs text-[12.5px] text-muted-foreground'>
+                Try a different status, or clear the filter to see everything here.
+              </p>
+            </div>
+          ) : (
+            <EmptyPaneV2 isRoot={isAtRoot} />
+          )
+        ) : view === 'grid' ? (
+          <EntryGridV2
+            entries={filteredEntries}
+            onOpen={onOpenEntry}
+            {...(isAtRoot || canEdit
+              ? {
+                  onDelete: (e: CollectionChild): void => {
+                    void onDelete(e);
+                  },
+                  onRename,
+                }
+              : {})}
+            editingId={renameTarget?.id ?? null}
+            onRenameCommit={onRenameCommit}
+            onRenameCancel={onRenameCancel}
+            scrollParentRef={mainRef}
+            onOpenStatus={onOpenStatus}
+            onAskAI={onAskAIAboutEntry}
+            onShare={onShare}
+            {...(isAtRoot ? { folderCaption: locationOf } : {})}
+          />
+        ) : (
+          <EntryListV2
+            entries={filteredEntries}
+            columns={isAtRoot ? [...KB_ROOT_COLUMNS] : [...KB_COLUMNS]}
+            onOpen={onOpenEntry}
+            {...(isAtRoot || canEdit
+              ? {
+                  onDelete: (e: CollectionChild): void => {
+                    void onDelete(e);
+                  },
+                  onRename,
+                }
+              : {})}
+            editingId={renameTarget?.id ?? null}
+            onRenameCommit={onRenameCommit}
+            onRenameCancel={onRenameCancel}
+            scrollParentRef={mainRef}
+            onOpenStatus={onOpenStatus}
+            onAskAI={onAskAIAboutEntry}
+            onShare={onShare}
+            {...(isAtRoot
+              ? {
+                  resolveColumnValue: (entry, key): string | undefined =>
+                    key === 'location' ? locationOf(entry) : undefined,
+                }
+              : {})}
+          />
+        )}
+      </div>
+    </main>
+  );
+
   return (
     <div
       className='flex h-full flex-col bg-background'
       onDragOver={e => {
         e.preventDefault();
-        if (collectionId) {
+        if (collectionId && canEdit) {
           setDragging(true);
         }
       }}
@@ -887,236 +1421,9 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
       }}
       onDrop={onDrop}
     >
-      <div className='flex flex-wrap items-center justify-between gap-3 border-b border-border bg-background px-5 py-2.5'>
-        <div className='flex min-w-0 flex-1 items-center gap-2'>
-          <button
-            type='button'
-            aria-label={
-              isAtRoot
-                ? 'Back to Ask AI'
-                : isAtCollectionRoot
-                  ? 'Back to collections'
-                  : 'Up one level'
-            }
-            onClick={() => {
-              if (isAtRoot) {
-                void navigate(workspaceId ? `/${workspaceId}/ai` : '/ai');
-              } else if (collectionId && !spParentId) {
-                goToCollections();
-              } else {
-                goUp();
-              }
-            }}
-            className='grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition hover:bg-secondary hover:text-foreground'
-            title={isAtRoot ? 'Back to Ask AI' : isAtCollectionRoot ? 'Back to collections' : 'Up'}
-            data-track-category='knowledge-base'
-            data-track-name='navigate-up'
-          >
-            <ArrowLeft className='h-3.5 w-3.5' aria-hidden strokeWidth={1.75} />
-          </button>
-
-          {isAtRoot ? (
-            <span className='text-[13px] font-medium text-foreground'>Knowledge</span>
-          ) : (
-            <CrumbsV2
-              currentCollectionId={collectionId}
-              currentFolderId={spParentId}
-              collectionName={rootLabel}
-              chain={chain}
-              onGoToCollections={goToCollections}
-              onGoToParent={parentId => {
-                goToParent(parentId);
-              }}
-              isAtRoot={isAtRoot}
-            />
-          )}
-        </div>
-
-        <div className='flex items-center gap-2'>
-          {!isAtRoot && (
-            <Tooltip
-              content={`Ask AI about this ${spParentId ? 'folder' : 'collection'}`}
-              side='bottom'
-            >
-              <button
-                type='button'
-                onClick={handleOpenAI}
-                data-track-category='knowledge-base'
-                data-track-name='kb-open-ai-chat'
-                className='inline-flex h-7 items-center gap-1 rounded-md border border-border bg-secondary px-2 text-[12px] text-foreground transition hover:bg-muted'
-              >
-                <XyneAIStar size={14} />
-                Ask AI
-              </button>
-            </Tooltip>
-          )}
-          {isAtRoot ? (
-            // Collections are channel-scoped, so creation must go through the
-            // CreateCollectionModal (it owns the channel picker + name step).
-            // The single-field NameDialog can't capture scope, so we wire
-            // root creation through the scoped modal.
-            <button
-              type='button'
-              onClick={() => setIsCreateModalOpen(true)}
-              className='inline-flex h-7 items-center gap-1 rounded-md border border-border bg-secondary px-2 text-[12px] text-foreground transition hover:bg-muted'
-              data-track-category='knowledge-base'
-              data-track-name='new-collection'
-            >
-              <Plus className='h-3.5 w-3.5' strokeWidth={1.75} />
-              New collection
-            </button>
-          ) : (
-            <>
-              <button
-                type='button'
-                onClick={() => setDialog('folder')}
-                className='inline-flex h-7 items-center gap-1 rounded-md border border-border bg-secondary px-2 text-[12px] text-foreground transition hover:bg-muted'
-                data-track-category='knowledge-base'
-                data-track-name='new-folder'
-              >
-                <FolderPlus className='h-3.5 w-3.5' strokeWidth={1.75} />
-                New folder
-              </button>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    type='button'
-                    className='inline-flex h-7 items-center gap-1 rounded-md border border-border bg-secondary px-2 text-[12px] text-foreground transition hover:bg-muted'
-                    data-track-category='knowledge-base'
-                    data-track-name='open-upload-menu'
-                  >
-                    {isUploadingForThisCollection ? (
-                      <Loader2 className='h-3.5 w-3.5 animate-spin' strokeWidth={1.75} />
-                    ) : (
-                      <Upload className='h-3.5 w-3.5' strokeWidth={1.75} />
-                    )}
-                    Upload
-                    <ChevronDown className='h-3 w-3' strokeWidth={1.75} />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align='end'>
-                  <DropdownMenuItem
-                    onClick={onPickFiles}
-                    data-track-category='knowledge-base'
-                    data-track-name='PICK_KB_FILES'
-                  >
-                    <File className='h-4 w-4' strokeWidth={1.75} />
-                    Upload files
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => folderInputRef.current?.click()}
-                    data-track-category='knowledge-base'
-                    data-track-name='PICK_KB_FOLDER'
-                  >
-                    <FolderOpen className='h-4 w-4' strokeWidth={1.75} />
-                    Upload folder
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => setDriveLinkOpen(true)}>
-                    <Link2 className='h-4 w-4' strokeWidth={1.75} />
-                    Add from Drive link
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <input
-                ref={fileInputRef}
-                type='file'
-                multiple
-                className='sr-only'
-                onChange={onFileInputChange}
-              />
-              <input
-                ref={setFolderInputRef}
-                type='file'
-                multiple
-                className='sr-only'
-                onChange={onFileInputChange}
-              />
-            </>
-          )}
-          <ViewToggleV2 value={view} onChange={setView} />
-          <SearchFieldV2
-            value={query}
-            onChange={setQuery}
-            className='w-64'
-            ariaLabel='Search files'
-            placeholder='Search files by name'
-          />
-        </div>
-      </div>
-
-      <main ref={mainRef} className='relative flex-1 overflow-auto px-5 py-5'>
-        {dragging ? (
-          <div className='pointer-events-none absolute inset-3 z-10 flex items-center justify-center rounded-2xl border-2 border-dashed border-primary/60 bg-background/80 text-[14px] font-medium text-foreground'>
-            Drop files to upload
-          </div>
-        ) : null}
-        <div className='mx-auto w-full max-w-7xl'>
-          {searching ? (
-            <SearchResultsV2
-              query={trimmedQuery}
-              loading={searchLoading}
-              error={searchError}
-              hits={searchHits}
-              onOpen={onOpenEntry}
-            />
-          ) : (
-            <>
-              <p className='mb-3 text-[12px] text-muted-foreground'>
-                {loading
-                  ? 'Loading...'
-                  : isAtRoot
-                    ? entries.length === 0
-                      ? 'No collections yet'
-                      : `${String(entries.length)} collection${entries.length === 1 ? '' : 's'}`
-                    : entries.length === 0
-                      ? 'This folder is empty'
-                      : `${String(folderCount)} folder${folderCount === 1 ? '' : 's'} · ${String(fileCount)} file${fileCount === 1 ? '' : 's'}`}
-              </p>
-
-              {entries.length === 0 && !loading && !isUploadingForThisCollection ? (
-                <EmptyPaneV2 isRoot={isAtRoot} />
-              ) : view === 'grid' ? (
-                <EntryGridV2
-                  entries={entries}
-                  onOpen={onOpenEntry}
-                  onDelete={(e): void => {
-                    void onDelete(e);
-                  }}
-                  onRename={onRename}
-                  editingId={renameTarget?.id ?? null}
-                  onRenameCommit={onRenameCommit}
-                  onRenameCancel={onRenameCancel}
-                  scrollParentRef={mainRef}
-                  onOpenStatus={onOpenStatus}
-                  {...(isAtRoot ? { folderCaption: locationOf, onShare } : {})}
-                />
-              ) : (
-                <EntryListV2
-                  entries={entries}
-                  columns={isAtRoot ? [...KB_ROOT_COLUMNS] : [...KB_COLUMNS]}
-                  onOpen={onOpenEntry}
-                  onDelete={(e): void => {
-                    void onDelete(e);
-                  }}
-                  onRename={onRename}
-                  editingId={renameTarget?.id ?? null}
-                  onRenameCommit={onRenameCommit}
-                  onRenameCancel={onRenameCancel}
-                  scrollParentRef={mainRef}
-                  onOpenStatus={onOpenStatus}
-                  {...(isAtRoot
-                    ? {
-                        onShare,
-                        resolveColumnValue: (entry, key): string | undefined =>
-                          key === 'location' ? locationOf(entry) : undefined,
-                      }
-                    : {})}
-                />
-              )}
-            </>
-          )}
-        </div>
-      </main>
+      {header}
+      {breadcrumbRow}
+      {mainContent}
 
       <NameDialogV2
         open={dialog === 'folder'}
@@ -1149,19 +1456,30 @@ export const KnowledgeBaseV2Screen: React.FC = () => {
       {shareTarget
         ? (() => {
             const owning = globalCollections.byId(shareTarget.id);
+            const link = buildEntryLink(shareTarget);
             return (
               <ShareCollectionModal
                 isOpen
                 onClose={closeShare}
                 collectionId={shareTarget.id}
                 collectionName={shareTarget.name}
-                channelId={owning?.scopeId ?? null}
+                channelId={owning?.scopeType === 'CHANNEL' ? (owning.scopeId ?? null) : null}
                 isPrivate={owning?.isPrivate ?? false}
                 canEditVisibility={owning?.role === 'OWNER'}
+                {...(link ? { link } : {})}
               />
             );
           })()
         : null}
+
+      {linkShareTarget ? (
+        <ShareLinkModal
+          isOpen
+          onClose={() => setLinkShareTarget(null)}
+          title={linkShareTarget.name}
+          link={buildEntryLink(linkShareTarget) ?? ''}
+        />
+      ) : null}
 
       <CollectionStatusDrawer collection={statusFor} onClose={() => setStatusFor(null)} />
 

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/EntryGridV2.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/EntryGridV2.tsx
@@ -11,9 +11,14 @@ interface EntryGridV2Props {
    *  Same predicate applies as `onDelete`: passing a handler enables it
    *  for the entry. */
   onRename?: (entry: CollectionChild) => void;
-  /** Surfaces a hover-revealed share button on FOLDER cards. Wired by
-   *  the root-level collections view only; files are not shareable. */
+  /** Surfaces a hover-revealed share button on every card, folder or file.
+   *  At root this opens the full collection access-management dialog;
+   *  inside a collection it opens a copy-link-only dialog. */
   onShare?: (entry: CollectionChild) => void;
+  /** Surfaces a hover-revealed Ask AI button on every card, folder or file.
+   *  Files scope precisely (kbDocId); folders fall back to their owning
+   *  collection — see KnowledgeBaseV2Screen's onAskAIAboutEntry. */
+  onAskAI?: (entry: CollectionChild) => void;
   /** Opens the per-collection ingestion status drawer (root collections view). */
   onOpenStatus?: (entry: CollectionChild) => void;
   /** Entry id currently in inline-rename mode (only one at a time). When
@@ -62,6 +67,7 @@ export const EntryGridV2: React.FC<EntryGridV2Props> = ({
   onDelete,
   onRename,
   onShare,
+  onAskAI,
   editingId,
   onRenameCommit,
   onRenameCancel,
@@ -118,6 +124,7 @@ export const EntryGridV2: React.FC<EntryGridV2Props> = ({
                       onDelete={onDelete ? () => onDelete(e) : undefined}
                       onRename={onRename ? () => onRename(e) : undefined}
                       onShare={onShare ? () => onShare(e) : undefined}
+                      onAskAI={onAskAI ? () => onAskAI(e) : undefined}
                       onOpenStatus={onOpenStatus}
                       isRenaming={isRenaming}
                       onRenameCommit={commitFor}
@@ -129,6 +136,8 @@ export const EntryGridV2: React.FC<EntryGridV2Props> = ({
                       onClick={() => onOpen(e)}
                       onDelete={onDelete ? () => onDelete(e) : undefined}
                       onRename={onRename ? () => onRename(e) : undefined}
+                      onAskAI={onAskAI ? () => onAskAI(e) : undefined}
+                      onShare={onShare ? () => onShare(e) : undefined}
                       isRenaming={isRenaming}
                       onRenameCommit={commitFor}
                       onRenameCancel={onRenameCancel}

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/EntryListV2.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/EntryListV2.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { cn } from '../../../utils/classNames';
 import { CollectionChild } from '../../../services/Knowledge/collectionService';
 import { StatusBadgeV2 } from './StatusBadgeV2';
 import { IngestStatusV2 } from './IngestStatusV2';
-import { CollectionStatusBadgeV2 } from './CollectionStatusBadgeV2';
 import { Folder, Pencil, Share2, Trash2 } from 'lucide-react';
 import { useInlineEdit } from './useInlineEdit';
+import { XyneAIStar } from '../../icons/xyne-ai';
+import { CollectionStatusBadgeV2 } from './CollectionStatusBadgeV2';
+import { FileFailedBadgeV2 } from './FileFailedBadgeV2';
 
 export interface ColumnDef {
   key: string;
@@ -23,9 +24,14 @@ interface EntryListV2Props {
   onOpen: (entry: CollectionChild) => void;
   onDelete?: (entry: CollectionChild) => void;
   onRename?: (entry: CollectionChild) => void;
-  /** When provided, FOLDER rows render a share button next to rename/delete.
-   *  The screen only passes this at root (collections view). */
+  /** When provided, every row renders a Share button. At root this opens
+   *  the full collection access-management dialog; inside a collection it
+   *  opens a copy-link-only dialog for the folder/file. */
   onShare?: (entry: CollectionChild) => void;
+  /** When provided, every row renders an Ask AI button next to share.
+   *  Files scope precisely (kbDocId); folders fall back to their owning
+   *  collection — see KnowledgeBaseV2Screen's onAskAIAboutEntry. */
+  onAskAI?: (entry: CollectionChild) => void;
   /** Opens the per-collection ingestion status drawer (root collections view). */
   onOpenStatus?: (entry: CollectionChild) => void;
   /** Inline-rename state: id of the row whose name should render as an
@@ -77,6 +83,7 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
   onDelete,
   onRename,
   onShare,
+  onAskAI,
   onOpenStatus,
   editingId,
   onRenameCommit,
@@ -87,7 +94,8 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
   // Reserve a tail gutter for whichever action affordances are wired up so
   // grid columns don't shift between rows with/without actions. Each button
   // is 36 px wide.
-  const actionCount = (onShare ? 1 : 0) + (onRename ? 1 : 0) + (onDelete ? 1 : 0);
+  const actionCount =
+    (onAskAI ? 1 : 0) + (onShare ? 1 : 0) + (onRename ? 1 : 0) + (onDelete ? 1 : 0);
   const actionsWidth = actionCount > 0 ? `${String(actionCount * 36)}px` : null;
   const template = [
     '1fr',
@@ -147,12 +155,13 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
   };
 
   return (
-    // Same surface tokens as the toolbar (bg-secondary) so the list view
-    // reads as part of the same surface family — matches xyne-search /kb.
-    <div className='overflow-hidden rounded-2xl border border-border bg-secondary'>
+    // Flat, borderless table — mirrors Drive's list view (no card
+    // background/rounded frame around the whole thing; each row is just
+    // separated by a thin hairline).
+    <div className='w-full'>
       {/* Header */}
       <div
-        className='grid items-center gap-3 border-b border-border bg-muted/60 px-4 py-2 text-[11.5px] font-medium uppercase tracking-wide text-muted-foreground'
+        className='grid items-center gap-3 border-b border-border px-4 py-2 text-[13px] font-medium text-muted-foreground'
         style={{ gridTemplateColumns: template }}
       >
         <span>Name</span>
@@ -180,10 +189,7 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
               key={virtualRow.key}
               data-index={virtualRow.index}
               ref={virtualizer.measureElement}
-              className={cn(
-                'group absolute left-0 right-0',
-                virtualRow.index > 0 && 'border-t border-border',
-              )}
+              className='group absolute left-0 right-0 border-b border-border/60'
               style={{
                 transform: `translateY(${String(virtualRow.start)}px)`,
               }}
@@ -199,11 +205,19 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
                   <div className='flex min-w-0 items-center gap-3'>
                     <span className='flex-shrink-0 pr-1'>
                       {e.type === 'FOLDER' ? (
-                        <div className='flex h-7 w-7 items-center justify-center'>
+                        <div className='relative flex h-7 w-7 items-center justify-center'>
                           <Folder className='h-5 w-5 text-muted-foreground' strokeWidth={1.5} />
+                          <span className='absolute -bottom-1 -right-1'>
+                            <CollectionStatusBadgeV2 entry={e} onOpenStatus={onOpenStatus} />
+                          </span>
                         </div>
                       ) : (
-                        <StatusBadgeV2 name={e.name} />
+                        <span className='relative inline-flex'>
+                          <StatusBadgeV2 name={e.name} />
+                          <span className='absolute -bottom-1 -right-1'>
+                            <FileFailedBadgeV2 status={e.ingestionStatus} />
+                          </span>
+                        </span>
                       )}
                     </span>
                     <InlineNameCell
@@ -215,30 +229,45 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
                   </div>
                 ) : (
                   <div className='flex min-w-0 items-center gap-2'>
-                    <button
-                      type='button'
+                    {/* Rendered as a role=button div (not a <button>) so the
+                        status badge below can be a real nested button —
+                        matches FolderCardV2's grid structure. */}
+                    <div
+                      role='button'
+                      tabIndex={0}
                       onClick={() => onOpen(e)}
-                      className='flex min-w-0 flex-1 items-center gap-3 text-left'
+                      onKeyDown={(ev): void => {
+                        if (ev.key === 'Enter' || ev.key === ' ') {
+                          ev.preventDefault();
+                          onOpen(e);
+                        }
+                      }}
+                      className='flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left'
                       data-track-category='knowledge-base'
                       data-track-name='open-entry'
                     >
                       <span className='flex-shrink-0 pr-1'>
                         {e.type === 'FOLDER' ? (
-                          <div className='flex h-7 w-7 items-center justify-center'>
+                          <div className='relative flex h-7 w-7 items-center justify-center'>
                             <Folder className='h-5 w-5 text-muted-foreground' strokeWidth={1.5} />
+                            <span className='absolute -bottom-1 -right-1'>
+                              <CollectionStatusBadgeV2 entry={e} onOpenStatus={onOpenStatus} />
+                            </span>
                           </div>
                         ) : (
-                          <StatusBadgeV2 name={e.name} />
+                          <span className='relative inline-flex'>
+                            <StatusBadgeV2 name={e.name} />
+                            <span className='absolute -bottom-1 -right-1'>
+                              <FileFailedBadgeV2 status={e.ingestionStatus} />
+                            </span>
+                          </span>
                         )}
                       </span>
-                      <span className='truncate text-[13.5px] font-medium text-foreground'>
+                      <span className='min-w-0 flex-1 truncate text-[13.5px] font-medium text-foreground'>
                         {e.name}
                       </span>
                       {e.type === 'FILE' ? <IngestStatusV2 status={e.ingestionStatus} /> : null}
-                    </button>
-                    {e.type === 'FOLDER' ? (
-                      <CollectionStatusBadgeV2 entry={e} onOpenStatus={onOpenStatus} />
-                    ) : null}
+                    </div>
                   </div>
                 )}
 
@@ -256,12 +285,29 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
                   </button>
                 ))}
 
-                {/* Row actions (share / rename / delete). Share is folder-only
-                    and only wired by the root view — matches V1's behaviour.
-                    Visibility (public/private) lives inside the share dialog. */}
+                {/* Row actions (share / rename / delete). Share opens the full
+                    collection access-management dialog at root, or a
+                    copy-link-only dialog for a folder/file — see
+                    KnowledgeBaseV2Screen's onShare. */}
                 {actionsWidth ? (
                   <div className='flex items-center justify-end gap-1'>
-                    {onShare && e.type === 'FOLDER' ? (
+                    {onAskAI ? (
+                      <button
+                        type='button'
+                        aria-label={`Ask AI about ${e.name}`}
+                        title='Ask AI'
+                        onClick={ev => {
+                          ev.stopPropagation();
+                          onAskAI(e);
+                        }}
+                        className='grid h-7 w-7 place-items-center rounded-md text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:bg-muted hover:text-foreground focus-visible:opacity-100'
+                        data-track-category='knowledge-base'
+                        data-track-name='ask-ai-entry'
+                      >
+                        <XyneAIStar size={14} />
+                      </button>
+                    ) : null}
+                    {onShare ? (
                       <button
                         type='button'
                         aria-label={`Share ${e.name}`}
@@ -270,7 +316,7 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
                           ev.stopPropagation();
                           onShare(e);
                         }}
-                        className='grid h-7 w-7 place-items-center rounded-md text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:bg-muted hover:text-foreground focus:opacity-100'
+                        className='grid h-7 w-7 place-items-center rounded-md text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:bg-muted hover:text-foreground focus-visible:opacity-100'
                         data-track-category='knowledge-base'
                         data-track-name='share-entry'
                       >
@@ -286,7 +332,7 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
                           ev.stopPropagation();
                           onRename(e);
                         }}
-                        className='grid h-7 w-7 place-items-center rounded-md text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:bg-muted hover:text-foreground focus:opacity-100'
+                        className='grid h-7 w-7 place-items-center rounded-md text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:bg-muted hover:text-foreground focus-visible:opacity-100'
                         data-track-category='knowledge-base'
                         data-track-name='rename-entry'
                       >
@@ -302,7 +348,7 @@ export const EntryListV2: React.FC<EntryListV2Props> = ({
                           ev.stopPropagation();
                           onDelete(e);
                         }}
-                        className='grid h-7 w-7 place-items-center rounded-md text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:bg-red-50 hover:text-red-600 focus:opacity-100 dark:hover:bg-red-950/40'
+                        className='grid h-7 w-7 place-items-center rounded-md text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:bg-red-50 hover:text-red-600 focus-visible:opacity-100 dark:hover:bg-red-950/40'
                         data-track-category='knowledge-base'
                         data-track-name='delete-entry'
                       >

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/FileCardPreviewV2.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/FileCardPreviewV2.tsx
@@ -366,10 +366,13 @@ export const FileCardPreviewV2: React.FC<FileCardPreviewV2Props> = ({ format, si
   const fmt = format.toLowerCase();
   const banner = BANNER[fmt] ?? 'bg-zinc-500 text-white';
   const dims = size === 'sm' ? 'w-9 h-[3rem] p-1.5 space-y-2' : 'w-14 h-[4.5rem] p-2 space-y-3';
+  // Top-right, not bottom-right — bottom-right is reserved for the
+  // ingestion status badge (FileFailedBadgeV2 in FileCardV2.tsx), which sits
+  // there to match FolderCardV2's CollectionStatusBadgeV2 corner.
   const bannerPos =
     size === 'sm'
-      ? '-right-1.5 bottom-1 text-[7px] px-1 py-px'
-      : '-right-2 bottom-1.5 text-[8px] px-1.5 py-0.5';
+      ? '-right-1.5 top-1 text-[7px] px-1 py-px'
+      : '-right-2 top-1.5 text-[8px] px-1.5 py-0.5';
 
   return (
     <div aria-hidden className='relative size-fit'>

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/FileCardV2.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/FileCardV2.tsx
@@ -6,12 +6,18 @@ import { CollectionStatusBadgeV2 } from './CollectionStatusBadgeV2';
 import { CollectionChild } from '../../../services/Knowledge/collectionService';
 import { Folder, Pencil, Share2, Trash2 } from 'lucide-react';
 import { useInlineEdit } from './useInlineEdit';
+import { XyneAIStar } from '../../icons/xyne-ai';
+import { FileFailedBadgeV2 } from './FileFailedBadgeV2';
 
 interface FileCardV2Props {
   file: CollectionChild;
   onClick: () => void;
   onDelete?: (() => void) | undefined;
   onRename?: (() => void) | undefined;
+  /** Opens Ask AI scoped to this specific file (kbDocId). */
+  onAskAI?: (() => void) | undefined;
+  /** Opens the copy-link share dialog for this file. */
+  onShare?: (() => void) | undefined;
   /** Inline-rename mode. When true the title becomes an editable input;
    *  Enter / blur calls `onRenameCommit`, Escape calls `onRenameCancel`. */
   isRenaming?: boolean;
@@ -79,7 +85,7 @@ const HoverAction: React.FC<HoverActionProps> = ({
     data-track-category='knowledge-base'
     data-track-name={trackName}
     className={cn(
-      'grid h-7 w-7 place-items-center rounded-md bg-background/80 text-muted-foreground opacity-0 shadow-sm ring-1 ring-border backdrop-blur-sm transition group-hover:opacity-100 focus:opacity-100',
+      'grid h-7 w-7 place-items-center rounded-md bg-background/80 text-muted-foreground opacity-0 shadow-sm ring-1 ring-border backdrop-blur-sm transition group-hover:opacity-100 focus-visible:opacity-100',
       intent === 'danger'
         ? 'hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/40'
         : 'hover:bg-muted hover:text-foreground',
@@ -100,6 +106,8 @@ export const FileCardV2: React.FC<FileCardV2Props> = ({
   onClick,
   onDelete,
   onRename,
+  onAskAI,
+  onShare,
   isRenaming,
   onRenameCommit,
   onRenameCancel,
@@ -126,8 +134,16 @@ export const FileCardV2: React.FC<FileCardV2Props> = ({
         data-track-category='knowledge-base'
         data-track-name='open-file-card'
       >
-        <div className='pl-1 pt-1'>
+        <div className='relative pl-1 pt-1'>
           <FileCardPreviewV2 format={ext} size='md' />
+          {/* Bottom-right, matching FolderCardV2's CollectionStatusBadgeV2
+              corner — FileCardPreviewV2's format banner moved to top-right
+              to free this corner up.
+              z-10 — FileCardPreviewV2's thumbnail/banner sit at z-[1]/z-[2],
+              which otherwise outrank this z-auto badge and clip it. */}
+          <span className='absolute -right-1 -bottom-1 z-10'>
+            <FileFailedBadgeV2 status={file.ingestionStatus} />
+          </span>
         </div>
         <span className='flex w-full min-w-0 flex-col gap-0.5'>
           <span className='flex min-w-0 items-center gap-1.5'>
@@ -147,8 +163,32 @@ export const FileCardV2: React.FC<FileCardV2Props> = ({
           ) : null}
         </span>
       </button>
-      {!isRenaming && (onRename || onDelete) ? (
-        <div className='absolute right-2 top-2 flex gap-1'>
+      {!isRenaming && (onAskAI || onShare || onRename || onDelete) ? (
+        <div className='absolute right-2 top-2 z-10 flex gap-1'>
+          {onAskAI ? (
+            <HoverAction
+              label={`Ask AI about ${file.name}`}
+              trackName='ask-ai-file-card'
+              onClick={ev => {
+                ev.stopPropagation();
+                onAskAI();
+              }}
+            >
+              <XyneAIStar size={14} />
+            </HoverAction>
+          ) : null}
+          {onShare ? (
+            <HoverAction
+              label={`Share ${file.name}`}
+              trackName='share-file-card'
+              onClick={ev => {
+                ev.stopPropagation();
+                onShare();
+              }}
+            >
+              <Share2 className='h-3.5 w-3.5' strokeWidth={1.75} />
+            </HoverAction>
+          ) : null}
           {onRename ? (
             <HoverAction
               label={`Rename ${file.name}`}
@@ -189,10 +229,13 @@ interface FolderCardV2Props {
   caption?: string;
   onDelete?: (() => void) | undefined;
   onRename?: (() => void) | undefined;
-  /** Optional share affordance. Only wired by the root-level collections
-   *  view — folders inside a collection don't surface this in V1 either.
-   *  Visibility (public/private) lives inside the share dialog. */
+  /** Opens the share dialog for this entry — the full access-management
+   *  dialog at the KB root (a collection card), or the copy-link-only
+   *  dialog for a regular subfolder. See KnowledgeBaseV2Screen's onShare. */
   onShare?: (() => void) | undefined;
+  /** Opens Ask AI scoped to this folder's owning collection (there's no
+   *  per-folder scope — see KnowledgeBaseV2Screen's onAskAIAboutEntry). */
+  onAskAI?: (() => void) | undefined;
   /** Opens the per-collection ingestion status drawer. Wired at the KB root
    *  only; clicking the badge must not trigger folder navigation. */
   onOpenStatus?: ((entry: CollectionChild) => void) | undefined;
@@ -209,6 +252,7 @@ export const FolderCardV2: React.FC<FolderCardV2Props> = ({
   onDelete,
   onRename,
   onShare,
+  onAskAI,
   onOpenStatus,
   isRenaming,
   onRenameCommit,
@@ -216,8 +260,10 @@ export const FolderCardV2: React.FC<FolderCardV2Props> = ({
 }) => {
   return (
     <div className='group relative'>
-      {/* Rendered as a role=button div (not a <button>) so the status badge can
-          be a real nested button on the folder glyph. */}
+      {/* Rendered as a role=button div (not a <button>) — matches FileCardV2's
+          structure so mixed grids line up. The status badge is a real nested
+          button overlaid on the folder glyph, so it needs its own
+          stopPropagation to avoid triggering navigation. */}
       <div
         role='button'
         tabIndex={isRenaming ? -1 : 0}
@@ -276,8 +322,20 @@ export const FolderCardV2: React.FC<FolderCardV2Props> = ({
           </span>
         </span>
       </div>
-      {!isRenaming && (onShare || onRename || onDelete) ? (
-        <div className='absolute right-2 top-2 flex gap-1'>
+      {!isRenaming && (onAskAI || onShare || onRename || onDelete) ? (
+        <div className='absolute right-2 top-2 z-10 flex gap-1'>
+          {onAskAI ? (
+            <HoverAction
+              label={`Ask AI about ${folder.name}`}
+              trackName='ask-ai-folder-card'
+              onClick={ev => {
+                ev.stopPropagation();
+                onAskAI();
+              }}
+            >
+              <XyneAIStar size={14} />
+            </HoverAction>
+          ) : null}
           {onShare ? (
             <HoverAction
               label={`Share ${folder.name}`}

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/FileFailedBadgeV2.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/FileFailedBadgeV2.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { AlertCircle } from 'lucide-react';
+import Tooltip from '../../ui/Tooltip';
+
+interface FileFailedBadgeV2Props {
+  status: string | null | undefined;
+}
+
+/**
+ * Small circular status indicator overlaid on a file's icon, matching
+ * CollectionStatusBadgeV2's folder styling — but only ever rendered for a
+ * FAILED file (PENDING/PROCESSING keep IngestStatusV2's text pill instead).
+ */
+export const FileFailedBadgeV2: React.FC<FileFailedBadgeV2Props> = ({ status }) => {
+  if ((status ?? '').toUpperCase() !== 'FAILED') return null;
+
+  return (
+    <Tooltip content='Failed to process this file' side='top'>
+      <span
+        aria-label='Failed to process this file'
+        className='grid h-5 w-5 place-items-center rounded-full bg-background ring-1 ring-border'
+      >
+        <AlertCircle className='h-3.5 w-3.5 text-red-500' strokeWidth={2} />
+      </span>
+    </Tooltip>
+  );
+};

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/IngestStatusV2.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/IngestStatusV2.tsx
@@ -1,10 +1,21 @@
 import React from 'react';
 import { cn } from '../../../utils/classNames';
-import { Loader2, AlertCircle } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 
 interface IngestStatusV2Props {
   status: string | null | undefined;
 }
+
+// Small pill badge — dot/icon + label, matching the tag chips on Canvas
+// cards (CanvasList.tsx's label pills: rounded-md border, muted background,
+// h-5, 11px text) rather than the bare unlabeled icon this used to be.
+// FAILED is deliberately absent here — a failed file instead gets the same
+// circular badge a failed folder does (see FileFailedBadgeV2), not a text
+// pill, so failure reads consistently across both.
+const STATUS_CONFIG: Record<string, { label: string; textClassName: string }> = {
+  PENDING: { label: 'Pending', textClassName: 'text-muted-foreground' },
+  PROCESSING: { label: 'Processing', textClassName: 'text-amber-600 dark:text-amber-400' },
+};
 
 export const IngestStatusV2: React.FC<IngestStatusV2Props> = ({ status }) => {
   if (!status || status === 'COMPLETED' || status === 'NONE') {
@@ -12,30 +23,19 @@ export const IngestStatusV2: React.FC<IngestStatusV2Props> = ({ status }) => {
   }
 
   const normalized = status.toUpperCase();
+  const config = STATUS_CONFIG[normalized];
+  if (!config) return null;
 
-  if (normalized === 'PENDING') {
-    return (
-      <span className={cn('inline-flex h-4 w-4 items-center justify-center')} title='Pending'>
-        <Loader2 className='h-3 w-3 animate-spin text-gray-400' strokeWidth={1.75} />
-      </span>
-    );
-  }
-
-  if (normalized === 'PROCESSING') {
-    return (
-      <span className={cn('inline-flex h-4 w-4 items-center justify-center')} title='Processing'>
-        <Loader2 className='h-3 w-3 animate-spin text-amber-500' strokeWidth={1.75} />
-      </span>
-    );
-  }
-
-  if (normalized === 'FAILED') {
-    return (
-      <span className={cn('inline-flex h-4 w-4 items-center justify-center')} title='Failed'>
-        <AlertCircle className='h-3 w-3 text-red-500' strokeWidth={1.75} />
-      </span>
-    );
-  }
-
-  return null;
+  return (
+    <span
+      className={cn(
+        'inline-flex h-5 max-w-full shrink-0 items-center gap-1 rounded-md border border-border bg-muted px-1.5 text-[11px] leading-none',
+        config.textClassName,
+      )}
+      title={config.label}
+    >
+      <Loader2 className='h-2.5 w-2.5 shrink-0 animate-spin' strokeWidth={2} />
+      <span className='truncate'>{config.label}</span>
+    </span>
+  );
 };

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/KbContentsPanel.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/KbContentsPanel.tsx
@@ -1,0 +1,560 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { PanelLeftCloseIcon, PanelLeftOpenIcon } from 'lucide-react';
+import { ChevronBigDown, ChevronBigRight, FileText, FolderDefault, SearchBig } from '@xyne/icons';
+import { CollectionTreeNode } from '../../knowledgeBase/tree/treeTypes';
+import { HighlightedText } from '../../Canvas/CanvasRow';
+import { cn } from '../../../utils/classNames';
+import Tooltip from '../../ui/Tooltip';
+import Input from '../../ui/Input';
+
+// Styled to match the Canvas sidebar's grouped list (CanvasListGroupedContent)
+// for a uniform feel across panels — same row/hover/selected treatment and
+// sidebar-* color tokens, same @xyne/icons chevrons/folder/file glyphs. The
+// chevron, icon, and label all live inside this one rounded box (not a
+// separate unstyled chevron beside a separately-rounded label), so hover and
+// the active/selected fill cover the whole row as a single pill, exactly
+// like CanvasListGroupedContent's folder row.
+// px-3/gap-3 (not px-2/gap-2) matters beyond visual match: the guide rail's
+// `ml-[18px]` below is derived from this exact padding (12px + half the
+// 12px chevron glyph = 18px, centring the rail under the chevron) — using
+// Canvas's own px-3 keeps that constant correct instead of silently
+// misaligning the rail by the padding difference.
+const ROW_CLASS =
+  'group flex items-center gap-3 h-9 px-3 rounded-[10px] border border-transparent text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground';
+const ROW_ACTIVE_CLASS = 'bg-sidebar-accent border-sidebar-border text-sidebar-accent-foreground';
+
+export interface KbContentsFile {
+  id: string;
+  name: string;
+}
+
+interface OutlineNode {
+  id: string;
+  name: string;
+  children: OutlineNode[];
+}
+
+// Folders only — mirrors a Wikipedia Contents box, which outlines headings
+// (sections) rather than body text. Files render as leaves under each
+// folder (see `filesByFolder`) once that folder is expanded.
+function buildOutline(ids: string[], nodes: Record<string, CollectionTreeNode>): OutlineNode[] {
+  return ids
+    .map(id => nodes[id])
+    .filter((n): n is CollectionTreeNode => n !== undefined && n.type === 'FOLDER')
+    .map(n => ({
+      id: n.id,
+      name: n.name,
+      children: buildOutline(n.childrenIds, nodes),
+    }));
+}
+
+// True if this folder's own name matches, any of its direct files match, or
+// anything further down its subtree does — used to decide whether a branch
+// survives filtering at all when searching.
+function outlineNodeMatches(
+  node: OutlineNode,
+  filesByFolder: Map<string, KbContentsFile[]>,
+  query: string,
+): boolean {
+  if (node.name.toLowerCase().includes(query)) return true;
+  const files = filesByFolder.get(node.id) ?? [];
+  if (files.some(f => f.name.toLowerCase().includes(query))) return true;
+  return node.children.some(child => outlineNodeMatches(child, filesByFolder, query));
+}
+
+function filterOutline(
+  list: OutlineNode[],
+  filesByFolder: Map<string, KbContentsFile[]>,
+  query: string,
+): OutlineNode[] {
+  return list
+    .filter(n => outlineNodeMatches(n, filesByFolder, query))
+    .map(n => ({ ...n, children: filterOutline(n.children, filesByFolder, query) }));
+}
+
+interface OutlineRowProps {
+  label: string;
+  isActive: boolean;
+  hasChildren: boolean;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  onClick: () => void;
+  highlightQuery?: string | undefined;
+}
+
+// No per-row indentation here — depth comes entirely from GuideRail wrapping
+// (below), same as CanvasListGroupedContent's folder rows: children sit
+// behind a vertical guide rail rather than an ever-larger flat padding, so
+// nested levels read as a connected tree instead of just shifting right.
+const OutlineRow: React.FC<OutlineRowProps> = ({
+  label,
+  isActive,
+  hasChildren,
+  isExpanded,
+  onToggleExpand,
+  onClick,
+  highlightQuery,
+}) => (
+  // The row itself owns the navigate click — not just the label button next
+  // to it — so the gap-3 space between the chevron/icon and the label (and
+  // the icon itself) is clickable too, instead of a dead zone in the middle
+  // of a row that visually hovers as one piece. The chevron stays its own
+  // nested button and stops propagation so it can still toggle independently
+  // without also firing a navigate.
+  <div
+    role='button'
+    tabIndex={0}
+    onClick={onClick}
+    onKeyDown={e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick();
+      }
+    }}
+    data-track-category='knowledge-base'
+    data-track-name='kb-contents-navigate'
+    className={cn(ROW_CLASS, isActive && ROW_ACTIVE_CLASS)}
+  >
+    {hasChildren ? (
+      <button
+        type='button'
+        onClick={e => {
+          e.stopPropagation();
+          onToggleExpand();
+        }}
+        aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
+        data-track-category='knowledge-base'
+        data-track-name='kb-contents-toggle-section'
+        className='flex shrink-0 items-center gap-2'
+      >
+        {isExpanded ? (
+          <ChevronBigDown size={12} className='shrink-0' />
+        ) : (
+          <ChevronBigRight size={12} className='shrink-0' />
+        )}
+        <FolderDefault size={16} className='shrink-0' />
+      </button>
+    ) : (
+      <span className='flex shrink-0 items-center'>
+        <FolderDefault size={16} className='shrink-0' />
+      </span>
+    )}
+    <span className='min-w-0 flex-1 truncate text-left text-sm font-medium tracking-[-0.14px]'>
+      <HighlightedText text={label} query={highlightQuery} />
+    </span>
+  </div>
+);
+
+const FileLeafRow: React.FC<{
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  highlightQuery?: string | undefined;
+}> = ({ label, isActive, onClick, highlightQuery }) => (
+  <button
+    type='button'
+    onClick={onClick}
+    data-track-category='knowledge-base'
+    data-track-name='kb-contents-open-file'
+    className={cn(ROW_CLASS, 'w-full text-left', isActive && ROW_ACTIVE_CLASS)}
+  >
+    {/* Mirrors a folder row's chevron slot exactly — same wrapper
+        (`flex items-center gap-2`), same 12px reserved width standing in
+        for the chevron glyph — so the file icon lands at the identical
+        offset a folder's icon does at the same depth, not just "close".
+        Deriving this from the row's own gap value instead (a file row has
+        no separate nested slot, so the icon would sit directly after the
+        spacer under the row's outer gap) breaks the moment that gap value
+        changes, which is exactly what silently misaligned this before. */}
+    <span className='flex shrink-0 items-center gap-2'>
+      <span className='w-3 shrink-0' aria-hidden='true' />
+      <FileText size={16} className='shrink-0' />
+    </span>
+    <Tooltip content={label} side='top' align='start' className='max-w-xs break-words'>
+      <span className='block min-w-0 flex-1 truncate text-sm font-medium tracking-[-0.14px]'>
+        <HighlightedText text={label} query={highlightQuery} />
+      </span>
+    </Tooltip>
+  </button>
+);
+
+// Indents a folder's children by the same amount whether or not a line is
+// drawn. `showLine` is only true for the files sitting directly inside a
+// folder — the last level before content, matching a Wikipedia TOC's
+// headings-then-page shape. Turning it on for every folder-to-folder level
+// too (KB nests folders arbitrarily deep, unlike Canvas's single-level
+// folders) stacks a rail per level and reads as visual noise well before
+// you reach any actual files. The 18px offset centres the rail on the
+// parent row's chevron (12px glyph + the row's own gap-2 to the icon).
+// `border-sidebar-border` (semi-transparent, not a flat light-mode gray)
+// over the generic `border-border` token — the latter is tuned for subtle
+// card-on-card dividers and reads as nearly invisible against this panel's
+// background; the alpha-based sidebar token stays visible on both a light
+// and a dark backdrop, matching the border the active-row highlight below
+// already uses.
+const GuideRail: React.FC<{ children: React.ReactNode; showLine: boolean }> = ({
+  children,
+  showLine,
+}) => (
+  <div className={cn('ml-[18px] pl-3', showLine && 'border-l border-sidebar-border')}>
+    {children}
+  </div>
+);
+
+interface TreeState {
+  activeFolderId: string | null;
+  activeFileId: string | null;
+  activePath: Set<string>;
+  filesByFolder: Map<string, KbContentsFile[]>;
+  // Explicit open/closed overrides, keyed by folder id — lifted to the top
+  // of the panel (not per-row local state) so a folder's expanded state
+  // survives its parent collapsing and re-expanding. Local state would
+  // unmount every descendant on collapse (they're not rendered) and lose
+  // it; Canvas avoids exactly this by keeping one flat `collapsedFolders`
+  // Set in its top-level list component instead of per-row state.
+  expandOverrides: Map<string, boolean>;
+  // While searching, every filtered-in branch renders fully expanded — the
+  // filtering already trimmed the tree to just the matches (and their
+  // ancestors), so there's nothing left to hide behind a closed chevron.
+  isSearchActive: boolean;
+  highlightQuery: string | undefined;
+  onToggleExpand: (folderId: string, currentlyExpanded: boolean) => void;
+  onNavigate: (folderId: string) => void;
+  // `folderId` is the file's actual parent (this folder, in every call site
+  // here) — not necessarily whichever folder is currently active. Every
+  // folder's files are preloaded, so you can open a file from a folder
+  // you're not browsing; using the active folder instead would point the
+  // resulting URL at the wrong folder and the viewer would show nothing.
+  onOpenFile: (fileId: string, folderId: string | null) => void;
+}
+
+const OutlineBranch: React.FC<{ node: OutlineNode; state: TreeState }> = ({ node, state }) => {
+  const {
+    activeFolderId,
+    activeFileId,
+    activePath,
+    filesByFolder,
+    expandOverrides,
+    isSearchActive,
+    highlightQuery,
+    onToggleExpand,
+    onNavigate,
+    onOpenFile,
+  } = state;
+  const isActive = activeFolderId === node.id;
+  const expanded = isSearchActive
+    ? true
+    : expandOverrides.has(node.id)
+      ? (expandOverrides.get(node.id) as boolean)
+      : activePath.has(node.id);
+  const files = filesByFolder.get(node.id) ?? [];
+  const hasKnownChildren = node.children.length > 0;
+
+  return (
+    <>
+      <OutlineRow
+        label={node.name}
+        isActive={isActive}
+        hasChildren
+        isExpanded={expanded}
+        highlightQuery={highlightQuery}
+        onToggleExpand={() => onToggleExpand(node.id, expanded)}
+        onClick={() => {
+          onNavigate(node.id);
+          // Not open yet → reveal it. Already open and already the folder
+          // you're in → a re-click is a deliberate "close this", matching
+          // the chevron. But navigating into a *different* folder that
+          // happens to already be expanded in the tree shouldn't collapse
+          // it out from under you the moment you arrive.
+          if (!expanded || isActive) onToggleExpand(node.id, expanded);
+        }}
+      />
+      {expanded && (hasKnownChildren || files.length > 0) ? (
+        // One rail for the whole sibling group (subfolders *and* files
+        // together), not two separate ones — splitting them made a root
+        // level with both a folder and a file (a common shape) show a line
+        // that only started partway down, right above the file, instead of
+        // connecting from the top the way the sibling folder above it does.
+        <GuideRail showLine={files.length > 0}>
+          {node.children.map(child => (
+            <OutlineBranch key={child.id} node={child} state={state} />
+          ))}
+          {files.map(file => (
+            <FileLeafRow
+              key={file.id}
+              label={file.name}
+              isActive={activeFileId === file.id}
+              onClick={() => onOpenFile(file.id, node.id)}
+              highlightQuery={highlightQuery}
+            />
+          ))}
+        </GuideRail>
+      ) : null}
+    </>
+  );
+};
+
+export interface KbContentsRootCollection {
+  id: string;
+  name: string;
+}
+
+interface KbContentsPanelProps {
+  collectionName: string;
+  collectionId: string;
+  activeFolderId: string | null;
+  activeFileId: string | null;
+  nodes: Record<string, CollectionTreeNode>;
+  rootChildrenIds: string[];
+  filesByFolder: Map<string, KbContentsFile[]>;
+  activePath: Set<string>;
+  collapsed: boolean;
+  onNavigate: (folderId: string | null) => void;
+  onOpenFile: (fileId: string, folderId: string | null) => void;
+  onToggleCollapsed: () => void;
+  /** KB root mode: no single collection is open, so the panel lists every
+   *  top-level collection flat (no nesting — a collection's own subfolders
+   *  aren't loaded until you're inside it) instead of one collection's
+   *  folder tree. When set, `onNavigateCollection` is required and the
+   *  single-collection props above (`nodes`/`rootChildrenIds`/etc.) are
+   *  ignored. */
+  rootCollections?: KbContentsRootCollection[] | undefined;
+  onNavigateCollection?: ((collectionId: string) => void) | undefined;
+}
+
+export const KbContentsPanel: React.FC<KbContentsPanelProps> = ({
+  collectionName,
+  collectionId,
+  activeFolderId,
+  activeFileId,
+  nodes,
+  rootChildrenIds,
+  filesByFolder,
+  activePath,
+  collapsed,
+  onNavigate,
+  onOpenFile,
+  onToggleCollapsed,
+  rootCollections,
+  onNavigateCollection,
+}) => {
+  const outline = useMemo(() => buildOutline(rootChildrenIds, nodes), [rootChildrenIds, nodes]);
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const isSearchActive = normalizedQuery.length > 0;
+
+  // Trims both the folder outline and each folder's own file list down to
+  // matches (plus, for folders, any ancestor of a match so the result is
+  // still reachable) — computed once here so neither `OutlineBranch` nor
+  // the root-level render needs to know search exists beyond reading these.
+  const filteredOutline = useMemo(
+    () => (isSearchActive ? filterOutline(outline, filesByFolder, normalizedQuery) : outline),
+    [outline, filesByFolder, isSearchActive, normalizedQuery],
+  );
+  const filteredFilesByFolder = useMemo(() => {
+    if (!isSearchActive) return filesByFolder;
+    const next = new Map<string, KbContentsFile[]>();
+    for (const [folderId, files] of filesByFolder) {
+      const matched = files.filter(f => f.name.toLowerCase().includes(normalizedQuery));
+      if (matched.length > 0) next.set(folderId, matched);
+    }
+    return next;
+  }, [filesByFolder, isSearchActive, normalizedQuery]);
+  const rootFiles = filteredFilesByFolder.get(collectionId) ?? [];
+
+  const filteredRootCollections = useMemo(() => {
+    if (!rootCollections) return undefined;
+    if (!isSearchActive) return rootCollections;
+    return rootCollections.filter(c => c.name.toLowerCase().includes(normalizedQuery));
+  }, [rootCollections, isSearchActive, normalizedQuery]);
+
+  const [expandOverrides, setExpandOverrides] = useState<Map<string, boolean>>(new Map());
+  const onToggleExpand = useCallback((folderId: string, currentlyExpanded: boolean): void => {
+    setExpandOverrides(prev => {
+      const next = new Map(prev);
+      next.set(folderId, !currentlyExpanded);
+      return next;
+    });
+  }, []);
+
+  // A manual toggle from an earlier visit shouldn't keep overriding a
+  // folder's default forever — e.g. collapsing it once, then navigating
+  // away and back later, should reflect "the active folder defaults open"
+  // again rather than the stale collapse from last time. Only the folder
+  // *newly* becoming active gets its override cleared; everything else you
+  // toggled while browsing elsewhere in the tree is left alone.
+  const lastActiveFolderIdRef = useRef(activeFolderId);
+  useEffect(() => {
+    if (activeFolderId === lastActiveFolderIdRef.current) return;
+    lastActiveFolderIdRef.current = activeFolderId;
+    if (!activeFolderId) return;
+    setExpandOverrides(prev => {
+      if (!prev.has(activeFolderId)) return prev;
+      const next = new Map(prev);
+      next.delete(activeFolderId);
+      return next;
+    });
+  }, [activeFolderId]);
+
+  // `activePath` (from the layout) is only ever "the path to wherever you
+  // are right now" — it's recomputed fresh on every navigation, so a folder
+  // that was open purely by being on *yesterday's* path (not by an explicit
+  // toggle) would drop out and read as closed the moment you navigated to a
+  // sibling instead, making it look like opening one folder closes another.
+  // Accumulating every path the tree has shown into this set instead means
+  // a folder that was ever revealed stays open (until the user explicitly
+  // collapses it — that's what `expandOverrides` is for) regardless of
+  // where you navigate to next, so multiple folders can stay open at once.
+  const [autoOpenedIds, setAutoOpenedIds] = useState<Set<string>>(() => new Set(activePath));
+  useEffect(() => {
+    setAutoOpenedIds(prev => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const id of activePath) {
+        if (!next.has(id)) {
+          next.add(id);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [activePath]);
+
+  const treeState: TreeState = {
+    activeFolderId,
+    activeFileId,
+    activePath: autoOpenedIds,
+    filesByFolder: filteredFilesByFolder,
+    expandOverrides,
+    isSearchActive,
+    highlightQuery: isSearchActive ? normalizedQuery : undefined,
+    onToggleExpand,
+    onNavigate,
+    onOpenFile,
+  };
+
+  if (collapsed) {
+    return (
+      <div className='flex h-full flex-col items-center bg-background py-3'>
+        <Tooltip content='Show contents panel' side='right'>
+          <button
+            type='button'
+            onClick={onToggleCollapsed}
+            aria-label='Show contents panel'
+            data-track-category='knowledge-base'
+            data-track-name='kb-show-contents'
+            className='grid size-7 shrink-0 place-items-center rounded-lg border border-transparent text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+          >
+            <PanelLeftOpenIcon className='size-4' strokeWidth={2.1} />
+          </button>
+        </Tooltip>
+      </div>
+    );
+  }
+
+  return (
+    <nav
+      aria-label='Collection contents'
+      className='flex h-full flex-col overflow-hidden bg-background'
+    >
+      <div className='shrink-0 px-2.5 pt-3'>
+        <div className='flex items-center justify-between gap-2 px-1.5 py-1'>
+          <h2 className='truncate text-base font-bold leading-normal text-sidebar-accent-foreground'>
+            Contents
+          </h2>
+          <Tooltip content='Hide contents panel' side='bottom' delayDuration={300}>
+            <button
+              type='button'
+              onClick={onToggleCollapsed}
+              aria-label='Hide contents panel'
+              data-track-category='knowledge-base'
+              data-track-name='kb-hide-contents'
+              className='size-7 flex items-center justify-center rounded-lg border border-transparent text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+            >
+              <PanelLeftCloseIcon className='size-4' strokeWidth={2.1} />
+            </button>
+          </Tooltip>
+        </div>
+        <div className='relative mt-2'>
+          <SearchBig
+            size={16}
+            className='absolute left-3 top-1/2 -translate-y-1/2 text-sidebar-foreground'
+          />
+          <Input
+            type='text'
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            placeholder='Search by name'
+            className='h-9 pl-9'
+            aria-label='Search files and folders by name'
+            data-track-category='knowledge-base'
+            data-track-name='kb-contents-search'
+          />
+        </div>
+      </div>
+
+      <div className='flex-1 min-h-0 overflow-auto no-scrollbar px-2.5 pt-2 pb-3'>
+        <div className='space-y-0.5'>
+          {filteredRootCollections ? (
+            filteredRootCollections.length > 0 ? (
+              filteredRootCollections.map(c => (
+                <OutlineRow
+                  key={c.id}
+                  label={c.name}
+                  isActive={false}
+                  hasChildren={false}
+                  isExpanded={false}
+                  onToggleExpand={() => {}}
+                  onClick={() => onNavigateCollection?.(c.id)}
+                  highlightQuery={treeState.highlightQuery}
+                />
+              ))
+            ) : (
+              <p className='px-1.5 py-1 text-[13px] text-sidebar-foreground/60'>
+                {isSearchActive
+                  ? `No collections match “${searchQuery.trim()}”`
+                  : 'No collections yet'}
+              </p>
+            )
+          ) : (
+            <>
+              {!isSearchActive ? (
+                <OutlineRow
+                  label={collectionName}
+                  isActive={activeFolderId === null}
+                  hasChildren={false}
+                  isExpanded={false}
+                  onToggleExpand={() => {}}
+                  onClick={() => onNavigate(null)}
+                />
+              ) : null}
+              {filteredOutline.length > 0 || rootFiles.length > 0 ? (
+                <GuideRail showLine={rootFiles.length > 0}>
+                  {filteredOutline.map(node => (
+                    <OutlineBranch key={node.id} node={node} state={treeState} />
+                  ))}
+                  {rootFiles.map(file => (
+                    <FileLeafRow
+                      key={file.id}
+                      label={file.name}
+                      isActive={activeFileId === file.id}
+                      onClick={() => onOpenFile(file.id, null)}
+                      highlightQuery={treeState.highlightQuery}
+                    />
+                  ))}
+                </GuideRail>
+              ) : isSearchActive ? (
+                <p className='px-1.5 py-1 text-[13px] text-sidebar-foreground/60'>
+                  No files or folders match &ldquo;{searchQuery.trim()}&rdquo;
+                </p>
+              ) : null}
+            </>
+          )}
+        </div>
+      </div>
+    </nav>
+  );
+};
+
+export default KbContentsPanel;

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/ShareLinkModal.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/ShareLinkModal.tsx
@@ -1,0 +1,92 @@
+import { ReactElement } from 'react';
+import { toast } from 'sonner';
+import { Globe, Link2, X } from 'lucide-react';
+import Dialog from '../../ui/Dialog';
+import { Button } from '../../ui/Button/Button';
+
+interface ShareLinkModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Entry name, shown in the dialog title ("Share <name>"). */
+  title: string;
+  /** Pre-built deep link to the entry. */
+  link: string;
+}
+
+/**
+ * Lightweight share dialog for individual files/folders — copy-link only, no
+ * per-user access management. Folders/files have no ACL of their own; access
+ * is entirely inherited from the owning collection (see buildEntryLink in
+ * KnowledgeBaseV2Screen.tsx), so unlike ShareCollectionModal there's nothing
+ * to grant here — just the link.
+ */
+export const ShareLinkModal = ({
+  isOpen,
+  onClose,
+  title,
+  link,
+}: ShareLinkModalProps): ReactElement => {
+  const handleCopyLink = (): void => {
+    void navigator.clipboard.writeText(link).then(
+      () => toast.success('Link copied'),
+      () => toast.error('Could not copy link'),
+    );
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={open => {
+        if (!open) onClose();
+      }}
+      title={`Share ${title}`}
+      description={`Share a link to "${title}"`}
+      className='max-w-md bg-popover border border-border'
+    >
+      <div className='p-6'>
+        <div className='flex items-center justify-between mb-6'>
+          <h2 className='text-lg font-semibold text-foreground truncate pr-4'>Share {title}</h2>
+          <button
+            onClick={onClose}
+            className='p-1 hover:bg-muted rounded transition-colors flex-shrink-0'
+            data-track-category='knowledge-base'
+            data-track-name='close-share-link-modal'
+          >
+            <X size={20} className='text-muted-foreground' />
+          </button>
+        </div>
+
+        <div className='mb-6'>
+          <div className='block text-sm font-medium text-foreground mb-2'>General access</div>
+          <div className='flex items-center gap-3 rounded-md border border-border bg-muted/40 p-3'>
+            <div className='flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-background ring-1 ring-border text-muted-foreground'>
+              <Globe size={16} />
+            </div>
+            <div className='flex-1 min-w-0'>
+              <div className='text-sm font-medium text-foreground'>Anyone with the link</div>
+              <p className='mt-0.5 text-xs text-muted-foreground'>
+                Anyone with access to the collection this belongs to can open it via the link.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className='flex items-center justify-between gap-3 border-t border-border pt-4'>
+          <button
+            type='button'
+            onClick={handleCopyLink}
+            data-track-category='knowledge-base'
+            data-track-name='share-link-modal-copy'
+            className='inline-flex items-center gap-2 rounded-md px-2.5 py-1.5 -ml-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-primary'
+          >
+            <Link2 size={16} />
+            Copy link
+          </button>
+          <Button onClick={onClose}>Done</Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export default ShareLinkModal;

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/StatusBadgeV2.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/StatusBadgeV2.tsx
@@ -30,9 +30,13 @@ function extOf(name: string): string | undefined {
 
 interface StatusBadgeV2Props {
   name: string;
+  /** 'sm' shrinks the badge to sit inline next to a plain 16px icon (e.g. a
+   *  dropdown filter row alongside the Folders option) instead of the
+   *  default card/list glyph size. */
+  size?: 'sm' | 'md';
 }
 
-export const StatusBadgeV2: React.FC<StatusBadgeV2Props> = ({ name }) => {
+export const StatusBadgeV2: React.FC<StatusBadgeV2Props> = ({ name, size = 'md' }) => {
   const ext = extOf(name) || 'file';
   const tone = TONE_FOR_EXT[ext] ?? 'bg-zinc-500 text-white';
   const label = ext.toUpperCase().slice(0, 4);
@@ -41,7 +45,8 @@ export const StatusBadgeV2: React.FC<StatusBadgeV2Props> = ({ name }) => {
     <span
       aria-hidden
       className={cn(
-        'grid h-7 w-7 flex-shrink-0 place-items-center rounded-md text-[8.5px] font-semibold uppercase tracking-wide',
+        'grid flex-shrink-0 place-items-center font-semibold uppercase tracking-wide',
+        size === 'sm' ? 'h-4 w-4 rounded text-[5px]' : 'h-7 w-7 rounded-md text-[8.5px]',
         tone,
       )}
     >

--- a/apps/dashboard/src/components/knowledgeBaseV2/hooks/useGlobalCollections.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/hooks/useGlobalCollections.tsx
@@ -1,22 +1,27 @@
-import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import React, { createContext, useContext, useMemo } from 'react';
 import { useAllVisibleChannels } from '../../../hooks/useChannels';
 import { useAuth } from '../../../hooks/useAuth';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useUserGroupMappings } from '../../../hooks/useUserGroup';
 import { IngestionStatus } from '@xyne/shared';
 import { queries } from '../../../zero/queries';
 import { CollectionRole, CollectionSummary } from '../../../services/Knowledge/collectionService';
 
-// Lists every collection the caller can read across all visible channels.
-// We can't add a global `myCollections` Zero query without touching shared
-// schema, so instead we fan `scopedCollections` out one channel at a time
-// and merge results in the provider. Each visible channel pays one Zero
-// subscription; for typical users that's a small handful.
+const ROLE_RANK: Record<CollectionRole, number> = { VIEWER: 1, EDITOR: 2, OWNER: 3 };
+
+// Lists every collection the caller can read across the whole workspace, in
+// a single Zero subscription. `scopedCollectionsWithItems` already treats
+// scopeType/scopeId as optional — omitting both returns every root
+// collection the Zero ACL allows (owner, explicit permission, or public),
+// regardless of channel scope or membership. Channel/project labels are then
+// resolved client-side per row (best-effort — a public collection scoped to
+// a channel the current user isn't a member of has no name/project to show).
 
 export interface GlobalCollection extends CollectionSummary {
   scopeType: string;
   scopeId: string;
-  /** projectId of the owning channel, when known. Needed to build the
-   *  existing /knowledge-base/<projectId>/<channelId>/<collectionId> URL. */
+  /** projectId of the owning channel, when known (CHANNEL-scoped rows whose
+   *  channel is in the current user's visible-channel list only). */
   projectId: string | null;
   isPrivate: boolean;
   /** Total number of (latest, non-deleted) files across the whole collection. */
@@ -39,150 +44,112 @@ interface GlobalCollectionsContextValue {
 
 const GlobalCollectionsContext = createContext<GlobalCollectionsContextValue | null>(null);
 
-interface ChannelCollectionsLoaderProps {
-  channelId: string;
-  projectId: string | null;
-  onLoad: (channelId: string, rows: GlobalCollection[]) => void;
-  onLoadingChange: (channelId: string, loading: boolean) => void;
-}
-
-const ChannelCollectionsLoader: React.FC<ChannelCollectionsLoaderProps> = React.memo(
-  ({ channelId, projectId, onLoad, onLoadingChange }) => {
-    const { user } = useAuth();
-    const enabled = !!user && !!channelId;
-    const [zeroCollections, { type: queryType }] = useCachedQuery(
-      queries.scopedCollectionsWithItems({ scopeType: 'CHANNEL', scopeId: channelId }),
-      // Object form required — a bare boolean is ignored by useCachedQuery.
-      { enabled },
-    );
-
-    const loading = enabled && queryType !== 'complete';
-    const lastLoadingRef = useRef<boolean | null>(null);
-    if (lastLoadingRef.current !== loading) {
-      lastLoadingRef.current = loading;
-      // Schedule the change after render to avoid setState-in-render warnings.
-      queueMicrotask(() => onLoadingChange(channelId, loading));
-    }
-
-    const mapped: GlobalCollection[] = useMemo(() => {
-      if (!zeroCollections || !user) return [];
-      return zeroCollections.map(col => {
-        const perm = col.permissions?.find(p => p.userId === user.id);
-        const isOwner = col.ownerId === user.id;
-        const defaultRole = isOwner ? 'OWNER' : col.isPrivate ? 'VIEWER' : 'EDITOR';
-
-        // Roll the collection's files up into an ingestion summary. Normalize
-        // casing the same way IngestStatusV2 does so status never slips through.
-        const items = col.allItems ?? [];
-        const fileTotal = items.length;
-        let fileFailed = 0;
-        let filePending = 0;
-        let fileProcessing = 0;
-        for (const it of items) {
-          const s = (it.ingestionStatus ?? '').toUpperCase() as IngestionStatus;
-          if (s === IngestionStatus.FAILED) fileFailed += 1;
-          else if (s === IngestionStatus.PROCESSING) fileProcessing += 1;
-          else if (s === IngestionStatus.PENDING) filePending += 1;
-        }
-        const fileIngested = fileTotal - fileFailed - fileProcessing - filePending;
-        // Loader colour: blue as soon as any file is actively PROCESSING; grey
-        // while everything in-flight is still only queued (PENDING); red alert
-        // when nothing is in-flight but something failed; nothing when settled.
-        const ingestionStatus =
-          fileProcessing > 0
-            ? IngestionStatus.PROCESSING
-            : filePending > 0
-              ? IngestionStatus.PENDING
-              : fileFailed > 0
-                ? IngestionStatus.FAILED
-                : null;
-
-        return {
-          id: col.id,
-          name: col.name,
-          description: col.description ?? null,
-          ownerId: col.ownerId,
-          role: (perm?.role ?? defaultRole) as CollectionRole,
-          canShare: perm?.canShare ?? isOwner,
-          scopeType: 'CHANNEL',
-          scopeId: channelId,
-          projectId,
-          isPrivate: col.isPrivate ?? false,
-          fileTotal,
-          fileIngested,
-          fileFailed,
-          ingestionStatus,
-        };
-      });
-    }, [zeroCollections, user, channelId, projectId]);
-
-    const lastMappedRef = useRef<GlobalCollection[] | null>(null);
-    if (lastMappedRef.current !== mapped) {
-      lastMappedRef.current = mapped;
-      queueMicrotask(() => onLoad(channelId, mapped));
-    }
-    return null;
-  },
-);
-ChannelCollectionsLoader.displayName = 'ChannelCollectionsLoader';
-
 export const GlobalCollectionsProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
+  const { user } = useAuth();
   const channels = useAllVisibleChannels();
-  const [byChannel, setByChannel] = useState<Record<string, GlobalCollection[]>>({});
-  const [loadingByChannel, setLoadingByChannel] = useState<Record<string, boolean>>({});
+  const userGroupMappings = useUserGroupMappings();
+  const userGroupIds = useMemo(
+    () => new Set(userGroupMappings.map(m => m.userGroupId)),
+    [userGroupMappings],
+  );
+  const channelById = useMemo(() => {
+    const m = new Map<string, { name: string; projectId: string | null }>();
+    for (const ch of channels) {
+      m.set(ch.id, { name: ch.name, projectId: ch.projectId ?? null });
+    }
+    return m;
+  }, [channels]);
 
-  const handleLoad = useCallback((channelId: string, rows: GlobalCollection[]): void => {
-    setByChannel(prev => {
-      if (prev[channelId] === rows) return prev;
-      return { ...prev, [channelId]: rows };
-    });
-  }, []);
+  const enabled = !!user;
+  const [zeroCollections, { type: queryType }] = useCachedQuery(
+    queries.scopedCollectionsWithItems({}),
+    { enabled },
+  );
+  const isLoading = enabled && queryType !== 'complete';
 
-  const handleLoadingChange = useCallback((channelId: string, loading: boolean): void => {
-    setLoadingByChannel(prev => {
-      if (prev[channelId] === loading) return prev;
-      return { ...prev, [channelId]: loading };
-    });
-  }, []);
-
-  const value: GlobalCollectionsContextValue = useMemo(() => {
-    const flat: GlobalCollection[] = [];
-    const idIndex = new Map<string, GlobalCollection>();
-    for (const channelId of Object.keys(byChannel)) {
-      const rows = byChannel[channelId];
-      if (!rows) continue;
-      for (const row of rows) {
-        if (!idIndex.has(row.id)) {
-          idIndex.set(row.id, row);
-          flat.push(row);
+  const collections: GlobalCollection[] = useMemo(() => {
+    if (!zeroCollections || !user) return [];
+    return zeroCollections.map(col => {
+      // Pick the highest role among any matching row — a direct grant, or a
+      // grant on a group this user belongs to. Without the group branch, a
+      // group-granted EDITOR shows as VIEWER here (write buttons hidden)
+      // even though the server mutators (resolveCollectionPermissionRole)
+      // would allow the write — client/server role mismatch.
+      let perm: NonNullable<typeof col.permissions>[number] | undefined;
+      for (const p of col.permissions ?? []) {
+        const matches =
+          p.userId === user.id || (p.userGroupId !== null && userGroupIds.has(p.userGroupId));
+        if (!matches) continue;
+        if (!perm || ROLE_RANK[p.role as CollectionRole] > ROLE_RANK[perm.role as CollectionRole]) {
+          perm = p;
         }
       }
-    }
-    flat.sort((a, b) => a.name.localeCompare(b.name));
-    const isLoading =
-      channels.length === 0 ? false : channels.some(ch => loadingByChannel[ch.id] !== false);
+      const isOwner = col.ownerId === user.id;
+      // Public collections are read-only by default — EDITOR only comes
+      // from an explicit CollectionPermission row (`perm` below).
+      const defaultRole = isOwner ? 'OWNER' : 'VIEWER';
+
+      const channelMeta = col.scopeType === 'CHANNEL' ? channelById.get(col.scopeId) : undefined;
+
+      // Roll the collection's files up into an ingestion summary. Normalize
+      // casing the same way IngestStatusV2 does so status never slips through.
+      const items = col.allItems ?? [];
+      const fileTotal = items.length;
+      let fileFailed = 0;
+      let filePending = 0;
+      let fileProcessing = 0;
+      for (const it of items) {
+        const s = (it.ingestionStatus ?? '').toUpperCase() as IngestionStatus;
+        if (s === IngestionStatus.FAILED) fileFailed += 1;
+        else if (s === IngestionStatus.PROCESSING) fileProcessing += 1;
+        else if (s === IngestionStatus.PENDING) filePending += 1;
+      }
+      const fileIngested = fileTotal - fileFailed - fileProcessing - filePending;
+      // Loader colour: blue as soon as any file is actively PROCESSING; grey
+      // while everything in-flight is still only queued (PENDING); red alert
+      // when nothing is in-flight but something failed; nothing when settled.
+      const ingestionStatus =
+        fileProcessing > 0
+          ? IngestionStatus.PROCESSING
+          : filePending > 0
+            ? IngestionStatus.PENDING
+            : fileFailed > 0
+              ? IngestionStatus.FAILED
+              : null;
+
+      return {
+        id: col.id,
+        name: col.name,
+        description: col.description ?? null,
+        ownerId: col.ownerId,
+        role: (perm?.role ?? defaultRole) as CollectionRole,
+        canShare: perm?.canShare ?? isOwner,
+        scopeType: col.scopeType,
+        scopeId: col.scopeId,
+        projectId: channelMeta?.projectId ?? null,
+        isPrivate: col.isPrivate ?? false,
+        fileTotal,
+        fileIngested,
+        fileFailed,
+        ingestionStatus,
+      };
+    });
+  }, [zeroCollections, user, channelById, userGroupIds]);
+
+  const value: GlobalCollectionsContextValue = useMemo(() => {
+    const sorted = [...collections].sort((a, b) => a.name.localeCompare(b.name));
+    const idIndex = new Map(sorted.map(c => [c.id, c]));
     return {
-      collections: flat,
+      collections: sorted,
       isLoading,
       byId: (id: string): GlobalCollection | undefined => idIndex.get(id),
     };
-  }, [byChannel, loadingByChannel, channels]);
+  }, [collections, isLoading]);
 
   return (
-    <GlobalCollectionsContext.Provider value={value}>
-      {channels.map(ch => (
-        <ChannelCollectionsLoader
-          key={ch.id}
-          channelId={ch.id}
-          projectId={ch.projectId ?? null}
-          onLoad={handleLoad}
-          onLoadingChange={handleLoadingChange}
-        />
-      ))}
-      {children}
-    </GlobalCollectionsContext.Provider>
+    <GlobalCollectionsContext.Provider value={value}>{children}</GlobalCollectionsContext.Provider>
   );
 };
 

--- a/apps/dashboard/src/components/knowledgeBaseV2/utils/kbRoutePaths.ts
+++ b/apps/dashboard/src/components/knowledgeBaseV2/utils/kbRoutePaths.ts
@@ -1,0 +1,18 @@
+const AI_KNOWLEDGE_SEGMENT = '/ai/knowledge';
+const KB_SEGMENT = '/knowledge-base';
+
+// The KB folder browser and file viewer are reachable from two routes — the
+// standalone /knowledge-base screen and the embedded /ai/knowledge screen —
+// sharing the same components (KbContentsShell, KnowledgeBaseV2Screen,
+// FileViewerLayout). Every navigation built from inside those components
+// (opening a folder, opening a file, going back from the viewer) must stay
+// under whichever of the two the user is currently on, rather than always
+// hopping to /knowledge-base. This resolves that base path from the current
+// location, workspace prefix included.
+export function resolveKbBasePath(pathname: string): string {
+  const aiIndex = pathname.indexOf(AI_KNOWLEDGE_SEGMENT);
+  if (aiIndex !== -1) return pathname.slice(0, aiIndex + AI_KNOWLEDGE_SEGMENT.length);
+  const kbIndex = pathname.indexOf(KB_SEGMENT);
+  if (kbIndex !== -1) return pathname.slice(0, kbIndex + KB_SEGMENT.length);
+  return KB_SEGMENT;
+}

--- a/apps/dashboard/src/hooks/useDisabledToolbarPaths.ts
+++ b/apps/dashboard/src/hooks/useDisabledToolbarPaths.ts
@@ -1,0 +1,31 @@
+import { useMemo } from 'react';
+import { useCacConfig } from '@xyne/shared/hooks';
+import { useAuth } from './useAuth';
+import {
+  DISABLED_TOOLBAR_PATHS_CAC_KEY,
+  DEFAULT_DISABLED_TOOLBAR_PATHS_CAC_CONFIG,
+  type DisabledToolbarPathsCacConfig,
+} from '../components/AppSidebar/toolbarCacConfig';
+
+// Toolbar paths hidden via Superposition CAC (disabled_toolbar_paths) — one
+// global key shared by all of xyne-spaces. The VALUE, not the key, carries
+// the per-workspace split: a map from xyne-spaces workspaceId to that
+// workspace's hidden-path list (see toolbarCacConfig.ts for why — the
+// upstream Superposition instance is provisioned as a single org/workspace
+// for all of xyne-spaces in prod). Shared by the sidebar's visibility
+// filter (useVisibleNavigationItems) and the route-level guard
+// (ToolbarProtectedRoute) so both read the same set.
+export const useDisabledToolbarPaths = (): Set<string> => {
+  const { user } = useAuth();
+  const { config } = useCacConfig<DisabledToolbarPathsCacConfig>({
+    key: DISABLED_TOOLBAR_PATHS_CAC_KEY,
+    fallbackConfig: DEFAULT_DISABLED_TOOLBAR_PATHS_CAC_CONFIG,
+  });
+  const paths = user?.workspaceId ? config[user.workspaceId] : undefined;
+  // config has stable identity across renders (react-query keeps the same
+  // `data` reference until a refetch resolves), so memoizing on it keeps
+  // this Set's identity stable too — callers put it in useMemo/useCallback
+  // deps (useVisibleNavigationItems), which would otherwise recompute every
+  // render against a freshly-built Set.
+  return useMemo(() => new Set(paths ?? []), [paths]);
+};

--- a/apps/dashboard/src/hooks/useVisibleNavigationItems.ts
+++ b/apps/dashboard/src/hooks/useVisibleNavigationItems.ts
@@ -9,6 +9,7 @@ import {
   type NavigationItem,
 } from '../components/AppSidebar/navigationConfig';
 import { useClawDashboardVisibility } from './useClawDashboardVisibility';
+import { useDisabledToolbarPaths } from './useDisabledToolbarPaths';
 
 // Navigation items the current user is allowed to see, in canonical order.
 export const useVisibleNavigationItems = (): NavigationItem[] => {
@@ -20,6 +21,7 @@ export const useVisibleNavigationItems = (): NavigationItem[] => {
   );
   const { showClawDashboard } = useClawDashboardVisibility();
   const isGuest = user?.role === WorkspaceRole.GUEST;
+  const disabledToolbarPaths = useDisabledToolbarPaths();
 
   return useMemo(() => {
     const permittedItems = filterNavItemsByPermission(
@@ -32,7 +34,9 @@ export const useVisibleNavigationItems = (): NavigationItem[] => {
     const withoutGuestBlocked = isGuest
       ? permittedItems.filter(item => item.path !== '/claw-agents')
       : permittedItems;
-    if (showClawDashboard) return withoutGuestBlocked;
-    return withoutGuestBlocked.filter(item => item.path !== '/claw-agents');
-  }, [permissions, canManageOwnUserGroups, showClawDashboard, isGuest]);
+    const visibleItems = showClawDashboard
+      ? withoutGuestBlocked
+      : withoutGuestBlocked.filter(item => item.path !== '/claw-agents');
+    return visibleItems.filter(item => !disabledToolbarPaths.has(item.path));
+  }, [permissions, canManageOwnUserGroups, showClawDashboard, isGuest, disabledToolbarPaths]);
 };

--- a/apps/dashboard/src/hooks/useXyneAIStream.ts
+++ b/apps/dashboard/src/hooks/useXyneAIStream.ts
@@ -22,6 +22,11 @@ export interface StreamOverrides {
   channelIds?: string[];
   collectionIds?: string[];
   fileIds?: string[];
+  /** Folder scopes from the composer picker. Sent to claw-auth as a single
+   *  'folder' attached_context pointer per id — xyneAIControllerV2.ts does
+   *  NOT expand this to a recursive file list; claw-auth resolves it itself,
+   *  at Vespa-query time. */
+  folderIds?: string[];
   webSearchEnabled?: boolean;
   deepResearchEnabled?: boolean;
   createCanvasEnabled?: boolean;
@@ -61,6 +66,11 @@ interface UseXyneAIStreamParams {
   researchContext?: ResearchContext | null;
   collectionIds?: string[];
   fileIds?: string[];
+  /** Folder scopes from the composer picker. Sent to claw-auth as a single
+   *  'folder' attached_context pointer per id — xyneAIControllerV2.ts does
+   *  NOT expand this to a recursive file list; claw-auth resolves it itself,
+   *  at Vespa-query time. */
+  folderIds?: string[];
   createCanvasEnabled?: boolean;
   instant?: boolean;
   isV2?: boolean;
@@ -131,6 +141,7 @@ export const useXyneAIStream = ({
   researchContext,
   collectionIds,
   fileIds,
+  folderIds,
   createCanvasEnabled = false,
   instant = false,
   isV2 = false,
@@ -314,6 +325,7 @@ export const useXyneAIStream = ({
       const eChannelIds = ov?.channelIds ?? channelIds;
       const eCollectionIds = ov?.collectionIds ?? collectionIds ?? [];
       const eFileIds = ov?.fileIds ?? fileIds ?? [];
+      const eFolderIds = ov?.folderIds ?? folderIds ?? [];
       const eTicketIds = ov?.ticketIds ?? ticketIds;
       const eCanvasIds = ov?.canvasIds ?? canvasIds;
       const eCallIds = ov?.callIds ?? callIds;
@@ -423,6 +435,7 @@ export const useXyneAIStream = ({
           channelIds: eChannelIds,
           collectionIds: eCollectionIds,
           fileIds: eFileIds,
+          folderIds: eFolderIds,
           conversationId,
           threadConversationId,
           attachmentIds,
@@ -466,6 +479,7 @@ export const useXyneAIStream = ({
       attachmentIds,
       canvasId,
       fileIds,
+      folderIds,
       researchContext,
       webSearchEnabled,
       deepResearchEnabled,

--- a/apps/dashboard/src/machines/knowledgeBaseMachine.ts
+++ b/apps/dashboard/src/machines/knowledgeBaseMachine.ts
@@ -17,6 +17,7 @@ export interface KnowledgeBaseContext {
   channelId: string | null;
   activeCollection: ActiveCollectionInfo | null;
   currentFolderId: string | null;
+  currentFileId: string | null;
   viewMode: ViewMode;
   expansionState: Record<string, boolean>;
   nodes: Record<string, CollectionTreeNode>;
@@ -31,6 +32,7 @@ export type KnowledgeBaseEvent =
   | { type: 'SET_ACTIVE_COLLECTION'; info: ActiveCollectionInfo | null }
   | { type: 'SET_VIEW_MODE'; mode: ViewMode }
   | { type: 'SET_CURRENT_FOLDER_ID'; id: string | null }
+  | { type: 'SET_CURRENT_FILE_ID'; id: string | null }
   | { type: 'TOGGLE_FOLDER'; folderId: string }
   | { type: 'EXPAND_FOLDER'; folderId: string }
   | { type: 'COLLAPSE_FOLDER'; folderId: string }
@@ -59,6 +61,7 @@ export const knowledgeBaseMachine = setup({
               channelId: null,
               activeCollection: null,
               currentFolderId: null,
+              currentFileId: null,
               expansionState: {},
               nodes: {},
               rootChildrenIds: [],
@@ -77,6 +80,7 @@ export const knowledgeBaseMachine = setup({
           ? {
               activeCollection: null,
               currentFolderId: null,
+              currentFileId: null,
               expansionState: {},
               nodes: {},
               rootChildrenIds: [],
@@ -94,6 +98,7 @@ export const knowledgeBaseMachine = setup({
         ...(idChanged
           ? {
               currentFolderId: null,
+              currentFileId: null,
               expansionState: {},
               nodes: {},
               rootChildrenIds: [],
@@ -110,6 +115,10 @@ export const knowledgeBaseMachine = setup({
     setCurrentFolderId: assign(({ event }) => {
       if (event.type !== 'SET_CURRENT_FOLDER_ID') return {};
       return { currentFolderId: event.id };
+    }),
+    setCurrentFileId: assign(({ event }) => {
+      if (event.type !== 'SET_CURRENT_FILE_ID') return {};
+      return { currentFileId: event.id };
     }),
     toggleFolder: assign(({ event, context }) => {
       if (event.type !== 'TOGGLE_FOLDER') return {};
@@ -154,6 +163,7 @@ export const knowledgeBaseMachine = setup({
     channelId: null,
     activeCollection: null,
     currentFolderId: null,
+    currentFileId: null,
     viewMode: 'list',
     expansionState: {},
     nodes: {},
@@ -169,6 +179,7 @@ export const knowledgeBaseMachine = setup({
         SET_ACTIVE_COLLECTION: { actions: 'setActiveCollection' },
         SET_VIEW_MODE: { actions: 'setViewMode' },
         SET_CURRENT_FOLDER_ID: { actions: 'setCurrentFolderId' },
+        SET_CURRENT_FILE_ID: { actions: 'setCurrentFileId' },
         TOGGLE_FOLDER: { actions: 'toggleFolder' },
         EXPAND_FOLDER: { actions: 'expandFolder' },
         COLLAPSE_FOLDER: { actions: 'collapseFolder' },

--- a/apps/dashboard/src/machines/xyneAIMachine.ts
+++ b/apps/dashboard/src/machines/xyneAIMachine.ts
@@ -123,6 +123,11 @@ export interface XyneAIContext {
   // Single-file scope when Ask AI is opened from a file viewer
   kbDocId: string | null;
   kbDocName: string | null;
+  // Single-folder scope when Ask AI is opened while browsing inside a
+  // sub-folder (not the collection root) — narrower than kbCollectionId,
+  // mutually exclusive with it (see the OPEN handler below).
+  kbFolderId: string | null;
+  kbFolderName: string | null;
   // Bumped on every OPEN dispatched with a kbCollectionId. Lets the input box
   // re-attach the KB collection chip when the user clicks the Ask AI button
   // again from /knowledge-base after manually removing the chip.
@@ -153,6 +158,8 @@ export type XyneAIEvent =
       kbChannelId?: string | null;
       kbDocId?: string | null;
       kbDocName?: string | null;
+      kbFolderId?: string | null;
+      kbFolderName?: string | null;
       initialContextSelections?: AskAIInitialContextSelections | null;
       researchContext?: XyneAIResearchContext | null;
       initialQuery?: string | null;
@@ -520,16 +527,20 @@ export const xyneAIMachine = setup({
           kbChannelId: event.kbChannelId ?? null,
           kbDocId: event.kbDocId ?? null,
           kbDocName: event.kbDocName ?? null,
+          kbFolderId: event.kbFolderId ?? null,
+          kbFolderName: event.kbFolderName ?? null,
           researchContext: event.researchContext ?? null,
           initialQuery: event.initialQuery?.trim() || null,
           autoSendNonce: event.initialQuery?.trim()
             ? context.autoSendNonce + 1
             : context.autoSendNonce,
-          // Bump the nonce on every KB-scoped OPEN (collection OR file) so the
-          // sidebar re-attaches the collection chip and/or file scope even if
-          // the user previously removed them.
+          // Bump the nonce on every KB-scoped OPEN (collection, file, OR
+          // folder) so the sidebar re-attaches the right chip even if the
+          // user previously removed it.
           kbOpenNonce:
-            event.kbCollectionId || event.kbDocId ? context.kbOpenNonce + 1 : context.kbOpenNonce,
+            event.kbCollectionId || event.kbDocId || event.kbFolderId
+              ? context.kbOpenNonce + 1
+              : context.kbOpenNonce,
         };
 
         // Persist to IndexedDB
@@ -600,14 +611,19 @@ export const xyneAIMachine = setup({
           kbChannelId: event.kbChannelId !== undefined ? event.kbChannelId : context.kbChannelId,
           kbDocId: event.kbDocId !== undefined ? event.kbDocId : context.kbDocId,
           kbDocName: event.kbDocName !== undefined ? event.kbDocName : context.kbDocName,
+          kbFolderId: event.kbFolderId !== undefined ? event.kbFolderId : context.kbFolderId,
+          kbFolderName:
+            event.kbFolderName !== undefined ? event.kbFolderName : context.kbFolderName,
           researchContext: event.researchContext ?? null,
           initialQuery: event.initialQuery?.trim() || null,
           autoSendNonce: event.initialQuery?.trim()
             ? context.autoSendNonce + 1
             : context.autoSendNonce,
-          // Re-bump on every KB-scoped OPEN (collection OR file).
+          // Re-bump on every KB-scoped OPEN (collection, file, OR folder).
           kbOpenNonce:
-            event.kbCollectionId || event.kbDocId ? context.kbOpenNonce + 1 : context.kbOpenNonce,
+            event.kbCollectionId || event.kbDocId || event.kbFolderId
+              ? context.kbOpenNonce + 1
+              : context.kbOpenNonce,
         };
 
         // Persist to IndexedDB
@@ -623,6 +639,8 @@ export const xyneAIMachine = setup({
         kbChannelId: null,
         kbDocId: null,
         kbDocName: null,
+        kbFolderId: null,
+        kbFolderName: null,
       };
       void saveContextToIndexedDB(newContext);
       return newContext;
@@ -656,6 +674,8 @@ export const xyneAIMachine = setup({
         kbChannelId: null,
         kbDocId: null,
         kbDocName: null,
+        kbFolderId: null,
+        kbFolderName: null,
         kbOpenNonce: context.kbOpenNonce,
         researchContext: null,
         initialQuery: null,
@@ -804,6 +824,8 @@ export const xyneAIMachine = setup({
     kbChannelId: null,
     kbDocId: null,
     kbDocName: null,
+    kbFolderId: null,
+    kbFolderName: null,
     kbOpenNonce: 0,
     researchContext: null,
     initialQuery: null,

--- a/apps/dashboard/src/routes/AIScreen/screens/AIKnowledgeScreen.tsx
+++ b/apps/dashboard/src/routes/AIScreen/screens/AIKnowledgeScreen.tsx
@@ -1,20 +1,25 @@
 import { type ReactElement } from 'react';
+import { Outlet } from 'react-router-dom';
 import { AIShell } from '../../../components/AIScreen/AIShell';
-import KnowledgeBaseV2Screen from '../../../components/knowledgeBaseV2/KnowledgeBaseV2Screen';
-import { GlobalCollectionsProvider } from '../../../components/knowledgeBaseV2/hooks/useGlobalCollections';
-import { CollectionTreeDataSync } from '../../../components/knowledgeBase/hooks/CollectionTreeDataSync';
+import { KbContentsShell } from '../../../components/knowledgeBaseV2/KbContentsShell';
 import { useAIChatHandoff } from '../useAIChatHandoff';
 
+// Layout for the /ai/knowledge subtree — wraps both the folder browser
+// (index route) and the file viewer (nested route, same as /knowledge-base's
+// own file-viewer path) so opening a file from here stays under /ai/knowledge
+// instead of hopping to the standalone KB screen.
 const AIKnowledgeScreen = (): ReactElement => {
   const { onCreateChat, onSelectSession } = useAIChatHandoff();
 
   return (
-    <AIShell onCreateChat={onCreateChat} onSelectSession={onSelectSession}>
-      <GlobalCollectionsProvider>
-        <CollectionTreeDataSync>
-          <KnowledgeBaseV2Screen />
-        </CollectionTreeDataSync>
-      </GlobalCollectionsProvider>
+    <AIShell
+      onCreateChat={onCreateChat}
+      onSelectSession={onSelectSession}
+      mainClassName='ai-page-bg'
+    >
+      <KbContentsShell>
+        <Outlet />
+      </KbContentsShell>
     </AIShell>
   );
 };

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -208,6 +208,7 @@ import { ResourceAccessScreen } from './ResourceAccessScreen/ResourceAccessScree
 import { RoleManagementScreen } from './RoleManagementScreen';
 import { ResourceProtectedRoute } from '../components/Auth/ResourceProtectedRoute';
 import { GuestBlockedRoute } from '../components/Auth/GuestBlockedRoute';
+import { ToolbarProtectedRoute } from '../components/Auth/ToolbarProtectedRoute';
 import { WorkspaceManagementScreen } from './WorkspaceManagementScreen';
 import OrganisationsScreen from './OrganisationsScreen/OrganisationsScreen';
 import { AcceptInvitation } from './InvitationScreen/AcceptInvitation';
@@ -1057,6 +1058,11 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'ai',
+                  element: (
+                    <ToolbarProtectedRoute path='/ai'>
+                      <Outlet />
+                    </ToolbarProtectedRoute>
+                  ),
                   children: [
                     { index: true, element: <Navigate to='chat/new' replace /> },
                     { path: 'chat/new', element: <AIScreen /> },
@@ -1144,6 +1150,11 @@ export const router = createBrowserRouter(
                     // Directory routes (nested under dir)
                     {
                       path: 'dir',
+                      element: (
+                        <ToolbarProtectedRoute path='/chat/dir'>
+                          <Outlet />
+                        </ToolbarProtectedRoute>
+                      ),
                       children: [
                         {
                           index: true,
@@ -1252,7 +1263,11 @@ export const router = createBrowserRouter(
                     // DM routes (full screen with DM list sidebar)
                     {
                       path: 'dm',
-                      element: <DmsPage />,
+                      element: (
+                        <ToolbarProtectedRoute path='/chat/dm'>
+                          <DmsPage />
+                        </ToolbarProtectedRoute>
+                      ),
                       children: [
                         { index: true, element: null },
                         { path: 'compose', element: <KeyedComposeDmPanel /> },
@@ -1292,7 +1307,11 @@ export const router = createBrowserRouter(
                     // Canvas (full screen with 2-panel layout on desktop)
                     {
                       path: 'canvas',
-                      element: <CanvasPanel />,
+                      element: (
+                        <ToolbarProtectedRoute path='/chat/canvas'>
+                          <CanvasPanel />
+                        </ToolbarProtectedRoute>
+                      ),
                       children: [
                         {
                           index: true,
@@ -1307,7 +1326,11 @@ export const router = createBrowserRouter(
                     // Activity (full screen with activity list sidebar)
                     {
                       path: 'activity',
-                      element: <ActivityListView />,
+                      element: (
+                        <ToolbarProtectedRoute path='/chat/activity'>
+                          <ActivityListView />
+                        </ToolbarProtectedRoute>
+                      ),
                       children: [
                         { index: true, element: null },
                         // Desk/Support tickets opened from the Activity list render
@@ -1362,9 +1385,11 @@ export const router = createBrowserRouter(
                 {
                   path: 'claw-agents',
                   element: (
-                    <GuestBlockedRoute>
-                      <ClawAgentsScreen />
-                    </GuestBlockedRoute>
+                    <ToolbarProtectedRoute path='/claw-agents'>
+                      <GuestBlockedRoute>
+                        <ClawAgentsScreen />
+                      </GuestBlockedRoute>
+                    </ToolbarProtectedRoute>
                   ),
                   children: [
                     { index: true, element: <AgentsTab /> },
@@ -1398,7 +1423,11 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'knowledge-base',
-                  element: <KnowledgeBaseV2Layout />,
+                  element: (
+                    <ToolbarProtectedRoute path='/knowledge-base'>
+                      <KnowledgeBaseV2Layout />
+                    </ToolbarProtectedRoute>
+                  ),
                   children: [
                     {
                       index: true,
@@ -1427,7 +1456,11 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'memory',
-                  element: <MemoryScreen />,
+                  element: (
+                    <ToolbarProtectedRoute path='/memory'>
+                      <MemoryScreen />
+                    </ToolbarProtectedRoute>
+                  ),
                 },
                 {
                   path: 'analytics',
@@ -1543,7 +1576,11 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'releaseManager',
-                  element: <ReleaseManagerView />,
+                  element: (
+                    <ToolbarProtectedRoute path='/releaseManager'>
+                      <ReleaseManagerView />
+                    </ToolbarProtectedRoute>
+                  ),
                 },
                 {
                   path: 'listProjects/:projectId',
@@ -1555,7 +1592,11 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'calls',
-                  element: <CallHistoryScreen />,
+                  element: (
+                    <ToolbarProtectedRoute path='/calls'>
+                      <CallHistoryScreen />
+                    </ToolbarProtectedRoute>
+                  ),
                   children: [
                     {
                       path: ':callId/detail',
@@ -1573,7 +1614,11 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'recordings',
-                  element: <RecordingsRoute />,
+                  element: (
+                    <ToolbarProtectedRoute path='/recordings'>
+                      <RecordingsRoute />
+                    </ToolbarProtectedRoute>
+                  ),
                 },
                 {
                   path: 'recordings/:recordingId',
@@ -1659,7 +1704,11 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'browser',
-                  element: <BrowserTabsScreen />,
+                  element: (
+                    <ToolbarProtectedRoute path='/browser'>
+                      <BrowserTabsScreen />
+                    </ToolbarProtectedRoute>
+                  ),
                 },
                 {
                   path: 'workspace-management',
@@ -1687,11 +1736,19 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'scheduled-messages',
-                  element: <ScheduledMessageScreen />,
+                  element: (
+                    <ToolbarProtectedRoute path='/scheduled-messages'>
+                      <ScheduledMessageScreen />
+                    </ToolbarProtectedRoute>
+                  ),
                 },
                 {
                   path: 'automations',
-                  element: <AutomationsScreen />,
+                  element: (
+                    <ToolbarProtectedRoute path='/automations'>
+                      <AutomationsScreen />
+                    </ToolbarProtectedRoute>
+                  ),
                   children: [
                     { index: true, element: <AutomationsListScreen /> },
                     { path: 'approvals', element: <AutomationApprovalsScreen /> },
@@ -1703,7 +1760,11 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'apps',
-                  element: <AppsScreen />,
+                  element: (
+                    <ToolbarProtectedRoute path='/apps'>
+                      <AppsScreen />
+                    </ToolbarProtectedRoute>
+                  ),
                 },
                 {
                   path: 'resource-access',
@@ -1747,7 +1808,11 @@ export const router = createBrowserRouter(
                 },
                 {
                   path: 'guide',
-                  element: <UserGuideScreen />,
+                  element: (
+                    <ToolbarProtectedRoute path='/guide'>
+                      <UserGuideScreen />
+                    </ToolbarProtectedRoute>
+                  ),
                 },
               ],
             },

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -463,6 +463,8 @@ const AppRoot = (): ReactElement => {
   const xyneAIKbChannelId = useSelector(xyneAIActor, state => state.context.kbChannelId);
   const xyneAIKbDocId = useSelector(xyneAIActor, state => state.context.kbDocId);
   const xyneAIKbDocName = useSelector(xyneAIActor, state => state.context.kbDocName);
+  const xyneAIKbFolderId = useSelector(xyneAIActor, state => state.context.kbFolderId);
+  const xyneAIKbFolderName = useSelector(xyneAIActor, state => state.context.kbFolderName);
   const xyneAIKbOpenNonce = useSelector(xyneAIActor, state => state.context.kbOpenNonce);
   const xyneAIResearchContext = useSelector(xyneAIActor, state => state.context.researchContext);
   const xyneAIInitialQuery = useSelector(xyneAIActor, state => state.context.initialQuery);
@@ -499,6 +501,12 @@ const AppRoot = (): ReactElement => {
   // like "/<workspaceId>/ai" or "/<workspaceId>/ai/<sub>". Match that
   // structure rather than a leading "/ai" prefix (which never matches).
   const isOnAIPage = /^\/[^/]+\/ai(\/|$)/.test(location.pathname);
+  // /ai/knowledge is a KB browser (AIKnowledgeScreen), not the full-screen
+  // chat experience the isOnAIPage suppression below exists for — it has no
+  // embedded chat pane of its own, so "Ask AI" there needs the same global
+  // XyneAISidebar drawer /knowledge-base uses, or clicking it does nothing.
+  const isOnAIKnowledgePage = /^\/[^/]+\/ai\/knowledge(\/|$)/.test(location.pathname);
+  const isOnAIChatExperiencePage = isOnAIPage && !isOnAIKnowledgePage;
 
   useEffect(() => {
     if (!reactNativeBridge.isAvailable()) {
@@ -537,7 +545,11 @@ const AppRoot = (): ReactElement => {
   // On SDLC routes the framed lane renders its own Ask AI panel inside the iframe,
   // so the host must not also show one (covers both /sdlc and /sdlc/<repoId>).
   const showXyneAIPanel =
-    isXyneAIDrawerOpen && !isMobile && !isOnAIPage && !isSdlcRoute && !showSdlcDebuggerPanel;
+    isXyneAIDrawerOpen &&
+    !isMobile &&
+    !isOnAIChatExperiencePage &&
+    !isSdlcRoute &&
+    !showSdlcDebuggerPanel;
   const showBrowserPanel = browserPanelState === 'open' && !location.pathname.endsWith('/browser');
 
   const shouldShowMobileHeader =
@@ -563,12 +575,13 @@ const AppRoot = (): ReactElement => {
   // global XyneAISidebar must never be open there. Close it on any pathname
   // change that lands inside /ai — this covers both opening it elsewhere and
   // then navigating in, and any code path that tries to open it while here.
+  // /ai/knowledge is exempt — see isOnAIKnowledgePage above.
   useEffect(() => {
-    if (!isOnAIPage) return;
+    if (!isOnAIChatExperiencePage) return;
     if (xyneAIActor.getSnapshot().matches('open')) {
       xyneAIActor.send({ type: 'CLOSE' });
     }
-  }, [isOnAIPage, isXyneAIDrawerOpen]);
+  }, [isOnAIChatExperiencePage, isXyneAIDrawerOpen]);
 
   // Monitor for pathname changes to update XyneAI context when navigating
   useEffect(() => {
@@ -710,6 +723,8 @@ const AppRoot = (): ReactElement => {
                                     kbChannelId={xyneAIKbChannelId ?? ''}
                                     kbDocId={xyneAIKbDocId ?? ''}
                                     kbDocName={xyneAIKbDocName ?? ''}
+                                    kbFolderId={xyneAIKbFolderId ?? ''}
+                                    kbFolderName={xyneAIKbFolderName ?? ''}
                                     kbOpenNonce={xyneAIKbOpenNonce}
                                     researchContext={xyneAIResearchContext}
                                     initialQuery={xyneAIInitialQuery ?? undefined}
@@ -824,6 +839,8 @@ const AppRoot = (): ReactElement => {
                                       kbChannelId={xyneAIKbChannelId ?? ''}
                                       kbDocId={xyneAIKbDocId ?? ''}
                                       kbDocName={xyneAIKbDocName ?? ''}
+                                      kbFolderId={xyneAIKbFolderId ?? ''}
+                                      kbFolderName={xyneAIKbFolderName ?? ''}
                                       kbOpenNonce={xyneAIKbOpenNonce}
                                       researchContext={xyneAIResearchContext}
                                       initialQuery={xyneAIInitialQuery ?? undefined}
@@ -950,6 +967,8 @@ const AppRoot = (): ReactElement => {
                             kbChannelId={xyneAIKbChannelId ?? ''}
                             kbDocId={xyneAIKbDocId ?? ''}
                             kbDocName={xyneAIKbDocName ?? ''}
+                            kbFolderId={xyneAIKbFolderId ?? ''}
+                            kbFolderName={xyneAIKbFolderName ?? ''}
                             kbOpenNonce={xyneAIKbOpenNonce}
                             researchContext={xyneAIResearchContext}
                             initialQuery={xyneAIInitialQuery ?? undefined}
@@ -960,7 +979,7 @@ const AppRoot = (): ReactElement => {
                         </div>
                       )}
                       {/* XyneAI Mobile Drawer */}
-                      {isMobile && !isInPanelWebview && !isOnAIPage && (
+                      {isMobile && !isInPanelWebview && !isOnAIChatExperiencePage && (
                         <Drawer
                           open={isXyneAIDrawerOpen}
                           onOpenChange={open => {
@@ -982,6 +1001,8 @@ const AppRoot = (): ReactElement => {
                             kbChannelId={xyneAIKbChannelId ?? ''}
                             kbDocId={xyneAIKbDocId ?? ''}
                             kbDocName={xyneAIKbDocName ?? ''}
+                            kbFolderId={xyneAIKbFolderId ?? ''}
+                            kbFolderName={xyneAIKbFolderName ?? ''}
                             kbOpenNonce={xyneAIKbOpenNonce}
                             researchContext={xyneAIResearchContext}
                             initialQuery={xyneAIInitialQuery ?? undefined}

--- a/apps/dashboard/src/routes/WorkspaceManagementScreen/ToolbarTab.tsx
+++ b/apps/dashboard/src/routes/WorkspaceManagementScreen/ToolbarTab.tsx
@@ -1,0 +1,139 @@
+import { ReactElement, useState } from 'react';
+import { Search, Shield } from 'lucide-react';
+import Input from '../../components/ui/Input/Input';
+import { useSelf } from '../../hooks/useUsers';
+import { useDisabledToolbarPaths } from '../../hooks/useDisabledToolbarPaths';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { queries } from '../../zero/queries';
+import { cn } from '../../utils/classNames';
+import { WorkspaceRole } from '@xyne/shared';
+import {
+  NAVIGATION_ITEMS,
+  TOOLBAR_ITEM_DESCRIPTIONS,
+} from '../../components/AppSidebar/navigationConfig';
+import { PATH_TO_RESOURCE } from '../../components/AppSidebar/utils/resourceMapping';
+
+const Card = ({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}): ReactElement => (
+  <div className={cn('rounded-xl border border-border bg-card shadow-sm', className)}>
+    {children}
+  </div>
+);
+
+interface ToolbarTabProps {
+  isActive?: boolean;
+}
+
+export const ToolbarTab = ({ isActive: _isActive = false }: ToolbarTabProps): ReactElement => {
+  const self = useSelf();
+  const isAdmin = self?.role === WorkspaceRole.ADMIN || self?.role === WorkspaceRole.OWNER;
+  const disabledPaths = useDisabledToolbarPaths();
+  const [workspace] = useCachedQuery(
+    queries.getWorkspaceById({ workspaceId: self?.workspaceId ?? '' }),
+    { enabled: !!self?.workspaceId },
+  );
+
+  // Permission-gated items (e.g. Roles, Workspace Management) are already restricted by the
+  // user/role permission system — a regular member can never see them regardless of this
+  // workspace-wide toggle, so surfacing them here would be misleading.
+  const manageableItems = NAVIGATION_ITEMS.filter(item => !(item.path in PATH_TO_RESOURCE));
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const visibleItems = manageableItems.filter(item =>
+    item.label.toLowerCase().includes(searchQuery.trim().toLowerCase()),
+  );
+
+  if (!isAdmin) {
+    return (
+      <div className='flex flex-col items-center justify-center h-full gap-2 text-center px-6'>
+        <Shield className='w-8 h-8 text-muted-foreground' />
+        <p className='text-sm font-medium text-foreground'>Admin access required</p>
+        <p className='text-sm text-muted-foreground max-w-sm'>
+          Only workspace admins and owners can manage which toolbar items are available.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div className='space-y-4'>
+        <div>
+          <h2 className='text-lg font-semibold text-foreground'>Toolbar items</h2>
+          <p className='text-sm text-muted-foreground'>
+            Which sidebar items are available to members of this workspace. Members can still choose
+            to hide enabled items for themselves under Preferences → Toolbar, but items disabled
+            here are unavailable to everyone. Managed centrally via Superposition — contact your ops
+            team to change the list for {workspace?.name ?? 'this workspace'}, under the key{' '}
+            <code className='rounded bg-muted px-1 py-0.5 text-xs'>disabled_toolbar_paths</code>,
+            entry{' '}
+            <code className='rounded bg-muted px-1 py-0.5 text-xs'>
+              {self?.workspaceId ?? '<workspaceId>'}
+            </code>
+            .
+          </p>
+        </div>
+        <Card className='p-4'>
+          <div className='relative mb-3'>
+            <Search className='absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground' />
+            <Input
+              type='text'
+              placeholder='Search toolbar items...'
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              className='pl-10'
+            />
+          </div>
+          <div className='flex flex-col gap-1.5'>
+            {visibleItems.length === 0 && (
+              <p className='text-sm text-muted-foreground text-center py-6'>
+                No toolbar items match “{searchQuery}”
+              </p>
+            )}
+            {visibleItems.map(item => {
+              const Icon = item.icon;
+              const enabled = !disabledPaths.has(item.path);
+              return (
+                <div
+                  key={item.path}
+                  className='flex items-center justify-between gap-4 p-3 rounded-lg border border-border bg-muted/30'
+                >
+                  <div className='flex items-center gap-3 min-w-0'>
+                    <div className='flex items-center justify-center size-8 rounded-md bg-muted border border-border shrink-0 text-muted-foreground'>
+                      <Icon className='size-4' />
+                    </div>
+                    <div className='min-w-0'>
+                      <p className='text-sm font-medium text-foreground truncate'>{item.label}</p>
+                      {TOOLBAR_ITEM_DESCRIPTIONS[item.path] && (
+                        <p className='text-xs text-muted-foreground truncate'>
+                          {TOOLBAR_ITEM_DESCRIPTIONS[item.path]}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <span
+                    className={cn(
+                      'shrink-0 text-xs font-medium px-2 py-1 rounded-full',
+                      enabled
+                        ? 'bg-emerald-500/10 text-emerald-600'
+                        : 'bg-muted-foreground/10 text-muted-foreground',
+                    )}
+                  >
+                    {enabled ? 'Enabled' : 'Disabled'}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default ToolbarTab;

--- a/apps/dashboard/src/routes/WorkspaceManagementScreen/WorkspaceManagementScreen.tsx
+++ b/apps/dashboard/src/routes/WorkspaceManagementScreen/WorkspaceManagementScreen.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useEffect, useState } from 'react';
-import { Settings, Mail, ChevronLeft, UserCheck, GitBranch } from 'lucide-react';
+import { Settings, Mail, ChevronLeft, UserCheck, GitBranch, LayoutGrid } from 'lucide-react';
 import { Button } from '../../components/ui/Button/Button';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
@@ -9,6 +9,7 @@ import { GeneralAndMembersTab } from './GeneralAndMembersTab';
 import { InvitationsTab } from './InvitationsTab';
 import { GuestUsersTab } from './GuestUsersTab';
 import { RepositoryCredentialsTab } from './RepositoryCredentialsTab';
+import { ToolbarTab } from './ToolbarTab';
 import * as Tabs from '@radix-ui/react-tabs';
 
 export const WorkspaceManagementScreen = (): ReactElement => {
@@ -85,6 +86,7 @@ export const WorkspaceManagementScreen = (): ReactElement => {
               />
               <TabTrigger value='invitations' icon={Mail} label='Invitations' />
               <TabTrigger value='guests' icon={UserCheck} label='Guest Users' />
+              <TabTrigger value='toolbar' icon={LayoutGrid} label='Toolbar' />
             </Tabs.List>
           </Tabs.Root>
         </div>
@@ -106,6 +108,9 @@ export const WorkspaceManagementScreen = (): ReactElement => {
               </Tabs.Content>
               <Tabs.Content value='guests' className='outline-none h-full'>
                 <GuestUsersTab isActive={activeTab === 'guests'} />
+              </Tabs.Content>
+              <Tabs.Content value='toolbar' className='outline-none h-full'>
+                <ToolbarTab isActive={activeTab === 'toolbar'} />
               </Tabs.Content>
             </div>
           </Tabs.Root>

--- a/apps/dashboard/src/services/Knowledge/collectionService.ts
+++ b/apps/dashboard/src/services/Knowledge/collectionService.ts
@@ -5,6 +5,22 @@ export type { IngestionStatus };
 export type NodeType = 'FILE' | 'FOLDER';
 export type CollectionRole = 'VIEWER' | 'EDITOR' | 'OWNER';
 
+/** The backend's own item-type vocabulary (lowercase, e.g. searchItems'
+ *  itemType field) — distinct from NodeType (the frontend's normalized,
+ *  uppercase vocabulary). Named so toNodeType can switch over it exhaustively:
+ *  if this union ever grows, toNodeType fails to compile until it's updated,
+ *  instead of the new value silently falling through to 'FILE'. */
+export type BackendItemType = 'file' | 'folder';
+
+function toNodeType(itemType: BackendItemType): NodeType {
+  switch (itemType) {
+    case 'file':
+      return 'FILE';
+    case 'folder':
+      return 'FOLDER';
+  }
+}
+
 export interface CollectionChild {
   id: string;
   name: string;
@@ -90,19 +106,24 @@ export async function searchCollectionItems(
   collectionId: string,
   query: string,
 ): Promise<CollectionChild[]> {
+  // The backend's search response shape doesn't match CollectionChild's field
+  // names — it sends `itemType: 'folder' | 'file'` (lowercase, not `type`)
+  // and `collectionId` (the item's containing folder, same field name Zero's
+  // synced schema uses everywhere else — see CollectionTreeDataSync's
+  // filesByFolder map) rather than `parentId`. Mapped explicitly below
+  // instead of trusting a response type that never matched reality.
   const response = await apiInstance.get<{
     success: boolean;
     items: Array<{
       id: string;
       name: string;
-      type: NodeType;
+      itemType: BackendItemType;
       createdAt: string;
       updatedAt: string;
-      uploadedByEmail: string;
       ingestionStatus: IngestionStatus;
-      fileSize: string;
-      mimeType: string;
-      parentId: string | null;
+      fileSize: string | null;
+      mimeType: string | null;
+      collectionId: string;
     }>;
     query: string;
   }>(`/collections/${collectionId}/search`, {
@@ -112,12 +133,15 @@ export async function searchCollectionItems(
   return response.data.items.map(item => ({
     id: item.id,
     name: item.name,
-    type: item.type,
+    type: toNodeType(item.itemType),
     updatedAt: item.updatedAt,
     ingestionStatus: item.ingestionStatus,
     size: item.fileSize ? parseInt(item.fileSize, 10) || 0 : 0,
-    mimeType: item.mimeType,
-    parentId: item.parentId ?? null,
+    mimeType: item.mimeType ?? '',
+    // Root-level items' collectionId equals the collection being searched —
+    // normalize that to null to match CollectionChild.parentId's
+    // "root has no parent" convention used everywhere else.
+    parentId: item.collectionId === collectionId ? null : item.collectionId,
   }));
 }
 

--- a/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
+++ b/apps/dashboard/src/services/XyneAI/XyneAIStreamManager.ts
@@ -79,6 +79,11 @@ export interface StreamRequest {
   channelIds: string[];
   collectionIds?: string[];
   fileIds?: string[];
+  /** Folder scopes from the composer picker. Sent to claw-auth as a single
+   *  'folder' attached_context pointer per id — xyneAIControllerV2.ts does
+   *  NOT expand this to a recursive file list; claw-auth resolves it itself,
+   *  at Vespa-query time. */
+  folderIds?: string[];
   canvasIds?: string[] | undefined;
   ticketIds?: string[] | undefined;
   callIds?: string[] | undefined;
@@ -1046,6 +1051,8 @@ class XyneAIStreamManager {
           ...(request.collectionIds &&
             request.collectionIds.length > 0 && { collectionIds: request.collectionIds }),
           ...(request.fileIds && request.fileIds.length > 0 && { fileIds: request.fileIds }),
+          ...(request.folderIds &&
+            request.folderIds.length > 0 && { folderIds: request.folderIds }),
           ...(request.canvasIds &&
             request.canvasIds.length > 0 && { canvasIds: request.canvasIds }),
           ...(request.ticketIds &&

--- a/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
+++ b/apps/dashboard/src/services/XyneAI/xyneAIStream.worker.ts
@@ -15,6 +15,7 @@ export interface WorkerStartStreamMessage {
       channelIds: string[];
       collectionIds?: string[];
       fileIds?: string[];
+      folderIds?: string[];
       canvasIds?: string[];
       ticketIds?: string[];
       callIds?: string[];
@@ -172,6 +173,8 @@ async function executeStream(
           requestBody.collectionIds.length > 0 && { collection_ids: requestBody.collectionIds }),
         ...(requestBody.fileIds &&
           requestBody.fileIds.length > 0 && { file_ids: requestBody.fileIds }),
+        ...(requestBody.folderIds &&
+          requestBody.folderIds.length > 0 && { folder_ids: requestBody.folderIds }),
         ...(requestBody.canvasIds &&
           requestBody.canvasIds.length > 0 && { canvas_ids: requestBody.canvasIds }),
         ...(requestBody.ticketIds &&

--- a/apps/dashboard/src/services/encryptionInterceptors.ts
+++ b/apps/dashboard/src/services/encryptionInterceptors.ts
@@ -129,6 +129,15 @@ export async function encryptionResponseInterceptor(
     return response;
   }
 
+  // A Blob/ArrayBuffer response has `typeof === 'object'` but no enumerable
+  // own properties, so decryptObject's Object.entries() walk would silently
+  // replace it with `{}` instead of leaving it alone — skip binary response
+  // types outright rather than only guarding on the value's shape.
+  const responseType = response.config.responseType;
+  if (responseType === 'blob' || responseType === 'arraybuffer' || responseType === 'stream') {
+    return response;
+  }
+
   // Only decrypt JSON responses
   if (!response.data || typeof response.data !== 'object') {
     return response;

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -125,6 +125,9 @@ export default {
           failure: 'var(--status-failure)',
           paused: 'var(--status-paused)',
         },
+        'claw-ai': {
+          fg: 'var(--claw-ai-fg)',
+        },
         sidebar: {
           DEFAULT: 'var(--sidebar)',
           foreground: 'var(--sidebar-foreground)',

--- a/packages/shared/src/zero/acl/tables/collection-permissions-acl.ts
+++ b/packages/shared/src/zero/acl/tables/collection-permissions-acl.ts
@@ -20,7 +20,21 @@ export class CollectionPermissionsACL extends BaseQueryACL<'collection_permissio
           c.where(({ or: innerOr, cmp: innerCmp, exists: innerExists }) =>
             innerOr(
               innerCmp('ownerId', '=', this.ctx.userID),
-              innerExists('permissions', (p) => p.where('userId', this.ctx.userID))
+              innerExists('permissions', (p) => p.where('userId', this.ctx.userID)),
+              // Group grants — mirrors CollectionsACL's own group check, so a
+              // group-granted user can see the Share modal's "Who has access"
+              // list instead of it silently resolving empty.
+              innerExists('permissions', (p) =>
+                p.whereExists('userGroup', (ug) =>
+                  ug.whereExists('userGroupMappings', (m) => m.where('userId', this.ctx.userID)),
+                ),
+              ),
+              // Channel grants — same reasoning as the group check above.
+              innerExists('permissions', (p) =>
+                p.whereExists('channel', (ch) =>
+                  ch.whereExists('participants', (cp) => cp.where('userId', this.ctx.userID)),
+                ),
+              ),
             )
           )
         )

--- a/packages/shared/src/zero/acl/tables/collections-acl.ts
+++ b/packages/shared/src/zero/acl/tables/collections-acl.ts
@@ -19,7 +19,25 @@ export class CollectionsACL extends BaseQueryACL<'collections'> {
         or(
           cmp('isPrivate', '=', false),
           cmp('ownerId', '=', this.ctx.userID),
-          exists('permissions', (p) => p.where('userId', this.ctx.userID))
+          exists('permissions', (p) => p.where('userId', this.ctx.userID)),
+          // Group grants — resolveCollectionAccess (REST/MCP) already honours
+          // these via userGroupId; without this, a group-only grant would
+          // authorize the REST path but Zero would silently filter the
+          // collection out of that user's sync, so it would never show up in
+          // the KB UI. Mirrors canvas-participants-acl.ts's group check.
+          exists('permissions', (p) =>
+            p.whereExists('userGroup', (ug) =>
+              ug.whereExists('userGroupMappings', (m) => m.where('userId', this.ctx.userID)),
+            ),
+          ),
+          // Channel grants — same reasoning as the group check above, for a
+          // permission row keyed by channelId instead of userGroupId.
+          // Mirrors canvas-participants-acl.ts's own channel check.
+          exists('permissions', (p) =>
+            p.whereExists('channel', (ch) =>
+              ch.whereExists('participants', (cp) => cp.where('userId', this.ctx.userID)),
+            ),
+          ),
         )
       );
   }

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -117,6 +117,49 @@ async function getCanvasThreadCommentCount(
   return comments.filter(comment => comment.deletedAt == null).length;
 }
 
+const COLLECTION_ROLE_RANK: Record<CollectionRole, number> = {
+  [CollectionRole.VIEWER]: 1,
+  [CollectionRole.EDITOR]: 2,
+  [CollectionRole.OWNER]: 3,
+};
+
+/**
+ * Resolve a user's CollectionRole on a collection from its collection_permissions
+ * rows, considering a direct grant (userId), a grant made to a group they
+ * belong to (userGroupId), or a grant made to a channel they participate in
+ * (channelId — always VIEWER, enforced at grant time, but still needs to be
+ * visible here so a channel-only Viewer can exercise "any role can share").
+ * Mirrors apps/backend's identical helper (and collectionAccess.ts's
+ * resolveCollectionAccess) so the client's optimistic result agrees with the
+ * server's authoritative one. Membership is resolved at check-time, not
+ * fanned out into per-member rows.
+ */
+async function resolveCollectionPermissionRole(
+  tx: Transaction<Schema>,
+  collectionId: string,
+  userId: string,
+): Promise<CollectionRole | null> {
+  const permissions = await tx.run(zql.collection_permissions.where('collectionId', collectionId));
+  const groupIds = new Set(
+    (await tx.run(zql.user_group_mappings.where('userId', userId))).map(m => m.userGroupId),
+  );
+  const channelIds = new Set(
+    (await tx.run(zql.channel_participants.where('userId', userId))).map(cp => cp.channelId),
+  );
+
+  let role: CollectionRole | null = null;
+  for (const p of permissions) {
+    const matches =
+      p.userId === userId ||
+      (p.userGroupId !== null && groupIds.has(p.userGroupId)) ||
+      (p.channelId !== null && channelIds.has(p.channelId));
+    if (!matches) continue;
+    const candidate = p.role as CollectionRole;
+    if (!role || COLLECTION_ROLE_RANK[candidate] > COLLECTION_ROLE_RANK[role]) role = candidate;
+  }
+  return role;
+}
+
 /** Build initial_message_md from message data. Single helper for all conversation creation sites. */
 function buildInitialMessageMd(msg: {
   messageId: string;
@@ -11796,33 +11839,32 @@ export const mutators = defineMutators({
           throw new Error('Collection not found');
         }
 
-        const isOwner = collection.ownerId === ctx.userID;
+        // OWNER is a real, multi-holder role — the creator (ownerId) is a
+        // separate, permanent label, not the sole authority. Either grants
+        // full owner privilege here.
+        const isCreator = collection.ownerId === ctx.userID;
+        const permissionRole = isCreator
+          ? null
+          : await resolveCollectionPermissionRole(tx, id, ctx.userID);
+        const canActAsOwner = isCreator || permissionRole === CollectionRole.OWNER;
 
         // Visibility is owner-only: changing isPrivate flips who can see the
         // collection at all, so EDITOR permissions are not enough.
-        if (isPrivate !== undefined && !isOwner) {
-          throw new Error('Collection update failed: only the owner can change visibility');
+        if (isPrivate !== undefined && !canActAsOwner) {
+          throw new Error('Collection update failed: only an owner can change visibility');
         }
 
         // Rename is owner-only too: collection names are surfaced wherever the
         // collection is referenced (sidebar, breadcrumbs, share UI), so we
-        // treat the title the same as visibility — a property only the owner
-        // is allowed to change.
-        if (name !== undefined && !isOwner) {
-          throw new Error('Collection update failed: only the owner can rename the collection');
+        // treat the title the same as visibility — a property only owners
+        // are allowed to change.
+        if (name !== undefined && !canActAsOwner) {
+          throw new Error('Collection update failed: only an owner can rename the collection');
         }
 
         // Verify OWNER or EDITOR permission for name/description edits
-        if (!isOwner && collection.isPrivate) {
-          const permission = await tx.run(
-            zql.collection_permissions
-              .where('collectionId', id)
-              .where('userId', ctx.userID)
-              .one(),
-          );
-          if (!permission || permission.role === CollectionRole.VIEWER) {
-            throw new Error('Collection update failed: requires EDITOR or OWNER permission');
-          }
+        if (!canActAsOwner && (!permissionRole || permissionRole === CollectionRole.VIEWER)) {
+          throw new Error('Collection update failed: requires EDITOR or OWNER permission');
         }
 
         await tx.mutate.collections.update({
@@ -11846,7 +11888,10 @@ export const mutators = defineMutators({
           throw new Error('Collection not found');
         }
         if (collection.ownerId !== ctx.userID) {
-          throw new Error('Collection deletion failed: only the owner can delete a collection');
+          const permissionRole = await resolveCollectionPermissionRole(tx, id, ctx.userID);
+          if (permissionRole !== CollectionRole.OWNER) {
+            throw new Error('Collection deletion failed: only an owner can delete a collection');
+          }
         }
 
         await tx.mutate.collections.update({
@@ -11881,14 +11926,9 @@ export const mutators = defineMutators({
         // Verify EDITOR+ permission against the root collection (permissions only exist on root collections)
         const rootCollectionId = parentCollection.rootCollectionId ?? parentId;
         const isOwner = parentCollection.ownerId === ctx.userID;
-        if (!isOwner && parentCollection.isPrivate) {
-          const permission = await tx.run(
-            zql.collection_permissions
-              .where('collectionId', rootCollectionId)
-              .where('userId', ctx.userID)
-              .one(),
-          );
-          if (!permission || permission.role === CollectionRole.VIEWER) {
+        if (!isOwner) {
+          const permissionRole = await resolveCollectionPermissionRole(tx, rootCollectionId, ctx.userID);
+          if (!permissionRole || permissionRole === CollectionRole.VIEWER) {
             throw new Error('Folder creation failed: requires EDITOR or OWNER permission');
           }
         }
@@ -11923,14 +11963,9 @@ export const mutators = defineMutators({
 
         // Verify EDITOR+ permission
         const isOwner = collection.ownerId === ctx.userID;
-        if (!isOwner && collection.isPrivate) {
-          const permission = await tx.run(
-            zql.collection_permissions
-              .where('collectionId', collectionId)
-              .where('userId', ctx.userID)
-              .one(),
-          );
-          if (!permission || permission.role === CollectionRole.VIEWER) {
+        if (!isOwner) {
+          const permissionRole = await resolveCollectionPermissionRole(tx, collectionId, ctx.userID);
+          if (!permissionRole || permissionRole === CollectionRole.VIEWER) {
             throw new Error('Item deletion failed: requires EDITOR or OWNER permission');
           }
         }
@@ -11960,14 +11995,9 @@ export const mutators = defineMutators({
 
         // Verify EDITOR+ permission
         const isOwner = collection.ownerId === ctx.userID;
-        if (!isOwner && collection.isPrivate) {
-          const permission = await tx.run(
-            zql.collection_permissions
-              .where('collectionId', collectionId)
-              .where('userId', ctx.userID)
-              .one(),
-          );
-          if (!permission || permission.role === CollectionRole.VIEWER) {
+        if (!isOwner) {
+          const permissionRole = await resolveCollectionPermissionRole(tx, collectionId, ctx.userID);
+          if (!permissionRole || permissionRole === CollectionRole.VIEWER) {
             throw new Error('Item rename failed: requires EDITOR or OWNER permission');
           }
         }
@@ -11988,30 +12018,34 @@ export const mutators = defineMutators({
         collectionId: z.string(),
         userId: z.string().optional(),
         userGroupId: z.string().optional(),
+        channelId: z.string().optional(),
         role: z.nativeEnum(CollectionRole),
-        canShare: z.boolean(),
         timestamp: z.number(),
       }),
-      async ({ tx, ctx, args: { id, collectionId, userId, userGroupId, role, canShare, timestamp } }) => {
+      async ({ tx, ctx, args: { id, collectionId, userId, userGroupId, channelId, role, timestamp } }) => {
         const collection = await tx.run(zql.collections.where('id', collectionId).one());
         if (!collection) {
           throw new Error('Collection not found');
         }
         if (collection.ownerId !== ctx.userID) {
-          const granterPermission = await tx.run(
-            zql.collection_permissions
-              .where('collectionId', collectionId)
-              .where('userId', ctx.userID)
-              .one(),
-          );
-          if (!granterPermission || !granterPermission.canShare) {
-            throw new Error('Permission grant failed: only owners or users with canShare can grant permissions');
+          // Anyone with an explicit role (Viewer/Editor/Owner) can share —
+          // there's no separate delegated "canShare" permission.
+          const granterRole = await resolveCollectionPermissionRole(tx, collectionId, ctx.userID);
+          if (!granterRole) {
+            throw new Error('Permission grant failed: you do not have access to this collection');
           }
         }
 
         // Prevent sharing with the collection owner
         if (userId && userId === collection.ownerId) {
           throw new Error('Cannot share collection with its owner');
+        }
+
+        // A channel grant is always read-only — a channel can have many
+        // members, so defaulting all of them to write access is a bigger
+        // blast radius than a person or a curated group.
+        if (channelId && role !== CollectionRole.VIEWER) {
+          throw new Error('Permission grant failed: channel grants are read-only (Viewer)');
         }
 
         const existing = userId
@@ -12021,13 +12055,31 @@ export const mutators = defineMutators({
                 .where('userId', userId)
                 .one(),
             )
-          : null;
+          : userGroupId
+            ? await tx.run(
+                zql.collection_permissions
+                  .where('collectionId', collectionId)
+                  .where('userGroupId', userGroupId)
+                  .one(),
+              )
+            : channelId
+              ? await tx.run(
+                  zql.collection_permissions
+                    .where('collectionId', collectionId)
+                    .where('channelId', channelId)
+                    .one(),
+                )
+              : null;
 
         if (existing) {
           await tx.mutate.collection_permissions.update({
             id: existing.id,
             role,
-            canShare,
+            // Dead field — nothing reads canShare anymore (sharing is
+            // purely role-based, see the escalation check above). Kept at
+            // the Prisma column default since it's still NOT NULL; not
+            // threaded through as a caller-supplied argument.
+            canShare: false,
             updatedAt: timestamp,
           });
         } else {
@@ -12037,8 +12089,9 @@ export const mutators = defineMutators({
             collectionId,
             userId,
             userGroupId,
+            channelId,
             role,
-            canShare,
+            canShare: false,
             grantedBy: ctx.userID,
             createdAt: timestamp,
             updatedAt: timestamp,
@@ -12058,7 +12111,10 @@ export const mutators = defineMutators({
           throw new Error('Collection not found');
         }
         if (collection.ownerId !== ctx.userID) {
-          throw new Error('Permission revoke failed: only the owner can revoke permissions');
+          const granterRole = await resolveCollectionPermissionRole(tx, collectionId, ctx.userID);
+          if (granterRole !== CollectionRole.OWNER) {
+            throw new Error('Permission revoke failed: only an owner can revoke permissions');
+          }
         }
 
         await tx.mutate.collection_permissions.delete({ id });

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -4480,7 +4480,20 @@ export const queries = defineQueries({
       const scoped =
         scopeType && scopeId ? base.where('scopeType', scopeType).where('scopeId', scopeId) : base;
       return scoped
-        .related('permissions', p => p.where('userId', ctx.userID))
+        .related('permissions', p =>
+          // Direct grant, OR a grant on a group/channel this user belongs to —
+          // otherwise a group/channel-only grant never resolves a role here
+          // (same fix as scopedCollectionsWithItems below).
+          p.where(({ or, cmp, exists }) =>
+            or(
+              cmp('userId', '=', ctx.userID),
+              exists('userGroup', ug =>
+                ug.whereExists('userGroupMappings', m => m.where('userId', ctx.userID)),
+              ),
+              exists('channel', ch => ch.whereExists('participants', cp => cp.where('userId', ctx.userID))),
+            ),
+          ),
+        )
         .orderBy('createdAt', 'asc');
     },
   ),
@@ -4497,9 +4510,36 @@ export const queries = defineQueries({
       const scoped =
         scopeType && scopeId ? base.where('scopeType', scopeType).where('scopeId', scopeId) : base;
       return scoped
-        .related('permissions', p => p.where('userId', ctx.userID))
+        .related('permissions', p =>
+          // Direct grant, OR a grant on a group/channel this user belongs to —
+          // otherwise a group/channel-only grant never reaches the client at
+          // all, and useGlobalCollections falls back to the VIEWER default
+          // even though the server mutators would allow the write.
+          p.where(({ or, cmp, exists }) =>
+            or(
+              cmp('userId', '=', ctx.userID),
+              exists('userGroup', ug =>
+                ug.whereExists('userGroupMappings', m => m.where('userId', ctx.userID)),
+              ),
+              exists('channel', ch => ch.whereExists('participants', cp => cp.where('userId', ctx.userID))),
+            ),
+          ),
+        )
         .related('allItems', i => i.where('isLatest', true).where('deletedAt', 'IS', null))
         .orderBy('createdAt', 'asc');
+    },
+  ),
+
+  // Every explicit grant (per-user or per-group) on a root collection — the
+  // "Who has access" list in ShareCollectionModal.
+  collectionPermissions: defineQuery(
+    z.object({ collectionId: z.string() }),
+    ({ args: { collectionId } }) => {
+      return zql.collection_permissions
+        .where('collectionId', collectionId)
+        .related('user')
+        .related('userGroup')
+        .related('channel');
     },
   ),
 

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -2221,6 +2221,9 @@ export const collectionPermissionTable = table('collection_permissions')
     collectionId: string(),
     userId: string().optional(),
     userGroupId: string().optional(),
+    // Grants every current+future member of this channel access — always
+    // VIEWER, only offered for workspace-scoped collections in the UI.
+    channelId: string().optional(),
     role: enumeration<CollectionRole>(),
     canShare: boolean(),
     grantedBy: string().optional(),
@@ -3140,6 +3143,11 @@ export const collectionPermissionTableRelationships = relationships(collectionPe
     sourceField: ['userGroupId'],
     destField: ['id'],
     destSchema: userGroupTable,
+  }),
+  channel: one({
+    sourceField: ['channelId'],
+    destField: ['id'],
+    destSchema: channelTable,
   }),
 }));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1133,6 +1133,9 @@ importers:
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
       rehype-stringify:
         specifier: 10.0.1
         version: 10.0.1


### PR DESCRIPTION
## Summary
Cherry-picks three squash-merged features from `main` (plus one already release-targeted branch) onto `release-20260825`, since this release branch has diverged from `main` and a direct merge would drag in ~125 unrelated commits:

- `d61204b33` — **Feature/workspace toolbar admin control** (#964, squash commit `a677279d9`)
- `f392b0f67` — **Feature/kb UI change** (#810, squash commit `7d867542f`) — 3 real conflicts resolved (`AppRoot.tsx`, `KnowledgeBaseV2Screen.tsx`, `ShareCollectionModal.tsx`), each verified against the intended refactor before resolving
- `5b7e649bf` — **XYNE-60825 PPTX viewer + search-text extraction** (cherry-picked from `feature/pptx-viewer-release-20260825`, formerly PR #1208 — closed as superseded by this PR)

Not included: `feature/claw-match-my-access-default` (PR #853) — its base was `feature/deploy-xyneclaw`, not `main`, and that branch's own PR into `main` (#979) is still open with 100 commits. No squash commit exists on `main` for it yet.

Each cherry-picked commit's file list was diffed against its original squash commit and confirmed identical before committing. Backend and dashboard typecheck clean on the combined result.

## Test plan
- [ ] Workspace toolbar admin control renders and functions as in the original PR #964
- [ ] KB UI (list/grid view, header/breadcrumb split, Ask AI pill, Share dialog) matches PR #810
- [ ] Upload a `.pptx` file to Knowledge and confirm it renders via the new PDF-conversion viewer
- [ ] No regressions from the 3 manually-resolved merge conflicts above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rb8ZqZykLKewRPCkLMMJgU