### PR TITLE
feat: XYNE-61473 summary generation alerting

### DIFF
--- a/apps/backend/src/services/callDocumentService.ts
+++ b/apps/backend/src/services/callDocumentService.ts
@@ -15,6 +15,7 @@ import { formatToISTLocaleString } from '@/utils/dateUtils';
 import type { Prisma, SummaryTemplate } from '@prisma/client';
 import { withServerEditor } from '@/utils/serverBlockNoteEditor';
 import { getCanvasUrl, findExistingDetailedSummaryCanvas } from '@/services/canvasService';
+import { logDetailedSummaryFailed } from '@/services/detailedSummaryFailureLog';
 import { CanvasSideEffectHandler } from '@/zero/side-effects/tables/canvas-handler';
 import { vespaQueue } from '@/queues/vespaQueue';
 import { fileSchema, SubApp } from '@/vespa/src/types';
@@ -1157,7 +1158,9 @@ MANDATORY OUTPUT CONTRACT:
     });
 
     if (!result.ok) {
-      logger.error(`[${callId}] detailed_summary_generation_failed`, { reason: result.reason });
+      // Diagnostic for the LLM step itself; the caller that gives up on the
+      // summary emits the alertable detailed_summary_generation_failed event.
+      logger.error(`[${callId}] detailed_summary_llm_request_failed`, { reason: result.reason });
       return null;
     }
 
@@ -2225,6 +2228,7 @@ A comprehensive detailed summary has been generated from this call.
           channel.callSummaryPrompt ?? undefined,
         );
         if (!detailedSummaryMarkdown) {
+          logDetailedSummaryFailed(callId, 'generation_failed');
           return { success: false, error: 'Failed to generate detailed summary' };
         }
 
@@ -2249,6 +2253,7 @@ A comprehensive detailed summary has been generated from this call.
           citationCtx,
         );
         if (!canvasId) {
+          logDetailedSummaryFailed(callId, 'canvas_update_failed');
           return { success: false, error: 'Failed to update detailed summary canvas' };
         }
 
@@ -2417,6 +2422,7 @@ A comprehensive detailed summary has been generated from this call.
       }
 
       if (!detailedSummaryMarkdown) {
+        logDetailedSummaryFailed(callId, 'generation_failed');
         if (newCanvasId) {
           await this.cleanupFailedDetailedSummaryCanvas(newCanvasId, conversationId, callId);
         }
@@ -2431,6 +2437,7 @@ A comprehensive detailed summary has been generated from this call.
       }
       const initializationFailure = getCanvasInitializationError();
       if (initializationFailure || !newCanvasId || !canvasUrl) {
+        logDetailedSummaryFailed(callId, 'canvas_create_failed', initializationFailure);
         if (newCanvasId) {
           await this.cleanupFailedDetailedSummaryCanvas(newCanvasId, conversationId, callId);
         }
@@ -2459,6 +2466,7 @@ A comprehensive detailed summary has been generated from this call.
         sideEffectContextPromise ?? undefined,
       );
       if (!finalized) {
+        logDetailedSummaryFailed(callId, 'canvas_finalize_failed');
         await this.cleanupFailedDetailedSummaryCanvas(finalizedCanvasId, conversationId, callId);
         return { success: false, error: 'Failed to write final detailed summary content' };
       }
