### PR TITLE
Revert "feat: add ordered encryption key rotation (#764)"

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -112,12 +112,6 @@ ENABLE_DEV_AUTH=true
 # Security
 ENCRYPTION_KEY=set-me
 
-# Ordered JSON array of additional Spaces encryption keys.
-# The LAST entry is the active key used for new writes.
-# Every entry remains available for decryption.
-# Unset or empty means new writes remain in legacy format.
-# ENCRYPTION_KEYS=[{"id":"k1","key":"<64-hex>"}]
-
 # External APIs (add when needed)
 # API_KEY=
 # API_SECRET=
@@ -346,6 +340,7 @@ SUDO_QUERY_TOKEN=xyz
 
 # Security
 # JWT_SECRET=
+# ENCRYPTION_KEY=
 
 # External APIs (add when needed)
 # API_KEY=
@@ -406,6 +401,7 @@ JUSPAY_JIRA_BASEURL=https://juspay.atlassian.net
 JIRA_MIGRATION_BOT_EMAIL=your-jira-migration-bot-email
 JIRA_MIGRATION_BOT_AUTH_TOKEN=your-jira-migration-bot-auth-token
 # ─── Zero Field Encryption ───────────────────────────────────────────────────
+# See docs/ENCRYPTION_IMPLEMENTATION_PLAN.md for full setup guide.
 #
 # Generate dev keys (one-time):
 #   mkdir -p .xyne/dev/keys

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -6,12 +6,6 @@ dotenv.config();
 import { parseInternalAppHostMap } from '@/utils/internalHostMap';
 
 const envSchema = Joi.object({
-  // Legacy AES-256-CBC key used for unversioned ciphertext.
-  ENCRYPTION_KEY: Joi.string().allow('').optional(),
-  // Ordered JSON key ring. The final entry is the active writer;
-  // all entries remain available for decryption.
-  ENCRYPTION_KEYS: Joi.string().allow('').optional(),
-
   NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
   SANDBOX_TEST_MODE: Joi.boolean().default(false),
   ORG_MEMBER_LIMIT: Joi.number().integer().min(1).allow(null).default(null),
@@ -415,7 +409,9 @@ const envSchema = Joi.object({
   ENABLE_DB_ENCRYPTION: Joi.boolean().default(false),
   ENC_ORG_PROVISION: Joi.boolean().default(false),
   ENC_WORKSPACE_PROVISION: Joi.boolean().default(false),
-  JIRA_MIGRATION_USER_MAP_CSV_LOCATION: Joi.string().allow('').default(''),
+  JIRA_MIGRATION_USER_MAP_CSV_LOCATION: Joi.string()
+    .allow('')
+    .default(''),
   JIRA_MIGRATION_ISSUE_PAGE_SIZE: Joi.number().integer().min(1).max(500).default(25),
   // Default to a conservative delay to avoid accidental Jira API hammering in environments
   // where `JIRA_MIGRATION_BATCH_DELAY_MS` isn't explicitly set.

--- a/apps/backend/src/services/encryptionService.ts
+++ b/apps/backend/src/services/encryptionService.ts
@@ -1,233 +1,74 @@
 /**
- * Rotation-aware AES-256-CBC encryption service.
- *
- * Legacy ciphertext:
- *   iv:ciphertext
- *
- * Versioned ciphertext:
- *   v2:keyId:iv:ciphertext
- *
- * ENCRYPTION_KEY stores the legacy key.
- *
- * ENCRYPTION_KEYS is an ordered JSON array:
- *   [{"id":"k1","key":"64-hex"},{"id":"k2","key":"64-hex"}]
- *
- * The final array entry is the active writer. All entries remain available
- * for decryption. If the array is absent or empty, writes remain legacy.
- *
- * To preload a future key without activating it, place it before the current
- * final entry. Move it to the end only after every reader has received it.
+ * Encryption Service
+ * AES-256-CBC encryption/decryption for sensitive data
  */
 
 import crypto from 'crypto';
 
 const ALGORITHM = 'aes-256-cbc';
 const IV_LENGTH = 16; // AES block size
-const VERSION_TAG = 'v2';
-const LEGACY_KEY_ID = 'legacy';
-
-interface KeyRing {
-  keys: Map<string, Buffer>;
-  activeKeyId: string | null;
-}
-
-let cachedRing: KeyRing | null = null;
 
 /**
- * Parse a 32-byte (64 hex char) key. Rejects anything that is not AES-256 sized.
+ * Get encryption key from environment
+ * Must be 32 bytes (64 hex characters) for AES-256
  */
-function parseHexKey(
-  raw: unknown,
-  label: string
-): Buffer {
-  if (typeof raw !== 'string') {
-    throw new Error(
-      `${label} must be 32 bytes (64 hex characters)`
-    );
-  }
+function getEncryptionKey(): Buffer {
+  const key = process.env.ENCRYPTION_KEY;
 
-  const normalized = raw.trim();
-
-  if (!/^[0-9a-fA-F]{64}$/.test(normalized)) {
-    throw new Error(
-      `${label} must be 32 bytes (64 hex characters)`
-    );
-  }
-
-  return Buffer.from(normalized, 'hex');
-}
-
-function parseOrderedKeys(raw: string): Array<{ id: string; key: string }> {
-  let parsed: unknown;
-
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(
-      'ENCRYPTION_KEYS must be an ordered JSON array ' + 'of objects with id and key fields'
-    );
-  }
-
-  if (!Array.isArray(parsed)) {
-    throw new Error(
-      'ENCRYPTION_KEYS must be an ordered JSON array ' + 'of objects with id and key fields'
-    );
-  }
-
-  const seen = new Set<string>();
-
-  return parsed.map((value, index) => {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      throw new Error('ENCRYPTION_KEYS[' + index + '] must be an object');
-    }
-
-    const entry = value as {
-      id?: unknown;
-      key?: unknown;
-    };
-
-    if (typeof entry.id !== 'string') {
-      throw new Error('ENCRYPTION_KEYS[' + index + '].id must be a string');
-    }
-
-    const id = entry.id.trim();
-
-    if (!id || id !== entry.id || id.includes(':') || id === VERSION_TAG || id === LEGACY_KEY_ID) {
-      throw new Error('Invalid key id at ENCRYPTION_KEYS[' + index + ']');
-    }
-
-    if (seen.has(id)) {
-      throw new Error('Duplicate encryption key id "' + id + '"');
-    }
-
-    seen.add(id);
-
-    parseHexKey(entry.key, 'ENCRYPTION_KEYS[' + index + '].key');
-
-    return {
-      id,
-      key: entry.key as string,
-    };
-  });
-}
-
-/**
- * Build (and cache) the key ring from the environment. The env is read once per
- * process; tests can force a rebuild with _resetKeyRingCache().
- */
-function loadKeyRing(): KeyRing {
-  if (cachedRing) {
-    return cachedRing;
-  }
-
-  const keys = new Map<string, Buffer>();
-
-  const legacy = process.env.ENCRYPTION_KEY;
-
-  if (legacy) {
-    keys.set(LEGACY_KEY_ID, parseHexKey(legacy, 'ENCRYPTION_KEY'));
-  }
-
-  const configured = process.env.ENCRYPTION_KEYS;
-
-  const orderedKeys = configured && configured.trim() ? parseOrderedKeys(configured) : [];
-
-  for (const entry of orderedKeys) {
-    keys.set(entry.id, parseHexKey(entry.key, 'ENCRYPTION_KEYS key "' + entry.id + '"'));
-  }
-
-  const activeKeyId = orderedKeys.length > 0 ? orderedKeys[orderedKeys.length - 1].id : null;
-
-  cachedRing = {
-    keys,
-    activeKeyId,
-  };
-
-  return cachedRing;
-}
-
-/**
- * Resolve a key by id or throw a clear error. A throw here on decrypt means the
- * ciphertext references a key that has already been retired from the ring —
- * the Phase 3 safety net.
- */
-function getKey(keyId: string): Buffer {
-  const key = loadKeyRing().keys.get(keyId);
   if (!key) {
-    throw new Error(
-      keyId === LEGACY_KEY_ID
-        ? 'ENCRYPTION_KEY not found in environment variables'
-        : `No encryption key registered for keyId "${keyId}"`
-    );
+    throw new Error('ENCRYPTION_KEY not found in environment variables');
   }
-  return key;
+
+  // Convert hex string to buffer
+  const keyBuffer = Buffer.from(key, 'hex');
+
+  if (keyBuffer.length !== 32) {
+    throw new Error('ENCRYPTION_KEY must be 32 bytes (64 hex characters)');
+  }
+
+  return keyBuffer;
 }
 
 /**
- * Clear the cached key ring. Intended for tests / hot config reloads only.
- */
-export function _resetKeyRingCache(): void {
-  cachedRing = null;
-}
-
-/**
- * Encrypt plaintext using AES-256-CBC.
- * Returns "v2:<keyId>:<iv>:<ciphertext>" when a write key is activated,
- * otherwise the legacy "<iv>:<ciphertext>" format (both hex).
+ * Encrypt plaintext using AES-256-CBC
+ * Returns format: "IV:ciphertext" (both as hex)
  */
 export function encrypt(plaintext: string): string {
-  const ring = loadKeyRing();
-  const writeKeyId = ring.activeKeyId ?? LEGACY_KEY_ID;
-  const key = getKey(writeKeyId);
-
+  const key = getEncryptionKey();
   const iv = crypto.randomBytes(IV_LENGTH);
+
   const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
   let encrypted = cipher.update(plaintext, 'utf8', 'hex');
   encrypted += cipher.final('hex');
 
-  if (ring.activeKeyId) {
-    return `${VERSION_TAG}:${writeKeyId}:${iv.toString('hex')}:${encrypted}`;
-  }
-  // Legacy format — byte-for-byte identical to the pre-rotation output.
+  // Return IV:ciphertext format
   return `${iv.toString('hex')}:${encrypted}`;
 }
 
 /**
- * Decrypt ciphertext using AES-256-CBC.
- * Accepts both the versioned "v2:<keyId>:<iv>:<ct>" and the legacy "<iv>:<ct>"
- * formats. Legacy rows are decrypted with the "legacy" key (ENCRYPTION_KEY).
+ * Decrypt ciphertext using AES-256-CBC
+ * Expects format: "IV:ciphertext" (both as hex)
  */
 export function decrypt(encryptedData: string): string {
+  const key = getEncryptionKey();
+
+  // Split IV and ciphertext
   const parts = encryptedData.split(':');
-
-  let keyId: string;
-  let ivHex: string;
-  let ciphertextHex: string;
-
-  if (parts.length === 4 && parts[0] === VERSION_TAG) {
-    // Versioned: v2:<keyId>:<iv>:<ciphertext>
-    keyId = parts[1];
-    ivHex = parts[2];
-    ciphertextHex = parts[3];
-  } else if (parts.length === 2) {
-    // Legacy: <iv>:<ciphertext>
-    keyId = LEGACY_KEY_ID;
-    ivHex = parts[0];
-    ciphertextHex = parts[1];
-  } else {
-    throw new Error(
-      'Invalid encrypted data format. Expected "IV:ciphertext" or "v2:keyId:IV:ciphertext"'
-    );
+  if (parts.length !== 2) {
+    throw new Error('Invalid encrypted data format. Expected "IV:ciphertext"');
   }
 
-  const key = getKey(keyId);
-  const iv = Buffer.from(ivHex, 'hex');
+  const iv = Buffer.from(parts[0], 'hex');
+  const encrypted = parts[1];
+
   if (iv.length !== IV_LENGTH) {
     throw new Error(`Invalid IV length. Expected ${IV_LENGTH} bytes`);
   }
 
   const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
-  let decrypted = decipher.update(ciphertextHex, 'hex', 'utf8');
+
+  let decrypted = decipher.update(encrypted, 'hex', 'utf8');
   decrypted += decipher.final('utf8');
 
   return decrypted;


### PR DESCRIPTION
## Revert: PR #764 — Ordered Encryption Key Rotation

This reverts commit `5a7f29d92b18918a44c7d593ce566c0ddc885504` (PR #764: "feat: add ordered encryption key rotation").

### What is being reverted

PR #764 introduced ordered encryption key rotation — versioned ciphertext (`v2:keyId:iv:ciphertext`), a `KeyRing` abstraction, `ENCRYPTION_KEYS` env var for multiple keys, and a new `spaces-encryption-key-ring.ts` module in xyne-claw-auth.

### Files changed (3 files)

| File | Change |
|---|---|
| `apps/backend/.env.example` | Removes `ENCRYPTION_KEYS` env documentation |
| `apps/backend/src/config/env.ts` | Removes `ENCRYPTION_KEYS` env parsing |
| `apps/backend/src/services/encryptionService.ts` | Reverts rotation-aware service to original AES-256-CBC service (-203 lines, +36 lines) |

### Conflict resolution

- `admin-backfill-signing-secrets.ts`: Conflict resolved by keeping `errMsg(err)` (a later refactor) instead of reverting to `err instanceof Error ? err.message : String(err)`.
- `config.ts`, `crypto.ts`, `spaces-app-secret.ts`: No net change — these files had already diverged from the #764 state on `main`.
- `spaces-encryption-key-ring.ts`: Already absent on `main` — nothing to delete.

### Release branch

`release-20260827` was **already reverted** by PR #1266 (commit `9b1f9a4`).