### PR TITLE
feat: XYNE-61738 Add multi-language transcript translation support on scribe and calls

### DIFF
--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -42,6 +42,9 @@ import {
   NotificationType,
   RecordingType,
   AttachmentEntityType,
+  SUPPORTED_TRANSCRIPT_LANGUAGES,
+  ORIGINAL_TRANSCRIPT_LANGUAGE,
+  type TranscriptTranslation,
 } from '@xyne/shared';
 import { storageService } from '@/services/storage';
 import { CallVespaFeedSource, queueCallVespaFeed } from '@/services/callVespaQueue';
@@ -1332,25 +1335,51 @@ export class CallController {
         return;
       }
 
-      // Fetch transcript content from GCS URL if available
+      // ?scope=status: polled every 10s for hasRecording/durationMs only.
+      const scope = req.query.scope as string | undefined;
+      if (scope === 'status') {
+        const uploadedRecording = await repositories.callRecordings
+          .findLatestUploadedByCallId(call.id)
+          .catch(() => null);
+        res.json({
+          success: true,
+          recording: {
+            hasRecording: !!uploadedRecording,
+            durationMs: call.endedAt
+              ? new Date(call.endedAt).getTime() - new Date(call.startedAt).getTime()
+              : null,
+          },
+        });
+        return;
+      }
+
+      // ?scope=metadata only needs presence, not text — skip the GCS reads below.
       let transcriptContent: string | null = null;
       let identifiedTranscriptContent: string | null = null;
+      let hasIdentifiedTranscript: boolean;
 
