### PR TITLE
fix: XYNE-57690 uppercase radar execution item status values

### DIFF
--- a/apps/backend/prisma/migrations/20260827080000_add_radar_execution_tables/migration.sql
+++ b/apps/backend/prisma/migrations/20260827080000_add_radar_execution_tables/migration.sql
@@ -7,7 +7,7 @@ CREATE TABLE "non_zero"."execution_items" (
     "sourceMessageId" TEXT NOT NULL,
     "title" TEXT NOT NULL,
     "contextSummary" TEXT,
-    "status" TEXT NOT NULL DEFAULT 'open',
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
     -- NOT NULL is load-bearing: a NULL array makes "pendingOn" @> ARRAY[me]
     -- evaluate to NULL rather than false, so the row would silently vanish
     -- from BOTH feeds -- including the NOT(...) branch of Waiting On, breaking

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4684,7 +4684,7 @@ model ExecutionItem {
   sourceMessageId String // message that created the ask; >1 item per source = split
   title           String
   contextSummary  String?
-  status          String    @default("open") // open | resolved (String: no new PG enums)
+  status          String    @default("OPEN") // OPEN | RESOLVED (String: no new PG enums)
   requestedBy     String[]  @default([]) // who asked (userIds); NOT NULL — see migration
   pendingOn       String[]  @default([]) // whose turn it is; [] = ownerless or resolved
   createdAt       DateTime  @default(now())

--- a/apps/backend/src/services/radar/radarApplier.ts
+++ b/apps/backend/src/services/radar/radarApplier.ts
@@ -77,8 +77,8 @@ class RadarApplier {
             // first. The predicates also stop a mis-scoped id cross-tenant.
             case 'resolve': {
               const { count } = await tx.executionItem.updateMany({
-                where: { id: op.itemId, workspaceId, conversationId, status: 'open' },
-                data: { status: 'resolved', resolvedAt: new Date(), pendingOn: [] },
+                where: { id: op.itemId, workspaceId, conversationId, status: 'OPEN' },
+                data: { status: 'RESOLVED', resolvedAt: new Date(), pendingOn: [] },
               });
               if (count === 0) break;
               auditRows.push(this.auditRow(params, op, op.itemId as string));
@@ -87,7 +87,7 @@ class RadarApplier {
             }
             case 'reassign': {
               const { count } = await tx.executionItem.updateMany({
-                where: { id: op.itemId, workspaceId, conversationId, status: 'open' },
+                where: { id: op.itemId, workspaceId, conversationId, status: 'OPEN' },
                 data: { pendingOn: op.pendingOn ?? [] },
               });
               if (count === 0) break;

--- a/apps/backend/src/services/radar/radarExecutionService.ts
+++ b/apps/backend/src/services/radar/radarExecutionService.ts
@@ -437,7 +437,7 @@ class RadarExecutionService {
 
   private async loadOpenItems(conversationId: string): Promise<ParserOpenItem[]> {
     const items = await prisma.executionItem.findMany({
-      where: { conversationId, status: 'open' },
+      where: { conversationId, status: 'OPEN' },
       select: {
         id: true,
         title: true,

--- a/apps/backend/src/services/radar/radarFeedService.ts
+++ b/apps/backend/src/services/radar/radarFeedService.ts
@@ -246,7 +246,7 @@ class RadarFeedService {
     return prisma.executionItem.findMany({
       where: {
         workspaceId: auth.workspaceId,
-        status: 'open',
+        status: 'OPEN',
         ...filter,
       },
       orderBy: { updatedAt: 'desc' },

--- a/apps/backend/src/services/radar/radarManualActions.ts
+++ b/apps/backend/src/services/radar/radarManualActions.ts
@@ -48,7 +48,7 @@ class RadarManualActionsService {
     // Bounded: the remainder stays open for the next click, which beats a
     // transaction that times out and rolls the whole batch back.
     const items = await prisma.executionItem.findMany({
-      where: { conversationId, workspaceId: auth.workspaceId, status: 'open' },
+      where: { conversationId, workspaceId: auth.workspaceId, status: 'OPEN' },
       select: { id: true, channelId: true },
       take: MAX_RESOLVE_ALL_ITEMS,
     });
@@ -82,7 +82,7 @@ class RadarManualActionsService {
     if (!(await canAccessConversation(auth, item.conversationId))) {
       throw new RadarActionError('not-found', 'Execution item not found');
     }
-    if (item.status !== 'open') {
+    if (item.status !== 'OPEN') {
       throw new RadarActionError('bad-request', 'Execution item is not open');
     }
     return item;

--- a/apps/backend/src/services/radar/radarTeamService.ts
+++ b/apps/backend/src/services/radar/radarTeamService.ts
@@ -111,7 +111,7 @@ class RadarTeamService {
     const items = await prisma.executionItem.findMany({
       where: {
         workspaceId: auth.workspaceId,
-        status: 'open',
+        status: 'OPEN',
         AND: [
           { requestedBy: { hasSome: team.memberIds } },
           {

--- a/apps/dashboard/src/components/RadarPanel/RadarPanel.tsx
+++ b/apps/dashboard/src/components/RadarPanel/RadarPanel.tsx
@@ -989,7 +989,7 @@ const RadarPanel = (): ReactElement => {
                     <span
                       className={cn(
                         'ml-auto shrink-0 px-2 py-0.5 rounded-full text-[11px] font-semibold',
-                        itemTrail.item.status === 'open'
+                        itemTrail.item.status === 'OPEN'
                           ? 'bg-amber-500/10 text-amber-600'
                           : 'bg-emerald-500/10 text-emerald-600',
                       )}


### PR DESCRIPTION
Review feedback: `status` stored 'open' / 'resolved' in lowercase, while every other string-as-enum column in the schema is uppercase — the schema already carries two `@default("OPEN")` columns, plus ACTIVE, PENDING, PUBLIC, PRIVATE and the rest. Radar was the outlier.

Changed in place in 20260827080000_add_radar_execution_tables rather than in a follow-up migration: the column default, the Prisma default, and the eight code sites that compare or write the value. No new PG enum — the column stays TEXT, so the enum freeze still holds.

Safe to edit in place only because the migration has not been applied to a deployed environment. Anywhere it already ran, existing rows keep the lowercase value and would drop out of both feeds, since the queries now filter on 'OPEN'; that case needs a follow-up migration doing
  UPDATE "non_zero"."execution_items" SET "status" = upper("status");
  ALTER TABLE "non_zero"."execution_items" ALTER COLUMN "status" SET DEFAULT 'OPEN';
instead.

