### PR TITLE
fix: XYNE-61651 add all recordings tab and summary template regen states

### DIFF
--- a/apps/dashboard/src/components/SummaryTemplateMenu/SummaryTemplateMenu.tsx
+++ b/apps/dashboard/src/components/SummaryTemplateMenu/SummaryTemplateMenu.tsx
@@ -8,9 +8,17 @@
  */
 
 import type { ReactElement } from 'react';
-import { Refresh, CheckTickSingle, GridDashboardBento, Hashtag, PlusDefault } from '@xyne/icons';
+import {
+  Refresh,
+  CheckTickSingle,
+  GridDashboardBento,
+  Hashtag,
+  PlusDefault,
+  Spinner,
+} from '@xyne/icons';
 import { XyneAIStar } from '@/components/icons/xyne-ai';
 import { cn } from '../../utils/classNames';
+import { Tooltip } from '../ui/Tooltip';
 import type { SummaryTemplateMenuProps, SummaryTemplateOption } from './SummaryTemplateMenu.types';
 import {
   getSummaryTemplateLabel,
@@ -49,6 +57,7 @@ export function SummaryTemplateMenu({
   templates,
   isLoading = false,
   isRegenerating = false,
+  regeneratingTemplateId,
   canRegenerate = true,
   onSelectTemplate,
   onRegenerate,
@@ -59,15 +68,59 @@ export function SummaryTemplateMenu({
 }: SummaryTemplateMenuProps): ReactElement {
   const fullLabel = getSummaryTemplateLabel(selectedTemplate);
   const label = truncateTemplateName(fullLabel);
+  const selectedTemplateId = selectedTemplate?.id ?? 'default';
+  const activeRegeneratingTemplateId = isRegenerating
+    ? (regeneratingTemplateId ?? selectedTemplateId)
+    : null;
+  const regeneratingTemplate =
+    templates.find(template => template.id === activeRegeneratingTemplateId) ??
+    (selectedTemplateId === activeRegeneratingTemplateId ? selectedTemplate : undefined);
+  const regeneratingTemplateLabel = regeneratingTemplate
+    ? getSummaryTemplateLabel(regeneratingTemplate)
+    : activeRegeneratingTemplateId === 'default' || !activeRegeneratingTemplateId
+      ? getSummaryTemplateLabel(undefined)
+      : 'selected template';
+  const regeneratingTooltipContent = `Generating ${regeneratingTemplateLabel} summary`;
+  const isSelectedTemplateRegenerating = activeRegeneratingTemplateId === selectedTemplateId;
+  const isDisabledDuringRegeneration = isRegenerating;
+  const renderRegeneratingSpinner = (): ReactElement => (
+    <Tooltip content={regeneratingTooltipContent} side='right'>
+      <span
+        className='flex size-full items-center justify-center'
+        aria-label={regeneratingTooltipContent}
+      >
+        <Spinner size={14} className='animate-spin text-muted-foreground' />
+      </span>
+    </Tooltip>
+  );
 
   return (
     <>
       <div className='flex items-center gap-0.5 rounded-lg p-0.5'>
-        <span className='flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2 py-1.5 text-sm font-semibold text-foreground'>
-          <span className='flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-background text-xs font-semibold shadow-sm'>
-            <SummaryTemplateGlyph template={selectedTemplate} size='menu' />
+        <span
+          className={cn(
+            'flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2 py-1.5 text-sm font-semibold',
+            isDisabledDuringRegeneration && !isSelectedTemplateRegenerating
+              ? 'text-muted-foreground'
+              : 'text-foreground',
+          )}
+        >
+          <span
+            className={cn(
+              'flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-background text-xs font-semibold shadow-sm',
+              isDisabledDuringRegeneration && !isSelectedTemplateRegenerating && 'opacity-50',
+            )}
+          >
+            {isSelectedTemplateRegenerating ? (
+              renderRegeneratingSpinner()
+            ) : (
+              <SummaryTemplateGlyph template={selectedTemplate} size='menu' />
+            )}
           </span>
-          <span className='min-w-0 flex-1 truncate' title={fullLabel}>
+          <span
+            className='min-w-0 flex-1 truncate'
+            title={isSelectedTemplateRegenerating ? regeneratingTooltipContent : fullLabel}
+          >
             {label}
           </span>
         </span>
@@ -83,7 +136,7 @@ export function SummaryTemplateMenu({
           data-track-category={trackCategory}
           data-track-name='regenerate_selected_summary_template'
         >
-          <Refresh strokeWidth={2.5} className={cn('size-4', isRegenerating && 'animate-spin')} />
+          <Refresh strokeWidth={2.5} className='size-4' />
         </button>
         <span className='flex w-5 shrink-0 items-center justify-center'>
           <CheckTickSingle
@@ -104,57 +157,97 @@ export function SummaryTemplateMenu({
         ) : (
           templates
             .filter(template => template.id !== selectedTemplate?.id)
-            .map(template => (
-              <button
-                key={template.id}
-                type='button'
-                onClick={() => {
-                  onRequestClose();
-                  onSelectTemplate(template.id);
-                }}
-                title={template.name}
-                className='flex w-full items-center gap-3 rounded-lg px-2.5 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted'
-                data-track-category={trackCategory}
-                data-track-name='select_summary_template'
-              >
-                <span className='flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-background text-xs font-semibold shadow-sm'>
-                  {template.icon}
-                </span>
-                <span className='min-w-0 flex-1 truncate'>
-                  {truncateTemplateName(template.name)}
-                </span>
-              </button>
-            ))
+            .map(template => {
+              const isTemplateRegenerating = activeRegeneratingTemplateId === template.id;
+              return (
+                <button
+                  key={template.id}
+                  type='button'
+                  aria-disabled={isDisabledDuringRegeneration}
+                  tabIndex={isDisabledDuringRegeneration ? -1 : undefined}
+                  onClick={() => {
+                    if (isDisabledDuringRegeneration) return;
+                    onRequestClose();
+                    onSelectTemplate(template.id);
+                  }}
+                  title={isTemplateRegenerating ? regeneratingTooltipContent : template.name}
+                  className={cn(
+                    'flex w-full items-center gap-3 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors',
+                    isTemplateRegenerating
+                      ? 'text-foreground'
+                      : isDisabledDuringRegeneration
+                        ? 'cursor-not-allowed text-muted-foreground/55'
+                        : 'text-foreground hover:bg-muted',
+                  )}
+                  data-track-category={trackCategory}
+                  data-track-name='select_summary_template'
+                >
+                  <span
+                    className={cn(
+                      'flex size-6 shrink-0 items-center justify-center rounded-md border border-border bg-background text-xs font-semibold shadow-sm',
+                      isDisabledDuringRegeneration && !isTemplateRegenerating && 'opacity-45',
+                    )}
+                  >
+                    {isTemplateRegenerating ? renderRegeneratingSpinner() : template.icon}
+                  </span>
+                  <span className='min-w-0 flex-1 truncate'>
+                    {truncateTemplateName(template.name)}
+                  </span>
+                </button>
+              );
+            })
         )}
       </div>
 
       <div className='mx-1.5 my-1.5 h-px bg-border' />
       <button
         type='button'
+        disabled={isDisabledDuringRegeneration}
         onClick={() => {
           onRequestClose();
           onOpenTemplates();
         }}
-        className='flex w-full items-center gap-3 rounded-lg px-1.5 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted'
+        className={cn(
+          'flex w-full items-center gap-3 rounded-lg px-1.5 py-1.5 text-left text-sm transition-colors',
+          isDisabledDuringRegeneration
+            ? 'cursor-not-allowed text-muted-foreground/55'
+            : 'text-foreground hover:bg-muted',
+        )}
         data-track-category={trackCategory}
         data-track-name='open_all_summary_templates'
       >
-        <span className='flex size-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40 text-muted-foreground'>
+        <span
+          className={cn(
+            'flex size-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40 text-muted-foreground',
+            isDisabledDuringRegeneration && 'opacity-45',
+          )}
+        >
           <GridDashboardBento strokeWidth={2} className='size-4' />
         </span>
         All templates…
       </button>
       <button
         type='button'
+        disabled={isDisabledDuringRegeneration}
         onClick={() => {
           onRequestClose();
           onNewTemplate();
         }}
-        className='flex w-full items-center gap-3 rounded-lg px-1.5 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted'
+        className={cn(
+          'flex w-full items-center gap-3 rounded-lg px-1.5 py-1.5 text-left text-sm transition-colors',
+          isDisabledDuringRegeneration
+            ? 'cursor-not-allowed text-muted-foreground/55'
+            : 'text-foreground hover:bg-muted',
+        )}
         data-track-category={trackCategory}
         data-track-name='new_summary_template'
       >
-        <span className='flex size-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40 text-muted-foreground'>
+        <span
+          className={cn(
+            'flex size-7 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40 text-muted-foreground',
+            isDisabledDuringRegeneration && 'opacity-45',
+          )}
+        >
           <PlusDefault className='size-4' />
         </span>
         New template

--- a/apps/dashboard/src/components/SummaryTemplateMenu/SummaryTemplateMenu.types.ts
+++ b/apps/dashboard/src/components/SummaryTemplateMenu/SummaryTemplateMenu.types.ts
@@ -10,18 +10,17 @@ export interface SummaryTemplateMenuProps {
   templates: SummaryTemplateOption[];
   /** Swaps the template list for a loading line. */
   isLoading?: boolean | undefined;
-  /** Spins the refresh icon and blocks the action while a regeneration is in flight. */
+  /** Shows pending state and blocks actions while a regeneration is in flight. */
   isRegenerating?: boolean | undefined;
+  /** Template currently being regenerated, which may differ from the rendered summary. */
+  regeneratingTemplateId?: string | undefined;
   /** False when there is nothing to regenerate with; disables the refresh action. */
   canRegenerate?: boolean | undefined;
   onSelectTemplate: (templateId: string) => void;
   onRegenerate: () => void;
   onOpenTemplates: () => void;
   onNewTemplate: () => void;
-  /**
-   * Closes the host's popover. Called before every action so each host keeps
-   * ownership of its own open state.
-   */
+  /** Closes the host's popover before menu actions. */
   onRequestClose: () => void;
   /** Analytics category of the host screen, e.g. `RecordingDetailV2`. */
   trackCategory: string;

--- a/apps/dashboard/src/hooks/usePaginatedOatsRecordings.ts
+++ b/apps/dashboard/src/hooks/usePaginatedOatsRecordings.ts
@@ -4,7 +4,7 @@ import { queries } from '../zero/queries';
 import { useCachedQuery } from './useCachedQuery';
 import { useZero } from './useZero';
 
-export type OatsRecordingScope = 'created' | 'shared';
+export type OatsRecordingScope = 'all' | 'created' | 'shared';
 export type OatsRecordingEntry = QueryResultType<typeof queries.createdOatsRecordings>[number];
 
 const FETCH_LIMIT = 20;
@@ -26,18 +26,34 @@ export function patchOatsRecordingLabels(recordingId: string, labels: string[]):
   for (const listener of labelsPatchListeners) listener(recordingId, labels);
 }
 type RecordingCursor = { id: string; startedAt: number } | null;
+type SingleOatsRecordingScope = Exclude<OatsRecordingScope, 'all'>;
 type OatsRecordingQuery =
   | ReturnType<typeof queries.createdOatsRecordings>
   | ReturnType<typeof queries.sharedOatsRecordings>;
 
 const recordingQuery = (
-  scope: OatsRecordingScope,
+  scope: SingleOatsRecordingScope,
   start: RecordingCursor,
   participantId: string | null,
 ): OatsRecordingQuery =>
   scope === 'created'
     ? queries.createdOatsRecordings({ limit: FETCH_LIMIT, start, participantId })
     : queries.sharedOatsRecordings({ limit: FETCH_LIMIT, start, participantId });
+
+const mergeRecordingPages = (
+  current: OatsRecordingEntry[],
+  ...pages: Array<readonly OatsRecordingEntry[] | null | undefined>
+): OatsRecordingEntry[] => {
+  const byId = new Map<string, OatsRecordingEntry>();
+  for (const recording of current) byId.set(recording.id, recording);
+  for (const page of pages) {
+    if (!page) continue;
+    for (const recording of page) byId.set(recording.id, recording);
+  }
+  return Array.from(byId.values()).sort(
+    (left, right) => right.startedAt - left.startedAt || right.id.localeCompare(left.id),
+  );
+};
 
 export interface UsePaginatedOatsRecordingsReturn {
   recordings: OatsRecordingEntry[];
@@ -54,47 +70,115 @@ export function usePaginatedOatsRecordings(
   participantId: string | null,
 ): UsePaginatedOatsRecordingsReturn {
   const zero = useZero();
+  const isAllScope = scope === 'all';
+  const queryScope: SingleOatsRecordingScope = scope === 'shared' ? 'shared' : 'created';
   const [cursor, setCursor] = useState<RecordingCursor>(null);
+  const [sharedCursor, setSharedCursor] = useState<RecordingCursor>(null);
   const [recordings, setRecordings] = useState<OatsRecordingEntry[]>([]);
   const [hasMoreRecordings, setHasMoreRecordings] = useState(true);
+  const [hasMoreSharedRecordings, setHasMoreSharedRecordings] = useState(true);
   const recordingsRef = useRef(recordings);
   recordingsRef.current = recordings;
 
-  const [page, details] = useCachedQuery(recordingQuery(scope, cursor, participantId));
+  const [page, details] = useCachedQuery(recordingQuery(queryScope, cursor, participantId));
+  const [sharedPage, sharedDetails] = useCachedQuery(
+    queries.sharedOatsRecordings({ limit: FETCH_LIMIT, start: sharedCursor, participantId }),
+    { enabled: isAllScope },
+  );
 
   useEffect(() => {
     setCursor(null);
+    setSharedCursor(null);
     setRecordings([]);
     setHasMoreRecordings(true);
+    setHasMoreSharedRecordings(true);
   }, [scope, participantId]);
 
   useEffect(() => {
     if (!page || details.type !== 'complete') return;
+
+    if (isAllScope) {
+      setRecordings(current => mergeRecordingPages(current, page));
+      setHasMoreRecordings(page.length === FETCH_LIMIT);
+      return;
+    }
 
     setRecordings(current => {
       const rows = cursor ? [...current, ...page] : [...page];
       return [...new Map(rows.map(recording => [recording.id, recording] as const)).values()];
     });
     setHasMoreRecordings(page.length === FETCH_LIMIT);
-  }, [cursor, details.type, page]);
+  }, [cursor, details.type, isAllScope, page]);
+
+  useEffect(() => {
+    if (!isAllScope || !sharedPage || sharedDetails.type !== 'complete') return;
+
+    setRecordings(current => mergeRecordingPages(current, sharedPage));
+    setHasMoreSharedRecordings(sharedPage.length === FETCH_LIMIT);
+  }, [isAllScope, sharedDetails.type, sharedPage]);
 
   const loadMoreRecordings = useCallback((): void => {
+    if (isAllScope) {
+      const currentUserId = zero.context.userID;
+      let nextCreatedCursor: RecordingCursor = null;
+      let nextSharedCursor: RecordingCursor = null;
+
+      for (let index = recordingsRef.current.length - 1; index >= 0; index -= 1) {
+        const recording = recordingsRef.current[index];
+        if (!recording) continue;
+
+        if (!nextCreatedCursor && recording.createdByUserId === currentUserId) {
+          nextCreatedCursor = { id: recording.id, startedAt: recording.startedAt };
+        }
+        if (!nextSharedCursor && recording.createdByUserId !== currentUserId) {
+          nextSharedCursor = { id: recording.id, startedAt: recording.startedAt };
+        }
+        if (
+          (!hasMoreRecordings || nextCreatedCursor) &&
+          (!hasMoreSharedRecordings || nextSharedCursor)
+        ) {
+          break;
+        }
+      }
+
+      if (hasMoreRecordings && nextCreatedCursor) setCursor(nextCreatedCursor);
+      if (hasMoreSharedRecordings && nextSharedCursor) setSharedCursor(nextSharedCursor);
+      return;
+    }
+
     if (!hasMoreRecordings) return;
     const last = recordingsRef.current.at(-1);
     if (!last) return;
     setCursor({ id: last.id, startedAt: last.startedAt });
-  }, [hasMoreRecordings]);
+  }, [hasMoreRecordings, hasMoreSharedRecordings, isAllScope, zero.context.userID]);
 
   const refreshRecordings = useCallback((): void => {
     setCursor(null);
+    if (isAllScope) {
+      setSharedCursor(null);
+      void Promise.all([
+        zero.run(recordingQuery('created', null, participantId), { type: 'complete' }),
+        zero.run(recordingQuery('shared', null, participantId), { type: 'complete' }),
+      ])
+        .then(([createdResult, sharedResult]) => {
+          const createdRows = (createdResult ?? []) as OatsRecordingEntry[];
+          const sharedRows = (sharedResult ?? []) as OatsRecordingEntry[];
+          setRecordings(mergeRecordingPages([], createdRows, sharedRows));
+          setHasMoreRecordings(createdRows.length === FETCH_LIMIT);
+          setHasMoreSharedRecordings(sharedRows.length === FETCH_LIMIT);
+        })
+        .catch(() => undefined);
+      return;
+    }
+
     void zero
-      .run(recordingQuery(scope, null, participantId), { type: 'complete' })
+      .run(recordingQuery(queryScope, null, participantId), { type: 'complete' })
       .then(result => {
         setRecordings((result ?? []) as OatsRecordingEntry[]);
         setHasMoreRecordings((result?.length ?? 0) === FETCH_LIMIT);
       })
       .catch(() => undefined);
-  }, [scope, participantId, zero]);
+  }, [isAllScope, participantId, queryScope, zero]);
 
   useEffect(() => {
     refreshListeners.add(refreshRecordings);
@@ -119,12 +203,19 @@ export function usePaginatedOatsRecordings(
     };
   }, []);
 
+  const hasMoreForScope = isAllScope
+    ? hasMoreRecordings || hasMoreSharedRecordings
+    : hasMoreRecordings;
+  const isLoadingForScope = isAllScope
+    ? recordings.length === 0 && (details.type === 'unknown' || sharedDetails.type === 'unknown')
+    : recordings.length === 0 && details.type === 'unknown';
+
   return {
     recordings,
-    hasMoreRecordings,
+    hasMoreRecordings: hasMoreForScope,
     loadMoreRecordings,
     onVisibleRangeChanged: () => undefined,
-    isLoading: recordings.length === 0 && details.type === 'unknown',
+    isLoading: isLoadingForScope,
     error: null,
     refreshRecordings,
   };

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -558,7 +558,11 @@ export default function RecordingDetailV2Screen(): ReactElement {
     // Prefer the explicit status when the backend has published it; the boolean
     // fallback keeps this working for recordings that predate the status field.
     const readyFromStatus = recording?.detailedSummaryStatus === 'ready';
-    const readyFromLegacyFlag = !!recording?.detailedSummaryReady;
+    const hasExplicitSummaryStatus =
+      recording?.detailedSummaryStatus === 'pending' ||
+      recording?.detailedSummaryStatus === 'ready' ||
+      recording?.detailedSummaryStatus === 'failed';
+    const readyFromLegacyFlag = !hasExplicitSummaryStatus && !!recording?.detailedSummaryReady;
     const isReady = readyFromStatus || readyFromLegacyFlag;
     const requestedSummaryIsReady = request.templateId
       ? recording?.summaryTemplateId === request.templateId && isReady
@@ -751,6 +755,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
       // Drop the placeholder too: a failed request leaves nothing on its way, and
       // leaving the mark set would restore the skeleton on the next visit.
       setAwaitingSummary(false);
+      setPendingSummaryTemplateId(null);
       setSummaryFailed(true);
       clearSummaryRequested(recordingId);
       const message = axios.isAxiosError(err)
@@ -760,7 +765,6 @@ export default function RecordingDetailV2Screen(): ReactElement {
         description: message ?? 'Please try again.',
       });
     } finally {
-      setPendingSummaryTemplateId(null);
       setIsRegeneratingSummary(false);
     }
   };
@@ -968,10 +972,12 @@ export default function RecordingDetailV2Screen(): ReactElement {
         icon: getTemplateIcon(template.name),
       })),
   ];
