### PR TITLE
feat: XYNE-61685 cert refresh

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -442,7 +442,19 @@ ENABLE_FILE_INDEXING=false
 # Internal Service Auth (S2S authentication)
 # Shared secret for internal service-to-service communication
 # CHANGE THIS IN PRODUCTION to a cryptographically secure random string
-INTERNAL_SERVICE_SECRET=change-me-in-production
+MTLS_SERVICE_SECRET=change-me-in-production
+
+# mTLS certificate rotation service. Ingress must strip and overwrite
+# x-verified-client-cert-serial and x-mtls-ingress-key after successful
+# client certificate verification.
+# MTLS_SERVICE_SECRET above is also sent as the x-s2s-key header for
+# outbound spaces->mtls-auth calls; must match mtls-auth's MTLS_SERVICE_SECRET.
+MTLS_AUTH_URL=http://localhost:3000
+# Secret injected by trusted mTLS ingress; clients must never receive this value.
+MTLS_INGRESS_SHARED_SECRET=
+MTLS_AUTH_REQUEST_TIMEOUT_MS=10000
+CERTIFICATE_ROTATION_RATE_LIMIT_WINDOW_MS=60000
+CERTIFICATE_ROTATION_RATE_LIMIT_MAX=10
 
 # XYNE Claw Integration (Ask AI v2)
 # Set ASK_AI_VERSION=v2 to use xyne-claw instead of xyneAIStream

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -197,6 +197,7 @@ import sdlcRoutes from '@/routes/sdlc';
 import sdlcClawRoutes from '@/routes/sdlcClaw';
 import sdlcVcsInternalRoutes from '@/routes/sdlcVcsInternal';
 import { handleSdlcClawCallback } from '@/sdlc/SdlcClawCallback';
