### PR TITLE
feat: XYNE-62932 removing ringing sounds when on another call

### DIFF
--- a/apps/dashboard/src/components/Call/CallModals/IncomingCallModal.tsx
+++ b/apps/dashboard/src/components/Call/CallModals/IncomingCallModal.tsx
@@ -16,10 +16,15 @@ import { globalClickTracker } from '../../../services/Analytics/globalClickTrack
 import { buildCallNotificationBody } from '../IncomingCall/callNotificationBody';
 import {
   buildIncomingCallViewModel,
+  getRingSilenceReason,
   isRingableCall,
   type IncomingCallRow,
+  type RingSilenceReason,
 } from '../IncomingCall/IncomingCallCard.utils';
 import type { IncomingCallViewModel } from '../IncomingCall/IncomingCallCard.types';
+import { useRecordingStore } from '../../../hooks/useRecordingStore';
+import { useExternalMeeting } from '../../../stores/externalMeetingStore';
+import { logger, Event } from '../../../utils/logger';
 
 type CallWithRelations = QueryResultType<typeof queries.userActiveCalls>[number];
 
@@ -34,6 +39,7 @@ export function IncomingCallModal(): React.ReactElement | null {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const processingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastViewModelRef = useRef<IncomingCallViewModel | null>(null);
+  const silenceRef = useRef<{ callId: string; reason: RingSilenceReason | null } | null>(null);
 
   // Get active calls from roomActor context and filter for incoming calls (where user is invited)
   const allActiveCalls = useSelector(roomActor, state => state.context.activeCalls);
@@ -56,6 +62,9 @@ export function IncomingCallModal(): React.ReactElement | null {
   // Only allow incoming call notifications in stable states (idle or connected)
   const canShowIncomingCalls =
     roomState === 'idle' || (typeof roomState === 'object' && 'connected' in roomState);
+
+  const recordingStatus = useRecordingStore(ctx => ctx.status);
+  const externalMeeting = useExternalMeeting();
 
   const allChannels = useAllChannels();
   const channelMap = useMemo(() => {
@@ -176,9 +185,44 @@ export function IncomingCallModal(): React.ReactElement | null {
   // Get the first call in the queue (active incoming call)
   const incomingCallData = incomingCallQueue[0];
 
+  // Whether the user is busy enough that this call should arrive quietly. The
+  // meeting half is Electron/macOS only; on web it is always null and the other
+  // two carry the feature on their own.
+  const liveSilenceReason = getRingSilenceReason({
+    isInActiveCall,
+    recordingStatus,
+    externalMeetingActive: externalMeeting !== null,
+  });
+
+  // Decided once per call and then held. Recomputing live would mean hanging up
+  // on your first call sends the second one into a full-volume ringtone
+  // mid-ring — the loudest possible moment for a surprise — and would re-fire
+  // the notification effect below, stacking a second OS banner. Same
+  // write-during-render shape as lastViewModelRef further down.
+  if (!incomingCallData) {
+    // Released once nothing is ringing, so a callId that somehow comes back
+    // around is decided afresh rather than inheriting an old answer.
+    silenceRef.current = null;
+  } else if (silenceRef.current?.callId !== incomingCallData.callId) {
+    silenceRef.current = { callId: incomingCallData.callId, reason: liveSilenceReason };
+    if (liveSilenceReason) {
+      logger.info(Event.LIVEKIT_ROOM_EVENT, {
+        callId: incomingCallData.callId,
+        eventName: 'incoming_call_silenced',
+        reason: liveSilenceReason,
+        // Carried separately because 'recording' outranks it: this is what
+        // distinguishes a meeting the user chose to record from one they only
+        // dismissed, and it is the only way to spot a browser-meeting false
+        // positive from the outside.
+        externalMeetingApp: externalMeeting?.app ?? null,
+      });
+    }
+  }
+  const silenceReason = incomingCallData ? (silenceRef.current?.reason ?? null) : null;
+
   // Play notification sound when incoming call appears
   useEffect(() => {
-    const shouldPlay = isRinging && incomingCallData;
+    const shouldPlay = isRinging && incomingCallData && !silenceReason;
 
     if (shouldPlay && audioRef.current) {
       audioRef.current.currentTime = 0;
@@ -189,7 +233,7 @@ export function IncomingCallModal(): React.ReactElement | null {
       audioRef.current.pause();
       audioRef.current.currentTime = 0;
     }
-  }, [isRinging, incomingCallData]);
+  }, [isRinging, incomingCallData, silenceReason]);
 
   const handleAcceptCall = useCallback(
     (callIdToAccept?: string): void => {
@@ -267,9 +311,18 @@ export function IncomingCallModal(): React.ReactElement | null {
       usersById,
       currentUserId: user?.id,
       isInActiveCall,
+      isSilenced: silenceReason !== null,
     });
     return buildCallNotificationBody(vm, incomingCallData.caller.name);
-  }, [incomingCallData, allActiveCalls, channelMap, usersById, user?.id, isInActiveCall]);
+  }, [
+    incomingCallData,
+    allActiveCalls,
+    channelMap,
+    usersById,
+    user?.id,
+    isInActiveCall,
+    silenceReason,
+  ]);
 
   // Show native Electron notification when app is in background. Keyed on the
   // ring state, the (reference-stable) incoming call, and the derived body, so
@@ -293,6 +346,9 @@ export function IncomingCallModal(): React.ReactElement | null {
       callerEmail: incomingCallData.caller.email,
       callType: incomingCallData.callType,
       body: notificationBody,
+      // Muting the ringtone alone leaves the OS chime, which is the louder half
+      // when the app is in the background — exactly the busy case.
+      silent: silenceReason !== null,
       ...(incomingCallData.caller.picture && { callerPicture: incomingCallData.caller.picture }),
     });
 
