### PR TITLE
fix: XYNE-60846 retry resumed runs before failure

### DIFF
--- a/apps/xyne-claw-auth/backend/src/queue/run-recovery-empty-result.test.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/run-recovery-empty-result.test.ts
@@ -1,0 +1,78 @@
+/**
+ * A resumed attempt may produce an empty completed callback after another pod
+ * interruption. The callback must not settle the logical run or post the
+ * generic apology while another bounded recovery attempt can answer.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string): string => readFileSync(resolve(here, rel), "utf8");
+const webhook = (): string => read("../routes/webhook.ts");
+const worker = (): string => read("./run-recovery-worker.ts");
+
+describe("empty completed callbacks defer to run recovery", () => {
+  it("does not settle recovery completed before the empty-result decision", () => {
+    const src = webhook();
+    expect(src).toContain("deferCompletedRecoveryForEmptyResult");
+    expect(src).toContain('recoveryCallbackDisposition === "active_continuation"');
+    expect(src).toContain('payload.status === "completed" && !deferCompletedRecoveryForEmptyResult');
+    expect(src).toContain('handleRunCompletion(sessionId, "failed", "empty_result")');
+  });
+
+  it("returns silently when recovery retries the empty result", () => {
+    const src = webhook();
+    const empty = src.slice(src.indexOf('handleRunCompletion(sessionId, "failed", "empty_result")'));
+    const retryGuard = empty.indexOf("recoveryEmptyResult?.stale || recoveryEmptyResult?.retried");
+    const apology = empty.indexOf('"Sorry, I wasn\'t able to produce a response');
+    expect(retryGuard).toBeGreaterThan(-1);
+    expect(apology).toBeGreaterThan(retryGuard);
+    expect(empty.slice(retryGuard, apology)).toContain("return;");
+  });
+
+  it("records the empty physical attempt as failed and undelivered", () => {
+    const src = webhook();
+    const finalize = src.slice(
+      src.indexOf("// Finalize the physical AgentRun record"),
+      src.indexOf('if (payload.status === "completed" && !deferCompletedRecoveryForEmptyResult)'),
+    );
+    expect(finalize).toContain('? "completed"');
+    expect(finalize).toContain(': "failed"');
+    expect(finalize).toContain('error: deferCompletedRecoveryForEmptyResult ? "empty_result"');
+    expect(finalize).toMatch(/result:\s*deferCompletedRecoveryForEmptyResult\s*\? null/);
+  });
+});
+
+describe("superseded pod callbacks are silent", () => {
+  it("only classifies an active retry or handoff attempt as a continuation", () => {
+    const src = worker();
+    const fn = src.slice(
+      src.indexOf("export async function classifyRunRecoveryCallback"),
+      src.indexOf("export async function handleRunCompletion"),
+    );
+    expect(fn).toContain('return "stale"');
+    expect(fn).toContain("state.retriesUsed > 0");
+    expect(fn).toContain("state.sessionHistory.some");
+    expect(fn).toContain('"active_continuation"');
+    expect(fn).toContain('"active_initial"');
+  });
+
+  it("rejects a callback whose physical session no longer owns the root", () => {
+    const src = worker();
+    const handler = src.slice(src.indexOf("export async function handleRunCompletion"));
+    const staleGuard = handler.indexOf('state.status !== "running" || state.activeSessionId !== sessionId');
+    const completion = handler.indexOf('if (status === "completed")');
+    expect(staleGuard).toBeGreaterThan(-1);
+    expect(staleGuard).toBeLessThan(completion);
+    expect(handler.slice(staleGuard, completion)).toContain("stale: true");
+  });
+
+  it("returns from the webhook for stale completed and failed callbacks", () => {
+    const src = webhook();
+    expect(src).toContain('if (recoveryCallbackDisposition === "stale")');
+    expect(src).toContain("if (recoveryCompletion?.stale)");
+    expect(src).toContain("if (recoveryFailure?.stale)");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts
@@ -1118,12 +1118,43 @@ export async function handleRunHandoff(sessionId: string): Promise<{ rootSession
   return { rootSessionId, newSessionId, retriesUsed: state.retriesUsed, maxRetries: state.maxRetries };
 }
 
-export async function handleRunCompletion(sessionId: string, status: "completed" | "failed", error?: string): Promise<{ retried: boolean; exhausted: boolean; rootSessionId: string; retriesUsed: number; maxRetries: number; terminalDrop?: boolean } | null> {
+export type RunRecoveryCallbackDisposition = "untracked" | "active_initial" | "active_continuation" | "stale";
+
+/** Classify callback ownership without mutating recovery state. */
+export async function classifyRunRecoveryCallback(sessionId: string): Promise<RunRecoveryCallbackDisposition> {
+  const rootSessionId = await getRecoveryRootSessionId(sessionId);
+  if (!rootSessionId) return "untracked";
+  const state = await loadState(rootSessionId);
+  if (!state) return "untracked";
+  if (state.status !== "running" || state.activeSessionId !== sessionId) return "stale";
+  return state.retriesUsed > 0 || state.sessionHistory.some((attemptId) => attemptId !== state.rootSessionId)
+    ? "active_continuation"
+    : "active_initial";
+}
+
+export async function handleRunCompletion(sessionId: string, status: "completed" | "failed", error?: string): Promise<{ retried: boolean; exhausted: boolean; rootSessionId: string; retriesUsed: number; maxRetries: number; terminalDrop?: boolean; stale?: boolean } | null> {
   const rootSessionId = await getRecoveryRootSessionId(sessionId);
   if (!rootSessionId) return null;
 
   const state = await loadState(rootSessionId);
   if (!state) return null;
+
+  // A callback from a superseded physical attempt, or a duplicate callback
+  // after terminal settlement, must not settle or deliver the logical root.
+  if (state.status !== "running" || state.activeSessionId !== sessionId) {
+    log.info(
+      `[run-recovery] ignoring stale callback root=${rootSessionId} callbackSession=${sessionId} activeSession=${state.activeSessionId} callbackStatus=${status} recoveryStatus=${state.status}`,
+    );
+    return {
+      retried: false,
+      exhausted: state.status === "exhausted",
+      rootSessionId,
+      retriesUsed: state.retriesUsed,
+      maxRetries: state.maxRetries,
+      terminalDrop: true,
+      stale: true,
+    };
+  }
 
   if (status === "completed") {
     state.status = "completed";

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -77,6 +77,7 @@ import {
   registerRunRecovery,
   touchRunRecovery,
   handleRunCompletion,
+  classifyRunRecoveryCallback,
   handleRunHandoff,
   hasActiveRunRecovery,
   getRecoveryContextForSession,
@@ -5112,13 +5113,50 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     }
   }
 
-  // Finalize the AgentRun record (fire-and-forget)
+  const recoveryCallbackDisposition = await classifyRunRecoveryCallback(sessionId).catch((err) => {
+    clog.warn(`[webhook/result] Failed to classify recovery callback session=${sessionId}:`, errMsg(err));
+    return "untracked" as const;
+  });
+  if (recoveryCallbackDisposition === "stale") {
+    clog.info(`[webhook/result] Ignoring callback from superseded or settled session=${sessionId}`);
+    return;
+  }
+
+  // A resumed attempt can finish without a deliverable response after its pod
+  // is interrupted again. Defer settlement until the empty-result branch asks
+  // recovery whether another bounded attempt will run; otherwise the generic
+  // apology can be posted before the resumed answer.
+  const emptyCompletedResult =
+    payload.status === "completed" &&
+    !resultWithCitations.trim() &&
+    !payload.attachments?.length &&
+    !payload.pendingResponses?.length &&
+    !payload.pendingGoalSuggestion &&
+    !payload.twinDelivery &&
+    !payload.pendingPlan &&
+    !payload.pendingAgentCard &&
+    !payload.pendingConnectorSuggestions;
+  // Do not replay every ordinary tool-only empty completion: a retry could
+  // duplicate writes. This recovery path is only for an active continuation
+  // created after a watchdog retry or graceful handoff.
+  const deferCompletedRecoveryForEmptyResult =
+    emptyCompletedResult && recoveryCallbackDisposition === "active_continuation";
+
+  // Finalize the physical AgentRun record (fire-and-forget). An empty attempt
+  // that recovery may retry is failed, not completed: marking it completed with
+  // result="" makes anyAttemptDelivered() suppress the eventual terminal notice.
   if (sessionId) {
-    const status = payload.status === "completed" ? "completed" : "failed";
+    const status = payload.status === "completed" && !deferCompletedRecoveryForEmptyResult
+      ? "completed"
+      : "failed";
     agentRunRepository.finalize(sessionId, {
       status,
-      result: payload.result !== undefined ? resultWithCitations : null,
-      error: payload.error ?? null,
+      result: deferCompletedRecoveryForEmptyResult
+        ? null
+        : payload.result !== undefined
+          ? resultWithCitations
+          : null,
+      error: deferCompletedRecoveryForEmptyResult ? "empty_result" : payload.error ?? null,
       ...(payload.provider !== undefined ? { provider: payload.provider } : {}),
       ...(payload.model !== undefined ? { model: payload.model } : {}),
       ...(payload.reasoning ? { reasoning: payload.reasoning } : {}),
@@ -5130,12 +5168,16 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     }).catch(() => {});
   }
 
-  if (payload.status === "completed") {
+  if (payload.status === "completed" && !deferCompletedRecoveryForEmptyResult) {
     const recoveryCompletion = await handleRunCompletion(sessionId, "completed").catch((err) => {
       clog.warn(`[webhook/result] Failed to mark ${sessionId} completed in run recovery:`, err instanceof Error ? err.message : err);
       return null;
     });
     externalCallbackSessionId = recoveryCompletion?.rootSessionId ?? sessionId;
+    if (recoveryCompletion?.stale) {
+      clog.info(`[webhook/result] Ignoring stale completed callback session=${sessionId} root=${externalCallbackSessionId}`);
+      return;
+    }
     if (ctx?.conversationId && ctx.agentSlug) {
       experimentContinues = await continueExperimentAfterResult(ctx, sessionId).catch((err) => {
         clog.warn(`[experiment] continuation hook failed session=${sessionId}:`, errMsg(err));
@@ -5224,6 +5266,11 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     });
 
     externalCallbackSessionId = recoveryFailure?.rootSessionId ?? sessionId;
+
+    if (recoveryFailure?.stale) {
+      clog.info(`[webhook/result] Ignoring stale failed callback session=${sessionId} root=${externalCallbackSessionId}`);
+      return;
+    }
 
     if (recoveryFailure?.retried) {
       clog.info(`[webhook/result] Session ${sessionId}: retry queued (${recoveryFailure.retriesUsed}/${recoveryFailure.maxRetries})`);
@@ -6532,6 +6579,30 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     !payload.pendingResponses?.length &&
     !postedAgentProfileCard
   ) {
+    if (deferCompletedRecoveryForEmptyResult) {
+      const recoveryEmptyResult = await handleRunCompletion(sessionId, "failed", "empty_result").catch((err) => {
+        log.warn(`[webhook/result] Failed to process empty result for ${sessionId} in run recovery`, {
+          error: errMsg(err),
+        });
+        return null;
+      });
+      externalCallbackSessionId = recoveryEmptyResult?.rootSessionId ?? sessionId;
+      if (recoveryEmptyResult?.stale || recoveryEmptyResult?.retried) {
+        log.info(
+          `[webhook/result] Empty result suppressed while recovery continues session=${sessionId} root=${externalCallbackSessionId}`
+        );
+        return;
+      }
+      if (recoveryEmptyResult?.exhausted || recoveryEmptyResult?.terminalDrop) {
+        // Recovery owns the one terminal notice. Do not add the generic empty
+        // result apology underneath the exhaustion/non-retryable failure card.
+        log.info(
+          `[webhook/result] Empty result notice suppressed after terminal recovery outcome session=${sessionId} root=${externalCallbackSessionId}`
+        );
+        return;
+      }
+    }
+
     if (ctx.responseMode === "approval") {
       log.warn("Empty result in approval mode — skipping (no thread message)");
       await deleteSession(sessionId);


### PR DESCRIPTION
1. Problem Description:
A Xyne Claw pod restart can move one logical run to a new physical session. A stale callback or an empty completion from a resumed attempt could still reach the generic empty-result path and post “Sorry, I wasn't able to produce a response” while bounded recovery was continuing.

Ticket: XYNE-60846

2. If this is a bug fix or an enhancement, how did you identify the issue?:
The restart-recovery flow was traced through the Claw result webhook and run-recovery worker. Recovery settlement occurred before empty-result delivery was classified, and callbacks were not rejected when their physical session no longer owned the logical root.

3. Explain the solution implemented in the PR:
- Classify callbacks as untracked, active initial attempts, active continuation attempts, or stale.
- Drop callbacks from superseded sessions and callbacks received after logical-run settlement.
- Treat an empty completion from an active continuation as a retryable recovery failure before the generic apology is posted.
- Preserve existing first-attempt empty-result behavior so tool-only runs are not replayed and side effects are not duplicated.
- Record retryable empty attempts as failed and undelivered so exhaustion reporting stays correct.
- Let recovery own the single terminal notice after bounded retries expire.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- `pnpm exec vitest run src/queue/run-recovery-empty-result.test.ts src/queue/run-recovery-duplicate-runs.test.ts src/queue/run-recovery-experiment.test.ts`
- 3 test files passed; 19 tests passed.
- `git diff --check` passed.
- Package-wide typecheck remains blocked in the sandbox by pre-existing generated Prisma-client and unrelated baseline TypeScript errors; no changed-file errors were identified.

9. Services to which this change is to be deployed:
xyne-claw-auth

10. Main PR link (if this PR is raised against a release branch):
N/A — this PR targets the Claw integration line `feature/deploy-xyneclaw`.