+import certificateRotationRoutes from '@/routes/certificateRotation';
 
 
 export class App {
@@ -346,6 +347,7 @@ export class App {
     this.app.use(express.json({ limit: '10mb' }));
     this.app.use(express.urlencoded({ extended: true, limit: '10mb' }));
     this.app.use(decryptRequestBodyMiddleware);
+    this.app.use('/api', certificateRotationRoutes);
     this.app.use(encryptResponseBodyMiddleware);
 
     this.app.use('/api/automation-webhooks', webhookLimiter, automationWebhookRoutes);

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -34,6 +34,12 @@ const envSchema = Joi.object({
   ),
   RATE_LIMIT_WINDOW_MS: Joi.number().default(900000),
   RATE_LIMIT_MAX_REQUESTS: Joi.number().default(100),
+  MTLS_AUTH_URL: Joi.string().uri().allow('').default(''),
+  MTLS_SERVICE_SECRET: Joi.string().allow('').default(''),
+  MTLS_INGRESS_SHARED_SECRET: Joi.string().allow('').default(''),
+  MTLS_AUTH_REQUEST_TIMEOUT_MS: Joi.number().integer().min(1000).default(10000),
+  CERTIFICATE_ROTATION_RATE_LIMIT_WINDOW_MS: Joi.number().integer().min(1000).default(60000),
+  CERTIFICATE_ROTATION_RATE_LIMIT_MAX: Joi.number().integer().min(1).default(10),
   LOG_LEVEL: Joi.string().valid('error', 'warn', 'info', 'debug').default('info'),
   // Streams error-level logs to Fluent Bit's forward input (see docker/fluent-bit/).
   // Off by default so envs without a Fluent Bit endpoint (e.g. prod, until one
@@ -580,6 +586,9 @@ export const config = {
   isTestEnv: envVars.NODE_ENV === 'test',
   isSandboxTestMode: envVars.SANDBOX_TEST_MODE === true,
   orgMemberLimit: (envVars.ORG_MEMBER_LIMIT as number | null) ?? null,
+  // Shared s2s secret with mtls-auth, used both to validate inbound internal
+  // requests and for outbound spaces->mtls-auth calls (sent as x-s2s-key).
+  mtlsServiceSecret: envVars.MTLS_SERVICE_SECRET as string,
   research_agent_url: envVars.RESEARCH_AGENT_URL,
   pythonAgentUrl: envVars.PYTHON_AGENT_URL as string,
   nx_graph_server_url: envVars.NX_GRAPH_SERVER_URL,
@@ -608,6 +617,13 @@ export const config = {
   rateLimit: {
     windowMs: envVars.RATE_LIMIT_WINDOW_MS,
     max: envVars.RATE_LIMIT_MAX_REQUESTS,
+  },
+  mtlsAuth: {
+    url: envVars.MTLS_AUTH_URL as string,
+    ingressSharedSecret: envVars.MTLS_INGRESS_SHARED_SECRET as string,
+    requestTimeoutMs: envVars.MTLS_AUTH_REQUEST_TIMEOUT_MS as number,
+    rateLimitWindowMs: envVars.CERTIFICATE_ROTATION_RATE_LIMIT_WINDOW_MS as number,
+    rateLimitMax: envVars.CERTIFICATE_ROTATION_RATE_LIMIT_MAX as number,
   },
   logging: {
     level: envVars.LOG_LEVEL,

--- a/apps/backend/src/middleware/internalServiceAuth.ts
+++ b/apps/backend/src/middleware/internalServiceAuth.ts
@@ -1,10 +1,11 @@
 import { Request, Response, NextFunction } from 'express';
 import crypto from 'crypto';
+import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 
 /**
  * Middleware to authenticate internal service-to-service requests.
- * Validates X-Internal-Service-Secret header against INTERNAL_SERVICE_SECRET env var.
+ * Validates X-Internal-Service-Secret header against config.mtlsServiceSecret.
  * Uses crypto.timingSafeEqual for constant-time comparison to prevent timing attacks.
  */
 export const internalServiceAuth = (
@@ -12,7 +13,7 @@ export const internalServiceAuth = (
   res: Response,
   next: NextFunction
 ): void => {
-  const expectedSecret = process.env.INTERNAL_SERVICE_SECRET;
+  const expectedSecret = config.mtlsServiceSecret;
   const providedSecret = req.headers['x-internal-service-secret'] as string | undefined;
 
   if (!expectedSecret) {

--- a/apps/backend/src/middleware/rateLimiters.ts
+++ b/apps/backend/src/middleware/rateLimiters.ts
@@ -1,4 +1,5 @@
 import rateLimit, { ipKeyGenerator, RateLimitRequestHandler } from 'express-rate-limit';
+import { config } from '@/config/env';
 
 /**
  * General rate limiter for all API endpoints
@@ -55,6 +56,22 @@ export const webhookLimiter: RateLimitRequestHandler = rateLimit({
     success: false,
     error: 'Webhook rate limit exceeded. Please try again later.',
     timestamp: new Date().toISOString(),
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+export const certificateRotationLimiter: RateLimitRequestHandler = rateLimit({
+  windowMs: config.mtlsAuth.rateLimitWindowMs,
+  max: config.mtlsAuth.rateLimitMax,
+  keyGenerator: req => req.user?.id ?? ipKeyGenerator(req.ip ?? 'unknown'),
+  handler: (_req, res) => {
+    res.status(429).json({
+      error: {
+        code: 'ROTATION_RATE_LIMITED',
+        message: 'Too many certificate rotation requests',
+      },
+    });
   },
   standardHeaders: true,
   legacyHeaders: false,

--- a/apps/backend/src/routes/certificateRotation.ts
+++ b/apps/backend/src/routes/certificateRotation.ts
@@ -1,0 +1,130 @@
+import { Router, type Request, type Response } from 'express';
+import { timingSafeEqual } from 'crypto';
+import { config } from '@/config/env';
+import { authMiddleware } from '@/middleware/auth';
+import { certificateRotationLimiter } from '@/middleware/rateLimiters';
+
+const router = Router();
+const serialPattern = /^[0-9a-f]{1,64}$/;
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const serialHeader = 'x-verified-client-cert-serial';
+
+type ErrorBody = { error: { code: string; message: string; retry_after?: string | number } };
+
+function sendError(res: Response, status: number, code: string, message: string): void {
+  res.status(status).json({ error: { code, message } });
+}
+
+function clientCertificateSerial(req: Request): string | null {
+  const suppliedSecret = req.header('x-mtls-ingress-key') ?? '';
+  const expectedSecret = config.mtlsAuth.ingressSharedSecret;
+  const supplied = Buffer.from(suppliedSecret);
+  const expected = Buffer.from(expectedSecret);
+  if (!expected.length || supplied.length !== expected.length || !timingSafeEqual(supplied, expected)) return null;
+  const value = req.header(serialHeader)?.trim().toLowerCase();
+  return value && serialPattern.test(value) ? value : null;
+}
+
+function hasOnlyKeys(body: unknown, keys: string[]): body is Record<string, unknown> {
+  return !!body
+    && typeof body === 'object'
+    && !Array.isArray(body)
+    && Object.keys(body).every(key => keys.includes(key))
+    && Object.keys(body).length === keys.length;
+}
+
+function isUpstreamError(value: unknown): value is ErrorBody {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const error = (value as { error?: unknown }).error;
+  return !!error
+    && typeof error === 'object'
+    && !Array.isArray(error)
+    && typeof (error as { code?: unknown }).code === 'string'
+    && typeof (error as { message?: unknown }).message === 'string';
+}
+
+async function proxyRotation(
+  req: Request,
+  res: Response,
+  path: string,
+  body: Record<string, string>,
+  forwardCurrentSerial = false,
+): Promise<void> {
+  const serial = clientCertificateSerial(req);
+  if (!serial) {
+    sendError(res, 401, 'CLIENT_CERTIFICATE_REQUIRED', 'Verified client certificate is required');
+    return;
+  }
+  if (!req.user || !config.mtlsAuth.url || !config.mtlsServiceSecret) {
+    sendError(res, 503, 'CERTIFICATE_SERVICE_UNAVAILABLE', 'Certificate service is unavailable');
+    return;
+  }
+
+  try {
+    const upstream = await fetch(new URL(path, `${config.mtlsAuth.url.replace(/\/$/, '')}/`), {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-s2s-key': config.mtlsServiceSecret,
+      },
+      body: JSON.stringify({
+        ...body,
+        user_email: req.user.email.toLowerCase(),
+        ...(forwardCurrentSerial ? { current_certificate_serial: serial } : {}),
+      }),
+      signal: AbortSignal.timeout(config.mtlsAuth.requestTimeoutMs),
+    });
+    const payload: unknown = await upstream.json().catch(() => null);
+    if (upstream.ok) {
+      if (!payload || typeof payload !== 'object') {
+        sendError(res, 502, 'INVALID_CERTIFICATE_SERVICE_RESPONSE', 'Certificate service returned an invalid response');
+        return;
+      }
+      res.status(upstream.status).json(payload);
+      return;
+    }
+    if (isUpstreamError(payload)) {
+      res.status(upstream.status).json(payload);
+      return;
+    }
+    sendError(res, 502, 'CERTIFICATE_SERVICE_ERROR', 'Certificate service request failed');
+  } catch (error) {
+    const timedOut = error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError');
+    sendError(
+      res,
+      timedOut ? 504 : 503,
+      timedOut ? 'CERTIFICATE_SERVICE_TIMEOUT' : 'CERTIFICATE_SERVICE_UNAVAILABLE',
+      timedOut ? 'Certificate service request timed out' : 'Certificate service is unavailable',
+    );
+  }
+}
+
+router.post('/re-enroll', authMiddleware.authenticate, certificateRotationLimiter, async (req, res) => {
+  if (!hasOnlyKeys(req.body, ['csr'])
+    || typeof req.body.csr !== 'string'
+    || req.body.csr.length === 0
+    || Buffer.byteLength(req.body.csr, 'utf8') > 32 * 1024) {
+    sendError(res, 400, 'INVALID_ROTATION_REQUEST', 'CSR is required');
+    return;
+  }
+  await proxyRotation(req, res, 'internal/v1/certificate-rotations', {
+    csr: req.body.csr,
+  }, true);
+});
+
+router.post('/cert-ack', authMiddleware.authenticate, certificateRotationLimiter, async (req, res) => {
+  if (!hasOnlyKeys(req.body, ['rotation_id'])
+    || typeof req.body.rotation_id !== 'string'
+    || !uuidPattern.test(req.body.rotation_id)) {
+    sendError(res, 400, 'INVALID_ACK_REQUEST', 'UUID rotation_id is required');
+    return;
+  }
+  await proxyRotation(
+    req,
+    res,
+    `internal/v1/certificate-rotations/${req.body.rotation_id}/ack`,
+    {},
+  );
+});
+
+export default router;

--- a/apps/backend/src/test/certificateRotation.test.ts
+++ b/apps/backend/src/test/certificateRotation.test.ts
@@ -1,0 +1,168 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('@/config/env', () => ({
+  config: {
+    mtlsServiceSecret: 'test-s2s-key',
+    mtlsAuth: {
+      url: 'https://mtls.example.test',
+      ingressSharedSecret: 'test-ingress-key',
+      requestTimeoutMs: 5000,
+      rateLimitWindowMs: 60000,
+      rateLimitMax: 100,
+    },
+  },
+}));
+
+jest.mock('@/middleware/auth', () => ({
+  authMiddleware: {
+    authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+      req.user = {
+        id: '11111111-1111-4111-8111-111111111111',
+        googleId: 'google-user',
+        email: 'test@example.com',
+        name: 'Test User',
+        workspaceId: 'workspace-id',
+        role: 'user',
+        orgRole: 'member',
+        memberId: 'member-id',
+      };
+      next();
+    },
+  },
+}));
+
+import certificateRotationRoutes from '@/routes/certificateRotation';
+
+const serial = '00aabbccddeeff112233445566778899';
+const rotationId = '33333333-3333-4333-8333-333333333333';
+
+function app() {
+  const instance = express();
+  instance.use(express.json());
+  instance.use(certificateRotationRoutes);
+  return instance;
+}
+
+describe('certificate rotation proxy', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects requests without ingress-verified certificate identity', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    const response = await request(app()).post('/re-enroll').send({
+      csr: '-----BEGIN CERTIFICATE REQUEST-----\ntest\n-----END CERTIFICATE REQUEST-----',
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.body.error.code).toBe('CLIENT_CERTIFICATE_REQUIRED');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('forwards re-enrollment using token user and normalized ingress serial', async () => {
+    const upstreamBody = {
+      rotation_id: rotationId,
+      certificate: 'leaf',
+      ca_chain: 'chain',
+      not_before: '2026-08-19T00:00:00.000Z',
+      not_after: '2027-02-19T00:00:00.000Z',
+      ack_deadline: '2026-08-19T01:00:00.000Z',
+    };
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(upstreamBody), { status: 201, headers: { 'content-type': 'application/json' } }),
+    );
+
+    const response = await request(app())
+      .post('/re-enroll')
+      .set('x-mtls-ingress-key', 'test-ingress-key')
+      .set('x-verified-client-cert-serial', serial.toUpperCase())
+      .send({
+        csr: '-----BEGIN CERTIFICATE REQUEST-----\ntest\n-----END CERTIFICATE REQUEST-----',
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual(upstreamBody);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toBe('https://mtls.example.test/internal/v1/certificate-rotations');
+    expect(init?.headers).toEqual(expect.objectContaining({ 'x-s2s-key': 'test-s2s-key' }));
+    expect(JSON.parse(String(init?.body))).toEqual({
+      csr: '-----BEGIN CERTIFICATE REQUEST-----\ntest\n-----END CERTIFICATE REQUEST-----',
+      user_email: 'test@example.com',
+      current_certificate_serial: serial,
+    });
+  });
+
+  it('requires ingress certificate identity but does not forward it for acknowledgment', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ status: 'acknowledged' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const response = await request(app())
+      .post('/cert-ack')
+      .set('x-mtls-ingress-key', 'test-ingress-key')
+      .set('x-verified-client-cert-serial', serial)
+      .send({ rotation_id: rotationId });
+
+    expect(response.status).toBe(200);
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(JSON.parse(String(init?.body))).toEqual({
+      user_email: 'test@example.com',
+    });
+  });
+
+  it('rejects invalid ingress secrets and certificate serials', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    const invalidSecret = await request(app())
+      .post('/cert-ack')
+      .set('x-mtls-ingress-key', 'wrong-ingress-key')
+      .set('x-verified-client-cert-serial', serial)
+      .send({ rotation_id: rotationId });
+    const invalidSerial = await request(app())
+      .post('/cert-ack')
+      .set('x-mtls-ingress-key', 'test-ingress-key')
+      .set('x-verified-client-cert-serial', 'aa:bb')
+      .send({ rotation_id: rotationId });
+
+    expect(invalidSecret.status).toBe(401);
+    expect(invalidSerial.status).toBe(401);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown body fields before proxying', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    const response = await request(app())
+      .post('/cert-ack')
+      .set('x-mtls-ingress-key', 'test-ingress-key')
+      .set('x-verified-client-cert-serial', serial)
+      .send({ rotation_id: rotationId, certificate_serial: serial });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('INVALID_ACK_REQUEST');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('preserves stable upstream errors', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: { code: 'NOT_IN_RENEWAL_WINDOW', message: 'Too early' } }), {
+        status: 422,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const response = await request(app())
+      .post('/re-enroll')
+      .set('x-mtls-ingress-key', 'test-ingress-key')
+      .set('x-verified-client-cert-serial', serial)
+      .send({ csr: 'csr' });
+
+    expect(response.status).toBe(422);
+    expect(response.body.error.code).toBe('NOT_IN_RENEWAL_WINDOW');
+  });
+});


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
