### PR TITLE
feat: XYNE-61431 add Ask AI user mention autocomplete

### DIFF
--- a/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
@@ -33,6 +33,7 @@ import { useXyneAIStream } from '../../hooks/useXyneAIStream';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
 import { useAskAIVersion } from '../../hooks/useAskAIVersion';
 import type {
+  UserTag,
   Message,
   MessageAttachment,
   ToolInvocation as ToolInvocationType,
@@ -104,6 +105,7 @@ interface AIChatThreadProps {
   sessionId?: string | undefined;
   initialQuery?: string | undefined;
   initialAttachments?: AIComposerAttachment[] | undefined;
+  initialUserTags?: Record<string, UserTag> | undefined;
   /** Context/toggles chosen on the landing composer — applied to the first
    *  auto-submitted turn and used to seed the chat composer. */
   initialExtras?: ComposerContext | undefined;
@@ -1342,6 +1344,7 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
     sessionId,
     initialQuery,
     initialAttachments,
+    initialUserTags,
     initialExtras,
     onSetMobileSidebarOpen,
     onConversationChange,
@@ -1826,7 +1829,7 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
         toMessageAttachments(initialAttachments ?? []),
         undefined,
         undefined,
-        undefined,
+        initialUserTags,
         undefined,
         undefined,
         undefined,
@@ -1838,7 +1841,14 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
       // attachments above are read before the parent drops them.
       onInitialQueryConsumed?.();
     }
-  }, [initialQuery, initialAttachments, initialExtras, submitQuery, onInitialQueryConsumed]);
+  }, [
+    initialQuery,
+    initialAttachments,
+    initialUserTags,
+    initialExtras,
+    submitQuery,
+    onInitialQueryConsumed,
+  ]);
 
   // Notify parent when conversationId changes (draft -> real session)
   useEffect(() => {
@@ -1970,6 +1980,7 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
       text: string,
       attachments?: AIComposerAttachment[],
       context?: ComposerContext,
+      userTags?: Record<string, UserTag>,
     ): Promise<void> => {
       const hasAttachments = (attachments?.length ?? 0) > 0;
       if (!text.trim() && !hasAttachments) return;
@@ -2011,7 +2022,7 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
         toMessageAttachments(attachments ?? []),
         undefined,
         undefined,
-        undefined,
+        userTags,
         parentMessageId,
         undefined,
         undefined,
@@ -2280,8 +2291,8 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
             <AIComposer
               ref={composerRef}
               autoFocus
-              onSubmit={(text, attachments, context): void => {
-                void handleSubmit(text, attachments, context);
+              onSubmit={(text, attachments, context, userTags): void => {
+                void handleSubmit(text, attachments, context, userTags);
               }}
               onAgentChange={onAgentChange}
               showAgentSelector={isV2}

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -7,7 +7,6 @@ import {
   forwardRef,
   useImperativeHandle,
   type FormEvent,
-  type KeyboardEvent,
   type ClipboardEvent,
   type ChangeEvent,
   type ReactElement,
@@ -48,6 +47,10 @@ import { EMPTY_COMPOSER_CONTEXT, type ComposerContext } from './composerContext'
 import { fetchAccessibleClawAgents } from '../../services/clawAgentListService';
 import { useSelectedAgent } from '../../hooks/useSelectedAgent';
 import useMeasure from '../../hooks/useMeasure';
+import { InputBox } from '../ui/InputBox';
+import type { InputBoxHandle } from '../../hooks/useDragAndDropAreaRef';
+import { useMentionSearch } from '../../hooks/useMentionSearch';
+import type { UserTag } from '../Chat/XyneAISidebar/utils/XyneAITypes';
 
 export interface AIComposerAttachment {
   id: string;
@@ -77,6 +80,7 @@ interface AIComposerProps {
     text: string,
     attachments?: AIComposerAttachment[],
     context?: ComposerContext,
+    userTags?: Record<string, UserTag>,
   ) => void;
   placeholder?: string;
   hideDisclaimer?: boolean;
@@ -223,8 +227,9 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
   const [value, setValue] = useState('');
   const [attachments, setAttachments] = useState<AIComposerAttachment[]>([]);
   const [isVoiceRecording, setIsVoiceRecording] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const inputBoxRef = useRef<InputBoxHandle | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { results: mentionResults, searchMentions } = useMentionSearch();
 
   // Measured off the composer box rather than the viewport: the same window can
   // hold a full-width composer or a squeezed one depending on whether the
@@ -359,19 +364,6 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
     onContextChangeRef.current?.(buildContext());
   }, [buildContext]);
 
-  useEffect((): void => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = '0px';
-    el.style.height = `${String(Math.min(el.scrollHeight, 200))}px`;
-  }, [value]);
-
-  useEffect((): void => {
-    if (autoFocus) {
-      textareaRef.current?.focus();
-    }
-  }, [autoFocus]);
-
   const handleFilesAdded = useCallback(
     async (files: File[]): Promise<void> => {
       if (files.length === 0) return;
@@ -484,11 +476,11 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
         setAttachments([]);
       },
       focus: (): void => {
-        textareaRef.current?.focus();
+        inputBoxRef.current?.focus();
       },
       setPrompt: (nextValue: string): void => {
         setValue(nextValue);
-        window.setTimeout(() => textareaRef.current?.focus(), 0);
+        window.setTimeout(() => inputBoxRef.current?.focus(), 0);
       },
       setContext: (items: AttachedContextItem[]): void => {
         const next = attachedContextToSelections(items);
@@ -507,12 +499,19 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
     [handleFilesAdded],
   );
 
-  const submit = (): void => {
+  const submit = (nextValue = value): void => {
     if (pending) return;
-    const trimmed = value.trim();
+    const trimmed = nextValue.trim();
     if (!trimmed) return;
-    onSubmit?.(trimmed, attachments.length > 0 ? attachments : undefined, buildContext());
+    const userTags = inputBoxRef.current?.getUserTags?.();
+    onSubmit?.(
+      trimmed,
+      attachments.length > 0 ? attachments : undefined,
+      buildContext(),
+      userTags && Object.keys(userTags).length > 0 ? userTags : undefined,
+    );
     setValue('');
+    inputBoxRef.current?.clearTextOnly();
     setAttachments([]);
     // Toggles/context persist across turns (mirrors the sidebar), so they are
     // intentionally NOT reset here.
@@ -523,14 +522,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
     submit();
   };
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
-    if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
-      e.preventDefault();
-      submit();
-    }
-  };
-
-  const handlePaste = (e: ClipboardEvent<HTMLTextAreaElement>): void => {
+  const handlePaste = (e: ClipboardEvent<HTMLDivElement>): void => {
     const clipboard = e.clipboardData;
     const files = clipboard?.files;
     if (files && files.length > 0) {
@@ -580,15 +572,15 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
     setAttachments(prev => prev.filter(att => att.id !== attachmentId));
   };
 
-  // Append a voice transcript to the current textarea value.
+  // Append a voice transcript to the canonical chat editor value.
   const handleTranscript = useCallback((text: string): void => {
     setValue(prev => (prev.trim().length > 0 ? `${prev.trimEnd()} ${text}` : text));
-    textareaRef.current?.focus();
+    inputBoxRef.current?.focus();
   }, []);
 
   const closeContextModal = useCallback((): void => {
     setShowContextModal(false);
-    setTimeout(() => textareaRef.current?.focus(), 0);
+    setTimeout(() => inputBoxRef.current?.focus(), 0);
   }, []);
 
   const removeChannel = (id: string): void =>
@@ -803,21 +795,36 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
             </div>
           )}
 
-          <div className='relative'>
-            <textarea
-              ref={textareaRef}
+          <div
+            className='relative'
+            onPasteCapture={handlePaste}
+            data-track-category='XyneAI'
+            data-track-name='ComposerInput'
+          >
+            <InputBox
+              ref={inputBoxRef}
+              id='ask-ai-composer'
               value={value}
-              onChange={e => setValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              onPaste={handlePaste}
+              autoFocus={autoFocus ? 'end' : null}
               placeholder={placeholder}
-              rows={1}
-              className={cn(
-                'block w-full min-h-[60px] resize-none bg-transparent px-2 py-1 text-[15px] leading-6 placeholder:text-muted-foreground/80 focus:outline-none',
-                isVoiceRecording && !value && 'invisible',
-              )}
-              data-track-category='XyneAI'
-              data-track-name='ComposerInput'
+              mentionItems={mentionResults}
+              onMentionSearch={searchMentions}
+              onTextChange={setValue}
+              onSendMessage={text => submit(text)}
+              features={{
+                richText: false,
+                mentions: true,
+                commands: false,
+                fileAttachments: false,
+                emojiPicker: false,
+              }}
+              editorOnly
+              hideComposerTools
+              hideVoiceInput
+              hideSendButton
+              sendDisabled={pending}
+              disabled={pending}
+              className={cn(isVoiceRecording && !value && 'invisible')}
             />
             {isVoiceRecording && !value && (
               <div className='pointer-events-none absolute inset-0 flex select-none items-center gap-3 px-2 py-1'>

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -151,6 +151,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       conversationId,
       onSendMessage,
       onContentChange,
+      onTextChange,
       onCancel,
       mentionItems = [],
       voiceMentionItems = [],
@@ -194,6 +195,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       hideComposerTools = false,
       hideVoiceInput = false,
       compact = false,
+      editorOnly = false,
       sendDisabled = false,
       bottomLeftSlot,
       disableDraftUpload = false,
@@ -668,7 +670,9 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
         setIsInCodeBlock(editor.isActive('codeBlock'));
       },
       onUpdate: ({ editor }) => {
-        const textContent = editor.getText().trim();
+        const editorText = editor.getText();
+        onTextChange?.(editorText);
+        const textContent = editorText.trim();
         setContent(prev => {
           const next = textContent.length > 0 ? 'has-content' : '';
           return prev === next ? prev : next;
@@ -1121,6 +1125,21 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       updateEmojiSizeClass(editor);
     }, [editor, value, updateEmojiSizeClass]);
 
+    const getUserTags = useCallback((): Record<string, { name: string; userId: string }> => {
+      if (!editor) return {};
+
+      const userTags: Record<string, { name: string; userId: string }> = {};
+      editor.state.doc.descendants(node => {
+        if (node.type.name !== 'mention' || node.attrs['mentionType'] !== 'user') return;
+        const userId = node.attrs['userId'] as string | null;
+        const username = node.attrs['username'] as string | null;
+        if (userId && username) {
+          userTags[`<${username}>`] = { name: username, userId };
+        }
+      });
+      return userTags;
+    }, [editor]);
+
     // Expose imperative API for drag and drop and clearing content
     useImperativeHandle(
       ref,
@@ -1151,6 +1170,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
           editor?.commands.focus();
         },
         getHtml: (): string => editor?.getHTML() ?? '',
+        getUserTags,
         isSuggestionOpen: (): boolean => {
           if (!editor) return false;
           const state = editor.state;
@@ -1437,6 +1457,38 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       },
       [editor],
     );
+
+    if (editorOnly) {
+      return (
+        <div className={`relative ${className}`} data-input-id={id}>
+          {features.mentions && (
+            <MentionSelector
+              editor={editor}
+              mentionItems={mentionItems}
+              {...(onMentionSearch && { onMentionSearch })}
+              {...(onMentionSelect && { onMentionSelect })}
+            />
+          )}
+          <div
+            className={`relative px-2 py-1 ${isSending ? '[&_.ProseMirror]:caret-transparent' : ''}`}
+          >
+            <EditorContent
+              editor={editor}
+              className={`
+                chat-input-field w-full min-h-[60px] resize-none border-0 outline-none bg-transparent
+                text-[15px] leading-6 break-words text-foreground placeholder:text-muted-foreground
+                [&_a]:pointer-events-none [&_p.is-editor-empty:before]:hidden ${emojiSizeClass}
+              `}
+            />
+            {!editor?.getText().length && !isInCodeBlock && (
+              <div className='pointer-events-none absolute inset-0 flex min-h-[60px] select-none items-start px-2 py-1 text-[15px] leading-6 text-muted-foreground/80'>
+                {placeholder}
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
 
     return (
       <div className={`flex-shrink-0 relative ${className}`} data-input-id={id}>

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
@@ -28,6 +28,8 @@ export interface InputBoxProps {
     videoThumbnails?: Map<File, Blob>,
   ) => void | Promise<void>;
   onContentChange?: (html: string, text: string) => void;
+  /** Immediate plain-text updates for hosts that render their own send controls. */
+  onTextChange?: (text: string) => void;
   onCancel?: () => void;
   mentionItems?: import('@xyne/shared').MentionResult[];
   voiceMentionItems?: import('@xyne/shared').MentionResult[];
@@ -70,6 +72,8 @@ export interface InputBoxProps {
   hideComposerTools?: boolean;
   hideVoiceInput?: boolean;
   compact?: boolean;
+  /** Render only the canonical TipTap editor and its suggestion popovers. */
+  editorOnly?: boolean;
   sendDisabled?: boolean;
   /** Extra buttons rendered in the left side of the desktop bottom action bar, after the # button */
   bottomLeftSlot?: React.ReactNode;

--- a/apps/dashboard/src/hooks/useDragAndDropAreaRef.ts
+++ b/apps/dashboard/src/hooks/useDragAndDropAreaRef.ts
@@ -10,6 +10,7 @@ export interface InputBoxHandle {
   isSuggestionOpen: () => boolean;
   focus: () => void;
   getHtml?: () => string;
+  getUserTags?: () => Record<string, { name: string; userId: string }>;
 }
 
 interface UseDragAndDropAreaRefReturn {

--- a/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
+++ b/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
@@ -12,6 +12,7 @@ import {
   type AIComposerAttachment,
 } from '../../components/AIScreen/AIComposer';
 import type { ComposerContext } from '../../components/AIScreen/composerContext';
+import type { UserTag } from '../../components/Chat/XyneAISidebar/utils/XyneAITypes';
 import { AIChatThread, type AIChatThreadHandle } from '../../components/AIScreen/AIChatThread';
 import { CitationDocsProvider } from '../../components/AIScreen/citationDocs';
 import { ChatWithCitationDocs } from '../../components/AIScreen/CitationDocsPanel';
@@ -44,6 +45,7 @@ const AIScreen = (): ReactElement => {
   const [initialAttachments, setInitialAttachments] = useState<AIComposerAttachment[] | undefined>(
     undefined,
   );
+  const [initialUserTags, setInitialUserTags] = useState<Record<string, UserTag> | undefined>();
   const [initialExtras, setInitialExtras] = useState<ComposerContext | undefined>(undefined);
   const [chatKey, setChatKey] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
@@ -98,6 +100,7 @@ const AIScreen = (): ReactElement => {
     setShowChatView(Boolean(sessionFromUrl));
     setInitialQuery('');
     setInitialAttachments(undefined);
+    setInitialUserTags(undefined);
     setChatKey(prev => prev + 1);
   }, [sessionFromUrl, activeSessionId]);
 
@@ -190,6 +193,7 @@ const AIScreen = (): ReactElement => {
     setActiveSessionId('');
     setInitialQuery('');
     setInitialAttachments(undefined);
+    setInitialUserTags(undefined);
     setInitialExtras(undefined);
     setChatKey(prev => prev + 1);
     setShowChatView(false); // Return to landing page
@@ -201,6 +205,7 @@ const AIScreen = (): ReactElement => {
       setActiveSessionId(sessionId);
       setInitialQuery('');
       setInitialAttachments(undefined);
+      setInitialUserTags(undefined);
       // Preserve the composer's current selections when opening a recent chat
       // (mirrors XyneAISidebar, where composer state lives in the parent and is
       // not reset on conversation load).
@@ -223,12 +228,19 @@ const AIScreen = (): ReactElement => {
   const handleInitialQueryConsumed = useCallback((): void => {
     setInitialQuery('');
     setInitialAttachments(undefined);
+    setInitialUserTags(undefined);
   }, []);
 
   const handleComposerSubmit = useCallback(
-    (text: string, attachments?: AIComposerAttachment[], context?: ComposerContext): void => {
+    (
+      text: string,
+      attachments?: AIComposerAttachment[],
+      context?: ComposerContext,
+      userTags?: Record<string, UserTag>,
+    ): void => {
       setInitialQuery(text);
       setInitialAttachments(attachments);
+      setInitialUserTags(userTags);
       setInitialExtras(context);
       setActiveSessionId('');
       setChatKey(prev => prev + 1);
@@ -245,6 +257,7 @@ const AIScreen = (): ReactElement => {
   const handleAgentChange = useCallback((_slug: string | null, context: ComposerContext): void => {
     setInitialQuery('');
     setInitialAttachments(undefined);
+    setInitialUserTags(undefined);
     setInitialExtras(context);
     setActiveSessionId('');
     setChatKey(prev => prev + 1);
@@ -353,6 +366,7 @@ const AIScreen = (): ReactElement => {
                 sessionId={activeSessionId || undefined}
                 initialQuery={initialQuery}
                 initialAttachments={initialAttachments}
+                initialUserTags={initialUserTags}
                 initialExtras={initialExtras}
                 onSetMobileSidebarOpen={setMobileSidebarOpen}
                 onConversationChange={handleConversationChange}


### PR DESCRIPTION
1. Problem Description:
Ask AI used a plain textarea, so workspace users could not autocomplete or preserve user mentions the way the existing chat composer does.

Ticket: https://spaces.xyne.juspay.net/chat/dir/cmlavlf4w0h2i2egl1vt3ntfz/cmthoanmy0wxd92zgqeecoyg8

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Enhancement requested in XYNE-61431. The Ask AI composer diverged from the canonical chat input implementation.

3. Explain the solution implemented in the PR:
- Reuse the canonical TipTap InputBox editor in an editor-only mode inside AIComposer.
- Reuse the existing workspace mention search and suggestion popover.
- Extract selected mention identities from the editor and pass userTags through both landing-page and in-thread Ask AI submissions.
- Preserve existing Ask AI attachments, voice input, context controls, keyboard submission, and analytics marker.

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
- ESLint passed for all six changed files.
- Prettier check passed for all six changed files.
- `git diff --check` passed.
- Dashboard typecheck was run; it remains blocked by 16 pre-existing errors in unrelated TicketActivity, TicketDetails, NodeRegistry, and ProfileAgentCard files. No errors were reported in changed files.

9. Services to which this change is to be deployed:
Dashboard

10. Main PR link (if this PR is raised against a release branch):
N/A