### PR TITLE
fix: XYNE-17516 preserve activity timestamps on read

### DIFF
--- a/apps/backend/src/services/activityReadStateService.test.ts
+++ b/apps/backend/src/services/activityReadStateService.test.ts
@@ -1,0 +1,41 @@
+import {
+  markChannelActivitiesRead,
+  markThreadActivitiesRead,
+} from './activityReadStateService';
+
+const executeRaw = jest.fn();
+const client = { $executeRaw: executeRaw };
+
+function renderedSql(call: unknown[]): string {
+  const [strings] = call as [TemplateStringsArray, ...unknown[]];
+  return strings.join('?').replace(/\s+/g, ' ').trim();
+}
+
+describe('activity read-state updates', () => {
+  beforeEach(() => {
+    executeRaw.mockReset();
+    executeRaw.mockResolvedValue(1);
+  });
+
+  it('marks channel activities read without updating their event timestamp', async () => {
+    await markChannelActivitiesRead(client, 'user-1', 'channel-1');
+
+    const call = executeRaw.mock.calls[0];
+    expect(renderedSql(call)).toBe(
+      'UPDATE "activities" SET "isRead" = true WHERE "userId" = ? AND "channelId" = ? AND "isRead" = false',
+    );
+    expect(call.slice(1)).toEqual(['user-1', 'channel-1']);
+    expect(renderedSql(call)).not.toContain('updatedAt');
+  });
+
+  it('marks thread activities read without updating their event timestamp', async () => {
+    await markThreadActivitiesRead(client, 'user-1', 'conversation-1');
+
+    const call = executeRaw.mock.calls[0];
+    expect(renderedSql(call)).toBe(
+      'UPDATE "activities" SET "isRead" = true WHERE "userId" = ? AND "conversationId" = ? AND "isRead" = false',
+    );
+    expect(call.slice(1)).toEqual(['user-1', 'conversation-1']);
+    expect(renderedSql(call)).not.toContain('updatedAt');
+  });
+});

--- a/apps/backend/src/services/activityReadStateService.ts
+++ b/apps/backend/src/services/activityReadStateService.ts
@@ -1,0 +1,40 @@
+type ActivityReadClient = {
+  $executeRaw(
+    query: TemplateStringsArray,
+    ...values: Array<string>
+  ): Promise<number>;
+};
+
+/**
+ * Read-state changes must not change Activity.updatedAt because the activity feed
+ * uses that field as the event timestamp. Prisma's @updatedAt behavior makes a
+ * normal update/updateMany unsuitable here.
+ */
+export async function markChannelActivitiesRead(
+  client: ActivityReadClient,
+  userId: string,
+  channelId: string,
+): Promise<number> {
+  return client.$executeRaw`
+    UPDATE "activities"
+    SET "isRead" = true
+    WHERE "userId" = ${userId}
+      AND "channelId" = ${channelId}
+      AND "isRead" = false
+  `;
+}
+
+/** See markChannelActivitiesRead. */
+export async function markThreadActivitiesRead(
+  client: ActivityReadClient,
+  userId: string,
+  conversationId: string,
+): Promise<number> {
+  return client.$executeRaw`
+    UPDATE "activities"
+    SET "isRead" = true
+    WHERE "userId" = ${userId}
+      AND "conversationId" = ${conversationId}
+      AND "isRead" = false
+  `;
+}

--- a/apps/backend/src/services/unreadService.ts
+++ b/apps/backend/src/services/unreadService.ts
@@ -2,6 +2,7 @@ import { DatabaseClient } from '@/database/client';
 import { NotificationType } from '@xyne/shared';
 import {logger} from '@/utils/logger';
 import { notificationService } from './notificationService';
+import { markChannelActivitiesRead, markThreadActivitiesRead } from './activityReadStateService';
 
 const prisma = DatabaseClient.getInstance();
 
@@ -31,16 +32,7 @@ export class UnreadService {
           lastReadAt: viewedAt,
         }
       });
-      await prisma.activity.updateMany({
-        where: {
-          userId,
-          conversationId,
-          isRead: false,
-        }, data: {
-          isRead: true,
-          updatedAt: new Date().toISOString(),
-        }
-      });
+      await markThreadActivitiesRead(prisma, userId, conversationId);
 
       await notificationService.createNotification(userId, {
         title: 'Silent notification',
@@ -101,16 +93,7 @@ export class UnreadService {
         take: 25,
         select: { createdAt: true },
       });
-      await prisma.activity.updateMany({
-        where: {
-          userId,
-          channelId,
-          isRead: false,
-        }, data: {
-          isRead: true,
-          updatedAt: new Date().toISOString(),
-        }
-      });
+      await markChannelActivitiesRead(prisma, userId, channelId);
       const conversationSeenCutoffAt =
         seenConversations[seenConversations.length - 1]?.createdAt ?? viewedAt;
 


### PR DESCRIPTION
Companion PR: #1218 — https://github.com/juspay/xyne-spaces/pull/1218

1. Problem Description:
Opening a channel or thread marks matching Activity rows as read. Activity.updatedAt also drives feed ordering and displayed event time, so Prisma's @updatedAt behavior made old items appear new.

Issue context: https://spaces.xyne.juspay.net/chat/dir/cmi39e2jj00fex66cheedyjc8/152423d0-286a-438b-ad8d-679ef6170278 (XYNE-17516)

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Correlated the production request with Activity.updateMany, traced channel/thread view handlers into UnreadService, and reproduced that Prisma updateMany changes updatedAt even when only isRead is supplied.

3. Explain the solution implemented in the PR:
Adds a small Activity read-state helper that performs parameterized SQL updates scoped by user plus channel or conversation. The statements update only isRead, deliberately preserving updatedAt. Both channel and thread view flows use the helper.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
None.

6. Data fix Details (if any):
N/A. Existing resurfaced timestamps are not rewritten.

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- Jest: activityReadStateService.test.ts — 2 tests passed.
- Backend TypeScript typecheck passed.
- ESLint passed with no errors (test file is ignored by the repository ESLint pattern).
- Local DB verification confirmed isRead changed while updatedAt remained byte-for-byte identical.

9. Services to which this change is to be deployed:
xyne-backend

10. Main PR link (if this PR is raised against a release branch):
N/A — targets main.

**Merge interaction:** this is the narrow containment PR. The companion systemic PR (#1218) is independently based on main. If both merge, merge this PR first, then resolve the companion's small unreadService conflict by retaining this PR's helper calls.