### PR TITLE
fix: XYNE-17198 club messages when thread tags are disabled

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatList/ChatListUtils.ts
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListUtils.ts
@@ -1,6 +1,6 @@
 import { QueryResultType } from '@rocicorp/zero';
 import { queries } from '../../../zero/queries';
-import { MessageType } from '@xyne/shared';
+import { MessageType, parseAppliedTags, visibleTags } from '@xyne/shared';
 import { MessageMetadata } from '../../ui/MessageBubble/MessageBubble.utils';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
 
@@ -48,10 +48,14 @@ export const extractMessageIdFromHash = (hash: string): string | null => {
  * - It's the first message
  * - Different sender than previous message
  * - Previous message was a conversation with replies
+ *
+ * `showThreadTags` is the reader's own preference: a tag chip only breaks grouping for
+ * someone who has the chips turned on.
  */
 export const shouldShowAvatar = (
   currentItem: CombinedMessageItem,
   prevItem: CombinedMessageItem | null,
+  showThreadTags: boolean,
 ): boolean => {
   if (!prevItem) return true;
 
@@ -100,15 +104,17 @@ export const shouldShowAvatar = (
   };
 
   // A tagged thread shows its chip beside the name and timestamp, so it needs its own
-  // header row — grouped under the previous message there is nowhere to put it. Raw check
-  // rather than parsing: '[]' means the tags were cleared, so there is nothing to show.
-  const hasThreadTag = (): boolean => {
+  // header row — grouped under the previous message there is nowhere to put it. Only when
+  // the reader has chips switched on: the classifier tags nearly every thread, so applying
+  // this unconditionally un-clubs the whole channel for people who see no chips at all.
+  // Goes through the shared parser so removed tags — which render nothing — don't count.
+  const hasVisibleThreadTag = (): boolean => {
+    if (!showThreadTags) return false;
     if (currentItem.type !== 'conversation') return false;
-    const raw = currentItem.data.threadType;
-    return !!raw && raw !== '[]';
+    return visibleTags(parseAppliedTags(currentItem.data.threadType)).length > 0;
   };
 
-  if (hasThreadTag()) return true;
+  if (hasVisibleThreadTag()) return true;
   if (isCurrentItemCallMessage()) return true;
   if (!isSameDayMessege()) return true;
 

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV2.utils.ts
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV2.utils.ts
@@ -1,6 +1,7 @@
 import { QueryResultType } from '@rocicorp/zero';
 import { queries } from '../../../zero/queries';
 import { useMemo } from 'react';
+import { useShowThreadTags } from '../../../hooks/useShowThreadTags';
 import { CombinedMessageItem, shouldShowAvatar } from './ChatListUtils';
 import { MessageMetadata } from '../../ui/MessageBubble/MessageBubble.utils';
 import { MessageType, parseReactionsMd } from '@xyne/shared';
@@ -144,12 +145,16 @@ function estimateImageDisplayHeight(
  * @param prevItem      - The item immediately before this one (or null)
  * @param isMobile      - Whether the viewport is in mobile mode
  * @param isNewMsgBoundary - Whether the red "New Messages" divider is shown above this item
+ * @param showThreadTags - Whether the reader has thread tag chips enabled; must match what
+ *                         ChatListItem passes to `shouldShowAvatar`, or the estimated height
+ *                         disagrees with the rendered one.
  */
 export function estimateMessageHeight(
   item: CombinedMessageItem,
   prevItem: CombinedMessageItem | null,
   isMobile: boolean,
   isNewMsgBoundary = false,
+  showThreadTags = false,
 ): number {
   // Only 'conversation' type items exist in this list (no date-separator via
   // useCombinedMesseges – those come from GroupedVirtuoso group headers).
@@ -164,7 +169,7 @@ export function estimateMessageHeight(
   const msgType = message.msgType;
 
   // ── Determine avatar visibility ──
-  const showAvatar = prevItem === null || shouldShowAvatar(item, prevItem);
+  const showAvatar = prevItem === null || shouldShowAvatar(item, prevItem, showThreadTags);
   let height = showAvatar ? WITH_AVATAR_PADDING : WITHOUT_AVATAR_PADDING;
 
   // ── New-message boundary divider ──
@@ -488,6 +493,8 @@ export const useCombinedMesseges = (
   isMobile: boolean,
   isNewMsgBoundaryIndex = -1,
 ): CombinedMesseges => {
+  const { showThreadTags } = useShowThreadTags();
+
   const combinedMessages: CombinedMessageItem[] = useMemo(() => {
     return conversations.map(conversation => ({
       type: 'conversation' as const,
@@ -525,9 +532,9 @@ export const useCombinedMesseges = (
     return combinedMessages.map((item, index) => {
       const prevItem = index > 0 ? (combinedMessages[index - 1] ?? null) : null;
       const isNewMsgBoundary = index === isNewMsgBoundaryIndex;
-      return estimateMessageHeight(item, prevItem, isMobile, isNewMsgBoundary);
+      return estimateMessageHeight(item, prevItem, isMobile, isNewMsgBoundary, showThreadTags);
     });
-  }, [combinedMessages, isMobile, isNewMsgBoundaryIndex]);
+  }, [combinedMessages, isMobile, isNewMsgBoundaryIndex, showThreadTags]);
 
   return {
     groupCounts,

--- a/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
@@ -10,6 +10,7 @@ import { ChannelScopeType, MessageAttachment } from '@xyne/shared';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
 import { useAuth } from '../../../hooks/useAuth';
 import { useZero } from '../../../hooks/useZero';
+import { useShowThreadTags } from '../../../hooks/useShowThreadTags';
 import {
   usePendingStatusByMessageId,
   usePendingByMessageId,
@@ -59,6 +60,7 @@ const ChatListItemComponent = ({
   const pendingMessageId = conversation?.initialMessageId ?? '';
   const pendingStatus = usePendingStatusByMessageId(pendingMessageId);
   const pendingEntry = usePendingByMessageId(pendingMessageId);
+  const { showThreadTags } = useShowThreadTags();
 
   // Render date separator
   if (item.type === 'date-separator') {
@@ -93,7 +95,7 @@ const ChatListItemComponent = ({
   let showAvatar = true;
 
   if (prevItem && prevItem.type !== 'date-separator') {
-    showAvatar = shouldShowAvatar(item, prevItem);
+    showAvatar = shouldShowAvatar(item, prevItem, showThreadTags);
   }
 
   return (


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
