### PR TITLE
fix: XYNE-1315 feed projectCode on mail docs for the xyneId number tier

### DIFF
--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -465,6 +465,8 @@ export interface VespaMailDocument extends VespaDocument {
   parentThreadId?: string;
   mailId?: string;
   xyneId?: string;
+  /** Project.code of the linked ticket — the "<code>" half of xyneId. */
+  projectCode?: string;
   ticketFormFields?: TicketFormFields;
   ticketFormFieldValues?: string[]; // Indexed copy used for Desk/All lexical search.
   subject: string;

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -1444,7 +1444,7 @@ export const mapEmail = async (email: Email, workspaceId?: string, orgId?: strin
 
   const ticket = await db.ticket.findFirst({
     where: { conversationId: email.conversationId },
-    select: { id: true, xyneId: true },
+    select: { id: true, xyneId: true, project: { select: { code: true } } },
   });
   const ticketFormFields = ticket ? await loadTicketFormFields(ticket.id) : [];
 
@@ -1505,6 +1505,7 @@ export const mapEmail = async (email: Email, workspaceId?: string, orgId?: strin
     parentThreadId: email.externalThreadId || undefined,
     mailId: email.externalMessageId || undefined,
     xyneId: ticket?.xyneId ?? undefined,
+    projectCode: ticket?.project?.code ?? undefined,
     ticketFormFields,
     ticketFormFieldValues: Array.from(new Set(ticketFormFields.map(field => field.fieldValue))),
     subject: email.subject,

--- a/vespa-core/vespa/common/schemas/mail.sd
+++ b/vespa-core/vespa/common/schemas/mail.sd
@@ -45,6 +45,12 @@ schema mail {
       index: enable-bm25
     }
 
+    # Project shortcode of the linked ticket, the "<code>" half of its xyneId "<code>-<number>".
+    field projectCode type string {
+      indexing: index | attribute | summary
+      index: enable-bm25
+    }
+
     field channelRef type reference<chat_container> {
       indexing: attribute
     }


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-1315. Feeds `projectCode` — the `<code>` half of a ticket's `xyneId` (`MERCHANTS1-52790`
→ `MERCHANTS1`) — onto mail documents, and declares the field in `mail.sd`.

**Why.** `mail.sd`'s `id_boost` mirrors `ticket.sd`'s `id_tier_score` but had its middle tier
collapsed to `0.0`. That tier means "the ticket *number* matched, the project code prefix did
not". Mail couldn't express it: a bare `MERCHANTS1` and a bare `52790` both produce
`fieldMatch(xyneId).queryCompleteness 1.0 / fieldCompleteness 0.5`, so there was nothing to
tell them apart, and the existing comment said as much — "Add projectCode + backfill to
recover it". `bm25(projectCode) > 0` is that discriminator: a code hit means the user named
the project, not a ticket, and earns no id boost.

**What a reviewer could get wrong — three things.**

1. **Ranking does not change.** The rank-profile half of this (in vespa-core) restores the
   0.90 tier, but nothing consumes it: `default_native`'s first-phase gates on
   `id_boost >= 0.99` and its else-branch carries no id term, and `personalized`'s involvement
   branch discards `firstPhase` outright. So `NUMBER_ID_SCORE` reaches `match-features` and
   nowhere else. Wiring it into the blend — `ticket.sd` does this via `NUMBER_ID_WEIGHT` — is
   a relevance change that wants a prod-eval run of its own, and is deliberately not here.

2. **`projectCode` joins the `default` fieldset (vespa-core side only).** This is required —
   `bm25(projectCode)` is zero unless the field is actually searched, and `YqlBuilder`'s
   `userInputClause()` queries the default fieldset. The side effect is real: a plain search
   for `MERCHANTS1` now *matches* every mail in that project where before it matched none.
   Tickets already behave this way, so it's consistent, but on a 52k-ticket project it is a
   meaningful recall widening. It scores near-zero on the blend (`projectCode` is in neither
   `combined_bm25` nor `combined_nativeRank`), so weakAnd should drop them — worth a
   spot-check on the eval set.

3. **Existing mail docs have no `projectCode` until re-fed.** No backfill in this PR. Safe to
   defer *only while the middle tier is unconsumed*: a missing value and a present one give
   identical ranking today. The backfill must land **before** anything wires up the number
   tier, or stale docs get `NUMBER_ID_SCORE` on bare-code queries — precisely the bug the
   field exists to prevent.

**Companion change:** vespa-core `c862e06` on `feat/mail-xyneid-id-boost` (field + default
fieldset + three-tier `id_boost`). This PR carries only the field declaration in the
xyne-spaces copy of `mail.sd`, plus the feed.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

Also `vespa-core/vespa/common/schemas/mail.sd` (Vespa schema, field declaration only).

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

No Prisma change: `Ticket.projectId` and the `project` relation already exist; `mapEmail`'s
existing ticket lookup just widens its `select`. The Vespa schema field is not a Prisma schema
change, but note the re-feed caveat in the Description.

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

**Vespa schema validated without deploying.** Staged the application package the way
`scripts/deploy-docker.sh` does (common schemas + docker `services.xml` + `vespa/models`,
`v[DIMS]` → `v[384]` to match the live app), POSTed it to the local configserver as a session
and `PUT .../prepared`:

| Check | Result |
|---|---|
| Prepare (session 53) | `error-code: (none)` — "Session 53 for tenant 'default' prepared." |
| Schema compiled, `bm25(projectCode)` resolves in `id_boost` | yes — prepare fails on unresolved rank refs |
| New warning class introduced | none — `projectCode`'s fieldset-normalization warning is the same one `xyneId`, `subject`, `chunks`, `from`, `to` already emit |
| Active generation after | **40, unchanged** — prepared only, never activated |

An earlier prepare attempt with `v[768]` failed with `field-type-change` on every embedding
field, which incidentally confirms schema compilation runs *before* that check — i.e. the
`.sd` itself was already valid at that point.

**Backend:** `tsc --noEmit` exit 0 (0 errors), `pnpm run build` exit 0.

**Pre-commit checks run by hand** (the hook needs `/dev/tty`, so the commit used
`--no-verify`): gitleaks clean, `validate-workspace-id.sh` pass, `change-analysis.sh` →
backend, `validate-schema-migrations.sh` (no Prisma changes), `test:enum` pass.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- the assertion worth making is "a fed mail doc carries projectCode", which needs a Vespa round-trip; no existing harness for mapEmail output -->

### Manual

Not exercised at runtime: the local `xyne_dev_db` has **zero** rows joining `emails` to
`tickets`, so `mapEmail` was never actually executed against data. The Prisma nested select is
type-checked only. Everything below is therefore honestly unticked.

**Users**
- [ ] Single user
- [ ] Two users at once
- [ ] Different roles or permission levels
- [ ] Different workspaces / spaces

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — n/a, no Zero changes

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes <!-- not run; dies on the corepack pnpm version pin (10.15.0 vs 11.21.0), pre-existing and unrelated -->
- [x] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass <!-- no dashboard files touched -->
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>` <!-- no new deps -->
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed <!-- behaviour unchanged; the reasoning lives in the mail.sd comments -->
- [x] No debug logging or commented-out code left behind