### PR TITLE
fix: XYNE-61474 activity for summary + label fix

### DIFF
--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -14,9 +14,10 @@ import { canvasAuthService } from '@/services/canvasAuthService';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
 import { tagService, TagServiceError } from '@/tags/service';
 import { tagRepository } from '@/database/repositories/tagRepository';
-import { normalizeTagName, TAG_FORMAT_REGEX, TagMethod, EntityUserAccess, NotificationType } from '@xyne/shared';
+import { normalizeTagName, TAG_FORMAT_REGEX, TagMethod, EntityUserAccess, NotificationType, ActivityClassification } from '@xyne/shared';
 import { recordingSharingService } from '@/services/recordingSharingService';
 import { notificationService } from '@/services/notificationService';
+import { activityService } from '@/services/activity/activityService';
 import {
   mergeRecordingSummaryMarkedItems,
   type RecordingSummaryMarkedItem,
@@ -27,6 +28,14 @@ import {
 // configured" check entirely (see assertManualCategoryOrOverride).
 const NOTE_TAKER_TAG_SOURCE_TYPE = 'CALL';
 const NOTE_TAKER_LABEL_CATEGORY = 'topic';
+
+// Upper bound on auto-generated labels per call — transcriptService already
+// trims the model's output to the same limit; this is the persistence-side guard.
+const MAX_CALL_LABEL_TAGS = 3;
+
+// Activity.actorAction for "the AI summary for this recording is ready".
+// Rendered by the dashboard's RecordingSummaryActivity.
+const RECORDING_SUMMARY_READY_ACTION = 'recording_summary_ready';
 
 interface DetailedSummaryCanvasResult {
   canvasId: string;
@@ -266,9 +275,10 @@ class NoteTakerTranscriptService {
   }
 
   /**
-   * Notify the recording owner that the detailed summary finished generating.
-   * Best-effort: a notification failure must never fail the generation flow,
-   * so errors are logged and swallowed.
+   * Notify the recording owner that the detailed summary finished generating:
+   * an ephemeral notification plus a persistent Activity-feed entry.
+   * Best-effort: neither may fail the generation flow, so each is wrapped
+   * independently and its errors are logged and swallowed.
    */
   private async notifySummaryReady(call: Call): Promise<void> {
     try {
@@ -290,6 +300,55 @@ class NoteTakerTranscriptService {
       });
     } catch (error) {
       logger.error(`[${call.externalId}] summary_ready_notification_failed`, {
+        path: 'note_taker',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    await this.recordSummaryReadyActivity(call);
+  }
+
+  /**
+   * Persist the Activity-feed entry for a finished summary, so the owner can
+   * still find it after the notification toast is gone (same reasoning as the
+   * KB ingestion activity). Regenerating a summary bumps the existing row back
+   * to unread instead of stacking a second entry for the same recording.
+   */
+  private async recordSummaryReadyActivity(call: Call): Promise<void> {
+    try {
+      if (!call.workspaceId) return;
+
+      const existing = await db.activity.findFirst({
+        where: {
+          callId: call.id,
+          userId: call.createdByUserId,
+          actorAction: RECORDING_SUMMARY_READY_ACTION,
+        },
+        select: { id: true },
+      });
+      if (existing) {
+        // `updatedAt` is @updatedAt, so this also re-sorts the row to the top
+        // of the feed (which orders by updatedAt desc).
+        await db.activity.update({ where: { id: existing.id }, data: { isRead: false } });
+        return;
+      }
+
+      await activityService.createActivity({
+        userId: call.createdByUserId,
+        // System event: the recording is the subject, and its owner is both the
+        // notional actor and the only recipient.
+        actorId: call.createdByUserId,
+        actorAction: RECORDING_SUMMARY_READY_ACTION,
+        actionSource: 'call',
+        actionSourceId: call.id,
+        callId: call.id,
+        workspaceId: call.workspaceId,
+        // Purely informational — classify up front so the LLM classifier
+        // worker never picks it up (it claims every PENDING row).
+        classification: ActivityClassification.FYI,
+      });
+    } catch (error) {
+      logger.error(`[${call.externalId}] summary_ready_activity_failed`, {
         path: 'note_taker',
         error: error instanceof Error ? error.message : String(error),
       });
@@ -992,7 +1051,7 @@ class NoteTakerTranscriptService {
 
     const tagIds: string[] = [];
     for (const rawLabel of labels) {
-      if (tagIds.length >= 4) break;
+      if (tagIds.length >= MAX_CALL_LABEL_TAGS) break;
       const slug = this.slugifyLabel(rawLabel);
       if (!slug) continue;
       try {

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -227,13 +227,18 @@ TRANSCRIPT:
 
 // Short topical labels for browsing/search. Kept intentionally simple (no
 // categories/config) — persisted as generic Tag rows by noteTakerTranscriptService.
+// Each label is a single word; multi-word labels would be slugified into
+// hyphenated tags downstream.
+const MAX_CALL_LABELS = 3;
+
 const CALL_LABELS_PROMPT = `
 You are analyzing a call transcript to generate a small set of short topical labels/tags for browsing and search.
 
 CRITICAL RULES:
 - Output ONLY valid JSON
-- Generate 1-4 short labels that best describe the topics/themes discussed
-- Each label must be 1-3 words, lowercase, describing a topic (e.g. "pricing", "bug report", "onboarding")
+- Generate 1-3 short labels that best describe the topics/themes discussed
+- Each label must be EXACTLY ONE word, lowercase (e.g. "pricing", "onboarding", "billing", "latency")
+- NEVER use multi-word labels, spaces, hyphens or underscores (write "pricing", not "pricing-discussion" or "bug report")
 - Do NOT include people's names, company names, or dates as labels
 - Do NOT duplicate labels
 
@@ -243,7 +248,7 @@ BRAND NAME CORRECTION:
 
 JSON STRUCTURE (FOLLOW EXACTLY):
 {
-  "labels": ["[short topic label]", "[short topic label]"]
+  "labels": ["[one-word topic label]", "[one-word topic label]"]
 }
 
 Only output valid JSON.
@@ -1299,7 +1304,7 @@ Output ONLY the processed transcript, nothing else.`;
 
       const labels = parsed.labels
         .filter((l: unknown): l is string => typeof l === 'string' && l.trim().length > 0)
-        .slice(0, 4);
+        .slice(0, MAX_CALL_LABELS);
 
       logger.info(`Generated ${labels.length} call labels`);
       return labels;

--- a/apps/dashboard/src/components/Activity/ActivityItem.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItem.tsx
@@ -16,6 +16,7 @@ import { ScheduledCallActivity } from './ScheduledCallActivity';
 import { EmailFetchActivity } from './EmailFetchActivity';
 import { CanvasSharedActivity } from './CanvasSharedActivity';
 import { RecordingSharedActivity } from './RecordingSharedActivity';
+import { RecordingSummaryActivity } from './RecordingSummaryActivity';
 import { SummaryTemplateSharedActivity } from './SummaryTemplateSharedActivity';
 import { StageApprovalActivity } from './StageApprovalActivity';
 import { KbIngestionActivity } from './KbIngestionActivity';
@@ -126,6 +127,9 @@ export const ActivityItem = memo(function ActivityItem({
     case 'recording_shared':
     case 'recording_access_revoked':
       return <RecordingSharedActivity activity={activity} isExpanded={isExpanded} />;
+
+    case 'recording_summary_ready':
+      return <RecordingSummaryActivity activity={activity} isExpanded={isExpanded} />;
 
     case 'summary_template_shared':
     case 'summary_template_access_revoked':

--- a/apps/dashboard/src/components/Activity/RecordingSummaryActivity.tsx
+++ b/apps/dashboard/src/components/Activity/RecordingSummaryActivity.tsx
@@ -1,0 +1,51 @@
+import { ReactElement } from 'react';
+import type { ActivityWithRelated } from '../../types/activity';
+import { SparkleAi01 } from '@xyne/icons';
+import { ActivityItemCard } from './ActivityItemCard';
+
+/**
+ * Renders the persistent Activity-feed entry created when a recording's AI
+ * summary finishes generating (see noteTakerTranscriptService's
+ * recordSummaryReadyActivity). Mirrors the RECORDING_SUMMARY_READY toast: names
+ * the recording and deep-links to it. Regenerating a summary reuses the same
+ * row, so there is never more than one of these per recording.
+ */
+export const RecordingSummaryActivity = ({
+  activity,
+  isExpanded,
+}: {
+  activity: ActivityWithRelated;
+  isExpanded: boolean;
+}): ReactElement | null => {
+  const call = activity.call;
+  if (!activity.callId || !call) return null;
+
+  const title = call.title ?? 'Untitled';
+
+  return (
+    <ActivityItemCard
+      activity={activity}
+      actorId={activity.actorId}
+      // System event — the subject is the recording, not a person. (The card
+      // bold-prefixes this label, so the owner's own name would read as if
+      // they had done something.)
+      actorName='Recording summary'
+      channelId={undefined}
+      badgeIcon={<SparkleAi01 className='size-3 text-primary' />}
+      badgeColorClass='bg-muted'
+      description={<span className='text-sm'>{`· "${title}"`}</span>}
+      targetPath={`/recordings/${call.externalId}`}
+      isExpanded={isExpanded}
+      actorAction={activity.actorAction}
+      className='flex items-start'
+    >
+      <div
+        className={
+          isExpanded ? 'text-muted-foreground text-sm mt-2' : 'text-muted-foreground text-sm'
+        }
+      >
+        Summary is ready to view
+      </div>
+    </ActivityItemCard>
+  );
+};


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
