### PR TITLE
fix: XYNE-60840 use canonical Spaces origin for review links

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/design-shares.test.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/design-shares.test.ts
@@ -5,7 +5,7 @@ const state = vi.hoisted(() => ({
   share: null as null | Record<string, any>,
   attachmentId: "attachment-1",
   orgMembers: [["user-1", "org-1"]] as Array<[string, string]>,
-  config: { encryptionKey: Buffer.alloc(32, 9), frontendUrl: "https://spaces.xyne.juspay.net/claw" },
+  config: { encryptionKey: Buffer.alloc(32, 9), spacesAppUrl: "https://app.spaces.xyne.juspay.net/claw" },
 }));
 
 vi.mock("../config.js", () => ({ CONFIG: state.config }));
@@ -179,14 +179,14 @@ describe("design artifact sharing", () => {
     expect(refreshed.sharePath).toBe(first.sharePath);
   });
 
-  it("does not duplicate the /claw prefix when building an external share URL", async () => {
+  it("builds external share URLs from the canonical public Spaces origin", async () => {
     const { designShareUrl } = await import("./design-shares.js");
     expect(designShareUrl("/claw/v3/design/shared#token")).toBe(
-      "https://spaces.xyne.juspay.net/claw/v3/design/shared#token",
+      "https://app.spaces.xyne.juspay.net/claw/v3/design/shared#token",
     );
-    state.config.frontendUrl = "https://spaces.xyne.juspay.net";
+    state.config.spacesAppUrl = "https://app.spaces.xyne.juspay.net";
     expect(designShareUrl("/claw/v3/design/shared#token")).toBe(
-      "https://spaces.xyne.juspay.net/claw/v3/design/shared#token",
+      "https://app.spaces.xyne.juspay.net/claw/v3/design/shared#token",
     );
   });
 

--- a/apps/xyne-claw-auth/backend/src/routes/design-shares.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/design-shares.ts
@@ -46,13 +46,13 @@ function sharePath(rawToken: string): string {
   return `/claw/v3/design/shared#${encodeURIComponent(rawToken)}`;
 }
 
-/** Build a browser URL whether FRONTEND_URL is origin-rooted or already `/claw`-rooted. */
+/** Build a browser URL from the canonical public Spaces origin. */
 export function designShareUrl(path: string): string {
-  const frontendBase = CONFIG.frontendUrl.replace(/\/+$/, "");
-  const relativePath = frontendBase.endsWith("/claw") && path.startsWith("/claw/")
+  const spacesBase = CONFIG.spacesAppUrl.replace(/\/+$/, "");
+  const relativePath = spacesBase.endsWith("/claw") && path.startsWith("/claw/")
     ? path.slice("/claw".length)
     : path;
-  return `${frontendBase}${relativePath}`;
+  return `${spacesBase}${relativePath}`;
 }
 
 function ownerResponse(


### PR DESCRIPTION
## Summary
- build design and review-room share links from the canonical public Spaces origin
- ensure generated links use `https://app.spaces.xyne.juspay.net`
- retain `/claw` prefix de-duplication

## Validation
- `pnpm exec vitest run src/routes/design-shares.test.ts src/lib/chain-workflow.test.ts src/routes/webhook-chain-pending-responses.test.ts`
- 42 tests passed
- `git diff --check`