### PR TITLE
fix: XYNE-61350 Generate Label action for older recording distinguish based on channel id

### DIFF
--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -63,6 +63,7 @@ export interface RecordingsV2PillProps {
     | 'transcript'
     | 'createdByUserId'
     | 'labels'
+    | 'channelId'
   >;
   creator: User | null;
   participantsLabel: string;
@@ -178,8 +179,13 @@ const RecordingsV2Pill = ({
   const isOwner = currentUserId !== undefined && currentUserId === recording.createdByUserId;
   const visibleTags = normalizeRecordingTags(tags);
   const visibleSuggestedTags = isOwner ? normalizeRecordingTags(suggestedTags) : [];
+
+  // Backfill for pre-Scribe recordings only — a channel anchor is what marks them.
   const showGenerateLabels =
-    isOwner && recording.labels.length === 0 && Boolean(recording.transcript?.trim());
+    Boolean(recording.channelId) &&
+    isOwner &&
+    recording.labels.length === 0 &&
+    Boolean(recording.transcript?.trim());
   const [menuOpen, setMenuOpen] = useState(false);
 
   // Populated on menu open — `hasRecording` isn't in the synced list data (it's


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-61350

"Generate labels" is a backfill for older, pre-Scribe recordings. The gate only checked
"has no labels yet", so it also showed up on new Scribe recordings.

Now gated on `channelId` — older recordings are anchored to a channel, Scribe recordings
never are. One expression, one file.

### POT: Can be only tested in Pre-Prod as this is a backfill for older recordings 

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Dashboard typecheck passes. Repro: recording with a `channelId` and no labels still shows
the button; a Scribe recording (no `channelId`) no longer does.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] No new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
