### PR TITLE
fix: XYNE-61737 decode FlowJSON in automation trigger message

### DIFF
--- a/apps/backend/src/automations/triggers/message-received.trigger.ts
+++ b/apps/backend/src/automations/triggers/message-received.trigger.ts
@@ -7,6 +7,7 @@ import { repositories } from '@/database/repositories';
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { extractGroupMentions, extractUserMentions } from '@/utils/mentionParser';
+import { getFlowJsonContentForNotification } from '@/utils/flowJson';
 import type { MessageReceivedEventPayload } from '../types/automation-events';
 
 export const MESSAGE_RECEIVED_EVENT = 'MESSAGE_RECEIVED';
@@ -294,7 +295,15 @@ async function hydrateMessageReceivedPayload(
     ...payload,
     message: {
       id: messageId,
-      content: messageRow?.content ?? null,
+      // FlowJSON alerts store the real text inside the data-flow-json attribute;
+      // the only visible node is the literal "Flow JSON". Decode to plaintext so
+      // downstream agents receive the actual message instead of the raw blob and
+      // don't have to call other tools just to read what triggered them.
+      // getFlowJsonContentForNotification returns null for normal messages, so
+      // plain content is passed through unchanged.
+      content: messageRow?.content
+        ? getFlowJsonContentForNotification(messageRow.content) ?? messageRow.content
+        : null,
       conversationId,
       channelId,
       createdAt: messageRow?.createdAt ?? new Date(),

--- a/apps/backend/src/automations/triggers/message-received.trigger.ts
+++ b/apps/backend/src/automations/triggers/message-received.trigger.ts
@@ -295,12 +295,7 @@ async function hydrateMessageReceivedPayload(
     ...payload,
     message: {
       id: messageId,
-      // FlowJSON alerts store the real text inside the data-flow-json attribute;
-      // the only visible node is the literal "Flow JSON". Decode to plaintext so
-      // downstream agents receive the actual message instead of the raw blob and
-      // don't have to call other tools just to read what triggered them.
-      // getFlowJsonContentForNotification returns null for normal messages, so
-      // plain content is passed through unchanged.
+      // Decode FlowJSON alerts to plaintext; returns null for normal messages.
       content: messageRow?.content
         ? getFlowJsonContentForNotification(messageRow.content) ?? messageRow.content
         : null,

--- a/apps/backend/src/automations/triggers/message-received.trigger.ts
+++ b/apps/backend/src/automations/triggers/message-received.trigger.ts
@@ -7,7 +7,7 @@ import { repositories } from '@/database/repositories';
 import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { extractGroupMentions, extractUserMentions } from '@/utils/mentionParser';
-import { getFlowJsonContentForNotification } from '@/utils/flowJson';
+import { toReadableMessageContent } from '@/utils/flowJson';
 import type { MessageReceivedEventPayload } from '../types/automation-events';
 
 export const MESSAGE_RECEIVED_EVENT = 'MESSAGE_RECEIVED';
@@ -295,10 +295,7 @@ async function hydrateMessageReceivedPayload(
     ...payload,
     message: {
       id: messageId,
-      // Decode FlowJSON alerts to plaintext; returns null for normal messages.
-      content: messageRow?.content
-        ? getFlowJsonContentForNotification(messageRow.content) ?? messageRow.content
-        : null,
+      content: toReadableMessageContent(messageRow?.content),
       conversationId,
       channelId,
       createdAt: messageRow?.createdAt ?? new Date(),

--- a/apps/backend/src/automations/triggers/message-received.trigger.ts
+++ b/apps/backend/src/automations/triggers/message-received.trigger.ts
@@ -45,6 +45,7 @@ export const MessageReceivedOutputSchema = z.object({
   message: z.object({
     id: z.string(),
     content: z.string().nullable(),
+    rawContent: z.string().nullable(),
     conversationId: z.string(),
     channelId: z.string(),
     createdAt: z.coerce.date(),
@@ -142,7 +143,11 @@ export class MessageReceivedTrigger extends BaseTrigger<typeof MessageReceivedCo
       const matchResults: boolean[] = [];
 
       if (contentFilterConfigured) {
-        const contentPasses = !!(p.message.content && p.message.content.toLowerCase().includes(cfg.contentContains!.toLowerCase()));
+        // Decoded text and the stored blob: a filter written against a FlowJSON
+        // card title or button label must keep firing after the decode.
+        const needle = cfg.contentContains!.toLowerCase();
+        const contentPasses = [p.message.content, p.message.rawContent]
+          .some(text => !!text && text.toLowerCase().includes(needle));
         matchResults.push(contentPasses);
       }
 
@@ -296,6 +301,7 @@ async function hydrateMessageReceivedPayload(
     message: {
       id: messageId,
       content: toReadableMessageContent(messageRow?.content),
+      rawContent: messageRow?.content ?? null,
       conversationId,
       channelId,
       createdAt: messageRow?.createdAt ?? new Date(),

--- a/apps/backend/src/utils/flowJson.ts
+++ b/apps/backend/src/utils/flowJson.ts
@@ -1,26 +1,13 @@
 /**
  * Shared FlowJSON text extraction helpers.
  *
- * FlowJSON messages are stored as
- * `<div data-flow-json="...escaped JSON...">Flow JSON</div>`. The visible text
- * node ("Flow JSON") is meaningless — the real content lives inside the escaped
- * JSON `data-flow-json` attribute. These helpers walk the component tree and
- * return readable plaintext.
- *
- * This lives in `utils` (not inside a zero side-effect handler) so it can be
- * shared by notification building, Vespa indexing, mention scanning AND the
- * automation trigger layer without creating an import cycle
- * (messages-handler imports the trigger, so the trigger must not import back
- * into messages-handler).
+ * FlowJSON is stored as `<div data-flow-json="...escaped JSON...">Flow JSON</div>`
+ * — the real text lives in the escaped attribute. Kept in `utils` (not in the
+ * zero messages handler) so the automation trigger can use it without an import
+ * cycle (messages-handler imports the trigger).
  */
 
-/**
- * Extract plaintext content strings from a FlowJSON payload for notification
- * preview and mention scanning.
- *
- * Walks the component tree and collects every text `content` prop, then joins
- * them. Returns '' for non-flow / unparseable content.
- */
+/** Collect text `content` props from a FlowJSON tree. '' for non-flow content. */
 export function extractTextFromFlowJson(content: string): string {
   const attrMatch = content.match(/data-flow-json="([^"]+)"/);
   if (!attrMatch) return '';
@@ -75,20 +62,13 @@ export function cleanNotificationText(raw: string): string {
     .replace(/\s+/g, ' ').trim();
 }
 
-/**
- * Like extractTextFromFlowJson but strips mrkdwn tokens for display in
- * notification previews (user mentions removed, broadcast → @channel, etc.).
- */
+/** Like extractTextFromFlowJson but strips mrkdwn tokens for display. */
 export function extractCleanTextFromFlowJson(content: string): string {
   const raw = extractTextFromFlowJson(content);
   return cleanNotificationText(raw);
 }
 
-/**
- * For flow JSON messages, returns the extracted plaintext from the FlowJSON
- * component tree (suitable for mention scanning and notification preview).
- * Returns null for non-flow-json content.
- */
+/** Extracted plaintext for a FlowJSON message; null for non-flow content. */
 export function getFlowJsonContentForNotification(content: string): string | null {
   if (!content.includes('data-flow-json')) return null;
   return extractCleanTextFromFlowJson(content) || null;

--- a/apps/backend/src/utils/flowJson.ts
+++ b/apps/backend/src/utils/flowJson.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared FlowJSON text extraction helpers.
+ *
+ * FlowJSON messages are stored as
+ * `<div data-flow-json="...escaped JSON...">Flow JSON</div>`. The visible text
+ * node ("Flow JSON") is meaningless — the real content lives inside the escaped
+ * JSON `data-flow-json` attribute. These helpers walk the component tree and
+ * return readable plaintext.
+ *
+ * This lives in `utils` (not inside a zero side-effect handler) so it can be
+ * shared by notification building, Vespa indexing, mention scanning AND the
+ * automation trigger layer without creating an import cycle
+ * (messages-handler imports the trigger, so the trigger must not import back
+ * into messages-handler).
+ */
+
+/**
+ * Extract plaintext content strings from a FlowJSON payload for notification
+ * preview and mention scanning.
+ *
+ * Walks the component tree and collects every text `content` prop, then joins
+ * them. Returns '' for non-flow / unparseable content.
+ */
+export function extractTextFromFlowJson(content: string): string {
+  const attrMatch = content.match(/data-flow-json="([^"]+)"/);
+  if (!attrMatch) return '';
+  try {
+    const json = attrMatch[1]
+      .replace(/&quot;/g, '"')
+      .replace(/&#10;/g, '\n')
+      .replace(/&#13;/g, '\r')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&');
+    const flow = JSON.parse(json) as { components?: unknown[] };
+
+    const texts: string[] = [];
+
+    function walk(components: unknown[]): void {
+      for (const comp of components) {
+        if (!comp || typeof comp !== 'object') continue;
+        const c = comp as Record<string, unknown>;
+        if (c['props'] && typeof c['props'] === 'object') {
+          const p = c['props'] as Record<string, unknown>;
+          if (typeof p['content'] === 'string' && p['content'].trim()) {
+            texts.push(p['content'].trim());
+          }
+        }
+        if (Array.isArray(c['children'])) {
+          walk(c['children'] as unknown[]);
+        }
+      }
+    }
+
+    if (Array.isArray(flow.components)) {
+      walk(flow.components);
+    }
+    return texts.join(' ').replace(/\s+/g, ' ').trim();
+  } catch {
+    return '';
+  }
+}
+
+/** Strip Flow mrkdwn tokens without exposing internal entity identifiers. */
+export function cleanNotificationText(raw: string): string {
+  if (!raw) return '';
+  return raw
+    .replace(/<userid:[^>]+>/g, '')
+    .replace(/<channelid:[^>]+>/g, '#channel')
+    .replace(/<broadcast:channel>/gi, '@channel ')
+    .replace(/<broadcast:here>/gi, '@here ')
+    .replace(/<broadcast:([^>]+)>/gi, '@$1')
+    .replace(/<([^|>]+)\|([^>]+)>/g, '$2')
+    .replace(/<(https?:[^>]+)>/g, '$1')
+    .replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Like extractTextFromFlowJson but strips mrkdwn tokens for display in
+ * notification previews (user mentions removed, broadcast → @channel, etc.).
+ */
+export function extractCleanTextFromFlowJson(content: string): string {
+  const raw = extractTextFromFlowJson(content);
+  return cleanNotificationText(raw);
+}
+
+/**
+ * For flow JSON messages, returns the extracted plaintext from the FlowJSON
+ * component tree (suitable for mention scanning and notification preview).
+ * Returns null for non-flow-json content.
+ */
+export function getFlowJsonContentForNotification(content: string): string | null {
+  if (!content.includes('data-flow-json')) return null;
+  return extractCleanTextFromFlowJson(content) || null;
+}
+
+/** Returns raw FlowJSON text with tokens intact (for mention scanning). */
+export function getFlowJsonRawTextForMentions(content: string): string | null {
+  if (!content.includes('data-flow-json')) return null;
+  return extractTextFromFlowJson(content) || null;
+}

--- a/apps/backend/src/utils/flowJson.ts
+++ b/apps/backend/src/utils/flowJson.ts
@@ -79,3 +79,15 @@ export function getFlowJsonRawTextForMentions(content: string): string | null {
   if (!content.includes('data-flow-json')) return null;
   return extractTextFromFlowJson(content) || null;
 }
+
+/**
+ * Message content rendered as readable plaintext: a FlowJSON payload is decoded
+ * to its underlying text, and a plain message is returned unchanged. Null/empty
+ * in → null out.
+ */
+export function toReadableMessageContent(
+  content: string | null | undefined,
+): string | null {
+  if (!content) return null;
+  return getFlowJsonContentForNotification(content) ?? content;
+}

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -49,6 +49,13 @@ import { botCatalog } from '@/bots/unified/catalog/bot-catalog';
 import { extractBotMentions, executeBotForMention, CHAT_ENABLED_BOT_IDS } from '@/services/bots';
 import { getSlackRecipientEmails } from '@/utils/notificationHelper';
 import { extractPlainTextFromHtml } from '@/utils/contentUtils';
+import {
+  cleanNotificationText,
+  getFlowJsonContentForNotification,
+  getFlowJsonRawTextForMentions,
+} from '@/utils/flowJson';
+// Re-exported so existing importers (e.g. vespa-injection mapper) keep working.
+export { getFlowJsonContentForNotification };
 import { matchKeywordsForUsers } from '@/utils/keywordMatchUtils';
 import type { BotDefinition } from '@/bots/unified/types/unified-bot';
 import { messageMetadataService } from '@/services/messageMetadataService';
@@ -59,93 +66,6 @@ import { prCheckApprovalService } from '@/services/prCheckApprovalService';
 const messageAttachmentRepository = new MessageAttachmentRepository();
 const channelRepository = new ChannelRepository();
 const installedAppsRepository = new InstalledAppsRepository();
-
-/**
- * Extract plaintext content strings from a FlowJSON payload for notification
- * preview and mention scanning.
- *
- * FlowJSON is stored as `<div data-flow-json="...escaped JSON...">Flow JSON</div>`.
- * The visible text node ("Flow JSON") is meaningless — we need to walk the
- * component tree and collect every text `content` prop, then join them.
- */
-function extractTextFromFlowJson(content: string): string {
-  const attrMatch = content.match(/data-flow-json="([^"]+)"/);
-  if (!attrMatch) return '';
-  try {
-    const json = attrMatch[1]
-      .replace(/&quot;/g, '"')
-      .replace(/&#10;/g, '\n')
-      .replace(/&#13;/g, '\r')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&amp;/g, '&');
-    const flow = JSON.parse(json) as { components?: unknown[] };
-
-    const texts: string[] = [];
-
-    function walk(components: unknown[]): void {
-      for (const comp of components) {
-        if (!comp || typeof comp !== 'object') continue;
-        const c = comp as Record<string, unknown>;
-        if (c['props'] && typeof c['props'] === 'object') {
-          const p = c['props'] as Record<string, unknown>;
-          if (typeof p['content'] === 'string' && p['content'].trim()) {
-            texts.push(p['content'].trim());
-          }
-        }
-        if (Array.isArray(c['children'])) {
-          walk(c['children'] as unknown[]);
-        }
-      }
-    }
-
-    if (Array.isArray(flow.components)) {
-      walk(flow.components);
-    }
-    return texts.join(' ').replace(/\s+/g, ' ').trim();
-  } catch {
-    return '';
-  }
-}
-
-/**
- * Like extractTextFromFlowJson but strips mrkdwn tokens for display in
- * notification previews (user mentions removed, broadcast → @channel, etc.).
- */
-function extractCleanTextFromFlowJson(content: string): string {
-  const raw = extractTextFromFlowJson(content);
-  return cleanNotificationText(raw);
-}
-
-/** Strip Flow mrkdwn tokens without exposing internal entity identifiers. */
-function cleanNotificationText(raw: string): string {
-  if (!raw) return '';
-  return raw
-    .replace(/<userid:[^>]+>/g, '')
-    .replace(/<channelid:[^>]+>/g, '#channel')
-    .replace(/<broadcast:channel>/gi, '@channel ')
-    .replace(/<broadcast:here>/gi, '@here ')
-    .replace(/<broadcast:([^>]+)>/gi, '@$1')
-    .replace(/<([^|>]+)\|([^>]+)>/g, '$2')
-    .replace(/<(https?:[^>]+)>/g, '$1')
-    .replace(/\s+/g, ' ').trim();
-}
-
-/**
- * For flow JSON messages, returns the extracted plaintext from the FlowJSON
- * component tree (suitable for mention scanning and notification preview).
- * Returns null for non-flow-json content.
- */
-export function getFlowJsonContentForNotification(content: string): string | null {
-  if (!content.includes('data-flow-json')) return null;
-  return extractCleanTextFromFlowJson(content) || null;
-}
-
-/** Returns raw FlowJSON text with tokens intact (for mention scanning). */
-function getFlowJsonRawTextForMentions(content: string): string | null {
-  if (!content.includes('data-flow-json')) return null;
-  return extractTextFromFlowJson(content) || null;
-}
 
 /**
  * Friendly notification label for a flow CARD whose title/content doesn't live


### PR DESCRIPTION
Ticket: XYNE-61737

1. Problem Description:
When an automation is triggered by a FlowJSON alert message, the trigger passed the raw stored message content into the agent's task. FlowJSON is stored as `<div data-flow-json="...escaped JSON...">Flow JSON</div>` — the real alert text (metric, merchant, window) lives inside the `data-flow-json` attribute and the only visible text node is the literal string "Flow JSON". As a result agents (e.g. rcaAgent) received "Flow JSON" instead of the alert and had to call other tools (the spaces subagent) just to read what triggered them, making runs slower and noisier.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Traced the automation RUN_AGENT path. `run-agent.step.ts` passes the configured prompt through as the agent task and only adds conversationId + channelId as visible context. `hydrateMessageReceivedPayload` in `message-received.trigger.ts` set `message.content` straight from the raw stored `messageRow.content`, with no FlowJSON decoding — unlike notifications, Vespa indexing and mention scanning, which already decode FlowJSON.

3. Explain the solution implemented in the PR:
- Extracted the FlowJSON text helpers (`extractTextFromFlowJson`, `cleanNotificationText`, `extractCleanTextFromFlowJson`, `getFlowJsonContentForNotification`, `getFlowJsonRawTextForMentions`) into a new shared module `apps/backend/src/utils/flowJson.ts`. They were previously private to `zero/side-effects/tables/messages-handler.ts`, which itself imports the message-received trigger — so importing the decoder back into the trigger would have created an import cycle.
- `message-received.trigger.ts` now decodes content via `getFlowJsonContentForNotification(...) ?? rawContent`. The helper returns null for non-FlowJSON content, so normal messages pass through unchanged.
- `messages-handler.ts` now consumes the shared helpers and re-exports `getFlowJsonContentForNotification`, so the existing `zero/vespa-injection/core/mapper.ts` import is unchanged. No behavior change for notifications/indexing.

4. Documentation (link to docs created/updated for this change): N/A

5. DB Alter Details (if any): N/A

6. Data fix Details (if any): N/A

7. Environment variable Changes (if any): N/A

8. Testing (how it was tested; screenshots/links): `npx tsc --noEmit` passes clean on apps/backend. Manual validation: fire one RCA automation and confirm the agent run receives the decoded metric/merchant text (not the literal "Flow JSON") and no longer calls the spaces subagent for why_now. Note: card-only flows (e.g. plan/diff artifacts) whose text isn't in `content` props decode to empty and fall back to raw content, so those are never worse than before.

9. Services to which this change is to be deployed: xyne-spaces backend (automations + zero side-effects).

10. Main PR link (if this PR is raised against a release branch): N/A (raised against main)