### PR TITLE
fix: XYNE-54619 activities count

### DIFF
--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -5179,9 +5179,17 @@ export function createMutators(
           });
         },
       ),
+      // KEEP IN SYNC with shared/src/zero/mutators.ts activities.markManyAsRead.
+      // Batch sibling of markAsRead, for cards that stand in for several
+      // activities (grouped ticket updates). Like markAsRead — and unlike
+      // markAsReadByFilter — it deliberately leaves channel_user_status alone:
+      // its callers pass ticket activities, which never contribute to a channel
+      // badge (both useUnreadCount and handleUnreadCountInner count only
+      // actionSource 'message'), so decrementing here would subtract from a
+      // counter these rows never incremented.
       markManyAsRead: defineMutator(
-        z.object({ activityIds: z.array(z.string()), timestamp: z.number() }),
-        async ({ tx, args: { activityIds, timestamp } }) => {
+        z.object({ activityIds: z.array(z.string()) }),
+        async ({ tx, args: { activityIds } }) => {
           if (activityIds.length === 0) {
             return;
           }
@@ -5190,49 +5198,15 @@ export function createMutators(
             zql.activities.where('id', 'IN', activityIds).where('userId', authData.sub),
           );
 
-          const unreadActivities = activities.filter(activity => !activity.isRead);
-          if (unreadActivities.length === 0) {
-            return;
-          }
-
           await Promise.all(
-            unreadActivities.map(activity =>
-              tx.mutate.activities.update({
-                id: activity.id,
-                isRead: true,
-              }),
-            ),
-          );
-
-          const channelIdCounts = new Map<string, number>();
-          unreadActivities.forEach(activity => {
-            if (activity.channelId) {
-              const currentCount = channelIdCounts.get(activity.channelId) || 0;
-              channelIdCounts.set(activity.channelId, currentCount + 1);
-            }
-          });
-
-          const uniqueChannelIds = Array.from(channelIdCounts.keys());
-          if (uniqueChannelIds.length === 0) {
-            return;
-          }
-
-          const channelUserStatuses = await tx.run(
-            zql.channel_user_status
-              .where('userId', authData.sub)
-              .where('channelId', 'IN', uniqueChannelIds)
-              .where('isDeleted', false),
-          );
-          await Promise.all(
-            channelUserStatuses.map(channelStatus => {
-              const readCount = channelIdCounts.get(channelStatus.channelId) || 0;
-              const newUnreadCount = Math.max(0, channelStatus.unreadCount - readCount);
-              return tx.mutate.channel_user_status.update({
-                id: channelStatus.id,
-                unreadCount: newUnreadCount,
-                updatedAt: timestamp,
-              });
-            }),
+            activities
+              .filter(activity => !activity.isRead)
+              .map(activity =>
+                tx.mutate.activities.update({
+                  id: activity.id,
+                  isRead: true,
+                }),
+              ),
           );
         },
       ),

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -1619,22 +1619,34 @@ export function createMutators(
             });
           }
 
+          // Only message-domain activities are cleared by viewing a channel —
+          // ticket/canvas/call activities are never marked read here.
           const unreadActivities = await tx.run(
             zql.activities
               .where('userId', authData.sub)
               .where('isRead', false)
-              .where('channelId', channelId),
+              .where('channelId', channelId)
+              .where('actionSource', 'message'),
           );
 
           if (unreadActivities.length === 0) {
             return;
           }
 
-
-          const activityBySourceId = new Map(
-            unreadActivities.map(a => [a.actionSourceId, a]),
-          );
-          const uniqueSourceIds = [...activityBySourceId.keys()];
+          // Group by source message id — several activities (e.g. a mention
+          // plus a reply) can share the same top-level message and must all
+          // be marked read together when that message is viewed.
+          const activitiesBySourceId = new Map<string, typeof unreadActivities>();
+          for (const activity of unreadActivities) {
+            const sourceId = activity.messageId ?? activity.actionSourceId;
+            const existing = activitiesBySourceId.get(sourceId);
+            if (existing) {
+              existing.push(activity);
+            } else {
+              activitiesBySourceId.set(sourceId, [activity]);
+            }
+          }
+          const uniqueSourceIds = [...activitiesBySourceId.keys()];
 
           const messages = await tx.run(
             zql.messages
@@ -1646,13 +1658,17 @@ export function createMutators(
             messages.map(m => [m.messageId, m]),
           );
 
-          for (const [sourceId, activity] of activityBySourceId) {
+          for (const [sourceId, activities] of activitiesBySourceId) {
             const message = messageByMessageId.get(sourceId);
             if (message?.conversation?.initialMessageId === message?.messageId) {
-              await tx.mutate.activities.update({
-                id: activity.id,
-                isRead: true,
-              });
+              await Promise.all(
+                activities.map(activity =>
+                  tx.mutate.activities.update({
+                    id: activity.id,
+                    isRead: true,
+                  }),
+                ),
+              );
             }
           }
         },
@@ -5161,6 +5177,63 @@ export function createMutators(
             id: activityId,
             isRead: true,
           });
