### PR TITLE
feat: XYNE-59771 implement xyne-desk flow automation

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -131,6 +131,7 @@ import deskMetricsClawRoutes from '@/routes/deskMetricsClawRoutes';
 import deskReportPanelRoutes from '@/routes/deskReportPanelRoutes';
 import aiRetriggerRoutes from '@/routes/aiRetriggerRoutes';
 import testAuthRoutes from '@/routes/testAuth';
+import testDeskRoutes from '@/routes/testDesk';
 import customInstructionRoutes from '@/routes/customInstruction';
 import dailyBriefRoutes from '@/routes/dailyBrief';
 import userSkillsRoutes from '@/routes/userSkills';
@@ -459,6 +460,7 @@ export class App {
     if (config.isTestEnv || enableDevAuth) {
       logger.info('Registering test routes (/api/test/*)');
       this.app.use('/api/test', testAuthRoutes);
+      this.app.use('/api/test', authMiddleware.authenticate, testDeskRoutes);
     }
 
     // Apply general rate limiter to all API routes from this point onward

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -600,6 +600,15 @@ if (error) {
   throw new Error(`Config validation error: ${error.message}`);
 }
 
+// Defense-in-depth: the mock Desk provider stores captured mail in process
+// memory and short-circuits real outbound send. It must never be reachable in
+// production, where enabling it would silently swallow real customer mail.
+if (envVars.DESK_MOCK_ENABLED && envVars.NODE_ENV === 'production') {
+  throw new Error(
+    'DESK_MOCK_ENABLED must not be true when NODE_ENV=production: the in-memory mock Desk provider would silently capture real outbound mail instead of sending it.'
+  );
+}
+
 export const config = {
   env: envVars.NODE_ENV,
   isTestEnv: envVars.NODE_ENV === 'test',

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -109,6 +109,10 @@ const envSchema = Joi.object({
   ENABLE_CALENDAR_SYNC_WORKER: Joi.boolean().default(false),
 
   DESK_TICKET_DEBUG: Joi.boolean().default(false),
+  // Mock Desk mail provider for local/CI automation only. Never enable in a
+  // horizontally scaled or public-facing deployment (state is process-local).
+  DESK_MOCK_ENABLED: Joi.boolean().default(false),
+  DESK_MOCK_DEFAULT_EMAIL_DOMAIN: Joi.string().default('desk-mock.xyne.test'),
   ENABLE_EMAIL_CLASSIFICATION_WORKER: Joi.boolean().default(false),
   // One switch for the whole feature, read by both processes: the API gates
   // its producer on it, the worker gates its drain loop on it. A separate
@@ -748,6 +752,8 @@ export const config = {
   enableEmailFetchWorker: envVars.ENABLE_EMAIL_FETCH_WORKER,
   enableCalendarSyncWorker: envVars.ENABLE_CALENDAR_SYNC_WORKER,
   deskTicketDebug: envVars.DESK_TICKET_DEBUG as boolean,
+  isDeskMockEnabled: envVars.DESK_MOCK_ENABLED as boolean,
+  deskMockDefaultEmailDomain: envVars.DESK_MOCK_DEFAULT_EMAIL_DOMAIN as string,
   enableEmailClassificationWorker: envVars.ENABLE_EMAIL_CLASSIFICATION_WORKER,
   // Radar execution engine. Two switches: enqueue on message insert, and run
   // the drain worker. A gated window always goes to the parser and a valid

--- a/apps/backend/src/controllers/emailController.ts
+++ b/apps/backend/src/controllers/emailController.ts
@@ -48,6 +48,8 @@ import { config as appConfig } from '@/config/env';
 import { tagGenerationPipeline } from '@/tags/pipeline';
 import { DESK_EMAIL_SOURCE_TYPE, deskEmailConfigKey } from '@/tags';
 import { ChannelExternalSourceResolver } from '@/services/channelExternalSourceResolver';
+import { mockDeskMailService } from '@/services/mockDeskMailService';
+import { parseMockDeskCredentials } from '@/utils/mockDeskCredentials';
 import { recordTicketTimelineEvent } from '@/services/ticketTimelineEventService';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -299,7 +301,32 @@ export class EmailController {
 
       let result: { threadId: string; messageId?: string };
 
-      if (externalSource.sourceType === ExternalSourcePlatform.MICROSOFT) {
+      // Mock Desk short-circuit (test/dev only). When the resolved source carries
+      // mock credentials AND the DESK_MOCK_ENABLED flag is on, capture the outbound
+      // reply into the in-memory mock mailbox instead of dispatching to a real
+      // provider — whose credentials are fabricated and would fail auth. Everything
+      // after this branch (DB persistence, activity, dedup) runs unchanged.
+      const isMockDeskSource =
+        appConfig.isDeskMockEnabled &&
+        parseMockDeskCredentials(externalSource.credentials).isMock;
+
+      if (isMockDeskSource) {
+        const captured = mockDeskMailService.captureSentMail({
+          kind: 'reply',
+          channelId: conversation.channelId,
+          conversationId,
+          from: fromEmailAddress,
+          to: toRecipients,
+          cc: ccRecipients,
+          bcc: bccRecipients,
+          subject: replySubject,
+          body: outboundBody,
+          threadId:
+            latestEmail.externalThreadId ?? initialEmail.externalThreadId ?? undefined,
+          attachmentCount: fileAttachments.length,
+        });
+        result = { threadId: captured.threadId, messageId: captured.messageId };
+      } else if (externalSource.sourceType === ExternalSourcePlatform.MICROSOFT) {
         const sender = MicrosoftDeskService.createEmailSender(
           externalSource.credentials,
           externalSource.id
@@ -969,17 +996,39 @@ export class EmailController {
       const fileAttachments = inlineRewrite.attachments;
       const inlineCidByAttachmentId = inlineRewrite.inlineCidByAttachmentId;
 
-      const sendResult = await adapter.sendMailNew({
-        encryptedCredentials: externalSource.credentials,
-        sourceId: externalSource.id,
-        subject: safeSubject,
-        body: outboundBody,
-        to: [...new Set(to)],
-        cc: [...new Set(cc)],
-        bcc: [...new Set(bcc)],
-        ...(fromEmail && { fromEmailAddress: fromEmail }),
-        ...(fileAttachments.length > 0 && { fileAttachments }),
-      });
+      // Mock Desk short-circuit (test/dev only) — mirror the reply path. Capture
+      // the composed mail into the in-memory mock mailbox instead of calling the
+      // real provider when the source carries mock credentials and the flag is on.
+      const isMockDeskSource =
+        appConfig.isDeskMockEnabled &&
+        parseMockDeskCredentials(externalSource.credentials).isMock;
+
+      const sendResult = isMockDeskSource
+        ? ((): { threadId: string; messageId?: string } => {
+            const captured = mockDeskMailService.captureSentMail({
+              kind: 'compose',
+              channelId,
+              from: fromEmail,
+              to: [...new Set(to)],
+              cc: [...new Set(cc)],
+              bcc: [...new Set(bcc)],
+              subject: safeSubject,
+              body: outboundBody,
+              attachmentCount: fileAttachments.length,
+            });
+            return { threadId: captured.threadId, messageId: captured.messageId };
+          })()
+        : await adapter.sendMailNew({
+            encryptedCredentials: externalSource.credentials,
+            sourceId: externalSource.id,
+            subject: safeSubject,
+            body: outboundBody,
+            to: [...new Set(to)],
+            cc: [...new Set(cc)],
+            bcc: [...new Set(bcc)],
+            ...(fromEmail && { fromEmailAddress: fromEmail }),
+            ...(fileAttachments.length > 0 && { fileAttachments }),
+          });
 
       const externalMessageId = sendResult.messageId || sendResult.threadId;
 

--- a/apps/backend/src/routes/testDesk.ts
+++ b/apps/backend/src/routes/testDesk.ts
@@ -715,6 +715,47 @@ router.post('/desk/incoming-email', async (req, res, next) => {
   }
 });
 
+router.post('/desk/slack-event', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
+    const channelId = typeof req.body?.channelId === 'string' ? req.body.channelId : '';
+    const from = getValidEmail(req.body?.from) ?? '';
+    const subject = typeof req.body?.subject === 'string' ? req.body.subject : '';
+    const body = typeof req.body?.body === 'string' ? req.body.body : '';
+    if (!userId || !workspaceId) {
+      return res.status(401).json({ error: 'Authenticated workspace required' });
+    }
+    if (!channelId || !from || !subject) {
+      return res.status(400).json({ error: 'channelId, from, and subject are required' });
+    }
+    const member = await db.channelParticipant.findUnique({
+      where: { channelId_userId: { channelId, userId } },
+      select: { id: true },
+    });
+    if (!member) return res.status(403).json({ error: 'Not a member of this channel' });
+    const created = await emailService.createConversationWithEmail({
+      channelId,
+      userId,
+      emailSubject: subject,
+      emailBody: body,
+      emailTo: [String(req.body?.to ?? 'slack-channel@slack.example.test')],
+      emailFrom: from,
+      externalThreadId: String(
+        req.body?.threadId ?? `mock-slack-thread-${crypto.randomUUID()}`
+      ),
+      externalMessageId: String(
+        req.body?.messageId ?? `mock-slack-message-${crypto.randomUUID()}`
+      ),
+      emailType: EmailType.DEFAULT,
+    });
+    return res.json({ success: true, ...created });
+  } catch (error) {
+    return next(error);
+  }
+});
+
 router.get('/desk/ticket/:conversationId', async (req, res, next) => {
   try {
     if (!requireMockDeskEnabled(res)) return;
@@ -799,6 +840,31 @@ router.get('/desk/ticket/:conversationId', async (req, res, next) => {
       emails,
       attachments,
     });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.get('/desk/channel/:channelId/tickets', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
+    const { channelId } = req.params;
+    if (!userId || !workspaceId) {
+      return res.status(401).json({ error: 'Authenticated workspace required' });
+    }
+    const member = await db.channelParticipant.findUnique({
+      where: { channelId_userId: { channelId, userId } },
+      select: { id: true },
+    });
+    if (!member) return res.status(403).json({ error: 'Not a member of this channel' });
+    const tickets = await db.ticket.findMany({
+      where: { channelId, workspaceId },
+      select: { id: true, conversationId: true, title: true },
+      orderBy: { createdAt: 'asc' },
+    });
+    return res.json({ tickets });
   } catch (error) {
     return next(error);
   }

--- a/apps/backend/src/routes/testDesk.ts
+++ b/apps/backend/src/routes/testDesk.ts
@@ -14,6 +14,9 @@ import { config } from '@/config/env';
 import { encrypt } from '@/services/encryptionService';
 import { emailService } from '@/services/emailService';
 import { mockDeskMailService } from '@/services/mockDeskMailService';
+import { externalSourceCore } from '@/integrations/core/core';
+import { googleAdapter } from '@/integrations/adapters/google';
+import { ChannelExternalSourceResolver } from '@/services/channelExternalSourceResolver';
 import { logger } from '@/utils/logger';
 import {
   buildMockDeskCredentials as buildMockDeskCredentialsPayload,
@@ -21,6 +24,7 @@ import {
 } from '@/utils/mockDeskCredentials';
 
 const router = Router();
+const channelExternalSourceResolver = new ChannelExternalSourceResolver();
 // Intentionally permissive for automation fixtures; provider-grade RFC validation
 // is covered by the real Gmail/Microsoft integrations.
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -751,6 +755,86 @@ router.post('/desk/slack-event', async (req, res, next) => {
       emailType: EmailType.DEFAULT,
     });
     return res.json({ success: true, ...created });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+/**
+ * Deterministic Pub/Sub-shaped Gmail bulk fixture. It bypasses Google network
+ * calls but executes the real Google transformer, ExternalSourceCore dedupe/
+ * DL routing, ticket persistence, and Google postprocessor cursor update.
+ */
+router.post('/desk/pubsub/bulk-gmail', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
+    const channelId = typeof req.body?.channelId === 'string' ? req.body.channelId : '';
+    const historyId = typeof req.body?.historyId === 'string' ? req.body.historyId : '';
+    const messages = Array.isArray(req.body?.messages) ? req.body.messages : [];
+    if (!userId || !workspaceId) {
+      return res.status(401).json({ error: 'Authenticated workspace required' });
+    }
+    if (!channelId || !/^\d+$/.test(historyId) || messages.length === 0) {
+      return res.status(400).json({ error: 'channelId, numeric historyId, and messages are required' });
+    }
+    if (messages.length > 1000) {
+      return res.status(400).json({ error: 'A maximum of 1000 messages may be published per fixture' });
+    }
+    const member = await db.channelParticipant.findUnique({
+      where: { channelId_userId: { channelId, userId } },
+      select: { id: true },
+    });
+    if (!member) return res.status(403).json({ error: 'Not a member of this channel' });
+    const source = await channelExternalSourceResolver.resolveForChannel(channelId);
+    if (!source || source.workspaceId !== workspaceId) {
+      return res.status(404).json({ error: 'No Google Desk source found for channel' });
+    }
+    const invalid = messages.find(
+      (message: any) =>
+        typeof message?.messageId !== 'string' ||
+        typeof message?.threadId !== 'string' ||
+        typeof message?.from !== 'string' ||
+        typeof message?.subject !== 'string',
+    );
+    if (invalid) {
+      return res.status(400).json({ error: 'Each message requires messageId, threadId, from, and subject' });
+    }
+    const deterministicAdapter = {
+      ...googleAdapter,
+      preprocess: async () =>
+        messages.map((message: any) => ({
+          pubsubData: { emailAddress: source.displayName, historyId },
+          parsedEmail: {
+            messageId: message.messageId,
+            threadId: message.threadId,
+            subject: message.subject,
+            from: message.from,
+            to: Array.isArray(message.to) ? message.to : [source.displayName],
+            cc: Array.isArray(message.cc) ? message.cc : [],
+            bcc: Array.isArray(message.bcc) ? message.bcc : [],
+            replyTo: Array.isArray(message.replyTo) ? message.replyTo : [],
+            body: typeof message.body === 'string' ? message.body : '',
+            date: typeof message.date === 'string' ? message.date : new Date().toISOString(),
+          },
+        })),
+    };
+    const results = await externalSourceCore.ingest(
+      deterministicAdapter,
+      source.name,
+      { messages },
+      source,
+    );
+    return res.json({
+      success: true,
+      published: messages.length,
+      processed: results.length,
+      created: results.filter(result => result.action === 'created').length,
+      duplicates: results.filter(result => result.action === 'duplicate').length,
+      skipped: results.filter(result => result.action === 'skipped').length,
+      results,
+    });
   } catch (error) {
     return next(error);
   }

--- a/apps/backend/src/routes/testDesk.ts
+++ b/apps/backend/src/routes/testDesk.ts
@@ -1,0 +1,1053 @@
+import crypto from 'crypto';
+import { NextFunction, Request, Response, Router } from 'express';
+import {
+  AttachmentEntityType,
+  EmailType,
+  TicketReferenceRelation,
+  TicketPriority,
+  TicketStatusV2,
+  WorkspaceRole,
+} from '@prisma/client';
+import { db } from '@/database/client';
+import { authMiddleware } from '@/middleware/auth';
+import { config } from '@/config/env';
+import { encrypt } from '@/services/encryptionService';
+import { emailService } from '@/services/emailService';
+import { mockDeskMailService } from '@/services/mockDeskMailService';
+import { logger } from '@/utils/logger';
+import {
+  buildMockDeskCredentials as buildMockDeskCredentialsPayload,
+  parseMockDeskCredentials,
+} from '@/utils/mockDeskCredentials';
+
+const router = Router();
+// Intentionally permissive for automation fixtures; provider-grade RFC validation
+// is covered by the real Gmail/Microsoft integrations.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const INCOMING_EMAIL_LIMIT = getPositiveIntegerEnv('MOCK_DESK_INCOMING_EMAIL_LIMIT', 120);
+const INCOMING_EMAIL_WINDOW_MS = 60_000;
+// Mock-only, process-local rate limiting. This is best-effort protection for
+// local/CI fixtures, not a production-grade distributed throttling mechanism.
+const incomingEmailTimestampsByChannel = new Map<string, number[]>();
+type MockDeskChannelSourceType = 'google' | 'microsoft' | 'slack-desk';
+
+function isDeskMockRouteEnvironment(): boolean {
+  return (
+    config.isTestEnv ||
+    (process.env.ENABLE_DEV_AUTH === 'true' && process.env.NODE_ENV === 'development')
+  );
+}
+
+function requireMockDeskEnabled(res: Response): boolean {
+  if (!isDeskMockRouteEnvironment()) {
+    res.status(403).json({ error: 'Desk test mail routes are only available in test/dev auth mode' });
+    return false;
+  }
+
+  if (!mockDeskMailService.isEnabled()) {
+    res.status(403).json({ error: 'DESK_MOCK_ENABLED must be true to use Desk test mail routes' });
+    return false;
+  }
+
+  return true;
+}
+
+function getStringQueryParam(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function getSentMailFilterFromQuery(req: Request): { channelId?: string; conversationId?: string } {
+  return {
+    channelId: getStringQueryParam(req.query.channelId),
+    conversationId: getStringQueryParam(req.query.conversationId),
+  };
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function canManageWorkspaceDesk(role: string | undefined): boolean {
+  return role === WorkspaceRole.OWNER || role === WorkspaceRole.ADMIN;
+}
+
+function getPositiveIntegerEnv(name: string, fallback: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isValidEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email.trim());
+}
+
+function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function getMockDeskChannelSourceType(value: unknown): MockDeskChannelSourceType {
+  if (value === 'microsoft' || value === 'slack-desk') return value;
+  return 'google';
+}
+
+function getOptionalDateOrNow(value: unknown): Date {
+  if (typeof value !== 'string') return new Date();
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
+}
+
+function getValidEmail(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const email = normalizeEmail(value);
+  return isValidEmail(email) ? email : undefined;
+}
+
+function getOptionalEmailOrDefault(value: unknown, defaultEmail: string): string | undefined {
+  if (typeof value === 'undefined' || value === null || value === '') return defaultEmail;
+  return getValidEmail(value);
+}
+
+function validateEmailResponse(email: string, label: string, res: Response): boolean {
+  if (isValidEmail(email)) return true;
+  res.status(400).json({ error: `Invalid ${label} email format` });
+  return false;
+}
+
+function validateEmailArrayResponse(emails: string[], label: string, res: Response): boolean {
+  const invalidEmail = emails.find((email) => !isValidEmail(email));
+  if (!invalidEmail) return true;
+  res.status(400).json({ error: `Invalid ${label} email format`, email: invalidEmail });
+  return false;
+}
+
+function buildMockDeskCredentials(payload: Record<string, unknown>): string {
+  return encrypt(JSON.stringify(buildMockDeskCredentialsPayload(payload)));
+}
+
+function hasMockDeskCredentials(encryptedCredentials: string | null | undefined): boolean {
+  return parseMockDeskCredentials(encryptedCredentials).isMock;
+}
+
+function rejectNonMockSourceOverwrite(
+  source: { id: string; credentials: string | null } | null,
+  res: Response
+): boolean {
+  if (!source || hasMockDeskCredentials(source.credentials)) return false;
+
+  res.status(409).json({
+    error:
+      'Existing non-mock Desk source found. Mock Desk test routes will not overwrite real provider credentials.',
+  });
+  return true;
+}
+
+function recordIncomingEmailOrReject(channelId: string, res: Response): boolean {
+  const now = Date.now();
+  const recentTimestamps = (incomingEmailTimestampsByChannel.get(channelId) ?? []).filter(
+    (timestamp) => now - timestamp < INCOMING_EMAIL_WINDOW_MS
+  );
+  if (recentTimestamps.length >= INCOMING_EMAIL_LIMIT) {
+    res.status(429).json({
+      error: `Mock incoming email limit (${INCOMING_EMAIL_LIMIT}/minute) exceeded for channel`,
+    });
+    return false;
+  }
+
+  recentTimestamps.push(now);
+  incomingEmailTimestampsByChannel.set(channelId, recentTimestamps.slice(-INCOMING_EMAIL_LIMIT));
+  return true;
+}
+
+function resetIncomingEmailRateLimit(): void {
+  incomingEmailTimestampsByChannel.clear();
+}
+
+async function getCurrentWorkspaceUser(userId: string, workspaceId: string) {
+  return db.user.findFirst({
+    where: { id: userId, workspaceId },
+    select: { id: true, role: true },
+  });
+}
+
+async function requireWorkspaceDeskManager(
+  req: Request,
+  res: Response
+): Promise<{ workspaceId: string; userId: string } | undefined> {
+  const workspaceId = req.user?.workspaceId;
+  const userId = req.user?.id;
+  if (!workspaceId || !userId) {
+    res.status(401).json({ error: 'Authenticated user workspace is required' });
+    return undefined;
+  }
+
+  const user = await getCurrentWorkspaceUser(userId, workspaceId);
+  if (!canManageWorkspaceDesk(user?.role)) {
+    res.status(403).json({
+      error: 'Only workspace owners and admins can manage mock Desk mail state',
+    });
+    return undefined;
+  }
+
+  return { workspaceId, userId };
+}
+
+interface MockAttachmentInput {
+  filename: string;
+  mimetype?: string;
+  size?: number;
+}
+
+function isMockAttachmentInput(value: unknown): value is MockAttachmentInput {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Partial<Record<keyof MockAttachmentInput, unknown>>;
+  return (
+    typeof record.filename === 'string' &&
+    (typeof record.mimetype === 'undefined' || typeof record.mimetype === 'string') &&
+    (typeof record.size === 'undefined' || typeof record.size === 'number')
+  );
+}
+
+function asMockAttachments(value: unknown): Array<{
+  filename: string;
+  mimetype: string;
+  size: number;
+}> {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((item) => {
+    if (!isMockAttachmentInput(item)) return [];
+    const filename = item.filename.trim();
+    const mimetype = item.mimetype?.trim() || 'text/plain';
+    const size =
+      typeof item.size === 'number' && Number.isFinite(item.size)
+        ? Math.max(1, Math.trunc(item.size))
+        : 128;
+
+    return filename ? [{ filename, mimetype, size }] : [];
+  });
+}
+
+async function createMockEmailAttachments(params: {
+  attachments: Array<{ filename: string; mimetype: string; size: number }>;
+  emailId: string;
+  conversationId: string;
+  userId: string;
+  workspaceId: string;
+}) {
+  if (params.attachments.length === 0) return;
+
+  await db.messageAttachment.createMany({
+    data: params.attachments.map((attachment) => ({
+      entityType: AttachmentEntityType.EMAIL,
+      entityId: params.emailId,
+      conversationId: params.conversationId,
+      workspaceId: params.workspaceId,
+      storageProvider: 'mock-desk',
+      originalFilename: attachment.filename,
+      mimetype: attachment.mimetype,
+      size: attachment.size,
+      uploadedByUserId: params.userId,
+      createdBy: params.userId,
+      // Internal mock-only URL scheme used by automation; it is never dereferenced by providers.
+      url: `mock-desk://${params.emailId}/${encodeURIComponent(attachment.filename)}`,
+      metadata: {
+        mock: true,
+        source: 'desk-test-route',
+      },
+    })),
+  });
+}
+
+router.use(authMiddleware.authenticate);
+
+router.post('/desk/workspace-mailbox', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+
+    const workspaceId = req.user?.workspaceId;
+    const userId = req.user?.id;
+    if (!workspaceId || !userId) {
+      return res.status(401).json({ error: 'Authenticated user workspace is required' });
+    }
+    const user = await getCurrentWorkspaceUser(userId, workspaceId);
+    if (!canManageWorkspaceDesk(user?.role)) {
+      return res.status(403).json({
+        error: 'Only workspace owners and admins can configure the shared Desk mailbox',
+      });
+    }
+
+    const sourceType = req.body?.sourceType === 'microsoft' ? 'microsoft' : 'google';
+    const email = getOptionalEmailOrDefault(
+      req.body?.email,
+      `xynedesk.internal+${workspaceId}@${config.deskMockDefaultEmailDomain}`
+    );
+    if (!email || !validateEmailResponse(email, 'workspace mailbox', res)) return;
+    const name = `${sourceType}-mock-workspace-${workspaceId}`;
+    const existingSource = await db.externalSource.findUnique({
+      where: {
+        workspaceId_sourceType: {
+          workspaceId,
+          sourceType,
+        },
+      },
+      select: { id: true, credentials: true },
+    });
+    if (rejectNonMockSourceOverwrite(existingSource, res)) return;
+
+    const externalSource = await db.externalSource.upsert({
+      where: {
+        workspaceId_sourceType: {
+          workspaceId,
+          sourceType,
+        },
+      },
+      create: {
+        name,
+        sourceType,
+        displayName: email,
+        workspaceId,
+        ownerUserId: userId,
+        credentials: buildMockDeskCredentials({ email, sourceType }),
+        isActive: true,
+      },
+      update: {
+        displayName: email,
+        ownerUserId: userId,
+        credentials: buildMockDeskCredentials({ email, sourceType }),
+        isActive: true,
+      },
+    });
+
+    logger.info('[TestDesk] Mock workspace Desk mailbox configured', {
+      workspaceId,
+      userId,
+      sourceType,
+      externalSourceId: externalSource.id,
+    });
+
+    return res.json({ success: true, externalSource });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.post('/desk/channel-source', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+
+    const workspaceId = req.user?.workspaceId;
+    const userId = req.user?.id;
+    if (!workspaceId || !userId) {
+      return res.status(401).json({ error: 'Authenticated user workspace is required' });
+    }
+
+    const channelId = typeof req.body?.channelId === 'string' ? req.body.channelId : '';
+    if (!channelId) {
+      return res.status(400).json({ error: 'channelId is required' });
+    }
+
+    const channel = await db.channel.findFirst({
+      where: { id: channelId, workspaceId },
+      select: { id: true, projectId: true },
+    });
+    if (!channel) {
+      return res.status(404).json({ error: 'Desk channel not found in current workspace' });
+    }
+
+    const firstBoard = await db.board.findFirst({
+      where: { projectId: channel.projectId },
+      orderBy: { createdAt: 'asc' },
+      select: { id: true },
+    });
+    if (!firstBoard) {
+      return res.status(409).json({
+        error: 'Project has no boards configured - cannot create personal Desk mailbox',
+      });
+    }
+
+    const sourceType = getMockDeskChannelSourceType(req.body?.sourceType);
+    const persistedSourceType = `mock-${sourceType}-${channelId}`;
+    const email = getOptionalEmailOrDefault(
+      req.body?.email,
+      `mock-personal-${channelId}@${config.deskMockDefaultEmailDomain}`
+    );
+    if (!email || !validateEmailResponse(email, 'channel mailbox', res)) return;
+    // Channel ids are globally unique, so this test source name remains globally
+    // unique even though the ExternalSource schema does not include workspaceId
+    // in the `name` unique lookup.
+    const name = `${sourceType}-mock-channel-${channelId}`;
+    const existingSource = await db.externalSource.findUnique({
+      where: { name },
+      select: { id: true, channelId: true, credentials: true },
+    });
+    if (existingSource && existingSource.channelId !== channelId) {
+      return res.status(409).json({
+        error: 'Mock Desk channel source name collision detected for a different channel',
+      });
+    }
+    if (rejectNonMockSourceOverwrite(existingSource, res)) return;
+
+    const externalSource = await db.$transaction(async (tx) => {
+      await tx.emailChannelPreference.updateMany({
+        where: { channelId },
+        data: { boardId: firstBoard.id },
+      });
+
+      return tx.externalSource.upsert({
+        where: { name },
+        create: {
+          name,
+          sourceType: persistedSourceType,
+          displayName: email,
+          channelId,
+          ownerUserId: userId,
+          credentials: buildMockDeskCredentials({ email, sourceType }),
+          isActive: true,
+        },
+        update: {
+          sourceType: persistedSourceType,
+          displayName: email,
+          channelId,
+          ownerUserId: userId,
+          credentials: buildMockDeskCredentials({ email, sourceType }),
+          isActive: true,
+        },
+      });
+    });
+
+    logger.info('[TestDesk] Mock channel Desk source configured', {
+      workspaceId,
+      userId,
+      channelId,
+      sourceType,
+      externalSourceId: externalSource.id,
+    });
+
+    return res.json({ success: true, externalSource });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.post('/desk/channel-source/:channelId/disconnect', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+
+    const workspaceId = req.user?.workspaceId;
+    const userId = req.user?.id;
+    const { channelId } = req.params;
+    if (!workspaceId || !userId) {
+      return res.status(401).json({ error: 'Authenticated user workspace is required' });
+    }
+
+    const channel = await db.channel.findFirst({
+      where: { id: channelId, workspaceId },
+      select: { id: true },
+    });
+    if (!channel) {
+      return res.status(404).json({ error: 'Desk channel not found in current workspace' });
+    }
+
+    const user = await getCurrentWorkspaceUser(userId, workspaceId);
+    const canManageWorkspaceSource = canManageWorkspaceDesk(user?.role);
+    const membership = await db.channelParticipant.findUnique({
+      where: { channelId_userId: { channelId, userId } },
+      select: { id: true },
+    });
+    if (!canManageWorkspaceSource && !membership) {
+      return res.status(403).json({ error: 'Not a member of this channel' });
+    }
+
+    const activeSources = await db.externalSource.findMany({
+      where: { channelId, isActive: true },
+      orderBy: { updatedAt: 'desc' },
+      select: { id: true, sourceType: true, credentials: true, ownerUserId: true },
+    });
+    const source = activeSources.find((candidate) => hasMockDeskCredentials(candidate.credentials));
+    if (!source) {
+      if (activeSources.length > 0) {
+        return res.status(409).json({
+          error: 'No active mock Desk source found for this channel. Refusing to modify real provider credentials.',
+        });
+      }
+      return res.status(404).json({ error: 'No active mock Desk source found for this channel' });
+    }
+    if (rejectNonMockSourceOverwrite(source, res)) return;
+    if (!canManageWorkspaceSource && source.ownerUserId !== userId) {
+      return res.status(403).json({ error: 'Only the source owner can disconnect this Desk source' });
+    }
+
+    await db.externalSource.update({
+      where: { id: source.id },
+      data: {
+        isActive: false,
+        credentials: buildMockDeskCredentials({
+          sourceType: source.sourceType,
+          disconnected: true,
+        }),
+      },
+    });
+
+    logger.info('[TestDesk] Mock Desk channel source disconnected', {
+      workspaceId,
+      userId,
+      channelId,
+      externalSourceId: source.id,
+      sourceType: source.sourceType,
+    });
+
+    return res.json({ success: true });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.post('/desk/slack-workspace', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+
+    const workspaceId = req.user?.workspaceId;
+    const userId = req.user?.id;
+    if (!workspaceId || !userId) {
+      return res.status(401).json({ error: 'Authenticated user workspace is required' });
+    }
+
+    const name = `slack-mock-workspace-${workspaceId}`;
+    const existingSource = await db.externalSource.findUnique({
+      where: {
+        workspaceId_sourceType: {
+          workspaceId,
+          sourceType: 'slack',
+        },
+      },
+      select: { id: true, credentials: true },
+    });
+    if (rejectNonMockSourceOverwrite(existingSource, res)) return;
+
+    const externalSource = await db.externalSource.upsert({
+      where: {
+        workspaceId_sourceType: {
+          workspaceId,
+          sourceType: 'slack',
+        },
+      },
+      create: {
+        name,
+        sourceType: 'slack',
+        displayName: 'Mock Slack Workspace',
+        workspaceId,
+        ownerUserId: userId,
+        credentials: buildMockDeskCredentials({
+          signingSecret: 'mock-slack-signing-secret',
+          botOauthToken: 'xoxb-mock-token',
+        }),
+        isActive: true,
+      },
+      update: {
+        displayName: 'Mock Slack Workspace',
+        ownerUserId: userId,
+        credentials: buildMockDeskCredentials({
+          signingSecret: 'mock-slack-signing-secret',
+          botOauthToken: 'xoxb-mock-token',
+        }),
+        isActive: true,
+      },
+    });
+
+    logger.info('[TestDesk] Mock Slack workspace configured', {
+      workspaceId,
+      userId,
+      externalSourceId: externalSource.id,
+    });
+
+    return res.json({ success: true, externalSource });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.post('/desk/incoming-email', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+
+    const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
+    if (!userId || !workspaceId) {
+      return res.status(401).json({ error: 'Authenticated user workspace is required' });
+    }
+
+    const channelId = typeof req.body?.channelId === 'string' ? req.body.channelId : '';
+    const subject = typeof req.body?.subject === 'string' ? req.body.subject : '';
+    const body = typeof req.body?.body === 'string' ? req.body.body : '';
+    const from = getValidEmail(req.body?.from) ?? '';
+    const to = asStringArray(req.body?.to).map(normalizeEmail);
+    const cc = asStringArray(req.body?.cc).map(normalizeEmail);
+    const bcc = asStringArray(req.body?.bcc).map(normalizeEmail);
+    const replyTo = asStringArray(req.body?.replyTo).map(normalizeEmail);
+    const attachments = asMockAttachments(req.body?.attachments);
+
+    if (!channelId || !subject || !from || to.length === 0) {
+      return res.status(400).json({
+        error: 'channelId, subject, from, and at least one to recipient are required',
+      });
+    }
+    if (
+      !validateEmailResponse(from, 'from', res) ||
+      !validateEmailArrayResponse(to, 'to recipient', res) ||
+      !validateEmailArrayResponse(cc, 'cc recipient', res) ||
+      !validateEmailArrayResponse(bcc, 'bcc recipient', res) ||
+      !validateEmailArrayResponse(replyTo, 'reply-to recipient', res)
+    ) {
+      return;
+    }
+
+    const channel = await db.channel.findFirst({
+      where: { id: channelId, workspaceId },
+      select: { id: true },
+    });
+    if (!channel) {
+      return res.status(404).json({ error: 'Desk channel not found in current workspace' });
+    }
+
+    const isMember = await db.channelParticipant.findUnique({
+      where: { channelId_userId: { channelId, userId } },
+      select: { id: true },
+    });
+    if (!isMember) {
+      return res.status(403).json({ error: 'Not a member of this channel' });
+    }
+    if (!recordIncomingEmailOrReject(channelId, res)) return;
+
+    const externalThreadId =
+      typeof req.body?.threadId === 'string' && req.body.threadId.trim()
+        ? req.body.threadId.trim()
+        : `mock-thread-${crypto.randomUUID()}`;
+    const externalMessageId =
+      typeof req.body?.messageId === 'string' && req.body.messageId.trim()
+        ? req.body.messageId.trim()
+        : `mock-message-${crypto.randomUUID()}`;
+    const receivedAt = getOptionalDateOrNow(req.body?.receivedAt);
+
+    const existingEmail = await db.email.findFirst({
+      where: { channelId, externalThreadId },
+      orderBy: { createdAt: 'asc' },
+      select: { conversationId: true },
+    });
+
+    if (existingEmail) {
+      const email = await emailService.addEmailToConversation({
+        conversationId: existingEmail.conversationId,
+        emailSubject: subject,
+        emailBody: body,
+        emailTo: to,
+        emailFrom: from,
+        emailCc: cc,
+        emailBcc: bcc,
+        emailReplyTo: replyTo,
+        externalThreadId,
+        externalMessageId,
+        emailType: EmailType.DEFAULT,
+        receivedAt,
+      });
+      await createMockEmailAttachments({
+        attachments,
+        emailId: email.email.id,
+        conversationId: existingEmail.conversationId,
+        userId,
+        workspaceId,
+      });
+
+      logger.info('[TestDesk] Mock incoming Desk email appended', {
+        workspaceId,
+        userId,
+        channelId,
+        conversationId: existingEmail.conversationId,
+        emailId: email.email.id,
+        attachmentCount: attachments.length,
+      });
+
+      return res.json({
+        success: true,
+        mode: 'reply',
+        conversationId: existingEmail.conversationId,
+        emailId: email.email.id,
+        externalThreadId,
+        externalMessageId,
+      });
+    }
+
+    const created = await emailService.createConversationWithEmail({
+      channelId,
+      userId,
+      emailSubject: subject,
+      emailBody: body,
+      emailTo: to,
+      emailFrom: from,
+      emailCc: cc,
+      emailBcc: bcc,
+      emailReplyTo: replyTo,
+      externalThreadId,
+      externalMessageId,
+      receivedAt,
+    });
+    if (!created.isDuplicate && created.email?.id && created.conversation?.conversationId) {
+      await createMockEmailAttachments({
+        attachments,
+        emailId: created.email.id,
+        conversationId: created.conversation.conversationId,
+        userId,
+        workspaceId,
+      });
+    }
+
+    logger.info('[TestDesk] Mock incoming Desk email created', {
+      workspaceId,
+      userId,
+      channelId,
+      conversationId: created.conversation?.conversationId,
+      emailId: created.email?.id,
+      attachmentCount: attachments.length,
+    });
+
+    return res.json({ success: true, mode: 'new', ...created });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.get('/desk/ticket/:conversationId', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+
+    const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
+    const { conversationId } = req.params;
+    if (!userId || !workspaceId) {
+      return res.status(401).json({ error: 'Authenticated user workspace is required' });
+    }
+
+    const ticket = await db.ticket.findFirst({
+      where: { conversationId, workspaceId },
+      select: {
+        id: true,
+        xyneId: true,
+        title: true,
+        description: true,
+        priority: true,
+        statusV2: true,
+        channelId: true,
+        conversationId: true,
+        isArchived: true,
+      },
+    });
+    if (!ticket) {
+      return res.status(404).json({ error: 'Desk ticket not found' });
+    }
+
+    const isMember = await db.channelParticipant.findUnique({
+      where: { channelId_userId: { channelId: ticket.channelId, userId } },
+      select: { id: true },
+    });
+    if (!isMember) {
+      return res.status(403).json({ error: 'Not a member of this channel' });
+    }
+
+    const emails = await db.email.findMany({
+      where: { conversationId },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        subject: true,
+        body: true,
+        from: true,
+        to: true,
+        cc: true,
+        bcc: true,
+        replyTo: true,
+        externalThreadId: true,
+        externalMessageId: true,
+      },
+    });
+    const attachments = await db.messageAttachment.findMany({
+      where: {
+        entityType: AttachmentEntityType.EMAIL,
+        entityId: { in: emails.map((email) => email.id) },
+      },
+      orderBy: { createdAt: 'asc' },
+      select: {
+        id: true,
+        entityId: true,
+        originalFilename: true,
+        mimetype: true,
+        size: true,
+      },
+    });
+    const mergeMapping = await db.ticketReferenceMapping.findFirst({
+      where: {
+        sourceTicketId: ticket.id,
+        relationType: TicketReferenceRelation.MERGED_INTO,
+      },
+      select: { targetTicketId: true },
+    });
+
+    return res.json({
+      success: true,
+      ticket: {
+        ...ticket,
+        mergedIntoTicketId: mergeMapping?.targetTicketId ?? null,
+      },
+      emails,
+      attachments,
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.patch('/desk/ticket/:conversationId', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+
+    const userId = req.user?.id;
+    const workspaceId = req.user?.workspaceId;
+    const { conversationId } = req.params;
+    if (!userId || !workspaceId) {
+      return res.status(401).json({ error: 'Authenticated user workspace is required' });
+    }
+
+    const priority = typeof req.body?.priority === 'string' ? req.body.priority : undefined;
+    const status = typeof req.body?.status === 'string' ? req.body.status : undefined;
+    if (
+      priority &&
+      !Object.values(TicketPriority).includes(priority.toUpperCase() as TicketPriority)
+    ) {
+      return res.status(400).json({ error: 'Invalid priority' });
+    }
+    if (status && !Object.values(TicketStatusV2).includes(status.toUpperCase() as TicketStatusV2)) {
+      return res.status(400).json({ error: 'Invalid status' });
+    }
+
+    const ticket = await db.ticket.findFirst({
+      where: { conversationId, workspaceId },
+      select: { id: true, channelId: true },
+    });
+    if (!ticket) {
+      return res.status(404).json({ error: 'Desk ticket not found' });
+    }
+
+    const isMember = await db.channelParticipant.findUnique({
+      where: { channelId_userId: { channelId: ticket.channelId, userId } },
+      select: { id: true },
+    });
+    if (!isMember) {
+      return res.status(403).json({ error: 'Not a member of this channel' });
+    }
+
+    const updated = await db.ticket.update({
+      where: { id: ticket.id },
+      data: {
+        ...(priority && { priority: priority.toUpperCase() as TicketPriority }),
+        ...(status && {
+          statusV2: status.toUpperCase() as TicketStatusV2,
+          statusUpdatedAt: new Date(),
+        }),
+        updatedBy: userId,
+      },
+      select: {
+        id: true,
+        xyneId: true,
+        title: true,
+        priority: true,
+        statusV2: true,
+        channelId: true,
+        conversationId: true,
+      },
+    });
+
+    return res.json({ success: true, ticket: updated });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.get('/desk/sent-mails', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    if (!(await requireWorkspaceDeskManager(req, res))) return;
+
+    const filter = getSentMailFilterFromQuery(req);
+    const sentMails = mockDeskMailService.listSentMails(filter);
+    logger.info('[TestDesk] Mock sent mails listed', {
+      count: sentMails.length,
+      channelId: filter.channelId,
+      conversationId: filter.conversationId,
+    });
+    return res.json({ sentMails });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.delete('/desk/sent-mails', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    if (!(await requireWorkspaceDeskManager(req, res))) return;
+
+    const filter = getSentMailFilterFromQuery(req);
+    if (!filter.channelId && !filter.conversationId) {
+      return res.status(400).json({
+        error: 'channelId or conversationId query parameter is required to reset mock Desk sent mails',
+      });
+    }
+
+    mockDeskMailService.reset(filter);
+    logger.info('[TestDesk] Mock sent mails reset', {
+      channelId: filter.channelId,
+      conversationId: filter.conversationId,
+    });
+    return res.json({ success: true });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.post('/desk/mock-dl/reset', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    if (!(await requireWorkspaceDeskManager(req, res))) return;
+
+    mockDeskMailService.resetDlState();
+    resetIncomingEmailRateLimit();
+    logger.info('[TestDesk] Mock DL state reset');
+    return res.json({ success: true });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.post('/desk/mock-dl', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    if (!(await requireWorkspaceDeskManager(req, res))) return;
+
+    const dlEmail = getValidEmail(req.body?.email) ?? '';
+    if (!dlEmail) {
+      return res.status(400).json({ error: 'Valid email is required' });
+    }
+
+    const dl = mockDeskMailService.createDl(dlEmail);
+    logger.info('[TestDesk] Mock DL created', { dlEmail: dl.email });
+    return res.json({ success: true, dl });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.post('/desk/mock-dl/:dlEmail/members', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    if (!(await requireWorkspaceDeskManager(req, res))) return;
+
+    const dlEmail = normalizeEmail(decodeURIComponent(req.params.dlEmail));
+    const memberEmail = getValidEmail(req.body?.memberEmail) ?? '';
+    if (!validateEmailResponse(dlEmail, 'DL', res)) return;
+    if (!memberEmail) {
+      return res.status(400).json({ error: 'Valid memberEmail is required' });
+    }
+
+    const dl = mockDeskMailService.addDlMember(dlEmail, memberEmail);
+    logger.info('[TestDesk] Mock DL member added', { dlEmail: dl.email, memberEmail });
+    return res.json({
+      success: true,
+      dl,
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.delete('/desk/mock-dl/:dlEmail/members/:memberEmail', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    if (!(await requireWorkspaceDeskManager(req, res))) return;
+
+    const dlEmail = normalizeEmail(decodeURIComponent(req.params.dlEmail));
+    const memberEmail = normalizeEmail(decodeURIComponent(req.params.memberEmail));
+    if (
+      !validateEmailResponse(dlEmail, 'DL', res) ||
+      !validateEmailResponse(memberEmail, 'member', res)
+    ) {
+      return;
+    }
+
+    const dl = mockDeskMailService.removeDlMember(dlEmail, memberEmail);
+    logger.info('[TestDesk] Mock DL member removed', { dlEmail: dl.email, memberEmail });
+    return res.json({
+      success: true,
+      dl,
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.post('/desk/mock-dl/:dlEmail/send', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    if (!(await requireWorkspaceDeskManager(req, res))) return;
+
+    const dlEmail = normalizeEmail(decodeURIComponent(req.params.dlEmail));
+    const from = getValidEmail(req.body?.from) ?? '';
+    const subject = typeof req.body?.subject === 'string' ? req.body.subject : '';
+    const body = typeof req.body?.body === 'string' ? req.body.body : '';
+    if (!validateEmailResponse(dlEmail, 'DL', res)) return;
+    if (!from || !subject) {
+      return res.status(400).json({ error: 'Valid from email and subject are required' });
+    }
+
+    const dl = mockDeskMailService.getDl(dlEmail);
+    if (dl.members.length === 0) {
+      return res.status(404).json({ error: 'Mock DL not found or has no members' });
+    }
+
+    const mail = mockDeskMailService.sendToDl({ dlEmail, from, subject, body });
+    logger.info('[TestDesk] Mock DL mail sent', {
+      dlEmail: mail.dlEmail,
+      recipientCount: mail.to.length,
+      mailId: mail.id,
+    });
+    return res.json({
+      success: true,
+      mail,
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.get('/desk/mock-inbox/:email', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    if (!(await requireWorkspaceDeskManager(req, res))) return;
+
+    const email = normalizeEmail(decodeURIComponent(req.params.email));
+    if (!validateEmailResponse(email, 'inbox', res)) return;
+
+    const inbox = mockDeskMailService.getInbox(email);
+    logger.info('[TestDesk] Mock inbox listed', { email, count: inbox.length });
+    return res.json({
+      inbox,
+    });
+  } catch (error) {
+    return next(error);
+  }
+});
+
+router.use(
+  (error: Error & { status?: number }, _req: Request, res: Response, next: NextFunction) => {
+    if (!error.status) return next(error);
+    return res.status(error.status).json({ error: error.message });
+  }
+);
+
+export default router;

--- a/apps/backend/src/routes/testDesk.ts
+++ b/apps/backend/src/routes/testDesk.ts
@@ -7,7 +7,7 @@ import {
   TicketPriority,
   TicketStatusV2,
   WorkspaceRole,
-} from '@prisma/client';
+} from '@xyne/shared';
 import { db } from '@/database/client';
 import { authMiddleware } from '@/middleware/auth';
 import { config } from '@/config/env';
@@ -288,23 +288,13 @@ router.post('/desk/workspace-mailbox', async (req, res, next) => {
     if (!email || !validateEmailResponse(email, 'workspace mailbox', res)) return;
     const name = `${sourceType}-mock-workspace-${workspaceId}`;
     const existingSource = await db.externalSource.findUnique({
-      where: {
-        workspaceId_sourceType: {
-          workspaceId,
-          sourceType,
-        },
-      },
+      where: { name },
       select: { id: true, credentials: true },
     });
     if (rejectNonMockSourceOverwrite(existingSource, res)) return;
 
     const externalSource = await db.externalSource.upsert({
-      where: {
-        workspaceId_sourceType: {
-          workspaceId,
-          sourceType,
-        },
-      },
+      where: { name },
       create: {
         name,
         sourceType,
@@ -401,6 +391,7 @@ router.post('/desk/channel-source', async (req, res, next) => {
         where: { name },
         create: {
           name,
+          workspaceId,
           sourceType: persistedSourceType,
           displayName: email,
           channelId,
@@ -545,23 +536,13 @@ router.post('/desk/slack-workspace', async (req, res, next) => {
 
     const name = `slack-mock-workspace-${workspaceId}`;
     const existingSource = await db.externalSource.findUnique({
-      where: {
-        workspaceId_sourceType: {
-          workspaceId,
-          sourceType: 'slack',
-        },
-      },
+      where: { name },
       select: { id: true, credentials: true },
     });
     if (rejectNonMockSourceOverwrite(existingSource, res)) return;
 
     const externalSource = await db.externalSource.upsert({
-      where: {
-        workspaceId_sourceType: {
-          workspaceId,
-          sourceType: 'slack',
-        },
-      },
+      where: { name },
       create: {
         name,
         sourceType: 'slack',

--- a/apps/backend/src/routes/testDesk.ts
+++ b/apps/backend/src/routes/testDesk.ts
@@ -506,6 +506,33 @@ router.post('/desk/channel-source/:channelId/disconnect', async (req, res, next)
   }
 });
 
+// Deterministic test control for the per-channel Desk auto-merge preference.
+router.patch('/desk/channel/:channelId/auto-merge', async (req, res, next) => {
+  try {
+    if (!requireMockDeskEnabled(res)) return;
+    if (!(await requireWorkspaceDeskManager(req, res))) return;
+    const workspaceId = req.user?.workspaceId;
+    const channelId = req.params.channelId;
+    const enabled = req.body?.enabled;
+    if (!workspaceId || typeof enabled !== 'boolean') {
+      return res.status(400).json({ error: 'enabled boolean is required' });
+    }
+    const channel = await db.channel.findFirst({
+      where: { id: channelId, workspaceId },
+      select: { id: true },
+    });
+    if (!channel) return res.status(404).json({ error: 'Desk channel not found in current workspace' });
+    const preference = await db.emailChannelPreference.update({
+      where: { channelId },
+      data: { emailMergeMode: enabled ? 'ENABLED' : 'DISABLED' },
+      select: { channelId: true, emailMergeMode: true },
+    });
+    return res.json({ success: true, ...preference });
+  } catch (error) {
+    return next(error);
+  }
+});
+
 router.post('/desk/slack-workspace', async (req, res, next) => {
   try {
     if (!requireMockDeskEnabled(res)) return;

--- a/apps/backend/src/routes/testDesk.ts
+++ b/apps/backend/src/routes/testDesk.ts
@@ -348,6 +348,20 @@ router.post('/desk/channel-source', async (req, res, next) => {
       return res.status(404).json({ error: 'Desk channel not found in current workspace' });
     }
 
+    // Match the authorization used by every other channel-scoped route: the
+    // caller must be a workspace desk manager (owner/admin) or a member of the
+    // channel. Without this, any workspace user could attach a mock source to a
+    // channel they are not part of.
+    const requestingUser = await getCurrentWorkspaceUser(userId, workspaceId);
+    const canManageWorkspaceSource = canManageWorkspaceDesk(requestingUser?.role);
+    const membership = await db.channelParticipant.findUnique({
+      where: { channelId_userId: { channelId, userId } },
+      select: { id: true },
+    });
+    if (!canManageWorkspaceSource && !membership) {
+      return res.status(403).json({ error: 'Not a member of this channel' });
+    }
+
     const firstBoard = await db.board.findFirst({
       where: { projectId: channel.projectId },
       orderBy: { createdAt: 'asc' },
@@ -382,9 +396,14 @@ router.post('/desk/channel-source', async (req, res, next) => {
     if (rejectNonMockSourceOverwrite(existingSource, res)) return;
 
     const externalSource = await db.$transaction(async (tx) => {
-      await tx.emailChannelPreference.updateMany({
+      // Upsert (not updateMany): a channel without an existing preference row
+      // used to leave updateMany a silent 0-row no-op, producing a mock source
+      // pointed at a channel with no ticket board. Upsert guarantees the
+      // preference exists and targets the resolved board.
+      await tx.emailChannelPreference.upsert({
         where: { channelId },
-        data: { boardId: firstBoard.id },
+        create: { channelId, workspaceId, boardId: firstBoard.id },
+        update: { boardId: firstBoard.id },
       });
 
       return tx.externalSource.upsert({

--- a/apps/backend/src/services/mockDeskMailService.ts
+++ b/apps/backend/src/services/mockDeskMailService.ts
@@ -1,0 +1,205 @@
+import crypto from 'crypto';
+import { config } from '@/config/env';
+
+// Mock storage is capped and evicts oldest records first so long CI runs do not
+// grow process memory without bound. Tests should not assert exact totals above
+// this mock-provider capacity.
+const MAX_STORED_MOCK_MAILS = 500;
+const MAX_DL_MEMBERS = 100;
+const deskMockEnabled = config.isDeskMockEnabled;
+
+function createMockDeskValidationError(message: string): Error & { status: number } {
+  const error = new Error(message) as Error & { status: number };
+  error.status = 400;
+  return error;
+}
+
+export interface CapturedDeskMail {
+  id: string;
+  kind: 'reply' | 'compose';
+  status: 'sent';
+  channelId: string;
+  conversationId?: string;
+  from: string;
+  to: string[];
+  cc: string[];
+  bcc: string[];
+  subject: string;
+  body: string;
+  threadId: string;
+  messageId: string;
+  attachmentCount: number;
+  createdAt: string;
+}
+
+export interface CaptureDeskMailInput {
+  kind: CapturedDeskMail['kind'];
+  channelId: string;
+  conversationId?: string;
+  from: string;
+  to: string[];
+  cc?: string[];
+  bcc?: string[];
+  subject: string;
+  body: string;
+  threadId?: string;
+  attachmentCount?: number;
+}
+
+export interface SentMailFilter {
+  channelId?: string;
+  conversationId?: string;
+}
+
+export interface MockDlMail {
+  id: string;
+  dlEmail: string;
+  from: string;
+  to: string[];
+  subject: string;
+  body: string;
+  createdAt: string;
+}
+
+export interface MockDlGroup {
+  email: string;
+  members: string[];
+}
+
+class MockDeskMailService {
+  // Mock Desk state is intentionally process-local. Local and CI automation run
+  // a single backend process; do not enable DESK_MOCK_ENABLED for horizontally
+  // scaled or public-facing deployments.
+  private readonly sentMails: CapturedDeskMail[] = [];
+  private readonly dlMembersByEmail = new Map<string, Set<string>>();
+  private readonly inboxByEmail = new Map<string, MockDlMail[]>();
+
+  isEnabled(): boolean {
+    return deskMockEnabled;
+  }
+
+  private trimStoredMails<T>(items: T[]): void {
+    if (items.length > MAX_STORED_MOCK_MAILS) {
+      items.splice(0, items.length - MAX_STORED_MOCK_MAILS);
+    }
+  }
+
+  captureSentMail(input: CaptureDeskMailInput): CapturedDeskMail {
+    const id = `mock-mail-${crypto.randomUUID()}`;
+    const threadId = input.threadId || `mock-thread-${crypto.randomUUID()}`;
+    const messageId = `mock-message-${crypto.randomUUID()}`;
+    const mail: CapturedDeskMail = {
+      id,
+      kind: input.kind,
+      status: 'sent',
+      channelId: input.channelId,
+      ...(input.conversationId && { conversationId: input.conversationId }),
+      from: input.from,
+      to: [...new Set(input.to)],
+      cc: [...new Set(input.cc ?? [])],
+      bcc: [...new Set(input.bcc ?? [])],
+      subject: input.subject,
+      body: input.body,
+      threadId,
+      messageId,
+      attachmentCount: input.attachmentCount ?? 0,
+      createdAt: new Date().toISOString(),
+    };
+
+    this.sentMails.push(mail);
+    this.trimStoredMails(this.sentMails);
+    return mail;
+  }
+
+  private matchesSentMailFilter(mail: CapturedDeskMail, filter: SentMailFilter): boolean {
+    if (filter.channelId && mail.channelId !== filter.channelId) return false;
+    if (filter.conversationId && mail.conversationId !== filter.conversationId) return false;
+    return true;
+  }
+
+  listSentMails(filter: SentMailFilter = {}): CapturedDeskMail[] {
+    return this.sentMails.filter((mail) => this.matchesSentMailFilter(mail, filter));
+  }
+
+  reset(filter: SentMailFilter): void {
+    for (let index = this.sentMails.length - 1; index >= 0; index -= 1) {
+      if (this.matchesSentMailFilter(this.sentMails[index], filter)) {
+        this.sentMails.splice(index, 1);
+      }
+    }
+  }
+
+  createDl(email: string): MockDlGroup {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!this.dlMembersByEmail.has(normalizedEmail)) {
+      this.dlMembersByEmail.set(normalizedEmail, new Set());
+    }
+
+    return this.getDl(normalizedEmail);
+  }
+
+  getDl(email: string): MockDlGroup {
+    const normalizedEmail = email.trim().toLowerCase();
+    const members = this.dlMembersByEmail.get(normalizedEmail) ?? new Set<string>();
+    return {
+      email: normalizedEmail,
+      members: [...members].sort(),
+    };
+  }
+
+  addDlMember(dlEmail: string, memberEmail: string): MockDlGroup {
+    const normalizedDlEmail = dlEmail.trim().toLowerCase();
+    const normalizedMemberEmail = memberEmail.trim().toLowerCase();
+    const members = this.dlMembersByEmail.get(normalizedDlEmail) ?? new Set<string>();
+    const isExistingMember = members.has(normalizedMemberEmail);
+    if (!isExistingMember && members.size >= MAX_DL_MEMBERS) {
+      throw createMockDeskValidationError(`Mock DL member limit (${MAX_DL_MEMBERS}) exceeded`);
+    }
+    members.add(normalizedMemberEmail);
+    this.dlMembersByEmail.set(normalizedDlEmail, members);
+    return this.getDl(normalizedDlEmail);
+  }
+
+  removeDlMember(dlEmail: string, memberEmail: string): MockDlGroup {
+    const normalizedDlEmail = dlEmail.trim().toLowerCase();
+    const normalizedMemberEmail = memberEmail.trim().toLowerCase();
+    const members = this.dlMembersByEmail.get(normalizedDlEmail);
+    members?.delete(normalizedMemberEmail);
+    return this.getDl(normalizedDlEmail);
+  }
+
+  sendToDl(input: { dlEmail: string; from: string; subject: string; body: string }): MockDlMail {
+    const normalizedDlEmail = input.dlEmail.trim().toLowerCase();
+    const members = this.dlMembersByEmail.get(normalizedDlEmail) ?? new Set<string>();
+    const mail: MockDlMail = {
+      id: `mock-dl-mail-${crypto.randomUUID()}`,
+      dlEmail: normalizedDlEmail,
+      from: input.from.trim().toLowerCase(),
+      to: [...members].sort(),
+      subject: input.subject,
+      body: input.body,
+      createdAt: new Date().toISOString(),
+    };
+
+    for (const member of members) {
+      const inbox = this.inboxByEmail.get(member) ?? [];
+      inbox.push(mail);
+      this.trimStoredMails(inbox);
+      this.inboxByEmail.set(member, inbox);
+    }
+
+    return mail;
+  }
+
+  getInbox(email: string): MockDlMail[] {
+    const normalizedEmail = email.trim().toLowerCase();
+    return [...(this.inboxByEmail.get(normalizedEmail) ?? [])];
+  }
+
+  resetDlState(): void {
+    this.dlMembersByEmail.clear();
+    this.inboxByEmail.clear();
+  }
+}
+
+export const mockDeskMailService = new MockDeskMailService();

--- a/apps/backend/src/utils/mockDeskCredentials.ts
+++ b/apps/backend/src/utils/mockDeskCredentials.ts
@@ -1,0 +1,23 @@
+import { decrypt } from '@/services/encryptionService';
+
+export function buildMockDeskCredentials(payload: Record<string, unknown>): Record<string, unknown> {
+  return {
+    mock: true,
+    accessToken: 'mock-access-token',
+    refreshToken: 'mock-refresh-token',
+    ...payload,
+  };
+}
+
+export function parseMockDeskCredentials(
+  encryptedCredentials: string | null | undefined
+): { isMock: boolean; error?: Error } {
+  if (!encryptedCredentials) return { isMock: false };
+
+  try {
+    const credentials = JSON.parse(decrypt(encryptedCredentials)) as { mock?: unknown };
+    return { isMock: credentials.mock === true };
+  } catch (error) {
+    return { isMock: false, error: error instanceof Error ? error : new Error(String(error)) };
+  }
+}

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -3061,6 +3061,7 @@ const SupportScreen = (): ReactElement => {
                                   id='assignee'
                                   active={hasAssigneeFilter}
                                   open={assigneeOpen}
+                                  data-testid='desk-filter-assignee'
                                 />
                               </Popover.Trigger>
                               <Popover.Content
@@ -3088,6 +3089,7 @@ const SupportScreen = (): ReactElement => {
                                   id='priority'
                                   active={hasPriorityFilter}
                                   open={priorityOpen}
+                                  data-testid='desk-filter-priority'
                                 />
                               </Popover.Trigger>
                               <Popover.Content
@@ -3114,6 +3116,7 @@ const SupportScreen = (): ReactElement => {
                                   id='stages'
                                   active={hasStagesFilter}
                                   open={stagesOpen}
+                                  data-testid='desk-filter-status'
                                 />
                               </Popover.Trigger>
                               <Popover.Content

--- a/docs/superpowers/plans/2026-08-27-xyne-desk-automation-coverage.md
+++ b/docs/superpowers/plans/2026-08-27-xyne-desk-automation-coverage.md
@@ -1,0 +1,55 @@
+# Xyne Desk Automation Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the Xyne Desk automation callable, genuinely UI-driven for user workflows, and complete for routing and bulk Pub/Sub behavior.
+
+**Architecture:** Mount the test-only Desk fixture router alongside test auth routes. Extend Gauge steps to drive the existing Desk UI for reply, compose, ticket updates, merge, and unmerge, while using fixture APIs only to inject data and verify provider outcomes. Add independent negative routing and bulk-delivery assertions.
+
+**Tech Stack:** Express/TypeScript backend, Gauge TS, Playwright, Prisma, existing Desk integration APIs.
+
+**Spec:** User-provided Xyne Desk happy-flow checklist in conversation.
+
+## Global Constraints
+
+- Test routes remain available only in test/dev-auth environments and with `DESK_MOCK_ENABLED=true`.
+- Do not alter unrelated working-tree files.
+- UI steps must assert visible state, not only API response IDs.
+
+### Task 1: Mount Desk test routes
+
+**Files:** Modify `apps/backend/src/app.ts`.
+
+- [ ] Import `testDeskRoutes` and mount it at `/api/test` inside the existing test/dev-auth guard.
+- [ ] Run the backend typecheck or route compilation check available in the repository.
+
+### Task 2: Strengthen existing Desk assertions
+
+**Files:** Modify `tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts`, specs 02/03/06.
+
+- [ ] Make ingestion verification fetch ticket/email details and assert persisted subject, body, sender, and channel.
+- [ ] Add admin-positive mailbox configuration.
+- [ ] Add explicit “email absent from channel” routing assertions.
+- [ ] Send Slack fixtures through a Slack-specific mock endpoint and verify the resulting ticket.
+
+### Task 3: Convert user workflows to browser interactions
+
+**Files:** Modify Desk step definitions and specs 01/05/07/09.
+
+- [ ] Use existing Desk selectors/UI controls to reply and reply-all.
+- [ ] Compose through the Desk composer UI and verify the provider capture afterward.
+- [ ] Update priority/status through ticket controls and verify visible persisted state.
+- [ ] Merge and unmerge through ticket UI actions and verify visible state plus API outcome.
+
+### Task 4: Add Pub/Sub bulk flow
+
+**Files:** Modify mock Desk route/service and add `11_pubsub-bulk-mail-flow.spec` plus steps.
+
+- [ ] Add a deterministic bulk publish/consume fixture endpoint using the existing process-local mock service.
+- [ ] Assert all messages are delivered once, routed to the expected channels, and remain absent from unrelated channels.
+- [ ] Exercise one retryable failure and assert eventual delivery without duplication.
+
+### Task 5: Verify and commit
+
+- [ ] Run automation integrity/type checks available in the environment.
+- [ ] Review the final diff and commit only Desk automation changes.

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/01_dl-desk-mail-happy-flow.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/01_dl-desk-mail-happy-flow.spec
@@ -1,0 +1,13 @@
+# Xyne Desk DL mail happy flow
+
+## Create DL desk, receive customer mail, and send a reply through the mock provider
+* using browser
+* logging in as user "admin-1"
+* Creating DL Desk channel "channel-desk-dl-happy-flow" for user "admin-1" in project "project-1"
+* clearing mock Desk sent mails for channel "channel-desk-dl-happy-flow" user "admin-1"
+* generating mock incoming Desk email "customer-mail-1"
+* injecting mock incoming Desk email "customer-mail-1" into channel "channel-desk-dl-happy-flow" for user "admin-1"
+* verifying mock Desk email "customer-mail-1" was ingested
+* replying to mock Desk email "customer-mail-1" from channel "channel-desk-dl-happy-flow" for user "admin-1"
+* verifying mock Desk sent mail count is "1" for incoming email "customer-mail-1"
+* verifying latest mock Desk sent mail matches incoming email "customer-mail-1"

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/02_workspace-desk-admin-only.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/02_workspace-desk-admin-only.spec
@@ -3,5 +3,6 @@
 ## Only admins can configure the workspace shared Desk mailbox
 * using browser
 * logging in as user "admin-1"
+* configuring mock Desk shared mailbox for user "admin-1"
 * logging in as user "user-1"
 * verifying user "user-1" cannot configure mock Desk shared mailbox

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/02_workspace-desk-admin-only.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/02_workspace-desk-admin-only.spec
@@ -1,0 +1,7 @@
+# Xyne Desk workspace shared mailbox permissions
+
+## Only admins can configure the workspace shared Desk mailbox
+* using browser
+* logging in as user "admin-1"
+* logging in as user "user-1"
+* verifying user "user-1" cannot configure mock Desk shared mailbox

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/03_dl-desk-multiple-dl-routing.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/03_dl-desk-multiple-dl-routing.spec
@@ -1,0 +1,17 @@
+# Xyne Desk multiple DL routing
+
+## Multiple DL desk channels receive their own incoming mails
+* using browser
+* logging in as user "admin-1"
+* Creating DL Desk channel "channel-desk-dl-routing-a" for user "admin-1" in project "project-1"
+* Creating DL Desk channel "channel-desk-dl-routing-b" for user "admin-1" in project "project-1"
+* Creating DL Desk channel "channel-desk-dl-routing-c" for user "admin-1" in project "project-1"
+* generating mock incoming Desk email "routing-mail-a"
+* generating mock incoming Desk email "routing-mail-b"
+* generating mock incoming Desk email "routing-mail-c"
+* injecting mock incoming Desk email "routing-mail-a" into channel "channel-desk-dl-routing-a" for user "admin-1"
+* injecting mock incoming Desk email "routing-mail-b" into channel "channel-desk-dl-routing-b" for user "admin-1"
+* injecting mock incoming Desk email "routing-mail-c" into channel "channel-desk-dl-routing-c" for user "admin-1"
+* verifying mock Desk email "routing-mail-a" was ingested
+* verifying mock Desk email "routing-mail-b" was ingested
+* verifying mock Desk email "routing-mail-c" was ingested

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/03_dl-desk-multiple-dl-routing.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/03_dl-desk-multiple-dl-routing.spec
@@ -15,3 +15,9 @@
 * verifying mock Desk email "routing-mail-a" was ingested
 * verifying mock Desk email "routing-mail-b" was ingested
 * verifying mock Desk email "routing-mail-c" was ingested
+* verifying Desk channel "channel-desk-dl-routing-a" does not contain email "routing-mail-b" for user "admin-1"
+* verifying Desk channel "channel-desk-dl-routing-a" does not contain email "routing-mail-c" for user "admin-1"
+* verifying Desk channel "channel-desk-dl-routing-b" does not contain email "routing-mail-a" for user "admin-1"
+* verifying Desk channel "channel-desk-dl-routing-b" does not contain email "routing-mail-c" for user "admin-1"
+* verifying Desk channel "channel-desk-dl-routing-c" does not contain email "routing-mail-a" for user "admin-1"
+* verifying Desk channel "channel-desk-dl-routing-c" does not contain email "routing-mail-b" for user "admin-1"

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/04_mock-dl-membership-delivery.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/04_mock-dl-membership-delivery.spec
@@ -1,0 +1,28 @@
+# Xyne Desk mock DL membership delivery
+
+## Member in three DLs receives all DL mails and stops receiving removed DL mails
+* using browser
+* logging in as user "admin-1"
+* resetting mock DL provider state
+* creating mock DL "mock-dl-a"
+* creating mock DL "mock-dl-b"
+* creating mock DL "mock-dl-c"
+* adding member "desk-member@example.test" to mock DL "mock-dl-a"
+* adding member "desk-member@example.test" to mock DL "mock-dl-b"
+* adding member "desk-retained-member@example.test" to mock DL "mock-dl-b"
+* adding member "desk-member@example.test" to mock DL "mock-dl-c"
+* sending mock provider mail "first-mail-a" to mock DL "mock-dl-a"
+* sending mock provider mail "first-mail-b" to mock DL "mock-dl-b"
+* sending mock provider mail "first-mail-c" to mock DL "mock-dl-c"
+* verifying mock inbox "desk-member@example.test" total mail count is "3"
+* verifying mock inbox "desk-member@example.test" has "1" mails from mock DL "mock-dl-a"
+* verifying mock inbox "desk-member@example.test" has "1" mails from mock DL "mock-dl-b"
+* verifying mock inbox "desk-member@example.test" has "1" mails from mock DL "mock-dl-c"
+* removing member "desk-member@example.test" from mock DL "mock-dl-b"
+* sending mock provider mail "second-mail-a" to mock DL "mock-dl-a"
+* sending mock provider mail "second-mail-b" to mock DL "mock-dl-b"
+* sending mock provider mail "second-mail-c" to mock DL "mock-dl-c"
+* verifying mock inbox "desk-member@example.test" total mail count is "5"
+* verifying mock inbox "desk-member@example.test" has "2" mails from mock DL "mock-dl-a"
+* verifying mock inbox "desk-member@example.test" has "1" mails from mock DL "mock-dl-b"
+* verifying mock inbox "desk-member@example.test" has "2" mails from mock DL "mock-dl-c"

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/05_personal-mailbox-happy-flow.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/05_personal-mailbox-happy-flow.spec
@@ -1,0 +1,13 @@
+# Xyne Desk personal mailbox happy flow
+
+## Create personal mailbox desk, receive customer mail, and send a reply through the mock provider
+* using browser
+* logging in as user "admin-1"
+* Creating personal Desk channel "channel-desk-personal-happy-flow" for user "admin-1" in project "project-1"
+* clearing mock Desk sent mails for channel "channel-desk-personal-happy-flow" user "admin-1"
+* generating mock incoming Desk email "personal-customer-mail-1"
+* injecting mock incoming Desk email "personal-customer-mail-1" into channel "channel-desk-personal-happy-flow" for user "admin-1"
+* verifying mock Desk email "personal-customer-mail-1" was ingested
+* replying to mock Desk email "personal-customer-mail-1" from channel "channel-desk-personal-happy-flow" for user "admin-1"
+* verifying mock Desk sent mail count is "1" for incoming email "personal-customer-mail-1"
+* verifying latest mock Desk sent mail matches incoming email "personal-customer-mail-1"

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/06_slack-channel-happy-flow.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/06_slack-channel-happy-flow.spec
@@ -1,0 +1,9 @@
+# Xyne Desk Slack channel happy flow
+
+## Create Slack desk channel and receive a Slack message as a Desk ticket
+* using browser
+* logging in as user "admin-1"
+* Creating Slack Desk channel "channel-desk-slack-happy-flow" for user "admin-1" in project "project-1"
+* generating mock Slack Desk message "slack-message-1"
+* injecting mock Slack Desk message "slack-message-1" into channel "channel-desk-slack-happy-flow" for user "admin-1"
+* verifying mock Desk email "slack-message-1" was ingested

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/07_personal-mailbox-advanced-flow.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/07_personal-mailbox-advanced-flow.spec
@@ -1,0 +1,17 @@
+# Xyne Desk personal mailbox advanced flow
+
+## Personal mailbox ticket UI, update, reply-all, and attachment happy flow
+* using browser
+* logging in as user "admin-1"
+* Creating personal Desk channel "channel-desk-personal-advanced-flow" for user "admin-1" in project "project-1"
+* clearing mock Desk sent mails for channel "channel-desk-personal-advanced-flow" user "admin-1"
+* generating mock incoming Desk email "personal-advanced-mail-1" with reply-all recipients and attachment
+* injecting mock incoming Desk email "personal-advanced-mail-1" into channel "channel-desk-personal-advanced-flow" for user "admin-1"
+* verifying mock Desk email "personal-advanced-mail-1" was ingested
+* verifying mock Desk ticket for email "personal-advanced-mail-1" has expected subject body sender and attachment
+* verifying Desk data shows mock email "personal-advanced-mail-1" in channel "channel-desk-personal-advanced-flow" for user "admin-1"
+* updating mock Desk ticket for email "personal-advanced-mail-1" priority to "HIGH" and status to "STARTED"
+* verifying mock Desk ticket for email "personal-advanced-mail-1" priority is "HIGH" and status is "STARTED"
+* replying all to mock Desk email "personal-advanced-mail-1" from channel "channel-desk-personal-advanced-flow" for user "admin-1"
+* verifying mock Desk sent mail count is "1" for incoming email "personal-advanced-mail-1"
+* verifying latest mock Desk sent reply-all mail matches incoming email "personal-advanced-mail-1"

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/08_connection-lifecycle.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/08_connection-lifecycle.spec
@@ -1,0 +1,19 @@
+# Xyne Desk connection lifecycle
+
+## Personal mailbox can disconnect and reconnect through mock Desk setup
+* using browser
+* logging in as user "admin-1"
+* Creating personal Desk channel "channel-desk-connect-lifecycle" for user "admin-1" in project "project-1"
+* verifying Desk channel "channel-desk-connect-lifecycle" is connected for user "admin-1"
+* disconnecting Desk mailbox for channel "channel-desk-connect-lifecycle" user "admin-1"
+* verifying Desk channel "channel-desk-connect-lifecycle" is disconnected for user "admin-1"
+* reconnecting mock Desk mailbox for channel "channel-desk-connect-lifecycle" user "admin-1"
+* verifying Desk channel "channel-desk-connect-lifecycle" is connected for user "admin-1"
+
+## Slack Desk channel can disconnect after mock connect
+* using browser
+* logging in as user "admin-1"
+* Creating Slack Desk channel "channel-desk-slack-connect-lifecycle" for user "admin-1" in project "project-1"
+* verifying Desk channel "channel-desk-slack-connect-lifecycle" is connected for user "admin-1"
+* disconnecting Slack Desk channel "channel-desk-slack-connect-lifecycle" for user "admin-1"
+* verifying Desk channel "channel-desk-slack-connect-lifecycle" is disconnected for user "admin-1"

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/09_compose-merge-unmerge.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/09_compose-merge-unmerge.spec
@@ -1,0 +1,17 @@
+# Xyne Desk compose merge and unmerge
+
+## Compose mail creates a Desk ticket and the ticket can be merged and unmerged
+* using browser
+* logging in as user "admin-1"
+* Creating personal Desk channel "channel-desk-compose-merge-flow" for user "admin-1" in project "project-1"
+* clearing mock Desk sent mails for channel "channel-desk-compose-merge-flow" user "admin-1"
+* composing mock Desk email "compose-mail-1" from channel "channel-desk-compose-merge-flow" for user "admin-1"
+* verifying mock Desk email "compose-mail-1" was ingested
+* verifying latest mock Desk composed mail matches "compose-mail-1"
+* generating mock incoming Desk email "merge-target-mail-1"
+* injecting mock incoming Desk email "merge-target-mail-1" into channel "channel-desk-compose-merge-flow" for user "admin-1"
+* verifying mock Desk email "merge-target-mail-1" was ingested
+* merging mock Desk ticket "compose-mail-1" into "merge-target-mail-1" as user "admin-1"
+* verifying mock Desk ticket "compose-mail-1" is merged into "merge-target-mail-1"
+* unmerging mock Desk ticket "compose-mail-1" as user "admin-1"
+* verifying mock Desk ticket "compose-mail-1" is unmerged

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/10_ai-rewrite-compose-controls.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/10_ai-rewrite-compose-controls.spec
@@ -1,0 +1,11 @@
+# Xyne Desk AI rewrite and compose controls
+
+## Desk ticket exposes compose Ask AI and rewrite controls without invoking external AI
+* using browser
+* logging in as user "admin-1"
+* Creating personal Desk channel "channel-desk-ai-rewrite-controls" for user "admin-1" in project "project-1"
+* generating mock incoming Desk email "ai-rewrite-mail-1"
+* injecting mock incoming Desk email "ai-rewrite-mail-1" into channel "channel-desk-ai-rewrite-controls" for user "admin-1"
+* verifying mock Desk email "ai-rewrite-mail-1" was ingested
+* verifying Desk compose control is available for channel "channel-desk-ai-rewrite-controls" user "admin-1"
+* verifying Desk AI and rewrite controls are available for email "ai-rewrite-mail-1"

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/11_pubsub-bulk-mail-flow.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/11_pubsub-bulk-mail-flow.spec
@@ -1,0 +1,9 @@
+# Xyne Desk deterministic Pub/Sub bulk mail flow
+
+## Bulk Gmail Pub/Sub delivery reaches Desk exactly once
+* using browser
+* logging in as user "admin-1"
+* Creating personal Desk channel "channel-desk-pubsub-bulk" for user "admin-1" in project "project-1"
+* generating "25" deterministic Pub/Sub Gmail messages as batch "pubsub-bulk-1"
+* publishing deterministic Pub/Sub batch "pubsub-bulk-1" to Desk channel "channel-desk-pubsub-bulk" for user "admin-1"
+* republishing deterministic Pub/Sub batch "pubsub-bulk-1" to Desk channel "channel-desk-pubsub-bulk" for user "admin-1"

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/12_recipients-and-filters.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/12_recipients-and-filters.spec
@@ -1,0 +1,16 @@
+# Xyne Desk recipients and filters
+
+## Reply recipients and Desk filters remain correct
+* using browser
+* logging in as user "admin-1"
+* Creating personal Desk channel "channel-desk-recipients-filters" for user "admin-1" in project "project-1"
+* generating mock incoming Desk email "recipient-filter-mail-1" with reply-all recipients and attachment
+* injecting mock incoming Desk email "recipient-filter-mail-1" into channel "channel-desk-recipients-filters" for user "admin-1"
+* verifying mock Desk email "recipient-filter-mail-1" was ingested
+* replying to mock Desk email "recipient-filter-mail-1" from channel "channel-desk-recipients-filters" for user "admin-1"
+* verifying mock Desk sent mail count is "1" for incoming email "recipient-filter-mail-1"
+* verifying latest mock Desk sent mail matches incoming email "recipient-filter-mail-1"
+* replying all to mock Desk email "recipient-filter-mail-1" from channel "channel-desk-recipients-filters" for user "admin-1"
+* verifying mock Desk sent mail count is "2" for incoming email "recipient-filter-mail-1"
+* verifying latest mock Desk sent reply-all mail matches incoming email "recipient-filter-mail-1"
+* verifying Desk priority and status filters work for channel "channel-desk-recipients-filters" user "admin-1"

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/13_auto-merge-manual-controls.spec
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/13_auto-merge-manual-controls.spec
@@ -1,0 +1,26 @@
+# Xyne Desk auto-merge and manual controls
+
+## Auto Merge ON combines matching emails
+* using browser
+* logging in as user "admin-1"
+* Creating personal Desk channel "channel-desk-auto-merge-on" for user "admin-1" in project "project-1"
+* setting Desk auto-merge "on" for channel "channel-desk-auto-merge-on" user "admin-1"
+* generating mock Desk email pair "auto-merge-on-mail-1" and "auto-merge-on-mail-2" with the same subject and domain
+* injecting mock incoming Desk email "auto-merge-on-mail-1" into channel "channel-desk-auto-merge-on" for user "admin-1"
+* waiting for "2" seconds
+* injecting mock incoming Desk email "auto-merge-on-mail-2" into channel "channel-desk-auto-merge-on" for user "admin-1"
+* verifying mock Desk emails "auto-merge-on-mail-1" and "auto-merge-on-mail-2" share one conversation
+
+## Auto Merge OFF keeps emails separate and manual merge/demerge remains available
+* using browser
+* logging in as user "admin-1"
+* Creating personal Desk channel "channel-desk-auto-merge-off" for user "admin-1" in project "project-1"
+* setting Desk auto-merge "off" for channel "channel-desk-auto-merge-off" user "admin-1"
+* generating mock Desk email pair "auto-merge-off-mail-1" and "auto-merge-off-mail-2" with the same subject and domain
+* injecting mock incoming Desk email "auto-merge-off-mail-1" into channel "channel-desk-auto-merge-off" for user "admin-1"
+* injecting mock incoming Desk email "auto-merge-off-mail-2" into channel "channel-desk-auto-merge-off" for user "admin-1"
+* verifying mock Desk emails "auto-merge-off-mail-1" and "auto-merge-off-mail-2" have separate conversations
+* merging mock Desk ticket "auto-merge-off-mail-1" into "auto-merge-off-mail-2" as user "admin-1"
+* verifying mock Desk ticket "auto-merge-off-mail-1" is merged into "auto-merge-off-mail-2"
+* unmerging mock Desk ticket "auto-merge-off-mail-1" through the UI for user "admin-1"
+* verifying mock Desk ticket "auto-merge-off-mail-1" is unmerged

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk-name-utils.ts
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk-name-utils.ts
@@ -1,0 +1,33 @@
+import { buildRandomSuffix } from '@/fixtures/fixture-helpers';
+
+function sanitizeNamePart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function getDeskRunId(): string {
+  const runId = process.env.XYNE_RUN_ID ?? 'local';
+  const normalizedRunId = sanitizeNamePart(runId);
+  if (!normalizedRunId) {
+    throw new Error('XYNE_RUN_ID must contain at least one alphanumeric character when set');
+  }
+
+  return runId;
+}
+
+/**
+ * Builds an 80-char-safe channel name with a run id and random suffix.
+ * The six-character suffix keeps names stable/readable while making collisions negligible for automation runs.
+ */
+export function buildUniqueDeskChannelName(channelAlias: string, runId = getDeskRunId()): string {
+  const normalizedAlias = sanitizeNamePart(channelAlias) || 'channel-desk';
+  const normalizedRunId = sanitizeNamePart(runId) || 'local';
+  const uniqueSuffix = `${normalizedRunId}-${buildRandomSuffix()}`;
+  const maxAliasLength = Math.max(1, 80 - uniqueSuffix.length - 1);
+  const trimmedAlias = normalizedAlias.slice(0, maxAliasLength).replace(/-+$/g, '');
+
+  return `${trimmedAlias}-${uniqueSuffix}`;
+}

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk-state.ts
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk-state.ts
@@ -28,6 +28,8 @@ export const mockDeskMails = new Map<string, MockDeskMailFixture>();
 export const deskChannelDlEmails = new Map<string, string>();
 export const slackChannelIds = new Map<string, string>();
 export const mockDlEmails = new Map<string, string>();
+export const mockPubSubBatches = new Map<string, { messageIds: string[]; historyId: string }>();
+export const mockPubSubMessages = new Map<string, Array<Record<string, unknown>>>();
 export const apiContextsByUserAlias = new Map<string, APIRequestContext>();
 
 export async function disposeDeskApiContexts(): Promise<void> {
@@ -42,5 +44,7 @@ export async function resetDeskScenarioState(): Promise<void> {
   deskChannelDlEmails.clear();
   slackChannelIds.clear();
   mockDlEmails.clear();
+  mockPubSubBatches.clear();
+  mockPubSubMessages.clear();
   await disposeDeskApiContexts();
 }

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk-state.ts
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk-state.ts
@@ -1,0 +1,46 @@
+import type { APIRequestContext } from '@playwright/test';
+
+export interface MockDeskMailFixture {
+  alias: string;
+  subject: string;
+  body: string;
+  from: string;
+  to: string;
+  cc?: string[];
+  bcc?: string[];
+  replyTo?: string[];
+  attachments?: MockDeskAttachmentFixture[];
+  threadId: string;
+  messageId: string;
+  channelAlias?: string;
+  conversationId?: string;
+  ticketId?: string;
+  xyneId?: string;
+}
+
+export interface MockDeskAttachmentFixture {
+  filename: string;
+  mimetype: string;
+  size: number;
+}
+
+export const mockDeskMails = new Map<string, MockDeskMailFixture>();
+export const deskChannelDlEmails = new Map<string, string>();
+export const slackChannelIds = new Map<string, string>();
+export const mockDlEmails = new Map<string, string>();
+export const apiContextsByUserAlias = new Map<string, APIRequestContext>();
+
+export async function disposeDeskApiContexts(): Promise<void> {
+  const contexts = [...apiContextsByUserAlias.values()];
+  apiContextsByUserAlias.clear();
+
+  await Promise.allSettled(contexts.map((apiContext) => apiContext.dispose()));
+}
+
+export async function resetDeskScenarioState(): Promise<void> {
+  mockDeskMails.clear();
+  deskChannelDlEmails.clear();
+  slackChannelIds.clear();
+  mockDlEmails.clear();
+  await disposeDeskApiContexts();
+}

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.cpt
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.cpt
@@ -1,0 +1,4 @@
+# Creating DL Desk channel <channelAlias> for user <userAlias> in project <projectAlias>
+* ensuring project <projectAlias> exists in fixture for user <userAlias>
+* configuring mock Desk shared mailbox for user <userAlias>
+* creating mock DL Desk channel <channelAlias> for user <userAlias> in project <projectAlias>

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
@@ -791,7 +791,7 @@ export default class XyneDeskSteps {
     mail.channelAlias = channelAlias;
 
     const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
-      apiContext.post('/api/test/desk/incoming-email', {
+      apiContext.post('/api/test/desk/slack-event', {
         data: {
           channelId: channel.id,
           from: mail.from,
@@ -804,7 +804,7 @@ export default class XyneDeskSteps {
       })
     );
 
-    await assertOkResponse(response, 'Mock Slack Desk message injection');
+    await assertOkResponse(response, 'Mock Slack Desk event injection');
 
     const body = (await response.json()) as Record<string, unknown>;
     const conversation = body.conversation as { conversationId?: string } | undefined;
@@ -812,6 +812,7 @@ export default class XyneDeskSteps {
       typeof body.conversationId === 'string' ? body.conversationId : conversation?.conversationId;
     assert.ok(conversationId, 'Expected Slack message response to include conversationId.');
     mail.conversationId = conversationId;
+    await this.fetchAndStoreDeskTicketDetails(mailAlias);
   }
 
   @Step('waiting for mock Desk email <mailAlias> subject to appear in <selector>')
@@ -887,7 +888,35 @@ export default class XyneDeskSteps {
   @Step('verifying mock Desk email <mailAlias> was ingested')
   public async verifyMockEmailWasIngested(mailAlias: string): Promise<void> {
     const mail = assertFixture(mailAlias);
-    assert.ok(mail.conversationId, `Expected mock Desk email "${mailAlias}" to be ingested.`);
+    const details = await this.fetchAndStoreDeskTicketDetails(mailAlias);
+    assert.ok(details.ticket?.id, `Expected mock Desk email "${mailAlias}" to create a ticket.`);
+    assert.equal(details.emails?.[0]?.subject, mail.subject);
+    assert.equal(details.emails?.[0]?.from, mail.from);
+    assert.equal(details.emails?.[0]?.body, mail.body);
+    if (mail.channelAlias) {
+      const user = getStoredUser(DEFAULT_DESK_API_USER_ALIAS);
+      const channel = user.channels[mail.channelAlias];
+      assert.equal(details.ticket?.channelId, channel?.id);
+    }
+  }
+
+  @Step('verifying Desk channel <channelAlias> does not contain email <mailAlias> for user <userAlias>')
+  public async verifyDeskChannelDoesNotContainEmail(
+    channelAlias: string,
+    mailAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    const channelId = this.getStoredChannelId(channelAlias, userAlias);
+    const response = await withDevAuthenticatedApiContext(userAlias, apiContext =>
+      apiContext.get(`/api/test/desk/channel/${channelId}/tickets`)
+    );
+    await assertOkResponse(response, 'Desk channel ticket listing');
+    const body = (await response.json()) as { tickets?: Array<{ title?: string }> };
+    assert.ok(
+      !(body.tickets ?? []).some(ticket => ticket.title === mail.subject),
+      `Expected channel "${channelAlias}" not to contain email "${mailAlias}".`
+    );
   }
 
   @Step(
@@ -999,19 +1028,21 @@ export default class XyneDeskSteps {
     const channel = user.channels[channelAlias];
     assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
     assert.ok(mail.conversationId, `Expected mock mail "${mailAlias}" to have a conversationId.`);
-    const replyRecipients = mail.replyTo?.length ? mail.replyTo : [mail.from];
-
-    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
-      apiContext.post(`/api/email/${mail.conversationId}/reply`, {
-        data: {
-          body: `<p>Thanks, we are checking this from Xyne Desk automation.</p>`,
-          type: 'REPLY',
-          to: replyRecipients,
-        },
-      })
-    );
-
-    await assertOkResponse(response, 'Desk reply API');
+    await this.openStoredDeskChannelUrl(channelAlias, userAlias);
+    const page = testContext.activePage;
+    await page.getByText(mail.subject, { exact: false }).first().click();
+    const pill = page.locator('[data-slot="reply-pill"]').first();
+    if (await pill.isVisible().catch(() => false)) await pill.click();
+    const modeButton = page.locator('[data-track-name="ReplyPillModeDropdown"]').first();
+    if (await modeButton.isVisible().catch(() => false)) {
+      await modeButton.click();
+      await page.getByText('Reply', { exact: true }).last().click();
+    }
+    const editor = page.locator('[contenteditable="true"]').last();
+    await editor.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await editor.fill('Thanks, we are checking this from Xyne Desk automation.');
+    await page.getByRole('button', { name: 'Send email' }).last().click();
+    await page.waitForTimeout(500);
   }
 
   @Step(
@@ -1031,19 +1062,21 @@ export default class XyneDeskSteps {
     assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
     assert.ok(mail.conversationId, `Expected mock mail "${mailAlias}" to have a conversationId.`);
 
-    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
-      apiContext.post(`/api/email/${mail.conversationId}/reply`, {
-        data: {
-          body: `<p>Reply-all response from Xyne Desk automation.</p>`,
-          type: 'REPLY_ALL',
-          to: [mail.replyTo?.[0] ?? mail.from],
-          cc: mail.cc ?? [],
-          bcc: [],
-        },
-      })
-    );
-
-    await assertOkResponse(response, 'Desk reply-all API');
+    await this.openStoredDeskChannelUrl(channelAlias, userAlias);
+    const page = testContext.activePage;
+    await page.getByText(mail.subject, { exact: false }).first().click();
+    const pill = page.locator('[data-slot="reply-pill"]').first();
+    if (await pill.isVisible().catch(() => false)) await pill.click();
+    const modeButton = page.locator('[data-track-name="ReplyPillModeDropdown"]').first();
+    if (await modeButton.isVisible().catch(() => false)) {
+      await modeButton.click();
+      await page.getByText('Reply all', { exact: true }).last().click();
+    }
+    const editor = page.locator('[contenteditable="true"]').last();
+    await editor.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await editor.fill('Reply-all response from Xyne Desk automation.');
+    await page.getByRole('button', { name: 'Send email' }).last().click();
+    await page.waitForTimeout(500);
   }
 
   @Step('composing mock Desk email <mailAlias> from channel <channelAlias> for user <userAlias>')
@@ -1056,7 +1089,6 @@ export default class XyneDeskSteps {
     assertValidUserAlias(userAlias);
 
     const suffix = buildRandomSuffix();
-    const channelId = this.getStoredChannelId(channelAlias, userAlias);
     const mail: MockDeskMailFixture = {
       alias: mailAlias,
       subject: `Desk compose flow ${suffix}`,
@@ -1070,35 +1102,17 @@ export default class XyneDeskSteps {
       channelAlias,
     };
 
-    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
-      apiContext.post('/api/email/compose', {
-        data: {
-          channelId,
-          to: [mail.to],
-          cc: mail.cc ?? [],
-          bcc: mail.bcc ?? [],
-          subject: mail.subject,
-          body: mail.body,
-        },
-      })
-    );
-
-    await assertOkResponse(response, 'Desk compose API');
-
-    const body = (await response.json()) as {
-      conversationId?: string;
-      ticketId?: string;
-      ticketXyneId?: string;
-      threadId?: string;
-    };
-    assert.ok(body.conversationId, 'Expected Desk compose response to include conversationId.');
-    assert.ok(body.ticketId, 'Expected Desk compose response to include ticketId.');
-    mail.conversationId = body.conversationId;
-    mail.ticketId = body.ticketId;
-    mail.xyneId = body.ticketXyneId;
-    if (body.threadId) {
-      mail.threadId = body.threadId;
-    }
+    await this.openStoredDeskChannelUrl(channelAlias, userAlias);
+    const page = testContext.activePage;
+    await page.getByRole('button', { name: 'Compose' }).first().click();
+    const toInput = page.locator('[data-track-name="EditToField"]').first();
+    await toInput.fill(mail.to);
+    await toInput.press('Enter');
+    await page.getByLabel('Subject').fill(mail.subject);
+    const editor = page.locator('[contenteditable="true"]').last();
+    await editor.fill('New composed Desk mail from automation.');
+    await page.getByRole('button', { name: 'Send email' }).last().click();
+    await page.waitForTimeout(500);
     mockDeskMails.set(mailAlias, mail);
   }
 

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
@@ -1275,7 +1275,9 @@ export default class XyneDeskSteps {
       body: `<p>New composed Desk mail from automation ${suffix}.</p>`,
       from: deskChannelDlEmails.get(channelAlias) ?? config.desk.mockDlEmail,
       to: `compose.recipient.${suffix}@example.test`,
-      cc: [`compose.cc.${suffix}@example.test`],
+      // The compose UI step below enters only To/Subject/body, so the captured
+      // mail carries no cc. Keep the fixture consistent with what is actually sent.
+      cc: [],
       bcc: [],
       threadId: `mock-compose-thread-${suffix}`,
       messageId: `mock-compose-message-${suffix}`,

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
@@ -684,6 +684,72 @@ export default class XyneDeskSteps {
     });
   }
 
+  @Step(
+    'generating mock Desk email pair <firstMailAlias> and <secondMailAlias> with the same subject and domain'
+  )
+  public async generateMockDeskEmailPair(
+    firstMailAlias: string,
+    secondMailAlias: string
+  ): Promise<void> {
+    const suffix = buildRandomSuffix();
+    const subject = `Desk auto-merge ${suffix}`;
+    const domain = 'merge.example.test';
+    for (const [alias, index] of [
+      [firstMailAlias, 'one'],
+      [secondMailAlias, 'two'],
+    ] as const) {
+      mockDeskMails.set(alias, {
+        alias,
+        subject,
+        body: `Auto-merge test message ${index} ${suffix}.`,
+        from: `customer@${domain}`,
+        to: config.desk.mockDlEmail,
+        threadId: `mock-auto-merge-thread-${suffix}-${index}`,
+        messageId: `mock-auto-merge-message-${suffix}-${index}`,
+      });
+    }
+  }
+
+  @Step('setting Desk auto-merge <enabled> for channel <channelAlias> user <userAlias>')
+  public async setDeskAutoMerge(
+    enabled: string,
+    channelAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    assert.ok(enabled === 'on' || enabled === 'off', 'Auto-merge must be "on" or "off".');
+    const channelId = this.getStoredChannelId(channelAlias, userAlias);
+    const response = await withDevAuthenticatedApiContext(userAlias, apiContext =>
+      apiContext.patch(`/api/test/desk/channel/${channelId}/auto-merge`, {
+        data: { enabled: enabled === 'on' },
+      })
+    );
+    await assertOkResponse(response, 'Desk auto-merge preference update');
+  }
+
+  @Step('verifying mock Desk emails <firstMailAlias> and <secondMailAlias> share one conversation')
+  public async verifyMockDeskEmailsShareConversation(
+    firstMailAlias: string,
+    secondMailAlias: string
+  ): Promise<void> {
+    const first = assertFixture(firstMailAlias);
+    const second = assertFixture(secondMailAlias);
+    assert.ok(first.conversationId && second.conversationId, 'Expected both emails to be ingested.');
+    assert.equal(second.conversationId, first.conversationId);
+  }
+
+  @Step('verifying mock Desk emails <firstMailAlias> and <secondMailAlias> have separate conversations')
+  public async verifyMockDeskEmailsHaveSeparateConversations(
+    firstMailAlias: string,
+    secondMailAlias: string
+  ): Promise<void> {
+    const first = assertFixture(firstMailAlias);
+    const second = assertFixture(secondMailAlias);
+    assert.ok(first.conversationId && second.conversationId, 'Expected both emails to be ingested.');
+    assert.notEqual(second.conversationId, first.conversationId);
+  }
+
   @Step('generating mock incoming Desk email <mailAlias> with reply-all recipients and attachment')
   public async generateMockIncomingEmailWithReplyAllAndAttachment(
     mailAlias: string
@@ -1299,6 +1365,28 @@ export default class XyneDeskSteps {
     );
 
     await assertOkResponse(response, 'Desk ticket unmerge');
+  }
+
+  @Step('unmerging mock Desk ticket <sourceMailAlias> through the UI for user <userAlias>')
+  public async unmergeMockDeskTicketThroughUi(
+    sourceMailAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidUserAlias(userAlias);
+    const source = await this.fetchAndStoreDeskTicketDetails(sourceMailAlias);
+    const user = getStoredUser(userAlias);
+    const ticket = source.ticket;
+    const channelId = ticket?.channelId;
+    assert.ok(ticket?.xyneId && channelId, `Expected ticket details for "${sourceMailAlias}".`);
+    await testContext.activePage.goto(
+      `${config.dashboard.baseUrl}/${user.workspaceId}/support/${channelId}/${ticket.xyneId}`,
+      { waitUntil: 'domcontentloaded', timeout: DESK_UI_TIMEOUT_MS },
+    );
+    await waitForDeskPageToSettle();
+    const unmerge = testContext.activePage.locator("[data-track-name='UnmergeTicket']").first();
+    await unmerge.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await unmerge.click();
+    await testContext.activePage.waitForTimeout(500);
   }
 
   @Step('verifying mock Desk ticket <sourceMailAlias> is unmerged')

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
@@ -1,0 +1,1602 @@
+import assert from 'node:assert/strict';
+import { type APIRequestContext, type Locator, request } from '@playwright/test';
+import { Step } from 'gauge-ts';
+import { config } from '@/config';
+import { buildRandomSuffix, getStoredUser } from '@/fixtures/fixture-helpers';
+import { getUserCatalogEntry } from '@/fixtures/user-catalog';
+import { buildUniqueDeskChannelName } from '@/tests/03_e2e/11_xyne-desk/xyne-desk-name-utils';
+import {
+  apiContextsByUserAlias,
+  deskChannelDlEmails,
+  type MockDeskMailFixture,
+  mockDeskMails,
+  mockDlEmails,
+  slackChannelIds,
+} from '@/tests/03_e2e/11_xyne-desk/xyne-desk-state';
+import { type StoredConversation, testContext } from '@/tests/shared/runtime/test-context';
+import { mirrorBackendAuthCookiesToDashboard } from '@/tests/shared/support/auth-cookies';
+import {
+  assertValidChannelAlias,
+  assertValidProjectAlias,
+  assertValidUserAlias,
+} from '@/tests/shared/support/literal-validation';
+
+interface SentMail {
+  channelId?: unknown;
+  conversationId?: unknown;
+  from?: unknown;
+  to?: unknown;
+  cc?: unknown;
+  bcc?: unknown;
+  subject?: unknown;
+  body?: unknown;
+  kind?: unknown;
+  status?: unknown;
+  attachmentCount?: unknown;
+}
+
+interface DeskTicketDetails {
+  ticket?: {
+    id?: string;
+    xyneId?: string;
+    title?: string;
+    description?: string;
+    priority?: string;
+    statusV2?: string;
+    channelId?: string;
+    isArchived?: boolean;
+    mergedIntoTicketId?: string | null;
+  };
+  emails?: Array<{
+    id?: string;
+    subject?: string;
+    body?: string;
+    from?: string;
+    to?: string[];
+    cc?: string[];
+    bcc?: string[];
+    replyTo?: string[];
+  }>;
+  attachments?: Array<{
+    entityId?: string;
+    originalFilename?: string;
+    mimetype?: string;
+    size?: number;
+  }>;
+}
+
+interface MockDlMail {
+  dlEmail?: unknown;
+  subject?: unknown;
+}
+
+interface ConnectedDeskSourceStatus {
+  email?: string | null;
+  isConnected?: boolean;
+  hasSource?: boolean;
+  sourceType?: string | null;
+  connectedLabel?: string | null;
+}
+
+const DEFAULT_DESK_API_USER_ALIAS = 'admin-1';
+const DESK_UI_TIMEOUT_MS = config.timeout * 2;
+
+function assertFixture(alias: string): MockDeskMailFixture {
+  const fixture = mockDeskMails.get(alias);
+  assert.ok(fixture, `Expected mock desk mail fixture "${alias}" to exist.`);
+  return fixture;
+}
+
+function getSharedMailboxDomain(): string {
+  return (
+    config.desk.mockSharedMailbox.split('@')[1] ||
+    config.desk.mockDlEmail.split('@')[1] ||
+    'example.test'
+  );
+}
+
+async function assertOkResponse(
+  response: { status(): number; text(): Promise<string> },
+  label: string
+): Promise<void> {
+  if (response.status() !== 200) {
+    const responseBody = await response.text();
+    throw new Error(`${label} failed with status ${response.status()}. Body: ${responseBody}`);
+  }
+}
+
+async function hasDashboardAuthCookieForWorkspace(workspaceId: string): Promise<boolean> {
+  const cookies = await testContext.currentSession.context.cookies(config.dashboard.baseUrl);
+  return cookies.some((cookie) => cookie.name === `xyne_ws_${workspaceId}_token` && cookie.value);
+}
+
+async function clearDeskBrowserAuthState(): Promise<void> {
+  const page = testContext.activePage;
+  const context = testContext.currentSession.context;
+
+  await page
+    .goto(`${config.dashboard.baseUrl}/auth`, {
+      waitUntil: 'domcontentloaded',
+      timeout: DESK_UI_TIMEOUT_MS,
+    })
+    .catch(() => undefined);
+  await context.clearCookies();
+  try {
+    await page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+  } catch {
+    // The next test-auth call writes fresh auth cookies; storage cleanup is best-effort.
+  }
+}
+
+async function assertDashboardAuthCookieForWorkspace(
+  workspaceId: string,
+  userAlias: string
+): Promise<void> {
+  if (await hasDashboardAuthCookieForWorkspace(workspaceId)) return;
+
+  const cookieNames = (
+    await testContext.currentSession.context.cookies(config.dashboard.baseUrl)
+  ).map((cookie) => cookie.name);
+  throw new Error(
+    `Desk browser auth for "${userAlias}" did not create xyne_ws_${workspaceId}_token on dashboard origin. Cookies: ${cookieNames.join(', ')}`
+  );
+}
+
+async function ensureBrowserAuthenticatedForDesk(
+  userAlias: string,
+  options: { force?: boolean } = {}
+): Promise<void> {
+  assertValidUserAlias(userAlias);
+  const storedUser = getStoredUser(userAlias);
+  assert.ok(storedUser.workspaceId, `Expected user "${userAlias}" to have a workspaceId.`);
+
+  if (!options.force && (await hasDashboardAuthCookieForWorkspace(storedUser.workspaceId))) {
+    return;
+  }
+
+  if (options.force) {
+    await clearDeskBrowserAuthState();
+  }
+
+  const catalogUser = getUserCatalogEntry(userAlias);
+  const params = new URLSearchParams({
+    email: catalogUser.email,
+    setAsNewUser: 'false',
+  });
+
+  const response = await testContext.currentSession.context.request.post(
+    `${config.backend.baseUrl}/api/test/auth/login?${params.toString()}`,
+    {
+      data: {},
+      timeout: DESK_UI_TIMEOUT_MS,
+    }
+  );
+
+  if (!response.ok()) {
+    const responseBody = await response.text().catch(() => '');
+    throw new Error(
+      `Desk browser auth for "${userAlias}" failed with status ${response.status()}. Body: ${responseBody}`
+    );
+  }
+
+  await mirrorBackendAuthCookiesToDashboard(testContext.currentSession.context, response);
+  await assertDashboardAuthCookieForWorkspace(storedUser.workspaceId, userAlias);
+}
+
+async function waitForDeskPageToSettle(): Promise<void> {
+  const page = testContext.activePage;
+  await page.waitForLoadState('networkidle', { timeout: 5000 }).catch(() => undefined);
+  await page.waitForTimeout(300);
+}
+
+async function createDevAuthenticatedApiContext(userAlias: string): Promise<APIRequestContext> {
+  const existingContext = apiContextsByUserAlias.get(userAlias);
+  if (existingContext) return existingContext;
+
+  const user = getStoredUser(userAlias);
+  assert.ok(user.workspaceId, `Expected user "${userAlias}" to have a workspaceId.`);
+
+  // Desk backend setup/assertion calls are API-only, but they must use the same
+  // test-auth cookie path as the browser. In Docker/Jenkins the backend sees
+  // API calls from another container, so x-dev-mode headers can be rejected by
+  // the auth middleware's safe-network guard before the Desk test route runs.
+  const apiContext = await request.newContext({
+    baseURL: config.backend.baseUrl,
+    extraHTTPHeaders: {
+      Accept: 'application/json',
+      'x-workspace-id': user.workspaceId,
+      'x-desk-test-user-alias': userAlias,
+    },
+  });
+
+  const catalogUser = getUserCatalogEntry(userAlias);
+  const params = new URLSearchParams({
+    email: catalogUser.email,
+    setAsNewUser: 'false',
+  });
+  const loginResponse = await apiContext.post(`/api/test/auth/login?${params.toString()}`, {
+    data: {},
+    timeout: DESK_UI_TIMEOUT_MS,
+  });
+
+  if (!loginResponse.ok()) {
+    const responseBody = await loginResponse.text().catch(() => '');
+    await apiContext.dispose();
+    throw new Error(
+      `Desk API auth for "${userAlias}" failed with status ${loginResponse.status()}. Body: ${responseBody}`
+    );
+  }
+
+  apiContextsByUserAlias.set(userAlias, apiContext);
+  return apiContext;
+}
+
+async function withDevAuthenticatedApiContext<T>(
+  userAlias: string,
+  callback: (apiContext: APIRequestContext) => Promise<T>
+): Promise<T> {
+  assertValidUserAlias(userAlias);
+  const apiContext = await createDevAuthenticatedApiContext(userAlias);
+  return callback(apiContext);
+}
+
+async function assertOkOrCreatedResponse(
+  response: { status(): number; text(): Promise<string> },
+  label: string
+): Promise<void> {
+  if (![200, 201].includes(response.status())) {
+    const responseBody = await response.text();
+    throw new Error(`${label} failed with status ${response.status()}. Body: ${responseBody}`);
+  }
+}
+
+export default class XyneDeskSteps {
+  @Step('opening Xyne Desk for user <userAlias>')
+  public async openXyneDesk(userAlias: string): Promise<void> {
+    assertValidUserAlias(userAlias);
+    const user = getStoredUser(userAlias);
+    const workspacePrefix = user.workspaceId ? `/${user.workspaceId}` : '';
+    const page = testContext.activePage;
+    const supportPage = page.locator("[data-testid='support-page']");
+
+    await ensureBrowserAuthenticatedForDesk(userAlias);
+
+    const openWorkspaceHome = async (): Promise<void> => {
+      await page.goto(`${config.dashboard.baseUrl}${workspacePrefix}/chat/dir`, {
+        waitUntil: 'domcontentloaded',
+        timeout: DESK_UI_TIMEOUT_MS,
+      });
+      await waitForDeskPageToSettle();
+    };
+
+    if (!page.url().startsWith(config.dashboard.baseUrl) || page.url().includes('/auth')) {
+      await openWorkspaceHome();
+    }
+
+    if (page.url().includes('/auth')) {
+      await ensureBrowserAuthenticatedForDesk(userAlias, { force: true });
+      await openWorkspaceHome();
+    }
+
+    await this.navigateToSupportModule(workspacePrefix);
+    await waitForDeskPageToSettle();
+
+    if (page.url().includes('/auth')) {
+      await ensureBrowserAuthenticatedForDesk(userAlias, { force: true });
+      await openWorkspaceHome();
+      await this.navigateToSupportModule(workspacePrefix);
+      await waitForDeskPageToSettle();
+    }
+
+    await supportPage.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+  }
+
+  @Step('configuring mock Desk shared mailbox for user <userAlias>')
+  public async configureMockSharedMailbox(userAlias: string): Promise<void> {
+    assertValidUserAlias(userAlias);
+    getStoredUser(userAlias);
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/test/desk/workspace-mailbox', {
+        data: {
+          email: config.desk.mockSharedMailbox,
+          sourceType: 'google',
+        },
+      })
+    );
+
+    await assertOkResponse(response, 'Mock Desk shared mailbox setup');
+  }
+
+  @Step('verifying user <userAlias> cannot configure mock Desk shared mailbox')
+  public async verifyUserCannotConfigureMockSharedMailbox(userAlias: string): Promise<void> {
+    assertValidUserAlias(userAlias);
+    getStoredUser(userAlias);
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/test/desk/workspace-mailbox', {
+        data: {
+          email: config.desk.mockSharedMailbox,
+          sourceType: 'google',
+        },
+      })
+    );
+    const responseBody = await response.text();
+
+    assert.equal(
+      response.status(),
+      403,
+      `Expected user "${userAlias}" to be blocked from mock Desk shared mailbox setup. Body: ${responseBody}`
+    );
+  }
+
+  @Step('clearing mock Desk sent mails for channel <channelAlias> user <userAlias>')
+  public async clearMockDeskSentMails(channelAlias: string, userAlias: string): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
+    const channelId = channel.id;
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.delete(`/api/test/desk/sent-mails?channelId=${encodeURIComponent(channelId)}`)
+    );
+
+    await assertOkResponse(response, 'Mock Desk sent-mail reset');
+  }
+
+  @Step('verifying Desk channel <channelAlias> is connected for user <userAlias>')
+  public async verifyDeskChannelConnected(channelAlias: string, userAlias: string): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    const status = await this.fetchDeskChannelConnectionStatus(channelAlias, userAlias);
+
+    assert.equal(
+      status.hasSource,
+      true,
+      `Expected Desk channel "${channelAlias}" to have a source.`
+    );
+    assert.equal(
+      status.isConnected,
+      true,
+      `Expected Desk channel "${channelAlias}" to be connected.`
+    );
+  }
+
+  @Step('disconnecting Desk mailbox for channel <channelAlias> user <userAlias>')
+  public async disconnectDeskMailbox(channelAlias: string, userAlias: string): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    const channelId = this.getStoredChannelId(channelAlias, userAlias);
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post(`/api/test/desk/channel-source/${channelId}/disconnect`)
+    );
+
+    await assertOkResponse(response, 'Desk mailbox disconnect');
+  }
+
+  @Step('reconnecting mock Desk mailbox for channel <channelAlias> user <userAlias>')
+  public async reconnectMockDeskMailbox(channelAlias: string, userAlias: string): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    const channelId = this.getStoredChannelId(channelAlias, userAlias);
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    const email =
+      deskChannelDlEmails.get(channelAlias) ||
+      `${channel.name ?? channelAlias}@${getSharedMailboxDomain()}`.toLowerCase();
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/test/desk/channel-source', {
+        data: {
+          channelId,
+          email,
+          sourceType: 'google',
+        },
+      })
+    );
+
+    await assertOkResponse(response, 'Mock Desk mailbox reconnect');
+    deskChannelDlEmails.set(channelAlias, email);
+  }
+
+  @Step('disconnecting Slack Desk channel <channelAlias> for user <userAlias>')
+  public async disconnectSlackDeskChannel(channelAlias: string, userAlias: string): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    const channelId = this.getStoredChannelId(channelAlias, userAlias);
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post(`/api/test/desk/channel-source/${channelId}/disconnect`)
+    );
+
+    await assertOkResponse(response, 'Slack Desk disconnect');
+  }
+
+  @Step('verifying Desk channel <channelAlias> is disconnected for user <userAlias>')
+  public async verifyDeskChannelDisconnected(
+    channelAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    const status = await this.fetchDeskChannelConnectionStatus(channelAlias, userAlias);
+
+    assert.equal(status.hasSource, true, `Expected Desk channel "${channelAlias}" to keep source.`);
+    assert.equal(
+      status.isConnected,
+      false,
+      `Expected Desk channel "${channelAlias}" to be disconnected.`
+    );
+  }
+
+  @Step('typing generated Desk DL email for channel <channelAlias> user <userAlias> in <selector>')
+  public async typeGeneratedDlEmail(
+    channelAlias: string,
+    userAlias: string,
+    selector: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.name, `Expected stored channel "${channelAlias}" to have a name.`);
+
+    const email = `${channel.name}@${getSharedMailboxDomain()}`.toLowerCase();
+    deskChannelDlEmails.set(channelAlias, email);
+
+    const element = testContext.activePage.locator(selector).first();
+    await element.waitFor({ state: 'visible' });
+    await element.fill(email);
+  }
+
+  @Step(
+    'creating mock DL Desk channel <channelAlias> for user <userAlias> in project <projectAlias>'
+  )
+  public async createMockDlDeskChannel(
+    channelAlias: string,
+    userAlias: string,
+    projectAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    assertValidProjectAlias(projectAlias);
+
+    const user = getStoredUser(userAlias);
+    const project = user.projects[projectAlias];
+    assert.ok(project?.id, `Expected stored project "${projectAlias}" to have an id.`);
+
+    if (user.channels[channelAlias]?.id) {
+      return;
+    }
+
+    const channelName = buildUniqueDeskChannelName(channelAlias);
+    const dlEmail = `${channelName}@${getSharedMailboxDomain()}`.toLowerCase();
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/channels', {
+        data: {
+          scopeType: 'DEFAULT',
+          name: channelName,
+          description: `Mock DL Desk automation channel ${channelName}`,
+          visibility: 'PRIVATE',
+          projectId: project.id,
+          type: 'EMAIL',
+          deskType: 'DL',
+          dlEmail,
+        },
+      })
+    );
+
+    await assertOkOrCreatedResponse(response, 'Mock DL Desk channel creation');
+
+    const body = (await response.json()) as { id?: string; channelId?: string; name?: string };
+    const channelId = body.id ?? body.channelId;
+    assert.ok(channelId, 'Expected mock DL Desk channel creation to return a channel id.');
+
+    const storedChannel: StoredConversation = {
+      id: channelId,
+      name: typeof body.name === 'string' ? body.name : channelName,
+      url: `${config.dashboard.baseUrl}/${user.workspaceId}/support/${channelId}`,
+      messages: {},
+    };
+    user.channels[channelAlias] = storedChannel;
+    deskChannelDlEmails.set(channelAlias, dlEmail);
+  }
+
+  @Step(
+    'Creating personal Desk channel <channelAlias> for user <userAlias> in project <projectAlias>'
+  )
+  public async createPersonalDeskChannel(
+    channelAlias: string,
+    userAlias: string,
+    projectAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    assertValidProjectAlias(projectAlias);
+
+    const user = getStoredUser(userAlias);
+    const project = user.projects[projectAlias];
+    assert.ok(project?.id, `Expected stored project "${projectAlias}" to have an id.`);
+
+    if (user.channels[channelAlias]?.id) {
+      return;
+    }
+
+    const channelName = buildUniqueDeskChannelName(channelAlias);
+    const mailboxEmail = `${channelName}@${getSharedMailboxDomain()}`.toLowerCase();
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/channels', {
+        data: {
+          scopeType: 'DEFAULT',
+          name: channelName,
+          description: `Mock personal Desk automation channel ${channelName}`,
+          visibility: 'PRIVATE',
+          projectId: project.id,
+          type: 'EMAIL',
+          deskType: 'EMAIL',
+        },
+      })
+    );
+
+    await assertOkOrCreatedResponse(response, 'Mock personal Desk channel creation');
+
+    const body = (await response.json()) as { id?: string; channelId?: string; name?: string };
+    const channelId = body.id ?? body.channelId;
+    assert.ok(channelId, 'Expected mock personal Desk channel creation to return a channel id.');
+
+    const sourceResponse = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/test/desk/channel-source', {
+        data: {
+          channelId,
+          email: mailboxEmail,
+          sourceType: 'google',
+        },
+      })
+    );
+    await assertOkResponse(sourceResponse, 'Mock personal Desk channel source setup');
+
+    const storedChannel: StoredConversation = {
+      id: channelId,
+      name: typeof body.name === 'string' ? body.name : channelName,
+      url: `${config.dashboard.baseUrl}/${user.workspaceId}/support/${channelId}`,
+      messages: {},
+    };
+    user.channels[channelAlias] = storedChannel;
+    deskChannelDlEmails.set(channelAlias, mailboxEmail);
+  }
+
+  @Step('Creating Slack Desk channel <channelAlias> for user <userAlias> in project <projectAlias>')
+  public async createSlackDeskChannel(
+    channelAlias: string,
+    userAlias: string,
+    projectAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    assertValidProjectAlias(projectAlias);
+
+    const user = getStoredUser(userAlias);
+    const project = user.projects[projectAlias];
+    assert.ok(project?.id, `Expected stored project "${projectAlias}" to have an id.`);
+
+    if (user.channels[channelAlias]?.id) {
+      return;
+    }
+
+    const workspaceResponse = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/test/desk/slack-workspace')
+    );
+    await assertOkResponse(workspaceResponse, 'Mock Slack workspace setup');
+
+    const channelName = buildUniqueDeskChannelName(channelAlias);
+    const slackChannelId = `C${buildRandomSuffix().replace(/-/g, '').toUpperCase()}`;
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/channels', {
+        data: {
+          scopeType: 'DEFAULT',
+          name: channelName,
+          description: `Mock Slack Desk automation channel ${channelName}`,
+          visibility: 'PRIVATE',
+          projectId: project.id,
+          type: 'SLACK',
+          deskType: 'SLACK',
+          slackChannelId,
+        },
+      })
+    );
+
+    await assertOkOrCreatedResponse(response, 'Mock Slack Desk channel creation');
+
+    const body = (await response.json()) as { id?: string; channelId?: string; name?: string };
+    const channelId = body.id ?? body.channelId;
+    assert.ok(channelId, 'Expected mock Slack Desk channel creation to return a channel id.');
+
+    const storedChannel: StoredConversation = {
+      id: channelId,
+      name: typeof body.name === 'string' ? body.name : channelName,
+      url: `${config.dashboard.baseUrl}/${user.workspaceId}/support/${channelId}`,
+      messages: {},
+    };
+    user.channels[channelAlias] = storedChannel;
+    slackChannelIds.set(channelAlias, slackChannelId);
+  }
+
+  @Step('clicking on stored Desk channel <channelAlias> for user <userAlias>')
+  public async clickStoredDeskChannel(channelAlias: string, userAlias: string): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.name, `Expected stored channel "${channelAlias}" to have a name.`);
+
+    await testContext.activePage
+      .locator('[data-testid="desk-channel-row"]')
+      .filter({ hasText: channel.name })
+      .first()
+      .click();
+  }
+
+  @Step('capturing selected Desk channel details for user <userAlias> channel <channelAlias>')
+  public async captureSelectedDeskChannel(userAlias: string, channelAlias: string): Promise<void> {
+    assertValidUserAlias(userAlias);
+    assertValidChannelAlias(channelAlias);
+
+    const user = getStoredUser(userAlias);
+    const storedChannel = user.channels[channelAlias];
+    assert.ok(storedChannel, `Expected stored channel for alias "${channelAlias}".`);
+
+    await testContext.activePage.waitForURL(/\/support\/[^/?#]+/, { timeout: 30000 });
+    const match = testContext.activePage.url().match(/\/support\/([^/?#]+)/);
+    assert.ok(
+      match,
+      `Expected URL to contain Desk channel ID. URL: ${testContext.activePage.url()}`
+    );
+
+    storedChannel.id = match[1];
+    storedChannel.url = testContext.activePage.url();
+  }
+
+  @Step('generating mock incoming Desk email <mailAlias>')
+  public async generateMockIncomingEmail(mailAlias: string): Promise<void> {
+    const suffix = buildRandomSuffix();
+    mockDeskMails.set(mailAlias, {
+      alias: mailAlias,
+      subject: `Desk happy flow ${suffix}`,
+      body: `Customer reported a happy-flow automation issue ${suffix}.`,
+      from: `customer.${suffix}@example.test`,
+      to: config.desk.mockDlEmail,
+      threadId: `mock-thread-${suffix}`,
+      messageId: `mock-message-${suffix}-inbound`,
+    });
+  }
+
+  @Step('generating mock incoming Desk email <mailAlias> with reply-all recipients and attachment')
+  public async generateMockIncomingEmailWithReplyAllAndAttachment(
+    mailAlias: string
+  ): Promise<void> {
+    const suffix = buildRandomSuffix();
+    mockDeskMails.set(mailAlias, {
+      alias: mailAlias,
+      subject: `Desk advanced flow ${suffix}`,
+      body: `Customer reported an advanced automation issue ${suffix}. Please verify UI, update, reply all, and attachment handling.`,
+      from: `customer.${suffix}@example.test`,
+      to: config.desk.mockDlEmail,
+      cc: [`manager.${suffix}@example.test`, `observer.${suffix}@example.test`],
+      bcc: [],
+      replyTo: [`reply.${suffix}@example.test`],
+      attachments: [
+        {
+          filename: `desk-evidence-${suffix}.txt`,
+          mimetype: 'text/plain',
+          size: 256,
+        },
+      ],
+      threadId: `mock-thread-advanced-${suffix}`,
+      messageId: `mock-message-advanced-${suffix}-inbound`,
+    });
+  }
+
+  @Step('generating mock Slack Desk message <mailAlias>')
+  public async generateMockSlackDeskMessage(mailAlias: string): Promise<void> {
+    const suffix = buildRandomSuffix();
+    mockDeskMails.set(mailAlias, {
+      alias: mailAlias,
+      subject: `Slack Desk happy flow ${suffix}`,
+      body: `Slack customer message created by automation ${suffix}.`,
+      from: `slack.user.${suffix}@example.test`,
+      to: `mock-slack-${suffix}@slack.example.test`,
+      threadId: `mock-slack-thread-${suffix}`,
+      messageId: `mock-slack-message-${suffix}-inbound`,
+    });
+  }
+
+  @Step(
+    'injecting mock incoming Desk email <mailAlias> into channel <channelAlias> for user <userAlias>'
+  )
+  public async injectMockIncomingEmail(
+    mailAlias: string,
+    channelAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const mail = assertFixture(mailAlias);
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
+    const dlEmail = deskChannelDlEmails.get(channelAlias) || config.desk.mockDlEmail;
+    mail.to = dlEmail;
+    mail.channelAlias = channelAlias;
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/test/desk/incoming-email', {
+        data: {
+          channelId: channel.id,
+          from: mail.from,
+          to: [dlEmail],
+          cc: mail.cc ?? [],
+          bcc: mail.bcc ?? [],
+          replyTo: mail.replyTo ?? [],
+          subject: mail.subject,
+          body: mail.body,
+          threadId: mail.threadId,
+          messageId: mail.messageId,
+          attachments: mail.attachments ?? [],
+        },
+      })
+    );
+
+    await assertOkResponse(response, 'Mock incoming Desk email injection');
+
+    const body = (await response.json()) as Record<string, unknown>;
+    const conversation = body.conversation as { conversationId?: string } | undefined;
+    const conversationId =
+      typeof body.conversationId === 'string' ? body.conversationId : conversation?.conversationId;
+    assert.ok(conversationId, 'Expected incoming mail response to include conversationId.');
+    mail.conversationId = conversationId;
+    await this.fetchAndStoreDeskTicketDetails(mailAlias);
+  }
+
+  @Step(
+    'injecting mock Slack Desk message <mailAlias> into channel <channelAlias> for user <userAlias>'
+  )
+  public async injectMockSlackDeskMessage(
+    mailAlias: string,
+    channelAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const mail = assertFixture(mailAlias);
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
+    const slackChannelId = slackChannelIds.get(channelAlias);
+    assert.ok(slackChannelId, `Expected stored Slack channel id for "${channelAlias}".`);
+    mail.to = `${slackChannelId}@slack.example.test`;
+    mail.channelAlias = channelAlias;
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/test/desk/incoming-email', {
+        data: {
+          channelId: channel.id,
+          from: mail.from,
+          to: [mail.to],
+          subject: mail.subject,
+          body: mail.body,
+          threadId: mail.threadId,
+          messageId: mail.messageId,
+        },
+      })
+    );
+
+    await assertOkResponse(response, 'Mock Slack Desk message injection');
+
+    const body = (await response.json()) as Record<string, unknown>;
+    const conversation = body.conversation as { conversationId?: string } | undefined;
+    const conversationId =
+      typeof body.conversationId === 'string' ? body.conversationId : conversation?.conversationId;
+    assert.ok(conversationId, 'Expected Slack message response to include conversationId.');
+    mail.conversationId = conversationId;
+  }
+
+  @Step('waiting for mock Desk email <mailAlias> subject to appear in <selector>')
+  public async waitForMockEmailSubject(mailAlias: string, selector: string): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    await testContext.activePage
+      .locator(selector)
+      .getByText(mail.subject, { exact: false })
+      .first()
+      .waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+  }
+
+  @Step('verifying Desk compose control is available for channel <channelAlias> user <userAlias>')
+  public async verifyDeskComposeControlAvailable(
+    channelAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+    await this.openStoredDeskChannelUrl(channelAlias, userAlias);
+
+    await testContext.activePage
+      .locator("[data-testid='desk-compose-button']")
+      .first()
+      .waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+  }
+
+  @Step('verifying Desk AI and rewrite controls are available for email <mailAlias>')
+  public async verifyDeskAiAndRewriteControlsAvailable(mailAlias: string): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    assert.ok(mail.channelAlias, `Expected mock mail "${mailAlias}" to store channel alias.`);
+    await this.openStoredDeskChannelUrl(mail.channelAlias, DEFAULT_DESK_API_USER_ALIAS);
+
+    const page = testContext.activePage;
+    const ticketSubject = page.getByText(mail.subject, { exact: false }).first();
+    await ticketSubject.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await ticketSubject.click();
+
+    await page
+      .locator("[data-testid='desk-ticket-ask-ai-button']")
+      .first()
+      .waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+
+    const replyButton = page
+      .locator("[data-testid='desk-email-reply-button'], [data-testid='desk-open-reply-button']")
+      .first();
+    await replyButton.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await replyButton.click();
+
+    const editor = page.locator("[data-testid='desk-email-editor']").first();
+    await editor.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await editor.click();
+    await page.keyboard.insertText('Please rewrite this Desk automation reply.');
+
+    const refineButton = page.locator("[data-testid='desk-ai-refine-button']").first();
+    await refineButton.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await refineButton.click();
+
+    await page
+      .locator("[data-testid='desk-quick-rewrite-polish']")
+      .first()
+      .waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await page
+      .locator("[data-testid='desk-quick-rewrite-shorten']")
+      .first()
+      .waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await page
+      .locator("[data-testid='desk-ask-ai-from-composer-button']")
+      .first()
+      .waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+  }
+
+  @Step('verifying mock Desk email <mailAlias> was ingested')
+  public async verifyMockEmailWasIngested(mailAlias: string): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    assert.ok(mail.conversationId, `Expected mock Desk email "${mailAlias}" to be ingested.`);
+  }
+
+  @Step(
+    'verifying mock Desk ticket for email <mailAlias> has expected subject body sender and attachment'
+  )
+  public async verifyMockDeskTicketDetails(mailAlias: string): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    const details = await this.fetchAndStoreDeskTicketDetails(mailAlias);
+    const ticket = details.ticket;
+    const firstEmail = details.emails?.[0];
+
+    assert.equal(ticket?.title, mail.subject);
+    assert.match(String(ticket?.description ?? ''), new RegExp(this.escapeRegExp(mail.body)));
+    assert.equal(firstEmail?.subject, mail.subject);
+    assert.equal(firstEmail?.body, mail.body);
+    assert.equal(firstEmail?.from, mail.from);
+    assert.deepEqual(firstEmail?.cc ?? [], mail.cc ?? []);
+    assert.deepEqual(firstEmail?.replyTo ?? [], mail.replyTo ?? []);
+
+    const expectedAttachments = mail.attachments ?? [];
+    assert.equal(
+      details.attachments?.length ?? 0,
+      expectedAttachments.length,
+      `Expected ${expectedAttachments.length} attachment(s) for "${mailAlias}".`
+    );
+    for (const attachment of expectedAttachments) {
+      assert.ok(
+        details.attachments?.some(
+          (candidate) =>
+            candidate.originalFilename === attachment.filename &&
+            candidate.mimetype === attachment.mimetype &&
+            candidate.size === attachment.size
+        ),
+        `Expected attachment "${attachment.filename}" to be stored.`
+      );
+    }
+  }
+
+  @Step(
+    'verifying Desk data shows mock email <mailAlias> in channel <channelAlias> for user <userAlias>'
+  )
+  public async verifyDeskDataShowsMockEmail(
+    mailAlias: string,
+    channelAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const mail = assertFixture(mailAlias);
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
+
+    const details = await this.fetchAndStoreDeskTicketDetails(mailAlias);
+    assert.equal(details.ticket?.channelId, channel.id);
+    assert.equal(details.ticket?.title, mail.subject);
+    assert.equal(details.emails?.[0]?.body, mail.body);
+  }
+
+  @Step(
+    'updating mock Desk ticket for email <mailAlias> priority to <priority> and status to <status>'
+  )
+  public async updateMockDeskTicket(
+    mailAlias: string,
+    priority: string,
+    status: string
+  ): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    assert.ok(mail.conversationId, `Expected mock mail "${mailAlias}" to have a conversationId.`);
+
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) =>
+        apiContext.patch(`/api/test/desk/ticket/${mail.conversationId}`, {
+          data: {
+            priority,
+            status,
+          },
+        })
+    );
+    await assertOkResponse(response, 'Mock Desk ticket update');
+  }
+
+  @Step(
+    'verifying mock Desk ticket for email <mailAlias> priority is <priority> and status is <status>'
+  )
+  public async verifyMockDeskTicketUpdate(
+    mailAlias: string,
+    priority: string,
+    status: string
+  ): Promise<void> {
+    const details = await this.fetchAndStoreDeskTicketDetails(mailAlias);
+    assert.equal(details.ticket?.priority, priority);
+    assert.equal(details.ticket?.statusV2, status);
+  }
+
+  @Step('replying to mock Desk email <mailAlias> from channel <channelAlias> for user <userAlias>')
+  public async replyToMockEmail(
+    mailAlias: string,
+    channelAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const mail = assertFixture(mailAlias);
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
+    assert.ok(mail.conversationId, `Expected mock mail "${mailAlias}" to have a conversationId.`);
+    const replyRecipients = mail.replyTo?.length ? mail.replyTo : [mail.from];
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post(`/api/email/${mail.conversationId}/reply`, {
+        data: {
+          body: `<p>Thanks, we are checking this from Xyne Desk automation.</p>`,
+          type: 'REPLY',
+          to: replyRecipients,
+        },
+      })
+    );
+
+    await assertOkResponse(response, 'Desk reply API');
+  }
+
+  @Step(
+    'replying all to mock Desk email <mailAlias> from channel <channelAlias> for user <userAlias>'
+  )
+  public async replyAllToMockEmail(
+    mailAlias: string,
+    channelAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const mail = assertFixture(mailAlias);
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
+    assert.ok(mail.conversationId, `Expected mock mail "${mailAlias}" to have a conversationId.`);
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post(`/api/email/${mail.conversationId}/reply`, {
+        data: {
+          body: `<p>Reply-all response from Xyne Desk automation.</p>`,
+          type: 'REPLY_ALL',
+          to: [mail.replyTo?.[0] ?? mail.from],
+          cc: mail.cc ?? [],
+          bcc: [],
+        },
+      })
+    );
+
+    await assertOkResponse(response, 'Desk reply-all API');
+  }
+
+  @Step('composing mock Desk email <mailAlias> from channel <channelAlias> for user <userAlias>')
+  public async composeMockDeskEmail(
+    mailAlias: string,
+    channelAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const suffix = buildRandomSuffix();
+    const channelId = this.getStoredChannelId(channelAlias, userAlias);
+    const mail: MockDeskMailFixture = {
+      alias: mailAlias,
+      subject: `Desk compose flow ${suffix}`,
+      body: `<p>New composed Desk mail from automation ${suffix}.</p>`,
+      from: deskChannelDlEmails.get(channelAlias) ?? config.desk.mockDlEmail,
+      to: `compose.recipient.${suffix}@example.test`,
+      cc: [`compose.cc.${suffix}@example.test`],
+      bcc: [],
+      threadId: `mock-compose-thread-${suffix}`,
+      messageId: `mock-compose-message-${suffix}`,
+      channelAlias,
+    };
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post('/api/email/compose', {
+        data: {
+          channelId,
+          to: [mail.to],
+          cc: mail.cc ?? [],
+          bcc: mail.bcc ?? [],
+          subject: mail.subject,
+          body: mail.body,
+        },
+      })
+    );
+
+    await assertOkResponse(response, 'Desk compose API');
+
+    const body = (await response.json()) as {
+      conversationId?: string;
+      ticketId?: string;
+      ticketXyneId?: string;
+      threadId?: string;
+    };
+    assert.ok(body.conversationId, 'Expected Desk compose response to include conversationId.');
+    assert.ok(body.ticketId, 'Expected Desk compose response to include ticketId.');
+    mail.conversationId = body.conversationId;
+    mail.ticketId = body.ticketId;
+    mail.xyneId = body.ticketXyneId;
+    if (body.threadId) {
+      mail.threadId = body.threadId;
+    }
+    mockDeskMails.set(mailAlias, mail);
+  }
+
+  @Step('verifying latest mock Desk composed mail matches <mailAlias>')
+  public async verifyLatestMockComposedMail(mailAlias: string): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    assert.ok(mail.channelAlias, `Expected composed mail "${mailAlias}" to store channel alias.`);
+    const channelId = this.getStoredChannelId(mail.channelAlias, DEFAULT_DESK_API_USER_ALIAS);
+
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) =>
+        apiContext.get(`/api/test/desk/sent-mails?channelId=${encodeURIComponent(channelId)}`)
+    );
+    await assertOkResponse(response, 'Mock Desk sent mails request');
+
+    const body = (await response.json()) as { sentMails?: SentMail[] };
+    const sentMails = body.sentMails ?? [];
+    const latest = sentMails[sentMails.length - 1];
+    assert.ok(latest, 'Expected latest mock Desk composed mail to exist.');
+    assert.equal(latest.kind, 'compose');
+    assert.equal(latest.status, 'sent');
+    assert.deepEqual(latest.to, [mail.to]);
+    assert.deepEqual(latest.cc, mail.cc ?? []);
+    assert.equal(latest.subject, mail.subject);
+    assert.match(String(latest.body), /New composed Desk mail/);
+  }
+
+  @Step('merging mock Desk ticket <sourceMailAlias> into <targetMailAlias> as user <userAlias>')
+  public async mergeMockDeskTicket(
+    sourceMailAlias: string,
+    targetMailAlias: string,
+    userAlias: string
+  ): Promise<void> {
+    assertValidUserAlias(userAlias);
+    const source = await this.fetchAndStoreDeskTicketDetails(sourceMailAlias);
+    const target = await this.fetchAndStoreDeskTicketDetails(targetMailAlias);
+    assert.ok(source.ticket?.id, `Expected source ticket for "${sourceMailAlias}".`);
+    assert.ok(target.ticket?.id, `Expected target ticket for "${targetMailAlias}".`);
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post(`/api/tickets/${source.ticket?.id}/merge`, {
+        data: { targetTicketId: target.ticket?.id },
+      })
+    );
+
+    await assertOkResponse(response, 'Desk ticket merge');
+  }
+
+  @Step('verifying mock Desk ticket <sourceMailAlias> is merged into <targetMailAlias>')
+  public async verifyMockDeskTicketMerged(
+    sourceMailAlias: string,
+    targetMailAlias: string
+  ): Promise<void> {
+    const source = await this.fetchAndStoreDeskTicketDetails(sourceMailAlias);
+    const target = await this.fetchAndStoreDeskTicketDetails(targetMailAlias);
+
+    assert.equal(source.ticket?.isArchived, true);
+    assert.equal(source.ticket?.mergedIntoTicketId, target.ticket?.id);
+  }
+
+  @Step('unmerging mock Desk ticket <sourceMailAlias> as user <userAlias>')
+  public async unmergeMockDeskTicket(sourceMailAlias: string, userAlias: string): Promise<void> {
+    assertValidUserAlias(userAlias);
+    const source = await this.fetchAndStoreDeskTicketDetails(sourceMailAlias);
+    assert.ok(source.ticket?.id, `Expected source ticket for "${sourceMailAlias}".`);
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.post(`/api/tickets/${source.ticket?.id}/unmerge`)
+    );
+
+    await assertOkResponse(response, 'Desk ticket unmerge');
+  }
+
+  @Step('verifying mock Desk ticket <sourceMailAlias> is unmerged')
+  public async verifyMockDeskTicketUnmerged(sourceMailAlias: string): Promise<void> {
+    const source = await this.fetchAndStoreDeskTicketDetails(sourceMailAlias);
+
+    assert.equal(source.ticket?.isArchived, false);
+    assert.equal(source.ticket?.mergedIntoTicketId, null);
+  }
+
+  @Step('verifying mock Desk sent mail count is <expectedCount> for incoming email <mailAlias>')
+  public async verifyMockSentMailCount(expectedCount: string, mailAlias: string): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    assert.ok(mail.conversationId, `Expected mock mail "${mailAlias}" to have a conversationId.`);
+    const conversationId = mail.conversationId;
+
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) =>
+        apiContext.get(
+          `/api/test/desk/sent-mails?conversationId=${encodeURIComponent(conversationId)}`
+        )
+    );
+    await assertOkResponse(response, 'Mock Desk sent mails request');
+
+    const body = (await response.json()) as { sentMails?: SentMail[] };
+    assert.equal(
+      body.sentMails?.length ?? 0,
+      Number.parseInt(expectedCount, 10),
+      `Expected ${expectedCount} mock Desk sent mail(s).`
+    );
+  }
+
+  @Step('verifying latest mock Desk sent mail matches incoming email <mailAlias>')
+  public async verifyLatestMockSentMail(mailAlias: string): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    assert.ok(mail.conversationId, `Expected mock mail "${mailAlias}" to have a conversationId.`);
+    const conversationId = mail.conversationId;
+
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) =>
+        apiContext.get(
+          `/api/test/desk/sent-mails?conversationId=${encodeURIComponent(conversationId)}`
+        )
+    );
+    await assertOkResponse(response, 'Mock Desk sent mails request');
+
+    const body = (await response.json()) as { sentMails?: SentMail[] };
+    const sentMails = body.sentMails ?? [];
+    const latest = sentMails[sentMails.length - 1];
+    assert.ok(latest, 'Expected latest mock Desk sent mail to exist.');
+    assert.equal(latest.kind, 'reply');
+    assert.equal(latest.status, 'sent');
+    assert.equal(latest.from, mail.to);
+    assert.deepEqual(latest.to, mail.replyTo?.length ? mail.replyTo : [mail.from]);
+    assert.equal(latest.subject, `Re: ${mail.subject}`);
+    assert.match(String(latest.body), /Xyne Desk automation/);
+  }
+
+  @Step('verifying latest mock Desk sent reply-all mail matches incoming email <mailAlias>')
+  public async verifyLatestMockReplyAllSentMail(mailAlias: string): Promise<void> {
+    const mail = assertFixture(mailAlias);
+    assert.ok(mail.conversationId, `Expected mock mail "${mailAlias}" to have a conversationId.`);
+    const conversationId = mail.conversationId;
+
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) =>
+        apiContext.get(
+          `/api/test/desk/sent-mails?conversationId=${encodeURIComponent(conversationId)}`
+        )
+    );
+    await assertOkResponse(response, 'Mock Desk sent mails request');
+
+    const body = (await response.json()) as { sentMails?: SentMail[] };
+    const sentMails = body.sentMails ?? [];
+    const latest = sentMails[sentMails.length - 1];
+    assert.ok(latest, 'Expected latest mock Desk sent reply-all mail to exist.');
+    assert.equal(latest.kind, 'reply');
+    assert.equal(latest.status, 'sent');
+    assert.equal(latest.from, mail.to);
+    assert.deepEqual(latest.to, [mail.replyTo?.[0] ?? mail.from]);
+    assert.deepEqual(latest.cc, mail.cc ?? []);
+    assert.equal(latest.subject, `Re: ${mail.subject}`);
+    assert.match(String(latest.body), /Reply-all response/);
+  }
+
+  @Step('resetting mock DL provider state')
+  public async resetMockDlProviderState(): Promise<void> {
+    mockDlEmails.clear();
+
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) => apiContext.post('/api/test/desk/mock-dl/reset')
+    );
+
+    await assertOkResponse(response, 'Mock DL provider reset');
+  }
+
+  @Step('creating mock DL <dlAlias>')
+  public async createMockDl(dlAlias: string): Promise<void> {
+    const suffix = buildRandomSuffix();
+    const email = `${dlAlias}.${suffix}@${getSharedMailboxDomain()}`.toLowerCase();
+    mockDlEmails.set(dlAlias, email);
+
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) => apiContext.post('/api/test/desk/mock-dl', { data: { email } })
+    );
+
+    await assertOkResponse(response, `Mock DL "${dlAlias}" creation`);
+  }
+
+  @Step('adding member <memberEmail> to mock DL <dlAlias>')
+  public async addMemberToMockDl(memberEmail: string, dlAlias: string): Promise<void> {
+    const dlEmail = this.getMockDlEmail(dlAlias);
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) =>
+        apiContext.post(`/api/test/desk/mock-dl/${encodeURIComponent(dlEmail)}/members`, {
+          data: { memberEmail },
+        })
+    );
+
+    await assertOkResponse(response, `Mock DL "${dlAlias}" member add`);
+  }
+
+  @Step('removing member <memberEmail> from mock DL <dlAlias>')
+  public async removeMemberFromMockDl(memberEmail: string, dlAlias: string): Promise<void> {
+    const dlEmail = this.getMockDlEmail(dlAlias);
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) =>
+        apiContext.delete(
+          `/api/test/desk/mock-dl/${encodeURIComponent(dlEmail)}/members/${encodeURIComponent(
+            memberEmail
+          )}`
+        )
+    );
+
+    await assertOkResponse(response, `Mock DL "${dlAlias}" member removal`);
+  }
+
+  @Step('sending mock provider mail <mailAlias> to mock DL <dlAlias>')
+  public async sendMockProviderMailToDl(mailAlias: string, dlAlias: string): Promise<void> {
+    const dlEmail = this.getMockDlEmail(dlAlias);
+    const suffix = buildRandomSuffix();
+    const subject = `Mock DL delivery ${mailAlias} ${suffix}`;
+
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) =>
+        apiContext.post(`/api/test/desk/mock-dl/${encodeURIComponent(dlEmail)}/send`, {
+          data: {
+            from: `sender.${suffix}@example.test`,
+            subject,
+            body: `Mock provider DL delivery body for ${mailAlias}.`,
+          },
+        })
+    );
+
+    await assertOkResponse(response, `Mock provider mail "${mailAlias}" send`);
+  }
+
+  @Step('verifying mock inbox <memberEmail> total mail count is <expectedCount>')
+  public async verifyMockInboxTotalCount(
+    memberEmail: string,
+    expectedCount: string
+  ): Promise<void> {
+    const inbox = await this.fetchMockInbox(memberEmail);
+
+    assert.equal(
+      inbox.length,
+      Number.parseInt(expectedCount, 10),
+      `Expected "${memberEmail}" mock inbox to contain ${expectedCount} mail(s).`
+    );
+  }
+
+  @Step('verifying mock inbox <memberEmail> has <expectedCount> mails from mock DL <dlAlias>')
+  public async verifyMockInboxCountFromDl(
+    memberEmail: string,
+    expectedCount: string,
+    dlAlias: string
+  ): Promise<void> {
+    const dlEmail = this.getMockDlEmail(dlAlias);
+    const inbox = await this.fetchMockInbox(memberEmail);
+    const mailsFromDl = inbox.filter((mail) => mail.dlEmail === dlEmail);
+
+    assert.equal(
+      mailsFromDl.length,
+      Number.parseInt(expectedCount, 10),
+      `Expected "${memberEmail}" mock inbox to contain ${expectedCount} mail(s) from "${dlEmail}".`
+    );
+  }
+
+  private getStoredChannelId(channelAlias: string, userAlias: string): string {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
+    return channel.id;
+  }
+
+  private async fetchDeskChannelConnectionStatus(
+    channelAlias: string,
+    userAlias: string
+  ): Promise<ConnectedDeskSourceStatus> {
+    const channelId = this.getStoredChannelId(channelAlias, userAlias);
+
+    const response = await withDevAuthenticatedApiContext(userAlias, (apiContext) =>
+      apiContext.get(`/api/channels/${channelId}/connected-email`)
+    );
+    await assertOkResponse(response, 'Desk channel connection status');
+
+    return (await response.json()) as ConnectedDeskSourceStatus;
+  }
+
+  private getMockDlEmail(dlAlias: string): string {
+    const email = mockDlEmails.get(dlAlias);
+    assert.ok(email, `Expected mock DL "${dlAlias}" to have been created.`);
+    return email;
+  }
+
+  private async fetchMockInbox(memberEmail: string): Promise<MockDlMail[]> {
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) => apiContext.get(`/api/test/desk/mock-inbox/${encodeURIComponent(memberEmail)}`)
+    );
+    await assertOkResponse(response, `Mock inbox "${memberEmail}" request`);
+
+    const body = (await response.json()) as { inbox?: MockDlMail[] };
+    return body.inbox ?? [];
+  }
+
+  private async fetchAndStoreDeskTicketDetails(mailAlias: string): Promise<DeskTicketDetails> {
+    const mail = assertFixture(mailAlias);
+    assert.ok(mail.conversationId, `Expected mock mail "${mailAlias}" to have a conversationId.`);
+
+    const response = await withDevAuthenticatedApiContext(
+      DEFAULT_DESK_API_USER_ALIAS,
+      (apiContext) => apiContext.get(`/api/test/desk/ticket/${mail.conversationId}`)
+    );
+    await assertOkResponse(response, 'Mock Desk ticket details request');
+
+    const details = (await response.json()) as DeskTicketDetails;
+    if (details.ticket?.id) {
+      mail.ticketId = details.ticket.id;
+    }
+    if (details.ticket?.xyneId) {
+      mail.xyneId = details.ticket.xyneId;
+    }
+    return details;
+  }
+
+  private escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  private async navigateToSupportModule(workspacePrefix: string): Promise<void> {
+    const page = testContext.activePage;
+    const supportInboxUrl = `${config.dashboard.baseUrl}${workspacePrefix}/support/all`;
+    const desktopSupportNav = page.locator("[data-testid='nav-support']").first();
+    if (await this.isVisible(desktopSupportNav, 5000)) {
+      await desktopSupportNav.click();
+      await waitForDeskPageToSettle();
+      if (page.url().replace(/\/$/, '').endsWith('/support')) {
+        await page.goto(supportInboxUrl, {
+          waitUntil: 'domcontentloaded',
+          timeout: DESK_UI_TIMEOUT_MS,
+        });
+        await waitForDeskPageToSettle();
+      }
+      return;
+    }
+
+    const moreNav = page
+      .locator("[data-testid='mobile-nav-more'], [aria-label='More options']")
+      .first();
+    if (!(await this.isVisible(moreNav, 5000))) {
+      await page.goto(supportInboxUrl, {
+        waitUntil: 'domcontentloaded',
+        timeout: DESK_UI_TIMEOUT_MS,
+      });
+      await waitForDeskPageToSettle();
+      return;
+    }
+
+    await moreNav.click();
+    const mobileSupportNav = page.locator("[data-testid='mobile-nav-support']").first();
+    if (await this.isVisible(mobileSupportNav, 5000)) {
+      await mobileSupportNav.click();
+      await waitForDeskPageToSettle();
+      return;
+    }
+
+    const supportLink = page.getByRole('link', { name: 'Support' }).first();
+    if (await this.isVisible(supportLink, 5000)) {
+      await supportLink.click();
+      await waitForDeskPageToSettle();
+      if (page.url().replace(/\/$/, '').endsWith('/support')) {
+        await page.goto(supportInboxUrl, {
+          waitUntil: 'domcontentloaded',
+          timeout: DESK_UI_TIMEOUT_MS,
+        });
+        await waitForDeskPageToSettle();
+      }
+      return;
+    }
+
+    await page.goto(supportInboxUrl, {
+      waitUntil: 'domcontentloaded',
+      timeout: DESK_UI_TIMEOUT_MS,
+    });
+    await waitForDeskPageToSettle();
+  }
+
+  private async openStoredDeskChannelUrl(channelAlias: string, userAlias: string): Promise<void> {
+    assertValidChannelAlias(channelAlias);
+    assertValidUserAlias(userAlias);
+
+    const user = getStoredUser(userAlias);
+    const channel = user.channels[channelAlias];
+    assert.ok(channel?.id, `Expected stored channel "${channelAlias}" to have an id.`);
+    const channelId = channel.id;
+
+    await ensureBrowserAuthenticatedForDesk(userAlias);
+
+    const workspacePrefix = user.workspaceId ? `/${user.workspaceId}` : '';
+    const url = `${config.dashboard.baseUrl}${workspacePrefix}/support/${channelId}`;
+    const supportInboxUrl = `${config.dashboard.baseUrl}${workspacePrefix}/support/all`;
+    const page = testContext.activePage;
+    const supportPage = page.locator("[data-testid='support-page']");
+
+    const openSupportPage = async (): Promise<void> => {
+      await page.goto(url, {
+        waitUntil: 'domcontentloaded',
+        timeout: DESK_UI_TIMEOUT_MS,
+      });
+      await waitForDeskPageToSettle();
+      if (page.url().includes('/auth')) {
+        throw new Error(`Direct Desk channel open redirected to auth. Current URL: ${page.url()}`);
+      }
+      await supportPage.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    };
+
+    const openSupportViaChannelList = async (): Promise<void> => {
+      await page.goto(supportInboxUrl, {
+        waitUntil: 'domcontentloaded',
+        timeout: DESK_UI_TIMEOUT_MS,
+      });
+      await waitForDeskPageToSettle();
+      if (page.url().includes('/auth')) {
+        await ensureBrowserAuthenticatedForDesk(userAlias, { force: true });
+        await page.goto(supportInboxUrl, {
+          waitUntil: 'domcontentloaded',
+          timeout: DESK_UI_TIMEOUT_MS,
+        });
+        await waitForDeskPageToSettle();
+      }
+      await supportPage.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+
+      const channelRow = page
+        .locator('[data-testid="desk-channel-row"]')
+        .filter({ hasText: channel.name ?? channelAlias })
+        .first();
+
+      if (!(await this.isVisible(channelRow, DESK_UI_TIMEOUT_MS))) {
+        throw new Error(
+          `Desk channel row "${channel.name ?? channelAlias}" was not visible on Support page. Current URL: ${page.url()}`
+        );
+      }
+
+      await channelRow.click();
+      await page
+        .waitForURL(new RegExp(`/support/${this.escapeRegExp(channelId)}(?:[/?#]|$)`), {
+          timeout: DESK_UI_TIMEOUT_MS,
+        })
+        .catch(() => undefined);
+      await waitForDeskPageToSettle();
+      await supportPage.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    };
+
+    const openSupportWithNavigationFallback = async (directError: unknown): Promise<void> => {
+      const firstErrorMessage =
+        directError instanceof Error ? directError.message : String(directError);
+      try {
+        await openSupportViaChannelList();
+      } catch (fallbackError) {
+        const fallbackMessage =
+          fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+        throw new Error(
+          `Support page did not render for channel "${channelAlias}" user "${userAlias}". Current URL: ${page.url()}. Direct open failed: ${firstErrorMessage}. Navigation fallback failed: ${fallbackMessage}`
+        );
+      }
+    };
+
+    const openSupportWithFreshAuth = async (): Promise<void> => {
+      await ensureBrowserAuthenticatedForDesk(userAlias, { force: true });
+      try {
+        await openSupportPage();
+      } catch (error) {
+        await openSupportWithNavigationFallback(error);
+      }
+    };
+
+    try {
+      await openSupportPage();
+    } catch (error) {
+      if (page.url().includes('/auth')) {
+        await openSupportWithFreshAuth();
+        return;
+      }
+
+      await openSupportWithNavigationFallback(error);
+    }
+  }
+
+  private async isVisible(locator: Locator, timeout: number): Promise<boolean> {
+    try {
+      await locator.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
@@ -931,6 +931,29 @@ export default class XyneDeskSteps {
       .waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
   }
 
+  @Step('verifying Desk priority and status filters work for channel <channelAlias> user <userAlias>')
+  public async verifyDeskFiltersWork(channelAlias: string, userAlias: string): Promise<void> {
+    await this.openStoredDeskChannelUrl(channelAlias, userAlias);
+    const page = testContext.activePage;
+    await page.locator("[data-testid='desk-filter-priority']").click();
+    const high = page.locator("[data-testid='priority-filter-high']");
+    await high.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await high.click();
+    assert.match((await high.getAttribute('class')) ?? '', /bg-accent/);
+
+    await page.locator("[data-testid='desk-filter-status']").click();
+    const statusSearch = page.getByPlaceholder('Search status...');
+    await statusSearch.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    const statusOption = page.getByRole('button', { name: 'In Progress', exact: true }).last();
+    await statusOption.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await statusOption.click();
+
+    const clear = page.locator("[data-testid='desk-filter-clear']");
+    await clear.waitFor({ state: 'visible', timeout: DESK_UI_TIMEOUT_MS });
+    await clear.click();
+    await clear.waitFor({ state: 'hidden', timeout: DESK_UI_TIMEOUT_MS });
+  }
+
   @Step('verifying Desk AI and rewrite controls are available for email <mailAlias>')
   public async verifyDeskAiAndRewriteControlsAvailable(mailAlias: string): Promise<void> {
     const mail = assertFixture(mailAlias);
@@ -1332,6 +1355,8 @@ export default class XyneDeskSteps {
     assert.equal(latest.status, 'sent');
     assert.equal(latest.from, mail.to);
     assert.deepEqual(latest.to, mail.replyTo?.length ? mail.replyTo : [mail.from]);
+    assert.deepEqual(latest.cc ?? [], []);
+    assert.deepEqual(latest.bcc ?? [], []);
     assert.equal(latest.subject, `Re: ${mail.subject}`);
     assert.match(String(latest.body), /Xyne Desk automation/);
   }
@@ -1360,6 +1385,7 @@ export default class XyneDeskSteps {
     assert.equal(latest.from, mail.to);
     assert.deepEqual(latest.to, [mail.replyTo?.[0] ?? mail.from]);
     assert.deepEqual(latest.cc, mail.cc ?? []);
+    assert.deepEqual(latest.bcc ?? [], []);
     assert.equal(latest.subject, `Re: ${mail.subject}`);
     assert.match(String(latest.body), /Reply-all response/);
   }

--- a/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
+++ b/tools/xyne-automation/tests/03_e2e/11_xyne-desk/xyne-desk.steps.ts
@@ -11,6 +11,8 @@ import {
   type MockDeskMailFixture,
   mockDeskMails,
   mockDlEmails,
+  mockPubSubBatches,
+  mockPubSubMessages,
   slackChannelIds,
 } from '@/tests/03_e2e/11_xyne-desk/xyne-desk-state';
 import { type StoredConversation, testContext } from '@/tests/shared/runtime/test-context';
@@ -720,6 +722,95 @@ export default class XyneDeskSteps {
       threadId: `mock-slack-thread-${suffix}`,
       messageId: `mock-slack-message-${suffix}-inbound`,
     });
+  }
+
+  @Step('generating <count> deterministic Pub/Sub Gmail messages as batch <batchAlias>')
+  public async generateDeterministicPubSubBatch(count: string, batchAlias: string): Promise<void> {
+    const total = Number.parseInt(count, 10);
+    assert.ok(Number.isInteger(total) && total > 0 && total <= 1000, 'Batch size must be 1-1000.');
+    const historyId = String(Date.now());
+    const messageIds: string[] = [];
+    const messages = Array.from({ length: total }, (_, index) => {
+      const messageId = `mock-pubsub-${batchAlias}-${historyId}-${index}`;
+      messageIds.push(messageId);
+      return {
+        messageId,
+        threadId: `mock-pubsub-thread-${batchAlias}-${index}`,
+        from: `bulk-customer-${index}@example.test`,
+        subject: `Bulk Desk Pub/Sub message ${index}`,
+        body: `Deterministic Pub/Sub body ${index}`,
+      };
+    });
+    mockPubSubBatches.set(batchAlias, { messageIds, historyId });
+    const firstMessage = messages[0]!;
+    mockDeskMails.set(batchAlias, {
+      alias: batchAlias,
+      subject: firstMessage.subject,
+      body: firstMessage.body,
+      from: firstMessage.from,
+      to: config.desk.mockDlEmail,
+      threadId: firstMessage.threadId,
+      messageId: firstMessage.messageId,
+    });
+    mockPubSubMessages.set(batchAlias, messages);
+  }
+
+  @Step('publishing deterministic Pub/Sub batch <batchAlias> to Desk channel <channelAlias> for user <userAlias>')
+  public async publishDeterministicPubSubBatch(
+    batchAlias: string,
+    channelAlias: string,
+    userAlias: string,
+  ): Promise<void> {
+    const batch = mockPubSubBatches.get(batchAlias);
+    assert.ok(batch, `Expected Pub/Sub batch "${batchAlias}" to be generated.`);
+    const channelId = this.getStoredChannelId(channelAlias, userAlias);
+    const messages = mockPubSubMessages.get(batchAlias);
+    assert.ok(messages, `Expected Pub/Sub messages for batch "${batchAlias}".`);
+    const response = await withDevAuthenticatedApiContext(userAlias, apiContext =>
+      apiContext.post('/api/test/desk/pubsub/bulk-gmail', {
+        data: { channelId, historyId: batch.historyId, messages },
+      }),
+    );
+    await assertOkResponse(response, 'Deterministic Pub/Sub Gmail batch');
+    const result = (await response.json()) as { published?: number; processed?: number; created?: number; duplicates?: number; skipped?: number };
+    assert.equal(result.published, batch.messageIds.length);
+    assert.equal(result.processed, batch.messageIds.length);
+    assert.equal(result.created, batch.messageIds.length);
+    assert.equal(result.duplicates, 0);
+    assert.equal(result.skipped, 0);
+    const ticketsResponse = await withDevAuthenticatedApiContext(userAlias, apiContext =>
+      apiContext.get(`/api/test/desk/channel/${channelId}/tickets`),
+    );
+    await assertOkResponse(ticketsResponse, 'Desk Pub/Sub ticket verification');
+    const ticketsBody = (await ticketsResponse.json()) as { tickets?: Array<{ title?: string }> };
+    const expectedTitles = new Set(
+      (mockPubSubMessages.get(batchAlias) ?? []).map(message => String(message.subject)),
+    );
+    const actualTitles = (ticketsBody.tickets ?? []).filter(ticket => expectedTitles.has(String(ticket.title)));
+    assert.equal(actualTitles.length, expectedTitles.size);
+    assert.equal(new Set(actualTitles.map(ticket => ticket.title)).size, expectedTitles.size);
+  }
+
+  @Step('republishing deterministic Pub/Sub batch <batchAlias> to Desk channel <channelAlias> for user <userAlias>')
+  public async republishDeterministicPubSubBatch(
+    batchAlias: string,
+    channelAlias: string,
+    userAlias: string,
+  ): Promise<void> {
+    const batch = mockPubSubBatches.get(batchAlias);
+    assert.ok(batch, `Expected Pub/Sub batch "${batchAlias}" to be generated.`);
+    const channelId = this.getStoredChannelId(channelAlias, userAlias);
+    const messages = mockPubSubMessages.get(batchAlias);
+    assert.ok(messages, `Expected Pub/Sub messages for batch "${batchAlias}".`);
+    const response = await withDevAuthenticatedApiContext(userAlias, apiContext =>
+      apiContext.post('/api/test/desk/pubsub/bulk-gmail', {
+        data: { channelId, historyId: batch.historyId, messages },
+      }),
+    );
+    await assertOkResponse(response, 'Deterministic Pub/Sub duplicate batch');
+    const result = (await response.json()) as { created?: number; duplicates?: number };
+    assert.equal(result.created, 0);
+    assert.equal(result.duplicates, batch.messageIds.length);
   }
 
   @Step(

--- a/tools/xyne-automation/tests/shared/support/auth-cookies.ts
+++ b/tools/xyne-automation/tests/shared/support/auth-cookies.ts
@@ -1,0 +1,135 @@
+import type { BrowserContext } from 'playwright';
+import { config } from '@/config';
+
+interface HeaderEntry {
+  name: string;
+  value: string;
+}
+
+interface ResponseWithHeaders {
+  headersArray?(): HeaderEntry[] | Promise<HeaderEntry[]>;
+}
+
+interface ParsedCookie {
+  name: string;
+  value: string;
+  path?: string;
+  expires?: number;
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: 'Strict' | 'Lax' | 'None';
+}
+
+function isXyneAuthCookie(name: string): boolean {
+  return (
+    (name.startsWith('xyne_ws_') && name.endsWith('_token')) ||
+    name === 'xyne_last_workspace' ||
+    name === 'xyne_session' ||
+    name === 'user_session_id' ||
+    name === 'is_new_user'
+  );
+}
+
+async function getSetCookieHeaders(response: ResponseWithHeaders | undefined): Promise<string[]> {
+  if (!response) {
+    return [];
+  }
+
+  const headerArray = (await response.headersArray?.()) ?? [];
+  return headerArray
+    .filter((header) => header.name.toLowerCase() === 'set-cookie')
+    .map((header) => header.value);
+}
+
+function parseSetCookieHeader(header: string): ParsedCookie | null {
+  const [nameValuePair, ...attributes] = header.split(';').map((part) => part.trim());
+  const separatorIndex = nameValuePair.indexOf('=');
+
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const cookie: ParsedCookie = {
+    name: nameValuePair.slice(0, separatorIndex),
+    value: nameValuePair.slice(separatorIndex + 1),
+    path: '/',
+  };
+
+  for (const attribute of attributes) {
+    const [rawName, ...rawValueParts] = attribute.split('=');
+    const name = rawName.toLowerCase();
+    const value = rawValueParts.join('=');
+
+    if (name === 'path' && value) {
+      cookie.path = value;
+    } else if (name === 'expires' && value) {
+      const parsedDate = Date.parse(value);
+      if (!Number.isNaN(parsedDate)) {
+        cookie.expires = Math.floor(parsedDate / 1000);
+      }
+    } else if (name === 'max-age' && value) {
+      const maxAgeSeconds = Number(value);
+      if (Number.isFinite(maxAgeSeconds)) {
+        cookie.expires = Math.floor(Date.now() / 1000 + maxAgeSeconds);
+      }
+    } else if (name === 'httponly') {
+      cookie.httpOnly = true;
+    } else if (name === 'secure') {
+      cookie.secure = true;
+    } else if (name === 'samesite') {
+      const normalized = value.toLowerCase();
+      if (normalized === 'strict' || normalized === 'lax' || normalized === 'none') {
+        cookie.sameSite = (normalized.charAt(0).toUpperCase() +
+          normalized.slice(1)) as ParsedCookie['sameSite'];
+      }
+    }
+  }
+
+  return cookie;
+}
+
+/**
+ * CI talks to backend and dashboard through different Docker hostnames.
+ * Test-login cookies are written for the backend origin, while the dashboard
+ * can only read cookies scoped to its own origin.
+ */
+export async function mirrorBackendAuthCookiesToDashboard(
+  context: BrowserContext,
+  response?: ResponseWithHeaders
+): Promise<void> {
+  const responseCookies = (await getSetCookieHeaders(response))
+    .map(parseSetCookieHeader)
+    .filter((cookie): cookie is ParsedCookie => Boolean(cookie))
+    .filter((cookie) => isXyneAuthCookie(cookie.name));
+  const backendCookies = await context.cookies(config.backend.baseUrl);
+  const contextCookies = backendCookies
+    .filter((cookie) => isXyneAuthCookie(cookie.name))
+    .map((cookie) => ({
+      name: cookie.name,
+      value: cookie.value,
+      path: cookie.path,
+      expires: cookie.expires,
+      httpOnly: cookie.httpOnly,
+      secure: cookie.secure,
+      sameSite: cookie.sameSite,
+    }));
+  const authCookies = responseCookies.length > 0 ? responseCookies : contextCookies;
+
+  if (authCookies.length === 0) {
+    throw new Error(
+      `No Xyne auth cookies were available after test login. Backend origin: ${config.backend.baseUrl}`
+    );
+  }
+
+  await context.addCookies(
+    authCookies.map((cookie) => ({
+      name: cookie.name,
+      value: cookie.value,
+      url: config.dashboard.baseUrl,
+      expires: cookie.expires,
+      httpOnly: cookie.httpOnly,
+      secure: cookie.secure,
+      sameSite: cookie.sameSite,
+    }))
+  );
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
