### PR TITLE
fix: XYNE-17516 make activity timestamps explicit

### DIFF
--- a/apps/backend/prisma/migrations/20260830214500_make_activity_updated_at_explicit/migration.sql
+++ b/apps/backend/prisma/migrations/20260830214500_make_activity_updated_at_explicit/migration.sql
@@ -1,0 +1,4 @@
+-- Activity.updatedAt is the event timestamp used for feed ordering. Prisma must
+-- not rewrite it for read-state, classification, or maintenance updates.
+ALTER TABLE "activities"
+ALTER COLUMN "updatedAt" SET DEFAULT CURRENT_TIMESTAMP;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2448,7 +2448,7 @@ model Activity {
   isRead          Boolean  @default(false)
   isThreadActivity Boolean?  // True when activity is for a message inside a thread (not the initial message)
   createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt  // For tracking when batched activity was last updated
+  updatedAt       DateTime @default(now())  // Event timestamp; update only when activity content changes
   conversationSeenCutoffAt  DateTime?    // Track createdAt of the 25th most recent conversation from the activity
 
   @@index([userId, createdAt, id]) // for userActivitiesPaginated

--- a/apps/backend/src/services/activity/activityService.ts
+++ b/apps/backend/src/services/activity/activityService.ts
@@ -437,6 +437,7 @@ export class ActivityService {
         data: {
           actorId: actorId,
           isRead: false,
+          updatedAt: new Date(),
           ...(isThreadActivity !== undefined ? { isThreadActivity } : {}),
           ...(conversationSeenCutoffAt ? { conversationSeenCutoffAt } : {}),
         },
@@ -572,6 +573,7 @@ export class ActivityService {
             actorId: actorId,
             isRead: false,
             messageId: latestReplyMessageId,
+            updatedAt: new Date(),
             actionSourceId: latestReplyMessageId,
             ...(conversationSeenCutoffAt ? { conversationSeenCutoffAt } : {}),
           },
@@ -656,6 +658,7 @@ export class ActivityService {
         actorId,
         messageId: latestReplyMessageId,
         actionSourceId: latestReplyMessageId,
+        updatedAt: new Date(),
       },
     });
   }

--- a/apps/backend/src/services/activity/activityTimestampPolicy.test.ts
+++ b/apps/backend/src/services/activity/activityTimestampPolicy.test.ts
@@ -1,0 +1,105 @@
+import type { PrismaClient } from '@prisma/client';
+
+jest.mock('@xyne/shared', () => ({
+  ActivityClassification: { FYI: 'FYI' },
+  ActivityClassificationJobType: {},
+  UserStatus: { ACTIVE: 'ACTIVE' },
+}));
+
+jest.mock('@/database/client', () => ({ db: {} }));
+jest.mock('@/database/repositories', () => ({
+  repositories: { channels: { getWorkspaceId: jest.fn() } },
+}));
+jest.mock('@/database/tenant/context', () => ({
+  currentWorkspaceId: jest.fn(),
+  withWorkspaceScope: (callback: () => unknown) => callback(),
+  runAsSystem: (callback: () => unknown) => callback(),
+}));
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+import { ActivityService } from './activityService';
+
+const activity = {
+  findFirst: jest.fn(),
+  update: jest.fn(),
+  updateMany: jest.fn(),
+};
+const message = { findUnique: jest.fn() };
+const conversation = { findUnique: jest.fn(), findMany: jest.fn() };
+const prisma = { activity, message, conversation } as unknown as PrismaClient;
+
+describe('Activity event timestamp policy', () => {
+  const service = new ActivityService(prisma);
+  const eventAt = new Date('2026-08-30T12:00:00.000Z');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers().setSystemTime(eventAt);
+    activity.update.mockResolvedValue({});
+    activity.updateMany.mockResolvedValue({ count: 1 });
+    message.findUnique.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('refreshes updatedAt when a new reaction changes a batched activity', async () => {
+    activity.findFirst.mockResolvedValue({
+      id: 'activity-1',
+      conversationSeenCutoffAt: eventAt,
+    });
+
+    await service.upsertReactionActivityV2({
+      messageId: 'message-1',
+      channelId: 'channel-1',
+      actorId: 'actor-2',
+      messageAuthorId: 'user-1',
+    });
+
+    expect(activity.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ updatedAt: eventAt }),
+      })
+    );
+  });
+
+  it('refreshes updatedAt when a new reply changes a batched activity', async () => {
+    activity.findFirst.mockResolvedValue({
+      id: 'activity-1',
+      conversationSeenCutoffAt: eventAt,
+    });
+
+    await service.upsertReplyActivityV2({
+      conversationId: 'conversation-1',
+      parentMessageId: 'message-1',
+      channelId: 'channel-1',
+      actorId: 'actor-2',
+      recipientUserId: 'user-1',
+      latestReplyMessageId: 'message-2',
+    });
+
+    expect(activity.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ updatedAt: eventAt }),
+      })
+    );
+  });
+
+  it('refreshes updatedAt when reply activity metadata moves to another message', async () => {
+    await service.updateReplyActivitiesMetadataV2({
+      conversationId: 'conversation-1',
+      recipientUserIds: ['user-1'],
+      actorId: 'actor-2',
+      latestReplyMessageId: 'message-2',
+    });
+
+    expect(activity.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ updatedAt: eventAt }),
+      })
+    );
+  });
+});