-  const activeSummaryTemplateId = pendingSummaryTemplateId ?? storedSummaryTemplateId;
+  const selectedSummaryTemplateId = storedSummaryTemplateId;
+  const regeneratingSummaryTemplateId =
+    (pendingSummaryTemplateId ?? selectedSummaryTemplateId) || DEFAULT_SUMMARY_TEMPLATE_OPTION.id;
   const selectedSummaryTemplate: RecordingSummaryTemplate =
-    summaryTemplateOptions.find(template => template.id === activeSummaryTemplateId) ??
-    (storedSummaryTemplate?.id === activeSummaryTemplateId
+    summaryTemplateOptions.find(template => template.id === selectedSummaryTemplateId) ??
+    (storedSummaryTemplate?.id === selectedSummaryTemplateId
       ? {
           id: storedSummaryTemplate.id,
           name: storedSummaryTemplate.name,
@@ -1169,6 +1175,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                       // backend-published 'pending' (e.g. auto-generation after
                       // the call ended, or a regen started from another tab).
                       isRegenerating: isRegeneratingSummary || showSummaryShimmer,
+                      regeneratingTemplateId: regeneratingSummaryTemplateId,
                       templates: summaryTemplateOptions,
                       templatesLoading: summaryTemplatesLoading,
                       onTemplateMenuOpen: () => setShouldLoadSummaryTemplates(true),
@@ -1329,7 +1336,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                   </Tooltip>
                 ) : null}
               </div>
-              {hasDetailedSummary && !awaitingSummary ? (
+              {hasDetailedSummary ? (
                 <>
                   <DetailedSummaryCanvas
                     key={`${recording.detailedSummaryCanvasId}:${summaryCanvasNonce}`}

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingContentTabs.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/RecordingContentTabs.tsx
@@ -26,6 +26,7 @@ import {
   getSummaryTemplateLabel,
   truncateTemplateName,
 } from '../../../components/SummaryTemplateMenu/SummaryTemplateMenu.utils';
+import { Tooltip } from '../../../components/ui/Tooltip';
 
 export type RecordingContentTab = 'notes' | 'transcript' | 'summary';
 
@@ -39,8 +40,10 @@ interface RecordingContentTabsProps {
   hasSummary: boolean;
   /** The template selected for this recording; labels the segment. */
   selectedTemplate?: RecordingSummaryTemplate;
-  /** Swaps the segment's icon for a spinner and locks the menu while regenerating. */
+  /** Adds a small busy indicator while a summary is regenerating. */
   isRegenerating?: boolean;
+  /** Template currently being regenerated, which may differ from the rendered summary. */
+  regeneratingTemplateId?: string;
   templates?: RecordingSummaryTemplate[];
   templatesLoading?: boolean;
   onTemplateMenuOpen?: () => void;
@@ -59,6 +62,7 @@ export const RecordingContentTabs = ({
   hasSummary,
   selectedTemplate,
   isRegenerating = false,
+  regeneratingTemplateId,
   templates = [],
   templatesLoading = false,
   onTemplateMenuOpen,
@@ -71,8 +75,8 @@ export const RecordingContentTabs = ({
   const [isTemplateMenuOpen, setIsTemplateMenuOpen] = useState(false);
 
   useEffect(() => {
-    if (visibleTab !== 'summary' || isRegenerating) setIsTemplateMenuOpen(false);
-  }, [isRegenerating, visibleTab]);
+    if (visibleTab !== 'summary') setIsTemplateMenuOpen(false);
+  }, [visibleTab]);
 
   const renderTab = (
     tab: RecordingContentTab,
@@ -120,6 +124,15 @@ export const RecordingContentTabs = ({
     const isActive = visibleTab === 'summary';
     const fullLabel = hasSummary ? getSummaryTemplateLabel(selectedTemplate) : 'Summary';
     const label = truncateTemplateName(fullLabel);
+    const regeneratingTemplate =
+      templates.find(template => template.id === regeneratingTemplateId) ??
+      (selectedTemplate?.id === regeneratingTemplateId ? selectedTemplate : undefined);
+    const regeneratingTemplateLabel = regeneratingTemplate
+      ? getSummaryTemplateLabel(regeneratingTemplate)
+      : regeneratingTemplateId === 'default' || !regeneratingTemplateId
+        ? getSummaryTemplateLabel(undefined)
+        : 'selected template';
+    const regeneratingTooltipContent = `Generating ${regeneratingTemplateLabel} summary`;
 
     const indicator = isActive ? (
       <motion.span
@@ -152,7 +165,7 @@ export const RecordingContentTabs = ({
             onSelect('summary');
           }
         }}
-        title={fullLabel}
+        title={isRegenerating ? regeneratingTooltipContent : fullLabel}
         data-track-category='RecordingDetailV2'
         data-track-name='open_summary_templates'
         className={cn(
@@ -174,6 +187,26 @@ export const RecordingContentTabs = ({
             >
               {label}
             </motion.span>
+          </AnimatePresence>
+          <AnimatePresence initial={false}>
+            {isRegenerating && hasSummary && (
+              <motion.span
+                initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.7 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: 0.7 }}
+                transition={{ duration: shouldReduceMotion ? 0 : 0.14 }}
+                className='flex shrink-0 items-center justify-center'
+              >
+                <Tooltip content={regeneratingTooltipContent} side='top'>
+                  <span
+                    className='flex size-3 items-center justify-center'
+                    aria-label={regeneratingTooltipContent}
+                  >
+                    <Spinner size={12} className='animate-spin text-muted-foreground' />
+                  </span>
+                </Tooltip>
+              </motion.span>
+            )}
           </AnimatePresence>
           <AnimatePresence initial={false}>
             {isActive && onOpenTemplates && hasSummary && (
@@ -200,7 +233,7 @@ export const RecordingContentTabs = ({
         trigger={trigger}
         open={isActive && isTemplateMenuOpen}
         onOpenChange={open => {
-          if (isActive && !isRegenerating) {
+          if (isActive) {
             if (open) onTemplateMenuOpen?.();
             setIsTemplateMenuOpen(open);
           }
@@ -215,6 +248,7 @@ export const RecordingContentTabs = ({
           templates={templates}
           isLoading={templatesLoading}
           isRegenerating={isRegenerating}
+          regeneratingTemplateId={regeneratingTemplateId}
           canRegenerate={Boolean(selectedTemplate?.id)}
           onSelectTemplate={templateId => onTemplateSelect?.(templateId)}
           onRegenerate={() => onRegenerate?.()}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -65,8 +65,9 @@ const RecordingsV2Screen = (): ReactElement => {
   const shouldOpenTemplatesFromUrl =
     searchParams.get('templates') === '1' || requestedSummaryTemplateId !== null;
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
+  const listTabParam = searchParams.get('tab');
   const activeListTab: RecordingOwnershipTab =
-    searchParams.get('tab') === 'shared' ? 'shared' : 'created';
+    listTabParam === 'created' || listTabParam === 'shared' ? listTabParam : 'all';
   const [selectedCreatorId, setSelectedCreatorId] = useState<string | null>(null);
   const [selectedDatePreset, setSelectedDatePreset] = useState<RecordingDatePreset>('all-time');
   const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
@@ -184,7 +185,7 @@ const RecordingsV2Screen = (): ReactElement => {
     liveRecording?.startedAt ?? (isLocalRecordingActive ? recordingStartTime : null);
   const liveRecordingTitle = liveRecording?.title ?? recordingTitle ?? DEFAULT_RECORDING_TITLE;
   const isOwnRecordingView =
-    activeListTab === 'created' && (!selectedCreatorId || selectedCreatorId === currentUser?.id);
+    activeListTab !== 'shared' && (!selectedCreatorId || selectedCreatorId === currentUser?.id);
   const showLiveRecording =
     isOwnRecordingView && liveRecordingStartedAt !== null && isLocalRecordingActive;
   const hiddenLiveRecordingId =
@@ -222,8 +223,8 @@ const RecordingsV2Screen = (): ReactElement => {
       setSearchParams(
         prev => {
           const next = new URLSearchParams(prev);
-          if (tab === 'shared') next.set('tab', 'shared');
-          else next.delete('tab');
+          if (tab === 'all') next.delete('tab');
+          else next.set('tab', tab);
           return next;
         },
         { replace: true },
@@ -400,6 +401,21 @@ const RecordingsV2Screen = (): ReactElement => {
                   role='group'
                   aria-label='Filter recordings by ownership'
                 >
+                  <button
+                    type='button'
+                    aria-pressed={activeListTab === 'all'}
+                    onClick={() => handleTabChange('all')}
+                    className={cn(
+                      LIST_TAB_CLASS_NAME,
+                      activeListTab === 'all'
+                        ? 'bg-background text-foreground font-medium'
+                        : 'text-muted-foreground/80 hover:text-foreground',
+                    )}
+                    data-track-category='RecordingsV2'
+                    data-track-name='show_all_recordings'
+                  >
+                    All
+                  </button>
                   <button
                     type='button'
                     aria-pressed={activeListTab === 'created'}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/utils/RecordingsV2.utils.ts
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/utils/RecordingsV2.utils.ts
@@ -25,7 +25,7 @@ export type RecordingDatePreset =
   | 'this-month'
   | 'last-month';
 
-export type RecordingOwnershipTab = 'created' | 'shared';
+export type RecordingOwnershipTab = 'all' | 'created' | 'shared';
 
 type FixedRecordingDateGroupId = 'today' | 'yesterday' | 'this-week' | 'last-week' | 'this-month';
 


### PR DESCRIPTION
Use this for PR body:

```md
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-61651

Adds an `All` recordings tab before `Created by me`, selected by default, combining created and shared recordings using existing frontend query paths.

Also improves recording summary template regeneration UI so existing summary content stays visible while regeneration runs, with spinner/disabled states in the summary template dropdown and trigger.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

Reused existing Zero queries; no schema, mutator, query definition, or ACL changes.

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed**
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — UI/state-only change using existing queries and API paths

Ran via pre-commit:

- `gitleaks git --staged`
- `bash scripts/validate-workspace-id.sh`
- `pnpm run lint:errors-only`
- `pnpm run validate`
- `pnpm run test:enum`

### Manual

- [x] Web browser
- [x] Local dev (`http://localhost:5174`)
- [ ] Electron desktop

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
```

pot: https://drive.google.com/file/d/1n3dshbzgKVLefzctcQQlDawfO1v1ztOk/view?usp=sharing