### PR TITLE
refactor: XYNE-60840 extract shared null-safe attachment MIME matcher

### DIFF
--- a/apps/xyne-claw/src/attachment-matcher.ts
+++ b/apps/xyne-claw/src/attachment-matcher.ts
@@ -1,0 +1,21 @@
+/** Shared MIME and extension matching for inbound attachments. */
+export function matchesAttachmentType(
+  fileName: string,
+  mimeType: string | null | undefined,
+  mimeTypes: ReadonlySet<string>,
+  extensions: ReadonlySet<string>,
+): boolean {
+  const normalizedMimeType = (mimeType ?? "").toLowerCase();
+  for (const candidate of mimeTypes) {
+    const matchesMimeType = candidate.endsWith("/")
+      ? normalizedMimeType.startsWith(candidate)
+      : normalizedMimeType === candidate;
+    if (matchesMimeType) {
+      return true;
+    }
+  }
+
+  const dot = fileName.lastIndexOf(".");
+  if (dot < 0) return false;
+  return extensions.has(fileName.slice(dot).toLowerCase());
+}

--- a/apps/xyne-claw/src/docx-attachment.ts
+++ b/apps/xyne-claw/src/docx-attachment.ts
@@ -10,6 +10,7 @@
  * file shouldn't fail the whole /run.
  */
 import mammoth from "mammoth";
+import { matchesAttachmentType } from "./attachment-matcher.js";
 
 // Mammoth's bundled .d.ts only types `convertToHtml` / `extractRawText`,
 // but the runtime exposes `convertToMarkdown` too (see node_modules/mammoth
@@ -24,14 +25,13 @@ type MammothMarkdown = {
 };
 const mammothMd = mammoth as unknown as MammothMarkdown;
 
-const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+const DOCX_MIME_TYPES = new Set([
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+]);
 export const DOCX_EXTENSIONS = new Set([".docx"]);
 
