### PR TITLE
fix: green up CI on the release branch

### DIFF
--- a/apps/backend/src/zero/mutators.ts
+++ b/apps/backend/src/zero/mutators.ts
@@ -5855,7 +5855,6 @@ export function createMutators(
           // ACL Business Logic: Check ticket transfer permission for assignedTo, userGroupId,
           // eta, stageName (which triggers stage ETA recalculation), or boardId changes
           const isAssigneeChanging = params.assignedTo !== undefined && params.assignedTo !== ticket.assignedTo;
-          const isUserGroupChanging = params.userGroupId !== undefined && params.userGroupId !== ticket.userGroupId;
           const isEtaChanging = params.eta !== undefined && params.eta !== ticket.eta;
           const isBoardChanging = params.boardId !== undefined && params.boardId !== ticket.boardId;
 

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -3553,10 +3553,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                 >
                   {stageReadOnly ? (
                     <span className='inline-flex items-center gap-2 rounded-md bg-muted px-2 py-1 text-sm'>
-                      <TicketStatusIcon
-                        size={14}
-                        color={getTicketStatusColor(ticket.statusV2)}
-                      />
+                      <TicketStatusIcon size={14} color={getTicketStatusColor(ticket.statusV2)} />
                       {ticket.stageName || 'Not set'}
                     </span>
                   ) : (
@@ -3566,10 +3563,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                       onValueChange={handleStageChange}
                       placeholder='Set Status'
                       icon={
-                        <TicketStatusIcon
-                          size={14}
-                          color={getTicketStatusColor(ticket.statusV2)}
-                        />
+                        <TicketStatusIcon size={14} color={getTicketStatusColor(ticket.statusV2)} />
                       }
                       getItemIcon={item =>
                         (() => {

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/PrioritySubmenu/PrioritySubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/PrioritySubmenu/PrioritySubmenu.tsx
@@ -78,30 +78,30 @@ export const PrioritySubmenu = ({
               {allSelected && <Check className='w-4 h-4 text-primary shrink-0' />}
             </button>
             {prioritiesToShow.map(([priority, config]) => {
-            const isSelected = selectedPriorities.includes(priority as TicketPriority);
+              const isSelected = selectedPriorities.includes(priority as TicketPriority);
 
-            return (
-              <button
-                key={priority}
-                onClick={() => handleToggle(priority as TicketPriority)}
-                type='button'
-                className={`flex items-center justify-between w-full px-3 py-2 transition-colors rounded-md
+              return (
+                <button
+                  key={priority}
+                  onClick={() => handleToggle(priority as TicketPriority)}
+                  type='button'
+                  className={`flex items-center justify-between w-full px-3 py-2 transition-colors rounded-md
                   ${isSelected ? 'bg-accent text-foreground' : 'hover:bg-muted text-foreground'}
                 `}
-                data-track-category='Tickets'
-                data-track-name='TogglePriorityFilter'
-                data-track-metadata={JSON.stringify({ priority, selected: !isSelected })}
-                data-testid={`priority-filter-${priority.toLowerCase()}`}
-              >
-                <div className='flex items-center gap-2'>
-                  <div className='flex items-center justify-center'>
-                    {getPriorityIcon(priority as TicketPriority)}
+                  data-track-category='Tickets'
+                  data-track-name='TogglePriorityFilter'
+                  data-track-metadata={JSON.stringify({ priority, selected: !isSelected })}
+                  data-testid={`priority-filter-${priority.toLowerCase()}`}
+                >
+                  <div className='flex items-center gap-2'>
+                    <div className='flex items-center justify-center'>
+                      {getPriorityIcon(priority as TicketPriority)}
+                    </div>
+                    <span className='text-sm font-medium'>{config.label}</span>
                   </div>
-                  <span className='text-sm font-medium'>{config.label}</span>
-                </div>
 
-                {isSelected && <Check className='w-5 h-5 text-foreground' strokeWidth={2.5} />}
-              </button>
+                  {isSelected && <Check className='w-5 h-5 text-foreground' strokeWidth={2.5} />}
+                </button>
               );
             })}
           </>

--- a/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/UserSubmenu/UserSubmenu.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/Submenus/UserSubmenu/UserSubmenu.tsx
@@ -210,10 +210,7 @@ export const UserSubmenu = ({
 
   // Select-all / deselect-all toggle: visible user IDs from the filtered rows
   const visibleUserIds = useMemo(
-    () =>
-      rows
-        .filter((r): r is User => typeof r === 'object' && 'id' in r)
-        .map(u => u.id),
+    () => rows.filter((r): r is User => typeof r === 'object' && 'id' in r).map(u => u.id),
     [rows],
   );
   const allVisibleSelected =

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -740,8 +740,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     // so opening that submenu enables this fetch too.
     enabled:
       viewMode === 'my-tickets' &&
-        (isBoardDropdownOpen || isSourceChannelsOpen || isFiltersDropdownOpen) &&
-        !!user?.id,
+      (isBoardDropdownOpen || isSourceChannelsOpen || isFiltersDropdownOpen) &&
+      !!user?.id,
     staleTime: 60_000,
     retry: 1,
     refetchOnWindowFocus: false,
@@ -3219,14 +3219,13 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
           label: 'View Details',
           onClick: () => {
             if (ticketChannelId && ticket.conversationId) {
-              navigate(
-                buildChannelRoute(
-                  `${ticketChannelId}/${ticket.conversationId}/${ticket.id}`,
-                  { selectedTab: 'details' },
-                ),
+              void navigate(
+                buildChannelRoute(`${ticketChannelId}/${ticket.conversationId}/${ticket.id}`, {
+                  selectedTab: 'details',
+                }),
               );
             } else if (ticketChannelId) {
-              navigate(
+              void navigate(
                 buildChannelRoute(ticketChannelId, {
                   tab: 'tickets',
                   ticketId: ticket.id,
@@ -3234,7 +3233,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                 }),
               );
             } else {
-              navigate(`${baseRoute}/tickets/${ticket.id}`);
+              void navigate(`${baseRoute}/tickets/${ticket.id}`);
             }
           },
         },
@@ -3439,8 +3438,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         MEDIUM: 2,
         LOW: 3,
       };
-      const getOrder = (key: string): number =>
-        PRIORITY_SORT_ORDER[key] ?? Number.MAX_SAFE_INTEGER;
+      const getOrder = (key: string): number => PRIORITY_SORT_ORDER[key] ?? Number.MAX_SAFE_INTEGER;
       mapped.sort((a, b) => {
         const orderA = getOrder(a.key);
         const orderB = getOrder(b.key);
@@ -4127,25 +4125,25 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                           groupBy.type === 'formField' &&
                           groupBy.fieldId === value.fieldId;
                     return (
-                    <DropdownMenu.CheckboxItem
-                      key={typeof value === 'object' ? `formField-${value.fieldId}` : value}
-                      className='relative flex items-center gap-2 justify-between py-3 px-4 text-sm rounded-xl text-foreground cursor-pointer outline-none select-none
+                      <DropdownMenu.CheckboxItem
+                        key={typeof value === 'object' ? `formField-${value.fieldId}` : value}
+                        className='relative flex items-center gap-2 justify-between py-3 px-4 text-sm rounded-xl text-foreground cursor-pointer outline-none select-none
       transition-colors
       data-[highlighted]:bg-muted data-[highlighted]:text-foreground
       data-[state=checked]:bg-accent data-[state=checked]:text-foreground data-[state=checked]:font-semibold'
-                      checked={isSelected}
-                      onCheckedChange={() =>
-                        handleSetGroupBy(isSelected ? 'none' : (value as GroupByType))
-                      }
-                      data-testid={`group-by-${typeof value === 'string' ? value : value.fieldId}`}
-                    >
-                      <div className='flex items-center gap-3'>
-                        <span className='text-muted-foreground group-data-[highlighted]:text-muted-foreground h-3 w-3'>
-                          {icon}
-                        </span>
-                        <span className='font-medium'>{label.replace('Group by: ', '')}</span>
-                      </div>
-                    </DropdownMenu.CheckboxItem>
+                        checked={isSelected}
+                        onCheckedChange={() =>
+                          handleSetGroupBy(isSelected ? 'none' : (value as GroupByType))
+                        }
+                        data-testid={`group-by-${typeof value === 'string' ? value : value.fieldId}`}
+                      >
+                        <div className='flex items-center gap-3'>
+                          <span className='text-muted-foreground group-data-[highlighted]:text-muted-foreground h-3 w-3'>
+                            {icon}
+                          </span>
+                          <span className='font-medium'>{label.replace('Group by: ', '')}</span>
+                        </div>
+                      </DropdownMenu.CheckboxItem>
                     );
                   })}
                 </DropdownMenu.Content>


### PR DESCRIPTION
## Why

Three CI checks fail on `feature/ticket_sev2_hotfix_release27` **itself**, so every PR targeting it goes red no matter what it contains — currently #1295 and #1296.

Reproduced on a clean checkout of the release branch with zero PR changes:

| Check | Failure on clean release branch |
|---|---|
| `ci / Backend typecheck + build` | `src/zero/mutators.ts(5858,17): error TS6133: 'isUserGroupChanging' is declared but its value is never read.` |
| `ci / Dashboard lint` | 3 × `@typescript-eslint/no-floating-promises` in `KanbanBoardScreen.tsx` |
| `ci / Dashboard typecheck` | fails at its `format:check` step — 4 unformatted files |

(The dashboard job is named "typecheck" but runs `typecheck && format:check && lint`; it is the **format** step that fails.)

## What

**Dashboard lint** — three `navigate(...)` calls inside a toast action were unhandled promises. Marked `void`, matching how the rest of the file already calls `navigate`.

**Backend typecheck** — removed the dead `isUserGroupChanging` binding.

> ⚠️ Worth a reviewer's eye. The comment directly above it says the transfer-permission check covers **`assignedTo`, `userGroupId`, `eta`, `stageName` or `boardId`** changes, but the condition only tests `isAssigneeChanging || isEtaChanging || isBoardChanging`. So either the comment is wrong, or `userGroupId` was dropped from the condition and group transfers silently skip the ACL check. Correcting that is a behaviour change to permission logic, not a lint cleanup, so this PR only removes the dead binding and leaves the decision to you.

**format:check** — ran Prettier over exactly the four files it flagged: `TicketDetails.tsx`, `PrioritySubmenu.tsx`, `UserSubmenu.tsx`, `KanbanBoardScreen.tsx`. No hand edits in those.

## Verification

All three run green locally on this branch:

```
format:check   → All matched files use Prettier code style!
dashboard lint → exit 0
backend tsc    → exit 0    (backend build also passes)
```

## Note for #1295 / #1296

This touches `KanbanBoardScreen.tsx` (formatting only), which both open PRs also modify. Merge this first, then rebase them — their conflicts will be whitespace-only.