### PR TITLE
fix: XYNE-61336 ticket link routing to include channel context

### DIFF
--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingTicketLink.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingTicketLink.tsx
@@ -82,10 +82,12 @@ export function RecordingTicketLink({
     [isUpdating, searchResults],
   );
 
-  /* A recording lives outside any project, so the ticket carries its own route. */
-  const ticketHref = linkedTicket
-    ? `/projects/${linkedTicket.projectId}/${linkedTicket.boardId}/${linkedTicket.id}`
-    : null;
+  /* The channel thread — where the rest of the app opens tickets; the
+     `/projects/:projectId/:boardId/:ticketId` route drops the channel context. */
+  const ticketHref =
+    linkedTicket?.channelId && linkedTicket.conversationId
+      ? `/chat/dir/${linkedTicket.channelId}/${linkedTicket.conversationId}/${linkedTicket.id}?selectedTab=details`
+      : null;
 
   const handleSelect = (ticketId: string | null): void => {
     if (isUpdating) return;


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-61336

The linked-ticket chip on a recording opened `/projects/:projectId/:boardId/:ticketId`.
Valid URL, wrong place — it carries no channel context, so the viewer lands in the
Projects Board shell instead of the ticket's thread.

Now routes to the channel thread, same as everywhere else in the app:
`/chat/dir/:channelId/:conversationId/:ticketId?selectedTab=details`

## POT: 
[Scribe Ticket Link Routing Tested ](https://github.com/user-attachments/assets/04457477-2592-453e-9aee-e6e0ef2d2356)



## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Dashboard typecheck passes. Repro: open a recording with a linked ticket, click the chip —
lands on the ticket in its channel thread, not the Projects Board shell.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [x] No new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
