### PR TITLE
fix:XYNE-61590 Added UI for the ticket creation in the canva

### DIFF
--- a/apps/backend/src/utils/ysweetUtils.ts
+++ b/apps/backend/src/utils/ysweetUtils.ts
@@ -43,6 +43,7 @@ const canvasCommentThreadStyleSpec = createStyleSpec(
   },
 );
 
+// Register a style spec for canvas tickets
 const canvasTicketStyleSpec = createStyleSpec(
   {
     type: 'canvasTicket',

--- a/apps/backend/src/utils/ysweetUtils.ts
+++ b/apps/backend/src/utils/ysweetUtils.ts
@@ -43,6 +43,39 @@ const canvasCommentThreadStyleSpec = createStyleSpec(
   },
 );
 
+const canvasTicketStyleSpec = createStyleSpec(
+  {
+    type: 'canvasTicket',
+    propSchema: 'string',
+  },
+  {
+    render: () => {
+      const doc = (globalThis as unknown as {
+        document?: { createElement: (tagName: string) => unknown };
+      }).document;
+      const span = doc?.createElement('span') ?? {};
+      return {
+        dom: span,
+        contentDOM: span,
+      } as never;
+    },
+    parse: element =>
+      (element as unknown as { getAttribute?: (name: string) => string | null }).getAttribute?.(
+        'data-canvas-ticket-id',
+      ) ?? undefined,
+    runsBefore: [
+      'bold',
+      'italic',
+      'underline',
+      'strike',
+      'code',
+      'textColor',
+      'backgroundColor',
+      'canvasCommentThread',
+    ],
+  },
+);
+
 function createServerSchema() {
   return BlockNoteSchema.create({
     blockSpecs: defaultBlockSpecs,
@@ -56,6 +89,7 @@ function createServerSchema() {
     styleSpecs: {
       ...defaultStyleSpecs,
       canvasCommentThread: canvasCommentThreadStyleSpec,
+      canvasTicket: canvasTicketStyleSpec,
     },
   });
 }

--- a/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
@@ -85,6 +85,8 @@ import { AnimatePresence } from 'framer-motion';
 import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasInlineCommentThread';
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
+import { useCanvasTicketEditorBridge } from '../useCanvasTicketEditorBridge';
+import { CanvasTicketCreationFlow } from '../CanvasTicketCreationFlow/CanvasTicketCreationFlow';
 
 const canvasDictionary = {
   ...en,
@@ -414,6 +416,17 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       initialCommentThreadId,
       onOpenCommentCountChange,
     });
+    const {
+      activeTicketAnchor,
+      isTicketChannelArchived,
+      openTicketForCurrentSelection,
+      closeTicketModal,
+      handleTicketCreated,
+    } = useCanvasTicketEditorBridge({
+      channelId,
+      containerRef,
+      getEditor: getCanvasCommentEditor,
+    });
 
     // Expose presentation and comment drawer methods via ref
     useImperativeHandle(
@@ -545,8 +558,17 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
           ...(canvasId && { canvasId }),
           ...(_canvasTitle && { canvasTitle: _canvasTitle }),
           canComment: editable,
+          canCreateTicket: editable && !isTicketChannelArchived,
+          onCreateTicket: openTicketForCurrentSelection,
         }),
-      [_canvasTitle, canvasId, editable, openCommentsForCurrentBlock],
+      [
+        _canvasTitle,
+        canvasId,
+        editable,
+        isTicketChannelArchived,
+        openCommentsForCurrentBlock,
+        openTicketForCurrentSelection,
+      ],
     );
 
     const handleSave = useCallback((): void => {
@@ -645,6 +667,13 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
             />
           )}
         </div>
