### PR TITLE
fix: XYNE-60697 canvas links, files, dark mode and keyboard support

### DIFF
--- a/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
@@ -12,6 +12,8 @@ import {
   useCreateBlockNote,
   SuggestionMenuController,
   FormattingToolbarController,
+  FilePanelController,
+  LinkToolbarController,
   getDefaultReactSlashMenuItems,
   DefaultReactSuggestionItem,
 } from '@blocknote/react';
@@ -34,6 +36,10 @@ import { getWhiteboardSlashMenuItems } from 'blocknote-layout-extensions';
 import { getMentionSuggestionMenuItems, insertGroupMention } from 'blocknote-layout-extensions';
 import { asBlockNoteEditorForView } from 'blocknote-layout-extensions';
 import { buildMentionProps, CanvasMentionContext } from '../CanvasMentionSpec';
+import { useCanvasBlockShortcuts, withBlockShortcutBadges } from '../canvasBlockShortcuts';
+import { withHeadingsTogether } from '../canvasSlashMenu';
+import { CanvasLinkToolbar, CanvasPastedLinkToolbar } from '../CanvasLinkToolbar';
+import { CanvasFilePanel } from '../CanvasFilePanel/CanvasFilePanel';
 import {
   canvasSchema,
   canvasTableOptions,
@@ -224,17 +230,20 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       return [...whiteboardItems, ...mathItems, ...diagramItems];
     }, [editor]);
 
-    // Get slash menu items with custom blocks
+    // Every slash item, each already showing the key that reaches it.
+    const allSlashItems = useMemo(() => {
+      if (!editor) return [];
+      const defaultItems = getDefaultReactSlashMenuItems(asBlockNoteEditorForView(editor));
+      return withBlockShortcutBadges(withHeadingsTogether([...defaultItems, ...customSlashItems]));
+    }, [editor, customSlashItems]);
+
     const getSlashMenuItems = useCallback(
-      (query: string): Promise<DefaultReactSuggestionItem[]> => {
-        if (!editor) return Promise.resolve([]);
-        const defaultItems = getDefaultReactSlashMenuItems(asBlockNoteEditorForView(editor));
-        return Promise.resolve(
-          filterSuggestionItems([...defaultItems, ...customSlashItems], query),
-        );
-      },
-      [editor, customSlashItems],
+      (query: string): Promise<DefaultReactSuggestionItem[]> =>
+        Promise.resolve(filterSuggestionItems(allSlashItems, query)),
+      [allSlashItems],
     );
+
+    useCanvasBlockShortcuts(editor, allSlashItems);
 
     // Get mention suggestion menu items for '@' trigger – same list as DM/channel: users + user groups
     // Event-based: on mention selection, insert + notify (blockId for activity redirect)
@@ -584,8 +593,13 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
                 formattingToolbar={false}
                 tableHandles={editable}
                 slashMenu={false}
+                linkToolbar={false}
+                filePanel={false}
               >
                 <FormattingToolbarController formattingToolbar={canvasFormattingToolbar} />
+                <LinkToolbarController linkToolbar={CanvasLinkToolbar} />
+                <CanvasPastedLinkToolbar />
+                <FilePanelController filePanel={CanvasFilePanel} />
                 <SuggestionMenuController triggerCharacter='/' getItems={getSlashMenuItems} />
                 <SuggestionMenuController triggerCharacter='@' getItems={getMentionItems} />
               </BlockNoteView>

--- a/apps/dashboard/src/components/Canvas/CanvasEmbedSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEmbedSpec.tsx
@@ -1,0 +1,214 @@
+import { createReactBlockSpec } from '@blocknote/react';
+import { Copy, ExternalLink, Link2, Trash2, Unlink } from 'lucide-react';
+import type { ReactElement } from 'react';
+import { toast } from 'sonner';
+import { useClipboard } from '../../hooks/useClipboard';
+import { resolveVideoEmbed } from './videoEmbedUrl';
+
+export const CANVAS_EMBED_TYPE = 'embed';
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Inside a block's render BlockNote narrows `editor` to that block's own schema,
+ * so handing replaceBlocks a paragraph does not typecheck. The call is valid at
+ * runtime — the editor is the whole canvas — so it is typed here rather than
+ * widened to any, which this package treats as an error.
+ */
+interface BlockReplacer {
+  replaceBlocks: (
+    replace: readonly unknown[],
+    withBlocks: ReadonlyArray<{
+      type: 'paragraph';
+      content: ReadonlyArray<{ type: 'link'; href: string; content: string }>;
+    }>,
+  ) => void;
+}
+
+const openInNewTab = (url: string): void => {
+  window.open(url, '_blank', 'noopener,noreferrer');
+};
+
+interface EmbedActionsProps {
+  url: string;
+  onUnembed: () => void;
+  onDelete: () => void;
+  editable: boolean;
+}
+
+/**
+ * Hover actions for an embed. The editor owns clicks inside its content, so every
+ * one of these fires on mousedown — by the time click lands the editor has taken
+ * the selection back and the button never hears it.
+ */
+function EmbedActions({ url, onUnembed, onDelete, editable }: EmbedActionsProps): ReactElement {
+  const { copy } = useClipboard();
+
+  const action =
+    (run: () => void) =>
+    (event: React.MouseEvent): void => {
+      event.preventDefault();
+      event.stopPropagation();
+      run();
+    };
+
+  const buttonClass =
+    'grid size-6 place-items-center rounded text-muted-foreground transition-colors ' +
+    'hover:bg-muted hover:text-foreground';
+
+  return (
+    <div
+      contentEditable={false}
+      className='absolute right-2 top-2 z-10 flex items-center gap-0.5 rounded-md border border-border bg-popover/95 p-0.5 opacity-0 shadow-sm backdrop-blur transition-opacity group-hover:opacity-100 focus-within:opacity-100'
+    >
+      <button
+        type='button'
+        title='Open in new tab'
+        className={buttonClass}
+        onMouseDown={action(() => openInNewTab(url))}
+      >
+        <ExternalLink size={13} />
+      </button>
+      <button
+        type='button'
+        title='Copy link'
+        className={buttonClass}
+        onMouseDown={action(() => {
+          void copy(url);
+          toast.success('Link copied');
+        })}
+      >
+        <Copy size={13} />
+      </button>
+      {editable && (
+        <>
+          <button
+            type='button'
+            title='Convert back to link'
+            className={buttonClass}
+            onMouseDown={action(onUnembed)}
+          >
+            <Unlink size={13} />
+          </button>
+          <button
+            type='button'
+            title='Delete'
+            className={buttonClass}
+            onMouseDown={action(onDelete)}
+          >
+            <Trash2 size={13} />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Anything we have no player for. Deliberately built from the URL alone — the
+ * title, description and image chat shows come from metadata the backend fetches
+ * and stores on the message, and no equivalent exists for canvas documents.
+ */
+function GenericEmbedCard({ url }: { url: string }): ReactElement {
+  return (
+    <div
+      contentEditable={false}
+      role='button'
+      tabIndex={0}
+      aria-label={`Open ${hostOf(url)}`}
+      onMouseDown={event => {
+        event.preventDefault();
+        event.stopPropagation();
+        openInNewTab(url);
+      }}
+      onKeyDown={event => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        openInNewTab(url);
+      }}
+      className='flex w-full cursor-pointer items-center gap-3 rounded-lg border border-border bg-muted/30 p-3 transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+    >
+      <span className='grid size-9 shrink-0 place-items-center rounded-md bg-background text-muted-foreground'>
+        <Link2 size={16} />
+      </span>
+      <span className='min-w-0 flex-1'>
+        <span className='block truncate text-sm font-medium text-foreground'>{hostOf(url)}</span>
+        <span className='block truncate text-xs text-muted-foreground'>{url}</span>
+      </span>
+    </div>
+  );
+}
+
+function PlayerEmbed({ embedUrl, provider }: { embedUrl: string; provider: string }): ReactElement {
+  return (
+    <div
+      className='relative w-full overflow-hidden rounded-lg border border-border pt-[56.25%]'
+      data-embed-provider={provider}
+      contentEditable={false}
+    >
+      <iframe
+        src={embedUrl}
+        title='Embedded video'
+        className='absolute inset-0 h-full w-full'
+        allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
+        // The frame runs scripts and reaches its own origin — a player cannot
+        // work otherwise — but it may not navigate the document hosting it.
+        sandbox='allow-scripts allow-same-origin allow-presentation allow-popups allow-popups-to-escape-sandbox'
+        referrerPolicy='strict-origin-when-cross-origin'
+        allowFullScreen
+      />
+    </div>
+  );
+}
+
+/**
+ * A link the reader asked to see in place rather than follow.
+ *
+ * Services like YouTube only play inside a frame, so BlockNote's own video block
+ * — which renders `<video src>`, meaning a video *file* — shows nothing when
+ * handed a watch page. Where we know the service, this plays it; where we do not,
+ * it degrades to a card rather than failing silently.
+ */
+export const canvasEmbedSpec = createReactBlockSpec(
+  {
+    type: CANVAS_EMBED_TYPE,
+    propSchema: {
+      url: { default: '' },
+    },
+    content: 'none',
+  },
+  {
+    render: ({ block, editor }) => {
+      const url = String(block.props.url ?? '');
+      const video = resolveVideoEmbed(url);
+      const editable = editor.isEditable;
+
+      return (
+        <div className='group relative my-1 w-full'>
+          {video ? (
+            <PlayerEmbed embedUrl={video.embedUrl} provider={video.provider} />
+          ) : (
+            <GenericEmbedCard url={url} />
+          )}
+          <EmbedActions
+            url={url}
+            editable={editable}
+            onUnembed={() =>
+              (editor as unknown as BlockReplacer).replaceBlocks(
+                [block],
+                [{ type: 'paragraph', content: [{ type: 'link', href: url, content: url }] }],
+              )
+            }
+            onDelete={() => editor.removeBlocks([block])}
+          />
+        </div>
+      );
+    },
+  },
+)();

--- a/apps/dashboard/src/components/Canvas/CanvasFileBlockSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasFileBlockSpec.tsx
@@ -1,0 +1,100 @@
+import { defaultBlockSpecs } from '@blocknote/core';
+import { AddFileButton, createReactBlockSpec, FileBlockWrapper } from '@blocknote/react';
+import axios from 'axios';
+import { Download, FileText } from 'lucide-react';
+import type { ReactElement } from 'react';
+import { toast } from 'sonner';
+
+const fileConfig = defaultBlockSpecs.file.config;
+
+const extensionOf = (name: string): string => {
+  const dot = name.lastIndexOf('.');
+  return dot > 0 ? name.slice(dot + 1).toUpperCase() : 'FILE';
+};
+
+/**
+ * Download rather than navigate.
+ *
+ * `<a download>` only applies same-origin, and uploads are served from storage,
+ * so the file is pulled down and handed over as a blob. Falling back to opening
+ * it keeps a blocked request from looking like a dead button.
+ */
+async function downloadFile(url: string, name: string): Promise<void> {
+  try {
+    const response = await axios.get<Blob>(url, { responseType: 'blob' });
+    const blobUrl = URL.createObjectURL(response.data);
+    const anchor = document.createElement('a');
+    anchor.href = blobUrl;
+    anchor.download = name || 'download';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(blobUrl);
+  } catch {
+    window.open(url, '_blank', 'noopener,noreferrer');
+    toast.error('Could not download', { description: 'Opened the file instead.' });
+  }
+}
+
+function FileCard({ url, name }: { url: string; name: string }): ReactElement {
+  const label = name || url;
+
+  return (
+    <div
+      contentEditable={false}
+      className='canvas-file-card group/file my-1 flex w-full items-center gap-3 rounded-lg border border-border bg-muted/30 p-3 transition-colors hover:bg-muted/60'
+    >
+      <span className='grid size-10 shrink-0 place-items-center rounded-md bg-background text-muted-foreground'>
+        <FileText size={18} />
+      </span>
+      <span className='min-w-0 flex-1'>
+        <span className='block truncate text-sm font-medium text-foreground' title={label}>
+          {label}
+        </span>
+        <span className='block text-xs text-muted-foreground'>{extensionOf(label)}</span>
+      </span>
+      <button
+        type='button'
+        title='Download'
+        aria-label={`Download ${label}`}
+        className='grid size-8 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground'
+        onMouseDown={event => {
+          // The editor reclaims the selection on mouseup, so a click never lands.
+          event.preventDefault();
+          event.stopPropagation();
+          void downloadFile(url, label);
+        }}
+      >
+        <Download size={16} />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * A file in the document, shown as a card you can download from.
+ *
+ * BlockNote renders an uploaded file as an icon and its name and nothing else,
+ * with no way to get the file back out. Before anything is uploaded this defers
+ * to BlockNote's own add-file button, so the upload flow is untouched.
+ */
+export const canvasFileBlockSpec = createReactBlockSpec(
+  fileConfig,
+  {
+    render: ({ block, editor }) => {
+      const url = String(block.props.url ?? '');
+      const name = String(block.props.name ?? '');
+
+      return (
+        <FileBlockWrapper block={block} editor={editor}>
+          {url ? (
+            <FileCard url={url} name={name} />
+          ) : (
+            <AddFileButton block={block} editor={editor} />
+          )}
+        </FileBlockWrapper>
+      );
+    },
+  },
+  defaultBlockSpecs.file.extensions,
+)();

--- a/apps/dashboard/src/components/Canvas/CanvasFilePanel/CanvasFilePanel.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasFilePanel/CanvasFilePanel.tsx
@@ -1,0 +1,95 @@
+import { type FilePanelProps, useBlockNoteEditor } from '@blocknote/react';
+import { type FC, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+
+const ACCEPT_BY_BLOCK: Readonly<Record<string, string>> = {
+  file: '*/*',
+  image: 'image/*',
+  video: 'video/*',
+  audio: 'audio/*',
+};
+
+const promptForFile = (accept: string): Promise<File | null> =>
+  new Promise(resolve => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = accept;
+    input.style.display = 'none';
+
+    // Cancelling a file dialog fires no event, so focus returning to the window is
+    // what tells us it closed; without it the promise would never settle.
+    const settle = (file: File | null): void => {
+      window.removeEventListener('focus', onFocus);
+      input.remove();
+      resolve(file);
+    };
+    const onFocus = (): void => {
+      window.setTimeout(() => settle(input.files?.[0] ?? null), 300);
+    };
+
+    input.addEventListener('change', () => settle(input.files?.[0] ?? null), { once: true });
+    window.addEventListener('focus', onFocus, { once: true });
+    document.body.appendChild(input);
+    input.click();
+  });
+
+interface CanvasBlock {
+  type: string;
+  props?: { url?: unknown };
+}
+
+interface UploadingEditor {
+  uploadFile?: (file: File, blockId?: string) => Promise<string | Record<string, unknown>>;
+  getBlock: (blockId: string) => CanvasBlock | undefined;
+  updateBlock: (blockId: string, update: { props: Record<string, unknown> }) => void;
+  removeBlocks: (blockIds: string[]) => void;
+}
+
+/** An empty file block is only ever a placeholder for the picker, so drop it. */
+const discardIfEmpty = (api: UploadingEditor, blockId: string): void => {
+  if (api.getBlock(blockId)?.props?.url) return;
+  try {
+    api.removeBlocks([blockId]);
+  } catch {
+    // The block is already gone; nothing to discard.
+  }
+};
+
+/**
+ * Stands in for BlockNote's file dialog and opens the file picker instead.
+ *
+ * Upload and embed both ended in the same place for a file, image, video or audio
+ * block, so with embed gone the dialog was a panel whose only content was a button
+ * that opened the picker. Being the panel rather than a separate watcher covers
+ * every way BlockNote asks for a file: inserting the block, and its add-file button.
+ */
+export const CanvasFilePanel: FC<FilePanelProps> = ({ blockId }): null => {
+  const editor = useBlockNoteEditor();
+  const promptedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    const api = editor as unknown as UploadingEditor | null;
+    const upload = api?.uploadFile;
+    if (!api || !upload || !blockId || promptedFor.current === blockId) return;
+    promptedFor.current = blockId;
+
+    void (async (): Promise<void> => {
+      const file = await promptForFile(ACCEPT_BY_BLOCK[api.getBlock(blockId)?.type ?? ''] ?? '*/*');
+      if (!file) {
+        discardIfEmpty(api, blockId);
+        return;
+      }
+      try {
+        const uploaded = await upload(file, blockId);
+        const url = typeof uploaded === 'string' ? uploaded : uploaded['url'];
+        if (typeof url !== 'string' || !url) throw new Error('upload returned no url');
+        api.updateBlock(blockId, { props: { url, name: file.name } });
+      } catch {
+        toast.error('Upload failed', { description: file.name });
+        discardIfEmpty(api, blockId);
+      }
+    })();
+  }, [editor, blockId]);
+
+  return null;
+};

--- a/apps/dashboard/src/components/Canvas/CanvasFilePanel/index.ts
+++ b/apps/dashboard/src/components/Canvas/CanvasFilePanel/index.ts
@@ -1,0 +1,1 @@
+export { CanvasFilePanel } from './CanvasFilePanel';

--- a/apps/dashboard/src/components/Canvas/CanvasLinkToolbar/CanvasLinkActions.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasLinkToolbar/CanvasLinkActions.tsx
@@ -1,0 +1,184 @@
+import { formatKeyboardShortcut } from '@blocknote/core';
+import {
+  EditLinkMenuItems,
+  type LinkToolbarProps,
+  useBlockNoteEditor,
+  useComponentsContext,
+} from '@blocknote/react';
+import { ExternalLink, LayoutTemplate, Pencil, Unlink } from 'lucide-react';
+import { type FC, type ReactElement, type ReactNode, useEffect, useState } from 'react';
+import { editorView } from '../canvasEditorView';
+import { findLinkRange, insertEmbedBlock, replaceLinkWithEmbed } from '../canvasEmbedActions';
+import { CANVAS_LINK_ACTION_EVENT, LINK_SHORTCUTS, linkUnderMenu } from '../canvasLinkShortcuts';
+
+/** Every button in the menu, in the order they are rendered. */
+const ROW_SELECTOR = '.canvas-link-menu button';
+
+const Row = ({
+  icon,
+  label,
+  shortcut,
+}: {
+  icon: ReactNode;
+  label: string;
+  shortcut: string | null;
+}): ReactElement => (
+  <span className='canvas-link-menu-item'>
+    {icon}
+    {label}
+    {shortcut !== null && (
+      <kbd className='canvas-link-menu-key'>{formatKeyboardShortcut(shortcut)}</kbd>
+    )}
+  </span>
+);
+
+/**
+ * The actions offered for a link, shared by the toolbar that opens on hover and
+ * the one offered on paste so the two cannot drift apart.
+ *
+ * Each row carries its own shortcut, which works without the menu ever being
+ * focused. Up and Down walk the rows and Enter picks one, the way the slash menu
+ * behaves; Escape leaves the menu and gives the arrows back to the text. This
+ * only renders while a menu is open, so its key handling is scoped to that.
+ */
+export const CanvasLinkActions: FC<LinkToolbarProps> = (props): ReactElement | null => {
+  const Components = useComponentsContext();
+  const editor = useBlockNoteEditor();
+  const [activeRow, setActiveRow] = useState(-1);
+
+  // The keys act on the link at the caret. Opened by hover the caret is usually
+  // somewhere else entirely, so there is nothing for them to act on and showing
+  // them would be a lie.
+  const view = editorView(editor);
+  const atCaret = view ? linkUnderMenu(view.state)?.url === props.url : false;
+  const keyFor = (shortcut: string): string | null => (atCaret ? shortcut : null);
+
+  useEffect(() => {
+    const dom = editorView(editor)?.dom;
+    if (!dom || !atCaret) return undefined;
+
+    const rows = (): HTMLButtonElement[] =>
+      Array.from(document.querySelectorAll<HTMLButtonElement>(ROW_SELECTOR));
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      const count = rows().length;
+      if (!count) return;
+
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        event.stopPropagation();
+        const step = event.key === 'ArrowDown' ? 1 : -1;
+        setActiveRow(current =>
+          current < 0 ? (step > 0 ? 0 : count - 1) : (current + step + count) % count,
+        );
+        return;
+      }
+
+      if (event.key === 'Enter' && activeRow >= 0) {
+        event.preventDefault();
+        event.stopPropagation();
+        rows()[activeRow]?.click();
+        return;
+      }
+
+      if (event.key === 'Escape') setActiveRow(-1);
+    };
+
+    const runRow = (event: Event): void => {
+      const row = (event as CustomEvent<{ row: number }>).detail?.row;
+      if (typeof row === 'number') rows()[row]?.click();
+    };
+
+    dom.addEventListener('keydown', onKeyDown, true);
+    dom.addEventListener(CANVAS_LINK_ACTION_EVENT, runRow);
+    return () => {
+      dom.removeEventListener('keydown', onKeyDown, true);
+      dom.removeEventListener(CANVAS_LINK_ACTION_EVENT, runRow);
+    };
+  }, [editor, activeRow, atCaret]);
+
+  if (!Components) return null;
+
+  const Button = Components.LinkToolbar.Button;
+  const close = (): void => props.setToolbarOpen?.(false);
+  const openState = {
+    ...(props.setToolbarOpen ? { setToolbarOpen: props.setToolbarOpen } : {}),
+    ...(props.setToolbarPositionFrozen
+      ? { setToolbarPositionFrozen: props.setToolbarPositionFrozen }
+      : {}),
+  };
+
+  const embedLink = (): void => {
+    const view = editorView(editor);
+    if (!view || !props.url) return;
+    const { from, to } = props.range;
+    const link = to > from ? { url: props.url, from, to } : findLinkRange(view, props.url);
+    if (link) replaceLinkWithEmbed(view, link);
+    else insertEmbedBlock(view, props.url);
+    close();
+  };
+
+  return (
+    <>
+      <Components.Generic.Popover.Root
+        {...(props.setToolbarPositionFrozen
+          ? { onOpenChange: props.setToolbarPositionFrozen }
+          : {})}
+      >
+        <Components.Generic.Popover.Trigger>
+          <Button className='bn-button' isSelected={activeRow === 0}>
+            <Row
+              icon={<Pencil size={14} />}
+              label='Edit link'
+              shortcut={keyFor(LINK_SHORTCUTS.edit)}
+            />
+          </Button>
+        </Components.Generic.Popover.Trigger>
+        <Components.Generic.Popover.Content
+          className='bn-popover-content bn-form-popover'
+          variant='form-popover'
+        >
+          <EditLinkMenuItems url={props.url} text={props.text} range={props.range} {...openState} />
+        </Components.Generic.Popover.Content>
+      </Components.Generic.Popover.Root>
+
+      <Button
+        className='bn-button'
+        isSelected={activeRow === 1}
+        onClick={(): void => {
+          window.open(props.url, '_blank', 'noopener,noreferrer');
+          close();
+        }}
+      >
+        <Row
+          icon={<ExternalLink size={14} />}
+          label='Open in new tab'
+          shortcut={keyFor(LINK_SHORTCUTS.open)}
+        />
+      </Button>
+
+      <Button className='bn-button' isSelected={activeRow === 2} onClick={embedLink}>
+        <Row
+          icon={<LayoutTemplate size={14} />}
+          label='Embed'
+          shortcut={keyFor(LINK_SHORTCUTS.embed)}
+        />
+      </Button>
+
+      <Button
+        className='bn-button'
+        isSelected={activeRow === 3}
+        onClick={(): void => {
+          editor?.deleteLink(props.range.from);
+          close();
+        }}
+      >
+        <Row
+          icon={<Unlink size={14} />}
+          label='Remove link'
+          shortcut={keyFor(LINK_SHORTCUTS.remove)}
+        />
+      </Button>
+    </>
+  );
+};

--- a/apps/dashboard/src/components/Canvas/CanvasLinkToolbar/CanvasLinkToolbar.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasLinkToolbar/CanvasLinkToolbar.tsx
@@ -1,0 +1,15 @@
+import { type LinkToolbarProps, useComponentsContext } from '@blocknote/react';
+import type { FC, ReactElement } from 'react';
+import { CanvasLinkActions } from './CanvasLinkActions';
+
+/** The link menu shown when the reader returns to a link. */
+export const CanvasLinkToolbar: FC<LinkToolbarProps> = (props): ReactElement | null => {
+  const Components = useComponentsContext();
+  if (!Components) return null;
+
+  return (
+    <Components.LinkToolbar.Root className='bn-toolbar bn-link-toolbar canvas-link-menu'>
+      <CanvasLinkActions {...props} />
+    </Components.LinkToolbar.Root>
+  );
+};

--- a/apps/dashboard/src/components/Canvas/CanvasLinkToolbar/CanvasPastedLinkToolbar.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasLinkToolbar/CanvasPastedLinkToolbar.tsx
@@ -1,0 +1,73 @@
+import { useBlockNoteEditor } from '@blocknote/react';
+import { posToDOMRect } from '@tiptap/core';
+import { editorView } from '../canvasEditorView';
+import { type FC, type ReactElement, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  clearPastedLink,
+  type PastedLink,
+  type PastedLinkHost,
+  subscribeToPastedLink,
+} from '../canvasPastedLink';
+import { CanvasLinkToolbar } from './CanvasLinkToolbar';
+
+/**
+ * Offers the link menu where a link was just pasted.
+ *
+ * BlockNote's own toolbar only opens once the caret is inside a link, and the
+ * caret a paste leaves behind sits just after it, so the menu would never appear
+ * without a hover. This renders the same menu at the pasted link, through the
+ * portal BlockNote's own popovers use: the toolbar's styling is scoped to the
+ * editor container, so anywhere else it renders unstyled.
+ */
+export const CanvasPastedLinkToolbar: FC = (): ReactElement | null => {
+  const editor = useBlockNoteEditor();
+  const host = editor?._tiptapEditor as PastedLinkHost | undefined;
+  const [link, setLink] = useState<PastedLink | null>(null);
+
+  useEffect(() => (host ? subscribeToPastedLink(host, setLink) : undefined), [host]);
+
+  useEffect(() => {
+    if (!link || !host || !editorView(host)) return undefined;
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') clearPastedLink(host);
+    };
+    // Hovering a link opens BlockNote's toolbar for it, which is this same menu;
+    // standing down leaves one on screen rather than two.
+    const onMouseOver = (event: MouseEvent): void => {
+      if (event.target instanceof HTMLElement && event.target.closest('a')) {
+        clearPastedLink(host);
+      }
+    };
+    const dom = editorView(host)?.dom;
+    if (!dom) return undefined;
+    window.addEventListener('keydown', onKeyDown);
+    dom.addEventListener('mouseover', onMouseOver);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      dom.removeEventListener('mouseover', onMouseOver);
+    };
+  }, [link, host]);
+
+  const view = editorView(host);
+  if (!link || !host || !view) return null;
+
+  const portal = editor?.portalElement ?? document.body;
+  const rect = posToDOMRect(view, link.from, link.to);
+  return createPortal(
+    <div
+      className='canvas-pasted-link-toolbar'
+      style={{ top: `${rect.bottom + 6}px`, left: `${rect.left}px` }}
+    >
+      <CanvasLinkToolbar
+        url={link.url}
+        text={view.state.doc.textBetween(link.from, link.to)}
+        range={{ from: link.from, to: link.to }}
+        setToolbarOpen={(open: boolean): void => {
+          if (!open) clearPastedLink(host);
+        }}
+      />
+    </div>,
+    portal,
+  );
+};

--- a/apps/dashboard/src/components/Canvas/CanvasLinkToolbar/index.ts
+++ b/apps/dashboard/src/components/Canvas/CanvasLinkToolbar/index.ts
@@ -1,0 +1,2 @@
+export { CanvasLinkToolbar } from './CanvasLinkToolbar';
+export { CanvasPastedLinkToolbar } from './CanvasPastedLinkToolbar';

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -11,6 +11,8 @@ import {
   useCreateBlockNote,
   SuggestionMenuController,
   FormattingToolbarController,
+  FilePanelController,
+  LinkToolbarController,
   getDefaultReactSlashMenuItems,
   DefaultReactSuggestionItem,
 } from '@blocknote/react';
@@ -58,6 +60,8 @@ import { filterSuggestionItems } from '@blocknote/core/extensions';
 import { getWhiteboardSlashMenuItems } from 'blocknote-layout-extensions';
 import { insertGroupMention } from 'blocknote-layout-extensions';
 import { buildMentionProps, CanvasMentionContext } from '../CanvasMentionSpec';
+import { useCanvasBlockShortcuts, withBlockShortcutBadges } from '../canvasBlockShortcuts';
+import { withHeadingsTogether } from '../canvasSlashMenu';
 import { canvasSchema, canvasTableOptions, canvasTiptapOptions } from '../canvasSchema';
 import { createElement } from 'react';
 import { RiGroupLine } from 'react-icons/ri';
