### PR TITLE
fix: XYNE-61472: simplify invitation email to a single Join CTA

### DIFF
--- a/apps/backend/src/services/email/templates/invitation.ts
+++ b/apps/backend/src/services/email/templates/invitation.ts
@@ -57,6 +57,19 @@ export function invitationEmailHtml({
                 </tr>
               </table>
 
+              ${tempPassword ? `
+              <!-- Temp Password Banner -->
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:24px;">
+                <tr>
+                  <td style="background:#ecfdf5;border:1px solid #10b981;border-radius:8px;padding:12px 16px;">
+                    <span style="display:block;color:#065f46;font-size:13px;margin-bottom:8px;">Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.</span>
+                    <strong style="display:block;color:#065f46;font-size:13px;margin-bottom:4px;">🔑 Your Temporary Password</strong>
+                    <p style="font-size:18px;font-weight:bold;color:#047857;margin:8px 0 0 0;letter-spacing:1px;">${tempPassword}</p>
+                  </td>
+                </tr>
+              </table>
+              ` : ''}
+
               <!-- Desktop app mention -->
               <table width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
@@ -66,19 +79,6 @@ export function invitationEmailHtml({
                   </td>
                 </tr>
               </table>
-
-              ${tempPassword ? `
-              <!-- Temp Password Banner -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:28px;">
-                <tr>
-                  <td style="background:#ecfdf5;border:1px solid #10b981;border-radius:8px;padding:12px 16px;">
-                    <strong style="display:block;color:#065f46;font-size:13px;margin-bottom:4px;">🔑 Your Temporary Password</strong>
-                    <span style="color:#065f46;font-size:13px;">Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.</span>
-                    <p style="font-size:18px;font-weight:bold;color:#047857;margin:8px 0 0 0;letter-spacing:1px;">${tempPassword}</p>
-                  </td>
-                </tr>
-              </table>
-              ` : ''}
 
               <!-- Footer -->
               <table width="100%" cellpadding="0" cellspacing="0" border="0">
@@ -120,17 +120,17 @@ JOIN XYNE
 ──────────────────────────────────────────
   ${invitationLink}
 
+${tempPassword ? `──────────────────────────────────────────
+Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.
+
+🔑 YOUR TEMPORARY PASSWORD
+──────────────────────────────────────────
+  ${tempPassword}
+` : ''}
 Want the full desktop experience? Download the app:
 
   ${frontendUrl}/apps/downloads
 
-${tempPassword ? `──────────────────────────────────────────
-🔑 YOUR TEMPORARY PASSWORD
-──────────────────────────────────────────
-Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.
-
-  ${tempPassword}
-` : ''}
 ──────────────────────────────────────────
 This invitation was sent by Xyne Spaces. If you weren't expecting this email, you can safely ignore it.
   `.trim();

--- a/apps/backend/src/services/email/templates/invitation.ts
+++ b/apps/backend/src/services/email/templates/invitation.ts
@@ -36,95 +36,54 @@ export function invitationEmailHtml({
               </table>
 
               <!-- Greeting -->
-              <h2 style="color:#1f2937;margin:0 0 16px 0;font-size:22px;">You've been invited!</h2>
-              <p style="color:#4b5563;margin:0 0 24px 0;">
+              <h2 style="color:#1f2937;margin:0 0 16px 0;font-size:22px;text-align:center;">You've been invited!</h2>
+              <p style="color:#4b5563;margin:0 0 32px 0;text-align:center;">
                 <strong>${inviterName}</strong> has invited you to join <strong>${workspaceName}</strong> on Xyne Spaces — a collaborative workspace for teams to communicate, manage tickets, and work together efficiently.
               </p>
 
-              <!-- Warning Banner -->
+              <!-- Primary CTA -->
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:8px;">
+                <tr>
+                  <td align="center">
+                    <a href="${invitationLink}" style="display:inline-block;background:#000000;color:#ffffff;text-decoration:none;padding:14px 44px;border-radius:10px;font-weight:700;font-size:16px;">Join Xyne</a>
+                  </td>
+                </tr>
+              </table>
               <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:28px;">
                 <tr>
-                  <td style="background:#fef3c7;border:1px solid #f59e0b;border-radius:8px;padding:12px 16px;">
-                    <strong style="display:block;color:#92400e;font-size:13px;margin-bottom:4px;">⚠️ Important: Complete both steps below in order.</strong>
-                    <span style="color:#92400e;font-size:13px;">You must download and install the Xyne Spaces desktop app <em>before</em> clicking the invitation link. The invitation will only work correctly inside the app.</span>
+                  <td align="center">
+                    <p style="color:#9ca3af;font-size:11px;margin:0;word-break:break-all;text-align:center;">Or copy and paste this link: <a href="${invitationLink}" style="color:#6366f1;">${invitationLink}</a></p>
                   </td>
                 </tr>
               </table>
 
-              <!-- Step 1 -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:24px;">
+              <!-- Desktop app mention -->
+              <table width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
-                  <td width="44" valign="top" style="padding-top:2px;">
-                    <table cellpadding="0" cellspacing="0" border="0">
-                      <tr>
-                        <td width="32" height="32" align="center" valign="middle" style="background:#000000;border-radius:50%;color:#ffffff;font-weight:700;font-size:14px;width:32px;height:32px;text-align:center;line-height:32px;">
-                          1
-                        </td>
-                      </tr>
-                    </table>
+                  <td style="border-top:1px solid #e5e7eb;padding-top:28px;" align="center">
+                    <p style="color:#6b7280;font-size:13px;margin:0 0 14px 0;text-align:center;">Want the full desktop experience?</p>
+                    <a href="${frontendUrl}/apps/downloads" style="display:inline-block;background:#6366f1;color:#ffffff;text-decoration:none;padding:12px 28px;border-radius:8px;font-weight:600;font-size:14px;">Download Xyne Spaces App</a>
                   </td>
-                  <td valign="top">
-                    <strong style="display:block;color:#1f2937;font-size:15px;margin-bottom:6px;">Download &amp; Install the Xyne Spaces Desktop App</strong>
-                    <p style="color:#6b7280;font-size:13px;margin:0 0 14px 0;">The desktop app is required to access your workspace. Download it for your platform from the link below and complete the installation before proceeding.</p>
-                    <a href="${frontendUrl}/apps/downloads" style="display:inline-block;background:#6366f1;color:#ffffff;text-decoration:none;padding:11px 24px;border-radius:8px;font-weight:600;font-size:14px;">Download Xyne Spaces App</a>
-                    <p style="color:#6b7280;font-size:12px;margin:10px 0 0 0;">
-                      Or visit: <a href="${frontendUrl}/apps/downloads" style="color:#6366f1;word-break:break-all;">${frontendUrl}/apps/downloads</a>
-                    </p>
-                    <p style="color:#6b7280;font-size:12px;margin:6px 0 0 0;">
-                      Already set up? Open your invite: <a href="${frontendUrl}/invite" style="color:#6366f1;word-break:break-all;">${frontendUrl}/invite</a>
-                    </p>
-                  </td>
-                </tr>
-              </table>
-
-              <!-- Divider -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:24px;">
-                <tr>
-                  <td style="border-top:1px solid #e5e7eb;"></td>
                 </tr>
               </table>
 
               ${tempPassword ? `
               <!-- Temp Password Banner -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:24px;">
+              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-top:28px;">
                 <tr>
                   <td style="background:#ecfdf5;border:1px solid #10b981;border-radius:8px;padding:12px 16px;">
                     <strong style="display:block;color:#065f46;font-size:13px;margin-bottom:4px;">🔑 Your Temporary Password</strong>
-                    <span style="color:#065f46;font-size:13px;">Use this password to sign in with your email. This will remain your password until you have set it manually. Alternately, sign-in with Google/Microsoft SSO instead.</span>
+                    <span style="color:#065f46;font-size:13px;">Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.</span>
                     <p style="font-size:18px;font-weight:bold;color:#047857;margin:8px 0 0 0;letter-spacing:1px;">${tempPassword}</p>
                   </td>
                 </tr>
               </table>
               ` : ''}
 
-              <!-- Step 2 -->
-              <table width="100%" cellpadding="0" cellspacing="0" border="0" style="margin-bottom:32px;">
-                <tr>
-                  <td width="44" valign="top" style="padding-top:2px;">
-                    <table cellpadding="0" cellspacing="0" border="0">
-                      <tr>
-                        <td width="32" height="32" align="center" valign="middle" style="background:#000000;border-radius:50%;color:#ffffff;font-weight:700;font-size:14px;width:32px;height:32px;text-align:center;line-height:32px;">
-                          2
-                        </td>
-                      </tr>
-                    </table>
-                  </td>
-                  <td valign="top">
-                    <strong style="display:block;color:#1f2937;font-size:15px;margin-bottom:6px;">Accept Your Invitation &amp; Log In</strong>
-                    <p style="color:#6b7280;font-size:13px;margin:0 0 6px 0;">Once the app is installed, click the button below to accept your invitation and log in to your workspace.</p>
-                    <p style="color:#6b7280;font-size:13px;margin:0 0 14px 0;"><strong style="color:#1f2937;">Do not open this link in a browser</strong> — it must be opened in the Xyne Spaces desktop app.</p>
-                    <a href="${invitationLink}" style="display:inline-block;background:#000000;color:#ffffff;text-decoration:none;padding:12px 28px;border-radius:8px;font-weight:600;font-size:15px;">Accept Invitation</a>
-                    <p style="color:#6b7280;font-size:12px;margin:10px 0 0 0;word-break:break-all;">
-                      Or copy and paste this link: <a href="${invitationLink}" style="color:#6366f1;">${invitationLink}</a>
-                    </p>
-                  </td>
-                </tr>
-              </table>
-
               <!-- Footer -->
               <table width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
-                  <td align="center" style="border-top:1px solid #e5e7eb;padding-top:24px;font-size:12px;color:#9ca3af;">
+                  <td align="center" style="border-top:1px solid #e5e7eb;padding-top:24px;margin-top:24px;font-size:12px;color:#9ca3af;">
                     <p style="margin:0;">This invitation was sent by Xyne Spaces.<br>If you weren't expecting this email, you can safely ignore it.</p>
                   </td>
                 </tr>
@@ -156,35 +115,22 @@ You've been invited to join ${workspaceName} on Xyne Spaces!
 
 ${inviterName} has invited you to collaborate on Xyne Spaces — a platform for teams to communicate, manage tickets, and work together efficiently.
 
-⚠️  IMPORTANT: You must complete BOTH steps below in order. The invitation will only work correctly inside the desktop app.
+──────────────────────────────────────────
+JOIN XYNE
+──────────────────────────────────────────
+  ${invitationLink}
 
-──────────────────────────────────────────
-STEP 1 — Download & Install the Desktop App (REQUIRED)
-──────────────────────────────────────────
-Before doing anything else, download and install the Xyne Spaces desktop app for your platform:
+Want the full desktop experience? Download the app:
 
   ${frontendUrl}/apps/downloads
-
-Already set up? Open your invite: ${frontendUrl}/invite
-
-Complete the installation before moving to Step 2.
-
-──────────────────────────────────────────
-STEP 2 — Accept Your Invitation & Log In
-──────────────────────────────────────────
-Once the app is installed, open the link below to accept your invitation and log in to your workspace.
-Do NOT open this link in a browser — it must be opened in the Xyne Spaces desktop app.
-
-  ${invitationLink}
 
 ${tempPassword ? `──────────────────────────────────────────
 🔑 YOUR TEMPORARY PASSWORD
 ──────────────────────────────────────────
-Use this password to sign in with your email. This will remain your password until you have set it manually. Alternately, sign-in with Google/Microsoft SSO instead.
+Sign in with Google/Microsoft SSO, or use this temporary password to sign in with your email — it will remain your password until you set it manually.
 
   ${tempPassword}
 ` : ''}
-
 ──────────────────────────────────────────
 This invitation was sent by Xyne Spaces. If you weren't expecting this email, you can safely ignore it.
   `.trim();

--- a/apps/backend/src/services/fileProcessor/FileProcessor.ts
+++ b/apps/backend/src/services/fileProcessor/FileProcessor.ts
@@ -11,6 +11,7 @@ import { ImageDescriptionStrategy } from "./strategies/ImageStrategy"
 import { SpreadsheetStrategy } from "./strategies/SpreadsheetStrategy"
 import { PdfFallbackProcessor } from "./PdfFallbackProcessor"
 import { DoclingService } from "./DoclingService"
+import { convertToPdf } from "@/services/officeConversionService"
 
 /**
  * Supported MIME types for file processing.
@@ -166,6 +167,28 @@ export class FileProcessor {
             )
         }
 
+        // PPTX/PPT: convert to PDF first (the same LibreOffice conversion
+        // officeConversionService already does for the viewer) and route
+        // through the SAME dedicated PDF OCR ladder (LightOnOCR → Docling →
+        // PdfJs) that PDFs get. The dedicated LightOnOCR model is only
+        // deployed for PDFs (see DOCLING_ROUTE_PDFS_TO_SCHEDULER) — going
+        // through tryDocling() below like every other non-PDF type would
+        // only ever reach the plain generic Docling endpoint, never
+        // LightOnOCR. Falls back to native slide-XML parsing (PptxStrategy)
+        // if the conversion or the whole PDF ladder fails outright.
+        if (FileProcessor.isPptx(filename, mimeType)) {
+            try {
+                const pdfBuffer = await convertToPdf(buffer, filename)
+                return await PdfFallbackProcessor.processWithFallback(pdfBuffer, filename, vespaDocId)
+            } catch (err) {
+                logger.warn(`[FileProcessor] PPTX-to-PDF OCR route failed for ${vespaDocId}, falling back to native slide parser`, {
+                    error: err instanceof Error ? err.message : String(err),
+                })
+                const processor = new FileProcessor(new PptxStrategy(config))
+                return processor.processBuffer(buffer, vespaDocId)
+            }
+        }
+
         // Prefer deterministic, coordinate-aware parsing over Docling for Excel.
         if (FileProcessor.isSpreadsheet(filename, mimeType)) {
             const processor = new FileProcessor(new SpreadsheetStrategy(config))
@@ -185,8 +208,14 @@ export class FileProcessor {
             return doclingResult
         }
 
-        // Fall back to local strategy
-        const strategy = FileProcessor.detectStrategyFromMimeType(mimeType, config)
+        // Fall back to local strategy, by extension rather than MIME type.
+        // mimeType is client-supplied and often generic (e.g.
+        // application/octet-stream) even for a real .pptx/.docx/etc, which
+        // silently routed those straight to TextStrategy instead of the
+        // matching format strategy — same reasoning fromGcs already applies
+        // below, and the same extension-primary approach
+        // officeConversionFileFilter uses in middleware/upload.ts.
+        const strategy = FileProcessor.detectStrategy(filename, config)
         const processor = new FileProcessor(strategy)
         return processor.processBuffer(buffer, vespaDocId)
     }
@@ -309,6 +338,16 @@ export class FileProcessor {
             extension === "xlsx" ||
             mimeType === "application/vnd.ms-excel" ||
             mimeType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+    }
+
+    private static isPptx(filename: string, mimeType?: string): boolean {
+        const extension = filename.split(".").pop()?.toLowerCase()
+        return (
+            extension === "ppt" ||
+            extension === "pptx" ||
+            mimeType === "application/vnd.ms-powerpoint" ||
+            mimeType === "application/vnd.openxmlformats-officedocument.presentationml.presentation"
         )
     }
 }

--- a/apps/backend/src/services/ingestion/docling/scheduler/intake.ts
+++ b/apps/backend/src/services/ingestion/docling/scheduler/intake.ts
@@ -5,6 +5,14 @@
  *   - CHAT_ATTACHMENT     (docId = messageAttachment.id)
  *   - TICKET_ATTACHMENT   (docId = messageAttachment.id)
  *
+ * Also handles PPTX/PPT the same way: the scheduler (and the LightOnOCR
+ * model behind it) only ever operates on PDF bytes, so a pptx/ppt
+ * attachment is converted to PDF first (the same LibreOffice conversion
+ * the viewer uses, GCS-cached by content hash) and the *converted* PDF is
+ * what actually gets staged/split -- otherwise pptx would only ever reach
+ * the synchronous FileProcessor path's plain generic Docling endpoint,
+ * never the dedicated OCR model real PDFs get here.
+ *
  * Called from the file worker when config.doclingScheduler.routePdfs is on.
  * Inserts the pending_split row; the splitter takes over.
  */
@@ -14,12 +22,24 @@ import { runAsServiceActor } from '@/database/tenant/context';
 import { SubApp } from '@/vespa/src/types';
 import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
+import { storageService } from '@/services/storage';
+import { convertToPdf, getConvertedPdfGcsPath } from '@/services/officeConversionService';
 import { getRuntimeConfig } from '../runtime/config';
 import { inferDoclingSourcePriority, upsertDoclingAsyncFileForSplit } from './store';
 
 const isPdf = (mime: string | null | undefined, name: string | null | undefined): boolean =>
   (mime || '').toLowerCase().includes('application/pdf') ||
   (name || '').toLowerCase().endsWith('.pdf');
+
+const isPptx = (mime: string | null | undefined, name: string | null | undefined): boolean => {
+  const ext = (name || '').toLowerCase().split('.').pop();
+  return (
+    ext === 'pptx' ||
+    ext === 'ppt' ||
+    mime === 'application/vnd.ms-powerpoint' ||
+    mime === 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+  );
+};
 
 const toGcsKey = (url: string): string => {
   if (url.startsWith('gs://')) {
@@ -32,6 +52,30 @@ const toGcsKey = (url: string): string => {
   return url;
 };
 
+/**
+ * Resolves the GCS key the splitter should read real PDF bytes from for
+ * this attachment. A genuine PDF resolves to its own stored file. A
+ * pptx/ppt is converted to PDF first and resolves to the converted file's
+ * (content-hash-keyed, already GCS-cached) location instead. Anything else
+ * returns null -- not routed to the scheduler, falls back to the
+ * synchronous FileProcessor path.
+ */
+const resolveSourceKey = async (
+  mime: string | null | undefined,
+  name: string | null | undefined,
+  url: string,
+): Promise<string | null> => {
+  if (isPdf(mime, name)) {
+    return toGcsKey(url);
+  }
+  if (isPptx(mime, name)) {
+    const buffer = await storageService.getFileBuffer(url);
+    await convertToPdf(buffer, name || 'file.pptx');
+    return getConvertedPdfGcsPath(buffer);
+  }
+  return null;
+};
+
 const pageChunkSize = () => getRuntimeConfig().pageChunkSize;
 
 const routeCollection = async (fileId: string): Promise<boolean> => {
@@ -42,9 +86,9 @@ const routeCollection = async (fileId: string): Promise<boolean> => {
     where: { entityId: item.id, entityType: AttachmentEntityType.COLLECTION },
   });
   if (!attachment?.url) return false;
-  if (!isPdf(attachment.mimetype, item.name)) return false;
+  const sourceKey = await resolveSourceKey(attachment.mimetype, item.name, attachment.url);
+  if (!sourceKey) return false;
 
-  const sourceKey = toGcsKey(attachment.url);
   const { basePriority } = inferDoclingSourcePriority({ collectionId: item.rootCollectionId });
 
   const inserted = await runAsServiceActor('docling-intake', attachment.workspaceId,
@@ -76,9 +120,9 @@ const routeCollection = async (fileId: string): Promise<boolean> => {
 const routeAttachment = async (attachmentId: string, app: SubApp): Promise<boolean> => {
   const att = await db.messageAttachment.findUnique({ where: { id: attachmentId } });
   if (!att?.url) return false;
-  if (!isPdf(att.mimetype, att.originalFilename)) return false;
+  const sourceKey = await resolveSourceKey(att.mimetype, att.originalFilename, att.url);
+  if (!sourceKey) return false;
 
-  const sourceKey = toGcsKey(att.url);
   const { basePriority } = inferDoclingSourcePriority({ collectionId: '' });
 
   const inserted = await runAsServiceActor('docling-intake', att.workspaceId,

--- a/apps/backend/src/services/officeConversionService.ts
+++ b/apps/backend/src/services/officeConversionService.ts
@@ -1,6 +1,6 @@
 import { spawn } from "child_process"
-import { createHash, randomBytes } from "crypto"
-import { mkdtemp, readFile, rm } from "fs/promises"
+import { createHash } from "crypto"
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import pLimit from "p-limit"
@@ -40,12 +40,6 @@ const conversionLimit = pLimit(SOFFICE_MAX_CONCURRENCY)
 // file/collection id, just bytes), so content is the only key available.
 // Content-addressed and immutable, so entries never need to expire.
 const GCS_CACHE_PREFIX = "office-conversion-cache"
-
-// Uploaded bytes are staged here (randomly-keyed, short-lived) so soffice
-// can fetch them via a signed URL instead of us writing them to local disk
-// ourselves. Deleted right after each conversion in the finally block below.
-const INPUT_GCS_PREFIX = "office-conversion-tmp-input"
-const SIGNED_URL_EXPIRY_HOURS = 10 / 60 // 10 min — comfortably longer than CONVERSION_TIMEOUT_MS below
 
 export class OfficeConversionError extends Error {
     constructor(
@@ -112,24 +106,15 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
     const profileDir = path.join(workDir, "profile")
     // originalFilename is attacker-controlled (the client-supplied upload
     // name); only accept a plain alphanumeric extension so nothing in it
-    // (path separators, "..", null bytes, ...) can influence the temp GCS
-    // key or the local output path.
+    // (path separators, "..", null bytes, ...) can influence where
+    // inputPath actually lands on disk.
     const rawExt = path.extname(originalFilename)
     const ext = /^\.[a-zA-Z0-9]{1,10}$/.test(rawExt) ? rawExt : ".bin"
+    const inputPath = path.join(workDir, `input${ext}`)
     const outputPath = path.join(workDir, "input.pdf")
 
-    // Random subdirectory (not just filename) so the object's full key is
-    // unguessable; the basename stays fixed as "input<ext>" so soffice's
-    // derived output filename stays predictable ("input.pdf") regardless of
-    // the signed URL's query-string suffix.
-    const inputGcsKey = `${INPUT_GCS_PREFIX}/${contentHash}-${randomBytes(8).toString("hex")}/input${ext}`
-
     try {
-        await storageService.uploadFileV2(buffer, {
-            path: inputGcsKey,
-            contentType: "application/octet-stream",
-        })
-        const inputUrl = await storageService.generateSignedUrl(inputGcsKey, SIGNED_URL_EXPIRY_HOURS)
+        await writeFile(inputPath, buffer)
 
         await conversionLimit(() => new Promise<void>((resolve, reject) => {
             const args = [
@@ -140,7 +125,7 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
                 "pdf",
                 "--outdir",
                 workDir,
-                inputUrl,
+                inputPath,
             ]
             const proc = spawn(SOFFICE_BINARY, args)
 
@@ -199,12 +184,6 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
         await rm(workDir, { recursive: true, force: true }).catch(err => {
             logger.warn("[OfficeConversion] Failed to clean up temp dir", {
                 workDir,
-                error: err instanceof Error ? err.message : String(err),
-            })
-        })
-        await storageService.deleteFile(inputGcsKey).catch(err => {
-            logger.warn("[OfficeConversion] Failed to clean up temp GCS input object", {
-                inputGcsKey,
                 error: err instanceof Error ? err.message : String(err),
             })
         })

--- a/apps/backend/src/services/officeConversionService.ts
+++ b/apps/backend/src/services/officeConversionService.ts
@@ -1,6 +1,6 @@
 import { spawn } from "child_process"
-import { createHash } from "crypto"
-import { mkdtemp, readFile, rm, writeFile } from "fs/promises"
+import { createHash, randomBytes } from "crypto"
+import { mkdtemp, readFile, rm } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import pLimit from "p-limit"
@@ -40,6 +40,12 @@ const conversionLimit = pLimit(SOFFICE_MAX_CONCURRENCY)
 // file/collection id, just bytes), so content is the only key available.
 // Content-addressed and immutable, so entries never need to expire.
 const GCS_CACHE_PREFIX = "office-conversion-cache"
+
+// Uploaded bytes are staged here (randomly-keyed, short-lived) so soffice
+// can fetch them via a signed URL instead of us writing them to local disk
+// ourselves. Deleted right after each conversion in the finally block below.
+const INPUT_GCS_PREFIX = "office-conversion-tmp-input"
+const SIGNED_URL_EXPIRY_HOURS = 10 / 60 // 10 min — comfortably longer than CONVERSION_TIMEOUT_MS below
 
 export class OfficeConversionError extends Error {
     constructor(
@@ -106,15 +112,24 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
     const profileDir = path.join(workDir, "profile")
     // originalFilename is attacker-controlled (the client-supplied upload
     // name); only accept a plain alphanumeric extension so nothing in it
-    // (path separators, "..", null bytes, ...) can influence where
-    // inputPath actually lands on disk.
+    // (path separators, "..", null bytes, ...) can influence the temp GCS
+    // key or the local output path.
     const rawExt = path.extname(originalFilename)
     const ext = /^\.[a-zA-Z0-9]{1,10}$/.test(rawExt) ? rawExt : ".bin"
-    const inputPath = path.join(workDir, `input${ext}`)
     const outputPath = path.join(workDir, "input.pdf")
 
+    // Random subdirectory (not just filename) so the object's full key is
+    // unguessable; the basename stays fixed as "input<ext>" so soffice's
+    // derived output filename stays predictable ("input.pdf") regardless of
+    // the signed URL's query-string suffix.
+    const inputGcsKey = `${INPUT_GCS_PREFIX}/${contentHash}-${randomBytes(8).toString("hex")}/input${ext}`
+
     try {
-        await writeFile(inputPath, buffer)
+        await storageService.uploadFileV2(buffer, {
+            path: inputGcsKey,
+            contentType: "application/octet-stream",
+        })
+        const inputUrl = await storageService.generateSignedUrl(inputGcsKey, SIGNED_URL_EXPIRY_HOURS)
 
         await conversionLimit(() => new Promise<void>((resolve, reject) => {
             const args = [
@@ -125,7 +140,7 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
                 "pdf",
                 "--outdir",
                 workDir,
-                inputPath,
+                inputUrl,
             ]
             const proc = spawn(SOFFICE_BINARY, args)
 
@@ -184,6 +199,12 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
         await rm(workDir, { recursive: true, force: true }).catch(err => {
             logger.warn("[OfficeConversion] Failed to clean up temp dir", {
                 workDir,
+                error: err instanceof Error ? err.message : String(err),
+            })
+        })
+        await storageService.deleteFile(inputGcsKey).catch(err => {
+            logger.warn("[OfficeConversion] Failed to clean up temp GCS input object", {
+                inputGcsKey,
                 error: err instanceof Error ? err.message : String(err),
             })
         })

--- a/apps/backend/src/services/officeConversionService.ts
+++ b/apps/backend/src/services/officeConversionService.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process"
 import { createHash, randomBytes } from "crypto"
+import { constants as fsConstants } from "fs"
 import { mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
@@ -64,9 +65,14 @@ async function readLocalCache(cachePath: string): Promise<Buffer | null> {
     // freshness check and the read see the same inode — a path-based
     // stat-then-readFile has a window where the file can be replaced or
     // deleted in between the two calls.
+    //
+    // cachePath is fully predictable (tmpdir()/office-conversion-cache/<sha256 of
+    // content>.pdf), so O_NOFOLLOW rejects a symlink someone else planted at that
+    // path before we get here — without it, a planted symlink would make us read
+    // and serve back whatever arbitrary file it points to as the "cached" PDF.
     let handle
     try {
-        handle = await open(cachePath, "r")
+        handle = await open(cachePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
         const stats = await handle.stat()
         if (Date.now() - stats.mtimeMs > CACHE_MAX_AGE_MS) return null
         return await handle.readFile()

--- a/apps/backend/src/services/officeConversionService.ts
+++ b/apps/backend/src/services/officeConversionService.ts
@@ -82,9 +82,19 @@ async function writeGcsCache(gcsPath: string, buffer: Buffer, contentHash: strin
     }
 }
 
+// Pure function of the content — callers that need to know where a
+// buffer's converted PDF lives in GCS (e.g. to point the async OCR
+// scheduler's page-splitter at it directly) can compute this without
+// re-running the conversion, since it's the exact path convertToPdf
+// itself reads from/writes to below.
+export function getConvertedPdfGcsPath(buffer: Buffer): string {
+    const contentHash = createHash("sha256").update(buffer).digest("hex")
+    return `${GCS_CACHE_PREFIX}/${contentHash}.pdf`
+}
+
 export async function convertToPdf(buffer: Buffer, originalFilename: string): Promise<Buffer> {
     const contentHash = createHash("sha256").update(buffer).digest("hex")
-    const gcsPath = `${GCS_CACHE_PREFIX}/${contentHash}.pdf`
+    const gcsPath = getConvertedPdfGcsPath(buffer)
 
     const gcsHit = await readGcsCache(gcsPath)
     if (gcsHit) {

--- a/apps/backend/src/services/officeConversionService.ts
+++ b/apps/backend/src/services/officeConversionService.ts
@@ -1,7 +1,6 @@
 import { spawn } from "child_process"
-import { createHash, randomBytes } from "crypto"
-import { constants as fsConstants } from "fs"
-import { mkdir, mkdtemp, open, readFile, rename, rm, writeFile } from "fs/promises"
+import { createHash } from "crypto"
+import { mkdtemp, readFile, rm, writeFile } from "fs/promises"
 import { tmpdir } from "os"
 import path from "path"
 import pLimit from "p-limit"
@@ -36,18 +35,10 @@ const CONVERSION_TIMEOUT_MS = 60_000
 const SOFFICE_MAX_CONCURRENCY = Number(process.env.SOFFICE_MAX_CONCURRENCY) || 3
 const conversionLimit = pLimit(SOFFICE_MAX_CONCURRENCY)
 
-// Two-tier cache, both keyed on the content hash (this endpoint is
-// stateless — no file/collection id, just bytes, so content is the only key
-// available):
-//   1. Local disk — near-zero latency, but wiped on pod restart and not
-//      shared across replicas.
-//   2. GCS (the same bucket every other upload in this app already uses) —
-//      survives restarts and is shared across every backend replica, at the
-//      cost of a network round trip instead of a local read.
-// A hit on tier 2 backfills tier 1, so a given pod only pays the GCS latency
-// once per content hash.
-const CACHE_DIR = path.join(tmpdir(), "office-conversion-cache")
-const CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000
+// Cached in GCS (the same bucket every other upload in this app already
+// uses), keyed on the content hash — this endpoint is stateless (no
+// file/collection id, just bytes), so content is the only key available.
+// Content-addressed and immutable, so entries never need to expire.
 const GCS_CACHE_PREFIX = "office-conversion-cache"
 
 export class OfficeConversionError extends Error {
@@ -58,47 +49,6 @@ export class OfficeConversionError extends Error {
         super(message)
         this.name = "OfficeConversionError"
     }
-}
-
-async function readLocalCache(cachePath: string): Promise<Buffer | null> {
-    // Stat and read via the same open file handle (not by path) so the
-    // freshness check and the read see the same inode — a path-based
-    // stat-then-readFile has a window where the file can be replaced or
-    // deleted in between the two calls.
-    //
-    // cachePath is fully predictable (tmpdir()/office-conversion-cache/<sha256 of
-    // content>.pdf), so O_NOFOLLOW rejects a symlink someone else planted at that
-    // path before we get here — without it, a planted symlink would make us read
-    // and serve back whatever arbitrary file it points to as the "cached" PDF.
-    let handle
-    try {
-        handle = await open(cachePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW)
-        const stats = await handle.stat()
-        if (Date.now() - stats.mtimeMs > CACHE_MAX_AGE_MS) return null
-        return await handle.readFile()
-    } catch {
-        return null
-    } finally {
-        await handle?.close().catch(() => {})
-    }
-}
-
-async function writeLocalCache(cachePath: string, buffer: Buffer, contentHash: string): Promise<void> {
-    // Write to a randomly-named file (exclusive create, so we never write
-    // through a pre-existing file/symlink an attacker planted at a
-    // predictable path) and rename it into place atomically, rather than
-    // writing straight to the guessable content-addressed cachePath.
-    const tmpPath = `${cachePath}.${randomBytes(8).toString("hex")}.tmp`
-    await mkdir(CACHE_DIR, { recursive: true })
-        .then(() => writeFile(tmpPath, buffer, { flag: "wx" }))
-        .then(() => rename(tmpPath, cachePath))
-        .catch(err => {
-            logger.warn("[OfficeConversion] Failed to write local cache entry", {
-                contentHash,
-                error: err instanceof Error ? err.message : String(err),
-            })
-            return rm(tmpPath, { force: true }).catch(() => {})
-        })
 }
 
 async function readGcsCache(gcsPath: string): Promise<Buffer | null> {
@@ -134,19 +84,11 @@ async function writeGcsCache(gcsPath: string, buffer: Buffer, contentHash: strin
 
 export async function convertToPdf(buffer: Buffer, originalFilename: string): Promise<Buffer> {
     const contentHash = createHash("sha256").update(buffer).digest("hex")
-    const cachePath = path.join(CACHE_DIR, `${contentHash}.pdf`)
     const gcsPath = `${GCS_CACHE_PREFIX}/${contentHash}.pdf`
-
-    const localHit = await readLocalCache(cachePath)
-    if (localHit) {
-        logger.info("[OfficeConversion] Local cache hit", { contentHash })
-        return localHit
-    }
 
     const gcsHit = await readGcsCache(gcsPath)
     if (gcsHit) {
         logger.info("[OfficeConversion] GCS cache hit", { contentHash })
-        await writeLocalCache(cachePath, gcsHit, contentHash)
         return gcsHit
     }
 
@@ -225,10 +167,7 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
 
         const result = await readFile(outputPath)
 
-        await Promise.all([
-            writeLocalCache(cachePath, result, contentHash),
-            writeGcsCache(gcsPath, result, contentHash),
-        ])
+        await writeGcsCache(gcsPath, result, contentHash)
 
         return result
     } finally {
@@ -240,4 +179,3 @@ export async function convertToPdf(buffer: Buffer, originalFilename: string): Pr
         })
     }
 }
-


### PR DESCRIPTION
Cherry-pick of #1365 onto `release-20260827`.

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
XYNE-61472. The invitation email forced a two-step flow — "install the desktop app, then click the invite link" — and claimed the link "will only work correctly inside the app," which isn't true and blocked/confused recipients who just wanted to open the invite in a browser.

Replaces it with a single primary "Join Xyne" CTA plus a copy-link fallback; downloading the desktop app is now an optional mention below the CTA, not a gate. Same simplification applied to the plain-text email variant.

## Areas Touched

- [x] `apps/backend` (API / worker) — only `apps/backend/src/services/email/templates/invitation.ts`
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?
Same commit as #1365, cherry-picked cleanly (no conflicts). Reviewed the diff; **have not** sent a test invitation or rendered the email in a client on this branch specifically.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — no existing coverage renders/asserts on this email template's markup

### Manual
Not yet performed on this branch — see #1365 for the source PR's test plan.

**Still to do before merge:**
- [ ] Send a real invitation and confirm the email renders with a single "Join Xyne" CTA + copy-link fallback
- [ ] Confirm the temp-password banner (brand-new, non-GUEST invitees) still renders correctly
- [ ] Click the invite link directly in a browser and confirm it works without the desktop app

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes — not run
- [ ] Backend `typecheck` + `build` pass — not run on this branch yet
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass — N/A, no dashboard files touched
- [x] No new deps added
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed — N/A
- [x] No debug logging or commented-out code left behind
