### PR TITLE
fix: XYNE-61785 Investigate missed call summary display logic

### DIFF
--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -18,6 +18,9 @@ import {
 
 export type { Call, CallParticipant };
 
+// Shorter channel calls skip post-call AI outputs (see getPostCallAiSkipReason).
+const MIN_CALL_DURATION_FOR_AI_SECONDS = 30;
+
 function parseRecordingParticipantIds(stored: string | null): string[] {
   if (!stored) return [];
   try {
@@ -347,6 +350,35 @@ export class CallRepository {
       WHERE "externalId" = ${externalId}
     `;
     return rowsUpdated > 0;
+  }
+
+  /**
+   * Why a channel call should get no post-call AI outputs, or null to proceed.
+   * Channel calls only: headless calls have no CallParticipant rows. A null
+   * endedAt (webhook race) never triggers the duration skip.
+   */
+  async getPostCallAiSkipReason(
+    call: Pick<Call, 'id' | 'startedAt' | 'endedAt'>,
+  ): Promise<{
+    reason: 'single_joined_participant' | 'call_too_short' | null;
+    joinedCount: number;
+    durationSeconds: number | null;
+  }> {
+    const joinedCount = await DatabaseClient.getInstance().callParticipant.count({
+      where: { callId: call.id, joinedAt: { not: null } },
+    });
+    const durationSeconds = call.endedAt
+      ? Math.max(0, (call.endedAt.getTime() - call.startedAt.getTime()) / 1000)
+      : null;
+
+    const reason =
+      joinedCount <= 1
+        ? 'single_joined_participant'
+        : durationSeconds !== null && durationSeconds < MIN_CALL_DURATION_FOR_AI_SECONDS
+          ? 'call_too_short'
+          : null;
+
+    return { reason, joinedCount, durationSeconds };
   }
 
   async updateRecordingParticipants(

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -1,7 +1,7 @@
 import { repositories } from '@/database/repositories';
 import { getCanvasUrl } from '@/services/canvasService';
 import { logger } from '@/utils/logger';
-import { Prisma } from '@prisma/client';
+import { Prisma, type Call } from '@prisma/client';
 import { config } from '@/config/env';
 import { Agent, createUserMessage } from '@framework';
 import { extractAgentContent } from '@/utils/agentUtils';
@@ -1723,10 +1723,40 @@ Output ONLY the processed transcript, nothing else.`;
   }
 
   /**
+   * Queue Vespa indexing for the stored transcript (call.id is the doc id).
+   * Best-effort: a queue failure is logged, never thrown, so it can run from
+   * both the normal tail of processing and the solo-call early exit.
+   */
+  private async queueTranscriptIndexing(
+    call: Pick<Call, 'id' | 'channelId' | 'createdByUserId'>,
+  ): Promise<void> {
+    try {
+      const callChannel = call.channelId
+        ? await db.channel.findUnique({ where: { id: call.channelId }, select: { workspaceId: true } })
+        : null;
+      await vespaQueue.addJob({
+        schema: fileSchema,
+        docId: call.id,
+        jobType: 'feed',
+        userId: call.createdByUserId,
+        app: SubApp.TRANSCRIPT,
+        ...(callChannel?.workspaceId ? { workspaceId: callChannel.workspaceId } : {}),
+      });
+      logger.info(`[TranscriptService] Queued Vespa indexing for transcript ${call.id}`);
+    } catch (vespaError) {
+      logger.error(`[TranscriptService] Failed to queue Vespa job for transcript ${call.id}:`, vespaError);
+    }
+  }
+
+  /**
    * NOTE_TAKER (HEADLESS / "Xyne Oats") calls never reach this method — their
    * entire pipeline (transcriptReady webhook, reconcile) is routed straight to
    * noteTakerTranscriptService, which never creates or posts a message. This
    * method is for the channel/conversation-based flow only.
+   *
+   * Solo or very short calls (see callRepository.getPostCallAiSkipReason) attach
+   * and index the transcript but produce no AI outputs — no summary, title,
+   * tickets, or detailed-summary canvas.
    */
 
   async processCallWithSummary(
@@ -1803,6 +1833,20 @@ Output ONLY the processed transcript, nothing else.`;
         logger.error(`[${callId}] post_transcript_failed`, { stage: 'post_call_transcript', error: transcriptError, stack: transcriptError instanceof Error ? transcriptError.stack : undefined });
         // Don't rethrow — retrieveTranscript below fetches raw content from GCS directly and
         // may still succeed even if the DB-side attachment step inside postCallTranscript failed.
+      }
+
+      // Solo or very short calls: keep the transcript but skip every LLM output.
+      // Headless recordings never reach this method, so the rule cannot misfire on
+      // note-taker calls.
+      const aiSkip = await repositories.calls.getPostCallAiSkipReason(call);
+      if (aiSkip.reason) {
+        logger.info(`[${callId}] ai_summary_skipped`, {
+          reason: aiSkip.reason,
+          joined_count: aiSkip.joinedCount,
+          duration_seconds: aiSkip.durationSeconds,
+        });
+        await this.queueTranscriptIndexing(call);
+        return;
       }
 
       // Retrieve and format transcript for AI.
@@ -2037,23 +2081,8 @@ Output ONLY the processed transcript, nothing else.`;
         // Use error (not warn) so LLM-down conditions generate alertable signal.
         logger.error(`[${callId}] ai_summary_skipped`, { reason: 'generation_failed' });
       }
-    // Queue Vespa indexing for the transcript (using call.id as the identifier)
-      try {
-        const callChannel = call.channelId
-          ? await db.channel.findUnique({ where: { id: call.channelId }, select: { workspaceId: true } })
-          : null;
-        await vespaQueue.addJob({
-          schema: fileSchema,
-          docId: call.id,
-          jobType: 'feed',
-          userId: call.createdByUserId,
-          app: SubApp.TRANSCRIPT,
-          ...(callChannel?.workspaceId ? { workspaceId: callChannel.workspaceId } : {}),
-        });
-        logger.info(`[TranscriptService] Queued Vespa indexing for transcript ${call.id}`);
-      } catch (vespaError) {
-        logger.error(`[TranscriptService] Failed to queue Vespa job for transcript ${call.id}:`, vespaError);
-      }
+      // Queue Vespa indexing for the transcript (using call.id as the identifier)
+      await this.queueTranscriptIndexing(call);
 
     } catch (error) {
       logger.error(`[${callId}] process_call_with_summary_failed`, { error: error, stack: error instanceof Error ? error.stack : undefined });


### PR DESCRIPTION

<img width="1117" height="356" alt="Screenshot 2026-09-02 at 4 28 06 PM" src="https://github.com/user-attachments/assets/cba6727a-699c-4d35-8c66-06045bd849b2" />


Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
