### PR TITLE
fix: XYNE-61187 one app per conversation, not one per generation

### DIFF
--- a/apps/dashboard/src/components/AIScreen/AIAgentSelector.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIAgentSelector.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useMemo, useState } from 'react';
+import { ReactElement, useCallback, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronDown, Bot, Search } from 'lucide-react';
 import { Popover } from '../ui/Popover';
@@ -16,6 +16,12 @@ export interface AIAgentSelectorProps {
    *  handleSelectAgent: parent uses this to open a fresh chat scoped to that
    *  agent. Skipped when the user re-selects the current agent. */
   onAgentChange?: ((slug: string | null) => void) | undefined;
+  /** Controlled open state. Paired with `hideTrigger` so a narrow composer can
+   *  drive the selector from the "+" menu instead of showing its own pill. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Render only the popover, anchored to a zero-size element in the toolbar. */
+  hideTrigger?: boolean;
 }
 
 const MAX_VISIBLE_AGENTS = 6;
@@ -27,8 +33,20 @@ const MAX_VISIBLE_AGENTS = 6;
 export function AIAgentSelector({
   disabled = false,
   onAgentChange,
+  open: controlledOpen,
+  onOpenChange,
+  hideTrigger = false,
 }: AIAgentSelectorProps): ReactElement {
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (isControlled) onOpenChange?.(next);
+      else setUncontrolledOpen(next);
+    },
+    [isControlled, onOpenChange],
+  );
   const [query, setQuery] = useState('');
 
   const { selectedAgentSlug, setSelectedAgentSlug } = useSelectedAgent();
