### PR TITLE
feat: XYNE-60922 add Topics Explorer to the desk support screen

### DIFF
--- a/apps/backend/src/controllers/deskTagsConfigController.ts
+++ b/apps/backend/src/controllers/deskTagsConfigController.ts
@@ -14,6 +14,27 @@ import { EmailRepository } from '@/database/repositories/emailRepository';
 import { generateLlmTags } from '@/tags/generators/llm';
 import { tagRepository } from '@/database/repositories/tagRepository';
 
+/**
+ * Epoch-ms query param as a Date, or null when it is missing or unusable. The
+ * blank guard is trimmed: Number('') and Number('  ') are both 0, so `?startMs=`
+ * or `?startMs=%20` would otherwise read as epoch 0 and scan all history.
+ */
+const epochMsToDate = (raw: unknown): Date | null => {
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  const ms = trimmed ? Number(trimmed) : NaN;
+  const date = new Date(ms);
+  return Number.isFinite(ms) && !Number.isNaN(date.getTime()) ? date : null;
+};
+
+/**
+ * Server-side ceiling on the generated-tags window. The Topics Explorer caps at
+ * 7 calendar days client-side, but that is not a control: without this a
+ * hand-crafted multi-year request reads the channel's whole email table and
+ * every tag row hanging off it. A 7-day inclusive range runs 00:00 on day one
+ * to 23:59 on day seven, so it measures one millisecond under the cap.
+ */
+const MAX_TAG_RANGE_MS = 7 * 24 * 60 * 60 * 1000;
+
 export class DeskTagsConfigController {
   private channelParticipantRepo = new ChannelParticipantRepository();
   private channelRepo = new ChannelRepository();
@@ -224,6 +245,61 @@ export class DeskTagsConfigController {
     } catch (error) {
       logger.error('[DESK-TAGS-CONFIG] filterConversationsByTags failed', { channelId, generatedTags, error });
       res.status(500).json({ error: 'Failed to filter conversations by tags' });
+    }
+  };
+
+  /**
+   * GET /api/channels/:channelId/tags-config/generated-tags-by-conversation?startMs=…&endMs=…
+   *
+   * Tag values per conversation for this channel in the given date range. Tags
+   * live in the `non_zero` schema, which Zero does not mirror, so this is the
+   * only read path for grouping tickets by tag category.
+   * ACL: channel member.
+   */
+  getGeneratedTagsByConversation = async (req: Request, res: Response): Promise<void> => {
+    const { channelId } = req.params;
+    const userId = await this.assertAccess(req, res, channelId);
+    if (!userId) return;
+
+    const start = epochMsToDate(req.query['startMs']);
+    const end = epochMsToDate(req.query['endMs']);
+    if (!start || !end || start > end) {
+      res.status(400).json({
+        error: 'startMs and endMs must be epoch-millisecond values, with startMs before endMs',
+      });
+      return;
+    }
+    if (end.getTime() - start.getTime() > MAX_TAG_RANGE_MS) {
+      res.status(400).json({
+        error: `Date range cannot exceed ${MAX_TAG_RANGE_MS / (24 * 60 * 60 * 1000)} days`,
+      });
+      return;
+    }
+
+    try {
+      const rows = await tagRepository.findGeneratedTagsByConversation(
+        channelId,
+        deskEmailConfigKey(channelId),
+        start,
+        end,
+      );
+
+      const byConversation = new Map<string, { category: string; tag: string }[]>();
+      for (const row of rows) {
+        const tags = byConversation.get(row.conversationId) ?? [];
+        tags.push({ category: row.tagCategory, tag: row.tag });
+        byConversation.set(row.conversationId, tags);
+      }
+
+      const conversations = [...byConversation].map(([conversationId, tags]) => ({
+        conversationId,
+        tags,
+      }));
+
+      res.status(200).json({ conversations });
+    } catch (error) {
+      logger.error('[DESK-TAGS-CONFIG] getGeneratedTagsByConversation failed', { channelId, error });
+      res.status(500).json({ error: 'Failed to load generated tags by conversation' });
     }
   };
 

--- a/apps/backend/src/database/repositories/tagRepository.ts
+++ b/apps/backend/src/database/repositories/tagRepository.ts
@@ -237,6 +237,68 @@ export class TagRepository {
 
     return rows.map(r => r.conversationId);
   }
+
+  /**
+   * Distinct (conversationId, tagCategory, tag) triples for every email of a desk
+   * channel created inside [start, end].
+   *
+   * Where `findConversationIdsByEmailTags` answers "which threads match this
+   * filter?", this is the grouping read: the caller gets the tag values themselves
+   * so it can bucket tickets by category.
+   */
+  async findGeneratedTagsByConversation(
+    channelId: string,
+    configKey: string,
+    start: Date,
+    end: Date,
+  ): Promise<{ conversationId: string; tagCategory: string; tag: string }[]> {
+    // Last email per conversation: a thread is re-tagged per email, so reading
+    // them all put one ticket in several sentiment groups at once.
+    const emails = await this.client().email.findMany({
+      where: { channelId, createdAt: { gte: start, lte: end } },
+      orderBy: [{ conversationId: 'asc' }, { createdAt: 'desc' }, { id: 'desc' }],
+      distinct: ['conversationId'],
+      select: { id: true, conversationId: true },
+    });
+    if (emails.length === 0) return [];
+
+    // Tags hang off the email (`sourceId`), and `non_zero.tags` has no relation
+    // to `public.emails` to traverse, so the conversation is joined back here.
+    const conversationByEmailId = new Map(emails.map(e => [e.id, e.conversationId]));
+
+    const tags = await this.client().tag.findMany({
+      where: {
+        sourceId: { in: [...conversationByEmailId.keys()] },
+        sourceType: 'desk-email',
+        configKey,
+        isDeleted: false,
+      },
+      select: { sourceId: true, tagCategory: true, tag: true },
+    });
+
+    // Dedupe: the same category and tag can be stored twice against one email.
+    // The key is
+    // NUL-joined because categories and tags are LLM-authored free text: any
+    // printable separator can occur inside them and would fold two distinct
+    // triples into one ("customer intent"/"billing" vs "customer"/"intent billing").
+    const seen = new Set<string>();
+    const rows: { conversationId: string; tagCategory: string; tag: string }[] = [];
+    for (const { sourceId, tagCategory, tag } of tags) {
+      const conversationId = conversationByEmailId.get(sourceId);
+      if (!conversationId) continue;
+      const key = `${conversationId}\u0000${tagCategory}\u0000${tag}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      rows.push({ conversationId, tagCategory, tag });
+    }
+
+    logger.info('[TAG-REPO] findGeneratedTagsByConversation success', {
+      channelId,
+      count: rows.length,
+    });
+
+    return rows;
+  }
 }
 
 export const tagRepository = new TagRepository();

--- a/apps/backend/src/routes/deskTagsConfig.ts
+++ b/apps/backend/src/routes/deskTagsConfig.ts
@@ -10,5 +10,6 @@ router.patch('/', authMiddleware.authenticate, controller.updateConfig);
 router.post('/preview', authMiddleware.authenticate, controller.previewTagGeneration);
 router.get('/all-generated-tags', authMiddleware.authenticate, controller.getAllGeneratedTags);
 router.get('/conversations-by-tags', authMiddleware.authenticate, controller.filterConversationsByTags);
+router.get('/generated-tags-by-conversation', authMiddleware.authenticate, controller.getGeneratedTagsByConversation);
 
 export default router;

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -1360,6 +1360,29 @@ export const queries: AnyQueryRegistry = defineQueries({
     }
   ),
 
+  // Topics Explorer: one desk's tickets in a created-at window, rolled up client-side.
+  // Not supportTicketsPageV3 — that pulls emailDrafts, emailReads, userMailbox and
+  // formEntityValues per row, where this reads scalar columns and no relation at all.
+  // The window bounds the sync: the panel caps its range at 7 days and opens on one.
+  // channelId + isMember are forwarded to TicketsACL for membership gating.
+  topicsExplorerTickets: defineQuery(
+    z.object({
+      channelId: z.string(),
+      isMember: z.boolean(),
+      createdAtStart: z.number(),
+      createdAtEnd: z.number(),
+    }).refine(
+      args => args.createdAtStart <= args.createdAtEnd,
+      'createdAtStart must be less than or equal to createdAtEnd',
+    ),
+    ({ args: { channelId, createdAtStart, createdAtEnd } }) =>
+      zql.tickets
+        .where('channelId', channelId)
+        .where('isArchived', false)
+        .where('createdAt', '>=', createdAtStart)
+        .where('createdAt', '<=', createdAtEnd)
+        .orderBy('createdAt', 'desc'),
+  ),
   // Single-row variant matching supportTicketsPage row shape (for @rocicorp/zero-virtual permalinks).
   // channelId + isMember are forwarded to TicketsACL for membership gating.
   // @deprecated

--- a/apps/dashboard/src/api/tagsConfigApi.ts
+++ b/apps/dashboard/src/api/tagsConfigApi.ts
@@ -25,6 +25,16 @@ export interface ChannelGeneratedTagItem {
   tag: string;
 }
 
+/** LLM tags carried by one conversation, used to group tickets by tag category. */
+export interface ConversationGeneratedTags {
+  conversationId: string;
+  tags: ChannelGeneratedTagItem[];
+}
+
+export interface GeneratedTagsByConversation {
+  conversations: ConversationGeneratedTags[];
+}
+
 export const tagsConfigApi = {
   getConfig: async (channelId: string): Promise<TagCategories> => {
     const res = await apiInstance.get<{ categories: TagCategories }>(
@@ -74,5 +84,23 @@ export const tagsConfigApi = {
       { params: { tags } },
     );
     return res.data.conversationIds;
+  },
+
+  /**
+   * LLM tags per conversation over a created-at window.
+   *
+   * These live in `non_zero.tags`, which Zero does not sync, so grouping by tag
+   * category has to come from the API rather than the synced ticket rows.
+   */
+  getGeneratedTagsByConversation: async (
+    channelId: string,
+    startMs: number,
+    endMs: number,
+  ): Promise<GeneratedTagsByConversation> => {
+    const res = await apiInstance.get<Partial<GeneratedTagsByConversation>>(
+      `/channels/${channelId}/tags-config/generated-tags-by-conversation`,
+      { params: { startMs, endMs } },
+    );
+    return { conversations: res.data.conversations ?? [] };
   },
 };

--- a/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDateRangePicker.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskMetrics/DeskMetricsDateRangePicker.tsx
@@ -17,6 +17,14 @@ const endOfDay = (d: Date): Date => {
   r.setHours(23, 59, 59, 999);
   return r;
 };
+/**
+ * Calendar days a range spans, inclusive. Off midnights, not elapsed time: a
+ * fall-back DST day is 25 hours, pushing "Last 30 days" past a 30-day cap.
+ */
+const rangeDays = (r: DateRangeValue): number =>
+  Math.round(
+    (startOfDay(r.endDate).getTime() - startOfDay(r.startDate).getTime()) / (24 * 60 * 60 * 1000),
+  ) + 1;
 const isSameDay = (a: Date, b: Date) =>
   a.getFullYear() === b.getFullYear() &&
   a.getMonth() === b.getMonth() &&
@@ -176,6 +184,8 @@ export interface DeskMetricsDateRangePickerProps {
   startTime: string;
   endTime: string;
   onChange: (dr: DateRangeValue, st: string, et: string) => void;
+  /** Longest selectable range, in days. Hides longer presets too. */
+  maxDays?: number;
 }
 
 export const DeskMetricsDateRangePicker: React.FC<DeskMetricsDateRangePickerProps> = ({
@@ -183,6 +193,7 @@ export const DeskMetricsDateRangePicker: React.FC<DeskMetricsDateRangePickerProp
   startTime,
   endTime,
   onChange,
+  maxDays = MAX_CUSTOM_DAYS,
 }) => {
   const [open, setOpen] = useState(false);
   const [showCustom, setShowCustom] = useState(false);
@@ -236,7 +247,7 @@ export const DeskMetricsDateRangePicker: React.FC<DeskMetricsDateRangePickerProp
           className='z-50 w-[264px] rounded-xl border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 duration-150'
         >
           <div className='p-1'>
-            {PRESETS.map(p => (
+            {PRESETS.filter(p => rangeDays(p.getValue()) <= maxDays).map(p => (
               <button
                 key={p.label}
                 type='button'
@@ -295,11 +306,8 @@ export const DeskMetricsDateRangePicker: React.FC<DeskMetricsDateRangePickerProp
                 <button
                   type='button'
                   onClick={() => {
-                    const diffDays =
-                      (pendingRange.endDate.getTime() - pendingRange.startDate.getTime()) /
-                      (24 * 60 * 60 * 1000);
-                    if (diffDays > MAX_CUSTOM_DAYS) {
-                      toast.error(`Date range cannot exceed ${MAX_CUSTOM_DAYS} days`);
+                    if (rangeDays(pendingRange) > maxDays) {
+                      toast.error(`Date range cannot exceed ${maxDays} days`);
                       return;
                     }
                     if (

--- a/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsExplorer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsExplorer.tsx
@@ -1,0 +1,809 @@
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from 'react';
+import type { DateRangeValue } from '../../ui/DateRangeFilter';
+import { DeskMetricsDateRangePicker } from '../DeskMetrics/DeskMetricsDateRangePicker';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
+import { ChevronLeft, ChevronRight, MultipleCrossCancelDefault } from '@xyne/icons';
+import { Dialog } from '../../ui/Dialog/Dialog';
+import { cn } from '../../../utils/classNames';
+import { queries } from '../../../zero/queries';
+// Not useCachedQuery: this rollup is throwaway, not warm-start state.
+import { useQuery } from '../../../hooks/useQuery';
+import { useGetChannelUserStatus } from '../../../hooks/useChannels';
+import { useDeskTagsConfig } from '../../../hooks/useDeskTagsConfig';
+import { useUsersById } from '../../../hooks/useUsers';
+import { tagsConfigApi } from '../../../api/tagsConfigApi';
+import { getApiErrorMessage } from '../../../utils/apiError';
+import type { TicketStatusV2 } from '@xyne/shared';
+import type { TicketFilters } from '../../Tickets/TicketFilters/types';
+import { TopicsFilterBar } from './TopicsFilterBar';
+import { TopicsTreemap } from './TopicsTreemap';
+import { TopicsTrendPanel } from './TopicsTrendPanel';
+import {
+  MAX_DEPTH,
+  MAX_BOXES,
+  MAX_RANGE_DAYS,
+  MS_PER_DAY,
+  applyTicketFilters,
+  buildDimensions,
+  buildTrend,
+  dimensionFor,
+  groupLevel,
+  labelFor,
+  maxDailyCount,
+  planDrill,
+  swatchFor,
+  templateFor,
+  ticketsForKey,
+  usefulDimensions,
+  type ConversationTag,
+  type ConversationTagMap,
+  type DimensionContext,
+  type DimensionKey,
+  type TopicsTicket,
+} from './TopicsExplorer.utils';
+
+/**
+ * Desk-scoped ticket volume grouped by any stack of columns: treemap left, one
+ * daily-volume trend row per group right. Zero has no aggregation, so the
+ * rollup runs client-side — hence one channel and a bounded created-at window.
+ */
+
+const PAGER_BUTTON =
+  'flex h-6 w-6 items-center justify-center rounded border border-border transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40 disabled:hover:bg-transparent';
+const PANEL = 'flex min-h-[320px] flex-col overflow-hidden rounded-xl border border-border bg-card';
+const PANEL_HEADER = 'flex items-baseline justify-between border-b border-border px-4 py-2';
+const PANEL_TITLE = 'text-xs font-medium uppercase tracking-wide text-muted-foreground';
+/** The filters this panel applies, keyed by the search-param the list reads. */
+const FILTER_KEYS = [
+  'aiCategory',
+  'priority',
+  'stages',
+  'assignee',
+  'userGroups',
+  'generatedTags',
+] as const satisfies readonly (keyof TicketFilters)[];
+
+/** Combine a calendar date with an HH:mm time into an epoch-ms bound. */
+const dateTimeMs = (date: Date, time: string, isEnd: boolean): number => {
+  const [hour = 0, minute = 0] = time.split(':').map(Number);
+  const result = new Date(date);
+  result.setHours(hour, minute, isEnd ? 59 : 0, isEnd ? 999 : 0);
+  return result.getTime();
+};
+
+const startOfDay = (ms: number): number => {
+  const d = new Date(ms);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+};
+
+export interface TopicsExplorerProps {
+  open: boolean;
+  onClose: () => void;
+  channelId: string;
+  channelName?: string;
+  /** Desk base path (e.g. `/ws/support`), used for the ticket-list drill-through. */
+  supportBase: string;
+  /**
+   * Board-derived option lists, passed in rather than derived from the synced
+   * rows: the date range would otherwise hide configured-but-unused values, so
+   * the filter menus would not match the ticket list's own.
+   */
+  availableAiCategories: string[];
+  availableStages: { name: string; status?: TicketStatusV2 }[];
+}
+
+export const TopicsExplorer = ({
+  open,
+  onClose,
+  channelId,
+  channelName,
+  supportBase,
+  availableAiCategories,
+  availableStages,
+}: TopicsExplorerProps): ReactElement => {
+  const navigate = useNavigate();
+  const [dims, setDims] = useState<DimensionKey[]>(['priority', 'aiCategory']);
+  const [filters, setFilters] = useState<TicketFilters>({});
+  // AI tags/sentiment live outside Zero, so they arrive per conversation.
+  const [aiTagsByConversation, setAiTagsByConversation] = useState<ConversationTagMap>(
+    () => new Map<string, readonly ConversationTag[]>(),
+  );
+  const [isLoadingAiTagDimensions, setIsLoadingAiTagDimensions] = useState(false);
+  const [aiTagsFailed, setAiTagsFailed] = useState(false);
+  const [path, setPath] = useState<string[]>([]);
+  const [page, setPage] = useState(0);
+  // Defaults to today: the rollup runs client-side over synced rows, so the
+  // panel opens on the cheapest window and widens only when asked.
+  const [dateRange, setDateRange] = useState<DateRangeValue>(() => ({
+    startDate: new Date(),
+    endDate: new Date(),
+  }));
+  const [startTime, setStartTime] = useState('00:00');
+  const [endTime, setEndTime] = useState('23:59');
+  const [hovered, setHovered] = useState<string | null>(null);
+  const isMember = !!useGetChannelUserStatus(channelId);
+  const usersById = useUsersById();
+  const prevPageRef = useRef<HTMLButtonElement | null>(null);
+  const nextPageRef = useRef<HTMLButtonElement | null>(null);
+
+  const { startMs, endMs, rangeDays } = useMemo(() => {
+    const from = dateTimeMs(dateRange.startDate, startTime, false);
+    const to = dateTimeMs(dateRange.endDate, endTime, true);
+    return {
+      startMs: from,
+      endMs: to,
+      // Calendar days spanned, inclusive — elapsed time goes fractional once a
+      // custom start/end time is set.
+      rangeDays: Math.max(Math.round((startOfDay(to) - startOfDay(from)) / MS_PER_DAY) + 1, 1),
+    };
+  }, [dateRange, startTime, endTime]);
+
+  // Memoized: a fresh query object rebuilds and rehashes the ZQL AST on every
+  // state change, including each mouse move.
+  const ticketsQuery = useMemo(
+    () =>
+      queries.topicsExplorerTickets({
+        channelId,
+        isMember,
+        createdAtStart: startMs,
+        createdAtEnd: endMs,
+      }),
+    [channelId, isMember, startMs, endMs],
+  );
+  const queryOptions = useMemo(() => ({ enabled: open && !!channelId }), [open, channelId]);
+
+  const [rows, details] = useQuery(ticketsQuery, queryOptions);
+
+  // Zero pushes a new array identity on every sync frame while rows stream in;
+  // deferring re-runs the rollup on the settled array rather than every push.
+  const deferredRows = useDeferredValue(rows);
+  const isSyncingRows = rows !== deferredRows;
+  const allTickets = useMemo<readonly TopicsTicket[]>(() => deferredRows ?? [], [deferredRows]);
+  // A deferred frame counts as loading, so a partial rollup never renders as final.
+  const isTicketsReady = details.type === 'complete' && !isSyncingRows;
+
+  const ctx = useMemo<DimensionContext>(
+    () => ({
+      userName: (id): string => {
+        const user = usersById.get(id);
+        return user?.displayName ?? user?.name ?? user?.email ?? 'Unknown user';
+      },
+    }),
+    [usersById],
+  );
+
+  // Tag categories are grouping dimensions, so they load with the panel and the
+  // date range rather than with the tag filter.
+  useEffect(() => {
+    if (!open || !channelId) return;
+    let cancelled = false;
+    setIsLoadingAiTagDimensions(true);
+    setAiTagsFailed(false);
+    tagsConfigApi
+      .getGeneratedTagsByConversation(channelId, startMs, endMs)
+      .then(result => {
+        if (cancelled) return;
+        const next = new Map<string, readonly ConversationTag[]>();
+        for (const row of result.conversations) {
+          if (row.conversationId) next.set(row.conversationId, row.tags ?? []);
+        }
+        setAiTagsByConversation(next);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setAiTagsByConversation(new Map<string, readonly ConversationTag[]>());
+        setAiTagsFailed(true);
+        // Otherwise the AI tag dimensions vanish from "Group by" unexplained.
+        toast.error(getApiErrorMessage(err, 'Could not load AI tag categories'));
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoadingAiTagDimensions(false);
+      });
+    return (): void => {
+      cancelled = true;
+    };
+  }, [open, channelId, startMs, endMs]);
+
+  // Category list comes from the desk's own tag config, so "Group by" offers
+  // exactly what Desk Settings configured — not whatever the range happens to
+  // have tagged.
+  const { categories: tagCategories } = useDeskTagsConfig(channelId, open && !!channelId);
+  const configuredTagCategories = useMemo(() => Object.keys(tagCategories), [tagCategories]);
+
+  const dimensions = useMemo(
+    () => buildDimensions(aiTagsByConversation, configuredTagCategories),
+    [aiTagsByConversation, configuredTagCategories],
+  );
+
+  /**
+   * The AI-tag filter reads the same window-scoped map the groupings read, so a
+   * ticket that passes the filter cannot then land in the grouping's "no tags in
+   * this range" bucket. Resolving it server-side scanned all history instead,
+   * which is exactly how the two scopes came apart.
+   */
+  const tagConversationIds = useMemo<string[] | null>(() => {
+    const selected = filters.generatedTags;
+    if (!selected?.length) return null;
+    const wanted = new Set(selected);
+    const matched: string[] = [];
+    for (const [conversationId, tags] of aiTagsByConversation) {
+      if (tags.some(t => wanted.has(`${t.category}:${t.tag}`))) matched.push(conversationId);
+    }
+    return matched;
+  }, [filters.generatedTags, aiTagsByConversation]);
+
+  // The map is the filter's only source, so a filter set while it loads has to
+  // hold the list empty rather than render one frame of unfiltered counts.
+  const tagsPending = !!filters.generatedTags?.length && isLoadingAiTagDimensions;
+
+  const tickets = useMemo(
+    () => applyTicketFilters(allTickets, filters, tagsPending ? [] : tagConversationIds),
+    [allTickets, filters, tagConversationIds, tagsPending],
+  );
+  const available = useMemo(() => usefulDimensions(tickets, dimensions), [tickets, dimensions]);
+
+  // A chosen tag category can vanish when the range changes; pruning in an
+  // effect would commit one render against a dead dimension.
+  const activeDims = useMemo<DimensionKey[]>(() => {
+    const kept = dims.filter(key => dimensions.has(key));
+    return kept.length > 0 ? kept : ['priority'];
+  }, [dims, dimensions]);
+
+  /** Walk the drill path, one dimension per step. */
+  const { allNodes, depth, scoped, validPath } = useMemo(() => {
+    let current = tickets;
+    let dimIndex = 0;
+    const walked: string[] = [];
+
+    for (const key of path) {
+      const dim = activeDims[dimIndex];
+      const nextDim = activeDims[dimIndex + 1];
+      if (!dim || !nextDim) break;
+      const subset = ticketsForKey(current, dimensionFor(dimensions, dim), key);
+      if (subset.length === 0) break;
+      current = subset;
+      dimIndex += 1;
+      walked.push(key);
+    }
+
+    return {
+      allNodes: groupLevel(current, dimensionFor(dimensions, activeDims[dimIndex]), ctx),
+      depth: dimIndex,
+      scoped: current,
+      validPath: walked,
+    };
+  }, [tickets, activeDims, dimensions, ctx, path]);
+
+  const pageCount = Math.max(Math.ceil(allNodes.length / MAX_BOXES), 1);
+  // Clamp rather than reset: paging state can outlive a filter change.
+  const safePage = Math.min(page, pageCount - 1);
+  const nodes = useMemo(
+    () => allNodes.slice(safePage * MAX_BOXES, safePage * MAX_BOXES + MAX_BOXES),
+    [allNodes, safePage],
+  );
+
+  // Charts exactly the queried range; a fixed bucket count would fabricate
+  // zeros past its end.
+  const trend = useMemo(() => buildTrend(nodes, rangeDays, endMs), [nodes, rangeDays, endMs]);
+
+  // Spans every group at this level, not just the page: per-page scaling drew a
+  // group peaking at 8 as tall as one peaking at 1,500.
+  const trendMax = useMemo(
+    () => maxDailyCount(allNodes, rangeDays, endMs),
+    [allNodes, rangeDays, endMs],
+  );
+
+  const currentDim = dimensionFor(dimensions, activeDims[depth]);
+  const isOverlapping = currentDim.multi === true;
+  // A leaf tile's click belongs to the ticket list, not to another level.
+  const isDrillable = activeDims.length > depth + 1;
+
+  // A leaf can only open the ticket list when every level of its path maps to a
+  // filter param. Where it cannot, the tile stays inert rather than opening a
+  // wider list than it counted — the three sets name what is responsible, kept
+  // apart so one inert box cannot speak for its whole dimension.
+  const { tiles, openBlockers, emptyBuckets, conflicting } = useMemo(() => {
+    const total = scoped.length || 1;
+    const blockers = new Set<string>();
+    const emptyBoxes = new Set<string>();
+    const combined = new Set<string>();
+
+    const built = nodes.map((node, i) => {
+      const share = Math.round((node.tickets.length / total) * 100);
+      let canOpen = true;
+      if (!isDrillable) {
+        const plan = planDrill(
+          [...validPath, node.key].map((key, level) => ({
+            dim: dimensionFor(dimensions, activeDims[level]),
+            key,
+          })),
+          filters.generatedTags,
+        );
+        canOpen =
+          plan.dropped.length === 0 &&
+          plan.emptyBuckets.length === 0 &&
+          plan.conflicting.length === 0;
+        for (const label of plan.dropped) blockers.add(label);
+        for (const label of plan.emptyBuckets) emptyBoxes.add(label);
+        for (const label of plan.conflicting) combined.add(label);
+      }
+      return {
+        name: node.label,
+        nodeKey: node.key,
+        ...swatchFor(i),
+        count: `${node.tickets.length.toLocaleString()} tickets`,
+        // Percentages of an overlapping level do not add up, so they are
+        // suppressed everywhere at once — tile text, aria-label and tooltip.
+        share: isOverlapping ? '' : `${share}%`,
+        sharePct: share,
+        canOpen,
+      };
+    });
+
+    return {
+      tiles: built,
+      openBlockers: [...blockers],
+      emptyBuckets: [...emptyBoxes],
+      conflicting: [...combined],
+    };
+  }, [
+    nodes,
+    scoped.length,
+    isOverlapping,
+    isDrillable,
+    validPath,
+    dimensions,
+    activeDims,
+    filters,
+  ]);
+
+  /**
+   * One trend row per tile, so the two panels cannot drift in order or shade.
+   * Memoized because `hovered` changes on every mouse move: rebuilt row objects
+   * would defeat `TrendRow`'s memo and re-render every chart on each move.
+   */
+  const rowsWithTrend = useMemo(
+    () =>
+      tiles.map((tile, i) => ({
+        key: tile.nodeKey,
+        label: tile.name,
+        colour: tile.fill,
+        points: trend[i] ?? [],
+        canSelect: isDrillable || tile.canOpen,
+      })),
+    [tiles, trend, isDrillable],
+  );
+
+  // No useMemo: templateFor indexes a module-level table, so the reference is stable.
+  const layout = templateFor(tiles.length);
+
+  // Formatted through each level's own dimension: raw keys are ids for Assignee
+  // and `category:tag` for AI tags.
+  const crumbs = [
+    { label: 'All tickets', to: [] as string[] },
+    ...validPath.map((key, i) => ({
+      label: labelFor(dimensionFor(dimensions, activeDims[i]), key, ctx),
+      to: path.slice(0, i + 1),
+    })),
+  ];
+
+  /** Caveats shown above the panels, so a capped or partial rollup says so. */
+  const notices = [
+    isOverlapping && {
+      id: 'overlap',
+      tone: 'muted' as const,
+      text: 'A ticket can carry several tags, so these groups overlap and add up to more than the total.',
+    },
+    openBlockers.length > 0 && {
+      id: 'noOpen',
+      tone: 'muted' as const,
+      text: `The ticket list has no filter for ${openBlockers.join(' or ')}, so these boxes can be read and charted here but not opened as a ticket list.`,
+    },
+    emptyBuckets.length > 0 && {
+      id: 'noEmptyValue',
+      tone: 'muted' as const,
+      text: `The ticket list cannot filter for ${emptyBuckets.map(label => `“${label}”`).join(' or ')}, so only ${emptyBuckets.length > 1 ? 'those boxes' : 'that box'} cannot be opened. The rest open as usual.`,
+    },
+    conflicting.length > 0 && {
+      id: 'conflicting',
+      tone: 'muted' as const,
+      text: `${conflicting.join(' and ')} reuses a filter an earlier level or the filter bar already set, and the ticket list combines repeats with OR, so opening would show more tickets than the box counts.`,
+    },
+  ].filter(Boolean) as { id: string; tone: 'muted' | 'warn'; text: string }[];
+
+  const openTickets = useCallback(
+    (nodeKey: string): void => {
+      const plan = planDrill(
+        [...validPath, nodeKey].map((key, i) => ({
+          dim: dimensionFor(dimensions, activeDims[i]),
+          key,
+        })),
+        filters.generatedTags,
+      );
+
+      // Guard, not a user path: the tile is already inert when this holds, since
+      // a list that cannot express every level is wider than the box clicked.
+      if (plan.dropped.length > 0 || plan.emptyBuckets.length > 0 || plan.conflicting.length > 0)
+        return;
+
+      const params = new URLSearchParams();
+
+      // Only the filters the rollup applies, each already the param name the
+      // list reads it from — `TicketFilters` keys are not all (`boards`/`board`).
+      for (const key of FILTER_KEYS) {
+        for (const value of filters[key] ?? []) params.append(key, value);
+      }
+
+      // The drill path replaces any filter on the same field: the list ORs
+      // repeated params, so Assignee={alice,bob} drilled into alice opens both.
+      for (const { param, value } of plan.assignments) {
+        params.delete(param);
+        params.append(param, value);
+      }
+
+      params.set('createdDateStart', String(startMs));
+      params.set('createdDateEnd', String(endMs));
+      // No onClose(): dropping `topics=open` from the URL already closes this.
+      void navigate(`${supportBase}/${channelId}?${params.toString()}`);
+    },
+    [activeDims, channelId, dimensions, endMs, filters, navigate, startMs, supportBase, validPath],
+  );
+
+  // Moves focus at either end: the pressed button goes `disabled`, dropping
+  // focus to <body> and dead-ending keyboard paging.
+  const goToPage = (next: number): void => {
+    const target = Math.min(Math.max(next, 0), pageCount - 1);
+    setPage(target);
+    if (target <= 0) nextPageRef.current?.focus();
+    else if (target >= pageCount - 1) prevPageRef.current?.focus();
+  };
+
+  /** Every drill rebuilds the group set, so path and page always move together. */
+  const showPath = useCallback((next: string[]): void => {
+    setPath(next);
+    setPage(0);
+    // The next level reuses group keys, so a stale hover lights up an unrelated group.
+    setHovered(null);
+  }, []);
+
+  // Keeps the first `keepLevels` drilled steps: the keys above the edited level
+  // came from dimensions that did not move, so dropping them would throw the
+  // user back to the root for an edit outside their branch.
+  const regroup = useCallback(
+    (next: DimensionKey[], keepLevels: number): void => {
+      setDims(next);
+      showPath(validPath.slice(0, keepLevels));
+    },
+    [showPath, validPath],
+  );
+
+  const onTileClick = useCallback(
+    (nodeKey: string): void => {
+      if (isDrillable) {
+        showPath([...validPath, nodeKey]);
+        return;
+      }
+      if (tiles.find(t => t.nodeKey === nodeKey)?.canOpen) openTickets(nodeKey);
+    },
+    [isDrillable, tiles, openTickets, showPath, validPath],
+  );
+
+  const selectClass =
+    'rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground';
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+      title='Topics Explorer'
+      className={cn(
+        'left-auto right-0 top-0 bottom-0 h-screen w-[85vw] max-h-none max-w-none translate-x-0 translate-y-0 rounded-l-[16px] rounded-r-none bg-transparent shadow-none',
+        'data-[state=open]:!zoom-in-100 data-[state=open]:!slide-in-from-top-[0%] data-[state=open]:!slide-in-from-right-full',
+        'data-[state=closed]:!zoom-out-100 data-[state=closed]:!slide-out-to-top-[0%] data-[state=closed]:!slide-out-to-right-full',
+      )}
+    >
+      <div className='relative h-full w-full'>
+        <button
+          type='button'
+          onClick={onClose}
+          className='absolute right-6 top-4 z-20 flex h-8 w-8 items-center justify-center rounded-[10px] border border-desk-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-accent hover:text-foreground dark:border-border'
+          aria-label='Close topics explorer'
+          data-track-category='TOPICS_EXPLORER'
+          data-track-name='CloseButton'
+        >
+          <MultipleCrossCancelDefault size={16} />
+        </button>
+
+        <div className='isolate flex h-full w-full flex-col overflow-hidden rounded-l-[16px] border border-desk-border bg-popover shadow-2xl dark:border-border'>
+          {/* pr-12 clears the absolutely-positioned close button — same
+              convention as DeskMetricsDashboard's header. */}
+          <div className='shrink-0 space-y-3 border-b border-desk-border px-6 pb-3 pr-12 pt-4 dark:border-border'>
+            <div>
+              <h2 className='text-base font-semibold'>
+                Topics Explorer
+                {channelName && <span className='text-muted-foreground'> · {channelName}</span>}
+              </h2>
+              <p className='mt-0.5 text-xs text-muted-foreground'>
+                Boxes are ordered by volume — read the count and bar for size. Click one to go
+                deeper.
+              </p>
+            </div>
+
+            {/* Desk's own submenus, so field list and value formats match the
+                ticket list exactly. */}
+            <div className='flex flex-wrap items-center gap-2'>
+              <TopicsFilterBar
+                channelId={channelId}
+                filters={filters}
+                onChange={next => {
+                  setFilters(next);
+                  showPath([]);
+                }}
+                availableAiCategories={availableAiCategories}
+                availableStages={availableStages}
+                isLoadingTags={tagsPending}
+              />
+
+              <span className='ml-auto'>
+                <DeskMetricsDateRangePicker
+                  dateRange={dateRange}
+                  startTime={startTime}
+                  endTime={endTime}
+                  maxDays={MAX_RANGE_DAYS}
+                  onChange={(dr, st, et) => {
+                    setDateRange(dr);
+                    setStartTime(st);
+                    setEndTime(et);
+                    showPath([]);
+                  }}
+                />
+              </span>
+            </div>
+
+            {/* Grouping — how the tickets are broken up */}
+            <div className='flex flex-wrap items-center gap-2'>
+              <span className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+                Group by
+              </span>
+
+              {activeDims.map((dim, level) => (
+                <span key={dim} className='flex items-center gap-1'>
+                  {/* Decorative: otherwise announced as "greater than". */}
+                  {level > 0 && (
+                    <span aria-hidden='true' className='text-muted-foreground'>
+                      ›
+                    </span>
+                  )}
+                  <select
+                    value={dim}
+                    onChange={e => {
+                      const next = [...activeDims];
+                      next[level] = e.target.value as DimensionKey;
+                      regroup(next, level);
+                    }}
+                    className={selectClass}
+                    aria-label={`Group level ${level + 1}`}
+                    data-track-category='TOPICS_EXPLORER'
+                    data-track-name='CHANGE_DIMENSION'
+                  >
+                    {/* Current dim first, then anything not already used at another
+                        level. `available` alone drops the selected dim once it stops
+                        splitting the data, leaving a value that matches no option. */}
+                    {[dim, ...available.filter(k => !activeDims.includes(k))].map(k => (
+                      <option key={k} value={k}>
+                        {dimensionFor(dimensions, k).label}
+                      </option>
+                    ))}
+                  </select>
+                  {activeDims.length > 1 && (
+                    <button
+                      type='button'
+                      onClick={() =>
+                        regroup(
+                          activeDims.filter((_, i) => i !== level),
+                          level,
+                        )
+                      }
+                      // 24x24 hit area: the bare glyph was under the WCAG 2.5.8 minimum.
+                      className='flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground'
+                      aria-label={`Remove level ${level + 1}`}
+                      data-track-category='TOPICS_EXPLORER'
+                      data-track-name='REMOVE_LEVEL'
+                    >
+                      <MultipleCrossCancelDefault size={12} aria-hidden />
+                    </button>
+                  )}
+                </span>
+              ))}
+
+              {activeDims.length < MAX_DEPTH && available.some(k => !activeDims.includes(k)) && (
+                <button
+                  type='button'
+                  onClick={() => {
+                    const unused = available.find(k => !activeDims.includes(k));
+                    // Appending leaves existing levels untouched, so the path survives.
+                    if (unused) regroup([...activeDims, unused], validPath.length);
+                  }}
+                  className='rounded-md border border-dashed border-border px-2 py-1 text-sm text-muted-foreground hover:text-foreground'
+                  data-track-category='TOPICS_EXPLORER'
+                  data-track-name='ADD_LEVEL'
+                >
+                  + Level
+                </button>
+              )}
+
+              {activeDims.length >= MAX_DEPTH && (
+                <span className='text-xs text-muted-foreground'>Max {MAX_DEPTH} levels</span>
+              )}
+
+              {isLoadingAiTagDimensions && (
+                <span className='text-xs text-muted-foreground'>Loading AI tag categories…</span>
+              )}
+            </div>
+          </div>
+
+          {/* Breadcrumb + counts */}
+          <div className='flex flex-wrap items-center gap-1 px-6 py-2 text-sm'>
+            {/* A real breadcrumb: bare buttons split by "›" are announced as
+                "greater than" between every level. */}
+            <nav aria-label='Drill path'>
+              <ol className='flex flex-wrap items-center gap-1'>
+                {crumbs.map((crumb, i) => (
+                  <li key={`${i}-${crumb.label}`} className='flex items-center gap-1'>
+                    {i > 0 && (
+                      <span aria-hidden='true' className='text-muted-foreground'>
+                        ›
+                      </span>
+                    )}
+                    <button
+                      type='button'
+                      onClick={() => showPath(crumb.to)}
+                      className={
+                        i === 0
+                          ? 'text-muted-foreground hover:text-foreground'
+                          : 'font-medium hover:underline'
+                      }
+                      aria-current={i === crumbs.length - 1 ? 'page' : undefined}
+                      data-track-category='TOPICS_EXPLORER'
+                      data-track-name={i === 0 ? 'BREADCRUMB_ROOT' : 'BREADCRUMB_LEVEL'}
+                    >
+                      {crumb.label}
+                    </button>
+                  </li>
+                ))}
+              </ol>
+            </nav>
+            <span className='ml-auto text-muted-foreground'>
+              {isTicketsReady
+                ? `${allNodes.length} groups · ${scoped.length.toLocaleString()} tickets`
+                : 'Loading tickets…'}
+            </span>
+          </div>
+
+          {notices.map(notice => (
+            <div
+              key={notice.id}
+              className={cn(
+                'mx-6 mb-2 rounded-md px-3 text-xs',
+                notice.tone === 'warn'
+                  ? 'bg-amber-500/10 py-2'
+                  : 'bg-muted py-1.5 text-muted-foreground',
+              )}
+            >
+              {notice.text}
+            </div>
+          ))}
+
+          {/* overflow-y-auto: below `lg` the two panels stack inside an
+              overflow-hidden ancestor, leaving the second unreachable. */}
+          <div className='grid min-h-0 flex-1 grid-cols-1 gap-4 overflow-y-auto px-6 pb-6 lg:grid-cols-[3fr_2fr]'>
+            {/* Left: treemap */}
+            <section className={PANEL}>
+              <header className={PANEL_HEADER}>
+                <h3 className={PANEL_TITLE}>{currentDim.label}</h3>
+                <nav
+                  aria-label='Topic pages'
+                  className='flex items-center gap-2 text-xs text-muted-foreground'
+                >
+                  <span className='tabular-nums' aria-live='polite'>
+                    {allNodes.length === 0
+                      ? 'no groups'
+                      : `${safePage * MAX_BOXES + 1}–${safePage * MAX_BOXES + nodes.length} of ${allNodes.length}`}
+                  </span>
+                  {pageCount > 1 && (
+                    <span className='flex items-center gap-1'>
+                      <button
+                        ref={prevPageRef}
+                        type='button'
+                        onClick={() => goToPage(safePage - 1)}
+                        disabled={safePage === 0}
+                        className={PAGER_BUTTON}
+                        aria-label='Previous page'
+                        data-track-category='TOPICS_EXPLORER'
+                        data-track-name='PREV_PAGE'
+                      >
+                        <ChevronLeft size={13} />
+                      </button>
+                      <span className='tabular-nums'>
+                        {safePage + 1}/{pageCount}
+                      </span>
+                      <button
+                        ref={nextPageRef}
+                        type='button'
+                        onClick={() => goToPage(safePage + 1)}
+                        disabled={safePage >= pageCount - 1}
+                        className={PAGER_BUTTON}
+                        aria-label='Next page'
+                        data-track-category='TOPICS_EXPLORER'
+                        data-track-name='NEXT_PAGE'
+                      >
+                        <ChevronRight size={13} />
+                      </button>
+                    </span>
+                  )}
+                </nav>
+              </header>
+
+              <div className='min-h-0 flex-1 p-2'>
+                {tiles.length === 0 ? (
+                  <div className='flex h-full items-center justify-center text-sm text-muted-foreground'>
+                    {/* The tag fetch feeds the filter, so its failure has to be
+                        named here — otherwise a dead filter reads as a confident
+                        "No tickets match". */}
+                    {tagsPending
+                      ? 'Loading AI tags…'
+                      : aiTagsFailed && !!filters.generatedTags?.length
+                        ? 'Could not load AI tags — clear that filter or retry.'
+                        : isTicketsReady
+                          ? 'No tickets match'
+                          : 'Loading tickets…'}
+                  </div>
+                ) : (
+                  <TopicsTreemap
+                    tiles={tiles}
+                    layout={layout}
+                    hovered={hovered}
+                    drillable={isDrillable}
+                    onSelect={onTileClick}
+                    onHover={setHovered}
+                  />
+                )}
+              </div>
+            </section>
+
+            {/* Right: one trend row per group, same order and shade as the tiles */}
+            <section className={PANEL}>
+              <header className={PANEL_HEADER}>
+                <h3 className={PANEL_TITLE}>Daily volume</h3>
+                {/* Not "last N days": the range can be any window, e.g. Yesterday. */}
+                <span className='text-xs text-muted-foreground'>
+                  {rangeDays} {rangeDays === 1 ? 'day' : 'days'}
+                </span>
+              </header>
+
+              <TopicsTrendPanel
+                rows={rowsWithTrend}
+                max={trendMax}
+                hovered={hovered}
+                onHover={setHovered}
+                onSelect={onTileClick}
+              />
+            </section>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+};

--- a/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsExplorer.utils.ts
+++ b/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsExplorer.utils.ts
@@ -1,0 +1,472 @@
+import { parseAssigneeFilter, UNASSIGNED_FILTER_VALUE } from '../../../zero/queries';
+import type { TicketFilters } from '../../Tickets/TicketFilters/types';
+
+// The rollup runs client-side over synced rows, so the window stays short
+// enough that one desk's tickets fit in the browser.
+export const MAX_RANGE_DAYS = 7;
+export const MAX_DEPTH = 4;
+export const MS_PER_DAY = 86_400_000;
+/** Key used when a ticket has no value for a dimension. */
+const NONE_KEY = '__none__';
+
+/** Ticket fields the rollup reads. Structurally assignable from a synced Zero row. */
+export interface TopicsTicket {
+  createdAt: number;
+  conversationId: string;
+  userGroupId?: string | null;
+  priority: string;
+  stageName: string;
+  assignedTo?: string | null;
+  aiCategory?: string | null;
+}
+
+/**
+ * `assignedTo` is stored either bare or prefixed (`user:`/`group:`/`userGroup:`),
+ * which is why the ticket-list filter expands a bare id back into every form.
+ * Grouping has to collapse the same way, or one person splits across two buckets
+ * and neither drills through correctly.
+ */
+const assigneeKey = (assignedTo: string | null | undefined): string => {
+  if (!assignedTo) return UNASSIGNED_FILTER_VALUE;
+  const bare = assignedTo.replace(/^(?:user|userGroup|group):/, '');
+  return bare || UNASSIGNED_FILTER_VALUE;
+};
+
+export interface DimensionContext {
+  /** Resolves assignee ids to display names; raw ids are meaningless as labels. */
+  userName: (id: string) => string;
+}
+
+export interface Dimension {
+  label: string;
+  values: (ticket: TopicsTicket) => string[];
+  format?: (key: string, ctx: DimensionContext) => string;
+  /** URL value for the "no value" bucket. `null` means the ticket list cannot express it. */
+  emptyParam?: string | null;
+  /** Display name of the "no value" bucket. Absent on dimensions that never produce one. */
+  emptyLabel?: string;
+  /** True when a ticket can land in more than one bucket, so groups overlap. */
+  multi?: boolean;
+  /** Search-param understood by `readFiltersFromUrl`; absent means undrillable. */
+  param?: string;
+}
+
+export interface ConversationTag {
+  category: string;
+  tag: string;
+}
+export type ConversationTagMap = ReadonlyMap<string, readonly ConversationTag[]>;
+
+export interface TopicNode {
+  key: string;
+  label: string;
+  tickets: TopicsTicket[];
+}
+export interface TrendPoint {
+  day: string;
+  count: number;
+}
+
+export interface Swatch {
+  fill: string;
+  /** Paired at authoring time; every combination clears WCAG AA (4.5:1). */
+  ink: string;
+}
+
+// Shared by a group's tile and its trend row so the two panels read as one view.
+const PALETTE: readonly Swatch[] = [
+  { fill: '#4C1D95', ink: '#FFFFFF' },
+  { fill: '#5B21B6', ink: '#FFFFFF' },
+  { fill: '#6D28D9', ink: '#FFFFFF' },
+  { fill: '#7C3AED', ink: '#FFFFFF' },
+  { fill: '#9333EA', ink: '#FFFFFF' },
+  { fill: '#A78BFA', ink: '#1F1147' },
+  { fill: '#C4B5FD', ink: '#1F1147' },
+  { fill: '#DDD6FE', ink: '#1F1147' },
+];
+
+export const swatchFor = (index: number): Swatch => PALETTE[index % PALETTE.length] as Swatch;
+
+const GRID_COLUMNS = 8;
+const GRID_ROWS = 6;
+/** Half-gap between adjacent boxes, in px. */
+const GUTTER = 3;
+
+/** Cell coords on the GRID_COLUMNS x GRID_ROWS grid. */
+export interface BoxShape {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Layout per box count, indexed by count: `x,y,w,h` boxes separated by spaces,
+ * in rank order. Every template tiles all 48 cells, and no box is under 2 rows
+ * tall, which is what label + count + bar needs.
+ */
+const SPECS: readonly string[] = [
+  '',
+  '0,0,8,6',
+  '0,0,4,6 4,0,4,6',
+  '0,0,4,6 4,0,4,3 4,3,4,3',
+  '0,0,5,4 5,0,3,4 0,4,5,2 5,4,3,2',
+  '0,0,4,3 4,0,4,3 0,3,3,3 3,3,3,3 6,3,2,3',
+  '0,0,4,3 4,0,4,3 0,3,2,3 2,3,2,3 4,3,2,3 6,3,2,3',
+  '0,0,3,3 3,0,3,3 6,0,2,3 0,3,2,3 2,3,2,3 4,3,2,3 6,3,2,3',
+  '0,0,4,2 4,0,4,2 0,2,3,2 3,2,3,2 0,4,3,2 3,4,3,2 6,2,2,2 6,4,2,2',
+];
+
+const LAYOUT_TEMPLATES: BoxShape[][] = SPECS.map(spec =>
+  spec
+    .split(' ')
+    .filter(Boolean)
+    .map(box => {
+      const [x, y, w, h] = box.split(',').map(Number) as [number, number, number, number];
+      return { x, y, w, h };
+    }),
+);
+
+// Capped by the palette too, so a page never runs past the ramp and gives two
+// groups the same shade.
+export const MAX_BOXES = Math.min(LAYOUT_TEMPLATES.length - 1, PALETTE.length);
+
+export const templateFor = (count: number): BoxShape[] =>
+  LAYOUT_TEMPLATES[Math.min(Math.max(count, 1), MAX_BOXES)] as BoxShape[];
+
+/** CSS position/size for a shape, as percentages of the panel. */
+export const shapeStyle = (
+  shape: BoxShape,
+): { left: string; top: string; width: string; height: string } => ({
+  left: `calc(${(shape.x / GRID_COLUMNS) * 100}% + ${GUTTER}px)`,
+  top: `calc(${(shape.y / GRID_ROWS) * 100}% + ${GUTTER}px)`,
+  width: `calc(${(shape.w / GRID_COLUMNS) * 100}% - ${GUTTER * 2}px)`,
+  height: `calc(${(shape.h / GRID_ROWS) * 100}% - ${GUTTER * 2}px)`,
+});
+
+const one = (v: string | null | undefined): string[] => [
+  v === null || v === undefined || v === '' ? NONE_KEY : v,
+];
+
+// `emptyParam` is always null: the ticket list has no "has no value" filter for
+// these columns, so a drill-through reports the level as dropped instead.
+const single = (
+  label: string,
+  read: (ticket: TopicsTicket) => string | null | undefined,
+  noneLabel: string,
+  param?: string,
+): Dimension => ({
+  label,
+  values: ticket => one(read(ticket)),
+  format: key => (key === NONE_KEY ? noneLabel : key),
+  ...(param ? { param } : {}),
+  emptyParam: null,
+  emptyLabel: noneLabel,
+});
+
+// All four map to a filter the ticket list already applies, so a tile opens the
+// set it counted. Every other grouping is a tag category configured in Desk
+// Settings, added by `buildDimensions` — no category is ever named here.
+const DIMENSION_DEFS = {
+  priority: single('Priority', t => t.priority, 'No priority', 'priority'),
+  aiCategory: single('AI Category', t => t.aiCategory, 'Unclassified', 'aiCategory'),
+  stageName: single('Stage', t => t.stageName, 'No stage', 'stages'),
+  assignedTo: {
+    label: 'Assignee',
+    values: (t): string[] => [assigneeKey(t.assignedTo)],
+    format: (key, ctx): string =>
+      key === UNASSIGNED_FILTER_VALUE ? 'Unassigned' : ctx.userName(key),
+    // No `emptyParam`: the unassigned bucket uses the sentinel the ticket list
+    // understands, so this dimension never yields NONE_KEY.
+    param: 'assignee',
+  },
+} satisfies Record<string, Dimension>;
+
+export type StaticDimensionKey = keyof typeof DIMENSION_DEFS;
+
+// The category suffix only exists at runtime, so the key type stays open.
+export const AI_TAG_DIMENSION_PREFIX = 'aiTag:';
+export type AiTagDimensionKey = `${typeof AI_TAG_DIMENSION_PREFIX}${string}`;
+export type DimensionKey = StaticDimensionKey | AiTagDimensionKey;
+export type DimensionMap = ReadonlyMap<DimensionKey, Dimension>;
+
+// Re-typed as a uniform record: `satisfies` alone keeps each entry's literal
+// shape, dropping the optional fields at the call site.
+const DIMENSIONS: Record<StaticDimensionKey, Dimension> = DIMENSION_DEFS;
+const STATIC_DIMENSION_KEYS = Object.keys(DIMENSIONS) as StaticDimensionKey[];
+
+/** Placeholder for a key that no longer resolves, e.g. a tag category the range dropped. */
+const MISSING_DIMENSION: Dimension = {
+  label: 'Unavailable',
+  values: () => [NONE_KEY],
+  emptyParam: null,
+};
+
+export const dimensionFor = (dimensions: DimensionMap, key: DimensionKey | undefined): Dimension =>
+  key ? (dimensions.get(key) ?? MISSING_DIMENSION) : MISSING_DIMENSION;
+
+/** `sentiment` / `customer_intent` → `Sentiment` / `Customer Intent`. */
+const titleise = (raw: string): string =>
+  raw
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+/**
+ * Static dimensions plus one per configured tag category. `tagCategories` is the
+ * desk's own config, not the categories present in `tagsByConversation`: reading
+ * the sample would drop a category the range happens not to cover, so the
+ * "Group by" list would shift with the date range and lose a selection.
+ */
+export const buildDimensions = (
+  tagsByConversation: ConversationTagMap,
+  tagCategories: readonly string[],
+): DimensionMap => {
+  const map = new Map<DimensionKey, Dimension>(
+    STATIC_DIMENSION_KEYS.map(key => [key, DIMENSIONS[key]] as const),
+  );
+
+  const categories = [...new Set(tagCategories.filter(Boolean))];
+  for (const category of categories.sort((a, b) => a.localeCompare(b))) {
+    const prefix = `${category}:`;
+    map.set(`${AI_TAG_DIMENSION_PREFIX}${category}`, {
+      // Prefixed: a desk can name a category "priority", which would otherwise
+      // be indistinguishable from the ticket's own Priority grouping.
+      label: `AI Tag · ${titleise(category)}`,
+      values: ticket => {
+        const keys = (tagsByConversation.get(ticket.conversationId) ?? [])
+          .filter(t => t.category === category && !!t.tag)
+          .map(t => `${prefix}${t.tag}`);
+        return keys.length > 0 ? [...new Set(keys)] : [NONE_KEY];
+      },
+      // "in this range": the tag fetch is bounded by the panel's date window, so
+      // a ticket tagged outside it lands here rather than in its tag's box.
+      format: key =>
+        key === NONE_KEY
+          ? 'No tags in this range'
+          : key.startsWith(prefix)
+            ? key.slice(prefix.length)
+            : key,
+      multi: true,
+      param: 'generatedTags',
+      emptyParam: null,
+      emptyLabel: 'No tags in this range',
+    });
+  }
+
+  return map;
+};
+
+export const labelFor = (dim: Dimension, key: string, ctx: DimensionContext): string =>
+  dim.format?.(key, ctx) ?? key;
+
+export interface DrillLevel {
+  dim: Dimension;
+  key: string;
+}
+
+export interface DrillPlan {
+  assignments: { param: string; value: string }[];
+  /** Levels the ticket list has no filter for. */
+  dropped: string[];
+  /**
+   * Names of the "no value" boxes the list cannot express — it can filter
+   * `aiCategory=Refund` but not "aiCategory is empty". Only that box is blocked;
+   * its siblings open normally, which is why it is not `dropped`.
+   */
+  emptyBuckets: string[];
+  /**
+   * Levels sharing a param with an earlier level or the filter bar. The list
+   * ORs repeated params, so emitting both opens a strictly wider set than the
+   * tile counted — nested AI-tag levels all share `generatedTags`.
+   */
+  conflicting: string[];
+}
+
+/**
+ * A drill path as ticket-list search params. Every level must be expressible for
+ * the opened list to equal the tile; the three failure lists are the ways that
+ * fails, and the caller stays put on any of them.
+ */
+export const planDrill = (
+  levels: readonly DrillLevel[],
+  tagFilter: readonly string[] = [],
+): DrillPlan => {
+  const assignments: { param: string; value: string }[] = [];
+  const dropped: string[] = [];
+  const emptyBuckets: string[] = [];
+  const conflicting: string[] = [];
+  const claimed = new Map<string, string>();
+
+  for (const { dim, key } of levels) {
+    if (!dim.param) {
+      dropped.push(dim.label);
+      continue;
+    }
+    const value = key === NONE_KEY ? dim.emptyParam : key;
+    if (value === null || value === undefined) {
+      emptyBuckets.push(dim.emptyLabel ?? dim.label);
+      continue;
+    }
+    // A box outside the AI-tag filter counted "both tags", which the list cannot
+    // express: keeping both ORs them, replacing drops the filter. A box the
+    // filter itself names is already the whole of `param=value`, so it is safe.
+    if (dim.multi && tagFilter.length > 0 && !tagFilter.includes(value)) {
+      conflicting.push(dim.label);
+      continue;
+    }
+    const existing = claimed.get(dim.param);
+    if (existing !== undefined) {
+      if (existing !== value) conflicting.push(dim.label);
+      continue;
+    }
+    claimed.set(dim.param, value);
+    assignments.push({ param: dim.param, value });
+  }
+
+  return { assignments, dropped, emptyBuckets, conflicting };
+};
+
+/** Dimensions worth offering: a column where every ticket shares one value splits nothing. */
+export const usefulDimensions = (
+  tickets: readonly TopicsTicket[],
+  dimensions: DimensionMap,
+): DimensionKey[] => {
+  const keys = [...dimensions.keys()];
+  if (tickets.length === 0) return keys;
+  return keys.filter(key => {
+    // Always offered: grouping by a tag nothing carries honestly shows one
+    // "not tagged" box, where hiding the option makes it look missing.
+    if (key.startsWith(AI_TAG_DIMENSION_PREFIX)) return true;
+    const dim = dimensionFor(dimensions, key);
+    const seen = new Set<string>();
+    for (const ticket of tickets) {
+      for (const value of dim.values(ticket)) {
+        seen.add(value);
+        if (seen.size > 1) return true;
+      }
+    }
+    return false;
+  });
+};
+
+/**
+ * Desk's own ticket filters over the synced rows. Every filter but AI tags is a
+ * column on the Zero row; AI tags live in `non_zero.tags`, so those arrive as a
+ * conversation-id list the caller derives from the window's fetched tags.
+ */
+export const applyTicketFilters = (
+  tickets: readonly TopicsTicket[],
+  filters: TicketFilters,
+  tagConversationIds: string[] | null,
+): readonly TopicsTicket[] => {
+  const aiCategory = filters.aiCategory?.length ? new Set(filters.aiCategory) : null;
+  const priority = filters.priority?.length ? new Set<string>(filters.priority) : null;
+  const stages = filters.stages?.length ? new Set(filters.stages) : null;
+  const groups = filters.userGroups?.length ? new Set(filters.userGroups) : null;
+  const conversations = tagConversationIds ? new Set(tagConversationIds) : null;
+
+  // Through the same parser the ticket query uses, so the invert marker and the
+  // "unassigned" sentinel mean here exactly what they mean there.
+  const parsed = filters.assignee?.length ? parseAssigneeFilter(filters.assignee) : null;
+  const assignee =
+    parsed && (parsed.ids.length > 0 || parsed.includeUnassigned)
+      ? { ...parsed, ids: new Set(parsed.ids) }
+      : null;
+
+  if (!aiCategory && !priority && !stages && !assignee && !groups && !conversations) return tickets;
+
+  return tickets.filter(t => {
+    if (aiCategory && !aiCategory.has(t.aiCategory ?? '')) return false;
+    if (priority && !priority.has(t.priority)) return false;
+    if (stages && !stages.has(t.stageName)) return false;
+    if (assignee) {
+      const key = assigneeKey(t.assignedTo);
+      const hit =
+        key === UNASSIGNED_FILTER_VALUE ? assignee.includeUnassigned : assignee.ids.has(key);
+      // Inverting turns the selection into its complement, so a hit is a miss.
+      if (hit === assignee.inverted) return false;
+    }
+    if (groups && !groups.has(t.userGroupId ?? '')) return false;
+    if (conversations && !conversations.has(t.conversationId)) return false;
+    return true;
+  });
+};
+
+/** Group tickets by one dimension, ranked by volume. Every group is returned; paging trims. */
+export const groupLevel = (
+  tickets: readonly TopicsTicket[],
+  dim: Dimension,
+  ctx: DimensionContext,
+): TopicNode[] => {
+  const buckets = new Map<string, TopicsTicket[]>();
+  for (const ticket of tickets) {
+    for (const value of dim.values(ticket)) {
+      const existing = buckets.get(value);
+      if (existing) existing.push(ticket);
+      else buckets.set(value, [ticket]);
+    }
+  }
+  return [...buckets.entries()]
+    .sort((a, b) => b[1].length - a[1].length || a[0].localeCompare(b[0]))
+    .map(([key, group]) => ({ key, label: labelFor(dim, key, ctx), tickets: group }));
+};
+
+export const ticketsForKey = (
+  tickets: readonly TopicsTicket[],
+  dim: Dimension,
+  key: string,
+): TopicsTicket[] => tickets.filter(t => dim.values(t).includes(key));
+
+const toDayKey = (ms: number): string => {
+  const d = new Date(ms);
+  return `${d.getFullYear()}-${`${d.getMonth() + 1}`.padStart(2, '0')}-${`${d.getDate()}`.padStart(2, '0')}`;
+};
+
+const trendStartMs = (days: number, endMs: number): number => {
+  const cursor = new Date(endMs);
+  cursor.setHours(0, 0, 0, 0);
+  cursor.setDate(cursor.getDate() - (days - 1));
+  return cursor.getTime();
+};
+
+/** Highest single-day count across every node — the shared Y domain. */
+export const maxDailyCount = (nodes: TopicNode[], days: number, endMs: number): number => {
+  const startMs = trendStartMs(days, endMs);
+  const byDay = new Map<string, number>();
+  let max = 1;
+  for (const node of nodes) {
+    byDay.clear();
+    for (const ticket of node.tickets) {
+      if (ticket.createdAt < startMs) continue;
+      const key = toDayKey(ticket.createdAt);
+      const next = (byDay.get(key) ?? 0) + 1;
+      byDay.set(key, next);
+      if (next > max) max = next;
+    }
+  }
+  return max;
+};
+
+/** Daily counts per node, zero-filled so a quiet day reads as 0 rather than a gap. */
+export const buildTrend = (nodes: TopicNode[], days: number, endMs: number): TrendPoint[][] => {
+  // Walk calendar days, not fixed milliseconds — a DST day is 23 or 25 hours long.
+  const startMs = trendStartMs(days, endMs);
+  const cursor = new Date(startMs);
+  const dayKeys: string[] = [];
+  for (let i = 0; i < days; i += 1) {
+    dayKeys.push(toDayKey(cursor.getTime()));
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return nodes.map(node => {
+    const byDay = new Map<string, number>();
+    for (const ticket of node.tickets) {
+      if (ticket.createdAt < startMs) continue;
+      const key = toDayKey(ticket.createdAt);
+      byDay.set(key, (byDay.get(key) ?? 0) + 1);
+    }
+    return dayKeys.map(day => ({ day, count: byDay.get(day) ?? 0 }));
+  });
+};

--- a/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsFilterBar.tsx
+++ b/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsFilterBar.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import { Popover } from '../../ui/Popover';
+import {
+  ChevronLeft,
+  FilterLines,
+  MultipleCrossCancelDefault,
+  SparkleAi01,
+  Tag as TagIcon,
+  UserDefault,
+  UserTwo,
+} from '@xyne/icons';
+import type { TicketStatusV2 } from '@xyne/shared';
+import type { TicketFilters } from '../../Tickets/TicketFilters/types';
+import {
+  AICategorySubmenu,
+  GeneratedTagsSubmenu,
+  PrioritySubmenu,
+  StagesSubmenu,
+  UserGroupSubmenu,
+  UserSubmenu,
+} from '../../Tickets/TicketFilters/Submenus';
+
+/**
+ * Filter bar for Topics Explorer. Reuses Desk's own filter submenus rather than
+ * re-implementing pickers, so field list, search behaviour and value formats
+ * (notably the `"category:tag"` composite for AI tags) match the ticket list.
+ */
+
+type FilterId = 'aiCategory' | 'generatedTags' | 'priority' | 'stages' | 'assignee' | 'userGroups';
+
+const MENU: { id: FilterId; label: string; icon: typeof SparkleAi01 }[] = [
+  { id: 'aiCategory', label: 'AI Category', icon: SparkleAi01 },
+  { id: 'generatedTags', label: 'AI Tags & Sentiment', icon: TagIcon },
+  { id: 'priority', label: 'Priority', icon: FilterLines },
+  { id: 'stages', label: 'Stage', icon: FilterLines },
+  { id: 'assignee', label: 'Assignee', icon: UserDefault },
+  { id: 'userGroups', label: 'Team', icon: UserTwo },
+];
+
+/**
+ * Selected values for a filter. Every `FilterId` is deliberately the
+ * TicketFilters key it reads, so this is a plain lookup; `priority` is a
+ * string-enum array, hence the cast.
+ */
+const selectedFor = (filters: TicketFilters, id: FilterId): string[] =>
+  (filters[id] ?? []) as unknown as string[];
+
+/** Filters whose values are opaque ids: their chips show a count, not a raw uuid. */
+const ID_VALUED = new Set<FilterId>(['assignee', 'userGroups']);
+
+export interface TopicsFilterBarProps {
+  channelId: string;
+  filters: TicketFilters;
+  onChange: (filters: TicketFilters) => void;
+  availableAiCategories: string[];
+  availableStages: { name: string; status?: TicketStatusV2 }[];
+  /** True while the window's AI tags are loading, so the tag filter cannot apply yet. */
+  isLoadingTags?: boolean;
+}
+
+export const TopicsFilterBar = ({
+  channelId,
+  filters,
+  onChange,
+  availableAiCategories,
+  availableStages,
+  isLoadingTags,
+}: TopicsFilterBarProps): ReactElement => {
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState<FilterId | null>(null);
+  const backRef = useRef<HTMLButtonElement | null>(null);
+
+  // Opening a submenu replaces the items that had focus, stranding keyboard
+  // users outside the popover.
+  useEffect(() => {
+    if (active) backRef.current?.focus();
+  }, [active]);
+
+  const activeChips = MENU.filter(item => selectedFor(filters, item.id).length > 0);
+
+  const clear = (id: FilterId): void => {
+    const next = { ...filters };
+    delete next[id];
+    onChange(next);
+  };
+
+  const renderSubmenu = (): ReactElement | null => {
+    switch (active) {
+      case 'aiCategory':
+        return (
+          <AICategorySubmenu
+            selectedCategories={filters.aiCategory ?? []}
+            onChange={v => onChange({ ...filters, aiCategory: v })}
+            availableCategories={availableAiCategories}
+          />
+        );
+      case 'generatedTags':
+        return (
+          <GeneratedTagsSubmenu
+            selectedTags={filters.generatedTags ?? []}
+            onChange={v => onChange({ ...filters, generatedTags: v })}
+            channelId={channelId}
+          />
+        );
+      case 'priority':
+        return (
+          <PrioritySubmenu
+            selectedPriorities={filters.priority ?? []}
+            onChange={v => onChange({ ...filters, priority: v })}
+          />
+        );
+      case 'stages':
+        return (
+          <StagesSubmenu
+            selectedStages={filters.stages ?? []}
+            onChange={v => onChange({ ...filters, stages: v })}
+            availableStages={availableStages}
+          />
+        );
+      case 'assignee':
+        return (
+          <UserSubmenu
+            selectedUsers={filters.assignee ?? []}
+            onChange={v => onChange({ ...filters, assignee: v })}
+            label='Assignee'
+            includeUnassigned
+            channelId={channelId}
+          />
+        );
+      case 'userGroups':
+        return (
+          <UserGroupSubmenu
+            selectedGroups={filters.userGroups ?? []}
+            onChange={v => onChange({ ...filters, userGroups: v })}
+            onClose={() => setActive(null)}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className='flex flex-wrap items-center gap-2'>
+      <Popover
+        open={open}
+        onOpenChange={next => {
+          setOpen(next);
+          if (!next) setActive(null);
+        }}
+        align='start'
+        sideOffset={6}
+        collisionPadding={8}
+        className='z-[10000] min-w-[220px] rounded-lg border border-border bg-popover p-1 shadow-xl'
+        trigger={
+          <button
+            type='button'
+            className='flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground'
+            aria-label={`Filter${activeChips.length ? `, ${activeChips.length} active` : ''}`}
+            data-track-category='TOPICS_EXPLORER'
+            data-track-name='OPEN_FILTERS'
+          >
+            <FilterLines size={14} />
+            Filter
+          </button>
+        }
+      >
+        {active ? (
+          <>
+            <button
+              ref={backRef}
+              type='button'
+              onClick={() => setActive(null)}
+              className='mb-1 flex w-full items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground'
+              data-track-category='TOPICS_EXPLORER'
+              data-track-name='FILTER_BACK'
+            >
+              <ChevronLeft size={13} />
+              {MENU.find(m => m.id === active)?.label}
+            </button>
+            {renderSubmenu()}
+          </>
+        ) : (
+          MENU.map(item => {
+            const count = selectedFor(filters, item.id).length;
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.id}
+                type='button'
+                onClick={() => setActive(item.id)}
+                className='flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-accent'
+                data-track-category='TOPICS_EXPLORER'
+                data-track-name='OPEN_FILTER_SUBMENU'
+              >
+                <Icon size={14} className='text-muted-foreground' />
+                <span className='flex-1 text-left'>{item.label}</span>
+                {count > 0 && <span className='text-xs text-muted-foreground'>{count}</span>}
+              </button>
+            );
+          })
+        )}
+      </Popover>
+
+      {activeChips.map(item => {
+        const values = selectedFor(filters, item.id);
+        const opaque = ID_VALUED.has(item.id);
+        // The value truncates at 160px, so the full selection needs a tooltip.
+        const summary =
+          values.length === 1 && !opaque ? (values[0] ?? '') : `${values.length} selected`;
+        return (
+          <span
+            key={item.id}
+            className='flex items-center gap-1 rounded-md border border-primary/40 bg-primary/10 px-2 py-1 text-xs'
+            title={opaque ? `${item.label}: ${summary}` : `${item.label}: ${values.join(', ')}`}
+          >
+            <span className='text-muted-foreground'>{item.label}</span>
+            <span className='max-w-[160px] truncate font-medium'>{summary}</span>
+            <button
+              type='button'
+              onClick={() => clear(item.id)}
+              className='text-muted-foreground hover:text-foreground'
+              aria-label={`Clear ${item.label} filter`}
+              data-track-category='TOPICS_EXPLORER'
+              data-track-name='CLEAR_ONE_FILTER'
+            >
+              <MultipleCrossCancelDefault size={12} />
+            </button>
+          </span>
+        );
+      })}
+
+      {activeChips.length > 0 && (
+        <button
+          type='button'
+          onClick={() => onChange({})}
+          className='text-xs text-muted-foreground underline hover:text-foreground'
+          data-track-category='TOPICS_EXPLORER'
+          data-track-name='CLEAR_FILTERS'
+        >
+          Clear all
+        </button>
+      )}
+
+      {isLoadingTags && <span className='text-xs text-muted-foreground'>Loading tags…</span>}
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsTreemap.tsx
+++ b/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsTreemap.tsx
@@ -1,0 +1,137 @@
+import type { ReactElement } from 'react';
+import { cn } from '../../../utils/classNames';
+import { Tooltip } from '../../ui/Tooltip';
+import { shapeStyle, type BoxShape } from './TopicsExplorer.utils';
+
+/** One box: a group's label plus its pre-formatted count and share. */
+export interface TopicTile {
+  name: string;
+  nodeKey: string;
+  /** Purple shade for this rank, with its paired foreground. */
+  fill: string;
+  ink: string;
+  count: string;
+  /** Empty when the level's groups overlap, where a percentage would mislead. */
+  share: string;
+  sharePct: number;
+  /** False when clicking would do nothing: a leaf the ticket list cannot express. */
+  canOpen: boolean;
+}
+
+export interface TopicsTreemapProps {
+  tiles: TopicTile[];
+  /** Cell geometry per tile, positionally matched to `tiles`. */
+  layout: BoxShape[];
+  hovered: string | null;
+  /** True when a click opens sub-groups rather than the ticket list. */
+  drillable: boolean;
+  onSelect: (nodeKey: string) => void;
+  /** Drives the shared highlight with the trend panel. */
+  onHover: (nodeKey: string | null) => void;
+}
+
+/** The left-hand mosaic: one box per group, placed and sized by the template. */
+export const TopicsTreemap = ({
+  tiles,
+  layout,
+  hovered,
+  drillable,
+  onSelect,
+  onHover,
+}: TopicsTreemapProps): ReactElement => (
+  <div className='relative h-full w-full'>
+    {tiles.map((tile, i) => {
+      const isHovered = hovered === tile.nodeKey;
+      const shape = layout[i];
+      if (!shape) return null;
+      const interactive = drillable || tile.canOpen;
+      const action = drillable
+        ? 'Opens sub-groups'
+        : tile.canOpen
+          ? 'Opens ticket list'
+          : 'Grouping only — the ticket list has no filter for this field';
+      const label = `${tile.name}: ${tile.count}${
+        tile.share ? `, ${tile.share} of tickets at this level` : ''
+      }. ${action}`;
+      return (
+        // Shared Tooltip: it portals out of the transformed dialog and handles collisions.
+        <Tooltip
+          key={tile.nodeKey}
+          side='bottom'
+          delayDuration={80}
+          content={
+            <span className='block max-w-[260px]'>
+              {/* Wraps rather than truncates: the full name is why this exists. */}
+              <span className='block break-words font-semibold'>{tile.name}</span>
+              <span className='mt-0.5 block text-muted-foreground'>
+                {tile.share ? `${tile.count} · ${tile.share}` : tile.count}
+              </span>
+              <span className='mt-0.5 block text-muted-foreground'>
+                {drillable
+                  ? 'Click to drill down'
+                  : tile.canOpen
+                    ? 'Click to open tickets'
+                    : 'Grouping only — no ticket-list filter for this field'}
+              </span>
+            </span>
+          }
+        >
+          <button
+            type='button'
+            // Still focusable and hoverable when inert, so the shared highlight
+            // with the trend panel keeps working; only the action is withheld.
+            onClick={interactive ? (): void => onSelect(tile.nodeKey) : undefined}
+            aria-disabled={!interactive}
+            onMouseEnter={() => onHover(tile.nodeKey)}
+            onFocus={() => onHover(tile.nodeKey)}
+            onMouseLeave={() => onHover(null)}
+            onBlur={() => onHover(null)}
+            className={cn(
+              'absolute flex min-w-0 flex-col justify-between overflow-hidden rounded-[10px] p-3 text-left',
+              'outline-none transition-[filter] duration-150',
+              // A dashed edge marks a tile that does nothing when clicked: the
+              // cursor alone left sighted users to find out by clicking, where
+              // the aria-label already says so. Not opacity — fading the tile
+              // blends fill and ink toward the panel and breaks the palette's
+              // paired AA contrast.
+              interactive ? 'cursor-pointer' : 'cursor-default border-2 border-dashed',
+              isHovered && 'z-10',
+            )}
+            style={{
+              ...shapeStyle(shape),
+              background: tile.fill,
+              color: tile.ink,
+              ...(interactive ? {} : { borderColor: tile.ink }),
+              // Inset ring so the focus/hover indicator sits inside the tile's own bounds.
+              boxShadow: isHovered ? `inset 0 0 0 3px ${tile.ink}` : undefined,
+              filter: isHovered ? 'brightness(1.08)' : undefined,
+            }}
+            aria-label={label}
+            data-track-category='TOPICS_EXPLORER'
+            // Only on a tile that does something: otherwise the funnel counts
+            // clicks that were never actions.
+            data-track-name={interactive ? 'SELECT_TOPIC_TILE' : undefined}
+          >
+            <span className='min-w-0'>
+              <span className='block truncate text-sm font-semibold'>{tile.name}</span>
+              <span className='mt-0.5 block truncate text-xs opacity-90'>
+                {tile.share ? `${tile.count} · ${tile.share}` : tile.count}
+              </span>
+            </span>
+
+            {/* Inherits the tile's foreground so it stays visible on light swatches. */}
+            <span
+              className='mt-2 block h-1.5 w-full overflow-hidden rounded-full'
+              style={{ backgroundColor: 'currentColor', opacity: 0.25 }}
+            >
+              <span
+                className='block h-full rounded-full'
+                style={{ width: `${Math.max(tile.sharePct, 2)}%`, backgroundColor: 'currentColor' }}
+              />
+            </span>
+          </button>
+        </Tooltip>
+      );
+    })}
+  </div>
+);

--- a/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsTrendPanel.tsx
+++ b/apps/dashboard/src/components/xyne-desk/TopicsExplorer/TopicsTrendPanel.tsx
@@ -1,0 +1,135 @@
+import { memo, type ReactElement } from 'react';
+import { Area, AreaChart, ResponsiveContainer, Tooltip, YAxis } from 'recharts';
+import { cn } from '../../../utils/classNames';
+import type { TrendPoint } from './TopicsExplorer.utils';
+
+/** One trend row: a group's label plus its daily-volume sparkline. */
+export interface TopicsTrendRow {
+  key: string;
+  label: string;
+  colour: string;
+  points: TrendPoint[];
+  /** False when clicking would do nothing, matching the paired tile. */
+  canSelect: boolean;
+}
+
+/**
+ * Hoisted: an inline `content={...}` is a fresh component type each render,
+ * making recharts throw away and rebuild every tooltip.
+ */
+const TrendTooltipContent = ({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: { payload?: unknown }[];
+}): ReactElement | null => {
+  if (!active || !payload?.length) return null;
+  const p = payload[0]?.payload as TrendPoint | undefined;
+  if (!p) return null;
+  return (
+    <div className='rounded-[8px] border border-border bg-background px-3 py-2 text-xs shadow-md'>
+      <div className='font-medium'>{p.count.toLocaleString()} tickets</div>
+      <div className='text-muted-foreground'>{p.day}</div>
+    </div>
+  );
+};
+
+export interface TopicsTrendPanelProps {
+  rows: TopicsTrendRow[];
+  /** Shared Y domain maximum across every group at this level. */
+  max: number;
+  hovered: string | null;
+  onHover: (key: string | null) => void;
+  onSelect: (key: string) => void;
+}
+
+/**
+ * One row, memoized individually so a hover re-renders the two rows whose
+ * `isHovered` changed rather than every chart in the list.
+ */
+const TrendRowBase = ({
+  row,
+  max,
+  isHovered,
+  onHover,
+  onSelect,
+}: {
+  row: TopicsTrendRow;
+  max: number;
+  isHovered: boolean;
+  onHover: (key: string | null) => void;
+  onSelect: (key: string) => void;
+}): ReactElement => (
+  <button
+    type='button'
+    onClick={row.canSelect ? (): void => onSelect(row.key) : undefined}
+    aria-disabled={!row.canSelect}
+    onMouseEnter={() => onHover(row.key)}
+    onMouseLeave={() => onHover(null)}
+    // Focus mirrors hover, so tabbing through the rows highlights the paired
+    // tile the same way pointing at one does.
+    onFocus={() => onHover(row.key)}
+    onBlur={() => onHover(null)}
+    className={cn(
+      'grid w-full grid-cols-[minmax(96px,150px)_1fr] items-center gap-3 border-b border-border/60 px-4 py-2 text-left transition-colors last:border-b-0',
+      isHovered ? 'bg-accent/50' : 'hover:bg-accent/30',
+      // Muted label, matching its paired tile's inert state. The token keeps a
+      // guaranteed contrast where a blanket opacity would not.
+      row.canSelect ? 'cursor-pointer' : 'cursor-default text-muted-foreground',
+    )}
+    data-track-category='TOPICS_EXPLORER'
+    data-track-name={row.canSelect ? 'SELECT_GROUP_ROW' : undefined}
+  >
+    <span className='flex min-w-0 items-center gap-2'>
+      <span className='h-2.5 w-2.5 shrink-0 rounded-full' style={{ background: row.colour }} />
+      <span className='truncate text-sm' title={row.label}>
+        {row.label}
+      </span>
+    </span>
+
+    <span className='block h-11'>
+      <ResponsiveContainer width='100%' height='100%'>
+        <AreaChart data={row.points} margin={{ top: 3, right: 0, bottom: 0, left: 0 }}>
+          {/* Shared domain: per-row scaling makes 12 look like 1,500. */}
+          <YAxis hide domain={[0, max]} />
+          <Tooltip cursor={false} content={<TrendTooltipContent />} />
+          <Area
+            dataKey='count'
+            type='monotone'
+            stroke={row.colour}
+            fill={row.colour}
+            fillOpacity={0.25}
+            strokeWidth={1.5}
+            dot={false}
+            isAnimationActive={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </span>
+  </button>
+);
+
+const TrendRow = memo(TrendRowBase);
+
+/** The right-hand trend list. */
+export const TopicsTrendPanel = ({
+  rows,
+  max,
+  hovered,
+  onHover,
+  onSelect,
+}: TopicsTrendPanelProps): ReactElement => (
+  <div className='min-h-0 flex-1 overflow-y-auto'>
+    {rows.map(row => (
+      <TrendRow
+        key={row.key}
+        row={row}
+        max={max}
+        isHovered={hovered === row.key}
+        onHover={onHover}
+        onSelect={onSelect}
+      />
+    ))}
+  </div>
+);

--- a/apps/dashboard/src/components/xyne-desk/TopicsExplorer/index.ts
+++ b/apps/dashboard/src/components/xyne-desk/TopicsExplorer/index.ts
@@ -1,0 +1,2 @@
+export { TopicsExplorer } from './TopicsExplorer';
+export type { TopicsExplorerProps } from './TopicsExplorer';

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -73,7 +73,7 @@ import { useHasResourceAccess } from '../../hooks/usePermissions';
 import { cn } from '../../utils/classNames';
 import { getApiErrorMessage } from '../../utils/apiError';
 import { surfaceMutationError } from '../../utils/zeroMutationToast';
-import { Hashtag, Star } from '@xyne/icons';
+import { GridDashboard01, Hashtag, Star } from '@xyne/icons';
 import ChannelIcon from '../../components/Chat/ChannelIcon/ChannelIcon';
 import { logger, Event } from '../../utils/logger';
 import Tooltip, { TruncatedTooltip } from '../../components/ui/Tooltip';
@@ -186,6 +186,7 @@ import { attachmentViewerActor, type AttachmentRef } from '../../machines/attach
 
 import { DeskSettings } from '../../components/xyne-desk/DeskSettings';
 import { DeskMetricsDashboard } from '../../components/xyne-desk/DeskMetrics';
+import { TopicsExplorer } from '../../components/xyne-desk/TopicsExplorer';
 import { AutoLabelWizard } from '../../components/xyne-desk/AutoLabelWizard/AutoLabelWizard';
 import {
   useChannelIntegrationInfo,
@@ -595,6 +596,7 @@ const SupportScreen = (): ReactElement => {
       const params = new URLSearchParams(searchParams);
       clearTicketFilterParams(params);
       params.delete('metrics');
+      params.delete('topics');
       params.delete('settings');
       const qs = params.toString();
       const path = next ? `${supportBase}/${next}` : supportBase;
@@ -1150,6 +1152,7 @@ const SupportScreen = (): ReactElement => {
       searchParams.get('settings') === 'open' || searchParams.get('openSettings') === 'signatures',
   );
   const [isMetricsOpen, setIsMetricsOpen] = useState(() => searchParams.get('metrics') === 'open');
+  const [isTopicsOpen, setIsTopicsOpen] = useState(() => searchParams.get('topics') === 'open');
   const [showCreateChannelModal, setShowCreateChannelModal] = useState(false);
   const [showDeskIntegrationsModal, setShowDeskIntegrationsModal] = useState(
     () =>
@@ -1417,6 +1420,7 @@ const SupportScreen = (): ReactElement => {
 
   useEffect(() => {
     setIsMetricsOpen(searchParams.get('metrics') === 'open');
+    setIsTopicsOpen(searchParams.get('topics') === 'open');
   }, [searchParams]);
 
   useEffect(() => {
@@ -1470,6 +1474,11 @@ const SupportScreen = (): ReactElement => {
   // and to flip the body to a Join-channel CTA when the user is on a public
   // channel they haven't joined yet.
   const isSelectedChannelJoined = !!selectedChannelId && joinedChannelIds.has(selectedChannelId);
+  // Topics Explorer rolls up one desk at a time, behind the same preference as metrics.
+  const canExploreTopics =
+    isSelectedChannelJoined &&
+    selectedChannelId !== ALL_CHANNELS_ID &&
+    !!channelPreference?.metricsEnabled;
 
   const metricsSelectableDesks = useMemo(
     () =>
@@ -2657,6 +2666,29 @@ const SupportScreen = (): ReactElement => {
                             </button>
                           </Tooltip>
                         )}
+                      {canExploreTopics && (
+                        <Tooltip content='Topics explorer' side='bottom'>
+                          <button
+                            type='button'
+                            onClick={() => {
+                              const base = `${supportBase}/${selectedChannelId}`;
+                              if (isTopicsOpen) void navigate(base, { replace: true });
+                              else void navigate(`${base}?topics=open`);
+                            }}
+                            className={cn(
+                              'p-1.5 rounded transition-colors',
+                              isTopicsOpen
+                                ? 'bg-muted text-foreground'
+                                : 'text-muted-foreground hover:text-foreground hover:bg-accent',
+                            )}
+                            data-track-category='Support'
+                            data-track-name='OpenTopicsExplorer'
+                            data-track-metadata={JSON.stringify({ channelId: selectedChannelId })}
+                          >
+                            <GridDashboard01 size={16} />
+                          </button>
+                        </Tooltip>
+                      )}
                       {isSelectedChannelJoined && (
                         <button
                           onClick={() => {
@@ -3297,6 +3329,19 @@ const SupportScreen = (): ReactElement => {
                   channelName={selectedChannelName ?? undefined}
                   availableDesks={metricsSelectableDesks}
                   customFieldDefinitions={deskDynamicFields}
+                  availableStages={availableStages}
+                />
+              )}
+              {isTopicsOpen && selectedChannelId && canExploreTopics && (
+                <TopicsExplorer
+                  open
+                  onClose={() =>
+                    void navigate(`${supportBase}/${selectedChannelId}`, { replace: true })
+                  }
+                  channelId={selectedChannelId}
+                  channelName={selectedChannelName ?? undefined}
+                  supportBase={supportBase}
+                  availableAiCategories={availableAiCategories}
                   availableStages={availableStages}
                 />
               )}

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -1263,6 +1263,29 @@ export const queries = defineQueries({
         );
     },
   ),
+  // Topics Explorer: one desk's tickets in a created-at window, rolled up client-side.
+  // Not supportTicketsPageV3 — that pulls emailDrafts, emailReads, userMailbox and
+  // formEntityValues per row, where this reads scalar columns and no relation at all.
+  // The window bounds the sync: the panel caps its range at 7 days and opens on one.
+  // channelId + isMember are forwarded to TicketsACL for membership gating.
+  topicsExplorerTickets: defineQuery(
+    z.object({
+      channelId: z.string(),
+      isMember: z.boolean(),
+      createdAtStart: z.number(),
+      createdAtEnd: z.number(),
+    }).refine(
+      args => args.createdAtStart <= args.createdAtEnd,
+      'createdAtStart must be less than or equal to createdAtEnd',
+    ),
+    ({ args: { channelId, createdAtStart, createdAtEnd } }) =>
+      zql.tickets
+        .where('channelId', channelId)
+        .where('isArchived', false)
+        .where('createdAt', '>=', createdAtStart)
+        .where('createdAt', '<=', createdAtEnd)
+        .orderBy('createdAt', 'desc'),
+  ),
   // Single-row variant matching supportTicketsPage row shape (for @rocicorp/zero-virtual permalinks).
   // channelId + isMember are forwarded to TicketsACL for membership gating.
   // emailDrafts is scoped to the current user (drafts are per-user private).


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Backport of **XYNE-60922 — Topics Explorer** (`e0117b2ba`, PR #974) onto `release-20260825`.

Adds a desk-scoped panel that breaks ticket volume down by any stack of columns, opened from the desk toolbar (`?topics=open`). A treemap on the left and one daily-volume trend row per group on the right share order and colour; clicking a tile either drills a level deeper or opens the ticket list filtered to exactly that group.

Zero has no aggregation, so the rollup runs client-side over synced rows — hence one channel at a time and a bounded created-at window (20k row cap, surfaced to the user when hit). LLM tag categories (sentiment, priority) live in `non_zero.tags`, which Zero does not mirror, so they are read through a new date-scoped endpoint and offered as "AI Tag" grouping dimensions alongside the Zero-backed columns.

- `packages/shared` + `apps/backend` zero registries: `topicsExplorerTickets`, kept byte-identical between the two copies
- `apps/backend`: `GET /channels/:id/tags-config/generated-tags-by-conversation`, parameterised, date-scoped, deterministically ordered
- `apps/dashboard`: TopicsExplorer panel, treemap, trend panel and filter bar, reusing Desk's own filter submenus so value formats match the ticket list

### Backport note

Only `SupportScreen.tsx` conflicted. The feature branch had migrated that file's icons to `@xyne/icons` and added the DeskReport panel; this release branch still imports icons from `lucide-react` and has no DeskReport. The conflict was resolved by keeping the release branch's version of the file and re-applying just the Topics Explorer delta on top:

- `GridDashboard01` added to the existing `@xyne/icons` import (lucide imports untouched)
- `TopicsExplorer` import, `params.delete('topics')` on channel switch
- `isTopicsOpen` state + `searchParams` effect, `canExploreTopics` guard
- toolbar button after Desk metrics, `<TopicsExplorer />` after `<DeskMetricsDashboard />`

No other behaviour from the source branch was pulled in. Every other file merged cleanly.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [x] `packages/shared` or another shared package

---

## Zero (Sync) Changes

- [x] Adds/modifies a **query or ACL**

`topicsExplorerTickets` added to both `packages/shared/src/zero/queries.ts` and `apps/backend/src/zero/queries.ts`, kept byte-identical. No schema or mutator changes.

## Schema & Data Changes

- [x] No schema changes — skip this section

## Config, Environment & URLs

- [x] No config changes — skip this section

## API Contract

- [x] New endpoint

`GET /channels/:id/tags-config/generated-tags-by-conversation` — date-scoped, read-only. Additive; no existing contract changed.

---

## How did you test it?

Backport only — the feature itself was reviewed and tested on #974 against `main`. This PR carries that commit unchanged except for the `SupportScreen.tsx` conflict resolution described above, which was verified by diffing the resolved file against the release branch's version (purely additive, matches the source commit hunk-for-hunk) and by checking that every import the new files pull resolves on this branch (`Submenus`, `useDeskTagsConfig`, `DateRangeFilter`, `DeskMetricsDateRangePicker`'s new `maxDays`, the `@xyne/icons` names, and `topicsExplorerTickets` re-exported from `@xyne/shared`).

Local build/typecheck were **not** run on this backport — relying on CI.

### Automated

- [ ] Not covered by tests

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind

Services-Requiring-Redeployment:
  - backend
  - dashboard
