### PR TITLE
feat: XYNE-60825 add PPTX viewer and search-text extraction

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -65,6 +65,7 @@ RUN apt-get update && apt-get install -y \
     openssh-client \
     libssl-dev \
     ca-certificates \
+    libreoffice \
     && rm -rf /var/lib/apt/lists/*
 
 RUN corepack enable && corepack prepare pnpm@10.15.0 --activate

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -191,6 +191,7 @@ import userMigrationRoutes from '@/routes/userMigration';
 import { decryptRequestBodyMiddleware, encryptResponseBodyMiddleware } from './middleware/decryptionMiddleware';
 import internalRoutes from '@/routes/internal';
 import collectionsRoutes from '@/routes/collections';
+import officeConversionRoutes from '@/routes/officeConversion';
 import sdlcRoutes from '@/routes/sdlc';
 import sdlcClawRoutes from '@/routes/sdlcClaw';
 import sdlcVcsInternalRoutes from '@/routes/sdlcVcsInternal';
@@ -687,6 +688,10 @@ export class App {
 
     // Collections routes
     this.app.use('/api/collections', authMiddleware.authenticate, collectionsRoutes);
+
+    // Office document (pptx, docx, ...) -> PDF conversion, via LibreOffice.
+    // Stateless: takes uploaded bytes, returns converted bytes, touches no stored data.
+    this.app.use('/api/office-conversion', authMiddleware.authenticate, officeConversionRoutes);
 
     // Activity logging routes (auth required)
     this.app.use('/api/activity', authMiddleware.authenticate, activityLogRoutes);

--- a/apps/backend/src/controllers/officeConversionController.ts
+++ b/apps/backend/src/controllers/officeConversionController.ts
@@ -1,0 +1,43 @@
+import { Request, Response } from "express"
+import { logger } from "@/utils/logger"
+import { convertToPdf, OfficeConversionError } from "@/services/officeConversionService"
+
+/**
+ * Stateless office-document-to-PDF conversion. Deliberately not scoped to a
+ * collection/attachment/item — every viewer that needs this (KB file viewer,
+ * chat attachment gallery, citation previews) already has the raw file
+ * bytes client-side (the same `source: File` contract every FileViewer uses),
+ * so there's no reason to require a stored resource's ID or duplicate
+ * per-context ACL checks for what is purely a transform, not a data access.
+ */
+export class OfficeConversionController {
+    convertToPdf = async (req: Request, res: Response): Promise<void> => {
+        const file = req.file
+        if (!file) {
+            res.status(400).json({ error: "A file is required", code: "MISSING_FILE" })
+            return
+        }
+
+        try {
+            const pdfBuffer = await convertToPdf(file.buffer, file.originalname)
+            res.setHeader("Content-Type", "application/pdf")
+            res.setHeader("Content-Length", pdfBuffer.length)
+            res.send(pdfBuffer)
+        } catch (error) {
+            if (error instanceof OfficeConversionError && error.code === "SOFFICE_NOT_FOUND") {
+                logger.error("[OfficeConversion] LibreOffice not installed on this host", error)
+                res.status(503).json({
+                    error: "PDF conversion is not available on this server",
+                    code: "CONVERTER_UNAVAILABLE",
+                })
+                return
+            }
+            if (error instanceof OfficeConversionError && error.code === "TIMEOUT") {
+                res.status(504).json({ error: "Conversion timed out", code: "TIMEOUT" })
+                return
+            }
+            logger.error("[OfficeConversion] Conversion failed", error)
+            res.status(500).json({ error: "Failed to convert file", code: "CONVERSION_FAILED" })
+        }
+    }
+}

--- a/apps/backend/src/middleware/rateLimiters.ts
+++ b/apps/backend/src/middleware/rateLimiters.ts
@@ -17,6 +17,20 @@ export const generalLimiter: RateLimitRequestHandler = rateLimit({
   legacyHeaders: false,
 });
 
