### PR TITLE
fix: XYNE-59705 run claw-auth frontend nginx as non-root (SCR PY-JP-009)

### DIFF
--- a/apps/xyne-claw-auth/frontend/Dockerfile
+++ b/apps/xyne-claw-auth/frontend/Dockerfile
@@ -42,6 +42,17 @@ RUN printf 'server {\n\
     }\n\
 }\n' > /etc/nginx/conf.d/default.conf
 
+# Run as the image's built-in non-root "nginx" user. The master no longer runs as
+# root, so the pid file and the dirs nginx writes at runtime are relocated/owned
+# accordingly. The port stays 80 (no Service targetPort change); binding a
+# privileged port as non-root requires NET_BIND_SERVICE, which the pod's
+# securityContext.capabilities must add (add: ["NET_BIND_SERVICE"]) in the deploy
+# manifest — otherwise nginx fails to bind on startup.
+RUN sed -i 's|pid .*nginx.pid;|pid /tmp/nginx.pid;|' /etc/nginx/nginx.conf \
+    && chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /etc/nginx/conf.d
+
 EXPOSE 80
+
+USER nginx
 
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Closes the SCR retest finding **PY-JP-009 (Unenforced Non-Root Container Execution)** for the claw-auth frontend image, which still ran nginx as root (UID 0).

Split out of the main-targeted mobile-MAPT PR — this container change belongs on the claw deploy line.

## Change
`apps/xyne-claw-auth/frontend/Dockerfile` now runs as the image's built-in non-root `nginx` user:
- pid file relocated to `/tmp/nginx.pid`
- runtime dirs (`/usr/share/nginx/html`, `/var/cache/nginx`, `/etc/nginx/conf.d`) chowned to `nginx`
- `USER nginx` before the entrypoint

## ⚠ Deploy-coordination (required)
The port stays **80**, so binding it as a non-root user needs the pod's `securityContext.capabilities` to **add `NET_BIND_SERVICE`** in the deploy manifest — otherwise nginx fails to bind on startup and the frontend won't come up. (Alternative: switch to port 8080 and update the Service `targetPort`.)

## Verify
After deploy, `id` / `whoami` inside the claw-auth frontend pod should show a non-root UID, and the frontend should serve normally.