### PR TITLE
feat: XYNE-56669 rebuild the Xyne AI Digital Twin screen (#890)

### DIFF
--- a/apps/dashboard/src/components/ui/SegmentedToggle/SegmentedToggle.tsx
+++ b/apps/dashboard/src/components/ui/SegmentedToggle/SegmentedToggle.tsx
@@ -8,11 +8,19 @@ export interface SegmentedToggleOption<T extends string> {
   title?: string;
 }
 
+const TONE = {
+  accent: { pill: 'bg-action-primary', label: 'text-action-primary-foreground' },
+  primary: { pill: 'bg-primary', label: 'text-primary-foreground' },
+} as const;
+
 interface SegmentedToggleProps<T extends string> {
   options: SegmentedToggleOption<T>[];
   value: T;
   onChange: (value: T) => void;
   className?: string;
+  tone?: keyof typeof TONE;
+  trackCategory?: string;
+  trackPrefix?: string;
 }
 
 export function SegmentedToggle<T extends string>({
@@ -20,7 +28,11 @@ export function SegmentedToggle<T extends string>({
   value,
   onChange,
   className,
+  tone = 'accent',
+  trackCategory,
+  trackPrefix,
 }: SegmentedToggleProps<T>): React.ReactElement {
+  const toneClass = TONE[tone];
   const containerRef = useRef<HTMLDivElement>(null);
   const [pillStyle, setPillStyle] = useState<{ left: number; width: number }>({
     left: 0,
@@ -60,7 +72,10 @@ export function SegmentedToggle<T extends string>({
     >
       {/* Inline style required: pill position is dynamically measured from DOM via ResizeObserver */}
       <div
-        className='absolute top-0.5 bottom-0.5 rounded-full bg-action-primary transition-[left,width] duration-200 ease-in-out'
+        className={cn(
+          'absolute top-0.5 bottom-0.5 rounded-full transition-[left,width] duration-200 ease-in-out',
+          toneClass.pill,
+        )}
         style={{ left: pillStyle.left, width: pillStyle.width }}
       />
 
@@ -73,16 +88,16 @@ export function SegmentedToggle<T extends string>({
             type='button'
             data-slot='segmented-toggle-item'
             onClick={() => onChange(option.value)}
-            data-track-category='SEGMENTED_TOGGLE'
-            data-track-name='CHANGE_SEGMENT'
+            data-track-category={trackCategory ?? 'SEGMENTED_TOGGLE'}
+            data-track-name={
+              trackPrefix ? `${trackPrefix}: ${option.label ?? option.value}` : 'CHANGE_SEGMENT'
+            }
             data-track-metadata={JSON.stringify({ value: option.value })}
             title={option.title}
             className={cn(
               'relative z-10 flex h-full items-center justify-center gap-1.5 rounded-full whitespace-nowrap',
               hasLabel ? 'px-2.5 text-sm font-normal' : 'size-8',
-              isActive
-                ? 'text-action-primary-foreground'
-                : 'text-muted-foreground hover:text-foreground',
+              isActive ? toneClass.label : 'text-muted-foreground hover:text-foreground',
             )}
           >
             {option.icon}

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/DigitalTwin.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/DigitalTwin.tsx
@@ -1,0 +1,191 @@
+import { useState, type ReactElement } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Refresh, StopCircle, UploadUp } from '@xyne/icons';
+import { Button } from '@/components/ui/Button/index';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { Tabs } from '@/components/ui/Tabs';
+import Tooltip from '@/components/ui/Tooltip';
+import { useClawDigitalTwinStatus } from '@/hooks/useClawDigitalTwin';
+import { DigitalTwinBanner } from './components/DigitalTwinBanner';
+import { DigitalTwinEnablePanel } from './components/DigitalTwinEnablePanel';
+import { EnableModal } from './components/EnableModal';
+import { DisableModal } from './components/DisableModal';
+import { UploadModal } from './components/UploadModal';
+import type { DigitalTwinStatus } from '@/services/claw/digitalTwinTypes';
+import DigitalTwinMemoriesTab from './tabs/DigitalTwinMemoriesTab';
+import DigitalTwinHotTab from './tabs/DigitalTwinHotTab';
+import DigitalTwinProposalsTab from './tabs/DigitalTwinProposalsTab';
+import DigitalTwinRecallTab from './tabs/DigitalTwinRecallTab';
+import DigitalTwinGraphTab from './tabs/DigitalTwinGraphTab';
+import DigitalTwinSettingsTab from './tabs/DigitalTwinSettingsTab';
+import DigitalTwinMetricsTab from './tabs/DigitalTwinMetricsTab';
+import { Pill } from '../library/shared/primitives/Pill';
+import { DIGITAL_TWIN_TABS, resolveDigitalTwinTab, type DigitalTwinTabId } from './digitalTwinTabs';
+
+const TRACK_CATEGORY = 'Claw Digital Twin';
+
+const statusDetail = (
+  status: DigitalTwinStatus,
+  backfillRunning: boolean,
+  backfillStalled: boolean,
+): string => {
+  if (backfillRunning) {
+    return backfillStalled
+      ? 'Backfill stalled — no progress recently.'
+      : 'Backfilling your Spaces history…';
+  }
+  const parts: string[] = [];
+  if (status.pendingCandidates > 0) parts.push(`${status.pendingCandidates} pending review`);
+  if (status.approvedCandidates > 0) parts.push(`${status.approvedCandidates} approved`);
+  if (status.mdFileCount > 0)
+    parts.push(`${status.mdFileCount} uploaded file${status.mdFileCount === 1 ? '' : 's'}`);
+  return parts.length ? parts.join(' · ') : 'No memories yet — run a backfill or upload a .md.';
+};
+
+const DigitalTwin = (): ReactElement => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = resolveDigitalTwinTab(searchParams.get('tab'));
+
+  const { data: status, isLoading, backfillStalled } = useClawDigitalTwinStatus();
+
+  const [showBackfill, setShowBackfill] = useState(false);
+  const [showDisable, setShowDisable] = useState(false);
+  const [showUpload, setShowUpload] = useState(false);
+
+  const enabled = !!status?.enabled;
+  const loadingFirst = isLoading && !status;
+  const backfillRunning = !!(
+    status?.backfillState && Object.values(status.backfillState).some(s => !s.complete)
+  );
+
+  const setActiveTab = (nextTab: DigitalTwinTabId): void => {
+    const next = new URLSearchParams(searchParams);
+    next.set('tab', nextTab);
+    setSearchParams(next, { replace: true });
+  };
+
+  return (
+    <div className='max-w-ai-content mx-auto flex h-full min-h-0 w-full flex-col px-6'>
+      <div className='bg-background flex shrink-0 flex-col'>
+        <div className='flex flex-col justify-center gap-1 pt-5'>
+          <div className='flex min-w-0 items-center gap-2'>
+            <h1 className='truncate text-2xl font-semibold leading-tight tracking-tight text-foreground'>
+              Digital Twin
+            </h1>
+            {enabled && status && (
+              <Tooltip
+                side='bottom'
+                content={statusDetail(status, backfillRunning, backfillStalled)}
+              >
+                <span className='flex'>
+                  <Pill tone={backfillRunning ? 'warning' : 'success'}>
+                    {backfillRunning ? (backfillStalled ? 'Stalled' : 'Backfilling') : 'Active'}
+                  </Pill>
+                </span>
+              </Tooltip>
+            )}
+
+            {enabled && (
+              <div className='ml-auto flex shrink-0 items-center gap-1'>
+                <Tooltip content='Backfill history' side='top'>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='iconSm'
+                    onClick={() => setShowBackfill(true)}
+                    aria-label='Backfill history'
+                    data-track-category={TRACK_CATEGORY}
+                    data-track-name='Digital Twin: open backfill'
+                    className='text-muted-foreground hover:text-foreground focus-visible:bg-muted focus-visible:ring-0'
+                  >
+                    <Refresh className='size-4' aria-hidden />
+                  </Button>
+                </Tooltip>
+                <Tooltip content='Upload markdown' side='top'>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='iconSm'
+                    onClick={() => setShowUpload(true)}
+                    aria-label='Upload markdown'
+                    data-track-category={TRACK_CATEGORY}
+                    data-track-name='Digital Twin: open upload'
+                    className='text-muted-foreground hover:text-foreground focus-visible:bg-muted focus-visible:ring-0'
+                  >
+                    <UploadUp className='size-4' aria-hidden />
+                  </Button>
+                </Tooltip>
+                <Tooltip content='Disable Twin' side='top'>
+                  <Button
+                    type='button'
+                    variant='ghost'
+                    size='iconSm'
+                    onClick={() => setShowDisable(true)}
+                    aria-label='Disable Twin'
+                    data-track-category={TRACK_CATEGORY}
+                    data-track-name='Digital Twin: open disable'
+                    className='text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:bg-muted focus-visible:ring-0'
+                  >
+                    <StopCircle className='size-4' aria-hidden />
+                  </Button>
+                </Tooltip>
+              </div>
+            )}
+          </div>
+          <p className='text-sm leading-tight text-muted-foreground'>
+            Learns how you work — you control what it remembers.
+          </p>
+        </div>
+
+        {enabled && (
+          <div className='mt-3 flex flex-col gap-3 pb-3 pt-2'>
+            <Tabs
+              items={DIGITAL_TWIN_TABS}
+              activeId={activeTab}
+              onSelect={id => setActiveTab(id as DigitalTwinTabId)}
+              trackCategory={TRACK_CATEGORY}
+              trackPrefix='Digital Twin tab'
+            />
+          </div>
+        )}
+      </div>
+
+      {loadingFirst ? (
+        <div className='flex min-h-0 flex-1 flex-col gap-4 overflow-auto no-scrollbar pb-6'>
+          <Skeleton className='h-20 w-full rounded-xl' />
+          <Skeleton className='h-64 w-full rounded-xl' />
+        </div>
+      ) : enabled ? (
+        <div className='flex min-h-0 flex-1 flex-col gap-6 overflow-auto no-scrollbar pb-6'>
+          {backfillRunning && (
+            <DigitalTwinBanner
+              status={status}
+              loading={isLoading}
+              backfillStalled={backfillStalled}
+              onEnable={() => undefined}
+              onDisable={() => setShowDisable(true)}
+            />
+          )}
+
+          {activeTab === 'memories' && <DigitalTwinMemoriesTab />}
+          {activeTab === 'hot' && <DigitalTwinHotTab />}
+          {activeTab === 'proposals' && <DigitalTwinProposalsTab />}
+          {activeTab === 'recall' && <DigitalTwinRecallTab />}
+          {activeTab === 'graph' && <DigitalTwinGraphTab />}
+          {activeTab === 'metrics' && <DigitalTwinMetricsTab />}
+          {activeTab === 'settings' && <DigitalTwinSettingsTab />}
+        </div>
+      ) : (
+        <div className='flex min-h-0 flex-1 flex-col overflow-auto no-scrollbar pb-6 pt-6'>
+          <DigitalTwinEnablePanel />
+        </div>
+      )}
+
+      <EnableModal open={showBackfill} mode='backfill' onClose={() => setShowBackfill(false)} />
+      <DisableModal open={showDisable} onClose={() => setShowDisable(false)} />
+      <UploadModal open={showUpload} onClose={() => setShowUpload(false)} />
+    </div>
+  );
+};
+
+export default DigitalTwin;

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/CandidateRow.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/CandidateRow.tsx
@@ -1,0 +1,241 @@
+import { ReactElement, ReactNode, useState } from 'react';
+import {
+  CheckTickCircle,
+  MultipleCrossCancelCircle,
+  MultipleCrossCancelDefault,
+  PencilEdit,
+  Spinner,
+} from '@xyne/icons';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/Button/index';
+import { Tooltip } from '@/components/ui/Tooltip/Tooltip';
+import { TruncatedTooltip } from '@/components/ui/Tooltip/TruncatedTooltip';
+import { HighlightMatch } from '@/routes/AIScreen/library/admin/components/HighlightMatch';
+import { cn } from '@/utils/classNames';
+import { usePatchDigitalTwinCandidate } from '@/hooks/useClawDigitalTwin';
+import type { DigitalTwinCandidate } from '@/services/claw/digitalTwinTypes';
+import { MetaRow } from '@/routes/AIScreen/library/shared/primitives/MetaRow';
+import { scoreToneClass } from './format';
+import { SUBSYSTEM_ICONS, subsystemLabel } from './subsystems';
+
+const TONE_CLASS: Record<'default' | 'success' | 'danger', string> = {
+  default: 'text-muted-foreground hover:text-foreground',
+  success: 'text-muted-foreground hover:bg-status-success/10 hover:text-status-success',
+  danger: 'text-muted-foreground hover:bg-destructive/10 hover:text-destructive',
+};
+
+const RowAction = ({
+  label,
+  icon,
+  onClick,
+  disabled,
+  tone = 'default',
+  trackName,
+}: {
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+  disabled: boolean;
+  tone?: 'default' | 'success' | 'danger';
+  trackName: string;
+}): ReactElement => (
+  <Tooltip side='top' content={label}>
+    <Button
+      type='button'
+      variant='ghost'
+      size='icon'
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      data-track-category='Claw Agents'
+      data-track-name={trackName}
+      className={cn('size-7 focus-visible:bg-muted focus-visible:ring-0', TONE_CLASS[tone])}
+    >
+      {icon}
+    </Button>
+  </Tooltip>
+);
+
+export const CandidateRow = ({
+  candidate,
+  onApproved,
+  onRejected,
+  query = '',
+}: {
+  candidate: DigitalTwinCandidate;
+  onApproved: (id: string) => void;
+  onRejected: (id: string) => void;
+  query?: string;
+}): ReactElement => {
+  const patch = usePatchDigitalTwinCandidate();
+  const [acting, setActing] = useState<'approve' | 'reject' | 'save' | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(candidate.editedText ?? candidate.text);
+  const [committed, setCommitted] = useState(candidate.editedText ?? candidate.text);
+
+  const isBusy = acting !== null;
+  const isDirty = text.trim() !== committed.trim();
+  const SubsystemIcon = SUBSYSTEM_ICONS[candidate.subsystem];
+
+  const handleApprove = async (): Promise<void> => {
+    setActing('approve');
+    try {
+      await patch.mutateAsync({
+        id: candidate.id,
+        patch: { ...(isDirty ? { editedText: text.trim() } : {}), status: 'approved' },
+      });
+      toast.success('Approved — memory saved to Hindsight');
+      onApproved(candidate.id);
+    } finally {
+      setActing(null);
+    }
+  };
+
+  const handleReject = async (): Promise<void> => {
+    setActing('reject');
+    try {
+      await patch.mutateAsync({ id: candidate.id, patch: { status: 'rejected' } });
+      toast.success('Rejected');
+      onRejected(candidate.id);
+    } finally {
+      setActing(null);
+    }
+  };
+
+  const handleSave = async (): Promise<void> => {
+    if (!isDirty) {
+      setEditing(false);
+      return;
+    }
+    setActing('save');
+    try {
+      await patch.mutateAsync({ id: candidate.id, patch: { editedText: text.trim() } });
+      setCommitted(text.trim());
+      setEditing(false);
+      toast.success('Edit saved');
+    } finally {
+      setActing(null);
+    }
+  };
+
+  return (
+    <li className='flex w-full items-center gap-3 border-b border-border px-1 py-4'>
+      <Tooltip side='top' content={subsystemLabel(candidate.subsystem)}>
+        <span className='flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground'>
+          {SubsystemIcon && <SubsystemIcon className='size-4' aria-hidden />}
+        </span>
+      </Tooltip>
+
+      <div className='min-w-0 flex-1'>
+        {editing ? (
+          <textarea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin edit candidate text'
+            disabled={isBusy}
+            rows={3}
+            autoFocus
+            className='w-full resize-none rounded-lg border border-primary bg-background px-2.5 py-1.5 text-sm leading-relaxed text-foreground focus:outline-none disabled:opacity-60'
+          />
+        ) : (
+          <TruncatedTooltip content={committed}>
+            <p className='truncate text-sm leading-relaxed text-foreground'>
+              <HighlightMatch text={committed} query={query} />
+            </p>
+          </TruncatedTooltip>
+        )}
+        <MetaRow
+          className='mt-1'
+          items={[
+            <span
+              key='confidence'
+              className={cn('font-medium', scoreToneClass(candidate.signalScore))}
+            >
+              {Math.round(candidate.signalScore * 100)}% confidence
+            </span>,
+            isDirty && !editing && (
+              <span key='edited' className='font-medium text-status-pending'>
+                edited
+              </span>
+            ),
+            (candidate.sourceRefs?.length ?? 0) > 0 && (
+              <span key='sources'>
+                {candidate.sourceRefs.length} source{candidate.sourceRefs.length !== 1 ? 's' : ''}
+              </span>
+            ),
+          ]}
+        />
+      </div>
+
+      <div className='flex shrink-0 items-center gap-2'>
+        {editing ? (
+          <>
+            <RowAction
+              label='Save edit'
+              trackName='Digital Twin save candidate edit'
+              disabled={isBusy}
+              tone='success'
+              onClick={() => void handleSave()}
+              icon={
+                acting === 'save' ? (
+                  <Spinner className='size-4 animate-spin' />
+                ) : (
+                  <CheckTickCircle className='size-4' />
+                )
+              }
+            />
+            <RowAction
+              label='Cancel'
+              trackName='Digital Twin cancel candidate edit'
+              disabled={isBusy}
+              onClick={() => {
+                setText(committed);
+                setEditing(false);
+              }}
+              icon={<MultipleCrossCancelDefault className='size-4' />}
+            />
+          </>
+        ) : (
+          <>
+            <RowAction
+              label='Edit'
+              trackName='Digital Twin edit candidate'
+              disabled={isBusy}
+              onClick={() => setEditing(true)}
+              icon={<PencilEdit className='size-4' />}
+            />
+            <RowAction
+              label={isDirty ? 'Save & approve' : 'Approve'}
+              trackName='Digital Twin approve candidate'
+              disabled={isBusy}
+              tone='success'
+              onClick={() => void handleApprove()}
+              icon={
+                acting === 'approve' ? (
+                  <Spinner className='size-4 animate-spin' />
+                ) : (
+                  <CheckTickCircle className='size-4' />
+                )
+              }
+            />
+            <RowAction
+              label='Reject'
+              trackName='Digital Twin reject candidate'
+              disabled={isBusy}
+              tone='danger'
+              onClick={() => void handleReject()}
+              icon={
+                acting === 'reject' ? (
+                  <Spinner className='size-4 animate-spin' />
+                ) : (
+                  <MultipleCrossCancelCircle className='size-4' />
+                )
+              }
+            />
+          </>
+        )}
+      </div>
+    </li>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/CategoryBadge.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/CategoryBadge.tsx
@@ -1,0 +1,25 @@
+import { ReactElement } from 'react';
+import { cn } from '@/utils/classNames';
+import { CATEGORY_STYLES } from './subsystems';
+
+export const CategoryBadge = ({ category }: { category: string | null }): ReactElement | null => {
+  if (!category) return null;
+  const style = CATEGORY_STYLES[category.toLowerCase()];
+  if (!style) {
+    return (
+      <span className='rounded border border-border px-1.5 py-px text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+        {category}
+      </span>
+    );
+  }
+  return (
+    <span
+      className={cn(
+        'rounded border px-1.5 py-px text-xs font-medium uppercase tracking-wide',
+        style.className,
+      )}
+    >
+      {style.label}
+    </span>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DateRangeInputs.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DateRangeInputs.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react';
+import {
+  isoDate,
+  type UseDigitalTwinRangeResult,
+} from '@/components/ClawAgents/digitalTwin/useDigitalTwinRange';
+
+const INPUT_CLASS =
+  'w-auto shrink-0 rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground focus:border-ring focus:outline-none';
+
+export const DateRangeInputs = ({
+  range,
+  trackName,
+  showDayCount = false,
+}: {
+  range: UseDigitalTwinRangeResult;
+  trackName: string;
+  showDayCount?: boolean;
+}): ReactElement => (
+  <div className='flex flex-wrap items-center gap-2'>
+    <input
+      type='date'
+      value={range.customFrom}
+      max={range.customTo}
+      onChange={e => range.setCustomFrom(e.target.value)}
+      data-track-category='Claw Agents'
+      data-track-name={`${trackName} from date`}
+      className={INPUT_CLASS}
+    />
+    <span className='shrink-0 text-xs text-muted-foreground'>→</span>
+    <input
+      type='date'
+      value={range.customTo}
+      min={range.customFrom}
+      max={isoDate(new Date())}
+      onChange={e => range.setCustomTo(e.target.value)}
+      data-track-category='Claw Agents'
+      data-track-name={`${trackName} to date`}
+      className={INPUT_CLASS}
+    />
+    {showDayCount && range.customDays > 0 && (
+      <span className='shrink-0 text-xs tabular-nums text-muted-foreground'>
+        {range.customDays}d
+      </span>
+    )}
+  </div>
+);

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DigitalTwinBanner.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DigitalTwinBanner.tsx
@@ -1,0 +1,235 @@
+import { ReactElement } from 'react';
+import { AlertTriangle, Brain, CheckCircle2, Info, Loader2, XCircle } from 'lucide-react';
+import { Tooltip } from '@/components/ui/Tooltip/Tooltip';
+import { cn } from '@/utils/classNames';
+import type { DigitalTwinStatus } from '@/services/claw/digitalTwinTypes';
+
+const LABEL_TOOLTIP =
+  'Your personal AI. When someone mentions you, the Twin drafts a reply on your behalf, grounded in memories you approved. Every memory passes through your review queue first.';
+
+const InfoDot = ({ text }: { text: string }): ReactElement => (
+  <Tooltip side='top' content={text}>
+    <Info className='size-3.5 text-muted-foreground' />
+  </Tooltip>
+);
+
+interface DigitalTwinBannerProps {
+  status: DigitalTwinStatus | undefined;
+  loading: boolean;
+  backfillStalled?: boolean;
+  onEnable: () => void;
+  onDisable: () => void;
+}
+
+export const DigitalTwinBanner = ({
+  status,
+  loading,
+  backfillStalled = false,
+  onEnable,
+  onDisable,
+}: DigitalTwinBannerProps): ReactElement => {
+  if (loading || !status) {
+    return (
+      <div className='rounded-xl border border-border bg-card p-4'>
+        <div className='flex items-center gap-2'>
+          <Loader2 className='size-4 animate-spin text-muted-foreground' />
+          <span className='text-sm text-muted-foreground'>Loading Digital Twin…</span>
+        </div>
+      </div>
+    );
+  }
+
+  const backfillRunning = status.backfillState
+    ? Object.values(status.backfillState).some(s => !s.complete)
+    : false;
+
+  if (!status.enabled) {
+    return (
+      <div className='overflow-hidden rounded-xl border border-status-success/30 bg-card'>
+        <div className='h-0.5 w-full bg-status-success/40' />
+        <div className='p-4'>
+          <div className='flex items-start gap-2.5'>
+            <Brain className='mt-px size-[18px] shrink-0 text-status-success' />
+            <div className='min-w-0 flex-1'>
+              <div className='flex items-center gap-1.5'>
+                <p className='text-sm font-semibold text-foreground'>Digital Twin</p>
+                <InfoDot text={LABEL_TOOLTIP} />
+              </div>
+              <p className='mt-0.5 text-xs leading-relaxed text-muted-foreground'>
+                Learns from your Spaces history — every memory passes your review before it&apos;s
+                saved.
+              </p>
+            </div>
+          </div>
+          <button
+            type='button'
+            onClick={onEnable}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin enable'
+            className='mt-3.5 flex w-full items-center justify-center gap-2 rounded-lg bg-status-success px-3.5 py-2 text-sm font-semibold text-white transition hover:bg-status-success/90'
+          >
+            <Brain className='size-4' />
+            Enable Digital Twin
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (backfillRunning) {
+    const entries = Object.values(status.backfillState!);
+    const overallPct = Math.round(
+      entries.reduce((sum, e) => {
+        if (e.complete) return sum + 100;
+        const total = new Date(e.to).getTime() - new Date(e.from).getTime();
+        const elapsed = new Date(e.to).getTime() - new Date(e.cursor).getTime();
+        return sum + (total > 0 ? Math.min(100, Math.round((elapsed / total) * 100)) : 100);
+      }, 0) / (entries.length || 1),
+    );
+
+    return (
+      <div className='overflow-hidden rounded-xl border border-border bg-card'>
+        <style>{`@keyframes dt-slide { 0%{transform:translateX(-130%)} 100%{transform:translateX(400%)} }`}</style>
+
+        {backfillStalled ? (
+          <div className='h-0.5 w-full bg-foreground' />
+        ) : (
+          <div className='h-0.5 w-full overflow-hidden bg-border'>
+            <div
+              className='h-full w-[38%] rounded-full bg-foreground opacity-50'
+              style={{ animation: 'dt-slide 2.2s cubic-bezier(0.4,0,0.6,1) infinite' }}
+            />
+          </div>
+        )}
+
+        {backfillStalled && (
+          <div className='flex flex-wrap items-center justify-between gap-2.5 border-b border-border bg-muted/40 px-3.5 py-2.5'>
+            <div className='flex items-center gap-2'>
+              <AlertTriangle className='size-3.5 shrink-0 text-foreground' />
+              <span className='text-xs font-semibold text-foreground'>Backfill stalled</span>
+              <span className='text-xs text-muted-foreground'>No progress in 30 s</span>
+            </div>
+            <button
+              type='button'
+              onClick={onDisable}
+              data-track-category='Claw Agents'
+              data-track-name='Digital Twin disable and retry backfill'
+              className='rounded-lg border border-border bg-card px-2.5 py-1 text-xs font-semibold text-foreground transition hover:bg-muted'
+            >
+              Disable &amp; retry
+            </button>
+          </div>
+        )}
+
+        <div className='flex items-center gap-2 border-b border-border px-3.5 py-2.5'>
+          {backfillStalled ? (
+            <XCircle className='size-3.5 shrink-0 text-muted-foreground' />
+          ) : (
+            <Loader2 className='size-3.5 shrink-0 animate-spin text-muted-foreground' />
+          )}
+          <span className='text-xs font-medium text-foreground'>Backfilling your history</span>
+          <span className='text-xs tabular-nums text-muted-foreground'>{overallPct}%</span>
+        </div>
+
+        <div
+          className='grid gap-px bg-border'
+          style={{ gridTemplateColumns: `repeat(${entries.length}, 1fr)` }}
+        >
+          {Object.entries(status.backfillState!).map(([source, entry]) => {
+            const to = new Date(entry.to);
+            const from = new Date(entry.from);
+            const cursor = new Date(entry.cursor);
+            const total = to.getTime() - from.getTime();
+            const elapsed = to.getTime() - cursor.getTime();
+            const pct =
+              total > 0 ? Math.min(100, Math.max(0, Math.round((elapsed / total) * 100))) : 100;
+            const isStuck = backfillStalled && !entry.complete;
+            const fillWidth = entry.complete ? 100 : isStuck ? Math.max(pct, 4) : pct;
+            const barOpacity = entry.complete
+              ? 'opacity-100'
+              : isStuck
+                ? 'opacity-30'
+                : pct > 0
+                  ? 'opacity-60'
+                  : 'opacity-0';
+            const badgeLabel = entry.complete
+              ? 'Done ✓'
+              : isStuck
+                ? 'Stalled'
+                : pct > 0
+                  ? `${pct}%`
+                  : 'Queued';
+            const badgeCls = entry.complete
+              ? 'bg-status-success text-white'
+              : isStuck
+                ? 'border border-status-pending/50 bg-status-pending/10 text-status-pending'
+                : pct > 0
+                  ? 'bg-foreground/15 text-foreground'
+                  : 'bg-border text-muted-foreground';
+
+            return (
+              <div key={source} className='flex flex-col gap-2 bg-card p-3'>
+                <div className='flex items-center justify-between gap-1.5'>
+                  <span className='text-xs font-semibold capitalize text-foreground'>{source}</span>
+                  {entry.complete ? (
+                    <CheckCircle2 className='size-4 text-status-success' />
+                  ) : (
+                    <span className={cn('rounded-full px-1.5 py-px text-xs font-medium', badgeCls)}>
+                      {badgeLabel}
+                    </span>
+                  )}
+                </div>
+                <div className='h-[3px] overflow-hidden rounded-full bg-border'>
+                  <div
+                    className={cn(
+                      'h-full rounded-full bg-foreground transition-all duration-700',
+                      barOpacity,
+                    )}
+                    style={{ width: `${fillWidth}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  const hasPending = status.pendingCandidates > 0;
+
+  return (
+    <div className='overflow-hidden rounded-xl border border-border bg-card'>
+      <div className='h-0.5 w-full bg-status-success/50' />
+      <div className='flex items-start gap-2.5 px-4 py-3.5'>
+        <CheckCircle2 className='mt-px size-[18px] shrink-0 text-status-success' />
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center gap-1.5 text-sm font-semibold text-foreground'>
+            Digital Twin is active
+            <InfoDot text={LABEL_TOOLTIP} />
+          </div>
+          <div className='mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground'>
+            {hasPending ? (
+              <span className='font-medium text-status-pending'>
+                {status.pendingCandidates} memor{status.pendingCandidates === 1 ? 'y' : 'ies'}{' '}
+                pending review
+              </span>
+            ) : status.approvedCandidates > 0 ? (
+              <span>
+                {status.approvedCandidates} approved memor
+                {status.approvedCandidates === 1 ? 'y' : 'ies'}
+              </span>
+            ) : (
+              <span>No memories yet — run a backfill or upload a .md to get started</span>
+            )}
+            {status.mdFileCount > 0 && (
+              <span>
+                · {status.mdFileCount} uploaded file{status.mdFileCount !== 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DigitalTwinEnablePanel.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DigitalTwinEnablePanel.tsx
@@ -1,0 +1,177 @@
+import { ReactElement } from 'react';
+import { Brain, Loader2, MessageSquare, RefreshCw, ShieldCheck } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/Button';
+import { SegmentedToggle } from '@/components/ui/SegmentedToggle';
+import { DetailSectionHeading } from '@/routes/AIScreen/library/shared/primitives/DetailPrimitives';
+import { cn } from '@/utils/classNames';
+import { useEnableDigitalTwin } from '@/hooks/useClawDigitalTwin';
+import {
+  QUICK_DAYS,
+  useDigitalTwinRange,
+} from '@/components/ClawAgents/digitalTwin/useDigitalTwinRange';
+import { DateRangeInputs } from './DateRangeInputs';
+
+const CUSTOM_VALUE = 'custom';
+
+const HIGHLIGHTS = [
+  {
+    icon: Brain,
+    title: 'Learns from your work',
+    body: 'Reads your public Spaces activity — messages you sent, calls you hosted, canvases you authored.',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'You approve every memory',
+    body: 'Nothing is saved until you review it. DMs and private channels are never read.',
+  },
+  {
+    icon: MessageSquare,
+    title: 'Speaks in your voice',
+    body: 'When someone mentions you, it drafts a reply grounded only in memories you approved.',
+  },
+];
+
+export const DigitalTwinEnablePanel = (): ReactElement => {
+  const r = useDigitalTwinRange('enable', true);
+  const enableMutation = useEnableDigitalTwin();
+
+  const submit = (): void => {
+    enableMutation.mutate(
+      { backfill: r.range },
+      { onSuccess: () => toast.success('Digital Twin enabled') },
+    );
+  };
+
+  return (
+    <div className='flex w-full flex-col gap-8 animate-in fade-in-0 slide-in-from-bottom-1 duration-500 motion-reduce:animate-none'>
+      <section className='flex flex-col gap-4'>
+        <DetailSectionHeading label='How your Digital Twin works' />
+        <ul className='grid gap-6 sm:grid-cols-3 sm:gap-0'>
+          {HIGHLIGHTS.map((highlight, i) => {
+            const IconComponent = highlight.icon;
+            return (
+              <li
+                key={highlight.title}
+                className={cn(
+                  'flex flex-col sm:px-5',
+                  i === 0 && 'sm:pl-0',
+                  i > 0 && 'sm:border-l sm:border-border',
+                  i === HIGHLIGHTS.length - 1 && 'sm:pr-0',
+                )}
+              >
+                <span className='flex size-8 items-center justify-center rounded-lg border border-border text-primary'>
+                  <IconComponent className='size-4' />
+                </span>
+                <p className='mt-3 text-sm font-medium text-foreground'>{highlight.title}</p>
+                <p className='mt-1 text-xs leading-relaxed text-muted-foreground'>
+                  {highlight.body}
+                </p>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      <section className='flex flex-col gap-4 border-t border-border pt-6'>
+        <DetailSectionHeading label='Backfill your history' />
+        <p className='max-w-xl text-xs leading-relaxed text-muted-foreground'>
+          Seed your Twin from past activity, or skip and start learning from today. You can run a
+          backfill any time.
+        </p>
+
+        <div className='flex flex-col'>
+          <div>
+            <p className='mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+              How far back
+            </p>
+            <SegmentedToggle
+              options={[
+                ...r.presets.map((preset, i) => ({ value: String(i), label: preset.short })),
+                { value: CUSTOM_VALUE, label: 'Custom' },
+              ]}
+              value={r.selection === 'custom' ? CUSTOM_VALUE : String(r.presetIdx)}
+              onChange={value =>
+                value === CUSTOM_VALUE ? r.selectCustom() : r.selectPreset(Number(value))
+              }
+              tone='primary'
+              trackCategory='Claw Agents'
+              trackPrefix='Digital Twin enable range'
+            />
+          </div>
+
+          {r.selection === 'custom' && (
+            <div className='mt-4 flex flex-col gap-2.5'>
+              <DateRangeInputs range={r} trackName='Digital Twin enable' />
+              <div className='flex flex-wrap gap-1.5'>
+                {QUICK_DAYS.map(n => (
+                  <button
+                    key={n}
+                    type='button'
+                    onClick={() => r.applyQuickDays(n)}
+                    data-track-category='Claw Agents'
+                    data-track-name='Digital Twin enable quick days'
+                    className='rounded-full border border-border px-2.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                  >
+                    last {n}d
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className='mt-6 flex flex-wrap items-center gap-x-4 gap-y-2'>
+            <Button
+              onClick={submit}
+              loading={enableMutation.isPending}
+              data-track-category='Claw Agents'
+              data-track-name='Digital Twin: enable'
+            >
+              {!enableMutation.isPending && <Brain className='size-4' />}
+              {enableMutation.isPending ? 'Enabling…' : 'Enable & start'}
+            </Button>
+
+            <span className='inline-flex min-w-0 items-center gap-1.5 text-xs leading-relaxed text-muted-foreground'>
+              {r.estimateLoading ? (
+                <>
+                  <Loader2 className='size-3.5 shrink-0 animate-spin' />
+                  Estimating scope…
+                </>
+              ) : !r.range ? (
+                <>
+                  <RefreshCw className='size-3.5 shrink-0' />
+                  No history imported — your Twin starts learning from today.
+                </>
+              ) : r.estimate ? (
+                <>
+                  <RefreshCw className='size-3.5 shrink-0' />
+                  <span>
+                    Reviews about{' '}
+                    <span className='font-medium tabular-nums text-foreground'>
+                      {(r.estimate.messages ?? 0).toLocaleString()}
+                    </span>{' '}
+                    messages,{' '}
+                    <span className='font-medium tabular-nums text-foreground'>
+                      {(r.estimate.calls ?? 0).toLocaleString()}
+                    </span>{' '}
+                    calls and{' '}
+                    <span className='font-medium tabular-nums text-foreground'>
+                      {(r.estimate.canvases ?? 0).toLocaleString()}
+                    </span>{' '}
+                    canvases · ~${(r.estimate.estCostUSD ?? 0).toFixed(2)} LLM cost, charged to your
+                    org.
+                  </span>
+                </>
+              ) : (
+                <>
+                  <RefreshCw className='size-3.5 shrink-0' />
+                  Choose a range to preview the scope.
+                </>
+              )}
+            </span>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DigitalTwinRangeSelector.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DigitalTwinRangeSelector.tsx
@@ -1,0 +1,164 @@
+import { ReactElement, useEffect } from 'react';
+import { BarchartDefault, CheckTickSingle, Spinner } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+import {
+  QUICK_DAYS,
+  useDigitalTwinRange,
+  type DigitalTwinRange,
+} from '@/components/ClawAgents/digitalTwin/useDigitalTwinRange';
+import { DateRangeInputs } from './DateRangeInputs';
+
+export type { DigitalTwinRange } from '@/components/ClawAgents/digitalTwin/useDigitalTwinRange';
+
+export const DigitalTwinRangeSelector = ({
+  mode,
+  active,
+  onRangeChange,
+}: {
+  mode: 'enable' | 'backfill';
+  active: boolean;
+  onRangeChange: (range: DigitalTwinRange) => void;
+}): ReactElement => {
+  const r = useDigitalTwinRange(mode, active);
+
+  useEffect(() => {
+    onRangeChange(r.range);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [r.range]);
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <div className='flex flex-col gap-1.5'>
+        <p className='text-xs font-semibold uppercase tracking-wide text-muted-foreground'>
+          How far back to look
+        </p>
+        <div className='flex flex-col gap-1.5'>
+          {r.presets.map((preset, i) => {
+            const isSelected = r.selection === 'preset' && r.presetIdx === i;
+            return (
+              <button
+                key={preset.label}
+                type='button'
+                onClick={() => r.selectPreset(i)}
+                data-track-category='Claw Agents'
+                data-track-name='Digital Twin backfill preset'
+                className={cn(
+                  'flex w-full items-center gap-3 rounded-xl border px-3.5 py-3 text-left transition',
+                  isSelected
+                    ? 'border-primary bg-primary/5'
+                    : 'border-border bg-card hover:bg-muted',
+                )}
+              >
+                <span
+                  className={cn(
+                    'flex size-[18px] shrink-0 items-center justify-center rounded-full border-2',
+                    isSelected ? 'border-primary' : 'border-border',
+                  )}
+                >
+                  {isSelected && <span className='size-2 rounded-full bg-primary' />}
+                </span>
+                <span className='flex-1'>
+                  <span className='block text-sm font-medium text-foreground'>{preset.label}</span>
+                  <span className='block text-xs text-muted-foreground'>{preset.sublabel}</span>
+                </span>
+                {isSelected && <CheckTickSingle className='size-3.5 shrink-0 text-primary' />}
+              </button>
+            );
+          })}
+
+          <div
+            className={cn(
+              'rounded-xl border transition',
+              r.selection === 'custom' ? 'border-primary bg-primary/5' : 'border-border bg-card',
+            )}
+          >
+            <button
+              type='button'
+              onClick={r.selectCustom}
+              data-track-category='Claw Agents'
+              data-track-name='Digital Twin backfill custom range'
+              className='flex w-full items-center gap-3 px-3.5 py-3 text-left'
+            >
+              <span
+                className={cn(
+                  'flex size-[18px] shrink-0 items-center justify-center rounded-full border-2',
+                  r.selection === 'custom' ? 'border-primary' : 'border-border',
+                )}
+              >
+                {r.selection === 'custom' && <span className='size-2 rounded-full bg-primary' />}
+              </span>
+              <span className='flex-1'>
+                <span className='block text-sm font-medium text-foreground'>Custom range</span>
+                {r.selection !== 'custom' && (
+                  <span className='block text-xs text-muted-foreground'>Pick exact dates</span>
+                )}
+              </span>
+              {r.selection === 'custom' && (
+                <CheckTickSingle className='size-3.5 shrink-0 text-primary' />
+              )}
+            </button>
+
+            {r.selection === 'custom' && (
+              <div className='border-t border-primary/20 px-3.5 pb-3 pt-2.5'>
+                <DateRangeInputs range={r} trackName='Digital Twin backfill' showDayCount />
+                <div className='mt-2 flex flex-wrap gap-1.5'>
+                  {QUICK_DAYS.map(n => (
+                    <button
+                      key={n}
+                      type='button'
+                      onClick={() => r.applyQuickDays(n)}
+                      data-track-category='Claw Agents'
+                      data-track-name='Digital Twin backfill quick days'
+                      className='rounded-lg border border-border bg-card px-2.5 py-0.5 text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground'
+                    >
+                      last {n}d
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className='overflow-hidden rounded-xl border border-border bg-muted/40'>
+        <div className='flex items-center gap-1.5 border-b border-border px-3.5 py-2'>
+          <BarchartDefault className='size-3.5 text-muted-foreground' aria-hidden />
+          <span className='text-xs font-semibold uppercase tracking-wide text-muted-foreground'>
+            Estimated scope
+          </span>
+          {r.estimateLoading && (
+            <Spinner className='ml-auto size-3 animate-spin text-muted-foreground' aria-hidden />
+          )}
+        </div>
+        <div className='grid grid-cols-3 divide-x divide-border'>
+          {[
+            { label: 'Messages', value: r.estimate?.messages },
+            { label: 'Calls', value: r.estimate?.calls },
+            { label: 'Canvases', value: r.estimate?.canvases },
+          ].map(({ label, value }) => (
+            <div key={label} className='flex flex-col items-center gap-0.5 px-3 py-2.5'>
+              <span className='text-base font-semibold tabular-nums text-foreground'>
+                {r.estimate ? (value ?? 0).toLocaleString() : '—'}
+              </span>
+              <span className='text-xs text-muted-foreground'>{label}</span>
+            </div>
+          ))}
+        </div>
+        <div className='truncate border-t border-border px-3.5 py-2 text-xs text-muted-foreground'>
+          {r.estimate ? (
+            <>
+              ~{r.estimate.estCandidates ?? 0} candidate memor
+              {(r.estimate.estCandidates ?? 0) === 1 ? 'y' : 'ies'} · ~$
+              {(r.estimate.estCostUSD ?? 0).toFixed(2)} LLM cost (charged to org)
+            </>
+          ) : r.range ? (
+            'Estimating scope…'
+          ) : (
+            'Pick a start and end date to preview the scope.'
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DisableModal.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/DisableModal.tsx
@@ -1,0 +1,70 @@
+import { ReactElement, useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Checkbox } from '@/components/ui/Checkbox/Checkbox';
+import { useDisableDigitalTwin } from '@/hooks/useClawDigitalTwin';
+import { V2Dialog } from '@/routes/AIScreen/library/shared/primitives/V2Dialog';
+
+const DESCRIPTION =
+  'Disabling stops the Twin from responding to mentions and pauses the nightly curator. Your approved memories and candidates remain unless you choose to delete them.';
+
+export const DisableModal = ({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactElement => {
+  const [deleteMemories, setDeleteMemories] = useState(false);
+  const disableMutation = useDisableDigitalTwin();
+
+  const submit = (): void => {
+    disableMutation.mutate({ deleteMemories }, { onSuccess: () => onClose() });
+  };
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+      title='Disable Digital Twin'
+      description={DESCRIPTION}
+      testId='digital-twin-disable-dialog'
+      footer={
+        <>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={onClose}
+            disabled={disableMutation.isPending}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin: cancel disable'
+          >
+            Cancel
+          </Button>
+          <Button
+            variant='destructive'
+            size='sm'
+            onClick={submit}
+            loading={disableMutation.isPending}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin: confirm disable'
+          >
+            Disable
+          </Button>
+        </>
+      }
+    >
+      <p className='text-sm font-normal leading-5 text-muted-foreground'>{DESCRIPTION}</p>
+
+      <div className='rounded-lg border border-border p-2.5'>
+        <Checkbox
+          checked={deleteMemories}
+          onChange={setDeleteMemories}
+          size='sm'
+          label='Also delete all my memories and candidates — this cannot be undone'
+        />
+      </div>
+    </V2Dialog>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/EnableModal.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/EnableModal.tsx
@@ -1,0 +1,91 @@
+import { ReactElement, useState } from 'react';
+import { ArrowRight, Brain } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/Button';
+import { useEnableDigitalTwin } from '@/hooks/useClawDigitalTwin';
+import { V2Dialog } from '@/routes/AIScreen/library/shared/primitives/V2Dialog';
+import { DigitalTwinRangeSelector, type DigitalTwinRange } from './DigitalTwinRangeSelector';
+
+export const EnableModal = ({
+  open,
+  mode,
+  onClose,
+}: {
+  open: boolean;
+  mode: 'enable' | 'backfill';
+  onClose: () => void;
+}): ReactElement => {
+  const [range, setRange] = useState<DigitalTwinRange>(null);
+  const enableMutation = useEnableDigitalTwin();
+  const enabling = enableMutation.isPending;
+
+  const submit = (): void => {
+    enableMutation.mutate(
+      { backfill: range },
+      {
+        onSuccess: () => {
+          toast.success(mode === 'enable' ? 'Digital Twin enabled' : 'Backfill started');
+          onClose();
+        },
+      },
+    );
+  };
+
+  const ctaLabel = enabling
+    ? mode === 'enable'
+      ? 'Enabling…'
+      : 'Starting…'
+    : mode === 'enable'
+      ? 'Enable & start'
+      : 'Start backfill';
+
+  const blurb =
+    mode === 'enable'
+      ? 'Your Twin learns from your public Spaces activity — messages you sent, calls you hosted, canvases you authored. Nothing in DMs or private channels is read.'
+      : 'Run another pass over your Spaces history. Adds candidate memories to your review queue.';
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+      title={mode === 'enable' ? 'Enable Digital Twin' : 'Backfill history'}
+      description={blurb}
+      testId='digital-twin-enable-dialog'
+      footer={
+        <>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={onClose}
+            disabled={enabling}
+            data-track-category='Claw Agents'
+            data-track-name={`Digital Twin: cancel ${mode}`}
+          >
+            Cancel
+          </Button>
+          <Button
+            size='sm'
+            onClick={submit}
+            loading={enabling}
+            data-track-category='Claw Agents'
+            data-track-name={`Digital Twin: confirm ${mode}`}
+          >
+            {ctaLabel}
+            {!enabling && <ArrowRight className='size-3.5' />}
+          </Button>
+        </>
+      }
+    >
+      <div className='flex items-center gap-3.5 rounded-xl border border-border bg-muted/40 p-3.5'>
+        <div className='flex size-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary'>
+          <Brain className='size-5' />
+        </div>
+        <p className='text-xs leading-relaxed text-muted-foreground'>{blurb}</p>
+      </div>
+
+      <DigitalTwinRangeSelector mode={mode} active={open} onRangeChange={setRange} />
+    </V2Dialog>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/MemoryCard.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/MemoryCard.tsx
@@ -1,0 +1,88 @@
+import { ReactElement, useState } from 'react';
+import { DeleteDustbin01 } from '@xyne/icons';
+import { Button } from '@/components/ui/Button/index';
+import Tooltip from '@/components/ui/Tooltip';
+import { TruncatedTooltip } from '@/components/ui/Tooltip/TruncatedTooltip';
+import { HighlightMatch } from '@/routes/AIScreen/library/admin/components/HighlightMatch';
+import type { MemoryBankMemory } from '@/services/claw/digitalTwinTypes';
+import { CategoryBadge } from './CategoryBadge';
+import { MetaRow } from '@/routes/AIScreen/library/shared/primitives/MetaRow';
+import { formatRelativeTime } from '@/utils/dateUtils';
+
+export const MemoryCard = ({
+  memory,
+  onDelete,
+  query = '',
+}: {
+  memory: MemoryBankMemory;
+  onDelete?: (hindsightMemoryId: string) => void;
+  query?: string;
+}): ReactElement => {
+  const [showReasoning, setShowReasoning] = useState(false);
+
+  return (
+    <li className='flex flex-col gap-1 border-b border-border px-1 py-4'>
+      <div className='flex items-center justify-between gap-3'>
+        <TruncatedTooltip content={memory.content}>
+          <p className='min-w-0 flex-1 truncate text-sm text-foreground'>
+            <HighlightMatch text={memory.content} query={query} />
+          </p>
+        </TruncatedTooltip>
+        {onDelete && (
+          <Tooltip content='Delete memory' side='top'>
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              onClick={() => onDelete(memory.hindsightMemoryId)}
+              aria-label='Delete memory'
+              data-track-category='Claw Agents'
+              data-track-name='Digital Twin delete memory'
+              className='shrink-0 text-muted-foreground hover:text-destructive focus-visible:bg-muted focus-visible:ring-0'
+            >
+              <DeleteDustbin01 className='size-4' aria-hidden />
+            </Button>
+          </Tooltip>
+        )}
+      </div>
+
+      <MetaRow
+        badge={<CategoryBadge category={memory.category} />}
+        items={[
+          memory.recallHits7d > 0 && (
+            <span key='recalls'>
+              {memory.recallHits7d} recall{memory.recallHits7d !== 1 ? 's' : ''} (7d)
+            </span>
+          ),
+          <span key='created'>created {formatRelativeTime(new Date(memory.createdAt))}</span>,
+          memory.lastRecalledAt && (
+            <span key='recalled'>
+              last recalled {formatRelativeTime(new Date(memory.lastRecalledAt))}
+            </span>
+          ),
+          memory.curatorReasoning && (
+            <button
+              key='curator'
+              type='button'
+              onClick={() => setShowReasoning(s => !s)}
+              data-track-category='Claw Agents'
+              data-track-name='Digital Twin memory curator reasoning'
+              className='underline-offset-2 hover:text-foreground hover:underline'
+            >
+              {showReasoning ? 'hide curator' : 'why?'}
+            </button>
+          ),
+        ]}
+      />
+
+      {showReasoning && memory.curatorReasoning && (
+        <div className='mt-1 rounded-lg border border-border bg-muted/40 px-2.5 py-2 text-xs text-muted-foreground'>
+          <span className='font-medium text-foreground'>Curator:</span> {memory.curatorReasoning}
+          {memory.curatorConfidence !== null && (
+            <span className='ml-1'>(confidence {memory.curatorConfidence.toFixed(2)})</span>
+          )}
+        </div>
+      )}
+    </li>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/SettingCardHeader.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/SettingCardHeader.tsx
@@ -1,0 +1,33 @@
+import type { ComponentType, ReactElement, ReactNode } from 'react';
+import type { PikaIconProps } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+
+export type CardHeaderIcon = ComponentType<PikaIconProps>;
+
+export const SettingCardHeader = ({
+  icon,
+  title,
+  description,
+  trailing,
+  divided = true,
+}: {
+  icon: CardHeaderIcon;
+  title: string;
+  description: string;
+  trailing?: ReactNode;
+  divided?: boolean;
+}): ReactElement => {
+  const IconComponent = icon;
+  return (
+    <div className={cn('flex items-center gap-3 px-4 py-3', divided && 'border-b border-border')}>
+      <span className='flex size-9 shrink-0 items-center justify-center rounded-xl bg-muted text-muted-foreground'>
+        <IconComponent className='size-4' aria-hidden />
+      </span>
+      <div className='min-w-0 flex-1'>
+        <p className='text-sm font-medium leading-5 text-foreground'>{title}</p>
+        <p className='text-xs leading-relaxed text-muted-foreground'>{description}</p>
+      </div>
+      {trailing}
+    </div>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/SubsystemMemoriesPanel.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/SubsystemMemoriesPanel.tsx
@@ -1,0 +1,63 @@
+import { ReactElement } from 'react';
+import { Loader2, X } from 'lucide-react';
+import { useClawDigitalTwinMemories } from '@/hooks/useClawDigitalTwin';
+import { MemoryCard } from './MemoryCard';
+
+export const SubsystemMemoriesPanel = ({
+  subsystem,
+  onClose,
+}: {
+  subsystem: string;
+  onClose: () => void;
+}): ReactElement => {
+  const { data, isLoading, isError, error } = useClawDigitalTwinMemories({ limit: 200, subsystem });
+  const memories = data?.memories;
+
+  return (
+    <div className='flex h-full flex-col rounded-lg border border-primary/40 bg-card'>
+      <div className='flex items-center gap-2 border-b border-border px-3 py-2'>
+        <span className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+          Subsystem
+        </span>
+        <span className='font-mono text-xs font-semibold text-primary'>{subsystem}</span>
+        {memories && (
+          <span className='text-xs text-muted-foreground'>
+            · {memories.length} {memories.length === 1 ? 'memory' : 'memories'}
+          </span>
+        )}
+        <button
+          type='button'
+          onClick={onClose}
+          data-track-category='Claw Agents'
+          data-track-name='Digital Twin close subsystem panel'
+          aria-label='Close subsystem panel'
+          className='ml-auto rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+        >
+          <X className='size-3.5' />
+        </button>
+      </div>
+      <div className='flex flex-1 flex-col gap-1.5 overflow-y-auto p-3'>
+        {isLoading && (
+          <div className='flex items-center gap-2 py-3 text-xs text-muted-foreground'>
+            <Loader2 className='size-3.5 animate-spin' />
+            Loading…
+          </div>
+        )}
+        {isError && (
+          <div className='rounded-lg border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive'>
+            {error instanceof Error ? error.message : 'Failed to load memories'}
+          </div>
+        )}
+        {memories && memories.length === 0 && (
+          <p className='py-3 text-center text-xs text-muted-foreground'>
+            No memories tagged{' '}
+            <span className='font-mono text-foreground'>subsystem:{subsystem}</span>
+          </p>
+        )}
+        {memories?.map(m => (
+          <MemoryCard key={m.hindsightMemoryId} memory={m} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/UploadModal.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/UploadModal.tsx
@@ -1,0 +1,193 @@
+import { ReactElement, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { MultipleCrossCancelCircle, UploadUp } from '@xyne/icons';
+import { Button } from '@/components/ui/Button';
+import Tooltip from '@/components/ui/Tooltip';
+import { useUploadDigitalTwinMd } from '@/hooks/useClawDigitalTwin';
+import { V2Dialog } from '@/routes/AIScreen/library/shared/primitives/V2Dialog';
+
+const MAX_FILE_BYTES = 200 * 1024; // 200 KB — matches backend limit
+const DESCRIPTION = 'Memories extracted from it land in Proposals for your review.';
+
+export const UploadModal = ({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactElement => {
+  const [content, setContent] = useState('');
+  const [filename, setFilename] = useState('');
+  const [sizeLabel, setSizeLabel] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const uploadMutation = useUploadDigitalTwinMd();
+
+  const reset = (): void => {
+    setContent('');
+    setFilename('');
+    setSizeLabel(null);
+    setErr(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    if (ext !== 'md' && ext !== 'markdown') {
+      setErr('Only .md / .markdown files are supported.');
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      return;
+    }
+    if (file.size > MAX_FILE_BYTES) {
+      setErr(
+        `File too large — maximum is 200 KB (this file is ${(file.size / 1024).toFixed(0)} KB).`,
+      );
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      return;
+    }
+    setErr(null);
+    setFilename(file.name);
+    setSizeLabel(`${(file.size / 1024).toFixed(0)} KB`);
+    const reader = new FileReader();
+    reader.onload = (ev): void =>
+      setContent(typeof ev.target?.result === 'string' ? ev.target.result : '');
+    reader.onerror = (): void => {
+      setErr('Failed to read file. Please try again.');
+      setFilename('');
+      setSizeLabel(null);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    };
+    reader.readAsText(file);
+  };
+
+  const submit = (): void => {
+    if (!filename || !content.trim()) return;
+    uploadMutation.mutate(
+      { filename, content: content.trim() },
+      {
+        onSuccess: data => {
+          toast.success(
+            `Added ${data.candidatesCreated} candidate${data.candidatesCreated === 1 ? '' : 's'} for review`,
+          );
+          reset();
+          onClose();
+        },
+      },
+    );
+  };
+
+  const close = (): void => {
+    reset();
+    onClose();
+  };
+
+  return (
+    <V2Dialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) close();
+      }}
+      title='Upload markdown file'
+      description={DESCRIPTION}
+      testId='digital-twin-upload-dialog'
+      footer={
+        <>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={close}
+            disabled={uploadMutation.isPending}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin: cancel upload'
+          >
+            Cancel
+          </Button>
+          <Button
+            size='sm'
+            onClick={submit}
+            loading={uploadMutation.isPending}
+            disabled={!filename || !content.trim()}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin: confirm upload'
+          >
+            Upload
+          </Button>
+        </>
+      }
+    >
+      <p className='text-sm font-normal leading-5 text-muted-foreground'>{DESCRIPTION}</p>
+
+      <input
+        ref={fileInputRef}
+        type='file'
+        accept='.md,.markdown,text/markdown'
+        onChange={handleFileSelect}
+        className='hidden'
+      />
+
+      <div className='flex items-center gap-3 rounded-xl border border-dashed border-border bg-muted/40 p-3'>
+        <span className='flex size-9 shrink-0 items-center justify-center rounded-xl bg-background text-muted-foreground'>
+          <UploadUp className='size-4' aria-hidden />
+        </span>
+        <div className='min-w-0 flex-1'>
+          <p className='truncate text-sm font-medium text-foreground'>
+            {filename || 'No file chosen'}
+          </p>
+          <p className='text-xs text-muted-foreground'>
+            {sizeLabel ?? '.md or .markdown · up to 200 KB'}
+          </p>
+        </div>
+        <Button
+          type='button'
+          variant='outline'
+          size='sm'
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploadMutation.isPending}
+          data-track-category='Claw Agents'
+          data-track-name='Digital Twin choose upload file'
+        >
+          {filename ? 'Change' : 'Choose file'}
+        </Button>
+        {filename && (
+          <Tooltip side='top' content='Remove file'>
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              onClick={reset}
+              disabled={uploadMutation.isPending}
+              aria-label='Remove file'
+              className='size-7 shrink-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:bg-muted focus-visible:ring-0'
+            >
+              <MultipleCrossCancelCircle className='size-4' aria-hidden />
+            </Button>
+          </Tooltip>
+        )}
+      </div>
+
+      {content && (
+        <div>
+          <span className='mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+            Content preview
+          </span>
+          <textarea
+            value={content}
+            onChange={e => setContent(e.target.value)}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin upload content preview'
+            rows={6}
+            className='w-full resize-none rounded-lg border border-border bg-background px-2.5 py-1.5 font-mono text-xs text-muted-foreground focus:border-ring focus:outline-none'
+          />
+        </div>
+      )}
+
+      {err && (
+        <div className='rounded-lg border border-destructive/30 bg-destructive/10 p-2.5 text-xs text-destructive'>
+          {err}
+        </div>
+      )}
+    </V2Dialog>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/format.ts
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/format.ts
@@ -1,0 +1,5 @@
+export function scoreToneClass(score: number): string {
+  if (score >= 0.8) return 'text-status-success';
+  if (score >= 0.6) return 'text-status-pending';
+  return 'text-status-failure';
+}

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/graphLayout.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/graphLayout.tsx
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument */
+
+import dagre from '@dagrejs/dagre';
+import type { Edge as RFEdge, Node as RFNode } from '@xyflow/react';
+import type {
+  DigitalTwinSubsystemEdge,
+  DigitalTwinSubsystemNode,
+} from '@/services/claw/digitalTwinTypes';
+
+const NODE_WIDTH = 220;
+const NODE_HEIGHT = 88;
+const NODE_ACCENT = 'hsl(var(--chart-1))';
+const TITLE_FONT_SIZE = 13;
+const LABEL_FONT_SIZE = 10;
+
+export function layoutSubsystems(
+  subsystems: DigitalTwinSubsystemNode[],
+  edges: DigitalTwinSubsystemEdge[],
+): RFNode[] {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({ rankdir: 'LR', nodesep: 60, ranksep: 120, marginx: 24, marginy: 24 });
+  g.setDefaultEdgeLabel(() => ({}));
+  subsystems.forEach(s => g.setNode(s.name, { width: NODE_WIDTH, height: NODE_HEIGHT }));
+  edges.forEach(e => {
+    if (g.hasNode(e.source) && g.hasNode(e.target)) g.setEdge(e.source, e.target);
+  });
+  dagre.layout(g);
+
+  const maxMemoryCount = Math.max(1, ...subsystems.map(s => s.memoryCount));
+
+  return subsystems.map(s => {
+    const pos = g.node(s.name) as { x: number; y: number } | undefined;
+    const sat = 0.4 + 0.5 * (s.memoryCount / maxMemoryCount);
+    return {
+      id: s.name,
+      position: { x: (pos?.x ?? 0) - NODE_WIDTH / 2, y: (pos?.y ?? 0) - NODE_HEIGHT / 2 },
+      data: {
+        label: (
+          <div style={{ textAlign: 'left', lineHeight: 1.25 }}>
+            <div style={{ fontWeight: 600, fontSize: TITLE_FONT_SIZE }}>{s.name}</div>
+            <div style={{ fontSize: LABEL_FONT_SIZE, opacity: 0.75, marginTop: 2 }}>
+              {s.memoryCount} {s.memoryCount === 1 ? 'memory' : 'memories'} · {s.sessionCount}{' '}
+              {s.sessionCount === 1 ? 'session' : 'sessions'}
+            </div>
+            <div
+              style={{
+                fontSize: LABEL_FONT_SIZE,
+                opacity: 0.55,
+                marginTop: 4,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical' as const,
+              }}
+            >
+              {s.sampleContent}
+            </div>
+          </div>
+        ),
+      },
+      style: {
+        width: NODE_WIDTH,
+        height: NODE_HEIGHT,
+        background: `color-mix(in srgb, ${NODE_ACCENT} ${Math.round((0.12 + 0.18 * sat) * 100)}%, transparent)`,
+        border: `1.5px solid color-mix(in srgb, ${NODE_ACCENT} ${Math.round(sat * 100)}%, transparent)`,
+        borderRadius: 10,
+        padding: '8px 12px',
+        display: 'flex',
+        alignItems: 'flex-start',
+        boxShadow: `0 2px 8px hsl(var(--foreground) / 0.15)`,
+        cursor: 'pointer',
+      },
+    };
+  });
+}
+
+export function makeSubsystemEdges(edges: DigitalTwinSubsystemEdge[]): RFEdge[] {
+  if (edges.length === 0) return [];
+  const maxShared = Math.max(1, ...edges.map(e => e.sharedSessions));
+  return edges.map(e => ({
+    id: `${e.source}::${e.target}`,
+    source: e.source,
+    target: e.target,
+    type: 'smoothstep',
+    animated: false,
+    style: {
+      stroke: `color-mix(in srgb, ${NODE_ACCENT} 55%, transparent)`,
+      strokeWidth: Math.max(1.5, (e.sharedSessions / maxShared) * 3.5),
+    },
+    label: `${e.sharedSessions} shared`,
+    labelStyle: { fontSize: LABEL_FONT_SIZE, fill: NODE_ACCENT },
+    labelBgPadding: [4, 4] as [number, number],
+    labelBgBorderRadius: 4,
+  }));
+}

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/metrics/DigitalTwinKpis.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/metrics/DigitalTwinKpis.tsx
@@ -1,0 +1,118 @@
+import { ReactElement } from 'react';
+import { cn } from '@/utils/classNames';
+import { formatPct } from '@/components/ClawAgents/metrics/formatters';
+import type { DigitalTwinMetrics } from '@/services/claw/digitalTwinTypes';
+
+type Tone = 'good' | 'bad' | 'flat';
+
+const toneClass = (tone: Tone): string => {
+  if (tone === 'good') return 'text-status-success';
+  if (tone === 'bad') return 'text-destructive';
+  return 'text-muted-foreground';
+};
+
+const deltaBadge = (
+  current: number | null,
+  previous: number | null,
+  higherIsBetter: boolean,
+): { label: string; tone: Tone } => {
+  if (current === null || previous === null || Number.isNaN(current) || Number.isNaN(previous)) {
+    return { label: '—', tone: 'flat' };
+  }
+  const diff = current - previous;
+  if (Math.abs(diff) < 0.001) return { label: '≈0', tone: 'flat' };
+  const up = diff > 0;
+  return {
+    label: `${up ? '+' : ''}${(diff * 100).toFixed(1)}pp`,
+    tone: up === higherIsBetter ? 'good' : 'bad',
+  };
+};
+
+const Hero = ({
+  label,
+  value,
+  help,
+  delta,
+}: {
+  label: string;
+  value: string;
+  help: string;
+  delta: { label: string; tone: Tone };
+}): ReactElement => (
+  <div className='rounded-xl border border-border bg-card px-5 py-4 shadow-sm'>
+    <p className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>{label}</p>
+    <div className='mt-1 flex items-baseline gap-3'>
+      <span className='text-3xl font-semibold tabular-nums text-foreground'>{value}</span>
+      <span className={cn('text-xs font-medium', toneClass(delta.tone))}>{delta.label}</span>
+    </div>
+    <p className='mt-1 text-xs text-muted-foreground'>{help}</p>
+  </div>
+);
+
+const Tile = ({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+}): ReactElement => (
+  <div className='rounded-xl border border-border bg-card px-4 py-3 shadow-sm'>
+    <p className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>{label}</p>
+    <p className='mt-1 text-xl font-semibold tabular-nums text-foreground'>{value}</p>
+    {detail && <p className='mt-0.5 text-xs text-muted-foreground'>{detail}</p>}
+  </div>
+);
+
+export const DigitalTwinKpis = ({ data }: { data: DigitalTwinMetrics }): ReactElement => {
+  const approvalDelta = deltaBadge(data.approvalRate, data.previousApprovalRate, true);
+  const editDelta = deltaBadge(data.editRate, data.previousEditRate, false);
+
+  return (
+    <div className='flex flex-col gap-3'>
+      <div className='grid gap-3 md:grid-cols-2'>
+        <Hero
+          label='Approval rate'
+          value={formatPct(data.approvalRate)}
+          delta={approvalDelta}
+          help='Share of reviewed candidates you approved.'
+        />
+        <Hero
+          label='Edit rate'
+          value={formatPct(data.editRate)}
+          delta={editDelta}
+          help='Share of approvals you tweaked before saving.'
+        />
+      </div>
+
+      <div className='grid grid-cols-2 gap-3 lg:grid-cols-4'>
+        <Tile
+          label='Total candidates'
+          value={String(data.total)}
+          detail={`+${data.addedSinceYesterday} since yesterday`}
+        />
+        <Tile
+          label='Approved'
+          value={String(data.totalApproved)}
+          detail={`${data.approvedClean} clean · ${data.approvedEdited} edited`}
+        />
+        <Tile label='Rejected' value={String(data.rejected)} />
+        <Tile
+          label='Pending'
+          value={String(data.pending)}
+          detail={
+            data.oldestPendingDays !== null ? `oldest ${data.oldestPendingDays}d in queue` : ''
+          }
+        />
+        {data.recallRatedCount > 0 && (
+          <Tile
+            label='Recall precision'
+            value={formatPct(data.recallPrecision)}
+            detail={`${data.recallRatedCount} rated`}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/metrics/DigitalTwinMetricsCharts.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/metrics/DigitalTwinMetricsCharts.tsx
@@ -1,0 +1,165 @@
+import { ReactElement } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { MetricsCard } from '@/components/ClawAgents/metrics/MetricsCard';
+import { subsystemLabel, sourceLabel } from '../subsystems';
+import type { DigitalTwinMetrics } from '@/services/claw/digitalTwinTypes';
+
+const CHART_HEIGHT = 240;
+const TICK_FONT_SIZE = 11;
+const LEGEND_FONT_SIZE = 12;
+const tick = { fontSize: TICK_FONT_SIZE, fill: 'currentColor', opacity: 0.65 };
+
+const OUTCOME_COLORS = {
+  approvedClean: 'var(--status-success)',
+  approvedEdited: 'var(--status-scheduled)',
+  rejected: 'var(--status-failure)',
+  pending: 'var(--status-pending)',
+} as const;
+
+export const DigitalTwinMetricsCharts = ({ data }: { data: DigitalTwinMetrics }): ReactElement => {
+  const outcomes = [
+    { name: 'Approved (clean)', value: data.approvedClean, fill: OUTCOME_COLORS.approvedClean },
+    { name: 'Approved (edited)', value: data.approvedEdited, fill: OUTCOME_COLORS.approvedEdited },
+    { name: 'Rejected', value: data.rejected, fill: OUTCOME_COLORS.rejected },
+    { name: 'Pending', value: data.pending, fill: OUTCOME_COLORS.pending },
+  ].filter(o => o.value > 0);
+
+  const bySubsystem = data.bySubsystem.map(s => ({
+    name: subsystemLabel(s.subsystem),
+    Approved: s.approved,
+    Rejected: s.rejected,
+    Pending: s.pending,
+  }));
+
+  const bySource = data.bySource.map(s => ({
+    name: sourceLabel(s.source),
+    Approved: s.approved,
+    Rejected: s.rejected,
+  }));
+
+  return (
+    <>
+      <div className='grid gap-5 lg:grid-cols-2'>
+        <MetricsCard title='Candidate outcomes' description='How reviewed candidates resolved.'>
+          {outcomes.length === 0 ? (
+            <p className='py-16 text-center text-sm text-muted-foreground'>No candidates yet.</p>
+          ) : (
+            <ResponsiveContainer width='100%' height={CHART_HEIGHT}>
+              <PieChart>
+                <Pie
+                  data={outcomes}
+                  dataKey='value'
+                  nameKey='name'
+                  innerRadius={60}
+                  outerRadius={90}
+                  paddingAngle={2}
+                  isAnimationActive={false}
+                  cursor='pointer'
+                >
+                  {outcomes.map(entry => (
+                    <Cell key={entry.name} fill={entry.fill} />
+                  ))}
+                </Pie>
+                <Tooltip cursor={false} />
+                <Legend wrapperStyle={{ fontSize: LEGEND_FONT_SIZE }} verticalAlign='bottom' />
+              </PieChart>
+            </ResponsiveContainer>
+          )}
+        </MetricsCard>
+
+        <MetricsCard
+          title='By subsystem'
+          description='Approved, rejected, and pending per subsystem.'
+        >
+          {bySubsystem.length === 0 ? (
+            <p className='py-16 text-center text-sm text-muted-foreground'>No subsystem data.</p>
+          ) : (
+            <ResponsiveContainer width='100%' height={CHART_HEIGHT}>
+              <BarChart
+                data={bySubsystem}
+                layout='vertical'
+                margin={{ top: 8, right: 16, bottom: 0, left: 8 }}
+              >
+                <CartesianGrid strokeDasharray='3 3' opacity={0.1} horizontal={false} />
+                <XAxis type='number' tick={tick} tickLine={false} allowDecimals={false} />
+                <YAxis type='category' dataKey='name' tick={tick} tickLine={false} width={110} />
+                <Tooltip cursor={false} />
+                <Legend
+                  wrapperStyle={{ fontSize: LEGEND_FONT_SIZE, paddingBottom: 8 }}
+                  verticalAlign='top'
+                  align='left'
+                />
+                <Bar
+                  dataKey='Approved'
+                  stackId='s'
+                  fill={OUTCOME_COLORS.approvedClean}
+                  cursor='pointer'
+                />
+                <Bar
+                  dataKey='Rejected'
+                  stackId='s'
+                  fill={OUTCOME_COLORS.rejected}
+                  cursor='pointer'
+                />
+                <Bar
+                  dataKey='Pending'
+                  stackId='s'
+                  fill={OUTCOME_COLORS.pending}
+                  radius={[0, 4, 4, 0]}
+                  cursor='pointer'
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </MetricsCard>
+      </div>
+
+      <MetricsCard
+        title='By source'
+        description='Which intake to trust — approvals vs rejections per source.'
+      >
+        {bySource.length === 0 ? (
+          <p className='py-16 text-center text-sm text-muted-foreground'>No source data.</p>
+        ) : (
+          <ResponsiveContainer width='100%' height={CHART_HEIGHT}>
+            <BarChart data={bySource} margin={{ top: 16, right: 16, bottom: 0, left: 0 }}>
+              <CartesianGrid strokeDasharray='3 3' opacity={0.1} vertical={false} />
+              <XAxis dataKey='name' tick={tick} tickLine={false} />
+              <YAxis tick={tick} tickLine={false} width={40} allowDecimals={false} />
+              <Tooltip cursor={false} />
+              <Legend
+                wrapperStyle={{ fontSize: LEGEND_FONT_SIZE, paddingBottom: 8 }}
+                verticalAlign='top'
+                align='left'
+              />
+              <Bar
+                dataKey='Approved'
+                fill={OUTCOME_COLORS.approvedClean}
+                radius={[4, 4, 0, 0]}
+                cursor='pointer'
+              />
+              <Bar
+                dataKey='Rejected'
+                fill={OUTCOME_COLORS.rejected}
+                radius={[4, 4, 0, 0]}
+                cursor='pointer'
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </MetricsCard>
+    </>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/components/subsystems.ts
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/components/subsystems.ts
@@ -1,0 +1,87 @@
+import type { ComponentType, SVGProps } from 'react';
+import {
+  ContactsBook,
+  FileDefault,
+  FolderDefault,
+  GitBranch,
+  GraduationHat,
+  PencilEdit,
+  Settings02,
+  UserThree,
+} from '@xyne/icons';
+
+type SubsystemIcon = ComponentType<SVGProps<SVGSVGElement> & { size?: number }>;
+
+export const SUBSYSTEM_LABELS: Record<string, string> = {
+  style: 'Communication style',
+  expertise: 'Expertise',
+  projects: 'Projects',
+  relationships: 'Relationships',
+  preferences: 'Preferences',
+  decisions: 'Decisions',
+  context: 'Context',
+  docs: 'Documents',
+};
+
+export const SUBSYSTEM_ICONS: Record<string, SubsystemIcon> = {
+  style: PencilEdit as SubsystemIcon,
+  expertise: GraduationHat as SubsystemIcon,
+  projects: FolderDefault as SubsystemIcon,
+  relationships: UserThree as SubsystemIcon,
+  preferences: Settings02 as SubsystemIcon,
+  decisions: GitBranch as SubsystemIcon,
+  context: ContactsBook as SubsystemIcon,
+  docs: FileDefault as SubsystemIcon,
+};
+
+export const subsystemLabel = (subsystem: string): string =>
+  SUBSYSTEM_LABELS[subsystem] ?? subsystem;
+
+export const SOURCE_LABELS: Record<string, string> = {
+  daily: 'Daily curator',
+  upload: 'Uploaded docs',
+  backfill: 'Backfill',
+};
+
+export const sourceLabel = (source: string): string => SOURCE_LABELS[source] ?? source;
+
+export interface CategoryStyle {
+  label: string;
+  className: string;
+}
+
+export const CATEGORY_STYLES: Record<string, CategoryStyle> = {
+  world: {
+    label: 'WORLD',
+    className: 'border-status-success/60 text-status-success',
+  },
+  experience: {
+    label: 'EXPERIENCE',
+    className: 'border-primary/60 text-primary',
+  },
+  observation: {
+    label: 'OBSERVATION',
+    className: 'border-status-pending/60 text-status-pending',
+  },
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- backend category key
+  mental_model: {
+    label: 'MENTAL MODEL',
+    className: 'border-border text-muted-foreground',
+  },
+};
+
+export const CATEGORY_LEGEND: Array<{ key: keyof typeof CATEGORY_STYLES; description: string }> = [
+  { key: 'world', description: 'Durable, objective fact about you or your work.' },
+  {
+    key: 'experience',
+    description: "Something observed during the agent's own runs — what it tried, what worked.",
+  },
+  {
+    key: 'observation',
+    description: 'Secondary extraction pass — often a near-duplicate rephrasing of a WORLD fact.',
+  },
+  {
+    key: 'mental_model',
+    description: 'Captured judgment call or framing the agent should respect.',
+  },
+];

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/digitalTwinTabs.ts
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/digitalTwinTabs.ts
@@ -1,0 +1,30 @@
+export type DigitalTwinTabId =
+  | 'memories'
+  | 'hot'
+  | 'proposals'
+  | 'recall'
+  | 'graph'
+  | 'metrics'
+  | 'settings';
+
+export interface DigitalTwinTab {
+  id: DigitalTwinTabId;
+  label: string;
+}
+
+export const DIGITAL_TWIN_TABS: readonly DigitalTwinTab[] = [
+  { id: 'memories', label: 'Memories' },
+  { id: 'hot', label: 'Hot' },
+  { id: 'proposals', label: 'Proposals' },
+  { id: 'recall', label: 'Recall' },
+  { id: 'graph', label: 'Graph' },
+  { id: 'metrics', label: 'Metrics' },
+  { id: 'settings', label: 'Settings' },
+];
+
+export const DEFAULT_DIGITAL_TWIN_TAB: DigitalTwinTabId = 'memories';
+
+export function resolveDigitalTwinTab(raw: string | null): DigitalTwinTabId {
+  const match = DIGITAL_TWIN_TABS.find(tab => tab.id === raw);
+  return match ? match.id : DEFAULT_DIGITAL_TWIN_TAB;
+}

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinGraphTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinGraphTab.tsx
@@ -1,0 +1,60 @@
+import { ReactElement, useMemo, useState } from 'react';
+import { Background, Controls, MiniMap, ReactFlow } from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { Loader2 } from 'lucide-react';
+import { useClawDigitalTwinGraph } from '@/hooks/useClawDigitalTwin';
+import { TabMessage } from '@/routes/AIScreen/library/admin/components/TabMessage';
+import { layoutSubsystems, makeSubsystemEdges } from '../components/graphLayout';
+import { SubsystemMemoriesPanel } from '../components/SubsystemMemoriesPanel';
+
+const DigitalTwinGraphTab = (): ReactElement => {
+  const { data, isLoading } = useClawDigitalTwinGraph();
+  const [selectedSubsystem, setSelectedSubsystem] = useState<string | null>(null);
+
+  const nodes = useMemo(() => (data ? layoutSubsystems(data.subsystems, data.edges) : []), [data]);
+  const edges = useMemo(() => (data ? makeSubsystemEdges(data.edges) : []), [data]);
+
+  if (isLoading) {
+    return (
+      <div className='flex h-[420px] items-center justify-center rounded-lg border border-border bg-card'>
+        <Loader2 className='size-5 animate-spin text-muted-foreground' />
+      </div>
+    );
+  }
+
+  if (nodes.length === 0) {
+    return (
+      <TabMessage>
+        No graph data — the subsystem graph will appear once you have approved memories.
+      </TabMessage>
+    );
+  }
+
+  return (
+    <div className='flex gap-3'>
+      <div className='h-[420px] flex-1 overflow-hidden rounded-lg border border-border bg-card'>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          fitView
+          attributionPosition='bottom-left'
+          onNodeClick={(_, node) => setSelectedSubsystem(node.id)}
+        >
+          <Background />
+          <Controls />
+          <MiniMap />
+        </ReactFlow>
+      </div>
+      {selectedSubsystem && (
+        <div className='h-[420px] w-[340px] shrink-0'>
+          <SubsystemMemoriesPanel
+            subsystem={selectedSubsystem}
+            onClose={() => setSelectedSubsystem(null)}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DigitalTwinGraphTab;

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinHotTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinHotTab.tsx
@@ -1,0 +1,151 @@
+import { ReactElement, useMemo, useState } from 'react';
+import { DeleteDustbin01 } from '@xyne/icons';
+import { AdminSearchField } from '@/routes/AIScreen/library/admin/components/AdminSearchField';
+import { TabMessage } from '@/routes/AIScreen/library/admin/components/TabMessage';
+import { HighlightMatch } from '@/routes/AIScreen/library/admin/components/HighlightMatch';
+import { Button } from '@/components/ui/Button/index';
+import Tooltip from '@/components/ui/Tooltip';
+import { TruncatedTooltip } from '@/components/ui/Tooltip/TruncatedTooltip';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { SegmentedToggle } from '@/components/ui/SegmentedToggle';
+import { ConfirmDialog } from '@/components/ClawAgents/ConfirmDialog';
+import { useClawDigitalTwinStats, useDeleteDigitalTwinMemory } from '@/hooks/useClawDigitalTwin';
+import { CategoryBadge } from '../components/CategoryBadge';
+import { MetaRow } from '@/routes/AIScreen/library/shared/primitives/MetaRow';
+import { formatRelativeTime } from '@/utils/dateUtils';
+import type { MemoryRange } from '@/services/claw/digitalTwinTypes';
+
+const RANGES: MemoryRange[] = ['7d', '30d', '90d'];
+const DELETE_COPY =
+  'This removes it from Hindsight and marks related review rows as rejected. Recall-hit history is retained.';
+
+const DigitalTwinHotTab = (): ReactElement => {
+  const [range, setRange] = useState<MemoryRange>('7d');
+  const { data: stats, isLoading } = useClawDigitalTwinStats(range);
+  const deleteMutation = useDeleteDigitalTwinMemory();
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+
+  const allHot = useMemo(() => stats?.hot ?? [], [stats]);
+  const hot = useMemo(() => {
+    const q = search.toLowerCase().trim();
+    if (!q) return allHot;
+    return allHot.filter(m => m.content.toLowerCase().includes(q));
+  }, [allHot, search]);
+
+  return (
+    <div className='flex flex-col gap-2.5'>
+      <div className='sticky top-0 z-10 -mb-2.5 flex flex-col gap-2.5 bg-background pb-2.5'>
+        <AdminSearchField
+          value={search}
+          onChange={setSearch}
+          placeholder='Search hot memories'
+          ariaLabel='Search hot memories'
+          trackCategory='Claw Agents'
+          trackName='Digital Twin: search hot memories'
+          className='w-full'
+        />
+
+        <div className='flex items-center justify-end'>
+          <SegmentedToggle<MemoryRange>
+            options={RANGES.map(r => ({ value: r, label: r }))}
+            value={range}
+            onChange={setRange}
+            tone='primary'
+            trackCategory='Claw Agents'
+            trackPrefix='Digital Twin hot range'
+          />
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className='flex flex-col gap-1.5'>
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className='h-12 rounded-lg' />
+          ))}
+        </div>
+      ) : hot.length === 0 && search.trim() ? (
+        <TabMessage>No hot memories match &ldquo;{search}&rdquo;</TabMessage>
+      ) : hot.length === 0 ? (
+        <TabMessage>
+          No hot memories — they appear here once they start getting recalled.
+        </TabMessage>
+      ) : (
+        <ul className='flex flex-col'>
+          {hot.map(m => {
+            const isRejected = m.status === 'rejected';
+            return (
+              <li
+                key={m.hindsightMemoryId}
+                className='flex flex-col gap-1 border-b border-border px-1 py-4'
+              >
+                <div className='flex items-center justify-between gap-3'>
+                  <TruncatedTooltip content={m.content}>
+                    <p className='min-w-0 flex-1 truncate text-sm text-foreground'>
+                      <HighlightMatch text={m.content} query={search} />
+                    </p>
+                  </TruncatedTooltip>
+                  {!isRejected && (
+                    <Tooltip content='Delete memory' side='top'>
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='icon'
+                        onClick={() => setPendingDelete(m.hindsightMemoryId)}
+                        aria-label='Delete memory'
+                        data-track-category='Claw Agents'
+                        data-track-name='Digital Twin delete hot memory'
+                        className='shrink-0 text-muted-foreground hover:text-destructive focus-visible:bg-muted focus-visible:ring-0'
+                      >
+                        <DeleteDustbin01 className='size-4' aria-hidden />
+                      </Button>
+                    </Tooltip>
+                  )}
+                </div>
+                <MetaRow
+                  badge={<CategoryBadge category={m.category} />}
+                  items={[
+                    <span key='recalls'>
+                      {m.hits} recall{m.hits !== 1 ? 's' : ''}
+                    </span>,
+                    m.lastRecalledAt && (
+                      <span key='recalled'>
+                        last recalled {formatRelativeTime(new Date(m.lastRecalledAt))}
+                      </span>
+                    ),
+                    isRejected && (
+                      <span key='deleted' className='text-destructive'>
+                        deleted from Hindsight
+                      </span>
+                    ),
+                  ]}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={open => {
+          if (!open) setPendingDelete(null);
+        }}
+        title='Delete this memory?'
+        description={DELETE_COPY}
+        confirmLabel='Delete'
+        danger
+        loading={deleteMutation.isPending}
+        onConfirm={() => {
+          if (!pendingDelete) return;
+          deleteMutation.mutate(
+            { hindsightMemoryId: pendingDelete },
+            { onSuccess: () => setPendingDelete(null) },
+          );
+        }}
+      />
+    </div>
+  );
+};
+
+export default DigitalTwinHotTab;

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinMemoriesTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinMemoriesTab.tsx
@@ -1,0 +1,131 @@
+import { ReactElement, useMemo, useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { AdminSearchField } from '@/routes/AIScreen/library/admin/components/AdminSearchField';
+import { TabMessage } from '@/routes/AIScreen/library/admin/components/TabMessage';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { ConfirmDialog } from '@/components/ClawAgents/ConfirmDialog';
+import { useClawDigitalTwinMemories, useDeleteDigitalTwinMemory } from '@/hooks/useClawDigitalTwin';
+import { MemoryCard } from '../components/MemoryCard';
+import { CategoryBadge } from '../components/CategoryBadge';
+import { CATEGORY_LEGEND, CATEGORY_STYLES } from '../components/subsystems';
+
+const DELETE_COPY =
+  'This removes it from Hindsight and marks all related review rows as rejected. Recall-hit history is retained.';
+
+const DigitalTwinMemoriesTab = (): ReactElement => {
+  const { data, isLoading } = useClawDigitalTwinMemories();
+  const deleteMutation = useDeleteDigitalTwinMemory();
+  const [search, setSearch] = useState('');
+  const [legendOpen, setLegendOpen] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
+
+  const memories = useMemo(() => data?.memories ?? [], [data]);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase().trim();
+    if (!q) return memories;
+    return memories.filter(m => m.content.toLowerCase().includes(q));
+  }, [memories, search]);
+
+  const visibleCategories = useMemo(
+    () =>
+      new Set(
+        memories.map(m => (m.category ?? '').toLowerCase()).filter(c => c in CATEGORY_STYLES),
+      ),
+    [memories],
+  );
+
+  return (
+    <div className='flex flex-col gap-2.5'>
+      <div className='sticky top-0 z-10 -mb-2.5 bg-background pb-2.5'>
+        <AdminSearchField
+          value={search}
+          onChange={setSearch}
+          placeholder='Search memories'
+          ariaLabel='Search memories'
+          trackCategory='Claw Agents'
+          trackName='Digital Twin: search memories'
+          className='w-full'
+        />
+      </div>
+
+      {visibleCategories.size > 0 && (
+        <div className='rounded-lg border border-border bg-muted/40'>
+          <button
+            type='button'
+            onClick={() => setLegendOpen(o => !o)}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin category legend toggle'
+            className='flex w-full items-center justify-between px-2.5 py-1.5 text-left'
+          >
+            <span className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+              Category guide
+            </span>
+            {legendOpen ? (
+              <ChevronUp className='size-3 text-muted-foreground' />
+            ) : (
+              <ChevronDown className='size-3 text-muted-foreground' />
+            )}
+          </button>
+          {legendOpen && (
+            <div className='flex flex-col gap-1.5 border-t border-border px-2.5 py-2'>
+              {CATEGORY_LEGEND.filter(row => visibleCategories.has(row.key)).map(row => (
+                <div key={row.key} className='flex items-start gap-2'>
+                  <CategoryBadge category={row.key} />
+                  <span className='text-xs text-muted-foreground'>{row.description}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className='flex flex-col gap-1.5'>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className='h-16 rounded-lg' />
+          ))}
+        </div>
+      ) : filtered.length === 0 && search.trim() ? (
+        <TabMessage>No memories match &ldquo;{search}&rdquo;</TabMessage>
+      ) : memories.length === 0 ? (
+        <TabMessage>
+          No memories yet — go to Proposals, approve the ones that look right, and they’ll show up
+          here.
+        </TabMessage>
+      ) : (
+        <ul className='flex flex-col'>
+          {filtered.map(memory => (
+            <MemoryCard
+              key={memory.hindsightMemoryId}
+              memory={memory}
+              onDelete={setPendingDelete}
+              query={search}
+            />
+          ))}
+        </ul>
+      )}
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={open => {
+          if (!open) setPendingDelete(null);
+        }}
+        title='Delete this memory?'
+        description={DELETE_COPY}
+        confirmLabel='Delete'
+        danger
+        loading={deleteMutation.isPending}
+        onConfirm={() => {
+          if (!pendingDelete) return;
+          deleteMutation.mutate(
+            { hindsightMemoryId: pendingDelete },
+            { onSuccess: () => setPendingDelete(null) },
+          );
+        }}
+      />
+    </div>
+  );
+};
+
+export default DigitalTwinMemoriesTab;

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinMetricsTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinMetricsTab.tsx
@@ -1,0 +1,65 @@
+import { ReactElement, useState } from 'react';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { SegmentedToggle } from '@/components/ui/SegmentedToggle';
+import { useClawDigitalTwinMetrics } from '@/hooks/useClawDigitalTwin';
+import { DigitalTwinKpis } from '../components/metrics/DigitalTwinKpis';
+import { DigitalTwinMetricsCharts } from '../components/metrics/DigitalTwinMetricsCharts';
+
+const DAY_OPTIONS: Array<{ label: string; value: number | null }> = [
+  { label: '7d', value: 7 },
+  { label: '30d', value: 30 },
+  { label: '90d', value: 90 },
+  { label: 'All', value: null },
+];
+
+const DigitalTwinMetricsTab = (): ReactElement => {
+  const [days, setDays] = useState<number | null>(30);
+  const { data, isLoading, error } = useClawDigitalTwinMetrics(days);
+  const activeRangeLabel = DAY_OPTIONS.find(option => option.value === days)?.label ?? 'All';
+
+  return (
+    <div className='flex flex-col gap-5'>
+      <div className='flex flex-wrap items-start justify-between gap-4'>
+        <div>
+          <h2 className='text-base font-semibold text-foreground'>Approval metrics</h2>
+          <p className='mt-1 text-sm text-muted-foreground'>
+            How your Twin&apos;s candidates are reviewed — approval, edits, and where memories come
+            from.
+          </p>
+        </div>
+
+        <SegmentedToggle
+          options={DAY_OPTIONS.map(option => ({ value: option.label, label: option.label }))}
+          value={activeRangeLabel}
+          onChange={label =>
+            setDays(DAY_OPTIONS.find(option => option.label === label)?.value ?? null)
+          }
+          tone='primary'
+          trackCategory='Claw Agents'
+          trackPrefix='Digital Twin metrics range'
+        />
+      </div>
+
+      {error && (
+        <div className='rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive'>
+          Failed to load metrics: {error.message}
+        </div>
+      )}
+
+      {isLoading || !data ? (
+        <div className='flex flex-col gap-5'>
+          <Skeleton className='h-28 w-full' />
+          <Skeleton className='h-72 w-full' />
+          <Skeleton className='h-72 w-full' />
+        </div>
+      ) : (
+        <>
+          <DigitalTwinKpis data={data} />
+          <DigitalTwinMetricsCharts data={data} />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default DigitalTwinMetricsTab;

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinProposalsTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinProposalsTab.tsx
@@ -1,0 +1,174 @@
+import { ReactElement, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { CheckTickCircle, FilterFunnel } from '@xyne/icons';
+import { AdminSearchField } from '@/routes/AIScreen/library/admin/components/AdminSearchField';
+import { TabMessage } from '@/routes/AIScreen/library/admin/components/TabMessage';
+import { FilterSelect } from '@/routes/AIScreen/library/admin/components/FilterSelect';
+import { Button } from '@/components/ui/Button/index';
+import { Skeleton } from '@/components/ui/Skeleton';
+import {
+  useApproveDigitalTwinCluster,
+  useClawDigitalTwinProposals,
+} from '@/hooks/useClawDigitalTwin';
+import { CandidateRow } from '../components/CandidateRow';
+import { SUBSYSTEM_ICONS, SUBSYSTEM_LABELS, subsystemLabel } from '../components/subsystems';
+import type { DigitalTwinCandidate } from '@/services/claw/digitalTwinTypes';
+
+const DigitalTwinProposalsTab = (): ReactElement => {
+  const { data: groups, isLoading, isError } = useClawDigitalTwinProposals();
+  const approveCluster = useApproveDigitalTwinCluster();
+
+  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set());
+  const [bulkActing, setBulkActing] = useState(false);
+  const [search, setSearch] = useState('');
+  const [subsystemFilter, setSubsystemFilter] = useState('');
+
+  const removeCandidate = (id: string): void => setRemovedIds(prev => new Set(prev).add(id));
+
+  const allCandidates = useMemo(
+    () =>
+      (groups ?? []).flatMap(g =>
+        g.candidates.map(c => ({ ...c, subsystem: c.subsystem || g.subsystem })),
+      ),
+    [groups],
+  );
+
+  const subsystemOptions = useMemo(() => {
+    const all = new Set<string>(Object.keys(SUBSYSTEM_LABELS));
+    for (const c of allCandidates) all.add(c.subsystem);
+    const options = [...all]
+      .sort((a, b) => subsystemLabel(a).localeCompare(subsystemLabel(b)))
+      .map(subsystem => {
+        const IconComponent = SUBSYSTEM_ICONS[subsystem];
+        return {
+          value: subsystem,
+          label: subsystemLabel(subsystem),
+          icon: IconComponent ? <IconComponent className='size-4' aria-hidden /> : undefined,
+        };
+      });
+    return [{ value: '', label: 'All subsystems' }, ...options];
+  }, [allCandidates]);
+
+  const visible = useMemo(() => {
+    const q = search.toLowerCase().trim();
+    return allCandidates.filter(c => {
+      if (removedIds.has(c.id)) return false;
+      if (subsystemFilter && c.subsystem !== subsystemFilter) return false;
+      if (!q) return true;
+      return (
+        (c.editedText ?? c.text).toLowerCase().includes(q) ||
+        subsystemLabel(c.subsystem).toLowerCase().includes(q)
+      );
+    });
+  }, [allCandidates, removedIds, subsystemFilter, search]);
+
+  const approveVisible = async (): Promise<void> => {
+    if (visible.length === 0) return;
+    const bySubsystem = new Map<string, string[]>();
+    for (const c of visible) {
+      const ids = bySubsystem.get(c.subsystem) ?? [];
+      ids.push(c.id);
+      bySubsystem.set(c.subsystem, ids);
+    }
+    setBulkActing(true);
+    try {
+      await Promise.all(
+        [...bySubsystem.entries()].map(([subsystem, candidateIds]) =>
+          approveCluster.mutateAsync({ subsystem, candidateIds }),
+        ),
+      );
+      toast.success(`Approving ${visible.length} — saving to Hindsight`);
+      setRemovedIds(prev => {
+        const next = new Set(prev);
+        visible.forEach(c => next.add(c.id));
+        return next;
+      });
+    } finally {
+      setBulkActing(false);
+    }
+  };
+
+  const narrowed = search.trim().length > 0 || subsystemFilter.length > 0;
+  const emptyMessage = search.trim()
+    ? `No proposals match “${search.trim()}”`
+    : subsystemFilter
+      ? `No proposals in ${subsystemLabel(subsystemFilter)}`
+      : 'No proposals pending';
+
+  return (
+    <div className='flex flex-col gap-2.5'>
+      <div className='sticky top-0 z-10 -mb-2.5 flex flex-col gap-2.5 bg-background pb-2.5'>
+        <AdminSearchField
+          value={search}
+          onChange={setSearch}
+          placeholder='Search proposals'
+          ariaLabel='Search proposals'
+          trackCategory='Claw Agents'
+          trackName='Digital Twin: search proposals'
+          className='w-full'
+        />
+
+        <div className='flex flex-wrap items-center justify-end gap-2'>
+          <FilterSelect
+            ariaLabel='Subsystem filter'
+            icon={<FilterFunnel className='size-4 shrink-0 text-muted-foreground' aria-hidden />}
+            value={subsystemFilter}
+            onChange={setSubsystemFilter}
+            options={subsystemOptions}
+            anchorLabel='All subsystems'
+          />
+          {visible.length > 0 && (
+            <Button
+              type='button'
+              size='sm'
+              onClick={() => void approveVisible()}
+              loading={bulkActing}
+              disabled={bulkActing}
+              data-track-category='Claw Agents'
+              data-track-name='Digital Twin approve all proposals'
+            >
+              {!bulkActing && <CheckTickCircle className='size-4' aria-hidden />}
+              Approve all
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <ul className='flex flex-col'>
+          {[0, 1, 2, 3].map(i => (
+            <li key={i} className='flex items-start gap-3 border-b border-border px-1 py-4'>
+              <Skeleton className='size-8 shrink-0 rounded-lg' />
+              <div className='min-w-0 flex-1 space-y-2'>
+                <Skeleton className='h-3.5 w-[85%] rounded' />
+                <Skeleton className='h-3 w-32 rounded' />
+              </div>
+              <Skeleton className='size-[30px] shrink-0 rounded-full' />
+            </li>
+          ))}
+        </ul>
+      ) : isError ? (
+        <TabMessage>Couldn’t load proposals.</TabMessage>
+      ) : visible.length === 0 ? (
+        <TabMessage>
+          {emptyMessage}
+          {!narrowed && ' — new candidates are added automatically each night.'}
+        </TabMessage>
+      ) : (
+        <ul className='flex flex-col'>
+          {visible.map((candidate: DigitalTwinCandidate) => (
+            <CandidateRow
+              key={candidate.id}
+              candidate={candidate}
+              onApproved={removeCandidate}
+              onRejected={removeCandidate}
+              query={search}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default DigitalTwinProposalsTab;

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinRecallTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinRecallTab.tsx
@@ -1,0 +1,101 @@
+import { ReactElement, useState } from 'react';
+import { ListDefault, SearchDefault } from '@xyne/icons';
+import { Button } from '@/components/ui/Button';
+import { cn } from '@/utils/classNames';
+import { DetailCard } from '@/routes/AIScreen/library/shared/primitives/DetailPrimitives';
+import { useRecallDigitalTwin } from '@/hooks/useClawDigitalTwin';
+import { MetaRow } from '@/routes/AIScreen/library/shared/primitives/MetaRow';
+import { SettingCardHeader } from '../components/SettingCardHeader';
+import { scoreToneClass } from '../components/format';
+import type { RecallResult } from '@/services/claw/digitalTwinTypes';
+
+const DigitalTwinRecallTab = (): ReactElement => {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<RecallResult[] | null>(null);
+  const recall = useRecallDigitalTwin();
+
+  const submit = (): void => {
+    const q = query.trim();
+    if (!q) return;
+    setResults(null);
+    recall.mutate({ query: q, budget: 'mid' }, { onSuccess: setResults });
+  };
+
+  return (
+    <div className='flex w-full flex-col gap-3'>
+      <DetailCard>
+        <SettingCardHeader
+          icon={SearchDefault}
+          title='Test recall'
+          description='Runs the same retrieval your Twin uses when drafting a reply. Nothing is saved.'
+        />
+        <div className='flex flex-col gap-4 p-4'>
+          <textarea
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin recall query'
+            placeholder='Ask a question your Twin might answer…'
+            rows={3}
+            className='w-full resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none'
+          />
+          <div className='flex justify-end'>
+            <Button
+              size='sm'
+              disabled={!query.trim()}
+              loading={recall.isPending}
+              onClick={submit}
+              data-track-category='Claw Agents'
+              data-track-name='Digital Twin run recall'
+            >
+              {!recall.isPending && <SearchDefault className='size-4' aria-hidden />}
+              {recall.isPending ? 'Recalling…' : 'Test recall'}
+            </Button>
+          </div>
+        </div>
+      </DetailCard>
+
+      {results && (
+        <DetailCard>
+          <SettingCardHeader
+            icon={ListDefault}
+            title='Results'
+            description={
+              results.length === 0
+                ? 'No memories were recalled for this query.'
+                : `${results.length} memor${results.length === 1 ? 'y' : 'ies'} your Twin would draw on.`
+            }
+            divided={results.length > 0}
+          />
+          {results.length > 0 && (
+            <ul className='flex flex-col px-4'>
+              {results.map((result, index) => (
+                <li
+                  key={result.id ?? index}
+                  className='flex flex-col gap-1 border-b border-border py-4 last:border-b-0'
+                >
+                  <p className='text-sm leading-relaxed text-foreground'>{result.text ?? '—'}</p>
+                  <MetaRow
+                    items={[
+                      result.fact_type && <span key='type'>{result.fact_type}</span>,
+                      result.score !== undefined && (
+                        <span
+                          key='score'
+                          className={cn('font-medium tabular-nums', scoreToneClass(result.score))}
+                        >
+                          {Math.round(result.score * 100)}% match
+                        </span>
+                      ),
+                    ]}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+        </DetailCard>
+      )}
+    </div>
+  );
+};
+
+export default DigitalTwinRecallTab;

--- a/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinSettingsTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/digitalTwin/tabs/DigitalTwinSettingsTab.tsx
@@ -1,0 +1,165 @@
+import { ReactElement, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { PencilEdit, ShieldCheck } from '@xyne/icons';
+import { Button } from '@/components/ui/Button';
+import { Switch } from '@/components/ui/Switch';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { cn } from '@/utils/classNames';
+import { DetailCard } from '@/routes/AIScreen/library/shared/primitives/DetailPrimitives';
+import { SettingCardHeader } from '../components/SettingCardHeader';
+import { useClawDigitalTwinStatus, useUpdateDigitalTwinSettings } from '@/hooks/useClawDigitalTwin';
+
+const MAX_SUFFIX_LEN = 500;
+const MIN_SCORE = 0.7;
+const MAX_SCORE = 1;
+const SCORE_STEP = 0.05;
+
+const DigitalTwinSettingsTab = (): ReactElement => {
+  const { data: status, isLoading } = useClawDigitalTwinStatus();
+  const updateMutation = useUpdateDigitalTwinSettings();
+
+  const initialSuffix = status?.responseSuffix ?? '';
+  const initialAuto = status?.memoryApprovalMode === 'auto';
+  const initialScore = status?.memoryAutoApproveMinScore ?? 0.9;
+
+  const [suffix, setSuffix] = useState(initialSuffix);
+  const [auto, setAuto] = useState(initialAuto);
+  const [score, setScore] = useState(initialScore);
+
+  useEffect(() => {
+    setSuffix(status?.responseSuffix ?? '');
+    setAuto(status?.memoryApprovalMode === 'auto');
+    setScore(status?.memoryAutoApproveMinScore ?? 0.9);
+  }, [status?.responseSuffix, status?.memoryApprovalMode, status?.memoryAutoApproveMinScore]);
+
+  const charCount = suffix.length;
+  const dirty =
+    suffix.trim() !== initialSuffix.trim() ||
+    auto !== initialAuto ||
+    (auto && score !== initialScore);
+
+  const save = (): void => {
+    updateMutation.mutate(
+      {
+        responseSuffix: suffix || null,
+        memoryApprovalMode: auto ? 'auto' : 'manual',
+        ...(auto ? { memoryAutoApproveMinScore: score } : {}),
+      },
+      { onSuccess: () => toast.success('Settings saved') },
+    );
+  };
+
+  if (isLoading && !status) {
+    return (
+      <div className='flex w-full flex-col gap-3'>
+        <Skeleton className='h-56 w-full rounded-2xl' />
+        <Skeleton className='h-28 w-full rounded-2xl' />
+      </div>
+    );
+  }
+
+  const fillPct = ((score - MIN_SCORE) / (MAX_SCORE - MIN_SCORE)) * 100;
+
+  return (
+    <div className='flex w-full flex-col gap-3'>
+      <DetailCard>
+        <SettingCardHeader
+          icon={PencilEdit}
+          title='Response suffix'
+          description='Appended to every reply your Twin sends on your behalf. Leave blank to post replies as-is.'
+          trailing={
+            <span
+              className={cn(
+                'shrink-0 text-xs tabular-nums',
+                charCount >= MAX_SUFFIX_LEN ? 'text-status-pending' : 'text-muted-foreground',
+              )}
+            >
+              {charCount} / {MAX_SUFFIX_LEN}
+            </span>
+          }
+        />
+        <div className='flex flex-col gap-4 p-4'>
+          <textarea
+            value={suffix}
+            onChange={e => setSuffix(e.target.value.slice(0, MAX_SUFFIX_LEN))}
+            placeholder='Sent by my Digital Twin · may contain mistakes'
+            rows={3}
+            maxLength={MAX_SUFFIX_LEN}
+            data-track-category='Claw Agents'
+            data-track-name='Digital Twin response suffix'
+            className='w-full resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:border-ring focus:outline-none'
+          />
+          {suffix.trim().length > 0 && (
+            <div className='rounded-lg border border-border bg-muted/40 p-3'>
+              <p className='mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+                Preview
+              </p>
+              <p className='whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground'>
+                <span>[your Twin&apos;s reply]</span>
+                {'\n\n'}
+                <span className='text-primary'>{suffix.trim()}</span>
+              </p>
+            </div>
+          )}
+        </div>
+      </DetailCard>
+
+      <DetailCard>
+        <SettingCardHeader
+          icon={ShieldCheck}
+          title='Memory approval'
+          description={
+            auto
+              ? 'High-confidence memories are saved automatically. Lower-confidence ones still wait for your review.'
+              : 'Every memory waits in your review queue until you approve it.'
+          }
+          divided={auto}
+          trailing={
+            <Switch
+              checked={auto}
+              onCheckedChange={setAuto}
+              aria-label='Auto-approve high-confidence memories'
+            />
+          }
+        />
+        <div className='flex flex-col gap-4 p-4 empty:hidden'>
+          {auto && (
+            <div className='rounded-lg border border-border bg-muted/40 p-4'>
+              <div className='mb-3 flex items-center justify-between gap-3 text-xs'>
+                <span className='text-muted-foreground'>Auto-approve at or above</span>
+                <span className='tabular-nums text-foreground'>{score.toFixed(2)}</span>
+              </div>
+              <input
+                type='range'
+                min={MIN_SCORE}
+                max={MAX_SCORE}
+                step={SCORE_STEP}
+                value={score}
+                onChange={e => setScore(Number(e.target.value))}
+                data-track-category='Claw Agents'
+                data-track-name='Digital Twin auto-approve threshold'
+                style={{
+                  background: `linear-gradient(to right, hsl(var(--primary)) ${fillPct}%, hsl(var(--border)) ${fillPct}%)`,
+                }}
+                className='h-1.5 w-full cursor-pointer appearance-none rounded-full [&::-moz-range-thumb]:size-3.5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-primary [&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:size-3.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary'
+              />
+              <div className='mt-3 flex items-center justify-between gap-3 text-xs text-muted-foreground'>
+                <span>{MIN_SCORE.toFixed(2)} · more memories</span>
+                <span>{MAX_SCORE.toFixed(2)} · only the surest</span>
+              </div>
+            </div>
+          )}
+        </div>
+      </DetailCard>
+
+      <div className='flex items-center justify-end gap-3 pt-1'>
+        {!dirty && <span className='text-xs text-muted-foreground'>No unsaved changes</span>}
+        <Button onClick={save} loading={updateMutation.isPending} disabled={!dirty}>
+          Save changes
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default DigitalTwinSettingsTab;

--- a/apps/dashboard/src/routes/AIScreen/library/admin/AgentsTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/admin/AgentsTab.tsx
@@ -381,7 +381,7 @@ export function AgentsTab({
   };
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col gap-6 overflow-auto'>
+    <div className='flex min-h-0 flex-1 flex-col gap-6 overflow-auto pb-6'>
       {searchBar}
 
       {registration.flow && (

--- a/apps/dashboard/src/routes/AIScreen/library/admin/GlobalMcpTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/admin/GlobalMcpTab.tsx
@@ -222,7 +222,7 @@ export function GlobalMcpTab({ userId }: { userId: string }): ReactElement {
     : servers;
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col gap-6 overflow-auto'>
+    <div className='flex min-h-0 flex-1 flex-col gap-6 overflow-auto pb-6'>
       {searchBar}
 
       {visibleServers.length === 0 ? (

--- a/apps/dashboard/src/routes/AIScreen/library/admin/RequestsTab.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/admin/RequestsTab.tsx
@@ -570,7 +570,7 @@ export function RequestsTab({
   );
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col gap-6 overflow-auto'>
+    <div className='flex min-h-0 flex-1 flex-col gap-6 overflow-auto pb-6'>
       {registration.flow && (
         <RegistrationFlowCard
           flow={registration.flow}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/primitives/MetaRow.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/primitives/MetaRow.tsx
@@ -1,0 +1,30 @@
+import { Fragment, type ReactElement, type ReactNode } from 'react';
+import { cn } from '@/utils/classNames';
+
+export const MetaRow = ({
+  badge,
+  items,
+  className,
+}: {
+  badge?: ReactNode;
+  items: ReactNode[];
+  className?: string;
+}): ReactElement => {
+  const parts = items.filter(Boolean);
+  return (
+    <div
+      className={cn(
+        'flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground',
+        className,
+      )}
+    >
+      {badge}
+      {parts.map((node, index) => (
+        <Fragment key={index}>
+          {index > 0 && <span aria-hidden>·</span>}
+          {node}
+        </Fragment>
+      ))}
+    </div>
+  );
+};

--- a/apps/dashboard/src/routes/AIScreen/screens/AIDigitalTwinScreen.tsx
+++ b/apps/dashboard/src/routes/AIScreen/screens/AIDigitalTwinScreen.tsx
@@ -1,0 +1,24 @@
+import { type ReactElement } from 'react';
+import { AIShell } from '../../../components/AIScreen/AIShell';
+import DigitalTwin from '../digitalTwin/DigitalTwin';
+import { useAIChatHandoff } from '../useAIChatHandoff';
+
+const AIDigitalTwinScreen = (): ReactElement => {
+  const { onCreateChat, onSelectSession } = useAIChatHandoff();
+
+  return (
+    <AIShell onCreateChat={onCreateChat} onSelectSession={onSelectSession}>
+      <main
+        data-id='ai-digital-twin-view'
+        className='relative flex h-full flex-1 flex-col overflow-hidden'
+      >
+        <div className='h-[32px] w-full shrink-0' />
+        <div className='relative flex min-h-0 flex-1 flex-col overflow-hidden'>
+          <DigitalTwin />
+        </div>
+      </main>
+    </AIShell>
+  );
+};
+
+export default AIDigitalTwinScreen;

--- a/apps/dashboard/src/routes/AppRoot.tsx
+++ b/apps/dashboard/src/routes/AppRoot.tsx
@@ -247,6 +247,7 @@ import AIMcpDetailScreen from './AIScreen/screens/AIMcpDetailScreen';
 import AIAgentEditScreen from './AIScreen/screens/AIAgentEditScreen';
 import AIKnowledgeScreen from './AIScreen/screens/AIKnowledgeScreen';
 import AIOrganizationScreen from './AIScreen/screens/AIOrganizationScreen';
+import AIDigitalTwinScreen from './AIScreen/screens/AIDigitalTwinScreen';
 import AISectionLayout from './AIScreen/AISectionLayout';
 import { EncryptionBootstrapProvider } from '../providers/EncryptionBootstrapProvider';
 import { EncryptionInit } from '../components/EncryptionInit';
@@ -1139,22 +1140,10 @@ export const router = createBrowserRouter(
                         </RequireOrgManager>
                       ),
                     },
+                    { path: 'digital-twin', element: <AIDigitalTwinScreen /> },
                     {
                       element: <AISectionLayout />,
                       children: [
-                        {
-                          path: 'digital-twin',
-                          element: <ClawDigitalTwinScreen />,
-                          children: [
-                            { index: true, element: <DigitalTwinMemoriesTab /> },
-                            { path: 'hot', element: <DigitalTwinHotTab /> },
-                            { path: 'proposals', element: <DigitalTwinProposalsTab /> },
-                            { path: 'recall', element: <DigitalTwinRecallTab /> },
-                            { path: 'graph', element: <DigitalTwinGraphTab /> },
-                            { path: 'metrics', element: <ClawDigitalTwinMetricsScreen /> },
-                            { path: 'settings', element: <DigitalTwinSettingsTab /> },
-                          ],
-                        },
                         { path: 'metrics', element: <ClawMetricsScreen /> },
                         { path: 'settings', element: <ClawSettingsScreen /> },
                       ],


### PR DESCRIPTION
Cherry-pick of #890 onto `release-20260901`.

Original merge commit `394fdbb` applied with `git cherry-pick` — no conflicts, and the resulting diff is byte-identical to the diff merged into `main` (33 files, +3045 / -22). No changes were made on top of the original.

---

[POT](https://drive.google.com/file/d/13FRPlc_w3kIfbFh2Rg6c2pnQbyqr_8Lg/view?usp=sharing)
[POT-N](https://drive.google.com/file/d/1C54h52wO0Q22ckKkUysJfnoq2XG-qiUm/view?usp=sharing)
## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [x] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-56669 — rebuilds the Digital Twin surface at `/ai/digital-twin` so it follows the Admin and Organization layout pattern, and gives it its own component tree.

**Structure**
- `AIDigitalTwinScreen` wraps `AIShell` and is registered as a flat route alongside `admin` and `organization`, lifted out of `AISectionLayout`.
- The seven nested routes collapse into a horizontal tab strip driven by `?tab=`.
- **No route guard.** Unlike Admin (`RequireClawAdmin`) and Organization (`RequireOrgManager`), every `/digital-twin/*` endpoint uses `requireUserAuth` with no admin elevation — the surface is per-user by contract, so a guard would lock users out of their own data.
- `routes/AIScreen/digitalTwin/` owns its own tabs and components. **`apps/dashboard/src/routes/ClawAgentsScreen/` and `components/ClawAgents/` are untouched** — `/claw-agents/digital-twin` renders exactly as before.

**Layout and theming**
- `max-w-ai-content`, `text-2xl` title, `Pill` status, and Admin's scroll model (fixed header, content scrolls in its own pane with a `pb-6` inset).
- Rows follow the Admin/Organization pattern — `border-b`, `text-sm` content, `text-xs` muted meta, single line with a tooltip only when the text is actually clipped.
- Icons come from `@xyne/icons`; tones use `status-*` and `primary` tokens instead of hardcoded hex.
- Reuses `AdminSearchField`, `FilterSelect` and `DetailCard`. `SegmentedToggle` replaces two hand-rolled range toggles that were styled differently from each other.

**Proposals**
- Per-subsystem accordions become a flat list with a subsystem filter.
- `Approve all` now sends explicit `candidateIds` for exactly what is on screen. A bare `{subsystem}` approve retains *every* pending candidate in that cluster, which with a filter or search active would have approved rows the user could not see — and approving is not reversible from this screen.

**Fixes**
- Backfill dialog no longer jumps when you pick a range. Each range is its own query key, so switching presets always started an uncached fetch; the estimate card used to unmount and the vertically-centred dialog collapsed ~120px and re-expanded. The card now stays mounted and only its values swap.
- Metrics charts show a pointer on hover instead of Recharts' default grey cursor block.
- Upload uses a themed file picker — WebKit ignores most `file:` pseudo-element styling, so it was rendering OS chrome.
- Admin agents / requests / global-MCP tabs gain a bottom inset; their scroll containers had no `pb-6`, so content sat flush against the viewport edge at the end of the scroll.

> **Reviewer decision:** this also adds a local-only `POST /digital-twin/dev-seed` (404s when `NODE_ENV === 'production'`, `requireUserAuth`, seeds only the caller's own Twin). It exists because no Hindsight instance is configured for local dev, so Memories/Hot/Graph cannot be exercised otherwise. Happy to drop that commit if it shouldn't ship.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

<!-- No env keys added. Note for local testing only: the dev-seed endpoint needs a memory
     provider, and no HINDSIGHT_URL is configured anywhere in the repo. Setting
     MEMORY_PROVIDER=stub in apps/xyne-claw-auth/backend/.env falls back to the in-process
     stub provider. That is a local .env change and is not part of this PR. -->

## API Contract

- [ ] No API changes
- [x] New endpoint <!-- POST /digital-twin/dev-seed, local-only, 404 in production -->
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?

Manually, in local dev, driving the screen tab by tab and comparing each surface against Admin and Organization. Every tab was exercised with seeded data (memories, recall hits across the 7d/30d/90d buckets, subsystem tags) and with empty data, plus the backfill / upload / disable dialogs.

Verified after each change: `typecheck` on both `apps/dashboard` and `apps/xyne-claw-auth/backend`, ESLint on every touched file (0 errors), and that each changed module still transforms through the running Vite dev server.

**Not covered by automated tests** — this is presentation-level work on a surface with no existing test coverage, and the one behavioural change (`Approve all` scoping) needs a Hindsight-backed integration environment to assert against. Worth adding if a reviewer disagrees.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- see note above -->

### Manual

**Users**
- [x] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [x] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [x] No Zero changes

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [x] Narrow viewport, dark + light theme <!-- spot-checked dark; not exhaustive -->
- [x] Empty state
- [ ] Large / realistic data volume
- [x] Error paths (network failure, denied permission, invalid input) <!-- upload validation, recall failures -->

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes <!-- not run; no shared package touched -->
- [x] Backend `typecheck` passes <!-- claw-auth; apps/backend not touched. build not run -->
- [x] Dashboard `lint:errors-only` + `typecheck` pass <!-- build not run -->
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides` <!-- no new deps -->
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

### Known gaps, called out deliberately

- **Graph renders nodes but never edges.** `subsystem-graph` builds edges only from shared `session:` tags, but neither Digital Twin approve path writes one — they write `user:`, `subsystem:`, `scope:user` and `pipeline:`. Pre-existing, not introduced here; the seeded data fakes `session:` tags so the graph is visible. Worth its own ticket.
- **`ConfirmDialog` stays shared** from `components/ClawAgents/`. It is unmodified and already used across `/ai` (Organization, Admin, Skills), so forking it would have made a fifth copy.
- `SegmentedToggle` gained optional `tone` and tracking props. Both default to existing behaviour, so its five other consumers are unaffected.