@@ -53,7 +71,11 @@ export function AIAgentSelector({
 
   const displayText = selectedAgent?.name ?? 'Ask AI';
 
-  const trigger = (
+  // Zero-size anchor when the pill is hidden — Radix positions the popover
+  // against the trigger, so it still needs an element in the toolbar.
+  const trigger = hideTrigger ? (
+    <span aria-hidden className='block h-0 w-0' />
+  ) : (
     <button
       disabled={disabled}
       className={cn(

--- a/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
@@ -69,6 +69,7 @@ import {
 import { CitationLink } from '../Chat/XyneAISidebar/components/CitationLink';
 import { useCitationDocs, panelDocFromCitation } from './citationDocs';
 import { MessageReactArtifacts } from './ReactArtifact';
+import { TOP_BAR_HEIGHT_CLASS } from '../AppNavigator/topBarHeight';
 import { Tooltip } from '../ui/Tooltip';
 import {
   ConversationToolInvocationsContext,
@@ -107,6 +108,10 @@ interface AIChatThreadProps {
   initialExtras?: ComposerContext | undefined;
   onSetMobileSidebarOpen?: ((open: boolean) => void) | undefined;
   onConversationChange?: ((sessionId: string) => void) | undefined;
+  /** App Creation mode: the id of the app this thread is building, or null.
+   *  A conversation owns exactly one app (Step 1), so the last artifact's
+   *  appId identifies it unambiguously. */
+  onAppChange?: ((appId: string | null, latestVersionId: string | null) => void) | undefined;
   /** Forwarded to the composer's AIAgentSelector — fires when the user picks
    *  a different agent from inside an active chat, so the parent can open a
    *  fresh conversation scoped to that agent. Carries the current composer
@@ -205,7 +210,9 @@ function ChatTopbar({
   onOpenSidebar?: () => void;
 }): ReactElement {
   return (
-    <header className='ai-chat-topbar flex h-12 shrink-0 items-center gap-1 border-b border-[#e5e2dc] bg-transparent px-3 backdrop-blur-md sm:px-4'>
+    <header
+      className={`ai-chat-topbar flex ${TOP_BAR_HEIGHT_CLASS} shrink-0 items-center gap-1 border-b border-sidebar-border-muted bg-transparent px-3 backdrop-blur-md sm:px-4`}
+    >
       <button
         type='button'
         onClick={onOpenSidebar}
@@ -1329,6 +1336,7 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
     initialExtras,
     onSetMobileSidebarOpen,
     onConversationChange,
+    onAppChange,
     onAgentChange,
     onContextChange,
     onInitialQueryConsumed,
@@ -1818,6 +1826,31 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
       onConversationChange(conversationId);
     }
   }, [conversationId, onConversationChange]);
+
+  // Surface this thread's app to the shell, so App Creation mode can render it
+  // in the right-hand pane. Scanned newest-first: a thread owns ONE app, so the
+  // most recent artifact carrying an appId names it, and older turns of the
+  // same app agree. Attachments that predate session-scoping have no appId and
+  // are correctly ignored — they never became apps.
+  useEffect(() => {
+    if (!onAppChange) return;
+    let foundApp: string | null = null;
+    let foundVersion: string | null = null;
+    for (let i = displayMessages.length - 1; i >= 0 && !foundApp; i--) {
+      for (const att of displayMessages[i]?.attachments ?? []) {
+        const artifact = att.metadata?.reactArtifact;
+        if (artifact?.appId) {
+          foundApp = artifact.appId;
+          // The newest generation's build. The pane's app query is cached, so
+          // this is the freshness signal: a versionId the loaded version list
+          // does not contain means "a generation just landed — refetch".
+          foundVersion = artifact.versionId ?? null;
+          break;
+        }
+      }
+    }
+    onAppChange(foundApp, foundVersion);
+  }, [displayMessages, onAppChange]);
 
   // Reset stick-to-bottom + hide the jump pill whenever the conversation
   // identity changes (draft → real session, or sidebar session swap that

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -14,13 +14,9 @@ import {
 } from 'react';
 import {
   ArrowUp,
-  Paperclip,
   Square,
   X,
   FileText,
-  Globe,
-  Microscope,
-  File as FileIcon,
   Folder,
   BookOpen,
   Ticket,
@@ -30,11 +26,12 @@ import {
   Lock,
   Zap,
 } from 'lucide-react';
+import { PlusDefault } from '@xyne/icons';
 import { toast } from 'sonner';
 import { useQuery } from '@tanstack/react-query';
 import { DANGEROUS_EXTENSIONS } from '@xyne/shared';
 import { AIAgentSelector } from './AIAgentSelector';
-import { ModelThinkingSelector } from './ModelThinkingSelector';
+import { ModelThinkingSelector, formatModelLabel } from './ModelThinkingSelector';
 import { fetchClawAgentModels } from '../../services/clawAgentModelsService';
 import { ComposerCollectionPicker } from './ComposerCollectionPicker';
 import { ComposerVoiceButton } from './ComposerVoiceButton';
@@ -44,9 +41,11 @@ import {
   ContextPickerPanel,
   type ContextSelections,
 } from '../Chat/XyneAISidebar/components/ContextPickerPanel';
+import { XyneAIPlusMenu } from '../Chat/XyneAISidebar/components/XyneAIPlusMenu';
 import { EMPTY_COMPOSER_CONTEXT, type ComposerContext } from './composerContext';
 import { fetchAccessibleClawAgents } from '../../services/clawAgentListService';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
+import useMeasure from '../../hooks/useMeasure';
 
 export interface AIComposerAttachment {
   id: string;
@@ -109,6 +108,17 @@ const LARGE_PASTE_THRESHOLD = 11500;
 
 const blockedExtensions = new Set(DANGEROUS_EXTENSIONS.map(ext => ext.toLowerCase()));
 
+/**
+ * Outer composer width below which the agent + model pills fold into the "+"
+ * menu. Both pills are text-sized (agent name truncates at 140px, model name at
+ * 160px), so together with the mic and send buttons the right cluster can ask
+ * for ~480px on its own — enough to push send past the right edge once the
+ * artifact pane or a narrow window shrinks the composer. The thread composer is
+ * max-w-3xl (768px) and the landing one max-w-2xl (672px), so at this threshold
+ * neither folds at its natural size; only a genuinely squeezed one does.
+ */
+const COMPACT_TOOLBAR_WIDTH = 600;
+
 const isValidBase64 = (str: string): boolean => {
   if (!str || str.length === 0) return false;
   const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
@@ -154,51 +164,37 @@ function ContextPill({
   );
 }
 
-// Ghost toolbar button matching the /ai composer's look. `visibleText` is
-// opt-in — when set, the button widens into a pill with the icon plus a text
-// node instead of the default icon-only circle (used for the Instant toggle
-// so it reads as a named mode, not just an icon other buttons could be
-// mistaken for).
+// Ghost icon button matching the /ai composer's look.
 function ToolbarButton({
   icon,
   label,
-  visibleText,
   onClick,
   active,
-  activeClass,
-  disabled,
   trackName,
 }: {
   icon: ReactElement;
   label: string;
-  visibleText?: string;
   onClick: () => void;
   active?: boolean;
-  activeClass?: string;
-  disabled?: boolean;
   trackName: string;
 }): ReactElement {
   return (
     <button
       type='button'
       onClick={onClick}
-      disabled={disabled}
       aria-label={label}
       title={label}
       aria-pressed={active}
       className={cn(
-        'inline-flex h-8 shrink-0 items-center justify-center rounded-full transition',
-        visibleText ? 'gap-1 px-2.5' : 'w-8',
+        'inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition',
         active
-          ? (activeClass ?? 'bg-secondary text-foreground')
+          ? 'bg-secondary text-foreground'
           : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
-        disabled && 'cursor-not-allowed opacity-50',
       )}
       data-track-category='XyneAI'
       data-track-name={trackName}
     >
       {icon}
-      {visibleText && <span className='text-xs font-medium'>{visibleText}</span>}
     </button>
   );
 }
@@ -224,9 +220,23 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+  // Measured off the composer box rather than the viewport: the same window can
+  // hold a full-width composer or a squeezed one depending on whether the
+  // artifact pane is open, and only the box knows which. Width is 0 before the
+  // first measurement and while the composer is detached — don't fold on that,
+  // or the toolbar renders compact for a frame on every mount.
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const { width: composerWidth } = useMeasure({ ref: wrapperRef, observeResize: true });
+  const compactToolbar = composerWidth > 0 && composerWidth < COMPACT_TOOLBAR_WIDTH;
+
   // ── Extra composer context/toggles (seeded from initialExtras once) ──────────
   const seed = initialExtras ?? EMPTY_COMPOSER_CONTEXT;
   const [showContextModal, setShowContextModal] = useState(false);
+  const [showCollectionPicker, setShowCollectionPicker] = useState(false);
+  // Popovers for the agent / model selectors. Only used while compact, where
+  // the pills are hidden and the "+" menu opens them instead.
+  const [showAgentPicker, setShowAgentPicker] = useState(false);
+  const [showModelPicker, setShowModelPicker] = useState(false);
   const [selections, setSelections] = useState<ContextSelections>(() => ({
     channels: seed.channels,
     tickets: seed.tickets,
@@ -589,6 +599,50 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
 
   const canSend = value.trim().length > 0;
 
+  // Labels for the "+" menu's agent/model rows, so a folded toolbar still shows
+  // what is selected without opening either picker. Mirrors what the pills read.
+  const agentLabel = selectedAgent?.name ?? 'Ask AI';
+  const modelLabel = useMemo(() => {
+    const pinned = (agentModelsData?.models ?? []).find(m => m.id === selectedModel);
+    if (pinned) return formatModelLabel(pinned.name);
+    const fallback = agentModelsData?.defaultModel;
+    return fallback ? formatModelLabel(fallback) : 'Recommended';
+  }, [agentModelsData, selectedModel]);
+
+  const agentSelectorNode = showAgentSelector ? (
+    <AIAgentSelector
+      disabled={pending}
+      onAgentChange={slug => onAgentChange?.(slug, buildContext())}
+      hideTrigger={compactToolbar}
+      {...(compactToolbar && { open: showAgentPicker, onOpenChange: setShowAgentPicker })}
+    />
+  ) : null;
+
+  const modelSelectorNode = (
+    <ModelThinkingSelector
+      models={agentModelsData?.models ?? []}
+      defaultModel={agentModelsData?.defaultModel ?? null}
+      selectedModel={selectedModel}
+      onSelectModel={setSelectedModel}
+      thinkingLevel={thinkingLevel}
+      onSelectThinking={setThinkingLevel}
+      disabled={pending}
+      hideTrigger={compactToolbar}
+      {...(compactToolbar && { open: showModelPicker, onOpenChange: setShowModelPicker })}
+    />
+  );
+
+  // Anything the "+" menu owns that is currently on. Collections/files/folders
+  // count even though they also show as pills — the menu is where they're
+  // cleared from, so the trigger should point back at it.
+  const hasMenuOptionActive =
+    webSearchEnabled ||
+    deepResearchEnabled ||
+    createCanvasEnabled ||
+    collections.length > 0 ||
+    fileScopes.length > 0 ||
+    folderScopes.length > 0;
+
   return (
     <form onSubmit={handleSubmit} className='relative'>
       {/* "/" context picker overlay */}
@@ -628,6 +682,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
         style={isVoiceRecording ? { borderRadius: '1.6rem' } : undefined}
       >
         <div
+          ref={wrapperRef}
           className={cn(
             'ai-composer-wrapper group flex flex-col gap-1 rounded-3xl border border-[#c0bcb4] bg-[#f5f4f0] px-3 pb-2 pt-3 transition shadow-[0_1px_0_rgba(0,0,0,0.05),0_8px_24px_-12px_rgba(0,0,0,0.08)] focus-within:border-[#a09c94] focus-within:shadow-[0_1px_0_rgba(0,0,0,0.1),0_12px_30px_-12px_rgba(0,0,0,0.12)]',
           )}
@@ -762,75 +817,79 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
           </div>
 
           <div className='flex items-center justify-between gap-2'>
-            {/* Left cluster: attach + all context / mode buttons. Kept on one row
-              (no wrap) so the toolbar never grows vertically; the fixed button
-              set fits within the composer width. Not scroll-clipped, so the
-              collection / research dropdowns can overflow upward freely. */}
+            {/* Left cluster. Attach, collections, canvas and the two search
+              toggles all live behind the "+" menu — same consolidation the
+              XyneAI sidebar uses — so the row stays two buttons wide however
+              many options exist. Not scroll-clipped, so the collection picker
+              can overflow upward freely. */}
             <div className='flex flex-nowrap items-center gap-0.5'>
-              <ToolbarButton
-                icon={<Paperclip className='h-4 w-4' aria-hidden strokeWidth={1.75} />}
-                label='Attach'
-                onClick={handleAttachClick}
-                trackName='ATTACH_FILE'
-              />
+              <div className='relative flex items-center'>
+                <XyneAIPlusMenu
+                  onAttachFiles={handleAttachClick}
+                  onOpenCollections={() => setShowCollectionPicker(true)}
+                  onCreateCanvasToggle={() => setCreateCanvasEnabled(v => !v)}
+                  createCanvasEnabled={createCanvasEnabled}
+                  onWebSearchToggle={() => {
+                    if (webSearchAccessible) setWebSearchEnabled(v => !v);
+                  }}
+                  webSearchEnabled={webSearchEnabled}
+                  webSearchAccessible={webSearchAccessible}
+                  onDeepResearchToggle={() => {
+                    if (deepResearchAccessible) setDeepResearchEnabled(v => !v);
+                  }}
+                  deepResearchEnabled={deepResearchEnabled}
+                  deepResearchAccessible={deepResearchAccessible}
+                  selectorsDisabled={pending}
+                  {...(compactToolbar &&
+                    showAgentSelector && {
+                      onOpenAgentSelector: () => setShowAgentPicker(true),
+                      agentLabel,
+                    })}
+                  {...(compactToolbar && {
+                    onOpenModelSelector: () => setShowModelPicker(true),
+                    modelLabel,
+                  })}
+                >
+                  <button
+                    type='button'
+                    aria-label='Add to conversation'
+                    title='Add to conversation'
+                    className={cn(
+                      'inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition',
+                      // The menu hides which modes are on, so the trigger carries
+                      // the "something is enabled" signal the flat row used to
+                      // give through per-button active states.
+                      hasMenuOptionActive
+                        ? 'bg-secondary text-foreground'
+                        : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
+                    )}
+                    data-track-category='XyneAI'
+                    data-track-name='OPEN_PLUS_MENU'
+                  >
+                    <PlusDefault className='h-4 w-4' aria-hidden />
+                  </button>
+                </XyneAIPlusMenu>
+                <ComposerCollectionPicker
+                  collections={collections}
+                  fileScopes={fileScopes}
+                  folderScopes={folderScopes}
+                  onCollectionsChange={setCollections}
+                  onFileScopesChange={setFileScopes}
+                  onFolderScopesChange={setFolderScopes}
+                  open={showCollectionPicker}
+                  onOpenChange={setShowCollectionPicker}
+                />
+                {/* Folded away: the pills are gone but their popovers still
+                    anchor here, beside the "+" button that now opens them. */}
+                {compactToolbar && agentSelectorNode}
+                {compactToolbar && modelSelectorNode}
+              </div>
               <ToolbarButton
                 icon={<span className='text-[15px] font-semibold leading-none'>/</span>}
                 label='Add context'
                 onClick={() => setShowContextModal(v => !v)}
                 active={showContextModal}
                 trackName='OPEN_CONTEXT_MODAL'
-              />
-              <ComposerCollectionPicker
-                collections={collections}
-                fileScopes={fileScopes}
-                folderScopes={folderScopes}
-                onCollectionsChange={setCollections}
-                onFileScopesChange={setFileScopes}
-                onFolderScopesChange={setFolderScopes}
-              />
-              <div className='mx-0.5 h-4 w-px bg-border' />
-
-              <ToolbarButton
-                icon={<Globe className='h-4 w-4' aria-hidden strokeWidth={1.75} />}
-                label={
-                  webSearchAccessible
-                    ? webSearchEnabled
-                      ? 'Web search enabled'
-                      : 'Enable web search'
-                    : "You don't have access to web search."
-                }
-                onClick={() => {
-                  if (webSearchAccessible) setWebSearchEnabled(v => !v);
-                }}
-                active={webSearchEnabled}
-                activeClass='bg-secondary text-status-success'
-                disabled={!webSearchAccessible}
-                trackName='TOGGLE_WEB_SEARCH'
-              />
-              <ToolbarButton
-                icon={<Microscope className='h-4 w-4' aria-hidden strokeWidth={1.75} />}
-                label={
-                  deepResearchAccessible
-                    ? deepResearchEnabled
-                      ? 'Deep research enabled'
-                      : 'Enable deep research'
-                    : "You don't have access to deep research."
-                }
-                onClick={() => {
-                  if (deepResearchAccessible) setDeepResearchEnabled(v => !v);
-                }}
-                active={deepResearchEnabled}
-                activeClass='bg-secondary text-status-pending'
-                disabled={!deepResearchAccessible}
-                trackName='TOGGLE_DEEP_RESEARCH'
-              />
-              <ToolbarButton
-                icon={<FileIcon className='h-4 w-4' aria-hidden strokeWidth={1.75} />}
-                label={createCanvasEnabled ? 'Create canvas enabled' : 'Create canvas'}
-                onClick={() => setCreateCanvasEnabled(v => !v)}
-                active={createCanvasEnabled}
-                activeClass='bg-secondary text-primary'
-                trackName='TOGGLE_CREATE_CANVAS'
               />
               {/* Locked indicator, not a toggle — only rendered when the
                   selected agent is configured as an "Instant Agent"
@@ -853,21 +912,8 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
             </div>
 
             <div className='flex shrink-0 items-center gap-1.5'>
-              {showAgentSelector && (
-                <AIAgentSelector
-                  disabled={pending}
-                  onAgentChange={slug => onAgentChange?.(slug, buildContext())}
-                />
-              )}
-              <ModelThinkingSelector
-                models={agentModelsData?.models ?? []}
-                defaultModel={agentModelsData?.defaultModel ?? null}
-                selectedModel={selectedModel}
-                onSelectModel={setSelectedModel}
-                thinkingLevel={thinkingLevel}
-                onSelectThinking={setThinkingLevel}
-                disabled={pending}
-              />
+              {!compactToolbar && agentSelectorNode}
+              {!compactToolbar && modelSelectorNode}
               <ComposerVoiceButton
                 onTranscript={handleTranscript}
                 onStateChange={({ isRecording }) => setIsVoiceRecording(isRecording)}

--- a/apps/dashboard/src/components/AIScreen/AIShell.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIShell.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactElement, type ReactNode, type RefObject } from 'react';
+import { useMemo, useRef, type ReactElement, type ReactNode, type RefObject } from 'react';
 import { cn } from '../../utils/classNames';
 import { AISidebar } from './AISidebar';
 import {
@@ -26,6 +26,12 @@ interface AIShellProps {
    *  `bg-background`) — e.g. `ai-page-bg` for screens (like /ai/knowledge)
    *  that need to match a different surface elsewhere in the app. */
   mainClassName?: string | undefined;
+  /**
+   * App Creation mode: a third, persistent panel to the right of the chat.
+   * Absent → the exact two-panel tree this shell has always rendered, which is
+   * what /ai/knowledge and the Library screens rely on via AISectionLayout.
+   */
+  rightPanel?: ReactNode | undefined;
   children: ReactNode;
 }
 
@@ -38,9 +44,29 @@ export function AIShell({
   onMobileOpenChange,
   mainRef,
   mainClassName,
+  rightPanel,
   children,
 }: AIShellProps): ReactElement {
   const sidebarPanelRef = useRef<PanelImperativeHandle>(null);
+  const splitMode = rightPanel !== undefined && rightPanel !== null;
+
+  // The sidebar is deliberately NOT collapsed when the split view opens.
+  // Driving it imperatively meant racing the group's own deferred re-layout,
+  // which produced a stuck-collapsed sidebar more than once; and auto-collapsing
+  // then auto-expanding overrode whatever width the user had chosen. The Panel
+  // stays `collapsible`, so collapsing is one drag away when someone wants the
+  // room. Do not re-add an automatic collapse without a settle strategy.
+
+  // This group's Panels are CONDITIONAL, which the persistence wrapper requires
+  // panelIds for: without it the group restores whichever layout was written
+  // last — a two-panel layout onto a three-panel tree — then recomputes, fires
+  // onLayoutChanged, and churns. Memoized because a fresh array on every render
+  // re-initializes useDefaultLayout and reproduces the same churn.
+  const panelIds = useMemo(
+    () =>
+      splitMode ? ['ai-sidebar-panel', 'ai-main', 'ai-app-pane'] : ['ai-sidebar-panel', 'ai-main'],
+    [splitMode],
+  );
 
   useSidebarResizeShortcut({
     panelRef: sidebarPanelRef,
@@ -53,6 +79,7 @@ export function AIShell({
       orientation='horizontal'
       className='flex h-full align-top'
       autoSaveId='ai-screen-resize'
+      panelIds={panelIds}
     >
       <Panel
         id='ai-sidebar-panel'
@@ -61,6 +88,8 @@ export function AIShell({
         minSize={CHAT_SIDEBAR_MIN_WIDTH}
         maxSize={CHAT_SIDEBAR_MAX_WIDTH}
         groupResizeBehavior='preserve-pixel-size'
+        collapsible
+        collapsedSize={0}
       >
         <aside id='ai-sidebar' aria-label='AI Sidebar' className='h-full w-full'>
           <AISidebar
@@ -89,6 +118,19 @@ export function AIShell({
           {children}
         </div>
       </Panel>
+
+      {splitMode && (
+        <>
+          <Separator className='group flex w-[2px] cursor-col-resize items-center justify-center transition-colors'>
+            <div className='h-full w-[2px] bg-transparent group-hover:bg-primary group-active:bg-primary' />
+          </Separator>
+          <Panel id='ai-app-pane' defaultSize='55%' minSize='30%'>
+            <div className='relative flex h-full min-w-0 flex-1 flex-col overflow-hidden'>
+              {rightPanel}
+            </div>
+          </Panel>
+        </>
+      )}
     </ResizableGroup>
   );
 }

--- a/apps/dashboard/src/components/AIScreen/ComposerCollectionPicker.tsx
+++ b/apps/dashboard/src/components/AIScreen/ComposerCollectionPicker.tsx
@@ -31,6 +31,11 @@ interface ComposerCollectionPickerProps {
   onCollectionsChange: (collections: SelectedCollection[]) => void;
   onFileScopesChange: (fileScopes: FileScope[]) => void;
   onFolderScopesChange: (folderScopes: FolderScope[]) => void;
+  /** Controlled open state. When passed, the picker's own "book" trigger is not
+   *  rendered — the composer opens it from the "+" menu's Collections row and
+   *  the popover anchors to wherever this component sits in the toolbar. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 /**
@@ -47,8 +52,19 @@ export function ComposerCollectionPicker({
   onCollectionsChange,
   onFileScopesChange,
   onFolderScopesChange,
+  open: controlledOpen,
+  onOpenChange,
 }: ComposerCollectionPickerProps): ReactElement {
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (isControlled) onOpenChange?.(next);
+      else setUncontrolledOpen(next);
+    },
+    [isControlled, onOpenChange],
+  );
   const [search, setSearch] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -124,7 +140,7 @@ export function ComposerCollectionPicker({
     };
     document.addEventListener('mousedown', onClick);
     return () => document.removeEventListener('mousedown', onClick);
-  }, [open]);
+  }, [open, setOpen]);
 
   // Disambiguate single-click (select) from double-click (open).
   const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -197,25 +213,27 @@ export function ComposerCollectionPicker({
 
   return (
     <div ref={containerRef} className='relative'>
-      <button
-        type='button'
-        onClick={() => setOpen(o => !o)}
-        aria-label='Select collections'
-        title='Select collections'
-        className={cn(
-          'inline-flex h-8 w-8 items-center justify-center rounded-full transition',
-          // Accent only while something is actually scoped — idle matches the
-          // neighbouring ToolbarButtons so the row reads as one set. Files count
-          // as a selection too: this picker sets both.
-          collections.length > 0 || fileScopes.length > 0 || folderScopes.length > 0
-            ? 'bg-secondary text-claw-ai-fg'
-            : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
-        )}
-        data-track-category='XyneAI'
-        data-track-name='OPEN_COLLECTION_SELECTOR'
-      >
-        <BookOpen className='h-4 w-4' aria-hidden />
-      </button>
+      {!isControlled && (
+        <button
+          type='button'
+          onClick={() => setOpen(!open)}
+          aria-label='Select collections'
+          title='Select collections'
+          className={cn(
+            'inline-flex h-8 w-8 items-center justify-center rounded-full transition',
+            // Accent only while something is actually scoped — idle matches the
+            // neighbouring ToolbarButtons so the row reads as one set. Files count
+            // as a selection too: this picker sets both.
+            collections.length > 0 || fileScopes.length > 0 || folderScopes.length > 0
+              ? 'bg-secondary text-claw-ai-fg'
+              : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
+          )}
+          data-track-category='XyneAI'
+          data-track-name='OPEN_COLLECTION_SELECTOR'
+        >
+          <BookOpen className='h-4 w-4' aria-hidden />
+        </button>
+      )}
 
       {open && (
         <div className='absolute bottom-full left-0 z-50 mb-2 w-72 overflow-hidden rounded-lg border border-border bg-popover shadow-lg'>

--- a/apps/dashboard/src/components/AIScreen/ModelThinkingSelector.tsx
+++ b/apps/dashboard/src/components/AIScreen/ModelThinkingSelector.tsx
@@ -5,7 +5,7 @@
  * credential, or the platform allowed list); `defaultModel` labels the
  * Recommended row.
  */
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Brain, Check, ChevronDown, ChevronRight, Search, Sparkles } from 'lucide-react';
 import { Popover } from '../ui/Popover';
 import { cn } from '../../utils/classNames';
@@ -48,6 +48,9 @@ export function ModelThinkingSelector({
   thinkingLevel,
   onSelectThinking,
   disabled,
+  open: controlledOpen,
+  onOpenChange,
+  hideTrigger = false,
 }: {
   models: ClawAgentModel[];
   defaultModel: string | null;
@@ -56,8 +59,23 @@ export function ModelThinkingSelector({
   thinkingLevel: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null;
   onSelectThinking: (v: 'off' | 'minimal' | 'low' | 'medium' | 'high' | null) => void;
   disabled?: boolean;
+  /** Controlled open state. Paired with `hideTrigger` so a narrow composer can
+   *  drive the menu from the "+" menu instead of showing its own pill. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Render only the popover, anchored to a zero-size element in the toolbar. */
+  hideTrigger?: boolean;
 }) {
-  const [open, setOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (isControlled) onOpenChange?.(next);
+      else setUncontrolledOpen(next);
+    },
+    [isControlled, onOpenChange],
+  );
   const [query, setQuery] = useState('');
   const [thinkingOpen, setThinkingOpen] = useState(false);
   // Which side the Thinking flyout opens on. Measured when it opens: in the
@@ -96,35 +114,45 @@ export function ModelThinkingSelector({
       align='end'
       sideOffset={4}
       trigger={
-        <button
-          type='button'
-          disabled={disabled}
-          title={
-            selected
-              ? selected.id
-              : defaultModel
-                ? `Recommended (${defaultModel})`
-                : 'Recommended model'
-          }
-          aria-label='Model and thinking'
-          data-track-category='XyneAI'
-          data-track-name='OPEN_MODEL_SELECTOR'
-          className={cn(
-            'flex h-7 items-center gap-1.5 rounded-lg border border-border px-2 text-sm transition-colors',
-            disabled ? 'cursor-not-allowed opacity-60' : 'hover:bg-accent cursor-pointer',
-          )}
-        >
-          <Sparkles className='h-3.5 w-3.5 shrink-0 text-primary' aria-hidden strokeWidth={1.75} />
-          <span className='font-medium text-foreground truncate max-w-[160px]'>
-            {selected
-              ? formatModelLabel(selected.name)
-              : defaultModel
-                ? formatModelLabel(defaultModel)
-                : 'Recommended'}
-          </span>
-          {thinkingLevel && <span className='text-muted-foreground'>{thinkingLabel}</span>}
-          <ChevronDown className='h-3 w-3 shrink-0 text-muted-foreground' aria-hidden />
-        </button>
+        // Zero-size anchor when the pill is hidden — Radix positions the
+        // popover against the trigger, so it still needs an element in the row.
+        hideTrigger ? (
+          <span aria-hidden className='block h-0 w-0' />
+        ) : (
+          <button
+            type='button'
+            disabled={disabled}
+            title={
+              selected
+                ? selected.id
+                : defaultModel
+                  ? `Recommended (${defaultModel})`
+                  : 'Recommended model'
+            }
+            aria-label='Model and thinking'
+            data-track-category='XyneAI'
+            data-track-name='OPEN_MODEL_SELECTOR'
+            className={cn(
+              'flex h-7 items-center gap-1.5 rounded-lg border border-border px-2 text-sm transition-colors',
+              disabled ? 'cursor-not-allowed opacity-60' : 'hover:bg-accent cursor-pointer',
+            )}
+          >
+            <Sparkles
+              className='h-3.5 w-3.5 shrink-0 text-primary'
+              aria-hidden
+              strokeWidth={1.75}
+            />
+            <span className='font-medium text-foreground truncate max-w-[160px]'>
+              {selected
+                ? formatModelLabel(selected.name)
+                : defaultModel
+                  ? formatModelLabel(defaultModel)
+                  : 'Recommended'}
+            </span>
+            {thinkingLevel && <span className='text-muted-foreground'>{thinkingLabel}</span>}
+            <ChevronDown className='h-3 w-3 shrink-0 text-muted-foreground' aria-hidden />
+          </button>
+        )
       }
       className='w-80 p-0 bg-popover border border-border rounded-lg shadow-lg overflow-visible'
     >

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactAppPane.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactAppPane.tsx
@@ -1,0 +1,97 @@
+/**
+ * The right-hand pane of App Creation mode: the thread's app, kept on screen
+ * while you talk to the agent about it.
+ *
+ * There is ONE header row, not two. `ReactArtifactView` already renders a header
+ * carrying the Preview/Code tabs and the saved state, so the pane hands it a
+ * `titleSlot` — icon, app title, version dropdown — and a close handler instead
+ * of stacking its own bar above it.
+ *
+ * The title here is the APP's, which can legitimately differ from
+ * `payload.title`: an app keeps the title of its first build, while a later
+ * generation may rename itself. Showing the app's own name keeps the pane
+ * agreeing with the Library and the transcript cards.
+ *
+ * Mounted ONCE per app and kept. A new generation must change this pane's
+ * `payload`, never its identity — re-creating it costs a full Sandpack iframe
+ * boot and throws away whatever state the running app had. That is also why the
+ * version dropdown swaps `versionId` on the same artifact ref.
+ */
+
+import type { ReactElement } from 'react';
+import { Check, ChevronDown } from 'lucide-react';
+import { DiamondComponent } from '@xyne/icons';
+import { ReactArtifactView } from './ReactArtifactView';
+import type { ReactArtifactRef } from './ReactArtifact.types';
+import type { AppCreationMode } from './useAppCreationMode';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../../ui/dropdown-menu';
+
+interface ArtifactAppPaneProps {
+  mode: AppCreationMode;
+}
+
+export const ArtifactAppPane = ({ mode }: ArtifactAppPaneProps): ReactElement | null => {
+  const { appId, viewing, versions, headVersionId, title, viewVersion, exit } = mode;
+
+  if (!appId || !viewing) return null;
+
+  const artifact: ReactArtifactRef = {
+    attachmentId: '',
+    manifest: viewing.manifest,
+    savedAppId: appId,
+    versionId: viewing.id,
+  };
+
+  const isHead = viewing.id === headVersionId;
+
+  const titleSlot = (
+    <div className='flex min-w-0 items-center gap-2'>
+      <DiamondComponent size={16} className='shrink-0 text-muted-foreground' aria-hidden='true' />
+      <span className='truncate text-sm font-medium text-foreground'>{title ?? 'App'}</span>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type='button'
+            className={`flex shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-xs transition-colors hover:bg-accent ${
+              isHead ? 'text-muted-foreground' : 'text-amber-600 dark:text-amber-400'
+            }`}
+            title={
+              isHead
+                ? 'Showing the current version'
+                : 'Showing an earlier version — the app itself has not changed'
+            }
+            data-track-category='AskAI'
+            data-track-name='ArtifactAppPaneVersionMenu'
+          >
+            v{viewing.versionNumber}
+            <ChevronDown className='h-3 w-3' aria-hidden='true' />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align='start' className='max-h-80 overflow-y-auto'>
+          {versions.map(v => (
+            <DropdownMenuItem key={v.id} onSelect={() => viewVersion(v.id)}>
+              <span className='flex w-full items-center gap-2'>
+                <Check
+                  className={`h-3.5 w-3.5 ${v.id === viewing.id ? 'opacity-100' : 'opacity-0'}`}
+                  aria-hidden='true'
+                />
+                <span className='flex-1'>Version {v.versionNumber}</span>
+                {v.id === headVersionId && (
+                  <span className='text-[11px] text-muted-foreground'>current</span>
+                )}
+              </span>
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+
+  return <ReactArtifactView artifact={artifact} fill titleSlot={titleSlot} onClose={exit} />;
+};

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactPaneReference.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactPaneReference.tsx
@@ -1,0 +1,79 @@
+/**
+ * What an artifact card becomes while App Creation mode has the app open in the
+ * pane: a marker of the build this turn produced, and a way to jump the pane
+ * back to it.
+ *
+ * The transcript must still say truthfully that a build happened here — that is
+ * why the version is stated plainly rather than hinted at — but mounting a
+ * second Sandpack for an app already on screen would double every iframe, data
+ * bridge and agent stream, and make writes ambiguous about which copy sent them.
+ *
+ * It is deliberately card-weight, not a footnote: scrolling a long thread is how
+ * you navigate an app's history, so each turn's version has to be legible in
+ * passing and clickable without hunting for a target.
+ */
+
+import type { ReactElement } from 'react';
+import { Check } from 'lucide-react';
+import { DiamondComponent } from '@xyne/icons';
+import type { ReactArtifactRef } from './ReactArtifact.types';
+import { useAppCreationModeSignal } from './appCreationModeContext';
+
+export const ArtifactPaneReference = ({
+  artifact,
+}: {
+  artifact: ReactArtifactRef;
+}): ReactElement => {
+  const { viewingVersionId, viewVersion } = useAppCreationModeSignal();
+  const version = artifact.manifest.versionNumber;
+  const isViewing = Boolean(artifact.versionId) && artifact.versionId === viewingVersionId;
+
+  return (
+    <button
+      type='button'
+      onClick={() => viewVersion(artifact.versionId ?? null)}
+      disabled={!artifact.versionId}
+      aria-current={isViewing ? 'true' : undefined}
+      className={`mb-2 flex w-full items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition-colors disabled:pointer-events-none ${
+        isViewing
+          ? 'border-primary/40 bg-primary/5'
+          : 'border-border bg-card hover:border-primary/30 hover:bg-accent/50'
+      }`}
+      title={isViewing ? 'This version is open in the pane' : 'Show this version in the pane'}
+      data-track-category='AskAI'
+      data-track-name='ArtifactPaneReferenceSelect'
+    >
+      <span
+        className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${
+          isViewing ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
+        }`}
+      >
+        <DiamondComponent size={16} aria-hidden='true' />
+      </span>
+
+      <span className='flex min-w-0 flex-col'>
+        <span className='truncate text-sm font-medium text-foreground'>
+          {artifact.manifest.title}
+        </span>
+        <span className='text-xs text-muted-foreground'>
+          {version !== undefined ? `Version ${version}` : 'App'}
+        </span>
+      </span>
+
+      <span
+        className={`ml-auto flex shrink-0 items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium ${
+          isViewing ? 'bg-primary/10 text-primary' : 'text-muted-foreground'
+        }`}
+      >
+        {isViewing ? (
+          <>
+            <Check className='h-3 w-3' aria-hidden='true' />
+            Showing
+          </>
+        ) : (
+          'View'
+        )}
+      </span>
+    </button>
+  );
+};

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactSavedIndicator.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactSavedIndicator.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tells a chat card two things it otherwise cannot say: that the artifact is
+ * already stored as an app, and whether the app has since moved past it.
+ *
+ * Session-scoping materializes every generation into an app automatically, so
+ * the Save button was removed — clicking it would only mint a duplicate. But
+ * nothing replaced it, which left no signal that the artifact was saved at all
+ * and no way to reach it from the card. This is that signal.
+ *
+ * The staleness half exists because cards deliberately pin the version their own
+ * turn produced: scrolling back through a thread must show what was actually
+ * said, not silently re-render the newest build. The cost of that honesty is
+ * that an old card looks current, so it needs to say it isn't.
+ *
+ * Staleness is measured against `headVersionId`, NOT the highest version number.
+ * After a restore, head is deliberately an earlier version and the card showing
+ * it IS current — calling that stale would be a lie in the opposite direction.
+ */
+
+import { ReactElement } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Check, History } from 'lucide-react';
+import { getArtifactApp } from '../../../services/claw/artifactAppsService';
+
+interface ArtifactSavedIndicatorProps {
+  appId: string;
+  /** The build this card rendered. Absent on artifacts that predate scoping. */
+  versionId?: string;
+}
+
+export const ArtifactSavedIndicator = ({
+  appId,
+  versionId,
+}: ArtifactSavedIndicatorProps): ReactElement | null => {
+  const { workspaceId, appId: routeAppId } = useParams<{
+    workspaceId?: string;
+    appId?: string;
+  }>();
+
+  // The Library's own app page renders this same view, where a link back to the
+  // page you are already on says nothing. Detected here rather than threaded
+  // through as a prop so a future caller cannot forget to pass it.
+  const isAppsOwnPage = routeAppId === appId;
+
+  // Keyed by app, so a thread rendering N cards of the same app issues ONE
+  // request rather than N. Owning the query here rather than in
+  // ReactArtifactView also keeps the settle out of that component's render —
+  // its memoized Sandpack must not be disturbed to draw a header chip.
+  const { data } = useQuery({
+    queryKey: ['artifact-app', appId],
+    queryFn: () => getArtifactApp(appId),
+    staleTime: 30_000,
+    enabled: !isAppsOwnPage,
+  });
+
+  if (isAppsOwnPage) return null;
+
+  const href = workspaceId ? `/${workspaceId}/ai/library/app/${appId}` : `/ai/library/app/${appId}`;
+
+  const head = data?.app.headVersionId ?? null;
+  // Until the app loads we know it is saved but not whether it is current.
+  // Default to "Saved": flashing a stale warning that resolves away is worse
+  // than showing the staleness a moment late.
+  const isStale = Boolean(head && versionId && head !== versionId);
+  const headNumber = head ? data?.versions.find(v => v.id === head)?.versionNumber : undefined;
+
+  if (isStale) {
+    return (
+      <Link
+        to={href}
+        className='flex shrink-0 items-center gap-1 rounded-full bg-sky-500/10 px-2 py-0.5 text-[11px] font-medium text-sky-600 transition-colors hover:bg-sky-500/20 dark:text-sky-400'
+        title={
+          headNumber
+            ? `This app has moved on to version ${headNumber}. Open the current version.`
+            : 'A newer version of this app exists. Open the current version.'
+        }
+        data-track-category='AskAI'
+        data-track-name='ReactArtifactOpenNewerVersion'
+      >
+        <History className='h-3 w-3' aria-hidden='true' />
+        {headNumber ? `Newer version (v${headNumber})` : 'Newer version'}
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      to={href}
+      className='flex shrink-0 items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium text-emerald-600 transition-colors hover:bg-emerald-500/20 dark:text-emerald-400'
+      title='Saved to your apps. Open it in the Library.'
+      data-track-category='AskAI'
+      data-track-name='ReactArtifactOpenSavedApp'
+    >
+      <Check className='h-3 w-3' aria-hidden='true' />
+      Saved
+    </Link>
+  );
+};

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/MessageReactArtifacts.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/MessageReactArtifacts.tsx
@@ -5,6 +5,8 @@ import type { Message } from '../../Chat/XyneAISidebar/utils/XyneAITypes';
 import { ReactArtifactView } from './ReactArtifactView';
 import { ReactArtifactDialog } from './ReactArtifactDialog';
 import { toArtifactRef, type ReactArtifactRef } from './ReactArtifact.types';
+import { useIsShownInPane } from './appCreationModeContext';
+import { ArtifactPaneReference } from './ArtifactPaneReference';
 import { saveArtifactApp } from '../../../services/claw/artifactAppsService';
 import { clawErrorText } from '../../../services/claw/clawRequest';
 import {
@@ -50,6 +52,10 @@ export function MessageReactArtifacts({ message }: { message: Message }): ReactE
     setExpanded(null);
   }, []);
 
+  // Anything generated since session-scoping is ALREADY an app — the thread owns
+  // one and each generation versioned it — so Save would create a confusing
+  // duplicate. The button survives only for pre-scoping artifacts and for the
+  // rare case where materialization failed. Publishing stays explicit either way.
   const saveMutation = useMutation({
     mutationFn: (artifact: ReactArtifactRef) =>
       saveArtifactApp({
@@ -89,16 +95,46 @@ export function MessageReactArtifacts({ message }: { message: Message }): ReactE
   return (
     <>
       {artifacts.map(artifact => (
-        <ReactArtifactView
+        <ArtifactCard
           key={artifact.attachmentId}
           artifact={artifact}
           onExpand={handleExpand}
-          {...(publishConfig.enabled ? { onSave: handleSave } : {})}
+          {...(publishConfig.enabled && !artifact.savedAppId ? { onSave: handleSave } : {})}
           saveState={saveStates[artifact.attachmentId] ?? 'idle'}
         />
       ))}
       {saveError && <p className='mb-2 text-xs text-destructive'>{saveError}</p>}
       <ReactArtifactDialog artifact={expanded} onClose={handleClose} />
     </>
+  );
+}
+
+/**
+ * One artifact in the transcript — live, or a reference when App Creation mode
+ * is already running this app in the pane. Split into its own component because
+ * the decision needs a hook, and hooks cannot be called inside a `.map`.
+ */
+function ArtifactCard({
+  artifact,
+  onExpand,
+  onSave,
+  saveState,
+}: {
+  artifact: ReactArtifactRef;
+  onExpand: (a: ReactArtifactRef) => void;
+  onSave?: (a: ReactArtifactRef) => void;
+  saveState: SaveState;
+}): ReactElement {
+  const shownInPane = useIsShownInPane(artifact.savedAppId);
+
+  if (shownInPane) return <ArtifactPaneReference artifact={artifact} />;
+
+  return (
+    <ReactArtifactView
+      artifact={artifact}
+      onExpand={onExpand}
+      {...(onSave ? { onSave } : {})}
+      saveState={saveState}
+    />
   );
 }

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifact.types.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifact.types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type {
   MessageAttachment,
   ReactArtifactManifest,
@@ -36,6 +37,10 @@ export interface ReactArtifactRef {
   inlineData?: string;
   /** Set once the artifact has been saved, so the header can show its state. */
   savedAppId?: string;
+  /** The exact build this turn produced. A thread's app moves on with each
+   *  generation, so a card must pin its own version or scrolling back would
+   *  show history saying one thing and rendering another. */
+  versionId?: string;
 }
 
 /**
@@ -58,6 +63,14 @@ export interface ReactArtifactViewProps {
   onExpand?: (artifact: ReactArtifactRef) => void;
   /** Shows a close affordance; set when rendered inside the full-screen dialog. */
   onClose?: () => void;
+  /**
+   * Replaces the header's title span. Lets a host own that side of the single
+   * header row — the App Creation pane puts the app icon, the app's own title
+   * and the version dropdown here, rather than stacking a second header above
+   * this one. Note the app's title and `payload.title` can legitimately differ:
+   * an app keeps its v1 title while a later build may rename itself.
+   */
+  titleSlot?: ReactNode;
   /** Shows a save affordance. Omitted when already saved or behind the flag. */
   onSave?: (artifact: ReactArtifactRef) => void;
   /** Drives the save button's appearance without the view owning the request. */
@@ -72,5 +85,9 @@ export function toArtifactRef(attachment: MessageAttachment): ReactArtifactRef |
     attachmentId: attachment.id,
     manifest,
     ...(attachment.data ? { inlineData: attachment.data } : {}),
+    // Present for anything generated since session-scoping: the artifact is a
+    // version of the conversation's app, not a standalone attachment.
+    ...(manifest.appId ? { savedAppId: manifest.appId } : {}),
+    ...(manifest.versionId ? { versionId: manifest.versionId } : {}),
   };
 }

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifactView.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifactView.tsx
@@ -34,6 +34,10 @@ import type { ReactArtifactPayload, ReactArtifactViewProps } from './ReactArtifa
 import { ArtifactCodeView } from './ArtifactCodeView';
 import { useArtifactDataBridge, type PreviewClientRef } from './useArtifactDataBridge';
 import { useArtifactAgentBridge } from './useArtifactAgentBridge';
+import { useArtifactDirectoryBridge } from './useArtifactDirectoryBridge';
+import { ArtifactSavedIndicator } from './ArtifactSavedIndicator';
+import { useAuthContextValues } from '../../../hooks/useAuth';
+import { TOP_BAR_HEIGHT_CLASS } from '../../AppNavigator/topBarHeight';
 import {
   DEFAULT_REACT_ARTIFACT_AGENT_CAC_CONFIG,
   REACT_ARTIFACT_AGENT_CAC_KEY,
@@ -97,6 +101,7 @@ const ArtifactSandpack = memo(
     refreshRef,
     canWrite,
     canInvokeAgents,
+    currentUserId,
     appId,
     attachmentId,
   }: {
@@ -104,6 +109,8 @@ const ArtifactSandpack = memo(
     theme: 'light' | 'dark';
     canWrite: boolean;
     canInvokeAgents: boolean;
+    /** Resolves DM names and excludes the viewer from participant lists. */
+    currentUserId: string;
     appId?: string;
     /** Identifies an artifact that has not been saved yet, so it can still run
      *  agents from the chat thread it was generated in. */
@@ -132,6 +139,11 @@ const ArtifactSandpack = memo(
       ...(attachmentId ? { attachmentId } : {}),
       previewRef,
     });
+
+    // Ids are opaque and two of the naming rules are not guessable, so the host
+    // resolves them with the app's own helpers rather than letting generated
+    // code join a user table and get it wrong.
+    useArtifactDirectoryBridge({ currentUserId, previewRef });
 
     const files = useMemo(() => toSandpackFiles(payload), [payload]);
     const customSetup = useMemo(
@@ -171,6 +183,7 @@ export const ReactArtifactView = ({
   fill = false,
   onExpand,
   onClose,
+  titleSlot,
   onSave,
   saveState = 'idle',
 }: ReactArtifactViewProps): ReactElement => {
@@ -182,12 +195,13 @@ export const ReactArtifactView = ({
     key: REACT_ARTIFACT_WRITE_CAC_KEY,
     fallbackConfig: DEFAULT_REACT_ARTIFACT_WRITE_CAC_CONFIG,
   });
+  const auth = useAuthContextValues();
   const { config: agentConfig } = useCacConfig<ReactArtifactAgentCacConfig>({
     key: REACT_ARTIFACT_AGENT_CAC_KEY,
     fallbackConfig: DEFAULT_REACT_ARTIFACT_AGENT_CAC_CONFIG,
   });
   const theme = useMemo(() => sandpackThemeName(), []);
-  const { attachmentId, inlineData, savedAppId } = artifact;
+  const { attachmentId, inlineData, savedAppId, versionId } = artifact;
 
   // Keyed on the ids, NOT on `artifact`: callers rebuild that object each
   // render, and depending on its identity would re-enter `loading` — tearing
@@ -196,11 +210,18 @@ export const ReactArtifactView = ({
     let cancelled = false;
     setState({ status: 'loading' });
 
-    // A saved app is addressed by its own id, which is the only route that works
-    // for someone who was never in the originating chat.
-    const load = savedAppId
-      ? loadSavedArtifactPayload(savedAppId)
-      : loadArtifactPayload({ attachmentId, ...(inlineData ? { inlineData } : {}) });
+    // Inline bytes win when present: the artifact was just generated in this
+    // session, so they are already here and exactly what this turn produced —
+    // fetching would be a needless round trip against a row written moments ago.
+    // Otherwise address the app by id, the only route that works for someone who
+    // was never in the originating chat, pinned to THIS turn's version so a card
+    // keeps rendering what its message described even after later generations
+    // move the app on.
+    const load = inlineData
+      ? loadArtifactPayload({ attachmentId, inlineData })
+      : savedAppId
+        ? loadSavedArtifactPayload(savedAppId, versionId)
+        : loadArtifactPayload({ attachmentId });
 
     load
       .then(payload => {
@@ -217,7 +238,7 @@ export const ReactArtifactView = ({
     return (): void => {
       cancelled = true;
     };
-  }, [attachmentId, inlineData, savedAppId]);
+  }, [attachmentId, inlineData, savedAppId, versionId]);
 
   const shellClass = fill
     ? 'flex h-full min-h-0 flex-1 flex-col'
@@ -251,8 +272,18 @@ export const ReactArtifactView = ({
 
   return (
     <div className={shellClass} data-testid='react-artifact'>
-      <div className='flex items-center justify-between gap-2 border-b border-border px-3 py-2'>
-        <span className='truncate text-sm font-medium text-foreground'>{payload.title}</span>
+      <div
+        className={`flex items-center justify-between gap-2 border-b px-3 ${
+          // Only when filling a panel does this sit on the same row as the
+          // AppNavigator, so it has to match both its height and its seam
+          // colour. Inline in a transcript it is a card header, not a top bar:
+          // content-sized, with the ordinary card border.
+          fill ? `${TOP_BAR_HEIGHT_CLASS} border-sidebar-border-muted` : 'border-border py-2'
+        }`}
+      >
+        {titleSlot ?? (
+          <span className='truncate text-sm font-medium text-foreground'>{payload.title}</span>
+        )}
 
         {/* One group, so the bar reads as title | actions. Without it,
             justify-between spreads every control evenly across the header. */}
@@ -302,6 +333,9 @@ export const ReactArtifactView = ({
               <Pencil className='h-3 w-3' aria-hidden='true' />
               Can make changes
             </span>
+          )}
+          {savedAppId && (
+            <ArtifactSavedIndicator appId={savedAppId} {...(versionId ? { versionId } : {})} />
           )}
           {payload.dataRequirements?.some(r => r.source) && (
             <button
@@ -390,6 +424,7 @@ export const ReactArtifactView = ({
           refreshRef={refreshRef}
           canWrite={writeConfig.enabled}
           canInvokeAgents={agentConfig.enabled}
+          currentUserId={auth.userID ?? ''}
           {...(artifact.savedAppId ? { appId: artifact.savedAppId } : {})}
           {...(!artifact.savedAppId && attachmentId ? { attachmentId } : {})}
         />

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/appCreationModeContext.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/appCreationModeContext.ts
@@ -1,0 +1,45 @@
+/**
+ * Tells cards deep in the transcript that the app is already on screen in the
+ * right-hand pane — and lets them drive which version it shows.
+ *
+ * Without this, App Creation mode runs the same app TWICE: the pane and every
+ * inline card each mount their own Sandpack iframe, their own `useXyneData`
+ * bridge and their own agent bridge. That means duplicate queries, duplicate
+ * live streams, and — worst — writes firing from whichever copy the user
+ * happened to click. A context rather than prop drilling because
+ * `MessageReactArtifacts` sits many levels below `AIScreen`, and threading this
+ * through `AIChatThread` would put it in the dependency arrays of components
+ * that must not re-render for it.
+ */
+
+import { createContext, useContext } from 'react';
+
+export interface AppCreationModeSignal {
+  /** True while the split-view pane is rendering this thread's app. */
+  active: boolean;
+  /** The app the pane is showing; cards for THIS app become references. */
+  appId: string | null;
+  /** The build currently in the pane, so a card can show itself as selected. */
+  viewingVersionId: string | null;
+  /** Point the pane at a version. A VIEW, not a restore — head does not move. */
+  viewVersion: (versionId: string | null) => void;
+}
+
+const AppCreationModeContext = createContext<AppCreationModeSignal>({
+  active: false,
+  appId: null,
+  viewingVersionId: null,
+  viewVersion: () => undefined,
+});
+
+export const AppCreationModeProvider = AppCreationModeContext.Provider;
+
+export function useAppCreationModeSignal(): AppCreationModeSignal {
+  return useContext(AppCreationModeContext);
+}
+
+/** Whether this card should become a reference instead of running its own copy. */
+export function useIsShownInPane(cardAppId: string | undefined): boolean {
+  const { active, appId } = useContext(AppCreationModeContext);
+  return active && Boolean(cardAppId) && cardAppId === appId;
+}

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/artifactData.constants.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/artifactData.constants.ts
@@ -116,6 +116,27 @@ export interface HostMutateResultMessage {
 }
 
 /**
+ * Finished, display-ready names — never raw rows. Resolved host-side with the
+ * same helpers the rest of Spaces uses, because two of the rules are not
+ * guessable: `displayName` is usually null (fall back to name, then email), and
+ * a DM channel's `name` column holds participant ids rather than a name.
+ */
+export interface ArtifactDirectory {
+  /** userId -> display name. */
+  users: Record<string, string>;
+  /** channelId -> channel name, with DMs already resolved to participant names. */
+  channels: Record<string, string>;
+}
+
+/** Host -> app. Idempotent, last write wins - same contract as a data snapshot. */
+export interface HostDirectoryMessage {
+  source: 'xyne-artifact-host';
+  v: number;
+  type: 'directory';
+  directory: ArtifactDirectory;
+}
+
+/**
  * Host → app: one event from a running agent, forwarded off the live
  * conversation stream. Fire-and-forget; the app accumulates them.
  */

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/artifactDirectory.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/artifactDirectory.ts
@@ -1,0 +1,91 @@
+/**
+ * Resolves ids to the names the rest of Spaces shows, for artifact apps.
+ *
+ * Apps used to resolve names themselves: declare a `user` data requirement, then
+ * join on it in generated code. That failed three ways at once —
+ *
+ *   1. `displayName` is null for most real users, so the obvious `u.displayName`
+ *      renders blank. The app-wide rule is `displayName || name || email`.
+ *   2. A DM channel's `name` column is NOT a name. It is the participant ids,
+ *      comma-separated and sorted ("id1,id2"), so rendering `channel.name` for a
+ *      DM prints raw cuids.
+ *   3. It burned one of the eight dataRequirement slots, and re-fetched the whole
+ *      user table on every open, for data the dashboard already holds in memory.
+ *
+ * So the host resolves instead, calling the SAME functions every other surface
+ * calls — `getUserDisplayName` and `getDMNames`, the latter documented in-tree as
+ * the canonical DM resolver — and pushes finished strings into the app. Generated
+ * code cannot get this wrong because it never does it.
+ *
+ * Everything here reads the XState store IMPERATIVELY via `getSnapshot()`. It
+ * must never use `useSelector`: this runs inside the memoized Sandpack child, and
+ * a re-render there tears down the iframe and forces a full re-bundle.
+ */
+
+import { stateMachineActor } from '../../../machines/stateMachine';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+import { getDMNames, isDMChannel } from '../../Chat/ChatDirectory/ChatDirectory.utils';
+import type { ArtifactDirectory } from './artifactData.constants';
+
+/**
+ * Names shown before the roll-up kicks in. Matches AddDmForm / ComposeDmPanel,
+ * which are what a user sees when composing the same conversation.
+ */
+const MAX_DM_NAMES_SHOWN = 3;
+
+/**
+ * Collapse a DM's participant names into ONE string, the way the compose surfaces
+ * do: up to three names joined, otherwise the first two plus a count. Apps get a
+ * single string rather than the array `getDMNames` returns, so every app renders
+ * a group DM identically instead of inventing its own truncation.
+ */
+function joinDmNames(names: string[]): string {
+  if (names.length === 0) return '';
+  if (names.length <= MAX_DM_NAMES_SHOWN) return names.join(', ');
+  return `${names.slice(0, 2).join(', ')} + ${names.length - 2} others`;
+}
+
+/**
+ * Snapshot every id → name the viewer can see.
+ *
+ * Reads the same store `InitialStateLoader` populates, so this costs no network
+ * call at all: the users and channels are already resident, hydrated from
+ * IndexedDB and kept current by Zero deltas.
+ */
+export function buildArtifactDirectory(currentUserId: string): ArtifactDirectory {
+  const { context } = stateMachineActor.getSnapshot();
+
+  const users: Record<string, string> = {};
+  const usersById = new Map<string, { name: string; displayName?: string | null }>();
+
+  for (const user of context.users ?? []) {
+    if (!user?.id) continue;
+    usersById.set(user.id, { name: user.name ?? '', displayName: user.displayName });
+    users[user.id] = getUserDisplayName(user);
+  }
+
+  const channels: Record<string, string> = {};
+  for (const channel of context.allChannels ?? []) {
+    if (!channel?.id) continue;
+    if (!isDMChannel(channel.scopeType)) {
+      channels[channel.id] = channel.name ?? '';
+      continue;
+    }
+    // DMs and group DMs: the ids live in `name`, so this must go through the
+    // canonical resolver — it also handles the self-DM "You" case.
+    const { display } = getDMNames(channel, currentUserId, usersById);
+    channels[channel.id] = joinDmNames(display);
+  }
+
+  return { users, channels };
+}
+
+/**
+ * Cheap identity check so the bridge only re-posts when something actually
+ * changed. The store replaces these arrays wholesale on update, so comparing
+ * references is enough and avoids rebuilding the directory on every store event.
+ */
+export function directorySourceRefs(): { users: unknown; channels: unknown } {
+  const { context } = stateMachineActor.getSnapshot();
+  return { users: context.users, channels: context.allChannels };
+}

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/useAppCreationMode.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/useAppCreationMode.ts
@@ -1,0 +1,185 @@
+/**
+ * App Creation mode — which app a chat thread is building, whether the split
+ * view is open, and which version the pane is showing.
+ *
+ * Step 1 made a conversation own exactly ONE app, which is what lets a single
+ * persistent pane be unambiguous: there is never a question of *which* artifact
+ * the right-hand side means.
+ *
+ * The open/closed state lives in the URL (`?mode=create-app`) rather than in
+ * component state, so a reload — or a link pasted to a teammate — comes back to
+ * the same layout instead of silently reverting to plain chat.
+ *
+ * Everything else here is keyed to the CONVERSATION. The pane must never carry
+ * over to another thread: switching to a chat with no app has to close it, and
+ * a version pinned in one thread is meaningless in another.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getArtifactApp,
+  type ArtifactAppVersionSummary,
+} from '../../../services/claw/artifactAppsService';
+
+export const APP_MODE_PARAM = 'mode';
+export const APP_MODE_VALUE = 'create-app';
+
+export interface AppCreationMode {
+  /** True when the split view should render: the mode is on AND there is an app. */
+  active: boolean;
+  /** True when this thread has an app at all — drives the reopen affordance. */
+  hasApp: boolean;
+  appId: string | null;
+  /** The version the pane is showing: an explicit pick, else head. */
+  viewingVersionId: string | null;
+  /** That version's row, so the pane has its manifest without refetching. */
+  viewing: ArtifactAppVersionSummary | null;
+  /** Every version, newest first. Empty until the app loads. */
+  versions: ArtifactAppVersionSummary[];
+  headVersionId: string | null;
+  title: string | null;
+  /** View an older build. A VIEW, not a restore — head does not move. */
+  viewVersion: (versionId: string | null) => void;
+  /** Open the pane (also used by the reopen affordance). */
+  open: () => void;
+  /** Close the pane; inline cards go live again. */
+  exit: () => void;
+}
+
+export function useAppCreationMode(
+  appId: string | null,
+  conversationId: string | null,
+  /** The build the thread's newest artifact carries — the freshness signal. */
+  latestVersionId: string | null,
+): AppCreationMode {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const modeOn = searchParams.get(APP_MODE_PARAM) === APP_MODE_VALUE;
+
+  // An explicit pick pins the pane to one build. Null means "follow head", so a
+  // new generation moves the pane forward on its own — which is what you want
+  // while iterating, and the reason this is not seeded to head.
+  const [pinnedVersionId, setPinnedVersionId] = useState<string | null>(null);
+
+  const setMode = useCallback(
+    (on: boolean) => {
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev);
+          if (on) next.set(APP_MODE_PARAM, APP_MODE_VALUE);
+          else next.delete(APP_MODE_PARAM);
+          return next;
+        },
+        // Toggling a panel is not a navigation: it must not stack history
+        // entries that Back then has to walk back through.
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  // Leaving a thread drops everything thread-specific. Without this the pane
+  // keeps showing the previous chat's app and a pinned version leaks across.
+  const lastConversation = useRef<string | null>(conversationId);
+  const autoEnteredFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (lastConversation.current === conversationId) return;
+    lastConversation.current = conversationId;
+    autoEnteredFor.current = null;
+    setPinnedVersionId(null);
+  }, [conversationId]);
+
+  // A new chat is a blank slate: no conversation, no app, nothing for the mode
+  // to describe. Strip ?mode=create-app rather than letting it ride along — a
+  // lingering param kept mode-derived layout (the collapsed sidebar) armed on
+  // /ai/chat/new. The next thread that generates an app re-enters on its own.
+  useEffect(() => {
+    if (!conversationId && modeOn) setMode(false);
+  }, [conversationId, modeOn, setMode]);
+
+  // Auto-enter ONCE per conversation. Tracking it per conversation is what lets
+  // an explicit close stick: closing marks this thread handled, so a later
+  // generation reopens nothing, while switching threads starts fresh.
+  useEffect(() => {
+    if (!appId) return;
+    if (autoEnteredFor.current === conversationId) return;
+    autoEnteredFor.current = conversationId;
+    if (!modeOn) setMode(true);
+  }, [appId, conversationId, modeOn, setMode]);
+
+  const { data } = useQuery({
+    queryKey: ['artifact-app', appId],
+    queryFn: () => getArtifactApp(appId as string),
+    enabled: Boolean(appId),
+    staleTime: 30_000,
+  });
+
+  // A generation just landed: the thread shows a versionId the cached app does
+  // not contain, so the pane would keep rendering the old head until a refocus
+  // refetched it. Invalidate once per new version — guarded by a ref, not by
+  // the versions array alone, so a version the server has not surfaced yet
+  // cannot put refetching in a loop.
+  const queryClient = useQueryClient();
+  const invalidatedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!appId || !latestVersionId) return;
+    if (invalidatedFor.current === latestVersionId) return;
+    invalidatedFor.current = latestVersionId;
+    const known = queryClient
+      .getQueryData<{ versions: ArtifactAppVersionSummary[] }>(['artifact-app', appId])
+      ?.versions.some(v => v.id === latestVersionId);
+    if (!known) void queryClient.invalidateQueries({ queryKey: ['artifact-app', appId] });
+  }, [appId, latestVersionId, queryClient]);
+
+  const open = useCallback(() => setMode(true), [setMode]);
+  const exit = useCallback(() => {
+    // Mark handled so the next generation does not reopen what was just closed.
+    autoEnteredFor.current = conversationId;
+    setMode(false);
+  }, [setMode, conversationId]);
+  const headVersionId = data?.app.headVersionId ?? null;
+
+  const viewVersion = useCallback(
+    (versionId: string | null) => {
+      // Selecting the CURRENT version clears the pin rather than pinning to it,
+      // so the pane resumes following head and the next generation moves it
+      // forward on its own. Pinning here would silently freeze the pane on the
+      // build that happened to be current when you clicked.
+      setPinnedVersionId(versionId === headVersionId ? null : versionId);
+    },
+    [headVersionId],
+  );
+  const versions = useMemo(() => data?.versions ?? [], [data]);
+
+  /** The build the pane should render — the manifest comes from here, so the
+   *  pane never needs a second fetch to know what it is showing. */
+  const viewing = useMemo(() => {
+    const id = pinnedVersionId ?? headVersionId;
+    return versions.find(v => v.id === id) ?? versions[0] ?? null;
+  }, [versions, pinnedVersionId, headVersionId]);
+
+  // Memoized: this object is a prop to the pane and is read by the context
+  // provider, so a fresh identity every render re-renders the pane (and through
+  // it the Sandpack) for no reason.
+  const title = data?.app.title ?? null;
+  const hasApp = Boolean(appId);
+  const active = hasApp && modeOn;
+
+  return useMemo(
+    () => ({
+      active,
+      hasApp,
+      appId,
+      viewingVersionId: viewing?.id ?? null,
+      viewing,
+      versions,
+      headVersionId,
+      title,
+      viewVersion,
+      open,
+      exit,
+    }),
+    [active, hasApp, appId, viewing, versions, headVersionId, title, viewVersion, open, exit],
+  );
+}

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/useArtifactDirectoryBridge.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/useArtifactDirectoryBridge.ts
@@ -1,0 +1,89 @@
+import { useEffect, type MutableRefObject } from 'react';
+import { stateMachineActor } from '../../../machines/stateMachine';
+import { buildArtifactDirectory, directorySourceRefs } from './artifactDirectory';
+import { ARTIFACT_DATA_PROTOCOL_VERSION, isAppArtifactMessage } from './artifactData.constants';
+import type { HostDirectoryMessage } from './artifactData.constants';
+import type { PreviewClientRef } from './useArtifactDataBridge';
+
+interface DirectoryBridgeArgs {
+  /** Needed by the canonical DM resolver: it excludes you from participant lists
+   *  and renders a self-DM as "You". A plain string, so it cannot destabilise the
+   *  memoized sandbox the way an object prop would. */
+  currentUserId: string;
+  previewRef: MutableRefObject<PreviewClientRef | null>;
+}
+
+/**
+ * Pushes resolved id → name lookups into an artifact app.
+ *
+ * Separate from the data bridge on purpose. That hook skips its listener
+ * entirely for an artifact with no `dataRequirements`, and the directory is
+ * useful beyond declared reads — an app rendering rows it got from an agent run
+ * still needs names. Keeping it apart also means this touches none of the
+ * working read/write path.
+ *
+ * Costs no network call: everything comes from the store `InitialStateLoader`
+ * already populated, so an app open resolves names for free rather than
+ * re-fetching the user table.
+ */
+export function useArtifactDirectoryBridge({
+  currentUserId,
+  previewRef,
+}: DirectoryBridgeArgs): void {
+  useEffect(() => {
+    if (!currentUserId) return;
+
+    let cancelled = false;
+    let lastRefs = { users: undefined as unknown, channels: undefined as unknown };
+
+    const appWindow = (): Window | null =>
+      previewRef.current?.getClient()?.iframe?.contentWindow ?? null;
+
+    const post = (): void => {
+      const target = appWindow();
+      if (!target) return;
+      const message: HostDirectoryMessage = {
+        source: 'xyne-artifact-host',
+        v: ARTIFACT_DATA_PROTOCOL_VERSION,
+        type: 'directory',
+        directory: buildArtifactDirectory(currentUserId),
+      };
+      try {
+        target.postMessage(message, '*');
+      } catch {
+        /* structured-clone failure — names simply stay unresolved in the app */
+      }
+    };
+
+    const onMessage = (event: MessageEvent): void => {
+      if (!isAppArtifactMessage(event.data)) return;
+      const target = appWindow();
+      if (!target || event.source !== target) return;
+      // An iframe reload loses the app's copy; `ready` is how it asks again.
+      if (event.data.type === 'ready') post();
+    };
+
+    window.addEventListener('message', onMessage);
+    post();
+
+    // Re-push only when the store actually swaps the arrays (a colleague joins,
+    // a DM is created). Reference comparison is enough because the machine
+    // replaces them wholesale, and it keeps a chatty store from rebuilding the
+    // directory on every unrelated event.
+    const subscription = stateMachineActor.subscribe(() => {
+      if (cancelled) return;
+      const refs = directorySourceRefs();
+      if (refs.users === lastRefs.users && refs.channels === lastRefs.channels) return;
+      lastRefs = refs;
+      post();
+    });
+
+    lastRefs = directorySourceRefs();
+
+    return (): void => {
+      cancelled = true;
+      window.removeEventListener('message', onMessage);
+      subscription.unsubscribe();
+    };
+  }, [currentUserId, previewRef]);
+}

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/xyneDataRuntime.source.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/xyneDataRuntime.source.ts
@@ -63,6 +63,7 @@ window.addEventListener('message', (event: MessageEvent) => {
     source?: string;
     v?: number;
     type?: string;
+    directory?: unknown;
     payloads?: Record<string, Entry>;
     requestId?: string;
     ok?: boolean;
@@ -80,6 +81,11 @@ window.addEventListener('message', (event: MessageEvent) => {
     window.clearTimeout(entry.timer);
     if (message.ok) entry.resolve();
     else entry.reject(new Error(message.error || 'The change could not be saved.'));
+    return;
+  }
+
+  if (message.type === 'directory') {
+    applyDirectory((message as unknown as { directory?: Directory }).directory);
     return;
   }
 
@@ -481,4 +487,94 @@ export function useXyneAgent(options?: { key?: string; agent?: string }): XyneAg
     agents: state.agents,
     available: state.available,
   };
+}
+
+// ── Names ─────────────────────────────────────────────────────────────────────
+//
+// Ids are opaque. Turning one into the name a person recognises has two rules
+// that are impossible to guess from the row alone, so the HOST resolves them
+// with the same helpers the rest of Spaces uses and sends finished strings:
+//
+//   • a user's display name is `displayName || name || email` — and displayName
+//     is null for most real people, so reading it alone renders blanks;
+//   • a DM channel's `name` column is not a name at all. It holds the
+//     participant ids, comma-separated ("id1,id2"), so rendering it prints raw
+//     ids. Group DMs collapse to "Alice, Bob + 3 others", and a DM with
+//     yourself reads "You".
+//
+// Never try to reproduce either rule in app code, and never join against a
+// `user` data source just to show a name — this is already loaded, costs no
+// request, and stays correct.
+
+interface Directory {
+  users: Record<string, string>;
+  channels: Record<string, string>;
+}
+
+let directory: Directory = { users: {}, channels: {} };
+let hasDirectory = false;
+const directoryListeners = new Set<() => void>();
+
+function applyDirectory(next: unknown): void {
+  const value = next as Directory | undefined;
+  directory = {
+    users: value?.users ?? {},
+    channels: value?.channels ?? {},
+  };
+  hasDirectory = true;
+  directoryListeners.forEach(listener => listener());
+}
+
+function subscribeDirectory(onChange: () => void): () => void {
+  directoryListeners.add(onChange);
+  return () => {
+    directoryListeners.delete(onChange);
+  };
+}
+
+export interface XyneDirectory {
+  /** Name for a user id. Falls back to the id itself, never to blank. */
+  displayName: (userId: string | null | undefined) => string;
+  /** Name for a channel id, with DMs and group DMs already resolved. */
+  channelName: (channelId: string | null | undefined) => string;
+  /** False until the first delivery, so you can hold off rendering names. */
+  ready: boolean;
+}
+
+/**
+ * Resolve user and channel ids to the names Spaces shows.
+ *
+ *   const { displayName, channelName } = useXyneDirectory();
+ *   <span>{displayName(message.senderId)}</span>
+ *   <h2>{channelName(dm.id)}</h2>
+ *
+ * Both are plain synchronous functions — safe to call while rendering a list.
+ */
+export function useXyneDirectory(): XyneDirectory {
+  const snapshot = useSyncExternalStore(
+    subscribeDirectory,
+    () => directory,
+    () => directory,
+  );
+
+  const displayName = useCallback(
+    (userId: string | null | undefined): string => {
+      if (!userId) return 'Unknown';
+      // Falling back to the raw id keeps a row identifiable rather than blank
+      // when someone is outside the viewer's directory (deactivated, or a
+      // workspace they cannot see).
+      return snapshot.users[userId] ?? userId;
+    },
+    [snapshot],
+  );
+
+  const channelName = useCallback(
+    (channelId: string | null | undefined): string => {
+      if (!channelId) return '';
+      return snapshot.channels[channelId] ?? channelId;
+    },
+    [snapshot],
+  );
+
+  return { displayName, channelName, ready: hasDirectory };
 }

--- a/apps/dashboard/src/components/AppNavigator/topBarHeight.ts
+++ b/apps/dashboard/src/components/AppNavigator/topBarHeight.ts
@@ -1,0 +1,13 @@
+/**
+ * The height every top bar must share.
+ *
+ * `AppNavigator` itself is `h-full` — it takes the height of whatever wraps it,
+ * and the wrappers across the app (AISidebar, DmsPage, BookmarksPanel,
+ * ChatDirectory) all hard-code 52px. Any bar that sits on the same row as the
+ * navigator has to match it exactly, or the panes look stepped where they meet.
+ *
+ * Exported as a class string rather than a number because these are Tailwind
+ * utilities; an arbitrary value has to be written literally for the compiler to
+ * see it, so it cannot be interpolated.
+ */
+export const TOP_BAR_HEIGHT_CLASS = 'h-[52px]';

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIPlusMenu.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIPlusMenu.tsx
@@ -1,5 +1,14 @@
-import type { ReactElement, ReactNode } from 'react';
-import { ChevronRight, FilePlus, FocusTarget, Globe, Notebook, PaperclipSlant } from '@xyne/icons';
+import { useCallback, useRef, type ReactElement, type ReactNode } from 'react';
+import {
+  Bot,
+  ChevronRight,
+  FilePlus,
+  FocusTarget,
+  Globe,
+  Notebook,
+  PaperclipSlant,
+  SparkleAi01,
+} from '@xyne/icons';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,6 +36,18 @@ const NOOP = (): void => {};
 const ReadonlySwitch = ({ checked }: { checked: boolean }): ReactElement => (
   <div className='pointer-events-none' aria-hidden>
     <Switch checked={checked} onCheckedChange={NOOP} />
+  </div>
+);
+
+/** Trailing "current value ›" for a row that opens another picker. */
+const ValueChevron = ({ value }: { value: string | undefined }): ReactElement => (
+  <div className='flex items-center gap-1'>
+    {value && (
+      <span className='max-w-[96px] truncate text-xs font-normal text-muted-foreground'>
+        {value}
+      </span>
+    )}
+    <ChevronRight className={ICON_CLASS} />
   </div>
 );
 
@@ -61,6 +82,18 @@ export interface XyneAIPlusMenuProps {
   deepResearchEnabled?: boolean;
   deepResearchAccessible?: boolean;
 
+  /** Agent / model rows. The /ai composer passes these only once its toolbar is
+   *  too narrow to keep both pills beside the send button; the sidebar, whose
+   *  toolbar wraps instead, never does. Each opens that selector's own popover
+   *  once this menu has closed — see the handoff note below. */
+  onOpenAgentSelector?: () => void;
+  agentLabel?: string;
+  onOpenModelSelector?: () => void;
+  modelLabel?: string;
+  /** Greys out the agent/model rows — the composer sets this while a run is
+   *  streaming, matching what the pills do when they are visible. */
+  selectorsDisabled?: boolean;
+
   /** The trigger — rendered as the menu's anchor. */
   children: ReactNode;
 }
@@ -84,12 +117,45 @@ export const XyneAIPlusMenu = ({
   onDeepResearchToggle,
   deepResearchEnabled = false,
   deepResearchAccessible = false,
+  onOpenAgentSelector,
+  agentLabel,
+  onOpenModelSelector,
+  modelLabel,
+  selectorsDisabled = false,
   children,
 }: XyneAIPlusMenuProps): ReactElement => {
   const hasSearchRow = !!onWebSearchToggle || !!onDeepResearchToggle;
+  const hasSelectorRow = !!onOpenAgentSelector || !!onOpenModelSelector;
+
+  // Rows that hand off to another popover can't just call their callback from
+  // `onSelect`: the menu closes right after and Radix returns focus to the "+"
+  // trigger, which the popover — non-modal, so it dismisses on focus-outside —
+  // reads as a click away and closes itself immediately. So park the callback,
+  // suppress the focus restore, and run it a frame later, once the menu's
+  // layer teardown (including the body pointer-events lock) has flushed.
+  const handoffRef = useRef<(() => void) | null>(null);
+  const handoff = useCallback(
+    (action: (() => void) | undefined) => (): void => {
+      handoffRef.current = action ?? null;
+    },
+    [],
+  );
+  const runHandoff = useCallback((event: Event): void => {
+    const action = handoffRef.current;
+    if (!action) return;
+    handoffRef.current = null;
+    event.preventDefault();
+    requestAnimationFrame(action);
+  }, []);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu
+      onOpenChange={open => {
+        // Drop anything parked by a close that never ran it (dismissed by an
+        // outside click, say) so it can't fire on some later close.
+        if (open) handoffRef.current = null;
+      }}
+    >
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
       {/* Anchored above the composer, which sits at the bottom of the sidebar. */}
       <DropdownMenuContent
@@ -97,7 +163,40 @@ export const XyneAIPlusMenu = ({
         side='top'
         sideOffset={8}
         className='min-w-[232px] rounded-2xl p-2 shadow-lg'
+        onCloseAutoFocus={runHandoff}
       >
+        {onOpenAgentSelector && (
+          <DropdownMenuItem
+            className={`${ITEM_CLASS} justify-between`}
+            disabled={selectorsDisabled}
+            onSelect={handoff(onOpenAgentSelector)}
+            data-track-category='XyneAI'
+            data-track-name='OPEN_AGENT_SELECTOR'
+          >
+            <SplitRow trailing={<ValueChevron value={agentLabel} />}>
+              <Bot className={ICON_CLASS} />
+              Agent
+            </SplitRow>
+          </DropdownMenuItem>
+        )}
+
+        {onOpenModelSelector && (
+          <DropdownMenuItem
+            className={`${ITEM_CLASS} justify-between`}
+            disabled={selectorsDisabled}
+            onSelect={handoff(onOpenModelSelector)}
+            data-track-category='XyneAI'
+            data-track-name='OPEN_MODEL_SELECTOR'
+          >
+            <SplitRow trailing={<ValueChevron value={modelLabel} />}>
+              <SparkleAi01 className={ICON_CLASS} />
+              Model
+            </SplitRow>
+          </DropdownMenuItem>
+        )}
+
+        {hasSelectorRow && <DropdownMenuSeparator />}
+
         <DropdownMenuItem
           className={ITEM_CLASS}
           onSelect={onAttachFiles}
@@ -112,7 +211,7 @@ export const XyneAIPlusMenu = ({
 
         <DropdownMenuItem
           className={`${ITEM_CLASS} justify-between`}
-          onSelect={onOpenCollections}
+          onSelect={handoff(onOpenCollections)}
           data-track-category='XyneAI'
           data-track-name='OPEN_COLLECTION_SELECTOR'
         >

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAITypes.ts
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAITypes.ts
@@ -421,6 +421,12 @@ export interface ReactArtifactManifest {
   invokesAgents?: boolean;
   /** Agents the app prefers. Narrowing hint; the viewer's access is the ceiling. */
   agents?: string[];
+  /** Stamped server-side once the conversation's app exists. A thread owns ONE
+   *  app, so every artifact in it shares `appId`; `versionId` is the specific
+   *  build this turn produced, which is what its card renders. */
+  appId?: string;
+  versionId?: string;
+  versionNumber?: number;
 }
 
 export interface MessageAttachment {

--- a/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
+++ b/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
@@ -1,7 +1,10 @@
-import { type ReactElement, useState, useCallback, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Upload } from 'lucide-react';
+import { type ReactElement, useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { Upload, PanelRightOpen } from 'lucide-react';
 import { AIShell } from '../../components/AIScreen/AIShell';
+import { ArtifactAppPane } from '../../components/AIScreen/ReactArtifact/ArtifactAppPane';
+import { AppCreationModeProvider } from '../../components/AIScreen/ReactArtifact/appCreationModeContext';
+import { useAppCreationMode } from '../../components/AIScreen/ReactArtifact/useAppCreationMode';
 import { AIEmptyState } from '../../components/AIScreen/AIEmptyState';
 import {
   AIComposer,
@@ -18,11 +21,23 @@ import { useSelectedAgent } from '../../hooks/useSelectedAgent';
 import { AI_ACTIVE_SESSION_KEY, AI_SHOW_CHAT_VIEW_KEY } from './aiSessionStorage';
 
 const AIScreen = (): ReactElement => {
-  const [activeSessionId, setActiveSessionId] = useState(
-    () => sessionStorage.getItem(AI_ACTIVE_SESSION_KEY) ?? '',
-  );
-  const [showChatView, setShowChatView] = useState(
-    () => sessionStorage.getItem(AI_SHOW_CHAT_VIEW_KEY) === '1',
+  const { workspaceId, sessionId: routeSessionId } = useParams<{
+    workspaceId?: string;
+    sessionId?: string;
+  }>();
+  const location = useLocation();
+  /** '' for the landing page — `chat/new` is the literal, not a session id. */
+  const sessionFromUrl = routeSessionId && routeSessionId !== 'new' ? routeSessionId : '';
+
+  // The URL is the source of truth for the thread. `/ai/chat/new` means a NEW
+  // chat — full stop. The old sessionStorage restore is gone: it predates
+  // threads having URLs, and once they did it turned "new" into "whatever you
+  // had open last" (observed: navigating to chat/new landed on the most recent
+  // thread). Reload-keeps-your-chat now comes from the thread being in the URL,
+  // and the Library/daily-brief handoff navigates to the thread URL directly.
+  const [activeSessionId, setActiveSessionId] = useState(() => sessionFromUrl);
+  const [showChatView, setShowChatView] = useState(() =>
+    sessionFromUrl ? true : sessionStorage.getItem(AI_SHOW_CHAT_VIEW_KEY) === '1',
   );
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [initialQuery, setInitialQuery] = useState<string>('');
@@ -50,6 +65,41 @@ const AIScreen = (): ReactElement => {
   useEffect(() => {
     showChatViewRef.current = showChatView;
   }, [showChatView]);
+
+  // ── Thread ↔ URL, two-way ────────────────────────────────────────────────
+  // Each direction fires only when ITS OWN source actually changed, tracked in
+  // a ref. Dep-array firing is not enough: effects run in the commit where the
+  // OTHER side is still stale. Concretely, clicking New Chat sets
+  // activeSessionId='' while the URL param still holds the old thread — an
+  // unguarded URL→state effect then "corrects" the state right back to the old
+  // thread, which is exactly the bounce this replaced.
+
+  // state → URL. `location.search` is carried so ?mode=create-app survives.
+  const lastPushedSession = useRef(activeSessionId);
+  useEffect(() => {
+    if (lastPushedSession.current === activeSessionId) return;
+    lastPushedSession.current = activeSessionId;
+    const target = activeSessionId || 'new';
+    if ((routeSessionId ?? 'new') === target) return;
+    if (!workspaceId) return;
+    void navigate(`/${workspaceId}/ai/chat/${target}${location.search}`, { replace: true });
+  }, [activeSessionId, routeSessionId, workspaceId, location.search, navigate]);
+
+  // URL → state, for Back/Forward and pasted links.
+  const lastSeenUrlSession = useRef(sessionFromUrl);
+  useEffect(() => {
+    if (lastSeenUrlSession.current === sessionFromUrl) return;
+    lastSeenUrlSession.current = sessionFromUrl;
+    if (sessionFromUrl === activeSessionId) return;
+    // Keep the other direction's ref in step, so this externally-driven change
+    // is not then re-announced as a state change.
+    lastPushedSession.current = sessionFromUrl;
+    setActiveSessionId(sessionFromUrl);
+    setShowChatView(Boolean(sessionFromUrl));
+    setInitialQuery('');
+    setInitialAttachments(undefined);
+    setChatKey(prev => prev + 1);
+  }, [sessionFromUrl, activeSessionId]);
 
   useEffect(() => {
     if (activeSessionId) {
@@ -215,68 +265,124 @@ const AIScreen = (): ReactElement => {
     void navigate('./settings');
   }, [navigate]);
 
+  // App Creation mode. The thread reports which app it is building; the mode
+  // hook decides whether the split view is on and which version the pane shows.
+  const [appId, setAppId] = useState<string | null>(null);
+  const [latestVersionId, setLatestVersionId] = useState<string | null>(null);
+  const appMode = useAppCreationMode(appId, activeSessionId || null, latestVersionId);
+
+  // The thread reports its app, but only while it is MOUNTED. On the landing
+  // page (showChatView false) and in the gap before a newly-selected thread has
+  // loaded, nothing reports — so a stale appId from the previous chat would
+  // keep the pane open over a thread that has no app. Clear it here instead of
+  // relying on the thread to say "none".
+  useEffect(() => {
+    if (!showChatView) {
+      setAppId(null);
+      setLatestVersionId(null);
+    }
+  }, [showChatView]);
+  useEffect(() => {
+    setAppId(null);
+    setLatestVersionId(null);
+  }, [activeSessionId]);
+  const handleAppChange = useCallback((id: string | null, versionId: string | null) => {
+    setAppId(id);
+    setLatestVersionId(versionId);
+  }, []);
+  // A fresh object here re-renders every context consumer — that is every
+  // artifact card in the transcript — on each AIScreen render.
+  const appModeSignal = useMemo(
+    () => ({
+      active: appMode.active,
+      appId: appMode.appId,
+      viewingVersionId: appMode.viewingVersionId,
+      viewVersion: appMode.viewVersion,
+    }),
+    [appMode.active, appMode.appId, appMode.viewingVersionId, appMode.viewVersion],
+  );
+  // Likewise a fresh element remounts the pane's subtree each render.
+  const appPane = useMemo(() => <ArtifactAppPane mode={appMode} />, [appMode]);
+
   return (
     <CitationDocsProvider>
-      <AIShell
-        activeSessionId={activeSessionId}
-        onCreateChat={handleCreateChat}
-        onSelectSession={handleSelectSession}
-        onAccount={handleAccount}
-        mobileOpen={mobileSidebarOpen}
-        onMobileOpenChange={setMobileSidebarOpen}
-        mainRef={dropZoneRef}
-      >
-        {isDragging && !showChatView && (
-          <div className='pointer-events-none absolute inset-0 z-50 flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-primary/50 bg-background/95 backdrop-blur-sm'>
-            <div className='flex flex-col items-center gap-3'>
-              <div className='rounded-full bg-primary/10 p-4'>
-                <Upload className='h-8 w-8 text-primary' />
-              </div>
-              <div className='text-center'>
-                <p className='text-lg font-medium text-foreground'>Drop files to attach</p>
-                <p className='text-sm text-muted-foreground'>
-                  Images, PDF, text, office documents, or data files
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
-        {showChatView ? (
-          <ChatWithCitationDocs>
-            <AIChatThread
-              ref={chatThreadRef}
-              key={chatKey}
-              sessionId={activeSessionId || undefined}
-              initialQuery={initialQuery}
-              initialAttachments={initialAttachments}
-              initialExtras={initialExtras}
-              onSetMobileSidebarOpen={setMobileSidebarOpen}
-              onConversationChange={handleConversationChange}
-              onAgentChange={handleAgentChange}
-              onContextChange={handleContextChange}
-              onInitialQueryConsumed={handleInitialQueryConsumed}
-            />
-          </ChatWithCitationDocs>
-        ) : (
-          /* Landing page – centred greeting + composer */
-          <main className='flex h-full flex-1 items-center justify-center px-6 py-8'>
-            <div className='flex w-full max-w-2xl flex-col'>
-              <AIEmptyState />
-              <div className='mt-6'>
-                <AIComposer
-                  ref={landingComposerRef}
-                  autoFocus
-                  onSubmit={handleComposerSubmit}
-                  onAgentChange={handleAgentChange}
-                  showAgentSelector={isV2}
-                  onContextChange={handleContextChange}
-                  hideDisclaimer
-                />
+      <AppCreationModeProvider value={appModeSignal}>
+        <AIShell
+          activeSessionId={activeSessionId}
+          onCreateChat={handleCreateChat}
+          onSelectSession={handleSelectSession}
+          onAccount={handleAccount}
+          mobileOpen={mobileSidebarOpen}
+          onMobileOpenChange={setMobileSidebarOpen}
+          mainRef={dropZoneRef}
+          {...(appMode.active ? { rightPanel: appPane } : {})}
+        >
+          {isDragging && !showChatView && (
+            <div className='pointer-events-none absolute inset-0 z-50 flex flex-col items-center justify-center rounded-xl border-2 border-dashed border-primary/50 bg-background/95 backdrop-blur-sm'>
+              <div className='flex flex-col items-center gap-3'>
+                <div className='rounded-full bg-primary/10 p-4'>
+                  <Upload className='h-8 w-8 text-primary' />
+                </div>
+                <div className='text-center'>
+                  <p className='text-lg font-medium text-foreground'>Drop files to attach</p>
+                  <p className='text-sm text-muted-foreground'>
+                    Images, PDF, text, office documents, or data files
+                  </p>
+                </div>
               </div>
             </div>
-          </main>
-        )}
-      </AIShell>
+          )}
+          {appMode.hasApp && !appMode.active && showChatView && (
+            <button
+              type='button'
+              onClick={appMode.open}
+              className='absolute right-4 top-3 z-40 flex items-center gap-1.5 rounded-full border border-border bg-background/95 px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm backdrop-blur-sm transition-colors hover:bg-accent hover:text-foreground'
+              title='Reopen the app panel'
+              data-track-category='AskAI'
+              data-track-name='ArtifactAppPaneReopen'
+            >
+              <PanelRightOpen className='h-3.5 w-3.5' aria-hidden='true' />
+              Open app
+            </button>
+          )}
+          {showChatView ? (
+            <ChatWithCitationDocs>
+              <AIChatThread
+                ref={chatThreadRef}
+                key={chatKey}
+                sessionId={activeSessionId || undefined}
+                initialQuery={initialQuery}
+                initialAttachments={initialAttachments}
+                initialExtras={initialExtras}
+                onSetMobileSidebarOpen={setMobileSidebarOpen}
+                onConversationChange={handleConversationChange}
+                onAppChange={handleAppChange}
+                onAgentChange={handleAgentChange}
+                onContextChange={handleContextChange}
+                onInitialQueryConsumed={handleInitialQueryConsumed}
+              />
+            </ChatWithCitationDocs>
+          ) : (
+            /* Landing page – centred greeting + composer */
+            <main className='flex h-full flex-1 items-center justify-center px-6 py-8'>
+              <div className='flex w-full max-w-2xl flex-col'>
+                <AIEmptyState />
+                <div className='mt-6'>
+                  <AIComposer
+                    ref={landingComposerRef}
+                    autoFocus
+                    onSubmit={handleComposerSubmit}
+                    onAgentChange={handleAgentChange}
+                    showAgentSelector={isV2}
+                    onContextChange={handleContextChange}
+                    hideDisclaimer
+                  />
+                </div>
+              </div>
+            </main>
+          )}
+        </AIShell>
+      </AppCreationModeProvider>
     </CitationDocsProvider>
   );
 };

--- a/apps/dashboard/src/routes/AIScreen/useAIChatHandoff.ts
+++ b/apps/dashboard/src/routes/AIScreen/useAIChatHandoff.ts
@@ -18,11 +18,17 @@ export function useAIChatHandoff(): {
 
   const onSelectSession = useCallback(
     (sessionId: string): void => {
+      // The thread lives in the URL now — navigate to it directly. The old
+      // write-to-storage-then-open-chat/new dance depended on AIScreen
+      // restoring the id on mount, which is gone (it made "new" mean "most
+      // recent"). The storage writes remain only as a mirror for anything
+      // still reading them.
       sessionStorage.setItem(AI_ACTIVE_SESSION_KEY, sessionId);
       sessionStorage.setItem(AI_SHOW_CHAT_VIEW_KEY, '1');
-      void navigate(chatPath);
+      const base = workspaceId ? `/${workspaceId}/ai/chat` : '/ai/chat';
+      void navigate(`${base}/${encodeURIComponent(sessionId)}`);
     },
-    [navigate, chatPath],
+    [navigate, workspaceId],
   );
 
   return { onCreateChat, onSelectSession };

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -1087,7 +1087,17 @@ export const router = createBrowserRouter(
                   ),
                   children: [
                     { index: true, element: <Navigate to='chat/new' replace /> },
-                    { path: 'chat/new', element: <AIScreen /> },
+                    // ONE route, with `new` as an ordinary value of :sessionId.
+                    //
+                    // Declaring `chat/new` separately looks harmless but makes two
+                    // DISTINCT routes out of the same component, so moving between
+                    // them unmounts and remounts AIScreen — wiping activeSessionId,
+                    // chatKey and showChatView. The remount re-seeds from
+                    // sessionStorage, which can still hold the previous thread, so
+                    // the URL effect navigates back to it and remounts again: the
+                    // screen visibly bounces between routes on every thread switch.
+                    // With a single route, changing the param re-renders in place.
+                    { path: 'chat/:sessionId', element: <AIScreen /> },
                     { path: 'daily-brief', element: <AIDailyBriefScreen /> },
                     { path: 'daily-brief/:briefDate', element: <AIDailyBriefScreen /> },
                     { path: 'library', element: <AILibraryScreen /> },

--- a/apps/dashboard/src/services/claw/artifactAppsService.ts
+++ b/apps/dashboard/src/services/claw/artifactAppsService.ts
@@ -37,6 +37,11 @@ export interface ArtifactAppDetail {
   visibility: ArtifactAppVisibility;
   ownerUserId: string;
   publishedVersionId: string | null;
+  /** The build the owner and the agent are currently on. Moves forward on every
+   *  generation and BACKWARD on restore — which is why staleness is measured
+   *  against this and not against the highest version number. Null for apps
+   *  saved before head tracking. */
+  headVersionId: string | null;
   publishedAt: string | null;
   isOwner: boolean;
 }

--- a/apps/dashboard/src/utils/markdownComponents.tsx
+++ b/apps/dashboard/src/utils/markdownComponents.tsx
@@ -147,6 +147,7 @@ const CodeBlock = ({
   className,
   children,
   node: _node,
+  messageId,
   ...props
 }: CodeProps & { messageId: string }): React.ReactElement => {
   const match = /language-(\w+)/.exec(String(className ?? ''));
@@ -160,37 +161,25 @@ const CodeBlock = ({
 
   // ── Mermaid ──
   if (language === 'mermaid') {
-    return (
-      <MermaidBlock chart={codeString} messageId={(props as { messageId: string }).messageId} />
-    );
+    return <MermaidBlock chart={codeString} messageId={messageId} />;
   }
 
   if (language === 'filesystem') {
-    return (
-      <FilesystemBlock
-        jsonSource={codeString}
-        messageId={(props as { messageId: string }).messageId}
-      />
-    );
+    return <FilesystemBlock jsonSource={codeString} messageId={messageId} />;
   }
 
   if (language === 'd2') {
     const looksLikeFilesystemJson = codeString.trimStart().startsWith('{');
     return looksLikeFilesystemJson ? (
-      <FilesystemBlock
-        jsonSource={codeString}
-        messageId={(props as { messageId: string }).messageId}
-      />
+      <FilesystemBlock jsonSource={codeString} messageId={messageId} />
     ) : (
-      <D2Block source={codeString} messageId={(props as { messageId: string }).messageId} />
+      <D2Block source={codeString} messageId={messageId} />
     );
   }
 
   // ── Chart (visualize tool output) ──
   if (language === 'chart') {
-    return (
-      <ChartBlock jsonSource={codeString} messageId={(props as { messageId: string }).messageId} />
-    );
+    return <ChartBlock jsonSource={codeString} messageId={messageId} />;
   }
 
   // ── Inline code — no className means no language fence ──

--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260830120000_artifact_app_session_scoping/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260830120000_artifact_app_session_scoping/migration.sql
@@ -1,0 +1,30 @@
+-- Session-scoped apps: a conversation owns exactly ONE app, and every later
+-- generation in that thread becomes a new version of it rather than a sibling.
+--
+-- Before this, `create-app` had no update path, so a thread that iterated five
+-- times produced five unrelated apps (observed locally: five copies of "Univer
+-- Spreadsheet"). The unique index below IS the one-app-per-session rule —
+-- enforced by the database so two concurrent generations cannot both insert.
+-- Nullable because apps saved before this, and any app created outside a
+-- conversation, have none; Postgres permits many NULLs under a unique index.
+ALTER TABLE "artifact_apps" ADD COLUMN "conversationId" TEXT;
+
+-- The version the owner and the agent currently see. Distinct from
+-- publishedVersionId, which is what everyone else sees. A pointer, not a copy:
+-- @@unique([appId, contentHash]) makes re-inserting an old version impossible,
+-- so "restore" has to mean "move this pointer".
+ALTER TABLE "artifact_apps" ADD COLUMN "headVersionId" TEXT;
+
+CREATE UNIQUE INDEX "artifact_apps_conversationId_key" ON "artifact_apps"("conversationId");
+
+-- Backfill head to each app's newest version so existing apps behave as if they
+-- had always tracked one.
+UPDATE "artifact_apps" a
+SET "headVersionId" = (
+  SELECT v."id"
+  FROM "artifact_app_versions" v
+  WHERE v."appId" = a."id"
+  ORDER BY v."versionNumber" DESC
+  LIMIT 1
+)
+WHERE a."headVersionId" IS NULL;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1174,6 +1174,18 @@ model ArtifactApp {
   /// identifier space and is not interchangeable with it.
   workspaceId        String
   ownerUserId        String
+  /// The chat thread that owns this app. A conversation has exactly ONE app —
+  /// the unique index IS that rule, enforced by the database rather than by
+  /// convention, so a race between two generations cannot create a sibling.
+  /// Null for apps saved before session-scoping, and for apps created outside a
+  /// conversation; Postgres allows many NULLs under a unique index.
+  conversationId     String?   @unique
+  /// The version the owner and the agent currently see. Moves forward on every
+  /// generation and backward on restore. Distinct from `publishedVersionId`,
+  /// which is what everyone ELSE sees and only moves when the owner publishes.
+  /// A pointer rather than a copy because @@unique([appId, contentHash]) makes
+  /// re-inserting an old version impossible by design.
+  headVersionId      String?
   title              String
   description        String?
   /// "PRIVATE" | "WORKSPACE". Follows the Spaces `Canvas.visibility` convention

--- a/apps/xyne-claw-auth/backend/src/lib/artifact-app-session.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/artifact-app-session.ts
@@ -1,0 +1,237 @@
+/**
+ * One app per conversation.
+ *
+ * `create-app` has no update path — every call emits a complete project — so
+ * before this a thread that iterated on one app produced N unrelated apps
+ * (observed: five copies of "Univer Spreadsheet" in a single conversation).
+ * Each was a full re-imagining, so "fix the header" could silently undo work
+ * from two turns earlier, and the Library filled with dead iterations.
+ *
+ * This turns the second and later generations in a thread into VERSIONS of the
+ * first app instead. Nothing about the tool or the wire format changes: the
+ * attachment still carries the whole project. We simply notice, at persist
+ * time, that this conversation already owns an app.
+ *
+ * It runs in the assistant-result path rather than inside the tool because the
+ * tool executes in xyne-claw (stateless, no database) and must stay a pure
+ * validator, while this needs Prisma, the workspace lookup, and GCS — all of
+ * which live here, next to the code that already writes the attachment.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import { prisma } from "../db.js";
+import { gcsService } from "../services/storageService.js";
+import { getWorkspaceIdForUser } from "./spaces-db.js";
+import { buildReactArtifact } from "xyne-claw-shared/tools/react-artifact";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("artifact-app-session");
+
+const ARTIFACT_MIME = "application/json";
+const MAX_TITLE = 120;
+
+/**
+ * Conversation id prefixes that are not user-facing chat threads and must never
+ * materialize an app: `scheduled_` is a cron firing, `app_` is an artifact app
+ * invoking an agent of its own. Both share the assistant-result path, and an
+ * app silently appearing in someone's Library from a nightly job would be
+ * baffling. Mirrors the prefix checks the runtime already keys behaviour off.
+ */
+const NON_CHAT_PREFIXES = ["scheduled_", "app_"] as const;
+
+export function isChatConversation(conversationId: string | null | undefined): boolean {
+  if (!conversationId) return false;
+  return !NON_CHAT_PREFIXES.some((prefix) => conversationId.startsWith(prefix));
+}
+
+/** Where a version's bytes live. Copied, never referenced from the attachment:
+ *  an app must not break because someone deleted the conversation that made it
+ *  (the same rule the explicit Save path follows). */
+function storagePathFor(appId: string): string {
+  return `artifact-apps/${appId}/${randomUUID()}.json`;
+}
+
+export interface SessionAppResult {
+  appId: string;
+  versionId: string;
+  versionNumber: number;
+  /** True on the generation that created the app, false when it versioned one. */
+  created: boolean;
+}
+
+/**
+ * Attach a freshly generated artifact to its conversation's app, creating that
+ * app on the first generation.
+ *
+ * Returns null — never throws — when the artifact should not be session-scoped
+ * (non-chat conversation, unvalidatable payload, no workspace) or when
+ * something goes wrong. A failure here must not lose the user's artifact: the
+ * attachment is still written and still renders, it simply is not yet an app.
+ */
+export async function attachArtifactToSessionApp(input: {
+  conversationId: string | null | undefined;
+  userId: string;
+  /** Raw artifact JSON — the same bytes written to the chat attachment. */
+  payload: Buffer;
+}): Promise<SessionAppResult | null> {
+  const { conversationId, userId, payload } = input;
+  if (!isChatConversation(conversationId) || !userId) return null;
+
+  // Re-validate rather than trust the bytes, exactly as the Save path does, and
+  // persist what the validator approved rather than the original buffer.
+  let canonical: Buffer;
+  let manifest: unknown;
+  let title: string;
+  try {
+    const built = buildReactArtifact(JSON.parse(payload.toString("utf8")) as Record<string, unknown>);
+    canonical = Buffer.from(JSON.stringify(built.payload), "utf8");
+    manifest = built.manifest;
+    title = built.payload.title.slice(0, MAX_TITLE);
+  } catch (err) {
+    log.warn(`artifact failed validation, not session-scoping: ${String(err)}`);
+    return null;
+  }
+
+  const workspaceId = await getWorkspaceIdForUser(userId, "artifact-apps");
+  if (!workspaceId) return null;
+
+  const contentHash = createHash("sha256").update(canonical).digest("hex");
+
+  try {
+    const existing = await prisma.artifactApp.findUnique({
+      where: { conversationId: conversationId as string },
+    });
+
+    if (!existing) {
+      return await createSessionApp({
+        conversationId: conversationId as string,
+        workspaceId,
+        userId,
+        title,
+        canonical,
+        manifest,
+        contentHash,
+      });
+    }
+
+    return await appendSessionVersion({ app: existing, userId, canonical, manifest, contentHash });
+  } catch (err) {
+    log.error(`failed to session-scope artifact for ${conversationId}: ${String(err)}`);
+    return null;
+  }
+}
+
+async function createSessionApp(input: {
+  conversationId: string;
+  workspaceId: string;
+  userId: string;
+  title: string;
+  canonical: Buffer;
+  manifest: unknown;
+  contentHash: string;
+}): Promise<SessionAppResult | null> {
+  const app = await prisma.artifactApp.create({
+    data: {
+      workspaceId: input.workspaceId,
+      ownerUserId: input.userId,
+      conversationId: input.conversationId,
+      title: input.title,
+      // Created, never shared. Auto-materializing must not auto-publish —
+      // publishing stays a deliberate act.
+      visibility: "PRIVATE",
+    },
+  });
+
+  const path = storagePathFor(app.id);
+  try {
+    await gcsService.uploadFile(input.canonical, path, ARTIFACT_MIME);
+  } catch (err) {
+    // Don't leave a titled app with nothing behind it.
+    await prisma.artifactApp.delete({ where: { id: app.id } }).catch(() => undefined);
+    log.error(`failed storing first version for app ${app.id}: ${String(err)}`);
+    return null;
+  }
+
+  const version = await prisma.artifactAppVersion.create({
+    data: {
+      workspaceId: app.workspaceId,
+      appId: app.id,
+      versionNumber: 1,
+      manifest: input.manifest as object,
+      storagePath: path,
+      contentHash: input.contentHash,
+      sizeBytes: input.canonical.byteLength,
+      createdBy: input.userId,
+    },
+  });
+
+  await prisma.artifactApp.update({
+    where: { id: app.id },
+    data: { headVersionId: version.id },
+  });
+
+  log.info(`session app created ${app.id} for ${input.conversationId}`);
+  return { appId: app.id, versionId: version.id, versionNumber: 1, created: true };
+}
+
+async function appendSessionVersion(input: {
+  app: { id: string; workspaceId: string };
+  userId: string;
+  canonical: Buffer;
+  manifest: unknown;
+  contentHash: string;
+}): Promise<SessionAppResult> {
+  const { app } = input;
+
+  // A byte-identical rebuild is the same version, not a new one — the agent
+  // regenerates unchanged projects readily. Head still moves to it so the
+  // pointer reflects what this turn produced.
+  const duplicate = await prisma.artifactAppVersion.findUnique({
+    where: { appId_contentHash: { appId: app.id, contentHash: input.contentHash } },
+  });
+  if (duplicate) {
+    await prisma.artifactApp.update({
+      where: { id: app.id },
+      data: { headVersionId: duplicate.id },
+    });
+    return {
+      appId: app.id,
+      versionId: duplicate.id,
+      versionNumber: duplicate.versionNumber,
+      created: false,
+    };
+  }
+
+  const last = await prisma.artifactAppVersion.findFirst({
+    where: { appId: app.id },
+    orderBy: { versionNumber: "desc" },
+    select: { versionNumber: true },
+  });
+  const versionNumber = (last?.versionNumber ?? 0) + 1;
+
+  const path = storagePathFor(app.id);
+  await gcsService.uploadFile(input.canonical, path, ARTIFACT_MIME);
+
+  const version = await prisma.artifactAppVersion.create({
+    data: {
+      workspaceId: app.workspaceId,
+      appId: app.id,
+      versionNumber,
+      manifest: input.manifest as object,
+      storagePath: path,
+      contentHash: input.contentHash,
+      sizeBytes: input.canonical.byteLength,
+      // The person whose turn produced it — not necessarily the app's owner,
+      // which is what makes per-author attribution work once threads are shared.
+      createdBy: input.userId,
+    },
+  });
+
+  await prisma.artifactApp.update({
+    where: { id: app.id },
+    data: { headVersionId: version.id, updatedAt: new Date() },
+  });
+
+  log.info(`session app ${app.id} advanced to v${versionNumber}`);
+  return { appId: app.id, versionId: version.id, versionNumber, created: false };
+}

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -32,6 +32,7 @@ import { subscribeLive, publishLiveEvent, type LiveEvent } from "../lib/live-con
 import { pushDelta, endDeltaCoalescer, liveUserIdForSession } from "../lib/live-delta-coalescer.js";
 import { resolveSdlcRepositoryForUser } from "../lib/sdlc-repository-context.js";
 
+import { attachArtifactToSessionApp } from "../lib/artifact-app-session.js";
 import { createLogger } from "../logger.js";
 const log = createLogger("agent-chat");
 
@@ -402,12 +403,37 @@ async function persistAssistantResult(args: {
 
         const inlineMeta = att.metadata && typeof att.metadata === "object" ? att.metadata : undefined;
         const fallbackSlide = fallbackSlides.get(att.fileName);
-        const attachmentMetadata: Record<string, unknown> | undefined =
+        let attachmentMetadata: Record<string, unknown> | undefined =
           inlineMeta && Object.keys(inlineMeta).length > 0
             ? inlineMeta
             : fallbackSlide
               ? { slideJson: fallbackSlide }
               : undefined;
+
+        // A conversation owns ONE app: the first generated artifact creates it,
+        // every later one becomes a version of it. Done here rather than in the
+        // tool because the tool runs in xyne-claw with no database. The ids are
+        // stamped onto the manifest so the chat card can address the app (and
+        // its version history) instead of only the raw attachment.
+        const reactArtifact = attachmentMetadata?.["reactArtifact"];
+        if (reactArtifact && typeof reactArtifact === "object") {
+          const session = await attachArtifactToSessionApp({
+            conversationId: args.conversationId,
+            userId: args.userId,
+            payload: buffer,
+          });
+          if (session) {
+            attachmentMetadata = {
+              ...attachmentMetadata,
+              reactArtifact: {
+                ...(reactArtifact as Record<string, unknown>),
+                appId: session.appId,
+                versionId: session.versionId,
+                versionNumber: session.versionNumber,
+              },
+            };
+          }
+        }
 
         const row = await prisma.chatAttachment.create({
           data: {

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-apps.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-apps.ts
@@ -446,7 +446,13 @@ artifactAppsRouter.get("/:id/payload", async (req: Request<{ id: string }>, res:
   }
 
   const requestedVersionId = typeof req.query["versionId"] === "string" ? req.query["versionId"] : null;
-  const versionId = isOwner ? (requestedVersionId ?? app.publishedVersionId) : app.publishedVersionId;
+  // Owner default is HEAD — the version they and the agent are working on —
+  // falling back to the pin for apps that predate head tracking. A non-owner is
+  // still served the pinned version and only that: honouring a caller-supplied
+  // versionId, or serving head, would expose drafts the owner has not published.
+  const versionId = isOwner
+    ? (requestedVersionId ?? app.headVersionId ?? app.publishedVersionId)
+    : app.publishedVersionId;
 
   const version = versionId
     ? await prisma.artifactAppVersion.findUnique({ where: { id: versionId } })

--- a/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/run-stream.ts
@@ -19,6 +19,7 @@ import {
   parseLateFollowUpCallback,
 } from "../lib/follow-up-suggestions.js";
 import { consumeClawStream } from "../lib/consume-claw-stream.js";
+import { attachArtifactToSessionApp } from "../lib/artifact-app-session.js";
 import { publishLiveEvent } from "../lib/live-conversation-bus.js";
 import { pushDelta, endDeltaCoalescer } from "../lib/live-delta-coalescer.js";
 import { redisService } from "../redis.js";
@@ -286,7 +287,33 @@ export async function persistRunStreamResult(args: {
         // the attachment rather than the tool-result text, which pi truncates.
         // Without persisting it here the artifact would survive a reload only
         // via the /agents/:convId/messages path and be missing from this run.
-        const hasMetadata = att.metadata && Object.keys(att.metadata).length > 0;
+        let attachmentMetadata = att.metadata as Record<string, unknown> | undefined;
+
+        // A conversation owns ONE app. This mirrors the identical hook in
+        // agent-chat.ts's persistAssistantResult: the dashboard's AI screen
+        // streams through THIS path, not /agent-chat, so scoping only that one
+        // left every AI-screen artifact unversioned and unowned.
+        const sessionArtifact = attachmentMetadata?.["reactArtifact"];
+        if (sessionArtifact && typeof sessionArtifact === "object") {
+          const session = await attachArtifactToSessionApp({
+            conversationId: args.conversationId,
+            userId: args.userId,
+            payload: buffer,
+          });
+          if (session) {
+            attachmentMetadata = {
+              ...attachmentMetadata,
+              reactArtifact: {
+                ...(sessionArtifact as Record<string, unknown>),
+                appId: session.appId,
+                versionId: session.versionId,
+                versionNumber: session.versionNumber,
+              },
+            };
+          }
+        }
+
+        const hasMetadata = attachmentMetadata && Object.keys(attachmentMetadata).length > 0;
         const row = await prisma.chatAttachment.create({
           data: {
             chatMessageId: assistantMsg.id,
@@ -296,12 +323,14 @@ export async function persistRunStreamResult(args: {
             originalFilename: att.fileName,
             mimeType: att.mimeType,
             size: buffer.length,
-            ...(hasMetadata ? { metadata: att.metadata as import("@prisma/client").Prisma.InputJsonValue } : {}),
+            ...(hasMetadata ? { metadata: attachmentMetadata as import("@prisma/client").Prisma.InputJsonValue } : {}),
           },
         });
         // Only `reactArtifact` goes back over the wire — the same allowlist the
         // message-history serializer applies, so `url` never reaches a client.
-        const reactArtifact = att.metadata?.["reactArtifact"];
+        // Read the STAMPED metadata, not att.metadata: the session ids were just
+        // added, and the card rendering this stream needs them immediately.
+        const reactArtifact = attachmentMetadata?.["reactArtifact"];
         persistedAttachments.push({
           id: row.id,
           mimeType: row.mimeType,

--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -1796,7 +1796,24 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
       const sessionDirPath = await ensureSessionDir(conversationId);
       if (isResume) {
         sessionManager = SessionManager.continueRecent(workingDir, sessionDirPath);
-        log.info(`[agent] Resuming session in ${sessionDirPath} (cwd=${workingDir})`);
+        // continueRecent NEVER fails loudly: when it finds no match it returns a
+        // valid, EMPTY SessionManager, so "resuming" and "silently started over"
+        // look identical from here. That cost a day of debugging when a per-run
+        // cwd made its internal cwd filter miss every time (see the workspace
+        // key note in routes/run.ts). Assert we actually got history back.
+        const resumedEntries = sessionManager.getEntries().length;
+        if (resumedEntries === 0) {
+          log.error(
+            `[agent] RESUME FOUND NO HISTORY for ${sessionDirPath} (cwd=${workingDir}) — ` +
+              `the session dir exists but pi matched no prior session, so this turn starts ` +
+              `with no context. Usually means cwd differs from the turn that created it.`,
+          );
+          metric.count("session_resume_empty", {});
+        } else {
+          log.info(
+            `[agent] Resuming session in ${sessionDirPath} (cwd=${workingDir}, ${resumedEntries} entries)`,
+          );
+        }
       } else {
         sessionManager = SessionManager.create(workingDir, sessionDirPath);
         log.info(`[agent] Created persistent session in ${sessionDirPath} (cwd=${workingDir})`);

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -1685,8 +1685,25 @@ async function processTask(
         : []),
     ];
 
-    // Use provided cwd, repo workspace, or create an ephemeral workspace
-    const workspaceDir = requestCwd ?? (await createWorkspace(sessionId));
+    // Key the workspace by the CONVERSATION, not the run.
+    //
+    // pi resolves a resumable session with SessionManager.continueRecent(cwd,
+    // sessionDir), and when an explicit sessionDir is passed it ALSO filters
+    // candidates by cwd. Naming the workspace after `sessionId` gave every turn
+    // a brand-new cwd, so that filter never matched: the session directory was
+    // correct and shared, `hasSession()` was true, we logged "Resuming" — and pi
+    // silently handed back an empty session. Every turn started from zero, and
+    // the agent would answer follow-ups with "I don't have any record of that in
+    // this conversation" (2026-08-30).
+    //
+    // Same identifier as the session store below, so cwd is stable exactly when
+    // the session is. Runs with no conversation (one-shots, automations) keep a
+    // per-run ephemeral workspace.
+    const workspaceStoreKey =
+      buildSandboxStoreKey(userId, piSessionConversationId ?? conversationId, agentSlug) ??
+      (piSessionConversationId ?? conversationId);
+    const workspaceDir =
+      requestCwd ?? (await createWorkspace(workspaceStoreKey ?? sessionId));
     if (mergedContextFiles.length > 0) {
       const written = await writeWorkspaceTextFiles(
         workspaceDir,

--- a/docs/artifact-app-lifecycle.md
+++ b/docs/artifact-app-lifecycle.md
@@ -1,0 +1,505 @@
+# Artifact Apps — Lifecycle, Versioning & Collaboration Plan
+
+> M1–M5 shipped in PR #855 (**merged to `main` as `11a759adb`**): `create-app`
+> tool, Sandpack rendering, live reads (`useXyneData`), writes
+> (`useXyneMutate`), agent invocation (`useXyneAgent`), save/publish, and
+> host-side name resolution (`useXyneDirectory`).
+>
+> **Step 1 (one app per conversation) is shipped and verified** — see below.
+> Steps 2–5 remain planned: in-place updates, version restore, collaborative
+> creation, and fork / change-requests.
+
+## The problem being fixed
+
+Today **every `create-app` call produces a brand-new, unrelated artifact.**
+The tool has no update path; each call writes fresh bytes to GCS and a fresh
+`ChatAttachment`. Real data from local dev: one conversation holds **five
+independent artifacts all titled "Univer Spreadsheet"** — one app iterated five
+times, stored as five orphans. Consequences:
+
+- clutter: threads and (if saved) the Library fill with near-duplicates, most
+  of them dead iterations;
+- cost + truncation: a one-line fix re-emits the entire project (up to 256KB)
+  from the model, which is exactly the output-budget failure that plagued M1;
+- regression risk: each "fix" is a from-memory re-imagining, so it can silently
+  drop something that worked two turns ago;
+- the M2 versioning machinery (`ArtifactAppVersion`, content-hash dedup,
+  `addArtifactAppVersion`) already exists but is **orphaned** — nothing in the
+  chat flow ever calls it.
+
+## Product decisions (user-confirmed, 2026-08-30)
+
+1. **One conversation = one app.** The first generation in a session creates
+   it; everything after updates it.
+2. **Updates modify the same app**, never spawn a sibling.
+3. **Restore version**: a user can roll the app back to any earlier iteration
+   with one click — still the *same* app.
+4. **No second app per session.** Deliberately not supported; do not build an
+   escape hatch for it.
+5. **Collaborative creation (later)**: invite others via the existing
+   group-DM constructs; if a group with those users exists, the app lives in a
+   message thread there so everyone sees the record.
+6. **Fork & change requests (later)**: published apps can be forked by other
+   users, or receive a change request that the owner approves/rejects — the
+   same review pattern claw agents use (`AgentRequest`).
+
+---
+
+## Architecture in one picture
+
+```
+conversation (chat thread, later: group-DM thread)
+     │ 1:1
+ArtifactApp ──── headVersionId ──► the version everyone currently sees
+     │ 1:N                         (restore = move this pointer)
+ArtifactAppVersion (immutable; contentHash-deduped; createdBy per author)
+     │
+     └── publishedVersionId (unchanged from M2: what non-owners see)
+```
+
+Two pointers, two audiences:
+
+- **`headVersionId`** — what the owner/collaborators see and what the agent
+  bases its next update on. Moves forward on every generation, backward on
+  restore.
+- **`publishedVersionId`** — what the rest of the workspace sees (M2,
+  unchanged). Publishing pins; head can keep moving without disturbing it.
+
+---
+
+## Step 1 — One app per conversation ✅ **SHIPPED 2026-08-31**
+
+**Delivered requirements 1, 2, 4.** The app is a first-class object from the
+first generation — no Save click — and every later generation versions it.
+
+### What shipped
+
+- **Schema**: `ArtifactApp.conversationId String? @unique` (the unique index IS
+  the one-app-per-session rule, enforced by Postgres) and
+  `headVersionId String?`. Migration
+  `20260830120000_artifact_app_session_scoping`.
+- **`src/lib/artifact-app-session.ts`** — `attachArtifactToSessionApp()`:
+  re-validates through `buildReactArtifact`, then creates the app (v1, always
+  `PRIVATE`) or appends a version with contentHash dedup, and moves head. It
+  returns `null` and never throws: a failure here must not lose the user's
+  artifact, which still renders as a plain attachment.
+- **Card addressing**: `{appId, versionId}` stamped onto
+  `metadata.reactArtifact`; `toArtifactRef` carries `versionId` so each card
+  pins the build *its* turn produced.
+- **Save button hidden** when `artifact.savedAppId` is set — saving is implicit
+  now. It survives only for pre-scoping artifacts and for the rare failed
+  materialization. Publish stays explicit; auto-materializing never auto-shares.
+- **Owner payload serves head** (`artifact-apps.ts`):
+  `requestedVersionId ?? headVersionId ?? publishedVersionId`. Non-owners are
+  still served the pin and only the pin — serving head, or honouring a
+  caller-supplied `versionId`, would expose unpublished drafts.
+- **Tool description** gained the SESSION section telling the agent a
+  conversation has ONE app.
+
+### Correction to the plan: there are TWO persistence paths, not one
+
+The plan put the hook in the agent-chat callback. That was wrong and shipping it
+that way missed the AI screen entirely — **`run-stream.ts` has its own
+attachment persistence**, and `/ai/chat` goes through it, not through
+`agent-chat.ts`. The materialization call therefore lives in the shared lib and
+is invoked from **both** paths:
+
+- `agent-chat.ts` → `persistAssistantResult`
+- `run-stream.ts` → its own assistant-result persistence
+
+Anything future that writes a `reactArtifact` attachment (the channel/webhook
+surface in Step 4) must call the same lib, or it will silently create orphans
+again. Grep for `attachArtifactToSessionApp` before adding a surface.
+
+### Verified end-to-end (2026-08-31, local)
+
+A "Counter" app generated then modified in one thread:
+
+| | version | bytes | contentHash | head |
+|---|---|---|---|---|
+| 08:42:25 | v1 | 4364 | `14675aac80ad` | |
+| 08:43:47 | v2 | 4477 | `19d77f541d42` | **←** |
+
+`count(*) FROM artifact_apps WHERE conversationId = …` = **1**. Diffing the two
+payloads out of the GCS emulator showed a genuinely targeted edit — the Reset
+button moved out of the badge row and became a full-width button — with the
+keyboard shortcuts, click counter and card structure byte-identical. Before this
+change that second turn produced a second unrelated app.
+
+### Deferred out of Step 1
+
+- ~~The "newer version exists" chip on stale cards.~~ **Shipped** after this
+  doc was first written, as `ArtifactSavedIndicator` — a Saved chip linking to
+  the app, and a "Newer version (vN)" chip when the card's build is behind head.
+  Staleness is measured against `headVersionId`, never the highest version
+  number, so a restored-to earlier head is correctly shown as current.
+- **Title drift** handling: the app keeps its v1 title unconditionally today.
+
+### Edge cases (as implemented)
+
+- **Regenerate / edit-message** forks the message tree but keeps one
+  `conversationId` → both branches version the same app; head is
+  last-write-wins. Restore (Step 3) is the recovery path.
+- **`scheduled_` / `app_` conversations** are skipped by `isChatConversation()`
+  — only real chat threads materialize apps.
+
+---
+
+## Step 2 — True incremental updates (read-back + patch mode)
+
+**Goal:** make "update" mean *edit*, not *re-imagine*. This is where the
+truncation risk and the regression risk actually die.
+
+**The gap:** the agent never sees the code it wrote. The tool result carries
+only the manifest (file *paths*); the bytes go to GCS. So today it rewrites the
+whole project from conversational memory.
+
+### Design: merge inside the tool, wire format unchanged
+
+`create-app` gains:
+
+```jsonc
+"mode": "update",              // default "create"; "update" only valid when the
+                               // conversation already has an app
+"files": [...],                // ONLY the files that changed
+"deleteFiles": ["/old.tsx"],   // removals, since patch mode can't infer them
+```
+
+In update mode the tool:
+
+1. Fetches the conversation's **head** payload from claw-auth over S2S
+   (new internal route
+   `GET /claw/api/v1/internal/artifact-apps/by-conversation/:convId/payload`,
+   `requireStrictS2S`; the tool context already carries `s2sKey` and the
+   claw-auth URL via platform config).
+2. Merges: base files ∪ changed files − deleted files; `dependencies` and
+   `dataRequirements` replace-if-present, inherit otherwise.
+3. Re-validates the **merged whole** through `buildReactArtifact` (entry still
+   present, limits, reserved paths — a patch must not be able to sneak past
+   validation that a full build would fail).
+4. Emits the full merged payload in the attachment exactly as today.
+
+The elegance: **nothing downstream changes.** Attachment bytes still carry the
+complete project, Step 1's callback versioning works untouched, the renderer is
+oblivious. Only the model's *output* shrinks from "entire project" to "the
+diff" — which is the whole point.
+
+### Read-back for the agent
+
+A tiny companion tool, `read-app-file` (`source: "custom:react-artifact"`):
+given a path (or no path → the file list + sizes), returns the head version's
+content over the same S2S route. Description: *"Before an update, read the
+files you intend to change; send back only those."* Stripped for
+`artifact_app` runs alongside `create-app` (recursion guard already exists in
+xyne-claw `run.ts`).
+
+### Failure modes
+
+- S2S fetch fails mid-update → tool returns a retryable error ("could not load
+  the current app; retry or use mode create") rather than silently doing a full
+  rebuild.
+- Update mode with no existing app → validation error steering to create.
+- Merged project over limits → normal limit error, names the biggest files.
+
+### Verification
+
+"Change the header colour" on a 15-file app → tool call contains **one** file;
+resulting version diffs from head in exactly that file (compare via the Code
+tab / `@pierre/diffs`). Delete flow removes a file and the merged build still
+validates. Output tokens for a small fix drop from ~10–16k to hundreds.
+
+---
+
+## Step 3 — Restore version
+
+**Goal:** requirement 3 — one click back to any earlier iteration, same app.
+
+### Why a head *pointer* and not a copy
+
+`@@unique([appId, contentHash])` (the dedup rule) makes "insert an old version
+again as a new row" impossible by design. A pointer sidesteps it: restore never
+duplicates content, it just declares which immutable version is current.
+
+### Backend
+
+- `POST /artifact-apps/:id/restore { versionId }` — owner (later: collaborator)
+  only; validates the version belongs to the app; sets `headVersionId`.
+- Reads: **already done in Step 1** — the owner payload route serves
+  `requestedVersionId ?? headVersionId ?? publishedVersionId`; non-owner
+  behaviour unchanged (pinned published version only). Only the write half
+  (the restore route) and the UI remain.
+- Step 2's update mode bases on head — so after a restore, "now add X" edits
+  the restored iteration, which is exactly what a user means.
+
+### UI
+
+The expanded dialog (and `ArtifactAppScreen`) gains a version dropdown —
+`GET /:id` already returns the full version list for owners — with per-version
+"Restore" . Restoring updates the card in place. Publish keeps offering "publish
+current head".
+
+### Verification
+
+v1→v2→v3, restore v1 → head=v1, card shows v1, agent update produces v4 based
+on v1 (v2/v3 still in history). Published pin untouched by restore.
+
+---
+
+## Step 4 — Collaborative creation via group DMs
+
+**Goal:** requirement 5. Several people build one app together, with the record
+visible to all of them.
+
+### Model: the conversation moves into the group DM
+
+Reuse the existing constructs end-to-end rather than inventing a sharing UI:
+
+- Inviting = adding people to a **group DM** (existing flow). If a group DM
+  with exactly those users exists, use it; otherwise Spaces already creates it.
+- The app's owning conversation becomes a **message thread in that channel**,
+  where the claw agent is invoked via the existing channel/mention surface —
+  every generation is a message all members see, which is requirement 5's
+  "record there" verbatim.
+- `ArtifactApp` gains `channelId String?`. Edit rights derive from **channel
+  membership at request time** (no new share table): any current participant
+  may generate updates and restore; the creator remains `ownerUserId` and alone
+  may publish/archive. Leaving the group loses edit access automatically —
+  the same semantics people already understand from DMs.
+- `ArtifactAppVersion.createdBy` (already exists) gives per-author attribution
+  in the version list.
+
+### What must be built
+
+1. A "make this collaborative / invite people" action on an existing app:
+   creates-or-finds the group DM, posts the app card into a new thread there,
+   and re-keys the app's `conversationId` to that thread.
+2. Channel-surface runs must flow through the same auto-materialize hook —
+   verify the webhook/channel callback path persists reactArtifact attachments
+   like the chat path (implementation-time check; it shares the attachment
+   pipeline).
+3. Concurrency: two members updating simultaneously → the second hits the
+   normal "one run per conversation" session lock; versions serialize. Head is
+   last-write-wins, restore is the safety net.
+
+### Open questions (decide at build time)
+
+- Does a collaborator's `useXyneData` still resolve as the *viewer* (it must —
+  M3's per-viewer ACL rule is non-negotiable), and is that clearly signalled
+  when collaborators see different data in "the same" app?
+- Can collaborators publish, or owner-only? (Default: owner-only.)
+
+---
+
+## Step 5 — Fork & change requests on published apps
+
+**Goal:** requirement 6, modelled on the claw-agent review flow
+(`AgentRequest`: `requestType` clone/push, `status` pending/approved/rejected —
+`schema.prisma:1199`).
+
+### Fork
+
+- `POST /artifact-apps/:id/fork` — any user who can *view* the published app.
+- Creates a new `ArtifactApp` owned by the requester (`forkedFromAppId`,
+  `forkedFromVersionId` recorded), version 1 = the **pinned published**
+  version's bytes (never the owner's drafts — same rule as the payload route).
+- The fork is re-keyed to the forker's own new conversation so they iterate on
+  it with the agent exactly like an app they created. Their ACLs apply to its
+  data from the first open (M3 guarantees this already).
+
+### Change request
+
+New model `ArtifactAppChangeRequest`, deliberately shaped like `AgentRequest`:
+
+```
+appId, requesterId, status: pending|approved|rejected,
+proposedStoragePath + contentHash + manifest   (a built, validated payload),
+note, reviewedBy, reviewedAt, workspaceId
+```
+
+Flow:
+
+1. Requester iterates on a fork (or a scratch conversation), then
+   "Request change on <original>" — submits their current head as the
+   proposal. The proposal's bytes are copied at submit time (same
+   copy-not-reference rule as M2 save).
+2. Owner sees pending requests on the app (Library badge + app screen list),
+   reviews the **diff against current head** using the existing Code tab /
+   `@pierre/diffs` infrastructure.
+3. **Approve** → append as a new `ArtifactAppVersion` with
+   `createdBy = requester`, move head; optionally re-publish. **Reject** →
+   status + note. Either way the requester is notified (existing notification
+   constructs; same as agent clone-request DMs).
+
+Guards: proposal re-validated through `buildReactArtifact` at approve time
+(stored bytes are never trusted — same rule as save); one pending CR per
+(app, requester); CRs against an app that was archived/unpublished are
+auto-rejected.
+
+---
+
+## Step 6 — App Creation mode (persistent split view)
+
+**Goal:** the v0 / Lovable / Replit shape. Chat on the left, the app itself
+persistent on the right, versions switchable from a dropdown. Requested
+2026-08-31 with a reference screenshot; the target is the *layout*, not the
+theme.
+
+Today the app is a card inside the transcript and "expand" is a **modal**
+(`ReactArtifactDialog`). That is backwards for a build session: the thing you
+are iterating on disappears behind the thing you are typing into, and every
+open/close remounts the Sandpack iframe. Step 1 made a conversation own exactly
+one app — which is precisely what makes a single persistent pane correct rather
+than ambiguous.
+
+### What already exists (do not rebuild)
+
+| Need | Already there |
+|---|---|
+| Split layout | `AIShell` is a `ResizableGroup[Panel(sidebar) │ Separator │ Panel(main)]` |
+| Sidebar collapse | `react-resizable-panels@4`: `collapsible` + handle `.collapse()`/`.expand()`; `AIShell` already holds `sidebarPanelRef` |
+| The renderer | `ReactArtifactView` with `fill` — the dialog already uses it this way |
+| "Which app is this thread's?" | Step 1's `conversationId @unique` + `headVersionId` |
+| Version list | `GET /artifact-apps/:id` already returns every version for the owner |
+| Serving one version | payload route already honours `requestedVersionId` for the owner |
+
+So Step 6 is **composition plus one new panel**, not new infrastructure. The
+only genuinely new UI is the version dropdown and the mode's empty state.
+
+### Design
+
+Three panels when the mode is on:
+
+```
+[ sidebar (collapsed) │ chat thread │ app pane (persistent) ]
+```
+
+- **The sidebar is not auto-collapsed** (reversed 2026-08-31, after shipping it
+  the other way). Driving the panel imperatively means racing the group's own
+  deferred re-layout: `expand()` is a no-op unless the panel is collapsed *at
+  the instant it is called*, so a single call fired in the commit where the
+  third panel unmounts gets clobbered a frame later and the sidebar stays shut.
+  Worse, auto-collapse/auto-expand overrides whatever width the user chose.
+  The Panel stays `collapsible`, so it is one drag away. If this ever returns,
+  it needs a settle strategy and a user preference, not a one-shot call.
+- **Entering the mode.** DECISION: auto-enter the first time the conversation
+  materializes an app, and expose an explicit toggle to leave. Rationale: it
+  matches the reference products (you type, it builds, the preview appears),
+  needs no new affordance to discover, and Step 1 guarantees there is exactly
+  one app to show. The trigger lives in ONE predicate so it can be changed to
+  explicit-only without touching the layout.
+- **The pane renders head by default**, and whatever version the dropdown
+  selects otherwise. Selecting an old version is a *view*, not a restore: head
+  does not move. Restore stays Step 3's verb, and lands in this same dropdown.
+- **A new generation updates the pane in place** — the pane is keyed by the
+  conversation's app, not by a message, so when head advances the pane follows.
+
+### The hazard that decides the implementation: two live Sandpacks
+
+If the pane renders the app while the transcript still renders its inline
+cards, the same app runs **twice** — two iframes, two `useXyneData` bridges, two
+agent bridges, double the queries, and writes firing from whichever the user
+happens to click. In the mode, the inline cards must therefore degrade to a
+compact, non-executing reference ("Version 3 — shown in the pane") that scrolls
+to / selects in the pane rather than mounting a second preview.
+
+Two further remount rules, both already learned the hard way:
+
+- `ArtifactSandpack` is `memo`'d with a shallow compare — anything crossing that
+  boundary must stay a stable ref or a plain boolean, never a fresh object or
+  callback. This is why the directory/data bridges read the store imperatively.
+- The pane must be **mounted once and kept**, not conditionally re-created per
+  turn. A new version should change its `payload`, not its identity — otherwise
+  every generation costs a full iframe boot and the running app's state.
+
+### Layout persistence
+
+`AIShell`'s group persists under `autoSaveId='ai-screen-resize'`. A saved
+two-panel layout must not be applied to the three-panel arrangement, so the
+mode uses its own `autoSaveId` and the plain chat layout keeps the existing one.
+`AIShell` is shared with `AISectionLayout` (knowledge, library) — those must
+render byte-identically, so the third panel is strictly opt-in via prop.
+
+### What must be built
+
+1. `AIShell` gains an optional `rightPanel` (ReactNode). Absent → today's exact
+   two-panel tree. **No `collapseSidebar`**: see the decision below.
+2. `ArtifactAppPane` — header (title, version dropdown, publish/expand), body
+   `ReactArtifactView fill`. Owns the `['artifact-app', appId]` query the
+   Saved/Newer chip already uses, so both stay consistent and a restore
+   invalidates one key.
+3. Mode state on the conversation (which app, which version is being viewed,
+   is the mode on) — one hook, so the trigger predicate is single-sourced.
+4. Inline cards become compact references while the mode is on.
+
+### Verification
+
+Generate in `/ai/chat/new` → pane appears, sidebar is left ALONE, exactly ONE
+Sandpack iframe in the DOM. Ask for a change → the SAME pane shows the new
+build; the iframe is not re-created (watch for a preview flash / lost app
+state). Dropdown to v1 → pane shows v1, `headVersionId` in the DB is unchanged.
+Toggle the mode off → sidebar returns, inline cards render live again, and the
+knowledge/library screens are untouched. A thread with no app never enters the
+mode.
+
+---
+
+## Sequencing & effort
+
+| Step | Ships | Depends on | Size |
+|---|---|---|---|
+| ~~1. One app per conversation~~ **done** | killed the clutter (reqs 1, 2, 4) | — | S — schema + shared hook on *both* persistence paths + card addressing |
+| 2. Incremental updates | kills truncation + regressions | 1 | M — S2S read route, merge+validate in tool, `read-app-file` |
+| 3. Restore | req 3 | 1 (head pointer lands with 1) | S — one route + version dropdown |
+| 4. Group-DM collaboration | req 5 | 1–3 stable | M/L — re-key flow, channel-surface parity, membership ACL |
+| 5. Fork + change requests | req 6 | 1–3 (4 independent) | M — two routes + CR model + review UI on existing diff view |
+| 6. App Creation mode (split view) | the v0/Lovable build surface | 1 (3 folds into its dropdown) | M — `AIShell` right panel + app pane + compact inline cards |
+
+Recommended order: **~~1~~ → 6 → 3 → 2 → 4 → 5.** Step 1 is done. Step 6 comes
+next because it is where the rest is *seen*: restore needs a version dropdown to
+live in, and incremental updates only feel different if you are watching the app
+change. Step 3 follows immediately — its read half already landed with Step 1,
+so it is one route plus a Restore item in Step 6's dropdown, and it de-risks
+Step 1's last-write-wins choice.
+
+## Standing constraints (do not rediscover)
+
+- Tool descriptions live in `xyne-claw-shared`; **`tsx --watch` does not reload
+  it** — claw + claw-auth restarts are required after every description change.
+- The four CAC flags (`react_artifact_config`, `_publish_`, `_write_`,
+  `_agent_`) all default `true` for local testing and **must flip to `false`
+  before merge**.
+- The wire markers `REACT_ARTIFACT_START/END` and the `metadata.reactArtifact`
+  key are frozen — persisted data depends on them.
+- Migrations on both DBs use the `migrate diff` / `db execute` /
+  `migrate resolve --applied` path; and the local Spaces DB has **no
+  `_prisma_migrations` ledger** — never run `migrate deploy` against it.
+- **Two assistant-result persistence paths exist** (`agent-chat.ts` and
+  `run-stream.ts`); the AI screen uses the latter. Any new artifact surface must
+  call `attachArtifactToSessionApp` from both, or it creates orphan apps.
+- **A conversation's workspace is keyed by conversation, not run**
+  (xyne-claw `run.ts`). pi's `SessionManager.continueRecent(cwd, sessionDir)`
+  *also filters candidates by cwd*, so a per-run workspace made every turn
+  resume an empty session — silently, while still logging "Resuming". Multi-turn
+  app updates depend on this; Step 2's read-back doubly so. A
+  `session_resume_empty` metric + error log now fires if it ever regresses.
+- **`deleteWorkspace()` has zero callers.** Now that workspaces are
+  conversation-scoped they are long-lived and unbounded — a reaper is owed
+  before this ships anywhere real.
+- Agent `orderBy` must be an **array**; the AST gateway 400s on the object form
+  models naturally write. Normalized client-side in `artifactAstClient.ts`.
+
+## Dev-environment traps that cost hours
+
+- **Running the dev stack under `pmg`** (SafeDep package-manager guard) exports
+  `HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS` to every child. When its temp CA cert is
+  cleaned up, *all* outbound HTTPS from claw fails with `unable to get local
+  issuer certificate`, which the LLM client reports as the generic
+  `"Connection error."` — zero tokens, empty content, runs still marked
+  `completed`. pmg guards `pnpm install`; do not wrap `pnpm run dev` in it.
+- **A run that fails every LLM turn still finalizes as `status: completed`**
+  with a zero-length result. That is why the above presented as "agents do
+  nothing" rather than an error. Worth fixing independently.
+- **The LiteLLM grid's team allowlist does not include `claude-sonnet-5`.** An
+  agent pinned to it that loses its direct-Claude creds falls back to `spaces`
+  carrying that model name and 403s on every call. Allowed ids include
+  `claude-sonnet-4-6`, `claude-opus-4-6`, `kimi-latest`.

--- a/packages/xyne-claw-shared/src/tools/react-artifact/tools.test.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/tools.test.ts
@@ -507,3 +507,35 @@ describe("ast source guidance", () => {
     expect(createReactArtifactTool.description).toMatch(/`where` may traverse relations/);
   });
 });
+
+describe("name resolution guidance", () => {
+  // Both rules are invisible in the row itself: displayName is usually null, and
+  // a DM channel's `name` column holds participant ids. An agent that guesses
+  // renders blanks or raw cuids, so the description has to state them outright.
+  it("points the model at useXyneDirectory instead of joining a user source", () => {
+    expect(createReactArtifactTool.description).toContain("useXyneDirectory");
+    expect(createReactArtifactTool.description).toMatch(/never join a `user` source/i);
+  });
+
+  it("states the displayName fallback chain", () => {
+    expect(createReactArtifactTool.description).toContain("displayName || name || email");
+  });
+
+  it("warns that a DM channel's name column is not a name", () => {
+    expect(createReactArtifactTool.description).toMatch(/is not a name at all/i);
+  });
+});
+
+describe("session scoping guidance", () => {
+  // The tool has no update path — the payload is always a whole project — so
+  // "update" is realised by the host versioning the conversation's app. The
+  // model has to be told, or it announces a brand-new app on every fix.
+  it("tells the model a conversation has one app", () => {
+    expect(createReactArtifactTool.description).toMatch(/ONE APP PER CONVERSATION/);
+    expect(createReactArtifactTool.description).toMatch(/new version of that same app/i);
+  });
+
+  it("warns against dropping earlier work on an update", () => {
+    expect(createReactArtifactTool.description).toMatch(/do not drop features you built/i);
+  });
+});

--- a/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
@@ -511,6 +511,12 @@ export const createReactArtifactTool: ToolDefinition = {
     "describing a UI in prose. Use it when the answer is better shown than told — a dashboard, a chart, " +
     "a comparison table, an interactive explainer. Write TypeScript React (.tsx) and default-export a " +
     "component from the `entry` file.\n\n" +
+    "ONE APP PER CONVERSATION — this thread has a single app. Your FIRST call creates it; " +
+    "every later call REPLACES its contents as a new version of that same app. So when asked " +
+    "to change or fix something, re-send the whole project with the change applied — do not " +
+    "announce a new app, do not rename it unless asked, and do not drop features you built " +
+    "earlier just because the latest message did not mention them. Users can roll back to any " +
+    "earlier version, so a mistake is recoverable — but a silent regression is not obvious.\n\n" +
     "DESIGN SYSTEM — the project is preloaded with Tailwind v4 and the shadcn/ui base set. Do NOT " +
     "write these yourself and do NOT list them in `dependencies`; they are injected for you:\n" +
     `  • shadcn/ui components at /components/ui/<name>: ${SHADCN_UI_COMPONENTS.join(", ")}\n` +
@@ -544,8 +550,18 @@ export const createReactArtifactTool: ToolDefinition = {
       )
       .join("\n") +
     "\n      Rows come back with EXACTLY these fields — do not invent others, and do not " +
-    "assume a field exists because it would be convenient. User ids (assignedTo, createdBy) " +
-    "are opaque ids: fetch the `user` model via an ast source and join on id to show names.\n" +
+    "assume a field exists because it would be convenient.\n" +
+    "NAMES — ids are opaque, so NEVER render one and never join a `user` source to get a " +
+    "name. Use the preloaded lookup, which is already resolved for you:\n" +
+    "        import { useXyneDirectory } from './lib/xyne-data';\n" +
+    "        const { displayName, channelName } = useXyneDirectory();\n" +
+    "        displayName(message.senderId)   // \"Megha Trivedi\"\n" +
+    "        channelName(row.channelId)      // \"#product\", or a DM\'s participants\n" +
+    "      It costs no request and needs no dataRequirement. It also gets two things right " +
+    "that you cannot infer from a row: a user\'s name is `displayName || name || email` and " +
+    "`displayName` is usually EMPTY, and a DM channel\'s `name` column is not a name at all — " +
+    "it holds the participant ids, so rendering `channel.name` for a DM prints raw ids. " +
+    "Group DMs come back collapsed (\"Alice, Bob + 3 others\") and your own DM reads \"You\".\n" +
     "\n" +
     `      Or a direct query — source: { "kind": "ast", "model": …, "where": …, "orderBy": …, "take": … } ` +
     `over: ${[...ALLOWED_AST_MODELS].sort().join(", ")} (findMany or count, take <= ${MAX_AST_TAKE}). ` +


### PR DESCRIPTION
Backport of #1245 (squash-merged to `main` as `9b5b1c891`) onto `release-20260827`.

**Applied with zero conflicts** — the full change, dashboard included. All 37 files, unchanged from what merged to main.

## What it does

`create-app` has no update path — every call emits a complete project — so a thread that iterated on one app produced N unrelated apps (observed: five copies of "Univer Spreadsheet" in one conversation). A conversation now owns exactly **one** app: the first generation creates it, every later one appends a version and moves head. The rule is a unique index on `ArtifactApp.conversationId`, enforced by the database rather than by convention, so a race between two generations cannot create a sibling.

Materialization runs at assistant-result persist time, not inside the tool: the tool executes in xyne-claw (stateless, no database) and must stay a pure validator. It returns `null` rather than throwing — a failure there must not cost the user their artifact.

> ⚠️ **There are TWO assistant-result persistence paths** — `agent-chat.ts` and `run-stream.ts` (the latter serves the AI screen). Both call the shared lib. Any surface that writes a `reactArtifact` attachment without calling `attachArtifactToSessionApp` will silently create orphan apps again.

Apps are created `PRIVATE`. Auto-materializing must not auto-publish.

**Also carries a conversation-history fix this exposed.** Workspaces were keyed by run, but pi's `SessionManager.continueRecent(cwd, sessionDir)` *also filters candidates by cwd* — so every turn got a fresh cwd, matched nothing, and resumed an empty session silently while still logging "Resuming". Now keyed by conversation, with a `session_resume_empty` metric if it regresses.

## Verified on this branch

| Check | Result |
|---|---|
| dashboard typecheck | **0 errors** |
| `xyne-claw-shared` tests | **63/63 pass** |
| `xyne-claw` typecheck | 1 error — pre-existing, see below |

The one `xyne-claw` error is `Cannot find module '@earendil-works/pi-ai/providers/all'` at `agent.ts:30`. That import exists on `release-20260827` **before** this commit and is untouched by it; my only change to that file is the resume assertion. It's a dependency-resolution artifact of my checkout having `node_modules` installed for `main`. **Reviewer: confirm CI installs deps per-branch** — if it does, this should be green.

## Deploy note

Ships migration `20260830120000_artifact_app_session_scoping` — adds `conversationId @unique` and `headVersionId` to `ArtifactApp`. Must be applied when this release deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
