### PR TITLE
feat: move calls into a dedicated window with a pre-join lobby

### DIFF
--- a/apps/dashboard/src/components/Call/CallBar/CallBar.tsx
+++ b/apps/dashboard/src/components/Call/CallBar/CallBar.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Mic, MicOff, PhoneOff, Video, VideoOff } from 'lucide-react';
+import {
+  isCallWindowActive,
+  requestCallWindowState,
+  sendCallWindowCommand,
+  subscribeCallWindowChannel,
+  type CallWindowState,
+} from '../../../utils/callWindowChannel';
+import { focusCallWindow } from '../../../utils/electronApp';
+
+export function CallBar(): React.ReactElement | null {
+  const [state, setState] = useState<CallWindowState | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeCallWindowChannel({
+      onState: setState,
+      onEnded: () => setState(null),
+    });
+    requestCallWindowState();
+    const staleTimer = setInterval(() => {
+      if (!isCallWindowActive()) setState(null);
+    }, 5000);
+    return () => {
+      clearInterval(staleTimer);
+      unsubscribe();
+    };
+  }, []);
+
+  if (!state) return null;
+
+  return createPortal(
+    <div className='pointer-events-none fixed inset-x-0 bottom-4 z-[45] flex justify-center'>
+      <div className='pointer-events-auto flex items-center gap-2 rounded-full border border-border bg-popover px-3 py-2 text-popover-foreground shadow-lg'>
+        <span
+          className={`h-2 w-2 shrink-0 rounded-full ${
+            state.connected ? 'bg-emerald-500' : 'bg-amber-500'
+          }`}
+          aria-hidden
+        />
+        <button
+          type='button'
+          onClick={focusCallWindow}
+          className='max-w-[220px] truncate text-sm font-medium'
+          title='Return to call'
+          data-track-category='CALLS'
+          data-track-name='Call_Bar_Return_To_Call'
+        >
+          {state.title ?? 'Call in progress'}
+        </button>
+
+        <div className='mx-1 h-4 w-px bg-border' aria-hidden />
+
+        <button
+          type='button'
+          aria-label={state.micEnabled ? 'Mute microphone' : 'Unmute microphone'}
+          onClick={() => sendCallWindowCommand('toggle-mic')}
+          data-track-category='CALLS'
+          data-track-name='Call_Bar_Toggle_Mic'
+          className='flex h-7 w-7 items-center justify-center rounded-full hover:bg-muted'
+        >
+          {state.micEnabled ? <Mic size={15} /> : <MicOff size={15} className='text-destructive' />}
+        </button>
+        <button
+          type='button'
+          aria-label={state.cameraEnabled ? 'Turn off camera' : 'Turn on camera'}
+          onClick={() => sendCallWindowCommand('toggle-camera')}
+          data-track-category='CALLS'
+          data-track-name='Call_Bar_Toggle_Camera'
+          className='flex h-7 w-7 items-center justify-center rounded-full hover:bg-muted'
+        >
+          {state.cameraEnabled ? (
+            <Video size={15} />
+          ) : (
+            <VideoOff size={15} className='text-muted-foreground' />
+          )}
+        </button>
+        <button
+          type='button'
+          aria-label='Leave call'
+          onClick={() => sendCallWindowCommand('leave')}
+          data-track-category='CALLS'
+          data-track-name='Call_Bar_Leave'
+          className='flex h-7 w-7 items-center justify-center rounded-full bg-destructive text-destructive-foreground'
+        >
+          <PhoneOff size={14} />
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/dashboard/src/components/Call/CallModals/IncomingCallModal.tsx
+++ b/apps/dashboard/src/components/Call/CallModals/IncomingCallModal.tsx
@@ -25,6 +25,9 @@ import type { IncomingCallViewModel } from '../IncomingCall/IncomingCallCard.typ
 import { useRecordingStore } from '../../../hooks/useRecordingStore';
 import { useExternalMeeting, useMicBusy } from '../../../stores/externalMeetingStore';
 import { logger, Event } from '../../../utils/logger';
+import { useCallWindowRing } from '../../../routes/CallWindow/useCallWindowRing';
+import { openJoinCallWindow } from '../../../routes/CallWindow/callWindowLauncher';
+import { sendCallWindowCommand } from '../../../utils/callWindowChannel';
 
 type CallWithRelations = QueryResultType<typeof queries.userActiveCalls>[number];
 
@@ -95,6 +98,18 @@ export function IncomingCallModal(): React.ReactElement | null {
     });
   });
 
+  // A stable identity for "which calls are ringable right now". incomingCalls is a
+  // fresh array on every render (it also recomputes Date.now()), so using it as a
+  // dependency re-arms the 500ms debounce below on every render — under call-related
+  // re-render churn the timer can be starved indefinitely and INCOMING_CALL for the
+  // new call never dispatches at all.
+  const ringableIdsKey = (incomingCalls ?? [])
+    .map(call => String(call.externalId))
+    .sort()
+    .join(',');
+  const incomingCallsRef = useRef(incomingCalls);
+  incomingCallsRef.current = incomingCalls;
+
   useEffect(() => {
     // Clear any existing timeout
     if (processingTimeoutRef.current) {
@@ -106,9 +121,10 @@ export function IncomingCallModal(): React.ReactElement | null {
       // Only process incoming calls when in stable states (not during transitions)
       if (!canShowIncomingCalls) return;
 
-      if (!incomingCalls?.length) return;
+      const ringable = incomingCallsRef.current;
+      if (!ringable?.length) return;
 
-      incomingCalls.forEach(call => {
+      ringable.forEach(call => {
         const callId = String(call.externalId);
         const callWithRelations = call as CallWithRelations;
 
@@ -144,17 +160,13 @@ export function IncomingCallModal(): React.ReactElement | null {
         clearTimeout(processingTimeoutRef.current);
       }
     };
-  }, [incomingCalls, incomingCallQueue, canShowIncomingCalls, user?.id]);
+  }, [ringableIdsKey, incomingCallQueue, canShowIncomingCalls, user?.id, usersById]);
 
   // The caller hanging up removes the call from activeCalls. Tear the modal
   // down on that change rather than inside the debounce below — half a second
   // of a card for a call that has already ended reads as an unresponsive UI,
   // and the debounce exists to settle calls *arriving*, not leaving.
   const ringingCallId = incomingCallQueue[0]?.callId;
-  const ringableIdsKey = (incomingCalls ?? [])
-    .map(call => String(call.externalId))
-    .sort()
-    .join(',');
 
   const hasLoadedActiveCalls = allActiveCalls !== undefined;
 
@@ -164,7 +176,7 @@ export function IncomingCallModal(): React.ReactElement | null {
     // that ended — concluding otherwise would hang up on a live caller.
     if (!hasLoadedActiveCalls) return;
     if (ringableIdsKey.split(',').includes(ringingCallId)) return;
-    callActor.send({ type: 'REJECT' });
+    callActor.send({ type: 'REJECT', callId: ringingCallId });
   }, [ringingCallId, ringableIdsKey, hasLoadedActiveCalls]);
 
   // Initialize audio once
@@ -222,6 +234,15 @@ export function IncomingCallModal(): React.ReactElement | null {
   }
   const silenceReason = incomingCallData ? (silenceRef.current?.reason ?? null) : null;
 
+  const ringingCall = (allActiveCalls ?? []).find(
+    call => String(call.externalId) === incomingCallData?.callId,
+  ) as CallWithRelations | undefined;
+
+  const { usesCallWindow, ringWindowShown, ringWindowCallId, focusRingWindow } = useCallWindowRing({
+    ringingCallId: isRinging && incomingCallData ? incomingCallData.callId : undefined,
+    callType: ringingCall?.callType,
+  });
+
   // Play notification sound when incoming call appears
   useEffect(() => {
     const shouldPlay = isRinging && incomingCallData && !silenceReason;
@@ -244,24 +265,51 @@ export function IncomingCallModal(): React.ReactElement | null {
         audioRef.current.currentTime = 0;
       }
 
+      // The id of the call actually being accepted. Every downstream step is keyed on
+      // this, never on the queue head — the head is the oldest queued call, which after
+      // a DM call is the DM, not the channel call the user just clicked.
+      const targetCallId = callIdToAccept ?? incomingCallData?.callId;
+
       // Close the native notification if in Electron
       if (
         window.electronAPI &&
-        callIdToAccept &&
+        targetCallId &&
         typeof window.electronAPI.closeCallNotification === 'function'
       ) {
-        window.electronAPI.closeCallNotification(callIdToAccept);
+        window.electronAPI.closeCallNotification(targetCallId);
+      }
+
+      if (usesCallWindow) {
+        // Focus only when the ring window is already showing this exact call. Focusing
+        // blind joins whatever that window happens to display, which is the previous
+        // call whenever its navigation was deferred.
+        if (targetCallId && ringWindowShown && ringWindowCallId === targetCallId) {
+          focusRingWindow();
+        } else if (targetCallId) {
+          sendCallWindowCommand('leave');
+          openJoinCallWindow(targetCallId, { replaceLiveCall: true });
+        }
+        callActor.send({ type: 'REJECT', callId: targetCallId });
+        return;
       }
 
       if (isInActiveCall) {
         // Send SWITCH_CALL event to disconnect current call and join new one
-        callActor.send({ type: 'SWITCH_CALL', zero });
+        callActor.send({ type: 'SWITCH_CALL', zero, callId: targetCallId });
       } else {
         // Normal accept flow
-        callActor.send({ type: 'ACCEPT', zero });
+        callActor.send({ type: 'ACCEPT', zero, callId: targetCallId });
       }
     },
-    [isInActiveCall, zero],
+    [
+      focusRingWindow,
+      incomingCallData?.callId,
+      isInActiveCall,
+      ringWindowCallId,
+      ringWindowShown,
+      usesCallWindow,
+      zero,
+    ],
   );
 
   const handleRejectCall = useCallback(
@@ -286,8 +334,8 @@ export function IncomingCallModal(): React.ReactElement | null {
         void zero.mutate(mutators.calls.reject({ callId, timestamp: Date.now() }));
       }
 
-      // Update UI state
-      callActor.send({ type: 'REJECT' });
+      // Update UI state — keyed, so the queue drops the same call the mutator ended.
+      callActor.send({ type: 'REJECT', callId });
     },
     [zero, incomingCallData?.callId],
   );
@@ -395,6 +443,10 @@ export function IncomingCallModal(): React.ReactElement | null {
       cleanupNotificationClicked();
     };
   }, [incomingCallQueue, handleAcceptCall, handleRejectCall]);
+
+  if (usesCallWindow && ringWindowShown) {
+    return null;
+  }
 
   // Show incoming call modal when in ringing state
   if (isRinging && incomingCallData) {

--- a/apps/dashboard/src/components/Call/CallViews/CustomLiveKitRoom.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/CustomLiveKitRoom.tsx
@@ -34,6 +34,7 @@ import { useScreenPickerFlag } from '../../ScreenPicker/useScreenPickerFlag';
 import { ScreenPickerModal } from '../../ScreenPicker/ScreenPickerModal';
 import { mutators } from '../../../zero/mutators';
 import { playAudio } from '../../../utils/audioPlayer';
+import { isCallWindow } from '../../../utils/electronApp';
 
 import { isParticipantScreenShareEnabled } from '../../../utils/livekitScreenShare';
 import { logger, Logger } from '../../../utils/logger';
@@ -66,6 +67,7 @@ export function CustomLiveKitRoom({
 }: CustomLiveKitRoomProps): React.ReactElement {
   // Sync custom screen picker on/off from CAC — only active while in a call
   useScreenPickerFlag();
+  const isInCallWindow = isCallWindow();
   const isSavingWhiteboardRef = useRef(false);
 
   // Subscribe to room state from global XState machine using a single snapshot
@@ -636,6 +638,8 @@ export function CustomLiveKitRoom({
         onToggleScreenShare={toggleScreenShare}
         onDisconnect={handleDisconnectClick}
         onMinimize={() => roomActor.send({ type: 'TOGGLE_VIEW' })}
+        hideMinimize={isInCallWindow}
+        isWindowChrome={isInCallWindow}
         onToggleThread={handleToggleThread}
         onRequestControl={handleRequestControl}
         requestedAiController={isAiControlRequested}

--- a/apps/dashboard/src/components/Call/CallViews/FullCallView.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/FullCallView.tsx
@@ -9,6 +9,7 @@ import {
 } from '../hooks/useParticipantNetworkQuality';
 import { type RecordingType } from '@xyne/shared';
 import type { ParticipantInfo } from '../../../machines/roomMachine';
+import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../../utils/electronApp';
 import { roomActor } from '../../../machines/roomMachine';
 import { cn } from '../../../utils/classNames';
 import ThreadMessages from '../../Chat/ThreadPannel';
@@ -100,6 +101,7 @@ interface FullCallViewProps {
   hideAIAssistant?: boolean | undefined;
   /** Hide minimize button (for external users) */
   hideMinimize?: boolean | undefined;
+  isWindowChrome?: boolean | undefined;
   /** Whether the current user is an external (unauthenticated) user */
   isExternalUser?: boolean | undefined;
   /** Call chat panel state */
@@ -152,6 +154,7 @@ export function FullCallView({
   hideThreadChat = false,
   hideAIAssistant = false,
   hideMinimize = false,
+  isWindowChrome = false,
   isExternalUser = false,
   isCallChatOpen = false,
   onToggleCallChat,
@@ -455,8 +458,9 @@ export function FullCallView({
       <div
         className={cn(
           'flex justify-between items-center pr-4 py-3',
-          isElectron && isMac ? 'pl-24' : 'pl-4',
+          isWindowChrome ? 'pl-[92px]' : isElectron && isMac ? 'pl-24' : 'pl-4',
         )}
+        style={isWindowChrome ? APP_DRAG_STYLE : undefined}
       >
         <div className='flex items-center gap-2'>
           <div className='relative visual-regression-hide'>
@@ -485,7 +489,10 @@ export function FullCallView({
             </>
           )}
         </div>
-        <div className='flex items-center gap-3'>
+        <div
+          className='flex items-center gap-3'
+          style={isWindowChrome ? APP_NO_DRAG_STYLE : undefined}
+        >
           <CallPrivacyIndicator
             isTranscriptionEnabled={isTranscriptionEnabled}
             isHost={isHost}

--- a/apps/dashboard/src/hooks/useCallActions.ts
+++ b/apps/dashboard/src/hooks/useCallActions.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useSyncExternalStore } from 'react';
 import type { SdlcCallLink } from '@xyne/shared';
 import { useSelector } from '@xstate/react';
 import { useZero } from './useZero';
@@ -12,6 +12,16 @@ import { QueryResultType } from '@rocicorp/zero';
 import { queries } from '../zero/queries';
 import { isSdlcSurface } from '../config';
 import { SDLC_FRAME_MESSAGE } from '../routes/SdlcScreen/sdlcFrameMessages';
+import {
+  getLiveCallWindowState,
+  sendCallWindowCommand,
+  subscribeLiveCallWindow,
+} from '../utils/callWindowChannel';
+import {
+  openInitiateCallWindow,
+  openJoinCallWindow,
+  shouldUseCallWindow,
+} from '../routes/CallWindow/callWindowLauncher';
 
 type ActiveCall = QueryResultType<typeof queries.userActiveCalls>[number];
 
@@ -75,17 +85,31 @@ export const useCallActions = ({
   // Get active calls from roomActor context
   const activeCalls = useSelector(roomActor, state => state.context.activeCalls) as ActiveCall[];
 
-  // Find active call in the current channel
+  // Find active call in the current channel. Match CHANNEL explicitly rather than
+  // excluding CONVERSATION — the query is ordered newest-first, so "anything but a
+  // thread call" follows a calendar call that started later and resolves the wrong
+  // call. CHANNEL is what the backend converges on in findActiveCallByChannelId.
   const currentChannelCall = activeCalls?.find(
-    call => call.channelId === channelId && call.callOrigin !== CallOrigin.CONVERSATION,
+    call => call.channelId === channelId && call.callOrigin === CallOrigin.CHANNEL,
   );
   const hasActiveCallInChannel = !!currentChannelCall;
 
+  const liveCallWindow = useSyncExternalStore(
+    subscribeLiveCallWindow,
+    getLiveCallWindowState,
+    () => null,
+  );
+  const isCallWindowOnThisChannel = !!(
+    currentChannelCall && liveCallWindow?.callId === currentChannelCall.externalId
+  );
+
   // Check if user is actually in this channel's call (for both initiator and receiver)
   const isUserInCurrentChannelCall = !!(
-    isInCall &&
-    currentChannelCall &&
-    (isCurrentChannelOnCall || stateSnapshot.context.externalId === currentChannelCall.externalId)
+    isCallWindowOnThisChannel ||
+    (isInCall &&
+      currentChannelCall &&
+      (isCurrentChannelOnCall ||
+        stateSnapshot.context.externalId === currentChannelCall.externalId))
   );
 
   // Check cross-device active status via DB participant record
@@ -148,6 +172,26 @@ export const useCallActions = ({
         },
         window.location.origin,
       );
+      return;
+    }
+
+    if (shouldUseCallWindow(isMobile)) {
+      if (isCallWindowOnThisChannel) {
+        sendCallWindowCommand('leave');
+        return;
+      }
+      if (hasActiveCallInChannel) {
+        openJoinCallWindow(currentChannelCall.externalId);
+      } else {
+        openInitiateCallWindow({
+          channelId,
+          callType: CallType.AUDIO,
+          targetUserIds,
+          callDisplayName,
+          conversationId,
+          sdlcLink,
+        });
+      }
       return;
     }
 

--- a/apps/dashboard/src/hooks/useCallAutoJoin.ts
+++ b/apps/dashboard/src/hooks/useCallAutoJoin.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useSyncExternalStore } from 'react';
 import { useSelector } from '@xstate/react';
 import { useSearchParams } from 'react-router-dom';
 import { ConnectionState } from 'livekit-client';
@@ -8,6 +8,11 @@ import { queries } from '../zero/queries';
 import { useCallJoinOrInitiate } from './useCallJoinOrInitiate';
 import { useAuth } from './useAuth';
 import { useCallAutoJoinEnabled } from './callAutoJoinCacConfig';
+import {
+  getLiveCallWindowState,
+  isCallWindowActive,
+  subscribeLiveCallWindow,
+} from '../utils/callWindowChannel';
 import {
   isAutoJoinRequested,
   parseCallUrlOverrides,
@@ -75,7 +80,14 @@ export const useCallAutoJoin = ({ channelId, isMember }: UseCallAutoJoinOptions)
   const stateSnapshot = useSelector(roomActor, state => state);
   const machineState = stateSnapshot.value;
   const currentCallId = stateSnapshot.context.externalId;
+  const liveCallWindow = useSyncExternalStore(
+    subscribeLiveCallWindow,
+    getLiveCallWindowState,
+    () => null,
+  );
   const isInCall =
+    !!liveCallWindow ||
+    isCallWindowActive() ||
     stateSnapshot.matches('initiating') ||
     stateSnapshot.matches('joining') ||
     stateSnapshot.matches('connecting') ||

--- a/apps/dashboard/src/hooks/useCallJoinOrInitiate.ts
+++ b/apps/dashboard/src/hooks/useCallJoinOrInitiate.ts
@@ -9,6 +9,11 @@ import { usePlatform } from './usePlatform';
 import { isSdlcSurface } from '../config';
 import { SDLC_FRAME_MESSAGE } from '../routes/SdlcScreen/sdlcFrameMessages';
 import type { CallUrlOverrides } from '../utils/callUrlOverrides';
+import {
+  openInitiateCallWindow,
+  openJoinCallWindow,
+  shouldUseCallWindow,
+} from '../routes/CallWindow/callWindowLauncher';
 
 /**
  * Call setup a caller can request up front, applied by roomMachine as the call
@@ -48,6 +53,7 @@ interface UseCallJoinOrInitiateReturn {
 export const useCallJoinOrInitiate = (): UseCallJoinOrInitiateReturn => {
   const zero = useZero();
   const { isMobile } = usePlatform();
+  const usesCallWindow = shouldUseCallWindow(isMobile);
 
   // Store pending action and completion callback
   const pendingActionRef = useRef<
@@ -138,6 +144,12 @@ export const useCallJoinOrInitiate = (): UseCallJoinOrInitiateReturn => {
   const joinCall = ({ callId, onComplete, ...overrides }: JoinCallParams): void => {
     if (!callId) return;
 
+    if (usesCallWindow && !overrides.callUrlOverrides) {
+      openJoinCallWindow(callId);
+      onComplete?.();
+      return;
+    }
+
     // Case 1: User not in any call - join directly
     if (!isInCall) {
       requestMediaPermissions();
@@ -194,6 +206,20 @@ export const useCallJoinOrInitiate = (): UseCallJoinOrInitiateReturn => {
         },
         window.location.origin,
       );
+      onComplete?.();
+      return;
+    }
+
+    if (usesCallWindow && !overrides.callUrlOverrides) {
+      openInitiateCallWindow({
+        channelId,
+        callType: CallType.AUDIO,
+        targetUserIds,
+        callDisplayName,
+        conversationId,
+        artifactMessageId,
+        sdlcLink,
+      });
       onComplete?.();
       return;
     }

--- a/apps/dashboard/src/hooks/useCallJoinSettings.ts
+++ b/apps/dashboard/src/hooks/useCallJoinSettings.ts
@@ -5,11 +5,17 @@ export const CALL_JOIN_SETTINGS_KEY = 'xyne:call-join-settings';
 interface CallJoinSettings {
   joinMuted: boolean;
   joinWithoutVideo: boolean;
+  micDeviceId: string | null;
+  cameraDeviceId: string | null;
+  speakerDeviceId: string | null;
 }
 
 export const DEFAULT_SETTINGS: CallJoinSettings = {
   joinMuted: false,
   joinWithoutVideo: true,
+  micDeviceId: null,
+  cameraDeviceId: null,
+  speakerDeviceId: null,
 };
 
 const listeners = new Set<() => void>();
@@ -22,6 +28,9 @@ const subscribe = (listener: () => void): (() => void) => {
 const getSnapshot = (): string => localStorage.getItem(CALL_JOIN_SETTINGS_KEY) ?? '';
 const getServerSnapshot = (): string => '';
 
+const parseDeviceId = (value: unknown): string | null =>
+  typeof value === 'string' && value.length > 0 ? value : null;
+
 const parseSettings = (raw: string): CallJoinSettings => {
   if (!raw) return DEFAULT_SETTINGS;
   try {
@@ -33,6 +42,9 @@ const parseSettings = (raw: string): CallJoinSettings => {
         typeof parsed.joinWithoutVideo === 'boolean'
           ? parsed.joinWithoutVideo
           : DEFAULT_SETTINGS.joinWithoutVideo,
+      micDeviceId: parseDeviceId(parsed.micDeviceId),
+      cameraDeviceId: parseDeviceId(parsed.cameraDeviceId),
+      speakerDeviceId: parseDeviceId(parsed.speakerDeviceId),
     };
   } catch {
     return DEFAULT_SETTINGS;
@@ -48,6 +60,10 @@ const saveSettings = (settings: CallJoinSettings): void => {
   const raw = JSON.stringify(settings);
   localStorage.setItem(CALL_JOIN_SETTINGS_KEY, raw);
   listeners.forEach(l => l());
+};
+
+export const saveCallDeviceChoice = (choice: Partial<CallJoinSettings>): void => {
+  saveSettings({ ...getCallJoinSettings(), ...choice });
 };
 
 export const useCallJoinSettings = (): {

--- a/apps/dashboard/src/hooks/useCallJoinState.ts
+++ b/apps/dashboard/src/hooks/useCallJoinState.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { useSelector } from '@xstate/react';
 import { InvitationResponse } from '@xyne/shared';
 import { roomActor } from '../machines/roomMachine';
+import { openJoinCallWindow, shouldUseCallWindow } from '../routes/CallWindow/callWindowLauncher';
 import { useZero } from './useZero';
 import { usePlatform } from './usePlatform';
 import { getUserCallAccessLevel } from './useCalls';
@@ -111,6 +112,10 @@ function consumeAutoJoinRequestKey(requestKey: string): boolean {
 }
 
 function sendJoinCall(callId: string, zero: ReturnType<typeof useZero>, isMobile: boolean): void {
+  if (shouldUseCallWindow(isMobile)) {
+    openJoinCallWindow(callId);
+    return;
+  }
   roomActor.send({
     type: 'JOIN_CALL',
     callId,

--- a/apps/dashboard/src/hooks/useQuickCall.ts
+++ b/apps/dashboard/src/hooks/useQuickCall.ts
@@ -8,23 +8,36 @@ import { reactNativeBridge } from '../utils/reactNativeBridge';
 import { useAuth } from './useAuth';
 import { useZero } from './useZero';
 import { usePlatform } from './usePlatform';
+import { isCallWindowActive } from '../utils/callWindowChannel';
+import {
+  openInitiateCallWindow,
+  openJoinCallWindow,
+  shouldUseCallWindow,
+} from '../routes/CallWindow/callWindowLauncher';
 
 // INITIATE_CALL is only handled in the machine's `idle` state; if we're already in
 // (or starting) a call, XState silently drops it. Guard so callers can bail *before*
 // any createDm, leaving no dangling channel for a call that never starts.
 const ensureRoomIdle = (): boolean => {
+  if (isCallWindowActive()) {
+    toast.error('Leave your current call before starting a new one.');
+    return false;
+  }
   if (roomActor.getSnapshot().matches('idle')) return true;
   toast.error('Leave your current call before starting a new one.');
   return false;
 };
 
-// A channel's live call = a non-thread (CONVERSATION-origin) ACTIVE call on that channel. Shared by
-// the "already live?" check (join directly) and joinOrStartCall's join-vs-initiate branch.
+// A channel's live call = the CHANNEL-origin ACTIVE call on that channel. Shared by the
+// "already live?" check (join directly) and joinOrStartCall's join-vs-initiate branch.
+// Match CHANNEL explicitly rather than excluding CONVERSATION — the query is ordered
+// newest-first, so "anything but a thread call" follows a calendar call that started
+// later. CHANNEL is what the backend converges on in findActiveCallByChannelId.
 const findLiveChannelCall = (channelId: string): Call | undefined =>
   roomActor
     .getSnapshot()
     .context.activeCalls.find(
-      call => call.channelId === channelId && call.callOrigin !== CallOrigin.CONVERSATION,
+      call => call.channelId === channelId && call.callOrigin === CallOrigin.CHANNEL,
     );
 
 interface UseQuickCallReturn {
@@ -64,6 +77,21 @@ export const useQuickCall = (): UseQuickCallReturn => {
       // CONVERSATION-origin calls are message-thread calls, not the channel call — exclude them
       // (mirrors useCallActions' currentChannelCall lookup).
       const activeCall = findLiveChannelCall(channelId);
+
+      if (shouldUseCallWindow(isMobile)) {
+        if (activeCall) {
+          openJoinCallWindow(activeCall.externalId);
+        } else {
+          openInitiateCallWindow({
+            channelId,
+            callType: CallType.AUDIO,
+            callDisplayName: displayName,
+            targetUserIds,
+          });
+        }
+        return;
+      }
+
       if (activeCall) {
         roomActor.send({ type: 'JOIN_CALL', callId: activeCall.externalId, zero, viewMode });
         return;

--- a/apps/dashboard/src/machines/callMachine.ts
+++ b/apps/dashboard/src/machines/callMachine.ts
@@ -30,9 +30,9 @@ export interface CallContext {
 // Simplified event types - only accept/reject for incoming calls
 export type CallEvent =
   | { type: 'INCOMING_CALL'; callData: CallContext['incomingCallQueue'][0] }
-  | { type: 'ACCEPT'; zero: Zero | null }
-  | { type: 'REJECT' }
-  | { type: 'SWITCH_CALL'; zero: Zero | null }
+  | { type: 'ACCEPT'; zero: Zero | null; callId?: string | undefined }
+  | { type: 'REJECT'; callId?: string | undefined }
+  | { type: 'SWITCH_CALL'; zero: Zero | null; callId?: string | undefined }
   | { type: 'SET_NATIVE_ACTIVE_CALL'; callId: string }
   | { type: 'CLEAR_NATIVE_ACTIVE_CALL' };
 
@@ -118,7 +118,11 @@ export const callMachine = setup({
 
     // Store the callId being accepted before removing from queue
     storeAcceptingCallId: assign({
-      acceptingCallId: ({ context }) => context.incomingCallQueue[0]?.callId || null,
+      acceptingCallId: ({ context, event }) => {
+        const requested =
+          event.type === 'ACCEPT' || event.type === 'SWITCH_CALL' ? event.callId : undefined;
+        return requested ?? context.incomingCallQueue[0]?.callId ?? null;
+      },
     }),
 
     // Clear the accepting callId and zero after joining
@@ -143,10 +147,25 @@ export const callMachine = setup({
       },
     }),
 
-    // Remove first call from queue (when accepted or rejected)
-    removeFromQueue: assign({
-      incomingCallQueue: ({ context }) => {
-        return context.incomingCallQueue.slice(1); // Remove first item
+    // Remove the accepted call by id. Positional removal drops whichever entry is at
+    // the head, which is the oldest call queued — not necessarily the one being joined.
+    removeAcceptedFromQueue: assign({
+      incomingCallQueue: ({ context }) =>
+        context.acceptingCallId
+          ? context.incomingCallQueue.filter(call => call.callId !== context.acceptingCallId)
+          : context.incomingCallQueue.slice(1),
+    }),
+
+    // Remove the rejected call by id, so the queue stays in step with the call the
+    // reject mutator actually ended.
+    removeRejectedFromQueue: assign({
+      incomingCallQueue: ({ context, event }) => {
+        const rejectedId =
+          (event.type === 'REJECT' ? event.callId : undefined) ??
+          context.incomingCallQueue[0]?.callId;
+        return rejectedId
+          ? context.incomingCallQueue.filter(call => call.callId !== rejectedId)
+          : context.incomingCallQueue.slice(1);
       },
     }),
 
@@ -197,16 +216,16 @@ export const callMachine = setup({
       on: {
         ACCEPT: {
           target: 'accepting',
-          actions: 'storeZero',
+          actions: ['storeZero', 'storeAcceptingCallId'],
         },
         REJECT: {
           target: 'ringing',
-          actions: 'removeFromQueue',
+          actions: 'removeRejectedFromQueue',
         },
         SWITCH_CALL: {
           guard: 'isInActiveCall',
           target: 'switching',
-          actions: 'storeZero',
+          actions: ['storeZero', 'storeAcceptingCallId'],
         },
         INCOMING_CALL: {
           actions: 'addIncomingCall',
@@ -240,15 +259,13 @@ export const callMachine = setup({
     accepting: {
       entry: [
         ({ context }): void => {
-          const callId = context.incomingCallQueue[0]?.callId ?? null;
           logger.info(Event.LIVEKIT_ROOM_EVENT, {
-            callId,
+            callId: context.acceptingCallId,
             eventName: 'accepting_state_entered',
             queueLength: context.incomingCallQueue.length,
           });
         },
-        'storeAcceptingCallId',
-        'removeFromQueue',
+        'removeAcceptedFromQueue',
       ],
       invoke: {
         src: 'joinCall',
@@ -256,12 +273,16 @@ export const callMachine = setup({
           callId: context.acceptingCallId || '',
           zero: context.zero,
         }),
+        // Back to ringing, not idle: a second call can still be queued, and idle only
+        // re-enters ringing on a fresh INCOMING_CALL — which addIncomingCall dedupes
+        // away, stranding that call. ringing's always-guard falls through to idle when
+        // the queue is empty.
         onDone: {
-          target: 'idle',
+          target: 'ringing',
           actions: 'clearAcceptingCallId',
         },
         onError: {
-          target: 'idle',
+          target: 'ringing',
           actions: 'clearAcceptingCallId',
         },
       },

--- a/apps/dashboard/src/machines/roomMachine.ts
+++ b/apps/dashboard/src/machines/roomMachine.ts
@@ -17,6 +17,8 @@ import {
   MediaDeviceFailure,
   Track,
   LocalVideoTrack,
+  LocalAudioTrack,
+  LocalTrack,
 } from 'livekit-client';
 import { BackgroundBlur } from '@livekit/track-processors';
 import type { Zero } from '@rocicorp/zero';
@@ -237,6 +239,19 @@ export interface RoomContext {
   // scoped to one call and clears with the rest of the context on disconnect.
   // Every consumer re-checks the CAC flag before acting on it.
   callUrlOverrides: CallUrlOverrides | null;
+  joinFailure: { message: string; terminal: boolean } | null;
+  awaitingAdmission: boolean;
+  initialTrackState: InitialTrackState | null;
+}
+
+export interface InitialTrackState {
+  mic: boolean;
+  camera: boolean;
+  micDeviceId?: string | undefined;
+  cameraDeviceId?: string | undefined;
+  speakerDeviceId?: string | undefined;
+  micTrack?: LocalAudioTrack | undefined;
+  cameraTrack?: LocalVideoTrack | undefined;
 }
 
 // Events for Room operations
@@ -248,6 +263,7 @@ export type RoomMachineEvent =
       callType: CallType;
       externalId: string;
       zero: Zero | null;
+      initialTrackState?: InitialTrackState;
     }
   | {
       type: 'INITIATE_CALL';
@@ -263,6 +279,7 @@ export type RoomMachineEvent =
       sdlcLink?: SdlcCallLink; // Optional: SDLC entity to link the call to
       // Omit for a join a person drove themselves (see RoomContext).
       callUrlOverrides?: CallUrlOverrides;
+      initialTrackState?: InitialTrackState;
     }
   | {
       type: 'JOIN_CALL';
@@ -274,6 +291,7 @@ export type RoomMachineEvent =
       // Set by the invite-link entry points, and only by them: where to send
       // the user if this call turns out not to be theirs to join.
       externalLobbyUrl?: string;
+      initialTrackState?: InitialTrackState;
     }
   | { type: 'TOGGLE_MIC' }
   | { type: 'PUSH_TO_TALK_START' }
@@ -1315,6 +1333,8 @@ export const roomMachine = setup({
       callType: ({ event }) => (event.type === 'CONNECT' ? event.callType : CallType.VIDEO),
       externalId: ({ event }) => (event.type === 'CONNECT' ? event.externalId : null),
       zero: ({ event }) => (event.type === 'CONNECT' ? event.zero : null),
+      initialTrackState: ({ event }) =>
+        event.type === 'CONNECT' ? (event.initialTrackState ?? null) : null,
     }),
 
     cleanupRoom: ({ context }) => {
@@ -1369,6 +1389,13 @@ export const roomMachine = setup({
       isBackgroundBlurEnabled: () => false,
       hostControls: () => DEFAULT_HOST_CONTROLS,
       callUrlOverrides: () => null,
+      initialTrackState: () => null,
+      // Identity of the call that just ended. Only INITIATE_CALL writes these; JOIN_CALL
+      // never does, so leaving them set makes the next joined call render the previous
+      // call's display name and type.
+      callDisplayName: () => null,
+      callType: () => CallType.VIDEO,
+      scopeType: () => null,
     }),
 
     enableLocalTracks: ({ context }) => {
@@ -1404,28 +1431,67 @@ export const roomMachine = setup({
             // exactly as if it had asked for nothing.
             const urlOverrides = isCallUrlApiAllowed() ? context.callUrlOverrides : null;
 
+            const lobbyChoice = context.initialTrackState;
+
             // Precedence, strongest first:
             //   1. host controls — never overridable by anyone but the host
-            //   2. an explicit request from the call URL (e.g. ?mic=on), once the
             //      flag above allows it
-            //   3. the user's saved join preferences + the crowded-room mute threshold
-            // Applying (2) here rather than toggling after 'connected' is deliberate:
-            // this action is the single writer of the initial track state, so there is
-            // no window where a post-connect compare-and-toggle could read a value
-            // these very awaits are about to overwrite and end up inverted.
             const enableMic =
-              !audioTurnedOffByHost && (urlOverrides?.mic ?? (!joinMuted && !shouldMuteByDefault));
+              !audioTurnedOffByHost &&
+              (lobbyChoice?.mic ?? urlOverrides?.mic ?? (!joinMuted && !shouldMuteByDefault));
 
             const enableCamera =
-              !cameraTurnedOffByHost && (urlOverrides?.camera ?? !joinWithoutVideo);
+              !cameraTurnedOffByHost &&
+              (lobbyChoice?.camera ?? urlOverrides?.camera ?? !joinWithoutVideo);
 
-            await context.room!.localParticipant.setMicrophoneEnabled(enableMic);
+            let micPublished = false;
+            let cameraPublished = false;
+            if (enableMic && lobbyChoice?.micTrack) {
+              try {
+                await context.room!.localParticipant.publishTrack(
+                  lobbyChoice.micTrack as unknown as LocalTrack,
+                );
+                micPublished = true;
+              } catch {
+                lobbyChoice.micTrack.stop();
+              }
+            }
+            if (enableCamera && lobbyChoice?.cameraTrack) {
+              try {
+                await context.room!.localParticipant.publishTrack(
+                  lobbyChoice.cameraTrack as unknown as LocalTrack,
+                );
+                cameraPublished = true;
+              } catch {
+                lobbyChoice.cameraTrack.stop();
+              }
+            }
 
-            await context.room!.localParticipant.setCameraEnabled(enableCamera);
+            if (!enableMic && lobbyChoice?.micTrack) lobbyChoice.micTrack.stop();
+            if (!enableCamera && lobbyChoice?.cameraTrack) lobbyChoice.cameraTrack.stop();
 
-            // Always select default audio devices regardless of mute state
-            await context.room!.switchActiveDevice('audioinput', 'default');
-            await context.room!.switchActiveDevice('audiooutput', 'default');
+            if (!micPublished && lobbyChoice?.micDeviceId) {
+              await context.room!.switchActiveDevice('audioinput', lobbyChoice.micDeviceId);
+            }
+            if (!cameraPublished && lobbyChoice?.cameraDeviceId) {
+              await context.room!.switchActiveDevice('videoinput', lobbyChoice.cameraDeviceId);
+            }
+
+            if (!micPublished) {
+              await context.room!.localParticipant.setMicrophoneEnabled(enableMic);
+            }
+
+            if (!cameraPublished) {
+              await context.room!.localParticipant.setCameraEnabled(enableCamera);
+            }
+
+            if (!lobbyChoice?.micDeviceId && !micPublished) {
+              await context.room!.switchActiveDevice('audioinput', 'default');
+            }
+            await context.room!.switchActiveDevice(
+              'audiooutput',
+              lobbyChoice?.speakerDeviceId ?? 'default',
+            );
           } catch {
             // Fail silently - error will be handled by MediaDevicesError event listener
           }
@@ -1455,6 +1521,32 @@ export const roomMachine = setup({
       if (!context.externalLobbyUrl) return;
       openLink(context.externalLobbyUrl, null, { force: 'external' });
     },
+
+    recordJoinFailure: assign({
+      joinFailure: ({ event }) => {
+        const cause = (event as { error?: unknown }).error;
+        const raw =
+          cause instanceof Error && cause.message ? cause.message : 'Could not join the call.';
+        const terminal = /ended|access|not allowed|forbidden|permission|not found/i.test(raw);
+        return { message: raw, terminal };
+      },
+      awaitingAdmission: () => false,
+    }),
+
+    stopUnpublishedTracks: ({ context }) => {
+      context.initialTrackState?.micTrack?.stop();
+      context.initialTrackState?.cameraTrack?.stop();
+    },
+
+    clearJoinOutcome: assign({
+      joinFailure: () => null,
+      awaitingAdmission: () => false,
+    }),
+
+    markAwaitingAdmission: assign({
+      awaitingAdmission: () => true,
+      joinFailure: () => null,
+    }),
 
     showJoinCallErrorToast: ({ context }) => {
       if (context.callUrlOverrides) return;
@@ -1574,6 +1666,9 @@ export const roomMachine = setup({
     isBackgroundBlurEnabled: false,
     hostControls: DEFAULT_HOST_CONTROLS,
     callUrlOverrides: null,
+    initialTrackState: null,
+    joinFailure: null,
+    awaitingAdmission: false,
   },
   id: 'roomMachine',
   on: {
@@ -1606,7 +1701,7 @@ export const roomMachine = setup({
       on: {
         CONNECT: {
           target: 'connecting',
-          actions: ['createRoom', 'storeConnectionParams', 'clearError'],
+          actions: ['createRoom', 'storeConnectionParams', 'clearError', 'clearJoinOutcome'],
         },
         INITIATE_CALL: {
           target: 'initiating',
@@ -1632,7 +1727,11 @@ export const roomMachine = setup({
               event.type === 'INITIATE_CALL' ? (event.sdlcLink ?? null) : null,
             callUrlOverrides: ({ event }) =>
               event.type === 'INITIATE_CALL' ? (event.callUrlOverrides ?? null) : null,
+            initialTrackState: ({ event }) =>
+              event.type === 'INITIATE_CALL' ? (event.initialTrackState ?? null) : null,
             isInitiator: () => true,
+            joinFailure: () => null,
+            awaitingAdmission: () => false,
           }),
         },
         JOIN_CALL: {
@@ -1651,7 +1750,11 @@ export const roomMachine = setup({
                 event.type === 'JOIN_CALL' ? (event.callUrlOverrides ?? null) : null,
               externalLobbyUrl: ({ event }) =>
                 event.type === 'JOIN_CALL' ? (event.externalLobbyUrl ?? null) : null,
+              initialTrackState: ({ event }) =>
+                event.type === 'JOIN_CALL' ? (event.initialTrackState ?? null) : null,
               isInitiator: () => false,
+              joinFailure: () => null,
+              awaitingAdmission: () => false,
             }),
           ],
         },
@@ -1696,6 +1799,10 @@ export const roomMachine = setup({
             error: () => 'Call setup was interrupted',
           }),
         },
+        DISCONNECT: {
+          target: 'idle',
+          actions: ['stopUnpublishedTracks', 'cleanupRoom', 'clearContext', 'clearError'],
+        },
       },
       invoke: {
         src: 'createCallEntry',
@@ -1731,7 +1838,11 @@ export const roomMachine = setup({
           {
             guard: ({ event }): boolean => event.output.pending === true,
             target: 'idle',
-            actions: ['showRequestingAdmissionToast'],
+            actions: [
+              'showRequestingAdmissionToast',
+              'markAwaitingAdmission',
+              'stopUnpublishedTracks',
+            ],
           },
           {
             target: 'connecting',
@@ -1753,10 +1864,14 @@ export const roomMachine = setup({
         ],
         onError: {
           target: 'failed',
-          actions: assign({
-            error: ({ event }) =>
-              event.error instanceof Error ? event.error.message : 'Failed to initiate call',
-          }),
+          actions: [
+            assign({
+              error: ({ event }) =>
+                event.error instanceof Error ? event.error.message : 'Failed to initiate call',
+            }),
+            'recordJoinFailure',
+            'stopUnpublishedTracks',
+          ],
         },
       },
     },
@@ -1789,7 +1904,11 @@ export const roomMachine = setup({
           {
             guard: ({ event }): boolean => event.output.pending === true,
             target: 'idle',
-            actions: ['showRequestingAdmissionToast'],
+            actions: [
+              'showRequestingAdmissionToast',
+              'markAwaitingAdmission',
+              'stopUnpublishedTracks',
+            ],
           },
           {
             target: 'connecting',
@@ -1827,6 +1946,7 @@ export const roomMachine = setup({
                 error: () => 'Call is not in this workspace',
               }),
               'routeToExternalCallLobby',
+              'stopUnpublishedTracks',
             ],
           },
           {
@@ -1837,9 +1957,17 @@ export const roomMachine = setup({
                   event.error instanceof Error ? event.error.message : 'Failed to join call',
               }),
               'showJoinCallErrorToast',
+              'recordJoinFailure',
+              'stopUnpublishedTracks',
             ],
           },
         ],
+      },
+      on: {
+        DISCONNECT: {
+          target: 'idle',
+          actions: ['stopUnpublishedTracks', 'cleanupRoom', 'clearContext', 'clearError'],
+        },
       },
     },
     connecting: {
@@ -1867,13 +1995,21 @@ export const roomMachine = setup({
         onError: {
           target: 'idle',
           actions: [
+            'stopUnpublishedTracks',
             'cleanupRoom',
             'clearContext',
             assign({
               error: ({ event }) =>
                 event.error instanceof Error ? event.error.message : 'Failed to connect',
             }),
+            'recordJoinFailure',
           ],
+        },
+      },
+      on: {
+        DISCONNECT: {
+          target: 'idle',
+          actions: ['stopUnpublishedTracks', 'cleanupRoom', 'clearContext', 'clearError'],
         },
       },
     },

--- a/apps/dashboard/src/providers/InitialStateLoader.tsx
+++ b/apps/dashboard/src/providers/InitialStateLoader.tsx
@@ -39,6 +39,7 @@ import { channelService } from '../services/Chat/channelService';
 
 interface InitialStateLoaderProps {
   children: ReactNode;
+  blockUntilReady?: boolean;
 }
 
 interface PermissionsApiResponse {
@@ -81,7 +82,10 @@ const areQueriesCompleted = (obj: QueryDetails[]): boolean => {
 // Show modal after 60 seconds of disconnected/error state
 const MODAL_DELAY_MS = 60000;
 
-const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): ReactNode => {
+const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({
+  children,
+  blockUntilReady = true,
+}): ReactNode => {
   const isRefreshing = useRef(false);
   const persistenceSetup = useRef(false);
 
@@ -500,7 +504,7 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
     permissionsQuery.data?.success === true &&
     permissionsHydrated;
 
-  if (areAllQueriesCompleted) {
+  if (areAllQueriesCompleted || !blockUntilReady) {
     return (
       <SharedAuthProvider value={context}>
         <HttpClientProvider client={axiosHttpClient}>
@@ -511,7 +515,7 @@ const InitialStateLoader: React.FC<InitialStateLoaderProps> = ({ children }): Re
               }
             >
               {showModal && <ZeroConnectionFailureModal onClose={() => setShowModal(false)} />}
-              <DeferredLoader />
+              {areAllQueriesCompleted && <DeferredLoader />}
               {children}
             </ChannelServiceProvider>
           </AffinityServiceProvider>

--- a/apps/dashboard/src/providers/ZeroProvider.tsx
+++ b/apps/dashboard/src/providers/ZeroProvider.tsx
@@ -6,6 +6,8 @@ import { mutators } from '../zero/mutators';
 import { schema } from '@xyne/shared';
 import { VITE_ZERO_SERVER, ZERO_STORAGE_KEY } from '../config';
 import { dropZeroDatabases, rememberZeroLane } from '../zero/dropZeroDatabases';
+import { isCallWindow } from '../utils/electronApp';
+import { isCallWindowActive } from '../utils/callWindowChannel';
 import { createBatchViewUpdatesWithMetrics } from '../services/otel';
 import { useSelector } from '@xstate/react';
 import { stateMachineActor } from '../machines/stateMachine';
@@ -55,12 +57,16 @@ const ZeroProvider: React.FC<ZeroProviderProps> = ({ children }): ReactElement |
 
     const prevWorkspaceId = prevWorkspaceIdRef.current;
     const currentWorkspaceId = user.workspaceId ?? '';
-    prevWorkspaceIdRef.current = currentWorkspaceId;
+    const needsDrop = prevWorkspaceId !== undefined && prevWorkspaceId !== currentWorkspaceId;
+    const deferDrop = needsDrop && isCallWindowActive();
+    if (!deferDrop) {
+      prevWorkspaceIdRef.current = currentWorkspaceId;
+    }
 
     const initZero = async (): Promise<void> => {
       // If workspaceId changed, drop this lane's local databases to prevent stale
       // cross-workspace cache. Scoped so a sibling bundle on the same origin keeps its own.
-      if (prevWorkspaceId !== undefined && prevWorkspaceId !== currentWorkspaceId) {
+      if (needsDrop && !deferDrop) {
         try {
           await dropZeroDatabases();
         } catch {
@@ -77,7 +83,7 @@ const ZeroProvider: React.FC<ZeroProviderProps> = ({ children }): ReactElement |
         pingTimeoutMs: 10000,
         schema,
         mutators: mutators,
-        hiddenTabDisconnectDelay: 60000,
+        hiddenTabDisconnectDelay: isCallWindow() ? 24 * 60 * 60 * 1000 : 60000,
         context: {
           userID: user.id,
           workspaceId: currentWorkspaceId,

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -84,6 +84,7 @@ import { EditWarningModal } from '../components/Chat/EditWarningModal/EditWarnin
 import { IncomingCallModal } from '../components/Call/CallModals/IncomingCallModal';
 import { IncomingCallDevHarness } from '../components/Call/IncomingCall/IncomingCallCard.dev';
 import { GlobalCallOverlay } from '../components/Call/CallOverlay/GlobalCallOverlay';
+import { CallBar } from '../components/Call/CallBar/CallBar';
 import { MobileCallHeader } from '../components/Call/MobileCallHeader/MobileCallHeader';
 import { NotificationHandler } from '../components/NotificationHandler/NotificationHandler';
 import { ElectronBadgeSync } from '../components/ElectronBadgeSync/ElectronBadgeSync';
@@ -133,7 +134,9 @@ import RecordingDetailRoute from './RecordingDetailRoute/RecordingDetailRoute';
 import { RecordingOverlay } from '../components/Recording/RecordingOverlay/RecordingOverlay';
 import { useRecordingVersion } from '../hooks/useRecordingVersion';
 import { stopRecordingForTeardown } from '../hooks/useRecordingStore';
-import { isElectronApp } from '../utils/electronApp';
+import { isElectronApp, isCallWindow } from '../utils/electronApp';
+import { CallWindowRoute } from './CallWindow/CallWindowRoute';
+import { CallWindowNavigationBridge } from './CallWindow/CallWindowNavigationBridge';
 import {
   confirmRecordingInterrupt,
   isRecordingInterruptible,
@@ -507,6 +510,8 @@ const AppRoot = (): ReactElement => {
 
   // The SDLC bundle wants the same chromeless layout as the browser panel.
   const isInPanelWebview = useIsInPanelWebview() || isSdlcSurface;
+
+  const isCallWindowRealm = isCallWindow();
 
   // Get current location to check if we're on onboarding
   const location = useLocation();
@@ -952,12 +957,13 @@ const AppRoot = (): ReactElement => {
                     attachments inside the conversation itself. */}
                       {!isInPanelWebview && (
                         <>
-                          <IncomingCallModal />
+                          {!isCallWindowRealm && <IncomingCallModal />}
                           {import.meta.env.DEV &&
                             new URLSearchParams(window.location.search).has('devIncomingCall') && (
                               <IncomingCallDevHarness />
                             )}
-                          <GlobalCallOverlay />
+                          {!isCallWindowRealm && <GlobalCallOverlay />}
+                          {!isCallWindowRealm && <CallBar />}
                           {recordingVersion === 'v2' ? (
                             <NoteTakerOverlayHost />
                           ) : (
@@ -967,7 +973,7 @@ const AppRoot = (): ReactElement => {
                           <NotificationHandler />
                           <ElectronBadgeSync />
                           {ELECTRON_UPDATE_NUDGE_ENABLED && <ElectronUpdateNudge />}
-                          <SosAlertBanner />
+                          {!isCallWindowRealm && <SosAlertBanner />}
                           <CallFromRecentsHandler />
                           <CloudAgentFloatingHost />
                           <BrowserPanelHandler />
@@ -2074,6 +2080,25 @@ export const router = createBrowserRouter(
                 </InitialStateLoader>
               </ZeroFallbackProvider>
             </ZeroProvider>
+          ),
+        },
+        {
+          path: '/newWindow/call/:callId/:callType',
+          element: (
+            <>
+              <CallWindowNavigationBridge />
+              <EncryptionBootstrapProvider>
+                <ZeroProvider>
+                  <ZeroFallbackProvider>
+                    <InitialStateLoader blockUntilReady={false}>
+                      <div className='h-full bg-background'>
+                        <CallWindowRoute />
+                      </div>
+                    </InitialStateLoader>
+                  </ZeroFallbackProvider>
+                </ZeroProvider>
+              </EncryptionBootstrapProvider>
+            </>
           ),
         },
         {

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -2091,9 +2091,11 @@ export const router = createBrowserRouter(
                 <ZeroProvider>
                   <ZeroFallbackProvider>
                     <InitialStateLoader blockUntilReady={false}>
-                      <div className='h-full bg-background'>
-                        <CallWindowRoute />
-                      </div>
+                      <EditProvider>
+                        <div className='h-full bg-background'>
+                          <CallWindowRoute />
+                        </div>
+                      </EditProvider>
                     </InitialStateLoader>
                   </ZeroFallbackProvider>
                 </ZeroProvider>

--- a/apps/dashboard/src/routes/CallHistoryScreen/useCallHistory.ts
+++ b/apps/dashboard/src/routes/CallHistoryScreen/useCallHistory.ts
@@ -5,6 +5,11 @@ import { QueryResultType } from '@rocicorp/zero';
 import { queries } from '../../zero/queries';
 import { mutators } from '../../zero/mutators';
 import { roomActor } from '../../machines/roomMachine';
+import {
+  openInitiateCallWindow,
+  openJoinCallWindow,
+  shouldUseCallWindow,
+} from '../CallWindow/callWindowLauncher';
 import { CallType, CallStatus, ChannelScopeType, MeetingStatus } from '@xyne/shared';
 import { useSelector } from '@xstate/react';
 import { toast } from 'sonner';
@@ -316,6 +321,10 @@ export function useCallHistory(userId: string | undefined): UseCallHistoryReturn
   // Get active calls to check if channel has ongoing call
 
   const joinCall = (callId: string): void => {
+    if (shouldUseCallWindow(isMobile)) {
+      openJoinCallWindow(callId);
+      return;
+    }
     // Use JOIN_CALL for all calls - backend API handles both regular and scheduled calls
     roomActor.send({
       type: 'JOIN_CALL',
@@ -333,6 +342,15 @@ export function useCallHistory(userId: string | undefined): UseCallHistoryReturn
 
   const initiateCall = (call: Call, participants = call.participants): void => {
     const participantUserIds = participants?.map(p => p.userId) || [];
+
+    if (shouldUseCallWindow(isMobile) && call.channelId) {
+      openInitiateCallWindow({
+        channelId: call.channelId,
+        callType: CallType.AUDIO,
+        targetUserIds: participantUserIds,
+      });
+      return;
+    }
 
     roomActor.send({
       type: 'INITIATE_CALL',
@@ -470,6 +488,10 @@ export function useCallHistory(userId: string | undefined): UseCallHistoryReturn
     if (channelSelection) {
       // Extract channel ID and start call in that channel
       const channelId = channelSelection.replace('channel:', '');
+      if (shouldUseCallWindow(isMobile)) {
+        openInitiateCallWindow({ channelId, callType: CallType.AUDIO });
+        return;
+      }
       roomActor.send({
         type: 'INITIATE_CALL',
         channelId,

--- a/apps/dashboard/src/routes/CallScreen/CallPage.tsx
+++ b/apps/dashboard/src/routes/CallScreen/CallPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate, useSearchParams, useLocation } from 'react-rout
 import { joinCallSwitchingIfNeeded } from '../../machines/roomMachine';
 import { useZero } from '../../hooks/useZero';
 import { usePlatform } from '../../hooks/usePlatform';
+import { openJoinCallWindow, shouldUseCallWindow } from '../CallWindow/callWindowLauncher';
 /**
  * CallPage handles deep-linked call URLs (/call/:callId)
  *
@@ -29,14 +30,18 @@ export default function CallPage(): null {
       // lobby it was shared from rather than a "failed to join" toast.
       const callInviteUrl = (location.state as { callInviteUrl?: string } | null)?.callInviteUrl;
 
-      // Send JOIN_CALL event - backend API handles both regular and scheduled calls
-      joinCallSwitchingIfNeeded({
-        type: 'JOIN_CALL',
-        callId,
-        zero,
-        viewMode: isMobile ? 'full' : 'mini',
-        ...(callInviteUrl && { externalLobbyUrl: callInviteUrl }),
-      });
+      if (shouldUseCallWindow(isMobile)) {
+        openJoinCallWindow(callId);
+      } else {
+        // Send JOIN_CALL event - backend API handles both regular and scheduled calls
+        joinCallSwitchingIfNeeded({
+          type: 'JOIN_CALL',
+          callId,
+          zero,
+          viewMode: isMobile ? 'full' : 'mini',
+          ...(callInviteUrl && { externalLobbyUrl: callInviteUrl }),
+        });
+      }
 
       // Redirect to home - GlobalCallOverlay will render the call UI
       void navigate('/', { replace: true });
@@ -44,7 +49,7 @@ export default function CallPage(): null {
       // Invalid call link - redirect to home
       void navigate('/', { replace: true });
     }
-  }, [callId, searchParams, zero, navigate, location.state]);
+  }, [callId, searchParams, zero, navigate, isMobile, location.state]);
 
   // No UI needed - GlobalCallOverlay handles all loading/error states
   return null;

--- a/apps/dashboard/src/routes/CallWindow/CallLobby.tsx
+++ b/apps/dashboard/src/routes/CallWindow/CallLobby.tsx
@@ -1,0 +1,338 @@
+import { useEffect, useRef } from 'react';
+import { AlertTriangle, Info, Mic, MicOff, Video, VideoOff, Volume2 } from 'lucide-react';
+import { cn } from '../../utils/classNames';
+import { APP_DRAG_STYLE, APP_NO_DRAG_STYLE } from '../../utils/electronApp';
+import { Button } from '../../components/ui/Button';
+import { Switch } from '../../components/ui/Switch';
+import { IncomingCallContextLine } from '../../components/Call/IncomingCall/IncomingCallContextLine';
+import type { IncomingCallContextVM } from '../../components/Call/IncomingCall/IncomingCallCard.types';
+import type { DeviceKind, LobbyPreviewState } from './useLobbyPreview';
+
+interface CallLobbyProps {
+  title: string;
+  windowLine: string;
+  subtitle?: string | null | undefined;
+  context?: IncomingCallContextVM | null | undefined;
+  status?: string | null | undefined;
+  error?: string | null | undefined;
+  preview: LobbyPreviewState;
+  rememberChoice: boolean;
+  onRememberChoiceChange: (value: boolean) => void;
+  joinLabel: string;
+  joinDisabled: boolean;
+  cancelLabel: string;
+  isRinging: boolean;
+  onJoin: () => void;
+  onCancel: () => void;
+}
+
+type NoticeTone = 'warning' | 'danger' | 'info';
+
+function LobbyNotice({
+  tone,
+  children,
+  action,
+}: {
+  tone: NoticeTone;
+  children: React.ReactNode;
+  action?: React.ReactNode;
+}): React.ReactElement {
+  const Icon = tone === 'info' ? Info : AlertTriangle;
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2 rounded-lg border px-3 py-2 text-xs',
+        tone === 'danger' && 'border-destructive/30 bg-destructive/10',
+        tone === 'warning' && 'border-[var(--call-notice-icon)]/40 bg-[var(--call-notice-icon)]/10',
+        tone === 'info' && 'border-border bg-muted/40',
+      )}
+    >
+      <Icon
+        size={14}
+        className={cn(
+          'mt-0.5 shrink-0',
+          tone === 'danger' && 'text-destructive',
+          tone === 'warning' && 'text-[var(--call-notice-icon)]',
+          tone === 'info' && 'text-muted-foreground',
+        )}
+        aria-hidden
+      />
+      <span className='flex-1 text-foreground'>{children}</span>
+      {action}
+    </div>
+  );
+}
+
+function PermissionNotice({
+  kind,
+  onOpenSettings,
+}: {
+  kind: DeviceKind;
+  onOpenSettings: (kind: DeviceKind) => void;
+}): React.ReactElement {
+  return (
+    <LobbyNotice
+      tone='warning'
+      action={
+        <button
+          type='button'
+          onClick={() => onOpenSettings(kind)}
+          className='shrink-0 font-medium text-foreground underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50'
+          data-track-category='CALLS'
+          data-track-name='Lobby_Open_System_Settings'
+        >
+          Open Settings
+        </button>
+      }
+    >
+      {kind === 'mic' ? 'Microphone' : 'Camera'} access is blocked.
+    </LobbyNotice>
+  );
+}
+
+function DeviceRow({
+  icon: Icon,
+  label,
+  devices,
+  currentDeviceId,
+  onChange,
+  fallbackLabel,
+}: {
+  icon: React.ElementType;
+  label: string;
+  devices: MediaDeviceInfo[];
+  currentDeviceId: string | null;
+  onChange: (deviceId: string) => void;
+  fallbackLabel: string;
+}): React.ReactElement {
+  const hasDevices = devices.length > 0;
+  return (
+    <label className='flex items-center gap-2.5 rounded-lg border border-border bg-background px-2.5 py-2 focus-within:ring-2 focus-within:ring-ring/50'>
+      <Icon size={15} className='shrink-0 text-muted-foreground' aria-hidden />
+      <span className='sr-only'>{label}</span>
+      <select
+        value={currentDeviceId ?? ''}
+        onChange={event => onChange(event.target.value)}
+        disabled={!hasDevices}
+        aria-label={label}
+        data-track-category='CALLS'
+        data-track-name='Lobby_Select_Device'
+        className='min-w-0 flex-1 truncate bg-transparent text-xs text-foreground outline-none disabled:text-muted-foreground'
+      >
+        {!currentDeviceId && <option value=''>{fallbackLabel}</option>}
+        {devices.map((device, index) => (
+          <option key={device.deviceId || index} value={device.deviceId}>
+            {device.label || `${label} ${index + 1}`}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export function CallLobby({
+  title,
+  windowLine,
+  subtitle,
+  context,
+  status,
+  error,
+  preview,
+  rememberChoice,
+  onRememberChoiceChange,
+  joinLabel,
+  joinDisabled,
+  cancelLabel,
+  isRinging,
+  onJoin,
+  onCancel,
+}: CallLobbyProps): React.ReactElement {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const element = videoRef.current;
+    const track = preview.cameraTrack;
+    if (!element || !track) return;
+    track.attach(element);
+    return () => {
+      track.detach(element);
+    };
+  }, [preview.cameraTrack]);
+
+  const micBlocked = preview.micPermission === 'denied';
+  const cameraBlocked = preview.cameraPermission === 'denied';
+
+  const toggleClass = (on: boolean): string =>
+    cn(
+      'flex h-10 w-10 items-center justify-center rounded-full shadow-sm transition-colors',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+      on
+        ? 'bg-background/95 text-foreground hover:bg-background'
+        : 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+    );
+
+  return (
+    <div className='flex h-screen w-full flex-col overflow-hidden bg-background text-foreground'>
+      <div className='flex h-[52px] shrink-0 items-center pl-[92px] pr-4' style={APP_DRAG_STYLE}>
+        <span className='truncate text-xs font-medium text-muted-foreground'>{windowLine}</span>
+      </div>
+
+      <div className='flex min-h-0 flex-1 flex-col gap-4 px-5 pb-5 md:flex-row md:items-stretch'>
+        <div className='relative min-h-0 flex-1 overflow-hidden rounded-lg border border-border bg-muted'>
+          {preview.cameraOn && preview.cameraTrack ? (
+            <video
+              ref={videoRef}
+              autoPlay
+              playsInline
+              muted
+              className='h-full w-full scale-x-[-1] object-cover'
+            />
+          ) : (
+            <div className='flex h-full w-full flex-col items-center justify-center gap-2 text-muted-foreground'>
+              <VideoOff size={26} />
+              <span className='text-xs'>Camera is off</span>
+            </div>
+          )}
+
+          <div
+            className='absolute inset-x-0 bottom-3 flex items-center justify-center gap-3'
+            style={APP_NO_DRAG_STYLE}
+          >
+            <button
+              type='button'
+              aria-label={preview.micOn ? 'Turn off microphone' : 'Turn on microphone'}
+              aria-pressed={preview.micOn}
+              onClick={() => preview.setMicOn(!preview.micOn)}
+              data-track-category='CALLS'
+              data-track-name='Lobby_Toggle_Mic'
+              className={toggleClass(preview.micOn)}
+            >
+              {preview.micOn ? <Mic size={17} /> : <MicOff size={17} />}
+            </button>
+            <button
+              type='button'
+              aria-label={preview.cameraOn ? 'Turn off camera' : 'Turn on camera'}
+              aria-pressed={preview.cameraOn}
+              onClick={() => preview.setCameraOn(!preview.cameraOn)}
+              data-track-category='CALLS'
+              data-track-name='Lobby_Toggle_Camera'
+              className={toggleClass(preview.cameraOn)}
+            >
+              {preview.cameraOn ? <Video size={17} /> : <VideoOff size={17} />}
+            </button>
+          </div>
+        </div>
+
+        <div
+          className='flex min-h-0 w-full shrink-0 flex-col md:w-[290px]'
+          style={APP_NO_DRAG_STYLE}
+        >
+          <div className='flex min-h-0 flex-1 flex-col gap-2.5 overflow-y-auto'>
+            <div>
+              {context && (
+                <div className='mb-1 [&>div]:mx-0 [&>div]:text-left'>
+                  <IncomingCallContextLine context={context} />
+                </div>
+              )}
+              <h1 className='truncate text-lg font-semibold leading-tight'>{title}</h1>
+              {subtitle && (
+                <p className='mt-0.5 text-xs leading-snug text-muted-foreground'>{subtitle}</p>
+              )}
+            </div>
+
+            {error && <LobbyNotice tone='danger'>{error}</LobbyNotice>}
+            {status && <LobbyNotice tone='info'>{status}</LobbyNotice>}
+
+            {micBlocked && (
+              <PermissionNotice kind='mic' onOpenSettings={preview.openSystemSettings} />
+            )}
+            {cameraBlocked && (
+              <PermissionNotice kind='camera' onOpenSettings={preview.openSystemSettings} />
+            )}
+
+            <div className='flex flex-col gap-1.5'>
+              <DeviceRow
+                icon={Mic}
+                label='Microphone'
+                devices={preview.micDevices}
+                currentDeviceId={preview.micDeviceId}
+                onChange={preview.selectMicDevice}
+                fallbackLabel='Default microphone'
+              />
+              <DeviceRow
+                icon={Volume2}
+                label='Speaker'
+                devices={preview.speakerDevices}
+                currentDeviceId={preview.speakerDeviceId}
+                onChange={preview.selectSpeakerDevice}
+                fallbackLabel='Default speaker'
+              />
+              <DeviceRow
+                icon={Video}
+                label='Camera'
+                devices={preview.cameraDevices}
+                currentDeviceId={preview.cameraDeviceId}
+                onChange={preview.selectCameraDevice}
+                fallbackLabel='Default camera'
+              />
+            </div>
+
+            <div className='flex items-center justify-between gap-3'>
+              <span className='text-xs text-muted-foreground'>Remember these settings</span>
+              <Switch
+                checked={rememberChoice}
+                onCheckedChange={onRememberChoiceChange}
+                aria-label='Remember these settings'
+              />
+            </div>
+          </div>
+
+          <div className='mt-3 flex shrink-0 items-center gap-2'>
+            <button
+              type='button'
+              onClick={onJoin}
+              disabled={joinDisabled}
+              data-track-category='CALLS'
+              data-track-name={isRinging ? 'Lobby_Answer' : 'Lobby_Join'}
+              className={cn(
+                'inline-flex h-9 flex-1 items-center justify-center rounded-md px-4 text-sm font-semibold',
+                'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+                'disabled:pointer-events-none disabled:opacity-50',
+                isRinging
+                  ? 'bg-[var(--call-accept-bg)] text-[var(--call-accept-fg)] hover:bg-[var(--call-accept-bg-hover)] active:bg-[var(--call-accept-bg-active)]'
+                  : 'bg-primary text-primary-foreground hover:bg-primary/90',
+              )}
+            >
+              {joinLabel}
+            </button>
+            {isRinging ? (
+              <button
+                type='button'
+                onClick={onCancel}
+                data-track-category='CALLS'
+                data-track-name='Lobby_Decline'
+                className={cn(
+                  'inline-flex h-9 items-center justify-center rounded-md px-4 text-sm font-medium',
+                  'transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+                  'bg-[var(--call-decline-bg)] text-[var(--call-decline-fg)]',
+                  'hover:bg-[var(--call-decline-bg-hover)] active:bg-[var(--call-decline-bg-active)]',
+                )}
+              >
+                {cancelLabel}
+              </button>
+            ) : (
+              <Button
+                variant='outline'
+                onClick={onCancel}
+                data-track-category='CALLS'
+                data-track-name='Lobby_Cancel'
+              >
+                {cancelLabel}
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/CallWindow/CallWindow.tsx
+++ b/apps/dashboard/src/routes/CallWindow/CallWindow.tsx
@@ -1,0 +1,538 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
+import { useSelector } from '@xstate/react';
+import { CallType, ChannelScopeType, InvitationResponse } from '@xyne/shared';
+import type { CallParticipant } from '@xyne/shared';
+import type { SdlcCallLink } from '@xyne/shared';
+import { RoomAudioRenderer } from '@livekit/components-react';
+import { roomActor, type InitialTrackState } from '../../machines/roomMachine';
+import { CustomLiveKitRoom } from '../../components/Call/CallViews/CustomLiveKitRoom';
+import { useZero } from '../../hooks/useZero';
+import { useAuth } from '../../hooks/useAuth';
+import { useUsers } from '../../hooks/useUsers';
+import { useAllChannels } from '../../hooks/useChannels';
+import { useChannelDisplayName } from '../../hooks/useChannelDisplayName';
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { queries } from '../../zero/queries';
+import { mutators } from '../../zero/mutators';
+import { getUserDisplayName } from '../../utils/userDisplayName';
+import { isDMChannel } from '../../components/Chat/ChatDirectory/ChatDirectory.utils';
+import { buildIncomingCallViewModel } from '../../components/Call/IncomingCall/IncomingCallCard.utils';
+import type { IncomingCallRow } from '../../components/Call/IncomingCall/IncomingCallCard.utils';
+import type { IncomingCallViewModel } from '../../components/Call/IncomingCall/IncomingCallCard.types';
+import { getCallJoinSettings, saveCallDeviceChoice } from '../../hooks/useCallJoinSettings';
+import { isElectronApp } from '../../utils/electronApp';
+import {
+  clearCallWindowActive,
+  markCallWindowActive,
+  publishCallWindowEnded,
+  publishCallWindowState,
+  subscribeCallWindowChannel,
+} from '../../utils/callWindowChannel';
+import { CallLobby } from './CallLobby';
+import { NEW_CALL_ID } from './callWindowLauncher';
+import { describeCallWindow } from './callWindowCopy';
+import { useLobbyPreview } from './useLobbyPreview';
+
+type Stage = 'lobby' | 'ring' | 'connecting' | 'waiting' | 'live' | 'ended' | 'failed';
+
+const isCallTypeValue = (value: string | undefined): value is CallType =>
+  value === CallType.VIDEO || value === CallType.AUDIO;
+
+export function CallWindow(): React.ReactElement {
+  const params = useParams<{ callId: string; callType: string }>();
+  const [searchParams] = useSearchParams();
+  const zero = useZero();
+  const { user } = useAuth();
+
+  const routeCallId = params.callId ?? '';
+  const isNewCall = routeCallId === NEW_CALL_ID;
+  const callId = isNewCall ? '' : routeCallId;
+  const callType = isCallTypeValue(params.callType) ? params.callType : CallType.VIDEO;
+  const isRingEntry = searchParams.get('stage') === 'ring';
+
+  const savedSettings = useMemo(() => getCallJoinSettings(), []);
+  const [stage, setStage] = useState<Stage>(isRingEntry ? 'ring' : 'lobby');
+  const [rememberChoice, setRememberChoice] = useState(false);
+  const hasJoinedRef = useRef(false);
+  const hasAttemptedJoinRef = useRef(false);
+  const autoRejoinedRef = useRef(false);
+
+  const preview = useLobbyPreview({
+    initialMicOn: !savedSettings.joinMuted,
+    initialCameraOn: !savedSettings.joinWithoutVideo,
+    initialMicDeviceId: savedSettings.micDeviceId,
+    initialCameraDeviceId: savedSettings.cameraDeviceId,
+    initialSpeakerDeviceId: savedSettings.speakerDeviceId,
+    autoStart: !isRingEntry,
+  });
+
+  const [activeCalls, activeCallsDetails] = useCachedQuery(queries.userActiveCalls());
+  const users = useUsers();
+
+  const call = useMemo(
+    () => activeCalls?.find(c => c.externalId === callId),
+    [activeCalls, callId],
+  );
+
+  const usersById = useMemo(() => {
+    const map = new Map<string, (typeof users)[number]>();
+    (users ?? []).forEach(entry => map.set(entry.id, entry));
+    return map;
+  }, [users]);
+
+  const allChannels = useAllChannels();
+  const channelMap = useMemo(() => {
+    const map = new Map<string, (typeof allChannels)[number]>();
+    (allChannels ?? []).forEach(channel => map.set(channel.id, channel));
+    return map;
+  }, [allChannels]);
+
+  const caller = useMemo(() => {
+    const participants = (call as { participants?: readonly CallParticipant[] } | undefined)
+      ?.participants;
+    const myParticipant = participants?.find(p => p.userId === user?.id);
+    const inviterId = myParticipant?.invitedBy ?? call?.createdByUserId ?? '';
+    const inviter = inviterId ? usersById.get(inviterId) : undefined;
+    return {
+      id: inviterId,
+      name: getUserDisplayName(inviter),
+      email: inviter?.email ?? '',
+    };
+  }, [call, user?.id, usersById]);
+
+  useEffect(() => {
+    if (activeCalls) {
+      roomActor.send({ type: 'UPDATE_ACTIVE_CALLS', calls: activeCalls });
+    }
+  }, [activeCalls]);
+
+  const snapshot = useSelector(roomActor, s => s);
+  const isConnected = snapshot.matches('connected');
+  const isIdle = snapshot.matches('idle');
+  const token = snapshot.context.token;
+  const serverUrl = snapshot.context.serverUrl;
+  const externalId = snapshot.context.externalId;
+  const room = snapshot.context.room;
+
+  const joinFailure = snapshot.context.joinFailure;
+  const awaitingAdmission = snapshot.context.awaitingAdmission;
+
+  const isInXyneCall =
+    snapshot.matches('initiating') ||
+    snapshot.matches('joining') ||
+    snapshot.matches('connecting') ||
+    isConnected;
+  useEffect(() => {
+    if (!isElectronApp()) return;
+    window.electronAPI?.ipcSend?.('call:state-changed', isInXyneCall);
+    return () => {
+      window.electronAPI?.ipcSend?.('call:state-changed', false);
+    };
+  }, [isInXyneCall]);
+
+  useEffect(() => {
+    if (!isElectronApp()) return;
+    window.electronAPI?.ipcSend?.('call:ringing-changed', stage === 'ring');
+  }, [stage]);
+
+  useEffect(() => {
+    if (isConnected) {
+      hasJoinedRef.current = true;
+      setStage('live');
+    }
+  }, [isConnected]);
+
+  const localParticipant = room?.localParticipant;
+  const micEnabled = localParticipant?.isMicrophoneEnabled ?? false;
+  const cameraEnabled = localParticipant?.isCameraEnabled ?? false;
+  const screenSharing = localParticipant?.isScreenShareEnabled ?? false;
+
+  const copyRef = useRef<string>('Call in progress');
+
+  const liveCallIdRef = useRef('');
+  if (externalId) liveCallIdRef.current = externalId;
+  else if (callId) liveCallIdRef.current = callId;
+  const publishCallId = liveCallIdRef.current;
+
+  const publishState = useCallback(() => {
+    if (!hasJoinedRef.current || !publishCallId) return;
+    publishCallWindowState({
+      callId: publishCallId,
+      title: copyRef.current,
+      micEnabled,
+      cameraEnabled,
+      screenSharing,
+      connected: isConnected,
+    });
+  }, [publishCallId, cameraEnabled, isConnected, micEnabled, screenSharing]);
+
+  useEffect(() => {
+    publishState();
+  }, [publishState]);
+
+  const publishStateRef = useRef(publishState);
+  publishStateRef.current = publishState;
+
+  useEffect(() => {
+    return subscribeCallWindowChannel({
+      onStateRequested: () => publishStateRef.current(),
+      onCommand: command => {
+        if (command === 'leave') {
+          roomActor.send({ type: 'DISCONNECT', endForAll: false });
+          return;
+        }
+        if (command === 'toggle-mic') {
+          roomActor.send({ type: 'TOGGLE_MIC' });
+          return;
+        }
+        roomActor.send({ type: 'TOGGLE_CAMERA' });
+      },
+    });
+  }, []);
+
+  useEffect(() => {
+    const dispose = window.electronAPI?.onCallWindowLeave?.(() => {
+      roomActor.send({ type: 'DISCONNECT', endForAll: false });
+    });
+    return () => {
+      dispose?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (stage !== 'ended' || !publishCallId) return;
+    publishCallWindowEnded(publishCallId);
+  }, [publishCallId, stage]);
+
+  useEffect(() => {
+    if (!isInXyneCall) {
+      clearCallWindowActive();
+      return;
+    }
+    markCallWindowActive();
+    const timer = setInterval(markCallWindowActive, 10_000);
+    return () => {
+      clearInterval(timer);
+      clearCallWindowActive();
+    };
+  }, [isInXyneCall]);
+
+  useEffect(() => {
+    if (!isIdle) return;
+    if (!hasAttemptedJoinRef.current) return;
+    if (joinFailure) {
+      setStage('failed');
+      return;
+    }
+    if (awaitingAdmission) {
+      setStage('waiting');
+      return;
+    }
+    if (hasJoinedRef.current) {
+      setStage('ended');
+    }
+  }, [awaitingAdmission, isIdle, joinFailure]);
+
+  const restorePreviewRef = useRef(preview);
+  restorePreviewRef.current = preview;
+  useEffect(() => {
+    if (stage !== 'failed' && stage !== 'waiting') return;
+    const current = restorePreviewRef.current;
+    if (current.cameraOn && !current.cameraTrack) current.setCameraOn(true);
+    if (current.micOn && !current.micTrack) current.setMicOn(true);
+  }, [stage]);
+
+  const hadCallRef = useRef(false);
+  if (call) hadCallRef.current = true;
+  const callVanished =
+    activeCallsDetails.type === 'complete' && hadCallRef.current && !call && !isNewCall;
+  useEffect(() => {
+    if (!callVanished) return;
+    if (hasJoinedRef.current) return;
+    setStage(current => (current === 'ring' || current === 'lobby' ? 'ended' : current));
+  }, [callVanished]);
+
+  const buildInitialTrackState = useCallback((): InitialTrackState => {
+    const state: InitialTrackState = {
+      mic: preview.micOn,
+      camera: preview.cameraOn,
+    };
+    if (preview.micDeviceId) state.micDeviceId = preview.micDeviceId;
+    if (preview.cameraDeviceId) state.cameraDeviceId = preview.cameraDeviceId;
+    if (preview.speakerDeviceId) state.speakerDeviceId = preview.speakerDeviceId;
+    if (preview.micOn && preview.micTrack) state.micTrack = preview.micTrack;
+    if (preview.cameraOn && preview.cameraTrack) state.cameraTrack = preview.cameraTrack;
+    return state;
+  }, [
+    preview.cameraDeviceId,
+    preview.cameraOn,
+    preview.cameraTrack,
+    preview.micDeviceId,
+    preview.micOn,
+    preview.micTrack,
+    preview.speakerDeviceId,
+  ]);
+
+  const handleJoinRef = useRef<(() => void) | null>(null);
+
+  const handleJoin = useCallback(() => {
+    const channelId = searchParams.get('channelId');
+    if (!callId && !(isNewCall && channelId)) return;
+
+    hasAttemptedJoinRef.current = true;
+
+    if (rememberChoice) {
+      saveCallDeviceChoice({
+        micDeviceId: preview.micDeviceId,
+        cameraDeviceId: preview.cameraDeviceId,
+        speakerDeviceId: preview.speakerDeviceId,
+        joinMuted: !preview.micOn,
+        joinWithoutVideo: !preview.cameraOn,
+      });
+    }
+
+    const initialTrackState = buildInitialTrackState();
+    preview.releaseTracks();
+    setStage('connecting');
+
+    if (isNewCall && channelId) {
+      const targetUserIds = searchParams.get('targetUserIds');
+      const callDisplayName = searchParams.get('callDisplayName');
+      const conversationId = searchParams.get('conversationId');
+      const artifactMessageId = searchParams.get('artifactMessageId');
+      const rawSdlcLink = searchParams.get('sdlcLink');
+      let sdlcLink: SdlcCallLink | undefined;
+      if (rawSdlcLink) {
+        try {
+          sdlcLink = JSON.parse(rawSdlcLink) as SdlcCallLink;
+        } catch {
+          sdlcLink = undefined;
+        }
+      }
+
+      roomActor.send({
+        type: 'INITIATE_CALL',
+        channelId,
+        callType,
+        zero,
+        viewMode: 'full',
+        initialTrackState,
+        ...(targetUserIds && { targetUserIds: targetUserIds.split(',').filter(Boolean) }),
+        ...(callDisplayName && { callDisplayName }),
+        ...(conversationId && { conversationId }),
+        ...(artifactMessageId && { artifactMessageId }),
+        ...(sdlcLink && { sdlcLink }),
+      });
+      return;
+    }
+
+    roomActor.send({
+      type: 'JOIN_CALL',
+      callId,
+      zero,
+      viewMode: 'full',
+      initialTrackState,
+    });
+  }, [
+    buildInitialTrackState,
+    callId,
+    callType,
+    isNewCall,
+    preview,
+    rememberChoice,
+    searchParams,
+    zero,
+  ]);
+
+  const myResponse = useMemo(() => {
+    if (!user?.id || !call) return null;
+    const participants = call.participants as
+      | readonly { userId: string; response: string | null }[]
+      | undefined;
+    return participants?.find(p => p.userId === user.id)?.response ?? null;
+  }, [call, user?.id]);
+
+  useEffect(() => {
+    if (stage !== 'waiting') return;
+    if (myResponse !== InvitationResponse.ACCEPTED) return;
+    if (autoRejoinedRef.current) return;
+    autoRejoinedRef.current = true;
+    handleJoinRef.current?.();
+  }, [myResponse, stage]);
+
+  handleJoinRef.current = handleJoin;
+
+  const handleCancel = useCallback(() => {
+    preview.stopPreview();
+    roomActor.send({ type: 'DISCONNECT', endForAll: false });
+    window.close();
+  }, [preview]);
+
+  const handleDecline = useCallback(() => {
+    preview.stopPreview();
+    if (zero && callId) {
+      try {
+        void zero.mutate(mutators.calls.reject({ callId, timestamp: Date.now() }));
+      } catch {
+        // The ring times out server-side after 32s regardless.
+      }
+    }
+    window.close();
+  }, [callId, preview, zero]);
+
+  useEffect(() => {
+    const leaveIfInCall = (): void => {
+      const current = roomActor.getSnapshot();
+      const inCall =
+        current.matches('initiating') ||
+        current.matches('joining') ||
+        current.matches('connecting') ||
+        current.matches('connected');
+      if (inCall) {
+        roomActor.send({ type: 'DISCONNECT', endForAll: false });
+      }
+    };
+    window.addEventListener('beforeunload', leaveIfInCall);
+    return () => {
+      window.removeEventListener('beforeunload', leaveIfInCall);
+      leaveIfInCall();
+    };
+  }, []);
+
+  const incomingVm: IncomingCallViewModel | null = useMemo(() => {
+    if (!call) return null;
+    return buildIncomingCallViewModel({
+      callId,
+      call: call as unknown as IncomingCallRow,
+      caller,
+      channelMap,
+      usersById,
+      currentUserId: user?.id,
+      isInActiveCall: false,
+      isSilenced: false,
+    });
+  }, [call, callId, caller, channelMap, user?.id, usersById]);
+
+  const outgoingChannelId = searchParams.get('channelId');
+  const outgoingChannel = outgoingChannelId ? channelMap.get(outgoingChannelId) : undefined;
+  const { displayName: outgoingChannelName } = useChannelDisplayName(
+    outgoingChannel ?? null,
+    user?.id ?? '',
+  );
+  const outgoingName = searchParams.get('callDisplayName') || outgoingChannelName || null;
+
+  const outgoingConversationId = searchParams.get('conversationId');
+  const outgoingIsDm = outgoingChannel ? isDMChannel(outgoingChannel.scopeType) : false;
+
+  const copy = useMemo(
+    () =>
+      describeCallWindow({
+        vm: incomingVm,
+        isRinging: stage === 'ring',
+        isNewCall,
+        outgoing: {
+          displayName: outgoingName,
+          channelName: outgoingChannel && !outgoingIsDm ? outgoingChannel.name : null,
+          isDm: outgoingIsDm,
+          isGroupDm: outgoingChannel?.scopeType === ChannelScopeType.GROUP_DM,
+          conversationId: outgoingConversationId,
+        },
+      }),
+    [
+      incomingVm,
+      isNewCall,
+      outgoingChannel,
+      outgoingConversationId,
+      outgoingIsDm,
+      outgoingName,
+      stage,
+    ],
+  );
+
+  copyRef.current = copy.windowLine;
+
+  useEffect(() => {
+    document.title = copy.windowLine;
+    publishStateRef.current();
+  }, [copy.windowLine]);
+
+  const status = useMemo(() => {
+    if (stage === 'waiting') return 'Waiting for the host to let you in.';
+    return null;
+  }, [stage]);
+
+  if (stage === 'live' && token && serverUrl && externalId) {
+    return (
+      <div className='h-full w-full bg-background'>
+        {room && <RoomAudioRenderer room={room} />}
+        <CustomLiveKitRoom
+          token={token}
+          serverUrl={serverUrl}
+          callId={externalId}
+          callType={callType}
+          externalId={externalId}
+          zero={zero}
+        />
+      </div>
+    );
+  }
+
+  if (stage === 'ended' || (stage === 'failed' && joinFailure?.terminal)) {
+    const message = joinFailure?.terminal
+      ? joinFailure.message
+      : hasJoinedRef.current
+        ? 'You left the call.'
+        : 'This call has ended.';
+    return (
+      <div className='flex h-full w-full flex-col items-center justify-center gap-3 bg-background text-foreground'>
+        <p className='max-w-[420px] px-6 text-center text-sm text-muted-foreground'>{message}</p>
+        <button
+          type='button'
+          onClick={() => window.close()}
+          className='rounded-md border border-border px-3 py-1.5 text-sm'
+          data-track-category='CALLS'
+          data-track-name='Call_Window_Close_After_End'
+        >
+          Close
+        </button>
+      </div>
+    );
+  }
+
+  const isBusy = stage === 'connecting';
+  const joinLabel =
+    stage === 'ring'
+      ? 'Answer'
+      : stage === 'failed'
+        ? 'Try again'
+        : stage === 'waiting'
+          ? 'Request again'
+          : isBusy
+            ? isNewCall
+              ? 'Starting…'
+              : 'Joining…'
+            : isNewCall
+              ? 'Start call'
+              : 'Join';
+
+  return (
+    <CallLobby
+      title={copy.name}
+      windowLine={copy.windowLine}
+      subtitle={copy.subtitle}
+      context={copy.context}
+      status={status}
+      error={stage === 'failed' ? (joinFailure?.message ?? null) : null}
+      preview={preview}
+      rememberChoice={rememberChoice}
+      onRememberChoiceChange={setRememberChoice}
+      joinLabel={joinLabel}
+      joinDisabled={isBusy || (!callId && !isNewCall)}
+      cancelLabel={stage === 'ring' ? 'Decline' : 'Cancel'}
+      isRinging={stage === 'ring'}
+      onJoin={handleJoin}
+      onCancel={stage === 'ring' ? handleDecline : handleCancel}
+    />
+  );
+}

--- a/apps/dashboard/src/routes/CallWindow/CallWindowNavigationBridge.tsx
+++ b/apps/dashboard/src/routes/CallWindow/CallWindowNavigationBridge.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { roomActor } from '../../machines/roomMachine';
+
+export function CallWindowNavigationBridge(): null {
+  const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
+  const pendingPathRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const isInCall = (): boolean => {
+      const current = roomActor.getSnapshot();
+      return (
+        current.matches('initiating') ||
+        current.matches('joining') ||
+        current.matches('connecting') ||
+        current.matches('disconnecting') ||
+        current.matches('connected')
+      );
+    };
+
+    const routeIfIdle = (relativePath: string): void => {
+      if (isInCall()) {
+        pendingPathRef.current = relativePath;
+        return;
+      }
+      pendingPathRef.current = null;
+      void navigateRef.current(relativePath, { replace: true });
+    };
+
+    const subscription = roomActor.subscribe(() => {
+      const next = pendingPathRef.current;
+      if (!next || isInCall()) return;
+      pendingPathRef.current = null;
+      void navigateRef.current(next, { replace: true });
+    });
+
+    const dispose = window.electronAPI?.onCallWindowNavigate?.(routeIfIdle);
+
+    let cancelled = false;
+    void window.electronAPI?.takePendingCallRoute?.().then(relativePath => {
+      if (cancelled || !relativePath) return;
+      routeIfIdle(relativePath);
+    });
+
+    return () => {
+      cancelled = true;
+      subscription.unsubscribe();
+      dispose?.();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/dashboard/src/routes/CallWindow/CallWindowRoute.tsx
+++ b/apps/dashboard/src/routes/CallWindow/CallWindowRoute.tsx
@@ -1,0 +1,22 @@
+import { useParams, useSearchParams } from 'react-router-dom';
+import { CallWindow } from './CallWindow';
+import { CallWindowWarmUp } from './CallWindowWarmUp';
+import { CALL_WINDOW_LAUNCH_PARAM } from '../../utils/electronApp';
+
+export const IDLE_CALL_ID = 'idle';
+
+export function CallWindowRoute(): React.ReactElement {
+  const params = useParams<{ callId: string; callType: string }>();
+  const [searchParams] = useSearchParams();
+  const callId = params.callId ?? IDLE_CALL_ID;
+
+  if (callId === IDLE_CALL_ID) {
+    return (
+      <div className='h-full w-full bg-background'>
+        <CallWindowWarmUp />
+      </div>
+    );
+  }
+
+  return <CallWindow key={searchParams.get(CALL_WINDOW_LAUNCH_PARAM) ?? callId} />;
+}

--- a/apps/dashboard/src/routes/CallWindow/CallWindowWarmUp.tsx
+++ b/apps/dashboard/src/routes/CallWindow/CallWindowWarmUp.tsx
@@ -1,0 +1,7 @@
+import { useCachedQuery } from '../../hooks/useCachedQuery';
+import { queries } from '../../zero/queries';
+
+export function CallWindowWarmUp(): null {
+  useCachedQuery(queries.userActiveCalls());
+  return null;
+}

--- a/apps/dashboard/src/routes/CallWindow/callWindowCopy.ts
+++ b/apps/dashboard/src/routes/CallWindow/callWindowCopy.ts
@@ -1,0 +1,112 @@
+import type {
+  IncomingCallContextVM,
+  IncomingCallPlace,
+  IncomingCallViewModel,
+} from '../../components/Call/IncomingCall/IncomingCallCard.types';
+import { formatCallPlace } from '../../components/Call/IncomingCall/IncomingCallCard.utils';
+
+export interface CallWindowCopy {
+  context: IncomingCallContextVM | null;
+  name: string;
+  subtitle: string | null;
+  windowLine: string;
+}
+
+const composeWindowLine = (
+  context: IncomingCallContextVM | null,
+  name: string,
+  preposition: 'from' | 'with',
+): string => {
+  if (!name) return context?.text ?? 'Call';
+  if (!context || context.kind === 'direct' || context.kind === 'unknown') {
+    return `Call ${preposition} ${name}`;
+  }
+  return `${context.text} ${preposition} ${name}`;
+};
+
+export interface OutgoingCallTarget {
+  displayName: string | null;
+  channelName: string | null;
+  isDm: boolean;
+  isGroupDm: boolean;
+  conversationId: string | null;
+}
+
+function describeOutgoing(target: OutgoingCallTarget): {
+  context: IncomingCallContextVM | null;
+  name: string;
+  windowLine: string;
+} {
+  const { displayName, channelName, isDm, isGroupDm, conversationId } = target;
+  const place: IncomingCallPlace = channelName
+    ? { kind: 'channel', name: channelName }
+    : isGroupDm
+      ? { kind: 'group-dm' }
+      : null;
+  const placeText = place ? formatCallPlace(place) : null;
+  const fallbackName = displayName ?? 'Start call';
+
+  if (conversationId) {
+    return {
+      context: {
+        kind: 'thread',
+        icon: 'thread',
+        place,
+        text: placeText ? `Thread call in ${placeText}` : 'Thread call',
+      },
+      name: placeText ?? fallbackName,
+      windowLine: placeText ? `Starting a thread call in ${placeText}` : 'Starting a thread call',
+    };
+  }
+
+  if (channelName && !isDm) {
+    return {
+      context: { kind: 'channel', icon: 'hash', place, text: `Call in #${channelName}` },
+      name: `#${channelName}`,
+      windowLine: `Starting a call in #${channelName}`,
+    };
+  }
+
+  if (isGroupDm) {
+    return {
+      context: { kind: 'group', icon: 'users', place: { kind: 'group-dm' }, text: 'Group call' },
+      name: fallbackName,
+      windowLine: displayName
+        ? `Starting a group call with ${displayName}`
+        : 'Starting a group call',
+    };
+  }
+
+  return {
+    context: null,
+    name: fallbackName,
+    windowLine: displayName ? `Calling ${displayName}` : 'Start call',
+  };
+}
+
+interface DescribeInput {
+  vm: IncomingCallViewModel | null;
+  isRinging: boolean;
+  isNewCall: boolean;
+  outgoing: OutgoingCallTarget;
+}
+
+export function describeCallWindow(input: DescribeInput): CallWindowCopy {
+  const { vm, isRinging, isNewCall, outgoing } = input;
+
+  if (isNewCall) {
+    const described = describeOutgoing(outgoing);
+    return { ...described, subtitle: null };
+  }
+
+  if (!vm) {
+    return { context: null, name: 'Join call', subtitle: null, windowLine: 'Join call' };
+  }
+
+  return {
+    context: vm.context,
+    name: vm.name,
+    subtitle: vm.subtitle,
+    windowLine: composeWindowLine(vm.context, vm.name, isRinging ? 'from' : 'with'),
+  };
+}

--- a/apps/dashboard/src/routes/CallWindow/callWindowLauncher.ts
+++ b/apps/dashboard/src/routes/CallWindow/callWindowLauncher.ts
@@ -1,0 +1,105 @@
+import type { SdlcCallLink } from '@xyne/shared';
+import { CallType } from '@xyne/shared';
+import { toast } from 'sonner';
+import { isCallWindow, isElectronApp, openCallWindow } from '../../utils/electronApp';
+import { isCallWindowActive } from '../../utils/callWindowChannel';
+import { isNativeCallSupported } from '../../utils/reactNativeBridge';
+import { logger } from '../../utils/logger';
+
+export const NEW_CALL_ID = 'new';
+
+export const readActiveWorkspaceId = (paramWorkspaceId?: string): string | null => {
+  if (paramWorkspaceId) return paramWorkspaceId;
+  try {
+    const email = logger.emailId || localStorage.getItem('user_email');
+    if (!email) return null;
+    return localStorage.getItem(`lastActiveWorkspaceId_${email}`);
+  } catch {
+    return null;
+  }
+};
+
+export const readTheme = (): string | null => {
+  try {
+    return localStorage.getItem('xyne-theme');
+  } catch {
+    return null;
+  }
+};
+
+export const shouldUseCallWindow = (isMobile: boolean): boolean =>
+  isElectronApp() && !isMobile && !isNativeCallSupported() && !isCallWindow();
+
+const blockedByLiveCall = (): boolean => {
+  if (!isCallWindowActive()) return false;
+  toast.error('Leave your current call before starting a new one.');
+  return true;
+};
+
+export interface InitiateCallWindowParams {
+  channelId: string;
+  callType?: CallType;
+  targetUserIds?: string[] | undefined;
+  callDisplayName?: string | undefined;
+  conversationId?: string | undefined;
+  artifactMessageId?: string | undefined;
+  sdlcLink?: SdlcCallLink | undefined;
+}
+
+export interface JoinCallWindowOptions {
+  callType?: CallType | undefined;
+  replaceLiveCall?: boolean | undefined;
+}
+
+export const openJoinCallWindow = (callId: string, options?: JoinCallWindowOptions): boolean => {
+  if (!options?.replaceLiveCall && blockedByLiveCall()) return false;
+  return openCallWindow({
+    callId,
+    callType: options?.callType ?? CallType.VIDEO,
+    stage: 'lobby',
+    workspaceId: readActiveWorkspaceId(),
+    theme: readTheme(),
+  });
+};
+
+export const openRingCallWindow = (params: {
+  callId: string;
+  callType?: CallType | undefined;
+  workspaceId: string | null;
+}): boolean => {
+  if (isCallWindowActive()) return false;
+  return openCallWindow({
+    callId: params.callId,
+    callType: params.callType ?? CallType.VIDEO,
+    stage: 'ring',
+    workspaceId: params.workspaceId,
+    theme: readTheme(),
+    inactive: true,
+  });
+};
+
+export const openInitiateCallWindow = (params: InitiateCallWindowParams): boolean => {
+  if (blockedByLiveCall()) return false;
+  const extra = new URLSearchParams();
+  extra.set('channelId', params.channelId);
+  if (params.targetUserIds?.length) extra.set('targetUserIds', params.targetUserIds.join(','));
+  if (params.callDisplayName) extra.set('callDisplayName', params.callDisplayName);
+  if (params.conversationId) extra.set('conversationId', params.conversationId);
+  if (params.artifactMessageId) extra.set('artifactMessageId', params.artifactMessageId);
+  if (params.sdlcLink) {
+    try {
+      extra.set('sdlcLink', JSON.stringify(params.sdlcLink));
+    } catch {
+      // A link that will not serialise is not worth failing the call over.
+    }
+  }
+
+  return openCallWindow({
+    callId: NEW_CALL_ID,
+    callType: params.callType ?? CallType.AUDIO,
+    stage: 'lobby',
+    workspaceId: readActiveWorkspaceId(),
+    theme: readTheme(),
+    extraParams: extra,
+  });
+};

--- a/apps/dashboard/src/routes/CallWindow/useCallWindowRing.ts
+++ b/apps/dashboard/src/routes/CallWindow/useCallWindowRing.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { CallType } from '@xyne/shared';
+import { usePlatform } from '../../hooks/usePlatform';
+import { focusCallWindow } from '../../utils/electronApp';
+import {
+  openRingCallWindow,
+  readActiveWorkspaceId,
+  shouldUseCallWindow,
+} from './callWindowLauncher';
+
+interface UseCallWindowRingOptions {
+  ringingCallId: string | undefined;
+  callType: CallType | undefined;
+}
+
+interface CallWindowRing {
+  usesCallWindow: boolean;
+  ringWindowShown: boolean;
+  /** The call the ring window was actually opened for, so callers never focus it blind. */
+  ringWindowCallId: string | null;
+  focusRingWindow: () => void;
+}
+
+export function useCallWindowRing(options: UseCallWindowRingOptions): CallWindowRing {
+  const { ringingCallId, callType } = options;
+  const { isMobile } = usePlatform();
+  const { workspaceId } = useParams<{ workspaceId?: string }>();
+  const openedForCallRef = useRef<string | null>(null);
+  const [ringWindowShown, setRingWindowShown] = useState(false);
+  const [ringWindowCallId, setRingWindowCallId] = useState<string | null>(null);
+
+  const usesCallWindow = shouldUseCallWindow(isMobile);
+
+  useEffect(() => {
+    if (!usesCallWindow) return;
+    window.electronAPI?.ipcSend?.('call:prewarm-window');
+  }, [usesCallWindow]);
+
+  useEffect(() => {
+    if (!usesCallWindow) return;
+    if (!ringingCallId) {
+      openedForCallRef.current = null;
+      setRingWindowShown(false);
+      setRingWindowCallId(null);
+      return;
+    }
+    if (openedForCallRef.current === ringingCallId) return;
+
+    const opened = openRingCallWindow({
+      callId: ringingCallId,
+      callType,
+      workspaceId: readActiveWorkspaceId(workspaceId),
+    });
+
+    // Only mark the call handled once the window actually opened. Marking it up front
+    // means a refused open — a live call still holding the window — is never retried,
+    // and that incoming call is dropped for good.
+    if (opened) openedForCallRef.current = ringingCallId;
+    setRingWindowShown(opened);
+    setRingWindowCallId(opened ? ringingCallId : null);
+  }, [callType, ringingCallId, usesCallWindow, workspaceId]);
+
+  const focusRingWindow = useCallback(() => {
+    focusCallWindow();
+  }, []);
+
+  return { usesCallWindow, ringWindowShown, ringWindowCallId, focusRingWindow };
+}

--- a/apps/dashboard/src/routes/CallWindow/useLobbyPreview.ts
+++ b/apps/dashboard/src/routes/CallWindow/useLobbyPreview.ts
@@ -1,0 +1,286 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createLocalAudioTrack,
+  createLocalVideoTrack,
+  type LocalAudioTrack,
+  type LocalVideoTrack,
+} from 'livekit-client';
+import { MACOS_PRIVACY_URLS } from '../../constants/permissions';
+import { isElectronApp } from '../../utils/electronApp';
+
+export type DeviceKind = 'mic' | 'camera';
+
+export type PermissionState = 'unknown' | 'granted' | 'denied' | 'prompt';
+
+export interface LobbyPreviewState {
+  micOn: boolean;
+  cameraOn: boolean;
+  micTrack: LocalAudioTrack | null;
+  cameraTrack: LocalVideoTrack | null;
+  micPermission: PermissionState;
+  cameraPermission: PermissionState;
+  micDevices: MediaDeviceInfo[];
+  cameraDevices: MediaDeviceInfo[];
+  speakerDevices: MediaDeviceInfo[];
+  micDeviceId: string | null;
+  cameraDeviceId: string | null;
+  speakerDeviceId: string | null;
+  setMicOn: (on: boolean) => void;
+  setCameraOn: (on: boolean) => void;
+  selectMicDevice: (deviceId: string) => void;
+  selectCameraDevice: (deviceId: string) => void;
+  selectSpeakerDevice: (deviceId: string) => void;
+  stopPreview: () => void;
+  releaseTracks: () => void;
+  openSystemSettings: (kind: DeviceKind) => void;
+}
+
+interface UseLobbyPreviewOptions {
+  initialMicOn: boolean;
+  initialCameraOn: boolean;
+  initialMicDeviceId: string | null;
+  initialCameraDeviceId: string | null;
+  initialSpeakerDeviceId: string | null;
+  autoStart: boolean;
+}
+
+const isPermissionDenied = (error: unknown): boolean =>
+  error instanceof Error &&
+  (error.name === 'NotAllowedError' || error.name === 'PermissionDeniedError');
+
+export function useLobbyPreview(options: UseLobbyPreviewOptions): LobbyPreviewState {
+  const [micOn, setMicOnState] = useState(options.initialMicOn);
+  const [cameraOn, setCameraOnState] = useState(options.initialCameraOn);
+  const [micTrack, setMicTrack] = useState<LocalAudioTrack | null>(null);
+  const [cameraTrack, setCameraTrack] = useState<LocalVideoTrack | null>(null);
+  const [micPermission, setMicPermission] = useState<PermissionState>('unknown');
+  const [cameraPermission, setCameraPermission] = useState<PermissionState>('unknown');
+  const [devices, setDevices] = useState<MediaDeviceInfo[]>([]);
+  const [micDeviceId, setMicDeviceId] = useState<string | null>(options.initialMicDeviceId);
+  const [cameraDeviceId, setCameraDeviceId] = useState<string | null>(
+    options.initialCameraDeviceId,
+  );
+  const [speakerDeviceId, setSpeakerDeviceId] = useState<string | null>(
+    options.initialSpeakerDeviceId,
+  );
+
+  const micTrackRef = useRef<LocalAudioTrack | null>(null);
+  const cameraTrackRef = useRef<LocalVideoTrack | null>(null);
+  const releasedRef = useRef(false);
+  const micTokenRef = useRef(0);
+  const cameraTokenRef = useRef(0);
+
+  micTrackRef.current = micTrack;
+  cameraTrackRef.current = cameraTrack;
+
+  const refreshDevices = useCallback(async (): Promise<void> => {
+    try {
+      const list = await navigator.mediaDevices.enumerateDevices();
+      setDevices(list);
+    } catch {
+      // Enumeration fails before any permission is granted; the lobby still works.
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const probe = async (): Promise<void> => {
+      if (!navigator.permissions?.query) return;
+      const read = async (name: string): Promise<PermissionState> => {
+        try {
+          const status = await navigator.permissions.query({
+            name: name as PermissionName,
+          });
+          return status.state as PermissionState;
+        } catch {
+          return 'unknown';
+        }
+      };
+      const [mic, camera] = await Promise.all([read('microphone'), read('camera')]);
+      if (cancelled) return;
+      setMicPermission(mic);
+      setCameraPermission(camera);
+    };
+    void probe();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    void refreshDevices();
+    const onChange = (): void => void refreshDevices();
+    navigator.mediaDevices?.addEventListener?.('devicechange', onChange);
+    return () => {
+      navigator.mediaDevices?.removeEventListener?.('devicechange', onChange);
+    };
+  }, [refreshDevices]);
+
+  const stopMic = useCallback(() => {
+    micTrackRef.current?.stop();
+    micTrackRef.current = null;
+    setMicTrack(null);
+  }, []);
+
+  const stopCamera = useCallback(() => {
+    cameraTrackRef.current?.stop();
+    cameraTrackRef.current = null;
+    setCameraTrack(null);
+  }, []);
+
+  const startMic = useCallback(
+    async (deviceId: string | null): Promise<void> => {
+      const token = ++micTokenRef.current;
+      try {
+        const track = await createLocalAudioTrack(
+          deviceId ? { deviceId: { exact: deviceId } } : {},
+        );
+        if (releasedRef.current || token !== micTokenRef.current) {
+          track.stop();
+          return;
+        }
+        stopMic();
+        micTrackRef.current = track;
+        setMicTrack(track);
+        setMicPermission('granted');
+        void refreshDevices();
+      } catch (error) {
+        if (token !== micTokenRef.current) return;
+        setMicOnState(false);
+        if (isPermissionDenied(error)) setMicPermission('denied');
+      }
+    },
+    [refreshDevices, stopMic],
+  );
+
+  const startCamera = useCallback(
+    async (deviceId: string | null): Promise<void> => {
+      const token = ++cameraTokenRef.current;
+      try {
+        const track = await createLocalVideoTrack(
+          deviceId ? { deviceId: { exact: deviceId } } : {},
+        );
+        if (releasedRef.current || token !== cameraTokenRef.current) {
+          track.stop();
+          return;
+        }
+        stopCamera();
+        cameraTrackRef.current = track;
+        setCameraTrack(track);
+        setCameraPermission('granted');
+        void refreshDevices();
+      } catch (error) {
+        if (token !== cameraTokenRef.current) return;
+        setCameraOnState(false);
+        if (isPermissionDenied(error)) setCameraPermission('denied');
+      }
+    },
+    [refreshDevices, stopCamera],
+  );
+
+  const setMicOn = useCallback(
+    (on: boolean) => {
+      setMicOnState(on);
+      if (on) {
+        void startMic(micDeviceId);
+      } else {
+        micTokenRef.current += 1;
+        stopMic();
+      }
+    },
+    [micDeviceId, startMic, stopMic],
+  );
+
+  const setCameraOn = useCallback(
+    (on: boolean) => {
+      setCameraOnState(on);
+      if (on) {
+        void startCamera(cameraDeviceId);
+      } else {
+        cameraTokenRef.current += 1;
+        stopCamera();
+      }
+    },
+    [cameraDeviceId, startCamera, stopCamera],
+  );
+
+  const selectMicDevice = useCallback(
+    (deviceId: string) => {
+      setMicDeviceId(deviceId);
+      if (micOn) void startMic(deviceId);
+    },
+    [micOn, startMic],
+  );
+
+  const selectCameraDevice = useCallback(
+    (deviceId: string) => {
+      setCameraDeviceId(deviceId);
+      if (cameraOn) void startCamera(deviceId);
+    },
+    [cameraOn, startCamera],
+  );
+
+  const selectSpeakerDevice = useCallback((deviceId: string) => {
+    setSpeakerDeviceId(deviceId);
+  }, []);
+
+  useEffect(() => {
+    if (!options.autoStart) return;
+    if (options.initialMicOn) void startMic(options.initialMicDeviceId);
+    if (options.initialCameraOn) void startCamera(options.initialCameraDeviceId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const stopPreview = useCallback(() => {
+    releasedRef.current = true;
+    stopMic();
+    stopCamera();
+  }, [stopCamera, stopMic]);
+
+  const releaseTracks = useCallback(() => {
+    micTokenRef.current += 1;
+    cameraTokenRef.current += 1;
+    micTrackRef.current = null;
+    cameraTrackRef.current = null;
+    setMicTrack(null);
+    setCameraTrack(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      releasedRef.current = true;
+      micTrackRef.current?.stop();
+      cameraTrackRef.current?.stop();
+    };
+  }, []);
+
+  const openSystemSettings = useCallback((kind: DeviceKind) => {
+    const url = MACOS_PRIVACY_URLS[kind === 'mic' ? 'microphone' : 'camera'];
+    if (isElectronApp() && url) {
+      window.electronAPI?.openExternal?.(url);
+    }
+  }, []);
+
+  return {
+    micOn,
+    cameraOn,
+    micTrack,
+    cameraTrack,
+    micPermission,
+    cameraPermission,
+    micDevices: devices.filter(d => d.kind === 'audioinput'),
+    cameraDevices: devices.filter(d => d.kind === 'videoinput'),
+    speakerDevices: devices.filter(d => d.kind === 'audiooutput'),
+    micDeviceId,
+    cameraDeviceId,
+    speakerDeviceId,
+    setMicOn,
+    setCameraOn,
+    selectMicDevice,
+    selectCameraDevice,
+    selectSpeakerDevice,
+    stopPreview,
+    releaseTracks,
+    openSystemSettings,
+  };
+}

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -50,6 +50,9 @@ export interface ElectronAPI {
   onCallAction: (
     callback: (data: { callId: string; action: 'accept' | 'reject' }) => void,
   ) => () => void;
+  onCallWindowLeave?: (callback: () => void) => () => void;
+  onCallWindowNavigate?: (callback: (relativePath: string) => void) => () => void;
+  takePendingCallRoute?: () => Promise<string | null>;
   focusApp: () => void;
   onNavigateTo: (callback: (url: string, workspaceId?: string) => void) => () => void;
   onBrowserNewTab: (callback: () => void) => () => void;

--- a/apps/dashboard/src/utils/callWindowChannel.ts
+++ b/apps/dashboard/src/utils/callWindowChannel.ts
@@ -1,0 +1,153 @@
+const CALL_WINDOW_CHANNEL = 'xyne-call-window-state';
+
+export interface CallWindowState {
+  callId: string;
+  title: string | null;
+  micEnabled: boolean;
+  cameraEnabled: boolean;
+  screenSharing: boolean;
+  connected: boolean;
+}
+
+type CallWindowMessage =
+  | { kind: 'state'; state: CallWindowState }
+  | { kind: 'ended'; callId: string }
+  | { kind: 'request-state' }
+  | { kind: 'command'; command: 'leave' | 'toggle-mic' | 'toggle-camera' };
+
+const openChannel = (): BroadcastChannel | null => {
+  if (typeof BroadcastChannel === 'undefined') return null;
+  try {
+    return new BroadcastChannel(CALL_WINDOW_CHANNEL);
+  } catch {
+    return null;
+  }
+};
+
+const post = (message: CallWindowMessage): void => {
+  const channel = openChannel();
+  if (!channel) return;
+  try {
+    channel.postMessage(message);
+  } finally {
+    channel.close();
+  }
+};
+
+export const publishCallWindowState = (state: CallWindowState): void => {
+  post({ kind: 'state', state });
+};
+
+export const publishCallWindowEnded = (callId: string): void => {
+  post({ kind: 'ended', callId });
+};
+
+export const requestCallWindowState = (): void => {
+  post({ kind: 'request-state' });
+};
+
+export const sendCallWindowCommand = (command: 'leave' | 'toggle-mic' | 'toggle-camera'): void => {
+  post({ kind: 'command', command });
+};
+
+const LIVE_STALE_CHECK_MS = 5_000;
+
+let liveState: CallWindowState | null = null;
+const liveListeners = new Set<() => void>();
+let liveChannel: BroadcastChannel | null = null;
+let liveStaleTimer: ReturnType<typeof setInterval> | null = null;
+
+const emitLive = (next: CallWindowState | null): void => {
+  liveState = next;
+  liveListeners.forEach(listener => listener());
+};
+
+const ensureLiveSubscription = (): void => {
+  if (liveChannel) return;
+  liveChannel = openChannel();
+  if (!liveChannel) return;
+  liveChannel.onmessage = (event: MessageEvent<CallWindowMessage>): void => {
+    const message = event.data;
+    if (!message) return;
+    if (message.kind === 'state') emitLive(message.state);
+    else if (message.kind === 'ended') emitLive(null);
+  };
+  liveStaleTimer ??= setInterval(() => {
+    if (liveState && !isCallWindowActive()) emitLive(null);
+  }, LIVE_STALE_CHECK_MS);
+  requestCallWindowState();
+};
+
+export const getLiveCallWindowState = (): CallWindowState | null => liveState;
+
+export const subscribeLiveCallWindow = (listener: () => void): (() => void) => {
+  ensureLiveSubscription();
+  liveListeners.add(listener);
+  return () => {
+    liveListeners.delete(listener);
+  };
+};
+
+interface CallWindowSubscribers {
+  onState?: (state: CallWindowState) => void;
+  onEnded?: (callId: string) => void;
+  onStateRequested?: () => void;
+  onCommand?: (command: 'leave' | 'toggle-mic' | 'toggle-camera') => void;
+}
+
+export const subscribeCallWindowChannel = (handlers: CallWindowSubscribers): (() => void) => {
+  const channel = openChannel();
+  if (!channel) return () => undefined;
+
+  channel.onmessage = (event: MessageEvent<CallWindowMessage>): void => {
+    const message = event.data;
+    if (!message) return;
+    switch (message.kind) {
+      case 'state':
+        handlers.onState?.(message.state);
+        break;
+      case 'ended':
+        handlers.onEnded?.(message.callId);
+        break;
+      case 'request-state':
+        handlers.onStateRequested?.();
+        break;
+      case 'command':
+        handlers.onCommand?.(message.command);
+        break;
+    }
+  };
+
+  return () => channel.close();
+};
+
+const CALL_WINDOW_ACTIVE_KEY = 'xyne:call-window-active';
+const CALL_WINDOW_ACTIVE_TTL_MS = 30_000;
+
+export const markCallWindowActive = (): void => {
+  try {
+    localStorage.setItem(CALL_WINDOW_ACTIVE_KEY, String(Date.now()));
+  } catch {
+    // A blocked localStorage only costs us the drop guard.
+  }
+};
+
+export const clearCallWindowActive = (): void => {
+  try {
+    localStorage.removeItem(CALL_WINDOW_ACTIVE_KEY);
+  } catch {
+    // ignore
+  }
+};
+
+export const isCallWindowActive = (): boolean => {
+  try {
+    const raw = localStorage.getItem(CALL_WINDOW_ACTIVE_KEY);
+    if (!raw) return false;
+    const stamp = Number(raw);
+    if (!Number.isFinite(stamp)) return false;
+    return Date.now() - stamp < CALL_WINDOW_ACTIVE_TTL_MS;
+  } catch {
+    return false;
+  }
+};

--- a/apps/dashboard/src/utils/electronApp.ts
+++ b/apps/dashboard/src/utils/electronApp.ts
@@ -69,7 +69,16 @@ export const isElectronStandaloneWindow = (): boolean => {
   return isElectronApp() && isStandaloneWindow();
 };
 
-const STANDALONE_SUPPORTED_ROUTES = ['/chat/'];
+export const CALL_WINDOW_PATH_PREFIX = '/newWindow/call/';
+
+export const isCallWindow = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return window.location.pathname.startsWith(CALL_WINDOW_PATH_PREFIX);
+};
+
+const STANDALONE_SUPPORTED_ROUTES = ['/chat/', '/call/'];
 
 export const isStandaloneSupportedPath = (path: string): boolean => {
   return STANDALONE_SUPPORTED_ROUTES.some(route => path.startsWith(route));
@@ -365,4 +374,69 @@ export const subscribeCreateTicketResult = (
   }
 
   return dispose;
+};
+
+export type CallWindowStage = 'ring' | 'lobby';
+
+export interface OpenCallWindowOptions {
+  callId: string;
+  callType: string;
+  stage: CallWindowStage;
+  workspaceId?: string | null | undefined;
+  theme?: string | null | undefined;
+  inactive?: boolean | undefined;
+  extraParams?: URLSearchParams | undefined;
+}
+
+const CALL_WINDOW_TARGET = 'xyne-call-window';
+const CALL_WINDOW_FEATURES = 'popup=yes,width=960,height=640';
+export const CALL_WINDOW_LAUNCH_PARAM = 'launch';
+
+let callWindowLaunchSeq = 0;
+
+export const buildCallWindowPath = (options: OpenCallWindowOptions): string => {
+  const search = new URLSearchParams();
+  search.set('stage', options.stage);
+  callWindowLaunchSeq += 1;
+  search.set(CALL_WINDOW_LAUNCH_PARAM, `${Date.now()}-${callWindowLaunchSeq}`);
+  if (options.workspaceId) search.set('workspaceId', options.workspaceId);
+  if (options.theme) search.set('theme', options.theme);
+  options.extraParams?.forEach((value, key) => search.set(key, value));
+  return `${CALL_WINDOW_PATH_PREFIX}${encodeURIComponent(options.callId)}/${encodeURIComponent(
+    options.callType,
+  )}?${search.toString()}`;
+};
+
+export const openCallWindow = (options: OpenCallWindowOptions): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const path = buildCallWindowPath(options);
+
+  if (isElectronApp() && window.electronAPI?.ipcSend) {
+    window.electronAPI.ipcSend('call:open-window', {
+      relativePath: path,
+      inactive: options.inactive === true,
+    });
+    return true;
+  }
+
+  const newWindow = window.open(path, CALL_WINDOW_TARGET, CALL_WINDOW_FEATURES);
+
+  if (newWindow) {
+    newWindow.focus();
+    return true;
+  }
+
+  logger.warn(LogEvent.FRONTEND_ERROR, {
+    type: 'migrated_console_warn',
+    message: String('Failed to open call window; popup may be blocked'),
+  });
+  return false;
+};
+
+export const focusCallWindow = (): void => {
+  if (typeof window === 'undefined') return;
+  window.electronAPI?.ipcSend?.('call:focus-window');
 };

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -5,6 +5,14 @@ import * as path from 'path';
 import { clearAllCookies, clearBrowserTabsData, syncXyneCookiesToBrowserPanel } from '../services/cookies';
 import { showNotification, NotificationData, showCallNotification, closeCallNotification, CallNotificationData } from '../services/notifications';
 import { getMainWindow, loadApp, toggleWindowCompactMode } from '../window/manager';
+import {
+  openCallWindow,
+  getCallWindow,
+  closeCallWindow,
+  prewarmCallWindow,
+  takePendingCallRoute,
+  setCallWindowRinging,
+} from '../window/call-window';
 import { setupMTLSIpcHandlers } from './mtls-handlers';
 import { config, ENABLE_LOCAL_HARNESS } from '../app/config';
 import { performHardReload } from '../services/version-checker';
@@ -651,9 +659,49 @@ export function setupIpcHandlers(): void {
     setRecordingPillTheme(theme);
   });
 
-  ipcMain.on('call:state-changed', (event, inCall: unknown) => {
+  ipcMain.on('call:open-window', (event, payload: unknown) => {
+    if (!isAppWindowSender(event)) return;
+    const request = payload as { relativePath?: unknown; inactive?: unknown } | null;
+    const relativePath = typeof request?.relativePath === 'string' ? request.relativePath : '';
+    if (!relativePath.startsWith('/newWindow/call/')) {
+      errorLogger.warn('[ipc] Rejected call:open-window with unexpected path');
+      return;
+    }
+    openCallWindow({ relativePath, inactive: request?.inactive === true });
+  });
+
+  ipcMain.on('call:prewarm-window', (event) => {
     if (!isMainWindowSender(event)) return;
-    setCallActive(!!inCall);
+    prewarmCallWindow();
+  });
+
+  ipcMain.handle('call:take-pending-route', (event) => {
+    if (!isAppWindowSender(event)) return null;
+    return takePendingCallRoute();
+  });
+
+  ipcMain.on('call:ringing-changed', (event, ringing: unknown) => {
+    if (!isAppWindowSender(event)) return;
+    setCallWindowRinging(!!ringing);
+  });
+
+  ipcMain.on('call:focus-window', (event) => {
+    if (!isAppWindowSender(event)) return;
+    const win = getCallWindow();
+    if (!win) return;
+    if (win.isMinimized()) win.restore();
+    win.show();
+    win.focus();
+  });
+
+  ipcMain.on('call:close-window', (event) => {
+    if (!isAppWindowSender(event)) return;
+    closeCallWindow();
+  });
+
+  ipcMain.on('call:state-changed', (event, inCall: unknown) => {
+    if (!isAppWindowSender(event)) return;
+    setCallActive(!!inCall, event.sender.id);
   });
 
   ipcMain.on('recording:renderer-ready', (event) => {

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -286,10 +286,30 @@ const electronAPI = {
   requestAllMediaPermissions: () =>
     ipcRenderer.invoke('request-all-media-permissions'),
 
+  takePendingCallRoute: (): Promise<string | null> =>
+    ipcRenderer.invoke('call:take-pending-route'),
+
+  onCallWindowLeave: (callback: () => void) => {
+    const listener = (): void => callback();
+    ipcRenderer.on('call:leave', listener);
+    return () => ipcRenderer.removeListener('call:leave', listener);
+  },
+
+  onCallWindowNavigate: (callback: (relativePath: string) => void) => {
+    const listener = (_event: unknown, relativePath: string): void => callback(relativePath);
+    ipcRenderer.on('call:navigate', listener);
+    return () => ipcRenderer.removeListener('call:navigate', listener);
+  },
+
   // Generic IPC send (used by standalone HTML windows like meeting-popup)
   ipcSend: (channel: string, ...args: unknown[]) => {
     const allowed = [
       'app:theme-changed',
+      'call:close-window',
+      'call:focus-window',
+      'call:open-window',
+      'call:prewarm-window',
+      'call:ringing-changed',
       'call:state-changed',
       'meeting-popup:content-height',
       'agent-consent:content-height',

--- a/apps/electron/src/services/agent-auth.ts
+++ b/apps/electron/src/services/agent-auth.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'crypto';
 import { dialog, BrowserWindow, session, net, app } from 'electron';
 import log from 'electron-log/main';
 import { config } from '../app/config';
+import { getMainWindow } from '../window/manager';
 import { Logger } from './logger/Logger';
 import ElectronEvent from './logger/electron-events';
 import * as fs from 'fs';
@@ -1586,7 +1587,7 @@ class AgentAuthService {
     authRequest: AuthRequest,
     peer: PeerProcess | null,
   ): Promise<{ approved: boolean; duration: DurationOption }> {
-    const mainWindow = BrowserWindow.getAllWindows()[0];
+    const mainWindow = getMainWindow() ?? BrowserWindow.getAllWindows()[0];
 
     if (!mainWindow) {
       log.error('[AgentAuth] No window available for consent dialog');

--- a/apps/electron/src/services/recording-controller.ts
+++ b/apps/electron/src/services/recording-controller.ts
@@ -37,7 +37,7 @@ let focusRequestTimer: ReturnType<typeof setTimeout> | null = null;
 
 let active = false;
 let startingRecording = false;
-let callActive = false;
+const callActiveByWindow = new Set<number>();
 let startingRecordingExpiry: ReturnType<typeof setTimeout> | null = null;
 let startTime: number | null = null;
 let paused = false;
@@ -85,19 +85,20 @@ export function onRecordingStateChange(
 function watchRendererLifecycle(win: BrowserWindow): void {
   if (watchedRenderers.has(win)) return;
   watchedRenderers.add(win);
+  const senderId = win.webContents.id;
   win.webContents.on('did-start-loading', () => {
     rendererReady = false;
     // A reload tears down the LiveKit connection, so any call is over; the
     // remounted renderer resends call state either way. Without this a renderer
     // that hangs mid-reload would strand the flag true and mute detection.
-    callActive = false;
+    clearCallActiveForWindow(senderId);
   });
   win.webContents.on('render-process-gone', () => {
     rendererReady = false;
     // syncRecordingState early-returns on inactive -> inactive, so a crash
     // mid-start would strand the flag.
     setRecordingStarting(false);
-    callActive = false;
+    clearCallActiveForWindow(senderId);
     syncRecordingState(false);
   });
 }
@@ -158,9 +159,10 @@ function isMainWindowFocused(): boolean {
 }
 
 function syncPowerSaveBlocker(): void {
-  if (active && powerSaveBlockerId === null) {
+  const shouldBlock = active || callActiveByWindow.size > 0;
+  if (shouldBlock && powerSaveBlockerId === null) {
     powerSaveBlockerId = powerSaveBlocker.start('prevent-app-suspension');
-  } else if (!active && powerSaveBlockerId !== null) {
+  } else if (!shouldBlock && powerSaveBlockerId !== null) {
     powerSaveBlocker.stop(powerSaveBlockerId);
     powerSaveBlockerId = null;
   }
@@ -407,12 +409,27 @@ export function isRecordingInProgress(): boolean {
 // Calls enable the mic the same way recordings do, so the meeting detector must
 // treat both as ours. The renderer reports call state on every transition and on
 // mount; the lifecycle hooks above clear it when the renderer reloads or dies.
-export function setCallActive(next: boolean): void {
-  callActive = next;
+export function setCallActive(next: boolean, senderId?: number): void {
+  const key = senderId ?? 0;
+  if (next) {
+    callActiveByWindow.add(key);
+  } else {
+    callActiveByWindow.delete(key);
+  }
+  syncPowerSaveBlocker();
+}
+
+export function isCallActiveForWindow(senderId: number): boolean {
+  return callActiveByWindow.has(senderId);
+}
+
+export function clearCallActiveForWindow(senderId: number): void {
+  callActiveByWindow.delete(senderId);
+  syncPowerSaveBlocker();
 }
 
 export function isMicOwnedByXyne(): boolean {
-  return active || startingRecording || callActive;
+  return active || startingRecording || callActiveByWindow.size > 0;
 }
 
 export function syncRecordingState(

--- a/apps/electron/src/services/request-interceptor.ts
+++ b/apps/electron/src/services/request-interceptor.ts
@@ -1,5 +1,5 @@
 import log from 'electron-log/main';
-import { session, BrowserWindow, app } from 'electron';
+import { session, BrowserWindow, app, webContents } from 'electron';
 import { config } from '../app/config';
 import { clearAllCookies } from './cookies';
 import path from 'path';
@@ -10,10 +10,15 @@ import { showScreenPicker } from './screen-picker';
 import Store from 'electron-store';
 
 let mainWindow: BrowserWindow | null = null;
+let callWindow: BrowserWindow | null = null;
 const store = new Store();
 
 export function setMainWindow(window: BrowserWindow | null): void {
   mainWindow = window;
+}
+
+export function setCallWindow(window: BrowserWindow | null): void {
+  callWindow = window;
 }
 
 let cachedUserEmail: string | null = null;
@@ -139,7 +144,8 @@ export function setupXyneSpacesInterceptor(): void {
 /**
  * XYNE-16859 Issue 24: deny screen/microphone capture web APIs
  * (`getUserMedia`, `getDisplayMedia`) for any webContents that is not the
- * top-level main application window. Without this, an XSS'd `<webview>` or
+ * top-level main application window or the registered call window (see
+ * `setCallWindow`). Without this, an XSS'd `<webview>` or
  * browser panel could bypass our error-report:* IPC gate entirely by calling
  * `navigator.mediaDevices.getUserMedia` / `getDisplayMedia` directly, since
  * macOS's app-level Screen-Recording + Microphone TCC grants would otherwise
@@ -173,10 +179,11 @@ function isAppOwnedWindowContents(webContents: Electron.WebContents | undefined)
   return owner.webContents === webContents && appOwnedWindows.has(owner);
 }
 
-function isTopLevelMainWindow(webContents: Electron.WebContents | undefined): boolean {
+function isTopLevelAppWindow(webContents: Electron.WebContents | undefined): boolean {
   if (!webContents) return false;
-  if (!mainWindow || mainWindow.isDestroyed()) return false;
-  return webContents === mainWindow.webContents;
+  if (mainWindow && !mainWindow.isDestroyed() && webContents === mainWindow.webContents) return true;
+  if (callWindow && !callWindow.isDestroyed() && webContents === callWindow.webContents) return true;
+  return false;
 }
 // Mirrors preload.ts isTrustedOrigin(), but evaluated main-side against a webContents URL.
 function isFirstPartyUrl(rawUrl: string | undefined): boolean {
@@ -196,11 +203,11 @@ function installMediaPermissionGuard(targetSession: Electron.Session, label: str
   targetSession.setPermissionRequestHandler((webContents, permission, callback, details) => {
     if (RESTRICTED_MEDIA_PERMISSIONS.has(permission)) {
       const allowed =
-        isTopLevelMainWindow(webContents) ||
+        isTopLevelAppWindow(webContents) ||
         (isAppOwnedWindowContents(webContents) && isFirstPartyUrl(details?.requestingUrl));
       if (!allowed) {
         Logger.warn(
-          `[permissions:${label}] denied ${permission} for non-main webContents (url=${webContents?.getURL() ?? 'n/a'})`,
+          `[permissions:${label}] denied ${permission} for non-app webContents (url=${webContents?.getURL() ?? 'n/a'})`,
         );
       }
       callback(allowed);
@@ -209,7 +216,7 @@ function installMediaPermissionGuard(targetSession: Electron.Session, label: str
     // Main window keeps permissive behaviour; first-party Xyne content outside it gets ONLY
     // the narrow clipboard/fullscreen set; every other session (in-app browser panel
     // `persist:browser-tabs`, the `preview` partition, embedded `<webview>`s) is denied.
-    if (isTopLevelMainWindow(webContents)) {
+    if (isTopLevelAppWindow(webContents)) {
       callback(true);
       return;
     }
@@ -218,21 +225,21 @@ function installMediaPermissionGuard(targetSession: Electron.Session, label: str
       return;
     }
     Logger.warn(
-      `[permissions:${label}] denied ${permission} for non-main webContents (url=${webContents?.getURL() ?? 'n/a'})`,
+      `[permissions:${label}] denied ${permission} for non-app webContents (url=${webContents?.getURL() ?? 'n/a'})`,
     );
     callback(false);
   });
   targetSession.setPermissionCheckHandler((webContents, permission, requestingOrigin) => {
     if (RESTRICTED_MEDIA_PERMISSIONS.has(permission)) {
       return (
-        isTopLevelMainWindow(webContents ?? undefined) ||
+        isTopLevelAppWindow(webContents ?? undefined) ||
         (isAppOwnedWindowContents(webContents ?? undefined) && isFirstPartyUrl(requestingOrigin))
       );
     }
     // Non-media permission checks succeed for the first-party main window,
     // and for the narrow clipboard/fullscreen set on first-party content hosted outside
     // it (e.g. the in-app browser panel); untrusted embedded content is denied.
-    if (isTopLevelMainWindow(webContents ?? undefined)) return true;
+    if (isTopLevelAppWindow(webContents ?? undefined)) return true;
     return FIRST_PARTY_NONMEDIA_PERMISSIONS.has(permission) && isFirstPartyUrl(webContents?.getURL());
   });
 }
@@ -366,7 +373,7 @@ export function setupRequestInterceptor(): void {
  * Called on startup and re-called after a native OS picker fallback completes.
  */
 function setupDisplayMediaHandler(): void {
-  session.defaultSession.setDisplayMediaRequestHandler((_request, callback) => {
+  session.defaultSession.setDisplayMediaRequestHandler((request, callback) => {
     const safeCallback = (streams: Electron.Streams): void => {
       try {
         callback(streams);
@@ -376,7 +383,14 @@ function setupDisplayMediaHandler(): void {
         Logger.info('[ScreenShare] Cancelled or no stream provided:', String(err));
       }
     };
-    showScreenPicker(safeCallback);
+    let requester: BrowserWindow | null = null;
+    try {
+      const senderContents = request.frame ? webContents.fromFrame(request.frame) : null;
+      requester = senderContents ? BrowserWindow.fromWebContents(senderContents) : null;
+    } catch {
+      requester = null;
+    }
+    showScreenPicker(safeCallback, requester);
   });
 }
 

--- a/apps/electron/src/services/screen-picker.ts
+++ b/apps/electron/src/services/screen-picker.ts
@@ -1,4 +1,4 @@
-import { desktopCapturer, ipcMain } from 'electron';
+import { BrowserWindow, desktopCapturer, ipcMain } from 'electron';
 import Logger from 'electron-log/main';
 import { getMainWindow } from '../window/manager';
 
@@ -14,20 +14,22 @@ export type ScreenPickerPayload =
   | { sources: ScreenSource[]; permissionError: null }
   | { sources: []; permissionError: 'denied' };
 
-let isPickerOpen = false;
+const openPickers = new Set<number>();
 
 /**
  * Cancels the pending getDisplayMedia() request and shows the permission-denied
  * state in the custom picker UI. Never falls back to the native OS picker.
  */
-function showPermissionError(callback: (streams: Electron.Streams) => void): void {
+function showPermissionError(
+  callback: (streams: Electron.Streams) => void,
+  requester: BrowserWindow,
+): void {
   Logger.info('[ScreenPicker] No sources — Screen Recording permission likely denied');
   // Cancel the pending request — Electron may throw when no video stream is provided
   try { callback({} as Electron.Streams); } catch { /* suppress */ }
 
-  const win = getMainWindow();
-  if (win && !win.isDestroyed()) {
-    win.webContents.send('screen-picker:show', {
+  if (!requester.isDestroyed()) {
+    requester.webContents.send('screen-picker:show', {
       sources: [],
       permissionError: 'denied',
     } satisfies ScreenPickerPayload);
@@ -39,39 +41,52 @@ function showPermissionError(callback: (streams: Electron.Streams) => void): voi
  *
  * Calls desktopCapturer.getSources() — this triggers the macOS "Screen Recording"
  * permission prompt on first run. If permission is denied (no sources returned),
- * falls back to one native OS picker attempt and shows the permission error UI.
+ * shows the permission error UI.
  */
-export function showScreenPicker(callback: (streams: Electron.Streams) => void): void {
-  if (isPickerOpen) {
-    getMainWindow()?.focus();
+export function showScreenPicker(
+  callback: (streams: Electron.Streams) => void,
+  requestingWindow?: BrowserWindow | null,
+): void {
+  const requester = requestingWindow ?? getMainWindow();
+  if (!requester || requester.isDestroyed()) {
+    Logger.warn('[ScreenPicker] Requesting window not available');
+    try { callback({} as Electron.Streams); } catch { /* suppress */ }
     return;
   }
 
-  const mainWindow = getMainWindow();
-  if (!mainWindow || mainWindow.isDestroyed()) {
-    Logger.warn('[ScreenPicker] Main window not available');
+  const requesterId = requester.webContents.id;
+
+  if (openPickers.has(requesterId)) {
+    requester.focus();
     return;
   }
 
-  isPickerOpen = true;
+  openPickers.add(requesterId);
   let callbackCalled = false;
 
-  const cleanup = (): void => {
-    isPickerOpen = false;
+  const isFromRequester = (event: Electron.IpcMainEvent): boolean =>
+    event.sender.id === requesterId;
+
+  const removeListeners = (): void => {
+    openPickers.delete(requesterId);
     ipcMain.removeListener('screen-picker:select', handleSelect);
     ipcMain.removeListener('screen-picker:cancel', handleCancel);
-    const win = getMainWindow();
-    if (win && !win.isDestroyed()) {
-      win.webContents.send('screen-picker:close');
+  };
+
+  const cleanup = (): void => {
+    removeListeners();
+    if (!requester.isDestroyed()) {
+      requester.webContents.send('screen-picker:close');
     }
   };
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const handleSelect = async (
-    _event: Electron.IpcMainEvent,
+    event: Electron.IpcMainEvent,
     sourceId: string,
     shareAudio: boolean,
   ): Promise<void> => {
+    if (!isFromRequester(event)) return;
     if (callbackCalled) return;
     callbackCalled = true;
     cleanup();
@@ -96,12 +111,21 @@ export function showScreenPicker(callback: (streams: Electron.Streams) => void):
     }
   };
 
-  const handleCancel = (): void => {
+  const handleCancel = (event: Electron.IpcMainEvent): void => {
+    if (!isFromRequester(event)) return;
     if (callbackCalled) return;
     callbackCalled = true;
     cleanup();
     try { callback({} as Electron.Streams); } catch { /* suppress "no video stream" error */ }
   };
+
+  const handleRequesterClosed = (): void => {
+    if (callbackCalled) return;
+    callbackCalled = true;
+    removeListeners();
+    try { callback({} as Electron.Streams); } catch { /* suppress */ }
+  };
+  requester.once('closed', handleRequesterClosed);
 
   ipcMain.on('screen-picker:select', handleSelect);
   ipcMain.on('screen-picker:cancel', handleCancel);
@@ -117,10 +141,9 @@ export function showScreenPicker(callback: (streams: Electron.Streams) => void):
       Logger.info(`[ScreenPicker] Got ${sources.length} sources`);
 
       if (sources.length === 0) {
-        isPickerOpen = false;
-        ipcMain.removeListener('screen-picker:select', handleSelect);
-        ipcMain.removeListener('screen-picker:cancel', handleCancel);
-        showPermissionError(callback);
+        callbackCalled = true;
+        removeListeners();
+        showPermissionError(callback, requester);
         return;
       }
 
@@ -136,17 +159,16 @@ export function showScreenPicker(callback: (streams: Electron.Streams) => void):
           type: s.id.startsWith('screen:') ? 'screen' : 'window',
         }));
 
-      mainWindow.webContents.send('screen-picker:show', {
+      if (requester.isDestroyed()) return;
+      requester.webContents.send('screen-picker:show', {
         sources: serialized,
         permissionError: null,
       } satisfies ScreenPickerPayload);
     } catch (err) {
       Logger.error('[ScreenPicker] getSources threw:', err);
-      isPickerOpen = false;
-      ipcMain.removeListener('screen-picker:select', handleSelect);
-      ipcMain.removeListener('screen-picker:cancel', handleCancel);
-      showPermissionError(callback);
+      callbackCalled = true;
+      removeListeners();
+      showPermissionError(callback, requester);
     }
   })();
 }
-

--- a/apps/electron/src/services/ui-updater.ts
+++ b/apps/electron/src/services/ui-updater.ts
@@ -4,6 +4,7 @@ import { pipeline } from 'stream/promises';
 import { createHash } from 'crypto';
 import path from 'path';
 import log from 'electron-log/main';
+import { getMainWindow } from '../window/manager';
 import {config} from '../app/config';
 
 // Track if there's a staged update waiting to be applied when window loses focus
@@ -481,7 +482,7 @@ export async function downloadUIUpdate(): Promise<boolean> {
     // Note: isFocused() can return false even when the user is looking at the window
     // (e.g., if they clicked on the desktop or another app momentarily)
     // isVisible() is more reliable for determining if the user can see the window
-    const mainWindow = BrowserWindow.getAllWindows()[0];
+    const mainWindow = getMainWindow();
    
     
     if (mainWindow && !mainWindow.isDestroyed()) {

--- a/apps/electron/src/window/call-window.ts
+++ b/apps/electron/src/window/call-window.ts
@@ -1,0 +1,211 @@
+import { BrowserWindow, shell } from 'electron';
+import path from 'path';
+import log from 'electron-log/main';
+import { config } from '../app/config';
+import { getIsQuitting } from '../app/main';
+import { getBundledUIUrl } from '../services/custom-protocol';
+import { setCallWindow as setInterceptorCallWindow } from '../services/request-interceptor';
+import { setupPermissionRequestOnFocus } from '../services/media-permission';
+import {
+  clearCallActiveForWindow,
+  isCallActiveForWindow,
+} from '../services/recording-controller';
+import { createWindowStateTracker } from './window-state';
+
+const CALL_WINDOW_ROUTE_PREFIX = '/newWindow/call/';
+
+const IDLE_CALL_ROUTE = '/newWindow/call/idle/VIDEO?stage=idle';
+
+const stateTracker = createWindowStateTracker({
+  storeName: 'call-window-state',
+  defaultWidth: 960,
+  defaultHeight: 640,
+  minWidth: 480,
+  minHeight: 360,
+  maximizeOnFirstRun: false,
+  logLabel: 'CallWindowState',
+});
+
+let callWindow: BrowserWindow | null = null;
+
+let pendingCallRoute: string | null = null;
+
+export function takePendingCallRoute(): string | null {
+  const route = pendingCallRoute;
+  pendingCallRoute = null;
+  return route;
+}
+
+function setRingAttention(win: BrowserWindow, ringing: boolean): void {
+  if (win.isDestroyed()) return;
+  if (ringing) {
+    win.setAlwaysOnTop(true, 'floating');
+    win.moveTop();
+    return;
+  }
+  win.setAlwaysOnTop(false);
+}
+
+export function setCallWindowRinging(ringing: boolean): void {
+  const win = getCallWindow();
+  if (win) setRingAttention(win, ringing);
+}
+
+export function getCallWindow(): BrowserWindow | null {
+  return callWindow && !callWindow.isDestroyed() ? callWindow : null;
+}
+
+function buildCallUrl(relativePath: string): string {
+  const suffix = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath;
+  return config.useBundledUI
+    ? `${getBundledUIUrl()}${suffix}`
+    : new URL(`/${suffix}`, config.FRONTEND_URL).toString();
+}
+
+function isCallRoute(navUrl: string): boolean {
+  try {
+    const target = new URL(navUrl);
+    const base = new URL(buildCallUrl(IDLE_CALL_ROUTE));
+    if (target.protocol !== base.protocol || target.host !== base.host) return false;
+    return target.pathname.startsWith(CALL_WINDOW_ROUTE_PREFIX);
+  } catch {
+    return false;
+  }
+}
+
+export interface OpenCallWindowRequest {
+  relativePath: string;
+  inactive?: boolean;
+}
+
+export function prewarmCallWindow(): void {
+  if (getCallWindow()) return;
+  log.info('[CallWindow] prewarming');
+  createCallWindow({ relativePath: IDLE_CALL_ROUTE, inactive: true }, { prewarm: true });
+}
+
+export function openCallWindow(request: OpenCallWindowRequest): BrowserWindow {
+  const existing = getCallWindow();
+  if (existing) {
+    pendingCallRoute = request.relativePath;
+    existing.webContents.send('call:navigate', request.relativePath);
+    if (request.inactive) {
+      setRingAttention(existing, true);
+      existing.showInactive();
+    } else {
+      if (existing.isMinimized()) existing.restore();
+      existing.show();
+      existing.focus();
+    }
+    return existing;
+  }
+
+  return createCallWindow(request);
+}
+
+function createCallWindow(
+  request: OpenCallWindowRequest,
+  options?: { prewarm?: boolean },
+): BrowserWindow {
+  const createOpts = stateTracker.getCreateOptions();
+
+  callWindow = new BrowserWindow({
+    ...createOpts,
+    show: false,
+    title: 'Xyne Call',
+    titleBarStyle: 'hiddenInset',
+    trafficLightPosition: { x: 19, y: 20 },
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, '..', 'preload.js'),
+      backgroundThrottling: false,
+    },
+  });
+
+  setInterceptorCallWindow(callWindow);
+
+  stateTracker.applyPostCreate(callWindow);
+  stateTracker.track(callWindow);
+
+  callWindow.once('ready-to-show', () => {
+    if (!callWindow || callWindow.isDestroyed()) return;
+    if (options?.prewarm) return;
+    if (request.inactive) {
+      setRingAttention(callWindow, true);
+      callWindow.showInactive();
+    } else {
+      callWindow.show();
+      callWindow.focus();
+    }
+  });
+
+  setupPermissionRequestOnFocus(callWindow);
+
+  callWindow.webContents.setWindowOpenHandler((details) => {
+    try {
+      const url = new URL(details.url);
+      if (url.protocol === 'http:' || url.protocol === 'https:') {
+        void shell.openExternal(details.url);
+      }
+    } catch (error) {
+      log.warn('[CallWindow] Failed to parse window-open URL, denying:', details.url, error);
+    }
+    return { action: 'deny' };
+  });
+
+  callWindow.webContents.on('will-navigate', (event, navUrl) => {
+    if (isCallRoute(navUrl)) return;
+    event.preventDefault();
+    log.warn('[CallWindow] Blocked navigation away from call route:', navUrl);
+  });
+
+  callWindow.on('close', (event) => {
+    if (callWindow && !callWindow.isDestroyed()) {
+      stateTracker.saveNow(callWindow);
+    }
+    if (getIsQuitting()) {
+      log.info('[CallWindow] closing during app quit');
+      return;
+    }
+    if (!callWindow || callWindow.isDestroyed()) return;
+
+    event.preventDefault();
+    setRingAttention(callWindow, false);
+
+    if (isCallActiveForWindow(callWindow.webContents.id)) {
+      callWindow.webContents.send('call:leave');
+      callWindow.hide();
+      return;
+    }
+
+    callWindow.hide();
+    pendingCallRoute = IDLE_CALL_ROUTE;
+    callWindow.webContents.send('call:navigate', IDLE_CALL_ROUTE);
+  });
+
+  const webContentsId = callWindow.webContents.id;
+  callWindow.webContents.on('did-start-loading', () => {
+    clearCallActiveForWindow(webContentsId);
+  });
+  callWindow.webContents.on('render-process-gone', () => {
+    clearCallActiveForWindow(webContentsId);
+    const win = getCallWindow();
+    if (win) setRingAttention(win, false);
+  });
+
+  callWindow.on('closed', () => {
+    clearCallActiveForWindow(webContentsId);
+    setInterceptorCallWindow(null);
+    callWindow = null;
+  });
+
+  void callWindow.loadURL(buildCallUrl(request.relativePath));
+
+  return callWindow;
+}
+
+export function closeCallWindow(): void {
+  const win = getCallWindow();
+  if (win) win.close();
+}

--- a/apps/electron/src/window/window-state.ts
+++ b/apps/electron/src/window/window-state.ts
@@ -1,10 +1,10 @@
 /**
- * Main-window state persistence.
+ * Window state persistence.
  *
- * Persists the main window's size / position / maximized flag to electron-store
+ * Persists a window's size / position / maximized flag to electron-store
  * (the same persistence primitive used elsewhere in this app) and restores it on
- * the next launch. On the very first run (no saved state) the window defaults to
- * maximized so it fills the work area while keeping the menu bar and Dock visible.
+ * the next launch. On the very first run (no saved state) the main window defaults
+ * to maximized so it fills the work area while keeping the menu bar and Dock visible.
  *
  * Deliberately does NOT persist/restore macOS full screen — full screen is a
  * separate Space and relaunching directly into it is jarring.
@@ -40,14 +40,23 @@ interface CreateOptions {
   minHeight: number;
 }
 
-const store = new Store<{ [STORE_KEY]?: WindowState }>({ name: 'window-state' });
+export interface WindowStateTrackerOptions {
+  storeName: string;
+  defaultWidth: number;
+  defaultHeight: number;
+  minWidth: number;
+  minHeight: number;
+  maximizeOnFirstRun: boolean;
+  logLabel: string;
+}
 
-// The last known *windowed* (non-maximized, non-compact) bounds. This is what we
-// restore to, so a maximized window doesn't persist the maximized rectangle as its
-// restore size.
-let lastNormalBounds: { width: number; height: number; x: number; y: number } | null = null;
-
-let saveTimer: ReturnType<typeof setTimeout> | null = null;
+export interface WindowStateTracker {
+  getSavedState: () => WindowState | null;
+  getCreateOptions: () => CreateOptions;
+  applyPostCreate: (win: BrowserWindow) => void;
+  saveNow: (win: BrowserWindow) => void;
+  track: (win: BrowserWindow, isSaveBlocked?: () => boolean) => void;
+}
 
 function isFiniteNumber(n: unknown): n is number {
   return typeof n === 'number' && Number.isFinite(n);
@@ -70,144 +79,158 @@ function isVisibleOnSomeDisplay(x: number, y: number, width: number, height: num
   });
 }
 
-/**
- * Read + validate the saved state. Returns null if there is no valid saved state.
- */
-export function getSavedState(): WindowState | null {
-  const raw = store.get(STORE_KEY);
-  if (!raw || typeof raw !== 'object') return null;
+export function createWindowStateTracker(options: WindowStateTrackerOptions): WindowStateTracker {
+  const store = new Store<{ [STORE_KEY]?: WindowState }>({ name: options.storeName });
 
-  if (!isFiniteNumber(raw.width) || !isFiniteNumber(raw.height)) return null;
+  // The last known *windowed* (non-maximized, non-compact) bounds. This is what we
+  // restore to, so a maximized window doesn't persist the maximized rectangle as its
+  // restore size.
+  let lastNormalBounds: { width: number; height: number; x: number; y: number } | null = null;
 
-  const width = Math.max(MIN_WIDTH, Math.round(raw.width));
-  const height = Math.max(MIN_HEIGHT, Math.round(raw.height));
-  const isMaximized = raw.isMaximized === true;
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const hasPosition = isFiniteNumber(raw.x) && isFiniteNumber(raw.y);
-  if (hasPosition) {
-    const x = Math.round(raw.x as number);
-    const y = Math.round(raw.y as number);
-    // Drop the position if it would place the window off every connected screen,
-    // but keep the size so we still restore dimensions (centered).
-    if (isVisibleOnSomeDisplay(x, y, width, height)) {
-      return { width, height, x, y, isMaximized };
+  /**
+   * Read + validate the saved state. Returns null if there is no valid saved state.
+   */
+  const getSavedState = (): WindowState | null => {
+    const raw = store.get(STORE_KEY);
+    if (!raw || typeof raw !== 'object') return null;
+
+    if (!isFiniteNumber(raw.width) || !isFiniteNumber(raw.height)) return null;
+
+    const width = Math.max(options.minWidth, Math.round(raw.width));
+    const height = Math.max(options.minHeight, Math.round(raw.height));
+    const isMaximized = raw.isMaximized === true;
+
+    const hasPosition = isFiniteNumber(raw.x) && isFiniteNumber(raw.y);
+    if (hasPosition) {
+      const x = Math.round(raw.x as number);
+      const y = Math.round(raw.y as number);
+      // Drop the position if it would place the window off every connected screen,
+      // but keep the size so we still restore dimensions (centered).
+      if (isVisibleOnSomeDisplay(x, y, width, height)) {
+        return { width, height, x, y, isMaximized };
+      }
+      log.info(`[${options.logLabel}] saved bounds off-screen; restoring size only, centered`);
+      return { width, height, isMaximized };
     }
-    log.info('[WindowState] saved bounds off-screen; restoring size only, centered');
+
     return { width, height, isMaximized };
-  }
-
-  return { width, height, isMaximized };
-}
-
-/**
- * Options to spread into the BrowserWindow constructor. Falls back to the config
- * default size (centered) when there is no valid saved state.
- */
-export function getCreateOptions(): CreateOptions {
-  const saved = getSavedState();
-  const base: CreateOptions = {
-    width: saved?.width ?? config.window.width,
-    height: saved?.height ?? config.window.height,
-    minWidth: MIN_WIDTH,
-    minHeight: MIN_HEIGHT,
-  };
-  if (saved && isFiniteNumber(saved.x) && isFiniteNumber(saved.y)) {
-    base.x = saved.x;
-    base.y = saved.y;
-  }
-  return base;
-}
-
-/**
- * Apply post-construction state. Must be called right after `new BrowserWindow`.
- * - If there is saved state and it was maximized -> maximize.
- * - If there is NO saved state (first run) -> maximize as the default so the window
- *   fills the work area (menu bar + Dock stay visible; this is NOT full screen).
- */
-export function applyPostCreate(win: BrowserWindow): void {
-  const saved = getSavedState();
-  if (!saved) {
-    log.info('[WindowState] no saved state (first run) -> maximize');
-    win.maximize();
-    return;
-  }
-  if (saved.isMaximized) {
-    log.info('[WindowState] restoring maximized window');
-    win.maximize();
-  } else {
-    log.info('[WindowState] restored windowed bounds', {
-      width: saved.width,
-      height: saved.height,
-      x: saved.x,
-      y: saved.y,
-    });
-  }
-}
-
-function computeAndSave(win: BrowserWindow): void {
-  if (win.isDestroyed()) return;
-  const isMaximized = win.isMaximized();
-
-  // Keep the windowed bounds current whenever the window is in a normal state.
-  if (!isMaximized && !win.isFullScreen()) {
-    const b = win.getBounds();
-    lastNormalBounds = { width: b.width, height: b.height, x: b.x, y: b.y };
-  }
-
-  const restore = lastNormalBounds ?? {
-    width: config.window.width,
-    height: config.window.height,
-    x: undefined as unknown as number,
-    y: undefined as unknown as number,
   };
 
-  const next: WindowState = {
-    width: restore.width,
-    height: restore.height,
-    isMaximized,
+  const getCreateOptions = (): CreateOptions => {
+    const saved = getSavedState();
+    const base: CreateOptions = {
+      width: saved?.width ?? options.defaultWidth,
+      height: saved?.height ?? options.defaultHeight,
+      minWidth: options.minWidth,
+      minHeight: options.minHeight,
+    };
+    if (saved && isFiniteNumber(saved.x) && isFiniteNumber(saved.y)) {
+      base.x = saved.x;
+      base.y = saved.y;
+    }
+    return base;
   };
-  if (isFiniteNumber(restore.x) && isFiniteNumber(restore.y)) {
-    next.x = restore.x;
-    next.y = restore.y;
-  }
-  store.set(STORE_KEY, next);
-}
 
-/**
- * Persist immediately (used on close so Cmd+Q and hide both capture latest bounds).
- */
-export function saveNow(win: BrowserWindow): void {
-  if (saveTimer) {
-    clearTimeout(saveTimer);
-    saveTimer = null;
-  }
-  computeAndSave(win);
-}
+  const applyPostCreate = (win: BrowserWindow): void => {
+    const saved = getSavedState();
+    if (!saved) {
+      if (options.maximizeOnFirstRun) {
+        log.info(`[${options.logLabel}] no saved state (first run) -> maximize`);
+        win.maximize();
+      }
+      return;
+    }
+    if (saved.isMaximized) {
+      log.info(`[${options.logLabel}] restoring maximized window`);
+      win.maximize();
+    } else {
+      log.info(`[${options.logLabel}] restored windowed bounds`, {
+        width: saved.width,
+        height: saved.height,
+        x: saved.x,
+        y: saved.y,
+      });
+    }
+  };
 
-function scheduleSave(win: BrowserWindow): void {
-  if (saveTimer) clearTimeout(saveTimer);
-  saveTimer = setTimeout(() => {
-    saveTimer = null;
+  const computeAndSave = (win: BrowserWindow): void => {
+    if (win.isDestroyed()) return;
+    const isMaximized = win.isMaximized();
+
+    // Keep the windowed bounds current whenever the window is in a normal state.
+    if (!isMaximized && !win.isFullScreen()) {
+      const b = win.getBounds();
+      lastNormalBounds = { width: b.width, height: b.height, x: b.x, y: b.y };
+    }
+
+    const restore = lastNormalBounds ?? {
+      width: options.defaultWidth,
+      height: options.defaultHeight,
+      x: undefined as unknown as number,
+      y: undefined as unknown as number,
+    };
+
+    const next: WindowState = {
+      width: restore.width,
+      height: restore.height,
+      isMaximized,
+    };
+    if (isFiniteNumber(restore.x) && isFiniteNumber(restore.y)) {
+      next.x = restore.x;
+      next.y = restore.y;
+    }
+    store.set(STORE_KEY, next);
+  };
+
+  /**
+   * Persist immediately (used on close so Cmd+Q and hide both capture latest bounds).
+   */
+  const saveNow = (win: BrowserWindow): void => {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
     computeAndSave(win);
-  }, SAVE_DEBOUNCE_MS);
-}
-
-/**
- * Wire up persistence listeners.
- *
- * @param win           the main window
- * @param isSaveBlocked optional predicate; when it returns true, resize/move events
- *                      are ignored (e.g. while compact mode has forced a small size).
- */
-export function track(win: BrowserWindow, isSaveBlocked?: () => boolean): void {
-  const onBoundsChange = () => {
-    if (isSaveBlocked?.()) return;
-    scheduleSave(win);
   };
 
-  win.on('resize', onBoundsChange);
-  win.on('move', onBoundsChange);
-  // Maximize/unmaximize should persist immediately and are never "blocked".
-  win.on('maximize', () => computeAndSave(win));
-  win.on('unmaximize', () => computeAndSave(win));
+  const scheduleSave = (win: BrowserWindow): void => {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      computeAndSave(win);
+    }, SAVE_DEBOUNCE_MS);
+  };
+
+  const track = (win: BrowserWindow, isSaveBlocked?: () => boolean): void => {
+    const onBoundsChange = () => {
+      if (isSaveBlocked?.()) return;
+      scheduleSave(win);
+    };
+
+    win.on('resize', onBoundsChange);
+    win.on('move', onBoundsChange);
+    // Maximize/unmaximize should persist immediately and are never "blocked".
+    win.on('maximize', () => computeAndSave(win));
+    win.on('unmaximize', () => computeAndSave(win));
+  };
+
+  return { getSavedState, getCreateOptions, applyPostCreate, saveNow, track };
 }
+
+const mainWindowTracker = createWindowStateTracker({
+  storeName: 'window-state',
+  defaultWidth: config.window.width,
+  defaultHeight: config.window.height,
+  minWidth: MIN_WIDTH,
+  minHeight: MIN_HEIGHT,
+  maximizeOnFirstRun: true,
+  logLabel: 'WindowState',
+});
+
+export const getSavedState = mainWindowTracker.getSavedState;
+export const getCreateOptions = mainWindowTracker.getCreateOptions;
+export const applyPostCreate = mainWindowTracker.applyPostCreate;
+export const saveNow = mainWindowTracker.saveNow;
+export const track = mainWindowTracker.track;


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Moves calls out of the main app shell into a dedicated Electron window with a
pre-join lobby, instead of rendering them as a portal overlay inside the main
window.

- New `apps/dashboard/src/routes/CallWindow/` route tree — `CallWindow`,
  `CallWindowRoute`, `CallLobby` (pre-join device preview), `CallWindowWarmUp`,
  and `CallWindowNavigationBridge` to keep main-window navigation in sync.
- New `apps/electron/src/window/call-window.ts` owning the call `BrowserWindow`
  (frameless, ring state, lifecycle).
- `callWindowChannel` / `callWindowLauncher` for main-window ↔ call-window
  messaging and launching.
- `CallBar` extracted as its own component.
- Incoming-call → window path wired through `IncomingCallModal`, `useQuickCall`,
  `useCallActions`, and the `callMachine` / `roomMachine` state machines.

No ticket ID — this work has no XYNE ticket, so the commit subject does not
carry one.

## Areas Touched

- [x] `apps/dashboard`
- [x] `apps/electron`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Static verification only so far — this PR has **not** been exercised manually
yet. What was actually run:

- `apps/dashboard` `typecheck` — pass
- `apps/electron` `typecheck` — pass
- `apps/dashboard` `lint:errors-only` — pass
- Full pre-commit suite passed: gitleaks staged secret scan, tenant-key guard,
  dashboard `xyne-doctor dashboard-validate`, service change analysis,
  schema-migration validation, Zero column parity, enum guard.

Manual verification below still needs to be filled in by a human — in
particular the Electron desktop run mode, since this is primarily an Electron
windowing change.

### Automated

- [x] Not covered by tests <!-- no test files added; verified via typecheck/lint/build -->

### Manual

Not yet performed — see note above.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Dashboard `lint:errors-only` + `typecheck` pass
- [x] No new deps
- [x] Branch is `feature/*`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>` — no ticket exists for this work
- [x] No debug logging or commented-out code left behind
