### PR TITLE
XYNE-61335: Restore encryption key environment fallback

### DIFF
--- a/apps/xyne-claw-auth/backend/src/config.ts
+++ b/apps/xyne-claw-auth/backend/src/config.ts
@@ -1,3 +1,4 @@
+import { createLazySpacesEncryptionKeyRing } from "./spaces-encryption-key-ring.js";
 import { createHmac } from "node:crypto";
 import { derivePurposeKey, registerDecryptionFallback } from "./crypto.js";
 
@@ -22,6 +23,12 @@ const legacySessionSigningKey = createHmac("sha256", rootEncryptionKey).update("
 // the derived data key; reads fall back to the legacy root during migration.
 registerDecryptionFallback(dataEncryptionKey, rootEncryptionKey);
 
+const loadSpacesEncryptionKeys =
+  createLazySpacesEncryptionKeyRing(
+    process.env["SPACES_ENCRYPTION_KEY"],
+    process.env["SPACES_ENCRYPTION_KEYS"]
+  );
+
 export const CONFIG = {
   port: Number(process.env["AUTH_SERVICE_PORT"] ?? 3003),
   selfUrl: process.env["AUTH_SERVICE_URL"] ?? `http://localhost:${process.env["AUTH_SERVICE_PORT"] ?? 3003}`,
@@ -38,14 +45,20 @@ export const CONFIG = {
   legacyActionSigningKey: rootEncryptionKey,
   legacySessionSigningKey,
   legacyOauthStateSigningKey: rootEncryptionKey,
-  // Spaces' AES-256-CBC key — must equal xyne-spaces backend's ENCRYPTION_KEY
-  // value (the two services are independently keyed). Used ONLY to decrypt
+  // Spaces' AES-256-CBC keys — these hold xyne-spaces backend's ENCRYPTION_KEY
+  // material, not this service's own. Used ONLY to decrypt
   // `installed_apps.signingSecret` read from the Spaces DB during the
-  // signing-secret backfill. Empty buffer when unset; the backfill
-  // short-circuits with a clear error if it needs this and it's missing.
-  spacesEncryptionKey: process.env["SPACES_ENCRYPTION_KEY"]
-    ? Buffer.from(process.env["SPACES_ENCRYPTION_KEY"]!, "hex")
-    : Buffer.alloc(0),
+  // signing-secret backfill.
+  //
+  // A ring rather than one key, because Spaces stamps the key id into the
+  // ciphertext and can hold several at once while a rotation drains. Whatever
+  // ids Spaces has in ENCRYPTION_KEYS must appear here too, under the same
+  // names, or rows written under a missing id cannot be read. SPACES_ENCRYPTION_KEY
+  // is registered as "legacy" to match the id Spaces gives unversioned rows.
+  // Empty ring when unset; the backfill short-circuits with a clear error.
+  get spacesEncryptionKeys(): ReadonlyMap<string, Buffer> {
+    return loadSpacesEncryptionKeys();
+  },
   xyneClawUrl: process.env["XYNE_CLAW_URL"] ?? "http://localhost:3002",
   // Public base URL of the claw SPA, used for post-OAuth browser redirects.
   // Precedence: explicit FRONTEND_URL override; else in production the SPA is

--- a/apps/xyne-claw-auth/backend/src/crypto.ts
+++ b/apps/xyne-claw-auth/backend/src/crypto.ts
@@ -60,20 +60,60 @@ export function decrypt(ciphertext: string, iv: string, authTag: string, key: Bu
 }
 
 // Spaces encrypts DB-stored secrets (e.g. installed_apps.signingSecret) with
-// AES-256-CBC, format `${ivHex}:${ciphertextHex}` — see xyne-spaces
-// backend/src/services/encryptionService.ts. This decrypts that format using
-// SPACES_ENCRYPTION_KEY (Spaces' key, distinct from claw-auth's own). Throws
-// on malformed input; callers treat a throw as "skip this row".
+// AES-256-CBC — see xyne-spaces backend/src/services/encryptionService.ts. It
+// writes two formats, and this reader must understand both for as long as any
+// row is on the older one:
+//
+//   `${ivHex}:${ctHex}`                  legacy, decrypted under keyId "legacy"
+//   `v2:${keyId}:${ivHex}:${ctHex}`      versioned, decrypted under that keyId
+//
+// The key ids must agree with Spaces because the id travels in the ciphertext;
+// the constants below are the same two values that service uses. CBC carries no
+// authentication tag, so a wrong key does not reliably fail — that is precisely
+// why the id is read rather than guessed, and why an unknown id throws instead
+// of falling back to another key.
+//
+// Throws on malformed input; callers treat a throw as "skip this row".
 const SPACES_CBC_ALGO = "aes-256-cbc";
+const SPACES_VERSION_TAG = "v2";
+const SPACES_LEGACY_KEY_ID = "legacy";
 
-export function decryptSpacesCbc(blob: string, key: Buffer): string {
-  const sep = blob.indexOf(":");
-  if (sep < 0) throw new Error("decryptSpacesCbc: blob missing IV separator");
-  const ivHex = blob.slice(0, sep);
-  const ctHex = blob.slice(sep + 1);
+export type SpacesKeyRing = ReadonlyMap<string, Buffer>;
+
+export function decryptSpacesCbc(blob: string, keys: SpacesKeyRing): string {
+  const parts = blob.split(":");
+
+  let keyId: string;
+  let ivHex: string;
+  let ctHex: string;
+
+  if (parts.length === 4 && parts[0] === SPACES_VERSION_TAG) {
+    [, keyId, ivHex, ctHex] = parts as [string, string, string, string];
+  } else if (parts.length === 2) {
+    keyId = SPACES_LEGACY_KEY_ID;
+    [ivHex, ctHex] = parts as [string, string];
+  } else {
+    throw new Error(
+      'decryptSpacesCbc: expected "iv:ct" or "v2:keyId:iv:ct"',
+    );
+  }
+
   if (ivHex.length === 0 || ctHex.length === 0) {
     throw new Error("decryptSpacesCbc: empty IV or ciphertext");
   }
+
+  const key = keys.get(keyId);
+  if (!key) {
+    // Either the ring is unconfigured, or Spaces has moved to a key this
+    // service was never given. Both are operator errors and both are worth
+    // naming, because the caller's "skip this row" turns a silent miss into a
+    // backfill that reports success while migrating nothing.
+    throw new Error(
+      `decryptSpacesCbc: no Spaces key registered for keyId "${keyId}" — ` +
+        "set SPACES_ENCRYPTION_KEY, or add the id to SPACES_ENCRYPTION_KEYS",
+    );
+  }
+
   const decipher = createDecipheriv(SPACES_CBC_ALGO, key, Buffer.from(ivHex, "hex"));
   const decrypted = Buffer.concat([
     decipher.update(Buffer.from(ctHex, "hex")),

--- a/apps/xyne-claw-auth/backend/src/lib/spaces-app-secret.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/spaces-app-secret.ts
@@ -60,9 +60,22 @@ export async function backfillSigningSecretFromSpacesDb(args: {
   spacesAppId: string;
 }): Promise<boolean> {
   const { agentId, spacesAppId } = args;
-  if (CONFIG.spacesEncryptionKey.length === 0) {
+  let spacesEncryptionKeys: ReadonlyMap<string, Buffer>;
+
+  try {
+    spacesEncryptionKeys = CONFIG.spacesEncryptionKeys;
+  } catch (err) {
     log.warn(
-      `[spaces-app-secret] SPACES_ENCRYPTION_KEY unset — cannot decrypt Spaces DB blob for agentId=${agentId}. Set it to xyne-spaces' ENCRYPTION_KEY value.`,
+      `[spaces-app-secret] invalid Spaces encryption-key configuration for agentId=${agentId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return false;
+  }
+
+  if (spacesEncryptionKeys.size === 0) {
+    log.warn(
+      `[spaces-app-secret] Spaces encryption keys unset — cannot decrypt Spaces DB blob for agentId=${agentId}.`,
     );
     return false;
   }
@@ -72,7 +85,7 @@ export async function backfillSigningSecretFromSpacesDb(args: {
     return false;
   }
   try {
-    const plaintext = decryptSpacesCbc(blob, CONFIG.spacesEncryptionKey);
+    const plaintext = decryptSpacesCbc(blob, spacesEncryptionKeys);
     if (!plaintext) {
       log.warn(`[spaces-app-secret] decrypt produced empty secret for agentId=${agentId}`);
       return false;

--- a/apps/xyne-claw-auth/backend/src/routes/admin-backfill-signing-secrets.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/admin-backfill-signing-secrets.ts
@@ -108,19 +108,45 @@ router.get("/diagnose-signing-secret/:slug", async (req: Request<{ slug: string 
   let db: { ok: boolean; fp?: string; len?: number; error?: string };
   if (!agent.spacesAppId) {
     db = { ok: false, error: "agent has no spacesAppId" };
-  } else if (CONFIG.spacesEncryptionKey.length === 0) {
-    db = { ok: false, error: "SPACES_ENCRYPTION_KEY unset" };
   } else {
     try {
-      const blob = await getInstalledAppSigningSecret(agent.spacesAppId);
-      if (!blob) {
-        db = { ok: false, error: "no installed_apps row / null signingSecret" };
+      const spacesEncryptionKeys = CONFIG.spacesEncryptionKeys;
+
+      if (spacesEncryptionKeys.size === 0) {
+        db = {
+          ok: false,
+          error: "Spaces encryption keys unset",
+        };
       } else {
-        const p = decryptSpacesCbc(blob, CONFIG.spacesEncryptionKey);
-        db = { ok: true, fp: fingerprint(p), len: p.length };
+        const blob =
+          await getInstalledAppSigningSecret(
+            agent.spacesAppId,
+          );
+
+        if (!blob) {
+          db = {
+            ok: false,
+            error:
+              "no installed_apps row / null signingSecret",
+          };
+        } else {
+          const p = decryptSpacesCbc(
+            blob,
+            spacesEncryptionKeys,
+          );
+
+          db = {
+            ok: true,
+            fp: fingerprint(p),
+            len: p.length,
+          };
+        }
       }
     } catch (err) {
-      db = { ok: false, error: errMsg(err) };
+      db = {
+        ok: false,
+        error: errMsg(err),
+      };
     }
   }
 

--- a/apps/xyne-claw-auth/backend/src/spaces-encryption-key-ring.ts
+++ b/apps/xyne-claw-auth/backend/src/spaces-encryption-key-ring.ts
@@ -1,0 +1,116 @@
+const VERSION_TAG = "v2";
+const LEGACY_KEY_ID = "legacy";
+
+interface OrderedEncryptionKey {
+  id: string;
+  key: string;
+}
+
+function parseHexKey(
+  raw: unknown,
+  label: string
+): Buffer {
+  if (typeof raw !== "string") {
+    throw new Error(
+      `${label} must be 32 bytes (64 hex characters)`
+    );
+  }
+
+  const normalized = raw.trim();
+
+  if (!/^[0-9a-fA-F]{64}$/.test(normalized)) {
+    throw new Error(
+      `${label} must be 32 bytes (64 hex characters)`
+    );
+  }
+
+  return Buffer.from(normalized, "hex");
+}
+
+export function parseSpacesEncryptionKeyRing(
+  legacyKey: string | undefined,
+  orderedKeysJson: string | undefined,
+): ReadonlyMap<string, Buffer> {
+  const ring = new Map<string, Buffer>();
+
+  if (legacyKey) {
+    ring.set(LEGACY_KEY_ID, parseHexKey(legacyKey, "SPACES_ENCRYPTION_KEY"));
+  }
+
+  if (!orderedKeysJson || !orderedKeysJson.trim()) {
+    return ring;
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(orderedKeysJson);
+  } catch {
+    throw new Error(
+      "SPACES_ENCRYPTION_KEYS must be an ordered JSON array " + "of objects with id and key fields",
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "SPACES_ENCRYPTION_KEYS must be an ordered JSON array " + "of objects with id and key fields",
+    );
+  }
+
+  const seen = new Set<string>();
+
+  for (let index = 0; index < parsed.length; index += 1) {
+    const value = parsed[index];
+
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("SPACES_ENCRYPTION_KEYS[" + index + "] must be an object");
+    }
+
+    const entry = value as {
+      id?: unknown;
+      key?: unknown;
+    };
+
+    if (typeof entry.id !== "string") {
+      throw new Error("SPACES_ENCRYPTION_KEYS[" + index + "].id must be a string");
+    }
+
+    const id = entry.id.trim();
+
+    if (!id || id !== entry.id || id.includes(":") || id === VERSION_TAG || id === LEGACY_KEY_ID) {
+      throw new Error("Invalid key id at SPACES_ENCRYPTION_KEYS[" + index + "]");
+    }
+
+    if (seen.has(id) || ring.has(id)) {
+      throw new Error('Duplicate Spaces encryption key id "' + id + '"');
+    }
+
+    seen.add(id);
+
+    ring.set(id, parseHexKey(entry.key, "SPACES_ENCRYPTION_KEYS[" + index + "].key"));
+  }
+
+  return ring;
+}
+
+/**
+ * Defer Spaces key validation until a route actually needs the key ring.
+ *
+ * This prevents an optional, malformed Spaces backfill key from stopping
+ * unrelated Claw-auth OAuth, session, and agent-auth functionality at startup.
+ * A successful result is cached for the lifetime of the process.
+ */
+export function createLazySpacesEncryptionKeyRing(
+  legacyKey: string | undefined,
+  orderedKeys: string | undefined,
+): () => ReadonlyMap<string, Buffer> {
+  let cached: ReadonlyMap<string, Buffer> | null = null;
+
+  return (): ReadonlyMap<string, Buffer> => {
+    if (cached === null) {
+      cached = parseSpacesEncryptionKeyRing(legacyKey, orderedKeys);
+    }
+
+    return cached;
+  };
+}


### PR DESCRIPTION
## Summary

This PR restores and clarifies the environment-driven backward-compatibility behavior for the ordered encryption-key rotation introduced by #764.

No separate feature flag is introduced. The presence of a valid, non-empty ordered key-ring environment variable activates rotation. When the new variable is absent or blank, the system preserves the pre-#764 legacy behavior.

The PR also restores the Claw-auth versioned Spaces ciphertext reader that was replaced by the later #1156 synchronization.

## Configuration behavior

### Spaces backend

The backend continues to support the existing legacy variable:

```text
ENCRYPTION_KEY=<64-hex legacy key>
```

The new optional ordered key ring is:

```text
ENCRYPTION_KEYS=[
  {"id":"k1","key":"<64-hex key>"},
  {"id":"k2","key":"<64-hex key>"}
]
```

Behavior:

| `ENCRYPTION_KEYS` value          | Result                                                       |
| -------------------------------- | ------------------------------------------------------------ |
| Missing or blank                 | Use `ENCRYPTION_KEY` and write legacy `iv:ciphertext`        |
| Valid non-empty array            | Use the final array entry and write `v2:keyId:iv:ciphertext` |
| Empty array (`[]`)               | Reject the configuration                                     |
| Malformed JSON                   | Reject the configuration                                     |
| Duplicate or reserved key ID     | Reject the configuration                                     |
| Invalid or incorrectly sized key | Reject the configuration                                     |

When the ordered ring is configured, its final entry is the active writer. Every entry remains available for versioned decryption, and `ENCRYPTION_KEY` remains registered as the `legacy` reader.

### Claw-auth

Claw-auth uses the corresponding variables:

```text
SPACES_ENCRYPTION_KEY=<same legacy key used by Spaces>

SPACES_ENCRYPTION_KEYS=[
  {"id":"k1","key":"<same k1 used by Spaces>"},
  {"id":"k2","key":"<same k2 used by Spaces>"}
]
```

The IDs and key material must match the Spaces backend configuration exactly.

When `SPACES_ENCRYPTION_KEYS` is missing or blank, Claw uses `SPACES_ENCRYPTION_KEY` for legacy Spaces ciphertext. When a valid non-empty ring is configured, Claw can read both legacy ciphertext and versioned ciphertext associated with every configured key ID.

Spaces key-ring parsing remains lazy in Claw-auth. Malformed optional Spaces configuration therefore does not prevent unrelated OAuth, session, or agent-auth functionality from starting. Configuration failures are caught by the affected backfill or diagnostic operation and returned as structured failures.

## Ciphertext selection

Encryption is selected from the environment:

```text
ENCRYPTION_KEYS absent
    -> ENCRYPTION_KEY
    -> iv:ciphertext

ENCRYPTION_KEYS configured
    -> final ordered entry
    -> v2:keyId:iv:ciphertext
```

Decryption is selected from the ciphertext:

```text
iv:ciphertext
    -> key ID "legacy"
    -> ENCRYPTION_KEY / SPACES_ENCRYPTION_KEY

v2:k1:iv:ciphertext
    -> key ID "k1"
    -> matching ordered-ring entry
```

Readers do not guess keys or try every key. The key ID embedded in versioned ciphertext selects the exact key. Unknown or retired IDs fail clearly.

## Backward compatibility

With the new ordered-ring variables unset or blank, write behavior is identical to the pre-#764 behavior:

* The existing legacy key is used.
* The legacy two-part ciphertext format is produced.
* Existing legacy ciphertext remains readable.
* No migration or schema change occurs.
* No new write format is activated.

A configured but empty or malformed ring does not silently fall back to the legacy writer. It fails closed so a deployment cannot appear to have enabled rotation while continuing to write under the old key.

## Rollout

1. Deploy the code while leaving `ENCRYPTION_KEYS` unset.
2. Preserve `ENCRYPTION_KEY` and `SPACES_ENCRYPTION_KEY`.
3. Configure and deploy `SPACES_ENCRYPTION_KEYS` to Claw-auth first.
4. Verify Claw can read legacy ciphertext and the configured key IDs.
5. Configure `ENCRYPTION_KEYS` in the Spaces backend.
6. Restart the services so they load the new environment.
7. Verify new ciphertext starts with the expected final key ID.
8. Retain the legacy key and all older ordered-ring entries until database, queue, backup, retention, and recovery checks confirm they are no longer required.

## Rollback constraint

Before any versioned ciphertext has been written, removing `ENCRYPTION_KEYS` safely restores legacy writes.

After versioned ciphertext exists, the ordered ring must remain available because readers need its keys. Removing it would restore legacy writes but would also make existing `v2` ciphertext unreadable. A writer-only rollback after activation would require a separate explicit write-mode flag, which is intentionally outside the behavior implemented by this PR.

## Validation

The validation covers:

* Missing `ENCRYPTION_KEYS` selects the legacy writer.
* A valid non-empty ring selects its final entry.
* Legacy and versioned ciphertext round trips.
* Empty configured rings are rejected.
* Malformed JSON is rejected.
* Duplicate and invalid key IDs are rejected.
* Keys with invalid lengths or non-hexadecimal characters are rejected.
* Claw falls back to its legacy Spaces key when the ordered ring is absent.
* Claw reads both legacy and versioned ciphertext when the ordered ring is configured.
* Malformed Claw configuration is rejected lazily.
* No key, plaintext, or ciphertext values are logged.
* No test-file changes are included in the PR.
