### PR TITLE
Feature/artifact app restore deploy xyneclaw

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260901120000_artifact_app_restores/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260901120000_artifact_app_restores/migration.sql
@@ -1,0 +1,38 @@
+-- The durable record of a restore.
+--
+-- Restoring moves `artifact_apps.headVersionId` and nothing else: it is a
+-- pointer, so once it lands the app is indistinguishable from one where that
+-- version had always been current. No version row changes, and no chat message
+-- is written. That made the act invisible — a thread whose newest generation is
+-- v5 while the pane shows v2 had no explanation anywhere in it.
+--
+-- Not modelled as a `chat_messages` row on purpose: those form the branching
+-- tree the transcript projects (parentId, sibling pagers, regenerate), so a
+-- non-conversational node there would become a selectable branch and would put
+-- a third value into a role column the client models as user|assistant.
+CREATE TABLE "artifact_app_restores" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "appId" TEXT NOT NULL,
+    "versionId" TEXT NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "fromVersionId" TEXT,
+    "fromVersionNumber" INTEGER,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "artifact_app_restores_pkey" PRIMARY KEY ("id")
+);
+
+-- The thread's read: every restore for one app, oldest first, to merge into the
+-- transcript by time.
+CREATE INDEX "artifact_app_restores_appId_createdAt_idx" ON "artifact_app_restores"("appId", "createdAt");
+
+-- Tenant key carried on every table (see artifact_app_versions), so a query
+-- that forgets to join the parent still cannot cross workspaces.
+CREATE INDEX "artifact_app_restores_workspaceId_idx" ON "artifact_app_restores"("workspaceId");
+
+-- Cascade: the events describe an app's history and mean nothing without it.
+ALTER TABLE "artifact_app_restores"
+    ADD CONSTRAINT "artifact_app_restores_appId_fkey"
+    FOREIGN KEY ("appId") REFERENCES "artifact_apps"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1210,6 +1210,7 @@ model ArtifactApp {
 
   versions  ArtifactAppVersion[]
   agentRuns ArtifactAppAgentRun[]
+  restores  ArtifactAppRestore[]
 
   @@index([workspaceId, visibility])
   @@index([ownerUserId])
@@ -1248,6 +1249,44 @@ model ArtifactAppVersion {
   @@index([appId, createdAt])
   @@index([workspaceId])
   @@map("artifact_app_versions")
+}
+
+/// One "head moved backward" event — the durable record of a restore.
+///
+/// A restore leaves no trace in the data it touches: `headVersionId` is a
+/// pointer, so after the move the app looks exactly as it would have if that
+/// version had always been current. Nothing in `artifact_app_versions` changed
+/// and no chat message was written. Without this table, "why is the thread's
+/// newest build not the one on screen?" is unanswerable an hour later.
+///
+/// Deliberately NOT a `chat_messages` row. Those form the branching tree the
+/// transcript projects (parentId, sibling pagers, regenerate), so injecting a
+/// non-conversational node would make a restore a selectable branch and put a
+/// third value into a role column the client models as user|assistant. This is
+/// an event stream the thread merges in by time instead.
+model ArtifactAppRestore {
+  id          String @id @default(cuid())
+  /// Denormalized tenant key, stamped from the parent app on insert — same
+  /// discipline as ArtifactAppVersion.
+  workspaceId String
+  appId       String
+  /// The version head moved TO.
+  versionId     String
+  versionNumber Int
+  /// The version head moved FROM. Null only for an app that had no head yet,
+  /// which is why this column — not the pointer — is the record of what was
+  /// left behind.
+  fromVersionId     String?
+  fromVersionNumber Int?
+  /// Who restored. Owner-only today; kept because Step 4 opens apps to a group.
+  userId    String
+  createdAt DateTime @default(now())
+
+  app ArtifactApp @relation(fields: [appId], references: [id], onDelete: Cascade)
+
+  @@index([appId, createdAt])
+  @@index([workspaceId])
+  @@map("artifact_app_restores")
 }
 
 /// One agent run triggered from inside an artifact app.

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-apps.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-apps.ts
@@ -56,6 +56,7 @@ const saveBody = z.object({
 
 const addVersionBody = z.object({ attachmentId: z.string().min(1) });
 const publishBody = z.object({ versionId: z.string().min(1) });
+const restoreBody = z.object({ versionId: z.string().min(1) });
 
 function badRequest(res: Response, parsed: z.ZodSafeParseError<unknown>): void {
   res.status(400).json({
@@ -286,6 +287,94 @@ artifactAppsRouter.post("/:id/publish", async (req: Request<{ id: string }>, res
 });
 
 /** POST /:id/unpublish — back to private; the pin is cleared. */
+/**
+ * POST /:id/restore — move HEAD back to an earlier version.
+ *
+ * A pointer move, never a copy. `@@unique([appId, contentHash])` makes
+ * re-inserting an old build as a new row impossible by design, so restore
+ * declares which immutable version is current rather than duplicating content.
+ * That also means restoring is free and endlessly reversible: every version
+ * stays in the list, including the one you restored away from.
+ *
+ * Deliberately does NOT touch `publishedVersionId`. Head is what the owner and
+ * the agent work on; the pin is what everyone else sees. Rolling back your own
+ * draft must not silently republish something different to the workspace —
+ * un-publishing is its own explicit act.
+ *
+ * Because the move leaves no trace in the data it touches, the act itself is
+ * recorded as an `ArtifactAppRestore` in the same transaction. That row is the
+ * only thing that can later explain why a thread whose newest generation is v5
+ * is showing v2.
+ */
+artifactAppsRouter.post("/:id/restore", async (req: Request<{ id: string }>, res: Response): Promise<void> => {
+  const requesterId = getRequesterId(req);
+  if (!requesterId) {
+    res.status(401).json({ success: false, error: "Unauthorized" });
+    return;
+  }
+
+  const parsed = restoreBody.safeParse(req.body);
+  if (!parsed.success) return badRequest(res, parsed);
+
+  const app = await prisma.artifactApp.findUnique({ where: { id: req.params.id } });
+  if (!app || app.isArchived) {
+    res.status(404).json({ success: false, error: "App not found" });
+    return;
+  }
+  // Owner-only for now. Step 4 widens this to group-DM participants, at which
+  // point the check becomes channel membership rather than ownership.
+  if (app.ownerUserId !== requesterId) {
+    res.status(403).json({ success: false, error: "Forbidden" });
+    return;
+  }
+
+  // The version must belong to THIS app — otherwise head could be pointed at
+  // another app's build, which the payload route would then happily serve.
+  const version = await prisma.artifactAppVersion.findUnique({ where: { id: parsed.data.versionId } });
+  if (!version || version.appId !== app.id) {
+    res.status(404).json({ success: false, error: "Version not found for this app" });
+    return;
+  }
+
+  // Restoring to what is already current is a no-op, and logging it would put a
+  // "Restored to v3" line in the transcript that explains nothing. Return the
+  // app unchanged rather than 400 — the caller asked for a state that holds.
+  if (app.headVersionId === version.id) {
+    res.json({ success: true, app, versionId: version.id, versionNumber: version.versionNumber });
+    return;
+  }
+
+  const from = app.headVersionId
+    ? await prisma.artifactAppVersion.findUnique({
+        where: { id: app.headVersionId },
+        select: { id: true, versionNumber: true },
+      })
+    : null;
+
+  // One transaction: a head that moved without its event would be exactly the
+  // silent rollback this table exists to prevent.
+  const [updated] = await prisma.$transaction([
+    prisma.artifactApp.update({
+      where: { id: app.id },
+      data: { headVersionId: version.id, updatedAt: new Date() },
+    }),
+    prisma.artifactAppRestore.create({
+      data: {
+        workspaceId: app.workspaceId,
+        appId: app.id,
+        versionId: version.id,
+        versionNumber: version.versionNumber,
+        fromVersionId: from?.id ?? null,
+        fromVersionNumber: from?.versionNumber ?? null,
+        userId: requesterId,
+      },
+    }),
+  ]);
+
+  log.info(`app ${app.id} head restored to v${version.versionNumber} by ${requesterId}`);
+  res.json({ success: true, app: updated, versionId: version.id, versionNumber: version.versionNumber });
+});
+
 artifactAppsRouter.post("/:id/unpublish", async (req: Request<{ id: string }>, res: Response): Promise<void> => {
   const requesterId = getRequesterId(req);
   if (!requesterId) {
@@ -411,7 +500,27 @@ artifactAppsRouter.get("/:id", async (req: Request<{ id: string }>, res: Respons
     select: { id: true, versionNumber: true, manifest: true, sizeBytes: true, createdAt: true },
   });
 
-  res.json({ success: true, app: { ...app, isOwner }, versions });
+  // Restore history is DRAFT history: it names versions a non-owner is not
+  // served and describes edits behind the published pin. Owners only — everyone
+  // else gets an empty list rather than a shorter one, so the thread renders the
+  // same way whether the feature has events or the caller has no right to them.
+  const restores = isOwner
+    ? await prisma.artifactAppRestore.findMany({
+        where: { appId: app.id },
+        orderBy: { createdAt: "asc" },
+        select: {
+          id: true,
+          versionId: true,
+          versionNumber: true,
+          fromVersionId: true,
+          fromVersionNumber: true,
+          userId: true,
+          createdAt: true,
+        },
+      })
+    : [];
+
+  res.json({ success: true, app: { ...app, isOwner }, versions, restores });
 });
 
 /**


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
