### PR TITLE
fix: XYNE-61445 remove Superposition blocking guard from email ingestion

### DIFF
--- a/apps/backend/src/integrations/adapters/social-media/google-play/replySender.ts
+++ b/apps/backend/src/integrations/adapters/social-media/google-play/replySender.ts
@@ -36,7 +36,6 @@ export class GooglePlayReviewsReplySender extends BaseInteractionReplySender {
         type: EmailType.REPLY,
         sentByUserId: context.userId,
         updateExisting: true,
-        skipBlockingCheck: true,
       },
       metadata: {
         eventType: SOCIAL_MEDIA_INTERACTION_TYPES.REPLY,

--- a/apps/backend/src/integrations/adapters/social-media/google-play/transformer.ts
+++ b/apps/backend/src/integrations/adapters/social-media/google-play/transformer.ts
@@ -45,7 +45,6 @@ export class GooglePlayReviewsTransformer extends BaseTransformer<unknown, Norma
           clientVersionName: review.clientVersionName,
           clientVersionCode: review.clientVersionCode,
           updateExisting: true,
-          skipBlockingCheck: true,
         },
         metadata: {
           eventType: SOCIAL_MEDIA_INTERACTION_TYPES.REVIEW,
@@ -90,7 +89,6 @@ export class GooglePlayReviewsTransformer extends BaseTransformer<unknown, Norma
           to: [],
           type: EmailType.REPLY,
           updateExisting: true,
-          skipBlockingCheck: true,
         },
         metadata: {
           eventType: SOCIAL_MEDIA_INTERACTION_TYPES.REPLY,

--- a/apps/backend/src/integrations/core/core.ts
+++ b/apps/backend/src/integrations/core/core.ts
@@ -340,7 +340,7 @@ export class ExternalSourceCore {
       );
 
     if (blocked) {
-      logger.warn(`Ingestion blocked (${blockedReason ?? 'unknown'}) for source ${sourceName}`, {
+      logger.warn(`Ingestion skipped (${blockedReason ?? 'unknown'}) for source ${sourceName}`, {
         externalThreadId: normalizedData.externalThreadId,
         externalId: normalizedData.externalId,
         blockedReason,
@@ -827,20 +827,17 @@ export class ExternalSourceCore {
         rfcMessageId: normalizedData.rfcMessageId,
         ticketMetadata: normalizedData.metadata,
         uploadedFiles: uploadedFiles,
-        sourceName: normalizedData.emailData.skipBlockingCheck
-          ? undefined
-          : source.name,
         receivedAt: normalizedData.metadata.timestamp,
         ...this.getEmailIntegrationFields(normalizedData),
       });
-      if ((createResult as any)?.blocked || (createResult as any)?.isDuplicate) {
+      if ((createResult as any)?.isDuplicate) {
         return {
           conversation: undefined,
           message: undefined,
           email: undefined,
           isNew: false,
           blocked: true,
-          blockedReason: (createResult as any)?.blocked ? 'superposition' : 'duplicate',
+          blockedReason: 'duplicate',
         };
       }
       const { conversation, email } = createResult as any;

--- a/apps/backend/src/integrations/core/types.ts
+++ b/apps/backend/src/integrations/core/types.ts
@@ -98,7 +98,6 @@ export interface NormalizedData {
     clientVersionCode?: string;
     updateExisting?: boolean;
     syncTicketOnUpdate?: boolean;
-    skipBlockingCheck?: boolean;
   };
 
   ticketCustomFields?: Array<{

--- a/apps/backend/src/services/emailService.ts
+++ b/apps/backend/src/services/emailService.ts
@@ -47,8 +47,6 @@ import {
   NotificationType, AutoDraftStatus, AutoDraftMode } from '@xyne/shared';
 import { UploadedFileResult } from './fileUploadService';
 import { config } from '@/config/env';
-import { superpositionClient } from './superpositionClient';
-import { createBlockingContext } from '@/utils/superpositionUtils';
 import { vespaQueue } from '@/queues/vespaQueue';
 import { ticketSchema, mailSchema } from '@/vespa/src/types';
 import { logger } from '@/utils/logger';
@@ -117,7 +115,6 @@ export interface CreateConversationWithEmailParams {
   rfcMessageId?: string | null;
   ticketMetadata?: Record<string, unknown>;
   uploadedFiles?: UploadedFileResult[];
-  sourceName?: string; // External source name for Superposition context
   receivedAt?: Date;
   // Type of the initial email row. Defaults to DEFAULT (inbound thread root).
   // Outbound-new flows (compose / apps email-ticket creation) pass COMPOSE.
@@ -205,7 +202,6 @@ export interface IngestEmailThreadParams {
     uploadedFiles?: UploadedFileResult[];
   }>;
   ticketMetadata?: Record<string, unknown>;
-  sourceName?: string;
   referencedMessageIds?: string[];
 }
 
@@ -1065,7 +1061,6 @@ export class EmailService {
       rfcMessageId,
       ticketMetadata,
       uploadedFiles = [],
-      sourceName,
       receivedAt,
       emailType = EmailType.DEFAULT,
       sentByUserId,
@@ -1086,54 +1081,6 @@ export class EmailService {
       await this.channelRepository.update(channelId, {
         type: ChannelType.EMAIL,
       });
-    }
-
-    // Step 0: Superposition guard — bail out before creating anything
-    if (sourceName) {
-      try {
-        const context = createBlockingContext({
-          sourceName: sourceName,
-          email: emailFrom,
-          emailSubject: emailSubject,
-        });
-
-        if (!superpositionClient.isReady()) {
-          logger.warn('[EmailService] SuperpositionClient not ready, proceeding without blocking check', {
-            sourceName,
-            email: emailFrom,
-            domain: context.domain,
-          });
-        } else {
-          const isBlocked = await superpositionClient.getBooleanValue('blocked', false, context);
-          
-          logger.info('[EmailService] Superposition check result', {
-            sourceName,
-            domain: context.domain,
-            email: emailFrom,
-            externalMessageId,
-            isBlocked,
-          });
-
-          if (isBlocked) {
-            const details = await superpositionClient.resolveAllConfigDetails(context);
-            logger.warn('[EmailService] Blocking ingestion (no conversation/ticket/email)', {
-              sourceName,
-              domain: context.domain,
-              email: emailFrom,
-              externalMessageId,
-              variant: details.blocked?.variant,
-              reason: details.blocked?.reason,
-            });
-            return { blocked: true };
-          }
-        }
-      } catch (error) {
-        logger.error('[EmailService] Error checking Superposition flag, proceeding with ticket creation', {
-          error: error instanceof Error ? error.message : 'Unknown error',
-          sourceName,
-        });
-        // If Superposition check fails, proceed with ticket creation (fail-open)
-      }
     }
 
     // Fetch boardId from EmailChannelPreference table
@@ -2070,7 +2017,6 @@ export class EmailService {
       externalSourceId,
       userId,
       ticketMetadata,
-      sourceName,
     } = params;
 
     if (params.emails.length === 0) {
@@ -2090,26 +2036,6 @@ export class EmailService {
       throw new Error(
         `[EmailService] refusing to ingest into non-EMAIL channel ${channelId} (type=${channel.type})`,
       );
-    }
-
-    if (sourceName) {
-      try {
-        const ctx = createBlockingContext({
-          sourceName,
-          email: firstEmail.from,
-          emailSubject: firstEmail.subject,
-        });
-        if (
-          superpositionClient.isReady() &&
-          (await superpositionClient.getBooleanValue('blocked', false, ctx))
-        ) {
-          return { conversationId: '', inserted: 0, duplicates: 0, isNew: false, blocked: true };
-        }
-      } catch (error) {
-        logger.error('[EmailService] Superposition check failed, proceeding', {
-          error: error,
-        });
-      }
     }
 
     const existingFirstEmail = await this.emailRepository.findFirstByThreadAndChannel(


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