@@ -301,7 +357,7 @@ export function IncomingCallModal(): React.ReactElement | null {
         window.electronAPI.closeCallNotification(incomingCallData.callId);
       }
     };
-  }, [isRinging, incomingCallData, notificationBody]);
+  }, [isRinging, incomingCallData, notificationBody, silenceReason]);
 
   // Handle Electron notification action callbacks (accept/reject from notification)
   useEffect(() => {
@@ -356,6 +412,7 @@ export function IncomingCallModal(): React.ReactElement | null {
       usersById,
       currentUserId: user?.id,
       isInActiveCall,
+      isSilenced: silenceReason !== null,
     });
 
     // Two things happen in the beat between the caller hanging up and this

--- a/apps/dashboard/src/components/Call/CallModals/IncomingCallModal.tsx
+++ b/apps/dashboard/src/components/Call/CallModals/IncomingCallModal.tsx
@@ -23,7 +23,7 @@ import {
 } from '../IncomingCall/IncomingCallCard.utils';
 import type { IncomingCallViewModel } from '../IncomingCall/IncomingCallCard.types';
 import { useRecordingStore } from '../../../hooks/useRecordingStore';
-import { useExternalMeeting } from '../../../stores/externalMeetingStore';
+import { useExternalMeeting, useMicBusy } from '../../../stores/externalMeetingStore';
 import { logger, Event } from '../../../utils/logger';
 
 type CallWithRelations = QueryResultType<typeof queries.userActiveCalls>[number];
@@ -64,6 +64,8 @@ export function IncomingCallModal(): React.ReactElement | null {
     roomState === 'idle' || (typeof roomState === 'object' && 'connected' in roomState);
 
   const recordingStatus = useRecordingStore(ctx => ctx.status);
+  const micBusy = useMicBusy();
+  // Not part of the decision — only the telemetry below, as attribution.
   const externalMeeting = useExternalMeeting();
 
   const allChannels = useAllChannels();
@@ -186,12 +188,12 @@ export function IncomingCallModal(): React.ReactElement | null {
   const incomingCallData = incomingCallQueue[0];
 
   // Whether the user is busy enough that this call should arrive quietly. The
-  // meeting half is Electron/macOS only; on web it is always null and the other
-  // two carry the feature on their own.
+  // mic half is Electron/macOS only; on web it is always false and the other two
+  // carry the feature on their own.
   const liveSilenceReason = getRingSilenceReason({
     isInActiveCall,
     recordingStatus,
-    externalMeetingActive: externalMeeting !== null,
+    micBusy,
   });
 
   // Decided once per call and then held. Recomputing live would mean hanging up
@@ -210,10 +212,10 @@ export function IncomingCallModal(): React.ReactElement | null {
         callId: incomingCallData.callId,
         eventName: 'incoming_call_silenced',
         reason: liveSilenceReason,
-        // Carried separately because 'recording' outranks it: this is what
-        // distinguishes a meeting the user chose to record from one they only
-        // dismissed, and it is the only way to spot a browser-meeting false
-        // positive from the outside.
+        // The mic tells us the user is busy but not with what. Null here means
+        // no meeting app was identified — a Zoom call detection missed, or the
+        // mic held by something that was never a meeting at all. It is the only
+        // way to see the false-positive rate from the outside.
         externalMeetingApp: externalMeeting?.app ?? null,
       });
     }

--- a/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.fixtures.ts
+++ b/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.fixtures.ts
@@ -34,8 +34,9 @@ const stack = (
 
 const base = {
   isInActiveCall: false,
+  isSilenced: false,
   invitedBy: null,
-} satisfies Pick<IncomingCallViewModel, 'isInActiveCall' | 'invitedBy'>;
+} satisfies Pick<IncomingCallViewModel, 'isInActiveCall' | 'isSilenced' | 'invitedBy'>;
 
 export interface IncomingCallFixture {
   /** Matches the numbering in the design doc; blocked states continue past 10. */
@@ -151,11 +152,14 @@ export const INCOMING_CALL_FIXTURES: IncomingCallFixture[] = [
   },
   {
     n: 8,
-    label: 'Already in a call — notice + Switch call',
+    label: 'Already in a call — silenced, notice + Switch call',
     vm: {
       ...base,
       callId: 'fx-8',
       isInActiveCall: true,
+      // Being in a call is the first thing that silences a ring, so this state
+      // never occurs without the bell.
+      isSilenced: true,
       context: { kind: 'direct', icon: 'user', place: null, text: 'Incoming call' },
       identity: { mode: 'solo', userId: null, displayName: 'Ankit Sharma' },
       name: 'Ankit Sharma',
@@ -255,6 +259,21 @@ export const INCOMING_CALL_FIXTURES: IncomingCallFixture[] = [
       identity: stack(['Rohan Mehta', 'Priya Nair', 'Harsh Iyer'], 4),
       name: 'Rohan Mehta',
       subtitle: 'with Priya, Harsh +5',
+    },
+  },
+  {
+    n: 14,
+    label: 'Silenced — recording or in a meeting elsewhere',
+    vm: {
+      ...base,
+      callId: 'fx-14',
+      // Unlike n:8 there is no active call, so the bell is the only thing
+      // marking this apart from n:1 — which is the whole point of the state.
+      isSilenced: true,
+      context: { kind: 'direct', icon: 'user', place: null, text: 'Incoming call' },
+      identity: { mode: 'solo', userId: null, displayName: 'Meera Pillai' },
+      name: 'Meera Pillai',
+      subtitle: 'meera.pillai@juspay.in',
     },
   },
 ];

--- a/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.tsx
+++ b/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.tsx
@@ -1,5 +1,5 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, BellOff } from 'lucide-react';
 import type { ReactElement } from 'react';
 import { useReducedMotion } from 'framer-motion';
 import { useOverlayEffect } from '../../../machines/stateMachine';
@@ -63,6 +63,22 @@ export function IncomingCallCard({ vm, onAccept, onReject }: IncomingCallCardPro
           )}
         >
           <DialogPrimitive.Title className='hidden'>Incoming call</DialogPrimitive.Title>
+
+          {/* Absolute so it never competes with the centred context line for
+              width, and so showing it cannot change the card's fixed height. */}
+          {vm.isSilenced && (
+            // Native tooltip on a wrapper rather than the shared Tooltip:
+            // nothing else on this card is hoverable, and the label is a
+            // nicety, not the reason the user is looking at it. (lucide icons
+            // take no `title`, hence the span.)
+            <span
+              aria-label='Ringing silently'
+              title='Ringing silently'
+              className='absolute right-5 top-5 text-muted-foreground'
+            >
+              <BellOff className='h-3.5 w-3.5' />
+            </span>
+          )}
 
           <IncomingCallContextLine context={vm.context} />
 

--- a/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.types.ts
+++ b/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.types.ts
@@ -85,6 +85,13 @@ export interface IncomingCallViewModel {
   /** Drives the notice block and swaps Accept for the Switch-call pill. */
   isInActiveCall: boolean;
   /**
+   * The call arrived without a ringtone because the user was already busy —
+   * on a call, recording, or in a meeting elsewhere. Purely an explanation for
+   * the muted-bell glyph; the sound itself is suppressed by the modal, and the
+   * card is otherwise identical either way.
+   */
+  isSilenced: boolean;
+  /**
    * Who invited the current user — `invitedBy`, falling back to the call
    * creator. Unused by the card today; it is the signal that separates "invited
    * because I am in the channel" from "someone picked me", which is what a

--- a/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.types.ts
+++ b/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.types.ts
@@ -86,7 +86,8 @@ export interface IncomingCallViewModel {
   isInActiveCall: boolean;
   /**
    * The call arrived without a ringtone because the user was already busy —
-   * on a call, recording, or in a meeting elsewhere. Purely an explanation for
+   * on a call, recording, or talking to someone outside Xyne. Purely an
+   * explanation for
    * the muted-bell glyph; the sound itself is suppressed by the modal, and the
    * card is otherwise identical either way.
    */

--- a/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.utils.ts
+++ b/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.utils.ts
@@ -80,7 +80,7 @@ export function isRingableCall(input: {
 }
 
 /** Why a call that is ringing is doing so without a sound. */
-export type RingSilenceReason = 'in-call' | 'recording' | 'external-meeting';
+export type RingSilenceReason = 'in-call' | 'recording' | 'mic-busy';
 
 /**
  * Whether a ringing call should stay quiet, and why.
@@ -102,14 +102,22 @@ export function getRingSilenceReason(input: {
   isInActiveCall: boolean;
   recordingStatus: RecordingStatus;
   /**
-   * A meeting on another platform. True whether or not the user accepted the
-   * offer to record it — detection alone means they are talking to someone.
+   * Something outside Xyne holds the mic — Zoom, Teams, Meet, a huddle, a
+   * browser tab. Deliberately not "a meeting was identified": the ring stays
+   * quiet whether or not the app was recognised, and whether or not the user
+   * left meeting detection switched on, because the cost of getting it wrong is
+   * asymmetric — a call that arrives quietly can still be seen and answered, a
+   * ringtone in a live meeting cannot be taken back.
+   *
+   * Electron/macOS only, and it inherits that platform's bluntness: macOS
+   * reports the mic as busy per *device*, so a dictation tool or QuickTime
+   * holding it silences calls too.
    */
-  externalMeetingActive: boolean;
+  micBusy: boolean;
 }): RingSilenceReason | null {
   if (input.isInActiveCall) return 'in-call';
   if (isRecordingSessionActive(input.recordingStatus)) return 'recording';
-  if (input.externalMeetingActive) return 'external-meeting';
+  if (input.micBusy) return 'mic-busy';
   return null;
 }
 

--- a/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.utils.ts
+++ b/apps/dashboard/src/components/Call/IncomingCall/IncomingCallCard.utils.ts
@@ -7,6 +7,7 @@ import {
   type User,
 } from '@xyne/shared';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
