### PR TITLE
fix: orphan-finalizer must verify per-session liveness before finalizing

### DIFF
--- a/apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/queue/run-recovery-worker.ts
@@ -229,7 +229,7 @@ const MAX_LIVENESS_REARMS = Number(process.env["RUN_RECOVERY_MAX_LIVENESS_REARMS
  * is unreachable the run really is unrecoverable, and preserving the old
  * behaviour there matters more than avoiding a duplicate.
  */
-async function isRunStillExecuting(sessionId: string): Promise<boolean> {
+export async function isRunStillExecuting(sessionId: string): Promise<boolean> {
   try {
     const res = await fetch(
       `${CONFIG.internalUrl}/claw/api/v1/internal/run/${encodeURIComponent(sessionId)}/alive`,

--- a/apps/xyne-claw-auth/backend/src/services/orphan-finalizer-liveness.test.ts
+++ b/apps/xyne-claw-auth/backend/src/services/orphan-finalizer-liveness.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The orphan-finalizer must not kill a run that is still executing.
+ *
+ * Its only liveness gate used to be the GLOBAL /healthz/ready active-run count.
+ * That count is per-pod and load-balanced: the readiness probe can land on a
+ * xyne-claw replica that is NOT running the session and report activeRuns=0,
+ * so the finalizer flips a live run's row to "failed". When that run later
+ * completes, its result callback is rejected as "superseded or settled" and the
+ * answer is lost (prod: session a1149216 on 2026-08-31 — finalized at age=36min
+ * while still executing, delivered its result 13min later to a dead row).
+ *
+ * The fix re-checks EACH candidate session before finalizing it, using two
+ * pod-independent signals: Redis recovery state and the per-session /alive probe.
+ * These assertions pin that guard so it cannot silently regress.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (rel: string): string => readFileSync(resolve(here, rel), "utf8");
+const worker = (): string => read("./orphan-finalizer-worker.ts");
+
+describe("orphan-finalizer verifies per-session liveness before finalizing", () => {
+  it("imports the two pod-independent liveness signals", () => {
+    const src = worker();
+    expect(src).toContain("hasActiveRunRecovery");
+    expect(src).toContain("isRunStillExecuting");
+    expect(src).toContain('from "../queue/run-recovery-worker.js"');
+  });
+
+  it("checks this session before calling finalizeOrphanedRun", () => {
+    const src = worker();
+    const loop = src.slice(src.indexOf("for (const run of candidates) {"));
+    const guard = loop.indexOf("hasActiveRunRecovery(run.sessionId)");
+    const finalize = loop.indexOf("finalizeOrphanedRun(run,");
+    expect(guard).toBeGreaterThan(-1);
+    // The guard must come BEFORE the destructive finalize, or it cannot prevent it.
+    expect(guard).toBeLessThan(finalize);
+  });
+
+  it("skips (continues) instead of finalizing when the session is still alive", () => {
+    const src = worker();
+    const block = src.slice(
+      src.indexOf("hasActiveRunRecovery(run.sessionId)"),
+      src.indexOf("finalizeOrphanedRun(run,"),
+    );
+    expect(block).toContain("isRunStillExecuting(run.sessionId)");
+    expect(block).toContain("continue;");
+  });
+});
+
+describe("run-recovery exposes the per-session probe the finalizer reuses", () => {
+  it("exports isRunStillExecuting", () => {
+    const src = read("../queue/run-recovery-worker.ts");
+    expect(src).toContain("export async function isRunStillExecuting(");
+  });
+});

--- a/apps/xyne-claw-auth/backend/src/services/orphan-finalizer-worker.ts
+++ b/apps/xyne-claw-auth/backend/src/services/orphan-finalizer-worker.ts
@@ -3,6 +3,7 @@ import { errMsg } from "../lib/errors.js";
 import { prisma } from "../db.js";
 import { createLogger } from "../logger.js";
 import { finalizeOrphanedRun } from "./orphan-run-finalizer.js";
+import { hasActiveRunRecovery, isRunStillExecuting } from "../queue/run-recovery-worker.js";
 
 const log = createLogger("orphan-finalizer");
 
@@ -76,8 +77,25 @@ async function tickOnce(): Promise<void> {
     }
 
     let finalized = 0;
+    let skippedLive = 0;
     const now = Date.now();
     for (const run of candidates) {
+      // The global gate above is a per-pod, load-balanced signal: /healthz/ready
+      // answers from ONE xyne-claw replica, so it can report activeRuns=0 while a
+      // DIFFERENT replica is still executing this exact session. Finalizing here
+      // would flip a live run's row to "failed"; when it later completes, its
+      // result callback is rejected as "superseded or settled" and the answer is
+      // lost (prod: session a1149216 on 2026-08-31, finalized at age=36min while
+      // still running, delivered its result 13min later to a dead row).
+      //
+      // So re-check THIS session before finalizing it, using two pod-independent
+      // signals: recovery state lives in Redis (authoritative across replicas),
+      // and the per-session /alive probe is the same one run-recovery trusts.
+      if ((await hasActiveRunRecovery(run.sessionId)) || (await isRunStillExecuting(run.sessionId))) {
+        skippedLive++;
+        log.info(`[orphan-finalizer] session=${run.sessionId} agent=${run.agentSlug} still alive — skipping finalize`);
+        continue;
+      }
       const ok = await finalizeOrphanedRun(run, ERROR, "orphan-finalizer");
       if (!ok) continue;
       finalized++;
@@ -87,7 +105,7 @@ async function tickOnce(): Promise<void> {
       // months-old zombie backlog — count them as inflight kills.
       if (ageMin < 120) log.warn(`[metric] name=inflight_killed kind=count value=1 cause=orphan_finalized agent=${run.agentSlug} session=${run.sessionId}`);
     }
-    log.info(`[metric] name=orphan_finalizer_finalized kind=count value=${finalized}`);
+    log.info(`[metric] name=orphan_finalizer_finalized kind=count value=${finalized} skippedLive=${skippedLive}`);
   } catch (err) {
     log.error("[orphan-finalizer] tick failed:", errMsg(err));
   } finally {


### PR DESCRIPTION
## Problem
The RCA automation ran but its result was never posted back to the channel. Root cause is a lifecycle race, not infra/network/auth.

The `orphan-finalizer` (`apps/xyne-claw-auth/backend/src/services/orphan-finalizer-worker.ts`) sweeps `agentRun` rows that have been `running` longer than `MIN_AGE_MS`. Its only safety gate is the GLOBAL `/healthz/ready` active-run count from xyne-claw. That count is per-pod and the readiness probe is load-balanced, so it can hit a replica that is NOT running the session and report `activeRuns=0` while another replica is still executing it. The finalizer then flips the live run's row to `failed`. When the run completes minutes later, its result callback is rejected by the webhook as `superseded or settled`, and the answer is lost.

Prod evidence: session `a1149216-acaa-46b5-a026-6fdb7e3e6ca2` finalized at age=36min while still executing (parent automation execution `cmth93g9w12kx4ncx3asztoin`), delivered a non-empty ~6KB result ~13min later to an already-finalized row. The final callback POST reached the service with HTTP 200 in 13–15ms — delivery infra was healthy.

## Fix
Re-check each candidate session before finalizing it, using two pod-independent signals already in the codebase:
- `hasActiveRunRecovery(sessionId)` — Redis recovery state, authoritative across replicas.
- `isRunStillExecuting(sessionId)` — the per-session `/alive` probe run-recovery already trusts (now exported from `run-recovery-worker.ts`).

If either says alive, skip the finalize and log/count it. The global gate is kept as a cheap early-out; the per-session guard is the correctness fix.

## Changes
- `services/orphan-finalizer-worker.ts`: per-session liveness guard in the finalize loop; corrected the stale comment claiming no per-session liveness route exists; added `skippedLive` to the tick metric.
- `queue/run-recovery-worker.ts`: export `isRunStillExecuting` so the finalizer and recovery share one probe (no drift).
- `services/orphan-finalizer-liveness.test.ts`: new static-assertion tests pinning the guard (4 tests, passing).

## Validation
- `tsc --noEmit`: no new errors in the edited files (baseline errors are pre-existing missing generated `@prisma/client`).
- `vitest run src/services/orphan-finalizer-liveness.test.ts`: 4/4 passing.

## Rollout / residual risk
- Immediate mitigation available independently: set `ORPHAN_FINALIZER_ENABLED=false` on `xyne-claw-auth`.
- Both probes are best-effort; `isRunStillExecuting` fails open (assumes dead) if xyne-claw is unreachable, but `hasActiveRunRecovery` (Redis) would still have protected this incident. Genuinely wedged old rows are still finalized on a later tick once recovery state clears.
- Follow-up (not in this PR): consider accepting a late non-empty completion while the parent automation stays PAUSED, and reducing reliance on per-pod in-memory active-run maps.