@@ -2486,7 +2494,7 @@ A comprehensive detailed summary has been generated from this call.
 
       return { success: true, canvasUrl: finalizedCanvasUrl };
     } catch (error) {
-      logger.error('[CallDocumentService] Error in generateAndPostDetailedSummary:', error);
+      logDetailedSummaryFailed(callId, 'unexpected_error', error);
       // If a brand-new canvas + link was already published before the throw,
       // tear it down so an exception doesn't leave a dangling canvas/message.
       if (newCanvasId) {

--- a/apps/backend/src/services/detailedSummaryFailureLog.ts
+++ b/apps/backend/src/services/detailedSummaryFailureLog.ts
@@ -1,0 +1,20 @@
+import { logger } from '@/utils/logger';
+
+/**
+ * One log line for "this recording's detailed summary did not get produced",
+ * keyed by the call's externalId so the failing recording is identifiable.
+ * Every give-up point in both summary pipelines (headless note-taker calls and
+ * channel calls) calls this, and only give-up points do, so the line counts one
+ * failure per recording — alerting can key on detailed_summary_generation_failed.
+ */
+export function logDetailedSummaryFailed(
+  callId: string,
+  reason: string,
+  error?: unknown,
+): void {
+  logger.error(`[${callId}] detailed_summary_generation_failed`, {
+    reason,
+    error,
+    stack: error instanceof Error ? error.stack : undefined,
+  });
+}

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -10,6 +10,7 @@ import { transcriptService, type TranscriptEntry } from '@/services/transcriptSe
 import type { SummaryModelType } from '@/services/callLlmRetry';
 import { callDocumentService, numberTranscriptSegments, type CitationContext } from '@/services/callDocumentService';
 import { findExistingDetailedSummaryCanvas } from '@/services/canvasService';
+import { logDetailedSummaryFailed } from '@/services/detailedSummaryFailureLog';
 import { canvasAuthService } from '@/services/canvasAuthService';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
 import { tagService, TagServiceError } from '@/tags/service';
@@ -224,6 +225,9 @@ class NoteTakerTranscriptService {
         resolvedModelType,
       );
     } catch (error) {
+      // generateDetailedSummaryCanvas swallows its own failures, so reaching
+      // here means something outside it threw and nothing has logged yet.
+      logDetailedSummaryFailed(call.externalId, 'unexpected_error', error);
       await this.markDetailedSummaryStatus(call, 'failed');
       throw error;
     }
@@ -718,19 +722,13 @@ class NoteTakerTranscriptService {
           modelType,
         );
         if (!generated) {
-          logger.error(`[${callId}] detailed_summary_skipped`, {
-            reason: 'generation_failed',
-            path: 'note_taker',
-          });
+          logDetailedSummaryFailed(callId, 'generation_failed');
           return null;
         }
 
         const xyneAutomaticBot = await xyneAutomaticBotPromise;
         if (!xyneAutomaticBot) {
-          logger.error(`[${callId}] detailed_summary_skipped`, {
-            reason: 'bot_not_found',
-            path: 'note_taker',
-          });
+          logDetailedSummaryFailed(callId, 'bot_not_found');
           return null;
         }
 
@@ -753,10 +751,7 @@ class NoteTakerTranscriptService {
           workspaceId,
         );
         if (!canvasId) {
-          logger.error(`[${callId}] detailed_summary_skipped`, {
-            reason: 'canvas_update_failed',
-            path: 'note_taker',
-          });
+          logDetailedSummaryFailed(callId, 'canvas_update_failed');
           return null;
         }
 
@@ -891,10 +886,7 @@ class NoteTakerTranscriptService {
       }
 
       if (!generated) {
-        logger.error(`[${callId}] detailed_summary_skipped`, {
-          reason: 'generation_failed',
-          path: 'note_taker',
-        });
+        logDetailedSummaryFailed(callId, 'generation_failed');
         return null;
       }
 
@@ -907,19 +899,13 @@ class NoteTakerTranscriptService {
 
       const initializationFailure = getCanvasInitializationError();
       if (initializationFailure || !newCanvasId) {
-        logger.error(`[${callId}] detailed_summary_skipped`, {
-          reason: initializationFailure?.message ?? 'canvas_create_failed',
-          path: 'note_taker',
-        });
+        logDetailedSummaryFailed(callId, 'canvas_create_failed', initializationFailure);
         return null;
       }
 
       const xyneAutomaticBot = await xyneAutomaticBotPromise;
       if (!xyneAutomaticBot) {
-        logger.error(`[${callId}] detailed_summary_skipped`, {
-          reason: 'bot_not_found',
-          path: 'note_taker',
-        });
+        logDetailedSummaryFailed(callId, 'bot_not_found');
         return null;
       }
 
@@ -940,10 +926,7 @@ class NoteTakerTranscriptService {
         citationCtx,
       );
       if (!finalized) {
-        logger.error(`[${callId}] detailed_summary_skipped`, {
-          reason: 'canvas_finalize_failed',
-          path: 'note_taker',
-        });
+        logDetailedSummaryFailed(callId, 'canvas_finalize_failed');
         return null;
       }
 
@@ -953,12 +936,7 @@ class NoteTakerTranscriptService {
         markedItems: generated.markedItems,
       };
     } catch (error) {
-      logger.error(`[${callId}] detailed_summary_failed`, {
-        stage: 'detailed_summary_generation',
-        path: 'note_taker',
-        error,
-        stack: error instanceof Error ? error.stack : undefined,
-      });
+      logDetailedSummaryFailed(callId, 'unexpected_error', error);
       return null;
     }
   }

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -20,6 +20,7 @@ import { getCallTicketSuggestionsTotal } from '@/services/otel/suggestionMetrics
 import { executeCallLlmWithRetry, executeStreamingLlmRequest, type SummaryModelType } from './callLlmRetry';
 import { callRecordingService } from '@/services/callRecordingService';
 import { callDocumentService } from '@/services/callDocumentService';
+import { logDetailedSummaryFailed } from '@/services/detailedSummaryFailureLog';
 import { RECORDING_TITLE_PROMPT } from '@/services/recordingSummaryTemplates';
 import { acquireLock, releaseLock } from '@/utils/distributedLock';
 import { orgLLMCredentialService } from '@/services/orgLLMCredentialService';
@@ -1854,11 +1855,9 @@ Output ONLY the processed transcript, nothing else.`;
         undefined,
         { callTitlePromise },
       ).catch((error) => {
-        logger.error(`[${callId}] detailed_summary_failed`, {
-          stage: 'detailed_summary_generation',
-          error,
-          stack: error instanceof Error ? error.stack : undefined,
-        });
+        // generateAndPostDetailedSummary logs its own failure exits; reaching
+        // here means it threw outside them, so this is the only record.
+        logDetailedSummaryFailed(callId, 'unexpected_error', error);
         return { success: false, error: error instanceof Error ? error.message : String(error) };
       });
 
@@ -2022,15 +2021,11 @@ Output ONLY the processed transcript, nothing else.`;
             const detailedSummaryResult = await detailedSummaryPromise;
             if (detailedSummaryResult.success) {
               logger.info(`Auto-generated detailed summary for call: ${callId}`);
-            } else {
-              logger.error(`[${callId}] detailed_summary_failed`, {
-                stage: 'detailed_summary_generation',
-                error: detailedSummaryResult.error || 'Unknown detailed summary failure',
-              });
             }
+            // A failure here was already logged by whichever exit gave up, so
+            // there is no second line and the alert counts one per recording.
           } catch (error) {
-            // Include stage label so LLM vs DB vs bot-message failures are distinguishable.
-            logger.error(`[${callId}] detailed_summary_failed`, { stage: 'detailed_summary_generation', error: error, stack: error instanceof Error ? error.stack : undefined });
+            logDetailedSummaryFailed(callId, 'unexpected_error', error);
           }
         }
       } else {


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
