### PR TITLE
fix: deduplicate message shortcut requests

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useId, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useZero } from '../../../hooks/useZero';
 import { useSummaryCache } from '../../../hooks/useSummaryQuery';
 import { MessageBubble } from '../../ui/MessageBubble/MessageBubble';
@@ -192,15 +193,13 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   // Get sender info from useUser hook
   const sender = useUser(message.senderId);
 
-  // Message shortcuts — fetched per channel, used by HoverActionsToolbar
-  const [messageShortcuts, setMessageShortcuts] = useState<AppShortcutWithApp[]>([]);
+  // Message shortcuts are channel-level data. React Query shares this request across every
+  // mounted ChatBubble instead of issuing one request per visible message.
+  const { data: messageShortcuts = [] } = useQuery({
+    queryKey: ['channel-shortcuts', channelId, 'MESSAGE'],
+    queryFn: () => appsService.getChannelShortcuts(channelId, { type: 'MESSAGE' }),
+  });
   const [shortcutModalOpen, setShortcutModalOpen] = useState(false);
-  useEffect(() => {
-    appsService
-      .getChannelShortcuts(channelId, { type: 'MESSAGE' })
-      .then(setMessageShortcuts)
-      .catch(() => undefined);
-  }, [channelId]);
 
   const messageConversationId = message.conversationId;
 


### PR DESCRIPTION
## Type of Change
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Message-level app shortcuts were fetched independently by every mounted `ChatBubble`, causing the same channel-level API request to be issued once per visible message. This changes the fetch to a shared TanStack Query keyed by channel and shortcut accessibility, so mounted message bubbles reuse one request and cached result.

## Areas Touched
- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

## Zero (Sync) Changes
- [x] No Zero changes — **skip this section**

## Schema & Data Changes
- [x] No schema changes — **skip this section**

## Config, Environment & URLs
- [x] No config changes — **skip this section**

## API Contract
- [x] No API changes

## How did you test it?
- Dashboard TypeScript typecheck passed.
- Targeted ESLint check passed for `ChatBubble.tsx`.
- Prettier check passed for `ChatBubble.tsx`.
- `git diff --check` passed.

### Automated
- [x] Not covered by tests — the change uses TanStack Query's existing request deduplication/cache behavior and has no local component test harness.

## Checklist
- [x] Reviewed my own diff; scoped to one thing
- [x] Dashboard targeted lint + typecheck pass
- [x] Formatting clean in the package touched
- [x] Branch uses the required `fix/*` prefix
- [x] No debug logging or commented-out code left behind