### PR TITLE
fix: XYNE-62321 video maximize/minimize button not working in thread attachment viewer

### DIFF
--- a/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
+++ b/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
@@ -116,7 +116,16 @@ const SlideContent: React.FC<{
   initialTime?: number | undefined;
   autoPlay?: boolean;
   onInteractionStateChange?: (state: ZoomState) => void;
-}> = ({ file, isActive, disableGestures, initialTime, autoPlay, onInteractionStateChange }) => {
+  onExpand?: () => void;
+}> = ({
+  file,
+  isActive,
+  disableGestures,
+  initialTime,
+  autoPlay,
+  onInteractionStateChange,
+  onExpand,
+}) => {
   const [fileData, setFileData] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -178,6 +187,7 @@ const SlideContent: React.FC<{
             fileName={file.fileName}
             attachmentId={file.attachmentId}
             autoPlay={Boolean(autoPlay)}
+            {...(onExpand && { onExpand })}
             {...(initialTime !== undefined && { initialTime })}
             {...(isCarouselMode && { disableGestures: true })}
             {...(isCarouselMode && onInteractionStateChange && { onInteractionStateChange })}
@@ -613,6 +623,7 @@ const FilePreviewModalInner: React.FC<FilePreviewModalProps> = ({
               <SlideContent
                 file={file}
                 isActive={index === currentFileIndex}
+                onExpand={onClose}
                 {...(disableCarouselGestures && { disableGestures: true })}
                 {...(index === currentFileIndex && {
                   onInteractionStateChange: (state: ZoomState) => {
@@ -1368,6 +1379,7 @@ const AttachmentGalleryModalInner: React.FC = () => {
               <SlideContent
                 file={file}
                 isActive={index === currentFileIndex}
+                onExpand={() => attachmentViewerActor.send({ type: 'CLOSE' })}
                 {...(disableCarouselGestures && { disableGestures: true })}
                 // Pass initialTime to active video
                 initialTime={initialTime}


### PR DESCRIPTION
## Problem
In the attachment/thread viewer (`FileViewerModal.tsx`), the video player's expand/minimize (maximize) button did nothing when a message had multiple attachments, while the equivalent button worked for images.

## Root cause
- `ImageViewer`'s fullscreen button is self-contained (uses the browser Fullscreen API), so it works regardless of how it is mounted.
- `VideoViewer`'s expand/minimize button is wired to the `onExpand` prop (`onClick={onExpand}`). The single-file render path passed `onExpand` (closes the viewer), but the carousel path — `SlideContent`, used whenever `files.length > 1` — rendered `VideoViewer` WITHOUT `onExpand`, so the button was a no-op.

## Fix
- Added an optional `onExpand?: () => void` prop to `SlideContent` and forward it to the `VideoViewer`.
- Pass the correct close handler from both carousels: `onClose` in `FilePreviewModal`, and `attachmentViewerActor.send({ type: 'CLOSE' })` in `AttachmentGalleryModal` — matching the existing single-file behavior.

## Validation
- `tsc --noEmit` shows no new type errors from this change.
- Recorded a before/after proof-of-test of the minimize button behavior.