### PR TITLE
fix: XYNE-55539 UI feedback v3

### DIFF
--- a/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
@@ -225,7 +225,7 @@ function ChatTopbar({
       >
         <Menu className='h-4 w-4' aria-hidden strokeWidth={1.75} />
       </button>
-      <h1 className='flex-1 truncate text-[13.5px] font-medium text-foreground'>{title}</h1>
+      <h1 className='flex-1 truncate text-base font-medium text-foreground'>{title}</h1>
     </header>
   );
 }
@@ -316,7 +316,7 @@ function ReasoningSection({
       style={{ transition: 'grid-template-rows 220ms ease-out, opacity 180ms ease-out' }}
     >
       <div className='overflow-hidden'>
-        <div className='my-1 text-[12.5px]'>
+        <div className='my-1 text-xs'>
           <button
             type='button'
             onClick={() => {
@@ -1064,7 +1064,7 @@ function ChatMessageBubble({
             )}
             <div
               className={cn(
-                'ai-user-bubble rounded-3xl bg-[#ececec] px-4 py-2.5 text-[14.5px] leading-relaxed text-gray-900',
+                'ai-user-bubble rounded-3xl bg-[#ececec] px-4 py-2.5 text-sm leading-relaxed text-gray-900',
                 isEditing ? 'w-full' : 'max-w-full',
               )}
             >
@@ -1086,7 +1086,7 @@ function ChatMessageBubble({
                         setIsEditing(false);
                       }
                     }}
-                    className='min-h-[60px] w-full resize-none bg-transparent text-[14.5px] leading-relaxed text-gray-900 outline-none'
+                    className='min-h-[60px] w-full resize-none bg-transparent text-sm leading-relaxed text-gray-900 outline-none'
                     rows={Math.max(2, editText.split('\n').length)}
                     data-track-category='XyneAI'
                     data-track-name='EDIT_TEXTAREA'
@@ -1174,7 +1174,7 @@ function ChatMessageBubble({
 
           {displayContent && displayContent.length > 0 && (
             <div
-              className={`bot-markdown-content xyne-ai-markdown text-[15px] font-normal leading-7 text-foreground${
+              className={`bot-markdown-content xyne-ai-markdown text-sm font-normal leading-7 text-foreground${
                 // Keyed off everStreamed (not isStreaming) so content that
                 // lands AT completion — the final tail words, finalized
                 // citation chips — still fades in instead of popping the

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -150,7 +150,7 @@ function ContextPill({
       {icon}
       <span
         className={cn(
-          'max-w-[140px] truncate text-[12.5px] font-medium',
+          'max-w-[140px] truncate text-sm font-medium',
           accent ? 'text-claw-ai-fg' : 'text-foreground',
         )}
       >
@@ -813,7 +813,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
               placeholder={placeholder}
               rows={1}
               className={cn(
-                'block w-full min-h-[60px] resize-none bg-transparent px-2 py-1 text-[15px] leading-6 placeholder:text-muted-foreground/80 focus:outline-none',
+                'block w-full min-h-[60px] resize-none bg-transparent px-2 py-1 text-sm leading-6 placeholder:text-muted-foreground/80 focus:outline-none',
                 isVoiceRecording && !value && 'invisible',
               )}
               data-track-category='XyneAI'
@@ -904,7 +904,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
                 {compactToolbar && modelSelectorNode}
               </div>
               <ToolbarButton
-                icon={<span className='text-[15px] font-semibold leading-none'>/</span>}
+                icon={<span className='text-sm font-semibold leading-none'>/</span>}
                 label='Add context'
                 onClick={() => setShowContextModal(v => !v)}
                 active={showContextModal}

--- a/apps/dashboard/src/components/AIScreen/AIEmptyState.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIEmptyState.tsx
@@ -34,7 +34,7 @@ export function AIEmptyState({ className }: AIEmptyStateProps): ReactElement {
   return (
     <h1
       className={
-        'animate-fadeUp text-center text-[28px] font-normal leading-tight tracking-tight text-foreground ' +
+        'animate-fadeUp text-center text-[24px] font-normal leading-tight tracking-tight text-foreground ' +
         (className ?? '')
       }
     >

--- a/apps/dashboard/src/components/Project/ProjectForm/ProjectForm.tsx
+++ b/apps/dashboard/src/components/Project/ProjectForm/ProjectForm.tsx
@@ -1,5 +1,7 @@
 import { ReactElement, useState } from 'react';
-import { TextInput, TextArea, Button, ButtonType } from '@juspay/blend-design-system';
+import { Button } from '../../ui/Button';
+import { Input } from '../../ui/Input';
+import { Textarea } from '../../ui/Textarea';
 import { mixpanelService } from '../../../services/Analytics/mixpanelService';
 import { EVENTS, EVENT_PROPERTIES } from '../../../services/Analytics/mixpanel.types';
 import { sanitizeProjectCode, isValidProjectCode } from '@xyne/shared';
@@ -90,16 +92,37 @@ export const ProjectForm = ({
   const isLoading = loading || isSubmitting;
 
   return (
-    <div className='space-y-4'>
+    <form
+      className='flex flex-col gap-4 p-6'
+      noValidate
+      onSubmit={e => {
+        e.preventDefault();
+        handleSubmit();
+      }}
+    >
+      <div className='flex flex-col gap-1.5'>
+        <h2 className='text-base font-semibold text-foreground'>
+          {isEdit ? 'Edit project' : 'Create new project'}
+        </h2>
+        <p className='text-sm text-muted-foreground'>
+          {isEdit
+            ? 'Update the name and description for this project.'
+            : 'Name your project and pick a code for its ticket IDs.'}
+        </p>
+      </div>
+
       {error && (
-        <div className='bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded'>
+        <p className='rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive'>
           {error}
-        </div>
+        </p>
       )}
 
-      <div>
-        <TextInput
-          label='Project Name'
+      <div className='flex flex-col gap-1.5'>
+        <label htmlFor='project-name' className='text-sm font-medium text-foreground'>
+          Project name
+        </label>
+        <Input
+          id='project-name'
           value={name}
           onChange={e => setName(e.target.value)}
           placeholder='Enter project name'
@@ -110,23 +133,31 @@ export const ProjectForm = ({
       </div>
 
       {!isEdit && (
-        <div>
-          <TextInput
-            label='Project Code (Ticket Prefix)'
+        <div className='flex flex-col gap-1.5'>
+          <label htmlFor='project-code' className='text-sm font-medium text-foreground'>
+            Project code
+          </label>
+          <Input
+            id='project-code'
             value={code}
             onChange={e => setCode(sanitizeProjectCode(e.target.value))}
             placeholder='e.g., EUL, PROJ, PRO1, XY2'
-            required={!isEdit}
+            required
             disabled={isLoading}
-            hintText={`Tickets will be: ${code || 'CODE'}-0001, ${code || 'CODE'}-0002...`}
             data-testid='project-code-input'
           />
+          <p className='text-xs text-muted-foreground'>
+            Tickets will be: {code || 'CODE'}-0001, {code || 'CODE'}-0002...
+          </p>
         </div>
       )}
 
-      <div>
-        <TextArea
-          label='Description'
+      <div className='flex flex-col gap-1.5'>
+        <label htmlFor='project-description' className='text-sm font-medium text-foreground'>
+          Description
+        </label>
+        <Textarea
+          id='project-description'
           value={description}
           onChange={e => setDescription(e.target.value)}
           placeholder='Enter project description (optional)'
@@ -135,34 +166,31 @@ export const ProjectForm = ({
         />
       </div>
 
-      <div className='flex gap-2 justify-end'>
+      <div className='flex justify-end gap-2'>
         <Button
-          buttonType={ButtonType.SECONDARY}
-          text='Cancel'
+          type='button'
+          variant='outline'
+          size='sm'
           onClick={onCancel}
           disabled={isLoading}
           data-track-category='Projects'
           data-track-name='CancelProjectForm'
           data-track-metadata={JSON.stringify({ projectId: project?.id, isEdit })}
-        />
+        >
+          Cancel
+        </Button>
         <Button
-          buttonType={ButtonType.PRIMARY}
-          text={
-            isLoading
-              ? isEdit
-                ? 'Updating...'
-                : 'Creating...'
-              : isEdit
-                ? 'Update Project'
-                : 'Create Project'
-          }
-          onClick={handleSubmit}
+          type='submit'
+          size='sm'
+          loading={isLoading}
           disabled={isLoading || !name.trim()}
           data-track-category='Projects'
           data-track-name='SubmitProjectForm'
           data-track-metadata={JSON.stringify({ projectId: project?.id, isEdit })}
-        />
+        >
+          {isEdit ? 'Update project' : 'Create project'}
+        </Button>
       </div>
-    </div>
+    </form>
   );
 };

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -3125,7 +3125,7 @@ img.inline-emoji,
 
 /* Base markdown content styling with text wrapping for overflow prevention.
    Typography sits in `components` so a surface that sets its own size on the
-   wrapper (e.g. AIChatThread's `text-[15px] leading-7`) still wins. */
+   wrapper still wins over this baseline. */
 @layer components {
   .bot-markdown-content,
   .bot-markdown-content-call-summary {

--- a/apps/dashboard/src/routes/ProjectDetailScreen/ProjectDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ProjectDetailScreen/ProjectDetailScreen.tsx
@@ -805,8 +805,9 @@ const ProjectDetailScreen = (): ReactElement => {
         open={showEditProjectModal}
         onOpenChange={setShowEditProjectModal}
         title='Edit Project'
+        className='debug'
       >
-        <div className='p-6'>
+        <div>
           <ProjectForm
             project={project}
             onSubmit={data => handleUpdateProject(project.id, data)}

--- a/apps/dashboard/src/routes/ProjectsScreen/ProjectsListView.tsx
+++ b/apps/dashboard/src/routes/ProjectsScreen/ProjectsListView.tsx
@@ -2,7 +2,8 @@ import { ReactElement, useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useZero } from '../../hooks/useZero';
 import { toast } from 'sonner';
-import { Button, ButtonType, Modal } from '@juspay/blend-design-system';
+import { Button } from '../../components/ui/Button';
+import { Dialog } from '../../components/ui/Dialog';
 import { ProjectForm, ProjectCard } from '../../components/Project';
 import { apiInstance } from '../../services/clients/apiClient';
 import { queries } from '../../zero/queries';
@@ -116,12 +117,13 @@ const ProjectsListView = (): ReactElement => {
                 </button>
               )}
               <Button
-                buttonType={ButtonType.PRIMARY}
-                text='New'
+                size='sm'
                 onClick={() => setShowCreateModal(true)}
                 data-track-category='Projects'
                 data-track-name='CreateProject'
-              />
+              >
+                New
+              </Button>
             </div>
           </div>
           <p className='text-xs text-muted-foreground'>Manage your projects</p>
@@ -169,37 +171,32 @@ const ProjectsListView = (): ReactElement => {
 
       {/* Create Modal */}
       {showCreateModal && (
-        <Modal
-          isOpen={true}
-          onClose={() => setShowCreateModal(false)}
-          title='Create New Project'
-          showCloseButton={true}
-          closeOnBackdropClick={false}
+        <Dialog
+          open={true}
+          onOpenChange={open => !open && setShowCreateModal(false)}
+          title='Create new project'
+          description='Name your project and pick a code for its ticket IDs.'
+          testId='create-project-dialog'
         >
-          <div data-testid='create-project-dialog'>
-            <ProjectForm
-              onSubmit={handleCreateProject}
-              onCancel={() => setShowCreateModal(false)}
-            />
-          </div>
-        </Modal>
+          <ProjectForm onSubmit={handleCreateProject} onCancel={() => setShowCreateModal(false)} />
+        </Dialog>
       )}
 
       {/* Edit Modal */}
       {editingProject && (
-        <Modal
-          isOpen={true}
-          onClose={() => setEditingProject(null)}
-          title='Edit Project'
-          showCloseButton={true}
-          closeOnBackdropClick={false}
+        <Dialog
+          open={true}
+          onOpenChange={open => !open && setEditingProject(null)}
+          title='Edit project'
+          description='Update the name and description for this project.'
+          testId='edit-project-dialog'
         >
           <ProjectForm
             project={editingProject}
             onSubmit={data => handleUpdateProject(editingProject.id, data)}
             onCancel={() => setEditingProject(null)}
           />
-        </Modal>
+        </Dialog>
       )}
     </div>
   );


### PR DESCRIPTION
## Type of Change

- [x] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Two UI-consistency fixes from the XYNE-55539 feedback round. Dashboard-only, no behaviour or data changes.

### 1. Create / edit project dialog — `3de4d84`

The dialog was still built on `@juspay/blend-design-system`, so it didn't pick up app theme tokens and looked foreign next to the rest of the dashboard.

- `ProjectForm` rebuilt on the local `ui/` primitives (`Button`, `Input`, `Textarea`) instead of blend's `TextInput` / `TextArea` / `Button`.
- Wrapped in a real `<form>` with `onSubmit` — **Enter now submits**, and the primary action is `type="submit"` rather than an `onClick` handler.
- Every field gained a proper `<label htmlFor>` (name, code, description). Previously these were `label` props on the blend inputs, so there was no associated label element.
- Ticket-prefix hint moved off blend's `hintText` into a `text-xs text-muted-foreground` line under the input.
- Error state restyled from hardcoded `red-50` / `red-200` / `red-700` to `destructive` tokens, so it themes correctly.
- `Modal` → local `Dialog` in `ProjectsListView`; `title` / `description` are passed for the a11y-only `DialogPrimitive.Title` / `Description`, with the visible heading now living in the form.
- Button copy sentence-cased ("Create project" / "Update project"); loading handled by the `loading` prop instead of swapping the label to "Creating…".

### 2. AI chat screen typography — `5dc01e2`

`/ai/chat` had drifted from Chat and the Ask AI panel — it was a fork of the Ask AI message renderer with bumped sizes on the wrappers. **Font sizes only** here; weights, letter-spacing and colours are untouched.

| Element | Was | Now | Now matches |
|---|---|---|---|
| Assistant answer body | 15px | 14px (`text-sm`) | Chat + Ask AI panel |
| User message bubble | 14.5px | 14px | Ask AI panel |
| Edit textarea | 14.5px | 14px | Ask AI panel |
| Thread header title | 13.5px | 16px (`text-base`) | `ConversationHeader`, `XyneAIHeader` |
| Reasoning toggle label | 12.5px | 12px (`text-xs`) | `ActivityBlock` |
| Composer input | 15px | 14px | both composers |
| Composer context pill | 12.5px | 14px | `ContextPillRow` |
| Composer `/` glyph | 15px | 14px | `XyneAIInputBox` |
| Greeting | 28px | 24px | `AILandingHero` |

The composer placeholder needed no edit — it's a native `::placeholder`, so it follows the textarea down to 14px on its own.

**Knock-on fix:** the shared markdown CSS (`.bot-markdown-content`) pins `h1` 16px / `h2` 15px / `h3–h6` 14px / code 14px / tables 13px against a 14px baseline. At the old 15px body, `h2` rendered at body size and `h3`–`h6` rendered *smaller* than the prose they introduced. Restoring the 14px baseline puts that ladder back without touching the CSS.

The stale comment in `global.css` naming the old `text-[15px] leading-7` override was updated.

### Deliberately not changed

- `leading-7` (28px) on the answer body — that's line-height, not font size, so it was out of scope for this pass. It's the one remaining reason the AI answer column reads looser than the panel.
- Font weights, letter-spacing, and the hardcoded `bg-[#ececec]` / `text-gray-900` / `#f5f4f0` composer colours on the AI screen.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Recording of the create / edit project dialog:
https://drive.google.com/file/d/1KPk0wjkGhps11iuYHKJrS0-G0DByp7Gh/view?usp=sharing

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- presentational only: font-size tokens and a component swap with no logic change -->

`pnpm --filter dashboard typecheck` passes on the branch. `lint:errors-only` and `build` have not been re-run.

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once
- [ ] Different roles or permission levels
- [ ] Different workspaces / spaces

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Electron desktop

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume

<!-- The recording covers the create/edit dialog flow. The AI-screen typography change still wants an eyeball pass in both light and midnight themes, and against a long answer containing headings, code blocks and tables — that's where the h2/h3 ladder fix shows up. -->

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass <!-- n/a, no backend changes -->
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass <!-- typecheck passes; lint + build not run -->
- [ ] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` <!-- none added; this PR removes two blend-design-system usages -->
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed <!-- n/a -->
- [ ] No debug logging or commented-out code left behind

> ⚠️ Last box is unchecked on purpose: `ProjectDetailScreen.tsx` passes `className='debug'` to the Edit Project `Dialog`, and `.debug` is `outline: 1px solid red` (`App.css:5`). That draws a red outline around the dialog. Needs removing before merge.
