### PR TITLE
fix: XYNE-61590 Added ticket creation flow in the canvas

### DIFF
--- a/apps/backend/src/utils/ysweetUtils.ts
+++ b/apps/backend/src/utils/ysweetUtils.ts
@@ -49,6 +49,39 @@ const canvasCommentThreadStyleSpec = createStyleSpec(
   },
 );
 
+const canvasTicketStyleSpec = createStyleSpec(
+  {
+    type: 'canvasTicket',
+    propSchema: 'string',
+  },
+  {
+    render: () => {
+      const doc = (globalThis as unknown as {
+        document?: { createElement: (tagName: string) => unknown };
+      }).document;
+      const span = doc?.createElement('span') ?? {};
+      return {
+        dom: span,
+        contentDOM: span,
+      } as never;
+    },
+    parse: element =>
+      (element as unknown as { getAttribute?: (name: string) => string | null }).getAttribute?.(
+        'data-canvas-ticket-id',
+      ) ?? undefined,
+    runsBefore: [
+      'bold',
+      'italic',
+      'underline',
+      'strike',
+      'code',
+      'textColor',
+      'backgroundColor',
+      'canvasCommentThread',
+    ],
+  },
+);
+
 function createServerSchema() {
   return BlockNoteSchema.create({
     // The canvas schema's own blocks, for the same reason as the inline specs
@@ -72,6 +105,7 @@ function createServerSchema() {
     styleSpecs: {
       ...defaultStyleSpecs,
       canvasCommentThread: canvasCommentThreadStyleSpec,
+      canvasTicket: canvasTicketStyleSpec,
     },
   });
 }

--- a/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasEditor/CanvasEditor.tsx
@@ -86,6 +86,8 @@ import { CanvasInlineCommentThread } from '../CanvasInlineCommentThread/CanvasIn
 import { createCanvasFormattingToolbar } from '../CanvasFormattingToolbar/CanvasFormattingToolbar';
 import { CanvasWidthHandles } from '../CanvasWidthHandles';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
+import { useCanvasTicketEditorBridge } from '../useCanvasTicketEditorBridge';
+import { CanvasTicketCreationFlow } from '../CanvasTicketCreationFlow/CanvasTicketCreationFlow';
 
 const canvasDictionary = {
   ...en,
@@ -418,6 +420,17 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
       initialCommentThreadId,
       onOpenCommentCountChange,
     });
+    const {
+      activeTicketAnchor,
+      isTicketChannelArchived,
+      openTicketForCurrentSelection,
+      closeTicketModal,
+      handleTicketCreated,
+    } = useCanvasTicketEditorBridge({
+      channelId,
+      containerRef,
+      getEditor: getCanvasCommentEditor,
+    });
 
     // Expose presentation and comment drawer methods via ref
     useImperativeHandle(
@@ -549,8 +562,17 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
           ...(canvasId && { canvasId }),
           ...(_canvasTitle && { canvasTitle: _canvasTitle }),
           canComment: editable,
+          canCreateTicket: editable && !isTicketChannelArchived,
+          onCreateTicket: openTicketForCurrentSelection,
         }),
