### PR TITLE
feat: XYNE-60735 multi-repo SDLC hubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.219.0-release-20260825.19](https://github.com/juspay/xyne-spaces/compare/v1.219.0-release-20260825.18...v1.219.0-release-20260825.19) (2026-08-30)
+
+
+### Bug Fixes
+
+* enable jemalloc heap profiling to trace native memory leak ([#1217](https://github.com/juspay/xyne-spaces/issues/1217)) ([9c0435e](https://github.com/juspay/xyne-spaces/commit/9c0435e6d8556adb3225ae0b125c678e9b0590fd))
+
 ## [1.219.0-release-20260825.18](https://github.com/juspay/xyne-spaces/compare/v1.219.0-release-20260825.17...v1.219.0-release-20260825.18) (2026-08-30)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.219.0-release-20260825.18](https://github.com/juspay/xyne-spaces/compare/v1.219.0-release-20260825.17...v1.219.0-release-20260825.18) (2026-08-30)
+
+
+### Features
+
+* pop out artifacts from tracks, and expand with the discussion ([#1210](https://github.com/juspay/xyne-spaces/issues/1210)) ([6ef1e05](https://github.com/juspay/xyne-spaces/commit/6ef1e056824f55c43271f9e5076eaf7b2a2afdf0))
+
 ## [1.219.0-release-20260825.17](https://github.com/juspay/xyne-spaces/compare/v1.219.0-release-20260825.16...v1.219.0-release-20260825.17) (2026-08-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.219.0-release-20260825.17](https://github.com/juspay/xyne-spaces/compare/v1.219.0-release-20260825.16...v1.219.0-release-20260825.17) (2026-08-29)
+
+
+### Features
+
+* open SDLC artifacts in a window of their own ([#1194](https://github.com/juspay/xyne-spaces/issues/1194)) ([#1206](https://github.com/juspay/xyne-spaces/issues/1206)) ([b9f07ac](https://github.com/juspay/xyne-spaces/commit/b9f07ac9f94d0d7fdeb9e4f9aeaf9b7070ea57b0))
+
 ## [1.219.0-release-20260825.16](https://github.com/juspay/xyne-spaces/compare/v1.219.0-release-20260825.15...v1.219.0-release-20260825.16) (2026-08-28)
 
 

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -65,6 +65,8 @@ RUN apt-get update && apt-get install -y \
     openssh-client \
     libssl-dev \
     ca-certificates \
+    libjemalloc2 \
+    && ln -sf "$(find /usr/lib -name 'libjemalloc.so.2' | head -1)" /usr/local/lib/libjemalloc.so.2 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
@@ -94,5 +96,8 @@ USER backend
 EXPOSE 3001
 
 ENV NODE_ENV=production
+
+ENV LD_PRELOAD=/usr/local/lib/libjemalloc.so.2
+ENV MALLOC_CONF=prof:true,prof_active:true,prof_prefix:/tmp/jeprof,lg_prof_sample:19,lg_prof_interval:30
 
 CMD ["pnpm", "run", "start"]

--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -1989,7 +1989,8 @@ export const sdlcEntityLinkTable = table("sdlc_entity_links")
   .columns({
     id: string(),
     workspaceId: string(),
-    repoId: string(),
+    repoId: string().optional(),
+    channelId: string().optional(),
     sourceType: string(),
     sourceId: string(),
     targetType: string(),
@@ -2004,7 +2005,7 @@ export const sdlcArtifactTable = table("sdlc_artifacts")
   .columns({
     workspaceId: string(),
     artifactId: string(),
-    repoId: string(),
+    repoId: string().optional(),
     artifactType: string(),
     artifactStatus: string(),
     workflowExecutionId: string().optional(),
@@ -2021,7 +2022,7 @@ export const sdlcTrackTable = table("sdlc_tracks")
   .columns({
     workspaceId: string(),
     id: string(),
-    repoId: string(),
+    repoId: string().optional(),
     name: string(),
     description: string().optional(),
     status: string(),
@@ -4050,6 +4051,11 @@ export const channelTableRelationships = relationships(channelTable, ({ one, man
     sourceField: ["id"],
     destField: ["channelId"],
     destSchema: repoTable,
+  }),
+  sdlcEntityLinks: many({
+    sourceField: ["id"],
+    destField: ["channelId"],
+    destSchema: sdlcEntityLinkTable,
   })
 }));
 
@@ -4477,6 +4483,11 @@ export const sdlcEntityLinkTableRelationships = relationships(sdlcEntityLinkTabl
     sourceField: ["repoId"],
     destField: ["id"],
     destSchema: repoTable,
+  }),
+  channel: one({
+    sourceField: ["channelId"],
+    destField: ["id"],
+    destSchema: channelTable,
   })
 }));
 

--- a/apps/backend/prisma/migrations/20260831033955_sdlc_multirepo_add/migration.sql
+++ b/apps/backend/prisma/migrations/20260831033955_sdlc_multirepo_add/migration.sql
@@ -1,0 +1,25 @@
+-- AlterTable
+ALTER TABLE "public"."sdlc_artifacts" ALTER COLUMN "repoId" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."sdlc_entity_links" ADD COLUMN     "channelId" TEXT,
+ALTER COLUMN "repoId" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "public"."sdlc_tracks" ALTER COLUMN "repoId" DROP NOT NULL;
+
+-- CreateIndex
+CREATE INDEX "sdlc_entity_links_workspaceId_idx" ON "public"."sdlc_entity_links"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "sdlc_entity_links_channelId_relationType_idx" ON "public"."sdlc_entity_links"("channelId", "relationType");
+
+-- CreateIndex
+CREATE INDEX "sdlc_entity_links_sourceType_sourceId_relationType_idx" ON "public"."sdlc_entity_links"("sourceType", "sourceId", "relationType");
+
+-- CreateIndex
+CREATE INDEX "sdlc_entity_links_targetType_targetId_relationType_idx" ON "public"."sdlc_entity_links"("targetType", "targetId", "relationType");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sdlc_entity_links_channel_edge_key" ON "public"."sdlc_entity_links"("channelId", "sourceType", "sourceId", "targetType", "targetId", "relationType");
+

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1782,7 +1782,10 @@ model Channel {
   canvasFolders      CanvasFolder[]
   emails             Email[]
   boardMappings      ChannelBoardMapping[]
-  sdlcRepos          Repo[] @relation("RepoSdlcChannel")
+  /// @deprecated -> back-relation of the legacy 1:1 Repo.channelId
+  sdlcRepos          Repo[]           @relation("RepoSdlcChannel")
+  // SDLC channel membership: the CHANNEL -> REPOSITORY edges in sdlcEntityLinks.
+  sdlcEntityLinks    SdlcEntityLink[] @relation("SdlcChannelLink")
 
   @@index([projectId])
   @@index([workspaceId, visibility, id]) // ACL workspace filtering + visibility
@@ -3213,15 +3216,20 @@ model Repo {
   prefix               String // Branch prefix: "feature"
   createdBy            String // User who added the repo
   projectId            String?
+  /// @deprecated -> membership is the CHANNEL -> REPOSITORY edge in sdlc_entity_links; never written since multi-repo
   channelId            String?
   sdlcSetupExecutionId String? @unique
   accessCapabilities   Json?
 
   project         Project?           @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  channel         Channel?           @relation("RepoSdlcChannel", fields: [channelId], references: [id], onDelete: Cascade)
+  /// @deprecated -> navigation for the legacy channelId; SetNull so deleting a channel keeps the repository
+  channel         Channel?           @relation("RepoSdlcChannel", fields: [channelId], references: [id], onDelete: SetNull)
   setupExecution  WorkflowExecution? @relation("RepoSetupExecution", fields: [sdlcSetupExecutionId], references: [id], onDelete: SetNull)
+  /// @deprecated -> back-relation of the legacy sdlc_entity_links.repoId
   sdlcEntityLinks SdlcEntityLink[]
+  /// @deprecated -> back-relation of the legacy sdlc_artifacts.repoId
   sdlcArtifacts   SdlcArtifact[]
+  /// @deprecated -> back-relation of the legacy sdlc_tracks.repoId
   sdlcTracks      SdlcTrack[]
 
   @@unique([url, createdBy]) // Same repo can be added by different users
@@ -3238,7 +3246,9 @@ model Repo {
 model SdlcEntityLink {
   id           String   @id @default(cuid())
   workspaceId  String
-  repoId       String
+  /// @deprecated -> scope is channelId; the repository is an endpoint of the edge, not a column
+  repoId       String?
+  channelId    String?
   sourceType   String
   sourceId     String
   targetType   String
@@ -3247,12 +3257,21 @@ model SdlcEntityLink {
   createdBy    String
   createdAt    DateTime @default(now())
 
-  repo Repo @relation(fields: [repoId], references: [id], onDelete: Cascade)
+  /// @deprecated -> navigation for the legacy repoId; SetNull so deleting a repository keeps the edge
+  repo    Repo?    @relation(fields: [repoId], references: [id], onDelete: SetNull)
+  channel Channel? @relation("SdlcChannelLink", fields: [channelId], references: [id], onDelete: Cascade)
 
-  @@unique([repoId, sourceType, sourceId, targetType, targetId, relationType])
-  @@index([workspaceId, repoId])
-  @@index([repoId, sourceType, sourceId])
-  @@index([repoId, targetType, targetId])
+  // The repository an edge is about is an endpoint, not a column: sourceId/targetId are
+  // polymorphic, so no relation covers them and readers filter on relationType.
+  @@unique([channelId, sourceType, sourceId, targetType, targetId, relationType], map: "sdlc_entity_links_channel_edge_key")
+  @@unique([repoId, sourceType, sourceId, targetType, targetId, relationType]) // deprecated
+  @@index([workspaceId])
+  @@index([channelId, relationType])
+  @@index([sourceType, sourceId, relationType])
+  @@index([targetType, targetId, relationType])
+  @@index([workspaceId, repoId]) // deprecated
+  @@index([repoId, sourceType, sourceId]) // deprecated
+  @@index([repoId, targetType, targetId]) // deprecated
   @@map("sdlc_entity_links")
   @@schema("public")
 }
@@ -3263,7 +3282,9 @@ model SdlcEntityLink {
 model SdlcArtifact {
   workspaceId         String
   artifactId          String   @id // canvas id (the only artifact kind for now) - Primary key
-  repoId              String
+  /// @deprecated -> repository comes from the link table; no new reads or writes. Still set, and still
+  /// read by the wiki and baseline lookups, until per-repo Wiki/Baseline folders replace it.
+  repoId              String?
   artifactType        String   @default("DEFAULT")
   artifactStatus      String   @default("ACTIVE")
   workflowExecutionId String?
@@ -3274,7 +3295,8 @@ model SdlcArtifact {
   createdAt           DateTime @default(now())
   updatedAt           DateTime @updatedAt
 
-  repo   Repo   @relation(fields: [repoId], references: [id], onDelete: Cascade)
+  /// @deprecated -> navigation for the legacy repoId
+  repo   Repo?  @relation(fields: [repoId], references: [id], onDelete: Cascade)
   canvas Canvas @relation(fields: [artifactId], references: [id], onDelete: Cascade)
 
   @@index([repoId])
@@ -3285,12 +3307,14 @@ model SdlcArtifact {
   @@schema("public")
 }
 
-// SDLC track: a named workstream inside a repo. Groups PRD canvases and
-// conversations via their nullable trackId columns (one track per item).
+// SDLC track: a named workstream inside a hub. Which hub is the CHANNEL -> TRACK edge in
+// sdlc_entity_links; the track row itself carries no scope. Groups canvases and tickets
+// through TRACK -> * TRACK_ITEM edges in the same table.
 model SdlcTrack {
   workspaceId String
   id          String   @id @default(cuid())
-  repoId      String
+  /// @deprecated -> scope is the CHANNEL -> TRACK edge in sdlc_entity_links; never written since multi-repo
+  repoId      String?
   name        String
   description String?
   status      String   @default("ACTIVE") // ACTIVE | COMPLETED | ARCHIVED
@@ -3298,9 +3322,10 @@ model SdlcTrack {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  repo Repo @relation(fields: [repoId], references: [id], onDelete: Cascade)
+  /// @deprecated -> navigation for the legacy repoId; SetNull so deleting a repository keeps the track
+  repo Repo? @relation(fields: [repoId], references: [id], onDelete: SetNull)
 
-  @@index([repoId, status])
+  @@index([repoId, status]) // deprecated
   @@index([workspaceId])
   @@map("sdlc_tracks")
   @@schema("public")

--- a/apps/backend/scripts/cleanup-sdlc-local.ts
+++ b/apps/backend/scripts/cleanup-sdlc-local.ts
@@ -6,6 +6,8 @@ import { getBaseRedisOptions } from '../src/services/redisFactory';
 
 const prisma = new PrismaClient();
 const SDLC_WORKFLOW_TYPES = ['SDLC_SETUP', 'SDLC_WORK', 'SDLC_WIKI'];
+// Mirrors SDLC_MEMBERSHIP_RELATION in packages/shared/src/sdlc.ts.
+const SDLC_MEMBERSHIP_RELATION = 'REPOSITORY';
 const PROTECTED_TABLES = new Set([
   'users',
   'workspaces',
@@ -63,16 +65,16 @@ type RepoRow = {
   name: string;
   url: string;
   canonicalUrl: string | null;
-  channelId: string;
   projectId: string | null;
 };
 
 async function resolveRepos(repoSelector?: string): Promise<RepoRow[]> {
+  // A project is what makes a repository an SDLC one; hub membership is optional
+  // now, and a repository registered into no hub still has to be cleaned up.
   const rows = await prisma.$queryRawUnsafe<RepoRow[]>(
-    `SELECT r.id, r.name, r.url, r."canonicalUrl", r."channelId", r."projectId"
+    `SELECT r.id, r.name, r.url, r."canonicalUrl", r."projectId"
        FROM public.repos r
-       JOIN public.channels c ON c.id = r."channelId"
-      WHERE c.metadata->>'surface' = 'SDLC'
+      WHERE r."projectId" IS NOT NULL
         AND ($1::text IS NULL OR $1 IN (r.id, r.name, r.url, r."canonicalUrl"))`,
     repoSelector ?? null
   );
@@ -83,6 +85,30 @@ async function resolveRepos(repoSelector?: string): Promise<RepoRow[]> {
     throw new Error(`Repository selector is ambiguous; use repo ID: ${repoSelector}`);
   }
   return rows;
+}
+
+/**
+ * Hubs safe to delete outright. Scoped to one repository that shares a hub, the
+ * hub survives: dropping it would take the other repositories' work with it.
+ */
+async function resolveChannels(repoIds: string[], scoped: boolean): Promise<string[]> {
+  if (!scoped) {
+    return textIds(`SELECT id FROM public.channels WHERE "type" = 'SDLC'`);
+  }
+  return textIds(
+    `SELECT c.id
+       FROM public.channels c
+      WHERE c."type" = 'SDLC'
+        AND EXISTS (SELECT 1 FROM public.sdlc_entity_links l
+                     WHERE l."channelId" = c.id
+                       AND l."relationType" = '${SDLC_MEMBERSHIP_RELATION}'
+                       AND l."targetId" = ANY($1::text[]))
+        AND NOT EXISTS (SELECT 1 FROM public.sdlc_entity_links l
+                         WHERE l."channelId" = c.id
+                           AND l."relationType" = '${SDLC_MEMBERSHIP_RELATION}'
+                           AND l."targetId" <> ALL($1::text[]))`,
+    [repoIds]
+  );
 }
 
 async function textIds(query: string, params: unknown[] = []): Promise<string[]> {
@@ -209,7 +235,7 @@ async function main(): Promise<void> {
 
   const repos = await resolveRepos(repoSelector);
   const repoIds = repos.map((repo) => repo.id);
-  const channelIds = repos.map((repo) => repo.channelId);
+  const channelIds = await resolveChannels(repoIds, Boolean(repoSelector));
   const workflowIds = await textIds(
     `SELECT id FROM public.workflows
       WHERE "workflowType" = ANY($1::text[])
@@ -238,11 +264,23 @@ async function main(): Promise<void> {
       JSON.stringify({ executionIds, conversationIds: clawConversationIds })
     );
   }
-  const canvases = channelIds.length
+  const hubCanvases = channelIds.length
     ? await textIds('SELECT id FROM public.canvases WHERE "channelId" = ANY($1::text[])', [
         channelIds,
       ])
     : [];
+  // In a hub that survives, only this repository's artifacts go.
+  const sharedHubCanvases = repoSelector
+    ? await textIds(
+        `SELECT a."artifactId" AS id
+           FROM public.sdlc_artifacts a
+           JOIN public.canvases cv ON cv.id = a."artifactId"
+          WHERE a."repoId" = ANY($1::text[])
+            AND cv."channelId" <> ALL($2::text[])`,
+        [repoIds, channelIds]
+      )
+    : [];
+  const canvases = [...new Set([...hubCanvases, ...sharedHubCanvases])];
   const folders = channelIds.length
     ? await textIds('SELECT id FROM public.canvas_folders WHERE "channelId" = ANY($1::text[])', [
         channelIds,
@@ -252,6 +290,16 @@ async function main(): Promise<void> {
     ? await textIds('SELECT id FROM public.tickets WHERE "channelId" = ANY($1::text[])', [
         channelIds,
       ])
+    : [];
+  // Tracks carry no channelId column, so the CHANNEL -> TRACK edges name them.
+  const tracks = channelIds.length
+    ? await textIds(
+        `SELECT DISTINCT "targetId" AS id FROM public.sdlc_entity_links
+          WHERE "channelId" = ANY($1::text[])
+            AND "targetType" = 'TRACK'
+            AND "relationType" = 'TRACK'`,
+        [channelIds]
+      )
     : [];
   const conversations = channelIds.length
     ? await textIds(
@@ -267,9 +315,23 @@ async function main(): Promise<void> {
     : [];
   const queue = await inspectQueue(repoSelector ? repoIds[0] : undefined);
 
+  const sharedHubs = repoSelector
+    ? (
+        await textIds(
+          `SELECT DISTINCT l."channelId" AS id
+             FROM public.sdlc_entity_links l
+            WHERE l."relationType" = '${SDLC_MEMBERSHIP_RELATION}'
+              AND l."targetId" = ANY($1::text[])
+              AND l."channelId" <> ALL($2::text[])`,
+          [repoIds, channelIds]
+        )
+      ).length
+    : 0;
+
   const summary = {
     repos: repoIds.length,
     channels: channelIds.length,
+    sharedHubsKept: sharedHubs,
     tickets: tickets.length,
     canvases: canvases.length,
     conversations: conversations.length,
@@ -329,11 +391,21 @@ async function main(): Promise<void> {
         repoIds
       );
     }
+    // sdlc_entity_links."repoId" is deprecated and unwritten: the repository is an endpoint.
+    if (repoIds.length > 0) {
+      await tx.$executeRawUnsafe(
+        `DELETE FROM public.sdlc_entity_links
+          WHERE ("targetType" = 'REPOSITORY' AND "targetId" = ANY($1::text[]))
+             OR ("sourceType" = 'REPOSITORY' AND "sourceId" = ANY($1::text[]))`,
+        repoIds
+      );
+    }
     const related = await deleteByKnownColumns(tx, sets);
     const targets: Array<[string, string, string, string[]]> = [
       ['public', 'messages', 'messageId', messages],
       ['public', 'conversations', 'conversationId', conversations],
       ['public', 'tickets', 'id', tickets],
+      ['public', 'sdlc_tracks', 'id', tracks],
       ['public', 'canvases', 'id', canvases],
       ['public', 'canvas_folders', 'id', folders],
       ['public', 'repos', 'id', repoIds],

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -415,6 +415,8 @@ export class App {
     // this one-off repair links summary canvases across every workspace. The
     // '-backfill' path suffix also puts it behind backfillMountGuard above.
     this.app.use('/api/admin/recording-pointer-backfill', recordingPointerBackfillRoutes);
+    // Same shape: the one-off SDLC multi-repo data migration spans every workspace,
+    // so it opens its own runAsSystem scope rather than taking workspaceScopedRoute.
 
     this.app.use('/migrate/api/users-data-migration', authMiddleware.authenticate, userMigrationRoutes);
 

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -48,6 +48,7 @@ import { callShareService } from '@/services/callShareService';
 import { noteTakerTranscriptService } from '@/services/noteTakerTranscriptService';
 import { summaryTemplateService } from '@/services/summaryTemplateService';
 import { canvasAuthService } from '@/services/canvasAuthService';
+import { isTrackInChannel } from '@/sdlc/sdlcChannelMembership';
 import { buildCallInviteUrl } from '@/utils/urlUtils';
 import { readRecordingGoogleDocLinks } from '@/utils/recordingGoogleDocs';
 
@@ -716,25 +717,15 @@ export class CallController {
         const parsedSdlcLink = sdlcCallLinkSchema.safeParse(sdlcLink);
         if (parsedSdlcLink.success) {
           const link = parsedSdlcLink.data;
-          const sdlcRepo = await db.repo.findFirst({
-            where: { id: link.repoId, channelId: channel.id },
-            select: { id: true },
-          });
-          const linkTargetValid = sdlcRepo
-            ? link.ownerType === 'CANVAS'
+          const linkTargetValid =
+            link.ownerType === 'CANVAS'
               ? Boolean(
                   await db.canvas.findFirst({
                     where: { id: link.ownerId, channelId: channel.id },
                     select: { id: true },
                   }),
                 )
-              : Boolean(
-                  await db.sdlcTrack.findFirst({
-                    where: { id: link.ownerId, repoId: link.repoId },
-                    select: { id: true },
-                  }),
-                )
-            : false;
+              : await isTrackInChannel(db, link.ownerId, channel.id);
           if (linkTargetValid) {
             validatedSdlcLink = link;
           } else {

--- a/apps/backend/src/controllers/livekitWebhookController.ts
+++ b/apps/backend/src/controllers/livekitWebhookController.ts
@@ -23,6 +23,7 @@ import { ParticipantInfo_Kind } from '@livekit/protocol';
 import { emitCallEnded, emitCallStarted } from '@/automations/triggers/call.trigger';
 import { noteTakerWebhookController } from '@/controllers/noteTakerWebhookController';
 import { buildCallInviteUrl } from '@/utils/urlUtils';
+import { isTrackInChannel } from '@/sdlc/sdlcChannelMembership';
 
 class LiveKitWebhookController {
   private receiver: WebhookReceiver;
@@ -504,17 +505,13 @@ class LiveKitWebhookController {
         // canvas or a track — either way the same two links are written:
         //   OWNER -> CALL (relation CALL) and OWNER -> CONVERSATION (DISCUSSION).
         const sdlcLink = (roomMetadata as {
-          sdlcLink?: { repoId?: string; ownerType?: string; ownerId?: string };
+          sdlcLink?: { ownerType?: string; ownerId?: string };
         }).sdlcLink;
-        if (sdlcLink?.repoId && sdlcLink.ownerType && sdlcLink.ownerId) {
+        if (sdlcLink?.ownerType && sdlcLink.ownerId) {
           try {
-            const sdlcRepo = await this.db.repo.findFirst({
-              where: { id: sdlcLink.repoId, channelId },
-              select: { id: true, workspaceId: true },
-            });
-            const linkWorkspaceId = channelRecord?.workspaceId ?? sdlcRepo?.workspaceId ?? null;
-            const ownerValid = sdlcRepo
-              ? sdlcLink.ownerType === 'CANVAS'
+            const linkWorkspaceId = channelRecord?.workspaceId ?? null;
+            const ownerValid =
+              sdlcLink.ownerType === 'CANVAS'
                 ? Boolean(
                     await this.db.canvas.findFirst({
                       where: { id: sdlcLink.ownerId, channelId },
@@ -522,20 +519,14 @@ class LiveKitWebhookController {
                     }),
                   )
                 : sdlcLink.ownerType === 'TRACK'
-                  ? Boolean(
-                      await this.db.sdlcTrack.findFirst({
-                        where: { id: sdlcLink.ownerId, repoId: sdlcRepo.id },
-                        select: { id: true },
-                      }),
-                    )
-                  : false
-              : false;
-            if (sdlcRepo && linkWorkspaceId && ownerValid) {
+                  ? await isTrackInChannel(this.db, sdlcLink.ownerId, channelId)
+                  : false;
+            if (linkWorkspaceId && ownerValid) {
               await this.db.sdlcEntityLink.createMany({
                 data: [
                   {
                     workspaceId: linkWorkspaceId,
-                    repoId: sdlcRepo.id,
+                    channelId,
                     sourceType: sdlcLink.ownerType,
                     sourceId: sdlcLink.ownerId,
                     targetType: 'CALL',
@@ -545,7 +536,7 @@ class LiveKitWebhookController {
                   },
                   {
                     workspaceId: linkWorkspaceId,
-                    repoId: sdlcRepo.id,
+                    channelId,
                     sourceType: sdlcLink.ownerType,
                     sourceId: sdlcLink.ownerId,
                     targetType: 'CONVERSATION',
@@ -557,7 +548,7 @@ class LiveKitWebhookController {
                 skipDuplicates: true,
               });
               logger.info(
-                `[LiveKit Webhook] sdlc_link_created | call=${callId} owner=${sdlcLink.ownerType}:${sdlcLink.ownerId} repo=${sdlcRepo.id}`,
+                `[LiveKit Webhook] sdlc_link_created | call=${callId} owner=${sdlcLink.ownerType}:${sdlcLink.ownerId}`,
               );
             }
           } catch (sdlcLinkError) {

--- a/apps/backend/src/controllers/xyneAIControllerV2.ts
+++ b/apps/backend/src/controllers/xyneAIControllerV2.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
+import { SDLC_MEMBERSHIP_RELATION } from '@xyne/shared';
 import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
@@ -358,9 +359,28 @@ export class XyneAIControllerV2 {
       }
 
       let sdlcDashboardContext: string | undefined;
-      const sdlcRepo = effectiveChannelIds[0]
+      // Honour the caller's pinned repository; otherwise the hub's oldest membership,
+      // which is exact whenever the hub covers one.
+      const sdlcChannelId = effectiveChannelIds[0];
+      const pinnedRepoId =
+        effectiveResearchContext?.type === 'repository' ? effectiveResearchContext.id : null;
+      const sdlcRepoId = sdlcChannelId
+        ? ((
+            await db.sdlcEntityLink.findFirst({
+              where: {
+                channelId: sdlcChannelId,
+                targetType: 'REPOSITORY',
+                relationType: SDLC_MEMBERSHIP_RELATION,
+                ...(pinnedRepoId ? { targetId: pinnedRepoId } : {}),
+              },
+              orderBy: { createdAt: 'asc' },
+              select: { targetId: true },
+            })
+          )?.targetId ?? null)
+        : null;
+      const sdlcRepo = sdlcRepoId
         ? await db.repo.findFirst({
-            where: { channelId: effectiveChannelIds[0] },
+            where: { id: sdlcRepoId },
             select: {
               id: true,
               name: true,
@@ -380,7 +400,7 @@ export class XyneAIControllerV2 {
           };
         }
         const contextLinks = await db.sdlcEntityLink.findMany({
-          where: { repoId: sdlcRepo.id, relationType: 'CONTEXT' },
+          where: { channelId: sdlcChannelId, relationType: 'CONTEXT' },
           orderBy: { createdAt: 'desc' },
           take: 50,
           select: { targetType: true, targetId: true },
@@ -414,7 +434,6 @@ export class XyneAIControllerV2 {
           sdlcVcs.resolveBaseBranchHead(sdlcRepo.id).catch(() => null),
           db.sdlcEntityLink.findMany({
             where: {
-              repoId: sdlcRepo.id,
               sourceType: 'REPOSITORY',
               sourceId: sdlcRepo.id,
               targetType: 'WORKFLOW_EXECUTION',
@@ -445,12 +464,35 @@ export class XyneAIControllerV2 {
             wikiCommitSha = null;
           }
         }
+        // Membership points at the repository through the polymorphic targetId, so
+        // no relation covers it: read the edges, then the repositories they name.
+        const siblingLinks = await db.sdlcEntityLink.findMany({
+          where: {
+            channelId: sdlcChannelId,
+            targetType: 'REPOSITORY',
+            relationType: SDLC_MEMBERSHIP_RELATION,
+            targetId: { not: sdlcRepo.id },
+          },
+          orderBy: { createdAt: 'asc' },
+          select: { targetId: true },
+        });
+        const siblingRepos = siblingLinks.length
+          ? await db.repo.findMany({
+              where: { id: { in: siblingLinks.map((link) => link.targetId) } },
+              select: { id: true, name: true, url: true, canonicalUrl: true },
+            })
+          : [];
         sdlcDashboardContext = buildSdlcAskAiContext({
           repo: {
             id: sdlcRepo.id,
             name: sdlcRepo.name,
             url: sdlcRepo.canonicalUrl || sdlcRepo.url,
           },
+          otherRepos: siblingRepos.map((sibling) => ({
+            id: sibling.id,
+            name: sibling.name,
+            url: sibling.canonicalUrl || sibling.url,
+          })),
           channelId: effectiveChannelIds[0],
           baselineDocuments: approvedBaseline,
           linkedContext,
@@ -932,7 +974,7 @@ export class XyneAIControllerV2 {
 
   /**
    * GET /api/xyne-ai/v2/conversations/:convId/live
-   * SSE proxy to claw-auth's live stream so a Spaces AI tab that reloaded
+   * SSE proxy to claw-auth's live stream so a Hubs AI tab that reloaded
    * mid-run can re-attach and stream the in-flight answer (snapshot + deltas)
    * instead of waiting for the run to finish. Verbatim frame passthrough.
    */

--- a/apps/backend/src/database/repositories/channelRepository.ts
+++ b/apps/backend/src/database/repositories/channelRepository.ts
@@ -1,3 +1,4 @@
+import { SDLC_MEMBERSHIP_RELATION } from '@xyne/shared';
 import { BaseRepository } from './base';
 import { Channel } from '@prisma/client';
 import { ChannelScopeType, ChannelVisibility, ChannelType, ProjectType } from '@xyne/shared';
@@ -190,8 +191,8 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
   }
 
   async delete(id: string): Promise<Channel> {
-    const attachedSdlcRepository = await this.db.repo.findFirst({
-      where: { channelId: id, projectId: { not: null } },
+    const attachedSdlcRepository = await this.db.sdlcEntityLink.findFirst({
+      where: { channelId: id, relationType: SDLC_MEMBERSHIP_RELATION },
       select: { id: true },
     });
     if (attachedSdlcRepository) {

--- a/apps/backend/src/database/repositories/projectRepository.ts
+++ b/apps/backend/src/database/repositories/projectRepository.ts
@@ -1,3 +1,4 @@
+import { SDLC_MEMBERSHIP_RELATION } from '@xyne/shared';
 import { BaseRepository } from './base';
 import { Project } from '@prisma/client';
 import { QueryOptions, PaginationOptions, PaginatedResult } from '@/types/database';
@@ -175,8 +176,14 @@ export class ProjectRepository extends BaseRepository<Project, CreateProjectInpu
   }
 
   async delete(id: string): Promise<Project> {
-    const attachedSdlcRepository = await this.db.repo.findFirst({
-      where: { projectId: id, channelId: { not: null } },
+    // Only repositories in a hub block deletion: an unattached one has nothing to
+    // detach and no UI to detach it from.
+    const attachedSdlcRepository = await this.db.sdlcEntityLink.findFirst({
+      where: {
+        relationType: SDLC_MEMBERSHIP_RELATION,
+        targetType: 'REPOSITORY',
+        channel: { projectId: id },
+      },
       select: { id: true },
     });
     if (attachedSdlcRepository) {

--- a/apps/backend/src/routes/sdlc.ts
+++ b/apps/backend/src/routes/sdlc.ts
@@ -1,6 +1,8 @@
 import { Router, type NextFunction, type Request, type Response } from 'express';
 import {
+  addSdlcChannelRepositoriesSchema,
   attachSdlcRepositorySchema,
+  createSdlcChannelSchema,
   checkSdlcRepositoryAccessSchema,
   createSdlcLinkSchema,
   configureSdlcVcsCredentialSchema,
@@ -11,10 +13,12 @@ import {
 import { AppError } from '@/middleware/errorHandler';
 import { sdlcQueue } from '@/queues/sdlcQueue';
 import { SdlcHubService, sdlcWiki, type SdlcActor } from '@/sdlc';
+import { requireSdlcProjectAccess } from '@/sdlc/sdlcProjectAccess';
 import { sdlcVcs } from '@/sdlc/vcs';
 import { deriveAccessStatus } from '@/sdlc/vcs/accessStatus';
 import { DatabaseClient } from '@/database/client';
 import { SdlcWikiPipelineService } from '@/sdlc/wiki/SdlcWikiPipeline';
+import sdlcCleanupRoutes from '@/sdlc/cleanup/routes';
 
 const router = Router();
 const sdlcHub = new SdlcHubService();
@@ -42,8 +46,50 @@ router.post(
   '/repositories',
   route(async (req, res) => {
     const input = attachSdlcRepositorySchema.parse(req.body);
-    const repository = await sdlcHub.attachRepository(actorFromRequest(req), input);
+    const repository = await sdlcHub.createRepository(actorFromRequest(req), input);
     res.status(201).json({ success: true, repository });
+  })
+);
+
+router.post(
+  '/channels',
+  route(async (req, res) => {
+    const input = createSdlcChannelSchema.parse(req.body);
+    const channel = await sdlcHub.createChannel(actorFromRequest(req), input);
+    res.status(201).json({ success: true, channel });
+  })
+);
+
+router.get(
+  '/channels/:channelId',
+  route(async (req, res) => {
+    const channel = await sdlcHub.getChannel(actorFromRequest(req), req.params.channelId);
+    res.status(200).json({ success: true, channel });
+  })
+);
+
+router.post(
+  '/channels/:channelId/repositories',
+  route(async (req, res) => {
+    const input = addSdlcChannelRepositoriesSchema.parse(req.body);
+    const result = await sdlcHub.addChannelRepositories(
+      actorFromRequest(req),
+      req.params.channelId,
+      input.repoIds
+    );
+    res.status(200).json({ success: true, ...result });
+  })
+);
+
+router.delete(
+  '/channels/:channelId/repositories/:repoId',
+  route(async (req, res) => {
+    await sdlcHub.removeChannelRepository(
+      actorFromRequest(req),
+      req.params.channelId,
+      req.params.repoId
+    );
+    res.status(204).send();
   })
 );
 
@@ -92,12 +138,10 @@ router.get(
       select: { id: true },
     });
     if (!project) throw new AppError('Project not found', 404);
+    // Project access is the gate, not hub membership.
+    await requireSdlcProjectAccess(prisma, actor, project.id);
     const repositories = await prisma.repo.findMany({
-      where: {
-        projectId: project.id,
-        workspaceId: actor.workspaceId,
-        channel: { participants: { some: { userId: actor.userId } } },
-      },
+      where: { projectId: project.id, workspaceId: actor.workspaceId },
       select: {
         id: true,
         name: true,
@@ -276,7 +320,13 @@ router.post(
   '/repositories/:repoId/links',
   route(async (req, res) => {
     const input = createSdlcLinkSchema.parse(req.body);
-    const link = await sdlcHub.linkContext(actorFromRequest(req), req.params.repoId, input);
+    const channelId = typeof req.body?.channelId === 'string' ? req.body.channelId : undefined;
+    const link = await sdlcHub.linkContext(
+      actorFromRequest(req),
+      req.params.repoId,
+      input,
+      channelId
+    );
     res.status(201).json({ success: true, link });
   })
 );
@@ -288,5 +338,9 @@ router.delete(
     res.status(204).send();
   })
 );
+
+// One-off SDLC data migrations. Delete with src/sdlc/cleanup/ once every
+// environment has run them.
+router.use('/cleanup', sdlcCleanupRoutes);
 
 export default router;

--- a/apps/backend/src/routes/sdlcClaw.ts
+++ b/apps/backend/src/routes/sdlcClaw.ts
@@ -23,6 +23,11 @@ function route(
   return (req, res, next) => void handler(req, res).catch(next);
 }
 
+function channelIdFromBody(req: Request): string | undefined {
+  const value = req.body?.channelId;
+  return typeof value === 'string' && value ? value : undefined;
+}
+
 async function actorFromRequest(req: Request): Promise<SdlcActor> {
   const userId = req.user?.id;
   const workspaceId = req.user?.workspaceId;
@@ -59,7 +64,12 @@ router.post(
       req.body,
     );
     const { repoId, ...linkInput } = input;
-    const link = await sdlcHub.linkContext(await actorFromRequest(req), repoId, linkInput);
+    const link = await sdlcHub.linkContext(
+      await actorFromRequest(req),
+      repoId,
+      linkInput,
+      channelIdFromBody(req)
+    );
     res.status(201).json({ success: true, link });
   }),
 );
@@ -69,7 +79,11 @@ router.post(
   route(async (req, res) => {
     const repoId = typeof req.body?.repoId === 'string' ? req.body.repoId : '';
     if (!repoId) throw new AppError('repoId is required', 400);
-    const tracks = await sdlcHub.listTracks(await actorFromRequest(req), repoId);
+    const tracks = await sdlcHub.listTracks(
+      await actorFromRequest(req),
+      repoId,
+      channelIdFromBody(req)
+    );
     res.status(200).json({ success: true, tracks });
   }),
 );
@@ -88,7 +102,11 @@ router.post(
   route(async (req, res) => {
     const repoId = typeof req.body?.repoId === 'string' ? req.body.repoId : '';
     if (!repoId) throw new AppError('repoId is required', 400);
-    const artifactTypes = await sdlcHub.listArtifactTypes(await actorFromRequest(req), repoId);
+    const artifactTypes = await sdlcHub.listArtifactTypes(
+      await actorFromRequest(req),
+      repoId,
+      channelIdFromBody(req)
+    );
     res.status(200).json({ success: true, artifactTypes });
   }),
 );
@@ -100,7 +118,8 @@ router.post(
     const artifactType = await sdlcHub.createArtifactType(
       await actorFromRequest(req),
       input.repoId,
-      input.name
+      input.name,
+      input.channelId
     );
     res.status(201).json({ success: true, artifactType });
   }),

--- a/apps/backend/src/sdlc/SdlcAgentContextService.ts
+++ b/apps/backend/src/sdlc/SdlcAgentContextService.ts
@@ -2,6 +2,7 @@ import type { PrismaClient } from '@prisma/client';
 import { DatabaseClient } from '@/database/client';
 import { AppError } from '@/middleware/errorHandler';
 import { allBaselinesReady } from './sdlcProgressiveGate';
+import { findSdlcMembershipForActor } from './sdlcChannelMembership';
 import { requireSdlcBaseBranch } from './sdlcRepositoryContext';
 import type { SdlcActor } from './types';
 import { sdlcVcs } from './vcs';
@@ -80,38 +81,30 @@ export class SdlcAgentContextService {
     repoId: string,
     input: SdlcAgentContextInput
   ): Promise<SdlcAgentContext> {
-    const repo = await this.prisma.repo.findFirst({
-      where: {
-        id: repoId,
-        workspaceId: actor.workspaceId,
-        projectId: { not: null },
-        channelId: { not: null },
-      },
-      select: {
-        id: true,
-        name: true,
-        url: true,
-        canonicalUrl: true,
-        baseBranch: true,
-        projectId: true,
-        channelId: true,
-        accessCapabilities: true,
-        channel: {
-          select: {
-            participants: {
-              where: { userId: actor.userId },
-              select: { role: true },
-              take: 1,
-            },
-          },
+    const [repo, membership] = await Promise.all([
+      this.prisma.repo.findFirst({
+        where: { id: repoId, workspaceId: actor.workspaceId, projectId: { not: null } },
+        select: {
+          id: true,
+          name: true,
+          url: true,
+          canonicalUrl: true,
+          baseBranch: true,
+          projectId: true,
+          accessCapabilities: true,
         },
-      },
-    });
-    if (!repo?.projectId || !repo.channelId) throw new AppError('SDLC repository not found', 404);
-    const participant = repo.channel?.participants[0];
-    if (!participant) throw new AppError('You are not a member of this repository', 403);
+      }),
+      findSdlcMembershipForActor(this.prisma, {
+        workspaceId: actor.workspaceId,
+        repoId,
+        userId: actor.userId,
+      }),
+    ]);
+    if (!repo?.projectId) throw new AppError('SDLC repository not found', 404);
+    if (!membership) throw new AppError('You are not a member of this repository', 403);
+    const channelId = membership.channelId;
     const baselines = await this.prisma.sdlcArtifact.findMany({
-      where: { canvas: { is: { channelId: repo.channelId } } },
+      where: { repoId: repo.id, canvas: { is: { channelId } } },
       select: { artifactType: true, artifactStatus: true },
     });
     const parsed = sdlcVcs.parseRepository('GITHUB', repo.canonicalUrl || repo.url);
@@ -120,7 +113,7 @@ export class SdlcAgentContextService {
       operation: input.operation,
       workspaceId: actor.workspaceId,
       projectId: repo.projectId,
-      channelId: repo.channelId,
+      channelId,
       actorUserId: actor.userId,
       repository: {
         id: repo.id,
@@ -129,7 +122,7 @@ export class SdlcAgentContextService {
         baseBranch: requireSdlcBaseBranch(repo.baseBranch),
       },
       permissions: {
-        repositoryRole: participant.role === 'ADMIN' ? 'ADMIN' : 'MEMBER',
+        repositoryRole: membership.role === 'ADMIN' ? 'ADMIN' : 'MEMBER',
       },
       gates: {
         capabilities: Array.isArray(repo.accessCapabilities) ? repo.accessCapabilities : [],

--- a/apps/backend/src/sdlc/SdlcArtifactVersionStore.ts
+++ b/apps/backend/src/sdlc/SdlcArtifactVersionStore.ts
@@ -1,5 +1,10 @@
 import { createHash } from 'crypto';
-import { isBaselineCanvasType, parseSdlcSourcePaths, parseSdlcSourceReferences } from '@xyne/shared';
+import {
+  isBaselineCanvasType,
+  parseSdlcSourcePaths,
+  parseSdlcSourceReferences,
+  SDLC_MEMBERSHIP_RELATION,
+} from '@xyne/shared';
 import { Prisma, type PrismaClient } from '@prisma/client';
 import { DatabaseClient } from '@/database/client';
 import { AppError } from '@/middleware/errorHandler';
@@ -135,7 +140,9 @@ export class SdlcArtifactVersionStore {
         channelId: repo.channelId,
         workspaceId: input.workspaceId,
         projectId: repo.projectId,
-        sdlcArtifact: { is: { artifactStatus: { not: 'REFRESH_CANDIDATE' } } },
+        // A hub can cover several repositories, so the artifact's repository is part of
+        // what identifies it, not just the channel it renders in.
+        sdlcArtifact: { is: { repoId: repo.id, artifactStatus: { not: 'REFRESH_CANDIDATE' } } },
       },
       orderBy: [{ updatedAt: 'desc' }, { id: 'desc' }],
       select: {
@@ -308,7 +315,7 @@ export class SdlcArtifactVersionStore {
             channelId: repo.channelId,
             workspaceId: input.workspaceId,
             projectId: repo.projectId,
-            sdlcArtifact: { is: { artifactType: 'WIKI' } },
+            sdlcArtifact: { is: { artifactType: 'WIKI', repoId: repo.id } },
           },
           select: {
             id: true,
@@ -331,7 +338,7 @@ export class SdlcArtifactVersionStore {
             channelId: repo.channelId,
             workspaceId: input.workspaceId,
             projectId: repo.projectId,
-            sdlcArtifact: { is: { artifactType: { not: 'DEFAULT' } } },
+            sdlcArtifact: { is: { repoId: repo.id, artifactType: { not: 'DEFAULT' } } },
           },
           select: {
             id: true,
@@ -382,18 +389,29 @@ export class SdlcArtifactVersionStore {
     workspaceId: string;
     userId: string;
   }) {
-    const repo = await this.prisma.repo.findFirst({
-      where: {
-        id: input.repoId,
-        workspaceId: input.workspaceId,
-        projectId: { not: null },
-        channelId: { not: null },
-        channel: { participants: { some: { userId: input.userId } } },
-      },
-      select: { id: true, channelId: true, projectId: true },
-    });
-    if (!repo?.channelId || !repo.projectId) throw new AppError('SDLC artifact not found', 404);
-    return { ...repo, channelId: repo.channelId, projectId: repo.projectId };
+    const [repo, membership] = await Promise.all([
+      this.prisma.repo.findFirst({
+        where: { id: input.repoId, workspaceId: input.workspaceId, projectId: { not: null } },
+        select: { id: true, projectId: true },
+      }),
+      // Membership is the read check: the actor must participate in a hub this
+      // repository belongs to.
+      this.prisma.sdlcEntityLink.findFirst({
+        where: {
+          workspaceId: input.workspaceId,
+          targetType: 'REPOSITORY',
+          targetId: input.repoId,
+          relationType: SDLC_MEMBERSHIP_RELATION,
+          channel: { participants: { some: { userId: input.userId } } },
+        },
+        orderBy: { createdAt: 'asc' },
+        select: { channelId: true },
+      }),
+    ]);
+    if (!repo?.projectId || !membership?.channelId) {
+      throw new AppError('SDLC artifact not found', 404);
+    }
+    return { id: repo.id, channelId: membership.channelId, projectId: repo.projectId };
   }
 
   private async loadWikiEvidence(
@@ -402,7 +420,6 @@ export class SdlcArtifactVersionStore {
   ): Promise<Map<string, RevisionRecord>> {
     const links = await this.prisma.sdlcEntityLink.findMany({
       where: {
-        repoId,
         sourceType: 'REPOSITORY',
         sourceId: repoId,
         targetType: 'WORKFLOW_EXECUTION',

--- a/apps/backend/src/sdlc/SdlcClawExecutionService.ts
+++ b/apps/backend/src/sdlc/SdlcClawExecutionService.ts
@@ -24,6 +24,7 @@ import {
   sdlcClawDeadlineExpired,
   sdlcClawTimeoutMessage,
 } from './sdlcClawDeadline';
+import { requireSdlcChannelId } from './sdlcChannelMembership';
 import { shouldHandleSdlcCallback } from './sdlcCallbackPolicy';
 import { allBaselinesReady } from './sdlcProgressiveGate';
 import { isSafeSdlcGitRef, requireSdlcBaseBranch } from './sdlcRepositoryContext';
@@ -44,6 +45,8 @@ interface ClawCallbackPayload {
 
 interface ExecutionContext {
   repoId: string;
+  /** The hub this run started from. Re-resolving later would pick the oldest. */
+  channelId?: string;
   phase: string;
   agentSlug?: typeof SDLC_AGENT_SLUG;
   conversationId?: string;
@@ -76,11 +79,12 @@ export class SdlcClawExecutionService {
       include: { workflow: true, sdlcRepo: true },
     });
     const repo = execution?.sdlcRepo;
-    if (!execution || !repo?.channelId || !repo.projectId || !execution.createdBy) {
+    if (!execution || !repo?.projectId || !execution.createdBy) {
       throw new Error(`Invalid SDLC setup execution ${executionId}`);
     }
     const repository = sdlcVcs.parseRepository('GITHUB', repo.canonicalUrl || repo.url);
     const current = this.readContext(execution.context, repo.id);
+    const channelId = await this.runChannelId(current, repo.id);
     const [user, wikiState] = await Promise.all([
       this.requireUser(execution.createdBy),
       // A setup retry may resume hours after Wiki state changed. Re-resolve it
@@ -91,7 +95,7 @@ export class SdlcClawExecutionService {
       current.generationCommit || (await sdlcVcs.resolveBaseBranchHead(repo.id));
     const completed = current.refreshExisting
       ? new Set(current.completedBaselineKinds ?? [])
-      : await this.completedBaselineKinds(repo.channelId, execution.id);
+      : await this.completedBaselineKinds(channelId, execution.id);
     const definition = BASELINE_DEFINITIONS.find((item) => !completed.has(item.kind));
     if (!definition) {
       await this.finishExecution(execution.id, execution.workflowId, {
@@ -145,7 +149,7 @@ export class SdlcClawExecutionService {
         repoName: repo.name,
         repoUrl: repository.cloneUrl,
         baseBranch: requireSdlcBaseBranch(repo.baseBranch),
-        channelId: repo.channelId,
+        channelId,
         setupExecutionId: execution.id,
         definition,
         wikiState,
@@ -157,7 +161,7 @@ export class SdlcClawExecutionService {
       callbackUrl: this.callbackUrl(execution.id, `baseline-${definition.kind}`),
       callbackSecret: config.xyneClaw.s2sKey,
       conversationId,
-      channelId: repo.channelId,
+      channelId,
       workspaceId: this.requiredWorkspaceId(repo.workspaceId),
       executionProfile: 'sdlc',
       sdlcOperation: 'baseline',
@@ -174,10 +178,14 @@ export class SdlcClawExecutionService {
     return true;
   }
 
+  /** The run's hub. The fallback is only for runs queued before it was stamped. */
+  private async runChannelId(context: ExecutionContext, repoId: string): Promise<string> {
+    return context.channelId ?? requireSdlcChannelId(this.prisma, repoId);
+  }
+
   private async resolveBaselineWikiState(repoId: string): Promise<BaselineWikiState> {
     const link = await this.prisma.sdlcEntityLink.findFirst({
       where: {
-        repoId,
         sourceType: 'REPOSITORY',
         sourceId: repoId,
         targetType: 'WORKFLOW_EXECUTION',
@@ -215,7 +223,8 @@ export class SdlcClawExecutionService {
       this.prisma.repo.findUnique({ where: { id: current.repoId } }),
       this.requireUser(execution.createdBy),
     ]);
-    if (!repo?.channelId) throw new Error('SDLC repository unavailable');
+    if (!repo) throw new Error('SDLC repository unavailable');
+    const channelId = await this.runChannelId(current, repo.id);
     const repository = sdlcVcs.parseRepository('GITHUB', repo.canonicalUrl || repo.url);
     const conversationId = current.conversationId || `chat-sdlc-work-${execution.id}`;
     const sessionId = randomUUID();
@@ -264,7 +273,7 @@ export class SdlcClawExecutionService {
       callbackUrl: this.callbackUrl(execution.id, 'work'),
       callbackSecret: config.xyneClaw.s2sKey,
       conversationId,
-      channelId: repo.channelId,
+      channelId,
       workspaceId: this.requiredWorkspaceId(repo.workspaceId),
       executionProfile: 'sdlc',
       sdlcOperation: 'work',
@@ -489,24 +498,18 @@ export class SdlcClawExecutionService {
         prUrl: true,
         repositoryUrl: true,
         ticketId: true,
+        // The execution that opened the PR names its repository; the TICKET ->
+        // PULL_REQUEST link describes the ticket, not the repo.
+        workflowExecution: { select: { context: true } },
       },
       orderBy: { updatedAt: 'asc' },
       take: 25,
     });
     if (pullRequests.length === 0) return;
-    const links = await this.prisma.sdlcEntityLink.findMany({
-      where: {
-        targetType: 'PULL_REQUEST',
-        relationType: 'PULL_REQUEST',
-        targetId: { in: pullRequests.map((pullRequest) => pullRequest.id) },
-      },
-      select: { targetId: true, repoId: true },
-    });
-    const repoIdByPullRequest = new Map(links.map((link) => [link.targetId, link.repoId]));
     const repository = new PRMetricsRepository();
     const results = await Promise.allSettled(
       pullRequests.map(async (pullRequest) => {
-        const repoId = repoIdByPullRequest.get(pullRequest.id);
+        const repoId = this.readContext(pullRequest.workflowExecution?.context).repoId;
         if (!repoId || !pullRequest.ticketId) return;
         const inspection = await sdlcVcs.inspectPullRequest(repoId, pullRequest.prId);
         if (inspection.state === 'MERGED') {
@@ -570,11 +573,12 @@ export class SdlcClawExecutionService {
       throw new Error('Invalid baseline callback');
     const context = await this.executionContext(executionId);
     const repo = await this.prisma.repo.findUnique({ where: { id: context.repoId } });
-    if (!repo?.channelId) throw new Error('SDLC repository unavailable');
+    if (!repo) throw new Error('SDLC repository unavailable');
+    const channelId = await this.runChannelId(context, repo.id);
     const reconciled = new Set(context.reconciledBaselineKinds ?? []);
     const completed = context.refreshExisting
       ? new Set(context.completedBaselineKinds ?? [])
-      : await this.completedBaselineKinds(repo.channelId, executionId);
+      : await this.completedBaselineKinds(channelId, executionId);
     if (context.refreshExisting) completed.add(kind);
     if (context.refreshExisting ? !reconciled.has(kind) : !completed.has(kind)) {
       throw new Error(`Claw completed without creating ${kind}`);
@@ -588,7 +592,7 @@ export class SdlcClawExecutionService {
     if (!active) return;
     if (completed.size === BASELINE_DEFINITIONS.length) {
       const baselines = await this.prisma.sdlcArtifact.findMany({
-        where: { canvas: { is: { channelId: repo.channelId } } },
+        where: { repoId: repo.id, canvas: { is: { channelId } } },
         select: { artifactType: true, artifactStatus: true },
       });
       const terminalPhase = allBaselinesReady(baselines) ? 'APPROVED' : 'READY_FOR_REVIEW';
@@ -620,6 +624,7 @@ export class SdlcClawExecutionService {
     if (!repo || !context.ticketId || !execution?.createdBy) {
       throw new Error('SDLC work context is incomplete');
     }
+    const channelId = await this.runChannelId(context, repo.id);
     const branchName = this.requiredString(result.branchName, 'branchName');
     const commitHash = this.requiredString(result.commitHash, 'commitHash');
     const pullRequestUrl = this.requiredString(result.pullRequestUrl, 'pullRequestUrl');
@@ -657,8 +662,8 @@ export class SdlcClawExecutionService {
       }),
       this.prisma.sdlcEntityLink.upsert({
         where: {
-          repoId_sourceType_sourceId_targetType_targetId_relationType: {
-            repoId: repo.id,
+          channelId_sourceType_sourceId_targetType_targetId_relationType: {
+            channelId,
             sourceType: 'TICKET',
             sourceId: context.ticketId,
             targetType: 'PULL_REQUEST',
@@ -668,7 +673,7 @@ export class SdlcClawExecutionService {
         },
         create: {
           workspaceId: this.requiredWorkspaceId(repo.workspaceId),
-          repoId: repo.id,
+          channelId,
           sourceType: 'TICKET',
           sourceId: context.ticketId,
           targetType: 'PULL_REQUEST',

--- a/apps/backend/src/sdlc/SdlcHubService.ts
+++ b/apps/backend/src/sdlc/SdlcHubService.ts
@@ -1,19 +1,21 @@
 import { createHash, randomUUID } from 'crypto';
 import { Prisma, PrismaClient } from '@prisma/client';
 import {
-  AccessType,
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_STRUCTURAL_RELATIONS,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
   CanvasVisibility,
   ChannelAddUserPolicy,
   ChannelRole,
   ChannelScopeType,
   ChannelType,
   ChannelVisibility,
-  WorkspaceRole,
   normalizeChannelName,
   validateChannelName,
   canvasTypeForSdlcArtifact,
   stringifySdlcSourceReferences,
   type AttachSdlcRepositoryInput,
+  type CreateSdlcChannelInput,
   type CreateSdlcClawArtifactInput,
   type CreateSdlcLinkInput,
   type CreateSdlcTrackInput,
@@ -45,6 +47,8 @@ import {
   finalizeBaselineDraft,
 } from './sdlcBaselineDraft';
 import { commitAndSyncCanvasArtifact } from './sdlcBaselineCanvasSync';
+import { requireSdlcProjectAccess } from './sdlcProjectAccess';
+import { isTrackInChannel, trackIdsForChannel } from './sdlcChannelMembership';
 import { sdlcChannelCanvasParticipant } from './sdlcCanvasAccess';
 import { BASELINE_CAPABILITIES } from './sdlcProgressiveGate';
 import type {
@@ -52,7 +56,8 @@ import type {
   SdlcArtifact,
   SdlcHub,
   SdlcLink,
-  SdlcRepositoryHub,
+  SdlcChannel,
+  SdlcRepository,
   SdlcRepositoryRunContext,
   SdlcSetupExecution,
 } from './types';
@@ -68,23 +73,23 @@ type TransactionClient = Prisma.TransactionClient;
 export class SdlcHubService implements SdlcHub {
   constructor(private readonly prisma: PrismaClient = DatabaseClient.getInstance()) {}
 
-  async attachRepository(
+  /** Register a repository. It joins no hub here; hubs pick their repositories. */
+  async createRepository(
     actor: SdlcActor,
     input: AttachSdlcRepositoryInput
-  ): Promise<SdlcRepositoryHub> {
+  ): Promise<SdlcRepository> {
     const parsedRepository = sdlcVcs.parseRepository('GITHUB', input.url);
     const canonicalUrl = parsedRepository.canonicalUrl;
-    const name = normalizeChannelName(input.name?.trim() || parsedRepository.name);
-    const nameError = validateChannelName(name);
-    if (nameError) {
-      throw new AppError(nameError, 400);
+    const name = (input.name?.trim() || parsedRepository.name).slice(0, 120);
+    if (!name) {
+      throw new AppError('Repository name is required', 400);
     }
 
     try {
       const repository = await this.prisma.$transaction(async (tx) => {
         const project = await tx.project.findFirst({
           where: { id: input.projectId, workspaceId: actor.workspaceId },
-          select: { id: true, name: true },
+          select: { id: true },
         });
         if (!project) {
           throw new AppError('Project not found', 404);
@@ -96,72 +101,12 @@ export class SdlcHubService implements SdlcHub {
           select: { id: true },
         });
         if (duplicate) {
-          throw new AppError('Repository already has an SDLC hub in this workspace', 409);
+          throw new AppError('This repository is already registered in this workspace', 409);
         }
-
-        if (await channelRepository.checkDuplicateName(name, actor.workspaceId)) {
-          throw new AppError(`Channel with name "${name}" already exists.`, 409);
-        }
-
-        const repoId = randomUUID();
-        const channelId = randomUUID();
-        const now = new Date();
-
-        await tx.channel.create({
-          data: {
-            id: channelId,
-            name,
-            description: `Private SDLC workspace for ${name}`,
-            type: ChannelType.SDLC,
-            scopeType: ChannelScopeType.DEFAULT,
-            visibility: ChannelVisibility.PRIVATE,
-            createdBy: actor.userId,
-            projectId: project.id,
-            workspaceId: actor.workspaceId,
-            participantCount: 1,
-            addUserPolicy: ChannelAddUserPolicy.ADMINS_ONLY,
-            showTicketsTabTicketsInChat: false,
-            metadata: {},
-            channelStats: {
-              create: {
-                workspaceId: actor.workspaceId,
-                lastActivityAt: now,
-                participantCount: 1,
-                addUserPolicy: ChannelAddUserPolicy.ADMINS_ONLY,
-              },
-            },
-            participants: {
-              create: {
-                workspaceId: actor.workspaceId,
-                userId: actor.userId,
-                role: ChannelRole.ADMIN,
-              },
-            },
-            participantsStatus: {
-              create: {
-                workspaceId: actor.workspaceId,
-                userId: actor.userId,
-                isDeleted: false,
-                updatedAt: now,
-              },
-            },
-          },
-        });
-
-        await tx.canvasFolder.createMany({
-          data: SDLC_FOLDERS.map((folderName) => ({
-            id: randomUUID(),
-            workspaceId: actor.workspaceId,
-            projectId: project.id,
-            channelId,
-            name: folderName,
-            createdBy: actor.userId,
-          })),
-        });
 
         const repo = await tx.repo.create({
           data: {
-            id: repoId,
+            id: randomUUID(),
             workspaceId: actor.workspaceId,
             name,
             url: input.url.trim(),
@@ -172,7 +117,6 @@ export class SdlcHubService implements SdlcHub {
             prefix: '',
             createdBy: actor.userId,
             projectId: project.id,
-            channelId,
           },
         });
 
@@ -182,7 +126,6 @@ export class SdlcHubService implements SdlcHub {
           url: repo.url,
           canonicalUrl,
           projectId: project.id,
-          channelId,
         };
       });
       try {
@@ -196,10 +139,214 @@ export class SdlcHubService implements SdlcHub {
       return repository;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
-        throw new AppError('Repository already has an SDLC hub in this workspace', 409);
+        throw new AppError('This repository is already registered in this workspace', 409);
       }
       throw error;
     }
+  }
+
+  /** The private channel a hub lives in, plus its starting artifact-type folders. */
+  private async createSdlcChannel(
+    tx: TransactionClient,
+    actor: SdlcActor,
+    input: { projectId: string; name: string }
+  ): Promise<string> {
+    const name = normalizeChannelName(input.name.trim());
+    const nameError = validateChannelName(name);
+    if (nameError) {
+      throw new AppError(nameError, 400);
+    }
+    if (await channelRepository.checkDuplicateName(name, actor.workspaceId)) {
+      throw new AppError(`Channel with name "${name}" already exists.`, 409);
+    }
+
+    const channelId = randomUUID();
+    const now = new Date();
+
+    await tx.channel.create({
+      data: {
+        id: channelId,
+        name,
+        description: `Private SDLC workspace for ${name}`,
+        type: ChannelType.SDLC,
+        scopeType: ChannelScopeType.DEFAULT,
+        visibility: ChannelVisibility.PRIVATE,
+        createdBy: actor.userId,
+        projectId: input.projectId,
+        workspaceId: actor.workspaceId,
+        participantCount: 1,
+        addUserPolicy: ChannelAddUserPolicy.ADMINS_ONLY,
+        showTicketsTabTicketsInChat: false,
+        metadata: {},
+        channelStats: {
+          create: {
+            workspaceId: actor.workspaceId,
+            lastActivityAt: now,
+            participantCount: 1,
+            addUserPolicy: ChannelAddUserPolicy.ADMINS_ONLY,
+          },
+        },
+        participants: {
+          create: {
+            workspaceId: actor.workspaceId,
+            userId: actor.userId,
+            role: ChannelRole.ADMIN,
+          },
+        },
+        participantsStatus: {
+          create: {
+            workspaceId: actor.workspaceId,
+            userId: actor.userId,
+            isDeleted: false,
+            updatedAt: now,
+          },
+        },
+      },
+    });
+
+    await tx.canvasFolder.createMany({
+      data: SDLC_FOLDERS.map((folderName) => ({
+        id: randomUUID(),
+        workspaceId: actor.workspaceId,
+        projectId: input.projectId,
+        channelId,
+        name: folderName,
+        createdBy: actor.userId,
+      })),
+    });
+
+    return channelId;
+  }
+
+  async createChannel(actor: SdlcActor, input: CreateSdlcChannelInput): Promise<SdlcChannel> {
+    return this.prisma.$transaction(async (tx) => {
+      const project = await tx.project.findFirst({
+        where: { id: input.projectId, workspaceId: actor.workspaceId },
+        select: { id: true },
+      });
+      if (!project) {
+        throw new AppError('Project not found', 404);
+      }
+      await this.requireProjectBoardAccess(tx, actor, project.id);
+
+      const channelId = await this.createSdlcChannel(tx, actor, {
+        projectId: project.id,
+        name: input.name,
+      });
+
+      const repoIds = await this.attachRepositoriesToChannel(tx, actor, channelId, input.repoIds);
+
+      return { id: channelId, name: input.name.trim(), projectId: project.id, repoIds };
+    });
+  }
+
+  async addChannelRepositories(
+    actor: SdlcActor,
+    channelId: string,
+    repoIds: string[]
+  ): Promise<{ repoIds: string[] }> {
+    await this.requireChannelRole(actor, channelId, true);
+    return this.prisma.$transaction(async (tx) => ({
+      repoIds: await this.attachRepositoriesToChannel(tx, actor, channelId, repoIds),
+    }));
+  }
+
+  /** Detach only. The repository survives; other hubs may still cover it. */
+  async removeChannelRepository(
+    actor: SdlcActor,
+    channelId: string,
+    repoId: string
+  ): Promise<void> {
+    await this.requireChannelRole(actor, channelId, true);
+    const artifacts = await this.prisma.sdlcArtifact.count({
+      where: { repoId, canvas: { is: { channelId } } },
+    });
+    if (artifacts > 0) {
+      throw new AppError(
+        'This repository still has artifacts in this hub. Delete them before detaching it.',
+        409
+      );
+    }
+    // With no repositories a hub renders nothing and cannot be deleted, since
+    // membership is what blocks channel deletion.
+    const remaining = await this.prisma.sdlcEntityLink.count({
+      where: { channelId, relationType: SDLC_MEMBERSHIP_RELATION },
+    });
+    if (remaining <= 1) {
+      throw new AppError('A hub must keep at least one repository', 409);
+    }
+    const removed = await this.prisma.sdlcEntityLink.deleteMany({
+      where: {
+        channelId,
+        targetType: 'REPOSITORY',
+        targetId: repoId,
+        relationType: SDLC_MEMBERSHIP_RELATION,
+      },
+    });
+    if (removed.count === 0) {
+      throw new AppError('Repository is not part of this hub', 404);
+    }
+  }
+
+  async getChannel(actor: SdlcActor, channelId: string): Promise<SdlcChannel> {
+    const channel = await this.requireChannelRole(actor, channelId, false);
+    const memberships = await this.prisma.sdlcEntityLink.findMany({
+      where: { channelId, relationType: SDLC_MEMBERSHIP_RELATION },
+      orderBy: { createdAt: 'asc' },
+      select: { targetId: true },
+    });
+    return {
+      id: channel.id,
+      name: channel.name,
+      projectId: channel.projectId,
+      repoIds: memberships.map((membership) => membership.targetId),
+    };
+  }
+
+  private async attachRepositoriesToChannel(
+    tx: TransactionClient,
+    actor: SdlcActor,
+    channelId: string,
+    repoIds: readonly string[]
+  ): Promise<string[]> {
+    const unique = [...new Set(repoIds)];
+    if (unique.length === 0) return [];
+
+    // The hub's canvas folders are project-scoped, so a repository from another
+    // project would render its artifacts into folders that are not its own.
+    const channel = await tx.channel.findFirst({
+      where: { id: channelId, workspaceId: actor.workspaceId },
+      select: { projectId: true },
+    });
+    if (!channel?.projectId) {
+      throw new AppError('SDLC hub not found', 404);
+    }
+    const repos = await tx.repo.findMany({
+      where: { id: { in: unique }, workspaceId: actor.workspaceId, projectId: channel.projectId },
+      select: { id: true },
+    });
+    if (repos.length !== unique.length) {
+      throw new AppError(
+        'One or more repositories were not found in this hub\'s project',
+        404
+      );
+    }
+
+    await tx.sdlcEntityLink.createMany({
+      data: repos.map((repo) => ({
+        workspaceId: actor.workspaceId,
+        channelId,
+        sourceType: 'CHANNEL',
+        sourceId: channelId,
+        targetType: 'REPOSITORY',
+        targetId: repo.id,
+        relationType: SDLC_MEMBERSHIP_RELATION,
+        createdBy: actor.userId,
+      })),
+      skipDuplicates: true,
+    });
+
+    return repos.map((repo) => repo.id);
   }
 
   async setupRepository(actor: SdlcActor, repoId: string): Promise<SdlcSetupExecution> {
@@ -223,6 +370,8 @@ export class SdlcHubService implements SdlcHub {
 
     const initialContext = JSON.stringify({
       repoId,
+      // The hub this run was started from; a repository can be in several.
+      channelId: repo.channelId,
       phase: 'QUEUED',
       completedBaselineKinds: [],
     });
@@ -324,6 +473,7 @@ export class SdlcHubService implements SdlcHub {
     delete context.admissionPermitId;
     context.phase = 'QUEUED';
     context.repoId = repoId;
+    context.channelId = repo.channelId;
     await this.prisma.$transaction([
       this.prisma.workflowExecution.update({
         where: { id: execution.id },
@@ -367,6 +517,7 @@ export class SdlcHubService implements SdlcHub {
     await sdlcVcs.requireCapabilities(actor, repoId, [...BASELINE_CAPABILITIES]);
     const context = JSON.stringify({
       repoId,
+      channelId: repo.channelId,
       phase: 'QUEUED',
       refreshExisting: true,
       completedBaselineKinds: [],
@@ -466,11 +617,21 @@ export class SdlcHubService implements SdlcHub {
   ): Promise<SdlcRepositoryRunContext[]> {
     const safeLimit = Math.max(1, Math.min(50, Math.floor(limit)));
     const trimmedQuery = query.trim();
+    const memberships = await this.prisma.sdlcEntityLink.findMany({
+      where: {
+        workspaceId: actor.workspaceId,
+        relationType: SDLC_MEMBERSHIP_RELATION,
+        channel: { participants: { some: { userId: actor.userId } } },
+      },
+      select: { targetId: true },
+    });
+    const repoIds = [...new Set(memberships.map((membership) => membership.targetId))];
+    if (repoIds.length === 0) return [];
+
     const repos = await this.prisma.repo.findMany({
       where: {
         workspaceId: actor.workspaceId,
-        channelId: { not: null },
-        channel: { participants: { some: { userId: actor.userId } } },
+        id: { in: repoIds },
         ...(trimmedQuery
           ? {
               OR: [
@@ -622,7 +783,14 @@ export class SdlcHubService implements SdlcHub {
     actor: SdlcActor,
     input: CreateSdlcClawArtifactInput
   ): Promise<SdlcArtifact> {
-    const repo = await this.requireRepositoryRole(actor, input.repoId, false);
+    const repo = await this.requireRepositoryRole(
+      actor,
+      input.repoId,
+      false,
+      (input.folderId ? await this.hubOf('canvasFolder', input.folderId) : undefined) ??
+        (input.setupExecutionId ? await this.hubOfExecution(input.setupExecutionId) : undefined) ??
+        input.channelId
+    );
     if (!repo?.channelId || !repo.projectId) {
       throw new AppError('SDLC repository not found', 404);
     }
@@ -684,11 +852,10 @@ export class SdlcHubService implements SdlcHub {
     }
 
     if (input.trackId) {
-      const track = await this.prisma.sdlcTrack.findFirst({
-        where: { id: input.trackId, repoId: repo.id },
-        select: { id: true },
-      });
-      if (!track) throw new AppError('SDLC track not found for this repository', 404);
+      const inHub =
+        Boolean(repo.channelId) &&
+        (await isTrackInChannel(this.prisma, input.trackId, repo.channelId!));
+      if (!inHub) throw new AppError('SDLC track not found for this repository', 404);
     }
 
     let artifactMarkdown = input.markdown;
@@ -745,7 +912,7 @@ export class SdlcHubService implements SdlcHub {
             await tx.sdlcEntityLink.create({
               data: {
                 workspaceId: actor.workspaceId,
-                repoId: repo.id,
+                channelId: repo.channelId,
                 sourceType: 'TRACK',
                 sourceId: input.trackId,
                 targetType: 'CANVAS',
@@ -786,7 +953,7 @@ export class SdlcHubService implements SdlcHub {
               await tx.sdlcEntityLink.create({
                 data: {
                   workspaceId: actor.workspaceId,
-                  repoId: repo.id,
+                  channelId: repo.channelId,
                   sourceType: 'CANVAS',
                   sourceId: related.id,
                   targetType: 'CANVAS',
@@ -836,7 +1003,12 @@ export class SdlcHubService implements SdlcHub {
     actor: SdlcActor,
     input: UpdateSdlcBaselineDraftInput
   ): Promise<SdlcArtifact> {
-    const repo = await this.requireRepositoryRole(actor, input.repoId, false);
+    const repo = await this.requireRepositoryRole(
+      actor,
+      input.repoId,
+      false,
+      await this.hubOfExecution(input.setupExecutionId)
+    );
     if (!repo?.channelId || !repo.projectId) {
       throw new AppError('SDLC repository not found', 404);
     }
@@ -1246,7 +1418,12 @@ export class SdlcHubService implements SdlcHub {
     actor: SdlcActor,
     input: UpdateSdlcClawArtifactInput
   ): Promise<SdlcArtifact> {
-    const repo = await this.requireRepositoryRole(actor, input.repoId, false);
+    const repo = await this.requireRepositoryRole(
+      actor,
+      input.repoId,
+      false,
+      await this.hubOf('canvas', input.canvasId)
+    );
     if (!repo.channelId || !repo.projectId) throw new AppError('SDLC repository not found', 404);
     const existing = await this.prisma.canvas.findFirst({
       where: {
@@ -1317,24 +1494,30 @@ export class SdlcHubService implements SdlcHub {
   async linkContext(
     actor: SdlcActor,
     repoId: string,
-    input: CreateSdlcLinkInput
+    input: CreateSdlcLinkInput,
+    channelId?: string
   ): Promise<SdlcLink> {
     if (input.relationType === 'DISCUSSION') {
       throw new AppError('SDLC discussions must be created with their conversation', 400);
     }
-    const repo = await this.requireRepositoryRole(actor, repoId, false);
+    const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
     await this.requireLinkSource(repoId, repo.channelId!, input.sourceType, input.sourceId);
     await this.requireAccessibleEntity(actor, input.targetType, input.targetId);
     try {
       const link = await this.prisma.sdlcEntityLink.create({
-        data: { ...input, workspaceId: actor.workspaceId, repoId, createdBy: actor.userId },
+        data: {
+          ...input,
+          workspaceId: actor.workspaceId,
+          channelId: repo.channelId,
+          createdBy: actor.userId,
+        },
       });
       // Propagate the source artifact's track onto the ticket so the ticket shows
       // under the same track (same TRACK_ITEM entity link we use for PRDs/Tech Docs).
       if (input.targetType === 'TICKET' && input.sourceType === 'CANVAS') {
         const trackLink = await this.prisma.sdlcEntityLink.findFirst({
           where: {
-            repoId,
+            channelId: repo.channelId,
             sourceType: 'TRACK',
             targetType: 'CANVAS',
             targetId: input.sourceId,
@@ -1347,7 +1530,7 @@ export class SdlcHubService implements SdlcHub {
             await this.prisma.sdlcEntityLink.create({
               data: {
                 workspaceId: actor.workspaceId,
-                repoId,
+                channelId: repo.channelId,
                 sourceType: 'TRACK',
                 sourceId: trackLink.sourceId,
                 targetType: 'TICKET',
@@ -1379,10 +1562,12 @@ export class SdlcHubService implements SdlcHub {
     }
   }
 
-  async listTracks(actor: SdlcActor, repoId: string) {
-    const repo = await this.requireRepositoryRole(actor, repoId, false);
+  async listTracks(actor: SdlcActor, repoId: string, channelId?: string) {
+    const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
+    // Tracks carry no scope column; the CHANNEL -> TRACK edges name the hub's tracks.
+    const trackIds = repo.channelId ? await trackIdsForChannel(this.prisma, repo.channelId) : [];
     return this.prisma.sdlcTrack.findMany({
-      where: { repoId: repo.id },
+      where: { id: { in: trackIds } },
       orderBy: { createdAt: 'asc' },
       select: {
         id: true,
@@ -1396,22 +1581,39 @@ export class SdlcHubService implements SdlcHub {
   }
 
   async createTrack(actor: SdlcActor, input: CreateSdlcTrackInput) {
-    const repo = await this.requireRepositoryRole(actor, input.repoId, false);
-    return this.prisma.sdlcTrack.create({
-      data: {
-        workspaceId: actor.workspaceId,
-        repoId: repo.id,
-        name: input.name,
-        ...(input.description ? { description: input.description } : {}),
-        status: 'ACTIVE',
-        createdBy: actor.userId,
-      },
-      select: { id: true, name: true, description: true, status: true },
+    const repo = await this.requireRepositoryRole(actor, input.repoId, false, input.channelId);
+    if (!repo.channelId) throw new AppError('SDLC repository not found', 404);
+    const channelId = repo.channelId;
+    return this.prisma.$transaction(async (tx) => {
+      const track = await tx.sdlcTrack.create({
+        data: {
+          workspaceId: actor.workspaceId,
+          name: input.name,
+          ...(input.description ? { description: input.description } : {}),
+          status: 'ACTIVE',
+          createdBy: actor.userId,
+        },
+        select: { id: true, name: true, description: true, status: true },
+      });
+      // The track carries no scope column; this edge is what places it in the hub.
+      await tx.sdlcEntityLink.create({
+        data: {
+          workspaceId: actor.workspaceId,
+          channelId,
+          sourceType: 'CHANNEL',
+          sourceId: channelId,
+          targetType: 'TRACK',
+          targetId: track.id,
+          relationType: SDLC_TRACK_MEMBERSHIP_RELATION,
+          createdBy: actor.userId,
+        },
+      });
+      return track;
     });
   }
 
-  async listArtifactTypes(actor: SdlcActor, repoId: string) {
-    const repo = await this.requireRepositoryRole(actor, repoId, false);
+  async listArtifactTypes(actor: SdlcActor, repoId: string, channelId?: string) {
+    const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
     if (!repo?.channelId) throw new AppError('SDLC repository not found', 404);
     return this.prisma.canvasFolder.findMany({
       where: { channelId: repo.channelId },
@@ -1420,8 +1622,8 @@ export class SdlcHubService implements SdlcHub {
     });
   }
 
-  async createArtifactType(actor: SdlcActor, repoId: string, name: string) {
-    const repo = await this.requireRepositoryRole(actor, repoId, false);
+  async createArtifactType(actor: SdlcActor, repoId: string, name: string, channelId?: string) {
+    const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
     if (!repo?.channelId || !repo.projectId) {
       throw new AppError('SDLC repository not found', 404);
     }
@@ -1446,7 +1648,12 @@ export class SdlcHubService implements SdlcHub {
   }
 
   async renameArtifactType(actor: SdlcActor, repoId: string, folderId: string, name: string) {
-    const repo = await this.requireRepositoryRole(actor, repoId, false);
+    const repo = await this.requireRepositoryRole(
+      actor,
+      repoId,
+      false,
+      await this.hubOf('canvasFolder', folderId)
+    );
     if (!repo?.channelId) throw new AppError('SDLC repository not found', 404);
     const trimmed = name.trim();
     if (!trimmed) throw new AppError('Artifact type name is required', 400);
@@ -1471,9 +1678,14 @@ export class SdlcHubService implements SdlcHub {
   }
 
   async unlinkContext(actor: SdlcActor, repoId: string, linkId: string): Promise<void> {
-    await this.requireRepositoryRole(actor, repoId, false);
+    const repo = await this.requireRepositoryRole(
+      actor,
+      repoId,
+      false,
+      await this.hubOf('sdlcEntityLink', linkId)
+    );
     const link = await this.prisma.sdlcEntityLink.findFirst({
-      where: { id: linkId, repoId, workspaceId: actor.workspaceId },
+      where: { id: linkId, channelId: repo.channelId, workspaceId: actor.workspaceId },
       select: { relationType: true },
     });
     if (!link) {
@@ -1482,8 +1694,11 @@ export class SdlcHubService implements SdlcHub {
     if (link.relationType === 'DISCUSSION') {
       throw new AppError('Delete the conversation to remove an SDLC discussion', 400);
     }
+    if ((SDLC_STRUCTURAL_RELATIONS as readonly string[]).includes(link.relationType)) {
+      throw new AppError('Structural SDLC edges are not deleted through the link API', 400);
+    }
     const result = await this.prisma.sdlcEntityLink.deleteMany({
-      where: { id: linkId, repoId, workspaceId: actor.workspaceId },
+      where: { id: linkId, channelId: repo.channelId, workspaceId: actor.workspaceId },
     });
     if (result.count === 0) {
       throw new AppError('SDLC relationship not found', 404);
@@ -1495,39 +1710,12 @@ export class SdlcHubService implements SdlcHub {
     actor: SdlcActor,
     projectId: string
   ): Promise<void> {
-    const [user, participant, projectAdmin] = await Promise.all([
-      tx.user.findFirst({
-        where: { id: actor.userId, workspaceId: actor.workspaceId },
-        select: { role: true },
-      }),
-      tx.channelParticipant.findFirst({
-        where: {
-          userId: actor.userId,
-          channel: { projectId, workspaceId: actor.workspaceId },
-        },
-        select: { id: true },
-      }),
-      tx.resourceAccess.findFirst({
-        where: {
-          workspaceId: actor.workspaceId,
-          accessType: AccessType.ADMIN,
-          resource: { name: 'LISTPROJECTS' },
-          OR: [
-            { userId: actor.userId },
-            {
-              userGroup: {
-                workspaceId: actor.workspaceId,
-                userGroupMappings: { some: { userId: actor.userId } },
-              },
-            },
-          ],
-        },
-        select: { id: true },
-      }),
-    ]);
-    if (!user || user.role === WorkspaceRole.GUEST || (!participant && !projectAdmin)) {
-      throw new AppError('You must be a project participant to attach a repository', 403);
-    }
+    await requireSdlcProjectAccess(
+      tx,
+      actor,
+      projectId,
+      'You must be a project participant to attach a repository'
+    );
   }
 
   private applyValidatedDraftSection(
@@ -1582,31 +1770,106 @@ export class SdlcHubService implements SdlcHub {
     };
   }
 
-  private async requireRepositoryRole(actor: SdlcActor, repoId: string, requireAdmin: boolean) {
+  /** Gate for hub-scoped work: artifact types, artifacts, links, tracks, membership. */
+  private async requireChannelRole(actor: SdlcActor, channelId: string, requireAdmin: boolean) {
+    const channel = await this.prisma.channel.findFirst({
+      where: { id: channelId, workspaceId: actor.workspaceId, type: ChannelType.SDLC },
+      select: {
+        id: true,
+        name: true,
+        projectId: true,
+        participants: { where: { userId: actor.userId }, select: { role: true } },
+      },
+    });
+    if (!channel) {
+      throw new AppError('SDLC hub not found', 404);
+    }
+    const participant = channel.participants[0];
+    if (!participant) {
+      throw new AppError('You are not a member of this hub', 403);
+    }
+    if (requireAdmin && participant.role !== ChannelRole.ADMIN) {
+      throw new AppError('Hub admin access is required', 403);
+    }
+    return channel;
+  }
+
+  /**
+   * Gate for repo-scoped work. Access comes from the hubs the repository belongs to,
+   * so this also resolves which hub the operation runs in and returns it as
+   * `channelId`. Pass `channelId` when the caller knows it; otherwise the actor's
+   * oldest accessible membership wins.
+   */
+  /**
+   * A repository sits in several hubs, so its hub cannot be inferred from it.
+   * Hub-scoped work reads the hub off the row it addresses.
+   */
+  private async hubOf(
+    table: 'canvasFolder' | 'canvas' | 'sdlcEntityLink',
+    id: string
+  ): Promise<string | undefined> {
+    const row = await (
+      this.prisma[table] as { findFirst: (args: unknown) => Promise<{ channelId: string | null } | null> }
+    ).findFirst({ where: { id }, select: { channelId: true } });
+    return row?.channelId ?? undefined;
+  }
+
+  private async hubOfExecution(executionId: string): Promise<string | undefined> {
+    const row = await this.prisma.workflowExecution.findUnique({
+      where: { id: executionId },
+      select: { context: true },
+    });
+    const channelId = this.parseJsonRecord(row?.context).channelId;
+    return typeof channelId === 'string' && channelId ? channelId : undefined;
+  }
+
+  private async requireRepositoryRole(
+    actor: SdlcActor,
+    repoId: string,
+    requireAdmin: boolean,
+    channelId?: string
+  ) {
     const repo = await this.prisma.repo.findFirst({
-      where: { id: repoId, workspaceId: actor.workspaceId, channelId: { not: null } },
-      include: {
+      where: { id: repoId, workspaceId: actor.workspaceId },
+    });
+    if (!repo || !repo.projectId) {
+      throw new AppError('SDLC repository not found', 404);
+    }
+
+    const memberships = await this.prisma.sdlcEntityLink.findMany({
+      where: {
+        targetType: 'REPOSITORY',
+        targetId: repoId,
+        relationType: SDLC_MEMBERSHIP_RELATION,
+        ...(channelId ? { channelId } : {}),
+        channel: { participants: { some: { userId: actor.userId } } },
+      },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        channelId: true,
         channel: {
           select: {
-            participants: {
-              where: { userId: actor.userId },
-              select: { role: true },
-            },
+            participants: { where: { userId: actor.userId }, select: { role: true } },
           },
         },
       },
     });
-    if (!repo || !repo.channelId || !repo.projectId) {
-      throw new AppError('SDLC repository not found', 404);
-    }
-    const participant = repo.channel?.participants[0];
-    if (!participant) {
+    if (memberships.length === 0) {
       throw new AppError('You are not a member of this repository', 403);
     }
-    if (requireAdmin && participant.role !== ChannelRole.ADMIN) {
+    // Role differs per hub, so an admin action is allowed from any hub the actor
+    // administers, not only the oldest.
+    const membership = requireAdmin
+      ? memberships.find(
+          (candidate) => candidate.channel?.participants[0]?.role === ChannelRole.ADMIN
+        )
+      : memberships[0];
+    if (!membership?.channelId) {
       throw new AppError('Repository admin access is required', 403);
     }
-    return repo;
+
+    // channelId replaces the old repos.channelId for every repo-scoped caller.
+    return { ...repo, channelId: membership.channelId };
   }
 
   private parseJsonRecord(value: string | null | undefined): Record<string, unknown> {

--- a/apps/backend/src/sdlc/cleanup/multirepoBackfill.ts
+++ b/apps/backend/src/sdlc/cleanup/multirepoBackfill.ts
@@ -1,0 +1,159 @@
+import { z } from 'zod';
+import { SDLC_MEMBERSHIP_RELATION, SDLC_TRACK_MEMBERSHIP_RELATION } from '@xyne/shared/sdlc';
+import { db } from '@/database/client';
+import { runAsSystem } from '@/database/tenant/context';
+import { logger } from '@/utils/logger';
+import {
+  membershipRowsFor,
+  trackMembershipRowsFor,
+  type LegacySdlcHub,
+} from '@/sdlc/sdlcMembershipRows';
+
+/**
+ * One-off data migration for SDLC multi-repo channels.
+ *
+ * Until now an SDLC hub was a repos row carrying both projectId and channelId, so
+ * a repository and its channel were locked 1:1. Membership now lives in
+ * sdlc_entity_links: a CHANNEL -> REPOSITORY edge for the repository, and a
+ * CHANNEL -> TRACK edge for each of its tracks. This writes both, and stamps the
+ * owning channel onto the content links that until now inherited it through their
+ * repository.
+ *
+ * Runs after 20260828121427_sdlc_multirepo_add and the branch deploy. Nothing is
+ * dropped: repos."channelId", sdlc_entity_links."repoId" and sdlc_tracks."repoId"
+ * stay in the database, deprecated, still holding their old values. Between the
+ * deploy and this run the deployed code reads everything by channelId and no new
+ * row carries one, so SDLC shows no hubs, links or tracks - the surface is dark
+ * until this runs and comes back the moment it does. Nothing is lost, and a
+ * rollback finds every legacy column intact.
+ *
+ * Idempotent. Every insert skips duplicates against the unique on
+ * (channelId, sourceType, sourceId, targetType, targetId, relationType), and the
+ * link update only touches rows whose channelId is still null, so a re-run after a
+ * partial pass picks up exactly the stragglers. A dryRun pass reports what a real
+ * one would write; all zeros means the migration is complete.
+ *
+ * Runs inside runAsSystem(): `db` is the ACL-wrapped client and every table here
+ * carries a workspaceId scalar, so an ordinary request context would silently
+ * narrow this to the calling admin's own workspace. This repair spans all of them.
+ */
+
+const TAG = '[SdlcMultirepoBackfill]';
+
+export const sdlcMultirepoBackfillSchema = z.object({
+  dryRun: z.boolean().default(true),
+  batchSize: z.number().int().positive().max(1000).default(100),
+});
+export type SdlcMultirepoBackfillInput = z.infer<typeof sdlcMultirepoBackfillSchema>;
+
+export interface SdlcMultirepoBackfillResult {
+  dryRun: boolean;
+  hubsSeen: number;
+  membershipCreated: number;
+  trackEdgesCreated: number;
+  linksStamped: number;
+}
+
+/**
+ * Hubs still carrying a channel, oldest first. Ordering by id keeps paging
+ * stable; nothing writes repos."channelId" any more, so the set never grows.
+ */
+async function readHubs(limit: number, afterId: string | null): Promise<LegacySdlcHub[]> {
+  const rows = await db.repo.findMany({
+    where: { channelId: { not: null }, ...(afterId ? { id: { gt: afterId } } : {}) },
+    orderBy: { id: 'asc' },
+    take: limit,
+    select: { id: true, workspaceId: true, channelId: true, createdBy: true },
+  });
+  return rows.map(row => ({ ...row, channelId: row.channelId! }));
+}
+
+/** A hub's tracks, by the repository column they were scoped by. */
+function readTracks(repoId: string) {
+  return db.sdlcTrack.findMany({
+    where: { repoId },
+    select: { id: true, workspaceId: true, createdBy: true },
+  });
+}
+
+export async function backfillSdlcMultirepo(
+  input: SdlcMultirepoBackfillInput
+): Promise<SdlcMultirepoBackfillResult> {
+  const startedAt = Date.now();
+  return runAsSystem(async () => {
+    let afterId: string | null = null;
+    let hubsSeen = 0;
+    let membershipCreated = 0;
+    let trackEdgesCreated = 0;
+    let linksStamped = 0;
+
+    for (;;) {
+      const hubs = await readHubs(input.batchSize, afterId);
+      if (hubs.length === 0) break;
+      hubsSeen += hubs.length;
+      afterId = hubs[hubs.length - 1]!.id;
+
+      const rows = membershipRowsFor(hubs);
+      if (input.dryRun) {
+        // createMany skips duplicates, so rows.length would report every hub.
+        const existing = await db.sdlcEntityLink.count({
+          where: {
+            relationType: SDLC_MEMBERSHIP_RELATION,
+            targetType: 'REPOSITORY',
+            OR: rows.map(row => ({ channelId: row.channelId, targetId: row.targetId })),
+          },
+        });
+        membershipCreated += rows.length - existing;
+      } else {
+        const created = await db.sdlcEntityLink.createMany({ data: rows, skipDuplicates: true });
+        membershipCreated += created.count;
+      }
+
+      for (const hub of hubs) {
+        const trackRows = trackMembershipRowsFor(hub.channelId, await readTracks(hub.id));
+        if (input.dryRun) {
+          const [existingTrackEdges, stampableLinks] = await Promise.all([
+            trackRows.length === 0
+              ? Promise.resolve(0)
+              : db.sdlcEntityLink.count({
+                  where: {
+                    channelId: hub.channelId,
+                    relationType: SDLC_TRACK_MEMBERSHIP_RELATION,
+                    targetType: 'TRACK',
+                    targetId: { in: trackRows.map(row => row.targetId) },
+                  },
+                }),
+            db.sdlcEntityLink.count({ where: { repoId: hub.id, channelId: null } }),
+          ]);
+          trackEdgesCreated += trackRows.length - existingTrackEdges;
+          linksStamped += stampableLinks;
+        } else {
+          const [trackEdges, links] = await Promise.all([
+            trackRows.length === 0
+              ? Promise.resolve({ count: 0 })
+              : db.sdlcEntityLink.createMany({ data: trackRows, skipDuplicates: true }),
+            db.sdlcEntityLink.updateMany({
+              where: { repoId: hub.id, channelId: null },
+              data: { channelId: hub.channelId },
+            }),
+          ]);
+          trackEdgesCreated += trackEdges.count;
+          linksStamped += links.count;
+        }
+      }
+
+      if (hubs.length < input.batchSize) break;
+    }
+
+    logger.info(`${TAG} finished`, {
+      hubsSeen,
+      membershipCreated,
+      trackEdgesCreated,
+      linksStamped,
+      dryRun: input.dryRun,
+      durationMs: Date.now() - startedAt,
+    });
+
+    return { dryRun: input.dryRun, hubsSeen, membershipCreated, trackEdgesCreated, linksStamped };
+  });
+}

--- a/apps/backend/src/sdlc/cleanup/routes.ts
+++ b/apps/backend/src/sdlc/cleanup/routes.ts
@@ -1,0 +1,43 @@
+import { Router, type NextFunction, type Request, type Response } from 'express';
+import { AccessType } from '@xyne/shared';
+import { authorize } from '@/middleware/authorize';
+import { backfillSdlcMultirepo, sdlcMultirepoBackfillSchema } from './multirepoBackfill';
+
+/**
+ * One-off SDLC data migrations. Mounted at /api/sdlc/cleanup, inheriting that
+ * router's auth. Delete this directory and its two lines in routes/sdlc.ts once
+ * every environment has run them.
+ */
+const router = Router();
+
+/** Spans every workspace, so it is admin-only rather than actor-scoped. */
+const adminAuth = authorize('TICKET-MIGRATION', AccessType.ADMIN);
+
+function route(
+  handler: (req: Request, res: Response) => Promise<void>
+): (req: Request, res: Response, next: NextFunction) => void {
+  return (req, res, next) => {
+    void handler(req, res).catch(next);
+  };
+}
+
+/**
+ * Turn every existing SDLC hub into a CHANNEL -> REPOSITORY membership edge, each
+ * of its tracks into a CHANNEL -> TRACK edge, and stamp the owning channel onto
+ * the content links that until now inherited it through their repository.
+ *
+ * Preview by default; send { "dryRun": false } to apply. Idempotent — re-running
+ * after a partial pass picks up only the stragglers, and a preview reporting all
+ * zeros is what says the migration is complete.
+ */
+router.post(
+  '/multirepo-backfill',
+  adminAuth,
+  route(async (req, res) => {
+    const input = sdlcMultirepoBackfillSchema.parse(req.body ?? {});
+    const result = await backfillSdlcMultirepo(input);
+    res.status(200).json({ success: true, ...result });
+  })
+);
+
+export default router;

--- a/apps/backend/src/sdlc/sdlcAskAiContext.ts
+++ b/apps/backend/src/sdlc/sdlcAskAiContext.ts
@@ -36,6 +36,8 @@ interface SdlcAskAiContextInput {
     url: string;
   };
   channelId: string;
+  /** The hub's other repositories. Named so the agent knows they exist; only `repo` is sandboxed. */
+  otherRepos?: Array<{ id: string; name: string; url: string }>;
   baselineDocuments: Array<{ title: string; content: string }>;
   linkedContext: string[];
   wikiFreshness?: WikiFreshnessContext;
@@ -81,6 +83,12 @@ export function buildSdlcAskAiContext(input: SdlcAskAiContextInput): string {
     `Repository: ${input.repo.name} (${input.repo.url})`,
     `SDLC repository ID: ${input.repo.id}`,
     `Repository channel ID: ${input.channelId}`,
+    input.otherRepos?.length
+      ? [
+          'This hub contains other repositories. Only the repository above is pinned and inspectable in this session; to work in another one, ask the user to switch to it in the SDLC hub first.',
+          ...input.otherRepos.map((other) => `- ${other.name} (${other.url}) - SDLC repository ID: ${other.id}`),
+        ].join('\n')
+      : 'This hub contains no other repositories.',
     repositoryAccessInstruction,
     implementationInstruction,
     selectedArtifactInstruction,

--- a/apps/backend/src/sdlc/sdlcChannelMembership.ts
+++ b/apps/backend/src/sdlc/sdlcChannelMembership.ts
@@ -1,0 +1,125 @@
+import type { Prisma, PrismaClient } from '@prisma/client';
+import {
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
+} from '@xyne/shared/sdlc';
+
+
+type Db = PrismaClient | Prisma.TransactionClient;
+
+/**
+ * The hub a repository belongs to, oldest membership first. Returns null when it
+ * belongs to none, which is a repository registered but not yet added to a hub.
+ *
+ * A repository can be in several hubs. Callers that know which one they mean
+ * should pass it down instead of calling this; this is the answer for background
+ * work that has no such context, and it is exact whenever the repository lives in
+ * a single hub.
+ */
+export async function resolveSdlcChannelId(db: Db, repoId: string): Promise<string | null> {
+  const membership = await db.sdlcEntityLink.findFirst({
+    where: {
+      targetType: 'REPOSITORY',
+      targetId: repoId,
+      relationType: SDLC_MEMBERSHIP_RELATION,
+    },
+    orderBy: { createdAt: 'asc' },
+    select: { channelId: true },
+  });
+  return membership?.channelId ?? null;
+}
+
+/** Same, but throws rather than returning null — for paths that cannot continue. */
+export async function requireSdlcChannelId(db: Db, repoId: string): Promise<string> {
+  const channelId = await resolveSdlcChannelId(db, repoId);
+  if (!channelId) {
+    throw new Error(`SDLC repository ${repoId} does not belong to a hub`);
+  }
+  return channelId;
+}
+
+/** Whether a repository is part of a given hub. */
+export async function isRepositoryInChannel(
+  db: Db,
+  repoId: string,
+  channelId: string
+): Promise<boolean> {
+  const membership = await db.sdlcEntityLink.findFirst({
+    where: {
+      channelId,
+      targetType: 'REPOSITORY',
+      targetId: repoId,
+      relationType: SDLC_MEMBERSHIP_RELATION,
+    },
+    select: { id: true },
+  });
+  return Boolean(membership);
+}
+
+/**
+ * The hub an actor reaches a repository through, plus their role in it.
+ *
+ * This is the read check for every repo-scoped SDLC surface: a repository is
+ * readable when the actor participates in at least one hub it belongs to.
+ * Returns null when they participate in none.
+ */
+export async function findSdlcMembershipForActor(
+  db: Db,
+  input: { workspaceId: string; repoId: string; userId: string; channelId?: string }
+): Promise<{ channelId: string; role: string } | null> {
+  const membership = await db.sdlcEntityLink.findFirst({
+    where: {
+      workspaceId: input.workspaceId,
+      targetType: 'REPOSITORY',
+      targetId: input.repoId,
+      relationType: SDLC_MEMBERSHIP_RELATION,
+      ...(input.channelId ? { channelId: input.channelId } : {}),
+      channel: { participants: { some: { userId: input.userId } } },
+    },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      channelId: true,
+      channel: {
+        select: {
+          participants: { where: { userId: input.userId }, select: { role: true }, take: 1 },
+        },
+      },
+    },
+  });
+  const role = membership?.channel?.participants[0]?.role;
+  return membership?.channelId && role ? { channelId: membership.channelId, role } : null;
+}
+
+/**
+ * The tracks of a hub. Tracks carry no scope column; the CHANNEL -> TRACK edge is
+ * what places one, so the id list comes from the link table.
+ */
+export async function trackIdsForChannel(db: Db, channelId: string): Promise<string[]> {
+  const edges = await db.sdlcEntityLink.findMany({
+    where: {
+      channelId,
+      targetType: 'TRACK',
+      relationType: SDLC_TRACK_MEMBERSHIP_RELATION,
+    },
+    select: { targetId: true },
+  });
+  return edges.map((edge) => edge.targetId);
+}
+
+/** Whether a track belongs to a given hub. */
+export async function isTrackInChannel(
+  db: Db,
+  trackId: string,
+  channelId: string
+): Promise<boolean> {
+  const edge = await db.sdlcEntityLink.findFirst({
+    where: {
+      channelId,
+      targetType: 'TRACK',
+      targetId: trackId,
+      relationType: SDLC_TRACK_MEMBERSHIP_RELATION,
+    },
+    select: { id: true },
+  });
+  return Boolean(edge);
+}

--- a/apps/backend/src/sdlc/sdlcDiscussionOwner.ts
+++ b/apps/backend/src/sdlc/sdlcDiscussionOwner.ts
@@ -16,7 +16,7 @@ export interface SdlcDiscussionOwnerLookup {
   } | null>;
   getPullRequest: (id: string) => Promise<{ id: string; workspaceId: string } | null>;
   findLinkSource: (input: {
-    repoId: string;
+    channelId: string;
     targetType: Extract<SdlcEntityType, 'CANVAS' | 'TICKET' | 'PULL_REQUEST'>;
     targetId: string;
     relationType: Extract<SdlcRelationType, 'TICKET' | 'PULL_REQUEST'>;
@@ -26,7 +26,6 @@ export interface SdlcDiscussionOwnerLookup {
 export async function resolveSdlcDiscussionOwnerId(
   input: {
     workspaceId: string;
-    repoId: string;
     channelId: string;
     surfaceType: SdlcDiscussionSurfaceType;
     surfaceId: string;
@@ -56,7 +55,7 @@ export async function resolveSdlcDiscussionOwnerId(
       return null;
     }
     const link = await lookup.findLinkSource({
-      repoId: input.repoId,
+      channelId: input.channelId,
       targetType: 'TICKET',
       targetId: ticket.id,
       relationType: 'TICKET',
@@ -70,7 +69,7 @@ export async function resolveSdlcDiscussionOwnerId(
   const pullRequest = await lookup.getPullRequest(input.surfaceId);
   if (!pullRequest || pullRequest.workspaceId !== input.workspaceId) return null;
   const pullRequestLink = await lookup.findLinkSource({
-    repoId: input.repoId,
+    channelId: input.channelId,
     targetType: 'PULL_REQUEST',
     targetId: pullRequest.id,
     relationType: 'PULL_REQUEST',

--- a/apps/backend/src/sdlc/sdlcMembershipRows.test.ts
+++ b/apps/backend/src/sdlc/sdlcMembershipRows.test.ts
@@ -1,0 +1,97 @@
+// @xyne/shared ships as ESM dist/, which this CJS jest setup cannot load, so it is
+// mocked here the same way src/zero/acl/tables/messages-acl.test.ts does. The value
+// mirrors SDLC_MEMBERSHIP_RELATION in packages/shared/src/sdlc.ts.
+jest.mock('@xyne/shared/sdlc', () => ({
+  SDLC_MEMBERSHIP_RELATION: 'REPOSITORY',
+  SDLC_TRACK_MEMBERSHIP_RELATION: 'TRACK',
+}));
+
+import {
+  membershipRowsFor,
+  trackMembershipRowsFor,
+  type LegacySdlcHub,
+} from './sdlcMembershipRows';
+
+const hub = (over: Partial<LegacySdlcHub> = {}): LegacySdlcHub => ({
+  id: 'repo-a',
+  workspaceId: 'w1',
+  channelId: 'chan-a',
+  createdBy: 'user-1',
+  ...over,
+});
+
+describe('membershipRowsFor', () => {
+  it('turns a hub into a CHANNEL -> REPOSITORY edge', () => {
+    expect(membershipRowsFor([hub()])).toEqual([
+      {
+        workspaceId: 'w1',
+        channelId: 'chan-a',
+        sourceType: 'CHANNEL',
+        sourceId: 'chan-a',
+        targetType: 'REPOSITORY',
+        targetId: 'repo-a',
+        relationType: 'REPOSITORY',
+        createdBy: 'user-1',
+      },
+    ]);
+  });
+
+  it('names both ends of the edge', () => {
+    // channelId repeats sourceId, and targetId is the only place the repository is
+    // recorded. The unique guarding one membership row per (repo, channel) is keyed
+    // on both, so these drifting apart would silently unguard it.
+    const hubs = [hub(), hub({ id: 'repo-b', channelId: 'chan-b' })];
+    for (const [index, row] of membershipRowsFor(hubs).entries()) {
+      expect(row.sourceId).toBe(row.channelId);
+      expect(row.targetId).toBe(hubs[index]!.id);
+    }
+  });
+
+  it('carries each hub its own workspace and creator', () => {
+    const rows = membershipRowsFor([
+      hub(),
+      hub({ id: 'repo-b', channelId: 'chan-b', workspaceId: 'w2', createdBy: 'user-2' }),
+    ]);
+    expect(rows.map(row => [row.workspaceId, row.createdBy])).toEqual([
+      ['w1', 'user-1'],
+      ['w2', 'user-2'],
+    ]);
+  });
+
+  it('emits nothing when no hub is left to migrate', () => {
+    expect(membershipRowsFor([])).toEqual([]);
+  });
+});
+
+describe('trackMembershipRowsFor', () => {
+  const track = (id: string) => ({ id, workspaceId: 'w1', createdBy: 'user-1' });
+
+  it('turns a track into a CHANNEL -> TRACK edge', () => {
+    expect(trackMembershipRowsFor('chan-a', [track('track-a')])).toEqual([
+      {
+        workspaceId: 'w1',
+        channelId: 'chan-a',
+        sourceType: 'CHANNEL',
+        sourceId: 'chan-a',
+        targetType: 'TRACK',
+        targetId: 'track-a',
+        relationType: 'TRACK',
+        createdBy: 'user-1',
+      },
+    ]);
+  });
+
+  it('scopes every edge to the hub it was given', () => {
+    // A track has no scope column, so this edge is the only thing placing it. If
+    // channelId and sourceId ever drift apart the unique stops guarding it.
+    const rows = trackMembershipRowsFor('chan-b', [track('track-a'), track('track-b')]);
+    expect(rows.map(row => [row.channelId, row.sourceId])).toEqual([
+      ['chan-b', 'chan-b'],
+      ['chan-b', 'chan-b'],
+    ]);
+  });
+
+  it('emits nothing for a hub with no tracks', () => {
+    expect(trackMembershipRowsFor('chan-a', [])).toEqual([]);
+  });
+});

--- a/apps/backend/src/sdlc/sdlcMembershipRows.ts
+++ b/apps/backend/src/sdlc/sdlcMembershipRows.ts
@@ -1,0 +1,74 @@
+import {
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
+} from '@xyne/shared/sdlc';
+
+/**
+ * Shaping for the structural edges the backfill writes — CHANNEL -> REPOSITORY for
+ * a hub's repository, CHANNEL -> TRACK for each of its tracks. Kept apart from the
+ * backfill controller so it can be checked without loading Prisma.
+ */
+
+/** A pre-multirepo hub: the repos row still carrying its owning channel. */
+export type LegacySdlcHub = {
+  id: string;
+  workspaceId: string;
+  channelId: string;
+  createdBy: string;
+};
+
+export type SdlcMembershipRow = {
+  workspaceId: string;
+  channelId: string;
+  sourceType: string;
+  sourceId: string;
+  targetType: string;
+  targetId: string;
+  relationType: string;
+  createdBy: string;
+};
+
+/**
+ * sourceId is the channel, targetId the repository. channelId repeats the source
+ * because it is the scope every row carries, and the unique is keyed on both.
+ */
+export function membershipRowsFor(hubs: readonly LegacySdlcHub[]): SdlcMembershipRow[] {
+  return hubs.map(hub => ({
+    workspaceId: hub.workspaceId,
+    channelId: hub.channelId,
+    sourceType: 'CHANNEL',
+    sourceId: hub.channelId,
+    targetType: 'REPOSITORY',
+    targetId: hub.id,
+    relationType: SDLC_MEMBERSHIP_RELATION,
+    createdBy: hub.createdBy,
+  }));
+}
+
+/** A pre-multirepo track: the sdlc_tracks row still carrying its owning repository. */
+export type LegacySdlcTrack = {
+  id: string;
+  workspaceId: string;
+  createdBy: string;
+};
+
+/**
+ * One CHANNEL -> TRACK edge per track. Tracks have no scope column of their own,
+ * so this edge is what places an existing track in the hub it already belonged to
+ * through its repository.
+ */
+export function trackMembershipRowsFor(
+  channelId: string,
+  tracks: readonly LegacySdlcTrack[]
+): SdlcMembershipRow[] {
+  return tracks.map(track => ({
+    workspaceId: track.workspaceId,
+    channelId,
+    sourceType: 'CHANNEL',
+    sourceId: channelId,
+    targetType: 'TRACK',
+    targetId: track.id,
+    relationType: SDLC_TRACK_MEMBERSHIP_RELATION,
+    createdBy: track.createdBy,
+  }));
+}

--- a/apps/backend/src/sdlc/sdlcProjectAccess.ts
+++ b/apps/backend/src/sdlc/sdlcProjectAccess.ts
@@ -1,0 +1,62 @@
+import type { Prisma, PrismaClient } from '@prisma/client';
+import { AccessType, WorkspaceRole } from '@xyne/shared';
+import { AppError } from '@/middleware/errorHandler';
+import type { SdlcActor } from './types';
+
+type Db = PrismaClient | Prisma.TransactionClient;
+
+/**
+ * Whether an actor may work on a project's SDLC repositories.
+ *
+ * Project access, not hub membership: a repository belongs to its project from the
+ * moment it is registered. Anything that writes into a hub is gated by membership.
+ */
+export async function hasSdlcProjectAccess(
+  db: Db,
+  actor: SdlcActor,
+  projectId: string
+): Promise<boolean> {
+  const [user, participant, projectAdmin] = await Promise.all([
+    db.user.findFirst({
+      where: { id: actor.userId, workspaceId: actor.workspaceId },
+      select: { role: true },
+    }),
+    db.channelParticipant.findFirst({
+      where: {
+        userId: actor.userId,
+        channel: { projectId, workspaceId: actor.workspaceId },
+      },
+      select: { id: true },
+    }),
+    db.resourceAccess.findFirst({
+      where: {
+        workspaceId: actor.workspaceId,
+        accessType: AccessType.ADMIN,
+        resource: { name: 'LISTPROJECTS' },
+        OR: [
+          { userId: actor.userId },
+          {
+            userGroup: {
+              workspaceId: actor.workspaceId,
+              userGroupMappings: { some: { userId: actor.userId } },
+            },
+          },
+        ],
+      },
+      select: { id: true },
+    }),
+  ]);
+  if (!user || user.role === WorkspaceRole.GUEST) return false;
+  return Boolean(participant || projectAdmin);
+}
+
+export async function requireSdlcProjectAccess(
+  db: Db,
+  actor: SdlcActor,
+  projectId: string,
+  message = 'You must be a project participant to do this'
+): Promise<void> {
+  if (!(await hasSdlcProjectAccess(db, actor, projectId))) {
+    throw new AppError(message, 403);
+  }
+}

--- a/apps/backend/src/sdlc/types.ts
+++ b/apps/backend/src/sdlc/types.ts
@@ -13,13 +13,21 @@ export interface SdlcActor {
   isApp?: boolean;
 }
 
-export interface SdlcRepositoryHub {
+/** A registered repository. Membership lives in sdlc_entity_links, not here. */
+export interface SdlcRepository {
   id: string;
   name: string;
   url: string;
   canonicalUrl: string;
   projectId: string;
-  channelId: string;
+}
+
+/** An SDLC hub: the private channel plus the repositories it covers. */
+export interface SdlcChannel {
+  id: string;
+  name: string;
+  projectId: string;
+  repoIds: string[];
 }
 
 export interface SdlcRepositoryRunContext {
@@ -52,7 +60,7 @@ export interface SdlcLink {
 }
 
 export interface SdlcHub {
-  attachRepository(actor: SdlcActor, input: AttachSdlcRepositoryInput): Promise<SdlcRepositoryHub>;
+  createRepository(actor: SdlcActor, input: AttachSdlcRepositoryInput): Promise<SdlcRepository>;
   setupRepository(actor: SdlcActor, repoId: string): Promise<SdlcSetupExecution>;
   refreshSetup(actor: SdlcActor, repoId: string): Promise<SdlcSetupExecution>;
   retrySetup(actor: SdlcActor, repoId: string): Promise<SdlcSetupExecution>;
@@ -75,7 +83,7 @@ export interface SdlcHub {
     actor: SdlcActor,
     input: UpdateSdlcBaselineDraftInput
   ): Promise<SdlcArtifact>;
-  listTracks(actor: SdlcActor, repoId: string): Promise<unknown>;
+  listTracks(actor: SdlcActor, repoId: string, channelId?: string): Promise<unknown>;
   createTrack(actor: SdlcActor, input: CreateSdlcTrackInput): Promise<unknown>;
   linkContext(actor: SdlcActor, repoId: string, input: CreateSdlcLinkInput): Promise<SdlcLink>;
   unlinkContext(actor: SdlcActor, repoId: string, linkId: string): Promise<void>;

--- a/apps/backend/src/sdlc/vcs/SdlcVcsService.ts
+++ b/apps/backend/src/sdlc/vcs/SdlcVcsService.ts
@@ -24,6 +24,8 @@ import type {
 } from './types';
 import { VcsProviderError } from './types';
 import { verifySdlcInteractiveGrant } from './sdlcInteractiveGrant';
+import { findSdlcMembershipForActor } from '../sdlcChannelMembership';
+import { requireSdlcProjectAccess } from '../sdlcProjectAccess';
 
 const adapters: Record<VcsProvider, VcsProviderAdapter> = {
   GITHUB: new GitHubVcsAdapter(),
@@ -209,7 +211,9 @@ export class SdlcVcsService implements SdlcVcs {
     repoId: string,
     options: { force?: boolean } = {}
   ): Promise<RepositoryAccessCheckResult> {
-    const repo = await this.requireRepositoryMember(actor, repoId);
+    // Project access, not hub membership: a repository is checked from the moment it
+    // is registered, and joins a hub only later.
+    const repo = await this.requireProjectRepository(actor, repoId);
     // Only a proven read short-circuits: failures persist non-empty capabilities, so a
     // length check here would leave a BLOCKED repository stuck forever.
     const current = deriveAccessStatus(repo.accessCapabilities);
@@ -938,25 +942,34 @@ export class SdlcVcsService implements SdlcVcs {
     }
   }
 
-  private async requireRepositoryMember(actor: SdlcActor, repoId: string) {
+  /** Reached through its project. For repo-scoped writes use requireRepositoryMember. */
+  private async requireProjectRepository(actor: SdlcActor, repoId: string) {
     const repo = await this.prisma.repo.findFirst({
-      where: {
-        id: repoId,
-        workspaceId: actor.workspaceId,
-        projectId: { not: null },
-        channelId: { not: null },
-      },
-      include: {
-        channel: {
-          select: {
-            participants: { where: { userId: actor.userId }, select: { id: true, role: true } },
-          },
-        },
-      },
+      where: { id: repoId, workspaceId: actor.workspaceId, projectId: { not: null } },
     });
+    if (!repo?.projectId) throw new AppError('SDLC repository not found', 404);
+    await requireSdlcProjectAccess(
+      this.prisma,
+      actor,
+      repo.projectId,
+      'You must be a project participant to check this repository'
+    );
+    return repo;
+  }
+
+  private async requireRepositoryMember(actor: SdlcActor, repoId: string) {
+    const [repo, membership] = await Promise.all([
+      this.prisma.repo.findFirst({
+        where: { id: repoId, workspaceId: actor.workspaceId, projectId: { not: null } },
+      }),
+      findSdlcMembershipForActor(this.prisma, {
+        workspaceId: actor.workspaceId,
+        repoId,
+        userId: actor.userId,
+      }),
+    ]);
     if (!repo) throw new AppError('SDLC repository not found', 404);
-    if (!repo.channel?.participants[0])
-      throw new AppError('You are not a member of this repository', 403);
+    if (!membership) throw new AppError('You are not a member of this repository', 403);
     return repo;
   }
 

--- a/apps/backend/src/sdlc/wiki/SdlcWikiExecutionService.ts
+++ b/apps/backend/src/sdlc/wiki/SdlcWikiExecutionService.ts
@@ -10,6 +10,7 @@ import {
   runS2SClawAgent,
 } from '@/services/clawAgentService';
 import { logger } from '@/utils/logger';
+import { resolveSdlcChannelId } from '../sdlcChannelMembership';
 import { SdlcBaselineReconciliationService } from '../SdlcBaselineReconciliationService';
 import { sdlcAgentContext, type SdlcWikiAgentRole } from '../SdlcAgentContextService';
 import {
@@ -95,7 +96,11 @@ export class SdlcWikiExecutionService {
         select: { id: true, name: true, email: true },
       }),
     ]);
-    if (!repo?.channelId || !repo.workspaceId || !user?.email) {
+    // The run names its hub; the repository's oldest is the wrong one when it is
+    // in several.
+    const channelId =
+      context.channelId ?? (repo && (await resolveSdlcChannelId(this.prisma, repo.id)));
+    if (!repo || !channelId || !repo.workspaceId || !user?.email) {
       throw new Error('Wiki repository or owner is unavailable');
     }
 
@@ -365,7 +370,7 @@ export class SdlcWikiExecutionService {
             }
           : {}),
       }),
-      `Reuse the existing repository sandbox and never destroy it. If the Wiki Git tool reports that the sandbox session is missing, call sandbox-repo-setup for ${repo.name} on ${context.baseBranch}, then retry. Trusted tool binding: executionId=${execution.id}, sessionId=${sessionId}, repoId=${repo.id}. Pass these exact values to every Spaces Wiki tool.`,
+      `Reuse the existing repository sandbox and never destroy it. If the Wiki Git tool reports that the sandbox session is missing, call sandbox-repo-setup for ${repo.name} on ${context.baseBranch}, then retry. Trusted tool binding: executionId=${execution.id}, sessionId=${sessionId}, repoId=${repo.id}. Pass these exact values to every Hubs Wiki tool.`,
     ].join('\n\n');
     await runS2SClawAgent({
       sessionId,
@@ -377,7 +382,7 @@ export class SdlcWikiExecutionService {
       callbackUrl: this.callbackUrl(execution.id, role),
       callbackSecret: config.xyneClaw.s2sKey,
       conversationId,
-      channelId: repo.channelId,
+      channelId,
       workspaceId: repo.workspaceId,
       executionProfile: 'sdlc',
       sdlcOperation: 'wiki',

--- a/apps/backend/src/sdlc/wiki/SdlcWikiPageStore.ts
+++ b/apps/backend/src/sdlc/wiki/SdlcWikiPageStore.ts
@@ -7,6 +7,7 @@ import type {
   SdlcWikiPageAction,
   WriteSdlcWikiPageInput,
 } from '@xyne/shared';
+import { SDLC_MEMBERSHIP_RELATION } from '@xyne/shared';
 import { DatabaseClient } from '@/database/client';
 import { AppError } from '@/middleware/errorHandler';
 import { vespaQueue } from '@/queues/vespaQueue';
@@ -21,6 +22,7 @@ import {
   stringifySdlcSourceReferences,
 } from '@xyne/shared';
 import { sdlcChannelCanvasParticipant } from '../sdlcCanvasAccess';
+import { resolveSdlcChannelId } from '../sdlcChannelMembership';
 import {
   assertWikiCommitAssignment,
   beginWikiCheckpoint,
@@ -375,9 +377,11 @@ export class SdlcWikiPageStore {
 
     const repo = await this.prisma.repo.findUnique({
       where: { id: context.repoId },
-      select: { id: true, workspaceId: true, projectId: true, channelId: true, url: true },
+      select: { id: true, workspaceId: true, projectId: true, url: true },
     });
-    if (!repo?.workspaceId || !repo.projectId || !repo.channelId) {
+    const channelId =
+      context.channelId ?? (repo && (await resolveSdlcChannelId(this.prisma, repo.id)));
+    if (!repo?.workspaceId || !repo.projectId || !channelId) {
       throw new AppError('Wiki repository is unavailable', 404);
     }
     const requestedReferences = (
@@ -420,18 +424,12 @@ export class SdlcWikiPageStore {
             }),
           };
     const action = await this.resolveSectionAction({
-      repo: { channelId: repo.channelId, id: repo.id },
+      repo: { channelId, id: repo.id },
       action: pageAction,
     });
     if (action.action !== 'archive') validateWikiMermaid(action.markdown);
     const revision = await this.applyPageAction({
-      repo: repo as {
-        id: string;
-        workspaceId: string;
-        projectId: string;
-        channelId: string;
-        url: string;
-      },
+      repo: { ...repo, workspaceId: repo.workspaceId, projectId: repo.projectId, channelId },
       actorId: execution.createdBy,
       executionId: execution.id,
       sessionId: input.sessionId,
@@ -542,14 +540,16 @@ export class SdlcWikiPageStore {
     }
     const repo = await this.prisma.repo.findUnique({
       where: { id: context.repoId },
-      select: { id: true, workspaceId: true, projectId: true, channelId: true },
+      select: { id: true, workspaceId: true, projectId: true },
     });
-    if (!repo?.workspaceId || !repo.projectId || !repo.channelId) throw new AppError('Wiki repository is unavailable', 404);
+    const channelId =
+      context.channelId ?? (repo && (await resolveSdlcChannelId(this.prisma, repo.id)));
+    if (!repo?.workspaceId || !repo.projectId || !channelId) throw new AppError('Wiki repository is unavailable', 404);
     const wikiRepo = {
       id: repo.id,
       workspaceId: repo.workspaceId,
       projectId: repo.projectId,
-      channelId: repo.channelId,
+      channelId,
     };
     const source = await this.findPage(wikiRepo.channelId, wikiRepo.id, sourcePath);
     const destination = await this.findPage(wikiRepo.channelId, wikiRepo.id, destinationPath);
@@ -1083,13 +1083,14 @@ export class SdlcWikiPageStore {
     return live.length > 0 ? live : (page.content as unknown as BlockNoteBlock[]);
   }
 
+  /** Two repositories in one hub can both have a page at the same path. */
   private async findPage(
     channelId: string,
-    _repoId: string,
+    repoId: string,
     path: string
   ): Promise<WikiPageRecord | null> {
     const pages = await this.prisma.canvas.findMany({
-      where: { channelId, sdlcArtifact: { is: { artifactType: 'WIKI' } } },
+      where: { channelId, sdlcArtifact: { is: { artifactType: 'WIKI', repoId } } },
       select: {
         id: true,
         title: true,
@@ -1139,16 +1140,21 @@ export class SdlcWikiPageStore {
     workspaceId: string;
     userId: string;
   }): Promise<{ id: string; channelId: string }> {
-    const repo = await this.prisma.repo.findFirst({
+    // Membership is the read check: the actor must participate in a hub this
+    // repository belongs to.
+    const membership = await this.prisma.sdlcEntityLink.findFirst({
       where: {
-        id: input.repoId,
         workspaceId: input.workspaceId,
+        targetType: 'REPOSITORY',
+        targetId: input.repoId,
+        relationType: SDLC_MEMBERSHIP_RELATION,
         channel: { participants: { some: { userId: input.userId } } },
       },
-      select: { id: true, channelId: true },
+      orderBy: { createdAt: 'asc' },
+      select: { channelId: true },
     });
-    if (!repo?.channelId) throw new AppError('SDLC repository not found', 404);
-    return { id: repo.id, channelId: repo.channelId };
+    if (!membership?.channelId) throw new AppError('SDLC repository not found', 404);
+    return { id: input.repoId, channelId: membership.channelId };
   }
 
   private async ensureFolder(

--- a/apps/backend/src/sdlc/wiki/SdlcWikiPipeline.ts
+++ b/apps/backend/src/sdlc/wiki/SdlcWikiPipeline.ts
@@ -11,6 +11,7 @@ import { DatabaseClient } from '@/database/client';
 import { AppError } from '@/middleware/errorHandler';
 import { sdlcAdmission } from '@/queues/sdlcAdmission';
 import { cancelS2SClawRun } from '@/services/clawAgentService';
+import { SDLC_MEMBERSHIP_RELATION } from '@xyne/shared';
 import { requireSdlcBaseBranch } from '../sdlcRepositoryContext';
 import { sdlcVcs } from '../vcs';
 import {
@@ -308,30 +309,38 @@ export class SdlcWikiPipelineService implements SdlcWikiPipeline {
         name: true,
         workspaceId: true,
         projectId: true,
-        channelId: true,
         createdBy: true,
         baseBranch: true,
         accessCapabilities: true,
+      },
+    });
+    const membership = await this.prisma.sdlcEntityLink.findFirst({
+      where: {
+        workspaceId: actor.workspaceId,
+        targetType: 'REPOSITORY',
+        targetId: repoId,
+        relationType: SDLC_MEMBERSHIP_RELATION,
+        channel: { participants: { some: { userId: actor.userId } } },
+      },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        channelId: true,
         channel: {
           select: {
-            participants: {
-              where: { userId: actor.userId },
-              select: { role: true },
-              take: 1,
-            },
+            participants: { where: { userId: actor.userId }, select: { role: true }, take: 1 },
           },
         },
       },
     });
-    const participant = repo?.channel?.participants[0];
-    if (!repo?.projectId || !repo.channelId || !participant) {
+    const participant = membership?.channel?.participants[0];
+    if (!repo?.projectId || !membership?.channelId || !participant) {
       throw new AppError('SDLC repository not found', 404);
     }
     if (requireAdmin && participant.role !== 'ADMIN') {
       throw new AppError('Repository admin access is required', 403);
     }
     if (requireAdmin) await sdlcVcs.requireCapabilities(actor, repo.id, ['READ_REPOSITORY']);
-    return repo as WikiRepositoryRecord;
+    return { ...repo, channelId: membership.channelId } as WikiRepositoryRecord;
   }
 
   private queuedContext(
@@ -348,6 +357,7 @@ export class SdlcWikiPipelineService implements SdlcWikiPipeline {
       version: 2,
       executionModel: 'HISTORY_WINDOW',
       repoId: repo.id,
+      channelId: repo.channelId,
       agentSlug: null,
       conversationId: null,
       sessionId: null,
@@ -389,7 +399,6 @@ export class SdlcWikiPipelineService implements SdlcWikiPipeline {
       await tx.$queryRaw`SELECT "id" FROM "public"."repos" WHERE "id" = ${repo.id} FOR UPDATE`;
       const activeLinks = await tx.sdlcEntityLink.findMany({
         where: {
-          repoId: repo.id,
           sourceType: 'REPOSITORY',
           sourceId: repo.id,
           targetType: 'WORKFLOW_EXECUTION',
@@ -434,7 +443,7 @@ export class SdlcWikiPipelineService implements SdlcWikiPipeline {
       await tx.sdlcEntityLink.create({
         data: {
           workspaceId: actor.workspaceId,
-          repoId: repo.id,
+          channelId: repo.channelId,
           sourceType: 'REPOSITORY',
           sourceId: repo.id,
           targetType: 'WORKFLOW_EXECUTION',
@@ -450,7 +459,6 @@ export class SdlcWikiPipelineService implements SdlcWikiPipeline {
   private async linkedRun(tx: Prisma.TransactionClient, repoId: string, executionId: string) {
     const link = await tx.sdlcEntityLink.findFirst({
       where: {
-        repoId,
         sourceType: 'REPOSITORY',
         sourceId: repoId,
         targetType: 'WORKFLOW_EXECUTION',
@@ -483,7 +491,6 @@ export class SdlcWikiPipelineService implements SdlcWikiPipeline {
   ): Promise<void> {
     const links = await tx.sdlcEntityLink.findMany({
       where: {
-        repoId,
         sourceType: 'REPOSITORY',
         sourceId: repoId,
         targetType: 'WORKFLOW_EXECUTION',
@@ -506,7 +513,6 @@ export class SdlcWikiPipelineService implements SdlcWikiPipeline {
   private async latestRun(repoId: string) {
     const link = await this.prisma.sdlcEntityLink.findFirst({
       where: {
-        repoId,
         sourceType: 'REPOSITORY',
         sourceId: repoId,
         targetType: 'WORKFLOW_EXECUTION',

--- a/apps/backend/src/sdlc/wiki/SdlcWikiService.ts
+++ b/apps/backend/src/sdlc/wiki/SdlcWikiService.ts
@@ -1,4 +1,5 @@
 import { Prisma, type PrismaClient } from '@prisma/client';
+import { SDLC_MEMBERSHIP_RELATION } from '@xyne/shared';
 import { DatabaseClient } from '@/database/client';
 import { AppError } from '@/middleware/errorHandler';
 import type { SdlcWiki, SdlcWikiActor, SdlcWikiPageSummary } from './types';
@@ -14,25 +15,30 @@ export class SdlcWikiService implements SdlcWiki {
   constructor(private readonly prisma: PrismaClient = DatabaseClient.getInstance()) {}
 
   async listPages(actor: SdlcWikiActor, repoId: string): Promise<SdlcWikiPageSummary[]> {
-    const repo = await this.prisma.repo.findFirst({
+    // Membership is the read check.
+    const membership = await this.prisma.sdlcEntityLink.findFirst({
       where: {
-        id: repoId,
         workspaceId: actor.workspaceId,
+        targetType: 'REPOSITORY',
+        targetId: repoId,
+        relationType: SDLC_MEMBERSHIP_RELATION,
         channel: { participants: { some: { userId: actor.userId } } },
       },
+      orderBy: { createdAt: 'asc' },
       select: { channelId: true },
     });
-    if (!repo?.channelId) throw new AppError('SDLC repository not found', 404);
+    if (!membership?.channelId) throw new AppError('SDLC repository not found', 404);
 
     const folders = await this.prisma.canvasFolder.findMany({
       where: {
-        channelId: repo.channelId,
+        channelId: membership.channelId,
         OR: [{ name: WIKI_FOLDER_PREFIX }, { name: { startsWith: `${WIKI_FOLDER_PREFIX}/` } }],
       },
       select: {
         name: true,
         canvases: {
-          where: { sdlcArtifact: { is: { artifactType: 'WIKI' } } },
+          // Wiki folders are shared by the hub; each page belongs to one repository.
+          where: { sdlcArtifact: { is: { artifactType: 'WIKI', repoId } } },
           select: {
             id: true,
             title: true,

--- a/apps/backend/src/sdlc/wiki/wikiRunState.ts
+++ b/apps/backend/src/sdlc/wiki/wikiRunState.ts
@@ -94,6 +94,11 @@ export const wikiExecutionContextSchema = z
     version: z.union([z.literal(1), z.literal(2)]),
     executionModel: z.literal('HISTORY_WINDOW').optional(),
     repoId: z.string().min(1),
+    /**
+         * The hub the run started from. Re-resolving later would pick the oldest
+         * and write pages into the wrong hub. Optional only for older runs.
+         */
+    channelId: z.string().min(1).nullish(),
     agentSlug: z.literal('sdlc-agent').nullable(),
     conversationId: z.string().nullable(),
     sessionId: z.string().nullable(),

--- a/apps/backend/src/zero/acl/tables/sdlc-entity-links-acl.ts
+++ b/apps/backend/src/zero/acl/tables/sdlc-entity-links-acl.ts
@@ -1,5 +1,10 @@
 import type { DeleteID, InsertValue, Transaction, UpdateValue, UpsertValue } from '@rocicorp/zero';
-import type { Schema } from '@xyne/shared';
+import {
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_STRUCTURAL_RELATIONS,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
+  type Schema,
+} from '@xyne/shared';
 import { BaseACL } from '../core/base-acl';
 import { MutationACLError, type TableSchema } from '../core/types';
 import { assertWorkspaceMatch } from '../core/workspace-match';
@@ -8,9 +13,31 @@ import { zql } from '../../queries';
 export class SdlcEntityLinksACL extends BaseACL<'sdlc_entity_links'> {
   async canInsert(
     args: InsertValue<TableSchema<'sdlc_entity_links'>>,
-    _tx: Transaction<Schema>,
+    tx: Transaction<Schema>,
   ): Promise<void> {
     assertWorkspaceMatch(this.ctx, args.workspaceId, 'sdlc_entity_links');
+    // Repository membership is structure, not content: only the hub endpoints write it.
+    if (args.relationType === SDLC_MEMBERSHIP_RELATION) {
+      throw new MutationACLError(
+        'Add a repository to a space through the SDLC space API',
+        'sdlc_entity_links',
+      );
+    }
+    // Track membership is structure too, but sdlc.createTrack writes it through this
+    // path, so it is gated rather than refused: the writer must be in that hub.
+    if (args.relationType === SDLC_TRACK_MEMBERSHIP_RELATION) {
+      const participant = args.channelId
+        ? await tx.run(
+            zql.channel_participants
+              .where('channelId', args.channelId)
+              .where('userId', this.ctx.userID)
+              .one(),
+          )
+        : null;
+      if (!participant) {
+        throw new MutationACLError('Hub membership required', 'sdlc_entity_links');
+      }
+    }
   }
 
   async canUpdate(
@@ -29,6 +56,12 @@ export class SdlcEntityLinksACL extends BaseACL<'sdlc_entity_links'> {
       throw new MutationACLError('SDLC entity link does not exist', 'sdlc_entity_links');
     }
     assertWorkspaceMatch(this.ctx, row.workspaceId, 'sdlc_entity_links');
+    if ((SDLC_STRUCTURAL_RELATIONS as readonly string[]).includes(row.relationType)) {
+      throw new MutationACLError(
+        'Structural SDLC edges are not deleted through the link API',
+        'sdlc_entity_links',
+      );
+    }
   }
 
   async canUpsert(

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -93,6 +93,9 @@ import {
   isDeskChannelType,
   deskTypeForChannelType,
   Platform,
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_STRUCTURAL_RELATIONS,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
   createSdlcLinkSchema,
   sdlcDiscussionSchema,
 } from '@xyne/shared';
@@ -2430,31 +2433,43 @@ export function createMutators(
           }
 
           if (sdlcDiscussion) {
-            const [repo, existingDiscussion] = await Promise.all([
+            const [repo, membership, existingDiscussion] = await Promise.all([
               tx.run(zql.repos.where('id', sdlcDiscussion.repoId).one()),
+              // The repository has to be part of this hub; it may be part of
+              // others too, which is why membership is the check.
               tx.run(
                 zql.sdlc_entity_links
-                  .where('repoId', sdlcDiscussion.repoId)
+                  .where('channelId', channelId)
+                  .where('targetType', 'REPOSITORY')
+                  .where('targetId', sdlcDiscussion.repoId)
+                  .where('relationType', SDLC_MEMBERSHIP_RELATION)
+                  .one(),
+              ),
+              tx.run(
+                zql.sdlc_entity_links
+                  .where('channelId', channelId)
                   .where('targetType', 'CONVERSATION')
                   .where('targetId', conversationId)
                   .where('relationType', 'DISCUSSION'),
               ),
             ]);
-            if (
-              !repo ||
-              repo.workspaceId !== authData.workspaceId ||
-              repo.channelId !== channelId
-            ) {
+            if (!repo || repo.workspaceId !== authData.workspaceId || !membership) {
               throw new Error('Invalid SDLC discussion owner');
             }
             if (existingDiscussion.length > 0) {
               throw new Error('Conversation already has an SDLC discussion owner');
             }
             if (sdlcDiscussion.ownerType === 'TRACK') {
-              const track = await tx.run(
-                zql.sdlc_tracks.where('id', sdlcDiscussion.ownerId).one(),
+              // A track has no scope column: its CHANNEL -> TRACK edge is the check.
+              const trackEdge = await tx.run(
+                zql.sdlc_entity_links
+                  .where('channelId', channelId)
+                  .where('targetType', 'TRACK')
+                  .where('targetId', sdlcDiscussion.ownerId)
+                  .where('relationType', SDLC_TRACK_MEMBERSHIP_RELATION)
+                  .one(),
               );
-              if (!track || track.repoId !== repo.id) {
+              if (!trackEdge) {
                 throw new Error('Invalid SDLC discussion owner');
               }
             } else {
@@ -2464,7 +2479,6 @@ export function createMutators(
             const canonicalOwnerCanvasId = await resolveSdlcDiscussionOwnerId(
               {
                 workspaceId: authData.workspaceId,
-                repoId: repo.id,
                 channelId,
                 surfaceType: sdlcDiscussion.surfaceType,
                 surfaceId: sdlcDiscussion.surfaceId,
@@ -2489,7 +2503,7 @@ export function createMutators(
                 findLinkSource: async input => {
                   const link = await tx.run(
                     zql.sdlc_entity_links
-                      .where('repoId', input.repoId)
+                      .where('channelId', input.channelId)
                       .where('targetType', input.targetType)
                       .where('targetId', input.targetId)
                       .where('relationType', input.relationType)
@@ -2528,7 +2542,7 @@ export function createMutators(
             await tx.mutate.sdlc_entity_links.insert({
               id: sdlcDiscussion.linkId,
               workspaceId: authData.workspaceId,
-              repoId: sdlcDiscussion.repoId,
+              channelId,
               sourceType: sdlcDiscussion.ownerType,
               sourceId: sdlcDiscussion.ownerId,
               targetType: 'CONVERSATION',
@@ -6963,8 +6977,14 @@ export function createMutators(
             throw new Error('Project not found');
           }
 
+          // Only repositories that are in a hub block deletion: one registered
+          // and never added to a hub has nothing to detach.
           const attachedSdlcRepository = await tx.run(
-            zql.repos.where('projectId', projectId).where('channelId', 'IS NOT', null).one(),
+            zql.sdlc_entity_links
+              .where('relationType', SDLC_MEMBERSHIP_RELATION)
+              .where('targetType', 'REPOSITORY')
+              .whereExists('channel', channel => channel.where('projectId', projectId))
+              .one(),
           );
           if (attachedSdlcRepository) {
             throw new Error('Detach SDLC repositories before deleting their project');
@@ -10748,49 +10768,44 @@ export function createMutators(
       createLink: defineMutator(
         createSdlcLinkSchema.extend({
           id: z.string(),
-          repoId: z.string(),
+          channelId: z.string(),
           timestamp: z.number(),
         }),
         async ({ tx, args }) => {
-          const repo = await tx.run(zql.repos.where('id', args.repoId).one());
-          if (!repo?.channelId) {
-            throw new Error('SDLC repository not found');
-          }
+          // Links belong to the hub. createSdlcLinkSchema already excludes the
+          // membership relation, so this cannot forge a CHANNEL -> REPOSITORY edge.
           const participant = await tx.run(
             zql.channel_participants
-              .where('channelId', repo.channelId)
+              .where('channelId', args.channelId)
               .where('userId', authData.sub)
-              .one()
+              .one(),
           );
           if (!participant) {
-            throw new Error('Repository membership required');
+            throw new Error('Hub membership required');
           }
           const sourceExists =
             args.sourceType === 'CANVAS'
               ? Boolean(
                   await tx.run(
-                    zql.canvases.where('id', args.sourceId).where('channelId', repo.channelId).one()
-                  )
+                    zql.canvases.where('id', args.sourceId).where('channelId', args.channelId).one(),
+                  ),
                 )
               : args.sourceType === 'TICKET'
                 ? Boolean(
                     await tx.run(
-                      zql.tickets
-                        .where('id', args.sourceId)
-                        .where('channelId', repo.channelId)
-                        .one()
-                    )
+                      zql.tickets.where('id', args.sourceId).where('channelId', args.channelId).one(),
+                    ),
                   )
                 : args.sourceType === 'CHANNEL'
-                  ? args.sourceId === repo.channelId
+                  ? args.sourceId === args.channelId
                   : false;
           if (!sourceExists) {
-            throw new Error('Relationship source does not belong to this SDLC repository');
+            throw new Error('Relationship source does not belong to this SDLC hub');
           }
           await tx.mutate.sdlc_entity_links.insert({
             id: args.id,
             workspaceId: authData.workspaceId,
-            repoId: args.repoId,
+            channelId: args.channelId,
             sourceType: args.sourceType,
             sourceId: args.sourceId,
             targetType: args.targetType,
@@ -10799,66 +10814,77 @@ export function createMutators(
             createdBy: authData.sub,
             createdAt: args.timestamp,
           });
-        }
+        },
       ),
       deleteLink: defineMutator(
-        z.object({ repoId: z.string(), linkId: z.string() }),
-        async ({ tx, args: { repoId, linkId } }) => {
-          const repo = await tx.run(zql.repos.where('id', repoId).one());
-          if (!repo?.channelId) {
-            throw new Error('SDLC repository not found');
-          }
+        z.object({ channelId: z.string(), linkId: z.string() }),
+        async ({ tx, args: { channelId, linkId } }) => {
           const participant = await tx.run(
             zql.channel_participants
-              .where('channelId', repo.channelId)
+              .where('channelId', channelId)
               .where('userId', authData.sub)
-              .one()
+              .one(),
           );
           if (!participant) {
-            throw new Error('Repository membership required');
+            throw new Error('Hub membership required');
           }
           const link = await tx.run(
-            zql.sdlc_entity_links.where('id', linkId).where('repoId', repoId).one()
+            zql.sdlc_entity_links.where('id', linkId).where('channelId', channelId).one(),
           );
           if (!link) {
             throw new Error('SDLC relationship not found');
           }
+          // Structural edges are not content: repository membership is detached through
+          // the hub API, track membership only with the track. The mutation ACL agrees.
+          if ((SDLC_STRUCTURAL_RELATIONS as readonly string[]).includes(link.relationType)) {
+            throw new Error('Structural SDLC edges are not deleted through the link API');
+          }
           await tx.mutate.sdlc_entity_links.delete({ id: linkId });
-        }
+        },
       ),
 
       createTrack: defineMutator(
         z.object({
           id: z.string(),
-          repoId: z.string(),
+          linkId: z.string(),
+          channelId: z.string(),
           name: z.string().trim().min(1).max(120),
           description: z.string().trim().max(2000).optional(),
           timestamp: z.number(),
         }),
         async ({ tx, args }) => {
-          const repo = await tx.run(zql.repos.where('id', args.repoId).one());
-          if (!repo?.channelId) {
-            throw new Error('SDLC repository not found');
-          }
+          // Tracks belong to the hub, never to one repository in it.
           const participant = await tx.run(
             zql.channel_participants
-              .where('channelId', repo.channelId)
+              .where('channelId', args.channelId)
               .where('userId', authData.sub)
               .one(),
           );
           if (!participant) {
-            throw new Error('Repository membership required');
+            throw new Error('Hub membership required');
           }
           await tx.mutate.sdlc_tracks.insert({
             id: args.id,
             workspaceId: authData.workspaceId,
-            repoId: args.repoId,
             name: args.name,
             description: args.description,
             status: 'ACTIVE',
             createdBy: authData.sub,
             createdAt: args.timestamp,
             updatedAt: args.timestamp,
+          });
+          // The track carries no scope column; this edge is what places it in the hub.
+          await tx.mutate.sdlc_entity_links.insert({
+            id: args.linkId,
+            workspaceId: authData.workspaceId,
+            channelId: args.channelId,
+            sourceType: 'CHANNEL',
+            sourceId: args.channelId,
+            targetType: 'TRACK',
+            targetId: args.id,
+            relationType: SDLC_TRACK_MEMBERSHIP_RELATION,
+            createdBy: authData.sub,
+            createdAt: args.timestamp,
           });
         },
       ),
@@ -10875,13 +10901,20 @@ export function createMutators(
           if (!track) {
             throw new Error('SDLC track not found');
           }
-          const repo = await tx.run(zql.repos.where('id', track.repoId).one());
-          if (!repo?.channelId) {
-            throw new Error('SDLC repository not found');
+          const membership = await tx.run(
+            zql.sdlc_entity_links
+              .where('targetType', 'TRACK')
+              .where('targetId', args.trackId)
+              .where('relationType', SDLC_TRACK_MEMBERSHIP_RELATION)
+              .one(),
+          );
+          if (!membership?.channelId) {
+            throw new Error('SDLC channel not found');
           }
+          const channelId = membership.channelId;
           const participant = await tx.run(
             zql.channel_participants
-              .where('channelId', repo.channelId)
+              .where('channelId', channelId)
               .where('userId', authData.sub)
               .one(),
           );

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -29,6 +29,9 @@ import {
   ChannelRole,
   AttachmentEntityType,
   ChannelType,
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_STRUCTURAL_RELATIONS,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
   EmailType,
   ActivityClassification, LinkVisibility,
   NudgeState,
@@ -4152,44 +4155,65 @@ dmChannelsLatestMessagesPaginated: defineQuery(
   getAllRepos: defineQuery(() => {
     return zql.repos.orderBy('name', 'asc');
   }),
-  getSdlcRepos: defineQuery(() => {
-    return zql.repos
-      .where('projectId', 'IS NOT', null)
-      .where('channelId', 'IS NOT', null)
-      .related('project')
-      .related('channel', channel => channel.related('participants').related('channelStats'))
-      .related('setupExecution')
-      .related('sdlcEntityLinks')
-      .orderBy('name', 'asc');
-  }),
-  getSdlcTracks: defineQuery(z.object({ repoId: z.string() }), ({ args: { repoId } }) =>
-    zql.sdlc_tracks.where('repoId', repoId).orderBy('createdAt', 'asc'),
+  /** SDLC hubs the viewer can reach, each with the repositories it covers. */
+  getSdlcChannels: defineQuery(({ ctx }) =>
+    zql.channels
+      .where('type', ChannelType.SDLC)
+      .where('isArchived', false)
+      // The channels ACL lets workspace admins and public channels through; a hub
+      // is only usable by its participants, and every write re-checks that.
+      .whereExists('participants', participant => participant.where('userId', ctx.userID))
+      .related('sdlcEntityLinks', link =>
+        link
+          .where('relationType', SDLC_MEMBERSHIP_RELATION)
+          .related('repo', repo => repo.related('project')),
+      )
+      .orderBy('name', 'asc'),
   ),
-  getSdlcRepoByChannelId: defineQuery(
-    z.object({ channelId: z.string() }),
-    ({ args: { channelId } }) => zql.repos.where('channelId', channelId).one(),
+  getSdlcChannelById: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
+    zql.channels
+      .where('id', channelId)
+      .where('type', ChannelType.SDLC)
+      .related('participants')
+      .related('channelStats')
+      .related('canvasFolders', folder =>
+        folder.related('canvases', canvas => canvas.related('sdlcArtifact')),
+      )
+      .related('sdlcEntityLinks', link =>
+        link
+          .where('relationType', SDLC_MEMBERSHIP_RELATION)
+          .related('repo', repo => repo.related('project').related('setupExecution')),
+      )
+      .one(),
   ),
-  getSdlcRepoById: defineQuery(z.object({ repoId: z.string() }), ({ args: { repoId } }) => {
-    return zql.repos
+  /** A hub's tracks. Tracks carry no scope column; the CHANNEL -> TRACK edge places them. */
+  getSdlcTracks: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
+    zql.sdlc_tracks
+      .whereExists('sdlcEntityLinks', link =>
+        link
+          .where('channelId', channelId)
+          .where('relationType', SDLC_TRACK_MEMBERSHIP_RELATION),
+      )
+      .orderBy('createdAt', 'asc'),
+  ),
+  getSdlcRepoById: defineQuery(z.object({ repoId: z.string() }), ({ args: { repoId } }) =>
+    zql.repos
       .where('id', repoId)
       .where('projectId', 'IS NOT', null)
-      .where('channelId', 'IS NOT', null)
       .related('project')
-      .related('channel', channel =>
-        channel
-          .related('participants')
-          .related('channelStats')
-          .related('canvasFolders', folder =>
-            folder.related('canvases', canvas => canvas.related('sdlcArtifact')),
-          ),
-      )
       .related('setupExecution')
-      .related('sdlcEntityLinks')
-      .one();
-  }),
-  getSdlcLinks: defineQuery(z.object({ repoId: z.string() }), ({ args: { repoId } }) => {
-    return zql.sdlc_entity_links.where('repoId', repoId).orderBy('createdAt', 'asc');
-  }),
+      .one(),
+  ),
+  /**
+     * The content graph for a hub. Structural edges (repository and track membership)
+     * share this table — grep SDLC_STRUCTURAL_RELATIONS for every exclusion.
+     */
+  getSdlcLinks: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
+    zql.sdlc_entity_links
+      .where('channelId', channelId)
+      .where(helpers => helpers.cmp('relationType', 'NOT IN', [...SDLC_STRUCTURAL_RELATIONS]))
+      .orderBy('createdAt', 'asc'),
+  ),
   sdlcTicketsByIds: defineQuery(
     z.object({ ticketIds: z.array(z.string()) }),
     ({ args: { ticketIds } }) =>

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyne-spaces-dashboard",
-  "version": "1.219.0-release-20260825.16",
+  "version": "1.219.0-release-20260825.17",
   "type": "module",
   "description": "Xyne Spaces - Workflow Automation Dashboard",
   "scripts": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyne-spaces-dashboard",
-  "version": "1.219.0-release-20260825.17",
+  "version": "1.219.0-release-20260825.18",
   "type": "module",
   "description": "Xyne Spaces - Workflow Automation Dashboard",
   "scripts": {

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xyne-spaces-dashboard",
-  "version": "1.219.0-release-20260825.18",
+  "version": "1.219.0-release-20260825.19",
   "type": "module",
   "description": "Xyne Spaces - Workflow Automation Dashboard",
   "scripts": {

--- a/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
@@ -13,8 +13,6 @@ import { resolveSdlcActivityTarget } from './sdlcActivityNavigation';
 const NofocusRefContext = createContext<React.RefObject<boolean>>({ current: false });
 export const NofocusRefProvider = NofocusRefContext.Provider;
 import { useChannel } from '../../hooks/useChannels';
-import { useCachedQuery } from '../../hooks/useCachedQuery';
-import { queries } from '../../zero/queries';
 import { useChannelDisplayName } from '../../hooks/useChannelDisplayName';
 import { useAuthContextValues } from '../../hooks/useAuth';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -81,11 +79,6 @@ export const ActivityItemCard = ({
   const nofocusRef = useContext(NofocusRefContext);
 
   const channel = useChannel(channelId || '');
-  const isSdlcChannel = channel?.type === ChannelType.SDLC;
-  const [sdlcRepo] = useCachedQuery(
-    queries.getSdlcRepoByChannelId({ channelId: channelId || '' }),
-    { enabled: isSdlcChannel && !!channelId },
-  );
   const { displayName: channelDisplayName } = useChannelDisplayName(channel, context.userID);
   const displayedChannelName = channel ? channelDisplayName : unresolvedChannelLabel;
 
@@ -135,7 +128,7 @@ export const ActivityItemCard = ({
     const path = resolveSdlcActivityTarget({
       activity,
       channelType: channel?.type,
-      repoId: sdlcRepo && !(sdlcRepo instanceof Error) ? sdlcRepo.id : null,
+      channelId,
       fallbackPath: defaultPath,
     });
 

--- a/apps/dashboard/src/components/Activity/sdlcActivityNavigation.ts
+++ b/apps/dashboard/src/components/Activity/sdlcActivityNavigation.ts
@@ -30,32 +30,32 @@ const canvasSpecialSection = (artifactType: unknown): string | null => {
   return null;
 };
 
-const sdlcPath = (repoId: string, section: string, search?: URLSearchParams): string => {
+const sdlcPath = (channelId: string, section: string, search?: URLSearchParams): string => {
   const query = search?.toString();
-  return `/sdlc/${encodeURIComponent(repoId)}/${section}${query ? `?${query}` : ''}`;
+  return `/sdlc/${encodeURIComponent(channelId)}/${section}${query ? `?${query}` : ''}`;
 };
 
 export function resolveSdlcActivityTarget(input: {
   activity: SdlcActivityNavigationActivity;
   channelType: string | null | undefined;
-  repoId: string | null | undefined;
+  channelId: string | null | undefined;
   fallbackPath: string;
 }): string {
-  // SDLC repository channels are identified by channel type; the repo comes
-  // from the repos table (1:1 with the channel), not from channel metadata.
-  if (input.channelType !== 'SDLC' || !input.repoId) return input.fallbackPath;
-  const repoId = input.repoId;
+  // SDLC spaces are addressed by their channel. A space can cover several
+  // repositories, so the repository is chosen inside the screen, not in the URL.
+  if (input.channelType !== 'SDLC' || !input.channelId) return input.fallbackPath;
+  const channelId = input.channelId;
 
   const canvasId = input.activity.canvasId ?? input.activity.canvas?.id;
   if (canvasId) {
     const special = canvasSpecialSection(input.activity.canvas?.sdlcArtifact?.artifactType);
     if (special) {
-      return sdlcPath(repoId, special, new URLSearchParams({ canvas: canvasId }));
+      return sdlcPath(channelId, special, new URLSearchParams({ canvas: canvasId }));
     }
     const folderId = input.activity.canvas?.folderId;
     if (folderId) {
       return sdlcPath(
-        repoId,
+        channelId,
         'artifacts',
         new URLSearchParams({ type: folderId, canvas: canvasId }),
       );
@@ -64,7 +64,7 @@ export function resolveSdlcActivityTarget(input: {
 
   const ticketId = input.activity.ticketId ?? input.activity.ticket?.id;
   if (ticketId) {
-    return sdlcPath(repoId, 'tickets', new URLSearchParams({ ticket: ticketId }));
+    return sdlcPath(channelId, 'tickets', new URLSearchParams({ ticket: ticketId }));
   }
 
   const conversationId =
@@ -78,8 +78,8 @@ export function resolveSdlcActivityTarget(input: {
     const messageId = input.activity.message?.messageId ?? input.activity.messageId;
     const hash = new URLSearchParams({ origin: conversationId });
     if (messageId) hash.set('messageId', messageId);
-    return `${sdlcPath(repoId, 'overview', search)}#${hash.toString()}`;
+    return `${sdlcPath(channelId, 'overview', search)}#${hash.toString()}`;
   }
 
-  return sdlcPath(repoId, 'overview');
+  return sdlcPath(channelId, 'overview');
 }

--- a/apps/dashboard/src/components/Call/CallOverlay/GlobalCallOverlay.tsx
+++ b/apps/dashboard/src/components/Call/CallOverlay/GlobalCallOverlay.tsx
@@ -10,13 +10,19 @@ import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { useAuth } from '../../../hooks/useAuth';
 import { useGlobalAutoJoinOnAccept } from '../../../hooks/useCallJoinState';
 
-export function GlobalCallOverlay(): React.ReactElement | null {
+interface GlobalCallOverlayProps {
+  autoJoinOnAccept?: boolean;
+}
+
+export function GlobalCallOverlay({
+  autoJoinOnAccept = true,
+}: GlobalCallOverlayProps = {}): React.ReactElement | null {
   const zero = useZero();
   const { user } = useAuth();
 
   // Query active calls and sync to roomActor
   const [calls] = useCachedQuery(queries.userActiveCalls());
-  useGlobalAutoJoinOnAccept(user?.id);
+  useGlobalAutoJoinOnAccept(autoJoinOnAccept ? user?.id : undefined);
 
   // Sync active calls to the machine
   useEffect(() => {

--- a/apps/dashboard/src/components/ui/EntitySelector/EntityMultiSelector.tsx
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntityMultiSelector.tsx
@@ -31,6 +31,7 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
   showSearch = false,
   collapseSelectedAfter,
   collapsedLabel = 'items',
+  matchTriggerWidth = false,
 }) => {
   // ==================== STATE ====================
   const [isOpen, setIsOpen] = useState(false);
@@ -244,6 +245,15 @@ export const EntityMultiSelector: React.FC<EntityMultiSelectorProps> = ({
               e.stopPropagation();
             }}
             className='z-[100] w-auto max-w-64 max-h-96 overflow-y-auto no-scrollbar rounded-lg border border-border bg-background shadow-lg'
+            // Never narrower than the trigger, matching EntitySelector. A compact
+            // trigger still lets the content size the popover as before.
+            style={{
+              minWidth: 'var(--radix-popover-trigger-width)',
+              ...(matchTriggerWidth && {
+                width: 'var(--radix-popover-trigger-width)',
+                maxWidth: 'var(--radix-popover-trigger-width)',
+              }),
+            }}
           >
             {/* Search input inside dropdown */}
             {showSearch && (

--- a/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.tsx
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.tsx
@@ -24,6 +24,7 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
   placeholder,
   searchPlaceholder,
   showSearch = true,
+  matchTriggerWidth = false,
   isLoading = false,
   width = 'auto',
   onSearchChange,
@@ -420,6 +421,10 @@ export const EntitySelector: React.FC<EntitySelectorProps> = ({
             // Never narrower than the trigger it drops from; a compact trigger
             // still lets the content size the popover as before.
             minWidth: 'var(--radix-popover-trigger-width)',
+            ...(matchTriggerWidth && {
+              width: 'var(--radix-popover-trigger-width)',
+              maxWidth: 'var(--radix-popover-trigger-width)',
+            }),
             // Virtuoso rows are absolutely positioned and can't size the popover;
             // lock it to the plain list's max width so widths stay consistent.
             ...(isVirtualized && { width: 'max(24rem, var(--radix-popover-trigger-width))' }),

--- a/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.types.ts
+++ b/apps/dashboard/src/components/ui/EntitySelector/EntitySelector.types.ts
@@ -120,6 +120,9 @@ export interface EntitySelectorProps {
     trackName?: string;
   };
 
+  /** Lock the dropdown to the trigger's width instead of letting content size it. */
+  matchTriggerWidth?: boolean;
+
   /** Opt in to virtualizing the options list (for large user/group lists). */
   virtualize?: boolean;
 

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -476,20 +476,20 @@ const AppRoot = (): ReactElement => {
 
   // Get current location to check if we're on onboarding
   const location = useLocation();
-  const sdlcRepoId = location.pathname.match(/\/sdlc\/([^/]+)/)?.[1] ?? null;
+  const sdlcChannelId = location.pathname.match(/\/sdlc\/([^/]+)/)?.[1] ?? null;
   // On an SDLC route the iframe lane renders its own Ask AI panel, so the host
   // must not also render one (that would double it).
   const isSdlcRoute = /\/sdlc(\/|$)/.test(location.pathname);
-  const previousSdlcRepoIdRef = useRef<string | null>(null);
+  const previousSdlcChannelIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    const previousRepoId = previousSdlcRepoIdRef.current;
-    if (previousRepoId && previousRepoId !== sdlcRepoId) {
+    const previousChannelId = previousSdlcChannelIdRef.current;
+    if (previousChannelId && previousChannelId !== sdlcChannelId) {
       useExternalDebuggerStore.getState().close();
       setIsXyneDebuggerOpen(false);
     }
-    previousSdlcRepoIdRef.current = sdlcRepoId;
-  }, [sdlcRepoId]);
+    previousSdlcChannelIdRef.current = sdlcChannelId;
+  }, [sdlcChannelId]);
 
   // Initialize activity tracking
   useActivityTracker(location.pathname);
@@ -529,12 +529,9 @@ const AppRoot = (): ReactElement => {
       (typeof state.value === 'object' && state.value !== null && 'connected' in state.value) ||
       state.value === 'connecting',
   );
-  // The external SDLC debugger takes the right panel over Ask AI. On an
-  // /sdlc/<repoId> route SdlcScreen renders its own assistant + debugger, so
-  // neither app-shell panel should appear there.
-  const showSdlcDebuggerPanel = isSdlcDebuggerOpen && !isMobile && sdlcRepoId === null;
+  const showSdlcDebuggerPanel = isSdlcDebuggerOpen && !isMobile && sdlcChannelId === null;
   // On SDLC routes the framed lane renders its own Ask AI panel inside the iframe,
-  // so the host must not also show one (covers both /sdlc and /sdlc/<repoId>).
+  // so the host must not also show one (covers both /sdlc and /sdlc/<channelId>).
   const showXyneAIPanel =
     isXyneAIDrawerOpen && !isMobile && !isOnAIPage && !isSdlcRoute && !showSdlcDebuggerPanel;
   const showBrowserPanel = browserPanelState === 'open' && !location.pathname.endsWith('/browser');
@@ -1484,7 +1481,7 @@ export const router = createBrowserRouter(
                   ),
                 },
                 {
-                  path: 'sdlc/:repoId',
+                  path: 'sdlc/:channelId',
                   element: (
                     <ResourceProtectedRoute resourceName='SDLC' minAccess='READ'>
                       <SdlcRouteElement />
@@ -1492,7 +1489,7 @@ export const router = createBrowserRouter(
                   ),
                 },
                 {
-                  path: 'sdlc/:repoId/:section',
+                  path: 'sdlc/:channelId/:section',
                   element: (
                     <ResourceProtectedRoute resourceName='SDLC' minAccess='READ'>
                       <SdlcRouteElement />
@@ -1821,7 +1818,7 @@ export const router = createBrowserRouter(
           ],
         },
         {
-          path: '/newWindow/sdlc/:workspaceId/:repoId/:section',
+          path: '/newWindow/sdlc/:workspaceId/:channelId/:section',
           element: (
             <EncryptionBootstrapProvider>
               <ZeroProvider>

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -50,6 +50,7 @@ import UserGroupsScreen from './UserGroupsScreen/UserGroupsScreen';
 import ProjectDetailScreen from './ProjectDetailScreen/ProjectDetailScreen';
 import SdlcScreen from './SdlcScreen/SdlcScreen';
 import { SdlcDebuggerPanel } from './SdlcScreen/SdlcDebuggerPanel';
+import SdlcWindow from './SdlcScreen/SdlcWindow';
 import { APP_BASE_PATH, isSdlcSurface } from '../config';
 import SdlcFrameHost from './SdlcScreen/SdlcFrameHost';
 import SdlcFrameViewport from './SdlcScreen/SdlcFrameViewport';
@@ -1818,6 +1819,24 @@ export const router = createBrowserRouter(
               element: <ThreadMessages />,
             },
           ],
+        },
+        {
+          path: '/newWindow/sdlc/:workspaceId/:repoId/:section',
+          element: (
+            <EncryptionBootstrapProvider>
+              <ZeroProvider>
+                <ZeroFallbackProvider>
+                  <InitialStateLoader>
+                    <div className='h-full bg-background'>
+                      <SdlcWindow />
+                    </div>
+                    {/* roomActor is a module singleton, so this window needs its own. */}
+                    <GlobalCallOverlay autoJoinOnAccept={false} />
+                  </InitialStateLoader>
+                </ZeroFallbackProvider>
+              </ZeroProvider>
+            </EncryptionBootstrapProvider>
+          ),
         },
         {
           path: '/newWindow/create-ticket',

--- a/apps/dashboard/src/routes/NotFoundScreen/NotFoundScreen.tsx
+++ b/apps/dashboard/src/routes/NotFoundScreen/NotFoundScreen.tsx
@@ -3,7 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from '@xyne/icons';
 import { Button } from '../../components/ui/Button/Button';
 
-const NotFoundScreen = (): ReactElement => {
+interface NotFoundScreenProps {
+  /** Where to return to. Skips history so a dead URL in it is never replayed. */
+  fallbackPath?: string;
+}
+
+const NotFoundScreen = ({ fallbackPath }: NotFoundScreenProps = {}): ReactElement => {
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -20,6 +25,10 @@ const NotFoundScreen = (): ReactElement => {
   // tracks its own position at `history.state.idx`; 0 means this is the first entry it
   // owns, so fall through to the default route, which resolves workspace + landing.
   const handleGoBack = (): void => {
+    if (fallbackPath) {
+      void navigate(fallbackPath, { replace: true });
+      return;
+    }
     const idx = (window.history.state as { idx?: number } | null)?.idx;
     if (typeof idx === 'number' && idx > 0) {
       void navigate(-1);

--- a/apps/dashboard/src/routes/ProjectDetailScreen/ProjectDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ProjectDetailScreen/ProjectDetailScreen.tsx
@@ -4,11 +4,8 @@ import {
   BoardType,
   deserializeFlowPlan,
   inferRepositoryNameFromUrl,
-  normalizeChannelName,
-  validateChannelName,
   type FlowPlan,
 } from '@xyne/shared';
-import { useQuery } from '@tanstack/react-query';
 import { ArrowLeft, Edit2, GitBranch, LayoutGrid, Rocket } from 'lucide-react';
 import { BoardsTable, type BoardWithStages } from '../../components/Board';
 import * as Tabs from '@radix-ui/react-tabs';
@@ -32,7 +29,6 @@ import { toast } from 'sonner';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { cn } from '../../utils/classNames';
 import { apiInstance } from '../../services/clients/apiClient';
-import { channelService } from '../../services/Chat/channelService';
 import { ProjectRepositoriesSection } from './ProjectRepositoriesSection';
 
 // Type for board data passed from BoardEditScreen to BoardStageConfigScreen
@@ -83,7 +79,6 @@ const ProjectDetailScreen = (): ReactElement => {
   const [repositoryUrl, setRepositoryUrl] = useState('');
   const [repositoryName, setRepositoryName] = useState('');
   const [repositoryNameEdited, setRepositoryNameEdited] = useState(false);
-  const [debouncedRepositoryName, setDebouncedRepositoryName] = useState('');
   const [repositoryBranch, setRepositoryBranch] = useState('main');
   const [addingRepository, setAddingRepository] = useState(false);
   const [repositoryRefreshKey, setRepositoryRefreshKey] = useState(0);
@@ -222,21 +217,6 @@ const ProjectDetailScreen = (): ReactElement => {
     fullBoardDetailsStatus.type,
   ]);
 
-  useEffect(() => {
-    const timeoutId = setTimeout(() => setDebouncedRepositoryName(repositoryName), 500);
-    return (): void => clearTimeout(timeoutId);
-  }, [repositoryName]);
-
-  const { data: channelDuplicateCheck } = useQuery({
-    queryKey: ['checkDuplicateChannel', debouncedRepositoryName, 'default'],
-    queryFn: () => channelService.checkDuplicateChannel(debouncedRepositoryName),
-    enabled:
-      Boolean(debouncedRepositoryName) && validateChannelName(debouncedRepositoryName) === null,
-    staleTime: 0,
-    retry: 1,
-    refetchOnWindowFocus: false,
-  });
-
   const loading = project === undefined || boards === undefined;
 
   // Early return if no projectId
@@ -291,15 +271,15 @@ const ProjectDetailScreen = (): ReactElement => {
     }
   };
 
-  const repositoryNameError = repositoryName
-    ? (validateChannelName(repositoryName) ??
-      (channelDuplicateCheck?.isDuplicate ? 'Channel name already exists' : null))
-    : null;
+  // A repository label, not a channel name: repositories no longer create a
+  // channel, and a space names itself when it is created.
+  const repositoryNameError =
+    repositoryName && repositoryName.length > 120 ? 'Keep the name under 120 characters' : null;
 
   const handleRepositoryUrlChange = (value: string): void => {
     setRepositoryUrl(value);
     if (repositoryNameEdited) return;
-    setRepositoryName(normalizeChannelName(inferRepositoryNameFromUrl(value) ?? ''));
+    setRepositoryName(inferRepositoryNameFromUrl(value) ?? '');
   };
 
   const closeAddRepositoryModal = (): void => {
@@ -838,7 +818,7 @@ const ProjectDetailScreen = (): ReactElement => {
             data-track-name='RepositoryUrlChanged'
           />
           <label htmlFor='sdlc-repository-name' className='mt-4 block text-sm font-medium'>
-            Channel name
+            Repository name
           </label>
           <input
             id='sdlc-repository-name'
@@ -846,7 +826,7 @@ const ProjectDetailScreen = (): ReactElement => {
             value={repositoryName}
             onChange={event => {
               setRepositoryNameEdited(true);
-              setRepositoryName(normalizeChannelName(event.target.value));
+              setRepositoryName(event.target.value);
             }}
             className={cn(
               'mt-2 h-10 w-full rounded-md border bg-background px-3 outline-none focus:ring-2 focus:ring-ring',
@@ -861,7 +841,7 @@ const ProjectDetailScreen = (): ReactElement => {
               repositoryNameError ? 'text-destructive' : 'text-muted-foreground',
             )}
           >
-            {repositoryNameError ?? "Names this repository's SDLC channel."}
+            {repositoryNameError ?? 'How this repository is labelled in SDLC spaces.'}
           </p>
           <div className='mt-4'>
             <label htmlFor='sdlc-repository-branch' className='block text-sm font-medium'>
@@ -885,7 +865,7 @@ const ProjectDetailScreen = (): ReactElement => {
               loading={addingRepository}
               disabled={!repositoryUrl.trim() || !repositoryName || Boolean(repositoryNameError)}
             >
-              Attach repository
+              Add repository
             </Button>
           </div>
         </form>

--- a/apps/dashboard/src/routes/ProjectDetailScreen/ProjectRepositoriesSection.tsx
+++ b/apps/dashboard/src/routes/ProjectDetailScreen/ProjectRepositoriesSection.tsx
@@ -1,5 +1,5 @@
 import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
-import { AlertCircle, CheckCircle2, ExternalLink, GitBranch, Lock, RefreshCw } from 'lucide-react';
+import { AlertCircle, CheckCircle2, GitBranch, Lock, RefreshCw } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { Button } from '../../components/ui/Button';
@@ -110,7 +110,6 @@ export function ProjectRepositoriesSection(props: {
           repository={repo}
           checking={checking === repo.id}
           onCheck={() => void check(repo.id)}
-          onOpen={() => void navigate(`/sdlc/${repo.id}/overview`)}
           onSettings={() =>
             void navigate(
               workspaceId
@@ -128,7 +127,6 @@ function RepositoryCard(props: {
   repository: ProjectRepository;
   checking: boolean;
   onCheck: () => void;
-  onOpen: () => void;
   onSettings: () => void;
 }): ReactElement {
   const repo = props.repository;
@@ -162,9 +160,6 @@ function RepositoryCard(props: {
         <div className='flex flex-wrap gap-2'>
           <Button variant='outline' loading={props.checking} onClick={props.onCheck}>
             <RefreshCw className='h-4 w-4' /> Refresh now
-          </Button>
-          <Button onClick={props.onOpen}>
-            <ExternalLink className='h-4 w-4' /> Open SDLC
           </Button>
         </div>
       </div>

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcHubDialog.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcHubDialog.tsx
@@ -1,0 +1,265 @@
+import { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { FolderKanban, GitBranch, Lock, Plus } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '../../components/ui/Button';
+import { Dialog } from '../../components/ui/Dialog/Dialog';
+import { EntityMultiSelector } from '../../components/ui/EntitySelector/EntityMultiSelector';
+import { EntitySelector } from '../../components/ui/EntitySelector/EntitySelector';
+import type { SelectorOption } from '../../components/ui/EntitySelector/EntitySelector.types';
+import Input from '../../components/ui/Input';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { apiInstance } from '../../services/clients/apiClient';
+import { queries } from '../../zero/queries';
+
+interface RepositoryOption {
+  id: string;
+  name: string;
+  url: string;
+  canonicalUrl: string | null;
+  visibility: string | null;
+  accessJobStatus: string;
+}
+
+/** `owner/repo`, so two same-named repositories stay distinct. */
+function repositorySlug(repository: RepositoryOption): string | null {
+  const source = repository.canonicalUrl || repository.url;
+  const match = /(?:[:/])([^/:]+\/[^/]+?)(?:\.git)?$/.exec(source.trim());
+  return match?.[1] ?? null;
+}
+
+interface SdlcHubDialogProps {
+  /** Omitted for the first hub of all; the dialog then asks for the project. */
+  projectId?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Editing an existing hub. No rename endpoint, so this only changes repositories. */
+  hub?: { channelId: string; repoIds: string[] };
+  onSaved: (channelId: string) => void;
+}
+
+function errorMessage(error: unknown): string {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const response = (error as { response?: { data?: { error?: unknown } } }).response;
+    if (typeof response?.data?.error === 'string') return response.data.error;
+  }
+  return error instanceof Error ? error.message : 'Action failed';
+}
+
+/** Create a hub, or change the repositories an existing one covers. */
+export function SdlcHubDialog({
+  projectId,
+  open,
+  onOpenChange,
+  hub,
+  onSaved,
+}: SdlcHubDialogProps): ReactElement {
+  const editing = hub !== undefined;
+  const [name, setName] = useState('');
+  const [repoIds, setRepoIds] = useState<string[]>([]);
+  const [pickedProjectId, setPickedProjectId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  // Seeded from the current hub's project when there is one, but still a picker: a
+  // new hub need not live in the same project.
+  const activeProjectId = pickedProjectId;
+
+  useEffect(() => {
+    if (!open) return;
+    setName('');
+    setRepoIds(hub?.repoIds ?? []);
+    setPickedProjectId(projectId ?? null);
+  }, [open, hub?.repoIds, projectId]);
+
+  const [projectRows] = useCachedQuery(queries.getAllProjectsList(), {
+    enabled: open && !editing,
+  });
+  const projects = useMemo(
+    () => (Array.isArray(projectRows) ? (projectRows as Array<{ id: string; name: string }>) : []),
+    [projectRows],
+  );
+  const projectOptions = useMemo<SelectorOption[]>(
+    () =>
+      projects.map(project => ({
+        value: project.id,
+        label: project.name,
+        icon: <FolderKanban className='size-4 text-muted-foreground' />,
+      })),
+    [projects],
+  );
+
+  const { data: repositories, isLoading: repositoriesLoading } = useQuery({
+    queryKey: ['sdlc-project-repositories', activeProjectId],
+    queryFn: async () => {
+      const response = await apiInstance.get<{ repositories: RepositoryOption[] }>(
+        `/sdlc/projects/${encodeURIComponent(activeProjectId!)}/repositories`,
+      );
+      return response.data.repositories;
+    },
+    enabled: open && Boolean(activeProjectId),
+  });
+
+  const options = useMemo(() => repositories ?? [], [repositories]);
+  // subtitle is `owner/repo`, which the selector also searches on.
+  const repositoryOptions = useMemo<SelectorOption[]>(
+    () =>
+      options.map(repository => ({
+        value: repository.id,
+        label: repository.name,
+        subtitle: repositorySlug(repository),
+        icon:
+          repository.visibility === 'PRIVATE' ? (
+            <Lock className='size-4 text-muted-foreground' />
+          ) : (
+            <GitBranch className='size-4 text-muted-foreground' />
+          ),
+        ...(repository.accessJobStatus !== 'READY' ? { badge: 'Access pending' } : {}),
+      })),
+    [options],
+  );
+  const submit = async (): Promise<void> => {
+    setBusy(true);
+    try {
+      if (editing) {
+        const added = repoIds.filter(id => !hub.repoIds.includes(id));
+        const removed = hub.repoIds.filter(id => !repoIds.includes(id));
+        if (added.length > 0) {
+          await apiInstance.post(
+            `/sdlc/channels/${encodeURIComponent(hub.channelId)}/repositories`,
+            { repoIds: added },
+          );
+        }
+        // Sequential: the server decides which one is the last, which it refuses.
+        for (const repoId of removed) {
+          await apiInstance.delete(
+            `/sdlc/channels/${encodeURIComponent(hub.channelId)}/repositories/${encodeURIComponent(repoId)}`,
+          );
+        }
+        toast.success('Hub repositories updated');
+        onSaved(hub.channelId);
+      } else {
+        const response = await apiInstance.post<{ channel: { id: string } }>('/sdlc/channels', {
+          projectId: activeProjectId,
+          name: name.trim(),
+          repoIds,
+        });
+        toast.success('Hub created');
+        onSaved(response.data.channel.id);
+      }
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(errorMessage(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const title = editing ? 'Hub repositories' : 'New hub';
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange} title={title}>
+      <form
+        className='p-6'
+        onSubmit={event => {
+          event.preventDefault();
+          void submit();
+        }}
+      >
+        <h2 className='text-lg font-semibold tracking-tight'>{title}</h2>
+        <p className='mt-1.5 text-sm leading-6 text-muted-foreground'>
+          {editing
+            ? 'Repositories this hub covers. A hub always keeps at least one.'
+            : 'A private workspace covering one or more repositories. It never appears in Chat.'}
+        </p>
+
+        <div className='mt-6 space-y-5'>
+          {!editing && (
+            <div>
+              <p className='mb-2 text-sm font-medium'>Project</p>
+              <EntitySelector
+                options={projectOptions}
+                selectedValue={activeProjectId}
+                onSelect={value => {
+                  setPickedProjectId(value);
+                  setRepoIds([]);
+                }}
+                placeholder={
+                  projectRows === undefined
+                    ? 'Loading projects…'
+                    : projectOptions.length === 0
+                      ? 'No projects available'
+                      : 'Select a project'
+                }
+                searchPlaceholder='Search projects...'
+                width='100%'
+                matchTriggerWidth
+              />
+            </div>
+          )}
+
+          {!editing && (
+            <div>
+              <label htmlFor='sdlc-hub-name' className='block text-sm font-medium'>
+                Name
+              </label>
+              <Input
+                id='sdlc-hub-name'
+                autoFocus
+                value={name}
+                onChange={event => setName(event.target.value)}
+                className='mt-2 h-10'
+                placeholder='e.g. Payments platform'
+              />
+            </div>
+          )}
+
+          <div>
+            <p className='mb-2 text-sm font-medium'>Repositories</p>
+            <EntityMultiSelector
+              options={repositoryOptions}
+              selectedValues={repoIds}
+              onMultiSelect={setRepoIds}
+              showSearch
+              isLoading={repositoriesLoading}
+              placeholder={
+                !activeProjectId
+                  ? 'Choose a project first'
+                  : repositoryOptions.length === 0
+                    ? 'This project has no repositories'
+                    : 'Select repositories'
+              }
+              searchPlaceholder='Search repositories...'
+              width='100%'
+              matchTriggerWidth
+              collapseSelectedAfter={2}
+              collapsedLabel='repositories'
+            />
+            {repoIds.length === 0 && (
+              <p className='mt-2 text-xs text-muted-foreground'>Pick at least one repository.</p>
+            )}
+          </div>
+        </div>
+
+        <div className='mt-7 flex justify-end gap-2'>
+          <Button
+            type='button'
+            variant='outline'
+            onClick={() => onOpenChange(false)}
+            data-track-category='SdlcHub'
+            data-track-name='HubDialogCancelled'
+          >
+            Cancel
+          </Button>
+          <Button
+            type='submit'
+            loading={busy}
+            disabled={repoIds.length === 0 || (!editing && (!name.trim() || !activeProjectId))}
+            data-track-category='SdlcHub'
+            data-track-name={editing ? 'HubRepositoriesSaved' : 'HubCreated'}
+          >
+            <Plus />
+            {editing ? 'Save' : 'Create hub'}
+          </Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcHubSidebar.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcHubSidebar.tsx
@@ -1,0 +1,135 @@
+import { useMemo, useState, type ReactElement } from 'react';
+import { ChevronRight, ExternalLink, GitBranch, Hash, Lock, Settings2 } from 'lucide-react';
+import { EntitySelector } from '../../components/ui/EntitySelector/EntitySelector';
+import type { SelectorOption } from '../../components/ui/EntitySelector/EntitySelector.types';
+import { Popover } from '../../components/ui/Popover';
+
+export interface SdlcHubRepository {
+  id: string;
+  name: string;
+  url: string;
+  canonicalUrl?: string | null;
+}
+
+export interface SdlcHubOption {
+  id: string;
+  name: string;
+  visibility: string;
+  repositories: SdlcHubRepository[];
+}
+
+function repositoryHref(repository: SdlcHubRepository): string {
+  return repository.canonicalUrl || repository.url;
+}
+
+/** Hub switcher. Repository names ride in the subtitle, which the selector searches. */
+export function SdlcHubPicker(props: {
+  hubs: SdlcHubOption[];
+  selectedHubId: string;
+  onSelect: (hubId: string) => void;
+}): ReactElement {
+  const options = useMemo<SelectorOption[]>(
+    () =>
+      props.hubs.map(hub => ({
+        value: hub.id,
+        label: hub.name,
+        subtitle:
+          hub.repositories.map(repository => repository.name).join(', ') || 'No repositories',
+        // Channel semantics: a lock for private, a hash for public.
+        icon:
+          hub.visibility === 'PUBLIC' ? (
+            <Hash className='size-4 text-muted-foreground' />
+          ) : (
+            <Lock className='size-4 text-muted-foreground' />
+          ),
+      })),
+    [props.hubs],
+  );
+
+  return (
+    <EntitySelector
+      options={options}
+      selectedValue={props.selectedHubId}
+      onSelect={value => {
+        if (value) props.onSelect(value);
+      }}
+      placeholder='Select hub'
+      searchPlaceholder='Search hubs and repositories...'
+      width='100%'
+      matchTriggerWidth
+    />
+  );
+}
+
+/** The hub's repositories, each opening in a new tab. */
+export function SdlcHubRepositories(props: {
+  repositories: SdlcHubRepository[];
+  onManage: () => void;
+}): ReactElement {
+  const [open, setOpen] = useState(false);
+  const count = props.repositories.length;
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+      side='top'
+      align='start'
+      sideOffset={6}
+      className='w-[260px] p-0'
+      trigger={
+        <button
+          type='button'
+          className='flex w-full items-center gap-2 rounded-lg px-2 py-2 font-medium transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-accent-ring'
+          aria-label='Repositories in this hub'
+          data-track-category='SdlcHub'
+          data-track-name='HubRepositoryListOpened'
+        >
+          <GitBranch className='size-4 shrink-0 text-sidebar-foreground/65' />
+          <span className='min-w-0 flex-1 truncate text-left'>Repositories</span>
+          <span className='shrink-0 text-[11px] tabular-nums text-sidebar-foreground/55'>
+            {count}
+          </span>
+          <ChevronRight className='size-3.5 shrink-0 text-sidebar-foreground/55' />
+        </button>
+      }
+    >
+      <div className='max-h-72 overflow-y-auto py-1'>
+        {count === 0 ? (
+          <p className='px-3 py-4 text-center text-xs text-muted-foreground'>
+            No repositories in this hub.
+          </p>
+        ) : (
+          props.repositories.map(repository => (
+            <a
+              key={repository.id}
+              href={repositoryHref(repository)}
+              target='_blank'
+              rel='noreferrer'
+              className='flex items-center gap-2 px-2.5 py-2 transition-colors hover:bg-muted/60'
+              data-track-category='SdlcHub'
+              data-track-name='HubRepositoryOpened'
+            >
+              <GitBranch className='size-3.5 shrink-0 text-muted-foreground' />
+              <span className='min-w-0 flex-1 truncate text-[12.5px]'>{repository.name}</span>
+              <ExternalLink className='size-3 shrink-0 text-muted-foreground' />
+            </a>
+          ))
+        )}
+      </div>
+      <button
+        type='button'
+        className='flex w-full items-center gap-2 border-t px-2.5 py-2 text-[12.5px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground'
+        onClick={() => {
+          setOpen(false);
+          props.onManage();
+        }}
+        data-track-category='SdlcHub'
+        data-track-name='HubRepositoriesOpened'
+      >
+        <Settings2 className='size-3.5' />
+        Manage repositories
+      </button>
+    </Popover>
+  );
+}

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -27,11 +27,9 @@ import {
   Boxes,
   Bug,
   Check,
-  ChevronDown,
   ChevronRight,
   CircleAlert,
   CircleDot,
-  ExternalLink,
   FileText,
   Folder,
   GitBranch,
@@ -51,6 +49,10 @@ import {
   Users,
   X,
 } from 'lucide-react';
+import { EntitySelector } from '../../components/ui/EntitySelector/EntitySelector';
+import NotFoundScreen from '../NotFoundScreen/NotFoundScreen';
+import { SdlcHubDialog } from './SdlcHubDialog';
+import { SdlcHubPicker, SdlcHubRepositories } from './SdlcHubSidebar';
 import {
   isFramedSdlcSurface,
   isSdlcDocumentWindow,
@@ -195,11 +197,11 @@ function actionErrorMessage(error: unknown): string {
 export default function SdlcScreen(): ReactElement {
   const {
     workspaceId,
-    repoId,
+    channelId,
     section: routeSection,
   } = useParams<{
     workspaceId?: string;
-    repoId?: string;
+    channelId?: string;
     section?: string;
   }>();
   const navigate = useNavigate();
@@ -208,13 +210,43 @@ export default function SdlcScreen(): ReactElement {
   const section: Section = (
     routeSection && SECTION_IDS.has(routeSection) ? routeSection : 'overview'
   ) as Section;
-  const [repos] = useCachedQuery(queries.getSdlcRepos());
-  const [repo, repoQueryDetails] = useCachedQuery(
-    queries.getSdlcRepoById({ repoId: repoId || '' }),
+  const routeSearchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const [channels] = useCachedQuery(queries.getSdlcChannels());
+  const [channelRow, repoQueryDetails] = useCachedQuery(
+    queries.getSdlcChannelById({ channelId: channelId || '' }),
     {
-      enabled: Boolean(repoId),
+      enabled: Boolean(channelId),
     },
   );
+  const channel = channelRow instanceof Error ? undefined : channelRow;
+
+  const channelRepos = useMemo(
+    () =>
+      (channel?.sdlcEntityLinks ?? [])
+        .map(link => link.repo)
+        .filter((candidate): candidate is NonNullable<typeof candidate> => Boolean(candidate)),
+    [channel],
+  );
+  // Repositories come along so the switcher can search on their names.
+  const hubOptions = useMemo(
+    () =>
+      (Array.isArray(channels) ? channels : []).map(item => ({
+        id: item.id,
+        name: item.name,
+        visibility: item.visibility,
+        repositories: (item.sdlcEntityLinks ?? []).flatMap(link => (link.repo ? [link.repo] : [])),
+      })),
+    [channels],
+  );
+  // Repositories in a hub coexist; there is no selection. Repo Knowledge and Wiki
+  // still address one repository and read the first until they cover all of them.
+  const selectedRepo = channelRepos[0];
+  const repo = useMemo(
+    () =>
+      selectedRepo && channel ? { ...selectedRepo, channel, channelId: channel.id } : undefined,
+    [selectedRepo, channel],
+  );
+  const repoId = repo?.id;
   const zero = useZero();
   const [busy, setBusy] = useState<string | null>(null);
   const [artifactDialog, setArtifactDialog] = useState<{ id: string; name: string } | null>(null);
@@ -230,6 +262,7 @@ export default function SdlcScreen(): ReactElement {
     null,
   );
   const [deriveTypeId, setDeriveTypeId] = useState<string | null>(null);
+  const [hubDialog, setHubDialog] = useState<'create' | 'manage' | null>(null);
   const [typeDialogOpen, setTypeDialogOpen] = useState(false);
   const [typeName, setTypeName] = useState('');
   const [renameTypeId, setRenameTypeId] = useState<string | null>(null);
@@ -257,20 +290,23 @@ export default function SdlcScreen(): ReactElement {
   const { selectedAgentSlug, setSelectedAgentSlug } = useSelectedAgent();
 
   useEffect(() => {
-    if (!repoId && Array.isArray(repos) && repos[0]) {
-      void navigate(`/sdlc/${repos[0].id}/overview`, { replace: true });
+    if (!channelId && Array.isArray(channels) && channels[0]) {
+      void navigate(`/sdlc/${channels[0].id}/overview`, { replace: true });
     }
-  }, [navigate, repoId, repos]);
+  }, [navigate, channelId, channels]);
 
   const canvases = useMemo(() => {
-    if (!repo || repo instanceof Error) return [];
-    return (repo.channel?.canvasFolders ?? []).flatMap(folder => folder.canvases ?? []);
-  }, [repo]);
-  const routeSearchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+    if (!channel) return [];
+    return (channel.canvasFolders ?? []).flatMap(folder => folder.canvases ?? []);
+  }, [channel]);
   const selectedCanvasId = routeSearchParams.get('canvas');
   const selectedCanvas = canvases.find(canvas => canvas.id === selectedCanvasId);
-  const [trackRows] = useCachedQuery(queries.getSdlcTracks({ repoId: repoId || '' }), {
-    enabled: Boolean(repoId),
+  const [trackRows] = useCachedQuery(queries.getSdlcTracks({ channelId: channelId || '' }), {
+    enabled: Boolean(channelId),
+  });
+  // Membership edges share this table and are excluded by the query.
+  const [linkRows] = useCachedQuery(queries.getSdlcLinks({ channelId: channelId || '' }), {
+    enabled: Boolean(channelId),
   });
   const tracks = useMemo(
     () =>
@@ -362,10 +398,7 @@ export default function SdlcScreen(): ReactElement {
       }),
     [baseline],
   );
-  const folders = useMemo(
-    () => (repo && !(repo instanceof Error) ? (repo.channel?.canvasFolders ?? []) : []),
-    [repo],
-  );
+  const folders = useMemo(() => (repo ? (repo.channel?.canvasFolders ?? []) : []), [repo]);
   const typeFolders = useMemo(
     () =>
       folders
@@ -414,8 +447,8 @@ export default function SdlcScreen(): ReactElement {
   }, [hoveredTypeId, renameTypeId, typeFolders]);
   const links = useMemo(
     () =>
-      repo && !(repo instanceof Error)
-        ? (repo.sdlcEntityLinks ?? []).flatMap(link =>
+      linkRows
+        ? linkRows.flatMap(link =>
             isSdlcEntityType(link.sourceType) &&
             isSdlcEntityType(link.targetType) &&
             isSdlcRelationType(link.relationType)
@@ -430,7 +463,7 @@ export default function SdlcScreen(): ReactElement {
               : [],
           )
         : [],
-    [repo],
+    [linkRows],
   );
   const trackPrdIdsByTrack = useMemo(() => {
     const byTrack = new Map<string, Set<string>>();
@@ -482,7 +515,7 @@ export default function SdlcScreen(): ReactElement {
   }, [links, tracks]);
 
   useEffect(() => {
-    const repoLoaded = !!repo && !(repo instanceof Error);
+    const repoLoaded = !!repo;
     const query = relatedSearchQuery.trim();
     if (!artifactTrack || !repoLoaded || query.length < 2) {
       setRelatedSearchResults([]);
@@ -654,7 +687,7 @@ export default function SdlcScreen(): ReactElement {
         const selectedIsSource = link.sourceId === selectedCanvas.id;
         const entityId = selectedIsSource ? link.targetId : link.sourceId;
         const entityType = selectedIsSource ? link.targetType : link.sourceType;
-        const repositoryChannelId = repo && !(repo instanceof Error) ? repo.channelId : null;
+        const repositoryChannelId = repo ? repo.channelId : null;
         return shouldShowSdlcRelatedLink({
           relationType: link.relationType,
           entityType,
@@ -663,16 +696,12 @@ export default function SdlcScreen(): ReactElement {
         });
       })
     : [];
-  const state = repoKnowledgeState(repo && !(repo instanceof Error) ? repo.setupExecution : null);
+  const state = repoKnowledgeState(repo ? repo.setupExecution : null);
   const setupRunning = isRepoKnowledgeRunning(state.phase);
 
   useEffect(() => {
     if (!repoId || externalDebuggerTarget?.repoId !== repoId) return;
-    if (
-      repo &&
-      !(repo instanceof Error) &&
-      externalDebuggerTarget.executionId === repo.setupExecution?.id
-    ) {
+    if (repo && externalDebuggerTarget.executionId === repo.setupExecution?.id) {
       updateExternalDebugger(repoId, {
         conversationId: state.conversationId || externalDebuggerTarget.conversationId,
         sessionId: state.sessionId || externalDebuggerTarget.sessionId,
@@ -711,9 +740,9 @@ export default function SdlcScreen(): ReactElement {
       .filter(canvas => canvas.sdlcArtifact?.artifactStatus === 'ACTIVE')
       .map(canvas => canvas.sdlcArtifact?.artifactType),
   ).size;
-  const accessRepoId = repo && !(repo instanceof Error) ? repo.id : '';
+  const accessRepoId = repo ? repo.id : '';
   const accessCapabilities =
-    repo && !(repo instanceof Error) && Array.isArray(repo.accessCapabilities)
+    repo && Array.isArray(repo.accessCapabilities)
       ? (repo.accessCapabilities as Array<{ capability?: string; state?: string; detail?: string }>)
       : [];
   const capabilityReady = (capability: string, states: string[]): boolean =>
@@ -749,7 +778,6 @@ export default function SdlcScreen(): ReactElement {
   }, [readReady, accessRepoId]);
   const isAdmin = Boolean(
     repo &&
-    !(repo instanceof Error) &&
     repo.channel?.participants?.some(
       participant => participant.userId === auth.userID && participant.role === ChannelRole.ADMIN,
     ),
@@ -863,9 +891,9 @@ export default function SdlcScreen(): ReactElement {
     canvasId: string,
     search: URLSearchParams,
   ): boolean => {
-    if (!workspaceId || !repoId) return false;
+    if (!workspaceId || !channelId) return false;
     return openStandaloneWindow(
-      `/sdlc/${workspaceId}/${repoId}/${targetSection}?${search.toString()}`,
+      `/sdlc/${workspaceId}/${channelId}/${targetSection}?${search.toString()}`,
       `sdlc-canvas:${canvasId}`,
     );
   };
@@ -884,7 +912,7 @@ export default function SdlcScreen(): ReactElement {
     setRelatedSourceId(null);
     const search = canvasSearch(canvasId, withDiscussion);
     navigateWithinSdlc(
-      `/sdlc/${repoId}/${section}`,
+      `/sdlc/${channelId}/${section}`,
       `?${search.toString()}`,
       resolveCanvasDiscussionOwner(canvasId, canvases)?.canvasId ?? null,
     );
@@ -902,7 +930,7 @@ export default function SdlcScreen(): ReactElement {
 
     setRelatedSourceId(null);
     navigateWithinSdlc(
-      `/sdlc/${repoId}/artifacts`,
+      `/sdlc/${channelId}/artifacts`,
       `?${search.toString()}`,
       resolveCanvasDiscussionOwner(canvasId, canvases)?.canvasId ?? null,
     );
@@ -912,7 +940,7 @@ export default function SdlcScreen(): ReactElement {
     if (!repoId) return;
     setRelatedSourceId(null);
     navigateWithinSdlc(
-      `/sdlc/${repoId}/wiki`,
+      `/sdlc/${channelId}/wiki`,
       `?canvas=${encodeURIComponent(page.canvasId)}`,
       page.canvasId,
     );
@@ -923,10 +951,13 @@ export default function SdlcScreen(): ReactElement {
     const typeFolder =
       selectedCanvasTypeFolder ?? (section === 'artifacts' ? activeTypeFolder : null);
     if (typeFolder) {
-      navigateWithinSdlc(`/sdlc/${repoId}/artifacts`, `?type=${encodeURIComponent(typeFolder.id)}`);
+      navigateWithinSdlc(
+        `/sdlc/${channelId}/artifacts`,
+        `?type=${encodeURIComponent(typeFolder.id)}`,
+      );
       return;
     }
-    navigateWithinSdlc(`/sdlc/${repoId}/${section}`);
+    navigateWithinSdlc(`/sdlc/${channelId}/${section}`);
   };
 
   const setDiscussionUrl = useCallback(
@@ -974,7 +1005,7 @@ export default function SdlcScreen(): ReactElement {
 
   const openSdlcAssistant = useCallback(
     (threadInfo?: ThreadInfo): void => {
-      if (!repo || repo instanceof Error || !repo.channelId) return;
+      if (!repo) return;
       closeExternalDebugger();
       // Ask AI renders inside the SDLC lane itself (the framed bundle's own
       // XyneAISidebar), so Ask AI changes ship with this lane and never need a
@@ -1007,7 +1038,7 @@ export default function SdlcScreen(): ReactElement {
 
   const askSdlcAssistant = useCallback(
     (query: string, canvas?: { canvasId: string; title: string }, forceFreshChat = false): void => {
-      if (!repo || repo instanceof Error || !repo.channelId) return;
+      if (!repo) return;
       closeExternalDebugger();
       const assistantState = xyneAIActor.getSnapshot();
       const pinnedContext = assistantState.context.researchContext;
@@ -1043,7 +1074,7 @@ export default function SdlcScreen(): ReactElement {
   );
 
   const renderRepoKnowledgeControls = (compact = false): ReactElement | undefined => {
-    if (!isAdmin || !repo || repo instanceof Error) return undefined;
+    if (!isAdmin || !repo) return undefined;
     const controlPresentation = {
       GENERATE: {
         icon: Rocket,
@@ -1118,7 +1149,7 @@ export default function SdlcScreen(): ReactElement {
     // Legacy ?chat=ai deep link: the assistant is the global sidebar now, not
     // a panel tab. Open it once and strip the param — keeping the param made
     // this effect re-open the sidebar every time the user closed it.
-    if (!repo || repo instanceof Error || !repo.channelId) return;
+    if (!repo) return;
     openSdlcAssistant();
     const next = new URLSearchParams(location.search);
     next.delete('chat');
@@ -1153,15 +1184,7 @@ export default function SdlcScreen(): ReactElement {
       .map(canvas => ({ canvasId: canvas.id, title: canvas.title }));
 
   const createArtifact = (): void => {
-    if (
-      !repoId ||
-      !repo ||
-      repo instanceof Error ||
-      !artifactDialog ||
-      !artifactTitle.trim() ||
-      !artifactTrack
-    )
-      return;
+    if (!repoId || !repo || !artifactDialog || !artifactTitle.trim() || !artifactTrack) return;
     const related = relatedArtifactsForPayload();
     const query = buildSdlcArtifactCreationPrompt({
       typeLabel: artifactDialog.name,
@@ -1177,7 +1200,7 @@ export default function SdlcScreen(): ReactElement {
   };
 
   const createTicketForArtifact = (canvas: { id: string; title: string }): void => {
-    if (!repo || repo instanceof Error) return;
+    if (!repo) return;
     askSdlcAssistant(
       `Create an implementation ticket for the artifact "${canvas.title}" in repository "${repo.name}". ` +
         `Call spaces-create-ticket with sdlcRepoId ${repo.id} and sourceCanvasId ${canvas.id} so the ticket is linked to this artifact. ` +
@@ -1188,20 +1211,14 @@ export default function SdlcScreen(): ReactElement {
   };
 
   const createBlankArtifact = async (): Promise<void> => {
-    if (
-      !repo ||
-      repo instanceof Error ||
-      !artifactDialog ||
-      !artifactTitle.trim() ||
-      !artifactTrack
-    )
-      return;
+    if (!repo || !channel || !artifactDialog || !artifactTitle.trim() || !artifactTrack) return;
     const folder = artifactDialog;
     const title = artifactTitle.trim();
     const response = await apiInstance.post<{ artifact: { canvasId: string } }>(
       '/sdlc/claw/artifacts',
       {
         repoId: repo.id,
+        channelId: channel.id,
         folderId: folder.id,
         title,
         markdown: `# ${title}\n`,
@@ -1213,30 +1230,30 @@ export default function SdlcScreen(): ReactElement {
     const newCanvasId = response.data.artifact.canvasId;
     setRelatedSourceId(null);
     navigateWithinSdlc(
-      `/sdlc/${repoId}/artifacts`,
+      `/sdlc/${channelId}/artifacts`,
       `?type=${encodeURIComponent(folder.id)}&canvas=${encodeURIComponent(newCanvasId)}`,
       null,
     );
   };
 
   const createArtifactType = async (): Promise<void> => {
-    if (!repo || repo instanceof Error || !typeName.trim()) return;
+    if (!repo || !channel || !typeName.trim()) return;
     const response = await apiInstance.post<{ artifactType: { id: string; name: string } }>(
       '/sdlc/claw/artifact-types',
-      { repoId: repo.id, name: typeName.trim() },
+      { repoId: repo.id, channelId: channel.id, name: typeName.trim() },
     );
     const created = response.data.artifactType;
     setTypeDialogOpen(false);
     setTypeName('');
     navigateWithinSdlc(
-      `/sdlc/${repoId}/artifacts`,
+      `/sdlc/${channelId}/artifacts`,
       `?type=${encodeURIComponent(created.id)}`,
       null,
     );
   };
 
   const renameArtifactType = async (folderId: string, name: string): Promise<void> => {
-    if (!repo || repo instanceof Error || !name.trim()) return;
+    if (!repo || !name.trim()) return;
     await apiInstance.patch(`/sdlc/claw/artifact-types/${folderId}`, {
       repoId: repo.id,
       name: name.trim(),
@@ -1264,6 +1281,7 @@ export default function SdlcScreen(): ReactElement {
         await Promise.all(
           targets.map(target =>
             apiInstance.post(`/sdlc/repositories/${repoId}/links`, {
+              channelId,
               sourceType: 'CANVAS',
               sourceId: relatedSourceId,
               targetType: target.type,
@@ -1278,7 +1296,11 @@ export default function SdlcScreen(): ReactElement {
     );
   };
 
-  if (repos === undefined || (repoId && repo === undefined)) {
+  // A deleted hub keeps returning undefined, so 'complete' is what separates a
+  // missing hub from one still loading.
+  const hubLoading =
+    Boolean(channelId) && channelRow === undefined && repoQueryDetails.type !== 'complete';
+  if (channels === undefined || hubLoading) {
     return (
       <div className='h-full grid place-items-center text-muted-foreground'>
         <Loader2 className='animate-spin' />
@@ -1286,30 +1308,59 @@ export default function SdlcScreen(): ReactElement {
     );
   }
 
-  if (!Array.isArray(repos) || repos.length === 0) {
+  // Before the empty state: a URL naming a hub that is gone is a 404, not an
+  // invitation to create the first one.
+  if (channelId && !channel) return <NotFoundScreen fallbackPath='/sdlc' />;
+
+  if (!Array.isArray(channels) || channels.length === 0) {
     return (
       <div className='h-full bg-muted/30 grid place-items-center p-8'>
         <div className='max-w-lg rounded-2xl border bg-background p-10 text-center shadow-sm'>
           <div className='mx-auto mb-5 grid size-14 place-items-center rounded-2xl bg-primary/10 text-primary'>
             <GitBranch size={26} />
           </div>
-          <h1 className='text-2xl font-semibold'>Your SDLC hubs start with a repository</h1>
+          <h1 className='text-2xl font-semibold'>No SDLC hubs yet</h1>
           <p className='mt-3 text-sm leading-6 text-muted-foreground'>
-            Open a project from List Projects and attach its first repository. Xyne will create a
-            private, repo-scoped hub without exposing it in Chat.
+            A hub covers one or more repositories from a project. It stays private and never appears
+            in Chat.
           </p>
-          <Button className='mt-6' onClick={() => void navigate('/listProjects')}>
-            Choose project
+          <Button
+            className='mt-6'
+            onClick={() => setHubDialog('create')}
+            data-track-category='SdlcHub'
+            data-track-name='FirstHubOpened'
+          >
+            <Plus />
+            New hub
           </Button>
         </div>
+        <SdlcHubDialog
+          open={hubDialog !== null}
+          onOpenChange={open => setHubDialog(open ? hubDialog : null)}
+          onSaved={savedChannelId => void navigate(`/sdlc/${savedChannelId}/overview`)}
+        />
       </div>
     );
   }
 
-  if (!repo || repo instanceof Error) {
+  // No hub in the URL yet: the redirect to the first one is a tick away.
+  if (!channel) {
     return (
       <div className='h-full grid place-items-center text-muted-foreground'>
-        Repository not found.
+        <Loader2 className='animate-spin' />
+      </div>
+    );
+  }
+
+  if (!repo) {
+    return (
+      <div className='h-full grid place-items-center p-8 text-center text-muted-foreground'>
+        <div>
+          <p className='text-sm'>This hub has no repositories.</p>
+          <p className='mt-1 text-xs'>
+            A hub always keeps at least one, so this should not happen.
+          </p>
+        </div>
       </div>
     );
   }
@@ -1320,13 +1371,14 @@ export default function SdlcScreen(): ReactElement {
   };
 
   const createTrackAction = async (): Promise<void> => {
-    if (!repo || repo instanceof Error) return;
+    if (!repo || !channel) return;
     const id = uuidv4();
     await runTrackMutation(
       zero.mutate(
         mutators.sdlc.createTrack({
           id,
-          repoId: repo.id,
+          linkId: uuidv4(),
+          channelId: channel.id,
           name: trackName.trim(),
           ...(trackDescription.trim() ? { description: trackDescription.trim() } : {}),
           timestamp: Date.now(),
@@ -1337,7 +1389,7 @@ export default function SdlcScreen(): ReactElement {
     setTrackName('');
     setTrackDescription('');
     if (repoId) {
-      navigateWithinSdlc(`/sdlc/${repoId}/tracks`, `?track=${encodeURIComponent(id)}`);
+      navigateWithinSdlc(`/sdlc/${channelId}/tracks`, `?track=${encodeURIComponent(id)}`);
     }
   };
 
@@ -1356,7 +1408,7 @@ export default function SdlcScreen(): ReactElement {
   const openTrack = (trackId: string | null): void => {
     if (!repoId) return;
     navigateWithinSdlc(
-      `/sdlc/${repoId}/tracks`,
+      `/sdlc/${channelId}/tracks`,
       trackId ? `?track=${encodeURIComponent(trackId)}` : '',
     );
   };
@@ -1454,7 +1506,7 @@ export default function SdlcScreen(): ReactElement {
                     type='button'
                     key={ticket.id}
                     className='group mb-1.5 flex w-full items-start gap-3 rounded-xl bg-primary/5 px-3 py-3 text-left transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                    onClick={() => navigateWithinSdlc(`/sdlc/${repo.id}/tickets`)}
+                    onClick={() => navigateWithinSdlc(`/sdlc/${channelId}/tickets`)}
                     data-track-category='SdlcHub'
                     data-track-name='TrackTicketOpened'
                     data-track-metadata={JSON.stringify({ ticketId: ticket.id })}
@@ -1573,6 +1625,14 @@ export default function SdlcScreen(): ReactElement {
     );
   };
 
+  const activeTrackOptions = tracks
+    .filter(track => track.status !== 'ARCHIVED')
+    .map(track => ({
+      value: track.id,
+      label: track.name,
+      icon: <Layers className='size-4 text-muted-foreground' />,
+    }));
+
   const openArtifactCreate = (folder: { id: string; name: string }): void => {
     clearArtifactDialogFields();
     setArtifactDialog({ id: folder.id, name: folder.name });
@@ -1685,29 +1745,26 @@ export default function SdlcScreen(): ReactElement {
               </button>
             )}
           </div>
-          <Select
-            value={repo.id}
-            onValueChange={nextRepoId => void navigate(`/sdlc/${nextRepoId}/overview`)}
-          >
-            <SelectTrigger
-              className='mt-2 h-[34px] w-full rounded-[8px] border-sidebar-border-muted bg-foreground/[0.03] px-2.5 text-[13px] font-medium text-sidebar-foreground shadow-none hover:bg-foreground/[0.06] focus-visible:border-sidebar-accent-ring focus-visible:ring-sidebar-accent-ring/30'
-              aria-label='Repository'
+          <div className='mt-2 flex items-center gap-1.5'>
+            <div className='min-w-0 flex-1'>
+              <SdlcHubPicker
+                hubs={hubOptions}
+                selectedHubId={channel.id}
+                onSelect={nextChannelId => void navigate(`/sdlc/${nextChannelId}/overview`)}
+              />
+            </div>
+            <button
+              type='button'
+              className='grid size-[34px] shrink-0 place-items-center rounded-[8px] border border-sidebar-border-muted bg-foreground/[0.03] text-sidebar-foreground/70 transition-colors hover:bg-foreground/[0.06] hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-accent-ring'
+              onClick={() => setHubDialog('create')}
+              title='New hub'
+              aria-label='New hub'
               data-track-category='SdlcHub'
-              data-track-name='RepositoryChanged'
+              data-track-name='NewHubOpened'
             >
-              <span className='flex min-w-0 items-center gap-2'>
-                <GitBranch className='size-3.5 shrink-0 text-sidebar-foreground/70' />
-                <SelectValue />
-              </span>
-            </SelectTrigger>
-            <SelectContent>
-              {repos.map(item => (
-                <SelectItem key={item.id} value={item.id}>
-                  {item.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+              <Plus className='size-3.5' />
+            </button>
+          </div>
         </div>
         <nav className='shrink-0 px-2 pt-2'>
           {SECTIONS.map(item => {
@@ -1715,7 +1772,7 @@ export default function SdlcScreen(): ReactElement {
             return (
               <div key={item.id} className='mb-0.5'>
                 <button
-                  onClick={() => navigateWithinSdlc(`/sdlc/${repo.id}/${item.id}`)}
+                  onClick={() => navigateWithinSdlc(`/sdlc/${channelId}/${item.id}`)}
                   className={cn(
                     'flex h-[34px] w-full items-center gap-2.5 rounded-[7px] px-2 text-[13.5px] text-sidebar-foreground transition-colors',
                     section === item.id
@@ -1809,7 +1866,7 @@ export default function SdlcScreen(): ReactElement {
                     <button
                       onClick={() =>
                         navigateWithinSdlc(
-                          `/sdlc/${repo.id}/artifacts`,
+                          `/sdlc/${channelId}/artifacts`,
                           `?type=${encodeURIComponent(folder.id)}`,
                         )
                       }
@@ -2002,17 +2059,10 @@ export default function SdlcScreen(): ReactElement {
                 <ChevronRight className='size-3.5 shrink-0 text-sidebar-foreground/55' />
               </button>
             )}
-            <a
-              href={repo.canonicalUrl || repo.url}
-              target='_blank'
-              rel='noreferrer'
-              className='flex w-full items-center gap-2 rounded-lg px-2 py-2 font-medium transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-accent-ring'
-              aria-label={`Open ${repo.name} repository`}
-            >
-              <GitBranch className='size-4 shrink-0 text-sidebar-foreground/65' />
-              <span className='min-w-0 flex-1 truncate'>Open repository</span>
-              <ExternalLink className='size-3.5 shrink-0 text-sidebar-foreground/55' />
-            </a>
+            <SdlcHubRepositories
+              repositories={channelRepos}
+              onManage={() => setHubDialog('manage')}
+            />
           </div>
         </div>
       </aside>
@@ -2116,7 +2166,6 @@ export default function SdlcScreen(): ReactElement {
                         return {
                           sdlcLink: {
                             ownerType: 'CANVAS',
-                            repoId: repo.id,
                             ownerId: discussionOwner.canvasId,
                           },
                         };
@@ -2125,7 +2174,6 @@ export default function SdlcScreen(): ReactElement {
                         return {
                           sdlcLink: {
                             ownerType: 'TRACK',
-                            repoId: repo.id,
                             ownerId: selectedTrack.id,
                           },
                         };
@@ -2642,36 +2690,19 @@ export default function SdlcScreen(): ReactElement {
                   </label>
                   <span className='text-[12.5px] text-destructive'>required</span>
                 </div>
-                <div className='relative flex'>
-                  <select
-                    id='sdlc-prd-track'
-                    disabled={artifactContextLocked}
-                    value={artifactTrack?.id ?? ''}
-                    onChange={event => {
-                      const track = tracks.find(item => item.id === event.target.value);
+                {/* Locked when a Tech Doc is derived from a PRD: the track comes with it. */}
+                <div className={cn(artifactContextLocked && 'pointer-events-none opacity-60')}>
+                  <EntitySelector
+                    options={activeTrackOptions}
+                    selectedValue={artifactTrack?.id ?? null}
+                    onSelect={value => {
+                      const track = tracks.find(item => item.id === value);
                       setArtifactTrack(track ? { id: track.id, name: track.name } : null);
                     }}
-                    className={cn(
-                      'h-[38px] w-full cursor-pointer appearance-none rounded-lg border bg-background pl-3 pr-9 text-[13.5px]',
-                      artifactContextLocked && 'cursor-not-allowed opacity-60',
-                    )}
-                    data-track-category='SdlcHub'
-                    data-track-name='PrdTrackChanged'
-                  >
-                    <option value='' disabled>
-                      Select a track
-                    </option>
-                    {tracks
-                      .filter(track => track.status !== 'ARCHIVED')
-                      .map(track => (
-                        <option key={track.id} value={track.id}>
-                          {track.name}
-                        </option>
-                      ))}
-                  </select>
-                  <ChevronDown
-                    size={14}
-                    className='pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground'
+                    placeholder='Select a track'
+                    searchPlaceholder='Search tracks...'
+                    width='100%'
+                    matchTriggerWidth
                   />
                 </div>
               </div>
@@ -2885,6 +2916,18 @@ export default function SdlcScreen(): ReactElement {
         </form>
       </Dialog>
 
+      <SdlcHubDialog
+        projectId={channel.projectId}
+        open={hubDialog !== null}
+        onOpenChange={open => setHubDialog(open ? hubDialog : null)}
+        {...(hubDialog === 'manage'
+          ? { hub: { channelId: channel.id, repoIds: channelRepos.map(item => item.id) } }
+          : {})}
+        onSaved={savedChannelId => {
+          if (savedChannelId !== channelId) void navigate(`/sdlc/${savedChannelId}/overview`);
+        }}
+      />
+
       <Dialog
         open={typeDialogOpen}
         onOpenChange={open => {
@@ -2968,6 +3011,7 @@ export default function SdlcScreen(): ReactElement {
                   'link',
                   async () => {
                     await apiInstance.post(`/sdlc/repositories/${repo.id}/links`, {
+                      channelId,
                       sourceType: 'CANVAS',
                       sourceId: relatedSourceId,
                       targetType: linkTargetType,

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -858,13 +858,20 @@ export default function SdlcScreen(): ReactElement {
     return search;
   };
 
-  const openCanvasInWindow = (canvasId: string, withDiscussion: boolean): boolean => {
+  const openWindowForCanvas = (
+    targetSection: string,
+    canvasId: string,
+    search: URLSearchParams,
+  ): boolean => {
     if (!workspaceId || !repoId) return false;
     return openStandaloneWindow(
-      `/sdlc/${workspaceId}/${repoId}/${section}?${canvasSearch(canvasId, withDiscussion).toString()}`,
+      `/sdlc/${workspaceId}/${repoId}/${targetSection}?${search.toString()}`,
       `sdlc-canvas:${canvasId}`,
     );
   };
+
+  const openCanvasInWindow = (canvasId: string, withDiscussion: boolean): boolean =>
+    openWindowForCanvas(section, canvasId, canvasSearch(canvasId, withDiscussion));
 
   const openCanvas = (canvasId: string, options?: OpenCanvasOptions): void => {
     if (!repoId) return;
@@ -883,12 +890,17 @@ export default function SdlcScreen(): ReactElement {
     );
   };
 
-  const openArtifactCanvas = (canvasId: string): void => {
+  const openArtifactCanvas = (canvasId: string, event?: ReactMouseEvent): void => {
     if (!repoId) return;
     const folder = typeFolders.find(item => item.canvases.some(canvas => canvas.id === canvasId));
-    setRelatedSourceId(null);
-    const search = new URLSearchParams({ canvas: canvasId });
+    const search = canvasSearch(canvasId, true);
     if (folder) search.set('type', folder.id);
+
+    if (shouldOpenInNewWindow(event) && openWindowForCanvas('artifacts', canvasId, search)) {
+      return;
+    }
+
+    setRelatedSourceId(null);
     navigateWithinSdlc(
       `/sdlc/${repoId}/artifacts`,
       `?${search.toString()}`,
@@ -1398,7 +1410,7 @@ export default function SdlcScreen(): ReactElement {
                         type='button'
                         key={canvas.id}
                         className='group mb-1.5 flex w-full items-start gap-3 rounded-xl bg-primary/5 px-3 py-3 text-left transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-                        onClick={() => openArtifactCanvas(canvas.id)}
+                        onClick={event => openArtifactCanvas(canvas.id, event)}
                         data-track-category='SdlcHub'
                         data-track-name='TrackArtifactOpened'
                         data-track-metadata={JSON.stringify({
@@ -2064,7 +2076,7 @@ export default function SdlcScreen(): ReactElement {
                     variant='ghost'
                     aria-label='Open in new window'
                     title='Open in new window'
-                    onClick={() => openCanvasInWindow(selectedCanvasId, chatLayout.panelOpen)}
+                    onClick={() => openCanvasInWindow(selectedCanvasId, true)}
                     data-track-category='SdlcHub'
                     data-track-name='ArtifactOpenedInWindow'
                   >

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -1,4 +1,13 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+} from 'react';
 import {
   ChannelRole,
   isBaselineCanvasType,
@@ -37,11 +46,16 @@ import {
   Search,
   ShieldCheck,
   Sparkles,
+  SquareArrowOutUpRight,
   Trash2,
   Users,
   X,
 } from 'lucide-react';
-import { isFramedSdlcSurface, requestSdlcFrameReset } from './useSdlcFrameBridge';
+import {
+  isFramedSdlcSurface,
+  isSdlcDocumentWindow,
+  requestSdlcFrameReset,
+} from './useSdlcFrameBridge';
 import { toast } from 'sonner';
 import AppNavigator from '../../components/AppNavigator/AppNavigator';
 import { Button } from '../../components/ui/Button';
@@ -77,6 +91,11 @@ import {
 } from '../../components/Chat/XyneAISidebar/components/ContextPickerPanel';
 import { useExternalDebuggerStore } from '../../store/useExternalDebuggerStore';
 import CanvasScreen from '../../components/Canvas/CanvasScreen';
+import {
+  isElectronApp,
+  openStandaloneWindow,
+  shouldOpenInNewWindow,
+} from '../../utils/electronApp';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
 import KanbanBoardScreen from '../KanbanBoardScreen/KanbanBoardScreen';
 import { buildSdlcArtifactCreationPrompt } from './artifactCreationPrompt';
@@ -174,7 +193,15 @@ function actionErrorMessage(error: unknown): string {
 }
 
 export default function SdlcScreen(): ReactElement {
-  const { repoId, section: routeSection } = useParams<{ repoId?: string; section?: string }>();
+  const {
+    workspaceId,
+    repoId,
+    section: routeSection,
+  } = useParams<{
+    workspaceId?: string;
+    repoId?: string;
+    section?: string;
+  }>();
   const navigate = useNavigate();
   const location = useLocation();
   const auth = useAuthContextValues();
@@ -814,12 +841,44 @@ export default function SdlcScreen(): ReactElement {
     [location.search, navigate, ownerHasConversations],
   );
 
-  const openCanvas = (canvasId: string): void => {
+  interface OpenCanvasOptions {
+    event?: ReactMouseEvent | undefined;
+    withDiscussion?: boolean;
+  }
+
+  const canvasSearch = (canvasId: string, withDiscussion: boolean): URLSearchParams => {
+    const search = new URLSearchParams({ canvas: canvasId });
+    if (
+      withDiscussion &&
+      ownerHasConversations(resolveCanvasDiscussionOwner(canvasId, canvases)?.canvasId ?? null)
+    ) {
+      search.set('discussion', '1');
+      search.set('chat', 'conversations');
+    }
+    return search;
+  };
+
+  const openCanvasInWindow = (canvasId: string, withDiscussion: boolean): boolean => {
+    if (!workspaceId || !repoId) return false;
+    return openStandaloneWindow(
+      `/sdlc/${workspaceId}/${repoId}/${section}?${canvasSearch(canvasId, withDiscussion).toString()}`,
+      `sdlc-canvas:${canvasId}`,
+    );
+  };
+
+  const openCanvas = (canvasId: string, options?: OpenCanvasOptions): void => {
     if (!repoId) return;
+
+    const withDiscussion = Boolean(options?.withDiscussion);
+    if (shouldOpenInNewWindow(options?.event) && openCanvasInWindow(canvasId, withDiscussion)) {
+      return;
+    }
+
     setRelatedSourceId(null);
+    const search = canvasSearch(canvasId, withDiscussion);
     navigateWithinSdlc(
       `/sdlc/${repoId}/${section}`,
-      `?canvas=${encodeURIComponent(canvasId)}`,
+      `?${search.toString()}`,
       resolveCanvasDiscussionOwner(canvasId, canvases)?.canvasId ?? null,
     );
   };
@@ -1555,7 +1614,7 @@ export default function SdlcScreen(): ReactElement {
                   title={canvas.title}
                   eyebrow={folder.name}
                   {...(cardMeta.length > 0 && { meta: cardMeta })}
-                  onOpen={() => openCanvas(canvas.id)}
+                  onOpen={event => openCanvas(canvas.id, { event, withDiscussion: true })}
                   actionLabel='Create Artifact'
                   onAction={() => {
                     setDeriveTypeId(null);
@@ -1575,6 +1634,8 @@ export default function SdlcScreen(): ReactElement {
     );
   };
 
+  const isDocumentWindow = isSdlcDocumentWindow();
+
   return (
     <div className='flex h-full min-w-0 overflow-hidden bg-transparent'>
       <aside
@@ -1585,6 +1646,7 @@ export default function SdlcScreen(): ReactElement {
             (section === 'tracks' && selectedTrack)
             ? 'w-72'
             : 'w-[260px]',
+          isDocumentWindow && 'hidden',
         )}
         style={{ backdropFilter: 'blur(var(--sidebar-background-blur))' }}
       >
@@ -1996,6 +2058,19 @@ export default function SdlcScreen(): ReactElement {
                 )}
               </div>
               <div className='flex shrink-0 items-center gap-2'>
+                {selectedCanvasId && isElectronApp() && !isDocumentWindow ? (
+                  <Button
+                    size='icon'
+                    variant='ghost'
+                    aria-label='Open in new window'
+                    title='Open in new window'
+                    onClick={() => openCanvasInWindow(selectedCanvasId, chatLayout.panelOpen)}
+                    data-track-category='SdlcHub'
+                    data-track-name='ArtifactOpenedInWindow'
+                  >
+                    <SquareArrowOutUpRight className='size-4' />
+                  </Button>
+                ) : null}
                 {chatPanelAvailable ? (
                   <Button
                     size='icon'
@@ -3049,7 +3124,7 @@ function ArtifactCard({
   title: string;
   eyebrow: string;
   meta?: string[];
-  onOpen: () => void;
+  onOpen: (event?: ReactMouseEvent) => void;
   onAction: () => void;
   onCreateTicket: () => void;
   actionLabel: string;

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcWindow.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcWindow.tsx
@@ -1,0 +1,74 @@
+import { ReactElement, useEffect, useRef, useState } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { SDLC_APP_BASE_PATH } from '../../config';
+import { useCallJoinOrInitiate } from '../../hooks/useCallJoinOrInitiate';
+import { parseSdlcFrameMessage, SDLC_FRAME_MESSAGE } from './sdlcFrameMessages';
+import { SDLC_WINDOW_FRAME_NAME } from './useSdlcFrameBridge';
+
+/**
+ * The SDLC lane as a whole window, at /newWindow/sdlc/:workspaceId/:repoId/:section.
+ * Hosts the same iframe SdlcFrameHost does, without its viewport and portal: here
+ * the frame is the window, so it is never hidden or reparented.
+ */
+const SdlcWindow = (): ReactElement => {
+  const { workspaceId, repoId, section } = useParams<{
+    workspaceId: string;
+    repoId: string;
+    section: string;
+  }>();
+  const location = useLocation();
+
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  const { initiateCall } = useCallJoinOrInitiate();
+  const initiateCallRef = useRef(initiateCall);
+  initiateCallRef.current = initiateCall;
+
+  const [src, setSrc] = useState(
+    () => `${SDLC_APP_BASE_PATH}/${workspaceId}/sdlc/${repoId}/${section}${location.search}`,
+  );
+  const [resetCount, setResetCount] = useState(0);
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent): void => {
+      if (event.origin !== window.location.origin) return;
+      if (!iframeRef.current || event.source !== iframeRef.current.contentWindow) return;
+
+      const message = parseSdlcFrameMessage(event.data);
+      if (!message) return;
+
+      if (message.type === SDLC_FRAME_MESSAGE.initiateCall) {
+        initiateCallRef.current({
+          channelId: message.channelId,
+          ...(message.targetUserIds && { targetUserIds: message.targetUserIds }),
+          ...(message.callDisplayName && { callDisplayName: message.callDisplayName }),
+          ...(message.conversationId && { conversationId: message.conversationId }),
+          ...(message.sdlcLink && { sdlcLink: message.sdlcLink }),
+        });
+        return;
+      }
+
+      if (message.type === SDLC_FRAME_MESSAGE.reset) {
+        setSrc(`${SDLC_APP_BASE_PATH}/${workspaceId}/sdlc?_reset=${Date.now()}`);
+        setResetCount(count => count + 1);
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+    return (): void => window.removeEventListener('message', onMessage);
+  }, [workspaceId]);
+
+  return (
+    <iframe
+      key={resetCount}
+      ref={iframeRef}
+      src={src}
+      title='SDLC'
+      name={SDLC_WINDOW_FRAME_NAME}
+      className='h-full w-full border-0'
+      allow='clipboard-read; clipboard-write'
+    />
+  );
+};
+
+export default SdlcWindow;

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcWindow.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcWindow.tsx
@@ -6,14 +6,14 @@ import { parseSdlcFrameMessage, SDLC_FRAME_MESSAGE } from './sdlcFrameMessages';
 import { SDLC_WINDOW_FRAME_NAME } from './useSdlcFrameBridge';
 
 /**
- * The SDLC lane as a whole window, at /newWindow/sdlc/:workspaceId/:repoId/:section.
+ * The SDLC lane as a whole window, at /newWindow/sdlc/:workspaceId/:channelId/:section.
  * Hosts the same iframe SdlcFrameHost does, without its viewport and portal: here
  * the frame is the window, so it is never hidden or reparented.
  */
 const SdlcWindow = (): ReactElement => {
-  const { workspaceId, repoId, section } = useParams<{
+  const { workspaceId, channelId, section } = useParams<{
     workspaceId: string;
-    repoId: string;
+    channelId: string;
     section: string;
   }>();
   const location = useLocation();
@@ -25,7 +25,7 @@ const SdlcWindow = (): ReactElement => {
   initiateCallRef.current = initiateCall;
 
   const [src, setSrc] = useState(
-    () => `${SDLC_APP_BASE_PATH}/${workspaceId}/sdlc/${repoId}/${section}${location.search}`,
+    () => `${SDLC_APP_BASE_PATH}/${workspaceId}/sdlc/${channelId}/${section}${location.search}`,
   );
   const [resetCount, setResetCount] = useState(0);
 

--- a/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
@@ -8,6 +8,14 @@ export function isFramedSdlcSurface(): boolean {
   return isSdlcSurface && typeof window !== 'undefined' && window.parent !== window;
 }
 
+/** Frame name SdlcWindow gives its iframe; survives the lane's own navigations. */
+export const SDLC_WINDOW_FRAME_NAME = 'xyne-sdlc-window';
+
+/** True in a popped-out document window, where the lane hides its hub sidebar. */
+export function isSdlcDocumentWindow(): boolean {
+  return isFramedSdlcSurface() && window.name === SDLC_WINDOW_FRAME_NAME;
+}
+
 /**
  * Escape hatch for a wedged frame. It is long-lived by design, so without this
  * the only way to a clean one is reloading the whole dashboard.

--- a/apps/dashboard/src/utils/electronApp.ts
+++ b/apps/dashboard/src/utils/electronApp.ts
@@ -142,6 +142,55 @@ export const standaloneNavigate = (
   void navigate(normalizedPath, navigateOptions);
 };
 
+export const shouldOpenInNewWindow = (event?: { metaKey: boolean; ctrlKey: boolean }): boolean =>
+  Boolean(event && (event.metaKey || event.ctrlKey) && isElectronApp());
+
+const standaloneWindows = new Map<string, Window>();
+
+const STANDALONE_WINDOW_PREFIX = 'xyne-window:';
+
+let standaloneOpenCount = 0;
+
+const standaloneWindowTarget = (key: string): string => {
+  if (!isElectronApp()) {
+    return `${STANDALONE_WINDOW_PREFIX}${key}`;
+  }
+  standaloneOpenCount += 1;
+  return `${STANDALONE_WINDOW_PREFIX}${key}#${standaloneOpenCount}`;
+};
+
+export const openStandaloneWindow = (path: string, key?: string): boolean => {
+  if (typeof window === 'undefined' || !path) {
+    return false;
+  }
+
+  if (key && !isElectronApp()) {
+    const existing = standaloneWindows.get(key);
+    if (existing && !existing.closed) {
+      existing.focus();
+      return true;
+    }
+    standaloneWindows.delete(key);
+  }
+
+  const opened = window.open(toStandalonePath(path), key ? standaloneWindowTarget(key) : '_blank');
+  if (!opened) {
+    if (key && isElectronApp() && standaloneWindows.has(key)) {
+      return true;
+    }
+    logger.warn(LogEvent.FRONTEND_ERROR, {
+      type: 'migrated_console_warn',
+      message: String('Failed to open standalone window; popup may be blocked'),
+    });
+    return false;
+  }
+  if (key) {
+    standaloneWindows.set(key, opened);
+  }
+  opened.focus();
+  return true;
+};
+
 export interface CreateTicketPopoutDraft {
   popoutId: string;
   workspaceId?: string | null | undefined;

--- a/apps/electron/src/services/request-interceptor.ts
+++ b/apps/electron/src/services/request-interceptor.ts
@@ -159,6 +159,20 @@ const RESTRICTED_MEDIA_PERMISSIONS = new Set(['media', 'display-capture', 'media
 const FIRST_PARTY_NONMEDIA_PERMISSIONS = new Set([
   'clipboard-sanitized-write', 'clipboard-read', 'fullscreen', 'pointerLock',
 ]);
+const appOwnedWindows = new Set<BrowserWindow>();
+
+export function registerAppOwnedWindow(window: BrowserWindow): void {
+  appOwnedWindows.add(window);
+  window.once('closed', () => appOwnedWindows.delete(window));
+}
+
+function isAppOwnedWindowContents(webContents: Electron.WebContents | undefined): boolean {
+  if (!webContents) return false;
+  const owner = BrowserWindow.fromWebContents(webContents);
+  if (!owner || owner.isDestroyed()) return false;
+  return owner.webContents === webContents && appOwnedWindows.has(owner);
+}
+
 function isTopLevelMainWindow(webContents: Electron.WebContents | undefined): boolean {
   if (!webContents) return false;
   if (!mainWindow || mainWindow.isDestroyed()) return false;
@@ -179,9 +193,11 @@ function isFirstPartyUrl(rawUrl: string | undefined): boolean {
   }
 }
 function installMediaPermissionGuard(targetSession: Electron.Session, label: string): void {
-  targetSession.setPermissionRequestHandler((webContents, permission, callback) => {
+  targetSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
     if (RESTRICTED_MEDIA_PERMISSIONS.has(permission)) {
-      const allowed = isTopLevelMainWindow(webContents);
+      const allowed =
+        isTopLevelMainWindow(webContents) ||
+        (isAppOwnedWindowContents(webContents) && isFirstPartyUrl(details?.requestingUrl));
       if (!allowed) {
         Logger.warn(
           `[permissions:${label}] denied ${permission} for non-main webContents (url=${webContents?.getURL() ?? 'n/a'})`,
@@ -206,9 +222,12 @@ function installMediaPermissionGuard(targetSession: Electron.Session, label: str
     );
     callback(false);
   });
-  targetSession.setPermissionCheckHandler((webContents, permission) => {
+  targetSession.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
     if (RESTRICTED_MEDIA_PERMISSIONS.has(permission)) {
-      return isTopLevelMainWindow(webContents ?? undefined);
+      return (
+        isTopLevelMainWindow(webContents ?? undefined) ||
+        (isAppOwnedWindowContents(webContents ?? undefined) && isFirstPartyUrl(requestingOrigin))
+      );
     }
     // Non-media permission checks succeed for the first-party main window,
     // and for the narrow clipboard/fullscreen set on first-party content hosted outside

--- a/apps/electron/src/window/manager.ts
+++ b/apps/electron/src/window/manager.ts
@@ -5,7 +5,10 @@ import { config } from '../app/config';
 import { getIsQuitting } from '../app/main';
 import { setMainWindow as setDeepLinksMainWindow } from '../services/deep-links';
 import { setupPermissionRequestOnFocus } from '../services/media-permission';
-import { setMainWindow as setInterceptorMainWindow } from '../services/request-interceptor';
+import {
+  registerAppOwnedWindow,
+  setMainWindow as setInterceptorMainWindow,
+} from '../services/request-interceptor';
 import { getBundledUIUrl } from '../services/custom-protocol';
 import { browserSettingsService } from '../services/browser-settings';
 import { getCreateOptions, applyPostCreate, track, saveNow } from './window-state';
@@ -110,6 +113,21 @@ export async function loadApp(window: BrowserWindow) {
   }
 }
 
+const namedChildWindows = new Map<string, BrowserWindow>();
+
+const STANDALONE_WINDOW_PREFIX = 'xyne-window:';
+
+function standaloneWindowKey(frameName: string | undefined): string | null {
+  if (!frameName || !frameName.startsWith(STANDALONE_WINDOW_PREFIX)) return null;
+  return frameName.slice(STANDALONE_WINDOW_PREFIX.length).split('#')[0] || null;
+}
+
+function focusWindow(window: BrowserWindow): void {
+  if (window.isMinimized()) window.restore();
+  window.show();
+  window.focus();
+}
+
 /**
  * Creates the main application window
  */
@@ -189,6 +207,16 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
       }
       
       // Internal URLs - allow new window
+      const windowKey = standaloneWindowKey(details.frameName);
+      if (windowKey) {
+        const existing = namedChildWindows.get(windowKey);
+        if (existing && !existing.isDestroyed()) {
+          focusWindow(existing);
+          return { action: 'deny' };
+        }
+        namedChildWindows.delete(windowKey);
+      }
+
       if (urlObj.pathname.startsWith('/newWindow/create-ticket')) {
         return {
           action: 'allow',
@@ -207,6 +235,19 @@ export async function createMainWindow(options?: { inactive?: boolean }): Promis
       return { action: 'deny' };
     }
 });
+
+  mainWindow.webContents.on('did-create-window', (childWindow, details) => {
+    registerAppOwnedWindow(childWindow);
+
+    const windowKey = standaloneWindowKey(details.frameName);
+    if (!windowKey) return;
+    namedChildWindows.set(windowKey, childWindow);
+    childWindow.on('closed', () => {
+      if (namedChildWindows.get(windowKey) === childWindow) {
+        namedChildWindows.delete(windowKey);
+      }
+    });
+  });
 
   // Plain <a href> clicks bypass setWindowOpenHandler; intercept here to keep the app from being replaced.
   mainWindow.webContents.on('will-navigate', (event, navUrl) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xyne-spaces",
   "license": "Apache-2.0",
-  "version": "1.219.0-release-20260825.17",
+  "version": "1.219.0-release-20260825.18",
   "description": "Xyne Spaces - Monorepo with Backend and Dashboard",
   "scripts": {
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xyne-spaces",
   "license": "Apache-2.0",
-  "version": "1.219.0-release-20260825.18",
+  "version": "1.219.0-release-20260825.19",
   "description": "Xyne Spaces - Monorepo with Backend and Dashboard",
   "scripts": {
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xyne-spaces",
   "license": "Apache-2.0",
-  "version": "1.219.0-release-20260825.16",
+  "version": "1.219.0-release-20260825.17",
   "description": "Xyne Spaces - Monorepo with Backend and Dashboard",
   "scripts": {
     "prepare": "husky",

--- a/packages/shared/src/sdlc.ts
+++ b/packages/shared/src/sdlc.ts
@@ -122,7 +122,27 @@ export const SDLC_ENTITY_TYPES = [
 export const sdlcEntityTypeSchema = z.enum(SDLC_ENTITY_TYPES);
 export type SdlcEntityType = z.infer<typeof sdlcEntityTypeSchema>;
 
-export const SDLC_RELATION_TYPES = [
+/**
+ * A CHANNEL -> REPOSITORY edge: the repository belongs to that hub. It shares a
+ * table with the content graph, so every read of that graph excludes it — grep
+ * this constant for those call sites. Written only by the hub endpoints.
+ */
+export const SDLC_MEMBERSHIP_RELATION = "REPOSITORY";
+
+/**
+ * A CHANNEL -> TRACK edge: the track belongs to that hub. Tracks carry no scope
+ * column of their own, so this edge is the only thing that places one.
+ */
+export const SDLC_TRACK_MEMBERSHIP_RELATION = "TRACK";
+
+/** Structure, not content. Every read of the content graph excludes these. */
+export const SDLC_STRUCTURAL_RELATIONS = [
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
+] as const;
+
+/** Relation types a user may create or delete through the generic link API. */
+export const SDLC_CONTENT_RELATION_TYPES = [
   "TICKET",
   "CONTEXT",
   "PULL_REQUEST",
@@ -132,7 +152,13 @@ export const SDLC_RELATION_TYPES = [
   "CALL",
 ] as const;
 
+export const SDLC_RELATION_TYPES = [
+  ...SDLC_CONTENT_RELATION_TYPES,
+  ...SDLC_STRUCTURAL_RELATIONS,
+] as const;
+
 export const sdlcRelationTypeSchema = z.enum(SDLC_RELATION_TYPES);
+export const sdlcContentRelationTypeSchema = z.enum(SDLC_CONTENT_RELATION_TYPES);
 export type SdlcRelationType = z.infer<typeof sdlcRelationTypeSchema>;
 
 export const sdlcDiscussionSchema = z
@@ -166,7 +192,6 @@ export const sdlcTrackStatusSchema = z.enum(SDLC_TRACK_STATUSES);
  * OWNER -> CALL [CALL] and OWNER -> CONVERSATION [DISCUSSION] links.
  */
 export const sdlcCallLinkSchema = z.object({
-  repoId: z.string().min(1),
   ownerType: z.enum(["CANVAS", "TRACK"]),
   ownerId: z.string().min(1),
 });
@@ -185,6 +210,21 @@ export const SDLC_SETUP_STATUSES = [
 
 export const sdlcSetupStatusSchema = z.enum(SDLC_SETUP_STATUSES);
 export type SdlcSetupStatus = z.infer<typeof sdlcSetupStatusSchema>;
+
+export const createSdlcChannelSchema = z.object({
+  projectId: z.string().min(1),
+  name: z.string().trim().min(1).max(120),
+  // At least one: a hub with no repositories has no screen to render.
+  repoIds: z.array(z.string().min(1)).min(1).max(100),
+});
+export type CreateSdlcChannelInput = z.infer<typeof createSdlcChannelSchema>;
+
+export const addSdlcChannelRepositoriesSchema = z.object({
+  repoIds: z.array(z.string().min(1)).min(1).max(100),
+});
+export type AddSdlcChannelRepositoriesInput = z.infer<
+  typeof addSdlcChannelRepositoriesSchema
+>;
 
 export const attachSdlcRepositorySchema = z.object({
   projectId: z.string().min(1),
@@ -588,6 +628,8 @@ export type BootstrapSdlcRuntimeCredentialInput = z.infer<
 export const createSdlcClawArtifactSchema = z
   .object({
     repoId: z.string().min(1),
+    // The hub to write into. A repository sits in several, so it cannot be inferred.
+    channelId: z.string().min(1).optional(),
     kind: sdlcArtifactKindSchema.optional(),
     folderId: z.string().min(1).optional(),
     title: z.string().trim().min(1).max(255),
@@ -678,12 +720,14 @@ export const createSdlcLinkSchema = z.object({
   sourceId: z.string().min(1),
   targetType: sdlcEntityTypeSchema,
   targetId: z.string().min(1),
-  relationType: sdlcRelationTypeSchema,
+  // Content relations only: membership is not a link a caller may forge.
+  relationType: sdlcContentRelationTypeSchema,
 });
 export type CreateSdlcLinkInput = z.infer<typeof createSdlcLinkSchema>;
 
 export const createSdlcTrackSchema = z.object({
   repoId: z.string().min(1),
+  channelId: z.string().min(1).optional(),
   name: z.string().trim().min(1).max(120),
   description: z.string().trim().max(2000).optional(),
 });
@@ -691,6 +735,7 @@ export type CreateSdlcTrackInput = z.infer<typeof createSdlcTrackSchema>;
 
 export const createSdlcArtifactTypeSchema = z.object({
   repoId: z.string().min(1),
+  channelId: z.string().min(1).optional(),
   name: z.string().trim().min(1).max(80),
 });
 export type CreateSdlcArtifactTypeInput = z.infer<typeof createSdlcArtifactTypeSchema>;

--- a/packages/shared/src/zero/acl/tables/repos-acl.ts
+++ b/packages/shared/src/zero/acl/tables/repos-acl.ts
@@ -1,4 +1,5 @@
 import type { Query } from '@rocicorp/zero';
+import { SDLC_MEMBERSHIP_RELATION } from '../../../sdlc';
 import type { Schema, Context } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import { denyGuestSelect, isGuestContext } from '../core/guest-acl-utils';
@@ -15,14 +16,32 @@ export class ReposACL extends BaseQueryACL<'repos'> {
 
     return query
       .where('workspaceId', '=', this.ctx.workspaceId)
-      .where(({ or, cmp, exists }) =>
+      .where(({ or, and, not, exists }) =>
         or(
-          // Legacy IDE repositories are not SDLC hubs.
-          cmp('channelId', 'IS', null),
-          exists('channel', (channel) =>
-            channel.whereExists('participants', (participant) =>
-              participant.where('userId', '=', this.ctx.userID),
+          // In no hub: the pool the hub picker offers, readable by the project's
+          // own people. Legacy IDE repositories carry no project and stay hidden.
+          and(
+            not(
+              exists('sdlcEntityLinks', (link) =>
+                link.where('relationType', '=', SDLC_MEMBERSHIP_RELATION),
+              ),
             ),
+            exists('project', (project) =>
+              project.whereExists('channels', (channel) =>
+                channel.whereExists('participants', (participant) =>
+                  participant.where('userId', '=', this.ctx.userID),
+                ),
+              ),
+            ),
+          ),
+          exists('sdlcEntityLinks', (link) =>
+            link
+              .where('relationType', '=', SDLC_MEMBERSHIP_RELATION)
+              .whereExists('channel', (channel) =>
+                channel.whereExists('participants', (participant) =>
+                  participant.where('userId', '=', this.ctx.userID),
+                ),
+              ),
           ),
         ),
       );

--- a/packages/shared/src/zero/acl/tables/sdlc-artifacts-acl.ts
+++ b/packages/shared/src/zero/acl/tables/sdlc-artifacts-acl.ts
@@ -17,8 +17,10 @@ export class SdlcArtifactsACL extends BaseQueryACL<'sdlc_artifacts'> {
 
     return query
       .where('workspaceId', '=', this.ctx.workspaceId)
-      .whereExists('repo', (repo) =>
-        repo.whereExists('channel', (channel) =>
+      // The artifact's own canvas, not its repository: going through the repository
+      // would leak metadata from every other hub that covers it.
+      .whereExists('canvas', (canvas) =>
+        canvas.whereExists('channel', (channel) =>
           channel.whereExists('participants', (participant) =>
             participant.where('userId', '=', this.ctx.userID),
           ),

--- a/packages/shared/src/zero/acl/tables/sdlc-entity-links-acl.ts
+++ b/packages/shared/src/zero/acl/tables/sdlc-entity-links-acl.ts
@@ -15,13 +15,12 @@ export class SdlcEntityLinksACL extends BaseQueryACL<'sdlc_entity_links'> {
       return denyGuestSelect(query, 'id');
     }
 
+    // Links are channel-scoped: channelId is the only scope they carry.
     return query
       .where('workspaceId', '=', this.ctx.workspaceId)
-      .whereExists('repo', (repo) =>
-        repo.whereExists('channel', (channel) =>
-          channel.whereExists('participants', (participant) =>
-            participant.where('userId', '=', this.ctx.userID),
-          ),
+      .whereExists('channel', (channel) =>
+        channel.whereExists('participants', (participant) =>
+          participant.where('userId', '=', this.ctx.userID),
         ),
       );
   }

--- a/packages/shared/src/zero/acl/tables/sdlc-tracks-acl.ts
+++ b/packages/shared/src/zero/acl/tables/sdlc-tracks-acl.ts
@@ -1,4 +1,5 @@
 import type { Query } from '@rocicorp/zero';
+import { SDLC_TRACK_MEMBERSHIP_RELATION } from '../../../sdlc';
 import type { Context, Schema } from '../../schema';
 import { BaseQueryACL } from '../core/base-acl';
 import { denyGuestSelect, isGuestContext } from '../core/guest-acl-utils';
@@ -15,14 +16,17 @@ export class SdlcTracksACL extends BaseQueryACL<'sdlc_tracks'> {
       return denyGuestSelect(query, 'id');
     }
 
+    // A track carries no scope column; its CHANNEL -> TRACK edge is what places it in a hub.
     return query
       .where('workspaceId', '=', this.ctx.workspaceId)
-      .whereExists('repo', (repo) =>
-        repo.whereExists('channel', (channel) =>
-          channel.whereExists('participants', (participant) =>
-            participant.where('userId', '=', this.ctx.userID),
+      .whereExists('sdlcEntityLinks', (link) =>
+        link
+          .where('relationType', '=', SDLC_TRACK_MEMBERSHIP_RELATION)
+          .whereExists('channel', (channel) =>
+            channel.whereExists('participants', (participant) =>
+              participant.where('userId', '=', this.ctx.userID),
+            ),
           ),
-        ),
       );
   }
 }

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -83,6 +83,9 @@ import {
 } from '../utils/canvasFolderNameConflict.js';
 import { resolveCanvasHierarchy } from '../utils/canvasHierarchy.js';
 import {
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_STRUCTURAL_RELATIONS,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
   createSdlcLinkSchema,
   sdlcDiscussionSchema,
 } from '../sdlc.js';
@@ -1754,7 +1757,7 @@ export const mutators = defineMutators({
           await tx.mutate.sdlc_entity_links.insert({
             id: sdlcDiscussion.linkId,
             workspaceId: ctx.workspaceId,
-            repoId: sdlcDiscussion.repoId,
+            channelId,
             sourceType: sdlcDiscussion.ownerType,
             sourceId: sdlcDiscussion.ownerId,
             targetType: 'CONVERSATION',
@@ -7848,41 +7851,44 @@ export const mutators = defineMutators({
     createLink: defineMutator(
       createSdlcLinkSchema.extend({
         id: z.string(),
-        repoId: z.string(),
+        channelId: z.string(),
         timestamp: z.number(),
       }),
       async ({ tx, ctx, args }) => {
-        const repo = await tx.run(zql.repos.where('id', args.repoId).one());
-        if (!repo?.channelId) {
-          throw new Error('SDLC repository not found');
-        }
+        // Links belong to the hub. createSdlcLinkSchema already excludes the
+        // membership relation, so this cannot forge a CHANNEL -> REPOSITORY edge.
         const participant = await tx.run(
           zql.channel_participants
-            .where('channelId', repo.channelId)
+            .where('channelId', args.channelId)
             .where('userId', ctx.userID)
             .one(),
         );
         if (!participant) {
-          throw new Error('Repository membership required');
+          throw new Error('Hub membership required');
         }
-        const sourceExists = args.sourceType === 'CANVAS'
-          ? Boolean(await tx.run(
-              zql.canvases.where('id', args.sourceId).where('channelId', repo.channelId).one(),
-            ))
-          : args.sourceType === 'TICKET'
-            ? Boolean(await tx.run(
-                zql.tickets.where('id', args.sourceId).where('channelId', repo.channelId).one(),
-              ))
-            : args.sourceType === 'CHANNEL'
-              ? args.sourceId === repo.channelId
-              : false;
+        const sourceExists =
+          args.sourceType === 'CANVAS'
+            ? Boolean(
+                await tx.run(
+                  zql.canvases.where('id', args.sourceId).where('channelId', args.channelId).one(),
+                ),
+              )
+            : args.sourceType === 'TICKET'
+              ? Boolean(
+                  await tx.run(
+                    zql.tickets.where('id', args.sourceId).where('channelId', args.channelId).one(),
+                  ),
+                )
+              : args.sourceType === 'CHANNEL'
+                ? args.sourceId === args.channelId
+                : false;
         if (!sourceExists) {
-          throw new Error('Relationship source does not belong to this SDLC repository');
+          throw new Error('Relationship source does not belong to this SDLC hub');
         }
         await tx.mutate.sdlc_entity_links.insert({
           id: args.id,
           workspaceId: ctx.workspaceId,
-          repoId: args.repoId,
+          channelId: args.channelId,
           sourceType: args.sourceType,
           sourceId: args.sourceId,
           targetType: args.targetType,
@@ -7894,26 +7900,27 @@ export const mutators = defineMutators({
       },
     ),
     deleteLink: defineMutator(
-      z.object({ repoId: z.string(), linkId: z.string() }),
-      async ({ tx, ctx, args: { repoId, linkId } }) => {
-        const repo = await tx.run(zql.repos.where('id', repoId).one());
-        if (!repo?.channelId) {
-          throw new Error('SDLC repository not found');
-        }
+      z.object({ channelId: z.string(), linkId: z.string() }),
+      async ({ tx, ctx, args: { channelId, linkId } }) => {
         const participant = await tx.run(
           zql.channel_participants
-            .where('channelId', repo.channelId)
+            .where('channelId', channelId)
             .where('userId', ctx.userID)
             .one(),
         );
         if (!participant) {
-          throw new Error('Repository membership required');
+          throw new Error('Hub membership required');
         }
         const link = await tx.run(
-          zql.sdlc_entity_links.where('id', linkId).where('repoId', repoId).one(),
+          zql.sdlc_entity_links.where('id', linkId).where('channelId', channelId).one(),
         );
         if (!link) {
           throw new Error('SDLC relationship not found');
+        }
+        // Structural edges are not content: repository membership is detached through
+        // the hub API, track membership only with the track. The mutation ACL agrees.
+        if ((SDLC_STRUCTURAL_RELATIONS as readonly string[]).includes(link.relationType)) {
+          throw new Error('Structural SDLC edges are not deleted through the link API');
         }
         await tx.mutate.sdlc_entity_links.delete({ id: linkId });
       },
@@ -7922,35 +7929,45 @@ export const mutators = defineMutators({
     createTrack: defineMutator(
       z.object({
         id: z.string(),
-        repoId: z.string(),
+        linkId: z.string(),
+        channelId: z.string(),
         name: z.string().trim().min(1).max(120),
         description: z.string().trim().max(2000).optional(),
         timestamp: z.number(),
       }),
       async ({ tx, ctx, args }) => {
-        const repo = await tx.run(zql.repos.where('id', args.repoId).one());
-        if (!repo?.channelId) {
-          throw new Error('SDLC repository not found');
-        }
+        // Tracks belong to the hub, never to one repository in it.
         const participant = await tx.run(
           zql.channel_participants
-            .where('channelId', repo.channelId)
+            .where('channelId', args.channelId)
             .where('userId', ctx.userID)
             .one(),
         );
         if (!participant) {
-          throw new Error('Repository membership required');
+          throw new Error('Hub membership required');
         }
         await tx.mutate.sdlc_tracks.insert({
           id: args.id,
           workspaceId: ctx.workspaceId,
-          repoId: args.repoId,
           name: args.name,
           description: args.description,
           status: 'ACTIVE',
           createdBy: ctx.userID,
           createdAt: args.timestamp,
           updatedAt: args.timestamp,
+        });
+        // The track carries no scope column; this edge is what places it in the hub.
+        await tx.mutate.sdlc_entity_links.insert({
+          id: args.linkId,
+          workspaceId: ctx.workspaceId,
+          channelId: args.channelId,
+          sourceType: 'CHANNEL',
+          sourceId: args.channelId,
+          targetType: 'TRACK',
+          targetId: args.id,
+          relationType: SDLC_TRACK_MEMBERSHIP_RELATION,
+          createdBy: ctx.userID,
+          createdAt: args.timestamp,
         });
       },
     ),
@@ -7967,13 +7984,20 @@ export const mutators = defineMutators({
         if (!track) {
           throw new Error('SDLC track not found');
         }
-        const repo = await tx.run(zql.repos.where('id', track.repoId).one());
-        if (!repo?.channelId) {
-          throw new Error('SDLC repository not found');
+        const membership = await tx.run(
+          zql.sdlc_entity_links
+            .where('targetType', 'TRACK')
+            .where('targetId', args.trackId)
+            .where('relationType', SDLC_TRACK_MEMBERSHIP_RELATION)
+            .one(),
+        );
+        if (!membership?.channelId) {
+          throw new Error('SDLC channel not found');
         }
+        const channelId = membership.channelId;
         const participant = await tx.run(
           zql.channel_participants
-            .where('channelId', repo.channelId)
+            .where('channelId', channelId)
             .where('userId', ctx.userID)
             .one(),
         );

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -17,6 +17,11 @@ import {
 } from './schema.js';
 import { z } from 'zod';
 import {
+  SDLC_MEMBERSHIP_RELATION,
+  SDLC_STRUCTURAL_RELATIONS,
+  SDLC_TRACK_MEMBERSHIP_RELATION,
+} from '../sdlc';
+import {
   ActivityClassification,
   AttachmentEntityType,
   CallStatus,
@@ -3624,43 +3629,64 @@ export const queries = defineQueries({
     },
   ),
   getAllRepos: defineQuery(() => zql.repos.orderBy('name', 'asc')),
-  getSdlcRepos: defineQuery(() =>
-    zql.repos
-      .where('projectId', 'IS NOT', null)
-      .where('channelId', 'IS NOT', null)
-      .related('project')
-      .related('channel', channel => channel.related('participants').related('channelStats'))
-      .related('setupExecution')
-      .related('sdlcEntityLinks')
+  /** SDLC hubs the viewer can reach, each with the repositories it covers. */
+  getSdlcChannels: defineQuery(({ ctx }) =>
+    zql.channels
+      .where('type', ChannelType.SDLC)
+      .where('isArchived', false)
+      // The channels ACL lets workspace admins and public channels through; a hub
+      // is only usable by its participants, and every write re-checks that.
+      .whereExists('participants', participant => participant.where('userId', ctx.userID))
+      .related('sdlcEntityLinks', link =>
+        link
+          .where('relationType', SDLC_MEMBERSHIP_RELATION)
+          .related('repo', repo => repo.related('project')),
+      )
       .orderBy('name', 'asc'),
   ),
-  getSdlcTracks: defineQuery(z.object({ repoId: z.string() }), ({ args: { repoId } }) =>
-    zql.sdlc_tracks.where('repoId', repoId).orderBy('createdAt', 'asc'),
+  getSdlcChannelById: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
+    zql.channels
+      .where('id', channelId)
+      .where('type', ChannelType.SDLC)
+      .related('participants')
+      .related('channelStats')
+      .related('canvasFolders', folder =>
+        folder.related('canvases', canvas => canvas.related('sdlcArtifact')),
+      )
+      .related('sdlcEntityLinks', link =>
+        link
+          .where('relationType', SDLC_MEMBERSHIP_RELATION)
+          .related('repo', repo => repo.related('project').related('setupExecution')),
+      )
+      .one(),
   ),
-  getSdlcRepoByChannelId: defineQuery(
-    z.object({ channelId: z.string() }),
-    ({ args: { channelId } }) => zql.repos.where('channelId', channelId).one(),
+  /** A hub's tracks. Tracks carry no scope column; the CHANNEL -> TRACK edge places them. */
+  getSdlcTracks: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
+    zql.sdlc_tracks
+      .whereExists('sdlcEntityLinks', link =>
+        link
+          .where('channelId', channelId)
+          .where('relationType', SDLC_TRACK_MEMBERSHIP_RELATION),
+      )
+      .orderBy('createdAt', 'asc'),
   ),
   getSdlcRepoById: defineQuery(z.object({ repoId: z.string() }), ({ args: { repoId } }) =>
     zql.repos
       .where('id', repoId)
       .where('projectId', 'IS NOT', null)
-      .where('channelId', 'IS NOT', null)
       .related('project')
-      .related('channel', channel =>
-        channel
-          .related('participants')
-          .related('channelStats')
-          .related('canvasFolders', folder =>
-            folder.related('canvases', canvas => canvas.related('sdlcArtifact')),
-          ),
-      )
       .related('setupExecution')
-      .related('sdlcEntityLinks')
       .one(),
   ),
-  getSdlcLinks: defineQuery(z.object({ repoId: z.string() }), ({ args: { repoId } }) =>
-    zql.sdlc_entity_links.where('repoId', repoId).orderBy('createdAt', 'asc'),
+  /**
+     * The content graph for a hub. Structural edges (repository and track membership)
+     * share this table — grep SDLC_STRUCTURAL_RELATIONS for every exclusion.
+     */
+  getSdlcLinks: defineQuery(z.object({ channelId: z.string() }), ({ args: { channelId } }) =>
+    zql.sdlc_entity_links
+      .where('channelId', channelId)
+      .where(helpers => helpers.cmp('relationType', 'NOT IN', [...SDLC_STRUCTURAL_RELATIONS]))
+      .orderBy('createdAt', 'asc'),
   ),
   sdlcTicketsByIds: defineQuery(
     z.object({ ticketIds: z.array(z.string()) }),

--- a/packages/shared/src/zero/schema.ts
+++ b/packages/shared/src/zero/schema.ts
@@ -1455,6 +1455,7 @@ export const repoTable = table('repos')
     prefix: string(), // Branch prefix: "feature"
     createdBy: string(),
     projectId: string().optional(),
+    /** @deprecated -> membership is the CHANNEL -> REPOSITORY edge in sdlc_entity_links */
     channelId: string().optional(),
     sdlcSetupExecutionId: string().optional(),
     accessCapabilities: json().optional(),
@@ -1465,7 +1466,10 @@ export const sdlcEntityLinkTable = table('sdlc_entity_links')
   .columns({
     id: string(),
     workspaceId: string(),
-    repoId: string(),
+    // The only scope these rows carry; a repository is one end of the edge.
+    channelId: string().optional(),
+    /** @deprecated -> scope is channelId; the repository is an endpoint of the edge */
+    repoId: string().optional(),
     sourceType: string(),
     sourceId: string(),
     targetType: string(),
@@ -1480,7 +1484,8 @@ export const sdlcArtifactTable = table('sdlc_artifacts')
   .columns({
     workspaceId: string(),
     artifactId: string(),
-    repoId: string(),
+    /** @deprecated -> repository comes from the link table; no new reads or writes */
+    repoId: string().optional(),
     artifactType: string(),
     artifactStatus: string(),
     workflowExecutionId: string().optional(),
@@ -1493,11 +1498,13 @@ export const sdlcArtifactTable = table('sdlc_artifacts')
   })
   .primaryKey('artifactId');
 
+// Tracks carry no scope column: the CHANNEL -> TRACK edge in sdlc_entity_links places them.
 export const sdlcTrackTable = table('sdlc_tracks')
   .columns({
     workspaceId: string(),
     id: string(),
-    repoId: string(),
+    /** @deprecated -> scope is the CHANNEL -> TRACK edge in sdlc_entity_links */
+    repoId: string().optional(),
     name: string(),
     description: string().optional(),
     status: string(),
@@ -3330,10 +3337,10 @@ export const channelTableRelationships = relationships(channelTable, ({ one, man
     destField: ['channelId'],
     destSchema: canvasFolderTable,
   }),
-  sdlcRepos: many({
+  sdlcEntityLinks: many({
     sourceField: ['id'],
     destField: ['channelId'],
-    destSchema: repoTable,
+    destSchema: sdlcEntityLinkTable,
   }),
   guestAccess: many({
     sourceField: ['id'],
@@ -3369,28 +3376,31 @@ export const repoTableRelationships = relationships(repoTable, ({ one, many }) =
     destField: ['id'],
     destSchema: projectTable,
   }),
-  channel: one({
-    sourceField: ['channelId'],
-    destField: ['id'],
-    destSchema: channelTable,
-  }),
   setupExecution: one({
     sourceField: ['sdlcSetupExecutionId'],
     destField: ['id'],
     destSchema: workflowExecutionTable,
   }),
+  // Membership edges pointing here. targetId is polymorphic, so readers filter
+  // by relationType.
   sdlcEntityLinks: many({
     sourceField: ['id'],
-    destField: ['repoId'],
+    destField: ['targetId'],
     destSchema: sdlcEntityLinkTable,
   }),
 }));
 
 export const sdlcEntityLinkTableRelationships = relationships(sdlcEntityLinkTable, ({ one }) => ({
+  // Only meaningful on membership edges, where targetId is the repository.
   repo: one({
-    sourceField: ['repoId'],
+    sourceField: ['targetId'],
     destField: ['id'],
     destSchema: repoTable,
+  }),
+  channel: one({
+    sourceField: ['channelId'],
+    destField: ['id'],
+    destSchema: channelTable,
   }),
 }));
 
@@ -3407,11 +3417,12 @@ export const sdlcArtifactTableRelationships = relationships(sdlcArtifactTable, (
   }),
 }));
 
-export const sdlcTrackTableRelationships = relationships(sdlcTrackTable, ({ one }) => ({
-  repo: one({
-    sourceField: ['repoId'],
-    destField: ['id'],
-    destSchema: repoTable,
+export const sdlcTrackTableRelationships = relationships(sdlcTrackTable, ({ many }) => ({
+  // Edges pointing here. targetId is polymorphic, so readers filter by relationType.
+  sdlcEntityLinks: many({
+    sourceField: ['id'],
+    destField: ['targetId'],
+    destSchema: sdlcEntityLinkTable,
   }),
 }));
 


### PR DESCRIPTION
## What

An SDLC hub used to *be* a repository. Adding a repository minted a private channel and bound the two 1:1 forever, so a team space could never cover more than one repository, and a repository could never appear in more than one space.

A hub now covers several repositories, and a repository can belong to several hubs.

## How

Membership is a `CHANNEL -> REPOSITORY` edge in `sdlc_entity_links`, and a track's hub is a `CHANNEL -> TRACK` edge in the same table. Neither needs a new table. Both are structural rather than content, so every read of the content graph excludes them through `SDLC_STRUCTURAL_RELATIONS`, and the generic link API refuses to create or delete them — membership changes only through the hub endpoints.

The URL is now the hub: `/sdlc/:channelId/:section` replaces `/sdlc/:repoId/:section`, including the standalone artifact window added in #1194.

New endpoints under `/sdlc/channels` create a hub with a chosen set of repositories, and add or remove repositories afterwards. Detaching removes the membership edge only — it never deletes the repository, and a hub cannot drop to zero repositories.

## Migration

`20260831033955_sdlc_multirepo_add` is **additive only**. `sdlc_entity_links` gains `channelId`, and the legacy `repoId` columns on `sdlc_entity_links`, `sdlc_tracks` and `sdlc_artifacts` become nullable. Nothing is dropped, so a lane still running the old code keeps working. The legacy columns stay in the schema marked `@deprecated` and are removed in a later change, once every environment has run the backfill.

Deploy order:

1. Apply `20260831033955_sdlc_multirepo_add`.
2. Deploy this branch.
3. `POST /api/sdlc/cleanup/multirepo-backfill` with `{"dryRun": false}`.

Between 2 and 3 no row carries a `channelId` yet, so SDLC reads empty. Nothing is lost and nothing is written wrong; the surface returns the moment the backfill runs. The endpoint previews by default, is idempotent, and a preview reporting all zeros is what says the migration is complete.

## Testing

Run end to end against a local database holding a real hub:

- dry run reported `hubsSeen: 1, membershipCreated: 1, trackEdgesCreated: 1, linksStamped: 4`, matching the row counts exactly, and wrote nothing
- the real run produced the same numbers; afterwards every link carries a `channelId` and both structural edges exist
- re-running the preview returns all zeros, confirming idempotence
- `prisma migrate diff` against the migrated database reports an empty migration, so schema and database agree
- backend and dashboard `tsc --noEmit` clean; `sdlcMembershipRows.test.ts` passes 7/7

## Known follow-ups

- Repo Knowledge and Wiki still read the hub's first repository only; the per-repo split needs a UI decision.
- Deleting a repository row leaves its structural edges behind, since they name it through the polymorphic `targetId` that no cascade covers. Not reachable from the UI today.
- There is no way to delete a hub yet, so the `CHANNEL -> TRACK` cascade cannot orphan tracks in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
