### PR TITLE
feat: XYNE-61764 add 'Last updated' and 'Created by' columns to ticket and desk table views

### DIFF
--- a/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx
@@ -438,6 +438,43 @@ export const TicketTable: React.FC<TicketTableProps> = ({
       },
 
       {
+        key: 'updatedAt',
+        headerName: 'Last updated',
+        field: 'updatedAt',
+        minWidth: 175,
+        cellRenderer: (params: ICellRendererParams<Ticket>) => {
+          if (!params.value) return <span className='text-muted-foreground'>—</span>;
+          const updatedAt = new Date(params.value as string | number | Date);
+          if (Number.isNaN(updatedAt.getTime())) {
+            return <span className='text-muted-foreground'>—</span>;
+          }
+          const fullTimestamp = updatedAt.toLocaleString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+          });
+          return (
+            <Tooltip content={fullTimestamp}>
+              <span className='text-sm text-muted-foreground whitespace-nowrap'>
+                {fullTimestamp}
+              </span>
+            </Tooltip>
+          );
+        },
+      },
+
+      {
+        key: 'createdBy',
+        headerName: 'Created by',
+        field: 'createdBy',
+        minWidth: 213,
+        cellRenderer: CreatedByCellRenderer,
+      },
+
+      {
         key: 'assignee',
         headerName: 'Assignee',
         field: 'assignedTo',
@@ -809,6 +846,42 @@ export const TicketTable: React.FC<TicketTableProps> = ({
         </div>
       </div>
     </>
+  );
+};
+
+const CreatedByCellRenderer = (params: ICellRendererParams<Ticket>) => {
+  const ticket = params.data;
+  const createdByUser = useUser(ticket?.createdBy ?? '');
+
+  if (!ticket) return null;
+
+  if (!ticket.createdBy) {
+    return (
+      <div className='flex items-center h-full'>
+        <span className='text-muted-foreground'>—</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className='flex items-center h-full'>
+      {createdByUser ? (
+        <div className='flex items-center gap-3'>
+          <Tooltip content={getUserDisplayName(createdByUser)}>
+            <Avatar
+              userId={createdByUser.id}
+              className='rounded-full size-6 flex items-center justify-center'
+              showActiveStatus={false}
+            />
+          </Tooltip>
+          <span className='text-muted-foreground truncate font-medium'>
+            {getUserDisplayName(createdByUser)}
+          </span>
+        </div>
+      ) : (
+        <span className='text-muted-foreground'>—</span>
+      )}
+    </div>
   );
 };
 

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -385,6 +385,7 @@ const availableColumns = [
   { key: 'stage', label: 'Sub-status', icon: <CircleCheckBig className='h-4 w-4' /> },
   { key: 'createdAt', label: 'Created At', icon: <Clock className='h-4 w-4' /> },
   { key: 'createdBy', label: 'Created By', icon: <User className='h-4 w-4' /> },
+  { key: 'updatedAt', label: 'Updated At', icon: <Clock className='h-4 w-4' /> },
 ];
 
 const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
@@ -3420,11 +3421,13 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     if (layoutView === 'table' || layoutView === 'flow') {
       // In table mode, hide TicketCard metadata columns
       return availableColumns.filter(
-        col => !['stage', 'board', 'createdAt', 'createdBy'].includes(col.key),
+        col => !['stage', 'board', 'createdAt', 'createdBy', 'updatedAt'].includes(col.key),
       );
     }
     if (layoutView === 'calendar') {
-      return availableColumns.filter(col => !['stage', 'board', 'createdBy'].includes(col.key));
+      return availableColumns.filter(
+        col => !['stage', 'board', 'createdBy', 'updatedAt'].includes(col.key),
+      );
     }
     return availableColumns.filter(col => col.key !== 'status');
   }, [layoutView]);

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -3333,9 +3333,11 @@ const SupportScreen = (): ReactElement => {
                           >
                             {DESK_TABLE_BUILTIN_COLUMNS.map(column => {
                               const Icon =
-                                column.key === 'assignee'
+                                column.key === 'assignee' || column.key === 'createdBy'
                                   ? User
-                                  : column.key === 'dueDate' || column.key === 'createdAt'
+                                  : column.key === 'dueDate' ||
+                                      column.key === 'createdAt' ||
+                                      column.key === 'updatedAt'
                                     ? CalendarDays
                                     : column.key === 'priority'
                                       ? BarChart4Icon

--- a/apps/dashboard/src/routes/SupportScreen/useDeskTableColumns.ts
+++ b/apps/dashboard/src/routes/SupportScreen/useDeskTableColumns.ts
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useState } from 'react';
 export const DESK_TABLE_BUILTIN_COLUMNS = [
   { key: 'createdAt', label: 'Created at' },
   { key: 'age', label: 'Age' },
+  { key: 'updatedAt', label: 'Last updated' },
+  { key: 'createdBy', label: 'Created by' },
   { key: 'assignee', label: 'Assignee' },
   { key: 'dueDate', label: 'Due date' },
   { key: 'status', label: 'Status Category' },
@@ -15,13 +17,14 @@ const DEFAULT_COLUMN_KEYS = DESK_TABLE_BUILTIN_COLUMNS.map(column => column.key 
 
 const storageKey = (channelId: string): string => `desk-table-columns-${channelId}`;
 
-const CURRENT_COLUMNS_VERSION = 3;
+const CURRENT_COLUMNS_VERSION = 4;
 
 // Adding a builtin column means bumping the version and listing its key here,
 // or desks with saved column choices never see it.
 const COLUMNS_ADDED_IN_VERSION: ReadonlyMap<number, readonly string[]> = new Map([
   [2, ['createdAt']],
   [3, ['age']],
+  [4, ['updatedAt', 'createdBy']],
 ]);
 
 const withColumnsAddedSince = (version: number, columns: Set<string>): Set<string> => {


### PR DESCRIPTION
## What
Adds two opt-in columns to the ticket AG Grid table (shared by the Projects board table view and the Support desk table view):
- **Last updated** (`updatedAt`) — formatted timestamp of the ticket record's last update (tooltip + inline text, matches the existing "Created at" column formatting)
- **Created by** (`createdBy`) — avatar + display name of the ticket creator via a new `CreatedByCellRenderer`

Both columns are toggleable from the existing **Customize view** pickers on both surfaces.

## Changes
1. `apps/dashboard/src/components/Tickets/TicketTable/TicketTable.tsx` — two new `ColDef`s in `allColumns` (`updatedAt` minWidth 175, `createdBy` minWidth 213 with `CreatedByCellRenderer` using `useUser` + `Avatar` + `Tooltip`).
2. `apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx` — `updatedAt` entry ("Updated At", Clock icon) in `availableColumns`; `filteredAvailableColumns` excludes it from table/flow/calendar TicketCard contexts (same as `createdBy`).
3. `apps/dashboard/src/routes/SupportScreen/useDeskTableColumns.ts` — version 3 → 4, `COLUMNS_ADDED_IN_VERSION[4] = ['updatedAt', 'createdBy']`, and both entries in `DESK_TABLE_BUILTIN_COLUMNS` so existing desks get both columns ON by default (same migration pattern used for `createdAt` and `age`).
4. `apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx` — desk column-picker icon mapping extended: `createdBy` → User, `updatedAt` → CalendarDays.

No backend / schema changes — both fields already exist on ticket rows and are stamped by mutators.

## Default visibility
- **Board table**: hidden by default; user enables via the Columns picker.
- **Desk table**: shown by default for all users via the localStorage column migration (v4).

## Testing
- `tsc --noEmit` exit 0; ESLint 0 errors; prettier clean.
- Manual POT in the sandboxed app (screenshots + walkthrough video in the tracking thread): board table shows the new columns after toggling them on in Customize view, rendering distinct per-row dates and avatar+creator names across 9 seeded tickets; desk table shows both columns on by default (v4 migration) for a user with a pre-existing localStorage selection. `@pot-verifier` gate passed.

Ticket: XYNE-61764