@@ -78,6 +82,8 @@ import { AnimatePresence } from 'framer-motion';
 
 import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasInlineCommentThread';
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
+import { CanvasLinkToolbar, CanvasPastedLinkToolbar } from '../CanvasLinkToolbar';
+import { CanvasFilePanel } from '../CanvasFilePanel/CanvasFilePanel';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
 
 const DEFAULT_CANVAS_PLACEHOLDER = "Write something, or press '/' for commands";
@@ -307,19 +313,22 @@ export const CollaborativeCanvasEditor = forwardRef<
       return [...whiteboardItems, ...mathItems, ...diagramItems];
     }, [editor]);
 
-    // Get slash menu items with custom blocks
+    // Every slash item, each already showing the key that reaches it.
+    const allSlashItems = useMemo(() => {
+      if (!editor) return [];
+      const defaultItems = getDefaultReactSlashMenuItems(
+        editor as unknown as BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>,
+      );
+      return withBlockShortcutBadges(withHeadingsTogether([...defaultItems, ...customSlashItems]));
+    }, [editor, customSlashItems]);
+
     const getSlashMenuItems = useCallback(
-      (query: string): Promise<DefaultReactSuggestionItem[]> => {
-        if (!editor) return Promise.resolve([]);
-        const defaultItems = getDefaultReactSlashMenuItems(
-          editor as unknown as BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>,
-        );
-        return Promise.resolve(
-          filterSuggestionItems([...defaultItems, ...customSlashItems], query),
-        );
-      },
-      [editor, customSlashItems],
+      (query: string): Promise<DefaultReactSuggestionItem[]> =>
+        Promise.resolve(filterSuggestionItems(allSlashItems, query)),
+      [allSlashItems],
     );
+
+    useCanvasBlockShortcuts(editor, allSlashItems);
 
     const users = useUsers();
     const allUserGroups = useUserGroups();
@@ -712,9 +721,14 @@ export const CollaborativeCanvasEditor = forwardRef<
                     formattingToolbar={false}
                     tableHandles={editable && !isReadOnly}
                     slashMenu={false}
+                    linkToolbar={false}
+                    filePanel={false}
                     onChange={handleCollaborativeChange}
                   >
                     <FormattingToolbarController formattingToolbar={canvasFormattingToolbar} />
+                    <LinkToolbarController linkToolbar={CanvasLinkToolbar} />
+                    <CanvasPastedLinkToolbar />
+                    <FilePanelController filePanel={CanvasFilePanel} />
                     <SuggestionMenuController triggerCharacter='/' getItems={getSlashMenuItems} />
                     <SuggestionMenuController triggerCharacter='@' getItems={getMentionItems} />
                   </BlockNoteView>

--- a/apps/dashboard/src/components/Canvas/canvasBlockShortcuts.ts
+++ b/apps/dashboard/src/components/Canvas/canvasBlockShortcuts.ts
@@ -1,0 +1,117 @@
+import { formatKeyboardShortcut } from '@blocknote/core';
+import type { DefaultReactSuggestionItem } from '@blocknote/react';
+import { useEffect } from 'react';
+import { editorView } from './canvasEditorView';
+
+/**
+ * A key for the blocks the slash menu left without one.
+ *
+ * Three families, each carrying on one BlockNote already uses, so a key says
+ * something about the block rather than being the next number free:
+ *
+ *   Mod-Alt-Shift-N  inserted blocks, numbered down the menu. 1 to 3 are the
+ *                    toggle headings, mirroring Mod-Alt-1 to 3 for the headings
+ *                    themselves; 4 to 7 are the Media group in its own order.
+ *   Mod-Shift-N      joins the list blocks, which hold 6 to 9, at the free end.
+ *   Mod-Alt-<letter> joins Mod-Alt-C for code and Mod-Alt-Q for quote: a block
+ *                    with a name rather than a place in a series.
+ *
+ * What is missing from all three is deliberate. Mod-Shift-3 to 5 are the system
+ * screenshots, Mod-Alt-D, M and W the Dock, Minimise All and Safari's close-other
+ * -tabs, Mod-Alt-I, J and C the browser's developer tools, and Mod-Alt with an
+ * arrow moves between its tabs. Mod-Ctrl is clear on a Mac but cannot be spelled
+ * on Windows, where Mod is already Ctrl.
+ */
+export const BLOCK_SHORTCUTS: Readonly<Record<string, string>> = {
+  // Basic blocks read as their initial, next to BlockNote's own Q and C. The
+  // lists answer to Mod-Shift-6 to 9 as well; the letter is what gets shown,
+  // being the one worth remembering.
+  Quote: 'Mod-Alt-Q',
+  'Bullet List': 'Mod-Alt-B',
+  'Numbered List': 'Mod-Alt-L',
+  'Check List': 'Mod-Alt-K',
+  'Toggle List': 'Mod-Alt-H',
+  Divider: 'Mod-Alt-R',
+
+  'Toggle Heading 1': 'Mod-Alt-Shift-1',
+  'Toggle Heading 2': 'Mod-Alt-Shift-2',
+  'Toggle Heading 3': 'Mod-Alt-Shift-3',
+
+  Image: 'Mod-Alt-Shift-4',
+  Video: 'Mod-Alt-Shift-5',
+  Audio: 'Mod-Alt-Shift-6',
+  File: 'Mod-Alt-Shift-7',
+
+  Diagram: 'Mod-Alt-Shift-8',
+  Whiteboard: 'Mod-Alt-Shift-9',
+
+  'Block Equation': 'Mod-Shift-1',
+  'Inline Equation': 'Mod-Shift-2',
+
+  Table: 'Mod-Alt-T',
+  Emoji: 'Mod-Alt-E',
+};
+
+/** BlockNote binds these itself; we only show them. */
+const ALREADY_BOUND = new Set(['Quote']);
+
+/**
+ * Whether an event is the given shortcut.
+ *
+ * Matched on `code` rather than `key`: Alt rewrites the character a key produces
+ * on macOS, so Mod-Alt-T arrives as `†`.
+ */
+function matches(event: KeyboardEvent, shortcut: string): boolean {
+  const parts = shortcut.split('-');
+  const key = parts[parts.length - 1] ?? '';
+
+  if (parts.includes('Mod') !== (event.metaKey || event.ctrlKey)) return false;
+  if (parts.includes('Alt') !== event.altKey) return false;
+  if (parts.includes('Shift') !== event.shiftKey) return false;
+
+  return event.code === (/^\d$/.test(key) ? `Digit${key}` : `Key${key.toUpperCase()}`);
+}
+
+/** The slash menu items, each showing the key that reaches it. */
+export function withBlockShortcutBadges(
+  items: DefaultReactSuggestionItem[],
+): DefaultReactSuggestionItem[] {
+  return items.map(item => {
+    const shortcut = BLOCK_SHORTCUTS[item.title];
+    return shortcut ? { ...item, badge: formatKeyboardShortcut(shortcut) } : item;
+  });
+}
+
+/**
+ * Binds those keys to the slash menu items themselves.
+ *
+ * A key runs the item's own handler rather than repeating what it does, so the
+ * two cannot drift apart — and inserting a file, image, video or audio block goes
+ * on to open the file picker exactly as picking it from the menu would.
+ */
+export function useCanvasBlockShortcuts(
+  editor: unknown,
+  items: DefaultReactSuggestionItem[],
+): void {
+  useEffect(() => {
+    const dom = editorView(editor)?.dom;
+    if (!dom || items.length === 0) return undefined;
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (!event.metaKey && !event.ctrlKey) return;
+
+      const item = items.find(candidate => {
+        const shortcut = BLOCK_SHORTCUTS[candidate.title];
+        return shortcut && !ALREADY_BOUND.has(candidate.title) && matches(event, shortcut);
+      });
+      if (!item) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      item.onItemClick?.();
+    };
+
+    dom.addEventListener('keydown', onKeyDown, true);
+    return () => dom.removeEventListener('keydown', onKeyDown, true);
+  }, [editor, items]);
+}