+import { isRecordingSessionActive, type RecordingStatus } from '../../../stores/recordingStore';
 import { isDMChannel } from '../../Chat/ChatDirectory/ChatDirectory.utils';
 import type {
   IncomingCallContextVM,
@@ -76,6 +77,40 @@ export function isRingableCall(input: {
   if (call.startsAt && now < new Date(call.startsAt).getTime()) return false;
 
   return myParticipant?.response === InvitationResponse.INVITED;
+}
+
+/** Why a call that is ringing is doing so without a sound. */
+export type RingSilenceReason = 'in-call' | 'recording' | 'external-meeting';
+
+/**
+ * Whether a ringing call should stay quiet, and why.
+ *
+ * Silencing is not suppression: the card still appears and is still answerable.
+ * The problem this solves is volume, not attention — someone on a call has their
+ * output turned up to hear the other person, so a full-volume ringtone is both
+ * startling and, on speakers, audible to everyone else on the call.
+ *
+ * Sits beside `isRingableCall` because it is the same kind of thing: a product
+ * decision about ringing, kept out of the render path. Unlike that one it reads
+ * the user's own state rather than the call's, so nothing here can be derived
+ * from a `calls` row.
+ *
+ * The order is a precedence, not a set — a silenced ring is attributed to one
+ * cause in telemetry, and the nearest one wins.
+ */
+export function getRingSilenceReason(input: {
+  isInActiveCall: boolean;
+  recordingStatus: RecordingStatus;
+  /**
+   * A meeting on another platform. True whether or not the user accepted the
+   * offer to record it — detection alone means they are talking to someone.
+   */
+  externalMeetingActive: boolean;
+}): RingSilenceReason | null {
+  if (input.isInActiveCall) return 'in-call';
+  if (isRecordingSessionActive(input.recordingStatus)) return 'recording';
+  if (input.externalMeetingActive) return 'external-meeting';
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -292,6 +327,8 @@ export function buildIncomingCallViewModel(input: {
   usersById: ReadonlyMap<string, User>;
   currentUserId: string | undefined;
   isInActiveCall: boolean;
+  /** Required rather than defaulted, so no call site can forget to decide. */
+  isSilenced: boolean;
   /** Overridable so fixtures can exercise the overflow chip cheaply. */
   maxVisibleAvatars?: number;
 }): IncomingCallViewModel {
@@ -303,6 +340,7 @@ export function buildIncomingCallViewModel(input: {
     usersById,
     currentUserId,
     isInActiveCall,
+    isSilenced,
     maxVisibleAvatars = MAX_VISIBLE_AVATARS,
   } = input;
 
@@ -360,6 +398,7 @@ export function buildIncomingCallViewModel(input: {
     // meeting's name both say what the call is about, which a roster cannot.
     subtitle: title || rosterLine || caller.email || null,
     isInActiveCall,
+    isSilenced,
     invitedBy: myParticipant?.invitedBy ?? null,
   };
 }

--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -29,7 +29,7 @@ import {
 import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout';
 import { sendSosAlertEvent } from '../../stores/sosAlertStore';
 import { globalClickTracker } from '../../services/Analytics/globalClickTracker';
-import { setExternalMeeting } from '../../stores/externalMeetingStore';
+import { setExternalMeeting, setMicBusy } from '../../stores/externalMeetingStore';
 import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 
 // Singleton: a fresh Audio element PER NOTIFICATION leaked native listener
@@ -681,6 +681,36 @@ export const NotificationHandler: React.FC = () => {
       // Nothing is listening for meeting:ended any more; leaving this set would
       // silence every later call.
       setExternalMeeting(null);
+    };
+  }, [isElectron]);
+
+  // The signal that actually silences an incoming call: is anything holding the
+  // mic. Gated on Electron and nothing else — in particular not on the
+  // meeting-detection preference, which used to take this whole path down with
+  // it and leave the user's Zoom call fighting a full-volume ringtone.
+  useEffect(() => {
+    const micMonitor = window.electronAPI?.micMonitor;
+    if (!isElectron || !micMonitor?.onStateChanged) return;
+
+    // Broadcasts are not replayed, so a renderer that reloaded mid-meeting has
+    // to ask.
+    let cancelled = false;
+    void micMonitor.getState?.().then(active => {
+      // A live event that landed while the seed was in flight is newer.
+      if (!cancelled) setMicBusy(active);
+    });
+
+    const cleanup = micMonitor.onStateChanged(active => {
+      cancelled = true;
+      setMicBusy(active);
+    });
+
+    return (): void => {
+      cancelled = true;
+      cleanup();
+      // Nothing is listening for the release any more; leaving this set would
+      // silence every later call.
+      setMicBusy(false);
     };
   }, [isElectron]);
 

--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -29,6 +29,7 @@ import {
 import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout';
 import { sendSosAlertEvent } from '../../stores/sosAlertStore';
 import { globalClickTracker } from '../../services/Analytics/globalClickTracker';
+import { setExternalMeeting } from '../../stores/externalMeetingStore';
 import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
 
 // Singleton: a fresh Audio element PER NOTIFICATION leaked native listener
@@ -651,6 +652,37 @@ export const NotificationHandler: React.FC = () => {
       sendRecordingEvent({ type: 'requestStop' });
     });
   }, [isElectron, goToRecordings]);
+
+  // Mirror the main process's meeting state into the renderer, so an incoming
+  // call can ring silently while the user is on Zoom/Meet/Teams. Lives here
+  // beside the two effects that already report call and recording state to main
+  // — this is the return leg of the same conversation.
+  useEffect(() => {
+    const meetingDetector = window.electronAPI?.meetingDetector;
+    if (!isElectron || !meetingDetector?.onMeetingStateChanged) return;
+
+    // Detection is broadcast once and never replayed, so a renderer that
+    // reloaded mid-meeting has to ask.
+    let cancelled = false;
+    void meetingDetector.getCurrentMeeting?.().then(meeting => {
+      // A live event that landed while the seed was in flight is newer than the
+      // seed, so it must not be clobbered by it.
+      if (!cancelled) setExternalMeeting(meeting);
+    });
+
+    const cleanup = meetingDetector.onMeetingStateChanged(meeting => {
+      cancelled = true;
+      setExternalMeeting(meeting);
+    });
+
+    return (): void => {
+      cancelled = true;
+      cleanup();
+      // Nothing is listening for meeting:ended any more; leaving this set would
+      // silence every later call.
+      setExternalMeeting(null);
+    };
+  }, [isElectron]);
 
   useEffect(() => {
     if (!isElectron || !window.electronAPI?.onRecordingSystemSuspend) return;

--- a/apps/dashboard/src/stores/externalMeetingStore.ts
+++ b/apps/dashboard/src/stores/externalMeetingStore.ts
@@ -1,0 +1,45 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Whether the user is in a meeting on another platform — Zoom, Teams, Google
+ * Meet, a Slack huddle, or a browser tab that has the mic open.
+ *
+ * The detection itself lives in the Electron main process (mic-monitor +
+ * `meeting-detector.ts`) and is macOS-only; this store is just the renderer's
+ * copy, fed by `NotificationHandler`. Off Electron it stays null forever, which
+ * is correct — there is nothing detecting meetings there.
+ *
+ * Set at *detection*, independently of whether the user then accepted the
+ * "record this meeting?" popup, so it covers both halves of that flow.
+ */
+export interface ExternalMeeting {
+  /** `zoom` | `microsoft-teams` | `slack-huddle` | `google-meet` | `browser-meeting`. */
+  app: string;
+  startedAt: string;
+}
+
+let meeting: ExternalMeeting | null = null;
+const listeners = new Set<() => void>();
+
+export function setExternalMeeting(next: ExternalMeeting | null): void {
+  if (meeting === next) return;
+  meeting = next;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function getExternalMeeting(): ExternalMeeting | null {
+  return meeting;
+}
+
+export function subscribeExternalMeeting(listener: () => void): () => void {
+  listeners.add(listener);
+  return (): void => {
+    listeners.delete(listener);
+  };
+}
+
+export function useExternalMeeting(): ExternalMeeting | null {
+  return useSyncExternalStore(subscribeExternalMeeting, getExternalMeeting);
+}

--- a/apps/dashboard/src/stores/externalMeetingStore.ts
+++ b/apps/dashboard/src/stores/externalMeetingStore.ts
@@ -1,16 +1,20 @@
 import { useSyncExternalStore } from 'react';
 
 /**
- * Whether the user is in a meeting on another platform — Zoom, Teams, Google
- * Meet, a Slack huddle, or a browser tab that has the mic open.
+ * What the user is doing outside Xyne, as seen by the Electron main process
+ * (mic-monitor + `meeting-detector.ts`, macOS only). This store is just the
+ * renderer's copy, fed by `NotificationHandler`; off Electron both halves stay
+ * empty forever, which is correct — nothing is watching there.
  *
- * The detection itself lives in the Electron main process (mic-monitor +
- * `meeting-detector.ts`) and is macOS-only; this store is just the renderer's
- * copy, fed by `NotificationHandler`. Off Electron it stays null forever, which
- * is correct — there is nothing detecting meetings there.
+ * Two separate signals, and the distinction matters:
  *
- * Set at *detection*, independently of whether the user then accepted the
- * "record this meeting?" popup, so it covers both halves of that flow.
+ * - `micBusy` — something holds the mic. This is what silences an incoming
+ *   call, precisely because it asks nothing else: not which app, and not
+ *   whether the user left meeting detection on.
+ * - `meeting` — which app, once identified. Attribution for telemetry only, so
+ *   a silenced ring with no meeting app is visible as a possible false
+ *   positive. Set at *detection*, whether or not the user then accepted the
+ *   "record this meeting?" popup.
  */
 export interface ExternalMeeting {
   /** `zoom` | `microsoft-teams` | `slack-huddle` | `google-meet` | `browser-meeting`. */
@@ -42,4 +46,32 @@ export function subscribeExternalMeeting(listener: () => void): () => void {
 
 export function useExternalMeeting(): ExternalMeeting | null {
   return useSyncExternalStore(subscribeExternalMeeting, getExternalMeeting);
+}
+
+// ── Mic activity ───────────────────────────────────────────────────
+
+let micBusy = false;
+const micListeners = new Set<() => void>();
+
+export function setMicBusy(next: boolean): void {
+  if (micBusy === next) return;
+  micBusy = next;
+  for (const listener of micListeners) {
+    listener();
+  }
+}
+
+export function getMicBusy(): boolean {
+  return micBusy;
+}
+
+export function subscribeMicBusy(listener: () => void): () => void {
+  micListeners.add(listener);
+  return (): void => {
+    micListeners.delete(listener);
+  };
+}
+
+export function useMicBusy(): boolean {
+  return useSyncExternalStore(subscribeMicBusy, getMicBusy);
 }

--- a/apps/dashboard/src/stores/recordingStore.ts
+++ b/apps/dashboard/src/stores/recordingStore.ts
@@ -140,6 +140,19 @@ const initialContext: RecordingState = {
 
 const ACTIVE_STATUSES: ReadonlySet<RecordingStatus> = new Set(['recording', 'paused', 'stopping']);
 
+/**
+ * Whether a recording session exists at all — including one still spinning up or
+ * winding down, where the mic is live or about to be.
+ *
+ * Broader than `ACTIVE_STATUSES`, which is about a session that has *started*.
+ * This is the test the start sites already use inline to refuse a second
+ * recording (ThreadPannel, ChatBubble, RecordingsV2Screen, useSlashCommands);
+ * named here so callers that need it stop re-spelling it.
+ */
+export function isRecordingSessionActive(status: RecordingStatus): boolean {
+  return status !== 'idle' && status !== 'error';
+}
+
 export const recordingStore = createStore({
   context: initialContext,
   on: {

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -135,6 +135,15 @@ export interface ElectronAPI {
     /** Seeds state on mount — detection broadcasts are not replayed. */
     getCurrentMeeting: () => Promise<{ app: string; startedAt: string } | null>;
   };
+  /**
+   * Raw mic activity, meeting app or not. Separate from `meetingDetector`
+   * because the meeting-detection preference does not gate it: this is what
+   * keeps a call quiet while the user is talking to someone else.
+   */
+  micMonitor?: {
+    onStateChanged: (callback: (active: boolean) => void) => () => void;
+    getState: () => Promise<boolean>;
+  };
   meetingPopup?: {
     onShow: (callback: (data: { app: string; startedAt: string }) => void) => () => void;
     onUpdate: (callback: (data: { app: string; startedAt: string }) => void) => () => void;

--- a/apps/dashboard/src/types/electron.d.ts
+++ b/apps/dashboard/src/types/electron.d.ts
@@ -42,6 +42,8 @@ export interface ElectronAPI {
     callType: CallType;
     callerPicture?: string;
     body?: string;
+    /** Suppresses the OS notification sound; the dock still bounces. */
+    silent?: boolean;
   }) => void;
   closeCallNotification: (callId: string) => void;
   onCallNotificationClicked: (callback: (data: { callId: string }) => void) => () => void;
@@ -126,6 +128,12 @@ export interface ElectronAPI {
     onStartRecordingFromMeeting: (callback: () => void) => () => void;
     onStopRecordingFromMeeting: (callback: () => void) => () => void;
     setEnabled: (enabled: boolean) => void;
+    /** Fires with the meeting on detection and with null when it ends. */
+    onMeetingStateChanged: (
+      callback: (meeting: { app: string; startedAt: string } | null) => void,
+    ) => () => void;
+    /** Seeds state on mount — detection broadcasts are not replayed. */
+    getCurrentMeeting: () => Promise<{ app: string; startedAt: string } | null>;
   };
   meetingPopup?: {
     onShow: (callback: (data: { app: string; startedAt: string }) => void) => () => void;

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -671,6 +671,9 @@ export function setupIpcHandlers(): void {
   // never learn one is running and would ring a call it should have silenced.
   ipcMain.handle('meeting:get-current', () => meetingDetectorService.getCurrentMeeting());
 
+  // Same reason, for the signal that actually silences the ring.
+  ipcMain.handle('mic:get-state', () => meetingDetectorService.getMicActive());
+
   // Meeting detection toggle (user preference from settings)
   ipcMain.on('meeting-detection:set-enabled', (_event, enabled: boolean) => {
     Logger.info(
@@ -680,12 +683,10 @@ export function setupIpcHandlers(): void {
       { enabled },
       'MeetingDetector',
     );
-    if (enabled) {
-      meetingDetectorService.start();
-    } else {
-      hideMeetingPopup();
-      meetingDetectorService.stop();
-    }
+    // Only the "record this meeting?" popup. Stopping the detector here used to
+    // take the mic signal down with it, so a user who turned detection off got a
+    // full-volume ringtone through every Zoom call.
+    meetingDetectorService.setPopupEnabled(enabled);
   });
 
   // Browser Settings handlers

--- a/apps/electron/src/ipc/handlers.ts
+++ b/apps/electron/src/ipc/handlers.ts
@@ -666,6 +666,11 @@ export function setupIpcHandlers(): void {
     syncRecordingState(false);
   });
 
+  // Seeds the renderer's meeting state. The 'meeting:detected' broadcast is
+  // fire-and-forget, so a renderer that reloads mid-meeting would otherwise
+  // never learn one is running and would ring a call it should have silenced.
+  ipcMain.handle('meeting:get-current', () => meetingDetectorService.getCurrentMeeting());
+
   // Meeting detection toggle (user preference from settings)
   ipcMain.on('meeting-detection:set-enabled', (_event, enabled: boolean) => {
     Logger.info(

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -97,6 +97,7 @@ const electronAPI = {
     callType: 'AUDIO' | 'VIDEO';
     callerPicture?: string;
     body?: string;
+    silent?: boolean;
   }) => {
     ipcRenderer.send('show-call-notification', data);
   },
@@ -314,6 +315,23 @@ const electronAPI = {
     setEnabled: (enabled: boolean) => {
       ipcRenderer.send('meeting-detection:set-enabled', enabled);
     },
+    // One subscription over both edges, so a consumer that only cares whether a
+    // meeting is running cannot end up handling one event and missing the other.
+    onMeetingStateChanged: (
+      callback: (meeting: { app: string; startedAt: string } | null) => void,
+    ) => {
+      const onDetected = (_event: unknown, meeting: { app: string; startedAt: string }) =>
+        callback(meeting);
+      const onEnded = () => callback(null);
+      ipcRenderer.on('meeting:detected', onDetected);
+      ipcRenderer.on('meeting:ended', onEnded);
+      return () => {
+        ipcRenderer.removeListener('meeting:detected', onDetected);
+        ipcRenderer.removeListener('meeting:ended', onEnded);
+      };
+    },
+    getCurrentMeeting: (): Promise<{ app: string; startedAt: string } | null> =>
+      ipcRenderer.invoke('meeting:get-current'),
   },
 
   // Meeting popup (used by the popup window itself)

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -334,6 +334,18 @@ const electronAPI = {
       ipcRenderer.invoke('meeting:get-current'),
   },
 
+  // Deliberately its own namespace rather than part of `meetingDetector`: this
+  // is raw mic activity, and unlike everything above it the meeting-detection
+  // preference has no say over it.
+  micMonitor: {
+    onStateChanged: (callback: (active: boolean) => void) => {
+      const listener = (_event: unknown, data: { active: boolean }) => callback(data.active);
+      ipcRenderer.on('mic:state-changed', listener);
+      return () => ipcRenderer.removeListener('mic:state-changed', listener);
+    },
+    getState: (): Promise<boolean> => ipcRenderer.invoke('mic:get-state'),
+  },
+
   // Meeting popup (used by the popup window itself)
   meetingPopup: {
     onShow: (callback: (data: { app: string; startedAt: string }) => void) => {

--- a/apps/electron/src/services/meeting-detector.ts
+++ b/apps/electron/src/services/meeting-detector.ts
@@ -31,6 +31,9 @@ interface MeetingInfo {
   startedAt: string;
 }
 
+/** Why a meeting stopped — carried into telemetry so a crash is not read as a hang-up. */
+type MeetingEndReason = 'mic-inactive' | 'detector-stopped' | 'detector-crashed';
+
 // ── Constants ──────────────────────────────────────────────────────
 
 /**
@@ -149,6 +152,9 @@ class MeetingDetectorService {
         log.error('[MeetingDetector] Process error:', err.message);
         Logger.logError(ElectronEvent.MEETING_DETECTOR_ERROR, err, {}, 'MeetingDetector');
         this.process = null;
+        // A dead mic-monitor can never report the mic going quiet, so any
+        // meeting it was tracking has to be closed out here.
+        this.clearMeeting('detector-crashed');
         this.scheduleRestart();
       });
 
@@ -156,6 +162,7 @@ class MeetingDetectorService {
         log.info(`[MeetingDetector] Process exited with code=${code} signal=${signal}`);
         Logger.info(ElectronEvent.MEETING_DETECTOR_PROCESS_EXIT, { code, signal }, 'MeetingDetector');
         this.process = null;
+        this.clearMeeting('detector-crashed');
 
         if (!this.stopped && code !== 0) {
           this.scheduleRestart();
@@ -170,6 +177,9 @@ class MeetingDetectorService {
 
   public stop(): void {
     this.stopped = true;
+    // Turning detection off mid-meeting kills the mic-monitor, so the
+    // mic-inactive event that would normally end this meeting never arrives.
+    this.clearMeeting('detector-stopped');
 
     if (this.meetingEndTimer) {
       clearTimeout(this.meetingEndTimer);
@@ -209,6 +219,31 @@ class MeetingDetectorService {
   }
 
   // ── Private ────────────────────────────────────────────────────
+
+  /**
+   * End the current meeting and tell everyone who is listening.
+   *
+   * Every path that makes further mic events impossible has to come through
+   * here. The renderer silences incoming-call ringing while a meeting is set, so
+   * a stranded `currentMeeting` means calls ring silently for the rest of the
+   * session — which reads to the user as the ringtone being broken, not as a
+   * detector that quietly died.
+   */
+  private clearMeeting(reason: MeetingEndReason): void {
+    if (this.meetingEndTimer) {
+      clearTimeout(this.meetingEndTimer);
+      this.meetingEndTimer = null;
+    }
+
+    const meeting = this.currentMeeting;
+    if (!meeting) return;
+    this.currentMeeting = null;
+
+    log.info(`[MeetingDetector] Meeting ended (${reason}):`, meeting);
+    Logger.info(ElectronEvent.MEETING_ENDED, { ...meeting, reason }, 'MeetingDetector');
+    this.notifyRenderer('meeting:ended', meeting);
+    hideMeetingPopup();
+  }
 
   private getBinaryPath(): string {
     if (app.isPackaged) {
@@ -324,15 +359,7 @@ class MeetingDetectorService {
 
       this.meetingEndTimer = setTimeout(() => {
         this.meetingEndTimer = null;
-        if (this.currentMeeting) {
-          const meeting = this.currentMeeting;
-          this.currentMeeting = null;
-
-          log.info('[MeetingDetector] Meeting ended:', meeting);
-          Logger.info(ElectronEvent.MEETING_ENDED, { ...meeting }, 'MeetingDetector');
-          this.notifyRenderer('meeting:ended', meeting);
-          hideMeetingPopup();
-        }
+        this.clearMeeting('mic-inactive');
       }, MEETING_END_DEBOUNCE_MS);
     }
   }

--- a/apps/electron/src/services/meeting-detector.ts
+++ b/apps/electron/src/services/meeting-detector.ts
@@ -121,6 +121,25 @@ class MeetingDetectorService {
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
   private stopped = false;
 
+  /**
+   * Whether *something* is holding the mic, meeting app or not.
+   *
+   * Deliberately separate from `currentMeeting`: this is what silences an
+   * incoming call's ringtone, and it must not depend on the meeting-detection
+   * preference or on `identifyMeetingApp()` recognising the app. Silencing a
+   * call that should have rung is a smaller failure than a full-volume ringtone
+   * landing in the middle of a live meeting.
+   */
+  private micActive = false;
+  private micInactiveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * The user's meeting-detection preference. Gates the "record this meeting?"
+   * popup and nothing else — detection, its broadcasts and its telemetry all
+   * keep running so the ring-silencing signal above is never at its mercy.
+   */
+  private popupEnabled = true;
+
   /** Last known frontmost app — updated by app_activated events from the native binary */
   private lastFrontApp: { bundleId: string; name: string } | null = null;
 
@@ -155,6 +174,7 @@ class MeetingDetectorService {
         // A dead mic-monitor can never report the mic going quiet, so any
         // meeting it was tracking has to be closed out here.
         this.clearMeeting('detector-crashed');
+        this.clearMicActive();
         this.scheduleRestart();
       });
 
@@ -163,6 +183,7 @@ class MeetingDetectorService {
         Logger.info(ElectronEvent.MEETING_DETECTOR_PROCESS_EXIT, { code, signal }, 'MeetingDetector');
         this.process = null;
         this.clearMeeting('detector-crashed');
+        this.clearMicActive();
 
         if (!this.stopped && code !== 0) {
           this.scheduleRestart();
@@ -177,9 +198,10 @@ class MeetingDetectorService {
 
   public stop(): void {
     this.stopped = true;
-    // Turning detection off mid-meeting kills the mic-monitor, so the
-    // mic-inactive event that would normally end this meeting never arrives.
+    // Only app quit reaches here now, but the mic events that would normally
+    // close these out still stop arriving, so both have to be released by hand.
     this.clearMeeting('detector-stopped');
+    this.clearMicActive();
 
     if (this.meetingEndTimer) {
       clearTimeout(this.meetingEndTimer);
@@ -218,6 +240,21 @@ class MeetingDetectorService {
     return this.currentMeeting;
   }
 
+  /** Seeds a renderer that mounted after the last `mic:state-changed`. */
+  public getMicActive(): boolean {
+    return this.micActive;
+  }
+
+  /**
+   * Apply the meeting-detection preference. It no longer starts or stops the
+   * monitor: doing so meant a user who turned detection off got a full-volume
+   * ringtone during every Zoom call, because nothing was left to notice the mic.
+   */
+  public setPopupEnabled(enabled: boolean): void {
+    this.popupEnabled = enabled;
+    if (!enabled) hideMeetingPopup();
+  }
+
   // ── Private ────────────────────────────────────────────────────
 
   /**
@@ -243,6 +280,57 @@ class MeetingDetectorService {
     Logger.info(ElectronEvent.MEETING_ENDED, { ...meeting, reason }, 'MeetingDetector');
     this.notifyRenderer('meeting:ended', meeting);
     hideMeetingPopup();
+  }
+
+  /**
+   * Track the raw mic signal, ahead of and independently of everything the
+   * meeting logic does with it.
+   *
+   * Only the release edge is debounced — swapping headsets mid-meeting drops the
+   * mic for a moment, and un-silencing across that gap would let the next call
+   * ring at full volume while the user is still talking.
+   */
+  private setMicActive(active: boolean): void {
+    if (active) {
+      if (this.micInactiveTimer) {
+        clearTimeout(this.micInactiveTimer);
+        this.micInactiveTimer = null;
+      }
+      if (this.micActive) return;
+
+      this.micActive = true;
+      log.info('[MeetingDetector] Mic in use — incoming calls will ring silently');
+      this.notifyRenderer('mic:state-changed', { active: true });
+      return;
+    }
+
+    if (!this.micActive || this.micInactiveTimer) return;
+
+    this.micInactiveTimer = setTimeout(() => {
+      this.micInactiveTimer = null;
+      this.clearMicActive();
+    }, MEETING_END_DEBOUNCE_MS);
+  }
+
+  /**
+   * Release the mic signal immediately, skipping the debounce.
+   *
+   * Every path that makes further mic events impossible has to come through
+   * here. A stranded `micActive` silences every call for the rest of the
+   * session, which reads to the user as a broken ringtone rather than as a
+   * monitor that quietly died.
+   */
+  private clearMicActive(): void {
+    if (this.micInactiveTimer) {
+      clearTimeout(this.micInactiveTimer);
+      this.micInactiveTimer = null;
+    }
+
+    if (!this.micActive) return;
+    this.micActive = false;
+
+    log.info('[MeetingDetector] Mic released — incoming calls ring normally again');
+    this.notifyRenderer('mic:state-changed', { active: false });
   }
 
   private getBinaryPath(): string {
@@ -299,6 +387,12 @@ class MeetingDetectorService {
   private handleMicEvent(event: MicEvent): void {
     const active = event.active ?? false;
 
+    // First, unconditionally: the ring-silencing signal cannot sit behind the
+    // early returns below, which skip a Xyne-owned mic and an already-tracked
+    // meeting. A Xyne call or recording is not filtered out here either — the
+    // renderer's precedence attributes those to 'in-call'/'recording' anyway.
+    this.setMicActive(active);
+
     if (active && !this.currentMeeting) {
       // A Xyne call or recording is what just turned the mic on. Bail out before
       // identifying anything — checkProcesses() would otherwise match a Zoom or
@@ -341,7 +435,8 @@ class MeetingDetectorService {
           log.info('[MeetingDetector] Meeting detected:', this.currentMeeting);
           Logger.info(ElectronEvent.MEETING_DETECTED, { ...this.currentMeeting }, 'MeetingDetector');
           this.notifyRenderer('meeting:detected', this.currentMeeting);
-          showMeetingPopup(this.currentMeeting);
+          // The preference reaches only this line — the state above still flows.
+          if (this.popupEnabled) showMeetingPopup(this.currentMeeting);
         })
         .catch((err) => {
           log.error('[MeetingDetector] Failed to identify meeting app:', err);

--- a/apps/electron/src/services/notifications.ts
+++ b/apps/electron/src/services/notifications.ts
@@ -17,6 +17,13 @@ export interface CallNotificationData {
   callerPicture?: string;
   /** Precomputed body from the renderer; falls back to the legacy line. */
   body?: string;
+  /**
+   * Set when the renderer has decided this call rings silently — the user is
+   * already on a call, recording, or in an external meeting. Muting the in-app
+   * ringtone alone is not enough: this notification is a second, independent
+   * sound source.
+   */
+  silent?: boolean;
 }
 
 // Keep references to prevent garbage collection
@@ -93,7 +100,7 @@ export function showCallNotification(
     const notification = new Notification({
       title: 'Incoming call',
       body: data.body ?? `${data.callerName} is calling you`,
-      silent: false,
+      silent: data.silent ?? false,
       urgency: 'critical',
       hasReply: false,
       timeoutType: 'never', 
@@ -140,6 +147,8 @@ export function showCallNotification(
 
     notification.show();
 
+    // Deliberately not gated on `data.silent`: a silenced call still earns the
+    // peripheral visual cue, it just must not make a sound.
     if (process.platform === 'darwin' && !mainWindow?.isFocused()) {
       app.dock?.bounce('critical');
     }


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
