### PR TITLE
fix: XYNE-61561 move focus from ticket title to description on Enter

### DIFF
--- a/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
+++ b/apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx
@@ -1897,6 +1897,15 @@ export const CreateTicketModal: React.FC<CreateTicketModalProps> = ({
                     }
                     field.handleChange(e.target.value);
                   }}
+                  onKeyDown={e => {
+                    // Enter in the single-line title moves focus to the
+                    // description instead of submitting / firing native
+                    // "Please fill out this field" validation.
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault();
+                      descriptionTextareaRef.current?.focus();
+                    }
+                  }}
                   aria-label='Ticket Title'
                   placeholder='Enter Ticket Title...'
                   data-testid='ticket-title-input'


### PR DESCRIPTION
Ticket: XYNE-61561 — Can we solve keyboard shortcut in the ticket creation UI

1. Problem Description:
In the New Ticket creation modal, pressing Enter in the title field did nothing useful — it fell through to native single-line input behaviour and triggered the browser's "Please fill out this field." validation bubble instead of advancing to the description.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported from a Spaces thread with a screenshot showing the native validation popup on the title/description block.

3. Explain the solution implemented in the PR:
Added an onKeyDown handler to the title Input in apps/dashboard/src/components/Tickets/CreateTicketModal/CreateTicketModal.tsx. On Enter (without Shift) it calls e.preventDefault() and focuses the existing descriptionTextareaRef, moving the caret into the description field. The description Textarea is unaffected, so Enter there still inserts newlines.

4. Documentation (link to docs created/updated for this change): N/A

5. DB Alter Details (if any): N/A

6. Data fix Details (if any): N/A

7. Environment variable Changes (if any): N/A

8. Testing (how it was tested; screenshots/links): Manually — open New Ticket modal, type a title, press Enter, focus moves to the description field; the native "Please fill out this field." bubble no longer appears. Shift+Enter and typing in the description behave as before.

9. Services to which this change is to be deployed: dashboard (frontend only)

10. Main PR link (if this PR is raised against a release branch): N/A