### PR TITLE
fix: XYNE-61620 gate message send on attachment upload completion.

### DIFF
--- a/apps/backend/src/controllers/draftAttachmentController.ts
+++ b/apps/backend/src/controllers/draftAttachmentController.ts
@@ -5,7 +5,7 @@ import { ChannelRepository } from '../database/repositories/channelRepository';
 import { uploadFiles, UploadedFileResult } from '../services/fileUploadService';
 import { logger } from '../utils/logger';
 import { Prisma } from '@prisma/client';
-import { AttachmentEntityType } from '@xyne/shared';
+import { AttachmentEntityType, AttachmentUploadStatus } from '@xyne/shared';
 import { config } from '@/config/env';
 
 export class DraftAttachmentController {
@@ -231,6 +231,7 @@ export class DraftAttachmentController {
             thumbnailUrl,
             storageProvider: config.fileStorage.provider,
             metadata: completeMetadata,
+            uploadStatus: AttachmentUploadStatus.COMPLETED,
           };
 
           try {
@@ -278,6 +279,7 @@ export class DraftAttachmentController {
           });
         } catch (error) {
           logger.error(`Failed to process draft attachment ${attachmentId}:`, error);
+          await this.markAttachmentsFailed([attachmentId]);
           // Continue with next file even if this one fails
           results.push({
             attachmentId,
@@ -287,20 +289,40 @@ export class DraftAttachmentController {
         }
       }
 
-      res.status(200).json({
-        success: true,
+      const failureCount = results.filter(r => !r.success).length;
+
+      res.status(failureCount > 0 ? 500 : 200).json({
+        success: failureCount === 0,
         uploadedAttachments: results,
         totalCount: results.length,
         successCount: results.filter(r => r.success).length,
-        failureCount: results.filter(r => !r.success).length,
+        failureCount,
       });
 
     } catch (error) {
       logger.error('Error uploading draft attachments:', error);
+      await this.markAttachmentsFailed(attachmentIdsArray);
       res.status(500).json({
         error: 'Failed to upload attachments',
         message: error instanceof Error ? error.message : 'Unknown error'
       });
+    }
+  };
+
+  /**
+   * Best-effort: park rows whose upload never completed in FAILED so the send gate
+   * rejects them and the UI can show the failure. Never throws — the caller is
+   * already on an error path.
+   */
+  private markAttachmentsFailed = async (attachmentIds: string[]): Promise<void> => {
+    if (attachmentIds.length === 0) return;
+    try {
+      await this.db.messageAttachment.updateMany({
+        where: { id: { in: attachmentIds }, url: '' },
+        data: { uploadStatus: AttachmentUploadStatus.FAILED },
+      });
+    } catch (error) {
+      logger.error('Failed to mark attachments as failed:', error);
     }
   };
 }

--- a/apps/backend/src/middleware/upload.ts
+++ b/apps/backend/src/middleware/upload.ts
@@ -2,6 +2,8 @@ import multer from 'multer';
 import { logger } from '../utils/logger';
 import { storageService } from '../services/storage';
 import { AppError } from './errorHandler';
+import { db } from '../database/client';
+import { AttachmentUploadStatus } from '@xyne/shared';
 
 const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024; // 1GB max file size
 const MAX_FILE_FIELDS = 20; // Supports files + thumbnails in one multipart request
@@ -301,6 +303,26 @@ export const uploadSingle = (options: UploadSingleOptions = {}) => {
   };
 };
 