+
+        <CanvasTicketCreationFlow
+          anchor={activeTicketAnchor}
+          channelId={channelId}
+          onClose={closeTicketModal}
+          onTicketCreated={handleTicketCreated}
+        />
 
         {/* Presentation Modal */}
         {showPresentation && (

--- a/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
@@ -7,7 +7,7 @@ import {
   TextAlignButton,
   useComponentsContext,
 } from '@blocknote/react';
-import { MessageSquarePlus } from 'lucide-react';
+import { MessageSquarePlus, Ticket } from 'lucide-react';
 import type { FC, ReactElement } from 'react';
 import { useCallback, useEffect, useRef } from 'react';
 import { xyneAIActor, type SelectionInfo } from '../../../machines/xyneAIMachine';
@@ -16,6 +16,8 @@ type CanvasFormattingToolbarOptions = {
   canvasId?: string;
   canvasTitle?: string;
   canComment?: boolean;
+  canCreateTicket?: boolean;
+  onCreateTicket?: (selectedText: string) => void;
 };
 
 function CanvasToolbarAttachedActions({
@@ -23,6 +25,8 @@ function CanvasToolbarAttachedActions({
   canvasId,
   canvasTitle,
   canComment = true,
+  canCreateTicket = false,
+  onCreateTicket,
 }: {
   onAddComment: () => void;
 } & CanvasFormattingToolbarOptions): ReactElement {
@@ -67,12 +71,20 @@ function CanvasToolbarAttachedActions({
     window.getSelection()?.removeAllRanges();
   }, [canvasId, canvasTitle]);
 
+  const handleCreateTicket = useCallback((): void => {
+    const selectedText = window.getSelection()?.toString().trim() || selectedTextRef.current;
+    if (!selectedText) return;
+    onCreateTicket?.(selectedText);
+  }, [onCreateTicket]);
+
+  const hasSecondaryAction = canComment || canCreateTicket;
+
   return (
     <div className='canvas-formatting-menu__attached-actions'>
       <button
         type='button'
         className={`canvas-formatting-menu__attached-button canvas-formatting-menu__attached-button--left ${
-          canComment ? '' : 'canvas-formatting-menu__attached-button--single'
+          hasSecondaryAction ? '' : 'canvas-formatting-menu__attached-button--single'
         }`}
         onMouseDown={event => event.preventDefault()}
         onClick={handleAskAI}
@@ -87,7 +99,11 @@ function CanvasToolbarAttachedActions({
       {canComment && (
         <button
           type='button'
-          className='canvas-formatting-menu__attached-button canvas-formatting-menu__attached-button--right'
+          className={`canvas-formatting-menu__attached-button ${
+            canCreateTicket
+              ? 'canvas-formatting-menu__attached-button--middle'
+              : 'canvas-formatting-menu__attached-button--right'
+          }`}
           onMouseDown={event => event.preventDefault()}
           onClick={onAddComment}
           data-track-category='CANVAS'
@@ -96,6 +112,20 @@ function CanvasToolbarAttachedActions({
         >
           <MessageSquarePlus className='size-3.5' aria-hidden='true' />
           <span>Comment</span>
+        </button>
+      )}
+      {canCreateTicket && (
+        <button
+          type='button'
+          className='canvas-formatting-menu__attached-button canvas-formatting-menu__attached-button--right'
+          onMouseDown={event => event.preventDefault()}
+          onClick={handleCreateTicket}
+          data-track-category='CANVAS'
+          data-track-name='Selection_Create_Ticket'
+          data-track-metadata={JSON.stringify({ canvasId })}
+        >
+          <Ticket className='size-3.5' aria-hidden='true' />
+          <span>Ticket</span>
         </button>
       )}
     </div>
@@ -111,13 +141,15 @@ export const createCanvasFormattingToolbar = (
   }: FormattingToolbarProps): ReactElement | null => {
     const Components = useComponentsContext();
     const canComment = options.canComment ?? true;
+    const canCreateTicket = options.canCreateTicket ?? false;
+    const hasEditorActions = canComment || canCreateTicket;
 
     if (!Components) return null;
 
     return (
       <Components.FormattingToolbar.Root
         className={`bn-toolbar bn-formatting-toolbar canvas-formatting-menu ${
-          canComment ? '' : 'canvas-formatting-menu--ask-only'
+          hasEditorActions ? '' : 'canvas-formatting-menu--ask-only'
         }`}
       >
         {canComment && (

--- a/apps/dashboard/src/components/Canvas/CanvasList/CanvasList.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasList/CanvasList.tsx
@@ -69,6 +69,7 @@ import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { getAvatarColorClassNames } from '../../ui/Avatar/Avatar';
 import { useDebouncedValue } from '../../../hooks/useDebouncedValue';
 import { canvasMatchesSharedByFilter } from '../canvasListFilters';
+import { isElectronApp, toStandalonePath } from '../../../utils/electronApp';
 
 type FilterTab = 'all' | 'created_by_me' | 'shared';
 type CanvasCursor = { id: string; updatedAt: number };
@@ -1603,7 +1604,8 @@ export const CanvasList: React.FC<CanvasListProps> = ({
   );
 
   const handleOpenCanvasInNewTab = useCallback((canvas: Canvas): void => {
-    window.open(`/chat/canvas/${canvas.id}`, '_blank');
+    const canvasPath = `/chat/canvas/${canvas.id}`;
+    window.open(isElectronApp() ? toStandalonePath(canvasPath) : canvasPath, '_blank');
   }, []);
 
   const renderCanvasItem = (canvas: Canvas): React.ReactNode => {

--- a/apps/dashboard/src/components/Canvas/CanvasPanel/CanvasPanel.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasPanel/CanvasPanel.tsx
@@ -42,7 +42,7 @@ import {
 } from './canvasSidebarWidth';
 import AppNavigator from '../../AppNavigator/AppNavigator';
 import { cn } from '../../../utils/classNames';
-import { APP_NO_DRAG_STYLE } from '../../../utils/electronApp';
+import { APP_NO_DRAG_STYLE, standaloneNavigate } from '../../../utils/electronApp';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { usePath } from '../../../hooks/usePath';
 import { useDebouncedValue } from '../../../hooks/useDebouncedValue';
@@ -193,15 +193,12 @@ const CanvasPanel = (): ReactElement => {
         return;
       }
 
-      const isCmdClick = 'metaKey' in e && (e.metaKey || e.ctrlKey);
       // Navigate to the canvas in the right panel
       const canvasUrl = `/chat/canvas/${canvas.id}`;
-      // Only open in new tab on desktop when Cmd/Ctrl+Click is pressed
-      if (!isMobile && isCmdClick) {
-        window.open(canvasUrl, '_blank');
-      } else {
-        void navigate(canvasUrl, { state: { canvas } });
-      }
+      standaloneNavigate(navigate, canvasUrl, {
+        event: !isMobile && 'button' in e ? e : undefined,
+        state: { canvas },
+      });
     },
     [navigate, isMobile],
   );

--- a/apps/dashboard/src/components/Canvas/CanvasTicketCreationFlow/CanvasTicketCreationFlow.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTicketCreationFlow/CanvasTicketCreationFlow.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from 'react';
+
+import { useChannel } from '../../../hooks/useChannels';
+import { CreateTicketModal } from '../../Tickets/CreateTicketModal/CreateTicketModal';
+import type { CanvasTicketAnchor } from '../useCanvasTicketEditorBridge';
+
+interface CreatedTicket {
+  id: string;
+  conversationId?: string;
+  xyneId?: string;
+  workflowType?: string;
+}
+
+interface CanvasTicketCreationFlowProps {
+  anchor: CanvasTicketAnchor | null;
+  channelId?: string | undefined;
+  onClose: () => void;
+  onTicketCreated: (ticket: CreatedTicket) => void;
+}
+
+export function CanvasTicketCreationFlow({
+  anchor,
+  channelId,
+  onClose,
+  onTicketCreated,
+}: CanvasTicketCreationFlowProps): ReactElement | null {
+  const effectiveChannelId = channelId ?? '';
+  const effectiveChannel = useChannel(effectiveChannelId);
+
+  if (!anchor) return null;
+
+  return (
+    <CreateTicketModal
+      isOpen={true}
+      onClose={onClose}
+      channelId={effectiveChannelId}
+      {...(effectiveChannel?.projectId ? { projectId: effectiveChannel.projectId } : {})}
+      allowChannelSelection={!channelId}
+      useLocalAttachments={true}
+      initialDescription={anchor.blockText}
+      onTicketCreated={onTicketCreated}
+    />
+  );
+}

--- a/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
@@ -1,0 +1,198 @@
+import { createReactStyleSpec } from '@blocknote/react';
+import { CircleHelp, Clock3, Flag, UserRound } from 'lucide-react';
+import { useCallback, useRef, useState, type ReactElement } from 'react';
+
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useUser } from '../../../hooks/useUsers';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+import { queries } from '../../../zero/queries';
+import Avatar from '../../ui/Avatar/Avatar';
+import { HoverCard } from '../../ui/HoverCard/HoverCard';
+
+export const CANVAS_TICKET_ATTR = 'data-canvas-ticket-id';
+export const CANVAS_TICKET_SELECTOR = `[${CANVAS_TICKET_ATTR}]`;
+
+interface CanvasTicketAnchorProps {
+  ticketId: string;
+  contentRef: (element: HTMLElement | null) => void;
+}
+
+const formatTicketStatus = (status: string | null | undefined): string => {
+  if (!status) return 'No status';
+  return status
+    .toLowerCase()
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
+
+function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): ReactElement {
+  const [ticket, ticketDetails] = useCachedQuery(queries.ticketRowById({ ticketId }), {
+    enabled: Boolean(ticketId),
+  });
+  const assignedUser = useUser(ticket?.assignedTo ?? '');
+  const anchorRef = useRef<HTMLSpanElement | null>(null);
+  const contentElementRef = useRef<HTMLElement | null>(null);
+  const [previewText, setPreviewText] = useState('');
+  const statusLabel = ticket?.stageName?.trim() || formatTicketStatus(ticket?.statusV2);
+  const isUnavailable = ticketDetails.type === 'complete' && !ticket;
+  const assigneeLabel = ticket?.assignedTo
+    ? assignedUser
+      ? getUserDisplayName(assignedUser)
+      : 'Assigned'
+    : 'Unassigned';
+  const priorityLabel = ticket?.priority ? formatTicketStatus(ticket.priority) : 'No priority';
+
+  const setContentElement = useCallback(
+    (element: HTMLElement | null): void => {
+      contentElementRef.current = element;
+      contentRef(element);
+    },
+    [contentRef],
+  );
+
+  const handlePreviewOpenChange = useCallback(
+    (open: boolean): void => {
+      if (!open) return;
+      setPreviewText(contentElementRef.current?.textContent?.trim() || ticket?.title || 'Ticket');
+    },
+    [ticket?.title],
+  );
+
+  const trigger = (
+    <span
+      ref={anchorRef}
+      data-canvas-ticket-id={ticketId}
+      data-canvas-ticket-channel-id={ticket?.channelId ?? undefined}
+      data-canvas-ticket-conversation-id={ticket?.conversationId ?? undefined}
+      data-canvas-ticket-status={ticket?.statusV2 ?? undefined}
+      className='canvas-ticket-anchor'
+      role='link'
+      tabIndex={0}
+      aria-label={ticket ? `Open ${ticket.xyneId}: ${ticket.title}` : 'Open ticket'}
+    >
+      {ticket?.xyneId && (
+        <span className='canvas-ticket-anchor__id' contentEditable={false}>
+          {ticket.xyneId}
+        </span>
+      )}
+      <span ref={setContentElement} className='canvas-ticket-anchor__text' />
+      {ticket && (
+        <span className='canvas-ticket-anchor__status' contentEditable={false}>
+          <Clock3 aria-hidden='true' />
+          <span>{statusLabel}</span>
+        </span>
+      )}
+      {ticket && (
+        <span
+          className={`canvas-ticket-anchor__assignee${ticket.assignedTo ? '' : ' canvas-ticket-anchor__assignee--unassigned'}`}
+          contentEditable={false}
+        >
+          {ticket.assignedTo ? (
+            <Avatar
+              userId={ticket.assignedTo}
+              size='xs'
+              rounded={true}
+              showActiveStatus={false}
+              className='canvas-ticket-avatar canvas-ticket-anchor__avatar'
+            />
+          ) : (
+            <UserRound aria-label='Unassigned' />
+          )}
+        </span>
+      )}
+      {isUnavailable && (
+        <span className='canvas-ticket-anchor__unavailable' contentEditable={false}>
+          Ticket unavailable
+        </span>
+      )}
+    </span>
+  );
+
+  if (!ticket) return trigger;
+
+  return (
+    <HoverCard
+      trigger={trigger}
+      onOpenChange={handlePreviewOpenChange}
+      openDelay={180}
+      closeDelay={100}
+      side='bottom'
+      align='start'
+      sideOffset={6}
+      collisionPadding={12}
+      className='w-80 rounded-xl p-3'
+    >
+      <div className='flex min-w-0 flex-col gap-3' data-canvas-ticket-preview={ticketId}>
+        <div className='flex min-w-0 items-center gap-2 text-xs'>
+          <span className='font-medium text-primary'>{ticket.xyneId}</span>
+          <span className='max-w-32 truncate rounded-full bg-muted px-2 py-0.5 text-muted-foreground'>
+            {statusLabel}
+          </span>
+        </div>
+
+        <p className='m-0 whitespace-normal text-sm font-semibold leading-5 text-foreground'>
+          {previewText || ticket.title}
+        </p>
+
+        <div className='flex min-w-0 items-center gap-4 text-xs text-muted-foreground'>
+          <span className='flex min-w-0 items-center gap-1.5'>
+            {ticket.assignedTo ? (
+              <Avatar
+                userId={ticket.assignedTo}
+                size='xs'
+                rounded={true}
+                showActiveStatus={false}
+                className='canvas-ticket-avatar'
+              />
+            ) : (
+              <CircleHelp className='size-4' aria-hidden='true' />
+            )}
+            <span className='max-w-24 truncate'>{assigneeLabel}</span>
+          </span>
+
+          <span className='flex min-w-0 items-center gap-1.5'>
+            <Flag className='size-3.5' aria-hidden='true' />
+            <span className='max-w-24 truncate'>{priorityLabel}</span>
+          </span>
+
+          <button
+            type='button'
+            className='ml-auto shrink-0 rounded-md border border-border bg-background px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent'
+            data-track-category='CANVAS'
+            data-track-name='OPEN_CANVAS_TICKET_PREVIEW'
+            onClick={event => {
+              event.preventDefault();
+              event.stopPropagation();
+              anchorRef.current?.click();
+            }}
+          >
+            Open
+          </button>
+        </div>
+      </div>
+    </HoverCard>
+  );
+}
+
+export const canvasTicketStyleSpec = createReactStyleSpec(
+  {
+    type: 'canvasTicket',
+    propSchema: 'string',
+  },
+  {
+    render: ({ value, contentRef }) => (
+      <CanvasTicketAnchor ticketId={value} contentRef={contentRef} />
+    ),
+    runsBefore: [
+      'bold',
+      'italic',
+      'underline',
+      'strike',
+      'code',
+      'textColor',
+      'backgroundColor',
+      'canvasCommentThread',
+    ],
+  },
+);

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -86,6 +86,8 @@ import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/Canvas
 import { CanvasLinkToolbar, CanvasPastedLinkToolbar } from '../CanvasLinkToolbar';
 import { CanvasFilePanel } from '../CanvasFilePanel/CanvasFilePanel';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
+import { useCanvasTicketEditorBridge } from '../useCanvasTicketEditorBridge';
+import { CanvasTicketCreationFlow } from '../CanvasTicketCreationFlow/CanvasTicketCreationFlow';
 
 const DEFAULT_CANVAS_PLACEHOLDER = "Write something, or press '/' for commands";
 const RECORDING_SUMMARY_EDITED_TEXT_COLOR = 'recording-summary-edited';
@@ -564,6 +566,18 @@ export const CollaborativeCanvasEditor = forwardRef<
       onOpenCommentCountChange,
       ready: isEditorReady,
     });
+    const {
+      activeTicketAnchor,
+      isTicketChannelArchived,
+      openTicketForCurrentSelection,
+      closeTicketModal,
+      handleTicketCreated,
+    } = useCanvasTicketEditorBridge({
+      channelId,
+      containerRef,
+      getEditor: getCanvasCommentEditor,
+      ready: isEditorReady,
+    });
 
     // Expose presentation and comment drawer methods via ref
     useImperativeHandle(
@@ -676,8 +690,18 @@ export const CollaborativeCanvasEditor = forwardRef<
           ...(canvasId && { canvasId }),
           ...(title && { canvasTitle: title }),
           canComment: editable && !isReadOnly,
+          canCreateTicket: editable && !isReadOnly && !isTicketChannelArchived,
+          onCreateTicket: openTicketForCurrentSelection,
         }),
-      [canvasId, editable, isReadOnly, openCommentsForCurrentBlock, title],
+      [
+        canvasId,
+        editable,
+        isReadOnly,
+        isTicketChannelArchived,
+        openCommentsForCurrentBlock,
+        openTicketForCurrentSelection,
+        title,
+      ],
     );
 
     useEffect((): (() => void) | void => {
@@ -834,6 +858,13 @@ export const CollaborativeCanvasEditor = forwardRef<
             />
           )}
         </div>
+
+        <CanvasTicketCreationFlow
+          anchor={activeTicketAnchor}
+          channelId={channelId}
+          onClose={closeTicketModal}
+          onTicketCreated={handleTicketCreated}
+        />
 
         {/* Presentation Modal */}
         {showPresentation && (

--- a/apps/dashboard/src/components/Canvas/canvasSchema.ts
+++ b/apps/dashboard/src/components/Canvas/canvasSchema.ts
@@ -11,6 +11,7 @@ import { mentionInlineContentSpec } from './CanvasMentionSpec';
 import { citationInlineContentSpec } from './CanvasCitationSpec';
 import { knownBlockTypesOf } from '../../utils/canvasUtils';
 import { canvasCommentThreadStyleSpec } from './CanvasCommentStyleSpec/CanvasCommentStyleSpec';
+import { canvasTicketStyleSpec } from './CanvasTicketStyleSpec/CanvasTicketStyleSpec';
 import { canvasCodeBlockSpec } from './CanvasCodeBlockSpec';
 import { CANVAS_EMBED_TYPE, canvasEmbedSpec } from './CanvasEmbedSpec';
 import { canvasFileBlockSpec } from './CanvasFileBlockSpec';
@@ -41,6 +42,7 @@ function createCanvasSchema() {
     },
     styleSpecs: {
       canvasCommentThread: canvasCommentThreadStyleSpec,
+      canvasTicket: canvasTicketStyleSpec,
     },
   });
 }

--- a/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
@@ -1,0 +1,237 @@
+import type {
+  BlockNoteEditor,
+  BlockSchema,
+  InlineContentSchema,
+  StyleSchema,
+} from '@blocknote/core';
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { useChannel } from '../../hooks/useChannels';
+import { useRouteContext } from '../../hooks/useRouteContext';
+import { standaloneNavigate } from '../../utils/electronApp';
+import { CANVAS_TICKET_SELECTOR } from './CanvasTicketStyleSpec/CanvasTicketStyleSpec';
+
+type CanvasEditorLike = BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>;
+
+export interface CanvasTicketAnchor {
+  blockId: string;
+  anchorText: string;
+  blockText: string;
+  selectionFrom: number;
+  selectionTo: number;
+}
+
+interface UseCanvasTicketEditorBridgeOptions {
+  channelId?: string | undefined;
+  containerRef: RefObject<HTMLElement | null>;
+  getEditor: () => CanvasEditorLike | null;
+  ready?: boolean;
+}
+
+interface UseCanvasTicketEditorBridgeResult {
+  activeTicketAnchor: CanvasTicketAnchor | null;
+  isTicketChannelArchived: boolean;
+  openTicketForCurrentSelection: () => void;
+  closeTicketModal: () => void;
+  handleTicketCreated: (ticket: { id: string }) => void;
+}
+
+interface TiptapEditorLike {
+  state: {
+    selection: {
+      from: number;
+      to: number;
+      empty?: boolean;
+      $from: { parent: { textContent: string } };
+    };
+    doc: {
+      textBetween: (from: number, to: number, blockSeparator?: string) => string;
+      nodesBetween: (
+        from: number,
+        to: number,
+        callback: (node: { marks?: Array<{ type: { name: string } }> }) => void,
+      ) => void;
+    };
+  };
+  commands: {
+    setTextSelection: (range: { from: number; to: number }) => boolean;
+  };
+}
+
+const getTiptapEditor = (editor: CanvasEditorLike): TiptapEditorLike | null =>
+  ((editor as unknown as { _tiptapEditor?: unknown })._tiptapEditor as
+    | TiptapEditorLike
+    | undefined) ?? null;
+
+const rangeHasTicketStyle = (editor: TiptapEditorLike, from: number, to: number): boolean => {
+  let hasTicketStyle = false;
+  editor.state.doc.nodesBetween(from, to, node => {
+    if (node.marks?.some(mark => mark.type.name === 'canvasTicket')) {
+      hasTicketStyle = true;
+    }
+  });
+  return hasTicketStyle;
+};
+
+export function useCanvasTicketEditorBridge({
+  channelId,
+  containerRef,
+  getEditor,
+  ready = true,
+}: UseCanvasTicketEditorBridgeOptions): UseCanvasTicketEditorBridgeResult {
+  const navigate = useNavigate();
+  const { baseRoute } = useRouteContext();
+  const channel = useChannel(channelId ?? '');
+  const [activeTicketAnchor, setActiveTicketAnchor] = useState<CanvasTicketAnchor | null>(null);
+
+  useEffect(() => {
+    setActiveTicketAnchor(null);
+  }, [channelId]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const getTicketAnchor = (target: EventTarget | null): HTMLElement | null => {
+      if (!(target instanceof Element)) return null;
+      const anchor = target.closest<HTMLElement>(CANVAS_TICKET_SELECTOR);
+      if (!anchor || !container.contains(anchor)) return null;
+      return anchor;
+    };
+
+    const openTicket = (anchor: HTMLElement): void => {
+      const ticketId = anchor.dataset['canvasTicketId'];
+      const ticketChannelId = anchor.dataset['canvasTicketChannelId'];
+      const conversationId = anchor.dataset['canvasTicketConversationId'];
+      if (!ticketId || !ticketChannelId) {
+        toast.error('Ticket details are still loading. Please try again.');
+        return;
+      }
+
+      const searchParams = new URLSearchParams({
+        tab: 'tickets',
+        ticketId,
+        ...(conversationId ? { conversationId } : {}),
+      });
+      standaloneNavigate(
+        navigate,
+        `${baseRoute}/${encodeURIComponent(ticketChannelId)}?${searchParams.toString()}`,
+      );
+    };
+
+    const handleClick = (event: MouseEvent): void => {
+      const anchor = getTicketAnchor(event.target);
+      if (!anchor) return;
+      event.preventDefault();
+      event.stopPropagation();
+      openTicket(anchor);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      const anchor = getTicketAnchor(event.target);
+      if (!anchor) return;
+      event.preventDefault();
+      event.stopPropagation();
+      openTicket(anchor);
+    };
+
+    container.addEventListener('click', handleClick);
+    container.addEventListener('keydown', handleKeyDown);
+    return (): void => {
+      container.removeEventListener('click', handleClick);
+      container.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [baseRoute, containerRef, navigate]);
+
+  const openTicketForCurrentSelection = useCallback((): void => {
+    if (!ready) return;
+    if (channel?.isArchived) {
+      toast.error('Tickets cannot be created in an archived channel');
+      return;
+    }
+
+    const editor = getEditor();
+    if (!editor) return;
+
+    try {
+      const blockId = editor.getTextCursorPosition().block?.id;
+      const tiptapEditor = getTiptapEditor(editor);
+      if (!blockId || !tiptapEditor || tiptapEditor.state.selection.empty) {
+        toast.error('Select text to create a ticket');
+        return;
+      }
+
+      const { from, to } = tiptapEditor.state.selection;
+      const anchorText = tiptapEditor.state.doc.textBetween(from, to, ' ').trim();
+      if (!anchorText) {
+        toast.error('Select text to create a ticket');
+        return;
+      }
+      if (rangeHasTicketStyle(tiptapEditor, from, to)) {
+        toast.error('Selected text is already linked to a ticket');
+        return;
+      }
+      const blockText = tiptapEditor.state.selection.$from.parent.textContent.trim();
+
+      setActiveTicketAnchor({
+        blockId,
+        anchorText,
+        blockText: blockText || anchorText,
+        selectionFrom: from,
+        selectionTo: to,
+      });
+    } catch {
+      toast.error('Unable to use the selected canvas text');
+    }
+  }, [channel?.isArchived, getEditor, ready]);
+
+  const closeTicketModal = useCallback((): void => {
+    setActiveTicketAnchor(null);
+  }, []);
+
+  const handleTicketCreated = useCallback(
+    (ticket: { id: string }): void => {
+      const anchor = activeTicketAnchor;
+      const editor = getEditor();
+      const tiptapEditor = editor ? getTiptapEditor(editor) : null;
+      let styleApplied = false;
+
+      if (anchor && editor && tiptapEditor && !tiptapEditor.state.selection.empty) {
+        try {
+          const { from, to } = tiptapEditor.state.selection;
+          const currentBlockId = editor.getTextCursorPosition().block?.id;
+          const currentText = tiptapEditor.state.doc.textBetween(from, to, ' ').trim();
+
+          if (
+            currentBlockId === anchor.blockId &&
+            currentText === anchor.anchorText &&
+            !rangeHasTicketStyle(tiptapEditor, from, to)
+          ) {
+            editor.addStyles({ canvasTicket: ticket.id } as never);
+            tiptapEditor.commands.setTextSelection({ from: to, to });
+            styleApplied = true;
+          }
+        } catch {
+          styleApplied = false;
+        }
+      }
+
+      setActiveTicketAnchor(null);
+      if (!styleApplied) {
+        toast.warning('Ticket created, but the selected canvas text changed and was not linked');
+      }
+    },
+    [activeTicketAnchor, getEditor],
+  );
+
+  return {
+    activeTicketAnchor,
+    isTicketChannelArchived: channel?.isArchived === true,
+    openTicketForCurrentSelection,
+    closeTicketModal,
+    handleTicketCreated,
+  };
+}

--- a/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
+++ b/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
@@ -131,6 +131,9 @@ interface CreateTicketModalProps {
   sourceConversation?: ConversationWithTicket | undefined;
   isFromSubTicket?: boolean;
   isFromAI?: boolean;
+  allowChannelSelection?: boolean;
+  useLocalAttachments?: boolean;
+  focusDescriptionOnOpen?: boolean;
   ticketSequence?: { current: number; total: number };
   parentTicketId?: string;
   onBeforeCreate?: (description: string, files: File[]) => Promise<void>;
@@ -213,6 +216,9 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
   initialTags = EMPTY_TAGS,
   isFromSubTicket = false,
   isFromAI = false,
+  allowChannelSelection = false,
+  useLocalAttachments = false,
+  focusDescriptionOnOpen = false,
   ticketSequence,
   parentTicketId,
   sourceConversation,
@@ -247,6 +253,8 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
 
   // Determine if we're creating from conversation or tickets tab
   const isFromTicketsTab = tab === 'tickets' && !sourceConversation;
+  const canSelectChannel = isFromSubTicket || isFromAI || allowChannelSelection;
+  const usesLocalAttachments = isFromTicketsTab || useLocalAttachments;
   // Fetch existing CHAT attachments from INITIAL MESSAGE ONLY using Zero
 
   const messageIdForQuery =
@@ -317,7 +325,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
         return;
       }
 
-      if (!isFromTicketsTab) {
+      if (!usesLocalAttachments) {
         // Load from DraftProvider (DB-backed)
         try {
           const map = getDroppedFilesForEntity(
@@ -345,12 +353,12 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
     };
 
     void loadAttachments();
-  }, [isOpen, isFromTicketsTab, sourceConversation, channelId, getDroppedFilesForEntity]);
+  }, [isOpen, usesLocalAttachments, sourceConversation, channelId, getDroppedFilesForEntity]);
 
   // Unified add file handler
   const addFile = useCallback(
     async (file: File): Promise<void> => {
-      if (!isFromTicketsTab) {
+      if (!usesLocalAttachments) {
         // Use DraftProvider (DB-backed)
         await providerAddDroppedFiles(file, channelId, sourceConversation?.conversationId);
       } else {
@@ -358,13 +366,13 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
         setTicketLocalFiles(prev => [...prev, { id: newLocalFileId(), file }]);
       }
     },
-    [isFromTicketsTab, providerAddDroppedFiles, channelId, sourceConversation],
+    [usesLocalAttachments, providerAddDroppedFiles, channelId, sourceConversation],
   );
 
   // Unified remove file handler
   const removeFile = useCallback(
     async (attachmentId: string, _file: File): Promise<void> => {
-      if (!isFromTicketsTab) {
+      if (!usesLocalAttachments) {
         // Use DraftProvider
         await providerRemoveDroppedFile(attachmentId);
       } else {
@@ -372,19 +380,24 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
         setTicketLocalFiles(prev => prev.filter(entry => entry.id !== attachmentId));
       }
     },
-    [isFromTicketsTab, providerRemoveDroppedFile],
+    [usesLocalAttachments, providerRemoveDroppedFile],
   );
 
   // Clear all files handler
   const clearFiles = useCallback(async () => {
-    if (!isFromTicketsTab) {
+    if (!usesLocalAttachments) {
       await providerClearDroppedFiles(channelId, sourceConversation?.conversationId ?? null);
     } else {
       setTicketLocalFiles([]);
     }
-  }, [isFromTicketsTab, providerClearDroppedFiles, channelId, sourceConversation]);
+  }, [usesLocalAttachments, providerClearDroppedFiles, channelId, sourceConversation]);
 
-  const channels = useAllVisibleChannels().filter(c => c.scopeType === ChannelScopeType.DEFAULT);
+  const channels = useAllVisibleChannels().filter(
+    channel =>
+      channel.scopeType === ChannelScopeType.DEFAULT &&
+      !channel.isArchived &&
+      Boolean(channel.projectId),
+  );
 
   // Track if title has been auto-generated for this modal session
   const [hasTitleBeenGenerated, setHasTitleBeenGenerated] = useState(false);
@@ -464,11 +477,8 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
 
   // Fetch boards for the selected channel's project (or default projectId)
   const selectedChannelProjectId =
-    (isFromSubTicket || isFromAI) && selectedChannel?.projectId
-      ? selectedChannel.projectId
-      : projectId;
-  const effectiveChannelId =
-    isFromSubTicket || isFromAI ? (selectedChannelId ?? channelId) : channelId;
+    canSelectChannel && selectedChannel?.projectId ? selectedChannel.projectId : projectId;
+  const effectiveChannelId = canSelectChannel ? (selectedChannelId ?? channelId) : channelId;
   const [channelBoardMappings, mappingDetails] = useCachedQuery(
     queries.boardsByChannel({ channelId: effectiveChannelId }),
     { enabled: !!effectiveChannelId },
@@ -761,7 +771,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
     }
 
     // Add newly uploaded files (from DraftProvider or local state)
-    if (!isFromTicketsTab) {
+    if (!usesLocalAttachments) {
       // From DraftProvider (DB)
       const draftFiles = Array.from(attachmentsMap.entries()).map(([attachmentId, file]) => ({
         attachmentId,
@@ -793,7 +803,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
     attachmentsMap,
     sourceConversation,
     excludedChatAttachmentIds,
-    isFromTicketsTab,
+    usesLocalAttachments,
     ticketLocalFiles,
   ]);
 
@@ -1115,6 +1125,9 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
       // Validate mandatory board-configured fields
       const mandatoryFieldErrors: string[] = [];
 
+      if (canSelectChannel && !formData.channelId.trim()) {
+        mandatoryFieldErrors.push('Channel is required');
+      }
       if (showUserGroupsOnly && mandatoryUserGroupsOnly && !formData.assignee?.value) {
         mandatoryFieldErrors.push('User Group is required');
       }
@@ -1201,10 +1214,10 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
       }
 
       // Collect draft attachment IDs from DraftProvider (for conversation case)
-      const draftAttachmentIds = !isFromTicketsTab ? Array.from(attachmentsMap.keys()) : [];
+      const draftAttachmentIds = !usesLocalAttachments ? Array.from(attachmentsMap.keys()) : [];
 
       // Get files to send - combine both sources
-      const draftFiles = !isFromTicketsTab
+      const draftFiles = !usesLocalAttachments
         ? Array.from(attachmentsMap.values()).filter((f): f is File => f instanceof File)
         : ticketLocalFiles.map(entry => entry.file);
 
@@ -1218,10 +1231,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
         formDataPayload.append('description', formData.description.trim());
         formDataPayload.append('boardId', formData.boardId);
         // For subtickets or AI-initiated tickets, use the selected channel from form; otherwise use the prop
-        formDataPayload.append(
-          'channelId',
-          isFromSubTicket || isFromAI ? formData.channelId : channelId,
-        );
+        formDataPayload.append('channelId', canSelectChannel ? formData.channelId : channelId);
         if (selectedBoard?.projectId) {
           formDataPayload.append('projectId', selectedBoard.projectId);
         }
@@ -1323,7 +1333,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
           userGroupId: userGroupId || undefined,
           boardId: formData.boardId,
           // For subtickets or AI-initiated tickets, use the selected channel from form; otherwise use the prop
-          channelId: isFromSubTicket || isFromAI ? formData.channelId : channelId,
+          channelId: canSelectChannel ? formData.channelId : channelId,
           fromTicketsTab: isFromTicketsTab,
           ...(selectedBoard?.projectId && { projectId: selectedBoard.projectId }),
           ticketType: formData.ticketType,
@@ -1388,7 +1398,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
   };
 
   const handleClose = (): void => {
-    if (isFromTicketsTab) {
+    if (usesLocalAttachments) {
       void clearFiles();
     }
     setExcludedChatAttachmentIds(new Set());
@@ -1420,7 +1430,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
       }
     }
 
-    if (isFromTicketsTab) {
+    if (usesLocalAttachments) {
       if (ticketLocalFiles.length > 0) return true;
     } else if (attachmentsMap.size > (baselineAttachmentCountRef.current ?? 0)) {
       return true;
@@ -1444,7 +1454,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
     handleClose();
   };
 
-  const canPopOut = !standalone && !ticketSequence;
+  const canPopOut = !standalone && !ticketSequence && !allowChannelSelection;
 
   const handlePopOut = (): void => {
     const popoutId = uuidv4();
@@ -2043,8 +2053,8 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
 
         {/* Channel and Board Selection */}
         <div className={cn('flex items-center gap-2.5 pb-2', subTickets.length > 0 && 'pt-4')}>
-          {/* Channel Selection - Only for SubTicket creation */}
-          {(isFromSubTicket || isFromAI) && (
+          {/* Optional channel selection for subtickets, AI, and context-free entry points. */}
+          {canSelectChannel && (
             <form.Field
               name='channelId'
               validators={{
@@ -2059,9 +2069,10 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
                   variant='inline'
                   options={channelOptions}
                   selectedValue={field.state.value || ''}
-                  onSelect={(value: string | null) =>
-                    field.handleChange(value as CreateTicketFormData['channelId'])
-                  }
+                  onSelect={(value: string | null) => {
+                    field.handleChange(value as CreateTicketFormData['channelId']);
+                    form.setFieldValue('boardId', '');
+                  }}
                   searchPlaceholder='channel'
                   placeholder='channel'
                   inputIcon={<Hash className='size-3.5' strokeWidth={2.33} />}
@@ -2927,7 +2938,9 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
       }}
       title='Create Ticket'
       description='Create and edit ticket details before submitting.'
-      {...(!isMobile ? { focusRef: titleInputRef } : {})}
+      {...(!isMobile
+        ? { focusRef: focusDescriptionOnOpen ? descriptionTextareaRef : titleInputRef }
+        : {})}
       data-testid='create-ticket-modal'
       className={cn(
         'w-full max-w-screen-md max-h-1/2 rounded-xl border border-border',

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2530,8 +2530,8 @@ html .bn-code-block-source-popup-ok-button:hover {
    BlockNote menus in chat, previews, and other editor surfaces keep their own
    layout. */
 .canvas-formatting-menu.bn-formatting-toolbar {
-  width: 200px;
-  min-width: 200px;
+  width: 270px;
+  min-width: 270px;
   flex-direction: column;
   align-items: stretch;
   gap: 0;
@@ -2654,6 +2654,11 @@ html .bn-code-block-source-popup-ok-button:hover {
   border-radius: 8px 0 0 8px;
 }
 
+.canvas-formatting-menu__attached-button--middle {
+  border-right-width: 0;
+  border-radius: 0;
+}
+
 .canvas-formatting-menu__attached-button--right {
   border-radius: 0 8px 8px 0;
 }
@@ -2666,6 +2671,153 @@ html .bn-code-block-source-popup-ok-button:hover {
 .canvas-formatting-menu__attached-button svg {
   width: 14px;
   height: 14px;
+}
+
+.canvas-ticket-anchor[data-canvas-ticket-id] {
+  display: inline-flex;
+  width: 490px;
+  max-width: 100%;
+  min-height: 30px;
+  box-sizing: border-box;
+  align-items: center;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  background: hsl(var(--card));
+  box-shadow: 0 1px 2px hsl(var(--foreground) / 0.05);
+  color: inherit;
+  cursor: pointer;
+  padding: 2px 4px 2px 9px;
+  line-height: 1.25;
+  vertical-align: middle;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.canvas-ticket-anchor[data-canvas-ticket-id]:hover,
+.canvas-ticket-anchor[data-canvas-ticket-id]:focus-visible {
+  border-color: hsl(var(--border));
+  background: hsl(var(--card));
+  box-shadow: 0 1px 2px hsl(var(--foreground) / 0.05);
+  outline: none;
+}
+
+.canvas-ticket-anchor__id {
+  flex: 0 0 auto;
+  margin-right: 10px;
+  color: hsl(var(--muted-foreground));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.76em;
+  font-weight: 500;
+  letter-spacing: 0.015em;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.canvas-ticket-anchor__text {
+  overflow: hidden;
+  min-width: 0;
+  flex: 1 1 auto;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.canvas-ticket-anchor__status,
+.canvas-ticket-anchor__assignee,
+.canvas-ticket-anchor__unavailable {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.canvas-ticket-anchor__status {
+  gap: 4px;
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding-left: 24px;
+  color: hsl(var(--primary));
+  font-size: 0.82em;
+  font-weight: 500;
+}
+
+.canvas-ticket-anchor__status svg {
+  width: 13px;
+  height: 13px;
+}
+
+.canvas-ticket-anchor__assignee {
+  flex: 0 0 auto;
+  margin-left: 10px;
+}
+
+.canvas-ticket-anchor__avatar {
+  width: 24px;
+  height: 24px;
+}
+
+.canvas-ticket-anchor__avatar [data-slot="avatar"] {
+  width: 100%;
+  height: 100%;
+}
+
+.canvas-ticket-avatar,
+.canvas-ticket-avatar [data-slot="avatar"],
+.canvas-ticket-avatar [data-slot="avatar-image"],
+.canvas-ticket-avatar [data-slot="avatar-fallback"] {
+  border-radius: 9999px;
+}
+
+.canvas-ticket-avatar [data-slot="avatar"],
+.canvas-ticket-avatar [data-slot="avatar-fallback"] {
+  background-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+
+.canvas-ticket-anchor__assignee--unassigned {
+  width: 24px;
+  height: 24px;
+  justify-content: center;
+  border: 1px dashed hsl(var(--muted-foreground) / 0.45);
+  border-radius: 7px;
+  color: hsl(var(--muted-foreground));
+}
+
+.canvas-ticket-anchor__assignee--unassigned svg {
+  width: 13px;
+  height: 13px;
+}
+
+.canvas-ticket-anchor__unavailable {
+  margin-left: 8px;
+  color: hsl(var(--destructive));
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.canvas-ticket-anchor[data-canvas-ticket-status="COMPLETED"] .canvas-ticket-anchor__status {
+  color: var(--status-success);
+}
+
+.canvas-ticket-anchor[data-canvas-ticket-status="CANCELLED"] .canvas-ticket-anchor__status {
+  color: hsl(var(--muted-foreground));
+}
+
+[data-theme="midnight"] .canvas-ticket-anchor[data-canvas-ticket-id] {
+  background: hsl(var(--card));
+  border-color: hsl(var(--border));
+}
+
+@media (max-width: 640px) {
+  .canvas-ticket-anchor__status,
+  .canvas-ticket-anchor__assignee {
+    display: none;
+  }
 }
 
 .canvas-inline-comment-composer button[aria-label="Mention channel"] {

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -1975,6 +1975,38 @@ export const router = createBrowserRouter(
           ),
         },
         {
+          path: '/newWindow/chat/canvas',
+          element: (
+            <EncryptionBootstrapProvider>
+              <ZeroProvider>
+                <ZeroFallbackProvider>
+                  <InitialStateLoader>
+                    <EditProvider>
+                      <div className='h-full bg-background'>
+                        <CanvasPanel />
+                      </div>
+                      <AttachmentGalleryModal />
+                      <AttachmentCitationPreview />
+                      <ThreadCitationModal />
+                      <TranscriptCitationModal />
+                    </EditProvider>
+                  </InitialStateLoader>
+                </ZeroFallbackProvider>
+              </ZeroProvider>
+            </EncryptionBootstrapProvider>
+          ),
+          children: [
+            {
+              index: true,
+              element: null,
+            },
+            {
+              path: ':canvasId',
+              element: <CanvasScreen />,
+            },
+          ],
+        },
+        {
           path: '/newWindow/create-ticket',
           element: (
             <ZeroProvider>


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard
POT : [POT](https://drive.google.com/file/d/1YR5bhRJB_gSCzdwj9YGu7LhgQ64i_4WZ/view?usp=sharing)
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
