### PR TITLE
fix: trigger workflow chain for pending responses

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/chain-workflow.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/chain-workflow.test.ts
@@ -6,6 +6,7 @@ import {
   evaluateChainToolConditions,
   evaluateChainCommandConditions,
   summarizeChainToolInvocations,
+  resolveChainResultText,
   chainCommandPatternMatches,
   CHAIN_COMMAND_PATTERN_MAX_LENGTH,
   type ChainWorkflowDefinition,
@@ -228,5 +229,26 @@ describe("judge invocation summary", () => {
   it("tolerates junk", () => {
     expect(summarizeChainToolInvocations(undefined)).toEqual([]);
     expect(summarizeChainToolInvocations([null, 3, {}])).toEqual([]);
+  });
+});
+
+describe("chain result text", () => {
+  it("prefers the normal result when it is non-empty", () => {
+    expect(resolveChainResultText("normal result", [{ message: "pending result" }])).toBe("normal result");
+  });
+
+  it("uses pending responses when respond-to-user leaves result empty", () => {
+    const resultText = resolveChainResultText("", [
+      { responseId: "first", message: "Implemented the fix." },
+      { responseId: "second", message: "Opened the PR." },
+    ]);
+
+    expect(resultText).toBe("Implemented the fix.\n\nOpened the PR.");
+    expect(evaluateChainCommandConditions({ commandsMustMatch: ["git commit"] }, [commit])).toBe(true);
+  });
+
+  it("ignores malformed pending responses", () => {
+    expect(resolveChainResultText(undefined, [null, { message: 42 }, { message: "valid" }])).toBe("valid");
+    expect(resolveChainResultText(undefined, undefined)).toBe("");
   });
 });

--- a/apps/xyne-claw-auth/backend/src/lib/chain-workflow.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/chain-workflow.ts
@@ -168,6 +168,23 @@ export function validateChainWorkflowDefinition(definition: ChainWorkflowDefinit
   return null;
 }
 
+export function resolveChainResultText(
+  result: unknown,
+  pendingResponses: unknown,
+): string {
+  if (typeof result === "string" && result.trim()) return result;
+  if (!Array.isArray(pendingResponses)) return "";
+
+  return pendingResponses
+    .map((response) => {
+      if (!response || typeof response !== "object") return "";
+      const message = (response as Record<string, unknown>)["message"];
+      return typeof message === "string" ? message : "";
+    })
+    .filter((message) => message.trim())
+    .join("\n\n");
+}
+
 export function evaluateChainToolConditions(
   conditions: { toolsMustInclude?: string[] | undefined; toolsMustExclude?: string[] | undefined } | undefined,
   toolsUsed: string[],

--- a/apps/xyne-claw-auth/backend/src/routes/webhook-chain-pending-responses.test.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook-chain-pending-responses.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const webhookSrc = readFileSync(resolve(here, "./webhook.ts"), "utf8");
+
+// Copilot and Verify Responses agents finish through pendingResponses while
+// result.text is empty. The pending-response branch used to return before the
+// workflow dispatcher, so downstream workflow nodes never started.
+describe("pending-response workflow chaining", () => {
+  it("dispatches the agent chain before returning from pending-response delivery", () => {
+    const branchStart = webhookSrc.indexOf(
+      "// ── Copilot mode: post pendingResponses instead of result.text ──",
+    );
+    const branchReturn = webhookSrc.indexOf(
+      "// Don't delete session — copilot sessions persist for multi-turn",
+      branchStart,
+    );
+    const pendingBranch = webhookSrc.slice(branchStart, branchReturn);
+
+    expect(branchStart).toBeGreaterThan(-1);
+    expect(branchReturn).toBeGreaterThan(branchStart);
+    expect(pendingBranch).toContain("await dispatchAgentChain();");
+  });
+
+  it("keeps workflow dispatch on both pending and normal result paths", () => {
+    expect(webhookSrc.match(/await dispatchAgentChain\(\);/g)).toHaveLength(2);
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -90,6 +90,7 @@ import {
   resolveChainEdgeMode,
   evaluateChainToolConditions,
   evaluateChainCommandConditions,
+  resolveChainResultText,
   summarizeChainToolInvocations,
   type ChainWorkflowDefinition,
   type ChainWorkflowEdge,
@@ -6690,6 +6691,172 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       return meta;
     };
 
+    const dispatchAgentChain = async (): Promise<void> => {
+      // ── Agent chaining: channel-level workflow keyed by (channelId, rootAgentSlug) ──
+      // Experiment/understanding epochs are exempt: they fire dozens of times per
+      // run and their result is a proof artifact, not a user turn to hand off. A
+      // chain here just makes the next agent (e.g. euler-reviewer) reject every
+      // epoch, once per epoch. The user drives the loop; the loop does not chain.
+      if (ctx.isExperiment) {
+        log.info(`Chain: skipped for experiment epoch (conversation=${ctx.conversationId})`);
+      } else if (ctx.agentSlug && ctx.agentOrgId) {
+        try {
+          const rootAgentSlug = ctx.rootAgentSlug ?? ctx.agentSlug;
+          const binding = await agentChainWorkflowRepository.findActiveWorkflowForChannel(ctx.channelId, rootAgentSlug, ctx.senderId);
+          if (!binding) {
+            log.info(`Chain: no active workflow bound for channel=${ctx.channelId} root=${rootAgentSlug}`);
+            return;
+          }
+
+          const workflow = parseWorkflowDefinition(binding.workflow.definition);
+          if (!workflow) {
+            log.warn(`Chain: workflow ${binding.workflowId} has invalid definition`);
+            return;
+          }
+
+          const currentDepth = ctx.chainDepth ?? 0;
+          const isCycleWorkflow = hasWorkflowCycle(workflow);
+          const maxDepth = isCycleWorkflow
+            ? 3
+            : Math.max(1, Math.min(workflow.maxDepth ?? 6, 12));
+          if (currentDepth >= maxDepth) {
+            await spacesAppFetch("/chat/postMessage", {
+              channelId: ctx.channelId,
+              conversationId: ctx.conversationId,
+              text: isCycleWorkflow
+                ? `<span data-mention="" data-mention-type="user" data-user-id="${ctx.senderId}" data-username="${ctx.senderName}" class="chat-input-mention">@${ctx.senderName}</span> Agent workflow cycle limit is breached (3 turns).`
+                : `<span data-mention="" data-mention-type="user" data-user-id="${ctx.senderId}" data-username="${ctx.senderName}" class="chat-input-mention">@${ctx.senderName}</span> Agent workflow reached max depth (${maxDepth}).`,
+              userId: ctx.spacesAppUserId,
+            }, token).catch(() => {});
+            log.info(`Chain: max depth ${maxDepth} reached for workflow ${binding.workflowId} (cycle=${isCycleWorkflow})`);
+            return;
+          }
+
+          const toolsUsed = (payload as { toolsUsed?: string[] }).toolsUsed ?? [];
+          const resultText = resolveChainResultText(payload.result, payload.pendingResponses);
+          // Feed the judge the REAL original user request, not the interpolated
+          // hand-off prompt (which `ctx.task` becomes after hop 1). On the first
+          // hop ctx.rootTask is unset and ctx.task IS the original request.
+          const originalTask = ctx.rootTask ?? ctx.task;
+          const selected = await selectNextWorkflowEdge(workflow, ctx.agentSlug, toolsUsed, resultText, originalTask, payload.toolInvocations);
+
+          if (!selected) {
+            log.info(`Chain: no matching edge from ${ctx.agentSlug} in workflow ${binding.workflowId}`);
+            return;
+          }
+
+          const taskTemplate = selected.edge.taskTemplate ?? selected.nextNode.taskTemplate ?? "{{result}}";
+          const interpolatedTask = interpolateChainTask(taskTemplate, {
+            result: resultText.slice(0, 4000),
+            agentSlug: ctx.agentSlug,
+            channelId: ctx.channelId,
+            conversationId: ctx.conversationId,
+            rootAgentSlug,
+          });
+
+          const targetAgentSlug = selected.nextNode.agentSlug;
+          const targetAgentRow = await agentRepository.findBySlug(targetAgentSlug, ctx.agentOrgId);
+          if (!targetAgentRow?.spacesAppToken || !targetAgentRow.spacesAppId) {
+            log.error(`Chain: target agent "${targetAgentSlug}" not found or not configured`);
+            return;
+          }
+
+          // Hand the next agent the previous agent's FINAL output verbatim (via
+          // `context`, independent of whether the task template used {{result}}),
+          // plus any attachments the previous agent produced — so artifacts (CSV,
+          // PDF, screenshots, …) carry across the hop instead of being dropped.
+          const handoffContext =
+            `--- Final output from the previous agent ("${ctx.agentSlug}") ---\n` +
+            resultText.slice(0, 8000);
+          const forwardedAttachments = payload.attachments ?? [];
+
+          const runRes = await fetch(`${CONFIG.internalUrl}/claw/api/v1/internal/run`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
+            },
+            body: JSON.stringify({
+              userId: ctx.senderId,
+              task: interpolatedTask,
+              context: handoffContext,
+              agentSlug: targetAgentSlug,
+              orgId: targetAgentRow.orgId,
+              channelId: ctx.channelId,
+              ...(forwardedAttachments.length > 0 ? { attachments: forwardedAttachments } : {}),
+              callbackUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/result`,
+              progressUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/progress`,
+            }),
+          });
+
+          if (!runRes.ok) { log.error(`Chain trigger HTTP ${runRes.status}`); return; }
+          const runBody = (await runRes.json()) as { success: boolean; sessionId?: string; error?: string };
+
+          if (runBody.success && runBody.sessionId && targetAgentRow.spacesAppToken && targetAgentRow.spacesAppId) {
+            const targetAppToken = decryptStoredField(targetAgentRow.spacesAppToken);
+            const targetContext: SessionContext = {
+              mentionedUserId: targetAgentRow.spacesAppUserId ?? "",
+              senderId: ctx.senderId,
+              senderName: ctx.senderName,
+              channelId: ctx.channelId,
+              channelName: ctx.channelName,
+              conversationId: ctx.conversationId,
+              task: interpolatedTask,
+              rootTask: originalTask,
+              agentId: targetAgentRow.id,
+              agentOrgId: targetAgentRow.orgId ?? null,
+              agentSlug: targetAgentSlug,
+              responseMode: "conversation",
+              appToken: targetAppToken,
+              spacesAppId: targetAgentRow.spacesAppId,
+              spacesAppUserId: targetAgentRow.spacesAppUserId ?? "",
+              chainDepth: currentDepth + 1,
+              rootAgentSlug,
+              workflowId: binding.workflowId,
+              triggerSource: "spaces",
+              ...(ctx.traceId ? { traceId: ctx.traceId } : {}),
+            };
+            await setSession(runBody.sessionId, targetContext);
+            const targetDispatchPayload = {
+              userId: ctx.senderId,
+              task: interpolatedTask,
+              context: handoffContext,
+              conversationId: ctx.conversationId,
+              agentSlug: targetAgentSlug,
+              orgId: targetAgentRow.orgId,
+              eventType: "APP_MENTIONED",
+              traceId: ctx.traceId ?? runBody.sessionId,
+              ...(forwardedAttachments.length > 0 ? { attachments: forwardedAttachments } : {}),
+              callbackUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/result`,
+              progressUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/progress`,
+              channelId: ctx.channelId,
+            };
+            await registerRunRecovery({
+              rootSessionId: runBody.sessionId,
+              maxRetries: CONFIG.runRecoveryMaxRetries,
+              timeoutMs: CONFIG.runRecoveryTimeoutMs,
+              retryBackoffMs: CONFIG.runRecoveryBackoffMs,
+              dispatchPayload: targetDispatchPayload,
+              sessionContext: targetContext,
+            });
+
+            log.info(`Chain: ${ctx.agentSlug} → ${targetAgentSlug} (step ${currentDepth + 1}/${maxDepth}, workflow ${binding.workflowId})`);
+            await spacesAppFetch("/chat/postMessage", {
+              channelId: ctx.channelId,
+              conversationId: ctx.conversationId,
+              markdownText: `⛓️ **Agent workflow**: \`${ctx.agentSlug}\` → \`${targetAgentSlug}\` (step ${currentDepth + 1}/${maxDepth})`,
+              userId: ctx.spacesAppUserId,
+              metadata: { contentFormat: "markdown" },
+            }, token).catch(() => {});
+          } else if (!runBody.success) {
+            log.error(`Chain: failed to trigger ${targetAgentSlug}: ${runBody.error ?? "unknown"}`);
+          }
+        } catch (chainErr) {
+          log.error("Chain trigger failed (non-fatal):", { error: errMsg(chainErr) });
+        }
+      }
+    };
+
     // ── Copilot mode: post pendingResponses instead of result.text ──
     if (payload.pendingResponses?.length) {
       if (ctx.responseMode === "approval") {
@@ -6841,6 +7008,11 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
         }
         log.info(`Copilot: posted ${copilotApprovalCardsSent}/${copilotPendingActions.length} write action approval(s)`);
       }
+
+      // Pending-response delivery must not bypass workflow chaining. Keep this
+      // before the persistent-copilot return so command/tool conditions observe
+      // the completed run, while the normal post-processing path stays skipped.
+      await dispatchAgentChain();
 
       // Don't delete session — copilot sessions persist for multi-turn
       return;
@@ -7262,169 +7434,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       log.info(`Sent ${approvalCardsSent}/${pendingActionsPayload.length} write action approval(s) to ${ctx.senderId}`);
     }
 
-    // ── Agent chaining: channel-level workflow keyed by (channelId, rootAgentSlug) ──
-    // Experiment/understanding epochs are exempt: they fire dozens of times per
-    // run and their result is a proof artifact, not a user turn to hand off. A
-    // chain here just makes the next agent (e.g. euler-reviewer) reject every
-    // epoch, once per epoch. The user drives the loop; the loop does not chain.
-    if (ctx.isExperiment) {
-      log.info(`Chain: skipped for experiment epoch (conversation=${ctx.conversationId})`);
-    } else if (ctx.agentSlug && ctx.agentOrgId) {
-      try {
-        const rootAgentSlug = ctx.rootAgentSlug ?? ctx.agentSlug;
-        const binding = await agentChainWorkflowRepository.findActiveWorkflowForChannel(ctx.channelId, rootAgentSlug, ctx.senderId);
-        if (!binding) {
-          log.info(`Chain: no active workflow bound for channel=${ctx.channelId} root=${rootAgentSlug}`);
-          return;
-        }
-
-        const workflow = parseWorkflowDefinition(binding.workflow.definition);
-        if (!workflow) {
-          log.warn(`Chain: workflow ${binding.workflowId} has invalid definition`);
-          return;
-        }
-
-        const currentDepth = ctx.chainDepth ?? 0;
-        const isCycleWorkflow = hasWorkflowCycle(workflow);
-        const maxDepth = isCycleWorkflow
-          ? 3
-          : Math.max(1, Math.min(workflow.maxDepth ?? 6, 12));
-        if (currentDepth >= maxDepth) {
-          await spacesAppFetch("/chat/postMessage", {
-            channelId: ctx.channelId,
-            conversationId: ctx.conversationId,
-            text: isCycleWorkflow
-              ? `<span data-mention="" data-mention-type="user" data-user-id="${ctx.senderId}" data-username="${ctx.senderName}" class="chat-input-mention">@${ctx.senderName}</span> Agent workflow cycle limit is breached (3 turns).`
-              : `<span data-mention="" data-mention-type="user" data-user-id="${ctx.senderId}" data-username="${ctx.senderName}" class="chat-input-mention">@${ctx.senderName}</span> Agent workflow reached max depth (${maxDepth}).`,
-            userId: ctx.spacesAppUserId,
-          }, token).catch(() => {});
-          log.info(`Chain: max depth ${maxDepth} reached for workflow ${binding.workflowId} (cycle=${isCycleWorkflow})`);
-          return;
-        }
-
-        const toolsUsed = (payload as { toolsUsed?: string[] }).toolsUsed ?? [];
-        const resultText = payload.result ?? "";
-        // Feed the judge the REAL original user request, not the interpolated
-        // hand-off prompt (which `ctx.task` becomes after hop 1). On the first
-        // hop ctx.rootTask is unset and ctx.task IS the original request.
-        const originalTask = ctx.rootTask ?? ctx.task;
-        const selected = await selectNextWorkflowEdge(workflow, ctx.agentSlug, toolsUsed, resultText, originalTask, payload.toolInvocations);
-
-        if (!selected) {
-          log.info(`Chain: no matching edge from ${ctx.agentSlug} in workflow ${binding.workflowId}`);
-          return;
-        }
-
-        const taskTemplate = selected.edge.taskTemplate ?? selected.nextNode.taskTemplate ?? "{{result}}";
-        const interpolatedTask = interpolateChainTask(taskTemplate, {
-          result: resultText.slice(0, 4000),
-          agentSlug: ctx.agentSlug,
-          channelId: ctx.channelId,
-          conversationId: ctx.conversationId,
-          rootAgentSlug,
-        });
-
-        const targetAgentSlug = selected.nextNode.agentSlug;
-        const targetAgentRow = await agentRepository.findBySlug(targetAgentSlug, ctx.agentOrgId);
-        if (!targetAgentRow?.spacesAppToken || !targetAgentRow.spacesAppId) {
-          log.error(`Chain: target agent "${targetAgentSlug}" not found or not configured`);
-          return;
-        }
-
-        // Hand the next agent the previous agent's FINAL output verbatim (via
-        // `context`, independent of whether the task template used {{result}}),
-        // plus any attachments the previous agent produced — so artifacts (CSV,
-        // PDF, screenshots, …) carry across the hop instead of being dropped.
-        const handoffContext =
-          `--- Final output from the previous agent ("${ctx.agentSlug}") ---\n` +
-          resultText.slice(0, 8000);
-        const forwardedAttachments = payload.attachments ?? [];
-
-        const runRes = await fetch(`${CONFIG.internalUrl}/claw/api/v1/internal/run`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}),
-          },
-          body: JSON.stringify({
-            userId: ctx.senderId,
-            task: interpolatedTask,
-            context: handoffContext,
-            agentSlug: targetAgentSlug,
-            orgId: targetAgentRow.orgId,
-            channelId: ctx.channelId,
-            ...(forwardedAttachments.length > 0 ? { attachments: forwardedAttachments } : {}),
-            callbackUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/result`,
-            progressUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/progress`,
-          }),
-        });
-
-        if (!runRes.ok) { log.error(`Chain trigger HTTP ${runRes.status}`); return; }
-        const runBody = (await runRes.json()) as { success: boolean; sessionId?: string; error?: string };
-
-        if (runBody.success && runBody.sessionId && targetAgentRow.spacesAppToken && targetAgentRow.spacesAppId) {
-          const targetAppToken = decryptStoredField(targetAgentRow.spacesAppToken);
-          const targetContext: SessionContext = {
-            mentionedUserId: targetAgentRow.spacesAppUserId ?? "",
-            senderId: ctx.senderId,
-            senderName: ctx.senderName,
-            channelId: ctx.channelId,
-            channelName: ctx.channelName,
-            conversationId: ctx.conversationId,
-            task: interpolatedTask,
-            rootTask: originalTask,
-            agentId: targetAgentRow.id,
-            agentOrgId: targetAgentRow.orgId ?? null,
-            agentSlug: targetAgentSlug,
-            responseMode: "conversation",
-            appToken: targetAppToken,
-            spacesAppId: targetAgentRow.spacesAppId,
-            spacesAppUserId: targetAgentRow.spacesAppUserId ?? "",
-            chainDepth: currentDepth + 1,
-            rootAgentSlug,
-            workflowId: binding.workflowId,
-            triggerSource: "spaces",
-            ...(ctx.traceId ? { traceId: ctx.traceId } : {}),
-          };
-          await setSession(runBody.sessionId, targetContext);
-          const targetDispatchPayload = {
-            userId: ctx.senderId,
-            task: interpolatedTask,
-            context: handoffContext,
-            conversationId: ctx.conversationId,
-            agentSlug: targetAgentSlug,
-            orgId: targetAgentRow.orgId,
-            eventType: "APP_MENTIONED",
-            traceId: ctx.traceId ?? runBody.sessionId,
-            ...(forwardedAttachments.length > 0 ? { attachments: forwardedAttachments } : {}),
-            callbackUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/result`,
-            progressUrl: `${CONFIG.internalUrl}/claw/api/v1/webhook/progress`,
-            channelId: ctx.channelId,
-          };
-          await registerRunRecovery({
-            rootSessionId: runBody.sessionId,
-            maxRetries: CONFIG.runRecoveryMaxRetries,
-            timeoutMs: CONFIG.runRecoveryTimeoutMs,
-            retryBackoffMs: CONFIG.runRecoveryBackoffMs,
-            dispatchPayload: targetDispatchPayload,
-            sessionContext: targetContext,
-          });
-
-          log.info(`Chain: ${ctx.agentSlug} → ${targetAgentSlug} (step ${currentDepth + 1}/${maxDepth}, workflow ${binding.workflowId})`);
-          await spacesAppFetch("/chat/postMessage", {
-            channelId: ctx.channelId,
-            conversationId: ctx.conversationId,
-            markdownText: `⛓️ **Agent workflow**: \`${ctx.agentSlug}\` → \`${targetAgentSlug}\` (step ${currentDepth + 1}/${maxDepth})`,
-            userId: ctx.spacesAppUserId,
-            metadata: { contentFormat: "markdown" },
-          }, token).catch(() => {});
-        } else if (!runBody.success) {
-          log.error(`Chain: failed to trigger ${targetAgentSlug}: ${runBody.error ?? "unknown"}`);
-        }
-      } catch (chainErr) {
-        log.error("Chain trigger failed (non-fatal):", { error: errMsg(chainErr) });
-      }
-    }
+    await dispatchAgentChain();
   } catch (err) {
     // Include enough context to diagnose env-mismatch / token / channel
     // issues from logs alone. Earlier the catch only surfaced `err.message`,


### PR DESCRIPTION
1. Problem Description:
Agents that complete through `pendingResponses` (including the Xyne Architect / Verify Responses flow) returned from the result webhook before agent-workflow edge selection. Their configured downstream agent/reviewer therefore never started. These runs also expose an empty `result.text`, so downstream judge context and handoff text would be blank without a pending-response fallback.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Traced `/webhook/result` delivery and found that normal conversation results reached workflow dispatch, while the Copilot/pending-response branch returned early.

3. Explain the solution implemented in the PR:
Extract the existing workflow dispatch block into one local helper used by both result-delivery paths. Invoke it before the persistent Copilot return, and derive chain result text from `pendingResponses` when the normal result is empty. Preserve approval-mode behavior and the existing Copilot session lifecycle.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `pnpm exec vitest run src/lib/chain-workflow.test.ts src/routes/webhook-chain-pending-responses.test.ts` — 35 tests passed.
- `git diff --check` — passed.
- Full backend test command was attempted but currently has unrelated baseline failures, including an ungenerated Prisma client and existing test/mocking failures.
- Backend typecheck was attempted; before Prisma generation it reported existing generated-client/type errors. Prisma generation did not complete in the sandbox environment.

9. Services to which this change is to be deployed:
`xyne-claw-auth` backend

10. Main PR link (if this PR is raised against a release branch):
N/A — targets `feature/deploy-xyneclaw`.