### PR TITLE
fix: XYNE-54658 add chat with agent button in draft agent card

### DIFF
--- a/apps/dashboard/src/components/flowUI/nodes/AgentSummaryNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/AgentSummaryNode.tsx
@@ -4,6 +4,7 @@ import type { FlowComponent } from '@xyne/shared';
 import { cn } from '../../../utils/classNames';
 import { buttonVariants } from '../../ui/Button/Button';
 import { CardShell } from './cardPrimitives';
+import { ChatWithAgentButton } from './agent/ChatWithAgentButton';
 
 /**
  * Agent roster — a sample of the workspace's agents, each opening its own page,
@@ -56,10 +57,18 @@ export const AgentSummaryNode: React.FC<{ node: FlowComponent; children?: React.
         </div>
 
         {agents.length > 0 && (
-          <div className='flex flex-col gap-2'>
+          <div className='flex flex-col'>
             {agents.map(agent => (
-              <div key={agent.slug} className='flex items-start gap-3 rounded-xl py-1.5 pl-1'>
-                <div className='flex min-w-0 flex-1 flex-col'>
+              <div
+                key={agent.slug}
+                className='-mx-1 flex items-center gap-3 rounded-xl px-2 py-2.5 hover:bg-foreground/[0.04]'
+              >
+                <Link
+                  to={`/ai/library/agent/${encodeURIComponent(agent.slug)}?tab=persona`}
+                  className={cn('flex min-w-0 flex-1 flex-col', LINK_BUTTON)}
+                  data-track-category='Claw Agents'
+                  data-track-name='ViewAgentFromCard'
+                >
                   <span className='truncate text-sm font-medium leading-5 text-foreground'>
                     {agent.name}
                   </span>
@@ -68,19 +77,8 @@ export const AgentSummaryNode: React.FC<{ node: FlowComponent; children?: React.
                       {agent.description}
                     </span>
                   )}
-                </div>
-                <Link
-                  to={`/ai/library/agent/${encodeURIComponent(agent.slug)}?tab=persona`}
-                  className={cn(
-                    buttonVariants({ variant: 'outline', size: 'sm' }),
-                    'h-7 shrink-0 rounded-lg px-2.5 text-sm font-medium',
-                    LINK_BUTTON,
-                  )}
-                  data-track-category='Claw Agents'
-                  data-track-name='ViewAgentFromCard'
-                >
-                  View
                 </Link>
+                <ChatWithAgentButton slug={agent.slug} />
               </div>
             ))}
           </div>

--- a/apps/dashboard/src/components/flowUI/nodes/McpSuggestNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/McpSuggestNode.tsx
@@ -33,6 +33,10 @@ interface McpSuggestItem {
   connected?: boolean;
 }
 
+// global.css paints every anchor inside message content link-blue and
+// underlined; these are buttons by intent, not links in prose.
+const LINK_BUTTON = '!text-foreground !no-underline hover:!text-foreground';
+
 interface McpSuggestProps {
   title?: string;
   reason?: string;
@@ -110,7 +114,7 @@ export const McpSuggestNode: React.FC<{ node: FlowComponent; children?: React.Re
           )}
         </div>
 
-        <div className='flex flex-col gap-2'>
+        <div className='flex flex-col'>
           {connectors.map(item => {
             const server = serverFor(item.serverType);
             const isConnected = server
@@ -119,8 +123,16 @@ export const McpSuggestNode: React.FC<{ node: FlowComponent; children?: React.Re
             const entry = entries.find(e => e.server?.type === item.serverType);
 
             return (
-              <div key={item.serverType} className='flex items-start gap-3 rounded-xl py-1.5 pl-1'>
-                <div className='flex min-w-0 flex-1 items-start gap-2'>
+              <div
+                key={item.serverType}
+                className='-mx-1 flex items-center gap-3 rounded-xl px-2 py-2.5 hover:bg-foreground/[0.04]'
+              >
+                <Link
+                  to={`/ai/library/mcp/${encodeURIComponent(item.serverType)}`}
+                  className={cn('flex min-w-0 flex-1 items-start gap-2', LINK_BUTTON)}
+                  data-track-category='Claw MCP'
+                  data-track-name='ViewMcpFromCard'
+                >
                   <McpLogo type={entry?.iconType ?? item.serverType} name={item.name} size='sm' />
                   <div className='flex min-w-0 flex-1 flex-col'>
                     <span className='truncate text-sm font-medium leading-5 text-foreground'>
@@ -137,7 +149,7 @@ export const McpSuggestNode: React.FC<{ node: FlowComponent; children?: React.Re
                       </span>
                     )}
                   </div>
-                </div>
+                </Link>
 
                 {isConnected ? (
                   <span className='shrink-0 rounded-lg px-2 py-1 text-xs font-medium leading-5 text-muted-foreground'>
@@ -174,9 +186,7 @@ export const McpSuggestNode: React.FC<{ node: FlowComponent; children?: React.Re
             className={cn(
               buttonVariants({ variant: 'ghost', size: 'sm' }),
               'h-7 shrink-0 rounded-[10px] px-2.5 text-sm font-medium',
-              // global.css paints every anchor inside message content link-blue
-              // and underlined; this is a button by intent, not a link in prose.
-              '!text-foreground !no-underline hover:!text-foreground',
+              LINK_BUTTON,
             )}
             data-track-category='Claw MCP'
             data-track-name='BrowseMcpLibrary'

--- a/apps/dashboard/src/components/flowUI/nodes/agent/ChatWithAgentButton.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/ChatWithAgentButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { MessageSquare } from 'lucide-react';
+import { cn } from '../../../../utils/classNames';
+import { useOpenAgentChat } from '../../../../hooks/useOpenAgentChat';
+
+export const ChatWithAgentButton: React.FC<{
+  slug: string;
+  label?: string;
+  className?: string;
+}> = ({ slug, label = 'Chat with agent', className }) => {
+  const { canOpenAgentChat, openAgentChat } = useOpenAgentChat();
+
+  if (!canOpenAgentChat) {
+    return null;
+  }
+
+  return (
+    <button
+      type='button'
+      onClick={(event): void => {
+        event.stopPropagation();
+        openAgentChat(slug);
+      }}
+      className={cn(
+        'inline-flex h-7 shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-2.5',
+        'text-sm font-medium leading-5 text-foreground hover:bg-foreground/[0.04]',
+        className,
+      )}
+      data-track-category='AGENT_ARTIFACT'
+      data-track-name='CLICK_CHAT_WITH_AGENT'
+    >
+      <MessageSquare size={14} className='shrink-0' aria-hidden />
+      {label}
+    </button>
+  );
+};

--- a/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
@@ -7,6 +7,7 @@ import { cn } from '../../../../utils/classNames';
 import { AuditLine, CardShell, Mention, StatusChip } from '../cardPrimitives';
 import Avatar from '../../../ui/Avatar/Avatar';
 import { AgentPreview, InsideAgentPreviewContext } from './AgentPreview';
+import { ChatWithAgentButton } from './ChatWithAgentButton';
 
 /**
  * The `agent` artifact's DRAFT variant — an agent an agent proposed, awaiting
@@ -120,6 +121,13 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
           </>
         )}
       </AuditLine>
+    </div>
+  );
+
+  const decidedFooter = (
+    <div className='flex w-full items-center justify-between gap-3'>
+      {auditNode}
+      {props.phase === 'created' && <ChatWithAgentButton slug={props.agent.slug} />}
     </div>
   );
 
@@ -265,10 +273,11 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
           decision lands (an audit line is shorter than a button row, and shorter
           again when there is no decider avatar), reflowing the thread under it. */}
       <div className='flex min-h-[44px] items-center justify-between gap-3 px-3 py-2'>
