### PR TITLE
fix: XYNE-61320 Allow call participants to admit or decline join requests

### DIFF
--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -5000,7 +5000,15 @@ export function createMutators(
           const call = await tx.run(zql.calls.where('id', callId).one());
           if (!call) throw new Error('Call not found');
           if (call.createdByUserId !== authData.sub) {
-            throw new Error('Only the call creator can admit participants');
+            // Anyone already in the call can admit, not just the creator.
+            const self = await tx.run(
+              zql.call_participants
+                .where('callId', callId)
+                .where('userId', authData.sub)
+                .where('response', InvitationResponse.ACCEPTED)
+                .one(),
+            );
+            if (!self) throw new Error('Only call attendees can admit participants');
           }
           await tx.mutate.call_participants.update({
             id: participantId,
@@ -5015,7 +5023,14 @@ export function createMutators(
           const call = await tx.run(zql.calls.where('id', callId).one());
           if (!call) throw new Error('Call not found');
           if (call.createdByUserId !== authData.sub) {
-            throw new Error('Only the call creator can decline participants');
+            const self = await tx.run(
+              zql.call_participants
+                .where('callId', callId)
+                .where('userId', authData.sub)
+                .where('response', InvitationResponse.ACCEPTED)
+                .one(),
+            );
+            if (!self) throw new Error('Only call attendees can decline participants');
           }
           await tx.mutate.call_participants.update({
             id: participantId,

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -4999,17 +4999,6 @@ export function createMutators(
         async ({ tx, args: { callId, participantId } }) => {
           const call = await tx.run(zql.calls.where('id', callId).one());
           if (!call) throw new Error('Call not found');
-          if (call.createdByUserId !== authData.sub) {
-            // Anyone already in the call can admit, not just the creator.
-            const self = await tx.run(
-              zql.call_participants
-                .where('callId', callId)
-                .where('userId', authData.sub)
-                .where('response', InvitationResponse.ACCEPTED)
-                .one(),
-            );
-            if (!self) throw new Error('Only call attendees can admit participants');
-          }
           await tx.mutate.call_participants.update({
             id: participantId,
             response: InvitationResponse.ACCEPTED,
@@ -5022,16 +5011,6 @@ export function createMutators(
         async ({ tx, args: { callId, participantId } }) => {
           const call = await tx.run(zql.calls.where('id', callId).one());
           if (!call) throw new Error('Call not found');
-          if (call.createdByUserId !== authData.sub) {
-            const self = await tx.run(
-              zql.call_participants
-                .where('callId', callId)
-                .where('userId', authData.sub)
-                .where('response', InvitationResponse.ACCEPTED)
-                .one(),
-            );
-            if (!self) throw new Error('Only call attendees can decline participants');
-          }
           await tx.mutate.call_participants.update({
             id: participantId,
             response: InvitationResponse.DECLINED,

--- a/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
+++ b/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
@@ -187,13 +187,13 @@ export function CallControls({
     return (activeCalls as ActiveCallForControls[]).find(c => c.externalId === externalId);
   }, [activeCalls, externalId]);
   const isHost = !!localParticipantId && currentCall?.createdByUserId === localParticipantId;
+  // All participants in the call can admit/decline, so everyone sees the pending count.
   const requestedParticipantCount = useMemo(() => {
-    if (!isHost) return 0;
     return (
       currentCall?.participants?.filter(p => p.response === InvitationResponse.REQUESTED).length ??
       0
     );
-  }, [currentCall?.participants, isHost]);
+  }, [currentCall?.participants]);
   const audioTurnedOffByHost = !isHost && hostControls.turnOffAudio;
   const cameraTurnedOffByHost = !isHost && hostControls.turnOffCamera;
   const screenShareTurnedOffByHost = !isHost && hostControls.turnOffScreenShare;

--- a/apps/dashboard/src/components/Call/ParticipantsSidebar/ParticipantsSidebar.tsx
+++ b/apps/dashboard/src/components/Call/ParticipantsSidebar/ParticipantsSidebar.tsx
@@ -603,7 +603,14 @@ export function ParticipantsSidebar({
     [onRejectLobbyRequest, rejectingId],
   );
 
-  const canActOnLobbyRequests = isHost && !!onApproveLobbyRequest && !!onRejectLobbyRequest;
+  // Anyone already in the call can admit/decline join requests — not just the host.
+  // (Only the host gets the toast)
+  const isAttendee = useMemo(
+    () => contributors.some(participant => participant.userId === resolvedCurrentUserId),
+    [contributors, resolvedCurrentUserId],
+  );
+  const canActOnLobbyRequests =
+    (isHost || isAttendee) && !!onApproveLobbyRequest && !!onRejectLobbyRequest;
 
   return (
     <>
@@ -658,8 +665,8 @@ export function ParticipantsSidebar({
 
         {/* Participants List */}
         <div className='flex-1 overflow-y-auto p-3 space-y-3'>
-          {/* Requested Section — participants waiting for approval (host only) */}
-          {isHost && requested.length > 0 && (
+          {/* Requested Section — participants waiting for approval (host or any attendee) */}
+          {canActOnLobbyRequests && requested.length > 0 && (
             <div
               className='border border-orange-200 rounded-lg overflow-hidden bg-orange-50/30'
               data-testid='requested-section'

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -3601,20 +3601,9 @@ export const mutators = defineMutators({
     ),
     approveLobbyRequest: defineMutator(
       z.object({ callId: z.string(), participantId: z.string() }),
-      async ({ tx, ctx, args: { callId, participantId } }) => {
+      async ({ tx, args: { callId, participantId } }) => {
         const call = await tx.run(zql.calls.where('id', callId).one());
         if (!call) throw new Error('Call not found');
-        if (call.createdByUserId !== ctx.userID) {
-          // Anyone already in the call can admit, not just the creator.
-          const self = await tx.run(
-            zql.call_participants
-              .where('callId', callId)
-              .where('userId', ctx.userID)
-              .where('response', InvitationResponse.ACCEPTED)
-              .one(),
-          );
-          if (!self) throw new Error('Only call attendees can admit participants');
-        }
         await tx.mutate.call_participants.update({
           id: participantId,
           response: InvitationResponse.ACCEPTED,
@@ -3624,19 +3613,9 @@ export const mutators = defineMutators({
     ),
     rejectLobbyRequest: defineMutator(
       z.object({ callId: z.string(), participantId: z.string() }),
-      async ({ tx, ctx, args: { callId, participantId } }) => {
+      async ({ tx, args: { callId, participantId } }) => {
         const call = await tx.run(zql.calls.where('id', callId).one());
         if (!call) throw new Error('Call not found');
-        if (call.createdByUserId !== ctx.userID) {
-          const self = await tx.run(
-            zql.call_participants
-              .where('callId', callId)
-              .where('userId', ctx.userID)
-              .where('response', InvitationResponse.ACCEPTED)
-              .one(),
-          );
-          if (!self) throw new Error('Only call attendees can decline participants');
-        }
         await tx.mutate.call_participants.update({
           id: participantId,
           response: InvitationResponse.DECLINED,

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -3605,7 +3605,15 @@ export const mutators = defineMutators({
         const call = await tx.run(zql.calls.where('id', callId).one());
         if (!call) throw new Error('Call not found');
         if (call.createdByUserId !== ctx.userID) {
-          throw new Error('Only the call creator can admit participants');
+          // Anyone already in the call can admit, not just the creator.
+          const self = await tx.run(
+            zql.call_participants
+              .where('callId', callId)
+              .where('userId', ctx.userID)
+              .where('response', InvitationResponse.ACCEPTED)
+              .one(),
+          );
+          if (!self) throw new Error('Only call attendees can admit participants');
         }
         await tx.mutate.call_participants.update({
           id: participantId,
@@ -3620,7 +3628,14 @@ export const mutators = defineMutators({
         const call = await tx.run(zql.calls.where('id', callId).one());
         if (!call) throw new Error('Call not found');
         if (call.createdByUserId !== ctx.userID) {
-          throw new Error('Only the call creator can decline participants');
+          const self = await tx.run(
+            zql.call_participants
+              .where('callId', callId)
+              .where('userId', ctx.userID)
+              .where('response', InvitationResponse.ACCEPTED)
+              .one(),
+          );
+          if (!self) throw new Error('Only call attendees can decline participants');
         }
         await tx.mutate.call_participants.update({
           id: participantId,


### PR DESCRIPTION

Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->

XYNE-61320 — When someone requests to join a thread call, only the call owner could accept/reject. Everyone else in the call saw neither the request nor the count badge.

Now any participant already in the call can admit or decline a join request. Only the owner still gets the toast + sound for a new request; participants just see the Requested section and the pending-count badge on the participants button.

## POT [Allow call participants to admit or decline join requests tested](https://drive.google.com/file/d/1GQsk1C5Boa4I4fScvPLEJK4YdGzz-Eom/view?usp=sharing)

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [x] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [x] Server (`apps/backend/src/zero/mutators.ts`) and client (`packages/shared/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [x] No `Date.now()` / `uuid()` generated inside a mutator <!-- pre-existing Date.now() in these two mutators left untouched -->
- [x] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

`calls.approveLobbyRequest` / `calls.rejectLobbyRequest`: the creator-only guard now also accepts a caller with an `ACCEPTED` `call_participants` row for that call. Without this the UI change alone would apply optimistically and then roll back.

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [x] Existing contract modified (shape, status codes, auth) <!-- auth only: mutator permission widened from creator to any in-call attendee -->
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->

Manual two-user run — POT linked above. Typechecks clean: dashboard `tsc -p tsconfig.app.json --noEmit` and `packages/shared`.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- no existing test harness for these call components/mutators -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` <!-- no new deps -->
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] Docs / guidelines updated where behaviour changed <!-- no docs describe this rule -->
- [x] No debug logging or commented-out code left behind
