### PR TITLE
Revert "feat: add ordered encryption key rotation (#764)"

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -112,12 +112,6 @@ ENABLE_DEV_AUTH=true
 # Security
 ENCRYPTION_KEY=set-me
 
-# Ordered JSON array of additional Spaces encryption keys.
-# The LAST entry is the active key used for new writes.
-# Every entry remains available for decryption.
-# Unset or empty means new writes remain in legacy format.
-# ENCRYPTION_KEYS=[{"id":"k1","key":"<64-hex>"}]
-
 # External APIs (add when needed)
 # API_KEY=
 # API_SECRET=
@@ -346,6 +340,7 @@ SUDO_QUERY_TOKEN=xyz
 
 # Security
 # JWT_SECRET=
+# ENCRYPTION_KEY=
 
 # External APIs (add when needed)
 # API_KEY=
@@ -406,6 +401,7 @@ JUSPAY_JIRA_BASEURL=https://juspay.atlassian.net
 JIRA_MIGRATION_BOT_EMAIL=your-jira-migration-bot-email
 JIRA_MIGRATION_BOT_AUTH_TOKEN=your-jira-migration-bot-auth-token
 # ─── Zero Field Encryption ───────────────────────────────────────────────────
+# See docs/ENCRYPTION_IMPLEMENTATION_PLAN.md for full setup guide.
 #
 # Generate dev keys (one-time):
 #   mkdir -p .xyne/dev/keys

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -6,12 +6,6 @@ dotenv.config();
 import { parseInternalAppHostMap } from '@/utils/internalHostMap';
 
 const envSchema = Joi.object({
-  // Legacy AES-256-CBC key used for unversioned ciphertext.
-  ENCRYPTION_KEY: Joi.string().allow('').optional(),
-  // Ordered JSON key ring. The final entry is the active writer;
-  // all entries remain available for decryption.
-  ENCRYPTION_KEYS: Joi.string().allow('').optional(),
-
   NODE_ENV: Joi.string().valid('development', 'production', 'test').default('development'),
   SANDBOX_TEST_MODE: Joi.boolean().default(false),
   ORG_MEMBER_LIMIT: Joi.number().integer().min(1).allow(null).default(null),
@@ -417,7 +411,9 @@ const envSchema = Joi.object({
   ENABLE_DB_ENCRYPTION: Joi.boolean().default(false),
   ENC_ORG_PROVISION: Joi.boolean().default(false),
   ENC_WORKSPACE_PROVISION: Joi.boolean().default(false),
-  JIRA_MIGRATION_USER_MAP_CSV_LOCATION: Joi.string().allow('').default(''),
+  JIRA_MIGRATION_USER_MAP_CSV_LOCATION: Joi.string()
+    .allow('')
+    .default(''),
   JIRA_MIGRATION_ISSUE_PAGE_SIZE: Joi.number().integer().min(1).max(500).default(25),
   // Default to a conservative delay to avoid accidental Jira API hammering in environments
   // where `JIRA_MIGRATION_BATCH_DELAY_MS` isn't explicitly set.

--- a/apps/backend/src/services/encryptionService.ts
+++ b/apps/backend/src/services/encryptionService.ts
@@ -1,233 +1,74 @@
 /**
- * Rotation-aware AES-256-CBC encryption service.
- *
- * Legacy ciphertext:
- *   iv:ciphertext
- *
- * Versioned ciphertext:
- *   v2:keyId:iv:ciphertext
- *
- * ENCRYPTION_KEY stores the legacy key.
- *
- * ENCRYPTION_KEYS is an ordered JSON array:
- *   [{"id":"k1","key":"64-hex"},{"id":"k2","key":"64-hex"}]
- *
- * The final array entry is the active writer. All entries remain available
- * for decryption. If the array is absent or empty, writes remain legacy.
- *
- * To preload a future key without activating it, place it before the current
- * final entry. Move it to the end only after every reader has received it.
+ * Encryption Service
+ * AES-256-CBC encryption/decryption for sensitive data
  */
 
 import crypto from 'crypto';
 
 const ALGORITHM = 'aes-256-cbc';
 const IV_LENGTH = 16; // AES block size
-const VERSION_TAG = 'v2';
-const LEGACY_KEY_ID = 'legacy';
-
-interface KeyRing {
-  keys: Map<string, Buffer>;
-  activeKeyId: string | null;
-}
-
-let cachedRing: KeyRing | null = null;
 
 /**
- * Parse a 32-byte (64 hex char) key. Rejects anything that is not AES-256 sized.
+ * Get encryption key from environment
+ * Must be 32 bytes (64 hex characters) for AES-256
  */
-function parseHexKey(
-  raw: unknown,
-  label: string
-): Buffer {
-  if (typeof raw !== 'string') {
-    throw new Error(
-      `${label} must be 32 bytes (64 hex characters)`
-    );
-  }
+function getEncryptionKey(): Buffer {
+  const key = process.env.ENCRYPTION_KEY;
 
-  const normalized = raw.trim();
-
-  if (!/^[0-9a-fA-F]{64}$/.test(normalized)) {
-    throw new Error(
-      `${label} must be 32 bytes (64 hex characters)`
-    );
-  }
-
-  return Buffer.from(normalized, 'hex');
-}
-
-function parseOrderedKeys(raw: string): Array<{ id: string; key: string }> {
-  let parsed: unknown;
-
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(
-      'ENCRYPTION_KEYS must be an ordered JSON array ' + 'of objects with id and key fields'
-    );
-  }
-
-  if (!Array.isArray(parsed)) {
-    throw new Error(
-      'ENCRYPTION_KEYS must be an ordered JSON array ' + 'of objects with id and key fields'
-    );
-  }
-
-  const seen = new Set<string>();
-
-  return parsed.map((value, index) => {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      throw new Error('ENCRYPTION_KEYS[' + index + '] must be an object');
-    }
-
-    const entry = value as {
-      id?: unknown;
-      key?: unknown;
-    };
-
-    if (typeof entry.id !== 'string') {
-      throw new Error('ENCRYPTION_KEYS[' + index + '].id must be a string');
-    }
-
-    const id = entry.id.trim();
-
-    if (!id || id !== entry.id || id.includes(':') || id === VERSION_TAG || id === LEGACY_KEY_ID) {
-      throw new Error('Invalid key id at ENCRYPTION_KEYS[' + index + ']');
-    }
-
-    if (seen.has(id)) {
-      throw new Error('Duplicate encryption key id "' + id + '"');
-    }
-
-    seen.add(id);
-
-    parseHexKey(entry.key, 'ENCRYPTION_KEYS[' + index + '].key');
-
-    return {
-      id,
-      key: entry.key as string,
-    };
-  });
-}
-
-/**
- * Build (and cache) the key ring from the environment. The env is read once per
- * process; tests can force a rebuild with _resetKeyRingCache().
- */
-function loadKeyRing(): KeyRing {
-  if (cachedRing) {
-    return cachedRing;
-  }
-
-  const keys = new Map<string, Buffer>();
-
-  const legacy = process.env.ENCRYPTION_KEY;
-
-  if (legacy) {
-    keys.set(LEGACY_KEY_ID, parseHexKey(legacy, 'ENCRYPTION_KEY'));
-  }
-
-  const configured = process.env.ENCRYPTION_KEYS;
-
-  const orderedKeys = configured && configured.trim() ? parseOrderedKeys(configured) : [];
-
-  for (const entry of orderedKeys) {
-    keys.set(entry.id, parseHexKey(entry.key, 'ENCRYPTION_KEYS key "' + entry.id + '"'));
-  }
-
-  const activeKeyId = orderedKeys.length > 0 ? orderedKeys[orderedKeys.length - 1].id : null;
-
-  cachedRing = {
-    keys,
-    activeKeyId,
-  };
-
-  return cachedRing;
-}
-
-/**
- * Resolve a key by id or throw a clear error. A throw here on decrypt means the
- * ciphertext references a key that has already been retired from the ring —
- * the Phase 3 safety net.
- */
-function getKey(keyId: string): Buffer {
-  const key = loadKeyRing().keys.get(keyId);
   if (!key) {
-    throw new Error(
-      keyId === LEGACY_KEY_ID
-        ? 'ENCRYPTION_KEY not found in environment variables'
-        : `No encryption key registered for keyId "${keyId}"`
-    );
+    throw new Error('ENCRYPTION_KEY not found in environment variables');
   }
-  return key;
+
+  // Convert hex string to buffer
+  const keyBuffer = Buffer.from(key, 'hex');
+
+  if (keyBuffer.length !== 32) {
+    throw new Error('ENCRYPTION_KEY must be 32 bytes (64 hex characters)');
+  }
+
+  return keyBuffer;
 }
 
 /**
- * Clear the cached key ring. Intended for tests / hot config reloads only.
- */
-export function _resetKeyRingCache(): void {
-  cachedRing = null;
-}
-
-/**
- * Encrypt plaintext using AES-256-CBC.
- * Returns "v2:<keyId>:<iv>:<ciphertext>" when a write key is activated,
- * otherwise the legacy "<iv>:<ciphertext>" format (both hex).
+ * Encrypt plaintext using AES-256-CBC
+ * Returns format: "IV:ciphertext" (both as hex)
  */
 export function encrypt(plaintext: string): string {
-  const ring = loadKeyRing();
-  const writeKeyId = ring.activeKeyId ?? LEGACY_KEY_ID;
-  const key = getKey(writeKeyId);
-
+  const key = getEncryptionKey();
   const iv = crypto.randomBytes(IV_LENGTH);
+
   const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
   let encrypted = cipher.update(plaintext, 'utf8', 'hex');
   encrypted += cipher.final('hex');
 
-  if (ring.activeKeyId) {
-    return `${VERSION_TAG}:${writeKeyId}:${iv.toString('hex')}:${encrypted}`;
-  }
-  // Legacy format — byte-for-byte identical to the pre-rotation output.
+  // Return IV:ciphertext format
   return `${iv.toString('hex')}:${encrypted}`;
 }
 
 /**
- * Decrypt ciphertext using AES-256-CBC.
- * Accepts both the versioned "v2:<keyId>:<iv>:<ct>" and the legacy "<iv>:<ct>"
- * formats. Legacy rows are decrypted with the "legacy" key (ENCRYPTION_KEY).
+ * Decrypt ciphertext using AES-256-CBC
+ * Expects format: "IV:ciphertext" (both as hex)
  */
 export function decrypt(encryptedData: string): string {
+  const key = getEncryptionKey();
+
+  // Split IV and ciphertext
   const parts = encryptedData.split(':');
-
-  let keyId: string;
-  let ivHex: string;
-  let ciphertextHex: string;
-
-  if (parts.length === 4 && parts[0] === VERSION_TAG) {
-    // Versioned: v2:<keyId>:<iv>:<ciphertext>
-    keyId = parts[1];
-    ivHex = parts[2];
-    ciphertextHex = parts[3];
-  } else if (parts.length === 2) {
-    // Legacy: <iv>:<ciphertext>
-    keyId = LEGACY_KEY_ID;
-    ivHex = parts[0];
-    ciphertextHex = parts[1];
-  } else {
-    throw new Error(
-      'Invalid encrypted data format. Expected "IV:ciphertext" or "v2:keyId:IV:ciphertext"'
-    );
+  if (parts.length !== 2) {
+    throw new Error('Invalid encrypted data format. Expected "IV:ciphertext"');
   }
 
-  const key = getKey(keyId);
-  const iv = Buffer.from(ivHex, 'hex');
+  const iv = Buffer.from(parts[0], 'hex');
+  const encrypted = parts[1];
+
   if (iv.length !== IV_LENGTH) {
     throw new Error(`Invalid IV length. Expected ${IV_LENGTH} bytes`);
   }
 
   const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
-  let decrypted = decipher.update(ciphertextHex, 'hex', 'utf8');
+
+  let decrypted = decipher.update(encrypted, 'hex', 'utf8');
   decrypted += decipher.final('utf8');
 
   return decrypted;


### PR DESCRIPTION
This reverts commit 5a7f29d92b18918a44c7d593ce566c0ddc885504.

Environment-Changes:
  - ENCRYPTION_KEY: reverted

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
