### PR TITLE
fix: XYNE-1315 feed projectCode on mail docs for the xyneId number tier

### DIFF
--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -465,6 +465,8 @@ export interface VespaMailDocument extends VespaDocument {
   parentThreadId?: string;
   mailId?: string;
   xyneId?: string;
+  /** Project.code of the linked ticket — the "<code>" half of xyneId. */
+  projectCode?: string;
   ticketFormFields?: TicketFormFields;
   ticketFormFieldValues?: string[]; // Indexed copy used for Desk/All lexical search.
   subject: string;

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -1465,7 +1465,7 @@ export const mapEmail = async (email: Email, workspaceId?: string, orgId?: strin
 
   const ticket = await db.ticket.findFirst({
     where: { conversationId: email.conversationId },
-    select: { id: true, xyneId: true },
+    select: { id: true, xyneId: true, project: { select: { code: true } } },
   });
   const ticketFormFields = ticket ? await loadTicketFormFields(ticket.id) : [];
 
@@ -1526,6 +1526,7 @@ export const mapEmail = async (email: Email, workspaceId?: string, orgId?: strin
     parentThreadId: email.externalThreadId || undefined,
     mailId: email.externalMessageId || undefined,
     xyneId: ticket?.xyneId ?? undefined,
+    projectCode: ticket?.project?.code ?? undefined,
     ticketFormFields,
     ticketFormFieldValues: Array.from(new Set(ticketFormFields.map(field => field.fieldValue))),
     subject: email.subject,

--- a/vespa-core/vespa/common/schemas/mail.sd
+++ b/vespa-core/vespa/common/schemas/mail.sd
@@ -38,6 +38,12 @@ schema mail {
       attribute: fast-search
     }
 
+    # Project shortcode of the linked ticket, the "<code>" half of its xyneId "<code>-<number>".
+    field projectCode type string {
+      indexing: index | attribute | summary
+      index: enable-bm25
+    }
+
     field channelRef type reference<chat_container> {
       indexing: attribute
     }


### PR DESCRIPTION
[mapEmail already resolves the linked ticket for xyneId; also select its project code and put it on the mail document, and declare the field in mail.sd so the feed is accepted.

mail.sd's id_boost had its middle tier ("ticket number matched, project code prefix did not") collapsed to 0 because mail had no projectCode to tell a bare "<code>" query from a bare "<number>" one -- both give queryCompleteness 1.0 / fieldCompleteness 0.5. This is the feed half of restoring it; the rank-profile half lives in vespa-core.

Existing mail docs carry no projectCode until they are re-fed. Harmless in the meantime: nothing consumes the middle tier yet, so ranking is unchanged either way.

Services-Requiring-Redeployment:
  - backend
