### PR TITLE
feat: XYNE-61539 schedule call fixes

### DIFF
--- a/apps/backend/src/controllers/scheduleCallController.ts
+++ b/apps/backend/src/controllers/scheduleCallController.ts
@@ -99,11 +99,12 @@ export class ScheduleCallController {
   /**
    * Decide what `userId` may change on `call`:
    *   - organizer                                    → every field
-   *   - participant of a direct (DM/GROUP_DM) call   → may only ADD people
+   *   - participant of a direct (DM/GROUP_DM) call   → may only change the invite list:
+   *     add anyone, and remove only the people they themselves invited
    *   - anyone else                                  → nothing
    * On success returns the participants that must survive the edit: empty for the
-   * organizer, the current roster for a participant editor, so a missing id in their
-   * `targetUserIds` can never be read as a removal.
+   * organizer, and for a participant editor everyone they did NOT invite, so a missing id
+   * in their `targetUserIds` can only ever remove their own invitees.
    */
   private async authorizeScheduledCallEdit(params: {
     call: { id: string; channelId: string | null; createdByUserId: string };
@@ -153,13 +154,94 @@ export class ScheduleCallController {
       edits.externalInvitees !== undefined;
 
     if (editsBeyondParticipants || edits.targetUserIds === undefined) {
-      return { allowed: false, status: 403, error: 'Participants can only add people to this call' };
+      return {
+        allowed: false,
+        status: 403,
+        error: 'Participants can only change who is invited to this call',
+      };
     }
 
-    // findParticipants already excludes external invitees.
-    const pinnedParticipantIds = (await repositories.calls.findParticipants(call.id)).map(
-      (p) => p.userId,
+    // Pin everyone this editor did not invite — they may drop their own invitees, but
+    // nobody else's. findParticipants already excludes external invitees.
+    const pinnedParticipantIds = (await repositories.calls.findParticipants(call.id))
+      .filter((p) => p.invitedBy !== userId)
+      .map((p) => p.userId);
+    return { allowed: true, pinnedParticipantIds };
+  }
+
+  /**
+   * Series counterpart of `authorizeScheduledCallEdit` — same rule, one level up:
+   *   - organizer                                       → every field
+   *   - participant of a direct (DM/GROUP_DM) series     → may only change the invite list:
+   *     add anyone, and remove only the people they themselves invited
+   *   - anyone else                                     → nothing
+   * Returns the participants that must survive the edit: empty for the organizer, and for a
+   * participant editor everyone they did NOT invite.
+   */
+  private async authorizeRecurringSeriesEdit(params: {
+    series: { id: string; channelId: string; organizerId: string };
+    userId: string;
+    edits: {
+      title?: unknown;
+      recurrenceRule?: unknown;
+      startTime?: unknown;
+      endTime?: unknown;
+      startsOn?: unknown;
+      endsOn?: unknown;
+      timezone?: unknown;
+      channelId?: unknown;
+      callUpdatesChannel?: unknown;
+      externalInvitees?: unknown;
+      targetUserIds?: string[] | undefined;
+    };
+  }): Promise<
+    { allowed: true; pinnedParticipantIds: string[] } | { allowed: false; status: number; error: string }
+  > {
+    const { series, userId, edits } = params;
+
+    if (series.organizerId === userId) {
+      return { allowed: true, pinnedParticipantIds: [] };
+    }
+
+    // getScopeType, not findById — see authorizeScheduledCallEdit for why the ACL can't be used.
+    const channelScopeType = await repositories.channels.getScopeType(series.channelId);
+    const isDirectCall =
+      channelScopeType === ChannelScopeType.DM || channelScopeType === ChannelScopeType.GROUP_DM;
+    const seriesParticipants = await repositories.recurringCallParticipants.findInternalParticipants(
+      series.id,
     );
+    const isParticipant = seriesParticipants.some((p) => p.userId === userId);
+
+    if (!isDirectCall || !isParticipant) {
+      logger.warn(
+        `[authorizeRecurringSeriesEdit] forbidden | seriesId=${series.id} userId=${userId} channelScopeType=${channelScopeType} isParticipant=${isParticipant}`,
+      );
+      return { allowed: false, status: 403, error: 'Only the organizer can edit this series' };
+    }
+
+    const editsBeyondParticipants =
+      edits.title !== undefined ||
+      edits.recurrenceRule !== undefined ||
+      edits.startTime !== undefined ||
+      edits.endTime !== undefined ||
+      edits.startsOn !== undefined ||
+      edits.endsOn !== undefined ||
+      edits.timezone !== undefined ||
+      edits.channelId !== undefined ||
+      edits.callUpdatesChannel !== undefined ||
+      edits.externalInvitees !== undefined;
+
+    if (editsBeyondParticipants || edits.targetUserIds === undefined) {
+      return {
+        allowed: false,
+        status: 403,
+        error: 'Participants can only change who is invited to this series',
+      };
+    }
+
+    const pinnedParticipantIds = seriesParticipants
+      .filter((p) => p.invitedBy !== userId)
+      .map((p) => p.userId);
     return { allowed: true, pinnedParticipantIds };
   }
 
@@ -517,7 +599,8 @@ export class ScheduleCallController {
    * PATCH /api/calls/:callId
    * Update a single SCHEDULED call instance (title, time, participants).
    * The organizer can edit every field. A non-organizer participant of a direct
-   * (DM/GROUP_DM-backed) call may only ADD people, and change nothing else.
+   * (DM/GROUP_DM-backed) call may only change the invite list — adding anyone, and
+   * removing only the people they themselves added — and nothing else.
    * Only SCHEDULED calls may be edited.
    */
   updateScheduledCall = async (req: Request, res: Response): Promise<void> => {
@@ -615,8 +698,11 @@ export class ScheduleCallController {
             req.user!.workspaceId!,
           );
         }
-        // callUpdatesChannel is orthogonal: apply the requested value, clearing it when omitted.
-        newCallUpdatesChannel = reqCallUpdatesChannel ?? null;
+        // callUpdatesChannel is orthogonal: apply the organizer's requested value, clearing it
+        // when they omit it. A participant editor may never send the field at all, so their
+        // silence must leave the organizer's choice alone instead of reading as "clear it".
+        newCallUpdatesChannel =
+          call.createdByUserId === userId ? (reqCallUpdatesChannel ?? null) : undefined;
         logger.info(`[updateScheduledCall] resolvedChannelId=${resolvedChannelId} newCallUpdatesChannel=${newCallUpdatesChannel}`);
       } else {
         logger.info(`[updateScheduledCall] no channel/participant change — keeping existing channelId=${call.channelId}`);
@@ -658,6 +744,7 @@ export class ScheduleCallController {
         channelId: resolvedChannelId,
         addUserIds,
         removeUserIds,
+        invitedByUserId: userId,
         callUpdatesChannel: newCallUpdatesChannel,
         externalInvitees: normalizedExternalInvitees,
       });
@@ -751,8 +838,10 @@ export class ScheduleCallController {
   /**
    * PATCH /api/calls/series/:seriesId
    * Update a recurring call series (title, recurrence rule, time, participants).
-   * Only the organizer can edit. Updates the series record and cascades title/time
-   * changes to ALL SCHEDULED instances in the series. If the recurrence rule or call times
+   * The organizer can edit every field. A non-organizer participant of a direct
+   * (DM/GROUP_DM-backed) series may only change the invite list — adding anyone, and
+   * removing only the people they themselves added. Updates the series record and cascades
+   * title/time changes to ALL SCHEDULED instances in the series. If the recurrence rule or call times
    * change, all SCHEDULED instances are deleted and regenerated.
    *
    * Scope: All SCHEDULED instances in the series are affected by series edits.
@@ -790,10 +879,35 @@ export class ScheduleCallController {
 
       logger.info(`[updateRecurringSeries] series found | currentChannelId=${series.channelId} organizerId=${series.organizerId}`);
 
-      if (series.organizerId !== userId) {
-        res.status(403).json({ success: false, error: 'Only the organizer can edit this series' });
+      const auth = await this.authorizeRecurringSeriesEdit({
+        series,
+        userId,
+        edits: {
+          title,
+          recurrenceRule,
+          startTime,
+          endTime,
+          endsOn,
+          timezone,
+          channelId: reqChannelId,
+          callUpdatesChannel: reqCallUpdatesChannel,
+          externalInvitees: normalizedExternalInvitees,
+          targetUserIds,
+        },
+      });
+      if (!auth.allowed) {
+        res.status(auth.status).json({ success: false, error: auth.error });
         return;
       }
+
+      // The frontend omits the viewer from `targetUserIds`, so fold the actor back in, along
+      // with the organizer and whatever the authorization pinned (see above).
+      const desiredParticipantIds =
+        targetUserIds !== undefined
+          ? Array.from(
+              new Set([...targetUserIds, ...auth.pinnedParticipantIds, userId, series.organizerId]),
+            )
+          : undefined;
 
       if (series.status === 'CANCELLED') {
         res.status(400).json({ success: false, error: 'Cannot edit a cancelled series' });
@@ -827,15 +941,20 @@ export class ScheduleCallController {
         } else if (targetUserIds !== undefined && targetUserIds.length > 0) {
           // Direct group call — create a GROUP_DM for the participants.
           logger.info(`[updateRecurringSeries] group call: creating GROUP_DM for targetUserIds=${JSON.stringify(targetUserIds)}`);
+          // Anchored on the organizer, not the actor: a participant editing the list must
+          // not drag the series onto their own DM/self-DM.
           resolvedChannelId = await repositories.channels.findOrCreateDMChannel(
-            userId,
-            targetUserIds,
+            series.organizerId,
+            desiredParticipantIds!.filter((id) => id !== series.organizerId),
             repositories.channelParticipants,
             req.user!.workspaceId!,
           );
         }
-        // callUpdatesChannel is orthogonal: apply the requested value, clearing it when omitted.
-        newCallUpdatesChannel = reqCallUpdatesChannel ?? null;
+        // callUpdatesChannel is orthogonal: apply the organizer's requested value, clearing it
+        // when they omit it. A participant editor may never send the field at all, so their
+        // silence must leave the organizer's choice alone instead of reading as "clear it".
+        newCallUpdatesChannel =
+          series.organizerId === userId ? (reqCallUpdatesChannel ?? null) : undefined;
         logger.info(`[updateRecurringSeries] resolvedChannelId=${resolvedChannelId} newCallUpdatesChannel=${newCallUpdatesChannel}`);
       } else {
         logger.info(`[updateRecurringSeries] no channelId change — keeping existing channelId=${series.channelId}`);
@@ -845,7 +964,7 @@ export class ScheduleCallController {
         targetUserIds !== undefined || resolvedChannelId !== undefined;
       const recurringParticipantUserIds = shouldReplaceRecurringInternalParticipants
         ? await this.resolveRecurringInternalParticipantUserIds({
-          targetUserIds,
+          targetUserIds: desiredParticipantIds,
           channelId: resolvedChannelId ?? series.channelId,
           logPrefix: '[updateRecurringSeries]',
         })
@@ -882,7 +1001,9 @@ export class ScheduleCallController {
         if (recurringParticipantUserIds !== undefined) {
           await repositories.recurringCallParticipants.replaceInternalParticipants({
             recurringSeriesId: seriesId,
-            organizerId: userId,
+            organizerId: series.organizerId,
+            // Credit the editor on rows they add, so they can remove them later.
+            invitedByUserId: userId,
             userIds: recurringParticipantUserIds,
             workspaceId: req.user!.workspaceId!,
             tx,
@@ -892,7 +1013,7 @@ export class ScheduleCallController {
         if (normalizedExternalInvitees !== undefined) {
           await repositories.recurringCallParticipants.replaceExternalInvitees({
             recurringSeriesId: seriesId,
-            organizerId: userId,
+            organizerId: series.organizerId,
             externalInvitees: normalizedExternalInvitees,
             workspaceId: req.user!.workspaceId!,
             tx,
@@ -1033,7 +1154,7 @@ export class ScheduleCallController {
           for (const instance of allScheduledInstances) {
             const { addUserIds, removeUserIds } = await this.resolveParticipantDelta(
               instance.id,
-              userId,
+              series.organizerId,
               recurringParticipantUserIds,
               effectiveChannelIdForDelta,
               `[updateRecurringSeries] instance=${instance.id}`,
@@ -1043,6 +1164,7 @@ export class ScheduleCallController {
                 callId: instance.id,
                 addUserIds: addUserIds.length > 0 ? addUserIds : undefined,
                 removeUserIds: removeUserIds.length > 0 ? removeUserIds : undefined,
+                invitedByUserId: userId,
               });
             }
           }

--- a/apps/backend/src/controllers/scheduleCallController.ts
+++ b/apps/backend/src/controllers/scheduleCallController.ts
@@ -4,7 +4,7 @@ import { DatabaseClient } from '@/database/client';
 import { logger } from '@/utils/logger';
 import { v4 as uuidv4 } from 'uuid';
 import { type Prisma } from '@prisma/client';
-import { CallOrigin, CallStatus, CallType, RecurringCallSeriesStatus, CalendarVisibility } from '@xyne/shared';
+import { CallOrigin, CallStatus, CallType, RecurringCallSeriesStatus, CalendarVisibility, ChannelScopeType } from '@xyne/shared';
 import { ZodError } from 'zod';
 import { scheduledCallNotificationService } from '@/services/scheduledCallNotificationService';
 import { ScheduleCallSchema, RecurringScheduleCallSchema, UpdateScheduleCallSchema, UpdateRecurringSeriesSchema, CancelScheduledCallSchema, CancelRecurringSeriesSchema } from '@/validators/callValidator';
@@ -96,6 +96,73 @@ export class ScheduleCallController {
     return { addUserIds, removeUserIds };
   }
 
+  /**
+   * Decide what `userId` may change on `call`:
+   *   - organizer                                    → every field
+   *   - participant of a direct (DM/GROUP_DM) call   → may only ADD people
+   *   - anyone else                                  → nothing
+   * On success returns the participants that must survive the edit: empty for the
+   * organizer, the current roster for a participant editor, so a missing id in their
+   * `targetUserIds` can never be read as a removal.
+   */
+  private async authorizeScheduledCallEdit(params: {
+    call: { id: string; channelId: string | null; createdByUserId: string };
+    userId: string;
+    edits: {
+      title?: unknown;
+      startsAt?: unknown;
+      endsAt?: unknown;
+      channelId?: unknown;
+      callUpdatesChannel?: unknown;
+      externalInvitees?: unknown;
+      targetUserIds?: string[] | undefined;
+    };
+  }): Promise<
+    { allowed: true; pinnedParticipantIds: string[] } | { allowed: false; status: number; error: string }
+  > {
+    const { call, userId, edits } = params;
+
+    if (call.createdByUserId === userId) {
+      return { allowed: true, pinnedParticipantIds: [] };
+    }
+
+    // Read the scope via getScopeType, not findById: the channel behind a large group call
+    // is the organizer's self-DM, which this caller isn't a member of, so the per-user
+    // channel ACL would hide it and every non-organizer edit would 403.
+    const channelScopeType = call.channelId
+      ? await repositories.channels.getScopeType(call.channelId)
+      : null;
+    const isDirectCall =
+      channelScopeType === ChannelScopeType.DM || channelScopeType === ChannelScopeType.GROUP_DM;
+    const isParticipant = !!(await repositories.calls.findParticipant(call.id, userId));
+
+    // Calls scoped to a real channel stay organizer-only: their invite list is the channel's.
+    if (!isDirectCall || !isParticipant) {
+      logger.warn(
+        `[authorizeScheduledCallEdit] forbidden | callId=${call.id} userId=${userId} channelScopeType=${channelScopeType} isParticipant=${isParticipant}`,
+      );
+      return { allowed: false, status: 403, error: 'Only the organizer can edit a scheduled call' };
+    }
+
+    const editsBeyondParticipants =
+      edits.title !== undefined ||
+      edits.startsAt !== undefined ||
+      edits.endsAt !== undefined ||
+      edits.channelId !== undefined ||
+      edits.callUpdatesChannel !== undefined ||
+      edits.externalInvitees !== undefined;
+
+    if (editsBeyondParticipants || edits.targetUserIds === undefined) {
+      return { allowed: false, status: 403, error: 'Participants can only add people to this call' };
+    }
+
+    // findParticipants already excludes external invitees.
+    const pinnedParticipantIds = (await repositories.calls.findParticipants(call.id)).map(
+      (p) => p.userId,
+    );
+    return { allowed: true, pinnedParticipantIds };
+  }
+
   private async resolveRecurringInternalParticipantUserIds(params: {
     targetUserIds: string[] | undefined;
     channelId: string;
@@ -153,7 +220,6 @@ export class ScheduleCallController {
           targetUserIds,
           repositories.channelParticipants,
           req.user!.workspaceId!,
-          title,
         );
       }
 
@@ -312,7 +378,6 @@ export class ScheduleCallController {
           targetUserIds,
           repositories.channelParticipants,
           req.user!.workspaceId!,
-          title,
         );
       }
 
@@ -451,7 +516,9 @@ export class ScheduleCallController {
   /**
    * PATCH /api/calls/:callId
    * Update a single SCHEDULED call instance (title, time, participants).
-   * Only the organizer can edit. Only SCHEDULED calls may be edited.
+   * The organizer can edit every field. A non-organizer participant of a direct
+   * (DM/GROUP_DM-backed) call may only ADD people, and change nothing else.
+   * Only SCHEDULED calls may be edited.
    */
   updateScheduledCall = async (req: Request, res: Response): Promise<void> => {
     const userId = req.user?.id;
@@ -485,8 +552,21 @@ export class ScheduleCallController {
 
       logger.info(`[updateScheduledCall] call found | callId=${call.id} currentChannelId=${call.channelId} status=${call.status} organizer=${call.createdByUserId}`);
 
-      if (call.createdByUserId !== userId) {
-        res.status(403).json({ success: false, error: 'Only the organizer can edit a scheduled call' });
+      const auth = await this.authorizeScheduledCallEdit({
+        call,
+        userId,
+        edits: {
+          title,
+          startsAt,
+          endsAt,
+          channelId: reqChannelId,
+          callUpdatesChannel: reqCallUpdatesChannel,
+          externalInvitees: normalizedExternalInvitees,
+          targetUserIds,
+        },
+      });
+      if (!auth.allowed) {
+        res.status(auth.status).json({ success: false, error: auth.error });
         return;
       }
 
@@ -500,6 +580,20 @@ export class ScheduleCallController {
       // callUpdatesChannel is stored orthogonally. No scopeType inspection.
       const modeChanged = reqChannelId !== undefined || targetUserIds !== undefined || reqCallUpdatesChannel !== undefined;
 
+      // The frontend omits the viewer from `targetUserIds`, so fold the actor back in, along
+      // with the organizer and whatever the authorization pinned (see above).
+      const desiredParticipantIds =
+        targetUserIds !== undefined
+          ? Array.from(
+              new Set([
+                ...targetUserIds,
+                ...auth.pinnedParticipantIds,
+                userId,
+                call.createdByUserId,
+              ]),
+            )
+          : undefined;
+
       let resolvedChannelId: string | undefined;
       let newCallUpdatesChannel: string | null | undefined; // undefined = don't touch
 
@@ -512,12 +606,13 @@ export class ScheduleCallController {
         } else if (targetUserIds !== undefined && targetUserIds.length > 0) {
           // Direct group call — create a GROUP_DM for the participants.
           logger.info(`[updateScheduledCall] group call: creating GROUP_DM for targetUserIds=${JSON.stringify(targetUserIds)}`);
+          // Anchored on the organizer, not the actor: a participant editing the list must
+          // not drag the call onto their own DM/self-DM.
           resolvedChannelId = await repositories.channels.findOrCreateDMChannel(
-            userId,
-            targetUserIds,
+            call.createdByUserId,
+            desiredParticipantIds!.filter((id) => id !== call.createdByUserId),
             repositories.channelParticipants,
             req.user!.workspaceId!,
-            title ?? call.title ?? undefined,
           );
         }
         // callUpdatesChannel is orthogonal: apply the requested value, clearing it when omitted.
@@ -538,7 +633,7 @@ export class ScheduleCallController {
         ({ addUserIds, removeUserIds } = await this.resolveParticipantDelta(
           call.id,
           userId,
-          targetUserIds,
+          desiredParticipantIds,
           resolvedChannelId ?? call.channelId ?? '',
           '[updateScheduledCall]',
         ));
@@ -737,7 +832,6 @@ export class ScheduleCallController {
             targetUserIds,
             repositories.channelParticipants,
             req.user!.workspaceId!,
-            title ?? series.title ?? undefined,
           );
         }
         // callUpdatesChannel is orthogonal: apply the requested value, clearing it when omitted.

--- a/apps/backend/src/controllers/scheduleCallController.ts
+++ b/apps/backend/src/controllers/scheduleCallController.ts
@@ -97,152 +97,66 @@ export class ScheduleCallController {
   }
 
   /**
-   * Decide what `userId` may change on `call`:
-   *   - organizer                                    → every field
-   *   - participant of a direct (DM/GROUP_DM) call   → may only change the invite list:
+   * Decide what `userId` may change on a scheduled call or a recurring series:
+   *   - organizer                                     → every field
+   *   - participant of a direct (DM/GROUP_DM) subject → may only change the invite list:
    *     add anyone, and remove only the people they themselves invited
-   *   - anyone else                                  → nothing
-   * On success returns the participants that must survive the edit: empty for the
-   * organizer, and for a participant editor everyone they did NOT invite, so a missing id
-   * in their `targetUserIds` can only ever remove their own invitees.
+   *   - anyone else                                   → nothing
+   * On success returns the participants that must survive the edit: empty for the organizer,
+   * and for a participant editor everyone they did NOT invite, so a missing id in their
+   * `targetUserIds` can only ever drop their own invitees.
+   *
+   * `hasEditsBeyondParticipants` is computed by the caller, which is the only place that
+   * knows its own request fields — a call has startsAt/endsAt, a series has the recurrence.
    */
-  private async authorizeScheduledCallEdit(params: {
-    call: { id: string; channelId: string | null; createdByUserId: string };
+  private async authorizeParticipantEdit(params: {
+    subject: { id: string; kind: 'call' | 'series'; channelId: string | null; organizerId: string };
     userId: string;
-    edits: {
-      title?: unknown;
-      startsAt?: unknown;
-      endsAt?: unknown;
-      channelId?: unknown;
-      callUpdatesChannel?: unknown;
-      externalInvitees?: unknown;
-      targetUserIds?: string[] | undefined;
-    };
+    hasEditsBeyondParticipants: boolean;
+    targetUserIds: string[] | undefined;
+    /** Internal participants of the subject, each with the user who invited them. */
+    loadParticipants: () => Promise<Array<{ userId: string; invitedBy: string }>>;
   }): Promise<
     { allowed: true; pinnedParticipantIds: string[] } | { allowed: false; status: number; error: string }
   > {
-    const { call, userId, edits } = params;
+    const { subject, userId, hasEditsBeyondParticipants, targetUserIds, loadParticipants } = params;
+    const noun = subject.kind === 'series' ? 'this series' : 'this call';
 
-    if (call.createdByUserId === userId) {
+    if (subject.organizerId === userId) {
       return { allowed: true, pinnedParticipantIds: [] };
     }
 
     // Read the scope via getScopeType, not findById: the channel behind a large group call
     // is the organizer's self-DM, which this caller isn't a member of, so the per-user
     // channel ACL would hide it and every non-organizer edit would 403.
-    const channelScopeType = call.channelId
-      ? await repositories.channels.getScopeType(call.channelId)
+    const channelScopeType = subject.channelId
+      ? await repositories.channels.getScopeType(subject.channelId)
       : null;
     const isDirectCall =
       channelScopeType === ChannelScopeType.DM || channelScopeType === ChannelScopeType.GROUP_DM;
-    const isParticipant = !!(await repositories.calls.findParticipant(call.id, userId));
+    const participants = await loadParticipants();
+    const isParticipant = participants.some((p) => p.userId === userId);
 
-    // Calls scoped to a real channel stay organizer-only: their invite list is the channel's.
+    // Subjects scoped to a real channel stay organizer-only: their invite list is the channel's.
     if (!isDirectCall || !isParticipant) {
       logger.warn(
-        `[authorizeScheduledCallEdit] forbidden | callId=${call.id} userId=${userId} channelScopeType=${channelScopeType} isParticipant=${isParticipant}`,
+        `[authorizeParticipantEdit] forbidden | ${subject.kind}=${subject.id} userId=${userId} channelScopeType=${channelScopeType} isParticipant=${isParticipant}`,
       );
-      return { allowed: false, status: 403, error: 'Only the organizer can edit a scheduled call' };
+      return { allowed: false, status: 403, error: `Only the organizer can edit ${noun}` };
     }
 
-    const editsBeyondParticipants =
-      edits.title !== undefined ||
-      edits.startsAt !== undefined ||
-      edits.endsAt !== undefined ||
-      edits.channelId !== undefined ||
-      edits.callUpdatesChannel !== undefined ||
-      edits.externalInvitees !== undefined;
-
-    if (editsBeyondParticipants || edits.targetUserIds === undefined) {
+    if (hasEditsBeyondParticipants || targetUserIds === undefined) {
       return {
         allowed: false,
         status: 403,
-        error: 'Participants can only change who is invited to this call',
+        error: `Participants can only change who is invited to ${noun}`,
       };
     }
 
-    // Pin everyone this editor did not invite — they may drop their own invitees, but
-    // nobody else's. findParticipants already excludes external invitees.
-    const pinnedParticipantIds = (await repositories.calls.findParticipants(call.id))
-      .filter((p) => p.invitedBy !== userId)
-      .map((p) => p.userId);
-    return { allowed: true, pinnedParticipantIds };
-  }
-
-  /**
-   * Series counterpart of `authorizeScheduledCallEdit` — same rule, one level up:
-   *   - organizer                                       → every field
-   *   - participant of a direct (DM/GROUP_DM) series     → may only change the invite list:
-   *     add anyone, and remove only the people they themselves invited
-   *   - anyone else                                     → nothing
-   * Returns the participants that must survive the edit: empty for the organizer, and for a
-   * participant editor everyone they did NOT invite.
-   */
-  private async authorizeRecurringSeriesEdit(params: {
-    series: { id: string; channelId: string; organizerId: string };
-    userId: string;
-    edits: {
-      title?: unknown;
-      recurrenceRule?: unknown;
-      startTime?: unknown;
-      endTime?: unknown;
-      startsOn?: unknown;
-      endsOn?: unknown;
-      timezone?: unknown;
-      channelId?: unknown;
-      callUpdatesChannel?: unknown;
-      externalInvitees?: unknown;
-      targetUserIds?: string[] | undefined;
+    return {
+      allowed: true,
+      pinnedParticipantIds: participants.filter((p) => p.invitedBy !== userId).map((p) => p.userId),
     };
-  }): Promise<
-    { allowed: true; pinnedParticipantIds: string[] } | { allowed: false; status: number; error: string }
-  > {
-    const { series, userId, edits } = params;
-
-    if (series.organizerId === userId) {
-      return { allowed: true, pinnedParticipantIds: [] };
-    }
-
-    // getScopeType, not findById — see authorizeScheduledCallEdit for why the ACL can't be used.
-    const channelScopeType = await repositories.channels.getScopeType(series.channelId);
-    const isDirectCall =
-      channelScopeType === ChannelScopeType.DM || channelScopeType === ChannelScopeType.GROUP_DM;
-    const seriesParticipants = await repositories.recurringCallParticipants.findInternalParticipants(
-      series.id,
-    );
-    const isParticipant = seriesParticipants.some((p) => p.userId === userId);
-
-    if (!isDirectCall || !isParticipant) {
-      logger.warn(
-        `[authorizeRecurringSeriesEdit] forbidden | seriesId=${series.id} userId=${userId} channelScopeType=${channelScopeType} isParticipant=${isParticipant}`,
-      );
-      return { allowed: false, status: 403, error: 'Only the organizer can edit this series' };
-    }
-
-    const editsBeyondParticipants =
-      edits.title !== undefined ||
-      edits.recurrenceRule !== undefined ||
-      edits.startTime !== undefined ||
-      edits.endTime !== undefined ||
-      edits.startsOn !== undefined ||
-      edits.endsOn !== undefined ||
-      edits.timezone !== undefined ||
-      edits.channelId !== undefined ||
-      edits.callUpdatesChannel !== undefined ||
-      edits.externalInvitees !== undefined;
-
-    if (editsBeyondParticipants || edits.targetUserIds === undefined) {
-      return {
-        allowed: false,
-        status: 403,
-        error: 'Participants can only change who is invited to this series',
-      };
-    }
-
-    const pinnedParticipantIds = seriesParticipants
-      .filter((p) => p.invitedBy !== userId)
-      .map((p) => p.userId);
-    return { allowed: true, pinnedParticipantIds };
   }
 
   private async resolveRecurringInternalParticipantUserIds(params: {
@@ -635,18 +549,24 @@ export class ScheduleCallController {
 
       logger.info(`[updateScheduledCall] call found | callId=${call.id} currentChannelId=${call.channelId} status=${call.status} organizer=${call.createdByUserId}`);
 
-      const auth = await this.authorizeScheduledCallEdit({
-        call,
-        userId,
-        edits: {
-          title,
-          startsAt,
-          endsAt,
-          channelId: reqChannelId,
-          callUpdatesChannel: reqCallUpdatesChannel,
-          externalInvitees: normalizedExternalInvitees,
-          targetUserIds,
+      const auth = await this.authorizeParticipantEdit({
+        subject: {
+          id: call.id,
+          kind: 'call',
+          channelId: call.channelId,
+          organizerId: call.createdByUserId,
         },
+        userId,
+        hasEditsBeyondParticipants:
+          title !== undefined ||
+          startsAt !== undefined ||
+          endsAt !== undefined ||
+          reqChannelId !== undefined ||
+          reqCallUpdatesChannel !== undefined ||
+          normalizedExternalInvitees !== undefined,
+        targetUserIds,
+        // findParticipants already excludes external invitees.
+        loadParticipants: () => repositories.calls.findParticipants(call.id),
       });
       if (!auth.allowed) {
         res.status(auth.status).json({ success: false, error: auth.error });
@@ -879,21 +799,27 @@ export class ScheduleCallController {
 
       logger.info(`[updateRecurringSeries] series found | currentChannelId=${series.channelId} organizerId=${series.organizerId}`);
 
-      const auth = await this.authorizeRecurringSeriesEdit({
-        series,
-        userId,
-        edits: {
-          title,
-          recurrenceRule,
-          startTime,
-          endTime,
-          endsOn,
-          timezone,
-          channelId: reqChannelId,
-          callUpdatesChannel: reqCallUpdatesChannel,
-          externalInvitees: normalizedExternalInvitees,
-          targetUserIds,
+      const auth = await this.authorizeParticipantEdit({
+        subject: {
+          id: series.id,
+          kind: 'series',
+          channelId: series.channelId,
+          organizerId: series.organizerId,
         },
+        userId,
+        hasEditsBeyondParticipants:
+          title !== undefined ||
+          recurrenceRule !== undefined ||
+          startTime !== undefined ||
+          endTime !== undefined ||
+          endsOn !== undefined ||
+          timezone !== undefined ||
+          reqChannelId !== undefined ||
+          reqCallUpdatesChannel !== undefined ||
+          normalizedExternalInvitees !== undefined,
+        targetUserIds,
+        loadParticipants: () =>
+          repositories.recurringCallParticipants.findInternalParticipants(series.id),
       });
       if (!auth.allowed) {
         res.status(auth.status).json({ success: false, error: auth.error });

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -88,6 +88,7 @@ export interface CreateCallWithParticipantsInput {
   startsAt: Date;
   endsAt: Date;
   targetUserIds?: string[];
+  participantInviters?: Record<string, string>;
   externalInvitees?: string[];
   metadata?: Record<string, unknown>; // Optional: e.g. { conversationId } for thread-linked calls
   callUpdatesChannel?: string | null;
@@ -647,7 +648,7 @@ export class CallRepository {
         callId: params.callId,
         workspaceId,
         userId,
-        invitedBy: params.createdByUserId,
+        invitedBy: params.participantInviters?.[userId] ?? params.createdByUserId,
         invitedAt: new Date(),
         response: InvitationResponse.INVITED,
         meetingStatus: userId === params.createdByUserId ? MeetingStatus.ACCEPTED : MeetingStatus.PENDING,

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -704,9 +704,9 @@ export class CallRepository {
   }
 
   /**
-   * Get all participants for a call
+   * Get all participants for a call, with the user who invited each of them.
    */
-  async findParticipants(callId: string): Promise<Array<{ userId: string }>> {
+  async findParticipants(callId: string): Promise<Array<{ userId: string; invitedBy: string }>> {
     return await DatabaseClient.getInstance().callParticipant.findMany({
       where: {
         callId,
@@ -714,6 +714,7 @@ export class CallRepository {
       },
       select: {
         userId: true,
+        invitedBy: true,
       },
     });
   }
@@ -1658,6 +1659,8 @@ export class CallRepository {
    * Update a SCHEDULED call's fields and manage participant delta.
    * Only modifies fields that are explicitly provided.
    * Participant changes: addUserIds are added (skipping duplicates), removeUserIds are deleted.
+   * `invitedByUserId` is stamped on the newly added rows — it is the editor, not necessarily
+   * the organizer, so a participant who added someone can later be allowed to remove them.
    */
   async updateScheduledCall(params: {
     callId: string;
@@ -1667,11 +1670,12 @@ export class CallRepository {
     channelId?: string;
     addUserIds?: string[];
     removeUserIds?: string[];
+    invitedByUserId?: string;
     metadata?: Record<string, unknown>;
     callUpdatesChannel?: string | null;
     externalInvitees?: string[];
   }): Promise<Call> {
-    const { callId, title, startsAt, endsAt, channelId, addUserIds, removeUserIds, metadata, callUpdatesChannel, externalInvitees } = params;
+    const { callId, title, startsAt, endsAt, channelId, addUserIds, removeUserIds, invitedByUserId, metadata, callUpdatesChannel, externalInvitees } = params;
     const db = DatabaseClient.getInstance();
 
     const updatedCall = await db.$transaction(async (tx) => {
@@ -1701,7 +1705,7 @@ export class CallRepository {
             callId,
             workspaceId: updatedCall.workspaceId,
             userId,
-            invitedBy: updatedCall.createdByUserId,
+            invitedBy: invitedByUserId ?? updatedCall.createdByUserId,
             invitedAt: new Date(),
             response: InvitationResponse.INVITED,
             meetingStatus: MeetingStatus.PENDING,

--- a/apps/backend/src/database/repositories/channelRepository.ts
+++ b/apps/backend/src/database/repositories/channelRepository.ts
@@ -5,7 +5,6 @@ import { ChannelScopeType, ChannelVisibility, ChannelType, ProjectType } from '@
 import { QueryOptions } from '@/types/database';
 import { logger } from '@/utils/logger';
 import { withWorkspaceScope } from '@/database/tenant/context';
-import { formatDateTimeShort } from '@/utils/dateUtils';
 //import { queueChannelIngestion } from '@/queues/vespaQueue';
 
 export interface CreateChannelInput {
@@ -107,6 +106,23 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
   async findById(id: string): Promise<Channel | null> {
     return await this.db.channel.findUnique({
       where: { id }
+    });
+  }
+
+  /**
+   * Scope of a channel, read under workspace scope so a legitimate non-member caller can
+   * still classify it — same rationale as `getDMChannel`'s existence probe. Callers that
+   * need to tell a direct call from a channel-scoped one can't use `findById`: a large
+   * group call sits in the organizer's self-DM, which no other participant belongs to,
+   * so the per-user channel ACL hides the row and the call looks channel-less.
+   */
+  async getScopeType(channelId: string): Promise<Channel['scopeType'] | null> {
+    return withWorkspaceScope(async () => {
+      const channel = await this.db.channel.findUnique({
+        where: { id: channelId },
+        select: { scopeType: true },
+      });
+      return channel?.scopeType ?? null;
     });
   }
 
@@ -345,20 +361,18 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
   /**
    * Find or create a DM or GROUP_DM channel based on the number of invited users.
    * If the resulting channel name would exceed 255 characters (>~10 members),
-   * falls back to creating a private DEFAULT channel to avoid the DB constraint.
+   * falls back to the initiator's self-DM to avoid the DB constraint.
    * @param userId - The ID of the user initiating the channel creation
    * @param invitedUserIds - Array of user IDs to include in the channel
    * @param channelParticipants - Channel participants repository for adding users
    * @param workspaceId - The workspace ID to get the DM project from
-   * @param channelName - Optional friendly name override (e.g. scheduled call title)
    * @returns The channel ID (either existing or newly created)
    */
   async findOrCreateDMChannel(
     userId: string,
     invitedUserIds: string[],
     channelParticipants: any, // We'll pass this from the controller to avoid circular dependency
-    workspaceId: string,
-    channelName?: string
+    workspaceId: string
   ): Promise<string> {
     if (invitedUserIds.length === 0) {
       throw new Error('No users to invite');
@@ -414,7 +428,7 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
     const groupDmName = allUserIds.join(',');
 
     // If the name would exceed 255 chars (large groups, ~9+ members),
-    // fall back to a private DEFAULT channel with a friendly name
+    // fall back to the initiator's self-DM
     const isLargeGroup = groupDmName.length > 255;
 
     if (!isLargeGroup) {
@@ -444,31 +458,27 @@ export class ChannelRepository extends BaseRepository<Channel, CreateChannelInpu
       return groupDMChannel.id;
     }
 
-    // Large group: create a private DEFAULT channel
-    // Use provided name, or generate a friendly human-readable name from the current time
-    const now = new Date();
-    const friendlyName = channelName
-      ? `Call-${channelName}-${formatDateTimeShort(now)}`.slice(0, 254) // ensure it fits within 255 chars
-      : `Call-${formatDateTimeShort(now)}`.slice(0, 254);
+    // Large group: create nothing — back the group with the initiator's own self-DM
+    // (the "Saved messages" DM, keyed on the bare userId). Calls get their access
+    // from call_participants, so invitees still see and join without a channel.
+    const selfDm = await this.getDMChannel(userId, userId);
+    if (selfDm) {
+      return selfDm.id;
+    }
 
-    // For large groups there won't be an existing channel to reuse (unique name),
-    // so we always create a new one.
-    const privateChannel = await this.create({
-      scopeType: ChannelScopeType.DEFAULT,
-      name: friendlyName,
+    // Self-DM is provisioned at login; create it here only if it is somehow missing.
+    const newSelfDm = await this.create({
+      scopeType: ChannelScopeType.DM,
+      name: userId,
+      description: 'Saved messages',
       visibility: ChannelVisibility.PRIVATE,
       createdBy: userId,
       projectId,
       workspaceId,
     });
+    await channelParticipants.addParticipant(newSelfDm.id, userId, 'ADMIN', false);
 
-    // Add all users as participants
-    await channelParticipants.addParticipant(privateChannel.id, userId, 'ADMIN', false);
-    for (const invitedId of invitedUserIds) {
-      await channelParticipants.addParticipant(privateChannel.id, invitedId, 'MEMBER', false);
-    }
-
-    return privateChannel.id;
+    return newSelfDm.id;
   }
 
 }

--- a/apps/backend/src/database/repositories/recurringCallParticipantRepository.ts
+++ b/apps/backend/src/database/repositories/recurringCallParticipantRepository.ts
@@ -192,17 +192,29 @@ export class RecurringCallParticipantRepository {
     return participants.map(p => p.userId);
   }
 
+  /**
+   * Everything a generated occurrence needs to mirror the series' invite list, including
+   * each participant's inviter — without it every new instance would credit the organizer
+   * for everyone, and a participant editor could no longer remove people they added.
+   */
   async findInstanceSeed(
     recurringSeriesId: string,
     tx?: Prisma.TransactionClient,
-  ): Promise<{ targetUserIds?: string[]; externalInvitees: string[] }> {
-    const internalParticipantUserIds = await this.findInternalParticipantUserIds(recurringSeriesId, tx);
+  ): Promise<{
+    targetUserIds?: string[];
+    participantInviters: Record<string, string>;
+    externalInvitees: string[];
+  }> {
+    const internalParticipants = await this.findInternalParticipants(recurringSeriesId, tx);
     const externalInvitees = await this.findExternalInviteeEmails(recurringSeriesId, tx);
 
     return {
-      targetUserIds: internalParticipantUserIds.length > 0
-        ? internalParticipantUserIds
+      targetUserIds: internalParticipants.length > 0
+        ? internalParticipants.map(p => p.userId)
         : undefined,
+      participantInviters: Object.fromEntries(
+        internalParticipants.map(p => [p.userId, p.invitedBy]),
+      ),
       externalInvitees,
     };
   }

--- a/apps/backend/src/database/repositories/recurringCallParticipantRepository.ts
+++ b/apps/backend/src/database/repositories/recurringCallParticipantRepository.ts
@@ -14,17 +14,28 @@ export class RecurringCallParticipantRepository {
     return tx ?? DatabaseClient.getInstance();
   }
 
+  /**
+   * Replace the series' internal participants with `userIds` (the organizer is always kept).
+   * `invitedByUserId` is the editor and is stamped only on rows that did not exist before —
+   * a participant who added someone must stay credited so they can remove them later, and
+   * everyone else's original inviter must survive an edit by someone other than the organizer.
+   */
   async replaceInternalParticipants(params: {
     recurringSeriesId: string;
     organizerId: string;
+    invitedByUserId?: string;
     userIds: string[];
     workspaceId: string;
     tx?: Prisma.TransactionClient;
   }): Promise<void> {
-    const { recurringSeriesId, organizerId, userIds, workspaceId, tx } = params;
+    const { recurringSeriesId, organizerId, invitedByUserId, userIds, workspaceId, tx } = params;
     const client = this.client(tx);
     const participantUserIds = normalizeUserIds(userIds, organizerId);
     const now = new Date();
+
+    const existingInviters = new Map(
+      (await this.findInternalParticipants(recurringSeriesId, tx)).map(p => [p.userId, p.invitedBy]),
+    );
 
     await client.recurringCallParticipant.deleteMany({
       where: {
@@ -40,7 +51,7 @@ export class RecurringCallParticipantRepository {
         recurringSeriesId,
         workspaceId,
         userId,
-        invitedBy: organizerId,
+        invitedBy: existingInviters.get(userId) ?? invitedByUserId ?? organizerId,
         invitedAt: now,
         response: InvitationResponse.INVITED,
         meetingStatus: userId === organizerId ? MeetingStatus.ACCEPTED : MeetingStatus.PENDING,
@@ -139,6 +150,26 @@ export class RecurringCallParticipantRepository {
     return participants
       .map(p => p.email)
       .filter((email): email is string => Boolean(email));
+  }
+
+  /** Internal participants with the user who invited each of them. */
+  async findInternalParticipants(
+    recurringSeriesId: string,
+    tx?: Prisma.TransactionClient,
+  ): Promise<Array<{ userId: string; invitedBy: string }>> {
+    return this.client(tx).recurringCallParticipant.findMany({
+      where: {
+        recurringSeriesId,
+        isExternal: false,
+      },
+      select: {
+        userId: true,
+        invitedBy: true,
+      },
+      orderBy: {
+        invitedAt: 'asc',
+      },
+    });
   }
 
   async findInternalParticipantUserIds(

--- a/apps/backend/src/services/recurringCallService.ts
+++ b/apps/backend/src/services/recurringCallService.ts
@@ -71,7 +71,7 @@ class RecurringCallService {
     const callId = uuidv4();
     const externalId = uuidv4();
     const roomLink = buildCallInviteUrl(externalId);
-    const { targetUserIds, externalInvitees } =
+    const { targetUserIds, participantInviters, externalInvitees } =
       await repositories.recurringCallParticipants.findInstanceSeed(recurringSeries.id, tx);
 
     // Background schedulers (callValidationWorker setInterval, scheduledCallNotificationService
@@ -112,6 +112,7 @@ class RecurringCallService {
         startsAt,
         endsAt,
         targetUserIds,
+        participantInviters,
         ...(externalInvitees.length > 0 && { externalInvitees }),
         callUpdatesChannel: callUpdatesChannel ?? null,
       }, tx);

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -527,13 +527,20 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
     !!user?.id &&
     initialCall.organizerUserId !== user.id;
 
-  // Restricted editors may only add, so everyone already on the call is pinned.
+  // Restricted editors may drop the people they invited themselves, so only the organizer
+  // and everyone invited by someone else is pinned. Mirrors the backend's pinned set in
+  // scheduleCallController.authorizeScheduledCallEdit.
   const lockedParticipantValues = useMemo(
     () =>
       participantsOnly && initialCall
         ? new Set(
             initialCall.participants
-              .filter(p => !p.isExternal && p.userId !== user?.id)
+              .filter(
+                p =>
+                  !p.isExternal &&
+                  p.userId !== user?.id &&
+                  (p.userId === initialCall.organizerUserId || p.invitedBy !== user?.id),
+              )
               .map(p => `user:${p.userId}`),
           )
         : undefined,
@@ -621,21 +628,29 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
       // ── Time validation ───────────────────────────────────────────────────
       // react-hook-form clears manual setError calls when handleSubmit re-validates,
       // so we re-check the constraint here to prevent saving invalid data.
-      if (isRecurring) {
-        const recurringTimeError = validateRecurringCallTimes(recurringStartTime, recurringEndTime);
-        if (recurringTimeError) {
-          setError('endsAt', { type: 'manual', message: recurringTimeError });
-          return;
-        }
-      } else {
-        const { startsAtError, endsAtError } = validateCallDateTimes(data.startsAt, data.endsAt);
-        if (startsAtError) {
-          setError('startsAt', { type: 'manual', message: startsAtError });
-          return;
-        }
-        if (endsAtError) {
-          setError('endsAt', { type: 'manual', message: endsAtError });
-          return;
+      // A restricted editor sends no times and their inputs are hidden, so an error here
+      // would be an invisible dead end — a call whose start has already passed, or a series
+      // that crosses midnight, would block them forever.
+      if (!participantsOnly) {
+        if (isRecurring) {
+          const recurringTimeError = validateRecurringCallTimes(
+            recurringStartTime,
+            recurringEndTime,
+          );
+          if (recurringTimeError) {
+            setError('endsAt', { type: 'manual', message: recurringTimeError });
+            return;
+          }
+        } else {
+          const { startsAtError, endsAtError } = validateCallDateTimes(data.startsAt, data.endsAt);
+          if (startsAtError) {
+            setError('startsAt', { type: 'manual', message: startsAtError });
+            return;
+          }
+          if (endsAtError) {
+            setError('endsAt', { type: 'manual', message: endsAtError });
+            return;
+          }
         }
       }
 
@@ -703,8 +718,9 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
       // ── EDIT MODE ──────────────────────────────────────────────────────────
       if (isEditMode && initialCall) {
         if (editEntireSeries && initialCall.recurringSeriesId) {
-          // Validate weekly requires at least one day
-          if (recurrenceFrequency === 'WEEK' && recurrenceDays.length === 0) {
+          // Validate weekly requires at least one day. A participant editor never sends the
+          // recurrence rule, so the check doesn't apply to them.
+          if (!participantsOnly && recurrenceFrequency === 'WEEK' && recurrenceDays.length === 0) {
             toast.error('Select at least one day', {
               description: 'Weekly recurrence requires at least one day.',
               duration: 3000,
@@ -712,22 +728,31 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
             return;
           }
           const resolvedChannelId = channelId; // selective calls stay on their channel
-          await callService.updateRecurringSeries(initialCall.recurringSeriesId, {
-            title: data.title,
-            // postCallUpdates mode: send callUpdatesChannel (backend checks membership)
-            // Selective call: send channelId (no callUpdatesChannel),
-            ...(postCallUpdates && updateChannelId ? { callUpdatesChannel: updateChannelId } : {}),
-            ...(resolvedChannelId ? { channelId: resolvedChannelId } : {}),
-            ...(userIds.length > 0 && { targetUserIds: userIds }),
-            recurrenceRule: buildRrule(),
-            timezone,
-            startTime: recurringStartTime,
-            endTime: recurringEndTime,
-            startsOn: data.startsAt.getTime(),
-            externalInvitees: effExternals,
-            ...(seriesEndsType === 'on' &&
-              seriesEndsOn !== null && { endsOn: seriesEndsOn.getTime() }),
-          });
+          // A participant editor may send nothing but the invite list — the backend rejects
+          // the request outright otherwise.
+          await callService.updateRecurringSeries(
+            initialCall.recurringSeriesId,
+            participantsOnly
+              ? { targetUserIds: userIds }
+              : {
+                  title: data.title,
+                  // postCallUpdates mode: send callUpdatesChannel (backend checks membership)
+                  // Selective call: send channelId (no callUpdatesChannel),
+                  ...(postCallUpdates && updateChannelId
+                    ? { callUpdatesChannel: updateChannelId }
+                    : {}),
+                  ...(resolvedChannelId ? { channelId: resolvedChannelId } : {}),
+                  ...(userIds.length > 0 && { targetUserIds: userIds }),
+                  recurrenceRule: buildRrule(),
+                  timezone,
+                  startTime: recurringStartTime,
+                  endTime: recurringEndTime,
+                  startsOn: data.startsAt.getTime(),
+                  externalInvitees: effExternals,
+                  ...(seriesEndsType === 'on' &&
+                    seriesEndsOn !== null && { endsOn: seriesEndsOn.getTime() }),
+                },
+          );
           toast.success('Recurring Series Updated', {
             description: `Changes applied to all occurrences of ${data.title}`,
             duration: 3000,
@@ -965,16 +990,23 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
 
   // Single source of truth for the submit button: drives `disabled`, the
   // hover-tooltip contents, and the label.
+  // A restricted editor submits the invite list and nothing else, and every other field is
+  // hidden or disabled for them — so gating Save on those fields would strand them behind a
+  // requirement they cannot see or fix.
   const missingRequirements: string[] = [];
-  if (!title.trim()) missingRequirements.push('Add a title');
   if (participants.length === 0) missingRequirements.push('Add at least one participant');
-  if (!scheduleStartIsValid || errors.startsAt) missingRequirements.push('Pick a valid start time');
-  if (!scheduleEndIsValid || errors.endsAt) missingRequirements.push('Pick a valid end time');
-  if (isRecurring && recurrenceFrequency === 'WEEK' && recurrenceDays.length === 0) {
-    missingRequirements.push('Pick at least one weekday');
-  }
-  if (postCallUpdates && !updateChannelId) {
-    missingRequirements.push('Pick a channel for post-call updates');
+  if (!participantsOnly) {
+    if (!title.trim()) missingRequirements.push('Add a title');
+    if (!scheduleStartIsValid || errors.startsAt) {
+      missingRequirements.push('Pick a valid start time');
+    }
+    if (!scheduleEndIsValid || errors.endsAt) missingRequirements.push('Pick a valid end time');
+    if (isRecurring && recurrenceFrequency === 'WEEK' && recurrenceDays.length === 0) {
+      missingRequirements.push('Pick at least one weekday');
+    }
+    if (postCallUpdates && !updateChannelId) {
+      missingRequirements.push('Pick a channel for post-call updates');
+    }
   }
   if (allChannelMembersExcluded) {
     missingRequirements.push('Include at least one channel participant');
@@ -1119,14 +1151,20 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                       )}
                     />
                   )}
-                  rules={{
-                    required: 'Title is required',
-                    maxLength: {
-                      value: 80,
-                      message: 'Title must be less than 80 characters',
-                    },
-                    validate: value => value.trim().length > 0 || 'Title cannot be empty',
-                  }}
+                  // No rules for a restricted editor: the field is disabled and the title is
+                  // never sent, so an existing empty or over-long title must not block Save.
+                  rules={
+                    participantsOnly
+                      ? {}
+                      : {
+                          required: 'Title is required',
+                          maxLength: {
+                            value: 80,
+                            message: 'Title must be less than 80 characters',
+                          },
+                          validate: value => value.trim().length > 0 || 'Title cannot be empty',
+                        }
+                  }
                 />
                 {errors.title && (
                   <p className='text-red-500 text-xs mt-1'>{errors.title.message}</p>
@@ -1975,14 +2013,20 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                 </div>
               )}
 
-              {/* Edit entire series checkbox — only for recurring calls in edit mode */}
-              {isEditMode && initialCall?.recurringSeriesId && !participantsOnly && (
+              {/* Edit entire series checkbox — only for recurring calls in edit mode. Restricted
+                  editors get it too: without it their invite changes would land on this one
+                  occurrence and silently vanish from the rest of the series. */}
+              {isEditMode && initialCall?.recurringSeriesId && (
                 <Checkbox
                   checked={editEntireSeries}
                   onChange={setEditEntireSeries}
                   data-track-category='CALLS'
                   data-track-name='APPLY_TO_SERIES_TOGGLE'
-                  label='Apply to all calls in this series'
+                  label={
+                    participantsOnly
+                      ? 'Apply these people to all calls in this series'
+                      : 'Apply to all calls in this series'
+                  }
                 />
               )}
 

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -9,7 +9,11 @@ import { useZero } from '../../../hooks/useZero';
 import { isUserDeactivated } from '../../../utils/userDisplayName';
 import { useAllVisibleChannels, useChannel } from '../../../hooks/useChannels';
 import { useUserGroupSearch } from '@xyne/shared/hooks';
-import { callService, type ScheduleCallRequest } from '../../../services/Call/callService';
+import {
+  ApiError,
+  callService,
+  type ScheduleCallRequest,
+} from '../../../services/Call/callService';
 import DOMPurify from 'dompurify';
 import { queries } from '../../../zero/queries';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
@@ -863,8 +867,14 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
         recurringSeriesId: initialCall?.recurringSeriesId ?? null,
         error: err instanceof Error ? err.message : String(err),
       });
-      toast.error('Error scheduling call', {
-        description: 'Failed to schedule call',
+      toast.error(isEditMode ? 'Error updating call' : 'Error scheduling call', {
+        // Surface the API's reason (e.g. the participant-edit 403) instead of a generic line.
+        description:
+          err instanceof ApiError && err.message
+            ? err.message
+            : isEditMode
+              ? 'Failed to update call'
+              : 'Failed to schedule call',
         duration: 5000,
       });
     }
@@ -947,6 +957,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
     setStep('participants');
     setSearchQuery('');
     setNotFoundUsers([]);
+    expandedGroupMembersRef.current.clear();
     resetRecurringState(defaultStart);
     setEditEntireSeries(false);
     resetPostCallUpdates();

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -133,6 +133,10 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
   // and whether the exclusion set has been initialized from the channel member list.
   const selectiveEditParticipantIdsRef = useRef<Set<string> | null>(null);
   const selectiveExclusionsInitializedRef = useRef<boolean>(false);
+  // groupId → member user IDs, cached when a group is expanded on select. A picked
+  // group leaves no `user_group:` value behind (it becomes `user:` pills), so this is
+  // the only way to know a group is already represented and hide it from the list.
+  const expandedGroupMembersRef = useRef<Map<string, string[]>>(new Map());
 
   // Fetch recurring call series data via Zero — only when the modal is open and
   // in edit mode for a recurring call, so the query doesn't run when the popup is closed.
@@ -438,15 +442,22 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
       type: 'user_group' as const,
     }));
 
-    // In edit mode, the call's existing channel may be a DM (filtered out of `channels`).
-    // Inject it into options so it remains searchable/selectable.
+    // In edit mode, the call's existing channel may be filtered out of `channels`
+    // (e.g. a Desk channel). Inject it into options so it remains searchable/selectable.
+    // DM/GROUP_DM-backed calls are excluded: they prefill individual participants from
+    // call_participants rather than a channel pill (see useScheduleCallInitialization),
+    // and their `name` is raw user IDs, so injecting one puts a UUID in the picker.
     if (isEditMode && initialCall?.channelId) {
       const alreadyIncluded = channelOptions.some(
         c => c.value === `channel:${initialCall.channelId}`,
       );
       if (!alreadyIncluded) {
         const existingChannel = allVisibleChannels.find(c => c.id === initialCall.channelId);
-        if (existingChannel) {
+        if (
+          existingChannel &&
+          existingChannel.scopeType !== ChannelScopeType.DM &&
+          existingChannel.scopeType !== ChannelScopeType.GROUP_DM
+        ) {
           channelOptions.push({
             ...existingChannel,
             label: existingChannel.name,
@@ -504,10 +515,43 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
     fullUserList,
   ]);
 
-  const rankedParticipantOptions = useMemo(
-    () => rankParticipantOptions(inviteUserOrChannelOptions, searchQuery),
-    [inviteUserOrChannelOptions, searchQuery],
+  // Drop groups whose every member is already picked. Re-reading the ref is safe here:
+  // expansion always writes it before updating `participants`, which re-runs this memo.
+  // Removing any one member drops the group back into the list.
+  // A non-organizer participant may only add/remove people (and only on a DM/GROUP_DM
+  // call, which is what gates the entry point). Mirrors the backend rule in
+  // scheduleCallController.updateScheduledCall, which rejects any other field from them.
+  const participantsOnly =
+    isEditMode &&
+    !!initialCall?.organizerUserId &&
+    !!user?.id &&
+    initialCall.organizerUserId !== user.id;
+
+  // Restricted editors may only add, so everyone already on the call is pinned.
+  const lockedParticipantValues = useMemo(
+    () =>
+      participantsOnly && initialCall
+        ? new Set(
+            initialCall.participants
+              .filter(p => !p.isExternal && p.userId !== user?.id)
+              .map(p => `user:${p.userId}`),
+          )
+        : undefined,
+    [participantsOnly, initialCall, user?.id],
   );
+
+  const rankedParticipantOptions = useMemo(() => {
+    const selectedUserIds = new Set(
+      participants.filter(v => v.startsWith('user:')).map(v => v.replace('user:', '')),
+    );
+    const remaining = inviteUserOrChannelOptions.filter(option => {
+      if (!option.value.startsWith('user_group:')) return true;
+      const members = expandedGroupMembersRef.current.get(option.value.replace('user_group:', ''));
+      if (!members?.length) return true;
+      return !members.every(id => selectedUserIds.has(id));
+    });
+    return rankParticipantOptions(remaining, searchQuery);
+  }, [inviteUserOrChannelOptions, searchQuery, participants]);
 
   const handleStartTimeChange = useCallback(
     (timeString: string): void => {
@@ -689,16 +733,24 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
             duration: 3000,
           });
         } else {
-          // Edit single occurrence
-          await callService.updateScheduledCall(initialCall.externalId, {
-            title: data.title,
-            startsAt: new Date(data.startsAt).getTime(),
-            endsAt: new Date(data.endsAt).getTime(),
-            ...(postCallUpdates && updateChannelId ? { callUpdatesChannel: updateChannelId } : {}),
-            ...(channelId ? { channelId } : {}),
-            ...(userIds.length > 0 && { targetUserIds: userIds }),
-            externalInvitees: effExternals,
-          });
+          // Edit single occurrence. A participant editor may send nothing but the
+          // invite list — the backend rejects the request outright otherwise.
+          await callService.updateScheduledCall(
+            initialCall.externalId,
+            participantsOnly
+              ? { targetUserIds: userIds }
+              : {
+                  title: data.title,
+                  startsAt: new Date(data.startsAt).getTime(),
+                  endsAt: new Date(data.endsAt).getTime(),
+                  ...(postCallUpdates && updateChannelId
+                    ? { callUpdatesChannel: updateChannelId }
+                    : {}),
+                  ...(channelId ? { channelId } : {}),
+                  ...(userIds.length > 0 && { targetUserIds: userIds }),
+                  externalInvitees: effExternals,
+                },
+          );
           toast.success('Call Updated', {
             description: 'This occurrence has been updated.',
             duration: 3000,
@@ -839,6 +891,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
           const memberIds = mappings
             .map((m: { userId: string }) => m.userId)
             .filter((id: string) => id !== user?.id);
+          expandedGroupMembersRef.current.set(groupId, memberIds);
           for (const id of memberIds) {
             expanded.add(`user:${id}`);
           }
@@ -1056,6 +1109,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                       id='call-title'
                       type='text'
                       placeholder='Enter call title'
+                      disabled={participantsOnly}
                       tabIndex={0}
                       className={cn(
                         '!text-[22px] truncate',
@@ -1078,7 +1132,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                   <p className='text-red-500 text-xs mt-1'>{errors.title.message}</p>
                 )}
               </div>
-              <div className='flex flex-col gap-3'>
+              <div className={cn('flex flex-col gap-3', participantsOnly && 'hidden')}>
                 {isRecurring ? (
                   /* ── Recurring mode: date on its own row, times side-by-side below ── */
                   <>
@@ -1880,6 +1934,9 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                       }
                       {...(channelMembersOptions ? { channelMembersOptions } : {})}
                       excludedChannelMembers={excludedChannelMembers}
+                      {...(lockedParticipantValues
+                        ? { lockedValues: lockedParticipantValues }
+                        : {})}
                       hoistSelectedChannelMembers={isEditMode}
                       toggleExcludedChannelMember={toggleExcludedChannelMember}
                     />
@@ -1895,7 +1952,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                 )}
               </div>
 
-              {canUseExternalInvitees && (
+              {canUseExternalInvitees && !participantsOnly && (
                 <div className='space-y-2 -mb-3'>
                   <div className='flex items-baseline justify-between'>
                     <p className='text-muted-foreground text-[13px] leading-5'>External Users</p>
@@ -1919,7 +1976,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
               )}
 
               {/* Edit entire series checkbox — only for recurring calls in edit mode */}
-              {isEditMode && initialCall?.recurringSeriesId && (
+              {isEditMode && initialCall?.recurringSeriesId && !participantsOnly && (
                 <Checkbox
                   checked={editEntireSeries}
                   onChange={setEditEntireSeries}
@@ -1931,7 +1988,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
 
               {/* Post call updates to channel — shown whenever participants are added; the broadcast
                   channel is independent of the call's own channel. */}
-              {showPostCallUpdates && (
+              {showPostCallUpdates && !participantsOnly && (
                 <div className='space-y-4'>
                   <div className='flex items-center gap-1.5 w-full'>
                     <Checkbox

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/types.ts
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/types.ts
@@ -12,6 +12,8 @@ export interface EditCallData {
   startsAt: string | number | Date;
   endsAt: string | number | Date;
   participants: Array<{ userId: string; email?: string | null; isExternal?: boolean | null }>;
+  /** Organizer of the call. A non-organizer participant may only edit the invite list. */
+  organizerUserId?: string | null;
   channelId?: string | null;
   recurringSeriesId?: string | null;
   callUpdatesChannel?: string | null;

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/types.ts
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/types.ts
@@ -11,7 +11,12 @@ export interface EditCallData {
   title: string;
   startsAt: string | number | Date;
   endsAt: string | number | Date;
-  participants: Array<{ userId: string; email?: string | null; isExternal?: boolean | null }>;
+  participants: Array<{
+    userId: string;
+    email?: string | null;
+    isExternal?: boolean | null;
+    invitedBy?: string | null;
+  }>;
   /** Organizer of the call. A non-organizer participant may only edit the invite list. */
   organizerUserId?: string | null;
   channelId?: string | null;

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/CallRow.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/CallRow.tsx
@@ -3,10 +3,12 @@ import { MoreVertical } from 'lucide-react';
 import { cn } from '../../../utils/classNames';
 import { CallStatus } from '@xyne/shared';
 import {
+  canEditScheduledCallParticipants,
   getPreviewParticipantUserIds,
   getCallParticipantCount,
   type Call,
 } from '../../../routes/CallHistoryScreen/callHistoryItem.utils';
+import { useAllVisibleChannels } from '../../../hooks/useChannels';
 import Button from '../../ui/Button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '../../ui/dropdown-menu';
 import { formatParticipantText } from '../../../hooks/useCalls';
@@ -43,6 +45,8 @@ export function CallRow({
     getCallParticipantCount(call),
   );
   const isOwner = currentUserId === call.createdByUserId;
+  const visibleChannels = useAllVisibleChannels();
+  const canEdit = isOwner || canEditScheduledCallParticipants(call, currentUserId, visibleChannels);
 
   return (
     <div className='flex items-center gap-2'>
@@ -113,6 +117,7 @@ export function CallRow({
           <UpcomingCallActionsMenuItems
             call={call}
             isOwner={isOwner}
+            canEdit={canEdit}
             onEdit={onEditCall ? () => onEditCall(call) : undefined}
             onCancel={onCancelCall ? () => onCancelCall(call) : undefined}
           />

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallActionsMenu.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallActionsMenu.tsx
@@ -7,6 +7,12 @@ import { type Call } from '../../../routes/CallHistoryScreen/callHistoryItem.uti
 interface UpcomingCallActionsMenuItemsProps {
   call: Call;
   isOwner: boolean;
+  /**
+   * Whether to offer Edit. Defaults to `isOwner`; callers pass true for a participant of
+   * a direct call, who opens the edit modal restricted to the invite list. Delete stays
+   * owner-only regardless.
+   */
+  canEdit?: boolean;
   onEdit?: (() => void) | undefined;
   onCancel?: (() => void) | undefined;
 }
@@ -19,6 +25,7 @@ interface UpcomingCallActionsMenuItemsProps {
 export function UpcomingCallActionsMenuItems({
   call,
   isOwner,
+  canEdit = isOwner,
   onEdit,
   onCancel,
 }: UpcomingCallActionsMenuItemsProps): React.JSX.Element {
@@ -44,7 +51,7 @@ export function UpcomingCallActionsMenuItems({
         <Copy className='size-4' />
         Copy Link
       </DropdownMenuItem>
-      {isOwner && onEdit && (
+      {canEdit && onEdit && (
         <DropdownMenuItem
           onClick={e => {
             e.stopPropagation();

--- a/apps/dashboard/src/routes/CallHistoryScreen/CalendarCallPopup.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/CalendarCallPopup.tsx
@@ -32,11 +32,13 @@ import {
   isMicrosoftCalendarCall,
   canJoinCall,
   isScheduledCallManageable,
+  canEditScheduledCallParticipants,
 } from './callHistoryItem.utils';
 import Button from '../../components/ui/Button';
 import Avatar from '../../components/ui/Avatar/Avatar';
 import { AvatarStackItem } from '../../components/ui/Avatar/AvatarGroup';
 import { useUser } from '../../hooks/useUsers';
+import { useAllVisibleChannels } from '../../hooks/useChannels';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { callService } from '../../services/Call/callService';
 import { toast } from 'sonner';
@@ -212,6 +214,7 @@ const CalendarCallPopup = ({
   const [localRsvp, setLocalRsvp] = useState<MeetingStatus | null>(null);
   const [isGuestsExpanded, setIsGuestsExpanded] = useState(false);
 
+  const allVisibleChannels = useAllVisibleChannels();
   const currentParticipant = call.participants?.find(p => p.userId === currentUserId);
   const isCurrentUserInCall = isRoomActive && currentCallExternalId === call.externalId;
   const previewParticipantUserIds = useMemo(
@@ -593,7 +596,11 @@ const CalendarCallPopup = ({
   const shouldUsePrimaryJoinStyle = isLive;
   const isManageableScheduledCall = isScheduledCallManageable(call, currentUserId);
 
-  const canEdit = isManageableScheduledCall && !!onEditClick;
+  // A non-organizer participant can still open the modal, restricted to adding people.
+  const canEdit =
+    (isManageableScheduledCall ||
+      canEditScheduledCallParticipants(call, currentUserId, allVisibleChannels)) &&
+    !!onEditClick;
   const canDelete = isManageableScheduledCall && !!onDeleteClick;
   const canHide =
     !isEnded && currentUserId !== organizerUserId && !!hydratedCurrentParticipant && !!onHideClick;

--- a/apps/dashboard/src/routes/CallHistoryScreen/SearchParticipants.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/SearchParticipants.tsx
@@ -134,6 +134,16 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
     return exclusiveSelection && selectedValues.some(v => v.startsWith('channel:'));
   }, [selectedValues, exclusiveSelection]);
 
+  // Only meaningful while `lockedValues` is set: the pinned roster vs. what this editor added.
+  const pinnedOptions = useMemo(
+    () => selectedOptions.filter(opt => lockedValues?.has(opt.value)),
+    [selectedOptions, lockedValues],
+  );
+  const addedByEditorOptions = useMemo(
+    () => selectedOptions.filter(opt => !lockedValues?.has(opt.value)),
+    [selectedOptions, lockedValues],
+  );
+
   const isEmailLikeQuery = useMemo(() => {
     const query = searchQuery.trim();
     return query.includes('@');
@@ -288,6 +298,30 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
         break;
     }
   };
+
+  const renderSelectedPill = (option: ParticipantOptions): React.ReactNode => (
+    <div
+      key={option.value}
+      className='flex items-center gap-1 px-2 py-1 bg-card rounded-md text-sm border border-border'
+    >
+      {option.icon && <span>{option.icon}</span>}
+      <span className='truncate max-w-60 text-foreground'>{option.label}</span>
+      {!lockedValues?.has(option.value) && (
+        <button
+          type='button'
+          onClick={e => {
+            e.stopPropagation();
+            toggleValue(option.value);
+          }}
+          className='ml-0.5 hover:bg-muted rounded p-0.5 text-foreground'
+          data-track-category='CALLS'
+          data-track-name='remove-participant'
+        >
+          <X className='size-3' />
+        </button>
+      )}
+    </div>
+  );
 
   const renderTrigger = () => {
     const selectedGroupOrChannel = exclusiveSelection
@@ -596,37 +630,61 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
         </Popover.Root>
       )}
 
+      {/* Restricted editors get the roster split into its own panel: one section for the
+          people already on the call, one for the people they added. Mixing both into a
+          single wrap left the removable pills indistinguishable from the pinned ones. */}
+      {lockedValues && selectedOptions.length > 0 && !hasChannelSelected && (
+        <div className='mt-2 rounded-xl border border-border bg-muted/20 divide-y divide-border overflow-hidden'>
+          {pinnedOptions.length > 0 && (
+            <div className='p-3 space-y-2'>
+              <p className='text-xs text-muted-foreground'>Already in this call</p>
+              <div className='flex flex-wrap gap-1.5 max-h-28 overflow-y-auto no-scrollbar'>
+                {pinnedOptions.map(renderSelectedPill)}
+              </div>
+            </div>
+          )}
+          <div className='p-3 space-y-2'>
+            <div className='flex items-center justify-between gap-2'>
+              <p className='text-xs text-muted-foreground'>
+                Added by you
+                {addedByEditorOptions.length > 0 && ` (${addedByEditorOptions.length})`}
+              </p>
+              {addedByEditorOptions.length > 0 && (
+                <button
+                  type='button'
+                  onClick={() =>
+                    void onMultiSelect(selectedValues.filter(v => lockedValues.has(v)))
+                  }
+                  className='shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors'
+                  data-track-category='CALLS'
+                  data-track-name='clear-all-participants'
+                >
+                  Clear all
+                </button>
+              )}
+            </div>
+            {addedByEditorOptions.length > 0 ? (
+              <div className='flex flex-wrap gap-1.5 max-h-28 overflow-y-auto no-scrollbar'>
+                {addedByEditorOptions.map(renderSelectedPill)}
+              </div>
+            ) : (
+              <p className='text-xs text-muted-foreground'>
+                Search above to invite more people to this call.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Selected participants rendered below the search bar */}
-      {selectedOptions.length > 0 && !hasChannelSelected && (
+      {!lockedValues && selectedOptions.length > 0 && !hasChannelSelected && (
         <div className='flex items-start justify-between mt-2'>
           <div className='flex flex-wrap gap-1.5 max-h-32 overflow-y-auto flex-1'>
-            {selectedOptions.map(option => (
-              <div
-                key={option.value}
-                className='flex items-center gap-1 px-2 py-1 bg-card rounded-md text-sm border border-border'
-              >
-                {option.icon && <span>{option.icon}</span>}
-                <span className='truncate max-w-60 text-foreground'>{option.label}</span>
-                {!lockedValues?.has(option.value) && (
-                  <button
-                    type='button'
-                    onClick={e => {
-                      e.stopPropagation();
-                      toggleValue(option.value);
-                    }}
-                    className='ml-0.5 hover:bg-muted rounded p-0.5 text-foreground'
-                    data-track-category='CALLS'
-                    data-track-name='remove-participant'
-                  >
-                    <X className='size-3' />
-                  </button>
-                )}
-              </div>
-            ))}
+            {selectedOptions.map(renderSelectedPill)}
           </div>
           <button
             type='button'
-            onClick={() => void onMultiSelect(selectedValues.filter(v => lockedValues?.has(v)))}
+            onClick={() => void onMultiSelect([])}
             className='ml-2 shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-0.5'
             data-track-category='CALLS'
             data-track-name='clear-all-participants'

--- a/apps/dashboard/src/routes/CallHistoryScreen/SearchParticipants.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/SearchParticipants.tsx
@@ -27,6 +27,8 @@ interface SearchParticipantsProps {
     allUserIds?: string[],
   ) => void;
   exclusiveSelection?: boolean;
+  /** Already-selected values that cannot be deselected (no X, no backspace, no clear-all). */
+  lockedValues?: ReadonlySet<string>;
   /**
    * Skip the built-in `label.includes(query)` substring filter. Set this when the
    * caller has already ranked `options` with the shared participant matcher
@@ -51,6 +53,7 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
   hoistSelectedChannelMembers = false,
   toggleExcludedChannelMember,
   exclusiveSelection = true,
+  lockedValues,
   disableClientFiltering = false,
 }) => {
   const [selectedOptionsMap, setSelectedOptionsMap] = useState<Map<string, ParticipantOptions>>(
@@ -91,12 +94,12 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
   const filteredOptions = useMemo(() => {
     let opts = options;
 
-    // Filter out channels, user groups if a user or user group is already selected
-    // (only applies in exclusive mode — non-exclusive mode allows any mix).
+    // A channel-scoped selection is its own mode (it unfurls a member checklist), so
+    // once any individual is picked the channel options drop out. User groups are NOT
+    // exclusive: callers expand a group into its members on select, so picking one is
+    // the same as picking those users by hand and must not hide the remaining groups.
     if (exclusiveSelection && (hasUserSelected || hasGroupSelected)) {
-      opts = opts.filter(
-        opt => !opt.value.startsWith('channel:') && !opt.value.startsWith('user_group:'),
-      );
+      opts = opts.filter(opt => !opt.value.startsWith('channel:'));
     }
 
     if (disableClientFiltering || !searchQuery.trim()) return opts;
@@ -160,14 +163,16 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
   ]);
 
   const toggleValue = (value: string) => {
+    if (lockedValues?.has(value) && selectedValues.includes(value)) return;
+
     const isChannel = value.startsWith('channel:');
-    const isUserGroup = value.startsWith('user_group:');
 
     if (!selectedValues.includes(value) && hasChannelSelected && !isChannel) {
       return;
     }
 
-    if (!selectedValues.includes(value) && hasGroupSelected && (isChannel || isUserGroup)) {
+    // Groups and channels still don't mix, but group + group does.
+    if (!selectedValues.includes(value) && hasGroupSelected && isChannel) {
       return;
     }
 
@@ -177,17 +182,6 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
         setSelectedOptionsMap(prev => new Map(prev).set(value, option));
       }
       void onMultiSelect([value]);
-      setSearchQuery('');
-      setIsOpen(false);
-      return;
-    }
-
-    if (exclusiveSelection && isUserGroup && !selectedValues.includes(value)) {
-      const option = options.find(opt => opt.value === value);
-      if (option) {
-        setSelectedOptionsMap(prev => new Map(prev).set(value, option));
-      }
-      void onMultiSelect([...selectedValues.filter(v => !v.startsWith('user_group:')), value]);
       setSearchQuery('');
       setIsOpen(false);
       return;
@@ -613,24 +607,26 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
               >
                 {option.icon && <span>{option.icon}</span>}
                 <span className='truncate max-w-60 text-foreground'>{option.label}</span>
-                <button
-                  type='button'
-                  onClick={e => {
-                    e.stopPropagation();
-                    toggleValue(option.value);
-                  }}
-                  className='ml-0.5 hover:bg-muted rounded p-0.5 text-foreground'
-                  data-track-category='CALLS'
-                  data-track-name='remove-participant'
-                >
-                  <X className='size-3' />
-                </button>
+                {!lockedValues?.has(option.value) && (
+                  <button
+                    type='button'
+                    onClick={e => {
+                      e.stopPropagation();
+                      toggleValue(option.value);
+                    }}
+                    className='ml-0.5 hover:bg-muted rounded p-0.5 text-foreground'
+                    data-track-category='CALLS'
+                    data-track-name='remove-participant'
+                  >
+                    <X className='size-3' />
+                  </button>
+                )}
               </div>
             ))}
           </div>
           <button
             type='button'
-            onClick={() => void onMultiSelect([])}
+            onClick={() => void onMultiSelect(selectedValues.filter(v => lockedValues?.has(v)))}
             className='ml-2 shrink-0 text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-0.5'
             data-track-category='CALLS'
             data-track-name='clear-all-participants'

--- a/apps/dashboard/src/routes/CallHistoryScreen/callHistoryItem.utils.ts
+++ b/apps/dashboard/src/routes/CallHistoryScreen/callHistoryItem.utils.ts
@@ -1,7 +1,13 @@
 import { QueryResultType } from '@rocicorp/zero';
 import { queries } from '../../zero/queries';
 import { formatDuration } from '../../utils/dateUtils';
-import { CallOrigin, CallStatus, InvitationResponse, type User } from '@xyne/shared';
+import {
+  CallOrigin,
+  CallStatus,
+  ChannelScopeType,
+  InvitationResponse,
+  type User,
+} from '@xyne/shared';
 import { hasJoinedExternalParticipant as hasJoinedExternalCallParticipant } from '../../components/Call/callParticipant.utils';
 
 export type RecentCallFilter = 'all' | 'incoming' | 'outgoing' | 'active' | 'missed';
@@ -354,4 +360,27 @@ export function isScheduledCallManageable(call: Call, currentUserId: string | un
 
   const organizerUserId = call.organizerId ?? call.createdByUserId;
   return organizerUserId === currentUserId;
+}
+
+/**
+ * A non-organizer participant may add people to a direct call — one whose channel is a
+ * DM/GROUP_DM, or isn't visible to them at all (a large group call sits in the organizer's
+ * self-DM, which no other participant belongs to). A channel-scoped call is visible only to
+ * its members, so a channel you CAN see that isn't a DM means the invite list is the
+ * channel's — organizer only. The API is what enforces this; this only shows the entry point.
+ */
+export function canEditScheduledCallParticipants(
+  call: Call,
+  currentUserId: string | undefined,
+  visibleChannels: readonly { id: string; scopeType: ChannelScopeType }[],
+): boolean {
+  if (!currentUserId || call.status !== CallStatus.SCHEDULED || !call.channelId) return false;
+  if (isScheduledCallManageable(call, currentUserId)) return false;
+
+  const channel = visibleChannels.find(c => c.id === call.channelId);
+  return (
+    !channel ||
+    channel.scopeType === ChannelScopeType.DM ||
+    channel.scopeType === ChannelScopeType.GROUP_DM
+  );
 }

--- a/apps/dashboard/src/routes/CallHistoryScreen/callHistoryItem.utils.ts
+++ b/apps/dashboard/src/routes/CallHistoryScreen/callHistoryItem.utils.ts
@@ -376,6 +376,7 @@ export function canEditScheduledCallParticipants(
 ): boolean {
   if (!currentUserId || call.status !== CallStatus.SCHEDULED || !call.channelId) return false;
   if (isScheduledCallManageable(call, currentUserId)) return false;
+  if (visibleChannels.length === 0) return false;
 
   const channel = visibleChannels.find(c => c.id === call.channelId);
   return (

--- a/apps/dashboard/src/routes/CallHistoryScreen/useCallHistory.ts
+++ b/apps/dashboard/src/routes/CallHistoryScreen/useCallHistory.ts
@@ -567,6 +567,7 @@ export function useCallHistory(userId: string | undefined): UseCallHistoryReturn
     startsAt: call.startsAt!,
     endsAt: call.endsAt!,
     participants: [...participants],
+    organizerUserId: call.organizerId ?? call.createdByUserId,
     channelId: call.channelId,
     recurringSeriesId: call.recurringSeriesId,
     callUpdatesChannel: call.callUpdatesChannel ?? null,


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
