### PR TITLE
XYNE-61443 Add logs to debug missing emails

### DIFF
--- a/apps/backend/src/integrations/adapters/google/refetch.ts
+++ b/apps/backend/src/integrations/adapters/google/refetch.ts
@@ -224,7 +224,10 @@ export class GoogleRefetch extends BaseRefetch {
       }
     }
 
-    logger.info(`${TAG} ${source.name}: processed=${processed} newTickets=${newTickets} skipped=${skipped} errors=${errors.length}`);
+    logger.info(
+      `${TAG} ${source.name}: processed=${processed} newTickets=${newTickets} skipped=${skipped} errors=${errors.length}`,
+      { dlEmail: options.dlEmail, ingestChannelId },
+    );
     return { processed, newTickets, skipped, errors };
   }
 

--- a/apps/backend/src/integrations/core/core.ts
+++ b/apps/backend/src/integrations/core/core.ts
@@ -100,7 +100,7 @@ export class ExternalSourceCore {
     const payloads = Array.isArray(enrichedPayload) ? enrichedPayload : [enrichedPayload];
 
     const allResults: IngestionResult[] = [];
-    let failedItemCount = 0;
+    const failedExternalIds: string[] = [];
     for (const payload of payloads) {
       if (payload && typeof payload === 'object' && (payload as any).__skipIngestion) {
         const reason = (payload as any).__skipReason || 'unspecified';
@@ -126,19 +126,24 @@ export class ExternalSourceCore {
           const results = await this.sync(adapter, sourceName, normalizedData, source);
           allResults.push(...results);
         } catch (error) {
-          failedItemCount += 1;
+          failedExternalIds.push(normalizedData.externalId);
           logger.error(`Failed to sync interaction from ${sourceName}`, {
             externalId: normalizedData.externalId,
             eventType: normalizedData.metadata.eventType,
+            errorMessage: error instanceof Error ? error.message : String(error),
             error,
           });
         }
       }
     }
 
-    if (failedItemCount > 0) {
+    if (failedExternalIds.length > 0) {
+      logger.error(
+        `[INGEST_INCOMPLETE] ${failedExternalIds.length} message(s) not ingested from ${sourceName}`,
+        { sourceName, externalIds: failedExternalIds },
+      );
       throw new Error(
-        `Failed to sync ${failedItemCount} interaction${failedItemCount === 1 ? '' : 's'} from ${sourceName}`,
+        `Failed to sync ${failedExternalIds.length} interaction${failedExternalIds.length === 1 ? '' : 's'} from ${sourceName}`,
       );
     }
 
@@ -326,17 +331,19 @@ export class ExternalSourceCore {
     }
 
     // 4. Find or create conversation
-    const { conversation, message, email, isNew, blocked } = await this.findOrCreateConversation(
-      source,
-      normalizedData,
-      downloadedAttachments,
-      isDeskChannel
-    );
+    const { conversation, message, email, isNew, blocked, blockedReason } =
+      await this.findOrCreateConversation(
+        source,
+        normalizedData,
+        downloadedAttachments,
+        isDeskChannel
+      );
 
     if (blocked) {
-      logger.warn(`Ingestion blocked by Superposition for source ${sourceName}`, {
+      logger.warn(`Ingestion blocked (${blockedReason ?? 'unknown'}) for source ${sourceName}`, {
         externalThreadId: normalizedData.externalThreadId,
         externalId: normalizedData.externalId,
+        blockedReason,
       });
       return {
         success: true,
@@ -377,7 +384,11 @@ export class ExternalSourceCore {
       });
     }
 
-    logger.info(`Successfully ingested data from ${sourceName}`);
+    logger.info(`Successfully ingested data from ${sourceName}`, {
+      externalId: normalizedData.externalId,
+      channelId: source.channelId,
+      isNew,
+    });
 
     return {
       success: true,
@@ -459,6 +470,8 @@ export class ExternalSourceCore {
         sourceName: source.name,
         workspaceId,
         addrs,
+        externalId: normalizedData.externalId,
+        externalThreadId: normalizedData.externalThreadId,
       });
       return [];
     }
@@ -821,7 +834,14 @@ export class ExternalSourceCore {
         ...this.getEmailIntegrationFields(normalizedData),
       });
       if ((createResult as any)?.blocked || (createResult as any)?.isDuplicate) {
-        return { conversation: undefined, message: undefined, email: undefined, isNew: false, blocked: true };
+        return {
+          conversation: undefined,
+          message: undefined,
+          email: undefined,
+          isNew: false,
+          blocked: true,
+          blockedReason: (createResult as any)?.blocked ? 'superposition' : 'duplicate',
+        };
       }
       const { conversation, email } = createResult as any;
       return { conversation, email, isNew: true };

--- a/apps/backend/src/services/emailService.ts
+++ b/apps/backend/src/services/emailService.ts
@@ -1110,14 +1110,19 @@ export class EmailService {
             sourceName,
             domain: context.domain,
             email: emailFrom,
+            externalMessageId,
             isBlocked,
           });
 
           if (isBlocked) {
-            logger.warn('[EmailService] Blocking Zoho ingestion (no conversation/ticket/email)', {
+            const details = await superpositionClient.resolveAllConfigDetails(context);
+            logger.warn('[EmailService] Blocking ingestion (no conversation/ticket/email)', {
               sourceName,
               domain: context.domain,
               email: emailFrom,
+              externalMessageId,
+              variant: details.blocked?.variant,
+              reason: details.blocked?.reason,
             });
             return { blocked: true };
           }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