+/**
+ * A disconnect mid-upload leaves the client-created attachment rows PENDING with no
+ * object behind them. The ids arrive as text fields ahead of the file bodies, so they
+ * are already parsed here and the rows can be parked in FAILED. Best-effort.
+ */
+const markUploadedAttachmentsFailed = async (req: any): Promise<void> => {
+  const raw = req.body?.attachmentIds;
+  if (!raw) return;
+  try {
+    const ids: string[] = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (!Array.isArray(ids) || ids.length === 0) return;
+    await db.messageAttachment.updateMany({
+      where: { id: { in: ids }, url: '' },
+      data: { uploadStatus: AttachmentUploadStatus.FAILED },
+    });
+  } catch (error) {
+    logger.error('[MULTER] Failed to mark interrupted attachments as failed:', error);
+  }
+};
+
 // Custom uploadMultiple that proxies multipart file streams directly to object storage
 export const uploadMultiple = (req: any, res: any, next: any) => {
   logger.info('fixingAttachment 🗂️ [MULTER] Starting multipart stream proxy...');
@@ -313,6 +335,7 @@ export const uploadMultiple = (req: any, res: any, next: any) => {
   multerMiddleware(req, res, (err: any) => {
     if (err) {
       logger.error('fixingAttachment ❌ [MULTER] Upload middleware error:', err.message);
+      void markUploadedAttachmentsFailed(req);
       return next(normalizeMulterError(err, MAX_FILE_SIZE_BYTES));
     }
 

--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -48,6 +48,7 @@ import {
   RCAStatus,
   SEVERITY,
   AttachmentEntityType,
+  AttachmentUploadStatus,
   AttributionConfidence,
   BaseTicketType,
   isReleaseTicket,
@@ -121,6 +122,11 @@ import {
   validateFlowPlan,
 } from '@xyne/shared';
 import { stringFromFormValue } from '@xyne/shared/zero';
+import {
+  ATTACHMENT_STILL_UPLOADING,
+  isAttachmentUploaded,
+  isAttachmentUploadInFlight,
+} from '@xyne/shared/zero/mutators';
 import {
   validateFieldBranches,
   validateUniqueFieldNames,
@@ -2617,7 +2623,7 @@ export function createMutators(
             // Explicit list from a pending-message-aware caller: transfer only
             // those ids, don't touch the draft row (client's clearContent owns it).
             if (attachmentIds.length > 0) {
-              message.hasAttachment = true;
+              let attachedCount = 0;
               for (const attachmentId of attachmentIds) {
                 const attachment = await tx.run(
                   zql.message_attachments.where('id', attachmentId).one(),
@@ -2627,6 +2633,15 @@ export function createMutators(
                   attachment.entityType === AttachmentEntityType.CHAT &&
                   attachment.entityId === messageId
                 ) {
+                  attachedCount++;
+                  continue;
+                }
+                if (!isAttachmentUploaded(attachment)) {
+                  if (isAttachmentUploadInFlight(attachment)) {
+                    throw new ApplicationError(ATTACHMENT_STILL_UPLOADING, {
+                      details: { attachmentId },
+                    });
+                  }
                   continue;
                 }
                 await tx.mutate.message_attachments.update({
@@ -2635,7 +2650,9 @@ export function createMutators(
                   entityType: AttachmentEntityType.CHAT,
                   conversationId,
                 });
+                attachedCount++;
               }
+              message.hasAttachment = attachedCount > 0;
             }
           } else {
             // Legacy path: scan the current draft and transfer everything.
@@ -2651,18 +2668,28 @@ export function createMutators(
                 .where('entityId', draft.id)
                 .where('entityType', AttachmentEntityType.DRAFT));
 
+              let attachedCount = 0;
               for (const attachment of draftAttachments) {
+                if (!isAttachmentUploaded(attachment)) {
+                  if (isAttachmentUploadInFlight(attachment)) {
+                    throw new ApplicationError(ATTACHMENT_STILL_UPLOADING, {
+                      details: { attachmentId: attachment.id },
+                    });
+                  }
+                  continue;
+                }
                 await tx.mutate.message_attachments.update({
                   id: attachment.id,
                   entityId: messageId,
                   entityType: AttachmentEntityType.CHAT,
                   conversationId: conversationId,
                 });
+                attachedCount++;
               }
 
               await tx.mutate.draft_messages.delete({ id: draft.id });
 
-              message.hasAttachment = draftAttachments.length > 0;
+              message.hasAttachment = attachedCount > 0;
             }
           }
 
@@ -3332,7 +3359,7 @@ export function createMutators(
             // Explicit list from a pending-message-aware caller: transfer only
             // those ids, don't touch the draft row (client's clearContent owns it).
             if (attachmentIds.length > 0) {
-              message.hasAttachment = true;
+              let attachedCount = 0;
               for (const attachmentId of attachmentIds) {
                 const attachment = await tx.run(
                   zql.message_attachments.where('id', attachmentId).one(),
@@ -3342,6 +3369,15 @@ export function createMutators(
                   attachment.entityType === AttachmentEntityType.CHAT &&
                   attachment.entityId === messageId
                 ) {
+                  attachedCount++;
+                  continue;
+                }
+                if (!isAttachmentUploaded(attachment)) {
+                  if (isAttachmentUploadInFlight(attachment)) {
+                    throw new ApplicationError(ATTACHMENT_STILL_UPLOADING, {
+                      details: { attachmentId },
+                    });
+                  }
                   continue;
                 }
                 await tx.mutate.message_attachments.update({
@@ -3350,7 +3386,9 @@ export function createMutators(
                   entityType: AttachmentEntityType.CHAT,
                   conversationId,
                 });
+                attachedCount++;
               }
+              message.hasAttachment = attachedCount > 0;
             }
           } else {
             const draft = channelDrafts.find(d => d.conversationId === conversationId);
@@ -3360,18 +3398,28 @@ export function createMutators(
                 .where('entityId', draft.id)
                 .where('entityType', AttachmentEntityType.DRAFT));
 
+              let attachedCount = 0;
               for (const attachment of draftAttachments) {
+                if (!isAttachmentUploaded(attachment)) {
+                  if (isAttachmentUploadInFlight(attachment)) {
+                    throw new ApplicationError(ATTACHMENT_STILL_UPLOADING, {
+                      details: { attachmentId: attachment.id },
+                    });
+                  }
+                  continue;
+                }
                 await tx.mutate.message_attachments.update({
                   id: attachment.id,
                   entityId: messageId,
                   entityType: AttachmentEntityType.CHAT,
                   conversationId: conversationId,
                 });
+                attachedCount++;
               }
 
               await tx.mutate.draft_messages.delete({ id: draft.id });
 
-              message.hasAttachment = draftAttachments.length > 0;
+              message.hasAttachment = attachedCount > 0;
             }
           }
 
@@ -12707,6 +12755,7 @@ export function createMutators(
                   position: index,
                   createdBy: authData.sub,
                   url: '', // Will be populated after upload completes
+                  uploadStatus: AttachmentUploadStatus.PENDING,
                   metadata: null,
                   conversationId: conversationId || null,
                   isDeleted: false,

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -52,6 +52,11 @@ import { getSlashCommandArtifactDefinition } from '@xyne/shared';
 import { sendMessage, type ConversationRef, type PendingAttachment } from '@xyne/shared/messages';
 import { useCanCreateTicket } from '../../../hooks/usePermissions';
 import { mutators } from '../../../zero/mutators';
+import {
+  ATTACHMENT_STILL_UPLOADING,
+  isAttachmentUploaded,
+  isAttachmentUploadInFlight,
+} from '@xyne/shared/zero/mutators';
 import { useShortcutById } from '../../../shortcuts';
 import { isTestEnv } from '../../../config';
 import { createTicket, CreateTicketRequest } from '../../../services/ticketService';
@@ -461,6 +466,19 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
     // composer; used to carry attachments through the pending-message send.
     const channelDraftForSend = useDraftFromDB(channelId, conversationId ?? null);
 
+    // An attachment row exists from the moment a file is picked; its bytes land later over
+    // a separate upload request. Sending in between would publish a tile with no file behind
+    // it, so the send button stays disabled until the upload finishes. Attachments whose
+    // upload died long ago are not held: the send mutator drops those instead.
+    const isAttachmentUploading = useMemo(
+      () =>
+        !messageId &&
+        (channelDraftForSend?.attachments ?? []).some(
+          a => !isAttachmentUploaded(a) && isAttachmentUploadInFlight(a),
+        ),
+      [messageId, channelDraftForSend?.attachments],
+    );
+
     // Load draft for current channel on mount (only if not editing a message)
     const editorValue = React.useMemo(() => {
       if (isForwardedContent || initialContent) return initialContent;
@@ -662,6 +680,15 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
             )
           : bodyHtml;
         const hasFiles = files && files.length > 0;
+
+        // Backstop for callers that reach the send handler with the button bypassed
+        // (the send mutators reject it too — this is only so the user is told why).
+        if (isAttachmentUploading) {
+          toast.warning('Attachment is still uploading', {
+            description: 'It will be ready in a moment — try sending again.',
+          });
+          throw new Error(ATTACHMENT_STILL_UPLOADING);
+        }
         const hasThreadBroadcastMention =
           !!conversationId &&
           !messageId &&
@@ -986,6 +1013,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
         allUsersForMentionResolution,
         onMessageChange,
         isOffline,
+        isAttachmentUploading,
         user?.id,
         context.workspaceId,
         allowThreadBroadcastMentions,
@@ -1254,7 +1282,10 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
               }}
               onCreateCanvas={handleCreateCanvasFromComposer}
               hasTicket={hasTicket}
-              sendDisabled={isOffline}
+              sendDisabled={isOffline || isAttachmentUploading}
+              {...(isAttachmentUploading && {
+                sendDisabledReason: 'Attachment is still uploading',
+              })}
               onScheduleSend={handleScheduleSend}
               {...(globalShortcuts.length > 0 && {
                 bottomLeftSlot: (

--- a/apps/dashboard/src/components/FileViewer/VideoViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/VideoViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback, useImperativeHandle } from 'react';
 import { Play, Pause, Volume2, VolumeX, Maximize2, Minimize2, Settings } from 'lucide-react';
 import { BaseViewerProps } from './utils';
-import { BASE_URL } from '../../services/clients/apiClient';
+import { BASE_URL, apiInstance } from '../../services/clients/apiClient';
 import { useScope, useShortcutById } from '../../shortcuts';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useMobileZoom } from '../../hooks/useMobileZoom';
@@ -410,9 +410,26 @@ const VideoViewer = React.forwardRef<HTMLVideoElement, VideoViewerProps>(
           }
         }, delay);
       } else {
-        // Retries exhausted → show error UI
+        // Retries exhausted → show error UI. A file that never finished uploading 404s
+        // here and surfaces as the same MediaError as an undecodable one, so ask the
+        // server which it is instead of always blaming the format.
         setIsLoading(false);
         setError('Failed to load video. The video format may not be supported.');
+        if (attachmentId) {
+          void apiInstance
+            .get(`/attachments/${attachmentId}/stream`, {
+              headers: { Range: 'bytes=0-0' },
+              validateStatus: () => true,
+            })
+            .then(res => {
+              if (res.status === 404) {
+                setError('This video did not finish uploading, so there is nothing to play.');
+              }
+            })
+            .catch(() => {
+              // Offline or blocked — leave the generic message in place.
+            });
+        }
       }
     };
 

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -195,6 +195,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       hideVoiceInput = false,
       compact = false,
       sendDisabled = false,
+      sendDisabledReason,
       bottomLeftSlot,
       disableDraftUpload = false,
       dockSlot,
@@ -1179,7 +1180,14 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
     );
 
     const handleSend = useCallback(async () => {
-      if (!editor || isSending || sendDisabled) return;
+      if (!editor || isSending) return;
+      if (sendDisabled) {
+        // The button is disabled, but Enter still lands here — say why rather than
+        // swallowing the keystroke. Disabled buttons emit no pointer events, so the
+        // tooltip carrying the same reason never opens.
+        if (sendDisabledReason) toast.warning(sendDisabledReason);
+        return;
+      }
 
       // If a voice stream is active, finalize it for send first: this strips any
       // unfinalized interim text and aborts the stream (discarding in-flight results)
@@ -1270,6 +1278,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       attachedCanvas,
       hasSendableContent,
       sendDisabled,
+      sendDisabledReason,
       commandItems,
       onCommandSelect,
       disableDraftUpload,
@@ -1998,7 +2007,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                           }`}
                         >
                           <Tooltip
-                            content='Send message'
+                            content={sendDisabledReason ?? 'Send message'}
                             side='top'
                             delayDuration={1000}
                             skipDelayDuration={1000}
@@ -2083,7 +2092,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                           }`}
                         >
                           <Tooltip
-                            content='Send message'
+                            content={sendDisabledReason ?? 'Send message'}
                             side='top'
                             delayDuration={1000}
                             skipDelayDuration={1000}
@@ -2149,7 +2158,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
                         </div>
                       ) : (
                         <Tooltip
-                          content='Send message'
+                          content={sendDisabledReason ?? 'Send message'}
                           side='top'
                           delayDuration={1000}
                           skipDelayDuration={1000}

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
@@ -71,6 +71,8 @@ export interface InputBoxProps {
   hideVoiceInput?: boolean;
   compact?: boolean;
   sendDisabled?: boolean;
+  /** Shown on the send button's tooltip in place of 'Send message' while sendDisabled. */
+  sendDisabledReason?: string;
   /** Extra buttons rendered in the left side of the desktop bottom action bar, after the # button */
   bottomLeftSlot?: React.ReactNode;
   disableDraftUpload?: boolean;

--- a/apps/dashboard/src/hooks/useDraft.ts
+++ b/apps/dashboard/src/hooks/useDraft.ts
@@ -265,22 +265,9 @@ export function useDraftAttachments() {
 
         const formData = new FormData();
 
-        // Add all files
-        filesArray.forEach(file => {
-          formData.append('files', file);
-        });
-
-        // Add all thumbnails (if available)
-        processedFiles.forEach(({ thumbnailBlob, file }) => {
-          if (thumbnailBlob) {
-            formData.append('thumbnails', thumbnailBlob, `${file.name}_thumb.jpg`);
-          } else {
-            // Add placeholder for consistent indexing
-            formData.append('thumbnails', new Blob([]), '');
-          }
-        });
-
-        // Add fileMetadata JSON with complete information for all files
+        // Text fields go in BEFORE the file bodies. Multipart parts are parsed in wire
+        // order, so on a mid-upload disconnect the server has already read the ids and
+        // can mark those rows FAILED; appended last, they would never arrive.
         const fileMetadataArray = processedFiles.map(
           ({ index, thumbnailBlob, width, height, duration }) => ({
             fileIndex: index,
@@ -300,6 +287,21 @@ export function useDraftAttachments() {
         if (conversationId) {
           formData.append('conversationId', conversationId);
         }
+
+        // Add all files
+        filesArray.forEach(file => {
+          formData.append('files', file);
+        });
+
+        // Add all thumbnails (if available)
+        processedFiles.forEach(({ thumbnailBlob, file }) => {
+          if (thumbnailBlob) {
+            formData.append('thumbnails', thumbnailBlob, `${file.name}_thumb.jpg`);
+          } else {
+            // Add placeholder for consistent indexing
+            formData.append('thumbnails', new Blob([]), '');
+          }
+        });
 
         await apiInstance.post('/drafts/attachments/upload', formData);
 

--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -25,6 +25,7 @@ import {
   CanvasCommentThreadStatus,
   BookmarkEntityType,
   AttachmentEntityType,
+  AttachmentUploadStatus,
   UserPresenceStatus,
   FormFieldType,
   FormContextType,
@@ -163,6 +164,41 @@ async function resolveCollectionPermissionRole(
     if (!role || COLLECTION_ROLE_RANK[candidate] > COLLECTION_ROLE_RANK[role]) role = candidate;
   }
   return role;
+}
+
+export const ATTACHMENT_STILL_UPLOADING = 'Attachment is still uploading';
+
+/**
+ * An attachment row is created the moment a file is picked, and its bytes land later over
+ * a separate upload request. Rows predating `uploadStatus` carry only a url.
+ */
+export function isAttachmentUploaded(attachment: {
+  url: string;
+  uploadStatus?: string | null;
+}): boolean {
+  return (
+    !!attachment.url &&
+    (attachment.uploadStatus == null ||
+      attachment.uploadStatus === AttachmentUploadStatus.COMPLETED)
+  );
+}
+
+/**
+ * Inside this window an unfinished upload is probably still streaming, so the send is
+ * rejected and the caller retries. Beyond it the upload is never coming back (the client
+ * died mid-transfer and its cleanup never reached the server), and the message goes
+ * without the attachment — otherwise one orphan row would block the composer forever.
+ */
+const ATTACHMENT_UPLOAD_WINDOW_MS = 30 * 60 * 1000;
+
+export function isAttachmentUploadInFlight(attachment: {
+  uploadStatus?: string | null;
+  createdAt: number;
+}): boolean {
+  return (
+    attachment.uploadStatus !== AttachmentUploadStatus.FAILED &&
+    Date.now() - attachment.createdAt < ATTACHMENT_UPLOAD_WINDOW_MS
+  );
 }
 
 /** Build initial_message_md from message data. Single helper for all conversation creation sites. */
@@ -1724,7 +1760,7 @@ export const mutators = defineMutators({
           // Transfer only these specific ids; leave any other draft attachments
           // alone so a concurrent compose isn't corrupted. Never delete the draft row.
           if (attachmentIds.length > 0) {
-            hasAttachments = true;
+            let attachedCount = 0;
             for (const attachmentId of attachmentIds) {
               const attachment = await tx.run(
                 zql.message_attachments.where('id', attachmentId).one(),
@@ -1734,6 +1770,13 @@ export const mutators = defineMutators({
                 attachment.entityType === AttachmentEntityType.CHAT &&
                 attachment.entityId === messageId
               ) {
+                attachedCount++;
+                continue;
+              }
+              if (!isAttachmentUploaded(attachment)) {
+                if (isAttachmentUploadInFlight(attachment)) {
+                  throw new Error(ATTACHMENT_STILL_UPLOADING);
+                }
                 continue;
               }
               await tx.mutate.message_attachments.update({
@@ -1742,7 +1785,9 @@ export const mutators = defineMutators({
                 entityType: AttachmentEntityType.CHAT,
                 conversationId,
               });
+              attachedCount++;
             }
+            hasAttachments = attachedCount > 0;
           }
         } else {
           // Legacy path: scan the current draft and transfer everything.
@@ -1761,17 +1806,23 @@ export const mutators = defineMutators({
                 .where('entityType', AttachmentEntityType.DRAFT),
             );
 
-            if (draftAttachments.length > 0) {
-              hasAttachments = true;
-              for (const attachment of draftAttachments) {
-                await tx.mutate.message_attachments.update({
-                  id: attachment.id,
-                  entityId: messageId,
-                  entityType: AttachmentEntityType.CHAT,
-                  conversationId: conversationId,
-                });
+            let attachedCount = 0;
+            for (const attachment of draftAttachments) {
+              if (!isAttachmentUploaded(attachment)) {
+                if (isAttachmentUploadInFlight(attachment)) {
+                  throw new Error(ATTACHMENT_STILL_UPLOADING);
+                }
+                continue;
               }
+              await tx.mutate.message_attachments.update({
+                id: attachment.id,
+                entityId: messageId,
+                entityType: AttachmentEntityType.CHAT,
+                conversationId: conversationId,
+              });
+              attachedCount++;
             }
+            hasAttachments = attachedCount > 0;
 
             await tx.mutate.draft_messages.delete({
               id: draft.id,
@@ -2340,7 +2391,7 @@ export const mutators = defineMutators({
           // those ids, leave any other DRAFT attachments alone, never touch
           // the draft row (the client's clearContent mutator owns draft state).
           if (attachmentIds.length > 0) {
-            hasAttachments = true;
+            let attachedCount = 0;
             for (const attachmentId of attachmentIds) {
               const attachment = await tx.run(
                 zql.message_attachments.where('id', attachmentId).one(),
@@ -2350,6 +2401,13 @@ export const mutators = defineMutators({
                 attachment.entityType === AttachmentEntityType.CHAT &&
                 attachment.entityId === messageId
               ) {
+                attachedCount++;
+                continue;
+              }
+              if (!isAttachmentUploaded(attachment)) {
+                if (isAttachmentUploadInFlight(attachment)) {
+                  throw new Error(ATTACHMENT_STILL_UPLOADING);
+                }
                 continue;
               }
               await tx.mutate.message_attachments.update({
@@ -2358,7 +2416,9 @@ export const mutators = defineMutators({
                 entityType: AttachmentEntityType.CHAT,
                 conversationId,
               });
+              attachedCount++;
             }
+            hasAttachments = attachedCount > 0;
           }
         } else {
           // Legacy path: scan the draft for this conversation and transfer everything.
@@ -2377,17 +2437,23 @@ export const mutators = defineMutators({
                 .where('entityType', AttachmentEntityType.DRAFT),
             );
 
-            if (draftAttachments.length > 0) {
-              hasAttachments = true;
-              for (const attachment of draftAttachments) {
-                await tx.mutate.message_attachments.update({
-                  id: attachment.id,
-                  entityId: messageId,
-                  entityType: AttachmentEntityType.CHAT,
-                  conversationId: conversationId,
-                });
+            let attachedCount = 0;
+            for (const attachment of draftAttachments) {
+              if (!isAttachmentUploaded(attachment)) {
+                if (isAttachmentUploadInFlight(attachment)) {
+                  throw new Error(ATTACHMENT_STILL_UPLOADING);
+                }
+                continue;
               }
+              await tx.mutate.message_attachments.update({
+                id: attachment.id,
+                entityId: messageId,
+                entityType: AttachmentEntityType.CHAT,
+                conversationId: conversationId,
+              });
+              attachedCount++;
             }
+            hasAttachments = attachedCount > 0;
 
             await tx.mutate.draft_messages.delete({
               id: draft.id,
@@ -3279,6 +3345,7 @@ export const mutators = defineMutators({
               position: index,
               createdBy: ctx.userID,
               url: '', // Will be populated after upload completes
+              uploadStatus: AttachmentUploadStatus.PENDING,
               workspaceId: ctx.workspaceId,
               metadata: attachmentMetadata,
               conversationId: conversationId || null,


### PR DESCRIPTION
## POT

https://github.com/user-attachments/assets/642bd496-8be0-4f3f-94e3-c3900bbaa77e



## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
