### PR TITLE
fix: XYNE-60272 route SDLC notifications and activities from entity ids

### DIFF
--- a/apps/backend/prisma/generated/zero/schema.ts
+++ b/apps/backend/prisma/generated/zero/schema.ts
@@ -1990,7 +1990,7 @@ export const sdlcEntityLinkTable = table("sdlc_entity_links")
     id: string(),
     workspaceId: string(),
     repoId: string().optional(),
-    channelId: string().optional(),
+    channelId: string(),
     sourceType: string(),
     sourceId: string(),
     targetType: string(),

--- a/apps/backend/prisma/migrations/20260831033955_sdlc_multirepo_add/migration.sql
+++ b/apps/backend/prisma/migrations/20260831033955_sdlc_multirepo_add/migration.sql
@@ -2,6 +2,8 @@
 ALTER TABLE "public"."sdlc_artifacts" ALTER COLUMN "repoId" DROP NOT NULL;
 
 -- AlterTable
+-- Left nullable for the rows written before multi-repo; the backfill stamps them.
+-- Prisma models it as required so no new write can omit the edge's scope.
 ALTER TABLE "public"."sdlc_entity_links" ADD COLUMN     "channelId" TEXT,
 ALTER COLUMN "repoId" DROP NOT NULL;
 

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -3248,7 +3248,9 @@ model SdlcEntityLink {
   workspaceId  String
   /// @deprecated -> scope is channelId; the repository is an endpoint of the edge, not a column
   repoId       String?
-  channelId    String?
+  /// Nullable in Postgres for pre-multirepo rows; required here so no new write
+  /// can omit the edge's scope.
+  channelId    String
   sourceType   String
   sourceId     String
   targetType   String

--- a/apps/backend/src/sdlc/SdlcHubService.ts
+++ b/apps/backend/src/sdlc/SdlcHubService.ts
@@ -852,9 +852,7 @@ export class SdlcHubService implements SdlcHub {
     }
 
     if (input.trackId) {
-      const inHub =
-        Boolean(repo.channelId) &&
-        (await isTrackInChannel(this.prisma, input.trackId, repo.channelId!));
+      const inHub = await isTrackInChannel(this.prisma, input.trackId, repo.channelId);
       if (!inHub) throw new AppError('SDLC track not found for this repository', 404);
     }
 
@@ -946,7 +944,7 @@ export class SdlcHubService implements SdlcHub {
           );
           if (relatedIds.length > 0) {
             const validRelated = await tx.canvas.findMany({
-              where: { id: { in: relatedIds }, channelId: repo.channelId! },
+              where: { id: { in: relatedIds }, channelId: repo.channelId },
               select: { id: true },
             });
             for (const related of validRelated) {
@@ -1501,7 +1499,7 @@ export class SdlcHubService implements SdlcHub {
       throw new AppError('SDLC discussions must be created with their conversation', 400);
     }
     const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
-    await this.requireLinkSource(repoId, repo.channelId!, input.sourceType, input.sourceId);
+    await this.requireLinkSource(repoId, repo.channelId, input.sourceType, input.sourceId);
     await this.requireAccessibleEntity(actor, input.targetType, input.targetId);
     try {
       const link = await this.prisma.sdlcEntityLink.create({

--- a/apps/backend/src/sdlc/cleanup/multirepoBackfill.ts
+++ b/apps/backend/src/sdlc/cleanup/multirepoBackfill.ts
@@ -68,6 +68,24 @@ async function readHubs(limit: number, afterId: string | null): Promise<LegacySd
   return rows.map(row => ({ ...row, channelId: row.channelId! }));
 }
 
+// Raw because the column is required in Prisma and nullable only for these rows,
+// so the typed filters cannot name them.
+function countLegacyLinks(repoId: string): Promise<number> {
+  return db
+    .$queryRaw<Array<{ count: bigint }>>`
+      SELECT count(*) FROM "public"."sdlc_entity_links"
+      WHERE "repoId" = ${repoId} AND "channelId" IS NULL
+    `
+    .then(rows => Number(rows[0]?.count ?? 0));
+}
+
+function stampLegacyLinks(repoId: string, channelId: string): Promise<number> {
+  return db.$executeRaw`
+    UPDATE "public"."sdlc_entity_links" SET "channelId" = ${channelId}
+    WHERE "repoId" = ${repoId} AND "channelId" IS NULL
+  `;
+}
+
 /** A hub's tracks, by the repository column they were scoped by. */
 function readTracks(repoId: string) {
   return db.sdlcTrack.findMany({
@@ -123,7 +141,7 @@ export async function backfillSdlcMultirepo(
                     targetId: { in: trackRows.map(row => row.targetId) },
                   },
                 }),
-            db.sdlcEntityLink.count({ where: { repoId: hub.id, channelId: null } }),
+            countLegacyLinks(hub.id),
           ]);
           trackEdgesCreated += trackRows.length - existingTrackEdges;
           linksStamped += stampableLinks;
@@ -132,13 +150,10 @@ export async function backfillSdlcMultirepo(
             trackRows.length === 0
               ? Promise.resolve({ count: 0 })
               : db.sdlcEntityLink.createMany({ data: trackRows, skipDuplicates: true }),
-            db.sdlcEntityLink.updateMany({
-              where: { repoId: hub.id, channelId: null },
-              data: { channelId: hub.channelId },
-            }),
+            stampLegacyLinks(hub.id, hub.channelId),
           ]);
           trackEdgesCreated += trackEdges.count;
-          linksStamped += links.count;
+          linksStamped += links;
         }
       }
 

--- a/apps/backend/src/services/notificationService.ts
+++ b/apps/backend/src/services/notificationService.ts
@@ -22,7 +22,8 @@ import { serializeInitialMessageMd,
   type InitialMessageSummary,
   ChannelScopeType,
   NotificationDeliveryMethod,
-  NotificationType, MessageType, NotificationStatus, UserStatus } from '@xyne/shared';
+  NotificationType, MessageType, NotificationStatus, UserStatus,
+  ChannelType } from '@xyne/shared';
 
 const prisma = DatabaseClient.getInstance();
 