-export function isDocxAttachment(fileName: string, mimeType: string): boolean {
-  if ((mimeType ?? "").toLowerCase() === DOCX_MIME) return true;
-  const dot = fileName.lastIndexOf(".");
-  if (dot < 0) return false;
-  return DOCX_EXTENSIONS.has(fileName.slice(dot).toLowerCase());
+export function isDocxAttachment(fileName: string, mimeType?: string | null): boolean {
+  return matchesAttachmentType(fileName, mimeType, DOCX_MIME_TYPES, DOCX_EXTENSIONS);
 }
 
 /** Cap on per-file markdown output so a 200-page contract doesn't drown

--- a/apps/xyne-claw/src/html-attachment.ts
+++ b/apps/xyne-claw/src/html-attachment.ts
@@ -10,15 +10,13 @@
  *
  * Sibling of pdf-attachment.ts, xlsx-attachment.ts, video-attachment.ts.
  */
+import { matchesAttachmentType } from "./attachment-matcher.js";
 
 const HTML_MIME_TYPES = new Set(["text/html", "application/xhtml+xml"]);
 export const HTML_EXTENSIONS = new Set([".html", ".htm", ".xhtml"]);
 
-export function isHtmlAttachment(fileName: string, mimeType: string): boolean {
-  if (HTML_MIME_TYPES.has((mimeType ?? "").toLowerCase())) return true;
-  const dot = fileName.lastIndexOf(".");
-  if (dot < 0) return false;
-  return HTML_EXTENSIONS.has(fileName.slice(dot).toLowerCase());
+export function isHtmlAttachment(fileName: string, mimeType?: string | null): boolean {
+  return matchesAttachmentType(fileName, mimeType, HTML_MIME_TYPES, HTML_EXTENSIONS);
 }
 
 /** Cap total HTML size we write into context — anything bigger is truncated

--- a/apps/xyne-claw/src/pdf-attachment.ts
+++ b/apps/xyne-claw/src/pdf-attachment.ts
@@ -16,6 +16,7 @@
  * whole run aborting.
  */
 import { extractText } from "unpdf";
+import { matchesAttachmentType } from "./attachment-matcher.js";
 
 const MAX_PAGES = 100;
 const MAX_CHARS_PER_PAGE = 10_000;
@@ -24,11 +25,8 @@ const MAX_TOTAL_CHARS = 200_000;
 export const PDF_MIME_TYPES = new Set(["application/pdf"]);
 export const PDF_EXTENSIONS = new Set([".pdf"]);
 
-export function isPdfAttachment(fileName: string, mimeType: string): boolean {
-  if (PDF_MIME_TYPES.has(mimeType.toLowerCase())) return true;
-  const dot = fileName.lastIndexOf(".");
-  if (dot < 0) return false;
-  return PDF_EXTENSIONS.has(fileName.slice(dot).toLowerCase());
+export function isPdfAttachment(fileName: string, mimeType?: string | null): boolean {
+  return matchesAttachmentType(fileName, mimeType, PDF_MIME_TYPES, PDF_EXTENSIONS);
 }
 
 function clampText(s: string, cap: number): { out: string; truncated: boolean } {

--- a/apps/xyne-claw/src/pptx-attachment.ts
+++ b/apps/xyne-claw/src/pptx-attachment.ts
@@ -15,15 +15,15 @@
  * Sibling of docx-attachment.ts, pdf-attachment.ts, xlsx-attachment.ts.
  */
 import JSZip from "jszip";
+import { matchesAttachmentType } from "./attachment-matcher.js";
 
-const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const PPTX_MIME_TYPES = new Set([
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+]);
 export const PPTX_EXTENSIONS = new Set([".pptx"]);
 
-export function isPptxAttachment(fileName: string, mimeType: string): boolean {
-  if ((mimeType ?? "").toLowerCase() === PPTX_MIME) return true;
-  const dot = fileName.lastIndexOf(".");
-  if (dot < 0) return false;
-  return PPTX_EXTENSIONS.has(fileName.slice(dot).toLowerCase());
+export function isPptxAttachment(fileName: string, mimeType?: string | null): boolean {
+  return matchesAttachmentType(fileName, mimeType, PPTX_MIME_TYPES, PPTX_EXTENSIONS);
 }
 
 const MAX_SLIDES = 200;          // refuse > 200-slide decks; will note in footer

--- a/apps/xyne-claw/src/video-attachment.ts
+++ b/apps/xyne-claw/src/video-attachment.ts
@@ -32,6 +32,7 @@ import { mkdtemp, writeFile, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LITELLM } from "./config.js";
+import { matchesAttachmentType } from "./attachment-matcher.js";
 
 import { createLogger } from "./logger.js";
 const log = createLogger("video-attachment");
@@ -49,15 +50,13 @@ const FFMPEG_TIMEOUT_MS = 120_000;  // 2 min per ffmpeg invocation
 const MODEL_TIMEOUT_MS = 60_000;    // per rolling-state model call
 
 export const VIDEO_MIME_PREFIX = "video/";
+const VIDEO_MIME_TYPES = new Set([VIDEO_MIME_PREFIX]);
 export const VIDEO_EXTENSIONS = new Set([
   ".mov", ".mp4", ".m4v", ".webm", ".avi", ".mkv", ".mpg", ".mpeg", ".wmv", ".flv",
 ]);
 
-export function isVideoAttachment(fileName: string, mimeType: string): boolean {
-  if ((mimeType ?? "").toLowerCase().startsWith(VIDEO_MIME_PREFIX)) return true;
-  const dot = fileName.lastIndexOf(".");
-  if (dot < 0) return false;
-  return VIDEO_EXTENSIONS.has(fileName.slice(dot).toLowerCase());
+export function isVideoAttachment(fileName: string, mimeType?: string | null): boolean {
+  return matchesAttachmentType(fileName, mimeType, VIDEO_MIME_TYPES, VIDEO_EXTENSIONS);
 }
 
 export interface VideoKeyframe {

--- a/apps/xyne-claw/src/xlsx-attachment.ts
+++ b/apps/xyne-claw/src/xlsx-attachment.ts
@@ -13,6 +13,7 @@
  * blob so the agent can still see the filename and skip cleanly.
  */
 import ExcelJS from "exceljs";
+import { matchesAttachmentType } from "./attachment-matcher.js";
 
 const MAX_SHEETS = 20;
 const MAX_ROWS_PER_SHEET = 1000;
@@ -25,11 +26,8 @@ export const XLSX_MIME_TYPES = new Set([
 ]);
 export const XLSX_EXTENSIONS = new Set([".xlsx", ".xlsm"]);
 
-export function isXlsxAttachment(fileName: string, mimeType: string): boolean {
-  if (XLSX_MIME_TYPES.has(mimeType.toLowerCase())) return true;
-  const dot = fileName.lastIndexOf(".");
-  if (dot < 0) return false;
-  return XLSX_EXTENSIONS.has(fileName.slice(dot).toLowerCase());
+export function isXlsxAttachment(fileName: string, mimeType?: string | null): boolean {
+  return matchesAttachmentType(fileName, mimeType, XLSX_MIME_TYPES, XLSX_EXTENSIONS);
 }
 
 function cellToString(cell: ExcelJS.Cell): string {

--- a/apps/xyne-claw/src/zip-attachment.ts
+++ b/apps/xyne-claw/src/zip-attachment.ts
@@ -21,6 +21,7 @@
  * namespaces them under the archive's own filename via `<zipName>/<path>`.
  */
 import JSZip from "jszip";
+import { matchesAttachmentType } from "./attachment-matcher.js";
 import { isPdfAttachment, pdfBufferToMarkdown } from "./pdf-attachment.js";
 import { isXlsxAttachment, xlsxBufferToMarkdown } from "./xlsx-attachment.js";
 import { isDocxAttachment, docxBufferToMarkdown } from "./docx-attachment.js";
@@ -34,11 +35,8 @@ const ZIP_MIMES = new Set([
 ]);
 export const ZIP_EXTENSIONS = new Set([".zip"]);
 
-export function isZipAttachment(fileName: string, mimeType: string): boolean {
-  if (ZIP_MIMES.has((mimeType ?? "").toLowerCase())) return true;
-  const dot = fileName.lastIndexOf(".");
-  if (dot < 0) return false;
-  return ZIP_EXTENSIONS.has(fileName.slice(dot).toLowerCase());
+export function isZipAttachment(fileName: string, mimeType?: string | null): boolean {
+  return matchesAttachmentType(fileName, mimeType, ZIP_MIMES, ZIP_EXTENSIONS);
 }
 
 const MAX_ENTRIES = 200;

--- a/apps/xyne-claw/test/attachment-matcher.test.ts
+++ b/apps/xyne-claw/test/attachment-matcher.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { isDocxAttachment } from "../src/docx-attachment.js";
+import { isHtmlAttachment } from "../src/html-attachment.js";
+import { isPdfAttachment } from "../src/pdf-attachment.js";
+import { isPptxAttachment } from "../src/pptx-attachment.js";
+import { isVideoAttachment } from "../src/video-attachment.js";
+import { isXlsxAttachment } from "../src/xlsx-attachment.js";
+import { isZipAttachment } from "../src/zip-attachment.js";
+
+type AttachmentMatcher = (fileName: string, mimeType?: string | null) => boolean;
+
+const attachmentTypes: Array<{
+  name: string;
+  match: AttachmentMatcher;
+  extension: string;
+  mimeType: string;
+}> = [
+  { name: "PDF", match: isPdfAttachment, extension: ".pdf", mimeType: "application/pdf" },
+  {
+    name: "XLSX",
+    match: isXlsxAttachment,
+    extension: ".xlsx",
+    mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  },
+  {
+    name: "DOCX",
+    match: isDocxAttachment,
+    extension: ".docx",
+    mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  },
+  {
+    name: "PPTX",
+    match: isPptxAttachment,
+    extension: ".pptx",
+    mimeType: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  },
+  { name: "ZIP", match: isZipAttachment, extension: ".zip", mimeType: "application/zip" },
+  { name: "HTML", match: isHtmlAttachment, extension: ".html", mimeType: "text/html" },
+  { name: "video", match: isVideoAttachment, extension: ".mp4", mimeType: "video/mp4" },
+];
+
+describe.each(attachmentTypes)("$name attachment matching", ({ match, extension, mimeType }) => {
+  it("matches a valid MIME type regardless of case", () => {
+    expect(match("attachment.unknown", mimeType.toUpperCase())).toBe(true);
+  });
+
+  it.each([null, undefined])(
+    "falls back to the extension when MIME is %s",
+    (missingMimeType) => {
+      expect(match(`attachment${extension.toUpperCase()}`, missingMimeType)).toBe(true);
+    },
+  );
+
+  it("does not match when MIME and extension are unsupported", () => {
+    expect(match("attachment.unknown", "application/octet-stream")).toBe(false);
+  });
+
+  it("does not match a missing MIME without a file extension", () => {
+    expect(match("attachment", undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Extracts the duplicated attachment MIME/extension checks into a shared null-safe `matchesAttachmentType` helper. PDF, XLSX, DOCX, PPTX, ZIP, HTML, and video matchers now delegate to it. Missing MIME values fall back to case-insensitive extension matching; video MIME-prefix matching remains supported.

Ticket: XYNE-60840

## Areas Touched

- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

## How did you test it?

- `pnpm --filter xyne-claw exec vitest run test/attachment-matcher.test.ts` — 35 tests passed.
- `pnpm --filter xyne-claw typecheck` is currently blocked by existing errors in untouched `src/pr-review-findings.ts` (`zod` cannot be resolved and an implicit `any`).

### Automated

- [x] Added / updated tests for this change

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Formatting clean in the package touched (`git diff --check`)
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind