### PR TITLE
fix: PIE-14458 use executor step name for agent callbacks

### DIFF
--- a/apps/backend/src/automations/engine/automation-executor.ts
+++ b/apps/backend/src/automations/engine/automation-executor.ts
@@ -13,7 +13,12 @@ import type { TriggerType } from '../types/trigger-types';
 import type { StepType } from '../types/step-types';
 import { CONTROL_FLOW_STEP_TYPES } from '../types/known-types';
 import type { StepRegistry } from '../steps/step-registry';
-import { BaseActionStep, BaseControlFlowStep, StepKind } from '../steps/base-step';
+import {
+  BaseActionStep,
+  BaseControlFlowStep,
+  StepKind,
+  type ActionExecutionContext,
+} from '../steps/base-step';
 import { VariableResolver, stripNullForOptionalKeys } from './variable-resolver';
 import { automationContextStorage } from './automation-context-storage';
 import { PauseStep } from './pause-step';
@@ -272,13 +277,17 @@ export class AutomationExecutor {
 
   private async invokeResume(
     actionImpl: BaseActionStep<z.ZodSchema, Record<string, unknown>>,
-    runId: string,
-    stepName: string,
+    execution: ActionExecutionContext,
     resolvedInput: Record<string, unknown>,
     context: AutomationContext,
   ): Promise<Record<string, unknown>> {
     const row = await this.prisma.workflowStep.findUnique({
-      where: { workflowExecutionId_stepName: { workflowExecutionId: runId, stepName } },
+      where: {
+        workflowExecutionId_stepName: {
+          workflowExecutionId: execution.runId,
+          stepName: execution.stepName,
+        },
+      },
       select: { data: true },
     });
     const rowData: Record<string, unknown> =
@@ -287,7 +296,7 @@ export class AutomationExecutor {
         : {};
 
     if (typeof actionImpl.onResume === 'function') {
-      return actionImpl.onResume(rowData, resolvedInput, context);
+      return actionImpl.onResume(rowData, resolvedInput, context, execution);
     }
     const fallback = rowData['output'];
     return (fallback && typeof fallback === 'object' && !Array.isArray(fallback)
@@ -536,7 +545,7 @@ export class AutomationExecutor {
   private async executeStep(
     step: AutomationStepConfig,
     context: AutomationContext,
-    callCtx: { runId: string; stepName: string; isResuming: boolean },
+    callCtx: ActionExecutionContext,
   ): Promise<void> {
     const stepImpl = this.stepRegistry.get(step.type);
 
@@ -591,8 +600,8 @@ export class AutomationExecutor {
     );
     try {
       const output = callCtx.isResuming
-        ? await this.invokeResume(actionImpl, callCtx.runId, callCtx.stepName, resolvedInput, context)
-        : await actionImpl.execute(resolvedInput, context);
+        ? await this.invokeResume(actionImpl, callCtx, resolvedInput, context)
+        : await actionImpl.execute(resolvedInput, context, callCtx);
       context.steps[step.id] = { type: step.type, input: persistedInput, output };
       logger.info(
         `[automations] step OK    id=${step.id} type=${step.type} elapsedMs=${Date.now() - t0}`,

--- a/apps/backend/src/automations/steps/base-step.ts
+++ b/apps/backend/src/automations/steps/base-step.ts
@@ -4,6 +4,12 @@ import type { AutomationContext } from '../types/context';
 import type { AutomationStepConfig } from '../types/automation-config';
 import { StepCategory } from '../types/categories';
 
+export interface ActionExecutionContext {
+  runId: string;
+  stepName: string;
+  isResuming: boolean;
+}
+
 export interface ControlFlowExecutionContext {
   walkBranch(steps: AutomationStepConfig[], context: AutomationContext): Promise<void>;
 }
@@ -43,12 +49,17 @@ export abstract class BaseActionStep<
 
   readonly mayEmit?: readonly string[];
 
-  abstract execute(config: z.infer<TConfig>, context: AutomationContext): Promise<TOutput>;
+  abstract execute(
+    config: z.infer<TConfig>,
+    context: AutomationContext,
+    execution: ActionExecutionContext,
+  ): Promise<TOutput>;
 
   onResume?(
     rowData: Record<string, unknown>,
     config: z.infer<TConfig>,
     context: AutomationContext,
+    execution: ActionExecutionContext,
   ): Promise<TOutput>;
 }
 

--- a/apps/backend/src/automations/steps/run-agent.step.test.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.test.ts
@@ -1,0 +1,136 @@
+import { automationContextStorage } from '../engine/automation-context-storage';
+import type { AutomationContext } from '../types/context';
+import { clawClient } from '../services/claw-client';
+import { RunAgentStep, type RunAgentConfig } from './run-agent.step';
+import { db } from '@/database/client';
+
+jest.mock('@xyne/shared', () => ({ TAG_FORMAT_REGEX: /^[a-z0-9_-]+$/i }));
+jest.mock('@xyne/shared/automations/variable-ref', () => ({
+  VARIABLE_REF_REGEX: /^\{\{(?:context\.)?[^}]+\}\}$/,
+  VARIABLE_REF_DESCRIPTION_PREFIX: '__variableRef__',
+}));
+
+jest.mock('../services/agent-attachment.service', () => ({
+  parseAgentAttachments: jest.fn(() => []),
+}));
+
+jest.mock('../services/claw-client', () => ({
+  clawClient: {
+    runAgent: jest.fn(),
+    listAgents: jest.fn(),
+  },
+}));
+
+jest.mock('@/database/client', () => ({
+  db: {
+    apps: { findUnique: jest.fn() },
+    installedApps: { findFirst: jest.fn() },
+    workspace: { findUnique: jest.fn() },
+    user: { findUnique: jest.fn() },
+    workspaceOrganization: { findFirst: jest.fn(), findMany: jest.fn() },
+  },
+}));
+
+jest.mock('@/config/env', () => ({
+  config: {
+    xyneClaw: { callbackUrl: 'https://spaces.example.test' },
+  },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockedRunAgent = jest.mocked(clawClient.runAgent);
+const mockedAppsFindUnique = db.apps.findUnique as jest.Mock;
+const mockedInstalledAppsFindFirst = db.installedApps.findFirst as jest.Mock;
+const mockedWorkspaceFindUnique = db.workspace.findUnique as jest.Mock;
+const mockedUserFindUnique = db.user.findUnique as jest.Mock;
+
+function automationContext(): AutomationContext {
+  return {
+    automation: {
+      id: 'automation-1',
+      workspaceId: 'workspace-1',
+      createdById: 'creator-1',
+    },
+    trigger: { type: 'MESSAGE_RECEIVED', data: {} } as AutomationContext['trigger'],
+    steps: {
+      conditional: { type: 'CONDITIONAL', output: {} },
+      nestedAction: { type: 'SEND_MESSAGE', input: {}, output: {} },
+      runAgent: { type: 'RUN_AGENT', input: {}, output: {} },
+    },
+  };
+}
+
+const config: RunAgentConfig = {
+  agentSlug: 'test-agent',
+  spacesAppId: 'app-1',
+  prompt: 'Return JSON',
+  outputSchema: { expected: 'string' },
+  maxRetries: 3,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAppsFindUnique.mockResolvedValue({ workspaceId: 'workspace-1', orgId: 'org-1' });
+  mockedInstalledAppsFindFirst.mockResolvedValue({ userId: 'app-user-1' });
+  mockedWorkspaceFindUnique.mockResolvedValue({ orgId: 'org-1' });
+  mockedUserFindUnique.mockResolvedValue({ orgMemberId: 'member-1' });
+  mockedRunAgent.mockResolvedValue({ success: true, sessionId: 'run-1:step_1' });
+});
+
+describe('RunAgentStep callback routing', () => {
+  it('uses the executor step name instead of counting context entries', async () => {
+    const step = new RunAgentStep();
+
+    await expect(
+      automationContextStorage.run(
+        { runId: 'run-1', automationId: 'automation-1', chain: [] },
+        () =>
+          step.execute(config, automationContext(), {
+            runId: 'run-1',
+            stepName: 'step_1',
+            isResuming: false,
+          })
+      )
+    ).rejects.toMatchObject({ name: 'PauseStep' });
+
+    expect(mockedRunAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'run-1:step_1',
+        callbackUrl:
+          'https://spaces.example.test/api/internal/automations/claw-callback/run-1/step_1',
+      })
+    );
+  });
+
+  it('keeps validation retries on the executor step name', async () => {
+    const step = new RunAgentStep();
+
+    await expect(
+      automationContextStorage.run(
+        { runId: 'run-1', automationId: 'automation-1', chain: [] },
+        () =>
+          step.onResume(
+            { agentRawResult: { status: 'completed', result: '{"other":"value"}' } },
+            config,
+            automationContext(),
+            { runId: 'run-1', stepName: 'step_1', isResuming: true }
+          )
+      )
+    ).rejects.toMatchObject({ name: 'PauseStep' });
+
+    expect(mockedRunAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'run-1:step_1:retry-1',
+        callbackUrl:
+          'https://spaces.example.test/api/internal/automations/claw-callback/run-1/step_1',
+      })
+    );
+  });
+});

--- a/apps/backend/src/automations/steps/run-agent.step.ts
+++ b/apps/backend/src/automations/steps/run-agent.step.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { BaseActionStep } from './base-step';
+import { BaseActionStep, type ActionExecutionContext } from './base-step';
 import { StepCategory } from '../types/categories';
 import { variableRef } from '../engine/variable-ref';
 import type { AutomationContext } from '../types/context';
@@ -55,6 +55,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
   async execute(
     cfg: z.infer<typeof RunAgentConfigSchema>,
     context: AutomationContext,
+    execution: ActionExecutionContext,
   ): Promise<RunAgentOutput> {
     const store = automationContextStorage.getStore();
     if (!store) {
@@ -63,11 +64,9 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
       );
     }
 
-    const stepCount = Object.keys(context.steps).length;
-    const currentIndex = Math.max(0, stepCount - 1);
-
-    const sessionId = `${store.runId}:step_${currentIndex}`;
-    const callbackUrl = buildCallbackUrl(store.runId, `step_${currentIndex}`);
+    const { runId, stepName } = execution;
+    const sessionId = `${runId}:${stepName}`;
+    const callbackUrl = buildCallbackUrl(runId, stepName);
 
     const agentSlug = cfg.agentSlug as string;
     const prompt = cfg.prompt as string;
@@ -77,7 +76,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     const visibleContext = resolveVisibleConversationContext(context);
 
     logger.info(
-      `[RUN_AGENT] firing — executionId=${store.runId} stepIndex=${currentIndex} agentSlug=${agentSlug} sessionId=${sessionId} userId=${runUserId}`,
+      `[RUN_AGENT] firing — executionId=${runId} step=${stepName} agentSlug=${agentSlug} sessionId=${sessionId} userId=${runUserId}`,
     );
 
     try {
@@ -93,7 +92,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
       });
     } catch (err) {
       logger.error(
-        `[RUN_AGENT] claw rejected the run — executionId=${store.runId} stepIndex=${currentIndex}:`,
+        `[RUN_AGENT] claw rejected the run — executionId=${runId} step=${stepName}:`,
         err,
       );
       throw err;
@@ -105,6 +104,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     rowData: Record<string, unknown>,
     cfg: z.infer<typeof RunAgentConfigSchema>,
     context: AutomationContext,
+    execution: ActionExecutionContext,
   ): Promise<RunAgentOutput> {
     const agentRawResult = rowData['agentRawResult'] as Record<string, unknown> | undefined;
     if (!agentRawResult) {
@@ -141,7 +141,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.warn(`[RUN_AGENT] validation failed: ${message}`);
-      return this.handleValidationFailure(message, rowData, cfg, context);
+      return this.handleValidationFailure(message, rowData, cfg, context, execution);
     }
   }
 
@@ -150,6 +150,7 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     rowData: Record<string, unknown>,
     cfg: z.infer<typeof RunAgentConfigSchema>,
     context: AutomationContext,
+    execution: ActionExecutionContext,
   ): Promise<RunAgentOutput> {
     const previousRetries = Number(rowData['agentRetryCount'] ?? 0);
     const maxRetries = cfg.maxRetries ?? DEFAULT_MAX_RETRIES;
@@ -163,16 +164,10 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     if (!store) {
       throw new Error('[RUN_AGENT] retry attempted outside an automation context');
     }
-    const stepName =
-      typeof rowData['stepName'] === 'string'
-        ? (rowData['stepName'] as string)
-        : deriveStepNameFromCtx(context);
-    if (!stepName) {
-      throw new Error('[RUN_AGENT] cannot derive stepName for retry');
-    }
+    const { runId, stepName } = execution;
 
     const nextRetry = previousRetries + 1;
-    const retrySessionId = `${store.runId}:${stepName}:retry-${nextRetry}`;
+    const retrySessionId = `${runId}:${stepName}:retry-${nextRetry}`;
     const agentSlug = cfg.agentSlug as string;
     const originalPrompt = cfg.prompt as string;
     const retryPrompt = buildRetryPrompt(
@@ -183,11 +178,11 @@ export class RunAgentStep extends BaseActionStep<typeof RunAgentConfigSchema, Ru
     const spacesAppId = await resolveSpacesAppId(cfg, agentSlug, context.automation.workspaceId);
     const runUserId = await resolveRunUserId(spacesAppId, context.automation.createdById);
     const identityContext = await resolveHeadlessIdentityContext(runUserId, context.automation.workspaceId);
-    const callbackUrl = buildCallbackUrl(store.runId, stepName);
+    const callbackUrl = buildCallbackUrl(runId, stepName);
     const visibleContext = resolveVisibleConversationContext(context);
 
     logger.info(
-      `[RUN_AGENT] retry ${nextRetry}/${maxRetries} firing — executionId=${store.runId} step=${stepName} sessionId=${retrySessionId}`,
+      `[RUN_AGENT] retry ${nextRetry}/${maxRetries} firing — executionId=${runId} step=${stepName} sessionId=${retrySessionId}`,
     );
 
     try {
@@ -352,12 +347,6 @@ async function resolveHeadlessIdentityContext(
     spacesOrgId: workspace.orgId,
     spacesOrgMemberId: user.orgMemberId,
   };
-}
-
-function deriveStepNameFromCtx(context: AutomationContext): string | null {
-  const stepCount = Object.keys(context.steps).length;
-  if (stepCount === 0) return null;
-  return `step_${stepCount - 1}`;
 }
 
 function buildRetryPrompt(


### PR DESCRIPTION
1. Problem Description:
RUN_AGENT derived its callback step from `Object.keys(context.steps).length`. Conditional branches add nested outputs to that object, so a later top-level RUN_AGENT could send its callback to a different workflow-step row than the executor was waiting on (PIE-14458).

2. If this is a bug fix or an enhancement, how did you identify the issue?:
A production automation paused after a conditional. Source tracing showed the executor named the action `step_1`, while RUN_AGENT independently derived `step_2` from accumulated context entries.

3. Explain the solution implemented in the PR:
Pass the executor's authoritative action execution context (`runId`, `stepName`, `isResuming`) into action `execute` and `onResume` methods. RUN_AGENT now uses that identity for the initial agent session, callback URL, and validation-retry callback URL instead of inferring identity from output context. Added regression coverage with conditional and nested context entries.

4. Documentation (link to docs created/updated for this change):
N/A — internal callback routing correction; no user-facing contract change.

5. DB Alter Details (if any):
N/A.

6. Data fix Details (if any):
N/A.

7. Environment variable Changes (if any):
N/A.

8. Testing (how it was tested; screenshots/links):
- `pnpm typecheck` in `apps/backend` — passed.
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm exec dotenv -e .env.local -- jest --runInBand src/automations/steps/run-agent.step.test.ts` — 2 tests passed.
- ESLint on the three modified backend source files — passed.
- `git diff --check` — passed.

9. Services to which this change is to be deployed:
Spaces backend / automation workers.

10. Main PR link (if this PR is raised against a release branch):
N/A — this PR targets `main`.