+/** Per-user limiter for office-document-to-PDF conversion: each request can spawn a LibreOffice process, so this caps request rate on top of the in-process concurrency cap in officeConversionService. */
+export const officeConversionLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10,
+  keyGenerator: (req): string => req.user?.id ?? ipKeyGenerator(req.ip ?? 'unknown'),
+  message: {
+    success: false,
+    error: 'Too many conversion requests. Please slow down and try again shortly.',
+    timestamp: new Date().toISOString(),
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 export const aiTitleLimiter: RateLimitRequestHandler = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 15,

--- a/apps/backend/src/middleware/upload.ts
+++ b/apps/backend/src/middleware/upload.ts
@@ -208,6 +208,14 @@ export const versionUpload = multer({
   limits: { fileSize: 100 * 1024 * 1024 },
 });
 
+// In-memory (not GCS-streamed): the file is transient input to a conversion,
+// never stored.
+export const officeConversionUpload = multer({
+  storage: multer.memoryStorage(),
+  fileFilter: uploadFileFilter,
+  limits: { fileSize: 100 * 1024 * 1024, files: 1 },
+});
+
 const createUploadStreamConfig = (fileSizeBytes: number, maxFiles: number) =>
   multer({
     storage: streamingStorage,

--- a/apps/backend/src/middleware/upload.ts
+++ b/apps/backend/src/middleware/upload.ts
@@ -60,6 +60,47 @@ const uploadFileFilter: multer.Options['fileFilter'] = (_req, file, cb) => {
   cb(null, true);
 };
 
+/**
+ * office-conversion is single-purpose (shell the upload out to LibreOffice's
+ * `soffice --convert-to pdf`), so unlike the generic uploadFileFilter above —
+ * a denylist covering every other upload path in the app — this one is an
+ * allowlist: only the office document types the FileViewer actually sends
+ * (apps/dashboard/src/components/FileViewer/utils.ts) are accepted, not
+ * "anything not explicitly blocked".
+ */
+const OFFICE_CONVERSION_EXTENSIONS = new Set([
+  '.pptx', '.ppt', '.docx', '.doc', '.xlsx', '.xls',
+]);
+
+const OFFICE_CONVERSION_MIME_TYPES = new Set([
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation', // .pptx
+  'application/vnd.ms-powerpoint', // .ppt
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document', // .docx
+  'application/msword', // .doc
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', // .xlsx
+  'application/vnd.ms-excel', // .xls
+]);
+
+const officeConversionFileFilter: multer.Options['fileFilter'] = (_req, file, cb) => {
+  // Extension-primary, same as isBlockedUpload above: file.mimetype is
+  // client-supplied and often generic (application/octet-stream) even for a
+  // real office document.
+  const name = (file.originalname ?? '').toLowerCase();
+  const dot = name.lastIndexOf('.');
+  const ext = dot === -1 ? '' : name.slice(dot);
+  const mime = (file.mimetype ?? '').split(';')[0].trim().toLowerCase();
+
+  if (!OFFICE_CONVERSION_EXTENSIONS.has(ext) && !OFFICE_CONVERSION_MIME_TYPES.has(mime)) {
+    logger.warn('[UPLOAD] Rejected non-office file for conversion', {
+      mimetype: file.mimetype,
+      originalname: file.originalname,
+    });
+    cb(null, false);
+    return;
+  }
+  cb(null, true);
+};
+
 // Generic streaming storage engine for message attachments.
 // Streams directly to object storage without buffering in memory.
 const streamingStorage: multer.StorageEngine = {
@@ -212,7 +253,7 @@ export const versionUpload = multer({
 // never stored.
 export const officeConversionUpload = multer({
   storage: multer.memoryStorage(),
-  fileFilter: uploadFileFilter,
+  fileFilter: officeConversionFileFilter,
   limits: { fileSize: 100 * 1024 * 1024, files: 1 },
 });
 

--- a/apps/backend/src/routes/officeConversion.ts
+++ b/apps/backend/src/routes/officeConversion.ts
@@ -1,6 +1,7 @@
 import express from "express"
 import { OfficeConversionController } from "../controllers/officeConversionController"
 import { officeConversionUpload } from "../middleware/upload"
+import { officeConversionLimiter } from "../middleware/rateLimiters"
 
 const router = express.Router()
 const officeConversionController = new OfficeConversionController()
@@ -8,6 +9,7 @@ const officeConversionController = new OfficeConversionController()
 // Converts an uploaded office document (pptx, docx, ...) to PDF via LibreOffice.
 router.post(
     "/pdf",
+    officeConversionLimiter,
     officeConversionUpload.single("file"),
     officeConversionController.convertToPdf,
 )

--- a/apps/backend/src/routes/officeConversion.ts
+++ b/apps/backend/src/routes/officeConversion.ts
@@ -1,0 +1,15 @@
+import express from "express"
+import { OfficeConversionController } from "../controllers/officeConversionController"
+import { officeConversionUpload } from "../middleware/upload"
+
+const router = express.Router()
+const officeConversionController = new OfficeConversionController()
+
+// Converts an uploaded office document (pptx, docx, ...) to PDF via LibreOffice.
+router.post(
+    "/pdf",
+    officeConversionUpload.single("file"),
+    officeConversionController.convertToPdf,
+)
+
+export default router

--- a/apps/backend/src/services/fileProcessor/DoclingService.ts
+++ b/apps/backend/src/services/fileProcessor/DoclingService.ts
@@ -225,7 +225,7 @@ export class DoclingService {
    * @returns True if page info should be appended
    */
   private shouldAppendPageInfo(extension: string): boolean {
-    const supportedExtensions = ["pdf", "docx"];
+    const supportedExtensions = ["pdf", "docx", "pptx", "ppt"];
     return supportedExtensions.includes(extension);
   }
 

--- a/apps/backend/src/services/fileProcessor/FileProcessor.ts
+++ b/apps/backend/src/services/fileProcessor/FileProcessor.ts
@@ -6,6 +6,7 @@ import { BaseStrategy } from "./strategies/BaseStrategy"
 import { TextStrategy } from "./strategies/TextStrategy"
 import { PdfJsStrategy } from "./strategies/PdfJsStrategy"
 import { DocxStrategy } from "./strategies/DocxStrategy"
+import { PptxStrategy } from "./strategies/PptxStrategy"
 import { ImageDescriptionStrategy } from "./strategies/ImageStrategy"
 import { SpreadsheetStrategy } from "./strategies/SpreadsheetStrategy"
 import { PdfFallbackProcessor } from "./PdfFallbackProcessor"
@@ -241,6 +242,9 @@ export class FileProcessor {
                 return new PdfJsStrategy(config)
             case "docx":
                 return new DocxStrategy(config)
+            case "pptx":
+            case "ppt":
+                return new PptxStrategy(config)
             case "xls":
             case "xlsx":
                 return new SpreadsheetStrategy(config)
@@ -275,6 +279,9 @@ export class FileProcessor {
                 return new PdfJsStrategy(config)
             case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
                 return new DocxStrategy(config)
+            case "application/vnd.ms-powerpoint":
+            case "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+                return new PptxStrategy(config)
             case "application/vnd.ms-excel":
             case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
                 return new SpreadsheetStrategy(config)

--- a/apps/backend/src/services/fileProcessor/pptxSlideParser.ts
+++ b/apps/backend/src/services/fileProcessor/pptxSlideParser.ts
@@ -1,0 +1,315 @@
+import JSZip from "jszip"
+import { XMLParser } from "fast-xml-parser"
+
+/**
+ * Low-level PPTX (OOXML) parser shared by PptxStrategy (text extraction for
+ * Vespa ingestion) and collectionController's slide-viewer endpoint (visual
+ * rendering). PPTX is a ZIP of XML, same family as DOCX — this mirrors
+ * DocxStrategy's JSZip + fast-xml-parser approach, just walking
+ * ppt/slides/slideN.xml's DrawingML shape tree instead of
+ * word/document.xml's WordprocessingML paragraph tree.
+ *
+ * Positions/sizes are returned in raw EMU (English Metric Units, OOXML's
+ * native unit — 914400 EMU per inch) alongside the slide's own EMU
+ * dimensions, so callers can convert to whatever target canvas they need
+ * rather than baking in an assumption here.
+ */
+
+const EMU_PER_INCH = 914400
+
+export interface ParsedTextRun {
+    text: string
+    bold?: boolean
+    italic?: boolean
+    /** 6-hex-digit RGB, no '#' prefix (matches OOXML's <a:srgbClr val="RRGGBB"/> directly) */
+    color?: string
+    /** Points */
+    fontSize?: number
+    bullet?: boolean
+}
+
+export interface ParsedShape {
+    kind: "text" | "image"
+    /** OOXML placeholder type, e.g. "title" | "ctrTitle" | "subTitle" | "body" — absent for non-placeholder shapes */
+    placeholderType?: string
+    /** One entry per paragraph in the shape's text body */
+    runs?: ParsedTextRun[]
+    /** EMU */
+    x?: number
+    y?: number
+    w?: number
+    h?: number
+    /** 6-hex-digit RGB, no '#' prefix */
+    fillColor?: string
+    image?: { base64: string; mimeType: string }
+}
+
+export interface ParsedSlide {
+    /** 1-based, in presentation (display) order */
+    index: number
+    shapes: ParsedShape[]
+}
+
+export interface ParsedPptx {
+    /** EMU */
+    slideWidthEmu: number
+    /** EMU */
+    slideHeightEmu: number
+    slides: ParsedSlide[]
+}
+
+const xmlParser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+    preserveOrder: false,
+    removeNSPrefix: true,
+    processEntities: {
+        maxTotalExpansions: 10000,
+        maxEntityCount: 1000,
+    },
+})
+
+// A second parser WITHOUT namespace stripping, used only for
+// ppt/presentation.xml's <p:sldId id="256" r:id="rId2"/> — its plain `id`
+// (the slide's own numeric id) and namespaced `r:id` (the relationship id
+// we actually need) would otherwise collide onto the same `@_id` key once
+// prefixes are stripped, silently picking whichever happened to parse last.
+const nsAwareXmlParser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+    preserveOrder: false,
+    removeNSPrefix: false,
+    processEntities: {
+        maxTotalExpansions: 10000,
+        maxEntityCount: 1000,
+    },
+})
+
+function asArray<T>(value: T | T[] | undefined): T[] {
+    if (value == null) return []
+    return Array.isArray(value) ? value : [value]
+}
+
+const IMAGE_EXT_TO_MIME: Record<string, string> = {
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    gif: "image/gif",
+    bmp: "image/bmp",
+    webp: "image/webp",
+    tiff: "image/tiff",
+    emf: "image/x-emf",
+    wmf: "image/x-wmf",
+}
+
+/**
+ * Resolve r:id -> target path for a part, from its sibling _rels/*.rels file.
+ */
+async function readRels(zip: JSZip, relsPath: string): Promise<Map<string, string>> {
+    const map = new Map<string, string>()
+    const relsFile = zip.file(relsPath)
+    if (!relsFile) return map
+    const xml = await relsFile.async("text")
+    const parsed = xmlParser.parse(xml)
+    const relationships = asArray(parsed?.Relationships?.Relationship)
+    for (const rel of relationships) {
+        const id = rel?.["@_Id"]
+        const target = rel?.["@_Target"]
+        if (id && target) map.set(id, target)
+    }
+    return map
+}
+
+/** Resolve a relationship target (possibly relative, e.g. "../media/image1.png") against its part's directory. */
+function resolveRelTarget(partDir: string, target: string): string {
+    if (target.startsWith("/")) return target.slice(1)
+    const parts = `${partDir}/${target}`.split("/")
+    const resolved: string[] = []
+    for (const part of parts) {
+        if (part === "." || part === "") continue
+        if (part === "..") resolved.pop()
+        else resolved.push(part)
+    }
+    return resolved.join("/")
+}
+
+function extractRunsFromTxBody(txBody: any): ParsedTextRun[] {
+    const runs: ParsedTextRun[] = []
+    const paragraphs = asArray(txBody?.p)
+    for (const p of paragraphs) {
+        const rNodes = asArray(p?.r)
+        const bullet = p?.pPr?.buChar != null || p?.pPr?.buAutoNum != null
+        let text = ""
+        let bold: boolean | undefined
+        let italic: boolean | undefined
+        let color: string | undefined
+        let fontSize: number | undefined
+        for (const r of rNodes) {
+            const t = r?.t
+            const runText = typeof t === "string" ? t : (t?.["#text"] ?? "")
+            text += runText
+            const rPr = r?.rPr
+            if (rPr) {
+                if (rPr["@_b"] === "1" || rPr["@_b"] === 1 || rPr["@_b"] === true) bold = true
+                if (rPr["@_i"] === "1" || rPr["@_i"] === 1 || rPr["@_i"] === true) italic = true
+                const sz = rPr["@_sz"]
+                if (sz != null) fontSize = Number(sz) / 100 // OOXML sz is in hundredths of a point
+                const srgb = rPr?.solidFill?.srgbClr?.["@_val"]
+                if (srgb) color = String(srgb)
+            }
+        }
+        if (text.trim().length > 0) {
+            runs.push({
+                text,
+                ...(bold !== undefined && { bold }),
+                ...(italic !== undefined && { italic }),
+                ...(color !== undefined && { color }),
+                ...(fontSize !== undefined && { fontSize }),
+                ...(bullet && { bullet: true }),
+            })
+        }
+    }
+    return runs
+}
+
+function extractXfrm(spPr: any): { x?: number; y?: number; w?: number; h?: number } {
+    const xfrm = spPr?.xfrm
+    if (!xfrm) return {}
+    const off = xfrm.off
+    const ext = xfrm.ext
+    return {
+        ...(off?.["@_x"] != null && { x: Number(off["@_x"]) }),
+        ...(off?.["@_y"] != null && { y: Number(off["@_y"]) }),
+        ...(ext?.["@_cx"] != null && { w: Number(ext["@_cx"]) }),
+        ...(ext?.["@_cy"] != null && { h: Number(ext["@_cy"]) }),
+    }
+}
+
+function extractFillColor(spPr: any): string | undefined {
+    const srgb = spPr?.solidFill?.srgbClr?.["@_val"]
+    return srgb ? String(srgb) : undefined
+}
+
+async function parseSlideXml(
+    zip: JSZip,
+    slideXmlPath: string,
+    slideIndex: number,
+): Promise<ParsedSlide> {
+    const xmlFile = zip.file(slideXmlPath)
+    if (!xmlFile) return { index: slideIndex, shapes: [] }
+    const xml = await xmlFile.async("text")
+    const parsed = xmlParser.parse(xml)
+
+    const relsPath = slideXmlPath.replace(/^(.*)\/([^/]+)$/, "$1/_rels/$2.rels")
+    const rels = await readRels(zip, relsPath)
+    const partDir = slideXmlPath.split("/").slice(0, -1).join("/")
+
+    const spTree = parsed?.sld?.cSld?.spTree
+    const shapes: ParsedShape[] = []
+
+    for (const sp of asArray(spTree?.sp)) {
+        const placeholderType: string | undefined = sp?.nvSpPr?.nvPr?.ph?.["@_type"]
+        const runs = extractRunsFromTxBody(sp?.txBody)
+        const { x, y, w, h } = extractXfrm(sp?.spPr)
+        const fillColor = extractFillColor(sp?.spPr)
+        if (runs.length > 0 || x !== undefined) {
+            shapes.push({
+                kind: "text",
+                ...(placeholderType && { placeholderType }),
+                runs,
+                x,
+                y,
+                w,
+                h,
+                ...(fillColor && { fillColor }),
+            })
+        }
+    }
+
+    for (const pic of asArray(spTree?.pic)) {
+        const embedId: string | undefined = pic?.blipFill?.blip?.["@_embed"]
+        const { x, y, w, h } = extractXfrm(pic?.spPr)
+        if (!embedId) continue
+        const target = rels.get(embedId)
+        if (!target) continue
+        const mediaPath = resolveRelTarget(partDir, target)
+        const mediaFile = zip.file(mediaPath)
+        if (!mediaFile) continue
+        const ext = mediaPath.split(".").pop()?.toLowerCase() ?? ""
+        const mimeType = IMAGE_EXT_TO_MIME[ext]
+        // Skip formats browsers can't render inline (EMF/WMF vector metafiles) —
+        // they'd need their own conversion step; leaving the shape out entirely
+        // is better than embedding a data URI the <img> tag can't decode.
+        if (!mimeType || mimeType.startsWith("image/x-")) continue
+        const base64 = await mediaFile.async("base64")
+        shapes.push({ kind: "image", x, y, w, h, image: { base64, mimeType } })
+    }
+
+    return { index: slideIndex, shapes }
+}
+
+/**
+ * Parse a PPTX buffer into per-slide shape data, in presentation (display)
+ * order — resolved via ppt/presentation.xml's slide id list and its
+ * relationship file, not by filename sort, since slideN.xml numbering isn't
+ * guaranteed to match display order after slides are reordered.
+ */
+export async function parsePptxSlides(buffer: Buffer): Promise<ParsedPptx> {
+    const zip = await JSZip.loadAsync(buffer)
+
+    const presentationFile = zip.file("ppt/presentation.xml")
+    if (!presentationFile) {
+        throw new Error("ppt/presentation.xml not found in PPTX archive")
+    }
+    const presentationXml = await presentationFile.async("text")
+    const presentation = xmlParser.parse(presentationXml)
+
+    const sldSz = presentation?.presentation?.sldSz
+    const slideWidthEmu = sldSz?.["@_cx"] != null ? Number(sldSz["@_cx"]) : 9144000 // 10in default
+    const slideHeightEmu = sldSz?.["@_cy"] != null ? Number(sldSz["@_cy"]) : 6858000 // 7.5in default (4:3)
+
+    // Namespace-preserved re-parse just for the slide id list: <p:sldId
+    // id="256" r:id="rId2"/> has both a plain `id` (the slide's own numeric
+    // id, unrelated) and a namespaced `r:id` (the relationship id we need) —
+    // removeNSPrefix would collide them onto one `@_id` key.
+    const presentationNsAware = nsAwareXmlParser.parse(presentationXml)
+    const sldIds = asArray(presentationNsAware?.["p:presentation"]?.["p:sldIdLst"]?.["p:sldId"])
+
+    const presentationRels = await readRels(zip, "ppt/_rels/presentation.xml.rels")
+
+    const slides: ParsedSlide[] = []
+    let index = 1
+    for (const sldId of sldIds) {
+        const relId: string | undefined = sldId?.["@_r:id"]
+        const target = relId ? presentationRels.get(relId) : undefined
+        if (!target) {
+            index++
+            continue
+        }
+        const slideXmlPath = resolveRelTarget("ppt", target)
+        slides.push(await parseSlideXml(zip, slideXmlPath, index))
+        index++
+    }
+
+    // Fallback: if the presentation.xml relationship walk found nothing
+    // (unexpected structure), enumerate ppt/slides/slideN.xml directly —
+    // correct in the common case, just not reorder-safe.
+    if (slides.length === 0) {
+        const slideFiles = Object.keys(zip.files)
+            .filter(name => /^ppt\/slides\/slide\d+\.xml$/.test(name))
+            .sort((a, b) => {
+                const numA = Number(a.match(/slide(\d+)\.xml$/)?.[1] ?? 0)
+                const numB = Number(b.match(/slide(\d+)\.xml$/)?.[1] ?? 0)
+                return numA - numB
+            })
+        let fallbackIndex = 1
+        for (const path of slideFiles) {
+            slides.push(await parseSlideXml(zip, path, fallbackIndex))
+            fallbackIndex++
+        }
+    }
+
+    return { slideWidthEmu, slideHeightEmu, slides }
+}
+
+export { EMU_PER_INCH }

--- a/apps/backend/src/services/fileProcessor/pptxSlideParser.ts
+++ b/apps/backend/src/services/fileProcessor/pptxSlideParser.ts
@@ -2,46 +2,34 @@ import JSZip from "jszip"
 import { XMLParser } from "fast-xml-parser"
 
 /**
- * Low-level PPTX (OOXML) parser shared by PptxStrategy (text extraction for
- * Vespa ingestion) and collectionController's slide-viewer endpoint (visual
- * rendering). PPTX is a ZIP of XML, same family as DOCX — this mirrors
- * DocxStrategy's JSZip + fast-xml-parser approach, just walking
- * ppt/slides/slideN.xml's DrawingML shape tree instead of
- * word/document.xml's WordprocessingML paragraph tree.
+ * Low-level PPTX (OOXML) parser for PptxStrategy's text extraction (Vespa
+ * ingestion) — its only consumer. PPTX is a ZIP of XML, same family as DOCX —
+ * this mirrors DocxStrategy's JSZip + fast-xml-parser approach, just walking
+ * ppt/slides/slideN.xml's DrawingML shape tree instead of word/document.xml's
+ * WordprocessingML paragraph tree.
  *
- * Positions/sizes are returned in raw EMU (English Metric Units, OOXML's
- * native unit — 914400 EMU per inch) alongside the slide's own EMU
- * dimensions, so callers can convert to whatever target canvas they need
- * rather than baking in an assumption here.
+ * Only extracts what PptxStrategy reads: each shape's text runs, its
+ * placeholder type (title vs body), and slide ordering. Image/geometry/fill
+ * extraction was removed — nothing in this branch consumed it (see XYNE-60825
+ * PR review); reintroduce that alongside whatever feature actually needs it
+ * (e.g. a native slide-viewer), rather than speculatively.
  */
 
-const EMU_PER_INCH = 914400
+function asArray<T>(value: T | T[] | undefined): T[] {
+    if (value == null) return []
+    return Array.isArray(value) ? value : [value]
+}
 
 export interface ParsedTextRun {
     text: string
-    bold?: boolean
-    italic?: boolean
-    /** 6-hex-digit RGB, no '#' prefix (matches OOXML's <a:srgbClr val="RRGGBB"/> directly) */
-    color?: string
-    /** Points */
-    fontSize?: number
-    bullet?: boolean
 }
 
 export interface ParsedShape {
-    kind: "text" | "image"
+    kind: "text"
     /** OOXML placeholder type, e.g. "title" | "ctrTitle" | "subTitle" | "body" — absent for non-placeholder shapes */
     placeholderType?: string
     /** One entry per paragraph in the shape's text body */
-    runs?: ParsedTextRun[]
-    /** EMU */
-    x?: number
-    y?: number
-    w?: number
-    h?: number
-    /** 6-hex-digit RGB, no '#' prefix */
-    fillColor?: string
-    image?: { base64: string; mimeType: string }
+    runs: ParsedTextRun[]
 }
 
 export interface ParsedSlide {
@@ -51,10 +39,6 @@ export interface ParsedSlide {
 }
 
 export interface ParsedPptx {
-    /** EMU */
-    slideWidthEmu: number
-    /** EMU */
-    slideHeightEmu: number
     slides: ParsedSlide[]
 }
 
@@ -85,25 +69,11 @@ const nsAwareXmlParser = new XMLParser({
     },
 })
 
-function asArray<T>(value: T | T[] | undefined): T[] {
-    if (value == null) return []
-    return Array.isArray(value) ? value : [value]
-}
-
-const IMAGE_EXT_TO_MIME: Record<string, string> = {
-    png: "image/png",
-    jpg: "image/jpeg",
-    jpeg: "image/jpeg",
-    gif: "image/gif",
-    bmp: "image/bmp",
-    webp: "image/webp",
-    tiff: "image/tiff",
-    emf: "image/x-emf",
-    wmf: "image/x-wmf",
-}
-
 /**
  * Resolve r:id -> target path for a part, from its sibling _rels/*.rels file.
+ * Only used for ppt/presentation.xml's slide-id relationships (slide
+ * ordering) — per-slide rels (media embeds) aren't read since shapes' image
+ * data isn't extracted.
  */
 async function readRels(zip: JSZip, relsPath: string): Promise<Map<string, string>> {
     const map = new Map<string, string>()
@@ -120,7 +90,7 @@ async function readRels(zip: JSZip, relsPath: string): Promise<Map<string, strin
     return map
 }
 
-/** Resolve a relationship target (possibly relative, e.g. "../media/image1.png") against its part's directory. */
+/** Resolve a relationship target (possibly relative, e.g. "../slides/slide1.xml") against its part's directory. */
 function resolveRelTarget(partDir: string, target: string): string {
     if (target.startsWith("/")) return target.slice(1)
     const parts = `${partDir}/${target}`.split("/")
@@ -138,71 +108,21 @@ function extractRunsFromTxBody(txBody: any): ParsedTextRun[] {
     const paragraphs = asArray(txBody?.p)
     for (const p of paragraphs) {
         const rNodes = asArray(p?.r)
-        const bullet = p?.pPr?.buChar != null || p?.pPr?.buAutoNum != null
         let text = ""
-        let bold: boolean | undefined
-        let italic: boolean | undefined
-        let color: string | undefined
-        let fontSize: number | undefined
         for (const r of rNodes) {
             const t = r?.t
-            const runText = typeof t === "string" ? t : (t?.["#text"] ?? "")
-            text += runText
-            const rPr = r?.rPr
-            if (rPr) {
-                if (rPr["@_b"] === "1" || rPr["@_b"] === 1 || rPr["@_b"] === true) bold = true
-                if (rPr["@_i"] === "1" || rPr["@_i"] === 1 || rPr["@_i"] === true) italic = true
-                const sz = rPr["@_sz"]
-                if (sz != null) fontSize = Number(sz) / 100 // OOXML sz is in hundredths of a point
-                const srgb = rPr?.solidFill?.srgbClr?.["@_val"]
-                if (srgb) color = String(srgb)
-            }
+            text += typeof t === "string" ? t : (t?.["#text"] ?? "")
         }
-        if (text.trim().length > 0) {
-            runs.push({
-                text,
-                ...(bold !== undefined && { bold }),
-                ...(italic !== undefined && { italic }),
-                ...(color !== undefined && { color }),
-                ...(fontSize !== undefined && { fontSize }),
-                ...(bullet && { bullet: true }),
-            })
-        }
+        if (text.trim().length > 0) runs.push({ text })
     }
     return runs
 }
 
-function extractXfrm(spPr: any): { x?: number; y?: number; w?: number; h?: number } {
-    const xfrm = spPr?.xfrm
-    if (!xfrm) return {}
-    const off = xfrm.off
-    const ext = xfrm.ext
-    return {
-        ...(off?.["@_x"] != null && { x: Number(off["@_x"]) }),
-        ...(off?.["@_y"] != null && { y: Number(off["@_y"]) }),
-        ...(ext?.["@_cx"] != null && { w: Number(ext["@_cx"]) }),
-        ...(ext?.["@_cy"] != null && { h: Number(ext["@_cy"]) }),
-    }
-}
-
-function extractFillColor(spPr: any): string | undefined {
-    const srgb = spPr?.solidFill?.srgbClr?.["@_val"]
-    return srgb ? String(srgb) : undefined
-}
-
-async function parseSlideXml(
-    zip: JSZip,
-    slideXmlPath: string,
-    slideIndex: number,
-): Promise<ParsedSlide> {
+async function parseSlideXml(zip: JSZip, slideXmlPath: string, slideIndex: number): Promise<ParsedSlide> {
     const xmlFile = zip.file(slideXmlPath)
     if (!xmlFile) return { index: slideIndex, shapes: [] }
     const xml = await xmlFile.async("text")
     const parsed = xmlParser.parse(xml)
-
-    const relsPath = slideXmlPath.replace(/^(.*)\/([^/]+)$/, "$1/_rels/$2.rels")
-    const rels = await readRels(zip, relsPath)
-    const partDir = slideXmlPath.split("/").slice(0, -1).join("/")
 
     const spTree = parsed?.sld?.cSld?.spTree
     const shapes: ParsedShape[] = []
@@ -210,39 +130,13 @@ async function parseSlideXml(
     for (const sp of asArray(spTree?.sp)) {
         const placeholderType: string | undefined = sp?.nvSpPr?.nvPr?.ph?.["@_type"]
         const runs = extractRunsFromTxBody(sp?.txBody)
-        const { x, y, w, h } = extractXfrm(sp?.spPr)
-        const fillColor = extractFillColor(sp?.spPr)
-        if (runs.length > 0 || x !== undefined) {
+        if (runs.length > 0) {
             shapes.push({
                 kind: "text",
                 ...(placeholderType && { placeholderType }),
                 runs,
-                x,
-                y,
-                w,
-                h,
-                ...(fillColor && { fillColor }),
             })
         }
-    }
-
-    for (const pic of asArray(spTree?.pic)) {
-        const embedId: string | undefined = pic?.blipFill?.blip?.["@_embed"]
-        const { x, y, w, h } = extractXfrm(pic?.spPr)
-        if (!embedId) continue
-        const target = rels.get(embedId)
-        if (!target) continue
-        const mediaPath = resolveRelTarget(partDir, target)
-        const mediaFile = zip.file(mediaPath)
-        if (!mediaFile) continue
-        const ext = mediaPath.split(".").pop()?.toLowerCase() ?? ""
-        const mimeType = IMAGE_EXT_TO_MIME[ext]
-        // Skip formats browsers can't render inline (EMF/WMF vector metafiles) —
-        // they'd need their own conversion step; leaving the shape out entirely
-        // is better than embedding a data URI the <img> tag can't decode.
-        if (!mimeType || mimeType.startsWith("image/x-")) continue
-        const base64 = await mediaFile.async("base64")
-        shapes.push({ kind: "image", x, y, w, h, image: { base64, mimeType } })
     }
 
     return { index: slideIndex, shapes }
@@ -262,13 +156,8 @@ export async function parsePptxSlides(buffer: Buffer): Promise<ParsedPptx> {
         throw new Error("ppt/presentation.xml not found in PPTX archive")
     }
     const presentationXml = await presentationFile.async("text")
-    const presentation = xmlParser.parse(presentationXml)
 
-    const sldSz = presentation?.presentation?.sldSz
-    const slideWidthEmu = sldSz?.["@_cx"] != null ? Number(sldSz["@_cx"]) : 9144000 // 10in default
-    const slideHeightEmu = sldSz?.["@_cy"] != null ? Number(sldSz["@_cy"]) : 6858000 // 7.5in default (4:3)
-
-    // Namespace-preserved re-parse just for the slide id list: <p:sldId
+    // Namespace-preserved parse just for the slide id list: <p:sldId
     // id="256" r:id="rId2"/> has both a plain `id` (the slide's own numeric
     // id, unrelated) and a namespaced `r:id` (the relationship id we need) —
     // removeNSPrefix would collide them onto one `@_id` key.
@@ -309,7 +198,5 @@ export async function parsePptxSlides(buffer: Buffer): Promise<ParsedPptx> {
         }
     }
 
-    return { slideWidthEmu, slideHeightEmu, slides }
+    return { slides }
 }
-
-export { EMU_PER_INCH }

--- a/apps/backend/src/services/fileProcessor/strategies/PptxStrategy.ts
+++ b/apps/backend/src/services/fileProcessor/strategies/PptxStrategy.ts
@@ -1,0 +1,140 @@
+import { BaseStrategy } from "./BaseStrategy"
+import type { ProcessingResult, StrategyConfig, ChunkMetadata } from "../types"
+import { parsePptxSlides } from "../pptxSlideParser"
+
+const TITLE_PLACEHOLDER_TYPES = new Set(["title", "ctrTitle", "subTitle"])
+
+/**
+ * PPTX parsing strategy — native text extraction for uploaded .ppt/.pptx
+ * files, used as the fallback when Docling is disabled/unavailable/fails
+ * (see FileProcessor.processBufferWithFallback). Docling remains the OCR
+ * path for text baked into slide images/screenshots; this strategy covers
+ * the common case of native, machine-readable slide text reliably and
+ * without any external dependency.
+ *
+ * PPTX files are ZIP archives containing XML, same family as DOCX — this
+ * mirrors DocxStrategy's structure (JSZip + fast-xml-parser, paragraph-style
+ * chunking with page/label metadata), reading ppt/slides/slideN.xml via the
+ * shared pptxSlideParser instead of DocxStrategy's word/document.xml walk.
+ * A slide stands in for a "page"; the placeholder type (title vs body)
+ * stands in for heading level.
+ */
+export class PptxStrategy extends BaseStrategy {
+    private config: Required<Pick<StrategyConfig, "chunkSize" | "chunkOverlap">>
+
+    constructor(config?: StrategyConfig) {
+        super()
+        this.config = {
+            chunkSize: config?.chunkSize ?? 1000,
+            chunkOverlap: config?.chunkOverlap ?? 200,
+        }
+    }
+
+    async parse(buffer: Buffer, vespaDocId: string): Promise<ProcessingResult> {
+        try {
+            const { slides } = await parsePptxSlides(buffer)
+
+            const paragraphs = this.extractParagraphsWithMeta(slides)
+            const { chunks, chunks_map } = this.chunkByParagraphsWithMeta(paragraphs)
+
+            const documentOutline = await this.buildDocumentOutline(chunks, chunks_map, vespaDocId)
+
+            return {
+                chunks,
+                chunks_map,
+                documentOutline,
+                processingMethod: this.getName(),
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error)
+            throw new Error(`PPTX parsing failed: ${message}`)
+        }
+    }
+
+    /**
+     * Flatten parsed slides into paragraph-like entries — one per shape's
+     * text-body paragraph, tagged with its slide number (standing in for
+     * page) and a "title"/"text" label derived from the shape's placeholder
+     * type — so the same greedy chunker DocxStrategy uses can run unchanged.
+     */
+    private extractParagraphsWithMeta(
+        slides: Awaited<ReturnType<typeof parsePptxSlides>>["slides"],
+    ): Array<{ text: string; page: number; blockLabel: string }> {
+        const results: Array<{ text: string; page: number; blockLabel: string }> = []
+
+        for (const slide of slides) {
+            for (const shape of slide.shapes) {
+                if (shape.kind !== "text" || !shape.runs) continue
+                const blockLabel =
+                    shape.placeholderType && TITLE_PLACEHOLDER_TYPES.has(shape.placeholderType)
+                        ? "title"
+                        : "text"
+                for (const run of shape.runs) {
+                    const text = run.text.trim()
+                    if (text.length > 0) {
+                        results.push({ text, page: slide.index, blockLabel })
+                    }
+                }
+            }
+        }
+
+        return results
+    }
+
+    /**
+     * Chunk paragraphs while building chunks_map with real slide numbers and
+     * placeholder-derived block labels. Identical shape to DocxStrategy's
+     * chunkByParagraphsWithMeta — [Slide N] instead of [Page N].
+     */
+    private chunkByParagraphsWithMeta(
+        paragraphs: Array<{ text: string; page: number; blockLabel: string }>,
+    ): { chunks: string[]; chunks_map: ChunkMetadata[] } {
+        const chunks: string[] = []
+        const chunks_map: ChunkMetadata[] = []
+
+        let currentChunk = ""
+        let currentPages = new Set<number>()
+        let currentLabels = new Set<string>()
+        let chunkIndex = 0
+        const { chunkSize } = this.config
+
+        const flush = () => {
+            if (currentChunk.trim().length === 0) return
+            const pages = Array.from(currentPages).sort((a, b) => a - b)
+            const pageLabel = pages.length === 1 ? `[Slide ${pages[0]}]` : `[Slides ${pages.join(", ")}]`
+            chunks.push(`${pageLabel}\n${currentChunk.trim()}`)
+            chunks_map.push({
+                chunk_index: chunkIndex++,
+                page_numbers: pages,
+                block_labels: Array.from(currentLabels),
+            })
+            currentChunk = ""
+            currentPages = new Set()
+            currentLabels = new Set()
+        }
+
+        for (const { text, page, blockLabel } of paragraphs) {
+            // A slide boundary always starts a fresh chunk — unlike DOCX,
+            // where an unbroken multi-page paragraph flow is common, PPTX
+            // slides are naturally discrete units and mixing two slides'
+            // text into one chunk (just because both are small) muddies the
+            // per-slide citation this is meant to preserve.
+            if (currentPages.size > 0 && !currentPages.has(page)) {
+                flush()
+            } else if (currentChunk.length + text.length + 2 > chunkSize && currentChunk.length > 0) {
+                flush()
+            }
+            currentChunk += (currentChunk ? "\n\n" : "") + text
+            currentPages.add(page)
+            currentLabels.add(blockLabel)
+        }
+
+        flush()
+
+        return { chunks, chunks_map }
+    }
+
+    getName(): string {
+        return "pptx-xml-parser"
+    }
+}

--- a/apps/backend/src/services/officeConversionService.ts
+++ b/apps/backend/src/services/officeConversionService.ts
@@ -1,6 +1,6 @@
 import { spawn } from "child_process"
-import { createHash } from "crypto"
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "fs/promises"
+import { createHash, randomBytes } from "crypto"
+import { mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import { logger } from "@/utils/logger"
@@ -50,23 +50,38 @@ export class OfficeConversionError extends Error {
 }
 
 async function readLocalCache(cachePath: string): Promise<Buffer | null> {
+    // Stat and read via the same open file handle (not by path) so the
+    // freshness check and the read see the same inode — a path-based
+    // stat-then-readFile has a window where the file can be replaced or
+    // deleted in between the two calls.
+    let handle
     try {
-        const stats = await stat(cachePath)
+        handle = await open(cachePath, "r")
+        const stats = await handle.stat()
         if (Date.now() - stats.mtimeMs > CACHE_MAX_AGE_MS) return null
-        return await readFile(cachePath)
+        return await handle.readFile()
     } catch {
         return null
+    } finally {
+        await handle?.close().catch(() => {})
     }
 }
 
 async function writeLocalCache(cachePath: string, buffer: Buffer, contentHash: string): Promise<void> {
+    // Write to a randomly-named file (exclusive create, so we never write
+    // through a pre-existing file/symlink an attacker planted at a
+    // predictable path) and rename it into place atomically, rather than
+    // writing straight to the guessable content-addressed cachePath.
+    const tmpPath = `${cachePath}.${randomBytes(8).toString("hex")}.tmp`
     await mkdir(CACHE_DIR, { recursive: true })
-        .then(() => writeFile(cachePath, buffer))
+        .then(() => writeFile(tmpPath, buffer, { flag: "wx" }))
+        .then(() => rename(tmpPath, cachePath))
         .catch(err => {
             logger.warn("[OfficeConversion] Failed to write local cache entry", {
                 contentHash,
                 error: err instanceof Error ? err.message : String(err),
             })
+            return rm(tmpPath, { force: true }).catch(() => {})
         })
 }
 
@@ -121,7 +136,12 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
 
     const workDir = await mkdtemp(path.join(tmpdir(), "office-convert-"))
     const profileDir = path.join(workDir, "profile")
-    const ext = path.extname(originalFilename) || ".bin"
+    // originalFilename is attacker-controlled (the client-supplied upload
+    // name); only accept a plain alphanumeric extension so nothing in it
+    // (path separators, "..", null bytes, ...) can influence where
+    // inputPath actually lands on disk.
+    const rawExt = path.extname(originalFilename)
+    const ext = /^\.[a-zA-Z0-9]{1,10}$/.test(rawExt) ? rawExt : ".bin"
     const inputPath = path.join(workDir, `input${ext}`)
     const outputPath = path.join(workDir, "input.pdf")
 

--- a/apps/backend/src/services/officeConversionService.ts
+++ b/apps/backend/src/services/officeConversionService.ts
@@ -3,6 +3,7 @@ import { createHash, randomBytes } from "crypto"
 import { mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
+import pLimit from "p-limit"
 import { logger } from "@/utils/logger"
 import { storageService } from "@/services/storage"
 import { isPreconditionFailed } from "@xyne/storage"
@@ -24,6 +25,15 @@ import { isPreconditionFailed } from "@xyne/storage"
 
 const SOFFICE_BINARY = process.env.SOFFICE_PATH || "soffice"
 const CONVERSION_TIMEOUT_MS = 60_000
+
+// Each soffice invocation is a real process with a non-trivial memory
+// footprint; an uncapped flood of requests for files the cache hasn't seen
+// yet (e.g. many first-time opens at once) would spawn one soffice per
+// request and risk OOM-ing the pod. Bounds how many run at once per pod —
+// excess requests queue behind this limiter rather than all spawning
+// immediately.
+const SOFFICE_MAX_CONCURRENCY = Number(process.env.SOFFICE_MAX_CONCURRENCY) || 3
+const conversionLimit = pLimit(SOFFICE_MAX_CONCURRENCY)
 
 // Two-tier cache, both keyed on the content hash (this endpoint is
 // stateless — no file/collection id, just bytes, so content is the only key
@@ -148,7 +158,7 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
     try {
         await writeFile(inputPath, buffer)
 
-        await new Promise<void>((resolve, reject) => {
+        await conversionLimit(() => new Promise<void>((resolve, reject) => {
             const args = [
                 "--headless",
                 "--norestore",
@@ -205,7 +215,7 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
                     )
                 }
             })
-        })
+        }))
 
         const result = await readFile(outputPath)
 

--- a/apps/backend/src/services/officeConversionService.ts
+++ b/apps/backend/src/services/officeConversionService.ts
@@ -1,0 +1,207 @@
+import { spawn } from "child_process"
+import { createHash } from "crypto"
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import { logger } from "@/utils/logger"
+import { storageService } from "@/services/storage"
+import { isPreconditionFailed } from "@xyne/storage"
+
+/**
+ * Converts an office document (pptx, docx, xlsx, ...) to PDF via LibreOffice's
+ * headless CLI — the same approach Google Drive/Slack/Notion previews use.
+ * Reimplementing OOXML rendering in the browser (the prior approach for the
+ * PPTX viewer) can never be "exact": OOXML is too large a spec, and every
+ * fixed gap (theme colors, placeholder inheritance, custom geometry, picture
+ * effects) just reveals the next one. Shelling out to a real office engine
+ * sidesteps that entirely by letting it do the rendering.
+ *
+ * `-env:UserInstallation` gives each conversion its own LibreOffice profile
+ * directory — soffice locks its profile against concurrent use, so sharing
+ * the default profile across concurrent requests causes conversions to hang
+ * or fail outright.
+ */
+
+const SOFFICE_BINARY = process.env.SOFFICE_PATH || "soffice"
+const CONVERSION_TIMEOUT_MS = 60_000
+
+// Two-tier cache, both keyed on the content hash (this endpoint is
+// stateless — no file/collection id, just bytes, so content is the only key
+// available):
+//   1. Local disk — near-zero latency, but wiped on pod restart and not
+//      shared across replicas.
+//   2. GCS (the same bucket every other upload in this app already uses) —
+//      survives restarts and is shared across every backend replica, at the
+//      cost of a network round trip instead of a local read.
+// A hit on tier 2 backfills tier 1, so a given pod only pays the GCS latency
+// once per content hash.
+const CACHE_DIR = path.join(tmpdir(), "office-conversion-cache")
+const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000
+const GCS_CACHE_PREFIX = "office-conversion-cache"
+
+export class OfficeConversionError extends Error {
+    constructor(
+        message: string,
+        public readonly code: "SOFFICE_NOT_FOUND" | "TIMEOUT" | "CONVERSION_FAILED",
+    ) {
+        super(message)
+        this.name = "OfficeConversionError"
+    }
+}
+
+async function readLocalCache(cachePath: string): Promise<Buffer | null> {
+    try {
+        const stats = await stat(cachePath)
+        if (Date.now() - stats.mtimeMs > CACHE_MAX_AGE_MS) return null
+        return await readFile(cachePath)
+    } catch {
+        return null
+    }
+}
+
+async function writeLocalCache(cachePath: string, buffer: Buffer, contentHash: string): Promise<void> {
+    await mkdir(CACHE_DIR, { recursive: true })
+        .then(() => writeFile(cachePath, buffer))
+        .catch(err => {
+            logger.warn("[OfficeConversion] Failed to write local cache entry", {
+                contentHash,
+                error: err instanceof Error ? err.message : String(err),
+            })
+        })
+}
+
+async function readGcsCache(gcsPath: string): Promise<Buffer | null> {
+    try {
+        // getFileBuffer retries with backoff on a missing file (it's built
+        // for "should exist, might not be finalized yet" reads) — pointless
+        // delay on a genuine cache miss, so check existence first.
+        const exists = await storageService.fileExists(gcsPath)
+        if (!exists) return null
+        return await storageService.getFileBuffer(gcsPath)
+    } catch {
+        return null
+    }
+}
+
+async function writeGcsCache(gcsPath: string, buffer: Buffer, contentHash: string): Promise<void> {
+    try {
+        // Content-addressed, so a collision means another replica already
+        // cached the identical bytes concurrently — not an error.
+        await storageService.uploadFileV2(buffer, {
+            path: gcsPath,
+            contentType: "application/pdf",
+            ifNotExists: true,
+        })
+    } catch (err) {
+        if (isPreconditionFailed(err)) return
+        logger.warn("[OfficeConversion] Failed to write GCS cache entry", {
+            contentHash,
+            error: err instanceof Error ? err.message : String(err),
+        })
+    }
+}
+
+export async function convertToPdf(buffer: Buffer, originalFilename: string): Promise<Buffer> {
+    const contentHash = createHash("sha256").update(buffer).digest("hex")
+    const cachePath = path.join(CACHE_DIR, `${contentHash}.pdf`)
+    const gcsPath = `${GCS_CACHE_PREFIX}/${contentHash}.pdf`
+
+    const localHit = await readLocalCache(cachePath)
+    if (localHit) {
+        logger.info("[OfficeConversion] Local cache hit", { contentHash })
+        return localHit
+    }
+
+    const gcsHit = await readGcsCache(gcsPath)
+    if (gcsHit) {
+        logger.info("[OfficeConversion] GCS cache hit", { contentHash })
+        await writeLocalCache(cachePath, gcsHit, contentHash)
+        return gcsHit
+    }
+
+    const workDir = await mkdtemp(path.join(tmpdir(), "office-convert-"))
+    const profileDir = path.join(workDir, "profile")
+    const ext = path.extname(originalFilename) || ".bin"
+    const inputPath = path.join(workDir, `input${ext}`)
+    const outputPath = path.join(workDir, "input.pdf")
+
+    try {
+        await writeFile(inputPath, buffer)
+
+        await new Promise<void>((resolve, reject) => {
+            const args = [
+                "--headless",
+                "--norestore",
+                `-env:UserInstallation=file://${profileDir}`,
+                "--convert-to",
+                "pdf",
+                "--outdir",
+                workDir,
+                inputPath,
+            ]
+            const proc = spawn(SOFFICE_BINARY, args)
+
+            let stderr = ""
+            let stdout = ""
+            const timer = setTimeout(() => {
+                proc.kill("SIGKILL")
+                reject(new OfficeConversionError("LibreOffice conversion timed out", "TIMEOUT"))
+            }, CONVERSION_TIMEOUT_MS)
+
+            proc.stderr.on("data", chunk => {
+                stderr += chunk.toString()
+            })
+            proc.stdout.on("data", chunk => {
+                stdout += chunk.toString()
+            })
+            proc.on("error", err => {
+                clearTimeout(timer)
+                if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+                    reject(
+                        new OfficeConversionError(
+                            `LibreOffice binary not found (looked for "${SOFFICE_BINARY}")`,
+                            "SOFFICE_NOT_FOUND",
+                        ),
+                    )
+                    return
+                }
+                reject(new OfficeConversionError(err.message, "CONVERSION_FAILED"))
+            })
+            proc.on("close", code => {
+                clearTimeout(timer)
+                if (code === 0) {
+                    resolve()
+                } else {
+                    logger.error("[OfficeConversion] soffice exited non-zero", {
+                        code,
+                        stderr: stderr.slice(-2000),
+                        stdout: stdout.slice(-2000),
+                    })
+                    reject(
+                        new OfficeConversionError(
+                            `LibreOffice exited with code ${code}`,
+                            "CONVERSION_FAILED",
+                        ),
+                    )
+                }
+            })
+        })
+
+        const result = await readFile(outputPath)
+
+        await Promise.all([
+            writeLocalCache(cachePath, result, contentHash),
+            writeGcsCache(gcsPath, result, contentHash),
+        ])
+
+        return result
+    } finally {
+        await rm(workDir, { recursive: true, force: true }).catch(err => {
+            logger.warn("[OfficeConversion] Failed to clean up temp dir", {
+                workDir,
+                error: err instanceof Error ? err.message : String(err),
+            })
+        })
+    }
+}
+

--- a/apps/dashboard/src/components/FileViewer/AttachmentCitationPreview.tsx
+++ b/apps/dashboard/src/components/FileViewer/AttachmentCitationPreview.tsx
@@ -23,6 +23,7 @@ import ReadmeViewer from './ReadmeViewer';
 import TxtViewer from './TxtViewer';
 import HtmlViewer from './HtmlViewer';
 import ImageViewer from './ImageViewer';
+import PptxFileViewer from './PptxFileViewer';
 import { DocumentOperationsProvider } from '../../contexts/DocumentOperationsContext';
 import type { DocumentOperations } from '../../contexts/DocumentOperationsContext';
 import { useScopedFind } from '../../hooks/useScopedFind';
@@ -111,6 +112,9 @@ function getExtension(mimeType: string, fileName: string): string {
     return 'xlsx';
   if (mimeType === 'text/csv') return 'csv';
   if (mimeType === 'text/tsv') return 'tsv';
+  if (mimeType === 'application/vnd.ms-powerpoint') return 'ppt';
+  if (mimeType === 'application/vnd.openxmlformats-officedocument.presentationml.presentation')
+    return 'pptx';
   if (mimeType.startsWith('image/')) return 'image';
   // fall back to filename extension
   return fileName.toLowerCase().split('.').pop() ?? '';
@@ -137,6 +141,10 @@ function getDefaultMimeType(ext: string): string {
       return 'application/vnd.ms-excel';
     case 'csv':
       return 'text/csv';
+    case 'pptx':
+      return 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+    case 'ppt':
+      return 'application/vnd.ms-powerpoint';
     default:
       return 'application/octet-stream';
   }
@@ -259,6 +267,9 @@ const AttachmentCitationPreviewInner: React.FC = () => {
       case 'csv':
       case 'tsv':
         return <CsvViewer source={fileWithType} />;
+      case 'pptx':
+      case 'ppt':
+        return <PptxFileViewer source={fileWithType} />;
       case 'txt':
       case 'text':
         return <TxtViewer source={fileWithType} />;

--- a/apps/dashboard/src/components/FileViewer/PptxFileViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/PptxFileViewer.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Presentation, Download } from 'lucide-react';
+import type { BaseViewerProps } from './utils';
+import PdfViewer from './PdfViewer';
+import { apiInstance } from '../../services/clients/apiClient';
+import { logger, Event as LogEvent } from '../../utils/logger';
+
+/**
+ * .ppt/.pptx viewer for the shared FileViewer registry — converts the
+ * already-fetched raw file to PDF server-side (LibreOffice, via the backend's
+ * /api/office-conversion/pdf endpoint) and hands the result to the existing
+ * PdfViewer.
+ *
+ * Why not parse the OOXML client-side and render it directly (the prior
+ * approach): that means reimplementing pieces of PowerPoint's own layout
+ * engine — placeholder inheritance, theme colors, custom freeform geometry,
+ * picture recolor/crop effects — one gap at a time, and OOXML is too large a
+ * spec to ever get pixel-exact that way. LibreOffice already implements the
+ * full spec, so shelling out to it for the actual rendering (the same
+ * approach Drive/Slack/Notion previews use) gets genuine fidelity instead of
+ * an ever-growing list of approximations.
+ */
+const PptxFileViewer: React.FC<BaseViewerProps> = props => {
+  const { source, fileName } = props;
+  const [pdfFile, setPdfFile] = useState<File | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const objectUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    setPdfFile(null);
+    setStatus('loading');
+    if (!source) return;
+
+    let cancelled = false;
+    const formData = new FormData();
+    formData.append('file', source, source.name);
+
+    apiInstance
+      .post('/office-conversion/pdf', formData, { responseType: 'blob' })
+      .then(response => {
+        if (cancelled) return;
+        const blob = response.data as Blob;
+        const displayName = (fileName ?? source.name).replace(/\.(pptx|ppt)$/i, '.pdf');
+        setPdfFile(new File([blob], displayName, { type: 'application/pdf' }));
+        setStatus('ready');
+      })
+      .catch(error => {
+        if (cancelled) return;
+        logger.warn(LogEvent.FRONTEND_ERROR, {
+          type: 'migrated_console_warn',
+          message: String('[PptxFileViewer] Failed to convert .pptx file to PDF:'),
+          error,
+        });
+        setStatus('error');
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, fileName]);
+
+  useEffect(() => {
+    if (!source) return;
+    const url = URL.createObjectURL(source);
+    objectUrlRef.current = url;
+    return () => {
+      URL.revokeObjectURL(url);
+      objectUrlRef.current = null;
+    };
+  }, [source]);
+
+  const displayName = fileName ?? 'Presentation';
+
+  if (status === 'loading') {
+    return (
+      <div className='flex h-full w-full items-center justify-center'>
+        <div className='text-center'>
+          <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-action-primary mx-auto mb-3' />
+          <p className='text-muted-foreground dark:text-muted text-sm'>Loading presentation...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === 'error' || !pdfFile) {
+    return (
+      <div className='flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center'>
+        <div className='flex h-20 w-20 items-center justify-center rounded-lg bg-orange-500 shadow-lg'>
+          <Presentation size={40} className='text-white' />
+        </div>
+        <div>
+          <h3 className='text-base font-semibold text-foreground'>PowerPoint Presentation</h3>
+          <p className='mt-2 max-w-md text-sm text-muted-foreground'>
+            Preview is not available for this file.
+            <br />
+            Download the file to view it.
+          </p>
+        </div>
+        {objectUrlRef.current && (
+          <a
+            href={objectUrlRef.current}
+            download={displayName}
+            className='inline-flex items-center gap-2 rounded-lg bg-orange-600 px-4 py-2 text-sm font-medium text-white hover:bg-orange-700'
+          >
+            <Download size={16} />
+            Download Presentation
+          </a>
+        )}
+      </div>
+    );
+  }
+
+  return <PdfViewer {...props} source={pdfFile} fileName={displayName} />;
+};
+
+export default PptxFileViewer;

--- a/apps/dashboard/src/components/FileViewer/utils.ts
+++ b/apps/dashboard/src/components/FileViewer/utils.ts
@@ -7,6 +7,7 @@ import PdfViewer from './PdfViewer';
 import VideoViewer from './VideoViewer';
 import CodeViewer from './CodeViewer';
 import HtmlViewer from './HtmlViewer';
+import PptxFileViewer from './PptxFileViewer';
 
 export interface ZoomState {
   scale: number;
@@ -87,6 +88,16 @@ export const FILE_TYPE_CONFIG: Record<string, FileTypeConfig<BaseViewerProps>> =
     component: DocxViewer,
     wrapperClass: 'h-full w-full overflow-auto',
     displayName: 'Word Document',
+  },
+  pptx: {
+    mimeTypes: [
+      'application/vnd.ms-powerpoint',
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    ],
+    extensions: ['.pptx', '.ppt'],
+    component: PptxFileViewer,
+    wrapperClass: 'h-full w-full overflow-auto',
+    displayName: 'PowerPoint Presentation',
   },
   code: {
     mimeTypes: [

--- a/apps/dashboard/src/services/encryptionInterceptors.ts
+++ b/apps/dashboard/src/services/encryptionInterceptors.ts
@@ -129,6 +129,15 @@ export async function encryptionResponseInterceptor(
     return response;
   }
 
+  // A Blob/ArrayBuffer response has `typeof === 'object'` but no enumerable
+  // own properties, so decryptObject's Object.entries() walk would silently
+  // replace it with `{}` instead of leaving it alone — skip binary response
+  // types outright rather than only guarding on the value's shape.
+  const responseType = response.config.responseType;
+  if (responseType === 'blob' || responseType === 'arraybuffer' || responseType === 'stream') {
+    return response;
+  }
+
   // Only decrypt JSON responses
   if (!response.data || typeof response.data !== 'object') {
     return response;


### PR DESCRIPTION
## Summary
- Uploaded .pptx/.ppt files in Knowledge now render with PowerPoint fidelity via server-side LibreOffice-to-PDF conversion (`officeConversionService`, `POST /api/office-conversion/pdf`), displayed through the existing pdf.js `PdfViewer`.
- Conversion results are cached by SHA-256 of the uploaded bytes, both on local disk and in GCS (shared across backend replicas, survives pod restarts).
- Adds native PPTX text extraction (`pptxSlideParser` + `PptxStrategy`) as a `FileProcessor` strategy so slide content is indexed for search, same as DOCX.

## Test plan
- [ ] Upload a .pptx/.ppt file to a Knowledge collection and confirm it renders with correct fonts/theme colors/layout
- [ ] Confirm repeat opens of the same file are fast (cache hit, local-disk tier)
- [ ] Confirm cache survives a backend restart (GCS tier)
- [ ] Confirm uploaded slide text is searchable in Knowledge search

Services-Requiring-Redeployment: backend, dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxtQW8nWbxfp1gURD6aYJY