--- a/apps/dashboard/src/components/Canvas/canvasEditorView.ts
+++ b/apps/dashboard/src/components/Canvas/canvasEditorView.ts
@@ -1,0 +1,24 @@
+import type { EditorView } from '@tiptap/pm/view';
+
+interface EditorWithView {
+  _tiptapEditor?: { view?: EditorView };
+  view?: EditorView;
+}
+
+/**
+ * The editor's ProseMirror view, or null before it is mounted.
+ *
+ * TipTap hands back a proxy that throws on any property access until the view
+ * exists, so optional chaining is not enough — the throw happens on the reach
+ * for `.dom`, not on the view itself.
+ */
+export function editorView(editor: unknown): EditorView | null {
+  const host = editor as EditorWithView | null | undefined;
+  const view = host?._tiptapEditor?.view ?? host?.view;
+  if (!view) return null;
+  try {
+    return view.dom ? view : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/dashboard/src/components/Canvas/canvasEmbedActions.ts
+++ b/apps/dashboard/src/components/Canvas/canvasEmbedActions.ts
@@ -1,0 +1,94 @@
+import type { EditorView } from '@tiptap/pm/view';
+import { CANVAS_EMBED_TYPE } from './CanvasEmbedSpec';
+
+export interface LinkRange {
+  url: string;
+  from: number;
+  to: number;
+}
+
+function buildEmbedBlock(
+  view: EditorView,
+  url: string,
+): ReturnType<EditorView['state']['schema']['nodes'][string]['createAndFill']> | null {
+  const embed = view.state.schema.nodes[CANVAS_EMBED_TYPE];
+  const blockContainer = view.state.schema.nodes['blockContainer'];
+  if (!embed || !blockContainer) return null;
+
+  const embedNode = embed.createAndFill({ url });
+  if (!embedNode) return null;
+  return blockContainer.createAndFill(undefined, embedNode);
+}
+
+/** Position just after the block containing `pos`, where a sibling block may go. */
+function afterBlockContaining(view: EditorView, pos: number, doc = view.state.doc): number | null {
+  const resolved = doc.resolve(pos);
+  for (let depth = resolved.depth; depth > 0; depth -= 1) {
+    if (resolved.node(depth).type.name === 'blockContainer') return resolved.after(depth);
+  }
+  return null;
+}
+
+/**
+ * Swap a link for an embed of it.
+ *
+ * The embed goes in a block of its own *after* the paragraph rather than in place
+ * of the link text: a paragraph cannot hold a block, so replacing the inline range
+ * directly leaves the link sitting next to a stray embed.
+ */
+export function replaceLinkWithEmbed(view: EditorView, link: LinkRange): boolean {
+  const block = buildEmbedBlock(view, link.url);
+  if (!block) return false;
+
+  const transaction = view.state.tr.delete(link.from, link.to);
+  const insertAt = afterBlockContaining(view, transaction.mapping.map(link.from), transaction.doc);
+  if (insertAt === null) return false;
+
+  view.dispatch(transaction.insert(insertAt, block).scrollIntoView());
+  return true;
+}
+
+/** Put an embed of `url` where the cursor is, as its own block. */
+export function insertEmbedBlock(view: EditorView, url: string): boolean {
+  const block = buildEmbedBlock(view, url);
+  if (!block) return false;
+
+  view.dispatch(view.state.tr.replaceSelectionWith(block).scrollIntoView());
+  return true;
+}
+
+/**
+ * The range of the link carrying `url`, nearest the cursor.
+ *
+ * Found by scanning rather than read off the selection: the link toolbar opens on
+ * hover, so the cursor is usually somewhere else entirely when its buttons are
+ * pressed. Adjacent text nodes are merged, since a link split by bold or italic
+ * spans several of them.
+ */
+export function findLinkRange(view: EditorView, url: string): LinkRange | null {
+  const linkMark = view.state.schema.marks['link'];
+  if (!linkMark || !url) return null;
+
+  const ranges: Array<{ from: number; to: number }> = [];
+  view.state.doc.descendants((node, pos) => {
+    if (!node.isText) return true;
+    const hasLink = node.marks.some(mark => mark.type === linkMark && mark.attrs['href'] === url);
+    if (!hasLink) return true;
+
+    const previous = ranges[ranges.length - 1];
+    if (previous && previous.to === pos) previous.to = pos + node.nodeSize;
+    else ranges.push({ from: pos, to: pos + node.nodeSize });
+    return true;
+  });
+
+  if (ranges.length === 0) return null;
+
+  const cursor = view.state.selection.from;
+  const nearest = ranges.reduce((best, range) => {
+    const distance = Math.min(Math.abs(cursor - range.from), Math.abs(cursor - range.to));
+    const bestDistance = Math.min(Math.abs(cursor - best.from), Math.abs(cursor - best.to));
+    return distance < bestDistance ? range : best;
+  });
+
+  return { url, from: nearest.from, to: nearest.to };
+}

--- a/apps/dashboard/src/components/Canvas/canvasLinkShortcuts.ts
+++ b/apps/dashboard/src/components/Canvas/canvasLinkShortcuts.ts
@@ -1,0 +1,85 @@
+import { Extension } from '@tiptap/core';
+import type { EditorState } from '@tiptap/pm/state';
+import type { LinkRange } from './canvasEmbedActions';
+import { getPastedLink } from './canvasPastedLink';
+
+/**
+ * The keys the link menu offers, in the order the menu lists them.
+ *
+ * They fire while the caret is in the link, so the menu never has to be focused
+ * to be used. None is a bare letter, so typing inside a link is untouched.
+ * Tab and Shift-Tab nest a block, but BlockNote stands down while a toolbar is
+ * open, which leaves them to us. Mod-K belongs to the app and Mod-Enter to the
+ * composers; Mod-Shift-B/E/H/J/L/R/S are TipTap's, so O and U are what is left.
+ */
+export const LINK_SHORTCUTS = {
+  edit: 'Shift-Tab',
+  open: 'Mod-Shift-O',
+  embed: 'Tab',
+  remove: 'Mod-Shift-U',
+} as const;
+
+/** Row order in the menu, which is also the order of LINK_SHORTCUTS. */
+export const LINK_MENU_ROWS = ['edit', 'open', 'embed', 'remove'] as const;
+
+/** Asks the open link menu to run one of its rows. */
+export const CANVAS_LINK_ACTION_EVENT = 'canvas:link-action';
+
+/** The link the menu is currently offering actions for, if any. */
+export function linkUnderMenu(state: EditorState): LinkRange | null {
+  const pasted = getPastedLink(state);
+  if (pasted) return pasted;
+
+  const linkMark = state.schema.marks['link'];
+  if (!linkMark) return null;
+
+  const caret = state.selection.$from;
+  const mark = caret.marks().find(candidate => candidate.type === linkMark);
+  if (!mark) return null;
+  const href = typeof mark.attrs['href'] === 'string' ? mark.attrs['href'] : null;
+  if (!href) return null;
+
+  // The mark's own span, which the caret sits somewhere inside.
+  const parentStart = caret.start();
+  let from = parentStart;
+  let to = parentStart;
+  caret.parent.forEach((node, offset) => {
+    if (!node.isText || !mark.isInSet(node.marks)) return;
+    const start = parentStart + offset;
+    const end = start + node.nodeSize;
+    if (caret.pos < start || caret.pos > end) return;
+    from = start;
+    to = end;
+  });
+
+  return to > from ? { url: href, from, to } : null;
+}
+
+/**
+ * Runs the link menu's rows from the keyboard.
+ *
+ * A shortcut presses its row rather than repeating what the row does, so the two
+ * cannot drift apart — and the row already handles the parts that are not a
+ * simple edit, like the form the Edit row opens, or unlinking without the
+ * autolinker immediately putting the link back.
+ */
+export const canvasLinkShortcutsExtension = Extension.create({
+  name: 'canvasLinkShortcuts',
+  // Ahead of BlockNote's own Tab handling, which would otherwise nest the block.
+  priority: 1000,
+
+  addKeyboardShortcuts() {
+    const press = (row: number) => (): boolean => {
+      const view = this.editor.view;
+      if (!linkUnderMenu(view.state)) return false;
+      view.dom.dispatchEvent(
+        new CustomEvent(CANVAS_LINK_ACTION_EVENT, { bubbles: true, detail: { row } }),
+      );
+      return true;
+    };
+
+    return Object.fromEntries(
+      LINK_MENU_ROWS.map((name, index) => [LINK_SHORTCUTS[name], press(index)]),
+    );
+  },
+});

--- a/apps/dashboard/src/components/Canvas/canvasPastedLink.ts
+++ b/apps/dashboard/src/components/Canvas/canvasPastedLink.ts
@@ -1,0 +1,139 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
+import { AddMarkStep } from '@tiptap/pm/transform';
+import type { EditorView } from '@tiptap/pm/view';
+import { editorView } from './canvasEditorView';
+
+export interface PastedLink {
+  url: string;
+  from: number;
+  to: number;
+}
+
+interface PasteState {
+  link: PastedLink | null;
+  /** A paste has landed and its autolink has not arrived yet. */
+  awaitingLink: boolean;
+}
+
+const EMPTY: PasteState = { link: null, awaitingLink: false };
+
+const pastedLinkKey = new PluginKey<PasteState>('canvasPastedLink');
+
+type Listener = (link: PastedLink | null) => void;
+
+/** The TipTap editor, which exists well before its ProseMirror view does. */
+export interface PastedLinkHost {
+  view: EditorView;
+}
+
+const listeners = new WeakMap<object, Set<Listener>>();
+
+/** The link the reader has just pasted and not yet acted on. */
+export const getPastedLink = (state: EditorState): PastedLink | null =>
+  pastedLinkKey.getState(state)?.link ?? null;
+
+export const clearPastedLink = (host: PastedLinkHost): void => {
+  const view = editorView(host);
+  view?.dispatch(view.state.tr.setMeta(pastedLinkKey, null));
+};
+
+/**
+ * Keyed on the editor rather than its view: a child of `BlockNoteView` subscribes
+ * before the view it would otherwise key on has been created.
+ */
+export function subscribeToPastedLink(host: PastedLinkHost, listener: Listener): () => void {
+  const forHost = listeners.get(host) ?? new Set<Listener>();
+  listeners.set(host, forHost);
+  forHost.add(listener);
+  const view = editorView(host);
+  listener(view ? getPastedLink(view.state) : null);
+  return () => {
+    forHost.delete(listener);
+  };
+}
+
+/**
+ * The link mark a transaction adds, if it adds one.
+ *
+ * Pasting a URL takes two transactions: the first inserts plain text, and a
+ * second autolinks it. Only the second carries the link, and a mark step moves
+ * nothing, so its range has to be read off the step itself rather than from the
+ * transaction's mapping.
+ */
+function linkMarkAddedIn(transaction: Transaction): PastedLink | null {
+  const linkMark = transaction.doc.type.schema.marks['link'];
+  if (!linkMark) return null;
+
+  for (let index = 0; index < transaction.steps.length; index += 1) {
+    const step = transaction.steps[index];
+    if (!(step instanceof AddMarkStep) || step.mark.type !== linkMark) continue;
+
+    const href: unknown = step.mark.attrs['href'];
+    if (typeof href !== 'string' || !href) continue;
+
+    const rest = transaction.mapping.slice(index + 1);
+    return { url: href, from: rest.map(step.from), to: rest.map(step.to) };
+  }
+
+  return null;
+}
+
+/**
+ * Tracks the link a paste just produced, so the link menu can be offered there.
+ *
+ * Watches for the link a paste created rather than handling the paste itself:
+ * BlockNote claims the paste event first in order to autolink the URL, so a
+ * handler here would never run. Link marks are not inclusive, so a caret left
+ * sitting after the pasted text reports no link and BlockNote's own toolbar
+ * stays shut — hence tracking it ourselves.
+ */
+export const canvasPastedLinkExtension = Extension.create({
+  name: 'canvasPastedLink',
+  addProseMirrorPlugins() {
+    const host = this.editor as unknown as object;
+    return [
+      new Plugin<PasteState>({
+        key: pastedLinkKey,
+        state: {
+          init: (): PasteState => EMPTY,
+          apply: (transaction, current): PasteState => {
+            const explicit = transaction.getMeta(pastedLinkKey) as PastedLink | null | undefined;
+            if (explicit !== undefined) return { link: explicit, awaitingLink: false };
+
+            const isPaste =
+              transaction.getMeta('paste') === true || transaction.getMeta('uiEvent') === 'paste';
+            if (isPaste) {
+              const immediate = linkMarkAddedIn(transaction);
+              return immediate
+                ? { link: immediate, awaitingLink: false }
+                : { link: null, awaitingLink: true };
+            }
+
+            if (current.awaitingLink) {
+              const linked = linkMarkAddedIn(transaction);
+              if (linked) return { link: linked, awaitingLink: false };
+              return transaction.docChanged ? EMPTY : current;
+            }
+
+            const { link } = current;
+            if (!link) return current;
+
+            // Any edit of the reader's own, or a move away from the link, makes a
+            // standing offer stale.
+            if (transaction.docChanged) return EMPTY;
+            const caret = transaction.selection.from;
+            return caret < link.from || caret > link.to ? EMPTY : current;
+          },
+        },
+        view: () => ({
+          update: (view, previousState): void => {
+            const link = getPastedLink(view.state);
+            if (link === getPastedLink(previousState)) return;
+            listeners.get(host)?.forEach(listener => listener(link));
+          },
+        }),
+      }),
+    ];
+  },
+});

--- a/apps/dashboard/src/components/Canvas/canvasSchema.ts
+++ b/apps/dashboard/src/components/Canvas/canvasSchema.ts
@@ -12,6 +12,11 @@ import { citationInlineContentSpec } from './CanvasCitationSpec';
 import { knownBlockTypesOf } from '../../utils/canvasUtils';
 import { canvasCommentThreadStyleSpec } from './CanvasCommentStyleSpec/CanvasCommentStyleSpec';
 import { canvasCodeBlockSpec } from './CanvasCodeBlockSpec';
+import { CANVAS_EMBED_TYPE, canvasEmbedSpec } from './CanvasEmbedSpec';
+import { canvasFileBlockSpec } from './CanvasFileBlockSpec';
+import { canvasLinkShortcutsExtension } from './canvasLinkShortcuts';
+import { canvasPastedLinkExtension } from './canvasPastedLink';
+import { canvasTableShortcutsExtension } from './canvasTableShortcuts';
 
 // Default blocks + whiteboard, then extended with mention and citation inline content.
 // Shared by the canvas editors and the read-only previews: a preview built on a
@@ -24,6 +29,8 @@ function createCanvasSchema() {
       diagram: createReactDiagramBlockSpec(),
       mathBlock: createReactMathBlockSpec(),
       codeBlock: canvasCodeBlockSpec,
+      [CANVAS_EMBED_TYPE]: canvasEmbedSpec,
+      file: canvasFileBlockSpec,
     }),
   } as Parameters<typeof BlockNoteSchema.create>[0]).extend({
     inlineContentSpecs: {
@@ -268,7 +275,12 @@ const handleCanvasTableKeyDown = (view: EditorView, event: KeyboardEvent): boole
 };
 
 export const canvasTiptapOptions = {
-  extensions: [canvasTablePendingExitRowExtension],
+  extensions: [
+    canvasTablePendingExitRowExtension,
+    canvasPastedLinkExtension,
+    canvasLinkShortcutsExtension,
+    canvasTableShortcutsExtension,
+  ],
   editorProps: {
     handleKeyDown: handleCanvasTableKeyDown,
   },

--- a/apps/dashboard/src/components/Canvas/canvasSlashMenu.ts
+++ b/apps/dashboard/src/components/Canvas/canvasSlashMenu.ts
@@ -1,0 +1,32 @@
+import type { DefaultReactSuggestionItem } from '@blocknote/react';
+
+const HEADING_TITLE = /^Heading (\d)$/;
+
+const headingLevel = (item: DefaultReactSuggestionItem): number =>
+  Number(HEADING_TITLE.exec(item.title)?.[1] ?? 0);
+
+/**
+ * Puts every heading under Headings.
+ *
+ * BlockNote files 4, 5 and 6 under Subheadings, beside the toggle headings, so
+ * the six levels of one thing were split across two groups a scroll apart. The
+ * group is read off Heading 1 rather than named here, so it survives however the
+ * dictionary labels it.
+ */
+export function withHeadingsTogether(
+  items: DefaultReactSuggestionItem[],
+): DefaultReactSuggestionItem[] {
+  const group = items.find(item => item.title === 'Heading 1')?.group;
+  if (!group) return items;
+
+  const strays = items.filter(item => HEADING_TITLE.test(item.title) && item.group !== group);
+  if (strays.length === 0) return items;
+
+  const rest = items.filter(item => !strays.includes(item));
+  const lastInGroup = rest.reduce((last, item, index) => (item.group === group ? index : last), -1);
+  const moved = [...strays]
+    .sort((a, b) => headingLevel(a) - headingLevel(b))
+    .map(item => ({ ...item, group }));
+
+  return [...rest.slice(0, lastInGroup + 1), ...moved, ...rest.slice(lastInGroup + 1)];
+}

--- a/apps/dashboard/src/components/Canvas/canvasTableShortcuts.ts
+++ b/apps/dashboard/src/components/Canvas/canvasTableShortcuts.ts
@@ -1,0 +1,78 @@
+import { Extension } from '@tiptap/core';
+import type { Command, EditorState } from '@tiptap/pm/state';
+import {
+  addColumnBefore,
+  addRowBefore,
+  CellSelection,
+  deleteColumn,
+  deleteRow,
+  isInTable,
+  selectionCell,
+} from '@tiptap/pm/tables';
+
+/**
+ * Excel's table keys, which the canvas had none of.
+ *
+ * Tab already walks the cells and Enter adds a row off the last one; reshaping
+ * the table had nothing at all. Excel needs only two editing keys because the
+ * selection says whether a row or a column is meant, and insert puts the new one
+ * above or to the left of it. Its modifier is Control, which leaves Cmd-plus and
+ * Cmd-minus to the browser's zoom.
+ */
+export const TABLE_SHORTCUTS = {
+  selectRow: 'Shift-Space',
+  selectColumn: 'Ctrl-Space',
+  insert: 'Ctrl-Shift-=',
+  delete: 'Ctrl--',
+} as const;
+
+/** Labels for the table handle menu, keyed by what the menu calls each action. */
+export const TABLE_SHORTCUT_HINTS: Readonly<Record<string, string>> = {
+  row: TABLE_SHORTCUTS.selectRow,
+  column: TABLE_SHORTCUTS.selectColumn,
+  insert: TABLE_SHORTCUTS.insert,
+  delete: TABLE_SHORTCUTS.delete,
+};
+
+const isColumnSelected = (state: EditorState): boolean =>
+  state.selection instanceof CellSelection && state.selection.isColSelection();
+
+/** Selects the whole row or column the caret is in, the way Excel does. */
+const selectAcross = (orientation: 'row' | 'column'): Command =>
+  function selectRowOrColumn(state, dispatch): boolean {
+    const cell = selectionCell(state);
+    if (!cell) return false;
+    if (dispatch) {
+      const selection =
+        orientation === 'row'
+          ? CellSelection.rowSelection(cell, cell)
+          : CellSelection.colSelection(cell, cell);
+      dispatch(state.tr.setSelection(selection));
+    }
+    return true;
+  };
+
+/** Insert and delete read the selection to know which way round they act. */
+const acrossSelection = (row: Command, column: Command): Command =>
+  function actOnSelection(state, dispatch, view): boolean {
+    return isColumnSelected(state) ? column(state, dispatch, view) : row(state, dispatch, view);
+  };
+
+export const canvasTableShortcutsExtension = Extension.create({
+  name: 'canvasTableShortcuts',
+
+  addKeyboardShortcuts() {
+    const run = (command: Command) => (): boolean => {
+      const view = this.editor.view;
+      if (!isInTable(view.state)) return false;
+      return command(view.state, view.dispatch.bind(view), view);
+    };
+
+    return {
+      [TABLE_SHORTCUTS.selectRow]: run(selectAcross('row')),
+      [TABLE_SHORTCUTS.selectColumn]: run(selectAcross('column')),
+      [TABLE_SHORTCUTS.insert]: run(acrossSelection(addRowBefore, addColumnBefore)),
+      [TABLE_SHORTCUTS.delete]: run(acrossSelection(deleteRow, deleteColumn)),
+    };
+  },
+});

--- a/apps/dashboard/src/components/Canvas/useCanvasTableFilters.tsx
+++ b/apps/dashboard/src/components/Canvas/useCanvasTableFilters.tsx
@@ -1006,7 +1006,7 @@ export const useCanvasTableFilters = (containerRef: RefObject<HTMLElement | null
       if (existing) {
         const isSameTableRegistration =
           existing.table === table && existing.blockContent === blockContent;
-        const isMountAttached = existing.mount.parentElement === wrapper;
+        const isMountAttached = existing.mount.parentElement === blockContent;
 
         if (isSameTableRegistration && isMountAttached) continue;
 
@@ -1014,9 +1014,11 @@ export const useCanvasTableFilters = (containerRef: RefObject<HTMLElement | null
         registrationsRef.current.delete(wrapper);
       }
 
+      // On the block, not the wrapper: the wrapper scrolls sideways for a wide
+      // table and would carry the button off with it.
       const mount = document.createElement('div');
       mount.className = TABLE_FILTER_MOUNT_CLASS;
-      wrapper.appendChild(mount);
+      blockContent.appendChild(mount);
 
       const reactRoot = createRoot(mount);
       reactRoot.render(

--- a/apps/dashboard/src/components/Canvas/videoEmbedUrl.ts
+++ b/apps/dashboard/src/components/Canvas/videoEmbedUrl.ts
@@ -1,0 +1,88 @@
+import { getYoutubeVideoId } from '../Chat/LinkPreview/youtubeUtils';
+
+export type VideoEmbedProvider = 'youtube' | 'vimeo' | 'loom';
+
+export interface VideoEmbed {
+  provider: VideoEmbedProvider;
+  embedUrl: string;
+}
+
+/**
+ * Whether a URL is served by `host` itself, or its www form.
+ *
+ * Compared whole rather than by suffix: `endsWith('loom.com')` also accepts
+ * `evil-loom.com`, which would put an attacker's page in the iframe.
+ */
+const hostIs = (url: URL, host: string): boolean => {
+  const hostname = url.hostname.toLowerCase();
+  return hostname === host || hostname === `www.${host}`;
+};
+
+/**
+ * A watch page is not a video file, so <video src> cannot play one. Each service
+ * publishes its own embeddable URL instead, and the shapes have nothing in
+ * common — hence a table rather than a rule. Adding a service is one entry.
+ */
+const RULES: ReadonlyArray<{
+  provider: VideoEmbedProvider;
+  toEmbedUrl: (url: URL) => string | null;
+}> = [
+  {
+    provider: 'youtube',
+    toEmbedUrl: (url): string | null => {
+      const shortsId = hostIs(url, 'youtube.com')
+        ? /^\/shorts\/([a-zA-Z0-9_-]+)/.exec(url.pathname)?.[1]
+        : undefined;
+      const videoId = getYoutubeVideoId(url.href) ?? shortsId;
+      if (!videoId) return null;
+
+      const embed = new URL(`https://www.youtube.com/embed/${videoId}`);
+      embed.searchParams.set('rel', '0');
+      // Carried over so a link copied from a playlist still plays as one, and a
+      // link copied mid-video still starts where the reader left it.
+      const list = url.searchParams.get('list');
+      if (list) embed.searchParams.set('list', list);
+      const start = url.searchParams.get('t') ?? url.searchParams.get('start');
+      if (start) {
+        const seconds = /^\d+$/.test(start) ? start : /^(\d+)s$/.exec(start)?.[1];
+        if (seconds) embed.searchParams.set('start', seconds);
+      }
+      return embed.href;
+    },
+  },
+  {
+    provider: 'vimeo',
+    toEmbedUrl: (url): string | null => {
+      if (!hostIs(url, 'vimeo.com')) return null;
+      const videoId = /^\/(\d+)/.exec(url.pathname)?.[1];
+      return videoId ? `https://player.vimeo.com/video/${videoId}` : null;
+    },
+  },
+  {
+    provider: 'loom',
+    toEmbedUrl: (url): string | null => {
+      if (!hostIs(url, 'loom.com')) return null;
+      const videoId = /^\/share\/([a-zA-Z0-9]+)/.exec(url.pathname)?.[1];
+      return videoId ? `https://www.loom.com/embed/${videoId}` : null;
+    },
+  },
+];
+
+/** The embeddable form of a video URL, or null when it is not one we can play. */
+export function resolveVideoEmbed(rawUrl: string): VideoEmbed | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl.trim());
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+
+  for (const rule of RULES) {
+    const embedUrl = rule.toEmbedUrl(url);
+    if (embedUrl) return { provider: rule.provider, embedUrl };
+  }
+  return null;
+}
+
+export const isVideoEmbedUrl = (rawUrl: string): boolean => resolveVideoEmbed(rawUrl) !== null;

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2281,11 +2281,18 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
    formatting toolbar, tooltips) is painted from these variables. They are
    normally set on the BlockNoteView root, but those menus render in a portal
    on <body>, so they fall out of that scope and land on the light defaults —
-   which is why the drag menu stayed white in midnight. Defining them at :root
-   fixes the portals, and because our own tokens already flip per theme this
-   single mapping serves light and midnight both.
+   which is why the drag menu stayed white in midnight. Because our own tokens
+   already flip per theme this single mapping serves light and midnight both.
+
+   It has to be set at both scopes. Portalled menus need :root; everything else
+   sits inside .bn-root, which BlockNote paints itself — a nearer ancestor, so
+   it won over :root and left the link toolbar, form popovers and the LaTeX
+   source popup on the stock light palette. The `html` prefix outranks
+   BlockNote's own [data-color-scheme] rule whatever order the sheets load in.
    ============================================================ */
-:root {
+:root,
+html .bn-root,
+html .bn-root[data-color-scheme] {
   --bn-colors-editor-text: hsl(var(--foreground));
   --bn-colors-editor-background: transparent;
   --bn-colors-menu-text: hsl(var(--popover-foreground));
@@ -2301,6 +2308,115 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
   --bn-colors-shadow: hsl(var(--foreground) / 0.12);
   --bn-colors-border: hsl(var(--border));
   --bn-colors-side-menu: hsl(var(--muted-foreground));
+}
+
+/* These few surfaces are painted from literal colours rather than the palette
+   above, with their dark variant gated on BlockNote's own `.dark` class, so the
+   mapping cannot reach them: the LaTeX / diagram placeholder, the add-file
+   button, and the OK button on a source popup — which was a stock blue in every
+   theme. Repainted from app tokens. The `html` prefix outranks the stock rules. */
+html .bn-preview-placeholder,
+html [data-file-block] .bn-add-file-button {
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+}
+
+html
+  .bn-editor[contenteditable="true"]
+  .bn-preview-placeholder:not(.bn-preview-placeholder-error):hover,
+html .bn-editor[contenteditable="true"] [data-file-block] .bn-add-file-button:hover {
+  background-color: hsl(var(--accent));
+}
+
+html .bn-code-block-source-popup-ok-button {
+  background-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+
+html .bn-code-block-source-popup-ok-button:hover {
+  background-color: hsl(var(--primary) / 0.9);
+}
+
+/* A file block lays its content out with flex, and the wrapper round the card is
+   an item that shrinks to fit, so the card would stop short of the column. */
+.bn-block-content[data-content-type="file"]
+  > .bn-file-block-content-wrapper:has(.canvas-file-card) {
+  width: 100%;
+  flex: 1 1 auto;
+}
+
+/* The link menu reads as a list, so it stacks and its buttons fill the width. */
+.canvas-link-menu {
+  flex-direction: column;
+  align-items: stretch;
+  min-width: 11rem;
+  padding: 0.25rem;
+}
+
+.canvas-link-menu .mantine-Button-root {
+  justify-content: flex-start;
+  width: 100%;
+  height: auto;
+  padding: 0.375rem 0.5rem;
+}
+
+.canvas-link-menu .mantine-Button-label {
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.canvas-link-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  font-weight: 400;
+}
+
+/* The table keys, shown where the same actions live. A footer rather than a
+   badge per item: the menu's children replace its defaults wholesale and the
+   header and colour buttons are not exported, so appending is the only way to
+   add to it without dropping them. Excel uses these keys on both platforms. */
+.bn-table-handle-menu::after {
+  content: "Row \21E7 Space  ·  Column \2303 Space  ·  Insert \2303\21E7=  ·  Delete \2303-";
+  display: block;
+  margin-top: 4px;
+  padding: 6px 8px 2px;
+  border-top: 1px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+  font-size: 0.7rem;
+  line-height: 1.2;
+}
+
+/* Shortcut badge, sat against the right edge like the slash menu's. */
+.canvas-link-menu-key {
+  margin-left: auto;
+  padding: 0.05rem 0.3rem;
+  border-radius: 0.25rem;
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-family: inherit;
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+/* Portalled out of the editor, so it carries its own stacking and placement. */
+.canvas-pasted-link-toolbar {
+  position: fixed;
+  z-index: 60;
+}
+
+/* BlockNote ships no link styling of its own, and Tailwind's preflight resets
+   anchors to `color: inherit`, so canvas links rendered as plain body text.
+   Same treatment the chat and email composers already give theirs. */
+.bn-editor a {
+  color: var(--link-color);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.bn-editor a:hover {
+  color: var(--link-hover-color);
 }
 
 /* BlockNote menus cap out at `max-height: inherit`, which resolves to the whole
@@ -2894,6 +3010,11 @@ span.chat-input-special-mention[data-mention-type="here"]:hover {
 /* Table cell selection fill — themed (BlockNote hardcodes a periwinkle #c8c8ff). */
 .canvas-surface .bn-editor .selectedCell:after {
   background: hsl(var(--ring) / 0.2);
+}
+/* Anchors the filter button to the block rather than the sideways-scrolling
+   wrapper, so it stays at the top right of a wide table. */
+.canvas-surface .bn-editor .bn-block-content[data-content-type="table"] {
+  position: relative;
 }
 /* Align the table grid's left edge with paragraphs/code blocks — BlockNote reserves a 9px
    left inset on .tableWrapper for the row handles; drop it so all blocks start at the same X. */

--- a/apps/electron/src/services/request-interceptor.ts
+++ b/apps/electron/src/services/request-interceptor.ts
@@ -267,7 +267,7 @@ function installFrontendCsp(): void {
     `media-src 'self' blob: ${xyneHosts}`,
     `connect-src 'self' ${xyneHosts} ${xyneWs} https://o4507796893925376.ingest.us.sentry.io https://accounts.google.com https://*.googleapis.com ${sandpackBundler}`,
     `font-src 'self' data: ${xyneHosts} ${googleFontsFiles}`,
-    `frame-src 'self' blob: ${xyneHosts} https://www.youtube.com https://accounts.google.com https://docs.google.com ${sandpackBundler}`,
+    `frame-src 'self' blob: ${xyneHosts} https://www.youtube.com https://player.vimeo.com https://www.loom.com https://accounts.google.com https://docs.google.com ${sandpackBundler}`,
     `worker-src 'self' blob:`,
     `object-src 'none'`,
     `base-uri 'none'`,


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-60697 — canvas fixes and keyboard support.

### Links

- **Links weren't blue.** BlockNote ships no anchor styling and Tailwind's preflight resets `color: inherit`.
- **Embedding a URL** — YouTube (incl. `&list=`/`&t=`), youtu.be, `/shorts/`, Vimeo, Loom get a player; anything else gets a clickable card. Offered on paste and from the link menu.
- **Embed left the link behind** — you can't replace an inline range with a block, so the embed goes in its own block after the paragraph.
- **The paste offer never appeared** — pasting a URL takes two transactions and only the second carries the link mark, which my first attempt at this missed entirely.
- **One link menu, as a list** — paste and hover were two hand-built menus that had drifted. Now one component: Edit · Open in new tab · Embed · Remove link.
- **The paste menu was unstyled, then stacked under the hover one** — wrong portal target, then no handover.

### Files, tables, dark mode

- **Uploaded files render as a card** (icon, name, type, download) at full column width — the width rule had been hanging off an attribute the block doesn't carry.
- **Insert a file/image/video/audio → the OS picker opens directly.** The Upload/Embed dialog is gone; cancelling removes the empty block.
- **The table filter button stayed put** — it lived inside the sideways-scrolling wrapper and slid 160px off-screen.
- **Dark mode reached BlockNote's surfaces.** The palette mapping sat at `:root` while BlockNote sets the same variables on `.bn-root`, so only body-portalled menus were ever fixed. Link toolbar, form popovers, LaTeX popup — plus the placeholder, add-file button and the source-popup OK button, which was a stock blue in both themes.

### Keyboard

- **Link menu:** `Tab` embed · `⇧Tab` edit · `⌘⇧O` open · `⌘⇧U` unlink, `↑`/`↓` + `Enter` to pick, without focus leaving the text. Keys show only when the caret is in the link.
- **Tables:** Excel's model — `⇧Space`/`⌃Space` select, `⌃⇧=` insert, `⌃-` delete. Listed in the table handle menu.
- **Slash menu: 9 badged → 25.** Basic blocks read as their initial (`⌘⌥B/L/K/H/R`), toggle headings mirror the headings, Media runs 4-7.
- **All six heading levels** now sit in one Headings group.

Shortcut families avoid keys the OS or browser claims: `⌘⇧3-5` (screenshots), `⌘⌥D/M/W` (Dock, Minimise All, Safari close-other-tabs), `⌘⌥I/J/C` (devtools), `⌘⌥`+arrows (tabs), `⌘K` (app), and `⌘⌃` (unspellable on Windows, where Mod is already Ctrl).

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [x] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

Electron is a one-line CSP change: `frame-src` gains `player.vimeo.com` and `www.loom.com` so those embeds render in the desktop app. YouTube was already allowed.

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed**
- [x] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

Only the Electron CSP `frame-src` allowlist above — two video hosts added, nothing removed. No env keys, no secrets.

## API Contract

- [x] No API changes

---

## How did you test it?

Behaviour was driven in a real BlockNote editor with Playwright rather than reasoned about, because most of these bugs only show up under interaction. Each fix was asserted against editor state or computed styles:

- **Paste** — logged every ProseMirror transaction to find that the link mark arrives in a second transaction with no paste meta and no mapped range. Verified the menu now appears on paste, and that hovering hands over to the standard toolbar instead of stacking (1 menu, not 2).
- **Embed** — `⌘⌥`/Tab/Enter paths all produce `youtube.com/embed/<id>?rel=0` and remove the anchor.
- **Link menu** — computed styles of the paste and hover menus compared field by field, identical; `Remove link` strips the anchor and keeps the text.
- **File card** — measured the ancestor chain: card 1540px = block content = a paragraph in the same doc, flush left.
- **Table filter** — asserted the gap to the right edge stays 28px at `scrollLeft` 0, 400 and 843 (previously 28 → 428 → off-screen).
- **Dark mode** — with the app in midnight, swept every rendered element for a light background: zero remaining. Re-checked light mode for regressions.
- **Shortcuts** — every key pressed for real and the resulting block type asserted (`bulletListItem`, `checkListItem`, `toggleListItem`, `divider`, `mathBlock`, table). Table shape asserted after each Excel key. Confirmed `Tab` still nests blocks outside a link.

Not automated — no test harness exists for the canvas editor; the scratch page used for the above was deleted.

### Automated

- [ ] Backend unit tests
- [ ] Claw tests
- [ ] End-to-end suite
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- no canvas editor test harness; verified interactively as above -->

### Manual

**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser
- [x] Narrow viewport, dark + light theme
- [x] Empty state

Reviewer note: the collaborative editor path (`CollaborativeCanvasEditor`) shares every component changed here but was exercised less directly than the standalone one — worth a look on a shared canvas.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass <!-- backend untouched -->
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [ ] New deps added <!-- none -->
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBL9sPsjewjPqHvCmMrXLE
