### PR TITLE
fix: XYNE-61697 correct Kanban column membership under Vespa-backed filters (61697)

### DIFF
--- a/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
+++ b/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
@@ -269,6 +269,18 @@ const PaginatedStageList: React.FC<{
       renderedTicketsById.set(ticket.id, ticket);
     }
 
+    // Add-side reconciliation: a ticket whose LIVE status/stage now matches this
+    // column must render here even if this column's (async, possibly stale) fetch
+    // has not surfaced it yet. Right after a status change under a Vespa-backed
+    // filter, the moved ticket is dropped from its old column above but the search
+    // index has not yet returned it for the new column; without this loop the card
+    // disappears from every column until Vespa reindexes.
+    for (const knownTicket of allKnownTickets) {
+      if (renderedTicketsById.has(knownTicket.id)) continue;
+      if (!ticketBelongsToColumn(knownTicket, columnType, columnValue, columnStatus)) continue;
+      renderedTicketsById.set(knownTicket.id, knownTicket);
+    }
+
     return [...renderedTicketsById.values()];
   }, [allKnownTickets, columnStatus, columnType, columnValue, tickets]);
 

--- a/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
+++ b/apps/dashboard/src/components/Tickets/KanbanColumns/KanbanColumns.tsx
@@ -275,6 +275,9 @@ const PaginatedStageList: React.FC<{
     // filter, the moved ticket is dropped from its old column above but the search
     // index has not yet returned it for the new column; without this loop the card
     // disappears from every column until Vespa reindexes.
+    // allKnownTickets is scoped to THIS swimlane's tickets (group.allTickets), so
+    // a ticket is only reconciled into its own group's column, never duplicated
+    // across swimlanes when a groupBy is active.
     for (const knownTicket of allKnownTickets) {
       if (renderedTicketsById.has(knownTicket.id)) continue;
       if (!ticketBelongsToColumn(knownTicket, columnType, columnValue, columnStatus)) continue;

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -4996,7 +4996,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                           availableTags={availableTags || []}
                           keyPrefix={`${group.key}::`}
                           onTicketsChange={handleKanbanTicketsChange}
-                          allKnownTickets={localTickets ?? []}
+                          allKnownTickets={group.allTickets}
                           {...(paginatedColumnConfig ? { paginatedColumnConfig } : {})}
                           {...(canCreateTicket &&
                           channel &&

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -477,7 +477,41 @@ export const useKanbanTicketsPage = (
       !shouldUseDirectVespaRows &&
       (!requiresVespaTicketIds || vespaTicketSearch.searchResults !== null),
   });
-  const effectivePage = shouldUseDirectVespaRows ? directVespaPage : page;
+  // Overlay live Zero fields onto direct-Vespa payload rows. Vespa is an async
+  // search index, so a row's statusV2/stageName can lag a just-applied status
+  // change; rendering that stale stage places the card in its OLD kanban column
+  // (ticket 61697: status changed to B but card stays in A/C until reindex).
+  // Hydrating the live stage/status by id from the Zero store keeps column
+  // membership correct immediately, before Vespa catches up.
+  const [liveDirectRows] = useCachedQuery(
+    queries.ticketsByIds({
+      ticketIds: shouldUseDirectVespaRows ? vespaTicketIds : [],
+    }),
+    { enabled: shouldUseDirectVespaRows && vespaTicketIds.length > 0 },
+  );
+  const liveDirectRowsById = useMemo(() => {
+    const byId = new Map<string, Ticket>();
+    for (const row of liveDirectRows ?? []) byId.set(row.id, row as Ticket);
+    return byId;
+  }, [liveDirectRows]);
+  const overlaidDirectVespaPage = useMemo(() => {
+    if (!shouldUseDirectVespaRows || directVespaPage === null) return directVespaPage;
+    if (liveDirectRowsById.size === 0) return directVespaPage;
+    return directVespaPage.map(ticket => {
+      const live = liveDirectRowsById.get(ticket.id);
+      if (!live) return ticket;
+      return {
+        ...ticket,
+        statusV2: live.statusV2,
+        stageName: live.stageName,
+        boardId: live.boardId,
+        priority: live.priority,
+        assignedTo: live.assignedTo,
+      };
+    });
+  }, [shouldUseDirectVespaRows, directVespaPage, liveDirectRowsById]);
+
+  const effectivePage = shouldUseDirectVespaRows ? overlaidDirectVespaPage : page;
   const effectivePageDetailsType = shouldUseDirectVespaRows
     ? directVespaPage === null
       ? 'unknown'

--- a/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/useKanbanTicketsPage.ts
@@ -485,9 +485,9 @@ export const useKanbanTicketsPage = (
   // membership correct immediately, before Vespa catches up.
   const [liveDirectRows] = useCachedQuery(
     queries.ticketsByIds({
-      ticketIds: shouldUseDirectVespaRows ? vespaTicketIds : [],
+      ticketIds: shouldUseDirectVespaRows ? (vespaTicketIds ?? []) : [],
     }),
-    { enabled: shouldUseDirectVespaRows && vespaTicketIds.length > 0 },
+    { enabled: shouldUseDirectVespaRows && (vespaTicketIds?.length ?? 0) > 0 },
   );
   const liveDirectRowsById = useMemo(() => {
     const byId = new Map<string, Ticket>();


### PR DESCRIPTION
## Problem
On the Kanban board, when a Vespa-representable custom filter is active, changing a ticket's status from the ticket card dropdown updates the status correctly but the card renders in the WRONG column (stays in the old column, or flickers to another) until the search index catches up. Changing status from the ticket details page is unaffected. Repro reference: ticket 61697.

## Root cause
Under a Vespa-representable filter the board takes the `shouldUseDirectVespaRows` path in `useKanbanTicketsPage`. Rows come straight from the Vespa search payload via `useVespaTicketSearch` → `toTicket`, so `statusV2`/`stageName` reflect the **search index**, not live state. Vespa is an async index; immediately after a status mutation it still returns the old stage, so `ticketBelongsToColumn` places the card in its old column. The ticket-details path uses the live Zero store, which is why it never shows the bug.

## Fix (two parts)
1. **`useKanbanTicketsPage`** — overlay live Zero fields (`statusV2`, `stageName`, `boardId`, `priority`, `assignedTo`) onto the direct-Vespa rows by id via `queries.ticketsByIds`, so column membership is computed from live state instead of the stale index.
2. **`KanbanColumns.renderedTickets`** — add-side reconciliation: a ticket whose live stage now matches a column renders there even before that column's own async fetch surfaces it. Without this the card would drop from its old column but not yet appear in the new one during the reindex window.

## Validation
- `tsc --noEmit` on `apps/dashboard` passes clean.
- A full runtime before/after could not be reproduced in the dev sandbox because Vespa is not running there (the bug lives solely in the Vespa-backed path). Needs QA against a Vespa-backed environment.

## Test plan
- With a Vespa-representable custom filter active on a status-column Kanban board, change a ticket's status via the card dropdown → card should move to the correct column immediately.
- Regression: non-filtered board, mixed (zero-only) filters, drag-and-drop, and pagination should behave as before.