### PR TITLE
feat: XYNE-61739 self service ingestion fixes

### DIFF
--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -95,9 +95,14 @@ const envSchema = Joi.object({
   MIGRATION_SLACK_PAGE_DELAY_MS: Joi.number().default(250),       // pause between paged Slack calls during collection (SDK still honors Retry-After on 429)
   MIGRATION_SLACK_LIST_DELAY_MS: Joi.number().default(3000),      // pause between Tier-2 list pages (conversations.list/users.list ≈ 20/min) to stay under the limit
   MIGRATION_SLACK_FILE_TIMEOUT_MS: Joi.number().default(600000),  // per-attachment download timeout (~10 min: enough for Slack's 1GB max at ~3MB/s)
+  MIGRATION_SLACK_FILE_CONCURRENCY: Joi.number().default(5),      // attachments streamed Slack→GCS in parallel per message during collection
   MIGRATION_SLACK_REQUEST_TIMEOUT_MS: Joi.number().default(30000),// per Slack API request timeout (aborts hung pages)
   MIGRATION_SLACK_STALL_LIMIT_MS: Joi.number().default(600000),   // no forward progress despite a live heartbeat ⇒ wedged (10 min)
-  MIGRATION_INGEST_MESSAGE_DELAY_MS: Joi.number().default(2),     // pause between messages at ingest (~500 msg/s cap)
+  MIGRATION_INGEST_MESSAGE_DELAY_MS: Joi.number().default(0),     // pause between messages at ingest (0 = unpaced; parallelism now caps rate, not this)
+  MIGRATION_INGEST_CONCURRENCY: Joi.number().default(3),          // conversations one worker process ingests in parallel (juggles DB waits); total in-flight = processes × this
+  MIGRATION_WORKER_PROCESSES: Joi.number().default(1),            // worker PROCESSES to fork inside the pod (Node cluster). This is the real CPU-parallelism knob; 1 = single process (no fork)
+  MIGRATION_INGEST_BULK: Joi.boolean().default(false),            // migration-only bulk-insert path (createMany, bypasses conversationService) — off by default until validated
+  MIGRATION_INGEST_BULK_BATCH_SIZE: Joi.number().default(500),    // rows per createMany in the bulk path (bounds memory + statement size)
   GCS_BUNDLE_BUCKET_NAME: Joi.string().allow('').default(''),
   GCS_CANVAS_BUCKET_NAME: Joi.string().allow('').default(''),
   GCS_DOCS_BUCKET_NAME: Joi.string().allow('').default(''),
@@ -682,6 +687,11 @@ export const config = {
     requestTimeoutMs: envVars.MIGRATION_SLACK_REQUEST_TIMEOUT_MS,
     stallLimitMs: envVars.MIGRATION_SLACK_STALL_LIMIT_MS,
     ingestMessageDelayMs: envVars.MIGRATION_INGEST_MESSAGE_DELAY_MS,
+    ingestConcurrency: envVars.MIGRATION_INGEST_CONCURRENCY,
+    workerProcesses: envVars.MIGRATION_WORKER_PROCESSES,
+    fileConcurrency: envVars.MIGRATION_SLACK_FILE_CONCURRENCY,
+    ingestBulk: envVars.MIGRATION_INGEST_BULK,
+    ingestBulkBatchSize: envVars.MIGRATION_INGEST_BULK_BATCH_SIZE,
   },
   gcs: {
     projectId: envVars.GCS_PROJECT_ID,

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -92,17 +92,8 @@ const envSchema = Joi.object({
   MIGRATION_ENC_KEYS: Joi.string().allow('').default('{}'),
   MIGRATION_ENC_ACTIVE: Joi.string().allow('').default(''),
   RUN_SLACK_MIGRATION_WORKERS: Joi.boolean().default(false),
-  MIGRATION_SLACK_PAGE_DELAY_MS: Joi.number().default(250),       // pause between paged Slack calls during collection (SDK still honors Retry-After on 429)
-  MIGRATION_SLACK_LIST_DELAY_MS: Joi.number().default(3000),      // pause between Tier-2 list pages (conversations.list/users.list ≈ 20/min) to stay under the limit
-  MIGRATION_SLACK_FILE_TIMEOUT_MS: Joi.number().default(600000),  // per-attachment download timeout (~10 min: enough for Slack's 1GB max at ~3MB/s)
-  MIGRATION_SLACK_FILE_CONCURRENCY: Joi.number().default(5),      // attachments streamed Slack→GCS in parallel per message during collection
-  MIGRATION_SLACK_REQUEST_TIMEOUT_MS: Joi.number().default(30000),// per Slack API request timeout (aborts hung pages)
-  MIGRATION_SLACK_STALL_LIMIT_MS: Joi.number().default(600000),   // no forward progress despite a live heartbeat ⇒ wedged (10 min)
-  MIGRATION_INGEST_MESSAGE_DELAY_MS: Joi.number().default(0),     // pause between messages at ingest (0 = unpaced; parallelism now caps rate, not this)
-  MIGRATION_INGEST_CONCURRENCY: Joi.number().default(3),          // conversations one worker process ingests in parallel (juggles DB waits); total in-flight = processes × this
-  MIGRATION_WORKER_PROCESSES: Joi.number().default(1),            // worker PROCESSES to fork inside the pod (Node cluster). This is the real CPU-parallelism knob; 1 = single process (no fork)
-  MIGRATION_INGEST_BULK: Joi.boolean().default(false),            // migration-only bulk-insert path (createMany, bypasses conversationService) — off by default until validated
-  MIGRATION_INGEST_BULK_BATCH_SIZE: Joi.number().default(500),    // rows per createMany in the bulk path (bounds memory + statement size)
+  MIGRATION_INGEST_CONCURRENCY: Joi.number().default(3),          // conversations one worker ingests in parallel; total in-flight = processes × this. RESTART-required (Bull binds concurrency at .process())
+  MIGRATION_WORKER_PROCESSES: Joi.number().default(1),            // worker PROCESSES forked inside the pod (the real CPU-parallelism knob). RESTART-required; 1 = single process (no fork)
   GCS_BUNDLE_BUCKET_NAME: Joi.string().allow('').default(''),
   GCS_CANVAS_BUCKET_NAME: Joi.string().allow('').default(''),
   GCS_DOCS_BUCKET_NAME: Joi.string().allow('').default(''),
@@ -681,17 +672,8 @@ export const config = {
   },
   runSlackMigrationWorkers: envVars.RUN_SLACK_MIGRATION_WORKERS,
   slackMigration: {
-    pageDelayMs: envVars.MIGRATION_SLACK_PAGE_DELAY_MS,
-    listDelayMs: envVars.MIGRATION_SLACK_LIST_DELAY_MS,
-    fileTimeoutMs: envVars.MIGRATION_SLACK_FILE_TIMEOUT_MS,
-    requestTimeoutMs: envVars.MIGRATION_SLACK_REQUEST_TIMEOUT_MS,
-    stallLimitMs: envVars.MIGRATION_SLACK_STALL_LIMIT_MS,
-    ingestMessageDelayMs: envVars.MIGRATION_INGEST_MESSAGE_DELAY_MS,
-    ingestConcurrency: envVars.MIGRATION_INGEST_CONCURRENCY,
-    workerProcesses: envVars.MIGRATION_WORKER_PROCESSES,
-    fileConcurrency: envVars.MIGRATION_SLACK_FILE_CONCURRENCY,
-    ingestBulk: envVars.MIGRATION_INGEST_BULK,
-    ingestBulkBatchSize: envVars.MIGRATION_INGEST_BULK_BATCH_SIZE,
+    ingestConcurrency: envVars.MIGRATION_INGEST_CONCURRENCY, // RESTART-required (Bull concurrency bound at .process())
+    workerProcesses: envVars.MIGRATION_WORKER_PROCESSES,     // RESTART-required (fork count at boot)
   },
   gcs: {
     projectId: envVars.GCS_PROJECT_ID,

--- a/apps/backend/src/database/repositories/channelParticipantRepository.ts
+++ b/apps/backend/src/database/repositories/channelParticipantRepository.ts
@@ -151,22 +151,21 @@ export class ChannelParticipantRepository extends BaseRepository<ChannelParticip
 
   // Channel Participant specific methods
   async addParticipant(channelId: string, userId: string, role: ChannelRole = ChannelRole.MEMBER, isClosed: boolean = false): Promise<ChannelParticipant> {
-    return await this.db.$transaction(async (tx) => {
-      const now = new Date();
-      const conversationSeenCutoffAt = await this.getConversationSeenCutoffAt(tx, channelId, now);
-      // Check if participant already exists
-      const existing = await tx.channelParticipant.findUnique({
-        where: {
-          channelId_userId: {
-            channelId,
-            userId
-          }
-        }
-      });
-      if (existing) {
-        return existing;
-      }
+    // Existence check + the seen-cutoff scan run OUTSIDE the write transaction. getConversationSeenCutoffAt is a
+    // per-channel `ORDER BY createdAt` scan that, under heavy parallel migration load, can take many seconds; leaving it
+    // inside the interactive transaction ate the 5s budget and made the next query die with P2028. The common resume
+    // re-add returns here without a transaction at all; the transaction below now holds only fast indexed writes.
+    const existing = await this.db.channelParticipant.findUnique({
+      where: { channelId_userId: { channelId, userId } },
+    });
+    if (existing) {
+      return existing;
+    }
 
+    const now = new Date();
+    const conversationSeenCutoffAt = await this.getConversationSeenCutoffAt(this.db, channelId, now);
+
+    return await this.db.$transaction(async (tx) => {
       const workspaceId = await resolveWorkspaceIdFromModel(tx, 'channel', { id: channelId });
 
       // Create participant

--- a/apps/backend/src/migration/scripts/bulkIngestConversationSlack.ts
+++ b/apps/backend/src/migration/scripts/bulkIngestConversationSlack.ts
@@ -38,6 +38,7 @@ import { ExternalAttachmentService, ExternalAttachment, DownloadedAttachment } f
 import { SlackFile, UserInfoCache } from '../slack/utils/extractConversation';
 import { encrypt } from '../../services/encryptionService';
 import { config } from '../../config/env';
+import { getMigrationRuntimeConfig } from '../self-serve/migrationRuntimeConfig';
 import { db } from '@/database/client';
 import { Prisma } from '@prisma/client';
 import { vespaQueue, vespaBackfillQueue } from '@/queues/vespaQueue';
@@ -82,7 +83,7 @@ function extractMentionedUserIds(content?: string | null): string[] {
 
 export async function bulkIngestConversationSlack(input: IngestConversationSlackInput): Promise<IngestConversationSlackResult> {
   const { slackMessages, externalSourceName, channelId, workspaceId, userToken, botToken: inputBotToken, skipChannelMigratedUpdate = false, onProgress } = input;
-  const BATCH = Math.max(1, config.slackMigration.ingestBulkBatchSize);
+  const BATCH = (await getMigrationRuntimeConfig()).bulkBatchSize; // live-tunable via Superposition; already clamped ≥50
   const errorDetails: string[] = [];
 
   const userRepo = new UserRepository();

--- a/apps/backend/src/migration/scripts/bulkIngestConversationSlack.ts
+++ b/apps/backend/src/migration/scripts/bulkIngestConversationSlack.ts
@@ -1,0 +1,388 @@
+/**
+ * Migration-only BULK ingest path (opt-in via MIGRATION_INGEST_BULK).
+ *
+ * Reproduces what conversationService.createConversationWithMessage / addMessageToConversation do per message,
+ * but as chunked Prisma createMany — one round-trip per BATCH instead of several per message. Bypasses the shared
+ * conversationService entirely (so it never touches live messaging code), and is safe because:
+ *  - every PK is a client-generated cuid, so ids are pre-generated and FKs wired in memory (no "temp then update");
+ *  - the DB has NO field-level encryption (the extension is a no-op), so createMany stores exactly what create would;
+ *  - migration already suppresses automations/meet-links/websocket, so there are no side effects to replicate.
+ *
+ * OOM-safe: rows accumulate up to MIGRATION_INGEST_BULK_BATCH_SIZE, then flush + release — never a whole channel at once.
+ *
+ * Parity with the per-message path (conversationService): mentions are resolved at collection; mentioned users are added
+ * as MENTIONED participants (addMentionedParticipants); thread aggregates (replyCount / lastActivityAt / replies_md) and
+ * participant read-state are re-synced on RESUME (see flush), so a retried/interrupted run doesn't leave a thread
+ * under-counted, sorted stale, or unread.
+ *
+ * Now at functional parity with the per-message path: mentioned users → MENTIONED participants; resume re-syncs thread
+ * aggregates + participant read-state; attachments are full-text indexed (fileSchema); custom emoji are replaced; and
+ * replyBroadcast replies create their standalone child conversation. The channel_migrated analytics event is emitted.
+ *
+ * A broadcast reply's child conversation gets replyCount 1 unless it is the thread's final message — matching the
+ * per-message path. Full parity; no known inconsistencies remain vs the serial/per-message path (bar suppressAutomations).
+ */
+import { logger } from '../../utils/logger';
+import { ExternalEntityType, MessageDirection, MessageType } from '@xyne/shared';
+import { serializeInitialMessageMd, serializeRepliesMd, serializeParentMessageMd, type InitialMessageSummary } from '@xyne/shared';
+import { createId } from '@paralleldrive/cuid2';
+import { replaceCustomEmojiShortcodesWithImg } from '@/utils/customEmojiUtils';
+import { isSupportedMimeType } from '@/services/fileProcessor';
+import { fileSchema, SubApp } from '@/vespa/src/types';
+import { UserRepository } from '../../database/repositories/users';
+import { MessageRepository } from '../../database/repositories/messageRepository';
+import { ExternalMessageRepository } from '../../database/repositories/externalMessageRepository';
+import { ExternalSourceRepository } from '../../database/repositories/externalSourceRepository';
+import { ChannelRepository } from '../../database/repositories/channelRepository';
+import { ExternalAttachmentService, ExternalAttachment, DownloadedAttachment } from '@/services/externalAttachmentService';
+import { SlackFile, UserInfoCache } from '../slack/utils/extractConversation';
+import { encrypt } from '../../services/encryptionService';
+import { config } from '../../config/env';
+import { db } from '@/database/client';
+import { Prisma } from '@prisma/client';
+import { vespaQueue, vespaBackfillQueue } from '@/queues/vespaQueue';
+import { parseSlackTimestamp, findOrCreateUser, findOrCreateApp, type IngestConversationSlackInput, type IngestConversationSlackResult } from './ingestConversationSlack';
+
+const VESPA_BACKFILL_AGE_DAYS = Number(process.env.VESPA_BACKFILL_AGE_DAYS ?? 365);
+
+/** Historical (migrated) timestamps go to the backfill queue, matching conversationService.pickVespaQueue. */
+function enqueueMessageVespa(messageId: string, workspaceId: string | undefined, createdAt: Date): void {
+  const historical = Date.now() - createdAt.getTime() > VESPA_BACKFILL_AGE_DAYS * 86_400_000;
+  const q = historical ? vespaBackfillQueue : vespaQueue;
+  void q.addJob({ schema: 'chat_message', jobType: 'feed', docId: messageId, ...(workspaceId ? { workspaceId } : {}) })
+    .catch((e) => logger.warn('[BulkIngest] vespa enqueue failed (non-fatal)', { messageId, error: e instanceof Error ? e.message : String(e) }));
+}
+
+/** Attachment full-text feed job (fileSchema) — mirrors conversationService.pushVespaJobForAttachments: supported MIME
+ *  types only, backfill-routed by age, so migrated files (PDF/DOCX/TXT…) become searchable like the per-message path. */
+function enqueueAttachmentVespa(attachmentId: string, mimeType: string, workspaceId: string | undefined, createdAt: Date): void {
+  if (!isSupportedMimeType(mimeType)) return;
+  const historical = Date.now() - createdAt.getTime() > VESPA_BACKFILL_AGE_DAYS * 86_400_000;
+  const q = historical ? vespaBackfillQueue : vespaQueue;
+  void q.addJob({ schema: fileSchema, jobType: 'feed', docId: attachmentId, app: SubApp.CHAT_ATTACHMENT, ...(workspaceId ? { workspaceId } : {}) })
+    .catch((e) => logger.warn('[BulkIngest] attachment vespa enqueue failed (non-fatal)', { attachmentId, error: e instanceof Error ? e.message : String(e) }));
+}
+
+/** Custom-emoji `:shortcode:` → <img>, mirroring conversationService.replaceEmojisInContent. Self-short-circuits when
+ *  content has no shortcodes (no DB hit in the common case); a no-op when the workspace has no matching custom emoji. */
+async function applyCustomEmojis(content: string): Promise<string> {
+  if (!content || content.includes('data-flow-json')) return content;
+  return replaceCustomEmojiShortcodesWithImg(content);
+}
+
+/** Mentioned Xyne user ids embedded in resolved content — mirrors conversationService.extractMentionedUserIdsFromContent
+ *  so the bulk path builds the same MENTIONED participant ("CC") rows the per-message path does. */
+const MENTION_SPAN_RE = /<span\b[^>]*\bdata-user-id=["']([^"']+)["'][^>]*>/g;
+function extractMentionedUserIds(content?: string | null): string[] {
+  if (!content) return [];
+  const ids: string[] = [];
+  for (const m of content.matchAll(MENTION_SPAN_RE)) if (m[1]) ids.push(m[1]);
+  return [...new Set(ids)];
+}
+
+export async function bulkIngestConversationSlack(input: IngestConversationSlackInput): Promise<IngestConversationSlackResult> {
+  const { slackMessages, externalSourceName, channelId, workspaceId, userToken, botToken: inputBotToken, skipChannelMigratedUpdate = false, onProgress } = input;
+  const BATCH = Math.max(1, config.slackMigration.ingestBulkBatchSize);
+  const errorDetails: string[] = [];
+
+  const userRepo = new UserRepository();
+  const externalSourceRepo = new ExternalSourceRepository();
+  const externalMessageRepo = new ExternalMessageRepository();
+  const channelRepo = new ChannelRepository();
+
+  logger.info('[BulkIngest] starting', { externalSourceName, channelId, messageCount: slackMessages.length, batch: BATCH });
+
+  // External source (same as the per-message path).
+  let externalSource = await externalSourceRepo.findByName(externalSourceName);
+  if (!externalSource) {
+    const botToken = inputBotToken || config.slackBotToken;
+    if (!botToken) throw new Error('SLACK_BOT_TOKEN is not configured');
+    externalSource = await externalSourceRepo.create({
+      name: externalSourceName, sourceType: 'slack', displayName: 'Slack Migration', channelId,
+      credentials: encrypt(JSON.stringify({ botToken })),
+    });
+  }
+  const externalSourceId = externalSource.id;
+
+  // One batched dedup read instead of one findByExternalId per message/reply.
+  const allExternalIds: string[] = [];
+  for (const m of slackMessages) {
+    allExternalIds.push(m.externalId);
+    for (const r of m.replies ?? []) allExternalIds.push(r.externalThreadId);
+  }
+  const existingRows = allExternalIds.length ? await externalMessageRepo.findByExternalIds(externalSourceId, allExternalIds) : [];
+  const existing = new Set((existingRows as Array<{ externalId: string }>).map((r) => r.externalId));
+
+  const userCache = new Map<string, { id: string; isDeactivated: boolean }>();
+  const botCache: UserInfoCache = new Map();
+  // User ids proven to exist (message senders + verified mentions). Guarding participant inserts against this set
+  // stops one stale mention id from FK-failing (and thus dropping) an entire flush batch. Mentions were resolved to
+  // real users at collection; we still verify any not-yet-seen id once via a single batched read.
+  const knownUserIds = new Set<string>();
+
+  const downloadFiles = async (files: SlackFile[] | undefined): Promise<DownloadedAttachment[]> => {
+    if (!files || files.length === 0) return [];
+    try {
+      const externalAttachments: ExternalAttachment[] = files
+        .filter((f) => f.prefetchedStoragePath || f.url_private)
+        .map((f) => f.prefetchedStoragePath
+          ? { fileName: f.name, mimeType: f.mimetype, size: f.size, storageSourcePath: f.prefetchedStoragePath, storageSourceEncrypted: true }
+          : { fileName: f.name, fileUrl: f.url_private, mimeType: f.mimetype, size: f.size });
+      return await new ExternalAttachmentService().downloadAttachmentsForSource(externalSourceName, externalAttachments, {
+        maxFileSize: 1024 * 1024 * 1024, timeout: 600000, scopeType: 'EXTERNAL_MESSAGE', scopeId: externalSourceName, overrideToken: userToken,
+      });
+    } catch (e) {
+      logger.error('[BulkIngest] attachment download failed', { error: e instanceof Error ? e.message : String(e) });
+      return [];
+    }
+  };
+
+  const resolveSender = async (msg: { userId?: string; userEmail?: string; userName?: string; isDeactivated?: boolean; botId?: string; botName?: string; botUserId?: string }): Promise<string | null> => {
+    if (msg.userId) return msg.userId;
+    if (msg.botId) return (await findOrCreateApp(msg.botName ?? msg.botId, msg.botId, botCache, msg.botUserId, workspaceId)) ?? null;
+    if (!msg.userEmail || !msg.userName) return null;
+    return findOrCreateUser(msg.userEmail, msg.userName, msg.isDeactivated ?? false, userRepo, userCache, workspaceId);
+  };
+
+  // Bounded accumulators — flushed at BATCH so memory never grows with conversation size.
+  // Typed with the Prisma CreateMany inputs so the compiler validates every field name against the schema.
+  let convRows: Prisma.ConversationCreateManyInput[] = [], msgRows: Prisma.MessageCreateManyInput[] = [];
+  let attRows: Prisma.MessageAttachmentCreateManyInput[] = [], extRows: Prisma.ExternalMessageCreateManyInput[] = [];
+  let partMap = new Map<string, Prisma.ConversationParticipantCreateManyInput>();
+  const pendingVespa: Array<{ id: string; createdAt: Date }> = [];
+  const pendingVespaFiles: Array<{ id: string; mimeType: string; createdAt: Date }> = [];
+  // Re-sync work for RESUMED threads (parent already migrated on an earlier run) — applied after the createMany calls.
+  const resumeUpdates: Array<{ conversationId: string; replyCount: number; lastActivityAt: Date; repliesMd: string | null; replierAuthorIds: string[] }> = [];
+  let pending = 0;
+
+  const flush = async (): Promise<void> => {
+    if (pending === 0 && resumeUpdates.length === 0) return;
+    if (convRows.length) await db.conversation.createMany({ data: convRows });
+    if (msgRows.length) await db.message.createMany({ data: msgRows });
+    if (attRows.length) await db.messageAttachment.createMany({ data: attRows });
+    if (extRows.length) await db.externalMessage.createMany({ data: extRows, skipDuplicates: true });
+    if (partMap.size) await db.conversationParticipant.createMany({ data: [...partMap.values()], skipDuplicates: true });
+    // Resume re-sync: bring an already-migrated parent thread + its FIRST-RUN participants up to the full thread state,
+    // so back-filled replies don't leave it under-counted, sorted stale, or unread. Values are authoritative from the dump.
+    for (const u of resumeUpdates) {
+      await db.conversation.update({
+        where: { conversationId: u.conversationId },
+        data: { replyCount: u.replyCount, lastActivityAt: u.lastActivityAt, replies_md: u.repliesMd },
+      }).catch((e) => logger.warn('[BulkIngest] resume conversation re-sync failed', { conversationId: u.conversationId, error: e instanceof Error ? e.message : String(e) }));
+      await db.conversationParticipant.updateMany({
+        where: { conversationId: u.conversationId, lastReplyAt: { lt: u.lastActivityAt } },
+        data: { lastReplyAt: u.lastActivityAt, lastReadAt: u.lastActivityAt },
+      }).catch(() => undefined);
+      if (u.replierAuthorIds.length) await db.conversationParticipant.updateMany({
+        where: { conversationId: u.conversationId, userId: { in: u.replierAuthorIds }, participationType: 'MENTIONED' },
+        data: { participationType: 'AUTHOR' },
+      }).catch(() => undefined);
+    }
+    for (const v of pendingVespa) enqueueMessageVespa(v.id, workspaceId, v.createdAt);
+    for (const f of pendingVespaFiles) enqueueAttachmentVespa(f.id, f.mimeType, workspaceId, f.createdAt);
+    convRows = []; msgRows = []; attRows = []; extRows = []; partMap = new Map();
+    pendingVespa.length = 0; pendingVespaFiles.length = 0; resumeUpdates.length = 0; pending = 0;
+  };
+
+  const addAttachments = (msgId: string, senderId: string, createdAt: Date, downloaded: DownloadedAttachment[], convId: string): void => {
+    for (const a of downloaded) {
+      const attId = createId();
+      attRows.push({
+        id: attId, entityId: msgId, entityType: 'CHAT', workspaceId, storageProvider: config.fileStorage.provider,
+        originalFilename: a.originalName, mimetype: a.mimeType, size: a.fileSize, url: a.fileUrl,
+        uploadedByUserId: senderId, createdBy: senderId, conversationId: convId,
+        thumbnailUrl: null, width: null, height: null, // migration attachments don't carry thumbnails/dimensions
+        metadata: a.metadata ?? {}, createdAt,
+      });
+      pendingVespaFiles.push({ id: attId, mimeType: a.mimeType, createdAt }); // full-text index the file, like the per-message path
+      pending++;
+    }
+  };
+
+  const addParticipant = (convId: string, userId: string, type: 'AUTHOR' | 'MENTIONED', readAt: Date): void => {
+    const key = `${convId}:${userId}`;
+    const existingP = partMap.get(key);
+    if (existingP) {
+      if (type === 'AUTHOR') existingP.participationType = 'AUTHOR';
+      if ((existingP.lastReplyAt as Date) < readAt) { existingP.lastReplyAt = readAt; existingP.lastReadAt = readAt; }
+      return;
+    }
+    partMap.set(key, {
+      id: createId(), conversationId: convId, workspaceId, userId, participationType: type, channelId,
+      lastReadAt: readAt, lastReplyAt: readAt,
+    });
+    pending++;
+  };
+
+  // Extract @mentions from the (already resolved) content and add each as a MENTIONED participant — the "CC" the UI
+  // shows. Unknown ids are verified once in a single batched read so a bad id never FK-fails the whole flush.
+  const addMentionedParticipants = async (convId: string, content: string, readAt: Date): Promise<void> => {
+    const ids = extractMentionedUserIds(content);
+    if (ids.length === 0) return;
+    const unknown = ids.filter((id) => !knownUserIds.has(id));
+    if (unknown.length) {
+      const rows = await db.user.findMany({ where: { id: { in: unknown } }, select: { id: true } });
+      for (const r of rows) knownUserIds.add(r.id);
+    }
+    for (const id of ids) if (knownUserIds.has(id)) addParticipant(convId, id, 'MENTIONED', readAt);
+  };
+
+  let processed = 0;
+  for (const m of slackMessages) {
+    try {
+      const parentDone = existing.has(m.externalId);
+      const newReplies = (m.replies ?? []).filter((r) => !existing.has(r.externalThreadId));
+      if (parentDone && newReplies.length === 0) continue; // whole thread already migrated → skip
+
+      const senderId = await resolveSender(m);
+      if (!senderId) throw new Error(`Missing sender for message ${m.externalId}`);
+      knownUserIds.add(senderId);
+      const createdAt = parseSlackTimestamp(m.externalId);
+
+      // Thread aggregates from the FULL inline reply set — authoritative for BOTH a fresh thread and a resumed one
+      // (the dump always carries every reply), so a resume can re-sync them rather than leaving stale first-run values.
+      const replyTimes = (m.replies ?? []).map((r) => parseSlackTimestamp(r.externalThreadId).getTime());
+      const lastActivityAt = new Date(Math.max(createdAt.getTime(), ...replyTimes));
+      let repliers: string[] = [];
+      for (const r of m.replies ?? []) { const s = r.userId; if (s) { repliers = repliers.filter((id) => id !== s); repliers.push(s); } }
+      const replyCount = (m.replies ?? []).length;
+      const repliesMd = repliers.length ? serializeRepliesMd({ repliers }) : null;
+      // The final message in the thread. A broadcast reply's child gets replyCount 1 unless it IS the final message —
+      // equivalent to the per-message path's "bump the previous broadcast child when a later message arrives", but
+      // derived from the complete dump so it's correct on a fresh run AND a resume (no stateful prev-message tracking).
+      const lastReplyExternalId = m.replies?.length ? m.replies[m.replies.length - 1].externalThreadId : undefined;
+
+      // Resolve the thread's conversationId: reuse if the parent was already migrated (resume), else create a new thread.
+      // parentRef carries the thread-root message so a replyBroadcast reply can point its child conversation back at it.
+      let convId: string;
+      let parentRef: { messageId: string; senderId: string; content: string; createdAt: Date };
+      if (parentDone) {
+        const threadRow = await externalMessageRepo.findByThreadId(externalSourceId, m.externalId, ExternalEntityType.MESSAGE);
+        const parentMsg = threadRow?.entityId ? await new MessageRepository().findById(threadRow.entityId) : null;
+        if (!parentMsg?.conversationId) throw new Error(`Cannot locate conversation for migrated parent ${m.externalId}`);
+        convId = parentMsg.conversationId;
+        parentRef = { messageId: parentMsg.messageId, senderId: parentMsg.senderId, content: parentMsg.content, createdAt: parentMsg.createdAt };
+        // Back-filling replies the first run missed → re-sync the parent's aggregates + participant read-state, which
+        // the per-message path does via incrementReplyCount but a plain createMany would otherwise leave frozen (see flush).
+        resumeUpdates.push({ conversationId: convId, replyCount, lastActivityAt, repliesMd, replierAuthorIds: repliers.slice() });
+      } else {
+        convId = createId();
+        const parentMsgId = createId();
+        const parentFiles = await downloadFiles(m.files);
+        let content = m.content ?? '';
+        if ((!content || !content.trim()) && parentFiles.length === 0 && (m.files?.length ?? 0) > 0) {
+          content = (m.files as SlackFile[]).map((f) => `📎 ${f.name}`).join(' ');
+        }
+        content = await applyCustomEmojis(content);
+        parentRef = { messageId: parentMsgId, senderId, content, createdAt };
+        const summary: InitialMessageSummary = {
+          messageId: parentMsgId, conversationId: convId, senderId, content, msgType: MessageType.USER as InitialMessageSummary['msgType'],
+          hasAttachment: parentFiles.length > 0, edited: false, isDeleted: false, showInChannel: false, visibleTo: null,
+          createdAt: createdAt.getTime(), metadata: JSON.stringify({ contentFormat: 'html' }), nudgeCount: 0, isSent: true,
+          reactions_md: null, link_preview_md: null, childConversationId: null,
+        };
+        convRows.push({
+          conversationId: convId, channelId, workspaceId, createdBy: senderId, initialMessageId: parentMsgId,
+          pinned: !!m.isPinned, createdAt, lastActivityAt, replyCount,
+          initial_message_md: serializeInitialMessageMd(summary), replies_md: repliesMd,
+        }); pending++;
+        msgRows.push({
+          messageId: parentMsgId, conversationId: convId, senderId, workspaceId, content, msgType: 'USER',
+          hasAttachment: parentFiles.length > 0, metadata: { contentFormat: 'html' }, createdAt,
+        }); pending++;
+        extRows.push({
+          workspaceId, externalSourceId, externalId: m.externalId, externalThreadId: m.externalId,
+          entityId: parentMsgId, messageId: parentMsgId, direction: MessageDirection.INCOMING, entityType: 'MESSAGE',
+        }); pending++;
+        addAttachments(parentMsgId, senderId, createdAt, parentFiles, convId);
+        addParticipant(convId, senderId, 'AUTHOR', lastActivityAt);
+        await addMentionedParticipants(convId, content, lastActivityAt);
+        pendingVespa.push({ id: parentMsgId, createdAt });
+      }
+
+      // Replies (new only) → attach to the thread conversation. Participant timestamps use the thread's lastActivityAt
+      // (matching the per-message path, where every participant's lastReplyAt = conversation.lastActivityAt).
+      for (const r of newReplies) {
+        try {
+          const replySender = await resolveSender(r);
+          if (!replySender) throw new Error(`Missing sender for reply ${r.externalThreadId}`);
+          knownUserIds.add(replySender);
+          const replyCreatedAt = parseSlackTimestamp(r.externalThreadId);
+          const replyMsgId = createId();
+          const replyFiles = await downloadFiles(r.files);
+          let content = r.content ?? '';
+          if ((!content || !content.trim()) && replyFiles.length === 0 && (r.files?.length ?? 0) > 0) {
+            content = (r.files as SlackFile[]).map((f) => `📎 ${f.name}`).join(' ');
+          }
+          content = await applyCustomEmojis(content);
+          // replyBroadcast ("also sent to channel"): the reply is ALSO the initial message of a standalone CHILD
+          // conversation in the channel, back-linked to the thread root — mirroring conversationService's child branch.
+          const childConvId = r.showInChannel ? createId() : undefined;
+          msgRows.push({
+            messageId: replyMsgId, conversationId: convId, senderId: replySender, workspaceId, content, msgType: 'USER',
+            hasAttachment: replyFiles.length > 0, showInChannel: !!r.showInChannel,
+            ...(childConvId ? { childConversationId: childConvId } : {}),
+            metadata: { contentFormat: 'html' }, createdAt: replyCreatedAt,
+          }); pending++;
+          extRows.push({
+            workspaceId, externalSourceId, externalId: r.externalThreadId, externalThreadId: m.externalId,
+            entityId: replyMsgId, messageId: replyMsgId, direction: MessageDirection.INCOMING, entityType: 'MESSAGE',
+          }); pending++;
+          if (childConvId) {
+            const childSummary: InitialMessageSummary = {
+              messageId: replyMsgId, conversationId: childConvId, senderId: replySender, content, msgType: MessageType.USER as InitialMessageSummary['msgType'],
+              hasAttachment: replyFiles.length > 0, edited: false, isDeleted: false, showInChannel: true, visibleTo: null,
+              createdAt: replyCreatedAt.getTime(), metadata: JSON.stringify({ contentFormat: 'html' }), nudgeCount: 0, isSent: true,
+              reactions_md: null, link_preview_md: null, childConversationId: childConvId,
+            };
+            convRows.push({
+              conversationId: childConvId, channelId, workspaceId, createdBy: replySender, initialMessageId: replyMsgId,
+              parentMessageId: parentRef.messageId, pinned: false, createdAt: replyCreatedAt, lastActivityAt: replyCreatedAt,
+              replyCount: r.externalThreadId === lastReplyExternalId ? 0 : 1,
+              initial_message_md: serializeInitialMessageMd(childSummary),
+              parent_message_md: serializeParentMessageMd({
+                messageId: parentRef.messageId, conversationId: convId, senderId: parentRef.senderId,
+                content: parentRef.content, msgType: MessageType.USER, createdAt: parentRef.createdAt.getTime(),
+              }),
+            }); pending++;
+          }
+          addAttachments(replyMsgId, replySender, replyCreatedAt, replyFiles, convId);
+          addParticipant(convId, replySender, 'AUTHOR', lastActivityAt);
+          await addMentionedParticipants(convId, content, lastActivityAt);
+          pendingVespa.push({ id: replyMsgId, createdAt: replyCreatedAt });
+        } catch (err) {
+          errorDetails.push(`reply ${r.externalThreadId}: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        if (pending >= BATCH) await flush();
+      }
+
+      if (pending >= BATCH) await flush();
+      if (++processed % 200 === 0) onProgress?.();
+    } catch (err) {
+      errorDetails.push(`message ${m.externalId}: ${err instanceof Error ? err.message : String(err)}`);
+      logger.error('[BulkIngest] thread failed', { externalId: m.externalId, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+  await flush();
+
+  // Once per conversation (channel/DM): set last-activity from the migrated messages and flip isMigrated.
+  await channelRepo.recalculateLastActivityFromMessages(channelId).catch(() => undefined);
+  if (!skipChannelMigratedUpdate) {
+    const channel = await channelRepo.findById(channelId);
+    if (channel && !(channel as { isMigrated?: boolean }).isMigrated) {
+      await channelRepo.update(channelId, { isMigrated: true }).catch(() => undefined);
+      // Match the per-message path's completion analytics (ingestConversationSlack) so bulk-migrated channels aren't undercounted.
+      const projectId = (channel as { projectId?: string | null }).projectId;
+      const project = projectId
+        ? await db.project.findUnique({ where: { id: projectId }, select: { name: true } }).catch(() => null)
+        : null;
+      logger.info('analytics_event', {
+        event: 'channel_migrated', timestamp: new Date().toISOString(), channelId,
+        channelName: (channel as { name?: string }).name, channelProjectName: project?.name ?? null, sourceType: 'slack',
+      });
+    }
+  }
+
+  logger.info('[BulkIngest] complete', { externalSourceName, channelId, errors: errorDetails.length });
+  return { success: errorDetails.length === 0, errorDetails: errorDetails.length ? errorDetails : undefined };
+}

--- a/apps/backend/src/migration/scripts/ingestConversationSlack.ts
+++ b/apps/backend/src/migration/scripts/ingestConversationSlack.ts
@@ -113,28 +113,42 @@ export const findOrCreateUser = async (
       if (!workspace) {
         throw new Error(`Workspace ${workspaceId} not found`);
       }
-      orgMember = await db.orgMember.create({
-        data: {
-          orgId: workspace.orgId,
-          email: userEmail,
-          role: OrgRole.MEMBER,
-        },
-        select: { memberId: true },
-      });
-      logger.info('[IngestSlack] OrgMember created for migration user', { userEmail });
+      try {
+        orgMember = await db.orgMember.create({
+          data: {
+            orgId: workspace.orgId,
+            email: userEmail,
+            role: OrgRole.MEMBER,
+          },
+          select: { memberId: true },
+        });
+        logger.info('[IngestSlack] OrgMember created for migration user', { userEmail });
+      } catch (err) {
+        // Parallel ingest workers can create the same org member at the same instant — on a unique-violation, re-read the winner.
+        if ((err as { code?: string })?.code !== 'P2002') throw err;
+        orgMember = await db.orgMember.findUnique({ where: { email: userEmail }, select: { memberId: true } });
+        if (!orgMember) throw err;
+      }
     }
 
-    user = await userRepo.create({
-      email: userEmail,
-      name: userName,
-      providerUserId: `slack-migrated-${userEmail}`,
-      authProvider: AuthProvider.GOOGLE,
-      status: isDeactivated ? 'INACTIVE' : 'ACTIVE',
-      workspace: { connect: { id: workspaceId } },
-      orgMember: { connect: { memberId: orgMember.memberId } },
-    });
-    logger.info('[IngestSlack] User created', { userId: user.id, userEmail });
-    await grantPermissionsForRole(user.id, userEmail, WorkspaceRole.MEMBER, workspaceId);
+    try {
+      user = await userRepo.create({
+        email: userEmail,
+        name: userName,
+        providerUserId: `slack-migrated-${userEmail}`,
+        authProvider: AuthProvider.GOOGLE,
+        status: isDeactivated ? 'INACTIVE' : 'ACTIVE',
+        workspace: { connect: { id: workspaceId } },
+        orgMember: { connect: { memberId: orgMember.memberId } },
+      });
+      logger.info('[IngestSlack] User created', { userId: user.id, userEmail });
+      await grantPermissionsForRole(user.id, userEmail, WorkspaceRole.MEMBER, workspaceId);
+    } catch (err) {
+      // Same race for the user row: another worker won — re-read and reuse it (its permissions are already granted).
+      if ((err as { code?: string })?.code !== 'P2002') throw err;
+      user = await userRepo.findByEmail(userEmail, workspaceId);
+      if (!user) throw err;
+    }
   }
 
   if (userCache) {
@@ -484,6 +498,7 @@ export async function ingestConversationSlack(
           createdAt,
           isAddingParticipant: false,
           pinned: isPinned || false,
+          suppressAutomations: true, // migrated history must never fire workflows/automations
         });
 
         message = result.message;
@@ -505,6 +520,7 @@ export async function ingestConversationSlack(
           createdAt,
           isAddingParticipant: false,
           markParticipantsRead: true,
+          suppressAutomations: true, // migrated history must never fire workflows/automations
         });
 
         message = result.message;

--- a/apps/backend/src/migration/self-serve/engine.ts
+++ b/apps/backend/src/migration/self-serve/engine.ts
@@ -17,6 +17,7 @@ import {
   findOrCreateApp,
   ingestConversationSlack,
 } from '@/migration/scripts/ingestConversationSlack';
+import { bulkIngestConversationSlack } from '@/migration/scripts/bulkIngestConversationSlack';
 import {
   transformMessage,
   collectRawFiles,
@@ -33,7 +34,7 @@ import { ChannelInput, MigrationJob, MigrationType } from './types';
 
 const PAGE = 1000;
 const UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024;
-const FILE_CONCURRENCY = 5;
+const FILE_CONCURRENCY = config.slackMigration.fileConcurrency;
 const PUBLIC_CHANNELS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 // Timing knobs (validated in config/env.ts): pageDelayMs (throttle paged Slack calls),
 // fileTimeoutMs (per-attachment), requestTimeoutMs (per Slack request), ingestMessageDelayMs (per-message DB/Vespa upper bound).
@@ -139,6 +140,43 @@ export class SlackMigrationEngine {
       throw new Error('MIGRATION_GCS_BUCKET is not configured — self-serve migration requires a dedicated bucket');
     }
     return getStorageService(bucket);
+  }
+
+  // Parallel ingest: each worker builds the offline reference + manifest ONCE per migration and reuses them across
+  // every conversation it drains (instead of once per conversation). Bounded by TTL; entries fall out after a job ends.
+  private readonly offlineRefCache = new Map<string, { at: number; ref: SlackOfflineReference }>();
+  private readonly manifestCache = new Map<string, { at: number; convs: CollectedConversation[] }>();
+  private static readonly WORKER_CACHE_TTL_MS = 30 * 60 * 1000;
+
+  async getOfflineReference(migrationId: string, gcsPrefix: string): Promise<SlackOfflineReference> {
+    let hit = this.offlineRefCache.get(migrationId);
+    if (!hit || Date.now() - hit.at >= SlackMigrationEngine.WORKER_CACHE_TTL_MS) {
+      hit = { at: Date.now(), ref: await this.buildOfflineReference(gcsPrefix) };
+      this.offlineRefCache.set(migrationId, hit);
+      this.evictStaleCache(this.offlineRefCache);
+    }
+    // Fresh shallow clone per call: concurrent loadConversation calls share the read-only users/groups/channels maps
+    // but each gets its own object so they don't race on the mutable `createUser` field loadConversation assigns.
+    return { users: hit.ref.users, groups: hit.ref.groups, channels: hit.ref.channels };
+  }
+
+  async getManifest(migrationId: string, gcsPrefix: string): Promise<CollectedConversation[]> {
+    let hit = this.manifestCache.get(migrationId);
+    if (!hit || Date.now() - hit.at >= SlackMigrationEngine.WORKER_CACHE_TTL_MS) {
+      hit = { at: Date.now(), convs: await this.readManifest(gcsPrefix) };
+      this.manifestCache.set(migrationId, hit);
+      this.evictStaleCache(this.manifestCache);
+    }
+    return hit.convs;
+  }
+
+  async getManifestConversation(migrationId: string, gcsPrefix: string, conversationId: string): Promise<CollectedConversation | undefined> {
+    return (await this.getManifest(migrationId, gcsPrefix)).find((c) => c.id === conversationId);
+  }
+
+  private evictStaleCache<T extends { at: number }>(cache: Map<string, T>): void {
+    const cutoff = Date.now() - SlackMigrationEngine.WORKER_CACHE_TTL_MS;
+    for (const [k, v] of cache) if (v.at < cutoff) cache.delete(k);
   }
 
   async collectDirectory(token: string, gcsPrefix: string): Promise<Record<string, DirUser>> {
@@ -532,7 +570,7 @@ export class SlackMigrationEngine {
         if (newest) await channelRepo.setLastActivity(channelId, newest);
       }
 
-      const ingestResult = await ingestConversationSlack({
+      const ingestInput = {
         slackMessages: messages,
         externalSourceName: `${isChannel ? 'channelMigration' : 'dmMigration'}-${channelId}`,
         channelId,
@@ -540,7 +578,11 @@ export class SlackMigrationEngine {
         botToken: 'slack-migration-offline',
         interMessageDelayMs: INGEST_MESSAGE_DELAY_MS,
         onProgress,
-      });
+      };
+      // Opt-in bulk path (createMany) — off by default; A/B against the per-message path before trusting it.
+      const ingestResult = config.slackMigration.ingestBulk
+        ? await bulkIngestConversationSlack(ingestInput)
+        : await ingestConversationSlack(ingestInput);
       await channelRepo.recalculateLastActivityFromMessages(channelId);
       return { ingested: messages.length, failed: ingestResult.errorDetails?.length ?? 0 };
     });
@@ -585,6 +627,11 @@ export class SlackMigrationEngine {
 
   readManifest(gcsPrefix: string): Promise<CollectedConversation[]> {
     return this.readJson<CollectedConversation[]>(paths.manifest(gcsPrefix));
+  }
+
+  /** Light read of the collected users dump (no Slack) — used to label skipped/truncated conversations for the UI. */
+  readDirectory(gcsPrefix: string): Promise<Record<string, DirUser>> {
+    return this.readJson<Record<string, DirUser>>(paths.users(gcsPrefix)).catch(() => ({} as Record<string, DirUser>));
   }
 
   manifestExists(gcsPrefix: string): Promise<boolean> {

--- a/apps/backend/src/migration/self-serve/engine.ts
+++ b/apps/backend/src/migration/self-serve/engine.ts
@@ -30,19 +30,12 @@ import { postMessage } from '@/migration/slack/utils/postMessage';
 import { getBotConfigByWorkspaceId } from '@/migration/slack/slackMigrationBotConfig';
 import { runWithSlackOfflineReference, type SlackOfflineReference } from '@/integrations/adapters/slack-webhook-tickets/utils/slackOfflineReference';
 import { encryptStream, decryptStream, encryptBuffer, decryptBuffer } from './migrationCrypto';
+import { getMigrationRuntimeConfig, MIGRATION_DEFAULTS } from './migrationRuntimeConfig';
 import { ChannelInput, MigrationJob, MigrationType } from './types';
 
 const PAGE = 1000;
 const UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024;
-const FILE_CONCURRENCY = config.slackMigration.fileConcurrency;
 const PUBLIC_CHANNELS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-// Timing knobs (validated in config/env.ts): pageDelayMs (throttle paged Slack calls),
-// fileTimeoutMs (per-attachment), requestTimeoutMs (per Slack request), ingestMessageDelayMs (per-message DB/Vespa upper bound).
-const PAGE_DELAY_MS = config.slackMigration.pageDelayMs;
-const LIST_PAGE_DELAY_MS = config.slackMigration.listDelayMs;
-const FILE_TIMEOUT_MS = config.slackMigration.fileTimeoutMs;
-const REQUEST_TIMEOUT_MS = config.slackMigration.requestTimeoutMs;
-const INGEST_MESSAGE_DELAY_MS = config.slackMigration.ingestMessageDelayMs;
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 // Route the Slack SDK's own diagnostics (esp. rate-limit "A rate limit was exceeded … retry in N seconds")
@@ -57,7 +50,7 @@ const sdkLogger = {
   setName: () => undefined,
 };
 // Per-request timeout so a hung page aborts (SDK retries) instead of wedging collection.
-const slackClient = (token: string) => new WebClient(token, { timeout: REQUEST_TIMEOUT_MS, logger: sdkLogger });
+const slackClient = (token: string, timeoutMs: number = MIGRATION_DEFAULTS.requestTimeoutMs) => new WebClient(token, { timeout: timeoutMs, logger: sdkLogger });
 
 // Time a Slack call and warn (with method + context) when it runs long, so a stall points at the exact culprit.
 async function timed<T>(label: string, ctx: Record<string, unknown>, fn: () => Promise<T>): Promise<T> {
@@ -180,7 +173,8 @@ export class SlackMigrationEngine {
   }
 
   async collectDirectory(token: string, gcsPrefix: string): Promise<Record<string, DirUser>> {
-    const client = slackClient(token);
+    const cfg = await getMigrationRuntimeConfig();
+    const client = slackClient(token, cfg.requestTimeoutMs);
     const users: Record<string, DirUser> = {};
     let cursor: string | undefined;
     do {
@@ -194,20 +188,21 @@ export class SlackMigrationEngine {
         };
       }
       cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
-      if (cursor && LIST_PAGE_DELAY_MS > 0) await sleep(LIST_PAGE_DELAY_MS);
+      if (cursor && cfg.listDelayMs > 0) await sleep(cfg.listDelayMs);
     } while (cursor);
     await this.writeJson(paths.users(gcsPrefix), users);
     return users;
   }
 
   async listConversations(token: string, type: MigrationType, channel?: ChannelInput): Promise<CollectedConversation[]> {
+    const cfg = await getMigrationRuntimeConfig();
     if (type === MigrationType.CHANNEL) {
       if (!channel) return [];
       // Real Slack membership → synced as Xyne participants at ingest.
       const members = await this.fetchChannelMembers(token, channel.slackChannelId);
       return [{ id: channel.slackChannelId, isMpim: false, members }];
     }
-    const client = slackClient(token);
+    const client = slackClient(token, cfg.requestTimeoutMs);
     const out: CollectedConversation[] = [];
     let cursor: string | undefined;
     do {
@@ -219,14 +214,15 @@ export class SlackMigrationEngine {
         out.push({ id: cc.id, isMpim: !!cc.is_mpim, members });
       }
       cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
-      if (cursor && LIST_PAGE_DELAY_MS > 0) await sleep(LIST_PAGE_DELAY_MS);
+      if (cursor && cfg.listDelayMs > 0) await sleep(cfg.listDelayMs);
     } while (cursor);
     return out;
   }
 
   /** All member Slack user ids of a channel (paginated). */
   private async fetchChannelMembers(token: string, channelId: string): Promise<string[]> {
-    const client = slackClient(token);
+    const cfg = await getMigrationRuntimeConfig();
+    const client = slackClient(token, cfg.requestTimeoutMs);
     const members: string[] = [];
     let cursor: string | undefined;
     try {
@@ -234,7 +230,7 @@ export class SlackMigrationEngine {
         const r = await client.conversations.members({ channel: channelId, limit: 1000, cursor });
         members.push(...(r.members ?? []));
         cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
-        if (cursor && PAGE_DELAY_MS > 0) await sleep(PAGE_DELAY_MS);
+        if (cursor && cfg.pageDelayMs > 0) await sleep(cfg.pageDelayMs);
       } while (cursor);
     } catch (e) {
       logger.warn('[SlackMigration] conversations.members failed — channel participants may be incomplete', {
@@ -245,7 +241,8 @@ export class SlackMigrationEngine {
   }
 
   async collectConversation(token: string, conv: CollectedConversation, gcsPrefix: string, startDate?: string, onProgress?: (p: { messages: number; newestTs: number; oldestTs: number }) => Promise<void>): Promise<{ messages: number; outcome: 'ok' | 'truncated' | 'skipped'; reason?: string }> {
-    const client = slackClient(token);
+    const cfg = await getMigrationRuntimeConfig();
+    const client = slackClient(token, cfg.requestTimeoutMs);
     const oldest = oldestFromStartDate(startDate);
     const pinned = await fetchPinnedMessageTimestamps(client, conv.id).catch(() => new Set<string>());
     const stream = new PassThrough();
@@ -281,7 +278,7 @@ export class SlackMigrationEngine {
         }
         if (onProgress) await onProgress({ messages: count, newestTs, oldestTs: oldestTs === Infinity ? 0 : oldestTs }); // live per-page progress
         cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
-        if (cursor && PAGE_DELAY_MS > 0) await sleep(PAGE_DELAY_MS);
+        if (cursor && cfg.pageDelayMs > 0) await sleep(cfg.pageDelayMs);
       } while (cursor);
     } catch (err) {
       if (!isSkippableConversationError(err)) throw err;
@@ -307,9 +304,10 @@ export class SlackMigrationEngine {
 
   /** Reference dumps so ingestion resolves users/groups/channels offline (no Slack). */
   async collectUsergroups(token: string, gcsPrefix: string): Promise<void> {
+    const cfg = await getMigrationRuntimeConfig();
     const groups: Record<string, unknown> = {};
     try {
-      const r = await slackClient(token).usergroups.list({ include_users: true });
+      const r = await slackClient(token, cfg.requestTimeoutMs).usergroups.list({ include_users: true });
       for (const g of r.usergroups ?? []) groups[(g as { id: string }).id] = g;
     } catch (e) {
       logger.warn('[SlackMigration] usergroups.list failed — mentions of usergroups will be unresolved', {
@@ -320,7 +318,8 @@ export class SlackMigrationEngine {
   }
 
   async collectChannels(token: string, gcsPrefix: string, teamId: string): Promise<void> {
-    const client = slackClient(token);
+    const cfg = await getMigrationRuntimeConfig();
+    const client = slackClient(token, cfg.requestTimeoutMs);
     const channels: Record<string, ChannelMeta> = {};
 
     try {
@@ -332,7 +331,7 @@ export class SlackMigrationEngine {
           channels[cc.id] = { id: cc.id, name: cc.name || cc.id, isPrivate: true };
         }
         cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
-        if (cursor && LIST_PAGE_DELAY_MS > 0) await sleep(LIST_PAGE_DELAY_MS);
+        if (cursor && cfg.listDelayMs > 0) await sleep(cfg.listDelayMs);
       } while (cursor);
     } catch (e) {
       logger.warn('[SlackMigration] conversations.list (private channels) failed — some channel mentions may be unresolved', {
@@ -348,6 +347,7 @@ export class SlackMigrationEngine {
   }
 
   private async publicChannels(client: WebClient, cachePath: string, teamId: string): Promise<Record<string, ChannelMeta>> {
+    const cfg = await getMigrationRuntimeConfig();
     const cached = (await this.storage.fileExists(cachePath))
       ? await this.readJson<{ fetchedAt: number; channels: Record<string, ChannelMeta> }>(cachePath).catch(() => null)
       : null;
@@ -366,7 +366,7 @@ export class SlackMigrationEngine {
           channels[cc.id] = { id: cc.id, name: cc.name || cc.id, isPrivate: false };
         }
         cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
-        if (cursor && LIST_PAGE_DELAY_MS > 0) await sleep(LIST_PAGE_DELAY_MS);
+        if (cursor && cfg.listDelayMs > 0) await sleep(cfg.listDelayMs);
       } while (cursor);
       complete = true;
     } catch (e) {
@@ -384,10 +384,11 @@ export class SlackMigrationEngine {
 
   /** Stream every Slack-hosted file on a message (top-level or reply) → storage, in bounded-concurrency batches. */
   private async prefetchFiles(token: string, m: unknown, gcsPrefix: string): Promise<void> {
+    const cfg = await getMigrationRuntimeConfig();
     const files = collectRawFiles(m).filter((f) => isDownloadableSlackFile(f));
-    for (let i = 0; i < files.length; i += FILE_CONCURRENCY) {
+    for (let i = 0; i < files.length; i += cfg.fileConcurrency) {
       await Promise.all(
-        files.slice(i, i + FILE_CONCURRENCY).map(async (f) => {
+        files.slice(i, i + cfg.fileConcurrency).map(async (f) => {
           const uri = await this.streamFileToGcs(token, f, gcsPrefix);
           if (uri) f.prefetchedStoragePath = uri;
         }),
@@ -397,7 +398,8 @@ export class SlackMigrationEngine {
 
   /** Fetch all replies of a thread (excluding the parent) and prefetch their files. */
   private async fetchReplies(token: string, channelId: string, ts: string, gcsPrefix: string): Promise<unknown[]> {
-    const client = slackClient(token);
+    const cfg = await getMigrationRuntimeConfig();
+    const client = slackClient(token, cfg.requestTimeoutMs);
     const replies: unknown[] = [];
     let cursor: string | undefined;
     do {
@@ -409,17 +411,18 @@ export class SlackMigrationEngine {
         replies.push(m);
       }
       cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
-      if (cursor && PAGE_DELAY_MS > 0) await sleep(PAGE_DELAY_MS);
+      if (cursor && cfg.pageDelayMs > 0) await sleep(cfg.pageDelayMs);
     } while (cursor);
     return replies;
   }
 
   /** Stream one Slack-hosted file straight to storage (never buffered); returns its storage path. */
   private async streamFileToGcs(token: string, file: { id: string; url_private: string; url_private_download?: string; mimetype?: string }, gcsPrefix: string): Promise<string | undefined> {
+    const cfg = await getMigrationRuntimeConfig();
     const dest = paths.file(gcsPrefix, file.id);
     const url = file.url_private_download || file.url_private;
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), FILE_TIMEOUT_MS);
+    const timer = setTimeout(() => controller.abort(), cfg.fileTimeoutMs);
     const startedAt = Date.now();
     try {
       const res = await fetch(url, {
@@ -475,6 +478,7 @@ export class SlackMigrationEngine {
   }
 
   async loadConversation(job: MigrationJob, conv: CollectedConversation, ref: SlackOfflineReference, onProgress?: () => void): Promise<{ ingested: number; failed: number }> {
+    const cfg = await getMigrationRuntimeConfig();
     return runAsServiceActor('slack-migration', job.workspaceId, async () => {
       const userRepo = new UserRepository();
       const channelRepo = new ChannelRepository();
@@ -576,11 +580,11 @@ export class SlackMigrationEngine {
         channelId,
         workspaceId: job.workspaceId,
         botToken: 'slack-migration-offline',
-        interMessageDelayMs: INGEST_MESSAGE_DELAY_MS,
+        interMessageDelayMs: cfg.messageDelayMs,
         onProgress,
       };
       // Opt-in bulk path (createMany) — off by default; A/B against the per-message path before trusting it.
-      const ingestResult = config.slackMigration.ingestBulk
+      const ingestResult = cfg.bulk
         ? await bulkIngestConversationSlack(ingestInput)
         : await ingestConversationSlack(ingestInput);
       await channelRepo.recalculateLastActivityFromMessages(channelId);

--- a/apps/backend/src/migration/self-serve/index.ts
+++ b/apps/backend/src/migration/self-serve/index.ts
@@ -1,4 +1,6 @@
 import { Router } from 'express';
+import { fork } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 import { getStorageService } from '@/services/storage';
@@ -12,34 +14,75 @@ import { buildRouter } from './routes';
 /**
  * Composition root for self-serve Slack migration, mounted at
  * /migrate/api/migration/slack-migration/*. Queues run one-at-a-time (§5.4).
- * Workers are opt-in via RUN_SLACK_MIGRATION_WORKERS on the single migration pod;
- * other pods serve the API only.
+ * Workers are opt-in via RUN_SLACK_MIGRATION_WORKERS; the API router is always mounted.
+ *
+ * MIGRATION_WORKER_PROCESSES scales the WORKERS without any deploy/CMD change: when > 1, this process (still serving
+ * everything else) forks that many `workerMain` CHILD processes that run ONLY the migration workers — so nothing else
+ * runs N×, and index.ts is untouched. When = 1, the workers run in-process here as before.
  */
 const store = new MigrationStore();
 const queues = new MigrationQueues();
 const engine = new SlackMigrationEngine();
 const service = new SlackMigrationService(store, queues, engine);
 
+/** Fork N dedicated worker children (workers only, no HTTP). Each gets a NODE_APP_INSTANCE; instance 0 owns the
+ *  singleton duties. MIGRATION_WORKER_PROCESSES=1 in the child env stops it from forking again. Respawns on crash. */
+function forkMigrationWorkerChildren(count: number): void {
+  const usingTs = import.meta.url.endsWith('.ts');
+  const workerPath = fileURLToPath(new URL(usingTs ? './workerMain.ts' : './workerMain.js', import.meta.url));
+  const instanceByPid = new Map<number, string>();
+  let stopping = false;
+
+  const spawn = (instance: string): void => {
+    const child = fork(workerPath, [], {
+      env: { ...process.env, MIGRATION_WORKER_PROCESSES: '1', MIGRATION_WORKER_CHILD: '1', NODE_APP_INSTANCE: instance },
+    });
+    if (child.pid) instanceByPid.set(child.pid, instance);
+    child.on('exit', (code, signal) => {
+      if (child.pid) instanceByPid.delete(child.pid);
+      if (stopping) return;
+      logger.warn('[SlackMigration] worker child exited — respawning', { instance, code, signal });
+      spawn(instance);
+    });
+  };
+
+  for (let i = 0; i < count; i++) spawn(String(i));
+  logger.info('[SlackMigration] forked migration worker children', { count });
+
+  const stop = (): void => {
+    stopping = true;
+    for (const pid of instanceByPid.keys()) { try { process.kill(pid, 'SIGTERM'); } catch { /* already gone */ } }
+  };
+  process.on('SIGTERM', stop);
+  process.on('SIGINT', stop);
+}
+
 if (config.runSlackMigrationWorkers) {
-  // Ensure the migration bucket exists before workers run (idempotent; auto-creates in fake-gcs).
-  if (config.gcs.migrationBucketName) {
-    void getStorageService(config.gcs.migrationBucketName)
-      .ensureBucketExists()
-      .catch((e: unknown) =>
-        logger.error('[SlackMigration] failed to ensure migration bucket exists', {
-          bucket: config.gcs.migrationBucketName, error: e instanceof Error ? e.message : String(e),
-        }),
-      );
+  const procs = Math.max(1, config.slackMigration.workerProcesses);
+  if (procs > 1 && !process.env.MIGRATION_WORKER_CHILD) {
+    // Multi-process: the workers run in forked children; this process keeps serving the API + everything else.
+    forkMigrationWorkerChildren(procs);
   } else {
-    logger.warn('[SlackMigration] MIGRATION_GCS_BUCKET is not set — migration jobs will fail until it is configured');
+    // Single in-process worker (procs = 1) — unchanged behaviour.
+    if (config.gcs.migrationBucketName) {
+      void getStorageService(config.gcs.migrationBucketName)
+        .ensureBucketExists()
+        .catch((e: unknown) =>
+          logger.error('[SlackMigration] failed to ensure migration bucket exists', {
+            bucket: config.gcs.migrationBucketName, error: e instanceof Error ? e.message : String(e),
+          }),
+        );
+    } else {
+      logger.warn('[SlackMigration] MIGRATION_GCS_BUCKET is not set — migration jobs will fail until it is configured');
+    }
+    // Ingestion starts paused: approvals only stage jobs until SLACK-MIGRATION-INGEST starts it.
+    void queues.pauseIngestionOnFirstInit().catch((e: unknown) =>
+      logger.error('[SlackMigration] failed to initialise ingestion queue paused', {
+        error: e instanceof Error ? e.message : String(e),
+      }),
+    );
+    new MigrationWorkers(queues, store, engine).register();
   }
-  // Ingestion starts paused: approvals only stage jobs until SLACK-MIGRATION-INGEST starts it.
-  void queues.pauseIngestionOnFirstInit().catch((e: unknown) =>
-    logger.error('[SlackMigration] failed to initialise ingestion queue paused', {
-      error: e instanceof Error ? e.message : String(e),
-    }),
-  );
-  new MigrationWorkers(queues, store, engine).register();
 }
 
 const router: Router = buildRouter(service);

--- a/apps/backend/src/migration/self-serve/migrationRuntimeConfig.ts
+++ b/apps/backend/src/migration/self-serve/migrationRuntimeConfig.ts
@@ -1,0 +1,38 @@
+import type { JsonValue } from '@openfeature/server-sdk';
+import { superpositionClient } from '@/services/superpositionClient';
+
+/** The one Superposition key holding the whole JSON blob. */
+export const SLACK_SELF_SERVICE_CONFIG_KEY = 'SlackSelfService';
+
+export interface MigrationRuntimeConfig {
+  bulk: boolean;            // bulk createMany path vs the per-message path
+  bulkBatchSize: number;   // rows per createMany in the bulk path
+  messageDelayMs: number;  // pause between messages at ingest (0 = unpaced)
+  fileConcurrency: number; // attachments streamed Slack→GCS in parallel during collection
+  pageDelayMs: number;     // pause between paged Slack history calls (collection)
+  listDelayMs: number;     // pause between Tier-2 list pages (conversations.list/users.list)
+  fileTimeoutMs: number;   // per-attachment download timeout
+  requestTimeoutMs: number;// per Slack API request timeout
+  stallLimitMs: number;    // live heartbeat but no forward progress ⇒ worker wedged
+}
+
+/** Defaults used for any field the Superposition key doesn't set (and when the key is empty/unreachable). */
+export const MIGRATION_DEFAULTS: MigrationRuntimeConfig = {
+  bulk: false,
+  bulkBatchSize: 500,
+  messageDelayMs: 0,
+  fileConcurrency: 5,
+  pageDelayMs: 250,
+  listDelayMs: 3000,
+  fileTimeoutMs: 600_000,
+  requestTimeoutMs: 30_000,
+  stallLimitMs: 600_000,
+};
+
+/** Read the JSON key and overlay any provided fields onto the defaults. */
+export async function getMigrationRuntimeConfig(): Promise<MigrationRuntimeConfig> {
+  const raw = await superpositionClient.getObjectValue(SLACK_SELF_SERVICE_CONFIG_KEY, MIGRATION_DEFAULTS as unknown as JsonValue);
+  return raw && typeof raw === 'object' && !Array.isArray(raw)
+    ? { ...MIGRATION_DEFAULTS, ...(raw as Partial<MigrationRuntimeConfig>) }
+    : MIGRATION_DEFAULTS;
+}

--- a/apps/backend/src/migration/self-serve/queues.ts
+++ b/apps/backend/src/migration/self-serve/queues.ts
@@ -2,14 +2,18 @@ import Bull from 'bull';
 import { getBaseRedisOptions } from '@/services/redisFactory';
 import { QueueName } from './types';
 
-interface JobRef { migrationId: string; }
+interface JobRef { migrationId: string; conversationId?: string; }
 
-/** Two serial (concurrency 1) queues — one-at-a-time for accountability (§5.4). Resume position: `lifo`=front (admin-stopped), normal add=end (failure). */
+/**
+ * Collection + ingestion-planner run one-at-a-time (§5.4). A third queue, CONV_INGEST, is fanned out:
+ * the planner drops one job per conversation and every worker process drains it in parallel.
+ * Resume position: `lifo`=front (admin-stopped), normal add=end (failure).
+ */
 export class MigrationQueues {
   private readonly queues = new Map<QueueName, Bull.Queue<JobRef>>();
 
   constructor() {
-    for (const name of [QueueName.COLLECTION, QueueName.INGESTION]) {
+    for (const name of [QueueName.COLLECTION, QueueName.INGESTION, QueueName.CONV_INGEST]) {
       this.queues.set(
         name,
         new Bull<JobRef>(name, {
@@ -55,6 +59,25 @@ export class MigrationQueues {
 
   process(name: QueueName, handler: (migrationId: string) => Promise<void>): void {
     this.queue(name).process(1, (job) => handler(job.data.migrationId));
+  }
+
+  /**
+   * Fan-out enqueue: one job per conversation. jobId dedups, so re-running the planner (resume) is idempotent.
+   * attempts:3 lets a transient infra blip (Redis/DB) retry — safe because re-ingesting a conversation is idempotent
+   * (done-set skip + per-message dedup), so a retry only back-fills what's missing.
+   */
+  async enqueueConv(migrationId: string, conversationId: string): Promise<void> {
+    await this.queue(QueueName.CONV_INGEST).add(
+      { migrationId, conversationId },
+      { jobId: `${migrationId}:${conversationId}`, attempts: 3, backoff: { type: 'fixed', delay: 5000 } },
+    );
+  }
+
+  /** Drain conversation jobs `concurrency`-at-a-time in THIS process; run in every worker process for cross-process parallelism. */
+  processConv(concurrency: number, handler: (migrationId: string, conversationId: string) => Promise<void>): void {
+    this.queue(QueueName.CONV_INGEST).process(Math.max(1, concurrency), (job) =>
+      handler(job.data.migrationId, job.data.conversationId ?? ''),
+    );
   }
 
   pause(name: QueueName): Promise<void> { return this.queue(name).pause(); }

--- a/apps/backend/src/migration/self-serve/service.ts
+++ b/apps/backend/src/migration/self-serve/service.ts
@@ -266,12 +266,14 @@ export class SlackMigrationService {
   async startIngestion(userId: string): Promise<{ running: boolean }> {
     await this.assertCanIngest(userId);
     await this.queues.resume(QueueName.INGESTION);
+    await this.queues.resume(QueueName.CONV_INGEST); // fan-out: the conversation workers must resume too, not just the planner
     return { running: true };
   }
 
   async stopIngestion(userId: string): Promise<{ running: boolean }> {
     await this.assertCanIngest(userId);
     await this.queues.pause(QueueName.INGESTION);
+    await this.queues.pause(QueueName.CONV_INGEST); // pausing the planner alone wouldn't halt already-fanned-out conversations
     return { running: false };
   }
 

--- a/apps/backend/src/migration/self-serve/store.ts
+++ b/apps/backend/src/migration/self-serve/store.ts
@@ -6,6 +6,10 @@ const KEY = (id: string) => `slackmig:job:${id}`;
 const INDEX = 'slackmig:index';
 const DM_LOCK = (workspaceId: string, userId: string) => `slackmig:dmlock:${workspaceId}:${userId}`;
 const CHANNEL_LOCK = (workspaceId: string, slackChannelId: string) => `slackmig:chanlock:${workspaceId}:${slackChannelId}`;
+// Parallel ingest: the set of conversations already ingested (atomic SADD, so many workers on one migration never lose each other's ticks),
+// and a once-only claim so exactly one worker runs the finalize (COMPLETED + announce + GCS cleanup).
+const INGESTED_SET = (id: string) => `slackmig:ingested:${id}`;
+const FINALIZE = (id: string) => `slackmig:finalize:${id}`;
 const channelKeyOf = (job: MigrationJob): string | undefined =>
   job.type === MigrationType.CHANNEL ? job.channelInput?.slackChannelId : undefined;
 
@@ -144,14 +148,62 @@ export class MigrationStore {
     await this.redis.expire(KEY(id), TTL_SECONDS);
   }
 
+  /**
+   * Parallel ingest: mark one conversation done. SADD is atomic, so concurrent workers on the same migration
+   * never clobber each other (unlike the checkpoint-blob RMW above). Returns whether this was the first time
+   * (increment the count only then, so a re-delivered job can't double-count) and the running total for finalize detection.
+   */
+  async markConversationDone(id: string, conversationId: string): Promise<{ firstTime: boolean; total: number }> {
+    const added = await this.redis.sadd(INGESTED_SET(id), conversationId);
+    const firstTime = added === 1;
+    if (firstTime) {
+      const now = String(Date.now());
+      const pipe = this.redis.pipeline();
+      pipe.hincrby(KEY(id), 'ingestedCount', 1);
+      pipe.hset(KEY(id), 'progressAt', now, 'heartbeatAt', now, 'updatedAt', now);
+      pipe.expire(KEY(id), TTL_SECONDS);
+      pipe.expire(INGESTED_SET(id), TTL_SECONDS);
+      await pipe.exec();
+    }
+    const total = await this.redis.scard(INGESTED_SET(id));
+    return { firstTime, total };
+  }
+
+  async isConversationDone(id: string, conversationId: string): Promise<boolean> {
+    return (await this.redis.sismember(INGESTED_SET(id), conversationId)) === 1;
+  }
+
+  /** Authoritative done count (the set itself, not the derived HINCRBY field) — used to gate finalize. */
+  async doneCount(id: string): Promise<number> {
+    return this.redis.scard(INGESTED_SET(id));
+  }
+
+  /** Seed the done-set from the existing checkpoint (resume / upgrade from the old serial array) and sync the count. */
+  async seedDoneSet(id: string, conversationIds: string[]): Promise<void> {
+    if (conversationIds.length) await this.redis.sadd(INGESTED_SET(id), ...conversationIds);
+    const total = await this.redis.scard(INGESTED_SET(id));
+    await this.redis.hset(KEY(id), 'ingestedCount', String(total));
+    await this.redis.expire(INGESTED_SET(id), TTL_SECONDS);
+  }
+
+  /** Once-only finalize claim: exactly one worker (the one that closed the last conversation) runs COMPLETED + announce + cleanup. */
+  async tryClaimFinalize(id: string): Promise<boolean> {
+    return (await this.redis.set(FINALIZE(id), '1', 'EX', TTL_SECONDS, 'NX')) === 'OK';
+  }
+
+  // Atomic append to the issues JSON array (server-side), so parallel ingest workers appending at once never lose entries.
+  private static readonly APPEND_ISSUE_LUA = `
+local cur = redis.call('HGET', KEYS[1], 'issues')
+local arr = cur and cjson.decode(cur) or {}
+table.insert(arr, cjson.decode(ARGV[1]))
+redis.call('HSET', KEYS[1], 'issues', cjson.encode(arr), 'heartbeatAt', ARGV[2], 'updatedAt', ARGV[2])
+redis.call('EXPIRE', KEYS[1], ARGV[3])
+return #arr`;
+
   /** Record a conversation that couldn't be fully collected/ingested so the UI can show it. */
   async addIssue(id: string, issue: MigrationIssue): Promise<void> {
-    const raw = await this.redis.hget(KEY(id), 'issues');
-    const issues: MigrationIssue[] = raw ? (JSON.parse(raw) as MigrationIssue[]) : [];
-    issues.push(issue);
     const now = String(Date.now());
-    await this.redis.hset(KEY(id), 'issues', JSON.stringify(issues), 'heartbeatAt', now, 'updatedAt', now);
-    await this.redis.expire(KEY(id), TTL_SECONDS);
+    await this.redis.eval(MigrationStore.APPEND_ISSUE_LUA, 1, KEY(id), JSON.stringify(issue), now, String(TTL_SECONDS));
   }
 
   async isStopRequested(id: string): Promise<boolean> {
@@ -175,7 +227,7 @@ export class MigrationStore {
 
   async delete(id: string): Promise<void> {
     const job = await this.findById(id);
-    await this.redis.del(KEY(id));
+    await this.redis.del(KEY(id), INGESTED_SET(id), FINALIZE(id));
     await this.redis.zrem(INDEX, id);
     if (job?.type === MigrationType.DM) await this.redis.del(DM_LOCK(job.workspaceId, job.submittedByUserId));
     if (job) { const chan = channelKeyOf(job); if (chan) await this.redis.del(CHANNEL_LOCK(job.workspaceId, chan)); }
@@ -235,6 +287,7 @@ function decode(h: Record<string, string>): MigrationJob {
     slackChannelCreated: numOpt('slackChannelCreated'),
     channelProgress: h.channelProgress ? (JSON.parse(h.channelProgress) as MigrationJob['channelProgress']) : undefined,
     checkpoint: h.checkpoint ? (JSON.parse(h.checkpoint) as Checkpoint) : emptyCheckpoint(),
+    ingestedCount: numOpt('ingestedCount'),
     stats: { conversations: numReq('statsConversations'), messages: numReq('statsMessages') },
     stopRequested: h.stopRequested === '1',
     stopReason: opt('stopReason') as MigrationJob['stopReason'],
@@ -243,6 +296,7 @@ function decode(h: Record<string, string>): MigrationJob {
     createdAt: numReq('createdAt'),
     updatedAt: numReq('updatedAt'),
     completedAt: numOpt('completedAt'),
+    ingestStartedAt: numOpt('ingestStartedAt'),
     error: opt('error'),
     issues: h.issues ? (JSON.parse(h.issues) as MigrationIssue[]) : undefined,
   };

--- a/apps/backend/src/migration/self-serve/types.ts
+++ b/apps/backend/src/migration/self-serve/types.ts
@@ -17,6 +17,7 @@ export enum MigrationStatus {
 export enum QueueName {
   COLLECTION = 'slack-migration-collection',
   INGESTION = 'slack-migration-ingestion',
+  CONV_INGEST = 'slack-migration-conv-ingest', // fan-out: one job per conversation, drained by all worker processes in parallel
 }
 
 export interface Checkpoint {
@@ -37,6 +38,7 @@ export interface MigrationIssue {
   conversationId: string;
   kind: 'skipped' | 'truncated' | 'ingest-error';
   reason: string;
+  label?: string; // human-readable conversation identifier captured at issue time (e.g. "DM with Jane Doe" / "#general")
 }
 
 export interface MigrationJob {
@@ -58,6 +60,8 @@ export interface MigrationJob {
   slackChannelCreated?: number; // creation unix ts (secs) — lower bound for collection progress
   channelProgress?: { start: number; end: number; through: number }; // epoch secs: window [start,end] + oldest collected
   checkpoint: Checkpoint;
+  ingestedCount?: number;       // parallel ingest: count of conversations done, tracked atomically (Redis SET) instead of the checkpoint array
+  ingestStartedAt?: number;     // when ingestion first began (planner set INGESTING) — with completedAt gives the ingest duration
   stats: { conversations: number; messages: number };
   stopRequested: boolean;
   stopReason?: 'admin' | 'system';
@@ -88,6 +92,8 @@ export interface MigrationJobView {
   createdAt: number;
   updatedAt: number;
   completedAt?: number;
+  ingestStartedAt?: number;
+  ingestDurationMs?: number; // completedAt − ingestStartedAt when both present — "how long ingestion took"
   error?: string;
 }
 
@@ -104,7 +110,7 @@ export const toView = (j: MigrationJob): MigrationJobView => ({
   progress: {
     total: j.checkpoint.totalConversations,
     collected: j.checkpoint.collectedConversationIds.length,
-    ingested: j.checkpoint.ingestedConversationIds.length,
+    ingested: j.ingestedCount ?? j.checkpoint.ingestedConversationIds.length,
   },
   channel: j.type === MigrationType.CHANNEL && j.channelInput ? {
     slackId: j.channelInput.slackChannelId,
@@ -121,6 +127,8 @@ export const toView = (j: MigrationJob): MigrationJobView => ({
   createdAt: j.createdAt,
   updatedAt: j.updatedAt,
   completedAt: j.completedAt,
+  ingestStartedAt: j.ingestStartedAt,
+  ingestDurationMs: j.ingestStartedAt && j.completedAt ? j.completedAt - j.ingestStartedAt : undefined,
   error: j.error,
   issues: j.issues,
 });

--- a/apps/backend/src/migration/self-serve/workerMain.ts
+++ b/apps/backend/src/migration/self-serve/workerMain.ts
@@ -1,0 +1,70 @@
+/**
+ * Worker entry for the self-serve Slack migration — booted as a forked CHILD by the migration composition root
+ * (`self-serve/index.ts`) when MIGRATION_WORKER_PROCESSES > 1, one child per process. It runs the migration WORKERS
+ * only (no HTTP, no other app services), so the main app process keeps serving everything else as a single copy.
+ *
+ * Each child is given a NODE_APP_INSTANCE (0..N-1): singleton duties (collection / ingestion planner / reconcile) run
+ * on instance 0 only; every child drains the fanned-out conversation jobs for cross-process parallelism. This process
+ * never forks again — the supervisor lives in the composition root.
+ */
+import { config } from '@/config/env';
+import { logger } from '@/utils/logger';
+import { getStorageService } from '@/services/storage';
+import { vespaQueue, vespaBackfillQueue } from '@/queues/vespaQueue';
+import { MigrationStore } from './store';
+import { MigrationQueues } from './queues';
+import { SlackMigrationEngine } from './engine';
+import { MigrationWorkers } from './workers';
+
+// Log the ORIGINAL rejection's stack (not this handler's frame) so an unawaited failure is actually diagnosable.
+process.on('unhandledRejection', (reason: unknown) => {
+  logger.error('[SlackMigration] UNHANDLED REJECTION', {
+    error: reason instanceof Error ? (reason.stack ?? reason.message) : String(reason),
+  });
+});
+process.on('uncaughtException', (error: Error) => {
+  logger.error('[SlackMigration] UNCAUGHT EXCEPTION', { error });
+});
+// In-flight conversations cut off by a restart are recovered by the reconcile watchdog + per-conversation dedup, so an immediate exit is safe.
+process.on('SIGTERM', () => { logger.info('[SlackMigration] worker received SIGTERM — exiting'); process.exit(0); });
+process.on('SIGINT', () => process.exit(0));
+
+const isPrimaryInstance = !process.env.NODE_APP_INSTANCE || process.env.NODE_APP_INSTANCE === '0';
+
+async function boot(): Promise<void> {
+  // These forked worker children never boot through app.ts, so the Vespa PRODUCER queues would be uninitialised here —
+  // every enqueueMessageVespa would then throw "Vespa queue not initialized Properly" and NO migrated message would be
+  // indexed. Initialise them (idempotent) BEFORE registering workers. Draining stays with the backfill worker pods.
+  await vespaQueue.initialize();
+  await vespaBackfillQueue.initialize();
+
+  const store = new MigrationStore();
+  const queues = new MigrationQueues();
+  const engine = new SlackMigrationEngine();
+
+  // One-time setup runs on instance 0 only (idempotent, but no need to do it N times).
+  if (isPrimaryInstance) {
+    if (config.gcs.migrationBucketName) {
+      await getStorageService(config.gcs.migrationBucketName).ensureBucketExists().catch((e: unknown) =>
+        logger.error('[SlackMigration] failed to ensure migration bucket exists', {
+          bucket: config.gcs.migrationBucketName, error: e instanceof Error ? e.message : String(e),
+        }),
+      );
+    } else {
+      logger.warn('[SlackMigration] MIGRATION_GCS_BUCKET is not set — migration jobs will fail until it is configured');
+    }
+    await queues.pauseIngestionOnFirstInit().catch((e: unknown) =>
+      logger.error('[SlackMigration] failed to initialise ingestion queue paused', { error: e instanceof Error ? e.message : String(e) }),
+    );
+  }
+
+  new MigrationWorkers(queues, store, engine).register();
+  logger.info('[SlackMigration] worker process up', {
+    instance: process.env.NODE_APP_INSTANCE ?? 'single',
+    ingestConcurrency: config.slackMigration.ingestConcurrency,
+  });
+}
+
+void boot().catch((e: unknown) =>
+  logger.error('[SlackMigration] worker boot failed', { error: e instanceof Error ? (e.stack ?? e.message) : String(e) }),
+);

--- a/apps/backend/src/migration/self-serve/workerMain.ts
+++ b/apps/backend/src/migration/self-serve/workerMain.ts
@@ -11,6 +11,7 @@ import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 import { getStorageService } from '@/services/storage';
 import { vespaQueue, vespaBackfillQueue } from '@/queues/vespaQueue';
+import { superpositionClient } from '@/services/superpositionClient';
 import { MigrationStore } from './store';
 import { MigrationQueues } from './queues';
 import { SlackMigrationEngine } from './engine';
@@ -37,6 +38,9 @@ async function boot(): Promise<void> {
   // indexed. Initialise them (idempotent) BEFORE registering workers. Draining stays with the backfill worker pods.
   await vespaQueue.initialize();
   await vespaBackfillQueue.initialize();
+  await superpositionClient.initialize().catch((e: unknown) =>
+    logger.warn('[SlackMigration] Superposition init failed — migration config will use defaults', { error: e instanceof Error ? e.message : String(e) }),
+  );
 
   const store = new MigrationStore();
   const queues = new MigrationQueues();

--- a/apps/backend/src/migration/self-serve/workers.ts
+++ b/apps/backend/src/migration/self-serve/workers.ts
@@ -2,13 +2,22 @@ import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 import { MigrationStore } from './store';
 import { MigrationQueues } from './queues';
-import { SlackMigrationEngine } from './engine';
+import { SlackMigrationEngine, type CollectedConversation, type DirUser } from './engine';
 import { MigrationJob, MigrationStatus, MigrationType, QueueName } from './types';
 
 const HEARTBEAT_MS = 15_000;
 const RECONCILE_EVERY_MS = 60_000;
 const RECLAIM_STALE_MS = 90_000; // several missed heartbeats ⇒ the pod that owned the job is gone
 const STALL_LIMIT_MS = config.slackMigration.stallLimitMs; // live heartbeat but no forward progress ⇒ worker wedged
+
+/** Human-readable ingest duration for the completion log, e.g. "7m 12s". */
+function formatDuration(ms: number): string {
+  const s = Math.round(ms / 1000);
+  const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60), sec = s % 60;
+  if (h) return `${h}h ${m}m ${sec}s`;
+  if (m) return `${m}m ${sec}s`;
+  return `${sec}s`;
+}
 
 /** Bull processors for the two queues, each with lifecycle + heartbeat + cooperative stop. */
 export class MigrationWorkers {
@@ -19,13 +28,21 @@ export class MigrationWorkers {
   ) {}
 
   register(): void {
-    this.queues.process(QueueName.COLLECTION, (id) => this.guard(id, (j) => this.collect(j)));
-    this.queues.process(QueueName.INGESTION, (id) => this.guard(id, (j) => this.ingest(j)));
-    logger.info('[SlackMigration] workers registered (collection + ingestion processors active)');
-    // Recover jobs orphaned by a pod kill (stuck COLLECTING/INGESTING, stale heartbeat). Store is the source of truth, not Bull.
-    const timer = setInterval(() => void this.reconcile().catch(() => undefined), RECONCILE_EVERY_MS);
-    timer.unref?.();
-    void this.reconcile().catch(() => undefined);
+    // Under pm2 cluster mode NODE_APP_INSTANCE is 0..N-1; single process → undefined. Singleton duties (collection,
+    // the ingestion planner, and reconcile) run on instance 0 only, so they don't fire N times. Every process drains
+    // the fanned-out conversation jobs for cross-process parallelism.
+    const isPrimary = !process.env.NODE_APP_INSTANCE || process.env.NODE_APP_INSTANCE === '0';
+    if (isPrimary) {
+      this.queues.process(QueueName.COLLECTION, (id) => this.guard(id, (j) => this.collect(j)));
+      this.queues.process(QueueName.INGESTION, (id) => this.guard(id, (j) => this.ingest(j)));
+      const timer = setInterval(() => void this.reconcile().catch(() => undefined), RECONCILE_EVERY_MS);
+      timer.unref?.();
+      void this.reconcile().catch(() => undefined);
+    }
+    this.queues.processConv(config.slackMigration.ingestConcurrency, (mid, cid) => this.ingestConversation(mid, cid));
+    logger.info('[SlackMigration] workers registered', {
+      primary: isPrimary, instance: process.env.NODE_APP_INSTANCE ?? 'single', ingestConcurrency: config.slackMigration.ingestConcurrency,
+    });
   }
 
   /** Recover running jobs that a live worker can no longer make progress on: pod died (stale heartbeat) → re-enqueue;
@@ -93,13 +110,15 @@ export class MigrationWorkers {
     logger.info('[SlackMigration] collection started', { id: job.id, type: job.type });
 
     let conversations;
+    let directory: Record<string, DirUser> = {};
     if (await this.engine.manifestExists(job.gcsPrefix)) {
       conversations = await this.engine.readManifest(job.gcsPrefix);
+      directory = await this.engine.readDirectory(job.gcsPrefix); // for issue labels on resume (no Slack)
       await this.store.markProgress(job.id).catch(() => undefined);
       await this.store.update(job.id, { checkpoint: { ...job.checkpoint, totalConversations: conversations.length } });
       logger.info('[SlackMigration] reusing existing collection plan (resume)', { id: job.id, conversations: conversations.length });
     } else {
-      const directory = await this.engine.collectDirectory(token, job.gcsPrefix);
+      directory = await this.engine.collectDirectory(token, job.gcsPrefix);
       await this.store.markProgress(job.id).catch(() => undefined);
       await this.engine.collectUsergroups(token, job.gcsPrefix);
       await this.engine.collectChannels(token, job.gcsPrefix, job.teamId);
@@ -116,6 +135,14 @@ export class MigrationWorkers {
     // A channel is a single conversation (conversation bar meaningless) and Slack gives no message total, so report progress
     // through the date window [start, newest message], where start = chosen startDate or the channel's creation ts.
     const isChannel = job.type === MigrationType.CHANNEL;
+    // Human-readable identifier for an issue: "#channel" for a channel, "DM with <names>" (resolved from the dump) for a DM.
+    const labelFor = (conv: CollectedConversation): string => {
+      if (isChannel) return `#${job.slackChannelName ?? conv.id}`;
+      const names = conv.members
+        .filter((m) => m !== job.ownerSlackId)
+        .map((m) => directory[m]?.real_name || directory[m]?.display_name || m);
+      return names.length ? `DM with ${names.join(', ')}` : `DM ${conv.id}`;
+    };
     const windowStart = job.channelInput?.startDate
       ? Math.floor(Date.parse(job.channelInput.startDate) / 1000)
       : (job.slackChannelCreated ?? 0);
@@ -136,7 +163,7 @@ export class MigrationWorkers {
         // the whole job; a DM job records the skip and keeps going with the rest.
         if (isChannel) throw new Error(result.reason ?? 'Channel is inaccessible on Slack.');
         skipped += 1;
-        await this.store.addIssue(job.id, { conversationId: conv.id, kind: 'skipped', reason: result.reason ?? 'Inaccessible on Slack.' });
+        await this.store.addIssue(job.id, { conversationId: conv.id, label: labelFor(conv), kind: 'skipped', reason: result.reason ?? 'Inaccessible on Slack.' });
         continue;
       }
       await this.store.addCollected(job.id, conv.id, isChannel ? 0 : result.messages); // channel count already live via setChannelProgress
@@ -144,7 +171,7 @@ export class MigrationWorkers {
       messages += result.messages;
       if (result.outcome === 'truncated') {
         truncated += 1;
-        await this.store.addIssue(job.id, { conversationId: conv.id, kind: 'truncated', reason: result.reason ?? 'Partial — lost Slack access mid-collection.' });
+        await this.store.addIssue(job.id, { conversationId: conv.id, label: labelFor(conv), kind: 'truncated', reason: result.reason ?? 'Partial — lost Slack access mid-collection.' });
       }
       if (conversations.length > PROGRESS_EVERY && (index + 1) % PROGRESS_EVERY === 0) {
         logger.info('[SlackMigration] collection progress', { id: job.id, done: index + 1, total: conversations.length, messages });
@@ -158,10 +185,16 @@ export class MigrationWorkers {
     });
   }
 
+  /**
+   * PLANNER (runs on the INGESTION queue, instance-0 only, one migration at a time): fan the conversations out
+   * as CONV_INGEST jobs that every worker process drains in parallel. Idempotent — re-running on resume/restart
+   * re-enqueues only conversations not yet in the done-set. Does NOT ingest anything itself.
+   */
   private async ingest(job: MigrationJob): Promise<void> {
-    // Idempotency: never re-ingest a completed job (its GCS data is already deleted).
+    // Idempotency: never re-plan a completed job (its GCS data is already deleted).
     if ([MigrationStatus.SUBMITTED, MigrationStatus.COLLECTING, MigrationStatus.COMPLETED].includes(job.status)) return;
-    await this.store.update(job.id, { status: MigrationStatus.INGESTING });
+    // Stamp the ingest start once (kept across resume) so the completion log/UI can report how long ingestion took.
+    await this.store.update(job.id, { status: MigrationStatus.INGESTING, ...(job.ingestStartedAt ? {} : { ingestStartedAt: Date.now() }) });
     let conversations;
     try {
       conversations = await this.engine.readManifest(job.gcsPrefix);
@@ -170,29 +203,86 @@ export class MigrationWorkers {
       logger.warn('[SlackMigration] ingest manifest missing — finalizing as complete', { id: job.id });
       return;
     }
-    logger.info('[SlackMigration] ingestion started', { id: job.id, total: conversations.length });
-    // Build the offline reference once per job so ingestion resolves users/usergroups/channels from the dumps, never Slack.
-    const ref = await this.engine.buildOfflineReference(job.gcsPrefix);
-    const done = new Set(job.checkpoint.ingestedConversationIds);
+    // Dedupe by id: the done-set is a Redis SET and enqueueConv dedups by jobId, so the total must be the DISTINCT
+    // count — otherwise a repeated id in the manifest makes SCARD unable to reach total and the job never finalizes.
+    const uniqueConversations = [...new Map(conversations.map((c) => [c.id, c])).values()];
+    // Seed the done-set from any prior checkpoint (resume, or upgrade from the old serial array) and set the total.
+    await this.store.seedDoneSet(job.id, job.checkpoint.ingestedConversationIds);
+    await this.store.update(job.id, { checkpoint: { ...job.checkpoint, totalConversations: uniqueConversations.length } });
 
-    for (const conv of conversations) {
+    let enqueued = 0;
+    for (const conv of uniqueConversations) {
       if (await this.store.isStopRequested(job.id)) {
-        logger.info('[SlackMigration] stop requested — halting at next conversation', { id: job.id, queue: job.currentQueue });
+        logger.info('[SlackMigration] stop requested — halting fan-out', { id: job.id, queue: job.currentQueue });
         return void this.store.update(job.id, { status: MigrationStatus.STOPPED });
       }
-      if (done.has(conv.id)) continue;
-      const loaded = await this.engine.loadConversation(job, conv, ref, () => void this.store.markProgress(job.id).catch(() => undefined));
-      if (loaded.failed > 0) {
-        await this.store.addIssue(job.id, { conversationId: conv.id, kind: 'ingest-error', reason: `${loaded.failed} message(s) couldn't be migrated (unresolved sender or attachment).` });
+      if (await this.store.isConversationDone(job.id, conv.id)) continue;
+      await this.queues.enqueueConv(job.id, conv.id);
+      enqueued += 1;
+    }
+    logger.info('[SlackMigration] ingestion fanned out', { id: job.id, enqueued, total: conversations.length, concurrency: config.slackMigration.ingestConcurrency });
+    // Nothing left to enqueue (all already done, or empty manifest) → no processor will fire, so finalize here.
+    if (enqueued === 0) await this.maybeFinalize(job.id);
+  }
+
+  /**
+   * PROCESSOR (runs on the CONV_INGEST queue in EVERY worker process, `ingestConcurrency`-at-a-time): ingest one
+   * conversation. Marks it done atomically afterwards and, when it closes the last one, claims the once-only finalize.
+   */
+  private async ingestConversation(migrationId: string, conversationId: string): Promise<void> {
+    const job = await this.store.findById(migrationId);
+    if (!job || job.status !== MigrationStatus.INGESTING) return;          // stopped/failed/completed → drop, don't mark done
+    if (await this.store.isStopRequested(migrationId)) {                   // admin stopped → flip status (old serial loop did this) and drop
+      await this.store.update(migrationId, { status: MigrationStatus.STOPPED }).catch(() => undefined);
+      return;
+    }
+    if (await this.store.isConversationDone(migrationId, conversationId)) return; // already done (stale re-delivery) → idempotent skip
+
+    const heartbeat = setInterval(() => void this.store.heartbeat(migrationId).catch(() => undefined), HEARTBEAT_MS);
+    heartbeat.unref?.();
+    try {
+      const conv = await this.engine.getManifestConversation(migrationId, job.gcsPrefix, conversationId);
+      if (conv) {
+        const ref = await this.engine.getOfflineReference(migrationId, job.gcsPrefix);
+        const loaded = await this.engine.loadConversation(job, conv, ref, () => void this.store.markProgress(migrationId).catch(() => undefined));
+        if (loaded.failed > 0) {
+          await this.store.addIssue(migrationId, { conversationId, kind: 'ingest-error', reason: `${loaded.failed} message(s) couldn't be migrated (unresolved sender or attachment).` });
+        }
       } else {
-        await this.store.addIngested(job.id, conv.id);
+        logger.warn('[SlackMigration] conversation missing from manifest — skipping', { migrationId, conversationId });
       }
+    } catch (err) {
+      // Record and move on so the migration can still finalize (never stuck). A hard-failed conversation is surfaced as an issue, not auto-retried.
+      logger.error('[SlackMigration] conversation ingest failed (recorded, not retried)', { migrationId, conversationId, error: err instanceof Error ? err.message : String(err) });
+      await this.store.addIssue(migrationId, { conversationId, kind: 'ingest-error', reason: err instanceof Error ? err.message : String(err) }).catch(() => undefined);
+    } finally {
+      clearInterval(heartbeat);
     }
 
-    await this.store.update(job.id, { status: MigrationStatus.COMPLETED, completedAt: Date.now() });
-    await this.engine.announceMigration(job).catch((err) => logger.warn('[SlackMigration] announce failed (non-fatal)', { id: job.id, error: err instanceof Error ? err.message : String(err) }));
+    const { total } = await this.store.markConversationDone(migrationId, conversationId);
+    if (total >= job.checkpoint.totalConversations) await this.maybeFinalize(migrationId);
+  }
+
+  /** Finalize a migration exactly once — the worker that closes the last conversation wins the SETNX claim. */
+  private async maybeFinalize(migrationId: string): Promise<void> {
+    const job = await this.store.findById(migrationId);
+    if (!job || job.status !== MigrationStatus.INGESTING) return;        // only an actively-ingesting job finalizes — never override STOPPED/FAILED/COMPLETED
+    if (await this.store.isStopRequested(migrationId)) return;           // a stop landed on the final conversation → let the stop win, don't complete
+    if (await this.store.doneCount(migrationId) < job.checkpoint.totalConversations) return; // SCARD is the source of truth, not the derived ingestedCount field
+    if (!(await this.store.tryClaimFinalize(migrationId))) return; // another worker is finalizing
+    const completedAt = Date.now();
+    await this.store.update(migrationId, { status: MigrationStatus.COMPLETED, completedAt });
+    await this.engine.announceMigration(job).catch((err) => logger.warn('[SlackMigration] announce failed (non-fatal)', { id: migrationId, error: err instanceof Error ? err.message : String(err) }));
     await this.engine.deletePrefix(job.gcsPrefix).catch(() => undefined);
-    logger.info('[SlackMigration] ingestion complete', { id: job.id, total: conversations.length });
+    const durationMs = job.ingestStartedAt ? completedAt - job.ingestStartedAt : undefined;
+    logger.info('[SlackMigration] ingestion complete', {
+      id: migrationId,
+      conversations: job.checkpoint.totalConversations,
+      messages: job.stats.messages,
+      ingestDurationMs: durationMs,
+      ingestDuration: durationMs !== undefined ? formatDuration(durationMs) : undefined,
+      messagesPerSec: durationMs && durationMs > 0 ? Math.round((job.stats.messages / durationMs) * 1000) : undefined,
+    });
   }
 
   /** Loads the record, runs a heartbeat ticker, and centralizes failure marking. */

--- a/apps/backend/src/migration/self-serve/workers.ts
+++ b/apps/backend/src/migration/self-serve/workers.ts
@@ -4,11 +4,12 @@ import { MigrationStore } from './store';
 import { MigrationQueues } from './queues';
 import { SlackMigrationEngine, type CollectedConversation, type DirUser } from './engine';
 import { MigrationJob, MigrationStatus, MigrationType, QueueName } from './types';
+import { getMigrationRuntimeConfig } from './migrationRuntimeConfig';
 
 const HEARTBEAT_MS = 15_000;
 const RECONCILE_EVERY_MS = 60_000;
 const RECLAIM_STALE_MS = 90_000; // several missed heartbeats ⇒ the pod that owned the job is gone
-const STALL_LIMIT_MS = config.slackMigration.stallLimitMs; // live heartbeat but no forward progress ⇒ worker wedged
+// stallLimitMs (live heartbeat but no forward progress ⇒ worker wedged) is now live-tunable via Superposition — read per reconcile tick.
 
 /** Human-readable ingest duration for the completion log, e.g. "7m 12s". */
 function formatDuration(ms: number): string {
@@ -49,6 +50,7 @@ export class MigrationWorkers {
    *  or wedged/looping (fresh heartbeat, no progress) → fail resumably. */
   private async reconcile(): Promise<void> {
     const now = Date.now();
+    const { stallLimitMs } = await getMigrationRuntimeConfig();
     for (const job of await this.store.list(1000, 0)) {
       // Queued/submitted jobs live in Bull, not here — but recover one whose Bull entry was lost (e.g. a crash
       // between the store write and enqueue) so it can't sit stranded forever. Only re-enqueue if genuinely absent.
@@ -75,7 +77,7 @@ export class MigrationWorkers {
         // retrying. We can't preempt the locked Bull job, so surface it as FAILED (resumable) rather than let it
         // masquerade as "running" forever. Threshold is generous so normal Slack rate-limit backoffs don't trip it.
         const lastProgress = job.progressAt ?? job.createdAt;
-        if (now - lastProgress >= STALL_LIMIT_MS) {
+        if (now - lastProgress >= stallLimitMs) {
           const minutes = Math.round((now - lastProgress) / 60_000);
           logger.error('[SlackMigration] migration stalled — live heartbeat but no progress; marking failed (resumable)', {
             id: job.id, status: job.status, stalledForMin: minutes,

--- a/apps/backend/src/services/conversationService.ts
+++ b/apps/backend/src/services/conversationService.ts
@@ -85,6 +85,8 @@ export interface CreateConversationWithMessageParams {
   isAddingParticipant?: boolean;
   isMarkdown?: boolean;
   pinned?: boolean;
+  /** Migration import: skip live-only side effects (MESSAGE_RECEIVED automations, meet-link extraction) so bulk-imported history never fires workflows. */
+  suppressAutomations?: boolean;
 }
 
 export interface AddMessageToConversationParams {
@@ -103,6 +105,8 @@ export interface AddMessageToConversationParams {
   isMarkdown?: boolean;
   /** Migration-only: advance participant read state to the imported reply timestamp. */
   markParticipantsRead?: boolean;
+  /** Migration import: skip live-only side effects (TICKET_COMMENTED automations, meet-link extraction) so bulk-imported history never fires workflows. */
+  suppressAutomations?: boolean;
 }
 
 export interface UpdateMessageParams {
@@ -335,6 +339,7 @@ export class ConversationService {
       createdAt,
       isAddingParticipant = true,
       pinned,
+      suppressAutomations = false,
     } = params;
 
     // Check if channel exists
@@ -485,6 +490,7 @@ export class ConversationService {
     await messageMetadataService.syncInitialMessageMd(conversation.conversationId);
 
     if (
+      !suppressAutomations &&
       !isBot &&
       message.msgType === MessageType.USER &&
       channel.workspaceId &&
@@ -534,13 +540,16 @@ export class ConversationService {
     // Fan out the automation `MESSAGE_RECEIVED` event for the first message in a
     // new channel conversation. Which message kinds fire is a user-configured
     // trigger condition; loops are prevented by the run chain. Fire-and-forget.
-    void emitMessageReceived({
-      messageId: message.messageId,
-      conversationId: conversation.conversationId,
-      channelId,
-      msgType: message.msgType as MessageType,
-      userId,
-    });
+    // Migration import suppresses this so bulk-imported history never fires workflows.
+    if (!suppressAutomations) {
+      void emitMessageReceived({
+        messageId: message.messageId,
+        conversationId: conversation.conversationId,
+        channelId,
+        msgType: message.msgType as MessageType,
+        userId,
+      });
+    }
 
     return {
       conversation,
@@ -571,6 +580,7 @@ export class ConversationService {
       createdAt,
       isAddingParticipant = true,
       markParticipantsRead = false,
+      suppressAutomations = false,
     } = params;
 
     const conversation = await this.conversationRepository.findById(conversationId);
@@ -713,6 +723,7 @@ export class ConversationService {
     });
 
     if (
+      !suppressAutomations &&
       !isBot &&
       message.msgType === MessageType.USER &&
       channel?.workspaceId &&
@@ -805,15 +816,18 @@ export class ConversationService {
     // helper itself filters out bot/system messages and conversations not
     // tied to a ticket, so it's safe to invoke unconditionally. Failures are
     // logged inside the helper and must not fail the message write.
-    void emitTicketCommented({
-      messageId: message.messageId,
-      conversationId,
-      content: message.content ?? undefined,
-      msgType: message.msgType as MessageType,
-      isBot,
-      userId,
-      createdAt: message.createdAt,
-    });
+    // Migration import suppresses this so bulk-imported history never fires workflows.
+    if (!suppressAutomations) {
+      void emitTicketCommented({
+        messageId: message.messageId,
+        conversationId,
+        content: message.content ?? undefined,
+        msgType: message.msgType as MessageType,
+        isBot,
+        userId,
+        createdAt: message.createdAt,
+      });
+    }
 
     return {
       conversation,

--- a/apps/backend/src/services/externalAttachmentService.ts
+++ b/apps/backend/src/services/externalAttachmentService.ts
@@ -159,7 +159,14 @@ export class ExternalAttachmentService {
   ): Promise<DownloadedAttachment[]> {
     if (!attachments || attachments.length === 0) return [];
 
-    logger.info(`Downloading ${attachments.length} attachments for source: ${sourceName}`);
+    // Migration attachments already live in our storage (collected earlier) — they are STREAM-COPIED bucket→bucket,
+    // not re-fetched from Slack. Say so, so the ingestion logs don't look like a second collection pass.
+    const fromStorageCount = attachments.filter((a) => a.storageSourcePath).length;
+    logger.info(
+      fromStorageCount === attachments.length
+        ? `Moving ${attachments.length} attachment(s) storage→storage (already collected — not re-downloading from Slack) for source: ${sourceName}`
+        : `Downloading ${attachments.length} attachments for source: ${sourceName}`,
+    );
 
     const source = await this.externalSourceRepo.findByName(sourceName);
     if (!source) throw new Error(`External source not found: ${sourceName}`);
@@ -224,7 +231,7 @@ export class ExternalAttachmentService {
       logger.warn(`Failed to download ${failed.length}/${attachments.length} attachments:`, failed);
     }
 
-    logger.info(`Successfully downloaded ${successful.length}/${attachments.length} attachments`);
+    logger.info(`Successfully transferred ${successful.length}/${attachments.length} attachment(s) to storage`);
     return successful;
   }
 
@@ -255,6 +262,9 @@ export class ExternalAttachmentService {
       // Read from the source bucket (gs://bucket/key from the collector); write final to default bucket.
       const { bucket, key } = parseStorageUri(attachment.storageSourcePath);
       const sourceStore = bucket ? getStorageService(bucket) : storageService;
+      logger.info('Moving attachment storage→storage (streamed, decrypted; no Slack fetch)', {
+        from: attachment.storageSourcePath, fileName, scopeId,
+      });
       const raw = await sourceStore.createReadStream(key);
       const source = attachment.storageSourceEncrypted ? decryptStream(raw) : raw;
       const gcsResult = await storageService.uploadStream(source, {

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -83,6 +83,10 @@ ENV VITE_POSTHOG_HOST=${VITE_POSTHOG_HOST}
 # Default workspace ID
 ENV VITE_DEFAULT_WORKSPACE_ID=6642623f-cca7-43ad-9a6b-5e49c33226b4
 
+# Slack app install URL shown on the self-serve migration page (public; baked into the bundle at build time)
+ARG VITE_SLACK_APP_INSTALL_URL="https://api.slack.com/apps/A09QL5AE5PY/install-on-team"
+ENV VITE_SLACK_APP_INSTALL_URL=${VITE_SLACK_APP_INSTALL_URL}
+
 # Build the Vite React app with increased memory
 ENV NODE_OPTIONS="--max-old-space-size=8192"
 RUN pnpm --filter xyne-spaces-dashboard run ${BUILD_SCRIPT}

--- a/apps/dashboard/src/api/slackMigrationApi.ts
+++ b/apps/dashboard/src/api/slackMigrationApi.ts
@@ -41,11 +41,14 @@ export interface MigrationJobView {
   createdAt: number;
   updatedAt: number;
   completedAt?: number;
+  ingestStartedAt?: number;
+  ingestDurationMs?: number; // how long ingestion took (completedAt − ingestStartedAt)
   error?: string;
   issues?: {
     conversationId: string;
     kind: 'skipped' | 'truncated' | 'ingest-error';
     reason: string;
+    label?: string; // human-readable conversation identifier (e.g. "DM with Jane Doe" / "#general")
   }[];
 }
 

--- a/apps/dashboard/src/pages/SlackMigration.tsx
+++ b/apps/dashboard/src/pages/SlackMigration.tsx
@@ -124,6 +124,17 @@ const ago = (ts: number): string => {
   return `${Math.round(h / 24)}d ago`;
 };
 
+// Human-readable ingest duration, e.g. "7m 12s".
+const fmtDuration = (ms: number): string => {
+  const s = Math.max(0, Math.round(ms / 1000));
+  const h = Math.floor(s / 3600),
+    m = Math.floor((s % 3600) / 60),
+    sec = s % 60;
+  if (h) return `${h}h ${m}m ${sec}s`;
+  if (m) return `${m}m ${sec}s`;
+  return `${sec}s`;
+};
+
 // Pipeline stages; position derived from status (and phase when stopped/failed).
 const STAGES = ['Collect', 'Approve', 'Ingest', 'Done'] as const;
 const activeStage = (j: MigrationJobView): number => {
@@ -394,6 +405,16 @@ function JobCard({
         <PhaseProgress job={job} />
       </div>
 
+      {job.status === 'COMPLETED' && typeof job.ingestDurationMs === 'number' && (
+        <div className='mt-3 flex items-start gap-2 rounded-lg bg-emerald-500/10 px-3 py-2 text-xs text-emerald-600 dark:text-emerald-400'>
+          <Info className='mt-0.5 size-3.5 shrink-0' />
+          <span>
+            Ingested {job.stats.messages.toLocaleString()} messages in{' '}
+            <span className='font-medium tabular-nums'>{fmtDuration(job.ingestDurationMs)}</span>
+          </span>
+        </div>
+      )}
+
       {job.status === 'FAILED' && job.error && (
         <div className='mt-3 flex items-start gap-2 rounded-lg bg-destructive/10 px-3 py-2 text-xs text-destructive'>
           <TriangleAlert className='mt-0.5 size-3.5 shrink-0' />
@@ -413,13 +434,19 @@ function JobCard({
       )}
 
       {job.issues && job.issues.length > 0 && (
-        <div className='mt-3 flex items-start gap-2 rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400'>
-          <TriangleAlert className='mt-0.5 size-3.5 shrink-0' />
-          <span className='break-words'>
-            {job.issues.length} conversation{job.issues.length > 1 ? 's' : ''} not fully migrated —{' '}
-            {job.issues[0]?.reason}
-            {job.issues.length > 1 ? ` (+${job.issues.length - 1} more)` : ''}
-          </span>
+        <div className='mt-3 rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400'>
+          <div className='flex items-center gap-2 font-medium'>
+            <TriangleAlert className='size-3.5 shrink-0' />
+            {job.issues.length} conversation{job.issues.length > 1 ? 's' : ''} not fully migrated
+          </div>
+          <ul className='mt-1.5 space-y-1 pl-5'>
+            {job.issues.map((issue, i) => (
+              <li key={`${issue.conversationId}-${i}`} className='break-words'>
+                <span className='font-medium'>{issue.label ?? issue.conversationId}</span>
+                <span className='text-amber-600/70 dark:text-amber-400/70'> — {issue.reason}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       )}
 


### PR DESCRIPTION
**Parallelize self-serve Slack migration ingestion** — fan conversations out across N forked worker processes (`MIGRATION_WORKER_PROCESSES`) draining a `CONV_INGEST` queue with an atomic Redis done-set + once-only finalize, plus an opt-in bulk `createMany` path — cuts ~120k-message migrations from ~2h to minutes, resumable and idempotent.

**Bulk-path parity** with the per-message path: mentioned users → MENTIONED participants; resume re-sync of `replyCount`/`lastActivityAt`/`replies_md` + participant read-state; attachment full-text Vespa; custom emoji; replyBroadcast child conversations; `channel_migrated` analytics. Also initialises the Vespa producer queues in the worker so migrated messages are actually indexed.

**Reliability + UX** — move the slow per-channel seen-cutoff scan out of the `addParticipant` write transaction (fixes P2028 timeouts under load); suppress workflows/automations for migrated history; surface per-conversation failures + ingest duration in the dashboard; bake `VITE_SLACK_APP_INSTALL_URL` at build.

**Runtime config → Superposition** — move the live-tunable migration knobs (bulk toggle, batch size, message delay, file concurrency, page/list delays, file/request timeouts, stall limit) out of env into a single Superposition JSON key `SlackSelfService`, resolved at point-of-use so they can be tuned without a redeploy. Present fields override in-code defaults; missing key / outage falls back to defaults (never breaks ingestion). Only restart-required knobs (`MIGRATION_WORKER_PROCESSES`, `MIGRATION_INGEST_CONCURRENCY`) and secrets stay in env.
