### PR TITLE
Fix: XYNE-58287 Rename Track- #1298

### DIFF
--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -30,6 +30,7 @@ import {
   ChevronRight,
   CircleAlert,
   CircleDot,
+  EllipsisVertical,
   FileText,
   Folder,
   GitBranch,
@@ -65,6 +66,12 @@ import { XyneAIStar } from '../../components/icons/xyne-ai';
 import { TicketToken } from '@xyne/icons';
 import { CreateTicketModal } from '../../components/Tickets/CreateTicketModal/CreateTicketModal';
 import { Dialog } from '../../components/ui/Dialog/Dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../../components/ui/dropdown-menu';
 import Input from '../../components/ui/Input';
 import Textarea from '../../components/ui/Textarea';
 import { Panel, ResizableGroup, Separator } from '../../components/ui/Resizable/Resizable';
@@ -271,6 +278,8 @@ export default function SdlcScreen(): ReactElement {
   const [renameTypeName, setRenameTypeName] = useState('');
   const [hoveredTypeId, setHoveredTypeId] = useState<string | null>(null);
   const [trackDialog, setTrackDialog] = useState(false);
+  // Set when the track dialog is editing an existing track instead of creating one.
+  const [trackEditId, setTrackEditId] = useState<string | null>(null);
   const [trackName, setTrackName] = useState('');
   const [trackDescription, setTrackDescription] = useState('');
   const [artifactTrack, setArtifactTrack] = useState<{ id: string; name: string } | null>(null);
@@ -1479,6 +1488,36 @@ export default function SdlcScreen(): ReactElement {
     if (response.type === 'error') throw new Error(response.error.message);
   };
 
+  const closeTrackDialog = (): void => {
+    setTrackDialog(false);
+    setTrackEditId(null);
+    setTrackName('');
+    setTrackDescription('');
+  };
+
+  const openTrackEditDialog = (track: { id: string; name: string; description: string }): void => {
+    setTrackEditId(track.id);
+    setTrackName(track.name);
+    setTrackDescription(track.description);
+    setTrackDialog(true);
+  };
+
+  const updateTrackDetailsAction = async (): Promise<void> => {
+    if (!trackEditId) return;
+    const description = trackDescription.trim();
+    await runTrackMutation(
+      zero.mutate(
+        mutators.sdlc.updateTrack({
+          trackId: trackEditId,
+          name: trackName.trim(),
+          description: description ? description : null,
+          timestamp: Date.now(),
+        }),
+      ),
+    );
+    closeTrackDialog();
+  };
+
   const createTrackAction = async (): Promise<void> => {
     if (!repo || !channel) return;
     const id = uuidv4();
@@ -1494,9 +1533,7 @@ export default function SdlcScreen(): ReactElement {
         }),
       ),
     );
-    setTrackDialog(false);
-    setTrackName('');
-    setTrackDescription('');
+    closeTrackDialog();
     if (repoId) {
       navigateWithinSdlc(`/sdlc/${channelId}/tracks`, `?track=${encodeURIComponent(id)}`);
     }
