### PR TITLE
fix: XYNE-61504 resolve KB collection scope and widen Contents panel

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
+++ b/apps/dashboard/src/components/AppSidebar/navigationConfig.ts
@@ -126,6 +126,7 @@ export const NAVIGATION_ITEMS: NavigationItem[] = [
 // Core items that are always in the toolbar. Users cannot remove these — their
 // toggle is locked on in the customize UI.
 export const REQUIRED_TOOLBAR_PATHS: string[] = [
+  '/ai',
   '/chat/dir',
   '/chat/dm',
   '/calls',

--- a/apps/dashboard/src/components/knowledgeBaseV2/KbContentsShell.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/KbContentsShell.tsx
@@ -16,7 +16,7 @@ import {
   type PanelImperativeHandle,
 } from '../ui/Resizable/Resizable';
 
-const KB_CONTENTS_DEFAULT_WIDTH = 240;
+const KB_CONTENTS_DEFAULT_WIDTH = 300;
 const KB_CONTENTS_MIN_WIDTH = 180;
 const KB_CONTENTS_MAX_WIDTH = 600;
 const KB_CONTENTS_COLLAPSED_WIDTH = 40;

--- a/apps/dashboard/src/components/knowledgeBaseV2/KbContentsShell.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/KbContentsShell.tsx
@@ -143,9 +143,12 @@ const KbContentsShellInner: React.FC<KbContentsShellProps> = ({ children }) => {
     (fileId: string, folderId: string | null): void => {
       if (!collectionId) return;
       const owning = globalCollections.byId(collectionId);
-      const projectId = owning?.projectId;
       const channelId = owning?.scopeId;
-      if (projectId && channelId) {
+      if (channelId) {
+        // `projectId` is only known for CHANNEL-scoped collections whose
+        // channel is in our visible-channel list — '_' for workspace-scoped
+        // (or unresolvable) collections, same sentinel as the folder segment.
+        const projectId = owning?.projectId ?? '_';
         void navigate(
           `${browseBasePath}/${projectId}/${channelId}/${collectionId}/${folderId ?? '_'}/${fileId}`,
         );


### PR DESCRIPTION
## Summary
- Adds `/ai` to `REQUIRED_TOOLBAR_PATHS` so Xyne AI shows "Always on" and a locked toggle in Preferences > Toolbar, matching every other core toolbar item.
- Bundles a second, unrelated fix (XYNE-61504) that landed on this branch from a concurrent session: opening a file from the KB Contents panel required both `projectId` and `channelId` to resolve, but `projectId` is only known for CHANNEL-scoped collections in the visible-channel list. WORKSPACE-scoped (or unresolved-channel) collections always had a null `projectId` and threw "Could not resolve collection scope" on every click. `projectId` now falls back to the `'_'` sentinel already used for the folder segment, matching `KnowledgeBaseV2Screen.tsx`.

## Test plan
- [x] Dashboard typecheck (0 errors)
- [x] Dashboard lint (0 errors)
- [ ] Manual QA: Preferences > Toolbar shows Xyne AI as "Always on" and non-toggleable
- [ ] Manual QA: opening a file in a workspace-scoped KB collection no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XUvuMEnt8ipsCDG8UGWM58