@@ -848,6 +849,17 @@ class NotificationService {
   ): Promise<{ deliveredViaApp: boolean }> {
     let deliveredViaApp = false;
 
+    // No actionUrl builder knows the SDLC routes. Builders already put the entity
+    // ids in metadata, so drop the URL and add the one key they lack — which hub.
+    const sdlcChannelId = await this.sdlcChannelId(data);
+    if (sdlcChannelId) {
+      data = {
+        ...data,
+        actionUrl: undefined,
+        metadata: { ...(data.metadata ?? {}), sdlcChannelId },
+      };
+    }
+
     try {
       logger.info(`[NOTIFICATION-SERVICE] createNotification called`, {
         userId,
@@ -955,6 +967,39 @@ class NotificationService {
     }
 
     return { deliveredViaApp };
+  }
+
+  /** The SDLC hub a notification belongs to, or null everywhere else. */
+  private async sdlcChannelId(data: NotificationData): Promise<string | null> {
+    const metadata = (data.metadata ?? {}) as Record<string, unknown>;
+    const asId = (value: unknown): string | undefined =>
+      typeof value === 'string' && value.length > 0 ? value : undefined;
+    const related = (type: string): string | undefined =>
+      data.relatedEntityType === type ? asId(data.relatedEntityId) : undefined;
+
+    try {
+      const canvasId = asId(metadata['canvasId']) ?? related('canvas');
+      const ticketId = asId(metadata['ticketId']) ?? related('ticket');
+      const channelId =
+        asId(metadata['channelId']) ??
+        (canvasId
+          ? (await prisma.canvas.findUnique({ where: { id: canvasId }, select: { channelId: true } }))
+              ?.channelId
+          : ticketId
+            ? (await prisma.ticket.findUnique({ where: { id: ticketId }, select: { channelId: true } }))
+                ?.channelId
+            : undefined);
+      if (!channelId) return null;
+      const channel = await prisma.channel.findUnique({
+        where: { id: channelId },
+        select: { type: true },
+      });
+      return channel?.type === ChannelType.SDLC ? channelId : null;
+    } catch (error) {
+      // Routing must never take a notification down; fall back to the actionUrl.
+      logger.warn('[SDLC] failed to resolve notification channel', { error });
+      return null;
+    }
   }
 
   async createChannelMessageNotifications(

--- a/apps/backend/src/services/notificationService.ts
+++ b/apps/backend/src/services/notificationService.ts
@@ -22,8 +22,7 @@ import { serializeInitialMessageMd,
   type InitialMessageSummary,
   ChannelScopeType,
   NotificationDeliveryMethod,
-  NotificationType, MessageType, NotificationStatus, UserStatus,
-  ChannelType } from '@xyne/shared';
+  NotificationType, MessageType, NotificationStatus, UserStatus } from '@xyne/shared';
 
 const prisma = DatabaseClient.getInstance();
 
@@ -849,17 +848,6 @@ class NotificationService {
   ): Promise<{ deliveredViaApp: boolean }> {
     let deliveredViaApp = false;
 
-    // No actionUrl builder knows the SDLC routes. Builders already put the entity
-    // ids in metadata, so drop the URL and add the one key they lack — which hub.
-    const sdlcChannelId = await this.sdlcChannelId(data);
-    if (sdlcChannelId) {
-      data = {
-        ...data,
-        actionUrl: undefined,
-        metadata: { ...(data.metadata ?? {}), sdlcChannelId },
-      };
-    }
-
     try {
       logger.info(`[NOTIFICATION-SERVICE] createNotification called`, {
         userId,
@@ -967,39 +955,6 @@ class NotificationService {
     }
 
     return { deliveredViaApp };
-  }
-
-  /** The SDLC hub a notification belongs to, or null everywhere else. */
-  private async sdlcChannelId(data: NotificationData): Promise<string | null> {
-    const metadata = (data.metadata ?? {}) as Record<string, unknown>;
-    const asId = (value: unknown): string | undefined =>
-      typeof value === 'string' && value.length > 0 ? value : undefined;
-    const related = (type: string): string | undefined =>
-      data.relatedEntityType === type ? asId(data.relatedEntityId) : undefined;
-
-    try {
-      const canvasId = asId(metadata['canvasId']) ?? related('canvas');
-      const ticketId = asId(metadata['ticketId']) ?? related('ticket');
-      const channelId =
-        asId(metadata['channelId']) ??
-        (canvasId
-          ? (await prisma.canvas.findUnique({ where: { id: canvasId }, select: { channelId: true } }))
-              ?.channelId
-          : ticketId
-            ? (await prisma.ticket.findUnique({ where: { id: ticketId }, select: { channelId: true } }))
-                ?.channelId
-            : undefined);
-      if (!channelId) return null;
-      const channel = await prisma.channel.findUnique({
-        where: { id: channelId },
-        select: { type: true },
-      });
-      return channel?.type === ChannelType.SDLC ? channelId : null;
-    } catch (error) {
-      // Routing must never take a notification down; fall back to the actionUrl.
-      logger.warn('[SDLC] failed to resolve notification channel', { error });
-      return null;
-    }
   }
 
   async createChannelMessageNotifications(
@@ -1382,6 +1337,8 @@ class NotificationService {
         senderId,
         ...(!isCommentMention ? { senderName } : {}),
         workspaceId,
+        // Every other builder sends it; the client routes on the channel's type.
+        ...(channelId ? { channelId } : {}),
         mentionContext,
         ...(blockId ? { blockId } : {}),
         ...(commentThreadId ? { commentThreadId } : {}),

--- a/apps/backend/src/zero/acl/tables/sdlc-entity-links-acl.ts
+++ b/apps/backend/src/zero/acl/tables/sdlc-entity-links-acl.ts
@@ -16,6 +16,11 @@ export class SdlcEntityLinksACL extends BaseACL<'sdlc_entity_links'> {
     tx: Transaction<Schema>,
   ): Promise<void> {
     assertWorkspaceMatch(this.ctx, args.workspaceId, 'sdlc_entity_links');
+    // The edge's only scope. Every reader filters on it, so an unscoped row is
+    // written and then invisible to everyone.
+    if (!args.channelId) {
+      throw new MutationACLError('SDLC entity links require a hub', 'sdlc_entity_links');
+    }
     // Repository membership is structure, not content: only the hub endpoints write it.
     if (args.relationType === SDLC_MEMBERSHIP_RELATION) {
       throw new MutationACLError(
@@ -26,14 +31,12 @@ export class SdlcEntityLinksACL extends BaseACL<'sdlc_entity_links'> {
     // Track membership is structure too, but sdlc.createTrack writes it through this
     // path, so it is gated rather than refused: the writer must be in that hub.
     if (args.relationType === SDLC_TRACK_MEMBERSHIP_RELATION) {
-      const participant = args.channelId
-        ? await tx.run(
-            zql.channel_participants
-              .where('channelId', args.channelId)
-              .where('userId', this.ctx.userID)
-              .one(),
-          )
-        : null;
+      const participant = await tx.run(
+        zql.channel_participants
+          .where('channelId', args.channelId)
+          .where('userId', this.ctx.userID)
+          .one(),
+      );
       if (!participant) {
         throw new MutationACLError('Hub membership required', 'sdlc_entity_links');
       }

--- a/apps/dashboard/src/components/Activity/sdlcActivityNavigation.ts
+++ b/apps/dashboard/src/components/Activity/sdlcActivityNavigation.ts
@@ -1,15 +1,8 @@
-import { isBaselineCanvasType } from '@xyne/shared/sdlc';
+import { buildSdlcPath } from '@xyne/shared/sdlc';
 
 interface SdlcActivityNavigationActivity {
   canvasId?: string | null;
-  canvas?:
-    | {
-        readonly id: string;
-        readonly folderId?: string | null;
-        readonly sdlcArtifact?: { readonly artifactType?: unknown } | null;
-      }
-    | null
-    | undefined;
+  canvas?: { readonly id: string } | null | undefined;
   ticketId?: string | null;
   ticket?: { readonly id: string } | null | undefined;
   conversationId?: string | null;
@@ -23,63 +16,21 @@ interface SdlcActivityNavigationActivity {
     | undefined;
 }
 
-const canvasSpecialSection = (artifactType: unknown): string | null => {
-  if (typeof artifactType !== 'string') return null;
-  if (isBaselineCanvasType(artifactType)) return 'baseline';
-  if (artifactType === 'WIKI') return 'wiki';
-  return null;
-};
-
-const sdlcPath = (channelId: string, section: string, search?: URLSearchParams): string => {
-  const query = search?.toString();
-  return `/sdlc/${encodeURIComponent(channelId)}/${section}${query ? `?${query}` : ''}`;
-};
-
+/** Maps an activity row onto the entity ids `buildSdlcPath` routes on. */
 export function resolveSdlcActivityTarget(input: {
   activity: SdlcActivityNavigationActivity;
   channelType: string | null | undefined;
   channelId: string | null | undefined;
   fallbackPath: string;
 }): string {
-  // SDLC spaces are addressed by their channel. A space can cover several
-  // repositories, so the repository is chosen inside the screen, not in the URL.
   if (input.channelType !== 'SDLC' || !input.channelId) return input.fallbackPath;
-  const channelId = input.channelId;
+  const activity = input.activity;
 
-  const canvasId = input.activity.canvasId ?? input.activity.canvas?.id;
-  if (canvasId) {
-    const special = canvasSpecialSection(input.activity.canvas?.sdlcArtifact?.artifactType);
-    if (special) {
-      return sdlcPath(channelId, special, new URLSearchParams({ canvas: canvasId }));
-    }
-    const folderId = input.activity.canvas?.folderId;
-    if (folderId) {
-      return sdlcPath(
-        channelId,
-        'artifacts',
-        new URLSearchParams({ type: folderId, canvas: canvasId }),
-      );
-    }
-  }
-
-  const ticketId = input.activity.ticketId ?? input.activity.ticket?.id;
-  if (ticketId) {
-    return sdlcPath(channelId, 'tickets', new URLSearchParams({ ticket: ticketId }));
-  }
-
-  const conversationId =
-    input.activity.message?.conversation?.conversationId ?? input.activity.conversationId;
-  if (conversationId) {
-    const search = new URLSearchParams({
-      discussion: '1',
-      chat: 'conversations',
-      conversation: conversationId,
-    });
-    const messageId = input.activity.message?.messageId ?? input.activity.messageId;
-    const hash = new URLSearchParams({ origin: conversationId });
-    if (messageId) hash.set('messageId', messageId);
-    return `${sdlcPath(channelId, 'overview', search)}#${hash.toString()}`;
-  }
-
-  return sdlcPath(channelId, 'overview');
+  return buildSdlcPath({
+    channelId: input.channelId,
+    canvasId: activity.canvasId ?? activity.canvas?.id,
+    ticketId: activity.ticketId ?? activity.ticket?.id,
+    conversationId: activity.message?.conversation?.conversationId ?? activity.conversationId,
+    messageId: activity.message?.messageId ?? activity.messageId,
+  });
 }

--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -11,10 +11,11 @@ import { API_BASE_URL } from '../../config';
 import { queryClient } from '../../services/clients/queryClient';
 import { NativeInboundMessageType, reactNativeBridge } from '../../utils/reactNativeBridge';
 import { useZero } from '../../hooks/useZero';
+import { useAllChannels } from '../../hooks/useChannels';
 import { callActor } from '../../machines/callMachine';
 import { roomActor } from '../../machines/roomMachine';
 import { useSelector } from '@xstate/react';
-import { CallType } from '@xyne/shared';
+import { CallType, ChannelType } from '@xyne/shared';
 import { buildSdlcPath } from '@xyne/shared/sdlc';
 import { setupPresenceListeners, cleanupPresenceListeners } from '../../machines/stateMachine';
 import { queryCacheActor, type Conversation } from '../../machines/queryCacheMachine';
@@ -74,7 +75,6 @@ interface NotificationData {
       commentThreadId?: string;
       conversation?: Conversation;
       notificationType?: string;
-      sdlcChannelId?: string;
       ticketId?: string;
     };
     metadata?: {
@@ -131,6 +131,14 @@ export const NotificationHandler: React.FC = () => {
   useEffect(() => {
     activeWorkspaceIdRef.current = activeWorkspaceId;
   }, [activeWorkspaceId]);
+  // Read inside the socket callback, which is registered once.
+  const allChannels = useAllChannels();
+  const sdlcChannelIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    sdlcChannelIdsRef.current = new Set(
+      allChannels.filter(channel => channel.type === ChannelType.SDLC).map(channel => channel.id),
+    );
+  }, [allChannels]);
   const isConnectedRef = useRef(false);
   const isElectron = typeof window !== 'undefined' && window.electronAPI !== undefined;
   const [suppressNativeToasts, setSuppressNativeToasts] = useState<boolean>(() =>
@@ -232,17 +240,20 @@ export const NotificationHandler: React.FC = () => {
         }
         // Socket delivery spreads metadata into `data`; the REST row keeps `metadata`.
         const ids = { ...data.notification.metadata, ...data.notification.data };
-        const sdlcActionUrl = ids.sdlcChannelId
-          ? buildSdlcPath({
-              channelId: ids.sdlcChannelId,
-              canvasId: ids.canvasId,
-              ticketId: ids.ticketId,
-              conversationId: ids.conversationId,
-              messageId: ids.messageId,
-              blockId: ids.blockId,
-              commentThreadId: ids.commentThreadId,
-            })
-          : undefined;
+        // No builder knows the SDLC routes, so the hub's own paths are built here
+        // from the ids they all send, against channels the client already holds.
+        const sdlcActionUrl =
+          ids.channelId && sdlcChannelIdsRef.current.has(ids.channelId)
+            ? buildSdlcPath({
+                channelId: ids.channelId,
+                canvasId: ids.canvasId,
+                ticketId: ids.ticketId,
+                conversationId: ids.conversationId,
+                messageId: ids.messageId,
+                blockId: ids.blockId,
+                commentThreadId: ids.commentThreadId,
+              })
+            : undefined;
         const resolvedRawActionUrl =
           sdlcActionUrl ||
           data.notification.actionUrl ||

--- a/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
+++ b/apps/dashboard/src/components/NotificationHandler/NotificationHandler.tsx
@@ -15,6 +15,7 @@ import { callActor } from '../../machines/callMachine';
 import { roomActor } from '../../machines/roomMachine';
 import { useSelector } from '@xstate/react';
 import { CallType } from '@xyne/shared';
+import { buildSdlcPath } from '@xyne/shared/sdlc';
 import { setupPresenceListeners, cleanupPresenceListeners } from '../../machines/stateMachine';
 import { queryCacheActor, type Conversation } from '../../machines/queryCacheMachine';
 import { MEETING_DETECTION_ENABLED_KEY } from '../../constants/settings';
@@ -73,6 +74,8 @@ interface NotificationData {
       commentThreadId?: string;
       conversation?: Conversation;
       notificationType?: string;
+      sdlcChannelId?: string;
+      ticketId?: string;
     };
     metadata?: {
       notificationType?: string;
@@ -227,10 +230,30 @@ export const NotificationHandler: React.FC = () => {
             ),
           });
         }
+        // Socket delivery spreads metadata into `data`; the REST row keeps `metadata`.
+        const ids = { ...data.notification.metadata, ...data.notification.data };
+        const sdlcActionUrl = ids.sdlcChannelId
+          ? buildSdlcPath({
+              channelId: ids.sdlcChannelId,
+              canvasId: ids.canvasId,
+              ticketId: ids.ticketId,
+              conversationId: ids.conversationId,
+              messageId: ids.messageId,
+              blockId: ids.blockId,
+              commentThreadId: ids.commentThreadId,
+            })
+          : undefined;
         const resolvedRawActionUrl =
-          data.notification.actionUrl || canvasRedirectUrl || fallbackChatActionUrl;
+          sdlcActionUrl ||
+          data.notification.actionUrl ||
+          canvasRedirectUrl ||
+          fallbackChatActionUrl;
         const resolvedActionUrl = resolvedRawActionUrl
-          ? withWorkspacePrefix(resolvedRawActionUrl, notificationWorkspaceId)
+          ? withWorkspacePrefix(
+              resolvedRawActionUrl,
+              // Unprefixed SDLC paths bind :workspaceId to "sdlc" — never ship one.
+              notificationWorkspaceId ?? activeWorkspaceIdRef.current,
+            )
           : undefined;
 
         // Always show workspace at the top when available, matching Slack.

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcFrameHost.tsx
@@ -59,9 +59,9 @@ const SdlcFrameHost = (): ReactElement | null => {
   // :workspaceId, so at mount the location is usually a different screen.
   useEffect(() => {
     if (!viewport || initialSrcRef.current || !workspaceId) return;
-    initialSrcRef.current = `${SDLC_APP_BASE_PATH}${location.pathname}${location.search}`;
+    initialSrcRef.current = `${SDLC_APP_BASE_PATH}${location.pathname}${location.search}${location.hash}`;
     setHasActivated(true);
-  }, [viewport, workspaceId, location.pathname, location.search]);
+  }, [viewport, workspaceId, location.pathname, location.search, location.hash]);
 
   // frame → parent
   useEffect(() => {
@@ -105,7 +105,7 @@ const SdlcFrameHost = (): ReactElement | null => {
 
       lastFromFrameRef.current = message.path;
       // Only while on screen — a hidden frame must not move the address bar.
-      const current = `${location.pathname}${location.search}`;
+      const current = `${location.pathname}${location.search}${location.hash}`;
       if (viewport && isSdlcPath(message.path) && message.path !== current) {
         void navigate(message.path, { replace: true });
       }
@@ -113,7 +113,7 @@ const SdlcFrameHost = (): ReactElement | null => {
 
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [location.pathname, location.search, navigate, viewport, workspaceId]);
+  }, [location.pathname, location.search, location.hash, navigate, viewport, workspaceId]);
 
   // parent → frame
   useEffect(() => {
@@ -121,13 +121,14 @@ const SdlcFrameHost = (): ReactElement | null => {
     const target = iframeRef.current?.contentWindow;
     if (!target) return;
 
-    const path = `${location.pathname}${location.search}`;
+    // The hash carries #origin/#messageId scroll targets, so it must ride along.
+    const path = `${location.pathname}${location.search}${location.hash}`;
     if (!isSdlcPath(location.pathname)) return;
     if (path === lastFromFrameRef.current || path === lastToFrameRef.current) return;
 
     lastToFrameRef.current = path;
     target.postMessage({ type: SDLC_FRAME_MESSAGE.navigate, path }, window.location.origin);
-  }, [isReady, viewport, location.pathname, location.search]);
+  }, [isReady, viewport, location.pathname, location.search, location.hash]);
 
   if (!container || !hasActivated || !initialSrcRef.current) return null;
 

--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -93,6 +93,7 @@ import {
 } from '../../components/Chat/XyneAISidebar/components/ContextPickerPanel';
 import { useExternalDebuggerStore } from '../../store/useExternalDebuggerStore';
 import CanvasScreen from '../../components/Canvas/CanvasScreen';
+import ThreadMessages from '../../components/Chat/ThreadPannel';
 import {
   isElectronApp,
   openStandaloneWindow,
@@ -605,6 +606,18 @@ export default function SdlcScreen(): ReactElement {
     [selectedCanvasRelatedConversations],
   );
   const selectedTicketId = routeSearchParams.get('ticket');
+  // ThreadMessages keys off the conversation, so a `?ticket=` deep link has to
+  // read the row to find one.
+  const [selectedTicketRow] = useCachedQuery(
+    queries.ticketRowById({ ticketId: selectedTicketId ?? '' }),
+    { enabled: Boolean(selectedTicketId) },
+  );
+  const closeTicketPanel = useCallback((): void => {
+    const next = new URLSearchParams(location.search);
+    next.delete('ticket');
+    const search = next.toString();
+    void navigate(`${location.pathname}${search ? `?${search}` : ''}`, { replace: true });
+  }, [location.pathname, location.search, navigate]);
   const chatLayout = sdlcChatLayout({
     chatParam: routeSearchParams.get('chat'),
     discussionParam: routeSearchParams.get('discussion'),
@@ -640,14 +653,101 @@ export default function SdlcScreen(): ReactElement {
     ],
   );
 
+  // Converting a discussion to a ticket leaves the artifact link on the
+  // conversation, not on the ticket, so the ticket alone resolves to nothing.
+  const ticketDiscussion = useMemo(() => {
+    const conversationId = selectedTicketRow?.conversationId;
+    if (!selectedTicketId || !conversationId) return null;
+    const canvasId = links.find(
+      link =>
+        link.sourceType === 'CANVAS' &&
+        link.targetType === 'CONVERSATION' &&
+        link.relationType === 'DISCUSSION' &&
+        link.targetId === conversationId,
+    )?.sourceId;
+    return canvasId ? { canvasId, conversationId } : null;
+  }, [links, selectedTicketId, selectedTicketRow]);
+
+  // A deep link names a conversation or a ticket, not a place. Both hang off an
+  // artifact, so open that one — a ticket with none stays on the board.
+  const canvasSectionFix = useMemo(() => {
+    const canvasId =
+      selectedCanvasId ?? discussionContext?.owner.canvasId ?? ticketDiscussion?.canvasId ?? null;
+    if (!canvasId) return null;
+    const canvas = canvases.find(item => item.id === canvasId);
+    if (!canvas) return null;
+    const artifactType = canvas.sdlcArtifact?.artifactType;
+    const target = isBaselineCanvasType(artifactType)
+      ? { section: 'baseline', type: null }
+      : artifactType === 'WIKI'
+        ? { section: 'wiki', type: null }
+        : { section: 'artifacts', type: canvas.folderId ?? null };
+    const settled =
+      section === target.section &&
+      selectedCanvasId === canvasId &&
+      (target.type === null || activeTypeFolderId === target.type);
+    return settled ? null : { ...target, canvasId, discussion: ticketDiscussion };
+  }, [
+    activeTypeFolderId,
+    canvases,
+    discussionContext,
+    section,
+    selectedCanvasId,
+    ticketDiscussion,
+  ]);
+
+  useEffect(() => {
+    if (!canvasSectionFix) return;
+    const search = new URLSearchParams(location.search);
+    search.set('canvas', canvasSectionFix.canvasId);
+    if (canvasSectionFix.type) search.set('type', canvasSectionFix.type);
+    else search.delete('type');
+    if (canvasSectionFix.discussion) {
+      // The ticket has served its purpose; its thread is what to show.
+      search.delete('ticket');
+      search.set('discussion', '1');
+      search.set('chat', 'conversations');
+      search.set('conversation', canvasSectionFix.discussion.conversationId);
+    }
+    void navigate(
+      `/sdlc/${channelId}/${canvasSectionFix.section}?${search.toString()}${location.hash}`,
+      { replace: true },
+    );
+  }, [canvasSectionFix, channelId, location.hash, location.search, navigate]);
+
+  // A track discussion has no canvas owner, so it would be stripped below.
+  const deepLinkedTrackId = useMemo(() => {
+    if (!selectedDiscussionConversationId || discussionContext) return null;
+    return (
+      links.find(
+        link =>
+          link.sourceType === 'TRACK' &&
+          link.targetType === 'CONVERSATION' &&
+          link.relationType === 'DISCUSSION' &&
+          link.targetId === selectedDiscussionConversationId,
+      )?.sourceId ?? null
+    );
+  }, [links, selectedDiscussionConversationId, discussionContext]);
+
+  useEffect(() => {
+    if (!deepLinkedTrackId || deepLinkedTrackId === selectedTrackId) return;
+    const search = new URLSearchParams(location.search);
+    search.set('track', deepLinkedTrackId);
+    void navigate(`/sdlc/${channelId}/tracks?${search.toString()}${location.hash}`, {
+      replace: true,
+    });
+  }, [channelId, deepLinkedTrackId, location.hash, location.search, navigate, selectedTrackId]);
+
   useEffect(() => {
     if (
       !shouldCloseInvalidSdlcConversationDeepLink({
-        repoQueryComplete: repoQueryDetails.type === 'complete',
+        dataLoaded: repoQueryDetails.type === 'complete' && linkRows !== undefined,
         discussionOpen,
         selectedConversationId: selectedDiscussionConversationId,
         discussionContextResolved:
-          Boolean(discussionContext) || Boolean(section === 'tracks' && selectedTrackId),
+          Boolean(discussionContext) ||
+          Boolean(deepLinkedTrackId) ||
+          Boolean(section === 'tracks' && selectedTrackId),
       })
     ) {
       return;
@@ -665,9 +765,11 @@ export default function SdlcScreen(): ReactElement {
     location.search,
     navigate,
     repoQueryDetails.type,
+    linkRows,
     section,
     selectedDiscussionConversationId,
     selectedTrackId,
+    deepLinkedTrackId,
   ]);
   const discussionOwner = discussionContext?.owner ?? null;
   const discussionSurface = discussionContext?.surface ?? null;
@@ -2385,8 +2487,19 @@ export default function SdlcScreen(): ReactElement {
                   ))}
                 {section === 'tracks' && renderTracks()}
                 {section === 'tickets' && repo.channelId && (
-                  <div className='h-[calc(100vh-8rem)] min-h-[36rem]'>
+                  <div className='relative h-[calc(100vh-8rem)] min-h-[36rem]'>
                     <KanbanBoardScreen channelId={repo.channelId} />
+                    {selectedTicketRow?.conversationId && (
+                      <div className='absolute bottom-4 right-4 top-4 z-20 flex w-[480px] max-w-[calc(100%-2rem)] flex-col overflow-hidden rounded-xl border border-border bg-background shadow-2xl'>
+                        <ThreadMessages
+                          ticketId={selectedTicketRow.id}
+                          channelId={selectedTicketRow.channelId ?? repo.channelId}
+                          conversationId={selectedTicketRow.conversationId}
+                          skipInputAutoFocus
+                          onClose={closeTicketPanel}
+                        />
+                      </div>
+                    )}
                   </div>
                 )}
               </div>

--- a/apps/dashboard/src/routes/SdlcScreen/sdlcChatPolicy.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/sdlcChatPolicy.ts
@@ -87,12 +87,13 @@ export const shouldStartFreshSdlcAssistant = (input: {
   input.actorRepositoryId !== input.repositoryId;
 
 export const shouldCloseInvalidSdlcConversationDeepLink = (input: {
-  repoQueryComplete: boolean;
+  /** Both the channel and the entity links, since the context needs both. */
+  dataLoaded: boolean;
   discussionOpen: boolean;
   selectedConversationId: string | null;
   discussionContextResolved: boolean;
 }): boolean =>
-  input.repoQueryComplete &&
+  input.dataLoaded &&
   input.discussionOpen &&
   Boolean(input.selectedConversationId) &&
   !input.discussionContextResolved;

--- a/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
+++ b/apps/dashboard/src/routes/SdlcScreen/useSdlcFrameBridge.ts
@@ -62,10 +62,10 @@ export function useSdlcFrameBridge(): void {
   useEffect(() => {
     if (!enabled) return;
 
-    const path = `${location.pathname}${location.search}`;
+    const path = `${location.pathname}${location.search}${location.hash}`;
     if (path === lastFromParentRef.current || path === lastReportedRef.current) return;
 
     lastReportedRef.current = path;
     window.parent.postMessage({ type: SDLC_FRAME_MESSAGE.route, path }, window.location.origin);
-  }, [enabled, location.pathname, location.search]);
+  }, [enabled, location.pathname, location.search, location.hash]);
 }

--- a/packages/shared/src/sdlc.ts
+++ b/packages/shared/src/sdlc.ts
@@ -757,3 +757,45 @@ export function inferRepositoryNameFromUrl(raw: string): string | null {
     .filter(Boolean);
   return segments.length >= 3 ? segments.at(-1)! : null;
 }
+
+/** Where to open in an SDLC hub, as entity ids only — `buildSdlcPath` makes the route. */
+export interface SdlcNavTarget {
+  channelId: string;
+  canvasId?: string | null | undefined;
+  ticketId?: string | null | undefined;
+  conversationId?: string | null | undefined;
+  messageId?: string | null | undefined;
+  blockId?: string | null | undefined;
+  commentThreadId?: string | null | undefined;
+}
+
+/** The repository is chosen inside the screen; the workspace prefix by the caller. */
+export function buildSdlcPath(target: SdlcNavTarget): string {
+  const search = new URLSearchParams();
+  let section = "overview";
+
+  if (target.canvasId) {
+    section = "artifacts";
+    search.set("canvas", target.canvasId);
+    // CanvasScreen reads both straight off the URL to focus an inline comment.
+    if (target.blockId) search.set("blockId", target.blockId);
+    if (target.commentThreadId) search.set("commentThreadId", target.commentThreadId);
+  } else if (target.ticketId) {
+    section = "tickets";
+    search.set("ticket", target.ticketId);
+  }
+
+  // A discussion hangs off whatever was opened above, not a section of its own.
+  // Without a message to scroll to, opening the panel is a guess — every ticket
+  // notification carries the ticket's conversationId whether or not it is about one.
+  let hash = "";
+  if (target.conversationId && target.messageId) {
+    search.set("discussion", "1");
+    search.set("chat", "conversations");
+    search.set("conversation", target.conversationId);
+    hash = `#${new URLSearchParams({ origin: target.conversationId, messageId: target.messageId }).toString()}`;
+  }
+
+  const query = search.toString();
+  return `/sdlc/${encodeURIComponent(target.channelId)}/${section}${query ? `?${query}` : ""}${hash}`;
+}


### PR DESCRIPTION
Stacked on #1236. Review only the last commit; the base branch carries the multi-repo work.

## Problem

An SDLC notification or activity did not land where it should. The backend built the route as a string, so the frontend could not change it, and every builder wrote a `/chat/` URL — a notification about an artifact or a ticket inside an SDLC hub navigated out of the hub entirely.

## Backend sends data, not routes

`createNotification` resolves whether a notification belongs to an SDLC hub and, when it does, drops `actionUrl` and adds `sdlcChannelId` to the metadata the builders already populate. One guard in the funnel every notification passes through, so mentions, replies, canvas shares and ticket notifications are covered without touching any of the builders.

`buildSdlcPath` in `packages/shared` turns those ids into a path, and is the only place the routes are named. Both the notification handler and the activity list call it.

The discussion panel now opens only when a `messageId` is present. All fourteen ticket builders put the ticket's own `conversationId` in metadata whether or not the notification is about a message, so without that condition every SDLC ticket notification force-opened a discussion.

## The destination resolves the section

A deep link names an id, not a place. `SdlcScreen` decides where that id lives on arrival, where the hub's canvases and entity links are already loaded:

- an artifact deep link picks `baseline`, `wiki` or `artifacts` from its artifact type
- a discussion deep link, which names only a conversation, falls back to that conversation's owning canvas
- a track discussion resolves through the `TRACK → CONVERSATION` link
- a ticket resolves through its conversation: converting a discussion to a ticket leaves the `CANVAS → CONVERSATION [DISCUSSION]` link on the conversation and creates no link on the ticket, so the ticket alone resolves to nothing. It now lands on the owning artifact with that thread open.

A ticket with no artifact behind it stays on the hub's board and opens in a panel there, rather than navigating out of SDLC as it did before.

## Two fixes the deep links depend on

- The iframe path sync dropped `location.hash`, so the `#origin`/`#messageId` scroll target died on every navigation after the first.
- The invalid-deep-link guard ran as soon as the channel query resolved, but the discussion context needs the entity links from a separate query. Conversation-only deep links are now the standard shape, so the guard was stripping the discussion params before they could be matched.

## Testing

Typecheck, lint and prettier clean on both apps. Verified end to end in a local hub: artifact activity opens the artifact, track discussion opens the track with its thread, a ticket converted from a PRD discussion opens that PRD, and a board-created ticket opens in the board panel.


---

## Update — two more commits

**Client decides SDLC routing.** `createNotification` no longer resolves whether a notification belongs to an SDLC hub. That cost a channel lookup per recipient on the path every notification passes through, and blanking `actionUrl` alongside it took the deeplink away from mobile, which has no `buildSdlcPath`. The client already holds every channel it can see, so `NotificationHandler` keeps a set of SDLC channel ids from `useAllChannels` and reads it through a ref, since the socket callback registers once. Builders are unchanged — the one gap was canvas mentions, which took `channelId` as a parameter and never forwarded it to metadata while every other builder did.

**A hub is now required on every SDLC entity link.** `channelId` is the only scope an `sdlc_entity_links` row carries; every read filters on it and the Zero query ACL resolves visibility through `channel -> participants`, so a row without one is written and then invisible to everyone. Prisma models it as required; Postgres keeps it nullable because the pre-multirepo rows are still waiting on the backfill, and the migration that added the column now says so. Every current write already satisfied this, so three `repo.channelId!` assertions are gone. The one path that could still write an unscoped row was the Zero mutation ACL, which checked `channelId` only for track membership and now rejects any insert without one.
