### PR TITLE
fix: XYNE-61740 video recording stream

### DIFF
--- a/apps/dashboard/src/components/ui/MessageBubble/InlineVideoPreview.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/InlineVideoPreview.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { BASE_URL } from '../../../services/clients/apiClient';
+import { recordingService } from '../../../services/Recording/recordingService';
+
+interface InlineVideoPreviewProps {
+  callId: string;
+  recordingId?: string;
+  /** The recording's own attachment row, when the message has one. */
+  attachmentId?: string;
+}
+
+/**
+ * Inline player for a call recording posted in a thread.
+ *
+ * Prefers the shared range-request stream endpoint — the same one VideoViewer
+ * uses for every other video — and keeps the legacy blob download as a fallback
+ * for messages that predate the recording's attachment row.
+ */
+export function InlineVideoPreview({
+  callId,
+  recordingId,
+  attachmentId,
+}: InlineVideoPreviewProps): React.ReactElement {
+  const [blobUrl, setBlobUrl] = React.useState<string | null>(null);
+  const [streamFailed, setStreamFailed] = React.useState(false);
+  const blobUrlRef = React.useRef<string | null>(null);
+
+  // Every recording posts its own attachment row, so the range-request stream
+  // endpoint can serve the file: playback starts on the first chunk and seeking
+  // works, instead of waiting for the whole recording to download. If that
+  // request fails the effect below falls back to the blob download.
+  const streamUrl =
+    attachmentId && !streamFailed ? `${BASE_URL}/attachments/${attachmentId}/stream` : null;
+
+  React.useEffect(() => {
+    // Streaming path needs no blob — skip the download entirely.
+    if (streamUrl) return;
+    let cancelled = false;
+    // Per-recording download when we have a recordingId; fall back to the legacy
+    // latest-recording path for older messages that predate the field.
+    const fetchBlob = recordingId
+      ? recordingService.downloadCallRecordingBlob(callId, recordingId)
+      : recordingService.downloadRecordingBlob(callId);
+    fetchBlob
+      .then(blob => {
+        if (cancelled) return;
+        const url = URL.createObjectURL(blob);
+        blobUrlRef.current = url;
+        setBlobUrl(url);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      if (blobUrlRef.current) URL.revokeObjectURL(blobUrlRef.current);
+    };
+  }, [callId, recordingId, streamUrl]);
+
+  const src = streamUrl ?? blobUrl;
+  if (!src) return <></>;
+  return (
+    <video
+      src={src}
+      // Credentialed CORS matches what the stream route's middleware serves —
+      // API_BASE_URL is a different origin in dev and in the desktop app. These
+      // are meaningless on a blob: URL, so the fallback stays as it was.
+      {...(streamUrl
+        ? {
+            crossOrigin: 'use-credentials' as const,
+            preload: 'metadata',
+            onError: () => setStreamFailed(true),
+          }
+        : {})}
+      controls
+      className='mt-2 rounded-md max-w-sm w-full'
+      style={{ maxHeight: '240px' }}
+    >
+      <track kind='captions' />
+    </video>
+  );
+}

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -97,6 +97,7 @@ import { isPreviewableDocument } from '../../../services/documentThumbnailServic
 import { ChannelEmailCard } from './ChannelEmailCard';
 import { AudioPlayer } from '../AudioPlayer/AudioPlayer';
 import { recordingService } from '../../../services/Recording/recordingService';
+import { InlineVideoPreview } from './InlineVideoPreview';
 import { loadEmojiData } from '../../../utils/emojiLookup';
 import { RecordingShareContent } from './RecordingShareContent';
 import { useRecordingShareMessage } from './recordingShareMessage';
@@ -130,50 +131,6 @@ const hasDocumentThumbnail = (attachment: AttachmentType): boolean => {
 const isHtmlAttachment = (attachment: AttachmentType): boolean => {
   return attachment.mimetype === 'text/html' || /\.html?$/i.test(attachment.originalFilename);
 };
-
-function InlineVideoPreview({
-  callId,
-  recordingId,
-}: {
-  callId: string;
-  recordingId?: string;
-}): React.ReactElement {
-  const [blobUrl, setBlobUrl] = React.useState<string | null>(null);
-  const blobUrlRef = React.useRef<string | null>(null);
-
-  React.useEffect(() => {
-    let cancelled = false;
-    // Per-recording download when we have a recordingId; fall back to the legacy
-    // latest-recording path for older messages that predate the field.
-    const fetchBlob = recordingId
-      ? recordingService.downloadCallRecordingBlob(callId, recordingId)
-      : recordingService.downloadRecordingBlob(callId);
-    fetchBlob
-      .then(blob => {
-        if (cancelled) return;
-        const url = URL.createObjectURL(blob);
-        blobUrlRef.current = url;
-        setBlobUrl(url);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-      if (blobUrlRef.current) URL.revokeObjectURL(blobUrlRef.current);
-    };
-  }, [callId, recordingId]);
-
-  if (!blobUrl) return <></>;
-  return (
-    <video
-      src={blobUrl}
-      controls
-      className='mt-2 rounded-md max-w-sm w-full'
-      style={{ maxHeight: '240px' }}
-    >
-      <track kind='captions' />
-    </video>
-  );
-}
 
 /**
  * AttachmentsBlock renders message attachments with expand/collapse functionality.
@@ -629,6 +586,18 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
       (a.metadata as Record<string, unknown> | null)?.['type'] === 'transcript' ||
       (a.metadata as Record<string, unknown> | null)?.['type'] === 'identified_transcript',
   );
+  // The recording message carries its own attachment row (filtered out of the
+  // attachments block below). Its id lets InlineVideoPreview stream the file
+  // through the range-request endpoint instead of downloading it whole.
+  const recordingAttachmentId =
+    metadata?.messageSubtype === 'recording'
+      ? attachments.find(a => {
+          const attMeta = a.metadata as { type?: string; recordingId?: string } | null;
+          if (attMeta?.type !== 'recording' || !a.mimetype.startsWith('video/')) return false;
+          // Older messages predate recordingId on the metadata — match on type alone there.
+          return !metadata?.recordingId || attMeta.recordingId === String(metadata.recordingId);
+        })?.id
+      : undefined;
   const isCallNoTranscript =
     isCallMessage && !isActiveCall && !isForwardedMessage && !hasTranscript;
   const isMentionUserAddition = metadata?.messageSubtype === 'user_not_in_channel';
@@ -1316,6 +1285,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                         {...(metadata?.recordingId
                           ? { recordingId: String(metadata.recordingId) }
                           : {})}
+                        {...(recordingAttachmentId ? { attachmentId: recordingAttachmentId } : {})}
                       />
                     ) : (
                       <div className='mt-2'>


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
