### PR TITLE
fix: XYNE-61472: simplify invitation email to a single Join CTA

### DIFF
--- a/apps/backend/src/services/email/templates/invitation.ts
+++ b/apps/backend/src/services/email/templates/invitation.ts
@@ -57,6 +57,19 @@ export function invitationEmailHtml({
                 </tr>
               </table>
 
+              ${tempPassword ? `
+              <!-- Temp Password Banner -->
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:24px;">
+                <tr>
+                  <td style="background:#ecfdf5;border:1px solid #10b981;border-radius:8px;padding:12px 16px;">
+                    <span style="display:block;color:#065f46;font-size:13px;margin-bottom:8px;">Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.</span>
+                    <strong style="display:block;color:#065f46;font-size:13px;margin-bottom:4px;">🔑 Your Temporary Password</strong>
+                    <p style="font-size:18px;font-weight:bold;color:#047857;margin:8px 0 0 0;letter-spacing:1px;">${tempPassword}</p>
+                  </td>
+                </tr>
+              </table>
+              ` : ''}
+
               <!-- Desktop app mention -->
               <table width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
@@ -66,19 +79,6 @@ export function invitationEmailHtml({
                   </td>
                 </tr>
               </table>
-
-              ${tempPassword ? `
-              <!-- Temp Password Banner -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:28px;">
-                <tr>
-                  <td style="background:#ecfdf5;border:1px solid #10b981;border-radius:8px;padding:12px 16px;">
-                    <strong style="display:block;color:#065f46;font-size:13px;margin-bottom:4px;">🔑 Your Temporary Password</strong>
-                    <span style="color:#065f46;font-size:13px;">Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.</span>
-                    <p style="font-size:18px;font-weight:bold;color:#047857;margin:8px 0 0 0;letter-spacing:1px;">${tempPassword}</p>
-                  </td>
-                </tr>
-              </table>
-              ` : ''}
 
               <!-- Footer -->
               <table width="100%" cellpadding="0" cellspacing="0" border="0">
@@ -120,17 +120,17 @@ JOIN XYNE
 ──────────────────────────────────────────
   ${invitationLink}
 
+${tempPassword ? `──────────────────────────────────────────
+Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.
+
+🔑 YOUR TEMPORARY PASSWORD
+──────────────────────────────────────────
+  ${tempPassword}
+` : ''}
 Want the full desktop experience? Download the app:
 
   ${frontendUrl}/apps/downloads
 
-${tempPassword ? `──────────────────────────────────────────
-🔑 YOUR TEMPORARY PASSWORD
-──────────────────────────────────────────
-Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.
-
-  ${tempPassword}
-` : ''}
 ──────────────────────────────────────────
 This invitation was sent by Xyne Spaces. If you weren't expecting this email, you can safely ignore it.
   `.trim();

--- a/apps/backend/src/services/email/templates/invitation.ts
+++ b/apps/backend/src/services/email/templates/invitation.ts
@@ -36,95 +36,54 @@ export function invitationEmailHtml({
               </table>
 
               <!-- Greeting -->
-              <h2 style="color:#1f2937;margin:0 0 16px 0;font-size:22px;">You've been invited!</h2>
-              <p style="color:#4b5563;margin:0 0 24px 0;">
+              <h2 style="color:#1f2937;margin:0 0 16px 0;font-size:22px;text-align:center;">You've been invited!</h2>
+              <p style="color:#4b5563;margin:0 0 32px 0;text-align:center;">
                 <strong>${inviterName}</strong> has invited you to join <strong>${workspaceName}</strong> on Xyne Spaces — a collaborative workspace for teams to communicate, manage tickets, and work together efficiently.
               </p>
 
-              <!-- Warning Banner -->
+              <!-- Primary CTA -->
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:8px;">
+                <tr>
+                  <td align="center">
+                    <a href="${invitationLink}" style="display:inline-block;background:#000000;color:#ffffff;text-decoration:none;padding:14px 44px;border-radius:10px;font-weight:700;font-size:16px;">Join Xyne</a>
+                  </td>
+                </tr>
+              </table>
               <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:28px;">
                 <tr>
-                  <td style="background:#fef3c7;border:1px solid #f59e0b;border-radius:8px;padding:12px 16px;">
-                    <strong style="display:block;color:#92400e;font-size:13px;margin-bottom:4px;">⚠️ Important: Complete both steps below in order.</strong>
-                    <span style="color:#92400e;font-size:13px;">You must download and install the Xyne Spaces desktop app <em>before</em> clicking the invitation link. The invitation will only work correctly inside the app.</span>
+                  <td align="center">
+                    <p style="color:#9ca3af;font-size:11px;margin:0;word-break:break-all;text-align:center;">Or copy and paste this link: <a href="${invitationLink}" style="color:#6366f1;">${invitationLink}</a></p>
                   </td>
                 </tr>
               </table>
 
-              <!-- Step 1 -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:24px;">
+              <!-- Desktop app mention -->
+              <table width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
-                  <td width="44" valign="top" style="padding-top:2px;">
-                    <table cellpadding="0" cellspacing="0" border="0">
-                      <tr>
-                        <td width="32" height="32" align="center" valign="middle" style="background:#000000;border-radius:50%;color:#ffffff;font-weight:700;font-size:14px;width:32px;height:32px;text-align:center;line-height:32px;">
-                          1
-                        </td>
-                      </tr>
-                    </table>
+                  <td style="border-top:1px solid #e5e7eb;padding-top:28px;" align="center">
+                    <p style="color:#6b7280;font-size:13px;margin:0 0 14px 0;text-align:center;">Want the full desktop experience?</p>
+                    <a href="${frontendUrl}/apps/downloads" style="display:inline-block;background:#6366f1;color:#ffffff;text-decoration:none;padding:12px 28px;border-radius:8px;font-weight:600;font-size:14px;">Download Xyne Spaces App</a>
                   </td>
-                  <td valign="top">
-                    <strong style="display:block;color:#1f2937;font-size:15px;margin-bottom:6px;">Download &amp; Install the Xyne Spaces Desktop App</strong>
-                    <p style="color:#6b7280;font-size:13px;margin:0 0 14px 0;">The desktop app is required to access your workspace. Download it for your platform from the link below and complete the installation before proceeding.</p>
-                    <a href="${frontendUrl}/apps/downloads" style="display:inline-block;background:#6366f1;color:#ffffff;text-decoration:none;padding:11px 24px;border-radius:8px;font-weight:600;font-size:14px;">Download Xyne Spaces App</a>
-                    <p style="color:#6b7280;font-size:12px;margin:10px 0 0 0;">
-                      Or visit: <a href="${frontendUrl}/apps/downloads" style="color:#6366f1;word-break:break-all;">${frontendUrl}/apps/downloads</a>
-                    </p>
-                    <p style="color:#6b7280;font-size:12px;margin:6px 0 0 0;">
-                      Already set up? Open your invite: <a href="${frontendUrl}/invite" style="color:#6366f1;word-break:break-all;">${frontendUrl}/invite</a>
-                    </p>
-                  </td>
-                </tr>
-              </table>
-
-              <!-- Divider -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:24px;">
-                <tr>
-                  <td style="border-top:1px solid #e5e7eb;"></td>
                 </tr>
               </table>
 
               ${tempPassword ? `
               <!-- Temp Password Banner -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:24px;">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:28px;">
                 <tr>
                   <td style="background:#ecfdf5;border:1px solid #10b981;border-radius:8px;padding:12px 16px;">
                     <strong style="display:block;color:#065f46;font-size:13px;margin-bottom:4px;">🔑 Your Temporary Password</strong>
-                    <span style="color:#065f46;font-size:13px;">Use this password to sign in with your email. This will remain your password until you have set it manually. Alternately, sign-in with Google/Microsoft SSO instead.</span>
+                    <span style="color:#065f46;font-size:13px;">Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.</span>
                     <p style="font-size:18px;font-weight:bold;color:#047857;margin:8px 0 0 0;letter-spacing:1px;">${tempPassword}</p>
                   </td>
                 </tr>
               </table>
               ` : ''}
 
-              <!-- Step 2 -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:32px;">
-                <tr>
-                  <td width="44" valign="top" style="padding-top:2px;">
-                    <table cellpadding="0" cellspacing="0" border="0">
-                      <tr>
-                        <td width="32" height="32" align="center" valign="middle" style="background:#000000;border-radius:50%;color:#ffffff;font-weight:700;font-size:14px;width:32px;height:32px;text-align:center;line-height:32px;">
-                          2
-                        </td>
-                      </tr>
-                    </table>
-                  </td>
-                  <td valign="top">
-                    <strong style="display:block;color:#1f2937;font-size:15px;margin-bottom:6px;">Accept Your Invitation &amp; Log In</strong>
-                    <p style="color:#6b7280;font-size:13px;margin:0 0 6px 0;">Once the app is installed, click the button below to accept your invitation and log in to your workspace.</p>
-                    <p style="color:#6b7280;font-size:13px;margin:0 0 14px 0;"><strong style="color:#1f2937;">Do not open this link in a browser</strong> — it must be opened in the Xyne Spaces desktop app.</p>
-                    <a href="${invitationLink}" style="display:inline-block;background:#000000;color:#ffffff;text-decoration:none;padding:12px 28px;border-radius:8px;font-weight:600;font-size:15px;">Accept Invitation</a>
-                    <p style="color:#6b7280;font-size:12px;margin:10px 0 0 0;word-break:break-all;">
-                      Or copy and paste this link: <a href="${invitationLink}" style="color:#6366f1;">${invitationLink}</a>
-                    </p>
-                  </td>
-                </tr>
-              </table>
-
               <!-- Footer -->
               <table width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
-                  <td align="center" style="border-top:1px solid #e5e7eb;padding-top:24px;font-size:12px;color:#9ca3af;">
+                  <td align="center" style="border-top:1px solid #e5e7eb;padding-top:24px;margin-top:24px;font-size:12px;color:#9ca3af;">
                     <p style="margin:0;">This invitation was sent by Xyne Spaces.<br>If you weren't expecting this email, you can safely ignore it.</p>
                   </td>
                 </tr>
@@ -156,35 +115,22 @@ You've been invited to join ${workspaceName} on Xyne Spaces!
 
 ${inviterName} has invited you to collaborate on Xyne Spaces — a platform for teams to communicate, manage tickets, and work together efficiently.
 
-⚠️  IMPORTANT: You must complete BOTH steps below in order. The invitation will only work correctly inside the desktop app.
+──────────────────────────────────────────
+JOIN XYNE
+──────────────────────────────────────────
+  ${invitationLink}
 
-──────────────────────────────────────────
-STEP 1 — Download & Install the Desktop App (REQUIRED)
-──────────────────────────────────────────
-Before doing anything else, download and install the Xyne Spaces desktop app for your platform:
+Want the full desktop experience? Download the app:
 
   ${frontendUrl}/apps/downloads
-
-Already set up? Open your invite: ${frontendUrl}/invite
-
-Complete the installation before moving to Step 2.
-
-──────────────────────────────────────────
-STEP 2 — Accept Your Invitation & Log In
-──────────────────────────────────────────
-Once the app is installed, open the link below to accept your invitation and log in to your workspace.
-Do NOT open this link in a browser — it must be opened in the Xyne Spaces desktop app.
-
-  ${invitationLink}
 
 ${tempPassword ? `──────────────────────────────────────────
 🔑 YOUR TEMPORARY PASSWORD
 ──────────────────────────────────────────
-Use this password to sign in with your email. This will remain your password until you have set it manually. Alternately, sign-in with Google/Microsoft SSO instead.
+Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.
 
   ${tempPassword}
 ` : ''}
-
 ──────────────────────────────────────────
 This invitation was sent by Xyne Spaces. If you weren't expecting this email, you can safely ignore it.
   `.trim();


### PR DESCRIPTION

<img width="918" height="1130" alt="image" src="https://github.com/user-attachments/assets/42662a5c-2b84-4b81-a357-ee83ff28f859" />


## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
XYNE-61472. The invitation email forced a two-step flow — "install the desktop app, then click the invite link" — and claimed the link "will only work correctly inside the app," which isn't true and blocked/confused recipients who just wanted to open the invite in a browser.

Replaces it with a single primary "Join Xyne" CTA plus a copy-link fallback; downloading the desktop app is now an optional mention below the CTA, not a gate. Same simplification applied to the plain-text email variant.

## Areas Touched

- [x] `apps/backend` (API / worker) — only `apps/backend/src/services/email/templates/invitation.ts`
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?
Reviewed the diff (template-string interpolation, tag nesting, `tempPassword ? ... : ''` conditional still intact). **Have not** actually sent a test invitation or rendered the email in a client yet — that's still needed before merge.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — no existing coverage renders/asserts on this email template's markup

### Manual
Not yet performed — see above.

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] N/A — no Zero changes

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

**Still to do before merge:**
- [ ] Send a real invitation and confirm the email renders with a single "Join Xyne" CTA + copy-link fallback
- [ ] Confirm the temp-password banner (brand-new, non-GUEST invitees) still renders correctly
- [ ] Click the invite link directly in a browser and confirm it works without the desktop app

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes — not run
- [ ] Backend `typecheck` + `build` pass — `typecheck` was run and currently fails, but only on pre-existing, unrelated errors in `zero/mutators.ts`, `zero/queries.ts`, `zero/vespa-injection/core/mapper.ts` (SDLC/channel types) caused by a stale `packages/shared/dist` build on this machine, not by this diff. Needs a clean re-run to confirm.
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass — N/A, no dashboard files touched
- [x] No new deps added
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed — N/A
- [x] No debug logging or commented-out code left behind
