### PR TITLE
Fix: XYNE-59762 spaces collaboration fixes

### DIFF
--- a/apps/backend/src/database/acl/tables/channel-user-status-acl.ts
+++ b/apps/backend/src/database/acl/tables/channel-user-status-acl.ts
@@ -28,15 +28,19 @@ export class ChannelUserStatusACL extends BaseQueryACL<
   async canCreate(data: Prisma.ChannelUserStatusUncheckedCreateInput): Promise<boolean> {
     const channel = await this.prisma.channel.findFirst({
       where: { id: data.channelId, workspaceId: this.ctx.workspaceId },
-      select: { addUserPolicy: true },
+      select: { id: true },
     })
     if (!channel) return false
+    const channelStats = await this.prisma.channelStats.findUnique({
+      where: { channelId: data.channelId },
+      select: { addUserPolicy: true },
+    })
     const participant = await this.prisma.channelParticipant.findFirst({
       where: { channelId: data.channelId, userId: this.ctx.userId },
       select: { role: true },
     })
     if (!participant) return false
-    if ((channel.addUserPolicy ?? 'EVERYONE') === 'ADMINS_ONLY' && participant.role !== 'ADMIN') {
+    if ((channelStats?.addUserPolicy ?? 'EVERYONE') === 'ADMINS_ONLY' && participant.role !== 'ADMIN') {
       return false
     }
     return true

--- a/apps/backend/src/sdlc/SdlcHubService.ts
+++ b/apps/backend/src/sdlc/SdlcHubService.ts
@@ -49,7 +49,7 @@ import {
 import { commitAndSyncCanvasArtifact } from './sdlcBaselineCanvasSync';
 import { requireSdlcProjectAccess } from './sdlcProjectAccess';
 import { isTrackInChannel, trackIdsForChannel } from './sdlcChannelMembership';
-import { sdlcChannelCanvasParticipant } from './sdlcCanvasAccess';
+import { SDLC_ARTIFACT_CANVAS_ROLE, sdlcChannelCanvasParticipant } from './sdlcCanvasAccess';
 import { ensureLink } from './entityLinkService';
 import { BASELINE_CAPABILITIES } from './sdlcProgressiveGate';
 import type {
@@ -903,7 +903,16 @@ export class SdlcHubService implements SdlcHub {
               isCollaborative: true,
               metadata: {} as Prisma.InputJsonValue,
               participants: {
-                create: sdlcChannelCanvasParticipant(actor.workspaceId, repo.channelId),
+                // PRDs and Tech Docs are collaborative for the whole repository
+                // channel; baselines keep the read-only default (editing them is gated to channel admins).
+                create:
+                  input.kind === 'BASELINE'
+                    ? sdlcChannelCanvasParticipant(actor.workspaceId, repo.channelId)
+                    : sdlcChannelCanvasParticipant(
+                        actor.workspaceId,
+                        repo.channelId,
+                        SDLC_ARTIFACT_CANVAS_ROLE
+                      ),
               },
             },
           });

--- a/apps/backend/src/sdlc/sdlcCanvasAccess.ts
+++ b/apps/backend/src/sdlc/sdlcCanvasAccess.ts
@@ -1,13 +1,20 @@
 import { CanvasRole } from '@xyne/shared';
 
-/** Repository-channel members receive read-only access to every new SDLC canvas. */
+/** Repository-channel members receive read-only access to new SDLC canvases by default (baselines, wiki pages). */
 export const SDLC_CHANNEL_CANVAS_ROLE = CanvasRole.VIEWER;
 
-export const sdlcChannelCanvasParticipant = (workspaceId: string, channelId: string | null) => {
+/** PRD / Tech Doc artifacts are collaborative: every repository-channel member can edit them by default. */
+export const SDLC_ARTIFACT_CANVAS_ROLE = CanvasRole.EDITOR;
+
+export const sdlcChannelCanvasParticipant = (
+  workspaceId: string,
+  channelId: string | null,
+  role: CanvasRole = SDLC_CHANNEL_CANVAS_ROLE
+) => {
   if (!channelId) throw new Error('SDLC canvas requires a repository channel');
   return {
     workspaceId,
     channelId,
-    role: SDLC_CHANNEL_CANVAS_ROLE,
+    role,
   };
 };

--- a/apps/backend/src/zero/acl/tables/channel-user-status-acl.ts
+++ b/apps/backend/src/zero/acl/tables/channel-user-status-acl.ts
@@ -26,8 +26,9 @@ export class ChannelUserStatusACL extends BaseACL<'channel_user_status'> {
     // Verify requesting user is a channel participant and get their record
     const requestingParticipant = await this.verifyChannelParticipant(args.channelId, tx, 'insert');
 
-    // Check addUserPolicy: if ADMINS_ONLY, only admins can add users
-    const addUserPolicy = channel?.addUserPolicy ?? ChannelAddUserPolicy.EVERYONE;
+    // Check addUserPolicy: if ADMINS_ONLY, only admins can add users.
+    const channelStats = await tx.run(zql.channel_stats.where('channelId', '=', args.channelId).one());
+    const addUserPolicy = channelStats?.addUserPolicy ?? ChannelAddUserPolicy.EVERYONE;
     if (addUserPolicy === ChannelAddUserPolicy.ADMINS_ONLY && requestingParticipant.role !== ChannelRole.ADMIN) {
       throw new MutationACLError('Channel user status insert failed: only channel admins can add users to this channel', 'channel_user_status');
     }
@@ -82,10 +83,10 @@ export class ChannelUserStatusACL extends BaseACL<'channel_user_status'> {
         throw new MutationACLError('Channel user status restore failed: invalid keys', 'channel_user_status');
       }
       
-      const channel = await tx.run(zql.channels.where('id', '=', status.channelId).one());
+      const channelStats = await tx.run(zql.channel_stats.where('channelId', '=', status.channelId).one());
       const requestingParticipant = await this.verifyChannelParticipant(status.channelId, tx, 'update');
       
-      const addUserPolicy = channel?.addUserPolicy ?? ChannelAddUserPolicy.EVERYONE;
+      const addUserPolicy = channelStats?.addUserPolicy ?? ChannelAddUserPolicy.EVERYONE;
       if (addUserPolicy === ChannelAddUserPolicy.ADMINS_ONLY && requestingParticipant.role !== ChannelRole.ADMIN) {
         throw new MutationACLError('Channel user status restore failed: only channel admins can restore users to this channel', 'channel_user_status');
       }


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
Two access-control fixes in Spaces:
### 1. Channel members — honor EVERYONE add-user policy
When a channel's add-user setting is EVERYONE, any member should be able to add
new members, but the add still failed for non-admins.
POT: https://drive.google.com/file/d/1XpJOUXFwULK5jKvvwIZwjkpmhjdbJHg6/view?usp=sharing
### 2. SDLC artifacts — channel members get edit access by default
POT: https://drive.google.com/file/d/1ueLIIqVTwTo8eo9mvwuGiMVx4wh0ApID/view?usp=sharing




## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