+        },
+      ),
+      markManyAsRead: defineMutator(
+        z.object({ activityIds: z.array(z.string()), timestamp: z.number() }),
+        async ({ tx, args: { activityIds, timestamp } }) => {
+          if (activityIds.length === 0) {
+            return;
+          }
+
+          const activities = await tx.run(
+            zql.activities.where('id', 'IN', activityIds).where('userId', authData.sub),
+          );
+
+          const unreadActivities = activities.filter(activity => !activity.isRead);
+          if (unreadActivities.length === 0) {
+            return;
+          }
+
+          await Promise.all(
+            unreadActivities.map(activity =>
+              tx.mutate.activities.update({
+                id: activity.id,
+                isRead: true,
+              }),
+            ),
+          );
+
+          const channelIdCounts = new Map<string, number>();
+          unreadActivities.forEach(activity => {
+            if (activity.channelId) {
+              const currentCount = channelIdCounts.get(activity.channelId) || 0;
+              channelIdCounts.set(activity.channelId, currentCount + 1);
+            }
+          });
+
+          const uniqueChannelIds = Array.from(channelIdCounts.keys());
+          if (uniqueChannelIds.length === 0) {
+            return;
+          }
+
+          const channelUserStatuses = await tx.run(
+            zql.channel_user_status
+              .where('userId', authData.sub)
+              .where('channelId', 'IN', uniqueChannelIds)
+              .where('isDeleted', false),
+          );
+          await Promise.all(
+            channelUserStatuses.map(channelStatus => {
+              const readCount = channelIdCounts.get(channelStatus.channelId) || 0;
+              const newUnreadCount = Math.max(0, channelStatus.unreadCount - readCount);
+              return tx.mutate.channel_user_status.update({
+                id: channelStatus.id,
+                unreadCount: newUnreadCount,
+                updatedAt: timestamp,
+              });
+            }),
+          );
         },
       ),
       markAsReadByFilter: defineMutator(

--- a/apps/backend/src/zero/side-effects/tables/tickets-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/tickets-handler.ts
@@ -342,8 +342,14 @@ export class TicketsSideEffectHandler extends BaseSideEffectHandler {
     }
 
     // Create activities for ALL changes (including title/description/board/userGroup)
+    // When a single update changes both stageName and statusV2 together (the common case,
+    // since stage transitions set statusV2 in the same write), only emit ticket_status —
+    // otherwise a plain status change produces a duplicate ticket_status_v2 row. A
+    // statusV2-only change (no stageName change) still emits its own ticket_status_v2.
+    const hasStatusChange = activities.some(a => a.activityType === 'STATUS');
     const relevantActivities = activities.filter(a =>
       ['STATUS', 'STATUS_V2', 'PRIORITY', 'ETA', 'BOARD', 'ASSIGNED', 'USER_GROUP', 'TITLE', 'DESCRIPTION'].includes(a.activityType)
+      && !(hasStatusChange && a.activityType === 'STATUS_V2')
     );
 
     if (activityRecipients.length === 0 || relevantActivities.length === 0) {

--- a/apps/backend/src/zero/utils/unreadCountUtlis.ts
+++ b/apps/backend/src/zero/utils/unreadCountUtlis.ts
@@ -56,34 +56,28 @@ async function handleUnreadCountInner(
     } else {
       await Promise.all(
         statuses.map(async (status) => {
+          // Only unread top-level message activities count toward a channel
+          // badge; ticket/canvas/call activities and thread replies never do.
           const activities = await db.activity.findMany({
             where: {
               userId: status.userId,
               channelId,
               isRead: false,
               actionSource: 'message',
-              actorAction: { not: 'added_v2' },
+              actorAction: { notIn: ['added', 'added_v2', 'removed'] },
+              classification: { not: 'SKIP' },
+              isThreadActivity: { not: true },
             },
             select: {
-              id: true,
+              messageId: true,
               actionSourceId: true
             }
           });
 
-          const messageIds = activities.map(a => a.actionSourceId);
-
-          let unreadActivitiesCount = 0;
-          if (messageIds.length > 0) {
-            for (const messageId of messageIds) {
-              const conversation = await db.conversation.findFirst({
-                where: { initialMessageId: messageId },
-                select: { conversationId: true }
-              });
-              if (conversation) {
-                unreadActivitiesCount++;
-              }
-            }
-          }
+          // Dedupe by message so several activities on the same top-level
+          // message (e.g. a reply plus a mention) still count once.
+          const uniqueMessageIds = new Set(activities.map(a => a.messageId ?? a.actionSourceId));
+          const unreadActivitiesCount = uniqueMessageIds.size;
 
           if (unreadActivitiesCount !== status.unreadCount) {
             await db.channelUserStatus.update({

--- a/apps/backend/src/zero/utils/unreadCountUtlis.ts
+++ b/apps/backend/src/zero/utils/unreadCountUtlis.ts
@@ -56,8 +56,8 @@ async function handleUnreadCountInner(
     } else {
       await Promise.all(
         statuses.map(async (status) => {
-          // Only unread top-level message activities count toward a channel
-          // badge; ticket/canvas/call activities and thread replies never do.
+          // Only unread message activities count toward a channel badge;
+          // ticket/canvas/call activities never do.
           const activities = await db.activity.findMany({
             where: {
               userId: status.userId,
@@ -66,7 +66,6 @@ async function handleUnreadCountInner(
               actionSource: 'message',
               actorAction: { notIn: ['added', 'added_v2', 'removed'] },
               classification: { not: 'SKIP' },
-              isThreadActivity: { not: true },
             },
             select: {
               messageId: true,
@@ -76,8 +75,21 @@ async function handleUnreadCountInner(
 
           // Dedupe by message so several activities on the same top-level
           // message (e.g. a reply plus a mention) still count once.
-          const uniqueMessageIds = new Set(activities.map(a => a.messageId ?? a.actionSourceId));
-          const unreadActivitiesCount = uniqueMessageIds.size;
+          const uniqueMessageIds = [
+            ...new Set(activities.map(a => a.messageId ?? a.actionSourceId)),
+          ];
+
+          let unreadActivitiesCount = 0;
+          if (uniqueMessageIds.length > 0) {
+            const topLevelMessages = await db.conversation.findMany({
+              where: { initialMessageId: { in: uniqueMessageIds } },
+              select: { initialMessageId: true }
+            });
+            // initialMessageId is indexed but not unique, so dedupe again.
+            unreadActivitiesCount = new Set(
+              topLevelMessages.map(c => c.initialMessageId),
+            ).size;
+          }
 
           if (unreadActivitiesCount !== status.unreadCount) {
             await db.channelUserStatus.update({

--- a/apps/dashboard/src/components/Activity/ActivityItem.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItem.tsx
@@ -84,6 +84,7 @@ export const ActivityItem = memo(function ActivityItem({
       return <TicketAssignmentActivity activity={activity} isExpanded={isExpanded} />;
 
     case 'ticket_status':
+    case 'ticket_status_v2':
     case 'ticket_eta':
     case 'ticket_board':
     case 'ticket_assigned_to':

--- a/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
@@ -122,12 +122,7 @@ export const ActivityItemCard = ({
       return;
     }
     if (groupActivityIds && groupActivityIds.length > 0) {
-      void zero.mutate(
-        mutators.activities.markManyAsRead({
-          activityIds: groupActivityIds,
-          timestamp: Date.now(),
-        }),
-      );
+      void zero.mutate(mutators.activities.markManyAsRead({ activityIds: groupActivityIds }));
     } else {
       void zero.mutate(mutators.activities.markAsRead({ activityId: activity.id }));
     }

--- a/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
@@ -50,6 +50,11 @@ interface ActivityItemCardProps {
   useActivityCutoff?: boolean;
   focusThread?: boolean;
   unresolvedChannelLabel?: string;
+  /** When this card represents a grouped set of activities (e.g. multiple field
+   * changes on the same ticket), ids of every underlying activity in the group.
+   * Marking the card read applies to all of them; `activity` itself must be the
+   * newest of the group and remains the sole target of mark-as-unread. */
+  groupActivityIds?: string[];
 }
 
 export const ActivityItemCard = ({
@@ -72,6 +77,7 @@ export const ActivityItemCard = ({
   useActivityCutoff = true,
   focusThread = false,
   unresolvedChannelLabel = 'Unknown Channel',
+  groupActivityIds,
 }: ActivityItemCardProps): ReactElement | null => {
   const navigate = useNavigate();
   const context = useAuthContextValues();
@@ -108,11 +114,28 @@ export const ActivityItemCard = ({
     return `${base}${sep}focusThread=1${hash}`;
   };
 
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    // Always mark as read on any click (including URL clicks per FR-4)
-    if (!activity.isRead) {
+  // For a grouped card, `activity.isRead` reflects the whole group (every
+  // underlying id read); marking it read must mark every id, not just the
+  // representative one shown on the card.
+  const markRead = () => {
+    if (activity.isRead) {
+      return;
+    }
+    if (groupActivityIds && groupActivityIds.length > 0) {
+      void zero.mutate(
+        mutators.activities.markManyAsRead({
+          activityIds: groupActivityIds,
+          timestamp: Date.now(),
+        }),
+      );
+    } else {
       void zero.mutate(mutators.activities.markAsRead({ activityId: activity.id }));
     }
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    // Always mark as read on any click (including URL clicks per FR-4)
+    markRead();
     // If the click originated from a hyperlink inside the message content,
     // let the browser handle it and do not navigate the card
     const target = e.target as HTMLElement;
@@ -211,9 +234,7 @@ export const ActivityItemCard = ({
   };
 
   const doMarkAsRead = () => {
-    if (!activity.isRead) {
-      void zero.mutate(mutators.activities.markAsRead({ activityId: activity.id }));
-    }
+    markRead();
   };
 
   const handleMarkAsRead = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -19,7 +19,7 @@ import { cn } from '../../../utils/classNames';
 import type { ActivityWithRelated } from '../../../types/activity';
 import { ActivityClassification, UserType } from '@xyne/shared';
 import { Bot, UserUser02 } from '@xyne/icons';
-import { groupActivities, type ActivityFeedItem } from '../activityGrouping';
+import { groupActivities, countGroupedActivities, type ActivityFeedItem } from '../activityGrouping';
 import {
   mixpanelService,
   EVENTS,
@@ -354,6 +354,7 @@ const ActivityListView = (): ReactElement => {
           'stage_eta_breach',
           'ticket_assigned',
           'ticket_status',
+          'ticket_status_v2',
           'ticket_eta',
           'ticket_board',
           'ticket_assigned_to',
@@ -736,7 +737,7 @@ const ActivityListView = (): ReactElement => {
   const unreadActivities = useSelector(stateMachineActor, state => state.context.unreadActivities);
 
   const activityCounts = useMemo(() => {
-    const counts: Record<ActivityTab, number> = {
+    const emptyCounts: Record<ActivityTab, number> = {
       all: 0,
       your_mentions: 0,
       replies: 0,
@@ -750,59 +751,45 @@ const ActivityListView = (): ReactElement => {
     };
 
     if (!unreadActivities) {
-      return counts;
+      return emptyCounts;
     }
 
-    unreadActivities.forEach(activity => {
-      // 'all' count includes everything visible
-      // Cast to ActivityWithRelated since unreadActivities has slightly different shape
-      // but isAllVisibleActivity only uses fields that exist in both
-      if (isAllVisibleActivity(activity as unknown as ActivityWithRelated)) {
-        counts.all++;
-      }
-
-      // Check specific tabs
-      if (activity.actorAction === 'mentioned_user') {
-        counts.your_mentions++;
-      } else if (activity.actorAction === 'group_mention') {
-        counts.group_mentions++;
-      } else if (
-        // added to maintain backward compat for now, to be deprecated
-        activity.actorAction === 'replied' ||
-        activity.actorAction === 'replied_v2'
-      ) {
-        counts.replies++;
-      } else if (
-        // added to maintain backward compat for now, to be deprecated
+    // Single pass over unreadActivities; each bucket collapses consecutive
+    // same-actor/same-ticket ticket_* activities within the grouping window
+    // into one count, matching what the grouped feed renders as one card.
+    // Cast to ActivityWithRelated in bucket predicates that reuse tab filters
+    // built for the fetched-feed shape — unreadActivities (state machine) has
+    // a slightly different shape, but these predicates only touch fields
+    // present on both.
+    const counts = countGroupedActivities(unreadActivities, {
+      all: activity => isAllVisibleActivity(activity as unknown as ActivityWithRelated),
+      your_mentions: activity => activity.actorAction === 'mentioned_user',
+      group_mentions: activity => activity.actorAction === 'group_mention',
+      // added to maintain backward compat for now, to be deprecated
+      replies: activity => activity.actorAction === 'replied' || activity.actorAction === 'replied_v2',
+      // added to maintain backward compat for now, to be deprecated
+      reactions: activity =>
         activity.actorAction === 'added' ||
         activity.actorAction === 'added_v2' ||
-        activity.actorAction === 'removed'
-      ) {
-        counts.reactions++;
-      }
-
-      if (
+        activity.actorAction === 'removed',
+      tickets: activity =>
+        activity.actorAction === 'eta_warning' ||
+        activity.actorAction === 'eta_breach' ||
+        activity.actorAction === 'stage_eta_breach' ||
+        activity.ticketId !== null,
+      canvas: activity =>
         activity.actorAction === 'canvas_shared' ||
         activity.actorAction === 'canvas_role_changed' ||
         activity.actorAction === 'canvas_access_revoked' ||
-        (activity.actorAction === 'mentioned_user' && activity.canvasId)
-      ) {
-        counts.canvas++;
-      }
-
-      if (CALL_ACTIVITY_TYPES.some(type => type === activity.actorAction)) {
-        counts.calls++;
-      }
-
-      const classification = activity.classification ?? ActivityClassification.PENDING;
-      if (classification === ActivityClassification.ACTIONABLE) {
-        counts.actionable++;
-      } else if (classification === ActivityClassification.FYI) {
-        counts.fyi++;
-      }
+        (activity.actorAction === 'mentioned_user' && !!activity.canvasId),
+      calls: activity => CALL_ACTIVITY_TYPES.some(type => type === activity.actorAction),
+      actionable: activity =>
+        (activity.classification ?? ActivityClassification.PENDING) === ActivityClassification.ACTIONABLE,
+      fyi: activity =>
+        (activity.classification ?? ActivityClassification.PENDING) === ActivityClassification.FYI,
     });
 
-    return counts;
+    return { ...emptyCounts, ...counts };
   }, [unreadActivities]);
 
   const renderActivityList = (feedItems: ActivityFeedItem[]): ReactElement => {

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -766,7 +766,8 @@ const ActivityListView = (): ReactElement => {
       your_mentions: activity => activity.actorAction === 'mentioned_user',
       group_mentions: activity => activity.actorAction === 'group_mention',
       // added to maintain backward compat for now, to be deprecated
-      replies: activity => activity.actorAction === 'replied' || activity.actorAction === 'replied_v2',
+      replies: activity =>
+        activity.actorAction === 'replied' || activity.actorAction === 'replied_v2',
       // added to maintain backward compat for now, to be deprecated
       reactions: activity =>
         activity.actorAction === 'added' ||
@@ -784,7 +785,8 @@ const ActivityListView = (): ReactElement => {
         (activity.actorAction === 'mentioned_user' && !!activity.canvasId),
       calls: activity => CALL_ACTIVITY_TYPES.some(type => type === activity.actorAction),
       actionable: activity =>
-        (activity.classification ?? ActivityClassification.PENDING) === ActivityClassification.ACTIONABLE,
+        (activity.classification ?? ActivityClassification.PENDING) ===
+        ActivityClassification.ACTIONABLE,
       fyi: activity =>
         (activity.classification ?? ActivityClassification.PENDING) === ActivityClassification.FYI,
     });

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -19,7 +19,11 @@ import { cn } from '../../../utils/classNames';
 import type { ActivityWithRelated } from '../../../types/activity';
 import { ActivityClassification, UserType } from '@xyne/shared';
 import { Bot, UserUser02 } from '@xyne/icons';
-import { groupActivities, countGroupedActivities, type ActivityFeedItem } from '../activityGrouping';
+import {
+  groupActivities,
+  countGroupedActivities,
+  type ActivityFeedItem,
+} from '../activityGrouping';
 import {
   mixpanelService,
   EVENTS,
@@ -736,33 +740,14 @@ const ActivityListView = (): ReactElement => {
   // Read unread activities from state machine (populated by DeferredLoader)
   const unreadActivities = useSelector(stateMachineActor, state => state.context.unreadActivities);
 
-  const activityCounts = useMemo(() => {
-    const emptyCounts: Record<ActivityTab, number> = {
-      all: 0,
-      your_mentions: 0,
-      replies: 0,
-      reactions: 0,
-      tickets: 0,
-      canvas: 0,
-      calls: 0,
-      actionable: 0,
-      fyi: 0,
-      group_mentions: 0,
-    };
-
-    if (!unreadActivities) {
-      return emptyCounts;
-    }
-
-    // Single pass over unreadActivities; each bucket collapses consecutive
-    // same-actor/same-ticket ticket_* activities within the grouping window
-    // into one count, matching what the grouped feed renders as one card.
-    // Cast to ActivityWithRelated in bucket predicates that reuse tab filters
-    // built for the fetched-feed shape — unreadActivities (state machine) has
-    // a slightly different shape, but these predicates only touch fields
-    // present on both.
-    const counts = countGroupedActivities(unreadActivities, {
-      all: activity => isAllVisibleActivity(activity as unknown as ActivityWithRelated),
+  const activityCounts = useMemo((): Record<ActivityTab, number> => {
+    // Each bucket is filtered then grouped then counted, so a run of ticket
+    // activities that renders as one grouped card counts once here too.
+    // unreadActivities (state machine) is a lighter row than the fetched feed;
+    // the cast is safe because both grouping and these predicates only touch
+    // fields present on both shapes.
+    return countGroupedActivities((unreadActivities ?? []) as unknown as ActivityWithRelated[], {
+      all: isAllVisibleActivity,
       your_mentions: activity => activity.actorAction === 'mentioned_user',
       group_mentions: activity => activity.actorAction === 'group_mention',
       // added to maintain backward compat for now, to be deprecated
@@ -783,15 +768,13 @@ const ActivityListView = (): ReactElement => {
         activity.actorAction === 'canvas_role_changed' ||
         activity.actorAction === 'canvas_access_revoked' ||
         (activity.actorAction === 'mentioned_user' && !!activity.canvasId),
-      calls: activity => CALL_ACTIVITY_TYPES.some(type => type === activity.actorAction),
+      calls: isCallActivity,
       actionable: activity =>
         (activity.classification ?? ActivityClassification.PENDING) ===
         ActivityClassification.ACTIONABLE,
       fyi: activity =>
         (activity.classification ?? ActivityClassification.PENDING) === ActivityClassification.FYI,
     });
-
-    return { ...emptyCounts, ...counts };
   }, [unreadActivities]);
 
   const renderActivityList = (feedItems: ActivityFeedItem[]): ReactElement => {

--- a/apps/dashboard/src/components/Activity/GroupedTicketActivity.tsx
+++ b/apps/dashboard/src/components/Activity/GroupedTicketActivity.tsx
@@ -66,9 +66,13 @@ export const GroupedTicketActivity = ({
       ? `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`
       : labels[0] || 'fields';
 
+  // A grouped card is unread as long as any underlying activity is unread —
+  // matches markManyAsRead, which clears every id in the group together.
+  const groupIsRead = activities.every(a => a.isRead);
+
   const content = (
     <span className='text-sm'>
-      <span className={first.isRead ? 'text-muted-foreground' : 'font-semibold'}>
+      <span className={groupIsRead ? 'text-muted-foreground' : 'font-semibold'}>
         {ticketXyneId}
       </span>
       <span className='text-muted-foreground'> {labelList} updated</span>
@@ -81,6 +85,7 @@ export const GroupedTicketActivity = ({
         {
           ...first,
           actorAction: 'ticket_multi_updated',
+          isRead: groupIsRead,
         } as ActivityWithRelated
       }
       actorId={actorId}
@@ -93,6 +98,7 @@ export const GroupedTicketActivity = ({
       focusThread
       supportTargetPath={supportTargetPath}
       isExpanded={isExpanded}
+      groupActivityIds={activities.map(a => a.id)}
     >
       {content}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/TicketUpdateActivity.tsx
+++ b/apps/dashboard/src/components/Activity/TicketUpdateActivity.tsx
@@ -32,6 +32,7 @@ interface ActivityConfig {
 const getActivityConfig = (actorAction: string): ActivityConfig => {
   switch (actorAction) {
     case 'ticket_status':
+    case 'ticket_status_v2':
       return {
         icon: <TicketToken className='size-3 text-green-600' />,
         badgeColor: 'bg-green-100',

--- a/apps/dashboard/src/components/Activity/activityGrouping.ts
+++ b/apps/dashboard/src/components/Activity/activityGrouping.ts
@@ -24,7 +24,10 @@ export interface ActivityGroupable {
 }
 
 function isTicketGroupCandidate(activity: ActivityGroupable): boolean {
-  return typeof activity.actorAction === 'string' && activity.actorAction.startsWith(TICKET_ACTIVITY_PREFIX);
+  return (
+    typeof activity.actorAction === 'string' &&
+    activity.actorAction.startsWith(TICKET_ACTIVITY_PREFIX)
+  );
 }
 
 function canExtendGroup(tail: ActivityGroupable, candidate: ActivityGroupable): boolean {
@@ -67,7 +70,7 @@ export function countGroupedActivities<T extends ActivityGroupable>(
         continue;
       }
 
-      counts[key]++;
+      counts[key] = (counts[key] ?? 0) + 1;
       tails[key] = activity;
     }
   }

--- a/apps/dashboard/src/components/Activity/activityGrouping.ts
+++ b/apps/dashboard/src/components/Activity/activityGrouping.ts
@@ -10,71 +10,27 @@ export type ActivityFeedItem = { type: 'single'; activity: ActivityWithRelated }
 const TICKET_ACTIVITY_PREFIX = 'ticket_';
 const GROUP_WINDOW_MS = 30 * 1000; // 30 seconds
 
-/** Minimal shape the grouping/counting rule needs — satisfied by both
- * `ActivityWithRelated` (the fetched feed) and `UnreadActivity` (the state
- * machine's lighter unread-activities row), so counters can share this logic
- * without re-fetching or re-shaping data. */
-export interface ActivityGroupable {
-  id: string;
-  actorAction: string;
-  actorId: string;
-  ticketId?: string | null;
-  updatedAt?: number | null;
-  createdAt?: number | null;
-}
-
-function isTicketGroupCandidate(activity: ActivityGroupable): boolean {
-  return (
-    typeof activity.actorAction === 'string' &&
-    activity.actorAction.startsWith(TICKET_ACTIVITY_PREFIX)
-  );
-}
-
-function canExtendGroup(tail: ActivityGroupable, candidate: ActivityGroupable): boolean {
-  if (!isTicketGroupCandidate(tail) || !isTicketGroupCandidate(candidate)) return false;
-  if (tail.actorId !== candidate.actorId) return false;
-  if (tail.ticketId !== candidate.ticketId) return false;
-
-  const tailTime = tail.updatedAt ?? tail.createdAt ?? 0;
-  const candidateTime = candidate.updatedAt ?? candidate.createdAt ?? 0;
-  return Math.abs(candidateTime - tailTime) <= GROUP_WINDOW_MS;
-}
-
 /**
- * Counts activities per bucket in a single O(activities × buckets) pass,
- * collapsing consecutive same-actor/same-ticket ticket_* activities within
- * the 30s grouping window into one count per bucket — the same rule
- * `groupActivities` uses for rendering, so tab/sidebar badges match what the
- * grouped feed actually shows. `activities` must be pre-sorted the same way
- * the rendered feed is (newest-first) for "consecutive" to mean the same
- * thing in both places.
+ * Counts activities per bucket the way the feed renders them: each bucket is
+ * filtered, then grouped, then counted, so a set of ticket activities that
+ * renders as one grouped card contributes 1 — not N — to its badge.
+ *
+ * Deliberately reuses `groupActivities` rather than reimplementing the
+ * grouping rule: a second copy of that rule is exactly how badges drifted
+ * from the feed in the first place. This mirrors the render path, which also
+ * filters before grouping (see ActivityListView).
+ *
+ * `activities` must be sorted the same way the rendered feed is (newest
+ * first) for "consecutive" to mean the same thing in both places.
  */
-export function countGroupedActivities<T extends ActivityGroupable>(
-  activities: readonly T[],
-  buckets: Record<string, (activity: T) => boolean>,
-): Record<string, number> {
-  const bucketKeys = Object.keys(buckets);
-  const counts: Record<string, number> = {};
-  const tails: Record<string, T | undefined> = {};
-  for (const key of bucketKeys) {
-    counts[key] = 0;
+export function countGroupedActivities<K extends string>(
+  activities: readonly ActivityWithRelated[],
+  buckets: Record<K, (activity: ActivityWithRelated) => boolean>,
+): Record<K, number> {
+  const counts = {} as Record<K, number>;
+  for (const key of Object.keys(buckets) as K[]) {
+    counts[key] = groupActivities(activities.filter(buckets[key])).length;
   }
-
-  for (const activity of activities) {
-    for (const key of bucketKeys) {
-      if (!buckets[key]!(activity)) continue;
-
-      const tail = tails[key];
-      if (tail && canExtendGroup(tail, activity)) {
-        tails[key] = activity;
-        continue;
-      }
-
-      counts[key] = (counts[key] ?? 0) + 1;
-      tails[key] = activity;
-    }
-  }
-
   return counts;
 }
 

--- a/apps/dashboard/src/components/Activity/activityGrouping.ts
+++ b/apps/dashboard/src/components/Activity/activityGrouping.ts
@@ -10,6 +10,71 @@ export type ActivityFeedItem = { type: 'single'; activity: ActivityWithRelated }
 const TICKET_ACTIVITY_PREFIX = 'ticket_';
 const GROUP_WINDOW_MS = 30 * 1000; // 30 seconds
 
+/** Minimal shape the grouping/counting rule needs — satisfied by both
+ * `ActivityWithRelated` (the fetched feed) and `UnreadActivity` (the state
+ * machine's lighter unread-activities row), so counters can share this logic
+ * without re-fetching or re-shaping data. */
+export interface ActivityGroupable {
+  id: string;
+  actorAction: string;
+  actorId: string;
+  ticketId?: string | null;
+  updatedAt?: number | null;
+  createdAt?: number | null;
+}
+
+function isTicketGroupCandidate(activity: ActivityGroupable): boolean {
+  return typeof activity.actorAction === 'string' && activity.actorAction.startsWith(TICKET_ACTIVITY_PREFIX);
+}
+
+function canExtendGroup(tail: ActivityGroupable, candidate: ActivityGroupable): boolean {
+  if (!isTicketGroupCandidate(tail) || !isTicketGroupCandidate(candidate)) return false;
+  if (tail.actorId !== candidate.actorId) return false;
+  if (tail.ticketId !== candidate.ticketId) return false;
+
+  const tailTime = tail.updatedAt ?? tail.createdAt ?? 0;
+  const candidateTime = candidate.updatedAt ?? candidate.createdAt ?? 0;
+  return Math.abs(candidateTime - tailTime) <= GROUP_WINDOW_MS;
+}
+
+/**
+ * Counts activities per bucket in a single O(activities × buckets) pass,
+ * collapsing consecutive same-actor/same-ticket ticket_* activities within
+ * the 30s grouping window into one count per bucket — the same rule
+ * `groupActivities` uses for rendering, so tab/sidebar badges match what the
+ * grouped feed actually shows. `activities` must be pre-sorted the same way
+ * the rendered feed is (newest-first) for "consecutive" to mean the same
+ * thing in both places.
+ */
+export function countGroupedActivities<T extends ActivityGroupable>(
+  activities: readonly T[],
+  buckets: Record<string, (activity: T) => boolean>,
+): Record<string, number> {
+  const bucketKeys = Object.keys(buckets);
+  const counts: Record<string, number> = {};
+  const tails: Record<string, T | undefined> = {};
+  for (const key of bucketKeys) {
+    counts[key] = 0;
+  }
+
+  for (const activity of activities) {
+    for (const key of bucketKeys) {
+      if (!buckets[key]!(activity)) continue;
+
+      const tail = tails[key];
+      if (tail && canExtendGroup(tail, activity)) {
+        tails[key] = activity;
+        continue;
+      }
+
+      counts[key]++;
+      tails[key] = activity;
+    }
+  }
+
+  return counts;
+}
+
 /**
  * Group consecutive ticket-related activities from the same actor on the same ticket
  * within a 30-second window.

--- a/apps/dashboard/src/hooks/useUnreadActivitiesCount.ts
+++ b/apps/dashboard/src/hooks/useUnreadActivitiesCount.ts
@@ -2,7 +2,8 @@ import { useMemo } from 'react';
 import { useSelector } from '@xstate/react';
 import { ActivityClassification } from '@xyne/shared';
 import { stateMachineActor } from '../machines/stateMachine';
-import { countGroupedActivities } from '../components/Activity/activityGrouping';
+import { groupActivities } from '../components/Activity/activityGrouping';
+import type { ActivityWithRelated } from '../types/activity';
 
 /**
  * Hook to get unread activities count with cancelled reactions filtered out
@@ -22,24 +23,25 @@ export const useUnreadActivitiesCount = (): number => {
       return 0;
     }
 
-    const counts = countGroupedActivities(unreadActivities, {
-      visible: activity => {
-        if (activity.actorAction === 'added_v2') return false;
-        if (activity.actorAction === 'removed') return false;
-        if (activity.actionSource === 'call' && activity.actorAction === 'missed_call')
-          return false;
-        const classification = activity.classification ?? ActivityClassification.PENDING;
-        if (classification === ActivityClassification.SKIP) return false;
-        if (activity.actorAction === 'direct_message') {
-          return (
-            classification === ActivityClassification.ACTIONABLE ||
-            classification === ActivityClassification.FYI
-          );
-        }
-        return true;
-      },
+    // Filter then group then count — the same order the Activity feed renders
+    // in, so a run of ticket activities shown as one grouped card counts once.
+    // The cast is safe: grouping and this predicate only touch fields present
+    // on both the state-machine row and the fetched-feed shape.
+    const visible = (unreadActivities as unknown as ActivityWithRelated[]).filter(activity => {
+      if (activity.actorAction === 'added_v2') return false;
+      if (activity.actorAction === 'removed') return false;
+      if (activity.actionSource === 'call' && activity.actorAction === 'missed_call') return false;
+      const classification = activity.classification ?? ActivityClassification.PENDING;
+      if (classification === ActivityClassification.SKIP) return false;
+      if (activity.actorAction === 'direct_message') {
+        return (
+          classification === ActivityClassification.ACTIONABLE ||
+          classification === ActivityClassification.FYI
+        );
+      }
+      return true;
     });
 
-    return counts['visible'] ?? 0;
+    return groupActivities(visible).length;
   }, [unreadActivities]);
 };

--- a/apps/dashboard/src/hooks/useUnreadActivitiesCount.ts
+++ b/apps/dashboard/src/hooks/useUnreadActivitiesCount.ts
@@ -2,10 +2,15 @@ import { useMemo } from 'react';
 import { useSelector } from '@xstate/react';
 import { ActivityClassification } from '@xyne/shared';
 import { stateMachineActor } from '../machines/stateMachine';
+import { countGroupedActivities } from '../components/Activity/activityGrouping';
 
 /**
  * Hook to get unread activities count with cancelled reactions filtered out
  * Reads from state machine (populated by DeferredLoader)
+ *
+ * Grouped ticket activities (same actor, same ticket, within the 30s grouping
+ * window) count once here to match the single card they render as in the
+ * Activity feed.
  *
  * @returns count - Number of unread activities
  */
@@ -17,19 +22,23 @@ export const useUnreadActivitiesCount = (): number => {
       return 0;
     }
 
-    return unreadActivities.filter(activity => {
-      if (activity.actorAction === 'added_v2') return false;
-      if (activity.actorAction === 'removed') return false;
-      if (activity.actionSource === 'call' && activity.actorAction === 'missed_call') return false;
-      const classification = activity.classification ?? ActivityClassification.PENDING;
-      if (classification === ActivityClassification.SKIP) return false;
-      if (activity.actorAction === 'direct_message') {
-        return (
-          classification === ActivityClassification.ACTIONABLE ||
-          classification === ActivityClassification.FYI
-        );
-      }
-      return true;
-    }).length;
+    const counts = countGroupedActivities(unreadActivities, {
+      visible: activity => {
+        if (activity.actorAction === 'added_v2') return false;
+        if (activity.actorAction === 'removed') return false;
+        if (activity.actionSource === 'call' && activity.actorAction === 'missed_call') return false;
+        const classification = activity.classification ?? ActivityClassification.PENDING;
+        if (classification === ActivityClassification.SKIP) return false;
+        if (activity.actorAction === 'direct_message') {
+          return (
+            classification === ActivityClassification.ACTIONABLE ||
+            classification === ActivityClassification.FYI
+          );
+        }
+        return true;
+      },
+    });
+
+    return counts.visible;
   }, [unreadActivities]);
 };

--- a/apps/dashboard/src/hooks/useUnreadActivitiesCount.ts
+++ b/apps/dashboard/src/hooks/useUnreadActivitiesCount.ts
@@ -26,7 +26,8 @@ export const useUnreadActivitiesCount = (): number => {
       visible: activity => {
         if (activity.actorAction === 'added_v2') return false;
         if (activity.actorAction === 'removed') return false;
-        if (activity.actionSource === 'call' && activity.actorAction === 'missed_call') return false;
+        if (activity.actionSource === 'call' && activity.actorAction === 'missed_call')
+          return false;
         const classification = activity.classification ?? ActivityClassification.PENDING;
         if (classification === ActivityClassification.SKIP) return false;
         if (activity.actorAction === 'direct_message') {
@@ -39,6 +40,6 @@ export const useUnreadActivitiesCount = (): number => {
       },
     });
 
-    return counts.visible;
+    return counts['visible'] ?? 0;
   }, [unreadActivities]);
 };

--- a/apps/dashboard/src/hooks/useUnreadCount.ts
+++ b/apps/dashboard/src/hooks/useUnreadCount.ts
@@ -27,17 +27,27 @@ export const useAllUnreadCount = (): UnreadCounts => {
       }
     }
 
-    // For non-DM channels: derive count from unread activities grouped by channelId
-    // Thread activities are excluded — only channel-level activities count for channel badges
+    // For non-DM channels: count only unread top-level message activities,
+    // deduped by (channelId, messageId ?? actionSourceId) so a message with
+    // several activities (e.g. a reply plus a mention) still contributes one
+    // to the badge, matching what markChannelAsViewed clears in one visit.
+    // Ticket/canvas/call activities never touch this badge — they only ever
+    // show up in the Activity feed.
+    const seenChannelMessageIds = new Set<string>();
     for (const activity of unreadActivities ?? []) {
       if (!activity.channelId) continue;
       if (dmChannelIds.has(activity.channelId)) continue;
+      if (activity.actionSource !== 'message') continue;
       if (activity.isThreadActivity === true) continue;
+      if (activity.actorAction === 'added') continue;
       if (activity.actorAction === 'added_v2') continue;
       if (activity.actorAction === 'removed') continue;
-      if (activity.actionSource === 'call' && activity.actorAction === 'missed_call') continue;
       const classification = activity.classification ?? ActivityClassification.PENDING;
       if (classification === ActivityClassification.SKIP) continue;
+
+      const messageKey = `${activity.channelId}:${activity.messageId ?? activity.actionSourceId}`;
+      if (seenChannelMessageIds.has(messageKey)) continue;
+      seenChannelMessageIds.add(messageKey);
 
       counts[activity.channelId] = (counts[activity.channelId] || 0) + 1;
     }

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -1010,21 +1010,34 @@ export const mutators = defineMutators({
           });
         }
 
+        // Only message-domain activities are cleared by viewing a channel —
+        // ticket/canvas/call activities are never marked read here.
         const unreadActivities = await tx.run(
           zql.activities
             .where('userId', ctx.userID)
             .where('isRead', false)
-            .where('channelId', channelId),
+            .where('channelId', channelId)
+            .where('actionSource', 'message'),
         );
 
         if (unreadActivities.length === 0) {
           return;
         }
 
-        const activityBySourceId = new Map(
-          unreadActivities.map(a => [a.actionSourceId, a]),
-        );
-        const uniqueSourceIds = [...activityBySourceId.keys()];
+        // Group by source message id — several activities (e.g. a mention
+        // plus a reply) can share the same top-level message and must all be
+        // marked read together when that message is viewed.
+        const activitiesBySourceId = new Map<string, typeof unreadActivities>();
+        for (const activity of unreadActivities) {
+          const sourceId = activity.messageId ?? activity.actionSourceId;
+          const existing = activitiesBySourceId.get(sourceId);
+          if (existing) {
+            existing.push(activity);
+          } else {
+            activitiesBySourceId.set(sourceId, [activity]);
+          }
+        }
+        const uniqueSourceIds = [...activitiesBySourceId.keys()];
 
         // Batch fetch messages
         const foundMessages = await tx.run(
@@ -1054,17 +1067,21 @@ export const mutators = defineMutators({
           conversations.map(c => [c.conversationId, c]),
         );
 
-        for (const [sourceId, activity] of activityBySourceId) {
+        for (const [sourceId, activities] of activitiesBySourceId) {
           const message = messageByMessageId.get(sourceId);
           if (!message) {
             continue;
           }
           const conv = convByConversationId.get(message.conversationId);
           if (conv?.initialMessageId === message.messageId) {
-            await tx.mutate.activities.update({
-              id: activity.id,
-              isRead: true,
-            });
+            await Promise.all(
+              activities.map(activity =>
+                tx.mutate.activities.update({
+                  id: activity.id,
+                  isRead: true,
+                }),
+              ),
+            );
           }
         }
       },
@@ -3647,6 +3664,63 @@ export const mutators = defineMutators({
           id: activityId,
           isRead: true,
         });
+      },
+    ),
+    markManyAsRead: defineMutator(
+      z.object({ activityIds: z.array(z.string()), timestamp: z.number() }),
+      async ({ tx, ctx, args: { activityIds, timestamp } }) => {
+        if (activityIds.length === 0) {
+          return;
+        }
+
+        const activities = await tx.run(
+          zql.activities.where('id', 'IN', activityIds).where('userId', ctx.userID),
+        );
+
+        const unreadActivities = activities.filter(activity => !activity.isRead);
+        if (unreadActivities.length === 0) {
+          return;
+        }
+
+        await Promise.all(
+          unreadActivities.map(activity =>
+            tx.mutate.activities.update({
+              id: activity.id,
+              isRead: true,
+            }),
+          ),
+        );
+
+        const channelIdCounts = new Map<string, number>();
+        unreadActivities.forEach(activity => {
+          if (activity.channelId) {
+            const currentCount = channelIdCounts.get(activity.channelId) || 0;
+            channelIdCounts.set(activity.channelId, currentCount + 1);
+          }
+        });
+
+        const uniqueChannelIds = Array.from(channelIdCounts.keys());
+        if (uniqueChannelIds.length === 0) {
+          return;
+        }
+
+        const channelUserStatuses = await tx.run(
+          zql.channel_user_status
+            .where('userId', ctx.userID)
+            .where('isDeleted', false)
+            .where('channelId', 'IN', uniqueChannelIds),
+        );
+        await Promise.all(
+          channelUserStatuses.map(channelStatus => {
+            const readCount = channelIdCounts.get(channelStatus.channelId) || 0;
+            const newUnreadCount = Math.max(0, channelStatus.unreadCount - readCount);
+            return tx.mutate.channel_user_status.update({
+              id: channelStatus.id,
+              unreadCount: newUnreadCount,
+              updatedAt: timestamp,
+            });
+          }),
+        );
       },
     ),
     markAsReadByFilter: defineMutator(

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -3666,9 +3666,16 @@ export const mutators = defineMutators({
         });
       },
     ),
+    // Batch sibling of markAsRead, for cards that stand in for several
+    // activities (grouped ticket updates). Like markAsRead — and unlike
+    // markAsReadByFilter — it deliberately leaves channel_user_status alone:
+    // its callers pass ticket activities, which never contribute to a channel
+    // badge (both useUnreadCount and handleUnreadCountInner count only
+    // actionSource 'message'), so decrementing here would subtract from a
+    // counter these rows never incremented.
     markManyAsRead: defineMutator(
-      z.object({ activityIds: z.array(z.string()), timestamp: z.number() }),
-      async ({ tx, ctx, args: { activityIds, timestamp } }) => {
+      z.object({ activityIds: z.array(z.string()) }),
+      async ({ tx, ctx, args: { activityIds } }) => {
         if (activityIds.length === 0) {
           return;
         }
@@ -3677,49 +3684,15 @@ export const mutators = defineMutators({
           zql.activities.where('id', 'IN', activityIds).where('userId', ctx.userID),
         );
 
-        const unreadActivities = activities.filter(activity => !activity.isRead);
-        if (unreadActivities.length === 0) {
-          return;
-        }
-
         await Promise.all(
-          unreadActivities.map(activity =>
-            tx.mutate.activities.update({
-              id: activity.id,
-              isRead: true,
-            }),
-          ),
-        );
-
-        const channelIdCounts = new Map<string, number>();
-        unreadActivities.forEach(activity => {
-          if (activity.channelId) {
-            const currentCount = channelIdCounts.get(activity.channelId) || 0;
-            channelIdCounts.set(activity.channelId, currentCount + 1);
-          }
-        });
-
-        const uniqueChannelIds = Array.from(channelIdCounts.keys());
-        if (uniqueChannelIds.length === 0) {
-          return;
-        }
-
-        const channelUserStatuses = await tx.run(
-          zql.channel_user_status
-            .where('userId', ctx.userID)
-            .where('isDeleted', false)
-            .where('channelId', 'IN', uniqueChannelIds),
-        );
-        await Promise.all(
-          channelUserStatuses.map(channelStatus => {
-            const readCount = channelIdCounts.get(channelStatus.channelId) || 0;
-            const newUnreadCount = Math.max(0, channelStatus.unreadCount - readCount);
-            return tx.mutate.channel_user_status.update({
-              id: channelStatus.id,
-              unreadCount: newUnreadCount,
-              updatedAt: timestamp,
-            });
-          }),
+          activities
+            .filter(activity => !activity.isRead)
+            .map(activity =>
+              tx.mutate.activities.update({
+                id: activity.id,
+                isRead: true,
+              }),
+            ),
         );
       },
     ),


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [x] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [x] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [x] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [x] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [x] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
