### PR TITLE
fix: XYNE-61728 scope message edit lock to the requesting list

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -18,7 +18,7 @@ import {
 import { useAuthContext } from '../../../providers/AuthProvider';
 import { ChatInput } from '../ChatInput';
 import { usePin } from '../../../hooks/usePin';
-import { useEditContext } from '../../../providers/EditProvider';
+import { useMessageEdit } from '../../../providers/EditProvider';
 import { toast } from 'sonner';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import {
@@ -193,7 +193,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   const shareableOrigin = useShareableOrigin();
   const location = useLocation();
   const { conversationId } = useParams<{ conversationId?: string }>();
-  const { editingMessageId, requestEdit, stopEditing } = useEditContext();
+  const { isEditingMessage, requestEdit, stopEditing } = useMessageEdit();
   const { setSkipMarkAsRead } = React.useContext(ConversationTabContext);
   const { isMobile } = usePlatform();
   const channel = useChannel(channelId);
@@ -257,7 +257,6 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   ]);
   const [showLinkPreview, setShowLinkPreview] = useState(true);
   const [showCanvasPreview, setShowCanvasPreview] = useState(true);
-  const [isEditing, setIsEditing] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isEmojiPickerOpen, setIsEmojiPickerOpen] = useState(false);
@@ -266,10 +265,6 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   const isScrollingRef = useRef(false);
   const pressTimerRef = useRef<NodeJS.Timeout | null>(null);
   const touchEndedInsideRef = useRef(false);
-
-  useEffect(() => {
-    setIsEditing(editingMessageId === message.messageId);
-  }, [editingMessageId, message.messageId]);
 
   const { isEntityBookmarked, getBookmarkByEntity } = useUserBookmarks();
 
