### PR TITLE
fix: XYNE-61396 enable table, calendar and flow layouts in saved views

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -984,6 +984,7 @@ export const queries: AnyQueryRegistry = defineQueries({
       viewMode: z.enum(['project', 'board', 'my-tickets', 'user-tickets', 'group-tickets']),
       projectId: z.string().optional(),
       boardId: z.string().optional(),
+      boardIds: z.array(z.string()).optional(),
       userId: z.string().optional(),
       groupId: z.string().optional(),
       ...flowStepVisibilitySchemaShape,
@@ -995,6 +996,7 @@ export const queries: AnyQueryRegistry = defineQueries({
         viewMode,
         projectId,
         boardId,
+        boardIds,
         userId,
         groupId,
         excludeFlowSteps,
@@ -1007,6 +1009,12 @@ export const queries: AnyQueryRegistry = defineQueries({
       // boardId implicitly scopes to project, so no need for separate projectId filter
       if (boardId && viewMode !== 'my-tickets') {
         query = query.where('boardId', boardId);
+      }
+
+      // Scope by selected boards server-side (mirrors kanbanTicketsPageV3) so a
+      // saved view spanning several boards stays bounded without a projectId.
+      if (!boardId && viewMode !== 'my-tickets' && boardIds?.length) {
+        query = query.where('boardId', 'IN', boardIds);
       }
 
       // Apply projectId filter ONLY if:

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -1523,6 +1523,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       channelId?: string;
       projectId?: string;
       boardId?: string;
+      boardIds?: string[];
       userId?: string;
       groupId?: string;
       formEntityValueFieldIds?: string[];
@@ -1538,6 +1539,14 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     // my-tickets can still scope by boardId, but it should never receive projectId.
     if (filters.boards && filters.boards.length === 1 && filters.boards[0]) {
       params.boardId = filters.boards[0];
+    }
+
+    // A workspace view has no projectId, so several selected boards can only be
+    // scoped by listing them — otherwise the query fans out across the workspace.
+    // Other view modes already scope by projectId, so leave them alone.
+    const selectedBoards = filters.boards;
+    if (isWorkspaceView && !params.boardId && selectedBoards && selectedBoards.length > 1) {
+      params.boardIds = selectedBoards;
     }
 
     // Pass projectId ONLY if:
@@ -1569,6 +1578,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   }, [
     viewMode,
     queryViewMode,
+    isWorkspaceView,
     boardId,
     effectiveProjectId,
     filterByUserId,
@@ -1586,6 +1596,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         !isKanbanLayout &&
         ((viewMode === 'board' && !!boardId) ||
           (viewMode === 'project' && !!effectiveProjectId) ||
+          // A workspace view has no channel or project to key on; `workspaceViewReady`
+          // is the equivalent guard (at least one board picked), the same one the
+          // kanban pagination path uses. Without this clause the table, calendar and
+          // flow layouts render no rows at all in a saved view.
+          (isWorkspaceView && workspaceViewReady) ||
           viewMode === 'my-tickets' ||
           (viewMode === 'user-tickets' && !!filterByUserId) ||
           (viewMode === 'group-tickets' && !!filterByGroupId)),
@@ -3446,6 +3461,12 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     hasMatchingLastKnownKanbanGroups,
   ]);
 
+  // The table renders one AG-Grid per group and suppresses AG-Grid's own no-rows
+  // overlay, so with no tickets it used to show a bare header strip (groupBy 'none')
+  // or nothing at all (any other groupBy). Say why the table is empty instead.
+  const isTableEmpty = processedGroups.every(group => group.allTickets.length === 0);
+  const tableGroups = isTableEmpty ? [] : processedGroups;
+
   const filteredAvailableColumns = useMemo(() => {
     if (layoutView === 'table' || layoutView === 'flow') {
       // In table mode, hide TicketCard metadata columns
@@ -4868,7 +4889,12 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         </div>
       ) : layoutView === 'table' ? (
         <div className='flex-1 overflow-y-auto p-4 space-y-4 bg-background pb-14'>
-          {processedGroups.map(group => {
+          {isTableEmpty && (
+            <div className='rounded-lg border border-border bg-muted p-4 text-sm text-muted-foreground'>
+              {isTicketsSyncing ? 'Loading tickets…' : 'No tickets match the current filters.'}
+            </div>
+          )}
+          {tableGroups.map(group => {
             const isExpanded = expandedGroups.has(group.key);
             const showGroupHeader = groupBy !== 'none';
             return (

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -904,6 +904,7 @@ export const queries = defineQueries({
       channelId: z.string().optional(),
       projectId: z.string().optional(),
       boardId: z.string().optional(),
+      boardIds: z.array(z.string()).optional(),
       userId: z.string().optional(),
       groupId: z.string().optional(),
       ...flowStepVisibilitySchemaShape,
@@ -916,6 +917,7 @@ export const queries = defineQueries({
         channelId,
         projectId,
         boardId,
+        boardIds,
         userId,
         groupId,
         excludeFlowSteps,
@@ -932,6 +934,11 @@ export const queries = defineQueries({
       // boardId implicitly scopes to project, so no need for separate projectId filter
       if (boardId && viewMode !== 'my-tickets') {
         query = query.where('boardId', boardId);
+      }
+      // Scope by selected boards server-side (mirrors kanbanTicketsPageV3) so a
+      // saved view spanning several boards stays bounded without a projectId.
+      if (!boardId && viewMode !== 'my-tickets' && boardIds?.length) {
+        query = query.where('boardId', 'IN', boardIds);
       }
       // Apply projectId filter ONLY if:
       // 1. No boardId exists (boardId is more specific and implies project)


### PR DESCRIPTION
POT - 

https://github.com/user-attachments/assets/eb94c38b-5e73-4fbf-93a7-d53a53b875cb



> **Issue:** Table view is broken in saved views; it works fine in regular channel boards.

## What

The table, calendar and flow layouts render inside a saved (workspace) view. Kanban was never affected — it goes through its own pagination path, which is exactly why the bug looked layout-specific.

## Root cause

The gate that enables `ticketsQueryV2` — the query every non-kanban layout reads from — enumerates view modes and had no clause for a workspace view:

```ts
!isKanbanLayout &&
((viewMode === 'board'   && !!boardId) ||
 (viewMode === 'project' && !!effectiveProjectId) ||
 viewMode === 'my-tickets' || ...)
```

A saved view is `viewMode === 'workspace-view'`, so every clause was false, the query never ran, and the table came up with zero rows.

## How

**1. The missing clause** — `KanbanBoardScreen.tsx`

```ts
(isWorkspaceView && workspaceViewReady) ||
```

`workspaceViewReady` ("at least one board picked") is the right guard: a saved view has neither a channel nor a project to key on, and it is the same guard the kanban pagination path already uses.

This is deliberately **not** a `viewMode` → `queryViewMode` swap. That would still fail — `effectiveProjectId` is `undefined` in a saved view, so the `'project'` clause stays false either way.

**2. Bounding the newly enabled query** — `packages/shared/src/zero/queries.ts` + `apps/backend/src/zero/queries.ts`

`ticketsQueryV2` gains an optional `boardIds` array applying `boardId IN (...)` server-side, mirroring `kanbanTicketsPageV3` verbatim including its rationale. Without it a saved view spanning 2+ boards has neither `boardId` nor `projectId`, and the query that was just switched on would fan out across the entire workspace.

The dashboard passes it only when `isWorkspaceView && !boardId && boards.length > 1`. Project views already narrow by `projectId`; server-scoping them too would be an unrequested behaviour change.

**3. Empty state** — the table renders one AG-Grid per group with AG-Grid's own no-rows overlay suppressed, so an empty result was a bare header strip (`groupBy: 'none'`) or nothing at all. It now says `Loading tickets…` or `No tickets match the current filters.` Done with an `isTableEmpty` flag and a `tableGroups` alias rather than a ternary around the map, to avoid re-indenting ~60 lines of JSX.

## Blast radius

`ticketsQueryParams` is also spread into `useKanbanCounts` and `useKanbanTicketsPage`, so adding a key there could have perturbed the working kanban path. It does not, and I verified both halves:

- `toRequest` (`useKanbanCounts.ts:558-577`) copies fields onto the request **explicitly by name**, so `boardIds` never reaches the REST call or its react-query key.
- Neither queries file uses `.strict()`, so zod strips the unknown key on the Zero path.

## Verification

`@xyne/shared` rebuilt first (a stale `dist` makes any downstream typecheck meaningless), then: dashboard `tsc` clean, dashboard `eslint --quiet` clean, backend `tsc` clean. Full pre-commit suite passed — gitleaks, tenant guard, backend typecheck + build, dashboard lint + `dashboard-validate`, change analysis, enum guard.

## Proof of Testing

Recorded against the local stack on the saved view **"Delivery triage"** (board = Delivery, 24 tickets). Same account, same view, same script — only the fix toggled.

<!-- POT: drag saved-view-table-layout-POT.mp4 onto this line -->

| | before | after |
|---|---|---|
| kanban (control) | 20 ticket ids | 20 ticket ids |
| **switch to table** | **0 ids, `0 to 0 of 0`** | **24 ids, `1 to 24 of 24`** |

```
before:  kanban 20 ids -> table  0 ids, pager "0 to 0 of 0"
after:   kanban 20 ids -> table 24 ids, pager "1 to 24 of 24"
```

Kanban is the control — identical on both sides, matching the report that channel boards were fine. (It reads 20 rather than 24 because the board is virtualised and only renders the visible cards.)

### What the recording does not cover

- **`boardIds` is not exercised.** This workspace has exactly one board, so a multi-board saved view cannot be constructed here and the `boards.length > 1` branch never fires. It is covered by typecheck and by mirroring `kanbanTicketsPageV3`, not by runtime evidence — the part of this PR most worth a careful read.
- Only `KanbanBoardScreen.tsx` is reverted for the *before* run. `@xyne/shared` resolves to `dist/`, so reverting its source without a rebuild would be a runtime no-op, and `boardIds` is unused for a single-board view either way.
- The new empty-state copy is not on camera: with the fix applied the table has rows, so the message correctly never appears. The *before* frame does show the bare header strip it replaces.

## Not in this PR

Tags wiring (`projectTags` is gated on `effectiveProjectId`, so the Labels editor is still inert in saved views), layout persistence, and the custom-field-columns gap (`extraColumns` is never passed by `KanbanBoardScreen`) — three separate follow-ups.