-        {/* A decided card shows the audit line only. No connect prompt in either
-            phase — it belongs with the capability chips, which this card no
-            longer renders; the expanded preview still surfaces both. */}
-        {decided ? auditNode : actionControls}
+        {/* A decided card shows the audit line, plus the chat entry point once the
+            agent exists. No connect prompt in either phase — it belongs with the
+            capability chips, which this card no longer renders; the expanded
+            preview still surfaces both. */}
+        {decided ? decidedFooter : actionControls}
       </div>
 
       <AgentPreview
@@ -280,7 +289,7 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
         note={props.note}
         statePill={statePill}
         conversationId={conversationId ?? undefined}
-        footer={decided ? auditNode : actionControls}
+        footer={decided ? decidedFooter : actionControls}
       />
     </CardShell>
   );

--- a/apps/dashboard/src/components/flowUI/nodes/agent/ProfileAgentCard.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/ProfileAgentCard.tsx
@@ -4,6 +4,7 @@ import type { AgentProfileProps, FlowComponent } from '@xyne/shared';
 import { useFlow } from '../../FlowContext';
 import { AuditLine, CardShell, Mention, StatusChip } from '../cardPrimitives';
 import Avatar from '../../../ui/Avatar/Avatar';
+import { ChatWithAgentButton } from './ChatWithAgentButton';
 import { AgentPreview, InsideAgentPreviewContext } from './AgentPreview';
 
 /**
@@ -44,6 +45,13 @@ export const ProfileAgentCard: React.FC<{ node: FlowComponent; props: AgentProfi
           'No owner'
         )}
       </AuditLine>
+    </div>
+  );
+
+  const footerNode = (
+    <div className='flex w-full items-center justify-between gap-3'>
+      {auditNode}
+      <ChatWithAgentButton slug={props.agent.slug} />
     </div>
   );
 
@@ -95,7 +103,7 @@ export const ProfileAgentCard: React.FC<{ node: FlowComponent; props: AgentProfi
       </div>
 
       <div className='flex min-h-[44px] items-center justify-between gap-3 px-3 py-2'>
-        {auditNode}
+        {footerNode}
       </div>
 
       <AgentPreview
@@ -105,7 +113,7 @@ export const ProfileAgentCard: React.FC<{ node: FlowComponent; props: AgentProfi
         agent={props.agent}
         note={props.note}
         statePill={statePill}
-        footer={auditNode}
+        footer={footerNode}
         conversationId={conversationId ?? undefined}
       />
     </CardShell>

--- a/apps/dashboard/src/hooks/useOpenAgentChat.ts
+++ b/apps/dashboard/src/hooks/useOpenAgentChat.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { useSelectedAgent } from './useSelectedAgent';
+import { useDisabledToolbarPaths } from './useDisabledToolbarPaths';
+import { AI_ACTIVE_SESSION_KEY, AI_SHOW_CHAT_VIEW_KEY } from '../routes/AIScreen/aiSessionStorage';
+
+const AI_SECTION_PATH = '/ai';
+const AI_NEW_CHAT_PATH = '/ai/chat/new';
+const ACCESSIBLE_AGENTS_QUERY_KEY = ['accessible-claw-agents'];
+
+export interface UseOpenAgentChatReturn {
+  canOpenAgentChat: boolean;
+  openAgentChat: (slug: string) => void;
+}
+
+export function useOpenAgentChat(): UseOpenAgentChatReturn {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { setSelectedAgentSlug } = useSelectedAgent();
+  const disabledToolbarPaths = useDisabledToolbarPaths();
+  const canOpenAgentChat = !disabledToolbarPaths.has(AI_SECTION_PATH);
+
+  const openAgentChat = useCallback(
+    (slug: string): void => {
+      if (!canOpenAgentChat || !slug) {
+        return;
+      }
+      setSelectedAgentSlug(slug);
+      sessionStorage.removeItem(AI_ACTIVE_SESSION_KEY);
+      sessionStorage.setItem(AI_SHOW_CHAT_VIEW_KEY, '0');
+      void queryClient.invalidateQueries({ queryKey: ACCESSIBLE_AGENTS_QUERY_KEY });
+      void navigate(`${AI_NEW_CHAT_PATH}?agent=${encodeURIComponent(slug)}`);
+    },
+    [canOpenAgentChat, navigate, queryClient, setSelectedAgentSlug],
+  );
+
+  return { canOpenAgentChat, openAgentChat };
+}


### PR DESCRIPTION
POT: https://drive.google.com/file/d/1gLZ8dJ3x5bTxypMt45w_ohKJvN7RHvza/view?usp=drive_link

Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [x] New feature
- [x] Enhancement

## Description

Agent cards in chat could describe an agent but never let you talk to it — the only way to start a conversation was to leave the thread, open Ask AI and hunt for the agent in the selector. This adds a **Chat with agent** entry point to every agent surface, landing the user in a fresh Ask AI chat with that agent already selected. XYNE-54658.

**The handoff** — one hook, `useOpenAgentChat`, backs every surface:

- selects the agent in the shared `useSelectedAgent` store (synchronously, so there is no flash of the previously selected agent),
- clears `AI_ACTIVE_SESSION_KEY` and forces the landing view, so the user gets a **new** chat rather than resuming their last session,
- invalidates the `accessible-claw-agents` query, and
- navigates to `/ai/chat/new?agent=<slug>`.

That invalidation is load-bearing: the selector caches its list with a 5-minute `staleTime`, so an agent created seconds earlier is not in a warm cache and the composer chip would read "Ask AI" while the chat was actually scoped to the new agent. The route is workspace-prefixed by the existing `react-router-dom` shim, and `?agent=` is what `useSelectedAgent` already reads, so the link is shareable. The button hides itself when `/ai` is disabled for the workspace, since that route sits behind `ToolbarProtectedRoute`.

**Surfaces**

- **Draft agent card** — the button sits in the card's footer, opposite "Created by @user". Only on `phase: 'created'`; a declined draft has no agent to chat with. The expanded preview footer gets the same control, so the two stay in sync.
- **Profile agent card** — same button in its footer.
- **Agent roster / "agents that can help" card** — the per-row **View** button is replaced by **Chat with agent**. View's destination is not lost: the row itself (name + description) is now the link to the agent's detail page, so the row click does what View used to do.
- **Connector / MCP suggest card** — rows now link to `/ai/library/mcp/:type`. **Connect** and the **Connected** state are untouched.

On both list cards the link wraps the text rather than the whole row, because a `<button>` cannot nest inside an `<a>` — this keeps the markup valid and the rows keyboard-navigable without a `role="button"` shim, and keeps a Connect/Chat click from also firing a navigation.

**No wire change.** Everything the button needs — the agent's slug, and whether it was created — is already in the flow payload the server posts, so there is no `@xyne/shared` schema change, no claw change, and no deploy coupling. Dashboard-only.

## Areas Touched

- [x] `apps/dashboard`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## Note for reviewers

On `main` as it stands these cards do not render at all, so the new buttons are not reachable without a local fix. `@xyne/shared` pins zod 3 while `apps/dashboard` pins zod 4, and Vite pre-bundles a single copy — so the shared schema's zod-3 code runs against zod 4 in the browser, where `z.record(valueType)` needs `z.record(keyType, valueType)`. The first `safeParse` then throws `TypeError: Cannot read properties of undefined (reading '_zod')` and the whole flow message goes blank. `flowSchema.ts` still has 10 such single-argument calls on main. Rewriting them to the two-argument form is behaviour-identical under both zod majors and makes the cards render; that fix is not part of this PR.

## How did you test it?

Manually against a local stack, in a Spaces thread carrying real agent cards.

- Created-agent card shows **Chat with agent** in the footer; a declined draft does not
- Clicking through lands on `/{workspaceId}/ai/chat/new?agent=<slug>` with the agent selected in the composer and an empty chat
- Agent list card: clicking a row opens the agent's detail page, **Chat with agent** opens the new chat
- Connector card: clicking a row opens `/ai/library/mcp/<type>`, **Connect** still connects

### Automated

- [x] Not covered by tests <!-- no test runner configured for apps/dashboard; the change is presentational plus one navigation hook -->

### Manual

**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind
