### PR TITLE
fix: XYNE-60618 update superposition with fix for memory leak

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -153,7 +153,7 @@
     "simple-oauth2": "^5.1.0",
     "socket.io": "^4.8.1",
     "sudo-query": "^1.0.0",
-    "superposition-provider": "^0.97.0",
+    "superposition-provider": "^0.117.2",
     "undici": "7.28.0",
     "unified": "^11.0.5",
     "unzipper": "^0.12.3",

--- a/apps/backend/src/services/superpositionClient.ts
+++ b/apps/backend/src/services/superpositionClient.ts
@@ -48,8 +48,10 @@ export interface SuperpositionConfig {
   token: string;
   org_id: string;
   workspace_id: string;
-  polling_interval?: number; // Polling interval in milliseconds (default: 60000)
-  timeout?: number; // Request timeout in milliseconds (default: 30000)
+  refreshStrategy?: {
+    interval: number;
+    timeout?: number;
+  };
 }
 
 /**
@@ -98,8 +100,10 @@ export class SuperpositionClient {
       token: encodeBase64(config.superposition.token), // Use the encoded base64 token
       org_id: config.superposition.orgId,
       workspace_id: config.superposition.workspaceId,
-      polling_interval: config.superposition.pollingInterval,
-      timeout: config.superposition.timeout,
+      refreshStrategy: {
+        interval: config.superposition.pollingInterval ?? 60000,
+        timeout: config.superposition.timeout ?? 30000,
+      },
     };
 
     try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,8 +460,8 @@ importers:
         specifier: ^1.0.0
         version: 1.1.1
       superposition-provider:
-        specifier: ^0.97.0
-        version: 0.97.4(@openfeature/server-sdk@1.23.0(@openfeature/core@1.12.0))
+        specifier: ^0.117.2
+        version: 0.117.2(@openfeature/server-sdk@1.23.0(@openfeature/core@1.12.0))
       undici:
         specifier: 7.29.0
         version: 7.29.0
@@ -18756,8 +18756,8 @@ packages:
     engines: {node: '>=6.4.0 <13 || >=14'}
     deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
 
-  superposition-provider@0.97.4:
-    resolution: {integrity: sha512-0+/RYIbmNjjMYcl7FJ0UBwagYpaLsMd5eQcukyJgVGx7MkR41zJTPPlEjQ/RYcqe7zz0y3f9kxHbb8gN3d5cDQ==}
+  superposition-provider@0.117.2:
+    resolution: {integrity: sha512-eCj6ICmIXAOGM/M93dMu5tirRy7pdhJ4GAvwrQ9Kftj1Kx73EWf3Hvw3RIu90iIj3t4DeCpkMF0z+kxZlne/Cg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@openfeature/server-sdk': ^1.13.0
@@ -22680,6 +22680,7 @@ snapshots:
       onnxruntime-node: 1.24.3
       onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
       sharp: 0.35.0
+    optional: true
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -40735,7 +40736,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  superposition-provider@0.97.4(@openfeature/server-sdk@1.23.0(@openfeature/core@1.12.0)):
+  superposition-provider@0.117.2(@openfeature/server-sdk@1.23.0(@openfeature/core@1.12.0)):
     dependencies:
       '@openfeature/server-sdk': 1.23.0(@openfeature/core@1.12.0)
       koffi: 2.16.3


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