-      if (call.transcript) {
-        try {
-          // Fetch transcript content from storage (handles both legacy gs:// URIs and plain paths)
-          transcriptContent = await transcriptService.getTranscriptContent(call.externalId);
-        } catch (fetchError) {
-          logger.warn(`Failed to fetch transcript from storage: ${fetchError}`);
+      if (scope === 'metadata') {
+        hasIdentifiedTranscript = await transcriptService.identifiedTranscriptExists(call.externalId);
+      } else {
+        if (call.transcript) {
+          try {
+            // Fetch transcript content from storage (handles both legacy gs:// URIs and plain paths)
+            transcriptContent = await transcriptService.getTranscriptContent(call.externalId);
+          } catch (fetchError) {
+            logger.warn(`Failed to fetch transcript from storage: ${fetchError}`);
+          }
         }
+
+        // Fetch real-time identified transcript (written during call by the Python agent)
+        try {
+          identifiedTranscriptContent = await transcriptService.getIdentifiedTranscriptContent(call.externalId);
+        } catch (fetchError) {
+          logger.warn(`Failed to fetch identified transcript: ${fetchError}`);
+        }
+        hasIdentifiedTranscript = !!identifiedTranscriptContent;
       }
 
-      // Fetch real-time identified transcript (written during call by the Python agent)
-      try {
-        identifiedTranscriptContent = await transcriptService.getIdentifiedTranscriptContent(call.externalId);
-      } catch (fetchError) {
-        logger.warn(`Failed to fetch identified transcript: ${fetchError}`);
-      }
+      const hasTranscript = scope === 'metadata' ? !!call.transcript : !!transcriptContent;
 
       // Determine AI summary format (markdown if starts with ## or has no HTML tags)
       let aiSummaryFormat: 'markdown' | 'html' | undefined;
@@ -1442,11 +1471,11 @@ export class CallController {
           durationMs: call.endedAt
             ? new Date(call.endedAt).getTime() - new Date(call.startedAt).getTime()
             : null,
-          hasTranscript: !!transcriptContent,
+          hasTranscript,
           hasSummary: !!call.aiSummary,
           transcript: transcriptContent,
           identifiedTranscript: identifiedTranscriptContent,
-          hasIdentifiedTranscript: !!identifiedTranscriptContent,
+          hasIdentifiedTranscript,
           aiSummary: call.aiSummary,
           aiSummaryFormat,
           labels: call.labels,
@@ -1880,6 +1909,138 @@ export class CallController {
     } catch (error) {
       logger.error(`[${callId}] download_transcript_failed | user_id=${userId}, error=${error}`);
       res.status(500).json({ success: false, error: 'Failed to download transcript' });
+    }
+  };
+
+  // POST /api/calls/:callId/translate-transcript — synchronous: returns the cached text (GCS
+  // hit) or translates now, writes GCS + metadata, and returns the result — always one call.
+  translateTranscript = async (req: Request, res: Response): Promise<void> => {
+    const userId = req.user?.id;
+    const { callId } = req.params;
+    const { language, variant } = (req.body ?? {}) as { language?: string; variant?: 'identified' };
+
+    if (!userId) {
+      res.status(401).json({ success: false, error: 'Unauthorized' });
+      return;
+    }
+
+    if (!callId) {
+      res.status(400).json({ success: false, error: 'Call ID is required' });
+      return;
+    }
+
+    // 'original' = no LLM, exempt from the whitelist below.
+    const isOriginal = language === ORIGINAL_TRANSCRIPT_LANGUAGE;
+
+    // Whitelist-only: this value is interpolated into the LLM prompt.
+    const supportedLanguage = isOriginal
+      ? undefined
+      : SUPPORTED_TRANSCRIPT_LANGUAGES.find(l => l.code === language);
+    if (!isOriginal && !supportedLanguage) {
+      res.status(400).json({ success: false, error: 'Unsupported language' });
+      return;
+    }
+
+    try {
+      const call = await repositories.calls.findByExternalId(callId);
+
+      if (!call) {
+        res.status(404).json({ success: false, error: 'Call not found' });
+        return;
+      }
+
+      if (!(await this.isCallAudience(call, userId))) {
+        res.status(403).json({ success: false, error: 'You do not have access to this call' });
+        return;
+      }
+
+      if (!(await this.assertCanViewCallRecordings(callId, userId))) {
+        res.status(403).json({ success: false, error: 'Access denied' });
+        return;
+      }
+
+      if (isOriginal) {
+        let text: string | null;
+        let generation: string | null = null;
+        if (variant === 'identified') {
+          text = await transcriptService.getIdentifiedTranscriptContent(callId);
+        } else {
+          const fetched = await transcriptService.getTranscriptContentWithGeneration(callId);
+          text = fetched?.text ?? null;
+          generation = fetched?.generation ?? null;
+        }
+        if (text === null) {
+          res.status(404).json({ success: false, error: 'Transcript not available for this call' });
+          return;
+        }
+        res.status(200).json({
+          success: true,
+          status: 'ready',
+          text,
+          ...(generation ? { generation } : {}),
+        });
+        return;
+      }
+
+      // Non-null: whitelist check above already returned otherwise.
+      const languageCode = supportedLanguage!.code;
+
+      const fetched = await transcriptService.getTranscriptContentWithGeneration(callId);
+      if (!fetched) {
+        res.status(404).json({ success: false, error: 'Transcript not available for this call' });
+        return;
+      }
+
+      const callMetadata = call.metadata as { translations?: Record<string, TranscriptTranslation> } | null;
+      const existing = callMetadata?.translations?.[languageCode];
+      const sameGeneration = !!fetched.generation && existing?.generation === fetched.generation;
+
+      const generationField = fetched.generation ? { generation: fetched.generation } : {};
+
+      if (existing?.status === 'ready' && sameGeneration) {
+        const text = await transcriptService.getTranslatedTranscript(
+          callId,
+          languageCode,
+          fetched.generation,
+        );
+        // Metadata says ready but the GCS file is gone — fall through and re-translate.
+        if (text !== null) {
+          res.status(200).json({
+            success: true,
+            status: 'ready',
+            text,
+            partial: existing.partial ?? false,
+            ...generationField,
+          });
+          return;
+        }
+      }
+
+      const { text, partial } = await transcriptService.translateTranscript(
+        fetched.text,
+        supportedLanguage!.label,
+        call.externalId,
+      );
+      const finalText = text ?? fetched.text;
+      // partial = LLM failed, don't cache the fallback or an outage permanently poisons this language.
+      if (!partial) {
+        await transcriptService.uploadTranslatedTranscript(
+          call.externalId,
+          languageCode,
+          fetched.generation,
+          finalText,
+        );
+        await repositories.calls.setTranslationStatus(call.id, languageCode, {
+          status: 'ready',
+          partial,
+          ...generationField,
+        });
+      }
+
+      res.status(200).json({ success: true, status: 'ready', text: finalText, partial, ...generationField });
+    } catch (error) {
+      logger.error(`[${callId}] Failed to translate transcript`, error);
+      res.status(500).json({ success: false, error: 'Failed to translate transcript' });
     }
   };
 

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -7,7 +7,7 @@ import { updateCallSystemMessageIfNeeded } from '@/zero/utils/systemMessagesUtil
 import { repositories } from './index';
 import { logger } from '@/utils/logger';
 import { messageMetadataService } from '@/services/messageMetadataService';
-import type { CallParticipantMetadata } from '@xyne/shared';
+import type { CallParticipantMetadata, TranscriptTranslation } from '@xyne/shared';
 import { normalizeEmailList } from '@/utils/email';
 import { CallVespaFeedSource, queueCallVespaDelete, queueCallVespaFeed } from '@/services/callVespaQueue';
 import { refreshCallParticipantPreview } from '@/utils/callParticipantCountUtils';
@@ -40,6 +40,7 @@ export interface CallMetadata {
   systemMessageId?: string;
   conversationId?: string;
   artifactMessageId?: string;
+  translations?: Record<string, TranscriptTranslation>;
 }
 
 const getArtifactMessageId = (metadata: Prisma.JsonValue | null): string | undefined =>
@@ -277,6 +278,26 @@ export class CallRepository {
     return result;
   }
 
+  // Writes one language's translation status into calls.metadata.translations. `id` is the internal Call.id, not externalId.
+  // Read-modify-write, not transactional — a concurrent write for another language could be lost.
+  async setTranslationStatus(
+    id: string,
+    language: string,
+    translation: TranscriptTranslation,
+  ): Promise<void> {
+    const client = DatabaseClient.getInstance();
+    const current = await client.call.findUnique({ where: { id }, select: { metadata: true } });
+    const currentMetadata = (current?.metadata as CallMetadata | null) ?? {};
+    const nextMetadata: CallMetadata = {
+      ...currentMetadata,
+      translations: { ...currentMetadata.translations, [language]: translation },
+    };
+    await client.call.update({
+      where: { id },
+      data: { metadata: nextMetadata as Prisma.InputJsonValue },
+    });
+  }
+
   /**
    * Adopt an already-running call as a slash-command artifact's call.
    *
@@ -305,9 +326,9 @@ export class CallRepository {
         where: { id: callId },
         data: {
           metadata: {
-            ...((metadata as CallMetadata | null) ?? {}),
+            ...((metadata as Record<string, Prisma.InputJsonValue> | null) ?? {}),
             artifactMessageId,
-          } as Prisma.InputJsonValue,
+          },
         },
       });
 

--- a/apps/backend/src/routes/calls.ts
+++ b/apps/backend/src/routes/calls.ts
@@ -75,6 +75,9 @@ router.post('/:callId/process-transcript', callController.processTranscript);
 // Download transcript endpoint (downloads transcript file from GCS)
 router.get('/:callId/download-transcript', callController.downloadTranscript);
 
+// Translate transcript into a user-picked language (synchronous — returns text directly).
+router.post('/:callId/translate-transcript', callController.translateTranscript);
+
 // Download recording endpoint (streams the call's latest recording — legacy/headless player)
 router.get('/:callId/download-recording', callController.downloadRecording);
 

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -6,7 +6,7 @@ import { config } from '@/config/env';
 import { Agent, createUserMessage } from '@framework';
 import { extractAgentContent } from '@/utils/agentUtils';
 import { unifiedBotUserService } from '@/bots/unified/services/unified-bot-user-service.js';
-import { MessageType, OrgLLMServiceAccountPurpose, AttachmentEntityType, CallOrigin, CallType, TicketPriority } from '@xyne/shared';
+import { MessageType, OrgLLMServiceAccountPurpose, AttachmentEntityType, CallOrigin, CallType, TicketPriority, type TranscriptTranslation } from '@xyne/shared';
 import { db } from '@/database/client';
 import { randomUUID } from 'crypto';
 import * as yaml from 'js-yaml';
@@ -17,7 +17,7 @@ import { vespaQueue } from '@/queues/vespaQueue';
 import { fileSchema, SubApp } from '@/vespa/src/types';
 import { CacConfigService } from '@/services/cacConfigService';
 import { getCallTicketSuggestionsTotal } from '@/services/otel/suggestionMetrics';
-import { executeCallLlmWithRetry, type SummaryModelType } from './callLlmRetry';
+import { executeCallLlmWithRetry, executeStreamingLlmRequest, type SummaryModelType } from './callLlmRetry';
 import { callRecordingService } from '@/services/callRecordingService';
 import { callLabelService } from '@/services/callLabelService';
 import { TagMethod } from '@xyne/shared';
@@ -28,6 +28,8 @@ import { acquireLock, releaseLock } from '@/utils/distributedLock';
 import { orgLLMCredentialService } from '@/services/orgLLMCredentialService';
 
 const SPEAKER_IDENTIFICATION_CAC_KEY = 'speaker_identification_config';
+
+export type TranslateTranscriptResult = Pick<TranscriptTranslation, 'text' | 'partial'>;
 
 export interface TranscriptEntry {
   user: string;
@@ -259,6 +261,26 @@ No explanations.
 
 TRANSCRIPT:
 {transcript}
+`;
+
+// Translation prompt for translateTranscript(); {targetLanguage} is filled in per-call.
+const TRANSCRIPT_TRANSLATION_PROMPT = `
+You are translating a call transcript into {targetLanguage}. Your ONLY task is to translate the spoken text into the target language.
+
+IMPORTANT:
+- Keep ALL timestamps exactly as they are: [MM:SS] format
+- Keep ALL speaker names exactly as they are, untranslated
+- Only translate the spoken text into the target language
+- Do not translate brand names, product names, or numbers
+- Do not modify, fix, or improve the text beyond translation
+- Do not add new lines or remove existing ones
+- Do not add commentary or explanations
+- Do not use placeholders like "[...]" or "[content continues]"
+- Preserve the exact line-by-line structure: [MM:SS] Speaker Name: text
+- Translate EVERY line completely, do not skip or truncate any content
+- If a line is already written in the target language, return it unchanged
+
+Output ONLY the translated transcript, nothing else.
 `;
 
 export interface TicketSuggestion {
@@ -525,7 +547,13 @@ export class TranscriptService {
 
       logger.info(`[${callId}] transcript_processing_completed`, { message_id: messageId });
 
-      // 13. Attach identified transcript (real-name labelled) as a second attachment when available.
+      // 13. Fire-and-forget: Translate transcript asynchronously in background
+      // This updates the same GCS file without blocking the response
+      this.translateTranscriptAsync(callId, txtStoragePath).catch((err) => {
+        logger.error(`[${callId}] background_translation_failed`, { error: err });
+      });
+
+      // 14. Attach identified transcript (real-name labelled) as a second attachment when available.
       // Written by the Python agent's RealtimeIdentifier during the call into
       // transcriptions/{callId}_identified.jsonl — may not exist if no voiceprints were enrolled.
       void this.attachIdentifiedTranscriptIfExists(callId, messageId, call.createdByUserId, callMessage.conversationId, channel.workspaceId);
@@ -761,6 +789,11 @@ export class TranscriptService {
         });
         logger.info(`[${callId}] identified_transcript_attachment_created`, { attachment_id: attachment.id });
       }
+
+      // Apply the same background translation as the plain transcript
+      this.translateIdentifiedTranscriptAsync(callId, formattedPath).catch((err) => {
+        logger.error(`[${callId}] identified_background_translation_failed`, { error: err });
+      });
     } catch (err) {
       logger.error(`[${callId}] identified_transcript_attach_failed`, { error: err });
     }
@@ -788,32 +821,82 @@ export class TranscriptService {
    * @returns Formatted transcript text or null if not found
    */
   async getTranscriptContent(callId: string): Promise<string | null> {
-    try {
-      // Try to fetch formatted transcript first
-      const formattedPath = `attachments/${callId}_formatted.txt`;
+    return (await this.getTranscriptContentWithGeneration(callId))?.text ?? null;
+  }
 
+  // Same as getTranscriptContent, plus the formatted object's GCS `generation` (null if unavailable).
+  async getTranscriptContentWithGeneration(
+    callId: string,
+  ): Promise<{ text: string; generation: string | null } | null> {
+    try {
+      const formattedPath = `attachments/${callId}_formatted.txt`;
       const formattedExists = await this.transcriptStorage.fileExists(formattedPath);
 
       if (formattedExists) {
-        const buffer = await this.transcriptStorage.getFileBuffer(formattedPath);
-        return buffer.toString('utf-8');
+        const [buffer, metadata] = await Promise.all([
+          this.transcriptStorage.getFileBuffer(formattedPath),
+          this.transcriptStorage.getFileMetadata(formattedPath).catch(() => null),
+        ]);
+        const generation = (metadata as Record<string, unknown> | null)?.['generation'];
+        return {
+          text: buffer.toString('utf-8'),
+          generation:
+            typeof generation === 'string' || typeof generation === 'number'
+              ? String(generation)
+              : null,
+        };
       }
 
-      // Fall back to raw JSONL and format it
       const rawContent = await this.retrieveTranscript(callId);
-      if (!rawContent) {
-        return null;
-      }
+      if (!rawContent) return null;
 
       const entries = this.parseTranscriptEntries(rawContent);
-      if (entries.length === 0) {
-        return null;
-      }
+      if (entries.length === 0) return null;
 
-      return this.formatTranscript(entries, callId);
+      return { text: this.formatTranscript(entries, callId), generation: null };
     } catch (error) {
-      logger.error(`Failed to get transcript content for ${callId}:`, error);
+      logger.error(`Failed to get transcript content with generation for ${callId}:`, error);
       return null;
+    }
+  }
+
+  private translatedTranscriptPath(callId: string, language: string, generation: string | null): string {
+    return `attachments/${callId}_translated_${language}_${generation ?? 'unversioned'}.txt`;
+  }
+
+  async uploadTranslatedTranscript(
+    callId: string,
+    language: string,
+    generation: string | null,
+    text: string,
+  ): Promise<void> {
+    await this.transcriptStorage.uploadFileV2(Buffer.from(text, 'utf-8'), {
+      path: this.translatedTranscriptPath(callId, language, generation),
+      contentType: 'text/plain',
+      metadata: { callId, type: 'translated_transcript', language },
+    });
+  }
+
+  async getTranslatedTranscript(
+    callId: string,
+    language: string,
+    generation: string | null,
+  ): Promise<string | null> {
+    const path = this.translatedTranscriptPath(callId, language, generation);
+    const exists = await this.transcriptStorage.fileExists(path);
+    if (!exists) return null;
+    const buffer = await this.transcriptStorage.getFileBuffer(path);
+    return buffer.toString('utf-8');
+  }
+
+  // fileExists()-only check, no download and no raw-JSONL fallback (unlike getIdentifiedTranscriptContent).
+  // ponytail: formatted-file-only, add raw-JSONL fallback if that gap turns out to matter.
+  async identifiedTranscriptExists(callId: string): Promise<boolean> {
+    try {
+      return await this.transcriptStorage.fileExists(`attachments/${callId}_identified_formatted.txt`);
+    } catch (error) {
+      logger.error(`Failed to check identified transcript existence for ${callId}:`, error);
+      return false;
     }
   }
 
@@ -868,6 +951,227 @@ export class TranscriptService {
         `[${callId}] formatted_transcript_download_failed | path=${storagePath}, error=${error}`
       );
       return null;
+    }
+  }
+
+  /**
+   * Translate transcript asynchronously in background (fire-and-forget)
+   * Downloads raw transcript from GCS, translates it, and overwrites the same file
+   * @param callId - The external call ID
+   * @param gcsPath - The GCS path to the transcript file
+   */
+  async translateTranscriptAsync(callId: string, storagePath: string): Promise<void> {
+    try {
+      logger.info(`Starting background translation for call: ${callId}`);
+
+      // 1. Download raw transcript
+      const buffer = await this.transcriptStorage.getFileBuffer(storagePath);
+      const rawTranscript = buffer.toString('utf-8');
+
+      // 2. Translate the transcript
+      const translatedTranscript = await this.postProcessTranscript(rawTranscript, callId);
+
+      // 3. Re-upload translated version (overwrites the same file)
+      await this.transcriptStorage.uploadFileV2(Buffer.from(translatedTranscript, 'utf-8'), {
+        path: storagePath,
+        contentType: 'text/plain',
+        metadata: { callId, type: 'transcript', translated: 'true' },
+      });
+
+      // 4. Update database attachment metadata to mark as translated
+      const attachments = await repositories.messageAttachments.findByCallId(callId);
+
+      if (attachments.length > 0) {
+        const transcriptAttachment = attachments[0];
+        const current = await repositories.messageAttachments.findById(transcriptAttachment.id);
+        const currentMetadata = (current?.metadata as Record<string, any>) || {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+        await repositories.messageAttachments.updateVersion(transcriptAttachment.id, {
+          ...currentMetadata,
+        });
+        logger.info(`Updated database attachment metadata for call: ${callId}`);
+      } else {
+        logger.warn(`No attachment found in database for call: ${callId}`);
+      }
+
+      logger.info(`Successfully completed background translation for call: ${callId}`);
+    } catch (error) {
+      logger.error(`Failed to translate transcript in background for call ${callId}:`, error);
+    }
+  }
+
+  /**
+   * Same as translateTranscriptAsync but for the identified transcript GCS file.
+   * Overwrites the identified formatted .txt with the translated version.
+   */
+  private async translateIdentifiedTranscriptAsync(callId: string, gcsPath: string): Promise<void> {
+    try {
+      logger.info(`[${callId}] identified_translation_started`);
+
+      const buffer = await this.transcriptStorage.getFileBuffer(gcsPath);
+      const rawTranscript = buffer.toString('utf-8');
+
+      const translatedTranscript = await this.postProcessTranscript(rawTranscript, callId);
+
+      await this.transcriptStorage.uploadFileV2(Buffer.from(translatedTranscript, 'utf-8'), {
+        path: gcsPath,
+        contentType: 'text/plain',
+        metadata: { callId, type: 'identified_transcript', translated: 'true' },
+      });
+
+      logger.info(`[${callId}] identified_translation_completed`);
+    } catch (error) {
+      logger.error(`[${callId}] identified_translation_failed`, { error: error });
+    }
+  }
+
+  /**
+   * Post-process transcript: translate to English
+   * Handles long transcripts by chunking them into smaller pieces
+   * @param transcript - The formatted transcript text
+   * @returns Post-processed transcript or original if processing fails
+   */
+  async postProcessTranscript(transcript: string, callId?: string): Promise<string> {
+    const systemInstructions = `You are processing a call transcript. Your task is to translate any non-English text to English, and to fix one specific brand name spelling.
+
+IMPORTANT:
+- Keep ALL timestamps exactly as they are: [MM:SS] format
+- Keep ALL speaker names exactly as they are
+- Only translate the spoken text to English
+- Do not modify, fix, or improve the text beyond translation
+- Do not add new lines or remove existing ones
+- Do not add commentary or explanations
+- Do not use placeholders like "[...]" or "[content continues]"
+- Preserve the exact line-by-line structure: [MM:SS] Speaker Name: text
+- Translate EVERY line completely, do not skip or truncate any content
+
+BRAND NAME CORRECTION:
+- The word "Xyne" (a product/brand name, pronounced like "zine") is often misspelled by speech-to-text as "Zain", "Zine", "Xine", "Zyane", or "Zyne"
+- When any of word that phonetically sounds like XYNE appear as a standalone word or as part of a compound like "Zain Spaces", "Zine Calls", etc., replace it with "Xyne"
+- Only apply this correction when the word is clearly a reference to the brand (e.g. "Xyne Spaces", "Xyne Calls"), not when it is part of an unrelated proper noun or personal name
+
+Output ONLY the processed transcript, nothing else.`;
+
+    const { text } = await this.runChunkedTranslation(transcript, systemInstructions, 'transcript_translation', callId);
+    return text ?? transcript;
+  }
+
+  async translateTranscript(
+    transcript: string,
+    targetLanguageName: string,
+    callId?: string,
+  ): Promise<TranslateTranscriptResult> {
+    const systemInstructions = TRANSCRIPT_TRANSLATION_PROMPT.replace('{targetLanguage}', targetLanguageName);
+    return this.runChunkedTranslation(transcript, systemInstructions, 'transcript_translation_user_language', callId);
+  }
+
+  // Shared chunking/streaming core for postProcessTranscript and translateTranscript.
+  private async runChunkedTranslation(
+    transcript: string,
+    systemInstructions: string,
+    operation: string,
+    callId?: string,
+  ): Promise<TranslateTranscriptResult> {
+    try {
+      const lines = transcript.split('\n').filter((l) => l.trim());
+      const MAX_LINES_PER_CHUNK = 100;
+
+      if (lines.length <= MAX_LINES_PER_CHUNK) {
+        const translated = await executeStreamingLlmRequest({
+          userPrompt: transcript,
+          systemPrompt: systemInstructions,
+          operation,
+          callId,
+        });
+
+        if (!translated.ok) {
+          logger.warn(`${operation}_failed | reason=${translated.reason} | using_original=true`);
+          return { text: transcript, partial: true };
+        }
+
+        logger.info(`Successfully processed transcript via ${operation} (streaming)`);
+        return { text: translated.content, partial: false };
+      }
+
+      // For long transcripts, process in chunks with LIMITED CONCURRENCY.
+      // Each chunk is a separate streaming request; a bounded worker pool keeps
+      // the number of concurrent streams in check (an earlier unbounded
+      // Promise.all overwhelmed the LiteLLM deployment).
+      const CHUNK_CONCURRENCY = 3;
+      const totalChunks = Math.ceil(lines.length / MAX_LINES_PER_CHUNK);
+
+      logger.info(
+        `Transcript has ${lines.length} lines, processing via ${operation} in ${totalChunks} chunks of ${MAX_LINES_PER_CHUNK} (concurrency ${CHUNK_CONCURRENCY})`
+      );
+
+      // Build chunk metadata up front so results can be reassembled in order.
+      const chunks: Array<{ chunkText: string; chunkIndex: number; startLine: number; endLine: number }> = [];
+      for (let i = 0; i < lines.length; i += MAX_LINES_PER_CHUNK) {
+        const chunkLines = lines.slice(i, i + MAX_LINES_PER_CHUNK);
+        chunks.push({
+          chunkText: chunkLines.join('\n'),
+          chunkIndex: Math.floor(i / MAX_LINES_PER_CHUNK) + 1,
+          startLine: i + 1,
+          endLine: i + chunkLines.length,
+        });
+      }
+
+      const results: string[] = new Array(chunks.length);
+      const chunkFellBack: boolean[] = new Array(chunks.length).fill(false);
+      let nextIndex = 0;
+
+      const processChunk = async (chunk: typeof chunks[0], index: number): Promise<void> => {
+        logger.info(
+          `Processing chunk ${chunk.chunkIndex}/${totalChunks} via ${operation} (lines ${chunk.startLine}-${chunk.endLine})`
+        );
+
+        try {
+          const translated = await executeStreamingLlmRequest({
+            userPrompt: chunk.chunkText,
+            systemPrompt: systemInstructions,
+            operation,
+            callId,
+          });
+
+          if (!translated.ok) {
+            logger.warn(`${operation}_chunk_failed | chunk=${chunk.chunkIndex}/${totalChunks} | reason=${translated.reason} | using_original=true`);
+            results[index] = chunk.chunkText;
+            chunkFellBack[index] = true;
+            return;
+          }
+
+          logger.info(`Chunk ${chunk.chunkIndex}/${totalChunks} completed`);
+          results[index] = translated.content;
+        } catch (error) {
+          logger.error(`Error processing chunk ${chunk.chunkIndex}:`, error);
+          results[index] = chunk.chunkText;
+          chunkFellBack[index] = true;
+        }
+      };
+
+      // Worker-pool: run up to CHUNK_CONCURRENCY chunks at a time.
+      const workers = Array.from(
+        { length: Math.min(CHUNK_CONCURRENCY, chunks.length) },
+        async () => {
+          while (nextIndex < chunks.length) {
+            const currentIndex = nextIndex;
+            nextIndex += 1;
+            await processChunk(chunks[currentIndex], currentIndex);
+          }
+        }
+      );
+
+      await Promise.all(workers);
+
+      const text = results.join('\n');
+      const partial = chunkFellBack.some(Boolean);
+      logger.info(
+        `Successfully processed transcript via ${operation} in ${results.length} chunks${partial ? ' (partial)' : ''}`
+      );
+      return { text, partial };
+    } catch (error) {
+      logger.error(`Error during ${operation}:`, error);
+      return { text: transcript, partial: true }; // Fallback to original if processing fails
     }
   }
 
@@ -1543,6 +1847,16 @@ export class TranscriptService {
       } catch (error) {
         logger.warn(`[${callId}] transcript_artifact_delete_failed`, { path, error });
       }
+    }
+
+    try {
+      const translated = await this.transcriptStorage.listFiles(`attachments/${callId}_translated_`);
+      for (const file of translated) {
+        await this.transcriptStorage.deleteFile(file.name);
+        logger.info(`[${callId}] transcript_artifact_deleted`, { path: file.name });
+      }
+    } catch (error) {
+      logger.warn(`[${callId}] translated_transcript_artifacts_delete_failed`, { error });
     }
   }
 

