### PR TITLE
feat: XYNE-60697 pop out artifacts from tracks, and expand with the discussion

### DIFF
--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -858,13 +858,20 @@ export default function SdlcScreen(): ReactElement {
     return search;
   };
 
-  const openCanvasInWindow = (canvasId: string, withDiscussion: boolean): boolean => {
+  const openWindowForCanvas = (
+    targetSection: string,
+    canvasId: string,
+    search: URLSearchParams,
+  ): boolean => {
     if (!workspaceId || !repoId) return false;
     return openStandaloneWindow(
-      `/sdlc/${workspaceId}/${repoId}/${section}?${canvasSearch(canvasId, withDiscussion).toString()}`,
+      `/sdlc/${workspaceId}/${repoId}/${targetSection}?${search.toString()}`,
       `sdlc-canvas:${canvasId}`,
     );
   };
+
+  const openCanvasInWindow = (canvasId: string, withDiscussion: boolean): boolean =>
+    openWindowForCanvas(section, canvasId, canvasSearch(canvasId, withDiscussion));
 
   const openCanvas = (canvasId: string, options?: OpenCanvasOptions): void => {
     if (!repoId) return;
@@ -883,12 +890,17 @@ export default function SdlcScreen(): ReactElement {
     );
   };
 
-  const openArtifactCanvas = (canvasId: string): void => {
+  const openArtifactCanvas = (canvasId: string, event?: ReactMouseEvent): void => {
     if (!repoId) return;
     const folder = typeFolders.find(item => item.canvases.some(canvas => canvas.id === canvasId));
-    setRelatedSourceId(null);
-    const search = new URLSearchParams({ canvas: canvasId });
+    const search = canvasSearch(canvasId, true);
     if (folder) search.set('type', folder.id);
+
+    if (shouldOpenInNewWindow(event) && openWindowForCanvas('artifacts', canvasId, search)) {
+      return;
+    }
+
+    setRelatedSourceId(null);
     navigateWithinSdlc(
       `/sdlc/${repoId}/artifacts`,
       `?${search.toString()}`,
@@ -1398,7 +1410,7 @@ export default function SdlcScreen(): ReactElement {
                         type='button'
                         key={canvas.id}
                         className='group mb-1.5 flex w-full items-start gap-3 rounded-xl bg-primary/5 px-3 py-3 text-left transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                        onClick={() => openArtifactCanvas(canvas.id)}
+                        onClick={event => openArtifactCanvas(canvas.id, event)}
                         data-track-category='SdlcHub'
                         data-track-name='TrackArtifactOpened'
                         data-track-metadata={JSON.stringify({
@@ -2064,7 +2076,7 @@ export default function SdlcScreen(): ReactElement {
                     variant='ghost'
                     aria-label='Open in new window'
                     title='Open in new window'
-                    onClick={() => openCanvasInWindow(selectedCanvasId, chatLayout.panelOpen)}
+                    onClick={() => openCanvasInWindow(selectedCanvasId, true)}
                     data-track-category='SdlcHub'
                     data-track-name='ArtifactOpenedInWindow'
                   >


### PR DESCRIPTION
Two gaps in the popped-out document window added by XYNE-60697.

Single file, `SdlcScreen.tsx`, +19/−7.

## 1. Artifacts reached from a track had no Cmd/Ctrl+click

The gesture was wired to the artifact **cards** only. A track's own list of artifacts is a different control, so opening a PRD from there always opened in place. It now pops out the same way, and opens the document's discussion beside it as the cards already do.

Its destination is the **artifacts** section rather than whatever route you were on, so the window opener now takes the section it should target instead of assuming the current one:

```ts
openWindowForCanvas(targetSection, canvasId, search)
```

`openCanvasInWindow` becomes a thin caller of it, so the card path and the track path share one implementation and cannot drift.

## 2. Expanding a document dropped its conversation

The header's expand control passed `chatLayout.panelOpen` through, so expanding a document you were reading with the conversation closed gave a window with no conversation. It now asks for the discussion unconditionally, matching every other way of opening an artifact.

Where a document genuinely has no discussion the panel still stays shut — `sdlcChatNavigationSearch` decides that, and this does not override it.

## Deployment

**SDLC lane image only.** `SdlcScreen` renders only in the SDLC bundle; the main bundle renders `SdlcFrameViewport` for `/sdlc` and never mounts it. No Electron change, and no main-bundle change — the popout route and `SdlcWindow` are already deployed and untouched here.

## Verification

- `typecheck`: **0 errors in `SdlcScreen.tsx`**
- `format:check`: clean
- `eslint`: 0 errors
- `gitleaks`: clean
- Exercised against a running local stack: the SDLC lane serves the updated module (`openWindowForCanvas`, the track row's event forwarding, and the unconditional expand all present in what the dev server returns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)