### PR TITLE
feat: XYNE-61401 fix search in group by

### DIFF
--- a/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
+++ b/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
@@ -4,7 +4,7 @@ import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import type { Ticket, TicketTagMapping } from '@xyne/shared';
+import type { Ticket, TicketTagMapping, FormEntityValues } from '@xyne/shared';
 import { TicketStatusV2 } from '@xyne/shared';
 
 type TicketWithTags = Ticket & { tagMappings?: TicketTagMapping[] };
@@ -247,13 +247,49 @@ const PaginatedStageList: React.FC<{
 }) => {
   const columnValue = columnType === 'status' ? stage.id : stage.name;
   const columnStatus = stage.defaultTicketStatusV2;
-  const { tickets, hasMore, isLoadingMore, loadMore } = useKanbanTicketsPage({
-    ...paginationArgs,
-    columnType,
-    stageName: columnValue,
-  });
+  const { groupBy } = paginationArgs;
+  const { tickets, hasMore, isLoadingMore, loadMore, isUsingDirectVespaRows } =
+    useKanbanTicketsPage({
+      ...paginationArgs,
+      columnType,
+      stageName: columnValue,
+    });
   const renderedTickets = React.useMemo(() => {
-    if (allKnownTickets.length === 0) return tickets;
+    const isGroupByActive = groupBy && groupBy !== 'none';
+
+    // When using direct Vespa rows, trust the results - they're already filtered
+    // by group-specific Vespa filters (dynamic field tokens, assignee, priority, etc.)
+    if (isUsingDirectVespaRows) {
+      // Merge with cached tickets for optimistic updates if available
+      if (allKnownTickets.length > 0) {
+        const knownTicketsById = new Map(allKnownTickets.map(t => [t.id, t]));
+        return tickets.map(ticket => knownTicketsById.get(ticket.id) ?? ticket);
+      }
+      return tickets;
+    }
+
+    // In normal view (no grouping), trust server-side filtering
+    if (!isGroupByActive) {
+      if (allKnownTickets.length === 0) {
+        return tickets;
+      }
+      // Merge with cached tickets for optimistic updates
+      const knownTicketsById = new Map(allKnownTickets.map(t => [t.id, t]));
+      return tickets.map(ticket => {
+        const known = knownTicketsById.get(ticket.id);
+        if (known && ticketBelongsToColumn(known, columnType, columnValue, columnStatus)) {
+          return known;
+        }
+        return ticket;
+      });
+    }
+
+    // In group by mode without direct Vespa rows, use allKnownTickets as source of truth.
+    // This path is used when Zero query provides the tickets.
+    if (allKnownTickets.length === 0) {
+      // Grouping not ready yet - return empty to prevent showing wrong tickets
+      return [];
+    }
 
     const knownTicketsById = new Map(allKnownTickets.map(ticket => [ticket.id, ticket]));
     const renderedTicketsById = new Map<string, Ticket>();
@@ -261,16 +297,32 @@ const PaginatedStageList: React.FC<{
     for (const ticket of tickets) {
       const knownTicket = knownTicketsById.get(ticket.id);
       if (knownTicket) {
-        if (!ticketBelongsToColumn(knownTicket, columnType, columnValue, columnStatus)) continue;
-        renderedTicketsById.set(ticket.id, knownTicket);
-        continue;
+        // Ticket exists in client-side grouped data - use cached version
+        // but validate it still belongs to this column
+        const belongsToColumn = ticketBelongsToColumn(
+          knownTicket,
+          columnType,
+          columnValue,
+          columnStatus,
+        );
+        if (belongsToColumn) {
+          renderedTicketsById.set(ticket.id, knownTicket);
+        }
       }
-
-      renderedTicketsById.set(ticket.id, ticket);
+      // If ticket is not in knownTicketsById, it doesn't belong to this group
+      // according to client-side grouping - skip it
     }
 
     return [...renderedTicketsById.values()];
-  }, [allKnownTickets, columnStatus, columnType, columnValue, tickets]);
+  }, [
+    allKnownTickets,
+    columnStatus,
+    columnType,
+    columnValue,
+    groupBy,
+    isUsingDirectVespaRows,
+    tickets,
+  ]);
 
   const fetchedTicketSnapshotSignature = React.useMemo(
     () => tickets.map(ticket => ticketBoardSnapshotSignature(ticket)).join(','),
@@ -359,6 +411,10 @@ interface KanbanColumnsProps {
    * stage-based SLA (no policy fetch needed in that case).
    */
   slaPolicies?: BoardSlaPolicy[];
+  /** Form field values by ticket ID - used for validating group membership when groupBy is a form field */
+  formValuesByTicketId?: Map<string, FormEntityValues[]>;
+  /** User names by ID - used for resolving user IDs to names in form field group validation */
+  userNamesById?: Map<string, string>;
 }
 
 export const KanbanIcon = ({ status }: { status?: TicketStatusV2 | undefined }) => {
@@ -389,12 +445,21 @@ export const KanbanColumns: React.FC<KanbanColumnsProps> = ({
   allKnownTickets,
   onTicketsChange,
   onAddTicketInColumn,
+  formValuesByTicketId,
+  userNamesById,
 }) => {
   const columnType = paginatedColumnConfig?.columnType ?? 'stage';
-  const knownTicketsForOptimisticMerge = React.useMemo(
-    () => allKnownTickets ?? Object.values(ticketsByStage).flat(),
-    [allKnownTickets, ticketsByStage],
-  );
+  const isGroupByActive =
+    paginatedColumnConfig?.baseArgs?.groupBy && paginatedColumnConfig.baseArgs.groupBy !== 'none';
+  const knownTicketsForOptimisticMerge = React.useMemo(() => {
+    // In group by mode, ticketsByStage contains only this group's tickets
+    // Use it as source of truth to prevent tickets from appearing in wrong groups
+    if (isGroupByActive) {
+      return Object.values(ticketsByStage).flat();
+    }
+    // In normal mode, use allKnownTickets for optimistic updates
+    return allKnownTickets ?? Object.values(ticketsByStage).flat();
+  }, [allKnownTickets, isGroupByActive, ticketsByStage]);
   // Only the paginated board can starve a collapsed column of its count; the
   // non-paginated board always has every ticket in `ticketsByStage`.
   const countsAreReliable = !(paginatedColumnConfig && searchActive);
@@ -587,6 +652,7 @@ export const KanbanColumns: React.FC<KanbanColumnsProps> = ({
                 <div className='flex-1 min-h-0'>
                   {paginatedColumnConfig ? (
                     <PaginatedStageList
+                      key={columnKey}
                       stage={stage}
                       columnKey={columnKey}
                       paginationArgs={paginatedColumnConfig.baseArgs}
@@ -600,6 +666,8 @@ export const KanbanColumns: React.FC<KanbanColumnsProps> = ({
                       onTicketClick={onTicketClick}
                       {...(handleAddTicket ? { onAddTicket: handleAddTicket } : {})}
                       {...(slaPolicies !== undefined && { slaPolicies })}
+                      {...(formValuesByTicketId !== undefined && { formValuesByTicketId })}
+                      {...(userNamesById !== undefined && { userNamesById })}
                     />
                   ) : (
                     <SortableContext items={ticketIds} strategy={verticalListSortingStrategy}>

--- a/apps/dashboard/src/hooks/useVespaTicketSearch.ts
+++ b/apps/dashboard/src/hooks/useVespaTicketSearch.ts
@@ -14,12 +14,17 @@ interface UseVespaTicketSearchParams {
   boardId?: string;
   status?: string;
   stage?: string;
+  priority?: string;
+  assignee?: string;
+  tags?: string;
+  createdBy?: string;
   dynamicFieldValues?: string[];
   dynamicFieldDateRanges?: Record<string, { start?: number; end?: number }>;
   enabled?: boolean;
   limit?: number;
   fetchAllDynamicFieldMatches?: boolean;
   maxFetchedResults?: number;
+  searchKey?: string;
 }
 
 interface UseVespaTicketSearchResult {
@@ -46,6 +51,10 @@ const getFilterOnlyDynamicFieldCacheKey = (filters: VespaSearchFilters): string 
     board: filters.board ?? null,
     status: filters.status ?? null,
     stage: filters.stage ?? null,
+    priority: filters.priority ?? null,
+    assignee: filters.assignee ?? null,
+    tags: filters.tags ?? null,
+    from: filters.from ?? null,
     dynamicFieldValues: filters.dynamicFieldValues ?? null,
     dynamicFieldDateRanges: filters.dynamicFieldDateRanges
       ? Object.entries(filters.dynamicFieldDateRanges).sort(([left], [right]) =>
@@ -172,12 +181,17 @@ export const useVespaTicketSearch = ({
   boardId,
   status,
   stage,
+  priority,
+  assignee,
+  tags,
+  createdBy,
   dynamicFieldValues = EMPTY_DYNAMIC_FIELD_VALUES,
   dynamicFieldDateRanges = {},
   enabled = true,
   limit = MAX_VESPA_TICKET_SEARCH_LIMIT,
   fetchAllDynamicFieldMatches = false,
   maxFetchedResults = 400,
+  searchKey,
 }: UseVespaTicketSearchParams): UseVespaTicketSearchResult => {
   const [searchResults, setSearchResults] = useState<Ticket[] | null>(null);
   const [isSearching, setIsSearching] = useState(false);
@@ -236,13 +250,23 @@ export const useVespaTicketSearch = ({
       if (boardId) vespaFilters.board = boardId;
       if (status) vespaFilters.status = status;
       if (stage) vespaFilters.stage = stage;
+      if (priority) vespaFilters.priority = priority;
+      if (assignee) vespaFilters.assignee = assignee;
+      if (tags) vespaFilters.tags = tags;
+      if (createdBy) vespaFilters.from = createdBy;
       if (normalizedDynamicFieldValues.length > 0) {
         vespaFilters.dynamicFieldValues = normalizedDynamicFieldValues;
-        vespaFilters.filterOnly = isFilterOnlyDynamicSearch;
+        // Only set filterOnly when true - when false, omit it so backend uses default behavior
+        // This ensures dynamic field values are always used as filters, even with search terms
+        if (isFilterOnlyDynamicSearch) {
+          vespaFilters.filterOnly = true;
+        }
       }
       if (Object.keys(normalizedDynamicFieldDateRanges).length > 0) {
         vespaFilters.dynamicFieldDateRanges = normalizedDynamicFieldDateRanges;
-        vespaFilters.filterOnly = isFilterOnlyDynamicSearch;
+        if (isFilterOnlyDynamicSearch) {
+          vespaFilters.filterOnly = true;
+        }
       }
 
       try {
@@ -277,6 +301,10 @@ export const useVespaTicketSearch = ({
       boardId,
       status,
       stage,
+      priority,
+      assignee,
+      tags,
+      createdBy,
       normalizedDynamicFieldValues,
       normalizedDynamicFieldDateRanges,
       safeLimit,
@@ -319,6 +347,7 @@ export const useVespaTicketSearch = ({
     normalizedDynamicFieldDateRanges,
     enabled,
     performSearch,
+    searchKey,
   ]);
 
   useEffect(() => {

--- a/apps/dashboard/src/hooks/useVespaTicketSearch.ts
+++ b/apps/dashboard/src/hooks/useVespaTicketSearch.ts
@@ -3,6 +3,7 @@ import { searchService } from '../services/searchService';
 import type { VespaSearchFilters, DisplaySearchResult } from '../types/search';
 import type { Ticket } from '@xyne/shared';
 import { TicketPriority, TicketStatusV2 } from '@xyne/shared';
+import { useCmdkDefaultRankProfiles } from './useCmdkSearchConfig';
 
 const MAX_VESPA_TICKET_SEARCH_LIMIT = 200;
 const FILTER_ONLY_DYNAMIC_FIELD_CACHE_TTL_MS = 30_000;
@@ -197,6 +198,8 @@ export const useVespaTicketSearch = ({
   const [isSearching, setIsSearching] = useState(false);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const defaultRankProfileFor = useCmdkDefaultRankProfiles();
+  const rankProfile = defaultRankProfileFor('tickets');
 
   const dynamicFieldValuesKey = dynamicFieldValues.join('\u001f');
   const normalizedDynamicFieldValues = useMemo(
@@ -245,6 +248,7 @@ export const useVespaTicketSearch = ({
       };
 
       vespaFilters.limit = pageLimit;
+      vespaFilters.rankProfile = rankProfile;
 
       if (projectId) vespaFilters.projectId = projectId;
       if (boardId) vespaFilters.board = boardId;
@@ -310,6 +314,7 @@ export const useVespaTicketSearch = ({
       safeLimit,
       fetchAllDynamicFieldMatches,
       maxFetchedResults,
+      rankProfile,
     ],
   );
 
@@ -329,12 +334,9 @@ export const useVespaTicketSearch = ({
     }
 
     setIsSearching(true);
-    debounceTimerRef.current = setTimeout(
-      () => {
-        void performSearch(trimmed || '*');
-      },
-      hasDynamicFieldFilters ? 0 : SEARCH_DEBOUNCE_MS,
-    );
+    debounceTimerRef.current = setTimeout(() => {
+      void performSearch(trimmed || '*');
+    }, SEARCH_DEBOUNCE_MS);
 
     return (): void => {
       if (debounceTimerRef.current) {

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -5273,6 +5273,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                               }
                             : {})}
                           slaPolicies={kanbanSlaPolicies}
+                          formValuesByTicketId={formValuesByTicketId}
+                          userNamesById={userNamesById}
                         />
                       </div>
                     )}

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -87,6 +87,8 @@ type UseKanbanTicketsPageResult = {
   isLoadingMore: boolean;
   loadMore: () => void;
   reset: () => void;
+  /** True when tickets come directly from Vespa search (trusted, already filtered) */
+  isUsingDirectVespaRows: boolean;
 };
 
 const DEFAULT_PAGE_SIZE = 20;
@@ -164,8 +166,14 @@ const canRepresentGroupInVespa = (
   groupKey: string | undefined,
 ): boolean => {
   if (!groupBy || groupBy === 'none') return true;
-  if (groupBy === 'assignee' || groupBy === 'status' || groupBy === 'priority') {
-    return true;
+  if (groupBy === 'assignee') {
+    return Boolean(groupKey) && groupKey !== 'Unassigned';
+  }
+  if (groupBy === 'priority') {
+    return Boolean(groupKey) && groupKey !== 'No Priority';
+  }
+  if (groupBy === 'status') {
+    return Boolean(groupKey);
   }
   if (typeof groupBy !== 'object' || groupBy.type !== 'formField') return false;
   if (!groupKey) return false;
@@ -378,15 +386,19 @@ export const useKanbanTicketsPage = (
   const trimmedSearchTerm = options.searchTerm?.trim() ?? '';
   const pageVespaTokensSet = new Set(options.dynamicFieldVespaTokens ?? []);
   const pageVespaDateRangeCount = Object.keys(options.dynamicFieldDateRanges ?? {}).length;
-  if (
-    typeof options.groupBy === 'object' &&
-    options.groupBy?.type === 'formField' &&
-    options.groupBy.fieldType !== FormFieldType.DATE
-  ) {
-    if (MISSING_FORM_FIELD_GROUP_KEYS.has(options.groupKey ?? '')) {
-      pageVespaTokensSet.add(`${options.groupBy.fieldId}::${VESPA_MISSING_DYNAMIC_FIELD_VALUE}`);
-    } else if (options.groupKey) {
-      pageVespaTokensSet.add(`${options.groupBy.fieldId}::${options.groupKey}`);
+  if (typeof options.groupBy === 'object' && options.groupBy?.type === 'formField') {
+    // Always add a token for form field groupBy to ensure Vespa search triggers
+    const fieldId = options.groupBy.fieldId;
+    const groupKey = options.groupKey ?? '';
+
+    if (options.groupBy.fieldType === FormFieldType.DATE) {
+      // For DATE grouping, always add a placeholder token to trigger Vespa
+      // The actual filtering is done via dynamicFieldDateRanges
+      pageVespaTokensSet.add(`${fieldId}::${VESPA_MISSING_DYNAMIC_FIELD_VALUE}`);
+    } else if (MISSING_FORM_FIELD_GROUP_KEYS.has(groupKey) || !groupKey) {
+      pageVespaTokensSet.add(`${fieldId}::${VESPA_MISSING_DYNAMIC_FIELD_VALUE}`);
+    } else {
+      pageVespaTokensSet.add(`${fieldId}::${groupKey}`);
     }
   }
   const pageVespaTokens = Array.from(pageVespaTokensSet).sort();
@@ -406,6 +418,58 @@ export const useKanbanTicketsPage = (
     canRepresentGroupInVespa(options.groupBy, options.groupKey) &&
     !options.showOverdueOnly;
 
+  // Convert filter arrays to comma-separated strings for Vespa (only if non-empty)
+  const vespaPriority =
+    options.filters?.priority && options.filters.priority.length > 0
+      ? options.filters.priority.join(',')
+      : undefined;
+  const vespaAssignee =
+    options.filters?.assignee && options.filters.assignee.length > 0
+      ? options.filters.assignee.join(',')
+      : undefined;
+  const vespaTags =
+    options.filters?.tags && options.filters.tags.length > 0
+      ? options.filters.tags.join(',')
+      : undefined;
+  const vespaCreatedBy =
+    options.filters?.createdBy && options.filters.createdBy.length > 0
+      ? options.filters.createdBy.join(',')
+      : undefined;
+
+  // Compute group-specific filter for Vespa based on groupBy/groupKey
+  // This ensures search results are filtered to only show in the correct group
+  const vespaGroupFilter: { priority?: string; assignee?: string; status?: string } = (() => {
+    if (!options.groupBy || options.groupBy === 'none' || !options.groupKey) {
+      return {};
+    }
+    if (options.groupBy === 'priority') {
+      // Don't filter if groupKey is the "No Priority" placeholder
+      if (options.groupKey === 'No Priority') return {};
+      return { priority: options.groupKey };
+    }
+    if (options.groupBy === 'assignee') {
+      // Don't filter if groupKey is "Unassigned" - Vespa can't filter for null assignee easily
+      if (options.groupKey === 'Unassigned') return {};
+      // Remove prefixes like "user:" or "group:" if present
+      const normalizedKey = options.groupKey.replace(/^(user:|group:|userGroup:)/, '');
+      return { assignee: normalizedKey };
+    }
+    if (options.groupBy === 'status') {
+      // Filter by the group's status value
+      return { status: options.groupKey };
+    }
+    // For formField grouping, dynamic field tokens already handle it
+    return {};
+  })();
+
+  // Create a search key that changes when the group context changes
+  // This forces the search to re-trigger when switching views
+  const groupByKey =
+    typeof options.groupBy === 'object'
+      ? `${options.groupBy.type}:${options.groupBy.fieldId}`
+      : String(options.groupBy ?? 'none');
+  const vespaSearchKey = `${groupByKey}:${options.groupKey ?? ''}:${options.stageName}`;
+
   const vespaTicketSearch = useVespaTicketSearch({
     searchTerm: trimmedSearchTerm,
     dynamicFieldValues: pageVespaTokens,
@@ -413,6 +477,7 @@ export const useKanbanTicketsPage = (
     limit: 200,
     fetchAllDynamicFieldMatches: true,
     maxFetchedResults: 400,
+    searchKey: vespaSearchKey,
     ...(options.dynamicFieldDateRanges
       ? { dynamicFieldDateRanges: options.dynamicFieldDateRanges }
       : {}),
@@ -420,6 +485,11 @@ export const useKanbanTicketsPage = (
     ...(effectiveVespaBoardId ? { boardId: effectiveVespaBoardId } : {}),
     ...(options.columnType === 'status' ? { status: options.stageName } : {}),
     ...(options.columnType === 'stage' ? { stage: options.stageName } : {}),
+    ...(vespaPriority ? { priority: vespaPriority } : {}),
+    ...(vespaAssignee ? { assignee: vespaAssignee } : {}),
+    ...(vespaTags ? { tags: vespaTags } : {}),
+    ...(vespaCreatedBy ? { createdBy: vespaCreatedBy } : {}),
+    ...vespaGroupFilter,
   });
   const localFilterKey = JSON.stringify({
     priority: options.filters?.priority ?? [],
@@ -594,5 +664,6 @@ export const useKanbanTicketsPage = (
     isLoadingMore,
     loadMore,
     reset,
+    isUsingDirectVespaRows: shouldUseDirectVespaRows,
   };
 };

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -177,8 +177,9 @@ const canRepresentGroupInVespa = (
   }
   if (typeof groupBy !== 'object' || groupBy.type !== 'formField') return false;
   if (!groupKey) return false;
-  if (MISSING_FORM_FIELD_GROUP_KEYS.has(groupKey)) return true;
-  return groupBy.fieldType !== FormFieldType.DATE;
+  // All form field groups can be represented (MISSING_FORM_FIELD_GROUP_KEYS handled via
+  // __VESPA_MISSING__ token). DATE groupBy is not supported in the UI, so no special case.
+  return true;
 };
 
 const getDynamicFieldScalarFilters = (
@@ -387,15 +388,12 @@ export const useKanbanTicketsPage = (
   const pageVespaTokensSet = new Set(options.dynamicFieldVespaTokens ?? []);
   const pageVespaDateRangeCount = Object.keys(options.dynamicFieldDateRanges ?? {}).length;
   if (typeof options.groupBy === 'object' && options.groupBy?.type === 'formField') {
-    // Always add a token for form field groupBy to ensure Vespa search triggers
+    // Add a token for form field groupBy to ensure Vespa search filters by this field.
+    // DATE groupBy is not supported in the UI, so no special handling needed.
     const fieldId = options.groupBy.fieldId;
     const groupKey = options.groupKey ?? '';
 
-    if (options.groupBy.fieldType === FormFieldType.DATE) {
-      // For DATE grouping, always add a placeholder token to trigger Vespa
-      // The actual filtering is done via dynamicFieldDateRanges
-      pageVespaTokensSet.add(`${fieldId}::${VESPA_MISSING_DYNAMIC_FIELD_VALUE}`);
-    } else if (MISSING_FORM_FIELD_GROUP_KEYS.has(groupKey) || !groupKey) {
+    if (MISSING_FORM_FIELD_GROUP_KEYS.has(groupKey) || !groupKey) {
       pageVespaTokensSet.add(`${fieldId}::${VESPA_MISSING_DYNAMIC_FIELD_VALUE}`);
     } else {
       pageVespaTokensSet.add(`${fieldId}::${groupKey}`);
@@ -423,10 +421,22 @@ export const useKanbanTicketsPage = (
     options.filters?.priority && options.filters.priority.length > 0
       ? options.filters.priority.join(',')
       : undefined;
+
+  // Parse assignee filter to extract real user IDs, excluding sentinels.
+  // Vespa can't handle 'unassigned' or inverted selections, so skip those cases.
+  const parsedAssignee = options.filters?.assignee?.length
+    ? parseAssigneeFilter(options.filters.assignee)
+    : null;
+  // Only send to Vespa when we have real IDs and not inverted/includeUnassigned
+  // (those semantics require the Zero/local filter path).
   const vespaAssignee =
-    options.filters?.assignee && options.filters.assignee.length > 0
-      ? options.filters.assignee.join(',')
+    parsedAssignee &&
+    parsedAssignee.ids.length > 0 &&
+    !parsedAssignee.inverted &&
+    !parsedAssignee.includeUnassigned
+      ? parsedAssignee.ids.flatMap(id => [id, `user:${id}`]).join(',')
       : undefined;
+
   const vespaTags =
     options.filters?.tags && options.filters.tags.length > 0
       ? options.filters.tags.join(',')

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -429,21 +429,34 @@ export const useKanbanTicketsPage = (
     : null;
   // Only send to Vespa when we have real IDs and not inverted/includeUnassigned
   // (those semantics require the Zero/local filter path).
+  // Send all 4 identity forms to match prefixedKanbanIdentityValues storage variants.
   const vespaAssignee =
     parsedAssignee &&
     parsedAssignee.ids.length > 0 &&
     !parsedAssignee.inverted &&
     !parsedAssignee.includeUnassigned
-      ? parsedAssignee.ids.flatMap(id => [id, `user:${id}`]).join(',')
+      ? parsedAssignee.ids
+          .flatMap(id => {
+            const bareId = id.replace(/^(user:|group:|userGroup:)/, '');
+            return [bareId, `user:${bareId}`, `group:${bareId}`, `userGroup:${bareId}`];
+          })
+          .join(',')
       : undefined;
 
   const vespaTags =
     options.filters?.tags && options.filters.tags.length > 0
       ? options.filters.tags.join(',')
       : undefined;
+
+  // Send all 4 identity forms to match prefixedKanbanIdentityValues storage variants.
   const vespaCreatedBy =
     options.filters?.createdBy && options.filters.createdBy.length > 0
-      ? options.filters.createdBy.join(',')
+      ? options.filters.createdBy
+          .flatMap(id => {
+            const bareId = id.replace(/^(user:|group:|userGroup:)/, '');
+            return [bareId, `user:${bareId}`, `group:${bareId}`, `userGroup:${bareId}`];
+          })
+          .join(',')
       : undefined;
 
   // Compute group-specific filter for Vespa based on groupBy/groupKey
@@ -460,9 +473,12 @@ export const useKanbanTicketsPage = (
     if (options.groupBy === 'assignee') {
       // Don't filter if groupKey is "Unassigned" - Vespa can't filter for null assignee easily
       if (options.groupKey === 'Unassigned') return {};
-      // Remove prefixes like "user:" or "group:" if present
-      const normalizedKey = options.groupKey.replace(/^(user:|group:|userGroup:)/, '');
-      return { assignee: normalizedKey };
+      // Vespa may store assignedTo in any of these forms (see prefixedKanbanIdentityValues).
+      // Send all variants so we match regardless of storage format.
+      const bareId = options.groupKey.replace(/^(user:|group:|userGroup:)/, '');
+      return {
+        assignee: [bareId, `user:${bareId}`, `group:${bareId}`, `userGroup:${bareId}`].join(','),
+      };
     }
     if (options.groupBy === 'status') {
       // Filter by the group's status value


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