--- a/apps/dashboard/src/components/Chat/TranscriptCitationModal/TranscriptSidePanel.tsx
+++ b/apps/dashboard/src/components/Chat/TranscriptCitationModal/TranscriptSidePanel.tsx
@@ -1,21 +1,34 @@
 import { Fragment, useCallback, useEffect, useMemo, useRef, type ReactElement } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import {
+  AlertTriangle,
   ChevronDown,
   ChevronUp,
   CopyDefault,
   DownloadDown,
+  FileText,
   MultipleCrossCancelDefault,
   SearchBig,
   Spinner,
+  Translate,
 } from '@xyne/icons';
 import { toast } from 'sonner';
+import { ORIGINAL_TRANSCRIPT_LANGUAGE, SUPPORTED_TRANSCRIPT_LANGUAGES } from '@xyne/shared';
 import { Button } from '../../ui/Button/Button';
 import { Tooltip } from '../../ui/Tooltip';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../ui/Select/Select';
 import { MarkedMomentDivider } from '../../Notetaker/MarkedMomentDivider';
 import { useTextSearch } from '../../../hooks/useTextSearch';
 import { HighlightedText } from '../../../routes/RecordingsScreen/components/HighlightedText';
 import { cn } from '../../../utils/classNames';
+import { sanitizeFilename } from '../../../utils/canvasExport';
+import { Skeleton } from '../../ui/Skeleton';
 import {
   CITATION_HIGHLIGHT,
   findTargetIndex,
@@ -27,6 +40,18 @@ import {
 
 /** Stable identity so the memos below don't recompute for callers passing no moments. */
 const NO_MARKED_MOMENTS: readonly number[] = [];
+
+/** Fixed varying widths so the loading shimmer reads as transcript lines, not uniform bars. */
+const TRANSCRIPT_SKELETON_ROWS: ReadonlyArray<readonly string[]> = [
+  ['w-11/12'],
+  ['w-4/5', 'w-2/3'],
+  ['w-full'],
+  ['w-3/4'],
+  ['w-5/6', 'w-1/2'],
+  ['w-2/3'],
+  ['w-11/12', 'w-3/5'],
+  ['w-4/5'],
+];
 
 /**
  * Which treatment the resolved line gets. `marker` is the amber one, for a line
@@ -49,6 +74,7 @@ export interface TranscriptSidePanelProps {
   openNonce?: number;
   isLoading?: boolean;
   error?: string | null;
+  onRetry?: () => void;
   /**
    * Offsets, in seconds from the recording start, the user flagged while recording —
    * the `moment` entries of Call.markedItems. Each is resolved to the line being
@@ -57,6 +83,13 @@ export interface TranscriptSidePanelProps {
   markedTimestampsSeconds?: readonly number[];
   onClose: () => void;
   className?: string;
+  title?: string;
+  // Translation dropdown
+  selectedLanguage?: string;
+  onLanguageChange?: (language: string) => void;
+  isTranslating?: boolean;
+  /** Some lines fell back to their original language — surfaced as a notice, not silently mixed in. */
+  translatePartial?: boolean;
 }
 
 export function TranscriptSidePanel({
@@ -65,9 +98,15 @@ export function TranscriptSidePanel({
   openNonce = 0,
   isLoading = false,
   error = null,
+  onRetry,
   markedTimestampsSeconds = NO_MARKED_MOMENTS,
   onClose,
   className = '',
+  title,
+  selectedLanguage = ORIGINAL_TRANSCRIPT_LANGUAGE,
+  onLanguageChange,
+  isTranslating = false,
+  translatePartial = false,
 }: TranscriptSidePanelProps): ReactElement {
   const lineRefs = useRef(new Map<number, HTMLDivElement>());
   const lines = useMemo(() => parseTranscript(transcript), [transcript]);
@@ -109,16 +148,23 @@ export function TranscriptSidePanel({
   }, [transcript]);
 
   const handleDownload = useCallback((): void => {
+    const languageLabel =
+      selectedLanguage === ORIGINAL_TRANSCRIPT_LANGUAGE
+        ? 'original'
+        : (SUPPORTED_TRANSCRIPT_LANGUAGES.find(language => language.code === selectedLanguage)
+            ?.label ?? selectedLanguage);
+    const filename = `${sanitizeFilename(title ?? 'transcript')}-scribe-${sanitizeFilename(languageLabel)}.txt`;
+
     const blob = new Blob([transcript], { type: 'text/plain;charset=utf-8' });
     const href = URL.createObjectURL(blob);
     const anchor = document.createElement('a');
     anchor.href = href;
-    anchor.download = 'transcript.txt';
+    anchor.download = filename;
     document.body.appendChild(anchor);
     anchor.click();
     anchor.remove();
     window.setTimeout(() => URL.revokeObjectURL(href), 0);
-  }, [transcript]);
+  }, [transcript, title, selectedLanguage]);
 
   const shouldReduceMotion = useReducedMotion();
 
@@ -185,85 +231,154 @@ export function TranscriptSidePanel({
       </header>
 
       <div className='shrink-0 border-b border-border px-4 py-3'>
-        <div className='flex h-10 items-center gap-1.5 rounded-xl border border-border bg-muted/45 px-3 text-muted-foreground focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/20'>
-          <SearchBig size={16} strokeWidth={2.2} className='shrink-0' aria-hidden='true' />
-          <input
-            type='text'
-            value={search.query}
-            onFocus={search.open}
-            onChange={event => search.setQuery(event.target.value)}
-            onKeyDown={search.handleKeyDown}
-            placeholder='Search transcript...'
-            aria-label='Search transcript'
-            className='h-full min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground'
-            data-track-category='TranscriptPanel'
-            data-track-name='search_transcript'
-          />
-          {search.query ? (
-            <>
-              <span className='shrink-0 text-xs tabular-nums'>
-                {search.matchCount > 0
-                  ? `${search.currentIndex + 1} of ${search.matchCount}`
-                  : 'No matches'}
-              </span>
-              <Button
-                type='button'
-                variant='ghost'
-                size='iconSm'
-                onClick={search.goToPrevious}
-                disabled={search.matchCount === 0}
-                className='size-6 rounded-full hover:bg-muted disabled:opacity-35'
-                aria-label='Previous match'
+        <div className='flex items-center gap-2'>
+          <div className='flex h-9 min-w-0 flex-1 items-center gap-1.5 rounded-xl border border-border bg-muted/45 px-3 text-muted-foreground focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/20'>
+            <SearchBig size={16} strokeWidth={2.2} className='shrink-0' aria-hidden='true' />
+            <input
+              type='text'
+              value={search.query}
+              onFocus={search.open}
+              onChange={event => search.setQuery(event.target.value)}
+              onKeyDown={search.handleKeyDown}
+              placeholder='Search transcript...'
+              aria-label='Search transcript'
+              className='h-full min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground'
+              data-track-category='TranscriptPanel'
+              data-track-name='search_transcript'
+            />
+            {search.query ? (
+              <>
+                <span className='shrink-0 text-xs tabular-nums'>
+                  {search.matchCount > 0
+                    ? `${search.currentIndex + 1} of ${search.matchCount}`
+                    : 'No matches'}
+                </span>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='iconSm'
+                  onClick={search.goToPrevious}
+                  disabled={search.matchCount === 0}
+                  className='size-6 rounded-full hover:bg-muted disabled:opacity-35'
+                  aria-label='Previous match'
+                  data-track-category='TranscriptPanel'
+                  data-track-name='transcript_search_previous'
+                >
+                  <ChevronUp className='size-3.5' aria-hidden='true' />
+                </Button>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='iconSm'
+                  onClick={search.goToNext}
+                  disabled={search.matchCount === 0}
+                  className='size-6 rounded-full hover:bg-muted disabled:opacity-35'
+                  aria-label='Next match'
+                  data-track-category='TranscriptPanel'
+                  data-track-name='transcript_search_next'
+                >
+                  <ChevronDown className='size-3.5' aria-hidden='true' />
+                </Button>
+                <Button
+                  type='button'
+                  variant='ghost'
+                  size='iconSm'
+                  onClick={search.close}
+                  className='size-6 rounded-full hover:bg-muted'
+                  aria-label='Clear transcript search'
+                  data-track-category='TranscriptPanel'
+                  data-track-name='clear_transcript_search'
+                >
+                  <MultipleCrossCancelDefault className='size-3.5' aria-hidden='true' />
+                </Button>
+              </>
+            ) : null}
+          </div>
+          {onLanguageChange ? (
+            <Select
+              value={selectedLanguage}
+              onValueChange={onLanguageChange}
+              disabled={isTranslating}
+            >
+              <SelectTrigger
+                aria-label='Translate transcript'
+                className='h-9 shrink-0 gap-1.5 rounded-xl border border-border bg-background px-3 text-sm font-medium text-foreground shadow-none hover:bg-muted'
                 data-track-category='TranscriptPanel'
-                data-track-name='transcript_search_previous'
+                data-track-name='translate_transcript'
               >
-                <ChevronUp className='size-3.5' aria-hidden='true' />
-              </Button>
-              <Button
-                type='button'
-                variant='ghost'
-                size='iconSm'
-                onClick={search.goToNext}
-                disabled={search.matchCount === 0}
-                className='size-6 rounded-full hover:bg-muted disabled:opacity-35'
-                aria-label='Next match'
-                data-track-category='TranscriptPanel'
-                data-track-name='transcript_search_next'
-              >
-                <ChevronDown className='size-3.5' aria-hidden='true' />
-              </Button>
-              <Button
-                type='button'
-                variant='ghost'
-                size='iconSm'
-                onClick={search.close}
-                className='size-6 rounded-full hover:bg-muted'
-                aria-label='Clear transcript search'
-                data-track-category='TranscriptPanel'
-                data-track-name='clear_transcript_search'
-              >
-                <MultipleCrossCancelDefault className='size-3.5' aria-hidden='true' />
-              </Button>
-            </>
+                {isTranslating ? (
+                  <Spinner
+                    size={16}
+                    className='shrink-0 text-muted-foreground !animate-spin'
+                    aria-hidden='true'
+                  />
+                ) : (
+                  <Translate size={16} aria-hidden='true' />
+                )}
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align='end'>
+                <SelectItem value={ORIGINAL_TRANSCRIPT_LANGUAGE}>Original</SelectItem>
+                {SUPPORTED_TRANSCRIPT_LANGUAGES.map(language => (
+                  <SelectItem key={language.code} value={language.code}>
+                    {language.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           ) : null}
         </div>
       </div>
 
       <div className='thin-scrollbar min-h-0 flex-1 overflow-y-auto px-5 pb-6 pt-3'>
         {isLoading ? (
-          <div
-            className='flex items-center gap-2 py-6 text-sm text-muted-foreground'
-            aria-live='polite'
-          >
-            <Spinner size={16} className='animate-spin' aria-hidden='true' />
-            Loading transcript
+          <div className='space-y-2.5' aria-busy='true' aria-label='Loading transcript'>
+            {TRANSCRIPT_SKELETON_ROWS.map((lineWidths, rowIndex) => (
+              <div key={rowIndex} className='-mx-3 rounded-lg px-3 py-2.5'>
+                <Skeleton className='mb-1.5 h-3 w-12' />
+                <div className='space-y-1.5'>
+                  {lineWidths.map((width, lineIndex) => (
+                    <Skeleton key={lineIndex} className={`h-3.5 ${width}`} />
+                  ))}
+                </div>
+              </div>
+            ))}
           </div>
         ) : null}
-        {!isLoading && error ? <p className='py-6 text-sm text-destructive'>{error}</p> : null}
+        {!isLoading && error ? (
+          <div className='flex flex-col items-center gap-3 py-6 text-center'>
+            <p className='text-sm text-destructive'>{error}</p>
+            {onRetry ? (
+              <Button type='button' variant='outline' size='sm' onClick={onRetry}>
+                Try again
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
         {!isLoading && !error && lines.length === 0 ? (
-          <p className='py-6 text-sm text-muted-foreground'>
-            No transcript is available for this call.
-          </p>
+          <div className='flex h-full min-h-[240px] flex-col items-center justify-center gap-3 text-center'>
+            <div className='flex size-11 items-center justify-center rounded-xl bg-muted'>
+              <FileText size={20} className='text-muted-foreground' aria-hidden='true' />
+            </div>
+            <div className='space-y-1'>
+              <p className='text-sm font-medium text-foreground'>No transcript available</p>
+              <p className='text-xs text-muted-foreground'>
+                This call doesn&apos;t have a transcript to show yet.
+              </p>
+            </div>
+          </div>
+        ) : null}
+        {!isLoading && !error && translatePartial ? (
+          <div className='mb-3 flex items-center justify-center gap-2 rounded-xl border border-border bg-muted p-2'>
+            <AlertTriangle
+              size={14}
+              className='shrink-0 text-muted-foreground'
+              aria-hidden='true'
+            />
+            <p className='text-xs text-muted-foreground'>
+              Some lines couldn&apos;t be translated and are shown in their original language
+            </p>
+          </div>
         ) : null}
         {!isLoading && !error && lines.length > 0 ? (
           <div className='space-y-2.5'>

--- a/apps/dashboard/src/hooks/useTranscriptTranslation.ts
+++ b/apps/dashboard/src/hooks/useTranscriptTranslation.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import type { TranscriptTranslation } from '@xyne/shared';
+import { recordingService } from '../services/Recording/recordingService';
+import { logRecordingError } from '../utils/recordingUtils';
+
+export interface UseTranscriptTranslationOptions {
+  externalId: string | undefined;
+  language: string;
+  /** Prefer the speaker-identified transcript for `original` (headless recordings only). */
+  variant?: 'identified' | undefined;
+  enabled: boolean;
+}
+
+export interface UseTranscriptTranslationResult {
+  /** Last successfully loaded text — sticky across language switches so the panel
+   *  keeps showing the previous language while the next one loads. */
+  text: string | undefined;
+  partial: boolean;
+  isLoading: boolean;
+  isTranslating: boolean;
+  error: string | undefined;
+  retry: () => void;
+}
+
+/**
+ * Lazily fetches transcript text per language via the translate-transcript endpoint
+ * (`original` is a no-LLM passthrough). Local state, deliberately not synced through
+ * Zero — Postgres never carries transcript text (see calls.metadata.translations).
+ */
+export function useTranscriptTranslation({
+  externalId,
+  language,
+  variant,
+  enabled,
+}: UseTranscriptTranslationOptions): UseTranscriptTranslationResult {
+  const [cache, setCache] = useState<Record<string, TranscriptTranslation>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [translatingLanguage, setTranslatingLanguage] = useState<string | null>(null);
+  const [displayed, setDisplayed] = useState<TranscriptTranslation | undefined>(undefined);
+
+  // Guards late responses from a call navigated away from before they resolved.
+  const externalIdRef = useRef(externalId);
+  externalIdRef.current = externalId;
+
+  useEffect(() => {
+    setCache({});
+    setErrors({});
+    setTranslatingLanguage(null);
+    setDisplayed(undefined);
+  }, [externalId]);
+
+  useEffect(() => {
+    if (!enabled || !externalId) return;
+    const existing = cache[language];
+    if (existing?.status === 'ready' && existing.text !== undefined) return;
+    // A failed language never auto-retries — retry() clears the error, which refires this effect.
+    if (errors[language] !== undefined) return;
+    if (translatingLanguage === language) return;
+
+    setTranslatingLanguage(language);
+    void recordingService
+      .translateTranscript(externalId, language, variant)
+      .then(result => {
+        if (externalIdRef.current !== externalId) return;
+        setCache(current => ({ ...current, [language]: result }));
+      })
+      .catch((err: unknown) => {
+        logRecordingError('useTranscriptTranslation', err);
+        if (externalIdRef.current !== externalId) return;
+        const message = axios.isAxiosError(err)
+          ? (err.response?.data as { error?: string } | undefined)?.error
+          : undefined;
+        setErrors(current => ({ ...current, [language]: message ?? 'Please try again.' }));
+      })
+      .finally(() => {
+        setTranslatingLanguage(current => (current === language ? null : current));
+      });
+  }, [enabled, language, externalId, variant, cache, errors, translatingLanguage]);
+
+  const active = cache[language];
+  useEffect(() => {
+    if (active?.status === 'ready' && active.text !== undefined) {
+      setDisplayed(active);
+    }
+  }, [active]);
+
+  const retry = useCallback((): void => {
+    setErrors(current => {
+      if (!(language in current)) return current;
+      const { [language]: _removed, ...rest } = current;
+      return rest;
+    });
+  }, [language]);
+
+  const error = errors[language];
+  return {
+    text: displayed?.text,
+    partial: !!displayed?.partial,
+    isLoading: enabled && !!externalId && displayed?.text === undefined && error === undefined,
+    isTranslating: translatingLanguage === language,
+    error,
+    retry,
+  };
+}

--- a/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
+++ b/apps/dashboard/src/routes/CallDetailScreen/CallDetailScreen.tsx
@@ -1,9 +1,13 @@
 import { ReactElement, useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useSelector } from '@xstate/react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { AnimatePresence } from 'framer-motion';
 import { ChevronLeft, ChevronRight, Loader2, FileText } from 'lucide-react';
+import { ORIGINAL_TRANSCRIPT_LANGUAGE } from '@xyne/shared';
+import { SidebarRightClose, SidebarRightOpen } from '@xyne/icons';
 import { toast } from 'sonner';
 import { recordingService } from '../../services/Recording/recordingService';
+import { Button } from '../../components/ui/Button/Button';
 import { AudioPlayer } from '../../components/ui/AudioPlayer/AudioPlayer';
 import { useCallPRD } from '../../hooks/useCallPRD';
 import { useAskAiTicketContext } from '../../hooks/useAskAiTicketContext';
@@ -14,6 +18,12 @@ import Tooltip from '../../components/ui/Tooltip/Tooltip';
 import { type Call } from '../CallHistoryScreen/callHistoryItem.utils';
 import { xyneAIActor } from '../../machines/xyneAIMachine';
 import { usePlatform } from '../../hooks/usePlatform';
+import { useTranscriptTranslation } from '../../hooks/useTranscriptTranslation';
+import {
+  TranscriptSidePanel,
+  type TranscriptPanelTarget,
+} from '../../components/Chat/TranscriptCitationModal/TranscriptSidePanel';
+import { transcriptCitationStore } from '../../components/Chat/TranscriptCitationModal';
 import { DetailedSummaryCanvasTab } from './DetailedSummaryCanvasTab';
 import { PrdCanvasTab } from './PrdCanvasTab';
 import { CallParticipantsPopover } from './CallParticipantsPopover';
@@ -134,6 +144,38 @@ export default function CallDetailScreen(): ReactElement {
     call?.startedAt && call?.endedAt
       ? new Date(call.endedAt).getTime() - new Date(call.startedAt).getTime()
       : null;
+
+  // Transcript side panel
+  const [showTranscriptPanel, setShowTranscriptPanel] = useState(false);
+  const [selectedTranscriptLanguage, setSelectedTranscriptLanguage] = useState(
+    ORIGINAL_TRANSCRIPT_LANGUAGE,
+  );
+  const [citationNonce, setCitationNonce] = useState(0);
+  const [citationRef, setCitationRef] = useState<TranscriptPanelTarget | null>(null);
+  const hasTranscript = Boolean(call?.transcript);
+  const transcript = useTranscriptTranslation({
+    externalId: call?.externalId,
+    language: selectedTranscriptLanguage,
+    enabled: showTranscriptPanel,
+  });
+
+  // Route canvas citations (detailed-summary pills carry callId = externalId) into this
+  // screen's own panel instead of the global TranscriptCitationModal.
+  const callExternalId = call?.externalId;
+  useEffect(() => {
+    if (!callExternalId) return;
+    return transcriptCitationStore.setHandler(ref => {
+      if (ref.callId !== callExternalId) return false;
+      setCitationRef({
+        ...(ref.timestamp ? { timestamp: ref.timestamp } : {}),
+        ...(ref.speaker ? { speaker: ref.speaker } : {}),
+        ...(ref.segment ? { segment: ref.segment } : {}),
+      });
+      setCitationNonce(value => value + 1);
+      setShowTranscriptPanel(true);
+      return true;
+    });
+  }, [callExternalId]);
 
   const { prdEntries } = useCallPRD({
     externalId: call?.externalId ?? '',
@@ -299,7 +341,12 @@ export default function CallDetailScreen(): ReactElement {
     // sidebar. Mirrors the recording detail screen's root.
     <div className='relative flex h-full overflow-hidden bg-background rounded-2xl'>
       <div className='flex-1 flex flex-col overflow-hidden min-w-0'>
-        <div className='flex-1 overflow-y-auto'>
+        <div
+          className={cn(
+            'flex-1 overflow-y-auto transition-[padding] duration-300',
+            showTranscriptPanel && 'md:pr-[560px]',
+          )}
+        >
           <div className='mx-auto w-full max-w-[820px] px-6 pt-6 pb-24 sm:px-8'>
             {/* Breadcrumb + Ask AI */}
             <div className='flex items-center gap-[7px] mb-[18px]'>
@@ -457,6 +504,33 @@ export default function CallDetailScreen(): ReactElement {
                   <ChevronRight className='size-3.5' />
                 </button>
               )}
+              {hasTranscript && (
+                <Tooltip
+                  content={!showTranscriptPanel ? 'Open transcript' : 'Close transcript'}
+                  side='left'
+                >
+                  <Button
+                    onClick={(): void => {
+                      setShowTranscriptPanel(open => !open);
+                      setCitationRef(null);
+                    }}
+                    variant='ghost'
+                    className={cn(
+                      'inline-flex size-8 items-center justify-center rounded-xl border border-border/70 transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                      showTranscriptPanel ? 'text-foreground' : 'text-muted-foreground',
+                    )}
+                    aria-label={!showTranscriptPanel ? 'Open transcript' : 'Close transcript'}
+                    data-track-category='CallDetail'
+                    data-track-name='open_transcript_panel'
+                  >
+                    {showTranscriptPanel ? (
+                      <SidebarRightClose className='size-4' aria-hidden='true' variant='Solid' />
+                    ) : (
+                      <SidebarRightOpen className='size-4' aria-hidden='true' variant='Solid' />
+                    )}
+                  </Button>
+                </Tooltip>
+              )}
             </div>
 
             {/* Tab content */}
@@ -495,6 +569,30 @@ export default function CallDetailScreen(): ReactElement {
           </div>
         </div>
       </div>
+
+      {/* Transcript side panel */}
+      <AnimatePresence>
+        {showTranscriptPanel && (
+          <TranscriptSidePanel
+            transcript={transcript.text ?? ''}
+            isLoading={transcript.isLoading}
+            error={transcript.error ?? null}
+            onRetry={transcript.retry}
+            target={citationRef}
+            openNonce={citationNonce}
+            title={title}
+            selectedLanguage={selectedTranscriptLanguage}
+            onLanguageChange={setSelectedTranscriptLanguage}
+            isTranslating={transcript.isTranslating}
+            translatePartial={transcript.partial}
+            onClose={(): void => {
+              setShowTranscriptPanel(false);
+              setCitationRef(null);
+            }}
+            className='absolute inset-y-0 right-0 z-30 w-full md:w-[560px]'
+          />
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/RecordingDetailV2Screen.tsx
@@ -6,6 +6,7 @@ import { type ReactElement, useState, useEffect, useCallback, useMemo, useRef } 
 import { AnimatePresence, motion } from 'framer-motion';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import axios from 'axios';
+import { ORIGINAL_TRANSCRIPT_LANGUAGE } from '@xyne/shared';
 import {
   recordingService,
   type RecordingDetail,
@@ -36,6 +37,7 @@ import {
 } from '../../utils/recordingSummaryRequest';
 import AppNavigator from '../../components/AppNavigator/AppNavigator';
 import { usePlatform } from '../../hooks/usePlatform';
+import { useTranscriptTranslation } from '../../hooks/useTranscriptTranslation';
 import { useSpeakerIdentificationEnabled } from '../../components/SpeakerIdentification/useSpeakerIdentificationEnabled';
 import {
   Spinner,
@@ -193,6 +195,9 @@ export default function RecordingDetailV2Screen(): ReactElement {
     requestedTab === 'notes' ? 'notes' : justStopped ? 'secondary' : getRecordingV2Tab(),
   );
   const [showTranscriptPanel, setShowTranscriptPanel] = useState(false);
+  const [selectedTranscriptLanguage, setSelectedTranscriptLanguage] = useState(
+    ORIGINAL_TRANSCRIPT_LANGUAGE,
+  );
   const [showShareModal, setShowShareModal] = useState(false);
   const [showPostToChannelModal, setShowPostToChannelModal] = useState(false);
   const [showPostToEmailModal, setShowPostToEmailModal] = useState(false);
@@ -626,13 +631,13 @@ export default function RecordingDetailV2Screen(): ReactElement {
       // Patch only the fields being polled for: a failed refresh must not tear down
       // the loaded screen, and Zero owns the rest.
       void recordingService
-        .getRecordingDetail(recordingId)
+        .getRecordingStatus(recordingId)
         .then(fresh =>
           setRecording(current =>
             current
               ? {
                   ...current,
-                  hasRecording: !!fresh.hasRecording,
+                  hasRecording: fresh.hasRecording,
                   durationMs: fresh.durationMs ?? current.durationMs,
                 }
               : current,
@@ -648,7 +653,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
     try {
       if (loadedRecordingIdRef.current !== id) setLoading(true);
       setFailure(null);
-      const data = await recordingService.getRecordingDetail(id);
+      const data = await recordingService.getRecordingDetail(id, { scope: 'metadata' });
       loadedRecordingIdRef.current = id;
       setRecording(prev =>
         prev && data.durationMs === null && prev.durationMs !== null
@@ -875,10 +880,21 @@ export default function RecordingDetailV2Screen(): ReactElement {
     [recordingId],
   );
 
-  const transcriptText =
-    speakerIdentificationEnabled && recording?.hasIdentifiedTranscript
-      ? (recording.identifiedTranscript ?? recording.transcript)
-      : recording?.transcript;
+  const transcriptVariant =
+    selectedTranscriptLanguage === ORIGINAL_TRANSCRIPT_LANGUAGE &&
+    speakerIdentificationEnabled &&
+    recording?.hasIdentifiedTranscript
+      ? ('identified' as const)
+      : undefined;
+  const transcript = useTranscriptTranslation({
+    externalId: recording?.externalId,
+    language: selectedTranscriptLanguage,
+    variant: transcriptVariant,
+    // Fetch only once the panel is actually opened, not on page load — mirrors
+    // getRecordingDetail no longer embedding the transcript body.
+    enabled: showTranscriptPanel,
+  });
+  const transcriptText = transcript.text;
 
   const markedMomentSeconds = useMemo(
     () =>
@@ -888,12 +904,9 @@ export default function RecordingDetailV2Screen(): ReactElement {
     [recording?.markedItems],
   );
 
-  /**
-   * Route canvas citations into this screen's own transcript panel instead of the
-   * global TranscriptCitationModal, so clicking a citation behaves like the toolbar
-   */
+  // Route canvas citations into this screen's own transcript panel instead of the global TranscriptCitationModal.
   useEffect(() => {
-    if (!recordingId || !transcriptText?.trim()) return;
+    if (!recordingId) return;
     return transcriptCitationStore.setHandler(ref => {
       if (ref.callId !== recordingId) return false;
       setCitationRef({
@@ -905,7 +918,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
       setShowTranscriptPanel(true);
       return true;
     });
-  }, [recordingId, transcriptText]);
+  }, [recordingId]);
 
   // Seeds the summary-request record for the auto-detected pending state (server
   // summarizing without an explicit "Generate summary" click), so its progress
@@ -1066,8 +1079,6 @@ export default function RecordingDetailV2Screen(): ReactElement {
           <AppNavigator />
         </div>
       )}
-      {/* layoutScroll: the tab indicator animates inside this scroller, so Motion has
-          to account for its scroll offset when measuring positions. */}
       <motion.div
         ref={scrollContainerRef}
         layoutScroll
@@ -1163,7 +1174,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                       recordingService.downloadRecordingBlob(recording.externalId, signal),
                   }
                 : {})}
-              {...(transcriptText
+              {...(hasTranscript
                 ? { onMarkerSelect: handleMarkerSelect, onOpenTranscript: openTranscriptPanel }
                 : {})}
             />
@@ -1321,7 +1332,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                     </span>
                   )}
                 </div>
-                {transcriptText ? (
+                {hasTranscript ? (
                   <Tooltip
                     content={!showTranscriptPanel ? 'Open transcript' : 'Close transcript'}
                     side='left'
@@ -1508,7 +1519,7 @@ export default function RecordingDetailV2Screen(): ReactElement {
                   initialProgress={getSummaryProgress(recordingId)}
                   initialStageIndex={getSummaryStage(recordingId)}
                   onProgressPause={handleSummaryProgressPause}
-                  onReadTranscript={transcriptText ? openTranscriptPanel : undefined}
+                  onReadTranscript={hasTranscript ? openTranscriptPanel : undefined}
                 />
               )}
               {/* Owner-only: the docs live in the owner's Drive, so these links are
@@ -1524,12 +1535,20 @@ export default function RecordingDetailV2Screen(): ReactElement {
 
       {/* Transcript side panel */}
       <AnimatePresence>
-        {showTranscriptPanel && transcriptText && (
+        {showTranscriptPanel && (
           <TranscriptSidePanel
-            transcript={transcriptText}
+            transcript={transcriptText ?? ''}
+            isLoading={transcript.isLoading}
+            error={transcript.error ?? null}
+            onRetry={transcript.retry}
             target={citationRef}
             openNonce={citationNonce}
             markedTimestampsSeconds={markedMomentSeconds}
+            title={recording.title}
+            selectedLanguage={selectedTranscriptLanguage}
+            onLanguageChange={setSelectedTranscriptLanguage}
+            isTranslating={transcript.isTranslating}
+            translatePartial={transcript.partial}
             onClose={() => {
               setShowTranscriptPanel(false);
               setCitationRef(null);

--- a/apps/dashboard/src/services/Recording/recordingService.ts
+++ b/apps/dashboard/src/services/Recording/recordingService.ts
@@ -5,7 +5,12 @@
 
 import { apiInstance } from '../clients/apiClient';
 import { AxiosResponse } from 'axios';
-import type { DefaultOutlet, GrantableEntityUserAccess, RecordingType } from '@xyne/shared';
+import type {
+  DefaultOutlet,
+  GrantableEntityUserAccess,
+  RecordingType,
+  TranscriptTranslation,
+} from '@xyne/shared';
 import { CallType, CallVisibility } from '@xyne/shared';
 import { getSummaryModelPreference } from '../../hooks/useSummaryModelPreference';
 
@@ -332,16 +337,30 @@ class RecordingService {
     return response.data;
   }
 
-  /**
-   * Get recording detail with transcript and summary
-   */
-  async getRecordingDetail(callId: string): Promise<RecordingDetail> {
+  // `scope: 'metadata'` skips the transcript-body GCS reads server-side; fetch text lazily
+  // via translateTranscript(callId, ORIGINAL_TRANSCRIPT_LANGUAGE) instead.
+  async getRecordingDetail(
+    callId: string,
+    opts?: { scope?: 'metadata' },
+  ): Promise<RecordingDetail> {
+    const query = opts?.scope ? `?scope=${opts.scope}` : '';
     const response: AxiosResponse<RecordingDetailResponse> = await apiInstance.get(
-      `/calls/recordings/${callId}`,
+      `/calls/recordings/${callId}${query}`,
     );
 
     const data: RecordingDetailResponse = response.data;
     return data.recording;
+  }
+
+  /** Lightweight poll target — only what's needed to detect post-call audio landing. */
+  async getRecordingStatus(
+    callId: string,
+  ): Promise<{ hasRecording: boolean; durationMs: number | null }> {
+    const response: AxiosResponse<{
+      success: true;
+      recording: { hasRecording: boolean; durationMs: number | null };
+    }> = await apiInstance.get(`/calls/recordings/${callId}?scope=status`);
+    return response.data.recording;
   }
 
   /**
@@ -364,6 +383,20 @@ class RecordingService {
       await apiInstance.post(`/calls/recordings/${callId}/generate-summary`, {
         summaryTemplateId,
         ...(modelType ? { modelType } : {}),
+      });
+    return response.data;
+  }
+
+  // `language: ORIGINAL_TRANSCRIPT_LANGUAGE` returns the transcript as recorded, no LLM call.
+  async translateTranscript(
+    callId: string,
+    language: string,
+    variant?: 'identified',
+  ): Promise<TranscriptTranslation> {
+    const response: AxiosResponse<{ success: true } & TranscriptTranslation> =
+      await apiInstance.post(`/calls/${callId}/translate-transcript`, {
+        language,
+        ...(variant ? { variant } : {}),
       });
     return response.data;
   }

--- a/packages/shared/src/types/call.ts
+++ b/packages/shared/src/types/call.ts
@@ -13,3 +13,27 @@ export const DEFAULT_HOST_CONTROLS: HostControls = {
     turnOffCamera: false,
     turnOffScreenShare: false,
 }
+
+export type TranscriptLanguage = {
+    code: string;
+    label: string;
+}
+
+export const SUPPORTED_TRANSCRIPT_LANGUAGES: TranscriptLanguage[] = [
+    { code: 'en', label: 'English' },
+    { code: 'hi', label: 'Hindi' },
+    { code: 'bn', label: 'Bengali' },
+    { code: 'ar', label: 'Arabic' },
+    { code: 'de', label: 'German' },
+    { code: 'pt', label: 'Portuguese' },
+    { code: 'ja', label: 'Japanese' },
+]
+
+export const ORIGINAL_TRANSCRIPT_LANGUAGE = 'original'
+
+export type TranscriptTranslation = {
+    status: 'pending' | 'ready' | 'failed';
+    generation?: string;
+    text?: string;
+    partial?: boolean;
+}


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->

XYNE-61738: Adds multi-language transcript translation, shared across both the **Calls** transcript panel and the **Scribe** recording detail view.

- New `POST /:callId/translate-transcript` endpoint: translates on demand via LLM and caches the result in GCS, keyed by language + source transcript generation (so a re-generated transcript invalidates stale translations). `original` is a no-LLM passthrough for the raw/identified transcript.
- Supported languages (en, hi, bn, ar, de, pt, ja) are whitelisted in `packages/shared` since the value is interpolated into the LLM prompt.
- New `useTranscriptTranslation` hook shared by `TranscriptSidePanel`, `CallDetailScreen`, and `RecordingDetailV2Screen` — lazy per-language fetch, sticky previous text while loading, per-language retry on failure.
- `GET /:callId` (call metadata) now supports `?scope=status` and `?scope=metadata` to skip GCS transcript reads for the polling/status-only cases.

## POT: [Transcript Translation Tested](https://drive.google.com/file/d/1B-MK3jz8jGP_MK3sf1ywq_ia2T3cAk_O/view?usp=sharing)

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [x] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [x] New endpoint
- [x] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind

