### PR TITLE
XYNE-61335: Align key-rotation fallback with release-20260827

### DIFF
--- a/apps/xyne-claw-auth/backend/src/config.ts
+++ b/apps/xyne-claw-auth/backend/src/config.ts
@@ -1,7 +1,4 @@
-import {
-  createLazySpacesEncryptionKeyRing,
-  parseSpacesEncryptionKeyRing,
-} from "./spaces-encryption-key-ring.js";
+import { createLazySpacesEncryptionKeyRing } from "./spaces-encryption-key-ring.js";
 import { createHmac } from "node:crypto";
 import { derivePurposeKey, registerDecryptionFallback } from "./crypto.js";
 


### PR DESCRIPTION
## Summary

This PR restores and clarifies the environment-driven backward-compatibility behavior for the ordered encryption-key rotation introduced by #764.

No separate feature flag is introduced. The presence of a valid, non-empty ordered key-ring environment variable activates rotation. When the new variable is absent or blank, the system preserves the pre-#764 legacy behavior.

The PR also restores the Claw-auth versioned Spaces ciphertext reader that was replaced by the later #1156 synchronization.

## Configuration behavior

### Spaces backend

The backend continues to support the existing legacy variable:

```text
ENCRYPTION_KEY=<64-hex legacy key>
```

The new optional ordered key ring is:

```text
ENCRYPTION_KEYS=[
  {"id":"k1","key":"<64-hex key>"},
  {"id":"k2","key":"<64-hex key>"}
]
```

Behavior:

| `ENCRYPTION_KEYS` value          | Result                                                       |
| -------------------------------- | ------------------------------------------------------------ |
| Missing or blank                 | Use `ENCRYPTION_KEY` and write legacy `iv:ciphertext`        |
| Valid non-empty array            | Use the final array entry and write `v2:keyId:iv:ciphertext` |
| Empty array (`[]`)               | Reject the configuration                                     |
| Malformed JSON                   | Reject the configuration                                     |
| Duplicate or reserved key ID     | Reject the configuration                                     |
| Invalid or incorrectly sized key | Reject the configuration                                     |

When the ordered ring is configured, its final entry is the active writer. Every entry remains available for versioned decryption, and `ENCRYPTION_KEY` remains registered as the `legacy` reader.

### Claw-auth

Claw-auth uses the corresponding variables:

```text
SPACES_ENCRYPTION_KEY=<same legacy key used by Spaces>

SPACES_ENCRYPTION_KEYS=[
  {"id":"k1","key":"<same k1 used by Spaces>"},
  {"id":"k2","key":"<same k2 used by Spaces>"}
]
```

The IDs and key material must match the Spaces backend configuration exactly.

When `SPACES_ENCRYPTION_KEYS` is missing or blank, Claw uses `SPACES_ENCRYPTION_KEY` for legacy Spaces ciphertext. When a valid non-empty ring is configured, Claw can read both legacy ciphertext and versioned ciphertext associated with every configured key ID.

Spaces key-ring parsing remains lazy in Claw-auth. Malformed optional Spaces configuration therefore does not prevent unrelated OAuth, session, or agent-auth functionality from starting. Configuration failures are caught by the affected backfill or diagnostic operation and returned as structured failures.

## Ciphertext selection

Encryption is selected from the environment:

```text
ENCRYPTION_KEYS absent
    -> ENCRYPTION_KEY
    -> iv:ciphertext

ENCRYPTION_KEYS configured
    -> final ordered entry
    -> v2:keyId:iv:ciphertext
```

Decryption is selected from the ciphertext:

```text
iv:ciphertext
    -> key ID "legacy"
    -> ENCRYPTION_KEY / SPACES_ENCRYPTION_KEY

v2:k1:iv:ciphertext
    -> key ID "k1"
    -> matching ordered-ring entry
```

Readers do not guess keys or try every key. The key ID embedded in versioned ciphertext selects the exact key. Unknown or retired IDs fail clearly.

## Backward compatibility

With the new ordered-ring variables unset or blank, write behavior is identical to the pre-#764 behavior:

* The existing legacy key is used.
* The legacy two-part ciphertext format is produced.
* Existing legacy ciphertext remains readable.
* No migration or schema change occurs.
* No new write format is activated.

A configured but empty or malformed ring does not silently fall back to the legacy writer. It fails closed so a deployment cannot appear to have enabled rotation while continuing to write under the old key.

## Rollout

1. Deploy the code while leaving `ENCRYPTION_KEYS` unset.
2. Preserve `ENCRYPTION_KEY` and `SPACES_ENCRYPTION_KEY`.
3. Configure and deploy `SPACES_ENCRYPTION_KEYS` to Claw-auth first.
4. Verify Claw can read legacy ciphertext and the configured key IDs.
5. Configure `ENCRYPTION_KEYS` in the Spaces backend.
6. Restart the services so they load the new environment.
7. Verify new ciphertext starts with the expected final key ID.
8. Retain the legacy key and all older ordered-ring entries until database, queue, backup, retention, and recovery checks confirm they are no longer required.

## Rollback constraint

Before any versioned ciphertext has been written, removing `ENCRYPTION_KEYS` safely restores legacy writes.

After versioned ciphertext exists, the ordered ring must remain available because readers need its keys. Removing it would restore legacy writes but would also make existing `v2` ciphertext unreadable. A writer-only rollback after activation would require a separate explicit write-mode flag, which is intentionally outside the behavior implemented by this PR.

## Validation

The validation covers:

* Missing `ENCRYPTION_KEYS` selects the legacy writer.
* A valid non-empty ring selects its final entry.
* Legacy and versioned ciphertext round trips.
* Empty configured rings are rejected.
* Malformed JSON is rejected.
* Duplicate and invalid key IDs are rejected.
* Keys with invalid lengths or non-hexadecimal characters are rejected.
* Claw falls back to its legacy Spaces key when the ordered ring is absent.
* Claw reads both legacy and versioned ciphertext when the ordered ring is configured.
* Malformed Claw configuration is rejected lazily.
* No key, plaintext, or ciphertext values are logged.
* No test-file changes are included in the PR.
