### PR TITLE
fix: XYNE-55716 keep the daily-brief regenerate SSE stream alive

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/daily-brief.ts
@@ -231,9 +231,21 @@ router.post("/regenerate", async (req: Request, res: Response) => {
     if (!res.writableEnded) res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
   };
 
+  // Nothing is written between the last tool call and `emit_brief`, so both
+  // downstream legs (Spaces backend ← here, browser ← Spaces backend) go idle
+  // for minutes and an L7 proxy severs them — surfacing as "terminated" even
+  // though the run completes. Same 15s comment frame as run-stream.ts; every
+  // SSE parser on the path ignores comment lines.
+  let keepalive: ReturnType<typeof setInterval> | null = setInterval(() => {
+    if (!res.writableEnded && !res.destroyed) {
+      try { res.write(":ka\n\n"); } catch { /* response already torn down */ }
+    }
+  }, 15_000);
+
   // Abort the underlying run if the client disconnects.
   const abort = new AbortController();
   res.on("close", () => {
+    if (keepalive) { clearInterval(keepalive); keepalive = null; }
     if (!res.writableEnded) abort.abort();
   });
 
@@ -263,6 +275,7 @@ router.post("/regenerate", async (req: Request, res: Response) => {
     log.error("[daily-brief] regenerate", err);
     send("error", { message: err instanceof Error ? err.message : "Regeneration failed" });
   } finally {
+    if (keepalive) { clearInterval(keepalive); keepalive = null; }
     if (!res.writableEnded) res.end();
   }
 });


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-55716. Daily-brief **Regenerate** fails in prod with `terminated`, and the run is recorded as a failed brief even though generation itself is healthy.

The regenerate SSE response writes nothing between the last tool call and `emit_brief` — the model is composing the whole brief. On a successful local run that gap measured **3m27s**, and the earlier gather gap measured **57.9s**. In prod both downstream legs then sit idle past the ingress read timeout and get severed. Two captured failures cut at **60.840s** and **60.824s** after their last event.

xyne-claw does send a 25s keepalive, but it is an SSE *comment*, and `consume-claw-stream.ts` parses comments to no event and never re-emits them — so it warms the claw → claw-auth leg only and dies there.

Consequences seen in prod:

- Spaces backend's `reader.read()` throws undici's `TypeError: terminated`, forwarded verbatim to the dashboard as the error message
- the cut closes claw-auth's response, firing `res.on("close")` → `abort.abort()` → the run is aborted → `markFailed`, so a transport failure is stored as a failed brief

**Fix:** write a 15s SSE comment frame (`:ka\n\n`) for the life of the response, cleared on close and in `finally`. This mirrors `backendKeepalive` in `routes/run-stream.ts:836`, which fixed the identical failure on the chat path. One frame covers both downstream legs because the Spaces backend pipes raw bytes through, and every SSE parser on the path ignores comment lines.

Scheduled (cron) briefs were never affected — that path has no SSE response and no browser leg, which is also what localises the cut to the two legs regenerate adds.

> **Requires redeployment of `xyne-claw-auth`.** `scripts/patterns.sh` has no `SERVICE_MAPPINGS` entry for `apps/xyne-claw*`, so `change-analysis.sh` reports "No service-impacting changes detected" and no redeployment trailer is generated for claw-only PRs.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

The `POST /daily-brief/regenerate` event stream is unchanged. The added `:ka` frames are SSE comment lines, which both consumers on the path already discard: `ClawSseParser` by design, and the dashboard's parser in `api/dailyBriefApi.ts` because `:ka` matches neither the `event:` nor the `data:` prefix.

---

## How did you test it?

**Wire behaviour** — ran the patched handler shape against a real HTTP client with a 32s silent window. Longest gap on the wire drops from 32s to 15s, events arrive intact and in order, interval confirmed cleared in `finally`:

```
+  0.0s  "event: start"
+  5.0s  "event: progress"
+ 15.0s  ":ka"
+ 30.0s  ":ka"
+ 37.0s  "event: complete"
```

**Parser tolerance** — replayed a stream carrying `:ka` frames through the exact dispatch loop from `apps/dashboard/src/api/dailyBriefApi.ts`, including a `:ka` between the two halves of an `event: complete` split across chunks. Events seen: `start, progress, complete`. No keepalive leaked through as a stray event.

**Static** — `tsc --noEmit` on `apps/xyne-claw-auth/backend`: 0 errors in the changed file. gitleaks on the staged diff: clean. `git diff --check`: clean.

Note: no CI job covers `apps/xyne-claw-auth` — "Backend typecheck + build" is `apps/backend`, and the pre-commit hook's path filters skip claw too. The `tsc` run above is the only typecheck this change has had.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- The failure only reproduces behind an L7 proxy with an idle-read timeout; there is no proxy in local or CI, so a regression test would need a proxy fixture in front of the SSE route. -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

**Post-deploy verification** — the fix cannot be exercised locally (no proxy in the path). After deploy: open DevTools → Network → the `regenerate` request → Response, and `:ka` lines should appear every 15s through the silent stretch where it previously died.

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
