### PR TITLE
fix: XYNE-17198 make lean as default presentation summary for vespa s…

### DIFF
--- a/apps/backend/src/routes/vespaSearch.ts
+++ b/apps/backend/src/routes/vespaSearch.ts
@@ -33,7 +33,7 @@ const router = Router();
  * @param {boolean} filterOnly - Enable filter-only mode (no query text required) (optional)
  * @param {boolean} includeDebugInfo - Include debug info in response (optional)
  * @param {boolean} searchId - searchId (optional)
- * @param {string} presentationSummary - Vespa presentation.summary profile, e.g. "lean" (optional)
+ * @param {string} presentationSummary - Vespa presentation.summary profile, e.g. "lean" (optional, defaults to "lean")
  */
 router.get('/', validateQuery(vespaSearchQuerySchema), validateSearchFilters(), searchHandler);
 

--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -31,6 +31,12 @@ import { superpositionClient } from '@/services/superpositionClient';
 import { sudoQueryService } from '@/services/hyperAnalytics/sudoQueryService';
 import { db } from '@/database/client';
 
+/**
+ * Vespa document-summary class used when the caller does not ask for a specific one.
+ * `lean` returns only the fields the search UI needs, keeping payloads small.
+ */
+const DEFAULT_PRESENTATION_SUMMARY = 'lean';
+
 function escapeQueryForUserInput(query: string): string {
   if (!query) return query;
 
@@ -92,6 +98,7 @@ interface SearchOptions {
   mail?: MailFilters;
   call?: CallFilters;
   prefixBoostWeight?: number;
+  /** Vespa document-summary class to request. Defaults to `lean` when not set. */
   presentationSummary?: string;
   captureDebug?: (info: VespaSearchDebugInfo) => void;
   // Display name(s) of scoped mention chips, highlighted as exact phrases in results (not in YQL).
@@ -220,7 +227,7 @@ export class SearchService {
       'ranking.profile': 'default_native',
       'input.query(alpha)': 0.35,
       timeout: '15s',
-      'presentation.summary': 'lean',
+      'presentation.summary': DEFAULT_PRESENTATION_SUMMARY,
       ...(useSemantic ? { 'input.query(e)': 'embed(hf-embedder, @query)' } : {}),
     };
 
@@ -292,7 +299,7 @@ export class SearchService {
         mail = {},
         call = {},
         prefixBoostWeight = 0.2,
-        presentationSummary,
+        presentationSummary = DEFAULT_PRESENTATION_SUMMARY,
         mentionHighlights = [],
         workspaceId,
         captureDebug,
@@ -449,7 +456,7 @@ export class SearchService {
           "input.query(time_from)": timeRangeStart,
           "input.query(time_to)": timeRangeEnd,
           "ranking.listFeatures": true,
-          ...(presentationSummary ? { "presentation.summary": presentationSummary } : {}),
+          "presentation.summary": presentationSummary?.trim() || DEFAULT_PRESENTATION_SUMMARY,
           tracelevel: 0,
           // Exact match turns off the default searchrules.sr rewriting (stopword removal + ranking
           // boosts): stripping a word like "is"/"the" mid-query silently breaks phrase adjacency.


### PR DESCRIPTION
…earch



## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
