### PR TITLE
fix: XYNE-1315 pass threadMentions as a rank-only term for messages

### DIFF
--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -279,6 +279,7 @@ export class YqlBuilder {
           rankTerms.add(`userId contains ${me()}`);
           rankTerms.add(`mentions contains ${me()}`);
           rankTerms.add(`threadSenders contains ${me()}`);
+          rankTerms.add(`threadMentions contains ${me()}`);
         }
         if (schemas.includes(ticketSchema)) {
           rankTerms.add(`createdBy contains ${me()}`);


### PR DESCRIPTION
## Type of Change
- [x] Bugfix

## Description
chat_message's `personalized` profile now reads involvement as
`in_thread = max(matches(threadSenders), matches(threadMentions))`, but the backend
only passed `threadSenders` as a rank-only term. `matches(threadMentions)` was
therefore always 0 and the schema change was a no-op — an @mention of the caller
anywhere in a thread would not lift that thread's messages into the involvement tier.

Adds `threadMentions contains @involvedUser` to the chat_message rank-term group in
YqlBuilder. The terms are a Set and the ticket group already contributes the same
string, so it collapses to one `rank()` argument when both schemas are queried.
`rank()`'s extra arguments never change what matches, so recall is unaffected.

Pairs with the vespa-core change to `vespa/common/schemas/chat_message.sd`
(`in_thread` + profile comment). XYNE-1315.

## Areas Touched
- [x] `apps/backend` (API / worker)

## Zero (Sync) Changes
- [x] No Zero changes — skip this section

## Schema & Data Changes
- [x] No schema changes — skip this section
(Vespa schema lives in vespa-core; that change is separate and needs a Vespa redeploy.)

## Config, Environment & URLs
- [x] No config changes — skip this section

## API Contract
- [x] No API changes

## How did you test it?
Static verification only — this is a one-line addition to a rank-term Set on a path
with no existing unit tests.

- Confirmed `threadMentions` is `index | attribute | summary` with bm25 on
  `chat_message`, so `contains` resolves as a rank-only term the same way
  `threadSenders` already does.
- Confirmed the Set dedups against the identical term in the ticket group.
- Confirmed the emitted term matches what the vespa-core `personalized` profile
  comment specifies.

Not yet exercised against a running Vespa — the profile change in vespa-core is
still uncommitted and undeployed, so `matches(threadMentions)` cannot be observed
end-to-end until that deploys.

### Automated
- [x] Not covered by tests — YqlBuilder has no unit test file; the change is one
      entry in a rank-term Set whose sibling entries are already exercised in prod.

### Manual
Nothing run — no user-facing surface to exercise until the Vespa profile deploys.

## Checklist
- [x] Reviewed my own diff; scoped to one thing
- [x] Backend `typecheck` + `build` pass
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [x] No debug logging or commented-out code left behind