-      [_canvasTitle, canvasId, editable, openCommentsForCurrentBlock],
+      [
+        _canvasTitle,
+        canvasId,
+        editable,
+        isTicketChannelArchived,
+        openCommentsForCurrentBlock,
+        openTicketForCurrentSelection,
+      ],
     );
 
     const handleSave = useCallback((): void => {
@@ -650,6 +672,13 @@ export const CanvasEditor = forwardRef<CanvasEditorRef, CanvasEditorProps>(
             />
           )}
         </div>
+
+        <CanvasTicketCreationFlow
+          anchor={activeTicketAnchor}
+          channelId={channelId}
+          onClose={closeTicketModal}
+          onTicketCreated={handleTicketCreated}
+        />
 
         {/* Presentation Modal */}
         {showPresentation && (

--- a/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasFormattingToolbar/CanvasFormattingToolbar.tsx
@@ -9,7 +9,7 @@ import {
   useComponentsContext,
 } from '@blocknote/react';
 import { TextSelection, type Selection } from '@tiptap/pm/state';
-import { MessageSquarePlus } from 'lucide-react';
+import { MessageSquarePlus, Ticket } from 'lucide-react';
 import type { FC, ReactElement } from 'react';
 import { useCallback, useEffect, useRef } from 'react';
 import { xyneAIActor, type SelectionInfo } from '../../../machines/xyneAIMachine';
@@ -33,6 +33,8 @@ type CanvasFormattingToolbarOptions = {
    * is what Ask AI is being asked about.
    */
   selectionText?: string;
+  canCreateTicket?: boolean;
+  onCreateTicket?: (selectedText: string) => void;
 };
 
 export function CanvasToolbarAttachedActions({
@@ -41,6 +43,8 @@ export function CanvasToolbarAttachedActions({
   canvasTitle,
   canComment = true,
   selectionText,
+  canCreateTicket = false,
+  onCreateTicket,
 }: {
   onAddComment: () => void;
 } & CanvasFormattingToolbarOptions): ReactElement {
@@ -131,12 +135,20 @@ export function CanvasToolbarAttachedActions({
     window.getSelection()?.removeAllRanges();
   }, [selectionText, readSelection, canvasId, canvasTitle]);
 
+  const handleCreateTicket = useCallback((): void => {
+    const selectedText = window.getSelection()?.toString().trim() || selectedTextRef.current;
+    if (!selectedText) return;
+    onCreateTicket?.(selectedText);
+  }, [onCreateTicket]);
+
+  const hasSecondaryAction = canComment || canCreateTicket;
+
   return (
     <div className='canvas-formatting-menu__attached-actions'>
       <button
         type='button'
         className={`canvas-formatting-menu__attached-button canvas-formatting-menu__attached-button--left ${
-          canComment ? '' : 'canvas-formatting-menu__attached-button--single'
+          hasSecondaryAction ? '' : 'canvas-formatting-menu__attached-button--single'
         }`}
         onMouseDown={event => event.preventDefault()}
         onClick={handleAskAI}
@@ -151,7 +163,11 @@ export function CanvasToolbarAttachedActions({
       {canComment && (
         <button
           type='button'
-          className='canvas-formatting-menu__attached-button canvas-formatting-menu__attached-button--right'
+          className={`canvas-formatting-menu__attached-button ${
+            canCreateTicket
+              ? 'canvas-formatting-menu__attached-button--middle'
+              : 'canvas-formatting-menu__attached-button--right'
+          }`}
           onMouseDown={event => event.preventDefault()}
           onClick={onAddComment}
           data-track-category='CANVAS'
@@ -160,6 +176,20 @@ export function CanvasToolbarAttachedActions({
         >
           <MessageSquarePlus className='size-3.5' aria-hidden='true' />
           <span>Comment</span>
+        </button>
+      )}
+      {canCreateTicket && (
+        <button
+          type='button'
+          className='canvas-formatting-menu__attached-button canvas-formatting-menu__attached-button--right'
+          onMouseDown={event => event.preventDefault()}
+          onClick={handleCreateTicket}
+          data-track-category='CANVAS'
+          data-track-name='Selection_Create_Ticket'
+          data-track-metadata={JSON.stringify({ canvasId })}
+        >
+          <Ticket className='size-3.5' aria-hidden='true' />
+          <span>Ticket</span>
         </button>
       )}
     </div>
@@ -175,13 +205,15 @@ export const createCanvasFormattingToolbar = (
   }: FormattingToolbarProps): ReactElement | null => {
     const Components = useComponentsContext();
     const canComment = options.canComment ?? true;
+    const canCreateTicket = options.canCreateTicket ?? false;
+    const hasEditorActions = canComment || canCreateTicket;
 
     if (!Components) return null;
 
     return (
       <Components.FormattingToolbar.Root
         className={`bn-toolbar bn-formatting-toolbar canvas-formatting-menu ${
-          canComment ? '' : 'canvas-formatting-menu--ask-only'
+          hasEditorActions ? '' : 'canvas-formatting-menu--ask-only'
         }`}
       >
         {canComment && (

--- a/apps/dashboard/src/components/Canvas/CanvasList/CanvasList.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasList/CanvasList.tsx
@@ -69,6 +69,7 @@ import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { getAvatarColorClassNames } from '../../ui/Avatar/Avatar';
 import { useDebouncedValue } from '../../../hooks/useDebouncedValue';
 import { canvasMatchesSharedByFilter } from '../canvasListFilters';
+import { isElectronApp, toStandalonePath } from '../../../utils/electronApp';
 
 type FilterTab = 'all' | 'created_by_me' | 'shared';
 type CanvasCursor = { id: string; updatedAt: number };
@@ -1603,7 +1604,8 @@ export const CanvasList: React.FC<CanvasListProps> = ({
   );
 
   const handleOpenCanvasInNewTab = useCallback((canvas: Canvas): void => {
-    window.open(`/chat/canvas/${canvas.id}`, '_blank');
+    const canvasPath = `/chat/canvas/${canvas.id}`;
+    window.open(isElectronApp() ? toStandalonePath(canvasPath) : canvasPath, '_blank');
   }, []);
 
   const renderCanvasItem = (canvas: Canvas): React.ReactNode => {

--- a/apps/dashboard/src/components/Canvas/CanvasPanel/CanvasPanel.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasPanel/CanvasPanel.tsx
@@ -42,7 +42,7 @@ import {
 } from './canvasSidebarWidth';
 import AppNavigator from '../../AppNavigator/AppNavigator';
 import { cn } from '../../../utils/classNames';
-import { APP_NO_DRAG_STYLE } from '../../../utils/electronApp';
+import { APP_NO_DRAG_STYLE, standaloneNavigate } from '../../../utils/electronApp';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { usePath } from '../../../hooks/usePath';
 import { useDebouncedValue } from '../../../hooks/useDebouncedValue';
@@ -193,15 +193,12 @@ const CanvasPanel = (): ReactElement => {
         return;
       }
 
-      const isCmdClick = 'metaKey' in e && (e.metaKey || e.ctrlKey);
       // Navigate to the canvas in the right panel
       const canvasUrl = `/chat/canvas/${canvas.id}`;
-      // Only open in new tab on desktop when Cmd/Ctrl+Click is pressed
-      if (!isMobile && isCmdClick) {
-        window.open(canvasUrl, '_blank');
-      } else {
-        void navigate(canvasUrl, { state: { canvas } });
-      }
+      standaloneNavigate(navigate, canvasUrl, {
+        event: !isMobile && 'button' in e ? e : undefined,
+        state: { canvas },
+      });
     },
     [navigate, isMobile],
   );

--- a/apps/dashboard/src/components/Canvas/CanvasTicketCreationFlow/CanvasTicketCreationFlow.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTicketCreationFlow/CanvasTicketCreationFlow.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from 'react';
+
+import { useChannel } from '../../../hooks/useChannels';
+import { CreateTicketModal } from '../../Tickets/CreateTicketModal/CreateTicketModal';
+import type { CanvasTicketAnchor } from '../useCanvasTicketEditorBridge';
+
+interface CreatedTicket {
+  id: string;
+  conversationId?: string;
+  xyneId?: string;
+  workflowType?: string;
+}
+
+interface CanvasTicketCreationFlowProps {
+  anchor: CanvasTicketAnchor | null;
+  channelId?: string | undefined;
+  onClose: () => void;
+  onTicketCreated: (ticket: CreatedTicket) => void;
+}
+
+export function CanvasTicketCreationFlow({
+  anchor,
+  channelId,
+  onClose,
+  onTicketCreated,
+}: CanvasTicketCreationFlowProps): ReactElement | null {
+  const effectiveChannelId = channelId ?? '';
+  const effectiveChannel = useChannel(effectiveChannelId);
+
+  if (!anchor) return null;
+
+  return (
+    <CreateTicketModal
+      isOpen={true}
+      onClose={onClose}
+      channelId={effectiveChannelId}
+      {...(effectiveChannel?.projectId ? { projectId: effectiveChannel.projectId } : {})}
+      allowChannelSelection={!channelId}
+      useLocalAttachments={true}
+      initialDescription={anchor.blockText}
+      onTicketCreated={onTicketCreated}
+    />
+  );
+}

--- a/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
@@ -33,7 +33,7 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
   const assignedUser = useUser(ticket?.assignedTo ?? '');
   const anchorRef = useRef<HTMLSpanElement | null>(null);
   const contentElementRef = useRef<HTMLElement | null>(null);
-  const [previewText, setPreviewText] = useState('');
+  const [sourceText, setSourceText] = useState('');
   const statusLabel = ticket?.stageName?.trim() || formatTicketStatus(ticket?.statusV2);
   const isUnavailable = ticketDetails.type === 'complete' && !ticket;
   const accessState = ticket ? 'available' : isUnavailable ? 'unavailable' : 'loading';
@@ -53,13 +53,12 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
     [contentRef],
   );
 
-  const handlePreviewOpenChange = useCallback(
-    (open: boolean): void => {
-      if (!open) return;
-      setPreviewText(contentElementRef.current?.textContent?.trim() || ticket?.title || 'Ticket');
-    },
-    [ticket?.title],
-  );
+  const handlePreviewOpenChange = useCallback((open: boolean): void => {
+    if (!open) return;
+    setSourceText(contentElementRef.current?.textContent?.trim() || '');
+  }, []);
+
+  const ticketDescription = ticket?.description?.trim() || sourceText;
 
   const trigger = (
     <span
@@ -86,7 +85,10 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
           {ticket.xyneId}
         </span>
       )}
-      <span ref={setContentElement} className='canvas-ticket-anchor__text' />
+      <span ref={setContentElement} className='canvas-ticket-anchor__source' aria-hidden='true' />
+      <span className='canvas-ticket-anchor__text' contentEditable={false}>
+        {ticket?.title || 'Ticket'}
+      </span>
       {ticket && (
         <span className='canvas-ticket-anchor__status' contentEditable={false}>
           <Clock3 aria-hidden='true' />
@@ -141,9 +143,16 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
           </span>
         </div>
 
-        <p className='m-0 whitespace-normal text-sm font-semibold leading-5 text-foreground'>
-          {previewText || ticket.title}
-        </p>
+        <div className='min-w-0 space-y-1.5'>
+          <p className='m-0 whitespace-normal text-sm font-semibold leading-5 text-foreground'>
+            {ticket.title}
+          </p>
+          {ticketDescription && (
+            <p className='m-0 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-muted-foreground'>
+              {ticketDescription}
+            </p>
+          )}
+        </div>
 
         <div className='flex min-w-0 items-center gap-4 text-xs text-muted-foreground'>
           <span className='flex min-w-0 items-center gap-1.5'>

--- a/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
@@ -70,13 +70,13 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
       data-canvas-ticket-access={accessState}
       className='canvas-ticket-anchor'
       role={isInteractive ? 'link' : undefined}
-      tabIndex={isInteractive ? 0 : -1}
+      tabIndex={0}
       aria-disabled={!isInteractive || undefined}
       aria-label={
-        isUnavailable
-          ? 'Ticket unavailable or you do not have access'
-          : ticket
-            ? `Open ${ticket.xyneId}: ${ticket.title}`
+        ticket
+          ? `Open ${ticket.xyneId}: ${ticket.title}`
+          : isUnavailable
+            ? 'Ticket unavailable or you do not have access'
             : 'Ticket details are loading'
       }
     >
@@ -87,7 +87,7 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
       )}
       <span ref={setContentElement} className='canvas-ticket-anchor__source' aria-hidden='true' />
       <span className='canvas-ticket-anchor__text' contentEditable={false}>
-        {ticket?.title || 'Ticket'}
+        {ticket?.title || (isUnavailable ? 'Ticket unavailable or no access' : 'Loading ticket…')}
       </span>
       {ticket && (
         <span className='canvas-ticket-anchor__status' contentEditable={false}>
@@ -113,15 +113,8 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
           )}
         </span>
       )}
-      {isUnavailable && (
-        <span className='canvas-ticket-anchor__unavailable' contentEditable={false}>
-          Ticket unavailable or no access
-        </span>
-      )}
     </span>
   );
-
-  if (!ticket) return trigger;
 
   return (
     <HoverCard
@@ -135,61 +128,71 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
       collisionPadding={12}
       className='w-80 rounded-xl p-3'
     >
-      <div className='flex min-w-0 flex-col gap-3' data-canvas-ticket-preview={ticketId}>
-        <div className='flex min-w-0 items-center gap-2 text-xs'>
-          <span className='font-medium text-primary'>{ticket.xyneId}</span>
-          <span className='max-w-32 truncate rounded-full bg-muted px-2 py-0.5 text-muted-foreground'>
-            {statusLabel}
-          </span>
-        </div>
+      {ticket ? (
+        <div className='flex min-w-0 flex-col gap-3' data-canvas-ticket-preview={ticketId}>
+          <div className='flex min-w-0 items-center gap-2 text-xs'>
+            <span className='font-medium text-primary'>{ticket.xyneId}</span>
+            <span className='max-w-32 truncate rounded-full bg-muted px-2 py-0.5 text-muted-foreground'>
+              {statusLabel}
+            </span>
+          </div>
 
-        <div className='min-w-0 space-y-1.5'>
-          <p className='m-0 whitespace-normal text-sm font-semibold leading-5 text-foreground'>
-            {ticket.title}
-          </p>
-          {ticketDescription && (
-            <p className='m-0 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-muted-foreground'>
-              {ticketDescription}
+          <div className='min-w-0 space-y-1.5'>
+            <p className='m-0 whitespace-normal text-sm font-semibold leading-5 text-foreground'>
+              {ticket.title}
+            </p>
+            {ticketDescription && (
+              <p className='m-0 max-h-32 overflow-y-auto whitespace-pre-wrap text-xs leading-5 text-muted-foreground'>
+                {ticketDescription}
+              </p>
+            )}
+          </div>
+
+          <div className='flex min-w-0 items-center gap-4 text-xs text-muted-foreground'>
+            <span className='flex min-w-0 items-center gap-1.5'>
+              {ticket.assignedTo ? (
+                <Avatar
+                  userId={ticket.assignedTo}
+                  size='xs'
+                  rounded={true}
+                  showActiveStatus={false}
+                  className='canvas-ticket-avatar'
+                />
+              ) : (
+                <CircleHelp className='size-4' aria-hidden='true' />
+              )}
+              <span className='max-w-24 truncate'>{assigneeLabel}</span>
+            </span>
+
+            <span className='flex min-w-0 items-center gap-1.5'>
+              <Flag className='size-3.5' aria-hidden='true' />
+              <span className='max-w-24 truncate'>{priorityLabel}</span>
+            </span>
+
+            <button
+              type='button'
+              className='ml-auto shrink-0 rounded-md border border-border bg-background px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent'
+              data-track-category='CANVAS'
+              data-track-name='OPEN_CANVAS_TICKET_PREVIEW'
+              onClick={event => {
+                event.preventDefault();
+                event.stopPropagation();
+                anchorRef.current?.click();
+              }}
+            >
+              Open
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className='flex min-w-0 flex-col gap-2' data-canvas-ticket-preview={ticketId}>
+          {sourceText && (
+            <p className='m-0 max-h-40 overflow-y-auto whitespace-pre-wrap text-sm leading-5 text-foreground'>
+              {sourceText}
             </p>
           )}
         </div>
-
-        <div className='flex min-w-0 items-center gap-4 text-xs text-muted-foreground'>
-          <span className='flex min-w-0 items-center gap-1.5'>
-            {ticket.assignedTo ? (
-              <Avatar
-                userId={ticket.assignedTo}
-                size='xs'
-                rounded={true}
-                showActiveStatus={false}
-                className='canvas-ticket-avatar'
-              />
-            ) : (
-              <CircleHelp className='size-4' aria-hidden='true' />
-            )}
-            <span className='max-w-24 truncate'>{assigneeLabel}</span>
-          </span>
-
-          <span className='flex min-w-0 items-center gap-1.5'>
-            <Flag className='size-3.5' aria-hidden='true' />
-            <span className='max-w-24 truncate'>{priorityLabel}</span>
-          </span>
-
-          <button
-            type='button'
-            className='ml-auto shrink-0 rounded-md border border-border bg-background px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent'
-            data-track-category='CANVAS'
-            data-track-name='OPEN_CANVAS_TICKET_PREVIEW'
-            onClick={event => {
-              event.preventDefault();
-              event.stopPropagation();
-              anchorRef.current?.click();
-            }}
-          >
-            Open
-          </button>
-        </div>
-      </div>
+      )}
     </HoverCard>
   );
 }

--- a/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
@@ -1,0 +1,198 @@
+import { createReactStyleSpec } from '@blocknote/react';
+import { CircleHelp, Clock3, Flag, UserRound } from 'lucide-react';
+import { useCallback, useRef, useState, type ReactElement } from 'react';
+
+import { useCachedQuery } from '../../../hooks/useCachedQuery';
+import { useUser } from '../../../hooks/useUsers';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+import { queries } from '../../../zero/queries';
+import Avatar from '../../ui/Avatar/Avatar';
+import { HoverCard } from '../../ui/HoverCard/HoverCard';
+
+export const CANVAS_TICKET_ATTR = 'data-canvas-ticket-id';
+export const CANVAS_TICKET_SELECTOR = `[${CANVAS_TICKET_ATTR}]`;
+
+interface CanvasTicketAnchorProps {
+  ticketId: string;
+  contentRef: (element: HTMLElement | null) => void;
+}
+
+const formatTicketStatus = (status: string | null | undefined): string => {
+  if (!status) return 'No status';
+  return status
+    .toLowerCase()
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
+
+function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): ReactElement {
+  const [ticket, ticketDetails] = useCachedQuery(queries.ticketRowById({ ticketId }), {
+    enabled: Boolean(ticketId),
+  });
+  const assignedUser = useUser(ticket?.assignedTo ?? '');
+  const anchorRef = useRef<HTMLSpanElement | null>(null);
+  const contentElementRef = useRef<HTMLElement | null>(null);
+  const [previewText, setPreviewText] = useState('');
+  const statusLabel = ticket?.stageName?.trim() || formatTicketStatus(ticket?.statusV2);
+  const isUnavailable = ticketDetails.type === 'complete' && !ticket;
+  const assigneeLabel = ticket?.assignedTo
+    ? assignedUser
+      ? getUserDisplayName(assignedUser)
+      : 'Assigned'
+    : 'Unassigned';
+  const priorityLabel = ticket?.priority ? formatTicketStatus(ticket.priority) : 'No priority';
+
+  const setContentElement = useCallback(
+    (element: HTMLElement | null): void => {
+      contentElementRef.current = element;
+      contentRef(element);
+    },
+    [contentRef],
+  );
+
+  const handlePreviewOpenChange = useCallback(
+    (open: boolean): void => {
+      if (!open) return;
+      setPreviewText(contentElementRef.current?.textContent?.trim() || ticket?.title || 'Ticket');
+    },
+    [ticket?.title],
+  );
+
+  const trigger = (
+    <span
+      ref={anchorRef}
+      data-canvas-ticket-id={ticketId}
+      data-canvas-ticket-channel-id={ticket?.channelId ?? undefined}
+      data-canvas-ticket-conversation-id={ticket?.conversationId ?? undefined}
+      data-canvas-ticket-status={ticket?.statusV2 ?? undefined}
+      className='canvas-ticket-anchor'
+      role='link'
+      tabIndex={0}
+      aria-label={ticket ? `Open ${ticket.xyneId}: ${ticket.title}` : 'Open ticket'}
+    >
+      {ticket?.xyneId && (
+        <span className='canvas-ticket-anchor__id' contentEditable={false}>
+          {ticket.xyneId}
+        </span>
+      )}
+      <span ref={setContentElement} className='canvas-ticket-anchor__text' />
+      {ticket && (
+        <span className='canvas-ticket-anchor__status' contentEditable={false}>
+          <Clock3 aria-hidden='true' />
+          <span>{statusLabel}</span>
+        </span>
+      )}
+      {ticket && (
+        <span
+          className={`canvas-ticket-anchor__assignee${ticket.assignedTo ? '' : ' canvas-ticket-anchor__assignee--unassigned'}`}
+          contentEditable={false}
+        >
+          {ticket.assignedTo ? (
+            <Avatar
+              userId={ticket.assignedTo}
+              size='xs'
+              rounded={true}
+              showActiveStatus={false}
+              className='canvas-ticket-avatar canvas-ticket-anchor__avatar'
+            />
+          ) : (
+            <UserRound aria-label='Unassigned' />
+          )}
+        </span>
+      )}
+      {isUnavailable && (
+        <span className='canvas-ticket-anchor__unavailable' contentEditable={false}>
+          Ticket unavailable
+        </span>
+      )}
+    </span>
+  );
+
+  if (!ticket) return trigger;
+
+  return (
+    <HoverCard
+      trigger={trigger}
+      onOpenChange={handlePreviewOpenChange}
+      openDelay={180}
+      closeDelay={100}
+      side='bottom'
+      align='start'
+      sideOffset={6}
+      collisionPadding={12}
+      className='w-80 rounded-xl p-3'
+    >
+      <div className='flex min-w-0 flex-col gap-3' data-canvas-ticket-preview={ticketId}>
+        <div className='flex min-w-0 items-center gap-2 text-xs'>
+          <span className='font-medium text-primary'>{ticket.xyneId}</span>
+          <span className='max-w-32 truncate rounded-full bg-muted px-2 py-0.5 text-muted-foreground'>
+            {statusLabel}
+          </span>
+        </div>
+
+        <p className='m-0 whitespace-normal text-sm font-semibold leading-5 text-foreground'>
+          {previewText || ticket.title}
+        </p>
+
+        <div className='flex min-w-0 items-center gap-4 text-xs text-muted-foreground'>
+          <span className='flex min-w-0 items-center gap-1.5'>
+            {ticket.assignedTo ? (
+              <Avatar
+                userId={ticket.assignedTo}
+                size='xs'
+                rounded={true}
+                showActiveStatus={false}
+                className='canvas-ticket-avatar'
+              />
+            ) : (
+              <CircleHelp className='size-4' aria-hidden='true' />
+            )}
+            <span className='max-w-24 truncate'>{assigneeLabel}</span>
+          </span>
+
+          <span className='flex min-w-0 items-center gap-1.5'>
+            <Flag className='size-3.5' aria-hidden='true' />
+            <span className='max-w-24 truncate'>{priorityLabel}</span>
+          </span>
+
+          <button
+            type='button'
+            className='ml-auto shrink-0 rounded-md border border-border bg-background px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent'
+            data-track-category='CANVAS'
+            data-track-name='OPEN_CANVAS_TICKET_PREVIEW'
+            onClick={event => {
+              event.preventDefault();
+              event.stopPropagation();
+              anchorRef.current?.click();
+            }}
+          >
+            Open
+          </button>
+        </div>
+      </div>
+    </HoverCard>
+  );
+}
+
+export const canvasTicketStyleSpec = createReactStyleSpec(
+  {
+    type: 'canvasTicket',
+    propSchema: 'string',
+  },
+  {
+    render: ({ value, contentRef }) => (
+      <CanvasTicketAnchor ticketId={value} contentRef={contentRef} />
+    ),
+    runsBefore: [
+      'bold',
+      'italic',
+      'underline',
+      'strike',
+      'code',
+      'textColor',
+      'backgroundColor',
+      'canvasCommentThread',
+    ],
+  },
+);

--- a/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasTicketStyleSpec/CanvasTicketStyleSpec.tsx
@@ -36,6 +36,8 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
   const [previewText, setPreviewText] = useState('');
   const statusLabel = ticket?.stageName?.trim() || formatTicketStatus(ticket?.statusV2);
   const isUnavailable = ticketDetails.type === 'complete' && !ticket;
+  const accessState = ticket ? 'available' : isUnavailable ? 'unavailable' : 'loading';
+  const isInteractive = accessState === 'available';
   const assigneeLabel = ticket?.assignedTo
     ? assignedUser
       ? getUserDisplayName(assignedUser)
@@ -66,10 +68,18 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
       data-canvas-ticket-channel-id={ticket?.channelId ?? undefined}
       data-canvas-ticket-conversation-id={ticket?.conversationId ?? undefined}
       data-canvas-ticket-status={ticket?.statusV2 ?? undefined}
+      data-canvas-ticket-access={accessState}
       className='canvas-ticket-anchor'
-      role='link'
-      tabIndex={0}
-      aria-label={ticket ? `Open ${ticket.xyneId}: ${ticket.title}` : 'Open ticket'}
+      role={isInteractive ? 'link' : undefined}
+      tabIndex={isInteractive ? 0 : -1}
+      aria-disabled={!isInteractive || undefined}
+      aria-label={
+        isUnavailable
+          ? 'Ticket unavailable or you do not have access'
+          : ticket
+            ? `Open ${ticket.xyneId}: ${ticket.title}`
+            : 'Ticket details are loading'
+      }
     >
       {ticket?.xyneId && (
         <span className='canvas-ticket-anchor__id' contentEditable={false}>
@@ -103,7 +113,7 @@ function CanvasTicketAnchor({ ticketId, contentRef }: CanvasTicketAnchorProps): 
       )}
       {isUnavailable && (
         <span className='canvas-ticket-anchor__unavailable' contentEditable={false}>
-          Ticket unavailable
+          Ticket unavailable or no access
         </span>
       )}
     </span>

--- a/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
+++ b/apps/dashboard/src/components/Canvas/CollaborativeCanvasEditor/CollaborativeCanvasEditor.tsx
@@ -89,6 +89,8 @@ import { CanvasWidthHandles } from '../CanvasWidthHandles';
 import { CanvasLinkToolbar, CanvasPastedLinkToolbar } from '../CanvasLinkToolbar';
 import { CanvasFilePanel } from '../CanvasFilePanel/CanvasFilePanel';
 import { useCanvasCommentEditorBridge } from '../useCanvasCommentEditorBridge';
+import { useCanvasTicketEditorBridge } from '../useCanvasTicketEditorBridge';
+import { CanvasTicketCreationFlow } from '../CanvasTicketCreationFlow/CanvasTicketCreationFlow';
 
 const DEFAULT_CANVAS_PLACEHOLDER = "Write something, or press '/' for commands";
 const RECORDING_SUMMARY_EDITED_TEXT_COLOR = 'recording-summary-edited';
@@ -578,6 +580,18 @@ export const CollaborativeCanvasEditor = forwardRef<
       onOpenCommentCountChange,
       ready: isEditorReady,
     });
+    const {
+      activeTicketAnchor,
+      isTicketChannelArchived,
+      openTicketForCurrentSelection,
+      closeTicketModal,
+      handleTicketCreated,
+    } = useCanvasTicketEditorBridge({
+      channelId,
+      containerRef,
+      getEditor: getCanvasCommentEditor,
+      ready: isEditorReady,
+    });
 
     // Expose presentation and comment drawer methods via ref
     useImperativeHandle(
@@ -690,8 +704,18 @@ export const CollaborativeCanvasEditor = forwardRef<
           ...(canvasId && { canvasId }),
           ...(title && { canvasTitle: title }),
           canComment: editable && !isReadOnly,
+          canCreateTicket: editable && !isReadOnly && !isTicketChannelArchived,
+          onCreateTicket: openTicketForCurrentSelection,
         }),
-      [canvasId, editable, isReadOnly, openCommentsForCurrentBlock, title],
+      [
+        canvasId,
+        editable,
+        isReadOnly,
+        isTicketChannelArchived,
+        openCommentsForCurrentBlock,
+        openTicketForCurrentSelection,
+        title,
+      ],
     );
 
     useEffect((): (() => void) | void => {
@@ -863,6 +887,13 @@ export const CollaborativeCanvasEditor = forwardRef<
             />
           )}
         </div>
+
+        <CanvasTicketCreationFlow
+          anchor={activeTicketAnchor}
+          channelId={channelId}
+          onClose={closeTicketModal}
+          onTicketCreated={handleTicketCreated}
+        />
 
         {/* Presentation Modal */}
         {showPresentation && (

--- a/apps/dashboard/src/components/Canvas/canvasSchema.ts
+++ b/apps/dashboard/src/components/Canvas/canvasSchema.ts
@@ -25,6 +25,7 @@ import { canvasLinkShortcutsExtension } from './canvasLinkShortcuts';
 import { canvasPastedLinkExtension } from './canvasPastedLink';
 import { canvasSourceBlockShortcutsExtension } from './canvasSourceBlockShortcuts';
 import { canvasTableShortcutsExtension } from './canvasTableShortcuts';
+import { canvasTicketUnlinkExtension } from './canvasTicketUnlink';
 
 // Default blocks + whiteboard, then extended with mention and citation inline content.
 // Shared by the canvas editors and the read-only previews: a preview built on a
@@ -288,6 +289,7 @@ const handleCanvasTableKeyDown = (view: EditorView, event: KeyboardEvent): boole
 
 export const canvasTiptapOptions = {
   extensions: [
+    canvasTicketUnlinkExtension,
     canvasTablePendingExitRowExtension,
     canvasPastedLinkExtension,
     canvasLinkShortcutsExtension,

--- a/apps/dashboard/src/components/Canvas/canvasSchema.ts
+++ b/apps/dashboard/src/components/Canvas/canvasSchema.ts
@@ -10,6 +10,7 @@ import { mentionInlineContentSpec } from './CanvasMentionSpec';
 import { citationInlineContentSpec } from './CanvasCitationSpec';
 import { knownBlockTypesOf } from '../../utils/canvasUtils';
 import { canvasCommentThreadStyleSpec } from './CanvasCommentStyleSpec/CanvasCommentStyleSpec';
+import { canvasTicketStyleSpec } from './CanvasTicketStyleSpec/CanvasTicketStyleSpec';
 import { canvasCodeBlockSpec } from './CanvasCodeBlockSpec';
 import { canvasDiagramBlockSpec } from './CanvasDiagramSpec';
 import { canvasMathBlockSpec } from './CanvasMathBlockSpec';
@@ -51,6 +52,7 @@ function createCanvasSchema() {
     },
     styleSpecs: {
       canvasCommentThread: canvasCommentThreadStyleSpec,
+      canvasTicket: canvasTicketStyleSpec,
     },
   });
 }

--- a/apps/dashboard/src/components/Canvas/canvasTicketUnlink.ts
+++ b/apps/dashboard/src/components/Canvas/canvasTicketUnlink.ts
@@ -1,0 +1,182 @@
+import { Extension } from '@tiptap/core';
+import type { Mark, MarkType, Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { Plugin, PluginKey, type Transaction } from '@tiptap/pm/state';
+import { Mapping } from '@tiptap/pm/transform';
+
+const canvasTicketUnlinkPluginKey = new PluginKey('canvasTicketUnlink');
+const Y_SYNC_META_KEY = 'y-sync$';
+
+interface TextblockRange {
+  from: number;
+  node: ProseMirrorNode;
+  to: number;
+}
+
+interface TicketOccurrence {
+  from: number;
+  mark: Mark;
+  ticketId: string;
+  to: number;
+}
+
+const getTextblockAt = (doc: ProseMirrorNode, position: number): TextblockRange | null => {
+  const clampedPosition = Math.max(0, Math.min(position, doc.content.size));
+  const positions = [clampedPosition, clampedPosition - 1, clampedPosition + 1];
+
+  for (const candidate of positions) {
+    if (candidate < 0 || candidate > doc.content.size) continue;
+    const resolved = doc.resolve(candidate);
+    for (let depth = resolved.depth; depth > 0; depth -= 1) {
+      const node = resolved.node(depth);
+      if (!node.isTextblock) continue;
+      return {
+        from: resolved.start(depth),
+        node,
+        to: resolved.end(depth),
+      };
+    }
+  }
+
+  return null;
+};
+
+const getTicketOccurrences = (
+  range: TextblockRange,
+  ticketMarkType: NonNullable<ReturnType<typeof getTicketMarkType>>,
+): TicketOccurrence[] => {
+  const occurrences: TicketOccurrence[] = [];
+
+  range.node.descendants((node, relativePosition) => {
+    if (!node.isText) return;
+    const mark = node.marks.find(candidate => candidate.type === ticketMarkType);
+    const ticketId = mark?.attrs['stringValue'] as unknown;
+    if (!mark || typeof ticketId !== 'string' || !ticketId) return;
+
+    const from = range.from + relativePosition;
+    const to = from + node.nodeSize;
+    const previous = occurrences.at(-1);
+    if (previous?.ticketId === ticketId && previous.to === from) {
+      previous.to = to;
+      return;
+    }
+
+    occurrences.push({ from, mark, ticketId, to });
+  });
+
+  return occurrences;
+};
+
+const getTicketMarkType = (doc: ProseMirrorNode): MarkType | undefined =>
+  doc.type.schema.marks['canvasTicket'];
+
+const getChangedTextblocks = (transaction: Transaction): TextblockRange[] => {
+  const ranges = new Map<string, TextblockRange>();
+
+  transaction.mapping.maps.forEach((stepMap, stepIndex) => {
+    const remainingMapping = transaction.mapping.slice(stepIndex + 1);
+    stepMap.forEach((_oldFrom, _oldTo, newFrom, newTo) => {
+      const mappedFrom = remainingMapping.map(newFrom, -1);
+      const mappedTo = remainingMapping.map(newTo, 1);
+      const candidatePositions = [mappedFrom, Math.max(mappedFrom, mappedTo - 1)];
+
+      for (const position of candidatePositions) {
+        const range = getTextblockAt(transaction.doc, position);
+        if (range) ranges.set(`${range.from}:${range.to}`, range);
+      }
+    });
+  });
+
+  return Array.from(ranges.values());
+};
+
+const isRemoteYjsTransaction = (transaction: Transaction): boolean => {
+  const metadata = transaction.getMeta(Y_SYNC_META_KEY) as { isChangeOrigin?: boolean } | undefined;
+  return metadata?.isChangeOrigin === true;
+};
+
+const appendLaterMappings = (transactions: readonly Transaction[], startIndex: number): Mapping => {
+  const mapping = new Mapping();
+  for (let index = startIndex; index < transactions.length; index += 1) {
+    mapping.appendMapping(transactions[index]!.mapping);
+  }
+  return mapping;
+};
+
+export const canvasTicketUnlinkExtension = Extension.create({
+  name: 'canvasTicketUnlink',
+
+  addProseMirrorPlugins(): Plugin[] {
+    return [
+      new Plugin({
+        key: canvasTicketUnlinkPluginKey,
+        appendTransaction(transactions, _oldState, newState): Transaction | null {
+          if (transactions.some(transaction => transaction.getMeta(canvasTicketUnlinkPluginKey))) {
+            return null;
+          }
+          if (!transactions.some(transaction => transaction.docChanged)) return null;
+          if (transactions.some(isRemoteYjsTransaction)) return null;
+
+          const finalTicketMarkType = getTicketMarkType(newState.doc);
+          if (!finalTicketMarkType) return null;
+
+          const rangesToUnlink = new Map<string, TicketOccurrence>();
+
+          transactions.forEach((transaction, transactionIndex) => {
+            if (!transaction.docChanged) return;
+
+            const beforeTicketMarkType = getTicketMarkType(transaction.before);
+            const afterTicketMarkType = getTicketMarkType(transaction.doc);
+            if (!beforeTicketMarkType || !afterTicketMarkType) return;
+
+            const inverseMapping = transaction.mapping.invert();
+            const laterMapping = appendLaterMappings(transactions, transactionIndex + 1);
+
+            for (const afterRange of getChangedTextblocks(transaction)) {
+              const beforePosition = inverseMapping.map(afterRange.from, -1);
+              const beforeRange = getTextblockAt(transaction.before, beforePosition);
+              if (!beforeRange || beforeRange.node.textContent === afterRange.node.textContent) {
+                continue;
+              }
+
+              const oldTicketIds = new Set(
+                getTicketOccurrences(beforeRange, beforeTicketMarkType).map(
+                  occurrence => occurrence.ticketId,
+                ),
+              );
+              if (oldTicketIds.size === 0) continue;
+
+              for (const occurrence of getTicketOccurrences(afterRange, afterTicketMarkType)) {
+                if (!oldTicketIds.has(occurrence.ticketId)) continue;
+
+                const finalFrom = laterMapping.map(occurrence.from, 1);
+                const finalTo = laterMapping.map(occurrence.to, -1);
+                if (finalFrom >= finalTo) continue;
+
+                const finalRange = getTextblockAt(newState.doc, finalFrom);
+                if (!finalRange) continue;
+                const finalOccurrence = getTicketOccurrences(finalRange, finalTicketMarkType).find(
+                  candidate => candidate.ticketId === occurrence.ticketId,
+                );
+                if (!finalOccurrence) continue;
+
+                rangesToUnlink.set(
+                  `${finalOccurrence.from}:${finalOccurrence.to}:${finalOccurrence.ticketId}`,
+                  finalOccurrence,
+                );
+              }
+            }
+          });
+
+          if (rangesToUnlink.size === 0) return null;
+
+          const cleanup = newState.tr;
+          for (const occurrence of rangesToUnlink.values()) {
+            cleanup.removeMark(occurrence.from, occurrence.to, occurrence.mark);
+          }
+          cleanup.setMeta(canvasTicketUnlinkPluginKey, true);
+          return cleanup;
+        },
+      }),
+    ];
+  },
+});

--- a/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
@@ -42,6 +42,8 @@ interface UseCanvasTicketEditorBridgeResult {
 interface ResolvedSelectionPositionLike {
   parent: { textContent: string };
   sameParent: (other: ResolvedSelectionPositionLike) => boolean;
+  start: () => number;
+  end: () => number;
 }
 
 interface TiptapEditorLike {
@@ -332,7 +334,9 @@ export function useCanvasTicketEditorBridge({
       }
 
       const { from, to } = tiptapEditor.state.selection;
-      if (rangeHasLink(tiptapEditor, from, to)) {
+      const blockFrom = $from.start();
+      const blockTo = $from.end();
+      if (rangeHasLink(tiptapEditor, blockFrom, blockTo)) {
         toast.error('Tickets cannot be created from linked text');
         return;
       }
@@ -350,7 +354,11 @@ export function useCanvasTicketEditorBridge({
         toast.error('Selected text is already linked to a ticket');
         return;
       }
-      const blockText = tiptapEditor.state.selection.$from.parent.textContent.trim();
+      if (rangeHasTicketStyle(tiptapEditor, blockFrom, blockTo)) {
+        toast.error('This block is already linked to a ticket');
+        return;
+      }
+      const blockText = $from.parent.textContent.trim();
 
       setActiveTicketAnchor({
         blockId,
@@ -377,17 +385,23 @@ export function useCanvasTicketEditorBridge({
 
       if (anchor && editor && tiptapEditor && !tiptapEditor.state.selection.empty) {
         try {
-          const { from, to } = tiptapEditor.state.selection;
+          const { from, to, $from, $to } = tiptapEditor.state.selection;
           const currentBlockId = editor.getTextCursorPosition().block?.id;
           const currentText = tiptapEditor.state.doc.textBetween(from, to, ' ').trim();
+          const currentBlockText = $from.parent.textContent.trim();
+          const blockFrom = $from.start();
+          const blockTo = $from.end();
 
           if (
             currentBlockId === anchor.blockId &&
+            $from.sameParent($to) &&
             currentText === anchor.anchorText &&
-            !rangeHasTicketStyle(tiptapEditor, from, to)
+            currentBlockText === anchor.blockText &&
+            !rangeHasTicketStyle(tiptapEditor, blockFrom, blockTo)
           ) {
+            tiptapEditor.commands.setTextSelection({ from: blockFrom, to: blockTo });
             editor.addStyles({ canvasTicket: ticket.id } as never);
-            tiptapEditor.commands.setTextSelection({ from: to, to });
+            tiptapEditor.commands.setTextSelection({ from: blockTo, to: blockTo });
             styleApplied = true;
           }
         } catch {

--- a/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
@@ -57,42 +57,16 @@ interface TiptapEditorLike {
     };
     doc: {
       textBetween: (from: number, to: number, blockSeparator?: string) => string;
-      descendants: (
-        callback: (
-          node: {
-            isText?: boolean;
-            text?: string | null;
-            nodeSize: number;
-            marks?: Array<{ type: { name: string }; attrs?: { stringValue?: string } }>;
-          },
-          position: number,
-        ) => void,
-      ) => void;
       nodesBetween: (
         from: number,
         to: number,
         callback: (node: { marks?: Array<{ type: { name: string } }> }) => void,
       ) => void;
     };
-    schema: { marks: { canvasTicket?: unknown } };
-    tr: {
-      removeMark: (from: number, to: number, markType: unknown) => TiptapEditorLike['state']['tr'];
-      setMeta: (key: string, value: unknown) => TiptapEditorLike['state']['tr'];
-    };
   };
-  view: { dispatch: (transaction: TiptapEditorLike['state']['tr']) => void };
   commands: {
     setTextSelection: (range: { from: number; to: number }) => boolean;
   };
-  on: (event: 'update', callback: TiptapUpdateHandler) => void;
-  off: (event: 'update', callback: TiptapUpdateHandler) => void;
-}
-
-type TiptapUpdateHandler = (event: { transaction: unknown }) => void;
-
-interface TicketMarkedTextSnapshot {
-  text: string;
-  ranges: Array<{ from: number; to: number }>;
 }
 
 const getTiptapEditor = (editor: CanvasEditorLike): TiptapEditorLike | null =>
@@ -130,62 +104,6 @@ const rangeHasLink = (editor: TiptapEditorLike, from: number, to: number): boole
   return hasLink;
 };
 
-const getTicketMarkedTextSnapshots = (
-  editor: TiptapEditorLike,
-): Map<string, TicketMarkedTextSnapshot> => {
-  const snapshots = new Map<string, TicketMarkedTextSnapshot>();
-
-  editor.state.doc.descendants((node, position) => {
-    if (!node.isText || !node.text) return;
-    const ticketMark = node.marks?.find(mark => mark.type.name === 'canvasTicket');
-    const ticketId = ticketMark?.attrs?.stringValue;
-    if (!ticketId) return;
-
-    const existing = snapshots.get(ticketId) ?? { text: '', ranges: [] };
-    existing.text += node.text;
-    const from = position;
-    const to = position + node.nodeSize;
-    const previousRange = existing.ranges.at(-1);
-    if (previousRange?.to === from) {
-      previousRange.to = to;
-    } else {
-      existing.ranges.push({ from, to });
-    }
-    snapshots.set(ticketId, existing);
-  });
-
-  return snapshots;
-};
-
-const removeChangedTicketStyles = (
-  editor: TiptapEditorLike,
-  previousSnapshots: Map<string, TicketMarkedTextSnapshot>,
-  currentSnapshots: Map<string, TicketMarkedTextSnapshot>,
-  sourceTransaction: unknown,
-): boolean => {
-  const ticketMarkType = editor.state.schema.marks.canvasTicket;
-  if (!ticketMarkType) return false;
-
-  const rangesToUnlink: Array<{ from: number; to: number }> = [];
-  for (const [ticketId, currentSnapshot] of currentSnapshots) {
-    const previousSnapshot = previousSnapshots.get(ticketId);
-    if (previousSnapshot && previousSnapshot.text !== currentSnapshot.text) {
-      rangesToUnlink.push(...currentSnapshot.ranges);
-    }
-  }
-  if (rangesToUnlink.length === 0) return false;
-
-  let transaction = editor.state.tr;
-  for (const range of rangesToUnlink) {
-    transaction = transaction.removeMark(range.from, range.to, ticketMarkType);
-  }
-  // Keep the automatic unlink in the same history event as the text edit that
-  // triggered it. One undo then restores both the edited text and its ticket mark.
-  transaction.setMeta('appendedTransaction', sourceTransaction);
-  editor.view.dispatch(transaction);
-  return true;
-};
-
 const getClosestCanvasBlock = (node: Node | null): HTMLElement | null => {
   const element = node instanceof Element ? node : node?.parentElement;
   return element?.closest<HTMLElement>('.bn-block-content[data-content-type]') ?? null;
@@ -217,30 +135,6 @@ export function useCanvasTicketEditorBridge({
   useEffect(() => {
     setActiveTicketAnchor(null);
   }, [channelId]);
-
-  useEffect(() => {
-    if (!ready) return;
-    const editor = getEditor();
-    const tiptapEditor = editor ? getTiptapEditor(editor) : null;
-    if (!editor || !tiptapEditor) return;
-
-    let previousSnapshots = getTicketMarkedTextSnapshots(tiptapEditor);
-    const handleUpdate: TiptapUpdateHandler = ({ transaction }) => {
-      const currentSnapshots = getTicketMarkedTextSnapshots(tiptapEditor);
-      const removedStyle = removeChangedTicketStyles(
-        tiptapEditor,
-        previousSnapshots,
-        currentSnapshots,
-        transaction,
-      );
-      previousSnapshots = removedStyle
-        ? getTicketMarkedTextSnapshots(tiptapEditor)
-        : currentSnapshots;
-    };
-    tiptapEditor.on('update', handleUpdate);
-
-    return (): void => tiptapEditor.off('update', handleUpdate);
-  }, [getEditor, ready]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
@@ -4,6 +4,7 @@ import type {
   InlineContentSchema,
   StyleSchema,
 } from '@blocknote/core';
+import { CellSelection } from '@tiptap/pm/tables';
 import { useCallback, useEffect, useState, type RefObject } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -38,26 +39,54 @@ interface UseCanvasTicketEditorBridgeResult {
   handleTicketCreated: (ticket: { id: string }) => void;
 }
 
+interface ResolvedSelectionPositionLike {
+  parent: { textContent: string };
+  sameParent: (other: ResolvedSelectionPositionLike) => boolean;
+}
+
 interface TiptapEditorLike {
   state: {
     selection: {
       from: number;
       to: number;
       empty?: boolean;
-      $from: { parent: { textContent: string } };
+      $from: ResolvedSelectionPositionLike;
+      $to: ResolvedSelectionPositionLike;
     };
     doc: {
       textBetween: (from: number, to: number, blockSeparator?: string) => string;
+      descendants: (
+        callback: (
+          node: {
+            isText?: boolean;
+            text?: string | null;
+            nodeSize: number;
+            marks?: Array<{ type: { name: string }; attrs?: { stringValue?: string } }>;
+          },
+          position: number,
+        ) => void,
+      ) => void;
       nodesBetween: (
         from: number,
         to: number,
         callback: (node: { marks?: Array<{ type: { name: string } }> }) => void,
       ) => void;
     };
+    schema: { marks: { canvasTicket?: unknown } };
+    tr: {
+      removeMark: (from: number, to: number, markType: unknown) => TiptapEditorLike['state']['tr'];
+      setMeta: (key: string, value: unknown) => TiptapEditorLike['state']['tr'];
+    };
   };
+  view: { dispatch: (transaction: TiptapEditorLike['state']['tr']) => void };
   commands: {
     setTextSelection: (range: { from: number; to: number }) => boolean;
   };
+}
+
+interface TicketMarkedTextSnapshot {
+  text: string;
+  ranges: Array<{ from: number; to: number }>;
 }
 
 const getTiptapEditor = (editor: CanvasEditorLike): TiptapEditorLike | null =>
@@ -75,6 +104,86 @@ const rangeHasTicketStyle = (editor: TiptapEditorLike, from: number, to: number)
   return hasTicketStyle;
 };
 
+const rangeHasCodeStyle = (editor: TiptapEditorLike, from: number, to: number): boolean => {
+  let hasCodeStyle = false;
+  editor.state.doc.nodesBetween(from, to, node => {
+    if (node.marks?.some(mark => mark.type.name === 'code')) {
+      hasCodeStyle = true;
+    }
+  });
+  return hasCodeStyle;
+};
+
+const getTicketMarkedTextSnapshots = (
+  editor: TiptapEditorLike,
+): Map<string, TicketMarkedTextSnapshot> => {
+  const snapshots = new Map<string, TicketMarkedTextSnapshot>();
+
+  editor.state.doc.descendants((node, position) => {
+    if (!node.isText || !node.text) return;
+    const ticketMark = node.marks?.find(mark => mark.type.name === 'canvasTicket');
+    const ticketId = ticketMark?.attrs?.stringValue;
+    if (!ticketId) return;
+
+    const existing = snapshots.get(ticketId) ?? { text: '', ranges: [] };
+    existing.text += node.text;
+    const from = position;
+    const to = position + node.nodeSize;
+    const previousRange = existing.ranges.at(-1);
+    if (previousRange?.to === from) {
+      previousRange.to = to;
+    } else {
+      existing.ranges.push({ from, to });
+    }
+    snapshots.set(ticketId, existing);
+  });
+
+  return snapshots;
+};
+
+const removeChangedTicketStyles = (
+  editor: TiptapEditorLike,
+  previousSnapshots: Map<string, TicketMarkedTextSnapshot>,
+  currentSnapshots: Map<string, TicketMarkedTextSnapshot>,
+): boolean => {
+  const ticketMarkType = editor.state.schema.marks.canvasTicket;
+  if (!ticketMarkType) return false;
+
+  const rangesToUnlink: Array<{ from: number; to: number }> = [];
+  for (const [ticketId, currentSnapshot] of currentSnapshots) {
+    const previousSnapshot = previousSnapshots.get(ticketId);
+    if (previousSnapshot && previousSnapshot.text !== currentSnapshot.text) {
+      rangesToUnlink.push(...currentSnapshot.ranges);
+    }
+  }
+  if (rangesToUnlink.length === 0) return false;
+
+  let transaction = editor.state.tr;
+  for (const range of rangesToUnlink) {
+    transaction = transaction.removeMark(range.from, range.to, ticketMarkType);
+  }
+  transaction.setMeta('addToHistory', false);
+  editor.view.dispatch(transaction);
+  return true;
+};
+
+const getClosestCanvasBlock = (node: Node | null): HTMLElement | null => {
+  const element = node instanceof Element ? node : node?.parentElement;
+  return element?.closest<HTMLElement>('.bn-block-content[data-content-type]') ?? null;
+};
+
+const domSelectionSpansMultipleBlocks = (container: HTMLElement | null): boolean => {
+  const selection = window.getSelection();
+  if (!container || !selection || selection.rangeCount === 0) return false;
+
+  const anchorBlock = getClosestCanvasBlock(selection.anchorNode);
+  const focusBlock = getClosestCanvasBlock(selection.focusNode);
+  if (!anchorBlock || !focusBlock) return false;
+  if (!container.contains(anchorBlock) || !container.contains(focusBlock)) return false;
+
+  return anchorBlock !== focusBlock;
+};
+
 export function useCanvasTicketEditorBridge({
   channelId,
   containerRef,
@@ -89,6 +198,28 @@ export function useCanvasTicketEditorBridge({
   useEffect(() => {
     setActiveTicketAnchor(null);
   }, [channelId]);
+
+  useEffect(() => {
+    if (!ready) return;
+    const editor = getEditor();
+    const tiptapEditor = editor ? getTiptapEditor(editor) : null;
+    if (!editor || !tiptapEditor) return;
+
+    let previousSnapshots = getTicketMarkedTextSnapshots(tiptapEditor);
+    const unsubscribe = editor.onChange(() => {
+      const currentSnapshots = getTicketMarkedTextSnapshots(tiptapEditor);
+      const removedStyle = removeChangedTicketStyles(
+        tiptapEditor,
+        previousSnapshots,
+        currentSnapshots,
+      );
+      previousSnapshots = removedStyle
+        ? getTicketMarkedTextSnapshots(tiptapEditor)
+        : currentSnapshots;
+    });
+
+    return unsubscribe;
+  }, [getEditor, ready]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -158,14 +289,35 @@ export function useCanvasTicketEditorBridge({
     if (!editor) return;
 
     try {
-      const blockId = editor.getTextCursorPosition().block?.id;
+      const currentBlock = editor.getTextCursorPosition().block;
+      const blockId = currentBlock?.id;
       const tiptapEditor = getTiptapEditor(editor);
       if (!blockId || !tiptapEditor || tiptapEditor.state.selection.empty) {
         toast.error('Select text to create a ticket');
         return;
       }
 
+      const { $from, $to } = tiptapEditor.state.selection;
+      const selectedBlocks = editor.getSelection()?.blocks;
+      if (tiptapEditor.state.selection instanceof CellSelection) {
+        toast.error('Select text within a single table cell to create a ticket');
+        return;
+      }
+      if (
+        !$from.sameParent($to) ||
+        (selectedBlocks?.length ?? 0) > 1 ||
+        domSelectionSpansMultipleBlocks(containerRef.current)
+      ) {
+        toast.error('Select text within a single block to create a ticket');
+        return;
+      }
+
       const { from, to } = tiptapEditor.state.selection;
+      if (rangeHasCodeStyle(tiptapEditor, from, to)) {
+        toast.error('Tickets cannot be created from code-formatted text');
+        return;
+      }
+
       const anchorText = tiptapEditor.state.doc.textBetween(from, to, ' ').trim();
       if (!anchorText) {
         toast.error('Select text to create a ticket');
@@ -187,7 +339,7 @@ export function useCanvasTicketEditorBridge({
     } catch {
       toast.error('Unable to use the selected canvas text');
     }
-  }, [channel?.isArchived, getEditor, ready]);
+  }, [channel?.isArchived, containerRef, getEditor, ready]);
 
   const closeTicketModal = useCallback((): void => {
     setActiveTicketAnchor(null);

--- a/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
@@ -82,7 +82,11 @@ interface TiptapEditorLike {
   commands: {
     setTextSelection: (range: { from: number; to: number }) => boolean;
   };
+  on: (event: 'update', callback: TiptapUpdateHandler) => void;
+  off: (event: 'update', callback: TiptapUpdateHandler) => void;
 }
+
+type TiptapUpdateHandler = (event: { transaction: unknown }) => void;
 
 interface TicketMarkedTextSnapshot {
   text: string;
@@ -112,6 +116,16 @@ const rangeHasCodeStyle = (editor: TiptapEditorLike, from: number, to: number): 
     }
   });
   return hasCodeStyle;
+};
+
+const rangeHasLink = (editor: TiptapEditorLike, from: number, to: number): boolean => {
+  let hasLink = false;
+  editor.state.doc.nodesBetween(from, to, node => {
+    if (node.marks?.some(mark => mark.type.name === 'link')) {
+      hasLink = true;
+    }
+  });
+  return hasLink;
 };
 
 const getTicketMarkedTextSnapshots = (
@@ -145,6 +159,7 @@ const removeChangedTicketStyles = (
   editor: TiptapEditorLike,
   previousSnapshots: Map<string, TicketMarkedTextSnapshot>,
   currentSnapshots: Map<string, TicketMarkedTextSnapshot>,
+  sourceTransaction: unknown,
 ): boolean => {
   const ticketMarkType = editor.state.schema.marks.canvasTicket;
   if (!ticketMarkType) return false;
@@ -162,7 +177,9 @@ const removeChangedTicketStyles = (
   for (const range of rangesToUnlink) {
     transaction = transaction.removeMark(range.from, range.to, ticketMarkType);
   }
-  transaction.setMeta('addToHistory', false);
+  // Keep the automatic unlink in the same history event as the text edit that
+  // triggered it. One undo then restores both the edited text and its ticket mark.
+  transaction.setMeta('appendedTransaction', sourceTransaction);
   editor.view.dispatch(transaction);
   return true;
 };
@@ -206,19 +223,21 @@ export function useCanvasTicketEditorBridge({
     if (!editor || !tiptapEditor) return;
 
     let previousSnapshots = getTicketMarkedTextSnapshots(tiptapEditor);
-    const unsubscribe = editor.onChange(() => {
+    const handleUpdate: TiptapUpdateHandler = ({ transaction }) => {
       const currentSnapshots = getTicketMarkedTextSnapshots(tiptapEditor);
       const removedStyle = removeChangedTicketStyles(
         tiptapEditor,
         previousSnapshots,
         currentSnapshots,
+        transaction,
       );
       previousSnapshots = removedStyle
         ? getTicketMarkedTextSnapshots(tiptapEditor)
         : currentSnapshots;
-    });
+    };
+    tiptapEditor.on('update', handleUpdate);
 
-    return unsubscribe;
+    return (): void => tiptapEditor.off('update', handleUpdate);
   }, [getEditor, ready]);
 
   useEffect(() => {
@@ -313,6 +332,10 @@ export function useCanvasTicketEditorBridge({
       }
 
       const { from, to } = tiptapEditor.state.selection;
+      if (rangeHasLink(tiptapEditor, from, to)) {
+        toast.error('Tickets cannot be created from linked text');
+        return;
+      }
       if (rangeHasCodeStyle(tiptapEditor, from, to)) {
         toast.error('Tickets cannot be created from code-formatted text');
         return;

--- a/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
@@ -98,6 +98,7 @@ export function useCanvasTicketEditorBridge({
       if (!(target instanceof Element)) return null;
       const anchor = target.closest<HTMLElement>(CANVAS_TICKET_SELECTOR);
       if (!anchor || !container.contains(anchor)) return null;
+      if (anchor.dataset['canvasTicketAccess'] !== 'available') return null;
       return anchor;
     };
 

--- a/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
+++ b/apps/dashboard/src/components/Canvas/useCanvasTicketEditorBridge.ts
@@ -1,0 +1,237 @@
+import type {
+  BlockNoteEditor,
+  BlockSchema,
+  InlineContentSchema,
+  StyleSchema,
+} from '@blocknote/core';
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { useChannel } from '../../hooks/useChannels';
+import { useRouteContext } from '../../hooks/useRouteContext';
+import { standaloneNavigate } from '../../utils/electronApp';
+import { CANVAS_TICKET_SELECTOR } from './CanvasTicketStyleSpec/CanvasTicketStyleSpec';
+
+type CanvasEditorLike = BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>;
+
+export interface CanvasTicketAnchor {
+  blockId: string;
+  anchorText: string;
+  blockText: string;
+  selectionFrom: number;
+  selectionTo: number;
+}
+
+interface UseCanvasTicketEditorBridgeOptions {
+  channelId?: string | undefined;
+  containerRef: RefObject<HTMLElement | null>;
+  getEditor: () => CanvasEditorLike | null;
+  ready?: boolean;
+}
+
+interface UseCanvasTicketEditorBridgeResult {
+  activeTicketAnchor: CanvasTicketAnchor | null;
+  isTicketChannelArchived: boolean;
+  openTicketForCurrentSelection: () => void;
+  closeTicketModal: () => void;
+  handleTicketCreated: (ticket: { id: string }) => void;
+}
+
+interface TiptapEditorLike {
+  state: {
+    selection: {
+      from: number;
+      to: number;
+      empty?: boolean;
+      $from: { parent: { textContent: string } };
+    };
+    doc: {
+      textBetween: (from: number, to: number, blockSeparator?: string) => string;
+      nodesBetween: (
+        from: number,
+        to: number,
+        callback: (node: { marks?: Array<{ type: { name: string } }> }) => void,
+      ) => void;
+    };
+  };
+  commands: {
+    setTextSelection: (range: { from: number; to: number }) => boolean;
+  };
+}
+
+const getTiptapEditor = (editor: CanvasEditorLike): TiptapEditorLike | null =>
+  ((editor as unknown as { _tiptapEditor?: unknown })._tiptapEditor as
+    | TiptapEditorLike
+    | undefined) ?? null;
+
+const rangeHasTicketStyle = (editor: TiptapEditorLike, from: number, to: number): boolean => {
+  let hasTicketStyle = false;
+  editor.state.doc.nodesBetween(from, to, node => {
+    if (node.marks?.some(mark => mark.type.name === 'canvasTicket')) {
+      hasTicketStyle = true;
+    }
+  });
+  return hasTicketStyle;
+};
+
+export function useCanvasTicketEditorBridge({
+  channelId,
+  containerRef,
+  getEditor,
+  ready = true,
+}: UseCanvasTicketEditorBridgeOptions): UseCanvasTicketEditorBridgeResult {
+  const navigate = useNavigate();
+  const { baseRoute } = useRouteContext();
+  const channel = useChannel(channelId ?? '');
+  const [activeTicketAnchor, setActiveTicketAnchor] = useState<CanvasTicketAnchor | null>(null);
+
+  useEffect(() => {
+    setActiveTicketAnchor(null);
+  }, [channelId]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const getTicketAnchor = (target: EventTarget | null): HTMLElement | null => {
+      if (!(target instanceof Element)) return null;
+      const anchor = target.closest<HTMLElement>(CANVAS_TICKET_SELECTOR);
+      if (!anchor || !container.contains(anchor)) return null;
+      return anchor;
+    };
+
+    const openTicket = (anchor: HTMLElement): void => {
+      const ticketId = anchor.dataset['canvasTicketId'];
+      const ticketChannelId = anchor.dataset['canvasTicketChannelId'];
+      const conversationId = anchor.dataset['canvasTicketConversationId'];
+      if (!ticketId || !ticketChannelId) {
+        toast.error('Ticket details are still loading. Please try again.');
+        return;
+      }
+
+      const searchParams = new URLSearchParams({
+        tab: 'tickets',
+        ticketId,
+        ...(conversationId ? { conversationId } : {}),
+      });
+      standaloneNavigate(
+        navigate,
+        `${baseRoute}/${encodeURIComponent(ticketChannelId)}?${searchParams.toString()}`,
+      );
+    };
+
+    const handleClick = (event: MouseEvent): void => {
+      const anchor = getTicketAnchor(event.target);
+      if (!anchor) return;
+      event.preventDefault();
+      event.stopPropagation();
+      openTicket(anchor);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      const anchor = getTicketAnchor(event.target);
+      if (!anchor) return;
+      event.preventDefault();
+      event.stopPropagation();
+      openTicket(anchor);
+    };
+
+    container.addEventListener('click', handleClick);
+    container.addEventListener('keydown', handleKeyDown);
+    return (): void => {
+      container.removeEventListener('click', handleClick);
+      container.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [baseRoute, containerRef, navigate]);
+
+  const openTicketForCurrentSelection = useCallback((): void => {
+    if (!ready) return;
+    if (channel?.isArchived) {
+      toast.error('Tickets cannot be created in an archived channel');
+      return;
+    }
+
+    const editor = getEditor();
+    if (!editor) return;
+
+    try {
+      const blockId = editor.getTextCursorPosition().block?.id;
+      const tiptapEditor = getTiptapEditor(editor);
+      if (!blockId || !tiptapEditor || tiptapEditor.state.selection.empty) {
+        toast.error('Select text to create a ticket');
+        return;
+      }
+
+      const { from, to } = tiptapEditor.state.selection;
+      const anchorText = tiptapEditor.state.doc.textBetween(from, to, ' ').trim();
+      if (!anchorText) {
+        toast.error('Select text to create a ticket');
+        return;
+      }
+      if (rangeHasTicketStyle(tiptapEditor, from, to)) {
+        toast.error('Selected text is already linked to a ticket');
+        return;
+      }
+      const blockText = tiptapEditor.state.selection.$from.parent.textContent.trim();
+
+      setActiveTicketAnchor({
+        blockId,
+        anchorText,
+        blockText: blockText || anchorText,
+        selectionFrom: from,
+        selectionTo: to,
+      });
+    } catch {
+      toast.error('Unable to use the selected canvas text');
+    }
+  }, [channel?.isArchived, getEditor, ready]);
+
+  const closeTicketModal = useCallback((): void => {
+    setActiveTicketAnchor(null);
+  }, []);
+
+  const handleTicketCreated = useCallback(
+    (ticket: { id: string }): void => {
+      const anchor = activeTicketAnchor;
+      const editor = getEditor();
+      const tiptapEditor = editor ? getTiptapEditor(editor) : null;
+      let styleApplied = false;
+
+      if (anchor && editor && tiptapEditor && !tiptapEditor.state.selection.empty) {
+        try {
+          const { from, to } = tiptapEditor.state.selection;
+          const currentBlockId = editor.getTextCursorPosition().block?.id;
+          const currentText = tiptapEditor.state.doc.textBetween(from, to, ' ').trim();
+
+          if (
+            currentBlockId === anchor.blockId &&
+            currentText === anchor.anchorText &&
+            !rangeHasTicketStyle(tiptapEditor, from, to)
+          ) {
+            editor.addStyles({ canvasTicket: ticket.id } as never);
+            tiptapEditor.commands.setTextSelection({ from: to, to });
+            styleApplied = true;
+          }
+        } catch {
+          styleApplied = false;
+        }
+      }
+
+      setActiveTicketAnchor(null);
+      if (!styleApplied) {
+        toast.warning('Ticket created, but the selected canvas text changed and was not linked');
+      }
+    },
+    [activeTicketAnchor, getEditor],
+  );
+
+  return {
+    activeTicketAnchor,
+    isTicketChannelArchived: channel?.isArchived === true,
+    openTicketForCurrentSelection,
+    closeTicketModal,
+    handleTicketCreated,
+  };
+}

--- a/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
+++ b/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
@@ -132,6 +132,9 @@ interface CreateTicketModalProps {
   entityLinkContext?: EntityLinkScope | undefined;
   isFromSubTicket?: boolean;
   isFromAI?: boolean;
+  allowChannelSelection?: boolean;
+  useLocalAttachments?: boolean;
+  focusDescriptionOnOpen?: boolean;
   ticketSequence?: { current: number; total: number };
   parentTicketId?: string;
   onBeforeCreate?: (description: string, files: File[]) => Promise<void>;
@@ -226,6 +229,9 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
   releaseChannelIds,
   isFromSubTicket = false,
   isFromAI = false,
+  allowChannelSelection = false,
+  useLocalAttachments = false,
+  focusDescriptionOnOpen = false,
   ticketSequence,
   parentTicketId,
   sourceConversation,
@@ -263,6 +269,8 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
 
   // Determine if we're creating from conversation or tickets tab
   const isFromTicketsTab = tab === 'tickets' && !sourceConversation;
+  const canSelectChannel = isFromSubTicket || isFromAI || releaseOnly || allowChannelSelection;
+  const usesLocalAttachments = isFromTicketsTab || useLocalAttachments;
   // Fetch existing CHAT attachments from INITIAL MESSAGE ONLY using Zero
 
   const messageIdForQuery =
@@ -339,7 +347,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
         return;
       }
 
-      if (!isFromTicketsTab) {
+      if (!usesLocalAttachments) {
         // Load from DraftProvider (DB-backed)
         try {
           const map = getDroppedFilesForEntity(
@@ -367,12 +375,12 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
     };
 
     void loadAttachments();
-  }, [isOpen, isFromTicketsTab, sourceConversation, channelId, getDroppedFilesForEntity]);
+  }, [isOpen, usesLocalAttachments, sourceConversation, channelId, getDroppedFilesForEntity]);
 
   // Unified add file handler
   const addFile = useCallback(
     async (file: File): Promise<void> => {
-      if (!isFromTicketsTab) {
+      if (!usesLocalAttachments) {
         // Use DraftProvider (DB-backed)
         await providerAddDroppedFiles(file, channelId, sourceConversation?.conversationId);
       } else {
@@ -380,13 +388,13 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
         setTicketLocalFiles(prev => [...prev, { id: newLocalFileId(), file }]);
       }
     },
-    [isFromTicketsTab, providerAddDroppedFiles, channelId, sourceConversation],
+    [usesLocalAttachments, providerAddDroppedFiles, channelId, sourceConversation],
   );
 
   // Unified remove file handler
   const removeFile = useCallback(
     async (attachmentId: string, _file: File): Promise<void> => {
-      if (!isFromTicketsTab) {
+      if (!usesLocalAttachments) {
         // Use DraftProvider
         await providerRemoveDroppedFile(attachmentId);
       } else {
@@ -394,19 +402,23 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
         setTicketLocalFiles(prev => prev.filter(entry => entry.id !== attachmentId));
       }
     },
-    [isFromTicketsTab, providerRemoveDroppedFile],
+    [usesLocalAttachments, providerRemoveDroppedFile],
   );
 
   // Clear all files handler
   const clearFiles = useCallback(async () => {
-    if (!isFromTicketsTab) {
+    if (!usesLocalAttachments) {
       await providerClearDroppedFiles(channelId, sourceConversation?.conversationId ?? null);
     } else {
       setTicketLocalFiles([]);
     }
-  }, [isFromTicketsTab, providerClearDroppedFiles, channelId, sourceConversation]);
+  }, [usesLocalAttachments, providerClearDroppedFiles, channelId, sourceConversation]);
 
-  const channels = useAllVisibleChannels().filter(c => c.scopeType === ChannelScopeType.DEFAULT);
+  const channels = useAllVisibleChannels().filter(
+    channel =>
+      channel.scopeType === ChannelScopeType.DEFAULT &&
+      (!allowChannelSelection || (!channel.isArchived && Boolean(channel.projectId))),
+  );
 
   // Track if title has been auto-generated for this modal session
   const [hasTitleBeenGenerated, setHasTitleBeenGenerated] = useState(false);
@@ -486,11 +498,8 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
 
   // Fetch boards for the selected channel's project (or default projectId)
   const selectedChannelProjectId =
-    (isFromSubTicket || isFromAI) && selectedChannel?.projectId
-      ? selectedChannel.projectId
-      : projectId;
-  const effectiveChannelId =
-    isFromSubTicket || isFromAI ? (selectedChannelId ?? channelId) : channelId;
+    canSelectChannel && selectedChannel?.projectId ? selectedChannel.projectId : projectId;
+  const effectiveChannelId = canSelectChannel ? (selectedChannelId ?? channelId) : channelId;
   const [channelBoardMappings, mappingDetails] = useCachedQuery(
     queries.boardsByChannel({ channelId: effectiveChannelId }),
     { enabled: !!effectiveChannelId },
@@ -828,7 +837,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
     }
 
     // Add newly uploaded files (from DraftProvider or local state)
-    if (!isFromTicketsTab) {
+    if (!usesLocalAttachments) {
       // From DraftProvider (DB)
       const draftFiles = Array.from(attachmentsMap.entries()).map(([attachmentId, file]) => ({
         attachmentId,
@@ -860,7 +869,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
     attachmentsMap,
     sourceConversation,
     excludedChatAttachmentIds,
-    isFromTicketsTab,
+    usesLocalAttachments,
     ticketLocalFiles,
   ]);
 
@@ -1237,6 +1246,11 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
       // Validate mandatory board-configured fields
       const mandatoryFieldErrors: string[] = [];
 
+      if (canSelectChannel && !formData.channelId.trim()) {
+        mandatoryFieldErrors.push(
+          releaseOnly ? 'Release channel is required' : 'Channel is required',
+        );
+      }
       if (
         !releaseOnly &&
         showUserGroupsOnly &&
@@ -1362,10 +1376,10 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
       }
 
       // Collect draft attachment IDs from DraftProvider (for conversation case)
-      const draftAttachmentIds = !isFromTicketsTab ? Array.from(attachmentsMap.keys()) : [];
+      const draftAttachmentIds = !usesLocalAttachments ? Array.from(attachmentsMap.keys()) : [];
 
       // Get files to send - combine both sources
-      const draftFiles = !isFromTicketsTab
+      const draftFiles = !usesLocalAttachments
         ? Array.from(attachmentsMap.values()).filter((f): f is File => f instanceof File)
         : ticketLocalFiles.map(entry => entry.file);
 
@@ -1378,12 +1392,9 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
         formDataPayload.append('title', formData.title.trim());
         formDataPayload.append('description', formData.description.trim());
         formDataPayload.append('boardId', formData.boardId);
-        // For subtickets, AI-initiated tickets, or a release-only launch, use the
-        // channel picked in the form; otherwise use the prop (the current channel).
-        formDataPayload.append(
-          'channelId',
-          isFromSubTicket || isFromAI || releaseOnly ? formData.channelId : channelId,
-        );
+        // Channel-selecting flows use the value picked in the form; regular flows
+        // remain tied to the channel supplied by their caller.
+        formDataPayload.append('channelId', canSelectChannel ? formData.channelId : channelId);
         if (selectedBoard?.projectId) {
           formDataPayload.append('projectId', selectedBoard.projectId);
         }
@@ -1496,8 +1507,8 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
           assignedTo: assignedTo || undefined,
           userGroupId: userGroupId || undefined,
           boardId: formData.boardId,
-          // Use the form channel for subtickets/AI/releaseOnly; else the prop. Matches the multipart branch.
-          channelId: isFromSubTicket || isFromAI || releaseOnly ? formData.channelId : channelId,
+          // Keep JSON and multipart channel resolution identical.
+          channelId: canSelectChannel ? formData.channelId : channelId,
           fromTicketsTab: isFromTicketsTab,
           ...(selectedBoard?.projectId && { projectId: selectedBoard.projectId }),
           ticketType: formData.ticketType,
@@ -1564,7 +1575,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
   };
 
   const handleClose = (): void => {
-    if (isFromTicketsTab) {
+    if (usesLocalAttachments) {
       void clearFiles();
     }
     setExcludedChatAttachmentIds(new Set());
@@ -1595,7 +1606,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
       }
     }
 
-    if (isFromTicketsTab) {
+    if (usesLocalAttachments) {
       if (ticketLocalFiles.length > 0) return true;
     } else if (attachmentsMap.size > (baselineAttachmentCountRef.current ?? 0)) {
       return true;
@@ -1619,7 +1630,7 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
     handleClose();
   };
 
-  const canPopOut = !standalone && !ticketSequence;
+  const canPopOut = !standalone && !ticketSequence && !allowChannelSelection;
 
   const handlePopOut = (): void => {
     const popoutId = uuidv4();
@@ -2300,8 +2311,8 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
 
         {/* Channel and Board Selection */}
         <div className={cn('flex items-center gap-2.5 pb-2', subTickets.length > 0 && 'pt-4')}>
-          {/* Channel Selection */}
-          {(isFromSubTicket || isFromAI || releaseOnly) && (
+          {/* Optional channel selection for subtickets, AI, and context-free entry points. */}
+          {canSelectChannel && (
             <form.Field
               name='channelId'
               validators={{
@@ -2317,9 +2328,10 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
                   variant='inline'
                   options={releaseOnly ? releaseChannelOptions : channelOptions}
                   selectedValue={field.state.value || ''}
-                  onSelect={(value: string | null) =>
-                    field.handleChange(value as CreateTicketFormData['channelId'])
-                  }
+                  onSelect={(value: string | null) => {
+                    field.handleChange(value as CreateTicketFormData['channelId']);
+                    if (allowChannelSelection) form.setFieldValue('boardId', '');
+                  }}
                   searchPlaceholder={releaseOnly ? 'release channel' : 'channel'}
                   placeholder={releaseOnly ? 'Select release channel' : 'channel'}
                   inputIcon={<Hash className='size-3.5' strokeWidth={2.33} />}
@@ -3163,7 +3175,9 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
       }}
       title='Create Ticket'
       description='Create and edit ticket details before submitting.'
-      {...(!isMobile ? { focusRef: titleInputRef } : {})}
+      {...(!isMobile
+        ? { focusRef: focusDescriptionOnOpen ? descriptionTextareaRef : titleInputRef }
+        : {})}
       data-testid='create-ticket-modal'
       className={cn(
         'w-full max-w-screen-md max-h-1/2 rounded-xl border border-border',

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2677,9 +2677,13 @@ html .bn-code-block-source-popup-ok-button:hover {
   display: inline-flex;
   width: 490px;
   max-width: 100%;
+  height: 30px;
   min-height: 30px;
+  max-height: 30px;
   box-sizing: border-box;
   align-items: center;
+  flex-wrap: nowrap;
+  overflow: hidden;
   box-decoration-break: clone;
   -webkit-box-decoration-break: clone;
   border: 1px solid hsl(var(--border));
@@ -2722,13 +2726,22 @@ html .bn-code-block-source-popup-ok-button:hover {
   user-select: none;
 }
 
+.canvas-ticket-anchor__source {
+  display: none;
+}
+
 .canvas-ticket-anchor__text {
+  display: block;
   overflow: hidden;
   min-width: 0;
+  max-width: 100%;
   flex: 1 1 auto;
   font-weight: 600;
+  line-height: 24px;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: normal !important;
+  white-space: nowrap !important;
+  word-break: normal !important;
 }
 
 .canvas-ticket-anchor__status,

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2530,8 +2530,8 @@ html .bn-code-block-source-popup-ok-button:hover {
    BlockNote menus in chat, previews, and other editor surfaces keep their own
    layout. */
 .canvas-formatting-menu.bn-formatting-toolbar {
-  width: 200px;
-  min-width: 200px;
+  width: 270px;
+  min-width: 270px;
   flex-direction: column;
   align-items: stretch;
   gap: 0;
@@ -2654,6 +2654,11 @@ html .bn-code-block-source-popup-ok-button:hover {
   border-radius: 8px 0 0 8px;
 }
 
+.canvas-formatting-menu__attached-button--middle {
+  border-right-width: 0;
+  border-radius: 0;
+}
+
 .canvas-formatting-menu__attached-button--right {
   border-radius: 0 8px 8px 0;
 }
@@ -2666,6 +2671,153 @@ html .bn-code-block-source-popup-ok-button:hover {
 .canvas-formatting-menu__attached-button svg {
   width: 14px;
   height: 14px;
+}
+
+.canvas-ticket-anchor[data-canvas-ticket-id] {
+  display: inline-flex;
+  width: 490px;
+  max-width: 100%;
+  min-height: 30px;
+  box-sizing: border-box;
+  align-items: center;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  background: hsl(var(--card));
+  box-shadow: 0 1px 2px hsl(var(--foreground) / 0.05);
+  color: inherit;
+  cursor: pointer;
+  padding: 2px 4px 2px 9px;
+  line-height: 1.25;
+  vertical-align: middle;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.canvas-ticket-anchor[data-canvas-ticket-id]:hover,
+.canvas-ticket-anchor[data-canvas-ticket-id]:focus-visible {
+  border-color: hsl(var(--border));
+  background: hsl(var(--card));
+  box-shadow: 0 1px 2px hsl(var(--foreground) / 0.05);
+  outline: none;
+}
+
+.canvas-ticket-anchor__id {
+  flex: 0 0 auto;
+  margin-right: 10px;
+  color: hsl(var(--muted-foreground));
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.76em;
+  font-weight: 500;
+  letter-spacing: 0.015em;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.canvas-ticket-anchor__text {
+  overflow: hidden;
+  min-width: 0;
+  flex: 1 1 auto;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.canvas-ticket-anchor__status,
+.canvas-ticket-anchor__assignee,
+.canvas-ticket-anchor__unavailable {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.canvas-ticket-anchor__status {
+  gap: 4px;
+  flex: 0 0 auto;
+  margin-left: auto;
+  padding-left: 24px;
+  color: hsl(var(--primary));
+  font-size: 0.82em;
+  font-weight: 500;
+}
+
+.canvas-ticket-anchor__status svg {
+  width: 13px;
+  height: 13px;
+}
+
+.canvas-ticket-anchor__assignee {
+  flex: 0 0 auto;
+  margin-left: 10px;
+}
+
+.canvas-ticket-anchor__avatar {
+  width: 24px;
+  height: 24px;
+}
+
+.canvas-ticket-anchor__avatar [data-slot="avatar"] {
+  width: 100%;
+  height: 100%;
+}
+
+.canvas-ticket-avatar,
+.canvas-ticket-avatar [data-slot="avatar"],
+.canvas-ticket-avatar [data-slot="avatar-image"],
+.canvas-ticket-avatar [data-slot="avatar-fallback"] {
+  border-radius: 9999px;
+}
+
+.canvas-ticket-avatar [data-slot="avatar"],
+.canvas-ticket-avatar [data-slot="avatar-fallback"] {
+  background-color: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+
+.canvas-ticket-anchor__assignee--unassigned {
+  width: 24px;
+  height: 24px;
+  justify-content: center;
+  border: 1px dashed hsl(var(--muted-foreground) / 0.45);
+  border-radius: 7px;
+  color: hsl(var(--muted-foreground));
+}
+
+.canvas-ticket-anchor__assignee--unassigned svg {
+  width: 13px;
+  height: 13px;
+}
+
+.canvas-ticket-anchor__unavailable {
+  margin-left: 8px;
+  color: hsl(var(--destructive));
+  font-size: 0.78em;
+  font-weight: 500;
+}
+
+.canvas-ticket-anchor[data-canvas-ticket-status="COMPLETED"] .canvas-ticket-anchor__status {
+  color: var(--status-success);
+}
+
+.canvas-ticket-anchor[data-canvas-ticket-status="CANCELLED"] .canvas-ticket-anchor__status {
+  color: hsl(var(--muted-foreground));
+}
+
+[data-theme="midnight"] .canvas-ticket-anchor[data-canvas-ticket-id] {
+  background: hsl(var(--card));
+  border-color: hsl(var(--border));
+}
+
+@media (max-width: 640px) {
+  .canvas-ticket-anchor__status,
+  .canvas-ticket-anchor__assignee {
+    display: none;
+  }
 }
 
 .canvas-inline-comment-composer button[aria-label="Mention channel"] {

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2697,12 +2697,17 @@ html .bn-code-block-source-popup-ok-button:hover {
     box-shadow 150ms ease;
 }
 
-.canvas-ticket-anchor[data-canvas-ticket-id]:hover,
-.canvas-ticket-anchor[data-canvas-ticket-id]:focus-visible {
+.canvas-ticket-anchor[data-canvas-ticket-access="available"]:hover,
+.canvas-ticket-anchor[data-canvas-ticket-access="available"]:focus-visible {
   border-color: hsl(var(--border));
   background: hsl(var(--card));
   box-shadow: 0 1px 2px hsl(var(--foreground) / 0.05);
   outline: none;
+}
+
+.canvas-ticket-anchor[data-canvas-ticket-access="loading"],
+.canvas-ticket-anchor[data-canvas-ticket-access="unavailable"] {
+  cursor: default;
 }
 
 .canvas-ticket-anchor__id {

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -2002,6 +2002,38 @@ export const router = createBrowserRouter(
           ),
         },
         {
+          path: '/newWindow/chat/canvas',
+          element: (
+            <EncryptionBootstrapProvider>
+              <ZeroProvider>
+                <ZeroFallbackProvider>
+                  <InitialStateLoader>
+                    <EditProvider>
+                      <div className='h-full bg-background'>
+                        <CanvasPanel />
+                      </div>
+                      <AttachmentGalleryModal />
+                      <AttachmentCitationPreview />
+                      <ThreadCitationModal />
+                      <TranscriptCitationModal />
+                    </EditProvider>
+                  </InitialStateLoader>
+                </ZeroFallbackProvider>
+              </ZeroProvider>
+            </EncryptionBootstrapProvider>
+          ),
+          children: [
+            {
+              index: true,
+              element: null,
+            },
+            {
+              path: ':canvasId',
+              element: <CanvasScreen />,
+            },
+          ],
+        },
+        {
           path: '/newWindow/create-ticket',
           element: (
             <ZeroProvider>


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard
POT : [POT](https://drive.google.com/file/d/1YR5bhRJB_gSCzdwj9YGu7LhgQ64i_4WZ/view)
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