--- a/apps/backend/src/services/unreadService.ts
+++ b/apps/backend/src/services/unreadService.ts
@@ -38,7 +38,6 @@ export class UnreadService {
           isRead: false,
         }, data: {
           isRead: true,
-          updatedAt: new Date().toISOString(),
         }
       });
 
@@ -108,7 +107,6 @@ export class UnreadService {
           isRead: false,
         }, data: {
           isRead: true,
-          updatedAt: new Date().toISOString(),
         }
       });
       const conversationSeenCutoffAt =


### PR DESCRIPTION
Companion PR: #1219 — https://github.com/juspay/xyne-spaces/pull/1219

1. Problem Description:
Activity.updatedAt is overloaded as feed ordering/display event time while Prisma manages it as a generic row-modification timestamp. Read-state, classification, or maintenance writes can therefore resurface old Activity items.

Issue context: https://spaces.xyne.juspay.net/chat/dir/cmi39e2jj00fex66cheedyjc8/152423d0-286a-438b-ad8d-679ef6170278 (XYNE-17516)

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Audited every Prisma Activity update/upsert path after reproducing @updatedAt behavior. Read-state writes are non-semantic; reaction/reply aggregation paths are genuine Activity event changes and must refresh ordering deliberately.

3. Explain the solution implemented in the PR:
- Replaces Activity.updatedAt @updatedAt with @default(now()), so creates retain a DB-generated timestamp while ordinary updates preserve it.
- Adds a migration that sets the activities.updatedAt database default without rewriting existing rows.
- Removes explicit updatedAt writes from channel/thread read-state updates.
- Explicitly refreshes updatedAt in the three semantic batched reaction/reply update paths.
- Leaves classification, workspace backfill, and classification-worker writes timestamp-neutral.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
ALTER TABLE activities ALTER COLUMN updatedAt SET DEFAULT CURRENT_TIMESTAMP. This is a schema-default change only; no row backfill or data rewrite.

6. Data fix Details (if any):
N/A. Existing timestamps are intentionally preserved.

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Jest: activityTimestampPolicy.test.ts — 3 tests passed for reaction/reply semantic refreshes.
- Backend TypeScript typecheck passed.
- ESLint passed with no errors (test file is ignored by the repository ESLint pattern).
- Prisma schema validation and client/schema generation passed.
- prisma migrate diff matched the checked-in ALTER COLUMN SET DEFAULT migration.
- Local DB verification confirmed: create receives the DB default; classification-only update preserves updatedAt; explicit event update changes updatedAt.

9. Services to which this change is to be deployed:
Database migration, then xyne-backend.

10. Main PR link (if this PR is raised against a release branch):
N/A — targets main.

**Merge interaction:** this is the systemic timestamp-policy PR and is independently based on main. If the narrow containment PR (#1219) merges first, retain its parameterized read-state helper calls while resolving the small unreadService conflict; the schema/default and semantic-update changes remain unchanged.