@@ -434,7 +429,6 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
 
   const handleEditMessage = (): void => {
     requestEdit(message.messageId, () => {
-      setIsEditing(true);
       // Scroll the message into view when editing starts
       setTimeout(() => {
         if (containerRef.current) {
@@ -823,7 +817,6 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   };
 
   const finishEditing = (): void => {
-    setIsEditing(false);
     stopEditing(); // release global lock
   };
 
@@ -870,7 +863,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   // Only show copy button if there's text content to copy
   const shouldShowCopyButton = hasTextContent;
 
-  const isCurrentEditing = editingMessageId === message.messageId;
+  const isCurrentEditing = isEditingMessage(message.messageId);
 
   // Check for canvas link
   const msgContent = message?.content as string | undefined;
@@ -1001,7 +994,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
     variant !== 'pinned' &&
     !isMentionUserAddition &&
     !isTicketActivity &&
-    !(isEditing && isCurrentEditing);
+    !isCurrentEditing;
 
   // No dependency array on purpose: re-registering is a cheap Map.set and this
   // keeps the registered handlers/capabilities in sync with the latest render.
@@ -1274,7 +1267,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
         }
       }}
     >
-      {isEditing && isCurrentEditing ? (
+      {isCurrentEditing ? (
         <ChatInput
           autoFocus='end' // eslint-disable-line jsx-a11y/no-autofocus
           channelId={channelId}

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV2.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV2.tsx
@@ -16,7 +16,7 @@ import { ChannelScopeType, MessageType } from '@xyne/shared';
 import { Conversation } from '../../../machines/stateMachine';
 import { ArrowDown } from 'lucide-react';
 import { useGetChannelConversations, useGetChannelUserStatus } from '../../../hooks/useChannels';
-import { useEditContext } from '../../../providers/EditProvider';
+import { EditSurfaceScope, useMessageEdit } from '../../../providers/EditProvider';
 import { useShortcutById } from '../../../shortcuts';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
 import { standaloneNavigate } from '../../../utils/electronApp';
@@ -61,7 +61,7 @@ const ChatListV2: React.FC<ChatListProps> = ({
   // Container for the shared hover toolbar overlay (one toolbar per list).
   const hoverToolbarContainerRef = useRef<HTMLDivElement>(null);
   const { user } = useAuth();
-  const { editingMessageId, requestEdit } = useEditContext();
+  const { isEditingMessage, requestEdit } = useMessageEdit();
   const particpantionStatus = useGetChannelUserStatus(channelId);
   const [oldConversations, oldConversationsDetails] = useQuery(
     queries.channelConversationsPaginatedV3({
@@ -136,13 +136,13 @@ const ChatListV2: React.FC<ChatListProps> = ({
       });
     };
 
-    if (editingMessageId === message.messageId) {
+    if (isEditingMessage(message.messageId)) {
       scrollToConversation();
       return;
     }
 
     requestEdit(message.messageId, scrollToConversation);
-  }, [conversations, user?.id, firstItemIndex, editingMessageId, requestEdit]);
+  }, [conversations, user?.id, firstItemIndex, isEditingMessage, requestEdit]);
 
   useShortcutById('composer.editLastMessage', handleEditLastMessage, {
     enabled: conversations.length > 0,
@@ -604,4 +604,10 @@ const ChatListV2: React.FC<ChatListProps> = ({
   );
 };
 
-export default ChatListV2;
+const ChatListV2WithEditSurface: React.FC<ChatListProps> = props => (
+  <EditSurfaceScope>
+    <ChatListV2 {...props} />
+  </EditSurfaceScope>
+);
+
+export default ChatListV2WithEditSurface;

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV2.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV2.tsx
@@ -16,7 +16,7 @@ import { ChannelScopeType, MessageType } from '@xyne/shared';
 import { Conversation } from '../../../machines/stateMachine';
 import { ArrowDown } from 'lucide-react';
 import { useGetChannelConversations, useGetChannelUserStatus } from '../../../hooks/useChannels';
-import { EditSurfaceScope, useMessageEdit } from '../../../providers/EditProvider';
+import { useMessageEdit, withEditSurface } from '../../../providers/EditProvider';
 import { useShortcutById } from '../../../shortcuts';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
 import { standaloneNavigate } from '../../../utils/electronApp';
@@ -604,10 +604,4 @@ const ChatListV2: React.FC<ChatListProps> = ({
   );
 };
 
-const ChatListV2WithEditSurface: React.FC<ChatListProps> = props => (
-  <EditSurfaceScope>
-    <ChatListV2 {...props} />
-  </EditSurfaceScope>
-);
-
-export default ChatListV2WithEditSurface;
+export default withEditSurface(ChatListV2);

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV3.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV3.tsx
@@ -15,7 +15,7 @@ import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
 import { useShortcutById } from '../../../shortcuts';
 import { useAuth } from '../../../hooks/useAuth';
-import { EditSurfaceScope, useMessageEdit } from '../../../providers/EditProvider';
+import { useMessageEdit, withEditSurface } from '../../../providers/EditProvider';
 import { useCombinedMesseges } from './ChatListV2.utils';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { formatDatePill } from '../../../utils/dateUtils';
@@ -1434,10 +1434,4 @@ const ChatListV3: React.FC<ChatListProps> = ({
   );
 };
 
-const ChatListV3WithEditSurface: React.FC<ChatListProps> = props => (
-  <EditSurfaceScope>
-    <ChatListV3 {...props} />
-  </EditSurfaceScope>
-);
-
-export default withProfiler(ChatListV3WithEditSurface, 'ChatListV3');
+export default withProfiler(withEditSurface(ChatListV3), 'ChatListV3');

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV3.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV3.tsx
@@ -15,7 +15,7 @@ import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
 import { useShortcutById } from '../../../shortcuts';
 import { useAuth } from '../../../hooks/useAuth';
-import { useEditContext } from '../../../providers/EditProvider';
+import { EditSurfaceScope, useMessageEdit } from '../../../providers/EditProvider';
 import { useCombinedMesseges } from './ChatListV2.utils';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { formatDatePill } from '../../../utils/dateUtils';
@@ -241,7 +241,7 @@ const ChatListV3: React.FC<ChatListProps> = ({
   const activityNavigationNonce =
     (location.state as { activityNavigationNonce?: number } | null)?.activityNavigationNonce ?? 0;
   const { baseRoute } = useRouteContext();
-  const { editingMessageId, requestEdit } = useEditContext();
+  const { isEditingMessage, requestEdit } = useMessageEdit();
   const channelParticipation = useChannelParticipation(channelId);
   const isMember = !!channelParticipation;
   const channel = useVisibleChannel(channelId);
@@ -1061,13 +1061,13 @@ const ChatListV3: React.FC<ChatListProps> = ({
       });
     };
 
-    if (editingMessageId === message.messageId) {
+    if (isEditingMessage(message.messageId)) {
       scrollToConversation();
       return;
     }
 
     requestEdit(message.messageId, scrollToConversation);
-  }, [conversations, user?.id, firstItemIndex, editingMessageId, requestEdit]);
+  }, [conversations, user?.id, firstItemIndex, isEditingMessage, requestEdit]);
 
   useShortcutById('composer.editLastMessage', handleEditLastMessage, {
     enabled: conversations.length > 0,
@@ -1434,4 +1434,10 @@ const ChatListV3: React.FC<ChatListProps> = ({
   );
 };
 
-export default withProfiler(ChatListV3, 'ChatListV3');
+const ChatListV3WithEditSurface: React.FC<ChatListProps> = props => (
+  <EditSurfaceScope>
+    <ChatListV3 {...props} />
+  </EditSurfaceScope>
+);
+
+export default withProfiler(ChatListV3WithEditSurface, 'ChatListV3');

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
@@ -20,7 +20,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
 import { useShortcutById } from '../../../shortcuts';
 import { useAuth } from '../../../hooks/useAuth';
-import { EditSurfaceScope, useMessageEdit } from '../../../providers/EditProvider';
+import { useMessageEdit, withEditSurface } from '../../../providers/EditProvider';
 import { useCombinedMesseges } from './ChatListV2.utils';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { formatDatePill } from '../../../utils/dateUtils';
@@ -1507,10 +1507,4 @@ const ChatListV4: React.FC<ChatListProps> = ({
   );
 };
 
-const ChatListV4WithEditSurface: React.FC<ChatListProps> = props => (
-  <EditSurfaceScope>
-    <ChatListV4 {...props} />
-  </EditSurfaceScope>
-);
-
-export default withProfiler(ChatListV4WithEditSurface, 'ChatListV4');
+export default withProfiler(withEditSurface(ChatListV4), 'ChatListV4');

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
@@ -20,7 +20,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
 import { useShortcutById } from '../../../shortcuts';
 import { useAuth } from '../../../hooks/useAuth';
-import { useEditContext } from '../../../providers/EditProvider';
+import { EditSurfaceScope, useMessageEdit } from '../../../providers/EditProvider';
 import { useCombinedMesseges } from './ChatListV2.utils';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { formatDatePill } from '../../../utils/dateUtils';
@@ -224,7 +224,7 @@ const ChatListV4: React.FC<ChatListProps> = ({
   const activityNavigationNonce =
     (location.state as { activityNavigationNonce?: number } | null)?.activityNavigationNonce ?? 0;
   const { baseRoute } = useRouteContext();
-  const { editingMessageId, requestEdit } = useEditContext();
+  const { isEditingMessage, requestEdit } = useMessageEdit();
   const channelParticipation = useChannelParticipation(channelId);
   const isMember = !!channelParticipation;
   const channel = useVisibleChannel(channelId);
@@ -1125,12 +1125,12 @@ const ChatListV4: React.FC<ChatListProps> = ({
       virtualizer.scrollToIndex(index, { align: 'center' });
     };
 
-    if (editingMessageId === message.messageId) {
+    if (isEditingMessage(message.messageId)) {
       scrollToConversation();
       return;
     }
     requestEdit(message.messageId, scrollToConversation);
-  }, [conversations, user?.id, editingMessageId, requestEdit, virtualizer]);
+  }, [conversations, user?.id, isEditingMessage, requestEdit, virtualizer]);
 
   useShortcutById('composer.editLastMessage', handleEditLastMessage, {
     enabled: conversations.length > 0,
@@ -1507,4 +1507,10 @@ const ChatListV4: React.FC<ChatListProps> = ({
   );
 };
 
-export default withProfiler(ChatListV4, 'ChatListV4');
+const ChatListV4WithEditSurface: React.FC<ChatListProps> = props => (
+  <EditSurfaceScope>
+    <ChatListV4 {...props} />
+  </EditSurfaceScope>
+);
+
+export default withProfiler(ChatListV4WithEditSurface, 'ChatListV4');

--- a/apps/dashboard/src/components/Chat/PinListV2.tsx
+++ b/apps/dashboard/src/components/Chat/PinListV2.tsx
@@ -8,7 +8,7 @@ import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { DelayedSpinner } from '../ui/DelayedSpinner';
 import { useGetChannelUserStatus } from '@xyne/shared/hooks';
 import { DatePill } from './DatePill';
-import { EditSurfaceScope } from '../../providers/EditProvider';
+import { withEditSurface } from '../../providers/EditProvider';
 import { formatDatePill } from '../../utils/dateUtils';
 
 interface PinListProps {
@@ -100,10 +100,4 @@ const PinListV2: React.FC<PinListProps> = ({ channelId }) => {
   );
 };
 
-const PinListV2WithEditSurface: React.FC<PinListProps> = props => (
-  <EditSurfaceScope>
-    <PinListV2 {...props} />
-  </EditSurfaceScope>
-);
-
-export default PinListV2WithEditSurface;
+export default withEditSurface(PinListV2);

--- a/apps/dashboard/src/components/Chat/PinListV2.tsx
+++ b/apps/dashboard/src/components/Chat/PinListV2.tsx
@@ -8,6 +8,7 @@ import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { DelayedSpinner } from '../ui/DelayedSpinner';
 import { useGetChannelUserStatus } from '@xyne/shared/hooks';
 import { DatePill } from './DatePill';
+import { EditSurfaceScope } from '../../providers/EditProvider';
 import { formatDatePill } from '../../utils/dateUtils';
 
 interface PinListProps {
@@ -99,4 +100,10 @@ const PinListV2: React.FC<PinListProps> = ({ channelId }) => {
   );
 };
 
-export default PinListV2;
+const PinListV2WithEditSurface: React.FC<PinListProps> = props => (
+  <EditSurfaceScope>
+    <PinListV2 {...props} />
+  </EditSurfaceScope>
+);
+
+export default PinListV2WithEditSurface;

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResultMessageCard.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResultMessageCard.tsx
@@ -10,6 +10,7 @@ import {
 import { getSmartSnippet } from '../RenderMessageWithHTML/searchSnippetRender';
 import { useNavigate } from 'react-router-dom';
 import { Home } from 'lucide-react';
+import { EditSurfaceScope } from '../../../providers/EditProvider';
 import { ChatBubble } from '../ChatBubble/ChatBubble';
 import AvatarGroup from '../../ui/Avatar/AvatarGroup';
 import { useChannel } from '../../../hooks/useChannels';
@@ -314,34 +315,36 @@ export const SearchResultMessageCard = memo(function SearchResultMessageCard({
           <div className='px-4 py-3 text-sm text-muted-foreground'>Message no longer available</div>
         ) : (
           <>
-            <ChatBubble
-              message={displayMessage ?? targetMessage}
-              channelId={channelId}
-              showAvatar
-              context='channel'
-              channelScopeType={channel?.scopeType}
-              searchItemView
-              {...(onSelectUser && { onUserClick: onSelectUser })}
-              {...(fabricatedConversation && { conversation: fabricatedConversation })}
-              {...(canExpand &&
-                isExpanded && {
-                  afterTextContent: (
-                    <button
-                      data-prevent-thread
-                      onClick={e => {
-                        e.stopPropagation();
-                        setIsExpanded(false);
-                      }}
-                      className='block text-muted-foreground hover:underline mt-1'
-                      style={{ fontSize: '0.75rem' }}
-                      data-track-category='SEARCH_RESULTS'
-                      data-track-name='COLLAPSE_MESSAGE'
-                    >
-                      Show less
-                    </button>
-                  ),
-                })}
-            />
+            <EditSurfaceScope>
+              <ChatBubble
+                message={displayMessage ?? targetMessage}
+                channelId={channelId}
+                showAvatar
+                context='channel'
+                channelScopeType={channel?.scopeType}
+                searchItemView
+                {...(onSelectUser && { onUserClick: onSelectUser })}
+                {...(fabricatedConversation && { conversation: fabricatedConversation })}
+                {...(canExpand &&
+                  isExpanded && {
+                    afterTextContent: (
+                      <button
+                        data-prevent-thread
+                        onClick={e => {
+                          e.stopPropagation();
+                          setIsExpanded(false);
+                        }}
+                        className='block text-muted-foreground hover:underline mt-1'
+                        style={{ fontSize: '0.75rem' }}
+                        data-track-category='SEARCH_RESULTS'
+                        data-track-name='COLLAPSE_MESSAGE'
+                      >
+                        Show less
+                      </button>
+                    ),
+                  })}
+              />
+            </EditSurfaceScope>
             {/* Reply preview: repliers' avatars (from Vespa threadSenders) + count.
                 The conversation isn't fetched, so avatars come from the surfaced
                 participant ids. */}

--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -11,7 +11,7 @@ import { DatePill } from '../DatePill';
 import { MessageType, ChannelScopeType } from '@xyne/shared';
 import { MessageMetadata } from '../../ui/MessageBubble/MessageBubble.utils';
 import { ConversationWithTicket } from '../../ui/MessageBubble/MessageBubble.types';
-import { useEditContext } from '../../../providers/EditProvider';
+import { EditSurfaceScope, useMessageEdit } from '../../../providers/EditProvider';
 import { useShortcutById } from '../../../shortcuts';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
 import { ArrowDown, ArrowUp, ChevronUp } from 'lucide-react';
@@ -76,7 +76,7 @@ const ThreadList = ({
   spawnedTicketMessageIds,
 }: ThreadListProps): ReactElement => {
   const { user } = useAuthContext();
-  const { editingMessageId, requestEdit } = useEditContext();
+  const { isEditingMessage, requestEdit } = useMessageEdit();
   const location = useLocation();
   const activityNavigationNonce =
     (location.state as { activityNavigationNonce?: number } | null)?.activityNavigationNonce ?? 0;
@@ -133,13 +133,13 @@ const ThreadList = ({
       }
     };
 
-    if (editingMessageId === message.messageId) {
+    if (isEditingMessage(message.messageId)) {
       scrollToMessage();
       return;
     }
 
     requestEdit(message.messageId, scrollToMessage);
-  }, [conversationId, threadMessages, user?.id, editingMessageId, requestEdit]);
+  }, [conversationId, threadMessages, user?.id, isEditingMessage, requestEdit]);
 
   useShortcutById('composer.editLastMessage', handleEditLastMessage, {
     enabled: threadMessages.length > 0,
@@ -713,4 +713,10 @@ const ThreadList = ({
   );
 };
 
-export default ThreadList;
+const ThreadListWithEditSurface = (props: ThreadListProps): ReactElement => (
+  <EditSurfaceScope>
+    <ThreadList {...props} />
+  </EditSurfaceScope>
+);
+
+export default ThreadListWithEditSurface;

--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -11,7 +11,7 @@ import { DatePill } from '../DatePill';
 import { MessageType, ChannelScopeType } from '@xyne/shared';
 import { MessageMetadata } from '../../ui/MessageBubble/MessageBubble.utils';
 import { ConversationWithTicket } from '../../ui/MessageBubble/MessageBubble.types';
-import { EditSurfaceScope, useMessageEdit } from '../../../providers/EditProvider';
+import { useMessageEdit, withEditSurface } from '../../../providers/EditProvider';
 import { useShortcutById } from '../../../shortcuts';
 import { findLastEditableMessage, isEventFromEmptyInput } from '../../../utils/chatUtils';
 import { ArrowDown, ArrowUp, ChevronUp } from 'lucide-react';
@@ -713,10 +713,4 @@ const ThreadList = ({
   );
 };
 
-const ThreadListWithEditSurface = (props: ThreadListProps): ReactElement => (
-  <EditSurfaceScope>
-    <ThreadList {...props} />
-  </EditSurfaceScope>
-);
-
-export default ThreadListWithEditSurface;
+export default withEditSurface(ThreadList);

--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -76,7 +76,7 @@ const ThreadList = ({
   spawnedTicketMessageIds,
 }: ThreadListProps): ReactElement => {
   const { user } = useAuthContext();
-  const { isEditingMessage, requestEdit } = useMessageEdit();
+  const { isEditingMessage, isEditingHere, requestEdit } = useMessageEdit();
   const location = useLocation();
   const activityNavigationNonce =
     (location.state as { activityNavigationNonce?: number } | null)?.activityNavigationNonce ?? 0;
@@ -157,8 +157,8 @@ const ThreadList = ({
 
   const isEditingRef = useRef(false);
   useEffect(() => {
-    isEditingRef.current = editingMessageId !== null;
-  }, [editingMessageId]);
+    isEditingRef.current = isEditingHere;
+  }, [isEditingHere]);
 
   const lastAutoScrolledMessageIdRef = useRef<string | null>(null);
 

--- a/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
+++ b/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
@@ -13,6 +13,7 @@ import { cn } from '../../utils/classNames';
 import { useSelector } from '@xstate/react';
 import { PreviewSplitDialog, PreviewThreadPanel } from '../ui/PreviewSplitDialog';
 import { ChatBubble } from '../Chat/ChatBubble/ChatBubble';
+import { EditSurfaceScope } from '../../providers/EditProvider';
 import { useCachedQuery } from '../../hooks/useCachedQuery';
 import { useGetChannelUserStatus } from '../../hooks/useChannels';
 import { queries } from '../../zero/queries';
@@ -1528,17 +1529,19 @@ const AttachmentGalleryModalInner: React.FC = () => {
     };
 
     return (
-      <div className='flex-1 overflow-auto py-4'>
-        <ChatBubble
-          message={message as unknown as Parameters<typeof ChatBubble>[0]['message']}
-          channelId={currentAttachment?.channelId || ''}
-          showAvatar={true}
-          context='thread'
-          isFirstInThread={true}
-          isTicketThread={false}
-          disableAskAI={true}
-        />
-      </div>
+      <EditSurfaceScope>
+        <div className='flex-1 overflow-auto py-4'>
+          <ChatBubble
+            message={message as unknown as Parameters<typeof ChatBubble>[0]['message']}
+            channelId={currentAttachment?.channelId || ''}
+            showAvatar={true}
+            context='thread'
+            isFirstInThread={true}
+            isTicketThread={false}
+            disableAskAI={true}
+          />
+        </div>
+      </EditSurfaceScope>
     );
   };
 

--- a/apps/dashboard/src/providers/EditProvider.tsx
+++ b/apps/dashboard/src/providers/EditProvider.tsx
@@ -115,6 +115,7 @@ export const useEditContext = (): EditContextType => {
 
 export const useMessageEdit = (): {
   isEditingMessage: (messageId: string) => boolean;
+  isEditingHere: boolean;
   requestEdit: (messageId: string, onConfirm: () => void) => void;
   stopEditing: () => void;
 } => {
@@ -131,5 +132,7 @@ export const useMessageEdit = (): {
     [requestEdit, surface],
   );
 
-  return { isEditingMessage, requestEdit: requestEditHere, stopEditing };
+  const isEditingHere = editingMessageId !== null && editingSurface === surface;
+
+  return { isEditingMessage, isEditingHere, requestEdit: requestEditHere, stopEditing };
 };

--- a/apps/dashboard/src/providers/EditProvider.tsx
+++ b/apps/dashboard/src/providers/EditProvider.tsx
@@ -1,9 +1,21 @@
-import { createContext, useContext, useState, ReactNode, useEffect, ReactElement } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useState,
+  ReactNode,
+  ReactElement,
+} from 'react';
 import { useLocation } from 'react-router-dom';
+
+type EditSurface = string;
 
 interface EditContextType {
   editingMessageId: string | null;
-  requestEdit: (id: string, onConfirm: () => void) => void;
+  editingSurface: EditSurface | null;
+  requestEdit: (id: string, surface: EditSurface, onConfirm: () => void) => void;
   stopEditing: () => void;
   pendingAction: (() => void) | undefined;
   clearPendingAction: () => void;
@@ -11,27 +23,29 @@ interface EditContextType {
 
 const EditContext = createContext<EditContextType | undefined>(undefined);
 
+const EditSurfaceContext = createContext<EditSurface>('root');
+
 /** Provides editing state and controls for message editing */
 export const EditProvider = ({ children }: { children: ReactNode }): ReactElement => {
-  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+  const [editing, setEditing] = useState<{ messageId: string; surface: EditSurface } | null>(null);
   const [pendingAction, setPendingAction] = useState<(() => void) | undefined>();
 
   const location = useLocation();
 
-  const requestEdit = (id: string, onConfirm: () => void): void => {
-    if (editingMessageId && editingMessageId !== id) {
+  const requestEdit = (id: string, surface: EditSurface, onConfirm: () => void): void => {
+    if (editing && (editing.messageId !== id || editing.surface !== surface)) {
       setPendingAction(() => (): void => {
-        setEditingMessageId(id);
+        setEditing({ messageId: id, surface });
         onConfirm();
       });
     } else {
-      setEditingMessageId(id);
+      setEditing({ messageId: id, surface });
       onConfirm();
     }
   };
 
   const stopEditing = (): void => {
-    setEditingMessageId(null);
+    setEditing(null);
   };
 
   useEffect(() => {
@@ -42,7 +56,8 @@ export const EditProvider = ({ children }: { children: ReactNode }): ReactElemen
   return (
     <EditContext.Provider
       value={{
-        editingMessageId,
+        editingMessageId: editing?.messageId ?? null,
+        editingSurface: editing?.surface ?? null,
         requestEdit,
         stopEditing,
         pendingAction,
@@ -54,10 +69,36 @@ export const EditProvider = ({ children }: { children: ReactNode }): ReactElemen
   );
 };
 
+export const EditSurfaceScope = ({ children }: { children: ReactNode }): ReactElement => {
+  const surface = useId();
+  return <EditSurfaceContext.Provider value={surface}>{children}</EditSurfaceContext.Provider>;
+};
+
 export const useEditContext = (): EditContextType => {
   const ctx = useContext(EditContext);
   if (!ctx) {
     throw new Error('useEditContext must be used inside EditProvider');
   }
   return ctx;
+};
+
+export const useMessageEdit = (): {
+  isEditingMessage: (messageId: string) => boolean;
+  requestEdit: (messageId: string, onConfirm: () => void) => void;
+  stopEditing: () => void;
+} => {
+  const { editingMessageId, editingSurface, requestEdit, stopEditing } = useEditContext();
+  const surface = useContext(EditSurfaceContext);
+
+  const isEditingMessage = useCallback(
+    (messageId: string): boolean => editingMessageId === messageId && editingSurface === surface,
+    [editingMessageId, editingSurface, surface],
+  );
+
+  const requestEditHere = useCallback(
+    (messageId: string, onConfirm: () => void): void => requestEdit(messageId, surface, onConfirm),
+    [requestEdit, surface],
+  );
+
+  return { isEditingMessage, requestEdit: requestEditHere, stopEditing };
 };

--- a/apps/dashboard/src/providers/EditProvider.tsx
+++ b/apps/dashboard/src/providers/EditProvider.tsx
@@ -5,6 +5,8 @@ import {
   useEffect,
   useId,
   useState,
+  ComponentType,
+  FC,
   ReactNode,
   ReactElement,
 } from 'react';
@@ -17,6 +19,7 @@ interface EditContextType {
   editingSurface: EditSurface | null;
   requestEdit: (id: string, surface: EditSurface, onConfirm: () => void) => void;
   stopEditing: () => void;
+  releaseSurface: (surface: EditSurface) => void;
   pendingAction: (() => void) | undefined;
   clearPendingAction: () => void;
 }
@@ -48,6 +51,10 @@ export const EditProvider = ({ children }: { children: ReactNode }): ReactElemen
     setEditing(null);
   };
 
+  const releaseSurface = useCallback((surface: EditSurface): void => {
+    setEditing(current => (current?.surface === surface ? null : current));
+  }, []);
+
   useEffect(() => {
     stopEditing();
     setPendingAction(undefined);
@@ -60,6 +67,7 @@ export const EditProvider = ({ children }: { children: ReactNode }): ReactElemen
         editingSurface: editing?.surface ?? null,
         requestEdit,
         stopEditing,
+        releaseSurface,
         pendingAction,
         clearPendingAction: () => setPendingAction(undefined),
       }}
@@ -71,7 +79,30 @@ export const EditProvider = ({ children }: { children: ReactNode }): ReactElemen
 
 export const EditSurfaceScope = ({ children }: { children: ReactNode }): ReactElement => {
   const surface = useId();
+  const { releaseSurface } = useEditContext();
+
+  useEffect(
+    () => (): void => {
+      releaseSurface(surface);
+    },
+    [releaseSurface, surface],
+  );
+
   return <EditSurfaceContext.Provider value={surface}>{children}</EditSurfaceContext.Provider>;
+};
+
+export const withEditSurface = <P extends object>(component: ComponentType<P>): FC<P> => {
+  const Component = component;
+
+  const WithEditSurface: FC<P> = (props): ReactElement => (
+    <EditSurfaceScope>
+      <Component {...props} />
+    </EditSurfaceScope>
+  );
+
+  WithEditSurface.displayName = `withEditSurface(${component.displayName ?? component.name})`;
+
+  return WithEditSurface;
 };
 
 export const useEditContext = (): EditContextType => {


### PR DESCRIPTION
[POT](https://drive.google.com/file/d/18cAnhT-a-yXZSoeuVkfhfFz-h0S6Ggxx/view?usp=sharing)
## Problem

A reply sent with "Also send to channel" renders in both the channel list and the thread panel. Clicking Edit on either copy turns **both** copies into editors at the same time. Each has its own draft and both autofocus, so they fight for the cursor and whichever is submitted last silently wins.

**Steps to reproduce**
1. Open a channel with the thread panel open beside it.
2. Reply in a thread with "Send to channel" ticked, so the reply shows in both panes.
3. Click Edit on either copy of that reply.

Expected: one editor, in the pane you clicked.
Actual: an editor opens in the channel list **and** in the thread panel.

Also reproducible with a pinned message (channel + Pins tab) and on the threads screen (preview card + thread detail).

## Root cause

The edit lock is a single global message id (`EditProvider.editingMessageId`). Every `ChatBubble` decides whether to show its editor by comparing that id to its own message id. "Also send to channel" does not create a second message — it sets `showInChannel` on the same row, which the channel query then picks up — so the two mounted bubbles share an id and both match.

## Fix

Scope the edit lock to the list it was requested from, not just the message. Each list is wrapped in an `EditSurfaceScope` that mints an id via `useId()`, and a `useMessageEdit()` hook binds that surface into `isEditingMessage()` / `requestEdit()`, so a bubble opens its editor only when the message **and** the surface match. Two mounts of the same list (thread preview card vs detail) get distinct ids automatically, so the surface never has to be declared by hand.

Editing the same message from a second surface now routes through the existing "You have unsaved edits" prompt instead of opening a second editor. Also drops `ChatBubble`'s local `isEditing` state, which only mirrored the context value a frame late.

## Scope

`apps/dashboard` only — `EditProvider`, `ChatBubble`, `ChatListV2/V3/V4`, `ThreadList`, `PinListV2`, `SearchResultMessageCard`, `FileViewerModal`.

No backend, schema, or query changes. `showInChannel` messages still appear in both places and are still editable from either.

## Test plan

- [ ] Broadcast reply: edit from channel, then from thread — one editor each time; save updates both copies
- [ ] Pinned message edited in the channel: pin card stays a bubble
- [ ] Threads screen: preview card and detail do not both open an editor
- [ ] Edit save / cancel (X, Esc); up-arrow edit-last-message in both composers
- [ ] Unsaved-edits modal across two messages, and across two panes for one message
- [ ] Navigating away while editing closes the editor and leaves no stuck lock
- [ ] Smoke: DM compose panel, search results, file viewer message preview, a ticket thread