@@ -1651,7 +1688,12 @@ export default function SdlcScreen(): ReactElement {
           description='Workstreams that group PRDs and their conversations.'
           action={
             <Button
-              onClick={() => setTrackDialog(true)}
+              onClick={() => {
+                setTrackEditId(null);
+                setTrackName('');
+                setTrackDescription('');
+                setTrackDialog(true);
+              }}
               data-track-category='SdlcHub'
               data-track-name='NewTrackOpened'
             >
@@ -1669,13 +1711,21 @@ export default function SdlcScreen(): ReactElement {
                 tabIndex={0}
                 onClick={event => {
                   const target = event.target as HTMLElement;
-                  if (target.closest('[data-status-select], [role="listbox"], [role="option"]'))
+                  if (
+                    target.closest(
+                      '[data-status-select], [data-card-menu], [role="listbox"], [role="option"], [role="menu"], [role="menuitem"]',
+                    )
+                  )
                     return;
                   openTrack(track.id);
                 }}
                 onKeyDown={event => {
                   const target = event.target as HTMLElement;
-                  if (target.closest('[data-status-select], [role="listbox"], [role="option"]'))
+                  if (
+                    target.closest(
+                      '[data-status-select], [data-card-menu], [role="listbox"], [role="option"], [role="menu"], [role="menuitem"]',
+                    )
+                  )
                     return;
                   if (event.key === 'Enter' || event.key === ' ') {
                     event.preventDefault();
@@ -1691,35 +1741,69 @@ export default function SdlcScreen(): ReactElement {
                   <div className='grid size-9 place-items-center rounded-lg bg-primary/10 text-primary'>
                     <Layers size={18} />
                   </div>
-                  <div data-status-select=''>
-                    <Select
-                      value={track.status}
-                      onValueChange={value =>
-                        void call(
-                          `track-status-${track.id}`,
-                          () => setTrackStatusAction(track.id, value),
-                          'Track updated',
-                        )
-                      }
-                    >
-                      <SelectTrigger
-                        className={cn(
-                          'h-7 w-auto gap-1 rounded-full border-none px-2.5 text-xs font-medium shadow-none focus:ring-0',
-                          TRACK_STATUS_STYLES[track.status] ?? TRACK_STATUS_STYLES['ACTIVE'],
-                        )}
-                        onClick={event => event.stopPropagation()}
-                        onKeyDown={event => event.stopPropagation()}
-                        data-track-category='SdlcHub'
-                        data-track-name='TrackStatusChanged'
+                  <div className='flex items-center gap-1'>
+                    <div data-status-select=''>
+                      <Select
+                        value={track.status}
+                        onValueChange={value =>
+                          void call(
+                            `track-status-${track.id}`,
+                            () => setTrackStatusAction(track.id, value),
+                            'Track updated',
+                          )
+                        }
                       >
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value='ACTIVE'>Active</SelectItem>
-                        <SelectItem value='COMPLETED'>Completed</SelectItem>
-                        <SelectItem value='ARCHIVED'>Archived</SelectItem>
-                      </SelectContent>
-                    </Select>
+                        <SelectTrigger
+                          className={cn(
+                            'h-7 w-auto gap-1 rounded-full border-none px-2.5 text-xs font-medium shadow-none focus:ring-0',
+                            TRACK_STATUS_STYLES[track.status] ?? TRACK_STATUS_STYLES['ACTIVE'],
+                          )}
+                          onClick={event => event.stopPropagation()}
+                          onKeyDown={event => event.stopPropagation()}
+                          data-track-category='SdlcHub'
+                          data-track-name='TrackStatusChanged'
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value='ACTIVE'>Active</SelectItem>
+                          <SelectItem value='COMPLETED'>Completed</SelectItem>
+                          <SelectItem value='ARCHIVED'>Archived</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div data-card-menu=''>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type='button'
+                            aria-label='Track actions'
+                            onClick={event => event.stopPropagation()}
+                            onKeyDown={event => event.stopPropagation()}
+                            className='grid size-7 place-items-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring'
+                            data-track-category='SdlcHub'
+                            data-track-name='TrackActionsOpened'
+                          >
+                            <EllipsisVertical size={16} />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align='end'>
+                          <DropdownMenuItem
+                            onSelect={() =>
+                              openTrackEditDialog({
+                                id: track.id,
+                                name: track.name,
+                                description: track.description ?? '',
+                              })
+                            }
+                            data-track-category='SdlcHub'
+                            data-track-name='TrackEditOpened'
+                          >
+                            Edit
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
                   </div>
                 </div>
                 <h3 className='mt-4 truncate font-semibold'>{track.name}</h3>
@@ -2667,17 +2751,21 @@ export default function SdlcScreen(): ReactElement {
 
       <Dialog
         open={trackDialog}
-        onOpenChange={open => !open && setTrackDialog(false)}
-        title='New Track'
+        onOpenChange={open => !open && closeTrackDialog()}
+        title={trackEditId ? 'Edit Track' : 'New Track'}
       >
         <form
           className='p-6'
           onSubmit={event => {
             event.preventDefault();
+            if (trackEditId) {
+              void call('track-update', updateTrackDetailsAction, 'Track updated');
+              return;
+            }
             void call('track-create', createTrackAction, 'Track created');
           }}
         >
-          <h2 className='text-lg font-semibold'>New Track</h2>
+          <h2 className='text-lg font-semibold'>{trackEditId ? 'Edit Track' : 'New Track'}</h2>
           <label htmlFor='sdlc-track-name' className='mt-5 block text-sm font-medium'>
             Name
           </label>
@@ -2706,17 +2794,17 @@ export default function SdlcScreen(): ReactElement {
             data-track-name='TrackDescriptionChanged'
           />
           <div className='mt-6 flex justify-end gap-2'>
-            <Button type='button' variant='outline' onClick={() => setTrackDialog(false)}>
+            <Button type='button' variant='outline' onClick={closeTrackDialog}>
               Cancel
             </Button>
             <Button
               type='submit'
-              loading={busy === 'track-create'}
+              loading={busy === (trackEditId ? 'track-update' : 'track-create')}
               disabled={!trackName.trim()}
               data-track-category='SdlcHub'
-              data-track-name='TrackCreated'
+              data-track-name={trackEditId ? 'TrackEdited' : 'TrackCreated'}
             >
-              Create Track
+              {trackEditId ? 'Save Changes' : 'Create Track'}
             </Button>
           </div>
         </form>


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Link: https://drive.google.com/file/d/1RnBZ-xka7prR3_SKEx7-FduO7r8mO-u2/view?usp=sharing


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
