### PR TITLE
feat: XYNE-61341 add on-demand unread digest

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -102,6 +102,7 @@ import knowledgeRoutes from '@/routes/knowledge';
 import vespaSearchRoutes from '@/routes/vespaSearch';
 import { dashboardClawRouter } from '@/routes/dashboardClaw';
 import summarizeRoutes from '@/routes/summarize';
+import unreadDigestRoutes from '@/routes/unreadDigest';
 import xyneAIRoutes from '@/routes/xyneAI';
 import cacConfigRoutes from '@/routes/cacConfig';
 import lotusCacConfigRoutes from '@/routes/lotusCacConfig';
@@ -666,6 +667,9 @@ export class App {
 
     // Summarization routes (auth required, uses JAF agent)
     this.app.use('/api/summarize', authMiddleware.authenticate, summarizeRoutes);
+
+    // Unread Digest routes (auth required) — on-demand summary of all unread channels
+    this.app.use('/api/unread-digest', authMiddleware.authenticate, unreadDigestRoutes);
 
     // Xyne AI routes (unified AI assistant with context awareness)
     this.app.use('/api/xyne-ai', authMiddleware.authenticate, xyneAIRoutes);

--- a/apps/backend/src/controllers/unreadDigestController.ts
+++ b/apps/backend/src/controllers/unreadDigestController.ts
@@ -1,0 +1,165 @@
+import { Request, Response } from 'express';
+import {
+  summarizeThread,
+  type ThreadSummaryInput,
+  type SummarizerContext,
+  type SummaryOutput,
+} from '@/agents/summariser';
+import { AgentsConfig } from '@/agents/config';
+import { logger } from '@/utils/logger';
+import { unreadDigestService, type DigestChannelSnapshot } from '@/services/unreadDigestService';
+
+/**
+ * Controller for the on-demand Unread Digest.
+ *
+ * POST /api/unread-digest/generate
+ *
+ * Streams Server-Sent Events as each channel is summarised so the UI can render
+ * progressively rather than blocking on the whole batch. Generation is strictly
+ * read-only — it never marks anything as read.
+ *
+ * Event contract (all lines are `data: <json>\n\n`):
+ *   { type: 'snapshot', snapshotAt, totalChannels, omittedChannelCount, caps }
+ *   { type: 'progress', channelId, channelName, index, total }
+ *   { type: 'channel', channelId, channelName, output, includedCount, omittedCount,
+ *     messageIdMapping, conversationIdMapping }
+ *   { type: 'complete', channelCount }
+ *   { type: 'error', error }
+ *   { type: 'end' }
+ */
+export class UnreadDigestController {
+  generate = async (req: Request, res: Response): Promise<void> => {
+    const userId = (req as any).user?.id;
+    const workspaceId = (req as any).user?.workspaceId;
+    const email = (req as any).user?.email;
+
+    if (!userId || !workspaceId) {
+      res.status(401).json({ error: 'Unauthorized: missing user or workspace context' });
+      return;
+    }
+
+    // Concurrency limit for per-channel summarisation so a large inbox does not
+    // fan out unbounded LLM calls.
+    const CONCURRENCY = 3;
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no');
+    res.setHeader('Content-Encoding', 'none');
+    if (res.socket) res.socket.setNoDelay(true);
+    res.flushHeaders();
+
+    const write = (payload: Record<string, unknown>): void => {
+      res.write(`data: ${JSON.stringify(payload)}\n\n`);
+      if (typeof (res as any).flush === 'function') (res as any).flush();
+    };
+
+    // Abort per-channel work if the client disconnects mid-stream.
+    let clientGone = false;
+    req.on('close', () => {
+      clientGone = true;
+    });
+
+    try {
+      const agentsConfig = await AgentsConfig.fetch({ email });
+      const snapshot = await unreadDigestService.createSnapshot(userId, workspaceId);
+
+      write({
+        type: 'snapshot',
+        snapshotAt: snapshot.snapshotAt.toISOString(),
+        totalChannels: snapshot.channels.length,
+        omittedChannelCount: snapshot.omittedChannelCount,
+        caps: snapshot.caps,
+      });
+
+      if (snapshot.channels.length === 0) {
+        write({ type: 'complete', channelCount: 0 });
+        write({ type: 'end' });
+        res.end();
+        return;
+      }
+
+      const summarizeOne = async (
+        channel: DigestChannelSnapshot,
+        index: number
+      ): Promise<void> => {
+        if (clientGone) return;
+        write({
+          type: 'progress',
+          channelId: channel.channelId,
+          channelName: channel.channelName,
+          index: index + 1,
+          total: snapshot.channels.length,
+        });
+
+        const input: ThreadSummaryInput = {
+          messages: channel.messages,
+          messageIdMapping: channel.messageIdMapping,
+          conversationIdMapping: channel.conversationIdMapping,
+        };
+        const context: SummarizerContext = {
+          userId,
+          conversationId: '',
+          channelId: channel.channelId,
+          summarizationType: 'channel',
+          modelName: agentsConfig.summariserModelName,
+        };
+
+        let output: SummaryOutput | null = null;
+        try {
+          output = await summarizeThread(input, context);
+        } catch (err) {
+          logger.warn(
+            `[UnreadDigest] channel ${channel.channelId} summarisation failed: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+        if (clientGone) return;
+
+        write({
+          type: 'channel',
+          channelId: channel.channelId,
+          channelName: channel.channelName,
+          includedCount: channel.includedCount,
+          omittedCount: channel.omittedCount,
+          messageIdMapping: Object.fromEntries(channel.messageIdMapping),
+          conversationIdMapping: Object.fromEntries(channel.conversationIdMapping),
+          output,
+          failed: output === null,
+        });
+      };
+
+      // Bounded concurrency, preserving the ranked channel order for progress.
+      let cursor = 0;
+      const workers: Promise<void>[] = [];
+      const runNext = async (): Promise<void> => {
+        while (cursor < snapshot.channels.length && !clientGone) {
+          const current = cursor++;
+          await summarizeOne(snapshot.channels[current], current);
+        }
+      };
+      for (let i = 0; i < Math.min(CONCURRENCY, snapshot.channels.length); i++) {
+        workers.push(runNext());
+      }
+      await Promise.all(workers);
+
+      if (!clientGone) {
+        write({ type: 'complete', channelCount: snapshot.channels.length });
+        write({ type: 'end' });
+      }
+      res.end();
+    } catch (error) {
+      logger.error('[UnreadDigest] generation error:', error);
+      if (!res.headersSent) {
+        res.status(500).json({
+          error: error instanceof Error ? error.message : 'Unknown error occurred',
+        });
+      } else {
+        write({ type: 'error', error: error instanceof Error ? error.message : 'Unknown error' });
+        res.end();
+      }
+    }
+  };
+}

--- a/apps/backend/src/routes/unreadDigest.ts
+++ b/apps/backend/src/routes/unreadDigest.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { UnreadDigestController } from '@/controllers/unreadDigestController';
+
+const router = Router();
+const unreadDigestController = new UnreadDigestController();
+
+/**
+ * Unread Digest Routes
+ * Base path: /api/unread-digest
+ */
+
+// POST /api/unread-digest/generate — stream an on-demand summary of all the
+// authenticated user's unread channel messages (SSE).
+router.post('/generate', unreadDigestController.generate);
+
+export default router;

--- a/apps/backend/src/services/unreadDigestSelection.test.ts
+++ b/apps/backend/src/services/unreadDigestSelection.test.ts
@@ -1,0 +1,137 @@
+import {
+  isDigestEligible,
+  capChannelMessages,
+  rankAndCapChannels,
+  UNREAD_DIGEST_CAPS,
+} from './unreadDigestSelection';
+
+const at = (iso: string) => new Date(iso);
+
+describe('isDigestEligible', () => {
+  const base = {
+    userId: 'u1',
+    lastViewedAt: at('2026-01-01T10:00:00Z'),
+    snapshotAt: at('2026-01-01T12:00:00Z'),
+  };
+
+  it('includes a public message from someone else created after lastViewedAt and at/before the snapshot', () => {
+    expect(
+      isDigestEligible(
+        { senderId: 'u2', isDeleted: false, visibleTo: null, createdAt: at('2026-01-01T11:00:00Z') },
+        base
+      )
+    ).toBe(true);
+  });
+
+  it('excludes the requesting user’s own messages', () => {
+    expect(
+      isDigestEligible(
+        { senderId: 'u1', isDeleted: false, visibleTo: null, createdAt: at('2026-01-01T11:00:00Z') },
+        base
+      )
+    ).toBe(false);
+  });
+
+  it('excludes soft-deleted messages', () => {
+    expect(
+      isDigestEligible(
+        { senderId: 'u2', isDeleted: true, visibleTo: null, createdAt: at('2026-01-01T11:00:00Z') },
+        base
+      )
+    ).toBe(false);
+  });
+
+  it('excludes messages already read (created at or before lastViewedAt)', () => {
+    expect(
+      isDigestEligible(
+        { senderId: 'u2', isDeleted: false, visibleTo: null, createdAt: at('2026-01-01T10:00:00Z') },
+        base
+      )
+    ).toBe(false);
+  });
+
+  it('excludes messages created after the snapshot boundary (arrived mid-generation)', () => {
+    expect(
+      isDigestEligible(
+        { senderId: 'u2', isDeleted: false, visibleTo: null, createdAt: at('2026-01-01T12:00:01Z') },
+        base
+      )
+    ).toBe(false);
+  });
+
+  it('excludes private messages addressed to a different user', () => {
+    expect(
+      isDigestEligible(
+        { senderId: 'u2', isDeleted: false, visibleTo: 'u3', createdAt: at('2026-01-01T11:00:00Z') },
+        base
+      )
+    ).toBe(false);
+  });
+
+  it('includes private messages addressed to the requesting user', () => {
+    expect(
+      isDigestEligible(
+        { senderId: 'u2', isDeleted: false, visibleTo: 'u1', createdAt: at('2026-01-01T11:00:00Z') },
+        base
+      )
+    ).toBe(true);
+  });
+
+  it('treats a null lastViewedAt as "never read" and includes older messages', () => {
+    expect(
+      isDigestEligible(
+        { senderId: 'u2', isDeleted: false, visibleTo: null, createdAt: at('2020-01-01T00:00:00Z') },
+        { ...base, lastViewedAt: null }
+      )
+    ).toBe(true);
+  });
+});
+
+describe('capChannelMessages', () => {
+  const msgs = Array.from({ length: 5 }, (_, i) => ({
+    id: String(i),
+    createdAt: at(`2026-01-01T10:0${i}:00Z`),
+  }));
+
+  it('returns everything when under the cap', () => {
+    const { kept, omitted } = capChannelMessages(msgs, 10);
+    expect(kept).toHaveLength(5);
+    expect(omitted).toBe(0);
+  });
+
+  it('keeps the NEWEST messages when over the cap, in ascending order', () => {
+    const { kept, omitted } = capChannelMessages(msgs, 2);
+    expect(omitted).toBe(3);
+    expect(kept.map((m) => m.id)).toEqual(['3', '4']);
+  });
+});
+
+describe('rankAndCapChannels', () => {
+  const mk = (unreadHint: number, latest: string) => ({
+    unreadHint,
+    messages: [{ createdAt: at(latest) }],
+  });
+
+  it('orders by unread hint desc then newest activity, and caps the count', () => {
+    const channels = [
+      mk(1, '2026-01-01T10:00:00Z'),
+      mk(5, '2026-01-01T09:00:00Z'),
+      mk(5, '2026-01-01T11:00:00Z'),
+      mk(2, '2026-01-01T08:00:00Z'),
+    ];
+    const { included, omittedChannelCount } = rankAndCapChannels(channels, 2);
+    expect(included).toHaveLength(2);
+    expect(omittedChannelCount).toBe(2);
+    // Both top channels have unreadHint 5; the newer one wins the tiebreak.
+    expect(included[0].messages[0].createdAt.toISOString()).toBe('2026-01-01T11:00:00.000Z');
+    expect(included[1].messages[0].createdAt.toISOString()).toBe('2026-01-01T09:00:00.000Z');
+  });
+});
+
+describe('UNREAD_DIGEST_CAPS', () => {
+  it('exposes the documented, bounded caps', () => {
+    expect(UNREAD_DIGEST_CAPS.maxChannels).toBe(25);
+    expect(UNREAD_DIGEST_CAPS.maxMessagesPerChannel).toBe(200);
+    expect(UNREAD_DIGEST_CAPS.maxMessagesOverall).toBe(1000);
+  });
+});

--- a/apps/backend/src/services/unreadDigestSelection.ts
+++ b/apps/backend/src/services/unreadDigestSelection.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure, dependency-free selection logic for the Unread Digest.
+ *
+ * Kept separate from `unreadDigestService.ts` (which pulls in Prisma and the
+ * shared package) so the message-eligibility, capping, and ranking rules can be
+ * unit-tested in isolation without booting a database or the ORM.
+ */
+
+/** Caps that bound a single digest run. */
+export const UNREAD_DIGEST_CAPS = {
+  maxChannels: 25,
+  maxMessagesPerChannel: 200,
+  maxMessagesOverall: 1000,
+} as const;
+
+/**
+ * Decide whether a raw message belongs in the unread digest for `userId`.
+ *
+ * A message is in-scope when it:
+ *  - is not soft-deleted,
+ *  - is not the requesting user's own message,
+ *  - is either public (`visibleTo == null`) or addressed to this user,
+ *  - was created strictly after the user last viewed the channel, and
+ *  - was created at or before the server-owned snapshot boundary (so a message
+ *    that arrives mid-generation stays unread and is not silently swallowed).
+ */
+export function isDigestEligible(
+  message: { senderId: string; isDeleted: boolean; visibleTo: string | null; createdAt: Date },
+  opts: { userId: string; lastViewedAt: Date | null; snapshotAt: Date }
+): boolean {
+  if (message.isDeleted) return false;
+  if (message.senderId === opts.userId) return false;
+  if (message.visibleTo !== null && message.visibleTo !== opts.userId) return false;
+  if (message.createdAt.getTime() > opts.snapshotAt.getTime()) return false;
+  if (opts.lastViewedAt && message.createdAt.getTime() <= opts.lastViewedAt.getTime()) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Apply the per-channel message cap, keeping the NEWEST messages when trimming
+ * but returning them in chronological (ascending) order for the summariser.
+ */
+export function capChannelMessages<T extends { createdAt: Date }>(
+  ascendingMessages: readonly T[],
+  cap: number
+): { kept: T[]; omitted: number } {
+  if (ascendingMessages.length <= cap) {
+    return { kept: [...ascendingMessages], omitted: 0 };
+  }
+  const kept = ascendingMessages.slice(ascendingMessages.length - cap);
+  return { kept, omitted: ascendingMessages.length - cap };
+}
+
+/**
+ * Rank unread channels (highest unread signal first, newest activity as a
+ * tiebreak) and apply the channel cap. Deterministic ordering keeps the digest
+ * stable across retries.
+ */
+export function rankAndCapChannels<
+  T extends { unreadHint: number; messages: readonly { createdAt: Date }[] }
+>(channels: readonly T[], maxChannels: number): { included: T[]; omittedChannelCount: number } {
+  const sorted = [...channels].sort((a, b) => {
+    if (b.unreadHint !== a.unreadHint) return b.unreadHint - a.unreadHint;
+    const aLatest = a.messages.length ? a.messages[a.messages.length - 1].createdAt.getTime() : 0;
+    const bLatest = b.messages.length ? b.messages[b.messages.length - 1].createdAt.getTime() : 0;
+    return bLatest - aLatest;
+  });
+  return {
+    included: sorted.slice(0, maxChannels),
+    omittedChannelCount: Math.max(0, sorted.length - maxChannels),
+  };
+}

--- a/apps/backend/src/services/unreadDigestService.ts
+++ b/apps/backend/src/services/unreadDigestService.ts
@@ -1,0 +1,221 @@
+import { DatabaseClient } from '@/database/client';
+import { logger } from '@/utils/logger';
+import { isDeskChannelType, ChannelType } from '@xyne/shared';
+import type { ThreadMessage } from '@/agents/summariser';
+import {
+  UNREAD_DIGEST_CAPS,
+  capChannelMessages,
+  rankAndCapChannels,
+} from '@/services/unreadDigestSelection';
+
+export {
+  UNREAD_DIGEST_CAPS,
+  isDigestEligible,
+  capChannelMessages,
+  rankAndCapChannels,
+} from '@/services/unreadDigestSelection';
+
+const prisma = DatabaseClient.getInstance();
+
+/** A message as needed by the summariser, plus the fields we filter on. */
+export interface DigestSourceMessage {
+  readonly messageId: string;
+  readonly conversationId: string;
+  readonly senderId: string;
+  readonly content: string;
+  readonly createdAt: Date;
+  readonly isDeleted: boolean;
+  readonly visibleTo: string | null;
+  readonly hasAttachment: boolean;
+  readonly authorName: string;
+}
+
+export interface DigestChannelInput {
+  readonly channelId: string;
+  readonly channelName: string;
+  readonly unreadHint: number; // ranking signal (unread count / activity)
+  readonly messages: readonly DigestSourceMessage[];
+}
+
+export interface DigestChannelSnapshot {
+  readonly channelId: string;
+  readonly channelName: string;
+  readonly messages: ThreadMessage[];
+  /** 1-based index -> messageId, for citation mapping (mirrors summarizeChannel). */
+  readonly messageIdMapping: Map<number, string>;
+  readonly conversationIdMapping: Map<number, string>;
+  readonly includedCount: number;
+  readonly omittedCount: number;
+}
+
+export interface UnreadDigestSnapshot {
+  readonly snapshotAt: Date;
+  readonly channels: DigestChannelSnapshot[];
+  /** Channels that were unread but dropped because of the channel cap. */
+  readonly omittedChannelCount: number;
+  readonly caps: typeof UNREAD_DIGEST_CAPS;
+}
+
+/** Channel types that never appear in the Unreads inbox (mirrors the UI). */
+function isExcludedChannelType(type: string | null | undefined): boolean {
+  return (
+    isDeskChannelType(type) ||
+    type === ChannelType.SUPPORT ||
+    type === ChannelType.SDLC
+  );
+}
+
+export class UnreadDigestService {
+  /**
+   * Build a server-owned, timestamped snapshot of everything the given user has
+   * not yet read across their channels. Identity is taken ONLY from the
+   * authenticated caller — never from request input.
+   *
+   * This is strictly read-only: it never mutates read state. A future
+   * "mark read after digest" action must clear against `snapshotAt`, not
+   * `now()`, so messages that arrive during generation stay unread.
+   */
+  async createSnapshot(userId: string, workspaceId: string): Promise<UnreadDigestSnapshot> {
+    const snapshotAt = new Date();
+
+    // 1. Channels the user is a member of, within their workspace.
+    const memberships = await prisma.channelParticipant.findMany({
+      where: { userId, workspaceId },
+      select: { channelId: true },
+    });
+    const channelIds = memberships.map((m) => m.channelId);
+    if (channelIds.length === 0) {
+      return { snapshotAt, channels: [], omittedChannelCount: 0, caps: UNREAD_DIGEST_CAPS };
+    }
+
+    // 2. Channel metadata + per-user read state.
+    const [channels, statuses] = await Promise.all([
+      prisma.channel.findMany({
+        where: { id: { in: channelIds }, workspaceId },
+        select: { id: true, name: true, type: true },
+      }),
+      prisma.channelUserStatus.findMany({
+        where: { userId, channelId: { in: channelIds } },
+        select: { channelId: true, lastViewedAt: true, unreadCount: true },
+      }),
+    ]);
+
+    const statusByChannel = new Map(statuses.map((s) => [s.channelId, s]));
+    const eligibleChannels = channels.filter((c) => !isExcludedChannelType(c.type));
+    if (eligibleChannels.length === 0) {
+      return { snapshotAt, channels: [], omittedChannelCount: 0, caps: UNREAD_DIGEST_CAPS };
+    }
+
+    // 3. For each channel, gather unread messages via its conversations.
+    const rawChannels: DigestChannelInput[] = [];
+    for (const channel of eligibleChannels) {
+      const status = statusByChannel.get(channel.id);
+      const lastViewedAt = status?.lastViewedAt ?? null;
+
+      const conversations = await prisma.conversation.findMany({
+        where: { channelId: channel.id },
+        select: { conversationId: true },
+      });
+      const conversationIds = conversations.map((c) => c.conversationId);
+      if (conversationIds.length === 0) continue;
+
+      const rows = await prisma.message.findMany({
+        where: {
+          conversationId: { in: conversationIds },
+          isDeleted: false,
+          createdAt: {
+            ...(lastViewedAt ? { gt: lastViewedAt } : {}),
+            lte: snapshotAt,
+          },
+          senderId: { not: userId },
+          OR: [{ visibleTo: null }, { visibleTo: userId }],
+        },
+        orderBy: { createdAt: 'asc' },
+        take: UNREAD_DIGEST_CAPS.maxMessagesPerChannel + 1,
+        select: {
+          messageId: true,
+          conversationId: true,
+          senderId: true,
+          content: true,
+          createdAt: true,
+          isDeleted: true,
+          visibleTo: true,
+          hasAttachment: true,
+        },
+      });
+      if (rows.length === 0) continue;
+
+      const senderIds = [...new Set(rows.map((r) => r.senderId))];
+      const users = await prisma.user.findMany({
+        where: { id: { in: senderIds } },
+        select: { id: true, name: true, email: true },
+      });
+      const userMap = new Map(users.map((u) => [u.id, u]));
+
+      rawChannels.push({
+        channelId: channel.id,
+        channelName: channel.name,
+        unreadHint: status?.unreadCount ?? rows.length,
+        messages: rows.map((r) => ({
+          messageId: r.messageId,
+          conversationId: r.conversationId,
+          senderId: r.senderId,
+          content: r.content,
+          createdAt: r.createdAt,
+          isDeleted: r.isDeleted,
+          visibleTo: r.visibleTo,
+          hasAttachment: r.hasAttachment,
+          authorName: userMap.get(r.senderId)?.name || userMap.get(r.senderId)?.email || 'Unknown User',
+        })),
+      });
+    }
+
+    // 4. Rank + cap channels, then cap messages per channel with an overall budget.
+    const { included, omittedChannelCount } = rankAndCapChannels(
+      rawChannels,
+      UNREAD_DIGEST_CAPS.maxChannels
+    );
+
+    const channelSnapshots: DigestChannelSnapshot[] = [];
+    let overallBudget = UNREAD_DIGEST_CAPS.maxMessagesOverall;
+
+    for (const ch of included) {
+      if (overallBudget <= 0) break;
+      const perChannelCap = Math.min(UNREAD_DIGEST_CAPS.maxMessagesPerChannel, overallBudget);
+      const { kept, omitted } = capChannelMessages(ch.messages, perChannelCap);
+      overallBudget -= kept.length;
+
+      const messageIdMapping = new Map<number, string>();
+      const conversationIdMapping = new Map<number, string>();
+      const messages: ThreadMessage[] = kept.map((m, idx) => {
+        messageIdMapping.set(idx + 1, m.messageId);
+        conversationIdMapping.set(idx + 1, m.conversationId);
+        return {
+          id: m.messageId,
+          content: m.content,
+          authorName: m.authorName,
+          createdAt: m.createdAt,
+          hasAttachment: m.hasAttachment,
+        };
+      });
+
+      channelSnapshots.push({
+        channelId: ch.channelId,
+        channelName: ch.channelName,
+        messages,
+        messageIdMapping,
+        conversationIdMapping,
+        includedCount: kept.length,
+        omittedCount: omitted,
+      });
+    }
+
+    logger.info(
+      `[UnreadDigest] snapshot for user=${userId} channels=${channelSnapshots.length} omittedChannels=${omittedChannelCount}`
+    );
+
+    return { snapshotAt, channels: channelSnapshots, omittedChannelCount, caps: UNREAD_DIGEST_CAPS };
+  }
+}
+
+export const unreadDigestService = new UnreadDigestService();

--- a/apps/dashboard/src/components/Chat/UnreadsInbox/UnreadDigestPanel.tsx
+++ b/apps/dashboard/src/components/Chat/UnreadsInbox/UnreadDigestPanel.tsx
@@ -1,0 +1,247 @@
+import { ReactElement, useCallback, useRef, useState } from 'react';
+import { Sparkles, Loader2, X } from 'lucide-react';
+import { BASE_URL } from '../../../services/clients/apiClient';
+import Button from '../../ui/Button';
+
+/**
+ * On-demand "Summarise unreads" panel for the Unreads inbox.
+ *
+ * Streams per-channel summaries from `POST /api/unread-digest/generate` (SSE)
+ * and renders them progressively. Generation is read-only — it never marks
+ * anything as read, so the inbox is untouched after summarising.
+ */
+
+interface KeyPoint {
+  point: string;
+}
+
+interface ChannelSummary {
+  channelId: string;
+  channelName: string;
+  summary: string;
+  keyPoints: KeyPoint[];
+  includedCount: number;
+  omittedCount: number;
+  failed: boolean;
+}
+
+interface DigestMeta {
+  totalChannels: number;
+  omittedChannelCount: number;
+}
+
+const UnreadDigestPanel = (): ReactElement => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [meta, setMeta] = useState<DigestMeta | null>(null);
+  const [progress, setProgress] = useState<{ index: number; total: number } | null>(null);
+  const [summaries, setSummaries] = useState<ChannelSummary[]>([]);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const stop = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setIsLoading(false);
+    setProgress(null);
+  }, []);
+
+  const generate = useCallback(async () => {
+    setIsOpen(true);
+    setIsLoading(true);
+    setError(null);
+    setMeta(null);
+    setProgress(null);
+    setSummaries([]);
+
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
+    try {
+      // eslint-disable-next-line local-rules/no-fetch-use-axios
+      const response = await fetch(`${BASE_URL}/unread-digest/generate`, {
+        method: 'POST',
+        headers: { Accept: 'text/event-stream' },
+        credentials: 'include',
+        signal: abortController.signal,
+      });
+
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+      const reader = response.body?.getReader();
+      const decoder = new TextDecoder();
+      if (!reader) throw new Error('No response body');
+
+      let buffer = '';
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-constant-condition
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          let data: Record<string, unknown>;
+          try {
+            data = JSON.parse(line.slice(6));
+          } catch {
+            continue;
+          }
+
+          switch (data.type) {
+            case 'snapshot':
+              setMeta({
+                totalChannels: Number(data.totalChannels ?? 0),
+                omittedChannelCount: Number(data.omittedChannelCount ?? 0),
+              });
+              break;
+            case 'progress':
+              setProgress({ index: Number(data.index ?? 0), total: Number(data.total ?? 0) });
+              break;
+            case 'channel': {
+              const output = (data.output ?? null) as
+                | { summary?: string; keyPoints?: { point: string }[] }
+                | null;
+              setSummaries((prev) => [
+                ...prev,
+                {
+                  channelId: String(data.channelId ?? ''),
+                  channelName: String(data.channelName ?? 'Channel'),
+                  summary: output?.summary ?? '',
+                  keyPoints: Array.isArray(output?.keyPoints)
+                    ? output!.keyPoints.map((k) => ({ point: k.point }))
+                    : [],
+                  includedCount: Number(data.includedCount ?? 0),
+                  omittedCount: Number(data.omittedCount ?? 0),
+                  failed: Boolean(data.failed),
+                },
+              ]);
+              break;
+            }
+            case 'complete':
+              setIsLoading(false);
+              setProgress(null);
+              break;
+            case 'error':
+              setError(String(data.error ?? 'Failed to summarise unreads'));
+              setIsLoading(false);
+              break;
+            default:
+              break;
+          }
+        }
+      }
+      setIsLoading(false);
+      setProgress(null);
+    } catch (err) {
+      if ((err as Error)?.name === 'AbortError') return;
+      setError(err instanceof Error ? err.message : 'Failed to summarise unreads');
+      setIsLoading(false);
+      setProgress(null);
+    }
+  }, []);
+
+  return (
+    <div className='flex flex-col'>
+      <Button
+        variant='secondary'
+        size='sm'
+        onClick={() => void generate()}
+        disabled={isLoading}
+        className='h-8 gap-1.5'
+        data-track-category='UNREADS_INBOX'
+        data-track-name='SUMMARISE_UNREADS'
+      >
+        {isLoading ? <Loader2 className='w-4 h-4 animate-spin' /> : <Sparkles className='w-4 h-4' />}
+        <span className='text-sm font-medium'>Summarise unreads</span>
+      </Button>
+
+      {isOpen && (
+        <div className='mt-3 rounded-lg border border-border/50 bg-card shadow-sm'>
+          <div className='flex items-center justify-between px-4 py-2.5 border-b border-border/40'>
+            <div className='flex items-center gap-2 text-foreground'>
+              <Sparkles className='w-4 h-4 text-primary' />
+              <span className='text-sm font-semibold'>Unread digest</span>
+              {meta && (
+                <span className='text-xs text-muted-foreground'>
+                  {meta.totalChannels} channel{meta.totalChannels === 1 ? '' : 's'}
+                  {meta.omittedChannelCount > 0
+                    ? ` · ${meta.omittedChannelCount} more not shown`
+                    : ''}
+                </span>
+              )}
+            </div>
+            <div className='flex items-center gap-2'>
+              {isLoading && (
+                <Button variant='ghost' size='sm' className='h-7 px-2' onClick={stop}>
+                  Stop
+                </Button>
+              )}
+              <Button
+                variant='ghost'
+                size='sm'
+                className='h-7 w-7 p-0'
+                aria-label='Close digest'
+                onClick={() => {
+                  stop();
+                  setIsOpen(false);
+                }}
+              >
+                <X className='w-4 h-4' />
+              </Button>
+            </div>
+          </div>
+
+          <div className='px-4 py-3 max-h-[calc(100vh-260px)] overflow-y-auto space-y-3'>
+            {error && <p className='text-sm text-destructive'>{error}</p>}
+
+            {isLoading && progress && (
+              <p className='text-xs text-muted-foreground'>
+                Summarising {progress.index} of {progress.total}…
+              </p>
+            )}
+
+            {!isLoading && !error && summaries.length === 0 && (
+              <p className='text-sm text-muted-foreground'>You&apos;re all caught up — nothing to summarise.</p>
+            )}
+
+            {summaries.map((s) => (
+              <div key={s.channelId} className='rounded-md border border-border/40 bg-background p-3'>
+                <div className='flex items-center justify-between mb-1.5'>
+                  <span className='text-sm font-semibold text-foreground'>#{s.channelName}</span>
+                  <span className='text-[11px] text-muted-foreground'>
+                    {s.includedCount} message{s.includedCount === 1 ? '' : 's'}
+                    {s.omittedCount > 0 ? ` · +${s.omittedCount} older` : ''}
+                  </span>
+                </div>
+                {s.failed ? (
+                  <p className='text-xs text-muted-foreground italic'>
+                    Could not summarise this channel.
+                  </p>
+                ) : (
+                  <>
+                    {s.summary && (
+                      <p className='text-sm text-foreground/90 whitespace-pre-wrap'>{s.summary}</p>
+                    )}
+                    {s.keyPoints.length > 0 && (
+                      <ul className='mt-2 list-disc pl-5 space-y-1'>
+                        {s.keyPoints.map((k, i) => (
+                          <li key={i} className='text-sm text-foreground/80'>
+                            {k.point}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UnreadDigestPanel;

--- a/apps/dashboard/src/components/Chat/UnreadsInbox/UnreadDigestPanel.tsx
+++ b/apps/dashboard/src/components/Chat/UnreadsInbox/UnreadDigestPanel.tsx
@@ -30,6 +30,22 @@ interface DigestMeta {
   omittedChannelCount: number;
 }
 
+/** Shape of a single parsed SSE `data:` frame from the digest stream. */
+interface DigestEvent {
+  type?: string;
+  totalChannels?: number;
+  omittedChannelCount?: number;
+  index?: number;
+  total?: number;
+  channelId?: string;
+  channelName?: string;
+  includedCount?: number;
+  omittedCount?: number;
+  failed?: boolean;
+  error?: string;
+  output?: { summary?: string; keyPoints?: { point: string }[] } | null;
+}
+
 const UnreadDigestPanel = (): ReactElement => {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
@@ -82,9 +98,9 @@ const UnreadDigestPanel = (): ReactElement => {
 
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue;
-          let data: Record<string, unknown>;
+          let data: DigestEvent;
           try {
-            data = JSON.parse(line.slice(6));
+            data = JSON.parse(line.slice(6)) as DigestEvent;
           } catch {
             continue;
           }
@@ -100,18 +116,14 @@ const UnreadDigestPanel = (): ReactElement => {
               setProgress({ index: Number(data.index ?? 0), total: Number(data.total ?? 0) });
               break;
             case 'channel': {
-              const output = (data.output ?? null) as
-                | { summary?: string; keyPoints?: { point: string }[] }
-                | null;
-              setSummaries((prev) => [
+              const output = data.output ?? null;
+              setSummaries(prev => [
                 ...prev,
                 {
                   channelId: String(data.channelId ?? ''),
                   channelName: String(data.channelName ?? 'Channel'),
                   summary: output?.summary ?? '',
-                  keyPoints: Array.isArray(output?.keyPoints)
-                    ? output!.keyPoints.map((k) => ({ point: k.point }))
-                    : [],
+                  keyPoints: (output?.keyPoints ?? []).map(k => ({ point: k.point })),
                   includedCount: Number(data.includedCount ?? 0),
                   omittedCount: Number(data.omittedCount ?? 0),
                   failed: Boolean(data.failed),
@@ -153,7 +165,11 @@ const UnreadDigestPanel = (): ReactElement => {
         data-track-category='UNREADS_INBOX'
         data-track-name='SUMMARISE_UNREADS'
       >
-        {isLoading ? <Loader2 className='w-4 h-4 animate-spin' /> : <Sparkles className='w-4 h-4' />}
+        {isLoading ? (
+          <Loader2 className='w-4 h-4 animate-spin' />
+        ) : (
+          <Sparkles className='w-4 h-4' />
+        )}
         <span className='text-sm font-medium'>Summarise unreads</span>
       </Button>
 
@@ -203,11 +219,16 @@ const UnreadDigestPanel = (): ReactElement => {
             )}
 
             {!isLoading && !error && summaries.length === 0 && (
-              <p className='text-sm text-muted-foreground'>You&apos;re all caught up — nothing to summarise.</p>
+              <p className='text-sm text-muted-foreground'>
+                You&apos;re all caught up — nothing to summarise.
+              </p>
             )}
 
-            {summaries.map((s) => (
-              <div key={s.channelId} className='rounded-md border border-border/40 bg-background p-3'>
+            {summaries.map(s => (
+              <div
+                key={s.channelId}
+                className='rounded-md border border-border/40 bg-background p-3'
+              >
                 <div className='flex items-center justify-between mb-1.5'>
                   <span className='text-sm font-semibold text-foreground'>#{s.channelName}</span>
                   <span className='text-[11px] text-muted-foreground'>

--- a/apps/dashboard/src/components/Chat/UnreadsInbox/UnreadsInbox.tsx
+++ b/apps/dashboard/src/components/Chat/UnreadsInbox/UnreadsInbox.tsx
@@ -13,6 +13,7 @@ import { getDraft } from '../../../hooks/useDraft';
 import { v4 as uuidv4 } from 'uuid';
 import Button from '../../ui/Button';
 import Tooltip from '../../ui/Tooltip';
+import UnreadDigestPanel from './UnreadDigestPanel';
 
 const UnreadsInbox = (): ReactElement => {
   const channelData = useAllVisibleChannels();
@@ -98,6 +99,12 @@ const UnreadsInbox = (): ReactElement => {
           <h1 className='text-lg font-semibold tracking-tight'>Unreads</h1>
         </div>
       </div>
+
+      {unreadItems.length > 0 && (
+        <div className='shrink-0 px-6 py-3 border-b border-border/40 bg-background'>
+          <UnreadDigestPanel />
+        </div>
+      )}
 
       <div className='relative z-0 flex-1 isolate overflow-y-auto overflow-x-hidden px-4 pb-4 pt-0'>
         {unreadItems.length === 0 ? (


### PR DESCRIPTION
## What & Why
Adds an on-demand **Unread Digest**: a "Summarise unreads" action in the Unreads inbox that summarises all of a user's unread channel messages in one place, so they no longer need to open each unread channel individually.

Ticket: XYNE-61341

## Changes
**Backend**
- `unreadDigestService.createSnapshot(userId, workspaceId)` — read-only, server-owned snapshot. Sets `snapshotAt = now()`; selects authorized, non-deleted unread messages (`createdAt > lastViewedAt AND createdAt <= snapshotAt`; `visibleTo IS NULL OR = userId`), excludes the requester's own messages and Desk/Support/SDLC channels. Never marks messages read.
- `unreadDigestSelection.ts` — pure, dependency-free selection/caps helpers (25 channels/run, 200 msgs/channel, 1000 overall; newest kept when capped).
- `unreadDigestController.generate` — SSE endpoint. Identity comes from `req.user` only; bounded concurrency (3); per-channel `summarizeThread`; client-disconnect abort. Emits `snapshot` / `progress` / `channel` / `complete` / `error` / `end`. A per-channel summariser failure is isolated (`failed: true`) and does not fail the whole run.
- Route `POST /api/unread-digest/generate` mounted behind `authMiddleware.authenticate`.

**Dashboard**
- `UnreadDigestPanel` — "Summarise unreads" action wired into the Unreads inbox; consumes the SSE stream and renders per-channel summaries, key points with citations, and omitted counts. Structured data rendered as plain text (React-escaped).

## Security / correctness notes
- Identity is taken from the authenticated session (`req.user`), never from the request body.
- The unread set is computed server-side against each channel's per-user `lastViewedAt`; the `snapshotAt` upper bound prevents mid-generation messages from leaking in.
- Read-only: generating a digest never marks messages read.

## Proof of Testing
- **Unit tests: 12/12 passing** (`unreadDigestSelection.test.ts`) — covers visibility, own-message exclusion, soft-deleted exclusion, already-read exclusion, `snapshotAt` boundary, private-message targeting, null `lastViewedAt`, and the documented caps.
- **Backend typecheck clean**: `tsc --noEmit` exits 0 with no errors in the new files.
- **Live end-to-end (authenticated SSE)** against a seeded 2-channel unread state (`engineering` = 5 unread, `design-reviews` = 2 unread):
  - `snapshot` event returns the correct `snapshotAt`, `totalChannels: 2`, and caps.
  - `progress` events stream per channel.
  - `channel` events return real per-channel `summary` + `keyPoints` (each with a `citation.messageId` resolving to a real seeded message) with `failed: false`.
  - `complete` then `end` close the stream.
  - Empty-state (no unreads) returns `snapshot` with `totalChannels: 0` then `complete`/`end`.
  - Graceful degradation verified: when the summariser model is unavailable, the affected `channel` event returns `output: null, failed: true` and the run still completes cleanly.

### Note on the demo environment
A headless authenticated UI screen recording was not captured because the dashboard derives auth state from the Zero realtime connection, whose host cannot be resolved inside the network-isolated build sandbox (redirects to `/auth`). This is an environment limitation unrelated to the feature — the full backend pipeline is proven end-to-end via the authenticated SSE stream above. The LLM summariser text in the live run was produced through the real summariser code path (JAF run → `parseAgentOutput` → SSE); only the model endpoint was substituted with a local OpenAI-compatible stand-in because the org LiteLLM host is likewise unreachable from the sandbox.

## Follow-ups (not in this PR)
- `spaces-unread-digest` MCP tool backed by the same service (agent access).
- Optional "mark all snapshotted as read" action (must use `snapshotAt` as the boundary).