### PR TITLE
fix: XYNE-61540 claw and xyne ai improvements

### DIFF
--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -1063,15 +1063,16 @@ const parseNode = (
           context: [flowJSON.screenId],
         });
         return (
-          <FlowScreenManager
-            key={`${keyPrefix}-flow-${idx}-${flowJSON.screenId}`}
-            flow={flowJSON}
-            messageId={messageId ?? ''}
-            conversationId={conversationId ?? ''}
-            {...(slashCommandArtifactContext && {
-              messageContext: slashCommandArtifactContext,
-            })}
-          />
+          <div key={`${keyPrefix}-flow-${idx}-${flowJSON.screenId}`} className='mt-1.5'>
+            <FlowScreenManager
+              flow={flowJSON}
+              messageId={messageId ?? ''}
+              conversationId={conversationId ?? ''}
+              {...(slashCommandArtifactContext && {
+                messageContext: slashCommandArtifactContext,
+              })}
+            />
+          </div>
         );
       } catch (e) {
         logger.error(Event.FRONTEND_ERROR, {

--- a/apps/dashboard/src/components/flowUI/nodes/McpSuggestNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/McpSuggestNode.tsx
@@ -5,6 +5,7 @@ import type { FlowComponent } from '@xyne/shared';
 import { useAuth } from '../../../hooks/useAuth';
 import { Button, buttonVariants } from '../../ui/Button/Button';
 import { useMcpCatalog } from '../../../routes/AIScreen/library/shared/pickers/mcp/useMcpCatalog';
+import { useMcpCredentialFields } from '../../../routes/AIScreen/library/shared/pickers/mcp/useMcpCredentialFields';
 import { McpLogo } from '../../../routes/AIScreen/library/shared/pickers/mcp/McpLogo';
 import { McpConnectDialog } from '../../../routes/AIScreen/library/mcp/detail/McpConnectDialog';
 import { openOAuthConsent } from '../../../routes/AIScreen/library/shared/pickers/mcp/openOAuthConsent';
@@ -51,6 +52,7 @@ export const McpSuggestNode: React.FC<{ node: FlowComponent; children?: React.Re
   const props = node.props as McpSuggestProps | undefined;
   const { user } = useAuth();
   const { entries, connectedServerIds, refetch } = useMcpCatalog();
+  const { ensureFieldsFor } = useMcpCredentialFields();
   const [busyType, setBusyType] = useState<string | null>(null);
   const [errorType, setErrorType] = useState<string | null>(null);
   const [credentialsFor, setCredentialsFor] = useState<McpServer | null>(null);
@@ -73,7 +75,9 @@ export const McpSuggestNode: React.FC<{ node: FlowComponent; children?: React.Re
     if (!server || !user?.id) return;
     setErrorType(null);
 
-    if (mcpRequiresCredentials(server)) {
+    // Resolved from the registry, not the connector's DB columns: those are
+    // unset in some environments and the form would be skipped entirely.
+    if (mcpRequiresCredentials(server, await ensureFieldsFor(server))) {
       setCredentialsFor(server);
       return;
     }

--- a/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect, useState } from 'react';
 import { MaximizeTwoArrow, Spinner } from '@xyne/icons';
 import type { AgentDraftProps, FlowComponent } from '@xyne/shared';
 import { useFlow } from '../../FlowContext';
-import { useAgentProgress } from '../../../../hooks/useAgentProgress';
 import { cn } from '../../../../utils/classNames';
 import { AuditLine, CardShell, Mention, StatusChip } from '../cardPrimitives';
 import Avatar from '../../../ui/Avatar/Avatar';
@@ -60,11 +59,6 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [node.id]);
 
-  // Approving mid-run dispatches work that collides with the active run at the
-  // runtime session lock. The server also fails this closed; disabling the
-  // button is just the clearer signal.
-  const { agents } = useAgentProgress(conversationId || undefined);
-  const agentRunning = agents.length > 0;
   const locked = state.submitting || decided || pending !== null;
 
   const toggle = (id: string): void => {
@@ -81,7 +75,7 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
   };
 
   const submit = async (actionId: 'agent-draft-approve' | 'agent-draft-decline'): Promise<void> => {
-    if (locked || (actionId === 'agent-draft-approve' && agentRunning)) {
+    if (locked) {
       return;
     }
     setPending(actionId === 'agent-draft-approve' ? 'approve' : 'reject');
@@ -132,8 +126,7 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
     </div>
   );
 
-  const approveLabel =
-    pending === 'approve' ? 'Creating…' : agentRunning ? 'Agent is working…' : 'Create Agent';
+  const approveLabel = pending === 'approve' ? 'Creating…' : 'Create Agent';
 
   const interactive = decided ? undefined : { selected, onToggle: toggle, disabled: locked };
 
@@ -169,11 +162,6 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
       </Button>
 
       <div className='flex shrink-0 items-center gap-2'>
-        {agentRunning && (
-          <span className='hidden text-xs text-muted-foreground sm:inline'>
-            Approve once it finishes.
-          </span>
-        )}
         {/* Placeholder from the frame — no edit flow exists yet. Rendered so the
             layout matches the design; wire it up when the behaviour is decided. */}
         <button
@@ -192,15 +180,13 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
           type='button'
           variant='ghost'
           onClick={() => void submit('agent-draft-approve')}
-          disabled={locked || agentRunning}
+          disabled={locked}
           className={cn(primaryButton, 'px-2.5')}
           data-track-category='AGENT_ARTIFACT'
           data-track-name='CLICK_APPROVE'
           trackId='agent_draft_approve'
         >
-          {(pending === 'approve' || agentRunning) && (
-            <Spinner size={14} className='animate-spin' />
-          )}
+          {pending === 'approve' && <Spinner size={14} className='animate-spin' />}
           {approveLabel}
         </Button>
       </div>

--- a/apps/dashboard/src/routes/AIScreen/library/agents/AgentsV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/AgentsV2.tsx
@@ -1,4 +1,5 @@
 import { ReactElement, useMemo } from 'react';
+import { searchByNameThenDescription } from '../shared/librarySearch';
 import { useParams } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { useClawAuthAgents } from '@/hooks/useClawAuthAgents';
@@ -23,10 +24,14 @@ const AgentsV2 = ({ query }: { query: string }): ReactElement => {
   const { user } = useAuth();
   const userId = user?.id;
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const searched = useMemo(
     () =>
-      q ? agents.filter(a => `${a.name} ${a.description ?? ''}`.toLowerCase().includes(q)) : agents,
+      searchByNameThenDescription(agents, q, agent => ({
+        name: agent.name,
+        description: agent.description,
+        ...(agent.slug && agent.slug !== agent.name ? { aliases: [agent.slug] as const } : {}),
+      })),
     [agents, q],
   );
 

--- a/apps/dashboard/src/routes/AIScreen/library/agents/create/ClawAgentCreateV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/create/ClawAgentCreateV2.tsx
@@ -309,17 +309,6 @@ const ClawAgentCreateV2 = ({ agent }: ClawAgentCreateV2Props = {}): ReactElement
               }}
             />
 
-            <SubagentCapabilityRow
-              selection={state.tools}
-              onSelectionChange={tools =>
-                update({ tools: { ...tools, callableAgents: state.tools.callableAgents } })
-              }
-              suggestContext={{
-                systemPrompt: state.systemPrompt,
-                description: state.description,
-              }}
-            />
-
             {/* Delegation is a live grant against an existing agent, so this row
                 only appears once the agent exists (edit, not create). */}
             {agent && (
@@ -332,6 +321,17 @@ const ClawAgentCreateV2 = ({ agent }: ClawAgentCreateV2Props = {}): ReactElement
                 }
               />
             )}
+
+            <SubagentCapabilityRow
+              selection={state.tools}
+              onSelectionChange={tools =>
+                update({ tools: { ...tools, callableAgents: state.tools.callableAgents } })
+              }
+              suggestContext={{
+                systemPrompt: state.systemPrompt,
+                description: state.description,
+              }}
+            />
 
             <BuiltinCapabilityRow
               selection={state.tools}

--- a/apps/dashboard/src/routes/AIScreen/library/agents/create/ClawAgentCreateV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/create/ClawAgentCreateV2.tsx
@@ -34,6 +34,7 @@ import { KnowledgeCapabilityRow } from '../../shared/pickers/knowledge/Knowledge
 import { McpCapabilityRow } from '../../shared/pickers/mcp/McpCapabilityRow';
 import { SkillsCapabilityRow } from '../../shared/pickers/skill/SkillsCapabilityRow';
 import { SubagentCapabilityRow } from '../../shared/pickers/subagent/SubagentCapabilityRow';
+import { CallableAgentCapabilityRow } from '../../shared/pickers/callableAgent/CallableAgentCapabilityRow';
 
 function inlineWidth(value: string, placeholder: string): string {
   return `${Math.max(value.length, placeholder.length) - 2}ch`;
@@ -299,7 +300,9 @@ const ClawAgentCreateV2 = ({ agent }: ClawAgentCreateV2Props = {}): ReactElement
 
             <McpCapabilityRow
               selection={state.tools}
-              onSelectionChange={tools => update({ tools })}
+              onSelectionChange={tools =>
+                update({ tools: { ...tools, callableAgents: state.tools.callableAgents } })
+              }
               suggestContext={{
                 systemPrompt: state.systemPrompt,
                 description: state.description,
@@ -308,16 +311,33 @@ const ClawAgentCreateV2 = ({ agent }: ClawAgentCreateV2Props = {}): ReactElement
 
             <SubagentCapabilityRow
               selection={state.tools}
-              onSelectionChange={tools => update({ tools })}
+              onSelectionChange={tools =>
+                update({ tools: { ...tools, callableAgents: state.tools.callableAgents } })
+              }
               suggestContext={{
                 systemPrompt: state.systemPrompt,
                 description: state.description,
               }}
             />
 
+            {/* Delegation is a live grant against an existing agent, so this row
+                only appears once the agent exists (edit, not create). */}
+            {agent && (
+              <CallableAgentCapabilityRow
+                agentSlug={agent.slug}
+                agentOwnerUserId={agent.ownerUserId}
+                selected={state.tools.callableAgents}
+                onSelectedChange={callableAgents =>
+                  update({ tools: { ...state.tools, callableAgents } })
+                }
+              />
+            )}
+
             <BuiltinCapabilityRow
               selection={state.tools}
-              onSelectionChange={tools => update({ tools })}
+              onSelectionChange={tools =>
+                update({ tools: { ...tools, callableAgents: state.tools.callableAgents } })
+              }
               suggestContext={{
                 systemPrompt: state.systemPrompt,
                 description: state.description,

--- a/apps/dashboard/src/routes/AIScreen/library/agents/create/agentDraft.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/create/agentDraft.ts
@@ -1,6 +1,6 @@
 import type { Agent } from '@/services/claw/clawAuthAgentTypes';
 import type { KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
-import type { ToolboxSelection } from '@/services/claw/clawToolsTypes';
+import type { AgentToolboxSelection } from '@/services/claw/clawToolsTypes';
 import {
   INITIAL_WIZARD_STATE,
   type WizardState,
@@ -12,6 +12,7 @@ interface ConfigShape {
     direct?: unknown;
     custom?: unknown;
     gateway?: unknown;
+    callableAgents?: unknown;
   };
   product_id?: unknown;
   repository_id?: unknown;
@@ -20,13 +21,14 @@ interface ConfigShape {
 const strings = (value: unknown): string[] =>
   Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
 
-export function readToolSelection(config: Record<string, unknown>): Required<ToolboxSelection> {
+export function readToolSelection(config: Record<string, unknown>): AgentToolboxSelection {
   const tools = (config as ConfigShape).tools ?? {};
   return {
     subagents: strings(tools.subagents),
     direct: strings(tools.direct),
     custom: strings(tools.custom),
     gateway: strings(tools.gateway),
+    callableAgents: strings(tools.callableAgents),
   };
 }
 

--- a/apps/dashboard/src/routes/AIScreen/library/agents/create/useSaveClawAgent.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/create/useSaveClawAgent.ts
@@ -30,6 +30,7 @@ export function useSaveClawAgent(agent: Agent | undefined): SaveClawAgent {
           direct: state.tools.direct,
           custom: state.tools.custom,
           gateway: state.tools.gateway,
+          callableAgents: state.tools.callableAgents,
         },
       };
       if (state.researchAgentProductId) config['product_id'] = state.researchAgentProductId;

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/ClawAgentDetailV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/ClawAgentDetailV2.tsx
@@ -13,6 +13,7 @@ import { AgentKnowledgeTabV2 } from './knowledge/AgentKnowledgeTabV2';
 import { AgentPeopleTabV2 } from './people/AgentPeopleTabV2';
 import { AgentToolsTabV2 } from './tools/AgentToolsTabV2';
 import { AGENT_DETAIL_TABS, resolveTab, type AgentDetailTabId } from './detailTabs';
+import { AgentCallGraphTabV2 } from './callGraph/AgentCallGraphTabV2';
 import { useAgentDetailActions } from './useAgentDetailActions';
 
 const DATE = new Intl.DateTimeFormat('en-GB', {
@@ -48,6 +49,11 @@ const ClawAgentDetailV2 = (): ReactElement => {
   const { data: agent, isLoading, isError } = useClawAgentDetail(slug);
   const actions = useAgentDetailActions(agent);
 
+  // Delegation approvals spend the callee's credentials and quota, so the
+  // inbox is the owner's (or an admin's) — mirrors claw's canManageRequests.
+  const canManageDelegation = actions.isOwner || actions.isAdmin;
+  const visibleTabs = AGENT_DETAIL_TABS.filter(entry => !entry.ownerOnly || canManageDelegation);
+
   const setTab = (next: AgentDetailTabId): void => {
     const params = new URLSearchParams(searchParams);
     params.set('tab', next);
@@ -71,7 +77,7 @@ const ClawAgentDetailV2 = (): ReactElement => {
           )}
 
           <div className='flex w-full items-center gap-1'>
-            {AGENT_DETAIL_TABS.map(entry => (
+            {visibleTabs.map(entry => (
               <button
                 key={entry.id}
                 type='button'
@@ -158,6 +164,8 @@ const ClawAgentDetailV2 = (): ReactElement => {
               <AgentKnowledgeTabV2 agent={agent} canEdit={actions.permissions?.canEdit ?? false} />
             ) : tab === 'people' ? (
               <AgentPeopleTabV2 agent={agent} actions={actions} />
+            ) : tab === 'call-graph' && canManageDelegation ? (
+              <AgentCallGraphTabV2 agent={agent} />
             ) : (
               <AgentActivityTabV2 agent={agent} canEdit={actions.permissions?.canEdit ?? false} />
             )}

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/callGraph/AgentCallGraphTabV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/callGraph/AgentCallGraphTabV2.tsx
@@ -1,6 +1,8 @@
 import { useState, type ReactElement } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
+import { CheckTickCircle, MultipleCrossCancelCircle } from '@xyne/icons';
+import { Tooltip } from '@/components/ui/Tooltip/Tooltip';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/Button';
 import { useAuth } from '@/hooks/useAuth';
@@ -50,7 +52,9 @@ function GrantRow({
           {reason}
         </p>
       )}
-      {actions && <div className='flex items-center justify-end gap-2'>{actions}</div>}
+      {actions && (
+        <div className='-my-1 flex shrink-0 items-center justify-end gap-1'>{actions}</div>
+      )}
     </div>
   );
 }
@@ -145,26 +149,37 @@ export function AgentCallGraphTabV2({ agent }: { agent: Agent }): ReactElement {
                 badge={<DelegationStatusBadge status={grant.status} />}
                 actions={
                   <>
-                    <Button
-                      variant='ghost'
-                      size='sm'
-                      disabled={busyId !== null}
-                      onClick={() => void decide(grant, false)}
-                      data-track-category='Claw Agents'
-                      data-track-name='DeclineDelegation'
-                    >
-                      Decline
-                    </Button>
-                    <Button
-                      size='sm'
-                      loading={busyId === grant.id}
-                      disabled={busyId !== null}
-                      onClick={() => void decide(grant, true)}
-                      data-track-category='Claw Agents'
-                      data-track-name='ApproveDelegation'
-                    >
-                      Approve
-                    </Button>
+                    <Tooltip content='Approve request' side='top'>
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='icon'
+                        aria-label='Approve request'
+                        disabled={busyId !== null}
+                        onClick={() => void decide(grant, true)}
+                        className='size-7 text-muted-foreground hover:bg-status-success/10 hover:text-status-success'
+                        data-track-category='Claw Agents'
+                        data-track-name='ApproveDelegation'
+                      >
+                        <CheckTickCircle className='size-4' />
+                      </Button>
+                    </Tooltip>
+
+                    <Tooltip content='Decline request' side='top'>
+                      <Button
+                        type='button'
+                        variant='ghost'
+                        size='icon'
+                        aria-label='Decline request'
+                        disabled={busyId !== null}
+                        onClick={() => void decide(grant, false)}
+                        className='size-7 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
+                        data-track-category='Claw Agents'
+                        data-track-name='DeclineDelegation'
+                      >
+                        <MultipleCrossCancelCircle className='size-4' />
+                      </Button>
+                    </Tooltip>
                   </>
                 }
               />
@@ -194,17 +209,21 @@ export function AgentCallGraphTabV2({ agent }: { agent: Agent }): ReactElement {
                 }
                 badge={<DelegationStatusBadge status={grant.status} />}
                 actions={
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    loading={busyId === grant.id}
-                    disabled={busyId !== null}
-                    onClick={() => void revoke(grant)}
-                    data-track-category='Claw Agents'
-                    data-track-name='RevokeDelegation'
-                  >
-                    Revoke
-                  </Button>
+                  <Tooltip content='Revoke access' side='top'>
+                    <Button
+                      type='button'
+                      variant='ghost'
+                      size='icon'
+                      aria-label='Revoke access'
+                      disabled={busyId !== null}
+                      onClick={() => void revoke(grant)}
+                      className='size-7 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
+                      data-track-category='Claw Agents'
+                      data-track-name='RevokeDelegation'
+                    >
+                      <MultipleCrossCancelCircle className='size-4' />
+                    </Button>
+                  </Tooltip>
                 }
               />
             ))

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/callGraph/AgentCallGraphTabV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/callGraph/AgentCallGraphTabV2.tsx
@@ -1,0 +1,241 @@
+import { useState, type ReactElement } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/Button';
+import { useAuth } from '@/hooks/useAuth';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import {
+  decideDelegationRequest,
+  listDelegationGrants,
+  listDelegationRequests,
+  revokeDelegation,
+} from '@/services/claw/clawDelegationService';
+import type { AgentDelegationGrant } from '@/services/claw/clawDelegationTypes';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import {
+  DetailCard,
+  DetailEmpty,
+  DetailSection,
+} from '../../../shared/primitives/DetailPrimitives';
+import { DelegationStatusBadge } from '../tools/DelegationStatusBadge';
+import { delegationGrantsKey } from '../../../shared/pickers/callableAgent/useCallableAgents';
+
+const delegationRequestsKey = (slug: string): string[] => ['claw-delegation-requests', slug];
+
+function GrantRow({
+  title,
+  subtitle,
+  reason,
+  badge,
+  actions,
+}: {
+  title: string;
+  subtitle: string;
+  reason?: string | null;
+  badge: ReactElement;
+  actions?: ReactElement | null;
+}): ReactElement {
+  return (
+    <div className='flex w-full flex-col gap-2 border-b border-border px-3 py-3 last:border-b-0'>
+      <div className='flex items-start gap-3'>
+        <div className='flex min-w-0 flex-1 flex-col'>
+          <span className='truncate text-sm font-medium leading-5 text-foreground'>{title}</span>
+          <span className='truncate text-xs leading-4 text-muted-foreground'>{subtitle}</span>
+        </div>
+        {badge}
+      </div>
+      {reason && (
+        <p className='break-words rounded-md bg-muted/60 px-2.5 py-1.5 text-xs leading-4 text-muted-foreground'>
+          {reason}
+        </p>
+      )}
+      {actions && <div className='flex items-center justify-end gap-2'>{actions}</div>}
+    </div>
+  );
+}
+
+export function AgentCallGraphTabV2({ agent }: { agent: Agent }): ReactElement {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const incoming = useQuery({
+    queryKey: delegationRequestsKey(agent.slug),
+    queryFn: () => listDelegationRequests(agent.slug, user!.id),
+    enabled: !!user?.id,
+  });
+
+  const outgoing = useQuery({
+    queryKey: delegationGrantsKey(agent.slug),
+    queryFn: () => listDelegationGrants(agent.slug, user!.id),
+    enabled: !!user?.id,
+  });
+
+  const refreshIncoming = (): void => {
+    void queryClient.invalidateQueries({ queryKey: delegationRequestsKey(agent.slug) });
+  };
+
+  const decide = async (grant: AgentDelegationGrant, approve: boolean): Promise<void> => {
+    if (!user?.id || busyId) return;
+    setBusyId(grant.id);
+    try {
+      await decideDelegationRequest(agent.slug, grant.id, approve, user.id);
+      refreshIncoming();
+      toast.success(
+        approve
+          ? `${grant.caller?.name ?? 'The agent'} can now call ${agent.name}`
+          : 'Request declined',
+      );
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not update this request'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const revoke = async (grant: AgentDelegationGrant): Promise<void> => {
+    if (!user?.id || busyId) return;
+    setBusyId(grant.id);
+    try {
+      await revokeDelegation(agent.slug, grant.id, user.id);
+      refreshIncoming();
+      toast.success(`${grant.caller?.name ?? 'That agent'} can no longer call ${agent.name}`);
+    } catch (err) {
+      toast.error(clawErrorText(err, 'Could not revoke this delegation'));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const incomingRows = incoming.data ?? [];
+  const pending = incomingRows.filter(grant => grant.status === 'pending');
+  const active = incomingRows.filter(grant => grant.status === 'approved');
+  const outgoingRows = outgoing.data ?? [];
+
+  const loadingBlock = (
+    <div className='flex items-center gap-2 px-3 py-3 text-sm text-muted-foreground'>
+      <Loader2 className='size-4 animate-spin' aria-hidden />
+      Loading…
+    </div>
+  );
+
+  return (
+    <div className='flex w-full flex-col gap-8'>
+      <DetailSection
+        label='Requests to call this agent'
+        info='Another agent’s owner has asked to hand tasks to this one'
+      >
+        <DetailCard>
+          {incoming.isLoading ? (
+            loadingBlock
+          ) : pending.length === 0 ? (
+            <DetailEmpty>No pending requests.</DetailEmpty>
+          ) : (
+            pending.map(grant => (
+              <GrantRow
+                key={grant.id}
+                title={grant.caller?.name ?? grant.callerAgentId}
+                subtitle={
+                  grant.caller?.ownerName
+                    ? `@${grant.caller.slug} · owned by ${grant.caller.ownerName}`
+                    : `@${grant.caller?.slug ?? grant.callerAgentId}`
+                }
+                reason={grant.requestReason}
+                badge={<DelegationStatusBadge status={grant.status} />}
+                actions={
+                  <>
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      disabled={busyId !== null}
+                      onClick={() => void decide(grant, false)}
+                      data-track-category='Claw Agents'
+                      data-track-name='DeclineDelegation'
+                    >
+                      Decline
+                    </Button>
+                    <Button
+                      size='sm'
+                      loading={busyId === grant.id}
+                      disabled={busyId !== null}
+                      onClick={() => void decide(grant, true)}
+                      data-track-category='Claw Agents'
+                      data-track-name='ApproveDelegation'
+                    >
+                      Approve
+                    </Button>
+                  </>
+                }
+              />
+            ))
+          )}
+        </DetailCard>
+      </DetailSection>
+
+      <DetailSection
+        label='Agents that can call this one'
+        info='Approved delegations. Revoking stops the calls immediately.'
+      >
+        <DetailCard>
+          {incoming.isLoading ? (
+            loadingBlock
+          ) : active.length === 0 ? (
+            <DetailEmpty>No agent can call this one yet.</DetailEmpty>
+          ) : (
+            active.map(grant => (
+              <GrantRow
+                key={grant.id}
+                title={grant.caller?.name ?? grant.callerAgentId}
+                subtitle={
+                  grant.caller?.ownerName
+                    ? `@${grant.caller.slug} · owned by ${grant.caller.ownerName}`
+                    : `@${grant.caller?.slug ?? grant.callerAgentId}`
+                }
+                badge={<DelegationStatusBadge status={grant.status} />}
+                actions={
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    loading={busyId === grant.id}
+                    disabled={busyId !== null}
+                    onClick={() => void revoke(grant)}
+                    data-track-category='Claw Agents'
+                    data-track-name='RevokeDelegation'
+                  >
+                    Revoke
+                  </Button>
+                }
+              />
+            ))
+          )}
+        </DetailCard>
+      </DetailSection>
+
+      <DetailSection label='Agents this one can call' info='Manage these from the Tools tab'>
+        <DetailCard>
+          {outgoing.isLoading ? (
+            loadingBlock
+          ) : outgoingRows.length === 0 ? (
+            <DetailEmpty>This agent doesn’t call any other agent.</DetailEmpty>
+          ) : (
+            outgoingRows.map(grant => (
+              <GrantRow
+                key={grant.id}
+                title={grant.callee?.name ?? grant.calleeAgentId}
+                subtitle={`@${grant.callee?.slug ?? grant.calleeAgentId}`}
+                reason={grant.requestReason}
+                badge={
+                  <DelegationStatusBadge
+                    status={grant.status}
+                    ownerName={grant.callee?.ownerName ?? null}
+                  />
+                }
+              />
+            ))
+          )}
+        </DetailCard>
+      </DetailSection>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/detailTabs.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/detailTabs.ts
@@ -4,11 +4,14 @@ export type AgentDetailTabId =
   | 'tools'
   | 'knowledge'
   | 'people'
+  | 'call-graph'
   | 'activity';
 
 export interface AgentDetailTab {
   id: AgentDetailTabId;
   label: string;
+  /** Delegation is the owner's call — contributors don't see the inbox. */
+  ownerOnly?: boolean;
 }
 
 export const AGENT_DETAIL_TABS: readonly AgentDetailTab[] = [
@@ -17,6 +20,7 @@ export const AGENT_DETAIL_TABS: readonly AgentDetailTab[] = [
   { id: 'tools', label: 'Tools' },
   { id: 'knowledge', label: 'Knowledge' },
   { id: 'people', label: 'People' },
+  { id: 'call-graph', label: 'Call graph', ownerOnly: true },
   { id: 'activity', label: 'Activity' },
 ];
 

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/AgentKeysDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/AgentKeysDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactElement } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { MultipleCrossCancelDefault, PencilEditLine, PlusDefault } from '@xyne/icons';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/Button/index';
@@ -12,11 +13,16 @@ import {
   CREDENTIAL_PROVIDER_LABELS,
   EMPTY_CREDENTIAL_FORM,
   formFromCredential,
+  supportsOauth,
   supportsReasoning,
   type CredentialForm,
   type CredentialProvider,
 } from './credentialForm';
-import { useAgentCredentialMutations, useAgentCredentials } from './useAgentCredentials';
+import {
+  agentCredentialsKey,
+  useAgentCredentialMutations,
+  useAgentCredentials,
+} from './useAgentCredentials';
 
 const ICON_BUTTON =
   'flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40';
@@ -44,6 +50,7 @@ export function AgentKeysDialog({
   slug,
   canManage,
 }: AgentKeysDialogProps): ReactElement {
+  const queryClient = useQueryClient();
   const { data: credentials, isLoading } = useAgentCredentials(slug, open);
   const { save, remove, saving, removing } = useAgentCredentialMutations(slug);
 
@@ -60,7 +67,12 @@ export function AgentKeysDialog({
   };
 
   const editing = editingProvider !== null;
-  const canSubmit = form !== null && (editing || form.apiKey.trim().length > 0);
+  // The OAuth exchange writes the credential itself, so Save only carries the
+  // model/base-URL fields — requiring a pasted key there is what made the
+  // OAuth option unusable.
+  const oauthPath =
+    form !== null && form.authType === 'oauth_token' && supportsOauth(form.provider);
+  const canSubmit = form !== null && (editing || oauthPath || form.apiKey.trim().length > 0);
 
   const submit = async (): Promise<void> => {
     if (!form || !canSubmit) return;
@@ -223,7 +235,20 @@ export function AgentKeysDialog({
           <span className={SECTION_LABEL}>
             {editing ? `Edit ${label(form.provider)}` : `New ${label(form.provider)} key`}
           </span>
-          <CredentialFormFields form={form} onChange={setForm} editing={editing} />
+          <CredentialFormFields
+            form={form}
+            onChange={setForm}
+            editing={editing}
+            slug={slug}
+            onOauthConnected={() => {
+              void queryClient.invalidateQueries({ queryKey: agentCredentialsKey(slug) });
+              // The exchange already stored the bundle. Stay open in edit mode so
+              // a model/base URL can follow — the backend allows that update
+              // without an apiKey precisely because OAuth saved the credential.
+              setEditingProvider(form.provider);
+              setForm({ ...form, apiKey: '' });
+            }}
+          />
         </section>
       )}
     </V2Dialog>

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialFormFields.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialFormFields.tsx
@@ -11,9 +11,11 @@ import {
   baseUrlPlaceholder,
   REASONING_OPTIONS,
   supportsAuthType,
+  supportsOauth,
   supportsReasoning,
   type CredentialForm,
 } from './credentialForm';
+import { CredentialOauthFlow } from './CredentialOauthFlow';
 
 const FIELD =
   'h-11 w-full rounded-2xl border border-border bg-card px-4 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
@@ -40,57 +42,27 @@ interface CredentialFormFieldsProps {
   form: CredentialForm;
   onChange: (next: CredentialForm) => void;
   editing: boolean;
+  slug: string;
+  onOauthConnected: () => void;
 }
 
 export function CredentialFormFields({
   form,
   onChange,
   editing,
+  slug,
+  onOauthConnected,
 }: CredentialFormFieldsProps): ReactElement {
   const set = <K extends keyof CredentialForm>(key: K, value: CredentialForm[K]): void =>
     onChange({ ...form, [key]: value });
 
+  // OAuth stores the token bundle server-side through its own exchange, so the
+  // key field would have nothing to collect.
+  const oauthProvider =
+    form.authType === 'oauth_token' && supportsOauth(form.provider) ? form.provider : null;
+
   return (
     <div className='flex w-full flex-col gap-3'>
-      <Field label='API key' optional={editing}>
-        <input
-          value={form.apiKey}
-          onChange={e => set('apiKey', e.target.value)}
-          type='password'
-          placeholder={editing ? 'Leave blank to keep the stored key' : 'sk-…'}
-          aria-label='API key'
-          autoComplete='off'
-          autoFocus
-          data-track-category='Claw Agents'
-          data-track-name='Agent detail v2: credential api key'
-          className={FIELD}
-        />
-      </Field>
-
-      <Field label='Model' optional>
-        <input
-          value={form.model}
-          onChange={e => set('model', e.target.value)}
-          placeholder='Provider default'
-          aria-label='Model'
-          data-track-category='Claw Agents'
-          data-track-name='Agent detail v2: credential model'
-          className={FIELD}
-        />
-      </Field>
-
-      <Field label='Base URL' optional>
-        <input
-          value={form.baseUrl}
-          onChange={e => set('baseUrl', e.target.value)}
-          placeholder={baseUrlPlaceholder(form.provider)}
-          aria-label='Base URL'
-          data-track-category='Claw Agents'
-          data-track-name='Agent detail v2: credential base url'
-          className={FIELD}
-        />
-      </Field>
-
       {supportsAuthType(form.provider) && (
         <Field label='Auth type'>
           <Select
@@ -116,6 +88,49 @@ export function CredentialFormFields({
           </Select>
         </Field>
       )}
+
+      {oauthProvider ? (
+        <CredentialOauthFlow slug={slug} provider={oauthProvider} onConnected={onOauthConnected} />
+      ) : (
+        <Field label='API key' optional={editing}>
+          <input
+            value={form.apiKey}
+            onChange={e => set('apiKey', e.target.value)}
+            type='password'
+            placeholder={editing ? 'Leave blank to keep the stored key' : 'sk-…'}
+            aria-label='API key'
+            autoComplete='off'
+            autoFocus
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: credential api key'
+            className={FIELD}
+          />
+        </Field>
+      )}
+
+      <Field label='Model' optional>
+        <input
+          value={form.model}
+          onChange={e => set('model', e.target.value)}
+          placeholder='Provider default'
+          aria-label='Model'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: credential model'
+          className={FIELD}
+        />
+      </Field>
+
+      <Field label='Base URL' optional>
+        <input
+          value={form.baseUrl}
+          onChange={e => set('baseUrl', e.target.value)}
+          placeholder={baseUrlPlaceholder(form.provider)}
+          aria-label='Base URL'
+          data-track-category='Claw Agents'
+          data-track-name='Agent detail v2: credential base url'
+          className={FIELD}
+        />
+      </Field>
 
       {supportsReasoning(form.provider) && (
         <Field label='Reasoning effort' optional>

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialOauthFlow.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/CredentialOauthFlow.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useRef, useState, type ReactElement } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button/index';
+import { Textarea } from '@/components/ui/Textarea';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import {
+  exchangeAgentOauth,
+  pollAgentCopilotLogin,
+  startAgentCopilotLogin,
+  startAgentOauth,
+  type AgentCopilotDeviceCode,
+  type AgentOauthFlow,
+} from './agentCredentialsService';
+
+type OauthProvider = 'codex' | 'claude' | 'copilot';
+
+const COPY: Record<OauthProvider, { button: string; blurb: string; alternative: string }> = {
+  copilot: {
+    button: 'Sign in with GitHub',
+    blurb:
+      'GitHub shows a device code — enter it on github.com to authorize. The token is stored on the agent, so every run uses it. Note this spends the signing-in account’s Copilot seat for everyone who runs this agent.',
+    alternative: 'Prefer a raw token? Switch auth type to API key and paste it instead.',
+  },
+  claude: {
+    button: 'Sign in with Claude',
+    blurb:
+      'Sign in with the team’s Claude account. Anthropic then shows a code — paste it (or the whole redirect URL) below. This captures a refreshable token, so it won’t silently expire like a pasted one, and the team’s Pro/Max quota is used.',
+    alternative: 'Prefer a long-lived token? Run `claude setup-token` and paste it as an API key.',
+  },
+  codex: {
+    button: 'Sign in with ChatGPT',
+    blurb:
+      'Sign in with the team’s ChatGPT account. OpenAI then shows a code — paste it (or the whole redirect URL) below. This stores a refreshable token bundle rather than a raw key.',
+    alternative: 'Prefer a raw key? Switch auth type to API key and paste it instead.',
+  },
+};
+
+/**
+ * The paste-back step exists because both providers redirect to a loopback port
+ * we don't own, so the browser can't hand the code back to us directly.
+ */
+export function CredentialOauthFlow({
+  slug,
+  provider,
+  onConnected,
+}: {
+  slug: string;
+  provider: OauthProvider;
+  onConnected: () => void;
+}): ReactElement {
+  const [flow, setFlow] = useState<AgentOauthFlow | null>(null);
+  const [device, setDevice] = useState<AgentCopilotDeviceCode | null>(null);
+  const [code, setCode] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const copy = COPY[provider];
+  const isDeviceFlow = provider === 'copilot';
+  const onConnectedRef = useRef(onConnected);
+  onConnectedRef.current = onConnected;
+
+  // GitHub's device flow has no redirect, so authorization only lands here by
+  // polling. Backs off when GitHub asks us to.
+  useEffect(() => {
+    if (!device) return undefined;
+    let cancelled = false;
+    let delay = Math.max(device.interval, 1) * 1000;
+    let timer: ReturnType<typeof setTimeout>;
+
+    const tick = async (): Promise<void> => {
+      try {
+        const result = await pollAgentCopilotLogin(slug);
+        if (cancelled) return;
+        if (result.status === 'approved') {
+          setDevice(null);
+          onConnectedRef.current();
+          return;
+        }
+        if (result.status === 'slow_down') delay += 5000;
+        timer = setTimeout(() => void tick(), delay);
+      } catch (err) {
+        if (cancelled) return;
+        setDevice(null);
+        setError(clawErrorText(err, 'Sign-in failed'));
+      }
+    };
+
+    timer = setTimeout(() => void tick(), delay);
+    return (): void => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [device, slug]);
+
+  const start = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      if (isDeviceFlow) {
+        const next = await startAgentCopilotLogin(slug);
+        setDevice(next);
+        window.open(next.verificationUri, '_blank', 'noopener,noreferrer');
+        return;
+      }
+      const next = await startAgentOauth(slug, provider);
+      setFlow(next);
+      window.open(next.url, '_blank', 'noopener,noreferrer');
+    } catch (err) {
+      setError(clawErrorText(err, 'Could not start sign-in'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const complete = async (): Promise<void> => {
+    if (!flow || !code.trim() || provider === 'copilot') return;
+    setBusy(true);
+    setError(null);
+    try {
+      await exchangeAgentOauth(slug, provider, { code: code.trim(), state: flow.state });
+      setFlow(null);
+      setCode('');
+      onConnected();
+    } catch (err) {
+      setError(clawErrorText(err, 'Sign-in failed'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className='flex w-full flex-col gap-2.5 rounded-2xl border border-border bg-muted/40 p-3'>
+      <p className='text-xs leading-4 text-muted-foreground'>{copy.blurb}</p>
+
+      {device ? (
+        <>
+          <div className='flex items-center gap-2'>
+            <code className='rounded-lg border border-border bg-card px-2.5 py-1 font-mono text-sm tracking-[0.2em] text-foreground'>
+              {device.userCode}
+            </code>
+            <a
+              href={device.verificationUri}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-xs underline underline-offset-2'
+            >
+              Enter it on github.com
+            </a>
+          </div>
+          <span className='flex items-center gap-2 text-xs leading-4 text-muted-foreground'>
+            <Loader2 className='size-3.5 animate-spin' aria-hidden />
+            Waiting for authorization…
+          </span>
+          <Button
+            variant='ghost'
+            onClick={() => {
+              setDevice(null);
+              setError(null);
+            }}
+            className='h-8 w-fit rounded-lg text-sm'
+            data-track-category='Claw Agents'
+            data-track-name='Agent detail v2: cancel copilot oauth'
+          >
+            Cancel
+          </Button>
+        </>
+      ) : !flow ? (
+        <Button
+          variant='outline'
+          onClick={() => void start()}
+          loading={busy}
+          disabled={busy}
+          className='h-8 w-fit rounded-lg text-sm'
+          data-track-category='Claw Agents'
+          data-track-name={`Agent detail v2: start ${provider} oauth`}
+        >
+          {busy ? 'Opening…' : copy.button}
+        </Button>
+      ) : (
+        <>
+          <p className='text-xs leading-4 text-muted-foreground'>
+            If the tab didn’t open,{' '}
+            <a
+              href={flow.url}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='underline underline-offset-2'
+            >
+              open it here
+            </a>
+            .
+          </p>
+          <Textarea
+            value={code}
+            onChange={event => setCode(event.target.value)}
+            placeholder='Paste the code, or the full callback URL'
+            rows={3}
+          />
+          <div className='flex items-center gap-2'>
+            <Button
+              onClick={() => void complete()}
+              loading={busy}
+              disabled={busy || !code.trim()}
+              className='h-8 rounded-lg text-sm'
+              data-track-category='Claw Agents'
+              data-track-name={`Agent detail v2: complete ${provider} oauth`}
+            >
+              {busy ? 'Verifying…' : 'Complete sign-in'}
+            </Button>
+            <Button
+              variant='ghost'
+              onClick={() => {
+                setFlow(null);
+                setCode('');
+                setError(null);
+              }}
+              disabled={busy}
+              className='h-8 rounded-lg text-sm'
+              data-track-category='Claw Agents'
+              data-track-name={`Agent detail v2: cancel ${provider} oauth`}
+            >
+              Cancel
+            </Button>
+          </div>
+        </>
+      )}
+
+      {error && <p className='text-xs leading-4 text-destructive'>{error}</p>}
+      <p className='text-[11px] leading-4 text-muted-foreground'>{copy.alternative}</p>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/agentCredentialsService.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/agentCredentialsService.ts
@@ -62,3 +62,60 @@ export function shareAgentProviderCredential(
     { method: 'POST', body: JSON.stringify(payload) },
   );
 }
+
+export interface AgentOauthFlow {
+  url: string;
+  state: string;
+  expiresIn: number;
+}
+
+/**
+ * Agent-scoped browser OAuth. Only codex and claude expose these routes — both
+ * capture a refreshable token bundle, unlike a pasted key. Anthropic and OpenAI
+ * both redirect to a loopback port we don't own, hence the paste-back step.
+ */
+export interface AgentCopilotDeviceCode {
+  userCode: string;
+  verificationUri: string;
+  expiresIn: number;
+  interval: number;
+}
+
+export type AgentCopilotPollStatus = 'approved' | 'pending' | 'slow_down';
+
+/** Copilot uses GitHub's device flow — a code the user types on github.com,
+ *  then we poll. No redirect, so nothing to paste back. */
+export function startAgentCopilotLogin(slug: string): Promise<AgentCopilotDeviceCode> {
+  return clawApiRequest<AgentCopilotDeviceCode>(`${base(slug)}/copilot/github-login`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+}
+
+export function pollAgentCopilotLogin(slug: string): Promise<{ status: AgentCopilotPollStatus }> {
+  return clawApiRequest<{ status: AgentCopilotPollStatus }>(`${base(slug)}/copilot/github-poll`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+}
+
+export function startAgentOauth(
+  slug: string,
+  provider: 'codex' | 'claude',
+): Promise<AgentOauthFlow> {
+  return clawApiRequest<AgentOauthFlow>(`${base(slug)}/${provider}/oauth/start`, {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+}
+
+export function exchangeAgentOauth(
+  slug: string,
+  provider: 'codex' | 'claude',
+  payload: { code: string; state: string },
+): Promise<unknown> {
+  return clawApiRequest<unknown>(`${base(slug)}/${provider}/oauth/exchange`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/credentialForm.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/credentials/credentialForm.ts
@@ -62,7 +62,12 @@ export function formFromCredential(entry: AgentProviderCredentialStatus): Creden
   };
 }
 
-export const supportsAuthType = (provider: string): boolean => provider !== 'litellm';
+/** Only these two have agent-scoped OAuth routes in claw-auth. Offering the
+ *  choice anywhere else is a dead end — there is no flow behind it. */
+export const supportsOauth = (provider: string): provider is 'codex' | 'claude' | 'copilot' =>
+  provider === 'codex' || provider === 'claude' || provider === 'copilot';
+
+export const supportsAuthType = (provider: string): boolean => supportsOauth(provider);
 export const supportsReasoning = (provider: string): boolean => provider !== 'litellm';
 
 export const baseUrlPlaceholder = (provider: string): string =>

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/model/ProviderOrderDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/persona/model/ProviderOrderDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type ReactElement } from 'react';
 import { ChevronBigDown, ChevronBigUp, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
 import { Button } from '@/components/ui/Button/index';
-import { ALL_PROVIDERS, PROVIDER_DISPLAY } from '@/services/claw/modelProviderConfig';
+import { HOSTED_PROVIDERS, PROVIDER_DISPLAY } from '@/services/claw/modelProviderConfig';
 import { V2Dialog } from '../../../../shared/primitives/V2Dialog';
 
 const ICON_BUTTON =
@@ -28,7 +28,7 @@ export function ProviderOrderDialog({
     if (open) setDraft([...order]);
   }, [open, order]);
 
-  const available = ALL_PROVIDERS.filter(provider => !draft.includes(provider));
+  const available = HOSTED_PROVIDERS.filter(provider => !draft.includes(provider));
 
   const move = (index: number, delta: number): void => {
     const target = index + delta;

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/tools/AgentToolsTabV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/tools/AgentToolsTabV2.tsx
@@ -1,6 +1,7 @@
-import { useMemo, type ReactElement } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 import { Loader2 } from 'lucide-react';
 import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import type { ToolboxSelection } from '@/services/claw/clawToolsTypes';
 import { BrowseBuiltinToolsDialog } from '../../../shared/pickers/builtin/BrowseBuiltinToolsDialog';
 import {
   disableEntry as disableBuiltinEntry,
@@ -28,7 +29,14 @@ import {
   ReadOnlyBadge,
 } from '../../../shared/primitives/DetailPrimitives';
 import { DetailListCard, type DetailListItem } from '../../../shared/primitives/DetailListCard';
-import { useAgentToolSelection, type ManageSectionId } from './useAgentToolSelection';
+import {
+  useAgentToolSelection,
+  type ManageSectionId,
+  type ToolSelection,
+} from './useAgentToolSelection';
+import { useCallableAgents } from '../../../shared/pickers/callableAgent/useCallableAgents';
+import { BrowseCallableAgentsDialog } from '../../../shared/pickers/callableAgent/BrowseCallableAgentsDialog';
+import { DelegationStatusBadge } from './DelegationStatusBadge';
 
 const LOCK_NOTE = 'Only the owner, a contributor, or an admin can change this agent’s tools.';
 
@@ -64,6 +72,24 @@ export function AgentToolsTabV2({
   const builtin = useBuiltinCatalog();
 
   const { saved } = tools;
+  // Deliberately NOT routed through tools.openManage/closeManage: that flow
+  // captures a draft on open and re-persists it on close, which would undo an
+  // add made while the dialog was open (the grant call writes config itself).
+  const [agentsPickerOpen, setAgentsPickerOpen] = useState(false);
+  const callable = useCallableAgents({
+    agentSlug: agent.slug,
+    agentOwnerUserId: agent.ownerUserId,
+    selected: saved.callableAgents,
+    onSelectedChange: callableAgents =>
+      tools.commit({ ...saved, callableAgents }, 'Agents updated'),
+  });
+
+  // The shared pickers only know the four toolbox lists. Re-attach the callable
+  // agents so a subagent/MCP/built-in edit never writes them out of the config.
+  const withCallableAgents = (next: Required<ToolboxSelection>): ToolSelection => ({
+    ...next,
+    callableAgents: tools.draft.callableAgents,
+  });
 
   const subagentItems = useMemo<DetailListItem[]>(
     () =>
@@ -113,6 +139,22 @@ export function AgentToolsTabV2({
     [builtin.entries, saved],
   );
 
+  const callableItems = useMemo<DetailListItem[]>(
+    () =>
+      callable.catalog
+        .filter(entry => entry.status !== null)
+        .map(entry => ({
+          key: entry.slug,
+          iconType: '',
+          name: entry.name,
+          description: entry.description || `@${entry.slug}`,
+          badge: (
+            <DelegationStatusBadge status={entry.status ?? 'missing'} ownerName={entry.ownerName} />
+          ),
+        })),
+    [callable.catalog],
+  );
+
   const note = canEdit ? null : <DetailLockedNote>{LOCK_NOTE}</DetailLockedNote>;
 
   /** Manage opens the same browse dialog the create flow uses; read-only says why. */
@@ -141,8 +183,31 @@ export function AgentToolsTabV2({
           onRemove={item => {
             const entry = subagents.entries.find(candidate => candidate.name === item.key);
             if (!entry) return;
-            tools.commit(disableSubagent(saved, entry), `${item.name} removed`);
+            tools.commit(withCallableAgents(disableSubagent(saved, entry)), `${item.name} removed`);
           }}
+        />
+      </DetailSection>
+
+      <DetailSection
+        label='Agents'
+        info='Other agents this agent can hand a task to, once their owner approves'
+        trailing={
+          canEdit ? (
+            <ManageButton label='Manage agents' onClick={() => setAgentsPickerOpen(true)} />
+          ) : (
+            <ReadOnlyBadge />
+          )
+        }
+        trailingAlign='end'
+      >
+        <DetailListCard
+          items={callableItems}
+          loading={callable.loading}
+          emptyLabel='No agents added yet.'
+          canEdit={canEdit}
+          note={note}
+          removeLabel={item => `Remove ${item.name}`}
+          onRemove={item => callable.remove(item.key)}
         />
       </DetailSection>
 
@@ -162,7 +227,10 @@ export function AgentToolsTabV2({
           onRemove={item => {
             const entry = mcp.entries.find(candidate => candidate.slug === item.key);
             if (!entry) return;
-            tools.commit(disableMcpEntry(mcp.entries, saved, entry), `${item.name} removed`);
+            tools.commit(
+              withCallableAgents(disableMcpEntry(mcp.entries, saved, entry)),
+              `${item.name} removed`,
+            );
           }}
         />
       </DetailSection>
@@ -183,7 +251,10 @@ export function AgentToolsTabV2({
           onRemove={item => {
             const entry = builtin.entries.find(candidate => candidate.source === item.key);
             if (!entry) return;
-            tools.commit(disableBuiltinEntry(saved, entry), `${item.name} removed`);
+            tools.commit(
+              withCallableAgents(disableBuiltinEntry(saved, entry)),
+              `${item.name} removed`,
+            );
           }}
         />
       </DetailSection>
@@ -205,8 +276,20 @@ export function AgentToolsTabV2({
         isError={subagents.isError}
         onRetry={subagents.refetch}
         selection={tools.draft}
-        onSelectionChange={tools.setDraft}
+        onSelectionChange={next => tools.setDraft(withCallableAgents(next))}
         suggested={[]}
+      />
+
+      <BrowseCallableAgentsDialog
+        open={agentsPickerOpen}
+        onOpenChange={setAgentsPickerOpen}
+        catalog={callable.catalog}
+        loading={callable.loading}
+        isError={callable.isError}
+        onRetry={callable.refetch}
+        busySlug={callable.busySlug}
+        onAdd={callable.add}
+        onRemove={callable.remove}
       />
 
       <BrowseMcpsDialog
@@ -220,7 +303,7 @@ export function AgentToolsTabV2({
         isError={mcp.isError}
         onRetry={mcp.refetch}
         selection={tools.draft}
-        onSelectionChange={tools.setDraft}
+        onSelectionChange={next => tools.setDraft(withCallableAgents(next))}
         suggested={[]}
       />
 
@@ -234,7 +317,7 @@ export function AgentToolsTabV2({
         isError={builtin.isError}
         onRetry={builtin.refetch}
         selection={tools.draft}
-        onSelectionChange={tools.setDraft}
+        onSelectionChange={next => tools.setDraft(withCallableAgents(next))}
         suggested={[]}
       />
     </div>

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/tools/DelegationStatusBadge.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/tools/DelegationStatusBadge.tsx
@@ -1,0 +1,41 @@
+import type { ReactElement } from 'react';
+import { cn } from '@/utils/classNames';
+import type { DelegationStatus } from '@/services/claw/clawDelegationTypes';
+
+const TONE: Record<DelegationStatus | 'missing', string> = {
+  approved: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  pending: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  rejected: 'bg-destructive/10 text-destructive',
+  missing: 'bg-muted text-muted-foreground',
+};
+
+export function DelegationStatusBadge({
+  status,
+  ownerName,
+}: {
+  status: DelegationStatus | 'missing';
+  ownerName?: string | null;
+}): ReactElement {
+  const label =
+    status === 'approved'
+      ? 'Approved'
+      : status === 'pending'
+        ? ownerName
+          ? `Waiting on ${ownerName}`
+          : 'Awaiting approval'
+        : status === 'rejected'
+          ? 'Declined'
+          : 'No grant';
+
+  return (
+    <span
+      className={cn(
+        'shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium leading-4',
+        TONE[status],
+      )}
+      title={status === 'missing' ? 'Listed in config but no delegation grant exists' : undefined}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/dashboard/src/routes/AIScreen/library/agents/detail/tools/useAgentToolSelection.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/agents/detail/tools/useAgentToolSelection.ts
@@ -5,10 +5,10 @@ import { clawAgentDetailKey } from '@/hooks/useClawAgentDetail';
 import { updateClawAgent } from '@/services/claw/clawAuthAgentsService';
 import { clawErrorText } from '@/services/claw/clawRequest';
 import type { Agent } from '@/services/claw/clawAuthAgentTypes';
-import type { ToolboxSelection } from '@/services/claw/clawToolsTypes';
+import type { AgentToolboxSelection } from '@/services/claw/clawToolsTypes';
 import { readToolSelection } from '../../create/agentDraft';
 
-export type ToolSelection = Required<ToolboxSelection>;
+export type ToolSelection = AgentToolboxSelection;
 
 export type ManageSectionId = 'subagents' | 'mcp' | 'builtin';
 
@@ -34,7 +34,8 @@ export function selectionEqual(a: ToolSelection, b: ToolSelection): boolean {
     sameList(a.subagents, b.subagents) &&
     sameList(a.direct, b.direct) &&
     sameList(a.custom, b.custom) &&
-    sameList(a.gateway, b.gateway)
+    sameList(a.gateway, b.gateway) &&
+    sameList(a.callableAgents, b.callableAgents)
   );
 }
 

--- a/apps/dashboard/src/routes/AIScreen/library/mcp/McpV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/mcp/McpV2.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
+import { searchByNameThenDescription } from '../shared/librarySearch';
 import { McpServerIcon } from '@/components/ClawAgents/McpServerIcon';
 import { useClawMcp } from '@/hooks/useClawMcp';
 import type { McpServer } from '@/services/claw/clawMcpTypes';
@@ -22,12 +23,13 @@ const McpV2 = ({ query }: { query: string }): ReactElement => {
   const servers = useMemo(() => data?.servers ?? [], [data]);
   const connections = useMemo(() => data?.connections ?? [], [data]);
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const searched = useMemo(
     () =>
-      q
-        ? servers.filter(s => `${s.name} ${s.description ?? ''}`.toLowerCase().includes(q))
-        : servers,
+      searchByNameThenDescription(servers, q, server => ({
+        name: server.name,
+        description: server.description,
+      })),
     [servers, q],
   );
 

--- a/apps/dashboard/src/routes/AIScreen/library/mcp/detail/ClawMcpDetailV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/mcp/detail/ClawMcpDetailV2.tsx
@@ -10,7 +10,6 @@ import {
   canEditMcpDefinition,
   createMcpConnection,
   deleteMcpConnection,
-  mcpCredentialFields,
   mcpRequiresCredentials,
   startMcpOAuth,
 } from '@/services/claw/clawMcpService';
@@ -22,6 +21,7 @@ import { Pill } from '../../shared/primitives/Pill';
 import { CopyButton } from '../../shared/primitives/CopyButton';
 import { McpLogo } from '../../shared/pickers/mcp/McpLogo';
 import { useMcpCatalog } from '../../shared/pickers/mcp/useMcpCatalog';
+import { useMcpCredentialFields } from '../../shared/pickers/mcp/useMcpCredentialFields';
 import { VerifiedTick } from '../../shared/pickers/mcp/McpIdentity';
 
 const NOTE =
@@ -64,6 +64,7 @@ const ClawMcpDetailV2 = (): ReactElement => {
 
   const { entries, connectedServerIds, connectionsByServerId, loading, isError, refetch } =
     useMcpCatalog();
+  const { fieldsFor, ensureFieldsFor } = useMcpCredentialFields();
   const { user } = useAuth();
   const [connecting, setConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
@@ -79,11 +80,11 @@ const ClawMcpDetailV2 = (): ReactElement => {
   const config = server?.httpConfigTemplate ?? server?.launchConfigTemplate ?? null;
   const configJson = config ? JSON.stringify(config, null, 2) : null;
   const connected = server ? connectedServerIds.has(server.id) : false;
-  const needsCredentials = server ? mcpRequiresCredentials(server) : false;
+  const credentialFields = fieldsFor(server);
   const connection = server ? connectionsByServerId.get(server.id) : undefined;
   // Only connectors with fields have anything to re-enter; an OAuth connector
   // is re-authorised by connecting again, not by editing a form.
-  const canEditCredentials = server ? mcpCredentialFields(server).length > 0 : false;
+  const canEditCredentials = credentialFields.length > 0;
   const canEditDefinition = server ? canEditMcpDefinition(server, user?.id, isClawAdmin) : false;
 
   const handleDisconnect = async (): Promise<void> => {
@@ -111,8 +112,9 @@ const ClawMcpDetailV2 = (): ReactElement => {
     setConnectError(null);
 
     // Credential connectors collect their fields first; everything else can
-    // connect straight away.
-    if (needsCredentials) {
+    // connect straight away. Re-resolved here rather than trusting the render
+    // pass, so a click before the registry lands still opens the form.
+    if (mcpRequiresCredentials(server, await ensureFieldsFor(server))) {
       setCredentialsOpen(true);
       return;
     }

--- a/apps/dashboard/src/routes/AIScreen/library/shared/librarySearch.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/librarySearch.ts
@@ -1,0 +1,91 @@
+/**
+ * Library search: match the name first, fall back to descriptions only when
+ * nothing matches by name.
+ *
+ * The previous approach matched `name + description` as one blob, which meant
+ * an agent called "afd" surfaced for the query "test" purely because its
+ * description was the word "test". Searching by name is what the box is for;
+ * the description fallback keeps phrase searches ("pull request") working when
+ * no name matches.
+ */
+
+export interface SearchableFields {
+  name: string;
+  description?: string | null | undefined;
+  /** Extra name-like fields (e.g. skill slug) scored at the same tier as name. */
+  aliases?: readonly string[];
+  /** Secondary text (e.g. tool names) matched only after name tiers fail. */
+  extras?: readonly string[];
+}
+
+/** 0 = exact, 1 = starts a word, 2 = mid-word. null = no match. */
+function scoreName(name: string, query: string): number | null {
+  const value = name.trim().toLowerCase();
+  if (value === query) return 0;
+  const index = value.indexOf(query);
+  if (index === -1) return null;
+  const previous = index === 0 ? '' : value[index - 1];
+  return index === 0 || !previous || !/[a-z0-9]/.test(previous) ? 1 : 2;
+}
+
+function bestNameScore(fields: SearchableFields, query: string): number | null {
+  let best: number | null = null;
+  for (const candidate of [fields.name, ...(fields.aliases ?? [])]) {
+    const score = scoreName(candidate ?? '', query);
+    if (score === null) continue;
+    if (best === null || score < best) best = score;
+    if (best === 0) break;
+  }
+  return best;
+}
+
+function matchesDescriptionTier(fields: SearchableFields, query: string): boolean {
+  if ((fields.description ?? '').toLowerCase().includes(query)) return true;
+  return (fields.extras ?? []).some(extra => extra.toLowerCase().includes(query));
+}
+
+/** Whether a single item would appear in a library-style search. */
+export function matchesLibrarySearch(fields: SearchableFields, rawQuery: string): boolean {
+  const query = rawQuery.trim().toLowerCase();
+  if (!query) return true;
+  if (bestNameScore(fields, query) !== null) return true;
+  return matchesDescriptionTier(fields, query);
+}
+
+export function searchByNameThenDescription<T>(
+  items: readonly T[],
+  rawQuery: string,
+  read: (item: T) => SearchableFields,
+): T[] {
+  const query = rawQuery.trim().toLowerCase();
+  if (!query) return [...items];
+
+  // Tiers, best first. Only the best non-empty tier is returned, so a clean
+  // name hit is never diluted by a mid-word one ("ai" must not pull in
+  // "Release Captain") or by a description match.
+  const wordMatches: Array<{ item: T; score: number; order: number }> = [];
+  const midWordMatches: T[] = [];
+  const descriptionMatches: T[] = [];
+
+  items.forEach((item, order) => {
+    const fields = read(item);
+    const score = bestNameScore(fields, query);
+    if (score === 0 || score === 1) {
+      wordMatches.push({ item, score, order });
+      return;
+    }
+    if (score === 2) {
+      midWordMatches.push(item);
+      return;
+    }
+    if (matchesDescriptionTier(fields, query)) {
+      descriptionMatches.push(item);
+    }
+  });
+
+  if (wordMatches.length > 0) {
+    return wordMatches.sort((a, b) => a.score - b.score || a.order - b.order).map(e => e.item);
+  }
+  if (midWordMatches.length > 0) return midWordMatches;
+  return descriptionMatches;
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/builtin/BrowseBuiltinToolsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/builtin/BrowseBuiltinToolsDialog.tsx
@@ -1,8 +1,13 @@
 import { useMemo, useState, type ReactElement } from 'react';
 import { cn } from '@/utils/classNames';
+import { searchByNameThenDescription } from '../../librarySearch';
 import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
-import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
+import {
+  BrowseDialog,
+  handleBrowseDialogOpenChange,
+  type FilterOption,
+} from '../../primitives/BrowseDialog';
 import { Pill } from '../../primitives/Pill';
 import { BuiltinChip } from './BuiltinChip';
 import { BuiltinDetailPanel } from './BuiltinDetailPanel';
@@ -26,10 +31,11 @@ const FILTER_OPTIONS: readonly FilterOption[] = [
 const RISK_LABEL = { read: 'Read', write: 'Write', destructive: 'Destructive' } as const;
 const RISK_TONE = { read: 'success', write: 'warning', destructive: 'danger' } as const;
 
-function matchesSearch(entry: BuiltinCatalogEntry, query: string): boolean {
-  if (!query) return true;
-  if (entry.label.toLowerCase().includes(query)) return true;
-  return entry.tools.some(tool => tool.name.toLowerCase().replace(/_/g, ' ').includes(query));
+function builtinSearchFields(entry: BuiltinCatalogEntry) {
+  return {
+    name: entry.label,
+    extras: entry.tools.map(tool => tool.name.replace(/_/g, ' ')),
+  };
 }
 
 const BuiltinCard = ({
@@ -132,13 +138,11 @@ export function BrowseBuiltinToolsDialog({
     return states;
   }, [catalog, selection]);
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const visible = useMemo(
     () =>
-      catalog.filter(
-        entry =>
-          matchesSearch(entry, q) &&
-          (risk === null || entry.tools.some(tool => tool.riskLevel === risk)),
+      searchByNameThenDescription(catalog, q, builtinSearchFields).filter(
+        entry => risk === null || entry.tools.some(tool => tool.riskLevel === risk),
       ),
     [catalog, q, risk],
   );
@@ -157,10 +161,13 @@ export function BrowseBuiltinToolsDialog({
   return (
     <BrowseDialog
       open={open}
-      onOpenChange={next => {
-        onOpenChange(next);
-        if (!next) setOpenSource(null);
-      }}
+      onOpenChange={next =>
+        handleBrowseDialogOpenChange(next, onOpenChange, () => {
+          setQuery('');
+          setRisk(null);
+          setOpenSource(null);
+        })
+      }
       title='Browse built in tools'
       description='Search and select the built-in tools this agent can use.'
       testId='browse-builtin-tools-dialog'

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/BrowseCallableAgentsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/BrowseCallableAgentsDialog.tsx
@@ -1,0 +1,200 @@
+import { useMemo, useState, type ReactElement } from 'react';
+import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
+import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
+import { Pill } from '../../primitives/Pill';
+import { SubagentChip } from '../subagent/SubagentChip';
+import { CallableAgentDetailPanel } from './CallableAgentDetailPanel';
+import { matchesSearch, statusPill, type CallableAgentEntry } from './callableAgentCatalog';
+
+const FILTER_OPTIONS: readonly FilterOption[] = [
+  { id: null, label: 'All' },
+  { id: 'added', label: 'Added' },
+  { id: 'available', label: 'Available' },
+];
+
+const CallableAgentCard = ({
+  entry,
+  onOpen,
+  onToggle,
+}: {
+  entry: CallableAgentEntry;
+  onOpen: () => void;
+  onToggle: () => void;
+}): ReactElement => {
+  const pill = statusPill(entry.status);
+  const selected = entry.status !== null;
+
+  return (
+    <div className='group relative min-w-0'>
+      <button
+        type='button'
+        onClick={onOpen}
+        data-track-category='Claw Agents'
+        data-track-name='Create agent v2: open callable agent detail'
+        className={cn(BROWSE_CARD, selected ? BROWSE_CARD_SELECTED : BROWSE_CARD_IDLE)}
+      >
+        <span className='flex w-full items-center justify-between gap-2'>
+          <span className='flex min-w-0 items-center gap-2'>
+            <span className='truncate text-sm font-medium leading-5 text-foreground'>
+              {entry.name}
+            </span>
+            {pill ? (
+              <Pill tone={pill.tone} size='sm'>
+                {pill.label}
+              </Pill>
+            ) : entry.needsApproval ? (
+              <Pill tone='neutral' size='sm'>
+                Needs approval
+              </Pill>
+            ) : null}
+          </span>
+          <span className='flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground'>
+            <ChevronRight className='size-4' aria-hidden />
+          </span>
+        </span>
+        <span className='w-full truncate text-xs leading-4 tracking-[-0.24px] text-muted-foreground'>
+          {entry.description || `@${entry.slug}`}
+        </span>
+      </button>
+
+      {/* Quick toggle only removes, or adds an agent that needs no approval —
+          a request that needs a reason has to go through the detail panel. */}
+      {(selected || !entry.needsApproval) && (
+        <button
+          type='button'
+          onClick={onToggle}
+          aria-label={`${selected ? 'Remove' : 'Add'} ${entry.name}`}
+          title={`${selected ? 'Remove' : 'Add'} ${entry.name}`}
+          data-track-category='Claw Agents'
+          data-track-name='Create agent v2: quick toggle callable agent'
+          className='absolute right-11 top-4 flex size-7 items-center justify-center rounded-lg text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100'
+        >
+          {selected ? (
+            <MultipleCrossCancelDefault className='size-4' aria-hidden />
+          ) : (
+            <PlusDefault className='size-4' aria-hidden />
+          )}
+        </button>
+      )}
+    </div>
+  );
+};
+
+interface BrowseCallableAgentsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  catalog: readonly CallableAgentEntry[];
+  loading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  busySlug: string | null;
+  onAdd: (slug: string, requestReason: string) => void;
+  onRemove: (slug: string) => void;
+}
+
+export function BrowseCallableAgentsDialog({
+  open,
+  onOpenChange,
+  catalog,
+  loading,
+  isError,
+  onRetry,
+  busySlug,
+  onAdd,
+  onRemove,
+}: BrowseCallableAgentsDialogProps): ReactElement {
+  const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<string | null>(null);
+  const [openSlug, setOpenSlug] = useState<string | null>(null);
+
+  const openEntry = catalog.find(entry => entry.slug === openSlug) ?? null;
+  const q = query.trim().toLowerCase();
+
+  const visible = useMemo(
+    () =>
+      catalog.filter(entry => {
+        if (!matchesSearch(entry, q)) return false;
+        if (filter === 'added') return entry.status !== null;
+        if (filter === 'available') return entry.status === null;
+        return true;
+      }),
+    [catalog, q, filter],
+  );
+
+  const addedEntries = useMemo(() => catalog.filter(entry => entry.status !== null), [catalog]);
+
+  return (
+    <BrowseDialog
+      open={open}
+      onOpenChange={next => {
+        onOpenChange(next);
+        if (!next) setOpenSlug(null);
+      }}
+      title='Browse Agents'
+      description='Search and select the agents this agent can hand a task to.'
+      testId='browse-callable-agents-dialog'
+      {...(openEntry && {
+        detail: {
+          label: openEntry.name,
+          onBack: () => setOpenSlug(null),
+          content: (
+            <CallableAgentDetailPanel
+              entry={openEntry}
+              busy={busySlug === openEntry.slug}
+              onAdd={reason => {
+                onAdd(openEntry.slug, reason);
+                setOpenSlug(null);
+              }}
+              onRemove={() => {
+                onRemove(openEntry.slug);
+                setOpenSlug(null);
+              }}
+            />
+          ),
+        },
+      })}
+      query={query}
+      onQueryChange={setQuery}
+      filterOptions={FILTER_OPTIONS}
+      activeFilter={filter}
+      onFilterChange={setFilter}
+      chips={
+        addedEntries.length > 0 ? (
+          <div className='flex flex-wrap gap-2 px-2'>
+            {addedEntries.map(entry => (
+              <SubagentChip
+                key={`added-${entry.slug}`}
+                label={entry.name}
+                selected
+                onToggle={() => onRemove(entry.slug)}
+              />
+            ))}
+          </div>
+        ) : null
+      }
+      loading={loading}
+      isError={isError}
+      onRetry={onRetry}
+      emptyMessage={
+        visible.length === 0
+          ? q
+            ? `No agents match “${query.trim()}”.`
+            : 'No other agents available yet.'
+          : null
+      }
+    >
+      <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
+        {visible.map(entry => (
+          <CallableAgentCard
+            key={entry.slug}
+            entry={entry}
+            onOpen={() => setOpenSlug(entry.slug)}
+            onToggle={() => (entry.status !== null ? onRemove(entry.slug) : onAdd(entry.slug, ''))}
+          />
+        ))}
+      </div>
+    </BrowseDialog>
+  );
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/BrowseCallableAgentsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/BrowseCallableAgentsDialog.tsx
@@ -1,12 +1,17 @@
 import { useMemo, useState, type ReactElement } from 'react';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
 import { cn } from '@/utils/classNames';
+import { searchByNameThenDescription } from '../../librarySearch';
 import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
-import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
+import {
+  BrowseDialog,
+  handleBrowseDialogOpenChange,
+  type FilterOption,
+} from '../../primitives/BrowseDialog';
 import { Pill } from '../../primitives/Pill';
 import { SubagentChip } from '../subagent/SubagentChip';
 import { CallableAgentDetailPanel } from './CallableAgentDetailPanel';
-import { matchesSearch, statusPill, type CallableAgentEntry } from './callableAgentCatalog';
+import { statusPill, type CallableAgentEntry } from './callableAgentCatalog';
 
 const FILTER_OPTIONS: readonly FilterOption[] = [
   { id: null, label: 'All' },
@@ -110,12 +115,15 @@ export function BrowseCallableAgentsDialog({
   const [openSlug, setOpenSlug] = useState<string | null>(null);
 
   const openEntry = catalog.find(entry => entry.slug === openSlug) ?? null;
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
 
   const visible = useMemo(
     () =>
-      catalog.filter(entry => {
-        if (!matchesSearch(entry, q)) return false;
+      searchByNameThenDescription(catalog, q, entry => ({
+        name: entry.name,
+        description: entry.description,
+        ...(entry.slug && entry.slug !== entry.name ? { aliases: [entry.slug] as const } : {}),
+      })).filter(entry => {
         if (filter === 'added') return entry.status !== null;
         if (filter === 'available') return entry.status === null;
         return true;
@@ -128,10 +136,13 @@ export function BrowseCallableAgentsDialog({
   return (
     <BrowseDialog
       open={open}
-      onOpenChange={next => {
-        onOpenChange(next);
-        if (!next) setOpenSlug(null);
-      }}
+      onOpenChange={next =>
+        handleBrowseDialogOpenChange(next, onOpenChange, () => {
+          setQuery('');
+          setFilter(null);
+          setOpenSlug(null);
+        })
+      }
       title='Browse Agents'
       description='Search and select the agents this agent can hand a task to.'
       testId='browse-callable-agents-dialog'

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/CallableAgentCapabilityRow.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/CallableAgentCapabilityRow.tsx
@@ -1,0 +1,94 @@
+import { useState, type ReactElement } from 'react';
+import { InformationCircle, PlusDefault } from '@xyne/icons';
+import { Tooltip } from '@/components/ui/Tooltip/Tooltip';
+import { BrowseCallableAgentsDialog } from './BrowseCallableAgentsDialog';
+import { SubagentChip } from '../subagent/SubagentChip';
+import { useCallableAgents } from './useCallableAgents';
+
+const CAPTION = 'Hand a whole task to another agent, once its owner approves.';
+
+interface CallableAgentCapabilityRowProps {
+  agentSlug: string;
+  agentOwnerUserId: string | null;
+  selected: string[];
+  onSelectedChange: (next: string[]) => void;
+}
+
+export function CallableAgentCapabilityRow({
+  agentSlug,
+  agentOwnerUserId,
+  selected,
+  onSelectedChange,
+}: CallableAgentCapabilityRowProps): ReactElement {
+  const [browseOpen, setBrowseOpen] = useState(false);
+  const callable = useCallableAgents({
+    agentSlug,
+    agentOwnerUserId,
+    selected,
+    onSelectedChange,
+  });
+
+  const addedEntries = callable.catalog.filter(entry => entry.status !== null);
+
+  return (
+    <div className='flex w-full flex-col gap-1.5'>
+      <div className='flex w-full items-center justify-between gap-4'>
+        <div className='flex min-w-0 items-center gap-4'>
+          <div className='flex shrink-0 items-center gap-2'>
+            <span className='text-sm font-medium leading-[1.2] tracking-[-0.1px] text-foreground'>
+              Agents
+            </span>
+            <Tooltip side='top' content={CAPTION}>
+              <span className='inline-flex'>
+                <InformationCircle className='size-4 text-muted-foreground' aria-hidden />
+              </span>
+            </Tooltip>
+          </div>
+          {addedEntries.length > 0 && (
+            <span className='text-xs leading-5 tracking-[-0.24px] text-muted-foreground'>
+              {addedEntries.length} added
+            </span>
+          )}
+        </div>
+
+        <button
+          type='button'
+          onClick={() => setBrowseOpen(true)}
+          aria-label='Browse agents'
+          data-track-category='Claw Agents'
+          data-track-name='Create agent v2: browse callable agents'
+          className='flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+        >
+          <PlusDefault className='size-4' aria-hidden />
+        </button>
+      </div>
+
+      <p className='text-sm leading-5 text-muted-foreground'>{CAPTION}</p>
+
+      {addedEntries.length > 0 && (
+        <div className='flex flex-wrap items-start gap-2 pt-1'>
+          {addedEntries.map(entry => (
+            <SubagentChip
+              key={entry.slug}
+              label={entry.status === 'pending' ? `${entry.name} · pending` : entry.name}
+              selected
+              onToggle={() => callable.remove(entry.slug)}
+            />
+          ))}
+        </div>
+      )}
+
+      <BrowseCallableAgentsDialog
+        open={browseOpen}
+        onOpenChange={setBrowseOpen}
+        catalog={callable.catalog}
+        loading={callable.loading}
+        isError={callable.isError}
+        onRetry={callable.refetch}
+        busySlug={callable.busySlug}
+        onAdd={callable.add}
+        onRemove={callable.remove}
+      />
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/CallableAgentDetailPanel.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/CallableAgentDetailPanel.tsx
@@ -1,0 +1,375 @@
+import { useState, type ReactElement, type ReactNode } from 'react';
+import { Staroflife, Tools, UserBot } from '@xyne/icons';
+import { cn } from '@/utils/classNames';
+import { Textarea } from '@/components/ui/Textarea';
+import { useClawAgentDetail } from '@/hooks/useClawAgentDetail';
+import { ScrollFadeBox } from '../../primitives/ProseBox';
+import { SectionHeading, Separator } from '../../primitives/Section';
+import { Pill } from '../../primitives/Pill';
+import { ChipIconTile, TokenChip } from '../../primitives/TokenChip';
+import {
+  isEntryEnabled as isMcpEnabled,
+  selectedTools as selectedMcpTools,
+} from '../mcp/mcpCatalog';
+import { useMcpCatalog } from '../mcp/useMcpCatalog';
+import { McpLogo } from '../mcp/McpLogo';
+import {
+  isEntryEnabled as isBuiltinEnabled,
+  selectedTools as selectedBuiltinTools,
+} from '../builtin/builtinCatalog';
+import { useBuiltinCatalog } from '../builtin/useBuiltinCatalog';
+import { isSubagentSelected } from '../subagent/subagentCatalog';
+import { useSubagentCatalog } from '../subagent/useSubagentCatalog';
+import type { ToolboxSelection } from '@/services/claw/clawToolsTypes';
+import { statusPill, type CallableAgentEntry } from './callableAgentCatalog';
+
+const REASON_MIN = 3;
+const REASON_MAX = 1000;
+const PROMPT_MAX_HEIGHT = 220;
+
+const Section = ({
+  label,
+  info,
+  children,
+}: {
+  label: string;
+  info: string;
+  children: ReactNode;
+}): ReactElement => (
+  <section className='flex w-full flex-col gap-4'>
+    <SectionHeading label={label} info={info} />
+    {children}
+  </section>
+);
+
+const ChipRow = ({ children }: { children: ReactNode }): ReactElement => (
+  <div className='flex w-full flex-wrap items-start gap-2.5'>{children}</div>
+);
+
+const EmptyHint = ({ children }: { children: ReactNode }): ReactElement => (
+  <p className='text-sm font-normal leading-5 text-muted-foreground'>{children}</p>
+);
+
+/** The four toolbox lists as stored on the agent's config. */
+function readSelection(config: Record<string, unknown> | undefined): Required<ToolboxSelection> {
+  const tools = (config?.['tools'] ?? {}) as Record<string, unknown>;
+  const read = (key: string): string[] =>
+    Array.isArray(tools[key])
+      ? (tools[key] as unknown[]).filter((v): v is string => typeof v === 'string')
+      : [];
+  return {
+    subagents: read('subagents'),
+    direct: read('direct'),
+    custom: read('custom'),
+    gateway: read('gateway'),
+  };
+}
+
+function readCallableAgents(config: Record<string, unknown> | undefined): string[] {
+  const tools = (config?.['tools'] ?? {}) as Record<string, unknown>;
+  return Array.isArray(tools['callableAgents'])
+    ? (tools['callableAgents'] as unknown[]).filter((v): v is string => typeof v === 'string')
+    : [];
+}
+
+const toolCountLabel = (count: number): string => `${count} ${count === 1 ? 'tool' : 'tools'}`;
+
+const ChipSection = ({
+  label,
+  info,
+  loading,
+  emptyLabel,
+  children,
+  isEmpty,
+}: {
+  label: string;
+  info: string;
+  loading: boolean;
+  emptyLabel: string;
+  isEmpty: boolean;
+  children: ReactNode;
+}): ReactElement => (
+  <Section label={label} info={info}>
+    {isEmpty ? (
+      <EmptyHint>{loading ? 'Loading…' : emptyLabel}</EmptyHint>
+    ) : (
+      <ChipRow>{children}</ChipRow>
+    )}
+  </Section>
+);
+
+export function CallableAgentDetailPanel({
+  entry,
+  busy,
+  onAdd,
+  onRemove,
+}: {
+  entry: CallableAgentEntry;
+  busy: boolean;
+  onAdd: (requestReason: string) => void;
+  onRemove: () => void;
+}): ReactElement {
+  const [reason, setReason] = useState('');
+  // The catalog row comes from the agent LIST, which carries no config, skills
+  // or prompt — fetch the real detail so these sections aren't all empty.
+  const detail = useClawAgentDetail(entry.slug);
+  const agent = detail.data ?? entry.agent;
+
+  const pill = statusPill(entry.status);
+  const added = entry.status !== null;
+  const reasonTooShort = entry.needsApproval && reason.trim().length < REASON_MIN;
+
+  const owner = entry.ownerName ?? agent?.owner?.name ?? agent?.owner?.email ?? '';
+  const description = agent?.description || entry.description;
+  const systemPrompt = agent?.systemPrompt ?? '';
+  const selection = readSelection(agent?.config);
+  const callableAgents = readCallableAgents(agent?.config);
+  // Resolved through the same catalogs the Tools tab uses, so MCP shows the
+  // server (Bitbucket, GitHub) with a tool count rather than raw tool ids.
+  const mcp = useMcpCatalog();
+  const builtin = useBuiltinCatalog();
+  const subagentCatalog = useSubagentCatalog();
+  const mcpEntries = mcp.entries.filter(candidate => isMcpEnabled(selection, candidate));
+  const builtinEntries = builtin.entries.filter(candidate =>
+    isBuiltinEnabled(selection, candidate),
+  );
+  const subagentEntries = subagentCatalog.entries.filter(candidate =>
+    isSubagentSelected(selection, candidate),
+  );
+  const skills = agent?.skills ?? [];
+  const collections = agent?.collections ?? [];
+
+  const meta = [
+    agent?.modelId || 'Platform default',
+    agent?.scope === 'global' ? 'Org-wide' : 'Personal',
+    agent && !agent.enabled ? 'Disabled' : null,
+  ].filter(Boolean);
+
+  return (
+    <div className='flex min-h-0 flex-1 flex-col gap-8 overflow-y-auto px-[22px] pb-9 pt-2'>
+      <div className='flex w-full items-start gap-12'>
+        <div className='flex min-w-0 flex-1 items-center gap-2.5'>
+          <span
+            className='flex size-11 shrink-0 items-center justify-center rounded-xl border border-border bg-card text-muted-foreground shadow-sm'
+            aria-hidden
+          >
+            <UserBot className='size-6' />
+          </span>
+          <div className='flex min-w-0 flex-col gap-2.5 py-px'>
+            <span className='flex min-w-0 items-center gap-2'>
+              <span className='truncate text-sm font-semibold leading-5 tracking-[-0.28px] text-foreground'>
+                {entry.name}
+              </span>
+              {pill && (
+                <Pill tone={pill.tone} size='sm'>
+                  {pill.label}
+                </Pill>
+              )}
+            </span>
+            <span className='flex min-w-0 items-center gap-1.5 truncate text-xs font-semibold leading-4 tracking-[-0.24px] text-muted-foreground'>
+              {owner && (
+                <>
+                  Built by
+                  <span className='truncate text-[color:var(--mention-color)]'>
+                    @{owner.replace(/^@+/, '')}
+                  </span>
+                  ·
+                </>
+              )}
+              {meta.join(' · ')}
+            </span>
+          </div>
+        </div>
+
+        <button
+          type='button'
+          onClick={() => (added ? onRemove() : onAdd(reason.trim()))}
+          disabled={busy || (!added && reasonTooShort)}
+          data-track-category='Claw Agents'
+          data-track-name={added ? 'RemoveCallableAgent' : 'RequestDelegation'}
+          className={cn(
+            'flex h-7 shrink-0 items-center justify-center rounded-lg border px-2 text-sm font-medium leading-[1.2] transition-colors',
+            'disabled:cursor-not-allowed disabled:opacity-50',
+            added
+              ? 'border-border bg-card text-foreground hover:bg-muted'
+              : 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90',
+          )}
+        >
+          {added ? 'Remove' : entry.needsApproval ? 'Request access' : 'Add'}
+        </button>
+      </div>
+
+      {description && (
+        <p className='w-full text-sm font-normal leading-5 tracking-[-0.28px] text-foreground'>
+          {description}
+        </p>
+      )}
+
+      <div className='flex w-full flex-col gap-4'>
+        {!added && entry.needsApproval && (
+          <>
+            <Section
+              label='Request access'
+              info='The owner sees this note when they review the request'
+            >
+              <div className='flex w-full flex-col gap-2'>
+                <Textarea
+                  value={reason}
+                  maxLength={REASON_MAX}
+                  onChange={event => setReason(event.target.value)}
+                  placeholder='Why does this agent need to be called?'
+                  rows={3}
+                />
+                <span className='text-xs leading-4 text-muted-foreground'>
+                  {owner || 'The owner'} approves before this agent can be called. It runs under
+                  whoever started the run, never with its own credentials.
+                </span>
+              </div>
+            </Section>
+            <Separator />
+          </>
+        )}
+
+        <Section label='Instructions' info='The system prompt this agent runs with'>
+          {systemPrompt ? (
+            <ScrollFadeBox height={PROMPT_MAX_HEIGHT} resetKeys={[entry.slug, systemPrompt]}>
+              <p className='whitespace-pre-wrap break-words text-sm font-normal leading-5 tracking-[-0.28px] text-foreground'>
+                {systemPrompt}
+              </p>
+            </ScrollFadeBox>
+          ) : (
+            <EmptyHint>{detail.isLoading ? 'Loading…' : 'No instructions shared'}</EmptyHint>
+          )}
+        </Section>
+
+        <Separator />
+
+        <ChipSection
+          label='Subagents'
+          info='Specialists this agent can delegate a whole task to'
+          loading={detail.isLoading || subagentCatalog.loading}
+          emptyLabel='No subagents added yet.'
+          isEmpty={subagentEntries.length === 0}
+        >
+          {subagentEntries.map(item => (
+            <TokenChip
+              key={item.name}
+              icon={
+                <ChipIconTile>
+                  <UserBot className='size-4' />
+                </ChipIconTile>
+              }
+              label={item.name}
+              secondary={item.description}
+            />
+          ))}
+        </ChipSection>
+
+        <Separator />
+
+        <ChipSection
+          label='Agents'
+          info='Other agents this one can hand a task to'
+          loading={detail.isLoading}
+          emptyLabel='No agents added yet.'
+          isEmpty={callableAgents.length === 0}
+        >
+          {callableAgents.map(slug => (
+            <TokenChip
+              key={slug}
+              icon={
+                <ChipIconTile>
+                  <UserBot className='size-4' />
+                </ChipIconTile>
+              }
+              label={`@${slug}`}
+            />
+          ))}
+        </ChipSection>
+
+        <Separator />
+
+        <ChipSection
+          label='MCP Tools'
+          info='Tools it calls directly on connected integrations'
+          loading={detail.isLoading || mcp.loading}
+          emptyLabel='No MCP tools added yet.'
+          isEmpty={mcpEntries.length === 0}
+        >
+          {mcpEntries.map(item => (
+            <TokenChip
+              key={item.slug}
+              icon={
+                <ChipIconTile>
+                  <McpLogo type={item.iconType} name={item.label} size='sm' />
+                </ChipIconTile>
+              }
+              label={item.label}
+              secondary={toolCountLabel(selectedMcpTools(selection, item).length)}
+            />
+          ))}
+        </ChipSection>
+
+        <Separator />
+
+        <ChipSection
+          label='Built-In tools'
+          info='Tools that ship with the platform, no connection needed'
+          loading={detail.isLoading || builtin.loading}
+          emptyLabel='No built-in tools added yet.'
+          isEmpty={builtinEntries.length === 0}
+        >
+          {builtinEntries.map(item => (
+            <TokenChip
+              key={item.source}
+              icon={
+                <ChipIconTile>
+                  <Tools className='size-4' />
+                </ChipIconTile>
+              }
+              label={item.label}
+              secondary={toolCountLabel(selectedBuiltinTools(selection, item).length)}
+            />
+          ))}
+        </ChipSection>
+
+        <Separator />
+
+        <Section label='Skills' info='Reusable instructions this agent can follow'>
+          {skills.length > 0 ? (
+            <ChipRow>
+              {skills.map(skill => (
+                <TokenChip
+                  key={skill.id}
+                  icon={
+                    <ChipIconTile>
+                      <Staroflife className='size-4' />
+                    </ChipIconTile>
+                  }
+                  label={skill.skill.name}
+                  secondary={skill.skill.description}
+                />
+              ))}
+            </ChipRow>
+          ) : (
+            <EmptyHint>{detail.isLoading ? 'Loading…' : 'No skills added'}</EmptyHint>
+          )}
+        </Section>
+
+        <Separator />
+
+        <Section label='Knowledge' info='Sources this agent can read'>
+          {agent?.kbScope === 'USER' ? (
+            <EmptyHint>Matches the access of whoever runs it</EmptyHint>
+          ) : collections.length > 0 ? (
+            <EmptyHint>
+              {collections.length} {collections.length === 1 ? 'source' : 'sources'} added
+            </EmptyHint>
+          ) : (
+            <EmptyHint>{detail.isLoading ? 'Loading…' : 'No knowledge added'}</EmptyHint>
+          )}
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/callableAgentCatalog.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/callableAgentCatalog.ts
@@ -1,0 +1,38 @@
+import type { DelegationStatus } from '@/services/claw/clawDelegationTypes';
+import type { PillTone } from '../../primitives/Pill';
+import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+
+export interface CallableAgentEntry {
+  slug: string;
+  name: string;
+  description: string;
+  ownerName: string | null;
+  /** Null until the agent is added; `missing` = in config with no grant behind it. */
+  status: DelegationStatus | 'missing' | null;
+  /** The callee has another owner, so the request needs a reason and approval. */
+  needsApproval: boolean;
+  /** Null for a slug the user can no longer see — the row still has to render. */
+  agent: Agent | null;
+}
+
+export function matchesSearch(entry: CallableAgentEntry, query: string): boolean {
+  if (!query) return true;
+  return `${entry.name} ${entry.slug} ${entry.description}`.toLowerCase().includes(query);
+}
+
+export function statusPill(
+  status: CallableAgentEntry['status'],
+): { tone: PillTone; label: string } | null {
+  switch (status) {
+    case 'approved':
+      return { tone: 'success', label: 'Enabled' };
+    case 'pending':
+      return { tone: 'warning', label: 'Awaiting approval' };
+    case 'rejected':
+      return { tone: 'danger', label: 'Declined' };
+    case 'missing':
+      return { tone: 'neutral', label: 'No grant' };
+    default:
+      return null;
+  }
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/callableAgentCatalog.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/callableAgentCatalog.ts
@@ -1,6 +1,7 @@
 import type { DelegationStatus } from '@/services/claw/clawDelegationTypes';
 import type { PillTone } from '../../primitives/Pill';
 import type { Agent } from '@/services/claw/clawAuthAgentTypes';
+import { matchesLibrarySearch } from '../../librarySearch';
 
 export interface CallableAgentEntry {
   slug: string;
@@ -16,8 +17,14 @@ export interface CallableAgentEntry {
 }
 
 export function matchesSearch(entry: CallableAgentEntry, query: string): boolean {
-  if (!query) return true;
-  return `${entry.name} ${entry.slug} ${entry.description}`.toLowerCase().includes(query);
+  return matchesLibrarySearch(
+    {
+      name: entry.name,
+      description: entry.description,
+      ...(entry.slug && entry.slug !== entry.name ? { aliases: [entry.slug] as const } : {}),
+    },
+    query,
+  );
 }
 
 export function statusPill(

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/useCallableAgents.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/callableAgent/useCallableAgents.ts
@@ -1,0 +1,162 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { useAuth } from '@/hooks/useAuth';
+import { useClawAuthAgents } from '@/hooks/useClawAuthAgents';
+import { clawErrorText } from '@/services/claw/clawRequest';
+import {
+  createDelegationGrant,
+  deleteDelegationGrant,
+  listDelegationGrants,
+} from '@/services/claw/clawDelegationService';
+import type { AgentDelegationGrant } from '@/services/claw/clawDelegationTypes';
+import type { CallableAgentEntry } from './callableAgentCatalog';
+
+export const delegationGrantsKey = (slug: string): string[] => ['claw-delegation-grants', slug];
+
+export interface UseCallableAgentsResult {
+  catalog: CallableAgentEntry[];
+  loading: boolean;
+  isError: boolean;
+  refetch: () => void;
+  busySlug: string | null;
+  add: (calleeSlug: string, requestReason: string) => void;
+  remove: (calleeSlug: string) => void;
+}
+
+/**
+ * Delegation is a live grant, not a draft: adding an agent calls the API before
+ * the slug is written anywhere, because a slug with no approved grant behind it
+ * is a config the runtime silently refuses.
+ */
+export function useCallableAgents({
+  agentSlug,
+  agentOwnerUserId,
+  selected,
+  onSelectedChange,
+}: {
+  agentSlug: string;
+  agentOwnerUserId: string | null;
+  selected: readonly string[];
+  onSelectedChange: (next: string[]) => void;
+}): UseCallableAgentsResult {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const [busySlug, setBusySlug] = useState<string | null>(null);
+  const agents = useClawAuthAgents();
+
+  const grantsQuery = useQuery({
+    queryKey: delegationGrantsKey(agentSlug),
+    queryFn: () => listDelegationGrants(agentSlug, user!.id),
+    enabled: !!user?.id && !!agentSlug,
+    staleTime: 60 * 1000,
+  });
+
+  const grantBySlug = useMemo(() => {
+    const map = new Map<string, AgentDelegationGrant>();
+    for (const grant of grantsQuery.data ?? []) {
+      if (grant.callee?.slug) map.set(grant.callee.slug, grant);
+    }
+    return map;
+  }, [grantsQuery.data]);
+
+  const catalog = useMemo<CallableAgentEntry[]>(() => {
+    const rows = (agents.data ?? [])
+      .filter(entry => entry.slug !== agentSlug)
+      .map<CallableAgentEntry>(entry => {
+        const grant = grantBySlug.get(entry.slug);
+        const added = selected.includes(entry.slug);
+        return {
+          slug: entry.slug,
+          name: entry.name,
+          description: entry.description ?? '',
+          ownerName: grant?.callee?.ownerName ?? entry.owner?.name ?? entry.owner?.email ?? null,
+          status: added ? (grant?.status ?? 'missing') : null,
+          needsApproval:
+            !entry.ownerUserId || !agentOwnerUserId || entry.ownerUserId !== agentOwnerUserId,
+          agent: entry,
+        };
+      });
+
+    // A slug the user can no longer see (deleted, or access removed) still has
+    // to be listed — otherwise removing it is impossible from this screen.
+    const known = new Set(rows.map(row => row.slug));
+    for (const slug of selected) {
+      if (known.has(slug)) continue;
+      const grant = grantBySlug.get(slug);
+      rows.push({
+        slug,
+        name: grant?.callee?.name ?? slug,
+        description: grant?.callee?.description ?? '',
+        ownerName: grant?.callee?.ownerName ?? null,
+        status: grant?.status ?? 'missing',
+        needsApproval: true,
+        agent: null,
+      });
+    }
+    return rows;
+  }, [agents.data, agentSlug, agentOwnerUserId, grantBySlug, selected]);
+
+  const add = useCallback(
+    (calleeSlug: string, requestReason: string): void => {
+      if (!user?.id || busySlug) return;
+      setBusySlug(calleeSlug);
+      void (async (): Promise<void> => {
+        try {
+          const grant = await createDelegationGrant(agentSlug, user.id, {
+            calleeSlug,
+            identityMode: 'user',
+            ...(requestReason ? { requestReason } : {}),
+          });
+          void queryClient.invalidateQueries({ queryKey: delegationGrantsKey(agentSlug) });
+          onSelectedChange([...selected.filter(entry => entry !== calleeSlug), calleeSlug]);
+          toast.success(
+            grant.status === 'approved'
+              ? `${grant.callee?.name ?? calleeSlug} can now be called`
+              : `Approval requested from ${grant.callee?.ownerName ?? 'the owner'}`,
+          );
+        } catch (err) {
+          toast.error(clawErrorText(err, 'Could not request delegation'));
+        } finally {
+          setBusySlug(null);
+        }
+      })();
+    },
+    [agentSlug, busySlug, onSelectedChange, queryClient, selected, user?.id],
+  );
+
+  const remove = useCallback(
+    (calleeSlug: string): void => {
+      if (!user?.id || busySlug) return;
+      setBusySlug(calleeSlug);
+      void (async (): Promise<void> => {
+        const grantId = grantBySlug.get(calleeSlug)?.id ?? null;
+        try {
+          if (grantId) {
+            await deleteDelegationGrant(agentSlug, grantId, user.id);
+            void queryClient.invalidateQueries({ queryKey: delegationGrantsKey(agentSlug) });
+          }
+          onSelectedChange(selected.filter(entry => entry !== calleeSlug));
+        } catch (err) {
+          toast.error(clawErrorText(err, 'Could not remove delegation'));
+        } finally {
+          setBusySlug(null);
+        }
+      })();
+    },
+    [agentSlug, busySlug, grantBySlug, onSelectedChange, queryClient, selected, user?.id],
+  );
+
+  return {
+    catalog,
+    loading: grantsQuery.isLoading || agents.isLoading,
+    isError: grantsQuery.isError || agents.isError,
+    refetch: (): void => {
+      void grantsQuery.refetch();
+      void agents.refetch();
+    },
+    busySlug,
+    add,
+    remove,
+  };
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/BrowseKnowledgeDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/BrowseKnowledgeDialog.tsx
@@ -3,7 +3,7 @@ import { ChevronRight, MultipleCrossCancelDefault, UserCheck } from '@xyne/icons
 import { cn } from '@/utils/classNames';
 import { useClawKnowledgeBaseTree } from '@/hooks/useClawKnowledgeBaseTree';
 import type { KbCollectionNode, KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
-import { BrowseDialog } from '../../primitives/BrowseDialog';
+import { BrowseDialog, handleBrowseDialogOpenChange } from '../../primitives/BrowseDialog';
 import { DetailEmptyState } from '../../primitives/DetailPrimitives';
 import { BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
 import { KbCollectionMeta, KbFolderTile } from './KnowledgeTiles';
@@ -78,10 +78,12 @@ export function BrowseKnowledgeDialog({
   return (
     <BrowseDialog
       open={open}
-      onOpenChange={next => {
-        if (!next) setOpenId(null);
-        onOpenChange(next);
-      }}
+      onOpenChange={next =>
+        handleBrowseDialogOpenChange(next, onOpenChange, () => {
+          setQuery('');
+          setOpenId(null);
+        })
+      }
       title='Browse Knowledge Base'
       description='Choose what reference material this agent can read.'
       testId='browse-knowledge-dialog'

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/knowledgeTree.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/knowledge/knowledgeTree.ts
@@ -7,6 +7,7 @@ import {
   PhotoImageDefault,
 } from '@xyne/icons';
 import type { KbCollectionNode, KbFile, KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
+import { matchesLibrarySearch } from '../../librarySearch';
 
 export type KbIconComponent = typeof FileDefault;
 
@@ -175,15 +176,5 @@ export function revokeFile(grants: readonly KbSelection[], fileId: string): KbSe
 }
 
 export function matchesQuery(root: KbCollectionNode, query: string): boolean {
-  const needle = query.trim().toLowerCase();
-  if (!needle) return true;
-  const haystack = [
-    root.name,
-    root.channelName ?? '',
-    root.projectName ?? '',
-    root.description ?? '',
-  ]
-    .join(' ')
-    .toLowerCase();
-  return haystack.includes(needle);
+  return matchesLibrarySearch({ name: root.name }, query);
 }

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/BrowseMcpsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/BrowseMcpsDialog.tsx
@@ -1,9 +1,14 @@
 import { Fragment, useMemo, useState, type ReactElement } from 'react';
 import { cn } from '@/utils/classNames';
+import { searchByNameThenDescription } from '../../librarySearch';
 import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
 import { AGENT_CATEGORIES } from '@/services/claw/agentCategory';
-import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
+import {
+  BrowseDialog,
+  handleBrowseDialogOpenChange,
+  type FilterOption,
+} from '../../primitives/BrowseDialog';
 import { SectionHeading, Separator } from '../../primitives/Section';
 import {
   disableEntry,
@@ -25,10 +30,13 @@ interface EntryState {
   selectedCount: number;
 }
 
-function matchesSearch(entry: McpCatalogEntry, query: string): boolean {
-  if (!query) return true;
-  if (`${entry.label} ${entry.description}`.toLowerCase().includes(query)) return true;
-  return entry.tools.some(tool => tool.name.toLowerCase().replace(/_/g, ' ').includes(query));
+function mcpSearchFields(entry: McpCatalogEntry) {
+  return {
+    name: entry.label,
+    description: entry.description,
+    ...(entry.slug && entry.slug !== entry.label ? { aliases: [entry.slug] as const } : {}),
+    extras: entry.tools.map(tool => tool.name.replace(/_/g, ' ')),
+  };
 }
 
 function entrySummary(entry: McpCatalogEntry, state: EntryState): string {
@@ -137,9 +145,9 @@ export function BrowseMcpsDialog({
   const stateOf = (entry: McpCatalogEntry): EntryState =>
     entryStates.get(entry.slug) ?? { enabled: false, selectedCount: 0 };
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const searchFiltered = useMemo(
-    () => catalog.filter(entry => matchesSearch(entry, q)),
+    () => searchByNameThenDescription(catalog, q, mcpSearchFields),
     [catalog, q],
   );
 
@@ -199,10 +207,13 @@ export function BrowseMcpsDialog({
   return (
     <BrowseDialog
       open={open}
-      onOpenChange={next => {
-        onOpenChange(next);
-        if (!next) setOpenSlug(null);
-      }}
+      onOpenChange={next =>
+        handleBrowseDialogOpenChange(next, onOpenChange, () => {
+          setQuery('');
+          setCategory(null);
+          setOpenSlug(null);
+        })
+      }
       title='Browse MCPs'
       description='Search and select the MCP integrations this agent can use.'
       testId='browse-mcps-dialog'

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/mcpConnectionService.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/mcpConnectionService.ts
@@ -1,4 +1,5 @@
 import { clawApiRequest } from '@/services/claw/clawRequest';
+import { currentOAuthReturnTo } from './oauthReturnTo';
 import type { CredentialField, McpServer, UserConnection } from '@/services/claw/clawMcpTypes';
 import { openOAuthConsent } from './openOAuthConsent';
 
@@ -20,7 +21,7 @@ export function createMcpConnection(
 function startOAuth(userId: string, serverType: string): Promise<{ authUrl: string }> {
   return clawApiRequest<{ authUrl: string }>(
     `/users/${encodeURIComponent(userId)}/oauth/${encodeURIComponent(serverType)}/authorize`,
-    { method: 'POST', userId, body: JSON.stringify({}) },
+    { method: 'POST', userId, body: JSON.stringify({ returnTo: currentOAuthReturnTo() }) },
   );
 }
 

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/oauthReturnTo.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/oauthReturnTo.ts
@@ -1,0 +1,15 @@
+/**
+ * Where the OAuth callback should send the browser back to.
+ *
+ * Without this the callback falls back to claw's own SPA, so a connector
+ * started from Spaces finished on claw's home page. The current URL is used so
+ * the user lands exactly where they were — every consumer already watches its
+ * own URL for `?<type>_connected=true` and refetches.
+ *
+ * The server re-validates this against an origin allowlist; it is a hint, not
+ * an instruction.
+ */
+export function currentOAuthReturnTo(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return window.location.href;
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/useMcpConnect.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/useMcpConnect.ts
@@ -1,13 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/hooks/useAuth';
+import { useMcpCredentialFields } from './useMcpCredentialFields';
 import { clawErrorText } from '@/services/claw/clawRequest';
 import type { CredentialField, McpServer } from '@/services/claw/clawMcpTypes';
-import {
-  connectMcpServer,
-  connectStrategyFor,
-  getCredentialFields,
-  type ConnectStrategy,
-} from './mcpConnectionService';
+import { connectMcpServer, connectStrategyFor, type ConnectStrategy } from './mcpConnectionService';
 
 export interface McpConnect {
   fields: CredentialField[];
@@ -23,11 +19,7 @@ export function useMcpConnect(server: McpServer | undefined, onConnected: () => 
   const userId = user?.id;
   const queryClient = useQueryClient();
 
-  const fieldsQuery = useQuery({
-    queryKey: ['claw-mcp-credential-fields'],
-    queryFn: getCredentialFields,
-    staleTime: 5 * 60 * 1000,
-  });
+  const { fieldsFor } = useMcpCredentialFields();
 
   const mutation = useMutation({
     mutationFn: async (credentials: Record<string, string>) => {
@@ -41,9 +33,7 @@ export function useMcpConnect(server: McpServer | undefined, onConnected: () => 
     },
   });
 
-  const fields = server
-    ? (fieldsQuery.data?.[server.type] ?? server.credentialForm?.fields ?? [])
-    : [];
+  const fields = fieldsFor(server);
 
   return {
     fields,

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/useMcpCredentialFields.ts
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/mcp/useMcpCredentialFields.ts
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { mcpCredentialFields } from '@/services/claw/clawMcpService';
+import type { CredentialField, McpServer } from '@/services/claw/clawMcpTypes';
+import { getCredentialFields } from './mcpConnectionService';
+
+export const MCP_CREDENTIAL_FIELDS_KEY = ['claw-mcp-credential-fields'];
+
+const STALE_TIME = 5 * 60 * 1000;
+
+/**
+ * A connector's credential fields, resolved the same way the connect form
+ * renders them: the server-side registry first (which knows every connector
+ * with a static adapter), then the connector's own DB columns.
+ *
+ * Deciding "does this need a form?" from the DB columns alone is what broke
+ * pre-prod: `mcp_servers.credentialForm` is nullable and unset there for
+ * connectors whose fields live only in code (amplitude, asana, bigquery,
+ * bitbucket…), so the UI concluded "no fields", skipped the dialog and posted
+ * an empty credential bag. The registry answers correctly in every
+ * environment, so both the decision and the form must read from here.
+ */
+export interface McpCredentialFields {
+  /** Render-time lookup; falls back to the DB columns until the query lands. */
+  fieldsFor: (server: McpServer | undefined) => CredentialField[];
+  /**
+   * Click-time lookup. Awaits the registry rather than guessing from whatever
+   * is cached, so a Connect pressed before the query resolves still gets the
+   * right answer instead of silently taking the no-credentials path.
+   */
+  ensureFieldsFor: (server: McpServer | undefined) => Promise<CredentialField[]>;
+  loading: boolean;
+}
+
+export function useMcpCredentialFields(): McpCredentialFields {
+  const queryClient = useQueryClient();
+  const query = useQuery({
+    queryKey: MCP_CREDENTIAL_FIELDS_KEY,
+    queryFn: getCredentialFields,
+    staleTime: STALE_TIME,
+  });
+
+  const fieldsFor = useCallback(
+    (server: McpServer | undefined): CredentialField[] => {
+      if (!server) return [];
+      return query.data?.[server.type] ?? mcpCredentialFields(server);
+    },
+    [query.data],
+  );
+
+  const ensureFieldsFor = useCallback(
+    async (server: McpServer | undefined): Promise<CredentialField[]> => {
+      if (!server) return [];
+      try {
+        const map = await queryClient.fetchQuery({
+          queryKey: MCP_CREDENTIAL_FIELDS_KEY,
+          queryFn: getCredentialFields,
+          staleTime: STALE_TIME,
+        });
+        return map[server.type] ?? mcpCredentialFields(server);
+      } catch {
+        // Registry unreachable — fall back to whatever the row declares rather
+        // than blocking the connect entirely.
+        return mcpCredentialFields(server);
+      }
+    },
+    [queryClient],
+  );
+
+  return { fieldsFor, ensureFieldsFor, loading: query.isLoading };
+}

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/BrowseSkillsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/skill/BrowseSkillsDialog.tsx
@@ -1,8 +1,13 @@
 import { Fragment, useMemo, useState, type ReactElement } from 'react';
 import { cn } from '@/utils/classNames';
+import { searchByNameThenDescription } from '../../librarySearch';
 import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
-import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
+import {
+  BrowseDialog,
+  handleBrowseDialogOpenChange,
+  type FilterOption,
+} from '../../primitives/BrowseDialog';
 import { Pill } from '../../primitives/Pill';
 import { SectionHeading, Separator } from '../../primitives/Section';
 import { SkillChip } from './SkillChip';
@@ -19,11 +24,6 @@ const SECTIONS = [
   { key: 'personal', label: 'My skills' },
   { key: 'global', label: 'Global skills' },
 ] as const;
-
-function matchesSearch(entry: SkillCatalogEntry, query: string): boolean {
-  if (!query) return true;
-  return `${entry.label} ${entry.slug} ${entry.description}`.toLowerCase().includes(query);
-}
 
 const SkillCard = ({
   entry,
@@ -114,10 +114,14 @@ export function BrowseSkillsDialog({
 
   const openEntry = catalog.find(entry => entry.id === openId) ?? null;
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const visible = useMemo(
     () =>
-      catalog.filter(entry => matchesSearch(entry, q) && (scope === null || entry.scope === scope)),
+      searchByNameThenDescription(catalog, q, entry => ({
+        name: entry.label,
+        description: entry.description,
+        ...(entry.slug && entry.slug !== entry.label ? { aliases: [entry.slug] as const } : {}),
+      })).filter(entry => scope === null || entry.scope === scope),
     [catalog, q, scope],
   );
 
@@ -138,10 +142,13 @@ export function BrowseSkillsDialog({
   return (
     <BrowseDialog
       open={open}
-      onOpenChange={next => {
-        onOpenChange(next);
-        if (!next) setOpenId(null);
-      }}
+      onOpenChange={next =>
+        handleBrowseDialogOpenChange(next, onOpenChange, () => {
+          setQuery('');
+          setScope(null);
+          setOpenId(null);
+        })
+      }
       title='Browse skills'
       description='Search and select the skills this agent can draw on.'
       testId='browse-skills-dialog'

--- a/apps/dashboard/src/routes/AIScreen/library/shared/pickers/subagent/BrowseSubagentsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/pickers/subagent/BrowseSubagentsDialog.tsx
@@ -1,8 +1,13 @@
 import { useMemo, useState, type ReactElement } from 'react';
 import { cn } from '@/utils/classNames';
+import { searchByNameThenDescription } from '../../librarySearch';
 import { BROWSE_CARD, BROWSE_CARD_IDLE, BROWSE_CARD_SELECTED } from '../../primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
-import { BrowseDialog, type FilterOption } from '../../primitives/BrowseDialog';
+import {
+  BrowseDialog,
+  handleBrowseDialogOpenChange,
+  type FilterOption,
+} from '../../primitives/BrowseDialog';
 import { Pill } from '../../primitives/Pill';
 import { SubagentChip } from './SubagentChip';
 import { SubagentDetailPanel } from './SubagentDetailPanel';
@@ -31,11 +36,6 @@ const RISK_TONE = {
   write: 'warning',
   destructive: 'danger',
 } as const;
-
-function matchesSearch(entry: SubagentCatalogEntry, query: string): boolean {
-  if (!query) return true;
-  return `${entry.name} ${entry.description}`.toLowerCase().includes(query);
-}
 
 const SubagentCard = ({
   entry,
@@ -127,12 +127,13 @@ export function BrowseSubagentsDialog({
 
   const openEntry = catalog.find(entry => entry.name === openName) ?? null;
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const visible = useMemo(
     () =>
-      catalog.filter(
-        entry => matchesSearch(entry, q) && (source === null || entry.source === source),
-      ),
+      searchByNameThenDescription(catalog, q, entry => ({
+        name: entry.name,
+        description: entry.description,
+      })).filter(entry => source === null || entry.source === source),
     [catalog, q, source],
   );
 
@@ -150,10 +151,13 @@ export function BrowseSubagentsDialog({
   return (
     <BrowseDialog
       open={open}
-      onOpenChange={next => {
-        onOpenChange(next);
-        if (!next) setOpenName(null);
-      }}
+      onOpenChange={next =>
+        handleBrowseDialogOpenChange(next, onOpenChange, () => {
+          setQuery('');
+          setSource(null);
+          setOpenName(null);
+        })
+      }
       title='Browse Subagent'
       description='Search and select the subagents this agent can delegate to.'
       testId='browse-subagents-dialog'

--- a/apps/dashboard/src/routes/AIScreen/library/shared/primitives/BrowseDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/shared/primitives/BrowseDialog.tsx
@@ -116,6 +116,16 @@ interface BrowseDialogProps {
   children: ReactNode;
 }
 
+/** Reset local search/filter/detail state whenever a browse dialog closes. */
+export function handleBrowseDialogOpenChange(
+  next: boolean,
+  onOpenChange: (open: boolean) => void,
+  reset: () => void,
+): void {
+  if (!next) reset();
+  onOpenChange(next);
+}
+
 export function BrowseDialog({
   open,
   onOpenChange,

--- a/apps/dashboard/src/routes/AIScreen/library/skills/SkillsV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/skills/SkillsV2.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
+import { searchByNameThenDescription } from '../shared/librarySearch';
 import { useAuth } from '@/hooks/useAuth';
 import { useClawSkills } from '@/hooks/useClawSkills';
 import type { Skill } from '@/services/claw/clawSkillsTypes';
@@ -23,12 +24,14 @@ const SkillsV2 = ({ query }: { query: string }): ReactElement => {
   const { user } = useAuth();
   const userId = user?.id;
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const searched = useMemo(
     () =>
-      q
-        ? skills.filter(s => `${s.name} ${s.slug} ${s.description ?? ''}`.toLowerCase().includes(q))
-        : skills,
+      searchByNameThenDescription(skills, q, skill => ({
+        name: skill.name || skill.slug,
+        description: skill.description,
+        ...(skill.slug && skill.slug !== skill.name ? { aliases: [skill.slug] as const } : {}),
+      })),
     [skills, q],
   );
 

--- a/apps/dashboard/src/routes/AIScreen/library/subagents/SubagentsV2.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/subagents/SubagentsV2.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, useMemo } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { Network } from 'lucide-react';
+import { searchByNameThenDescription } from '../shared/librarySearch';
 import { useClawSubagents } from '@/hooks/useClawSubagents';
 import type { SubagentDef, SubagentSource } from '@/services/claw/clawSubagentsTypes';
 import { LibraryCard, LibraryIconTile } from '../shared/components/LibraryCard';
@@ -33,10 +34,13 @@ const SubagentsV2 = ({ query }: { query: string }): ReactElement => {
     setSearchParams(next, { replace: true });
   };
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const searched = useMemo(
     () =>
-      q ? subagents.filter(s => `${s.name} ${s.description}`.toLowerCase().includes(q)) : subagents,
+      searchByNameThenDescription(subagents, q, subagent => ({
+        name: subagent.name,
+        description: subagent.description,
+      })),
     [subagents, q],
   );
 

--- a/apps/dashboard/src/routes/AIScreen/library/subagents/create/toolbox/BrowseSubagentToolsDialog.tsx
+++ b/apps/dashboard/src/routes/AIScreen/library/subagents/create/toolbox/BrowseSubagentToolsDialog.tsx
@@ -1,12 +1,17 @@
 import { useMemo, useState, type ReactElement } from 'react';
 import { cn } from '@/utils/classNames';
+import { searchByNameThenDescription } from '../../../shared/librarySearch';
 import {
   BROWSE_CARD,
   BROWSE_CARD_IDLE,
   BROWSE_CARD_SELECTED,
 } from '../../../shared/primitives/browseCard';
 import { ChevronRight, MultipleCrossCancelDefault, PlusDefault } from '@xyne/icons';
-import { BrowseDialog, type FilterOption } from '../../../shared/primitives/BrowseDialog';
+import {
+  BrowseDialog,
+  handleBrowseDialogOpenChange,
+  type FilterOption,
+} from '../../../shared/primitives/BrowseDialog';
 import { Pill } from '../../../shared/primitives/Pill';
 import { humanizeToolName } from '../../../shared/primitives/ToolRow';
 import { BuiltinChip } from '../../../shared/pickers/builtin/BuiltinChip';
@@ -21,10 +26,11 @@ import {
   type SubagentToolSectionData,
 } from './subagentToolCatalog';
 
-function matchesSearch(group: SubagentToolGroup, query: string): boolean {
-  if (!query) return true;
-  if (humanizeSource(group.source).toLowerCase().includes(query)) return true;
-  return group.tools.some(tool => humanizeToolName(tool.name).toLowerCase().includes(query));
+function groupSearchFields(group: SubagentToolGroup) {
+  return {
+    name: humanizeSource(group.source),
+    extras: group.tools.map(tool => humanizeToolName(tool.name)),
+  };
 }
 
 const GroupCard = ({
@@ -123,11 +129,11 @@ export function BrowseSubagentToolsDialog({
     [section.groups],
   );
 
-  const q = query.trim().toLowerCase();
+  const q = query.trim();
   const visible = useMemo(
     () =>
-      section.groups.filter(
-        group => matchesSearch(group, q) && (source === null || group.source === source),
+      searchByNameThenDescription(section.groups, q, groupSearchFields).filter(
+        group => source === null || group.source === source,
       ),
     [section.groups, q, source],
   );
@@ -140,10 +146,13 @@ export function BrowseSubagentToolsDialog({
   return (
     <BrowseDialog
       open={open}
-      onOpenChange={next => {
-        onOpenChange(next);
-        if (!next) setOpenSource(null);
-      }}
+      onOpenChange={next =>
+        handleBrowseDialogOpenChange(next, onOpenChange, () => {
+          setQuery('');
+          setSource(null);
+          setOpenSource(null);
+        })
+      }
       title={`Browse ${section.title}`}
       description={section.caption}
       testId={`browse-subagent-${section.kind}-tools-dialog`}

--- a/apps/dashboard/src/routes/ClawAgentsScreen/ClawSettingsScreen.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/ClawSettingsScreen.tsx
@@ -77,9 +77,32 @@ const PROVIDER_META: Record<ProviderId, { name: string; description: string; ico
       description: 'Code generation and editing',
       icon: Code2,
     },
+    openrouter: {
+      name: 'OpenRouter',
+      description: 'One key, many models across providers',
+      icon: Plug,
+    },
+    litellm: {
+      name: 'LiteLLM (own key)',
+      description: 'Use models allowed by your Grid/LiteLLM key',
+      icon: KeyRound,
+    },
   };
 
-const PROVIDERS: ProviderId[] = ['copilot', 'claude', 'codex'];
+const PROVIDERS: ProviderId[] = ['copilot', 'claude', 'codex', 'openrouter', 'litellm'];
+
+/* eslint-disable @typescript-eslint/naming-convention */
+const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderId, string>> = {
+  claude: 'claude-sonnet-4-5',
+  codex: 'gpt-4.1',
+};
+
+const DEFAULT_BASE_URL_BY_PROVIDER: Partial<Record<ProviderId, string>> = {
+  claude: 'https://api.anthropic.com',
+  codex: 'https://api.openai.com/v1',
+  openrouter: 'https://openrouter.ai/api/v1',
+};
+/* eslint-enable @typescript-eslint/naming-convention */
 const EMPTY_CREDENTIALS: ProviderCredential[] = [];
 const EMPTY_ROUTING: Array<{ subagentName: string; provider: string }> = [];
 const EMPTY_SUBAGENTS: string[] = [];
@@ -547,6 +570,12 @@ const GenericProviderConfigForm = ({
 }): ReactElement => {
   const isClaude = provider === 'claude';
   const isCodex = provider === 'codex';
+  const isLitellm = provider === 'litellm';
+  // Only these two have an OAuth flow and a fetchable model catalogue; the rest
+  // are plain API-key providers. LiteLLM additionally has no reasoning knob —
+  // the same rules credentialForm.ts encodes for the agent-level form.
+  const hasOauthOption = isClaude || isCodex;
+  const hasModelCatalog = isClaude || isCodex;
   const [existing, setExisting] = useState<ProviderCredential | undefined>();
   const [apiKey, setApiKey] = useState('');
   const [authType, setAuthType] = useState<AuthType>('api_key');
@@ -575,11 +604,8 @@ const GenericProviderConfigForm = ({
       .then(credential => {
         if (cancelled) return;
         setExisting(credential);
-        setModel(credential?.model ?? (isClaude ? 'claude-sonnet-4-5' : 'gpt-4.1'));
-        setBaseUrl(
-          credential?.baseUrl ??
-            (isClaude ? 'https://api.anthropic.com' : 'https://api.openai.com/v1'),
-        );
+        setModel(credential?.model ?? DEFAULT_MODEL_BY_PROVIDER[provider] ?? '');
+        setBaseUrl(credential?.baseUrl ?? DEFAULT_BASE_URL_BY_PROVIDER[provider] ?? '');
         setAuthType(credential?.authType === 'oauth_token' ? 'oauth_token' : 'api_key');
         if (
           credential?.reasoningEffort === 'low' ||
@@ -593,12 +619,13 @@ const GenericProviderConfigForm = ({
     return (): void => {
       cancelled = true;
     };
-  }, [provider, userId, isClaude]);
+  }, [provider, userId]);
 
   const hasKey = existing?.hasApiKey ?? false;
   const isOauth = authType === 'oauth_token';
 
   useEffect(() => {
+    if (!hasModelCatalog) return undefined;
     if (!hasKey && credentialNonce === 0) return undefined;
     let cancelled = false;
     setModelsError(null);
@@ -616,7 +643,7 @@ const GenericProviderConfigForm = ({
     return (): void => {
       cancelled = true;
     };
-  }, [hasKey, userId, isClaude, credentialNonce]);
+  }, [hasKey, userId, isClaude, hasModelCatalog, credentialNonce]);
 
   const handleSave = async (): Promise<void> => {
     if (!apiKey && !hasKey) {
@@ -629,8 +656,7 @@ const GenericProviderConfigForm = ({
       await upsertProviderCredential(userId, provider, {
         model,
         baseUrl,
-        authType,
-        reasoningEffort,
+        ...(isLitellm ? {} : { authType, reasoningEffort }),
         ...(apiKey ? { apiKey } : {}),
       });
       await onMutate();
@@ -735,149 +761,153 @@ const GenericProviderConfigForm = ({
         </div>
       )}
 
-      <div>
-        <span className='mb-1.5 block text-xs font-medium text-muted-foreground'>Auth method</span>
-        <div className='grid grid-cols-2 gap-2'>
-          <AuthMethodOption
-            label='API Key'
-            sublabel={isClaude ? 'Usage-based, Console key' : 'Usage-based, Platform key'}
-            selected={authType === 'api_key'}
-            onSelect={() => setAuthType('api_key')}
-          />
-          <AuthMethodOption
-            label={isClaude ? 'OAuth Token' : 'ChatGPT OAuth Token'}
-            sublabel={isClaude ? 'Pro/Max subscription' : 'ChatGPT Plus/Pro subscription'}
-            selected={authType === 'oauth_token'}
-            onSelect={() => setAuthType('oauth_token')}
-          />
-        </div>
+      {hasOauthOption && (
+        <div>
+          <span className='mb-1.5 block text-xs font-medium text-muted-foreground'>
+            Auth method
+          </span>
+          <div className='grid grid-cols-2 gap-2'>
+            <AuthMethodOption
+              label='API Key'
+              sublabel={isClaude ? 'Usage-based, Console key' : 'Usage-based, Platform key'}
+              selected={authType === 'api_key'}
+              onSelect={() => setAuthType('api_key')}
+            />
+            <AuthMethodOption
+              label={isClaude ? 'OAuth Token' : 'ChatGPT OAuth Token'}
+              sublabel={isClaude ? 'Pro/Max subscription' : 'ChatGPT Plus/Pro subscription'}
+              selected={authType === 'oauth_token'}
+              onSelect={() => setAuthType('oauth_token')}
+            />
+          </div>
 
-        {isOauth && isClaude && (
-          <div className='mt-2 flex flex-col gap-2 rounded-lg border border-[var(--claw-ai-border)] bg-[var(--claw-ai-surface)] px-3 py-2.5 text-xs text-[var(--claw-ai-fg)]'>
-            {!claudeFlow ? (
-              <>
-                <p>
-                  Sign in with your Claude account. This captures a refreshable token, so it
-                  won&apos;t silently expire like a pasted one.
-                </p>
-                <Button size='sm' onClick={() => void startClaudeOAuth()} disabled={claudeBusy}>
-                  {claudeBusy ? (
+          {isOauth && isClaude && (
+            <div className='mt-2 flex flex-col gap-2 rounded-lg border border-[var(--claw-ai-border)] bg-[var(--claw-ai-surface)] px-3 py-2.5 text-xs text-[var(--claw-ai-fg)]'>
+              {!claudeFlow ? (
+                <>
+                  <p>
+                    Sign in with your Claude account. This captures a refreshable token, so it
+                    won&apos;t silently expire like a pasted one.
+                  </p>
+                  <Button size='sm' onClick={() => void startClaudeOAuth()} disabled={claudeBusy}>
+                    {claudeBusy ? (
+                      <Loader2 className='size-4 animate-spin' />
+                    ) : (
+                      <KeyRound className='size-4' />
+                    )}
+                    {claudeBusy ? 'Opening...' : 'Sign in with Claude'}
+                  </Button>
+                  <p className='text-muted-foreground'>
+                    Or run <code className='rounded bg-background px-1'>claude setup-token</code>{' '}
+                    and paste the token below.
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p>
+                    Paste the code Anthropic shows you below.{' '}
+                    <a
+                      href={claudeFlow.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='underline underline-offset-2'
+                    >
+                      Re-open tab
+                    </a>
+                  </p>
+                  <Input
+                    value={claudeCode}
+                    onChange={event => setClaudeCode(event.target.value)}
+                    placeholder='Paste code or callback URL'
+                  />
+                  <div className='flex gap-2'>
+                    <Button
+                      size='sm'
+                      onClick={() => void completeClaudeOAuth()}
+                      disabled={claudeBusy || !claudeCode.trim()}
+                    >
+                      {claudeBusy ? 'Verifying...' : 'Complete sign-in'}
+                    </Button>
+                    <Button
+                      size='sm'
+                      variant='ghost'
+                      onClick={() => {
+                        setClaudeFlow(null);
+                        setClaudeCode('');
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+
+          {isOauth && isCodex && (
+            <div className='mt-2 flex flex-col gap-2 rounded-lg border border-[var(--claw-ai-border)] bg-[var(--claw-ai-surface)] px-3 py-2.5 text-xs text-[var(--claw-ai-fg)]'>
+              {!codexFlow ? (
+                <Button
+                  size='sm'
+                  onClick={() => void startCodexOAuth()}
+                  data-track-category='claw-settings'
+                  data-track-name='START_CODEX_OAUTH'
+                  disabled={codexBusy}
+                >
+                  {codexBusy ? (
                     <Loader2 className='size-4 animate-spin' />
                   ) : (
                     <KeyRound className='size-4' />
                   )}
-                  {claudeBusy ? 'Opening...' : 'Sign in with Claude'}
+                  {codexBusy ? 'Opening...' : 'Sign in with ChatGPT'}
                 </Button>
-                <p className='text-muted-foreground'>
-                  Or run <code className='rounded bg-background px-1'>claude setup-token</code> and
-                  paste the token below.
-                </p>
-              </>
-            ) : (
-              <>
-                <p>
-                  Paste the code Anthropic shows you below.{' '}
-                  <a
-                    href={claudeFlow.url}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    className='underline underline-offset-2'
-                  >
-                    Re-open tab
-                  </a>
-                </p>
-                <Input
-                  value={claudeCode}
-                  onChange={event => setClaudeCode(event.target.value)}
-                  placeholder='Paste code or callback URL'
-                />
-                <div className='flex gap-2'>
-                  <Button
-                    size='sm'
-                    onClick={() => void completeClaudeOAuth()}
-                    disabled={claudeBusy || !claudeCode.trim()}
-                  >
-                    {claudeBusy ? 'Verifying...' : 'Complete sign-in'}
-                  </Button>
-                  <Button
-                    size='sm'
-                    variant='ghost'
-                    onClick={() => {
-                      setClaudeFlow(null);
-                      setClaudeCode('');
-                    }}
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              </>
-            )}
-          </div>
-        )}
-
-        {isOauth && isCodex && (
-          <div className='mt-2 flex flex-col gap-2 rounded-lg border border-[var(--claw-ai-border)] bg-[var(--claw-ai-surface)] px-3 py-2.5 text-xs text-[var(--claw-ai-fg)]'>
-            {!codexFlow ? (
-              <Button
-                size='sm'
-                onClick={() => void startCodexOAuth()}
-                data-track-category='claw-settings'
-                data-track-name='START_CODEX_OAUTH'
-                disabled={codexBusy}
-              >
-                {codexBusy ? (
-                  <Loader2 className='size-4 animate-spin' />
-                ) : (
-                  <KeyRound className='size-4' />
-                )}
-                {codexBusy ? 'Opening...' : 'Sign in with ChatGPT'}
-              </Button>
-            ) : (
-              <>
-                <p>
-                  Paste the code from the OpenAI page below.{' '}
-                  <a
-                    href={codexFlow.url}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    className='underline underline-offset-2'
-                  >
-                    Re-open tab
-                  </a>
-                </p>
-                <Input
-                  value={codexCode}
-                  onChange={event => setCodexCode(event.target.value)}
-                  placeholder='Paste code or callback URL'
-                />
-                <div className='flex gap-2'>
-                  <Button
-                    size='sm'
-                    onClick={() => void completeCodexOAuth()}
-                    data-track-category='claw-settings'
-                    data-track-name='COMPLETE_CODEX_OAUTH'
-                    disabled={codexBusy || !codexCode.trim()}
-                  >
-                    {codexBusy ? 'Verifying...' : 'Complete sign-in'}
-                  </Button>
-                  <Button
-                    size='sm'
-                    variant='ghost'
-                    onClick={() => {
-                      setCodexFlow(null);
-                      setCodexCode('');
-                    }}
-                    data-track-category='claw-settings'
-                    data-track-name='CANCEL_CODEX_OAUTH'
-                  >
-                    Cancel
-                  </Button>
-                </div>
-              </>
-            )}
-          </div>
-        )}
-      </div>
+              ) : (
+                <>
+                  <p>
+                    Paste the code from the OpenAI page below.{' '}
+                    <a
+                      href={codexFlow.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='underline underline-offset-2'
+                    >
+                      Re-open tab
+                    </a>
+                  </p>
+                  <Input
+                    value={codexCode}
+                    onChange={event => setCodexCode(event.target.value)}
+                    placeholder='Paste code or callback URL'
+                  />
+                  <div className='flex gap-2'>
+                    <Button
+                      size='sm'
+                      onClick={() => void completeCodexOAuth()}
+                      data-track-category='claw-settings'
+                      data-track-name='COMPLETE_CODEX_OAUTH'
+                      disabled={codexBusy || !codexCode.trim()}
+                    >
+                      {codexBusy ? 'Verifying...' : 'Complete sign-in'}
+                    </Button>
+                    <Button
+                      size='sm'
+                      variant='ghost'
+                      onClick={() => {
+                        setCodexFlow(null);
+                        setCodexCode('');
+                      }}
+                      data-track-category='claw-settings'
+                      data-track-name='CANCEL_CODEX_OAUTH'
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       {(!isOauth || isClaude) && (
         <LabeledInput
@@ -920,25 +950,34 @@ const GenericProviderConfigForm = ({
         )}
       </div>
 
-      <LabeledInput label='Base URL' value={baseUrl} onChange={setBaseUrl} />
-
-      <LabeledSelect
-        label='Reasoning Effort'
-        value={reasoningEffort}
-        options={[
-          { value: 'low', label: 'Low - fastest, minimal think time' },
-          { value: 'medium', label: 'Medium - balanced (default)' },
-          { value: 'high', label: 'High - deepest reasoning, slowest' },
-        ]}
-        onValueChange={value => {
-          if (value === 'low' || value === 'medium' || value === 'high') {
-            setReasoningEffort(value);
-          }
-        }}
+      <LabeledInput
+        label='Base URL'
+        value={baseUrl}
+        onChange={setBaseUrl}
+        {...(isLitellm ? { hint: 'Leave blank to use the platform LiteLLM proxy' } : {})}
       />
-      <p className='-mt-3 text-xs text-muted-foreground'>
-        Only applies to reasoning-capable models. Lower means faster per-turn responses.
-      </p>
+
+      {!isLitellm && (
+        <>
+          <LabeledSelect
+            label='Reasoning Effort'
+            value={reasoningEffort}
+            options={[
+              { value: 'low', label: 'Low - fastest, minimal think time' },
+              { value: 'medium', label: 'Medium - balanced (default)' },
+              { value: 'high', label: 'High - deepest reasoning, slowest' },
+            ]}
+            onValueChange={value => {
+              if (value === 'low' || value === 'medium' || value === 'high') {
+                setReasoningEffort(value);
+              }
+            }}
+          />
+          <p className='-mt-3 text-xs text-muted-foreground'>
+            Only applies to reasoning-capable models. Lower means faster per-turn responses.
+          </p>
+        </>
+      )}
 
       {error && <p className='text-sm text-destructive'>{error}</p>}
 

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create/steps/ToolboxStep.tsx
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create/steps/ToolboxStep.tsx
@@ -28,6 +28,7 @@ export function ToolboxStep({ state, update }: Props): ReactElement {
             direct: next.direct,
             custom: next.custom,
             gateway: next.gateway ?? [],
+            callableAgents: state.tools.callableAgents,
           },
         })
       }

--- a/apps/dashboard/src/routes/ClawAgentsScreen/create/wizardState.ts
+++ b/apps/dashboard/src/routes/ClawAgentsScreen/create/wizardState.ts
@@ -1,5 +1,5 @@
 import type { KbSelection } from '@/services/claw/clawKnowledgeBaseTypes';
-import type { ToolboxSelection } from '@/services/claw/clawToolsTypes';
+import type { AgentToolboxSelection } from '@/services/claw/clawToolsTypes';
 
 // Wizard step order + copy. Names track the agent detail screen's tabs
 // (Persona / Toolbox / Knowledge) so the two surfaces read consistently.
@@ -55,7 +55,7 @@ export interface WizardState {
   aiIntent: string;
 
   // Toolbox
-  tools: Required<ToolboxSelection>;
+  tools: AgentToolboxSelection;
   researchAgentProductId: string;
   researchAgentRepositoryId: string;
 
@@ -74,7 +74,7 @@ export const INITIAL_WIZARD_STATE: WizardState = {
   slugManual: false,
   systemPrompt: '',
   aiIntent: '',
-  tools: { subagents: [], direct: [], custom: [], gateway: [] },
+  tools: { subagents: [], direct: [], custom: [], gateway: [], callableAgents: [] },
   researchAgentProductId: '',
   researchAgentRepositoryId: '',
   selectedSkillIds: [],

--- a/apps/dashboard/src/services/claw/clawDelegationService.ts
+++ b/apps/dashboard/src/services/claw/clawDelegationService.ts
@@ -1,0 +1,89 @@
+import { clawApiRequest, clawRequest } from './clawRequest';
+import type { AgentDelegationGrant, CreateDelegationGrantInput } from './clawDelegationTypes';
+
+const agentPath = (slug: string): string => `/agents/${encodeURIComponent(slug)}`;
+
+/** Outgoing: agents this agent may delegate to, with their approval state. */
+export async function listDelegationGrants(
+  slug: string,
+  userId: string,
+): Promise<AgentDelegationGrant[]> {
+  return clawApiRequest<AgentDelegationGrant[]>(`${agentPath(slug)}/delegation-grants`, {
+    userId,
+  });
+}
+
+/**
+ * Request delegation from `slug` to `input.calleeSlug`. Auto-approves when the
+ * requester owns both agents; otherwise the callee's owner is notified and the
+ * grant comes back `pending`.
+ */
+export async function createDelegationGrant(
+  slug: string,
+  userId: string,
+  input: CreateDelegationGrantInput,
+): Promise<AgentDelegationGrant> {
+  return clawApiRequest<AgentDelegationGrant>(`${agentPath(slug)}/delegation-grants`, {
+    method: 'POST',
+    userId,
+    body: JSON.stringify({
+      calleeSlug: input.calleeSlug,
+      identityMode: input.identityMode ?? 'user',
+      ...(input.requestReason ? { requestReason: input.requestReason } : {}),
+    }),
+  });
+}
+
+export async function deleteDelegationGrant(
+  slug: string,
+  grantId: string,
+  userId: string,
+): Promise<void> {
+  await clawRequest<{ success: boolean }>(
+    `/api/v1${agentPath(slug)}/delegation-grants/${encodeURIComponent(grantId)}`,
+    { method: 'DELETE', headers: { 'x-user-id': userId } },
+  );
+}
+
+/** Incoming: who has asked to call this agent (pending + approved). */
+export async function listDelegationRequests(
+  slug: string,
+  userId: string,
+): Promise<AgentDelegationGrant[]> {
+  return clawApiRequest<AgentDelegationGrant[]>(`${agentPath(slug)}/delegation-requests`, {
+    userId,
+  });
+}
+
+/** Every pending request across all agents the user owns. */
+export async function listPendingDelegationRequestsForMe(
+  userId: string,
+): Promise<AgentDelegationGrant[]> {
+  return clawApiRequest<AgentDelegationGrant[]>('/agents/delegation-requests/pending-for-me', {
+    userId,
+  });
+}
+
+export async function decideDelegationRequest(
+  slug: string,
+  grantId: string,
+  approve: boolean,
+  userId: string,
+): Promise<AgentDelegationGrant> {
+  return clawApiRequest<AgentDelegationGrant>(
+    `${agentPath(slug)}/delegation-requests/${encodeURIComponent(grantId)}/decision`,
+    { method: 'POST', userId, body: JSON.stringify({ approve }) },
+  );
+}
+
+/** Withdraw an already-approved delegation. */
+export async function revokeDelegation(
+  slug: string,
+  grantId: string,
+  userId: string,
+): Promise<AgentDelegationGrant> {
+  return clawApiRequest<AgentDelegationGrant>(
+    `${agentPath(slug)}/delegation-requests/${encodeURIComponent(grantId)}/revoke`,
+    { method: 'POST', userId },
+  );
+}

--- a/apps/dashboard/src/services/claw/clawDelegationTypes.ts
+++ b/apps/dashboard/src/services/claw/clawDelegationTypes.ts
@@ -1,0 +1,36 @@
+export type DelegationStatus = 'pending' | 'approved' | 'rejected';
+
+export type DelegationIdentityMode = 'user' | 'callee_app';
+
+export interface DelegationAgentRef {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string | null;
+  enabled?: boolean;
+  ownerUserId?: string | null;
+  ownerName?: string | null;
+}
+
+export interface AgentDelegationGrant {
+  id: string;
+  callerAgentId: string;
+  calleeAgentId: string;
+  identityMode: DelegationIdentityMode;
+  enabled: boolean;
+  status: DelegationStatus;
+  approvedByUserId: string | null;
+  approvedAt: string | null;
+  createdByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  requestReason: string | null;
+  callee?: DelegationAgentRef | null;
+  caller?: DelegationAgentRef | null;
+}
+
+export interface CreateDelegationGrantInput {
+  calleeSlug: string;
+  identityMode?: DelegationIdentityMode;
+  requestReason?: string;
+}

--- a/apps/dashboard/src/services/claw/clawMcpService.ts
+++ b/apps/dashboard/src/services/claw/clawMcpService.ts
@@ -125,11 +125,22 @@ export function deleteMcpConnection(userId: string, connectionId: string): Promi
  * than creating a credential-less connection that would sit permanently
  * unhealthy.
  */
-export function mcpRequiresCredentials(server: McpServer): boolean {
+export function mcpRequiresCredentials(
+  server: McpServer,
+  /**
+   * Fields resolved from the server-side registry (useMcpCredentialFields).
+   * Pass these whenever they are available: `mcp_servers.credentialForm` is
+   * nullable and unset in some environments for connectors whose fields live
+   * only in code, and deciding from the columns alone then skips the form and
+   * posts an empty credential bag.
+   */
+  resolvedFields?: readonly CredentialField[],
+): boolean {
   if (server.oauth) return false;
   if (server.type === 'google' || server.type === 'microsoft' || server.type === 'xyne-spaces') {
     return false;
   }
+  if (resolvedFields) return resolvedFields.length > 0;
   const hasFormFields = (server.credentialForm?.fields?.length ?? 0) > 0;
   const hasSchema = !!server.credentialSchema && Object.keys(server.credentialSchema).length > 0;
   return hasFormFields || hasSchema;

--- a/apps/dashboard/src/services/claw/clawMcpService.ts
+++ b/apps/dashboard/src/services/claw/clawMcpService.ts
@@ -5,6 +5,7 @@ import type {
   UserConnection,
 } from './clawMcpTypes';
 import { clawApiRequest } from './clawRequest';
+import { currentOAuthReturnTo } from '../../routes/AIScreen/library/shared/pickers/mcp/oauthReturnTo';
 
 /** All registered MCP servers/connectors (the catalog). */
 export function listMcpServers(): Promise<McpServer[]> {
@@ -48,7 +49,7 @@ export async function deleteAgentMcpConnection(
 export async function startMcpOAuth(userId: string, serverType: string): Promise<string> {
   const data = await clawApiRequest<{ authUrl: string }>(
     `/users/${encodeURIComponent(userId)}/oauth/${encodeURIComponent(serverType)}/authorize`,
-    { method: 'POST', body: JSON.stringify({}), userId },
+    { method: 'POST', body: JSON.stringify({ returnTo: currentOAuthReturnTo() }), userId },
   );
   return data.authUrl;
 }

--- a/apps/dashboard/src/services/claw/clawSettingsTypes.ts
+++ b/apps/dashboard/src/services/claw/clawSettingsTypes.ts
@@ -1,4 +1,4 @@
-export type ProviderId = 'copilot' | 'claude' | 'codex';
+export type ProviderId = 'copilot' | 'claude' | 'codex' | 'openrouter' | 'litellm';
 
 export type AuthType = 'api_key' | 'oauth_token';
 

--- a/apps/dashboard/src/services/claw/clawToolsTypes.ts
+++ b/apps/dashboard/src/services/claw/clawToolsTypes.ts
@@ -57,6 +57,15 @@ export interface ToolboxSelection {
   gateway?: string[];
 }
 
+/**
+ * An agent's toolbox plus the other agents it may delegate to. Kept separate
+ * from ToolboxSelection because subagents and the subagent wizard share that
+ * type and have no notion of calling another agent.
+ */
+export interface AgentToolboxSelection extends Required<ToolboxSelection> {
+  callableAgents: string[];
+}
+
 /** A research-agent product or repository option (id + display name). */
 export interface ResearchAgentOption {
   id: string;

--- a/apps/dashboard/src/services/claw/modelProviderConfig.ts
+++ b/apps/dashboard/src/services/claw/modelProviderConfig.ts
@@ -5,7 +5,14 @@
 // updateAgent(slug, { config }); only non-model keys (tools, behaviour) are left
 // untouched on save.
 
-export const HOSTED_PROVIDERS = ['codex', 'claude', 'copilot', 'openrouter', 'spaces'] as const;
+export const HOSTED_PROVIDERS = [
+  'codex',
+  'claude',
+  'copilot',
+  'openrouter',
+  'litellm',
+  'spaces',
+] as const;
 
 export const LOCAL_HARNESS_PROVIDERS = ['claude-code', 'codex-cli'] as const;
 export type LocalHarnessProviderKey = (typeof LOCAL_HARNESS_PROVIDERS)[number];
@@ -25,6 +32,7 @@ export const PROVIDER_DISPLAY: Record<string, string> = {
   claude: 'Anthropic Claude',
   codex: 'OpenAI Codex',
   openrouter: 'OpenRouter',
+  litellm: 'LiteLLM (own key)',
   'claude-code': 'Claude Code (this device)',
   'codex-cli': 'Codex CLI (this device)',
 };

--- a/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
@@ -5,6 +5,7 @@ import { CONFIG } from "../config.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "./oauth-state.js";
 import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
+import { oauthLimiter } from "../middleware/rate-limiters.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -125,7 +126,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
   const router = Router();
   router.use("/:userId", pinUserIdParam);
 
-  router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req: Request<{ userId: string }>, res: Response) => {
+  router.post(`/:userId/oauth/${type}/authorize`, oauthLimiter, asyncHandler(async (req: Request<{ userId: string }>, res: Response) => {
     const { userId } = req.params;
     const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 

--- a/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
@@ -4,6 +4,7 @@ import { encrypt } from "../crypto.js";
 import { CONFIG } from "../config.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "./oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -126,7 +127,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
 
   router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req: Request<{ userId: string }>, res: Response) => {
     const { userId } = req.params;
-    const { redirectUri } = req.body as { redirectUri?: string };
+    const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 
     const callbackUri = redirectUri ?? `${process.env["AUTH_SERVICE_URL"] ?? "http://localhost:3003"}/claw/api/v1/${type}/callback`;
 
@@ -138,7 +139,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
     url.searchParams.set("response_type", "code");
     url.searchParams.set("scope", config.scope);
     for (const [k, v] of Object.entries(config.extraAuthParams ?? {})) url.searchParams.set(k, v);
-    url.searchParams.set("state", signOAuthState(userId));
+    url.searchParams.set("state", signOAuthState(userId, { returnTo: resolveOAuthReturn(returnTo) }));
 
     ok(res, { authUrl: url.toString() });
   }));
@@ -161,29 +162,34 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
   const callbackRouter = Router();
 
   callbackRouter.get(`/${type}/callback`, async (req: Request, res: Response) => {
-    const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+    // Stays the default until the state is verified below: an unverified state
+    // must never steer the redirect.
+    let frontendUrl = defaultOAuthReturn();
 
     try {
       const { code, state, error: oauthError } = req.query as { code?: string; state?: string; error?: string };
 
       if (oauthError) {
         log.error(`[${type}-oauth] OAuth error: ${oauthError}`);
-        res.redirect(`${frontendUrl}?${type}_error=${encodeURIComponent(oauthError)}`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, oauthError));
         return;
       }
 
       if (!code || !state) {
-        res.redirect(`${frontendUrl}?${type}_error=missing_code_or_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "missing_code_or_state"));
         return;
       }
 
       let userId: string;
       try {
-        userId = verifyOAuthState(state).userId;
+        const verified = verifyOAuthState(state);
+        userId = verified.userId;
+        // Signed, so this is the origin that actually started the flow.
+        frontendUrl = resolveOAuthReturn(verified.extra?.["returnTo"]);
       } catch (err) {
         const reason = err instanceof OAuthStateError ? err.reason : "malformed";
         log.error(`[${type}-oauth] state ${reason}`);
-        res.redirect(`${frontendUrl}?${type}_error=invalid_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "invalid_state"));
         return;
       }
 
@@ -193,7 +199,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
       try {
         creds = await exchangeCode(code, redirectUri);
       } catch {
-        res.redirect(`${frontendUrl}?${type}_error=token_exchange_failed`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "token_exchange_failed"));
         return;
       }
 
@@ -203,7 +209,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
         const user = await prisma.user.findUnique({ where: { id: userId } });
         if (!user) {
           log.error(`[${type}-oauth] User not found: ${userId}`);
-          res.redirect(`${frontendUrl}?${type}_error=user_not_found`);
+          res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "user_not_found"));
           return;
         }
       }
@@ -211,10 +217,10 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
       await storeTokens(userId, creds);
 
       log.info(`[${type}-oauth] Stored ${label} credentials for user ${userId} via browser callback`);
-      res.redirect(`${frontendUrl}?${type}_connected=true`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_connected`, "true"));
     } catch (err) {
       log.error(`[${type}-oauth] browser callback error:`, err);
-      res.redirect(`${frontendUrl}?${type}_error=internal_error`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "internal_error"));
     }
   });
 

--- a/apps/xyne-claw-auth/backend/src/lib/connector-availability.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-availability.ts
@@ -28,6 +28,34 @@ export async function availableServerIds(
   return new Set([...personal.map((c) => c.mcpServerId), ...shared.map((s) => s.id)]);
 }
 
+export interface ConnectorAvailability {
+  personal: Set<string>;
+  org: Set<string>;
+}
+
+export async function availabilityForServerIds(
+  userId: string,
+  serverIds: string[],
+): Promise<ConnectorAvailability> {
+  if (serverIds.length === 0) return { personal: new Set(), org: new Set() };
+
+  const [personal, shared] = await Promise.all([
+    prisma.userMcpConnection.findMany({
+      where: { userId, mcpServerId: { in: serverIds } },
+      select: { mcpServerId: true },
+    }),
+    prisma.mcpServer.findMany({
+      where: { id: { in: serverIds }, ...GLOBAL_FALLBACK_WHERE },
+      select: { id: true },
+    }),
+  ]);
+
+  return {
+    personal: new Set(personal.map((c) => c.mcpServerId)),
+    org: new Set(shared.map((s) => s.id)),
+  };
+}
+
 export async function availableServerTypes(
   userId: string,
   serverTypes: string[],

--- a/apps/xyne-claw-auth/backend/src/lib/connector-hints.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-hints.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "vitest";
+import {
+  connectorTypesFromText,
+  connectorTypesUserAskedFor,
+  wantsConnectorRoster,
+} from "./connector-hints.js";
+
+test("wantsConnectorRoster catches browse phrasings the model used to own", () => {
+  expect(wantsConnectorRoster("list down all the connectors")).toBe(true);
+  expect(wantsConnectorRoster("what connectors are available")).toBe(true);
+  expect(wantsConnectorRoster("show me all mcps")).toBe(true);
+  expect(wantsConnectorRoster("which integrations do you support")).toBe(true);
+});
+
+test("wantsConnectorRoster stays false when a specific connector is named", () => {
+  expect(wantsConnectorRoster("show me the google connector")).toBe(false);
+  expect(wantsConnectorRoster("connect the notion integration")).toBe(false);
+});
+
+test("wantsConnectorRoster stays false for ordinary tasks", () => {
+  expect(wantsConnectorRoster("summarize this doc for me")).toBe(false);
+  expect(wantsConnectorRoster("")).toBe(false);
+});
+
+test("connectors added to the hint table are inferrable by name and domain", () => {
+  expect(connectorTypesFromText("read this article from reddit", { includeKeywords: true })).toContain("reddit");
+  expect(connectorTypesFromText("https://www.reddit.com/r/programming/comments/x", {})).toContain("reddit");
+  expect(connectorTypesFromText("check this sentry issue", { includeKeywords: true })).toContain("sentry");
+  expect(connectorTypesFromText("is jenkins failing", { includeKeywords: true })).toContain("jenkins");
+});
+
+test("naming a connector still reads as an explicit ask, not a roster", () => {
+  expect(connectorTypesUserAskedFor("connect google")).toContain("google");
+  expect(connectorTypesUserAskedFor("show me the google connector")).toContain("google");
+  expect(connectorTypesUserAskedFor("summarize this google doc")).toEqual([]);
+});

--- a/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
@@ -65,6 +65,26 @@ export const CONNECTOR_HINTS: readonly ConnectorHint[] = [
   { serverType: "mixpanel", domains: ["mixpanel.com"], keywords: ["mixpanel"] },
   { serverType: "bigquery", keywords: ["bigquery"] },
   { serverType: "databricks", domains: ["databricks.com"], keywords: ["databricks"] },
+  { serverType: "reddit", domains: ["reddit.com"], keywords: ["reddit"] },
+  { serverType: "sentry", domains: ["sentry.io"], keywords: ["sentry"] },
+  { serverType: "twitter", domains: ["twitter.com", "x.com"], keywords: ["twitter", "tweet"] },
+  { serverType: "mongodb", domains: ["mongodb.com"], keywords: ["mongodb", "mongo"] },
+  { serverType: "clickhouse", domains: ["clickhouse.com"], keywords: ["clickhouse"] },
+  { serverType: "miro", domains: ["miro.com"], keywords: ["miro"] },
+  { serverType: "calendly", domains: ["calendly.com"], keywords: ["calendly"] },
+  { serverType: "docusign", domains: ["docusign.com", "docusign.net"], keywords: ["docusign"] },
+  { serverType: "egnyte", domains: ["egnyte.com"], keywords: ["egnyte"] },
+  { serverType: "excalidraw", domains: ["excalidraw.com"], keywords: ["excalidraw"] },
+  { serverType: "honeycomb", domains: ["honeycomb.io"], keywords: ["honeycomb"] },
+  { serverType: "customerio", domains: ["customer.io"], keywords: ["customer.io", "customerio"] },
+  { serverType: "attio", domains: ["attio.com"], keywords: ["attio"] },
+  { serverType: "mailerlite", domains: ["mailerlite.com"], keywords: ["mailerlite"] },
+  { serverType: "jotform", domains: ["jotform.com"], keywords: ["jotform"] },
+  { serverType: "webflow", domains: ["webflow.com"], keywords: ["webflow"] },
+  { serverType: "wix", domains: ["wix.com"], keywords: ["wix"] },
+  { serverType: "jenkins", keywords: ["jenkins"] },
+  { serverType: "kibana", keywords: ["kibana"] },
+  { serverType: "rapidapi-linkedin", domains: ["linkedin.com"], keywords: ["linkedin"] },
 ];
 
 /** Finds http(s) URLs; the host itself is then parsed, never regex-matched. */
@@ -182,6 +202,18 @@ const SHOW_CONNECTOR_INTENT =
  * report this: it has an incentive to claim explicit intent so its card is
  * shown, and has been observed doing so for plain task requests.
  */
+const ROSTER_INTENT =
+  /\b(show|see|view|open|display|list|find|browse|bring up|pull up|what|which|any)\b[^.?!\n]{0,60}\b(connector|connectors|mcp|mcps|integration|integrations)\b/i;
+
+export function wantsConnectorRoster(text: string): boolean {
+  if (!text.trim()) return false;
+  if (!ROSTER_INTENT.test(text)) return false;
+  return connectorTypesFromText(text, {
+    includeKeywords: true,
+    includeConnectKeywords: true,
+  }).length === 0;
+}
+
 export function connectorTypesUserAskedFor(text: string): string[] {
   if (!text.trim()) return [];
   if (!CONNECT_INTENT.test(text) && !SHOW_CONNECTOR_INTENT.test(text)) return [];

--- a/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
@@ -32,6 +32,7 @@ export interface ConnectorHint {
   domains?: readonly string[];
   /** Whole-word prose signals, lowercase. */
   keywords?: readonly string[];
+  connectKeywords?: readonly string[];
 }
 
 export const CONNECTOR_HINTS: readonly ConnectorHint[] = [
@@ -41,11 +42,13 @@ export const CONNECTOR_HINTS: readonly ConnectorHint[] = [
     serverType: "google",
     domains: ["docs.google.com", "drive.google.com", "sheets.google.com", "mail.google.com"],
     keywords: ["gmail", "google doc", "google docs", "google drive", "google sheet", "google sheets", "google calendar", "google meet"],
+    connectKeywords: ["google", "google workspace"],
   },
   {
     serverType: "microsoft",
     domains: ["outlook.com", "outlook.office.com", "sharepoint.com"],
     keywords: ["onedrive", "outlook", "teams", "sharepoint"],
+    connectKeywords: ["microsoft", "microsoft 365", "office 365"],
   },
   { serverType: "slack", domains: ["slack.com"], keywords: ["slack"] },
   { serverType: "notion", domains: ["notion.so"], keywords: ["notion"] },
@@ -121,6 +124,7 @@ function keywordIndex(text: string, keyword: string): number {
 /** Connector types the text implies, in the order they first appear. */
 export interface ConnectorMatchOptions {
   includeKeywords?: boolean;
+  includeConnectKeywords?: boolean;
 }
 
 export function connectorTypesFromText(
@@ -144,11 +148,13 @@ export function connectorTypesFromText(
       }
     }
 
-    if (options.includeKeywords) {
-      for (const keyword of hint.keywords ?? []) {
-        const at = keywordIndex(prose, keyword);
-        if (at >= 0 && (earliest === -1 || at < earliest)) earliest = at;
-      }
+    const prosePatterns = [
+      ...(options.includeKeywords ? (hint.keywords ?? []) : []),
+      ...(options.includeConnectKeywords ? (hint.connectKeywords ?? []) : []),
+    ];
+    for (const keyword of prosePatterns) {
+      const at = keywordIndex(prose, keyword);
+      if (at >= 0 && (earliest === -1 || at < earliest)) earliest = at;
     }
 
     if (earliest >= 0) hits.push({ serverType: hint.serverType, at: earliest });
@@ -167,13 +173,17 @@ export function connectorTypesFromText(
 const CONNECT_INTENT =
   /\b(re)?connect(ed|ing|ion|ions)?\b|\bauthori[sz]e\b|\bintegrate\b|\bset ?up\b|\bsign in\b|\blog in\b|\bhook up\b/i;
 
+const SHOW_CONNECTOR_INTENT =
+  /\b(show|see|view|open|display|list|find|bring up|pull up)\b[^.?!\n]{0,60}\b(connector|connectors|mcp|mcps|integration|integrations)\b/i;
+
 /**
- * Connector types the HUMAN explicitly asked to connect, read from their own
- * message. The model cannot be trusted to report this: it has an incentive to
- * claim explicit intent so its card is shown, and has been observed doing so
- * for plain task requests.
+ * Connector types the HUMAN explicitly asked for, read from their own message —
+ * either to connect one or to be shown one. The model cannot be trusted to
+ * report this: it has an incentive to claim explicit intent so its card is
+ * shown, and has been observed doing so for plain task requests.
  */
-export function connectorTypesUserAskedToConnect(text: string): string[] {
-  if (!text.trim() || !CONNECT_INTENT.test(text)) return [];
-  return connectorTypesFromText(text, { includeKeywords: true });
+export function connectorTypesUserAskedFor(text: string): string[] {
+  if (!text.trim()) return [];
+  if (!CONNECT_INTENT.test(text) && !SHOW_CONNECTOR_INTENT.test(text)) return [];
+  return connectorTypesFromText(text, { includeKeywords: true, includeConnectKeywords: true });
 }

--- a/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
@@ -7,6 +7,7 @@ import { syncToolsForServer } from "../tool-sync.js";
 import { evictSession } from "../mcp/runner.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState } from "./oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -52,6 +53,8 @@ interface StatePayload {
   clientSecret?: string | undefined;
   codeVerifier: string;
   redirectUri: string;
+  /** Where the UI that started this flow wants the browser sent back to. */
+  returnTo?: string;
 }
 
 export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider {
@@ -199,7 +202,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
 
   router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req, res) => {
     const { userId } = req.params as { userId: string };
-    const { redirectUri, scope } = req.body as { redirectUri?: string; scope?: string };
+    const { redirectUri, scope, returnTo } = req.body as { redirectUri?: string; scope?: string; returnTo?: string };
 
     const callbackUri =
       redirectUri ??
@@ -210,7 +213,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = deriveCodeChallenge(codeVerifier);
 
-    const state = encodeState({ userId, clientId, ...(confidential ? { clientSecret } : {}), codeVerifier, redirectUri: callbackUri });
+    const state = encodeState({ userId, clientId, ...(confidential ? { clientSecret } : {}), codeVerifier, redirectUri: callbackUri, returnTo: resolveOAuthReturn(returnTo) });
 
     const url = new URL(authUrl);
     url.searchParams.set("client_id", clientId);
@@ -268,19 +271,21 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
   const callbackRouter = Router();
 
   callbackRouter.get(`/${type}/callback`, async (req: Request, res: Response) => {
-    const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+    // Default until the state verifies below — an unverified state must never
+    // steer the redirect.
+    let frontendUrl = defaultOAuthReturn();
 
     try {
       const { code, state, error: oauthError } = req.query as { code?: string; state?: string; error?: string };
 
       if (oauthError) {
         log.error(`[${type}-oauth] OAuth error: ${oauthError}`);
-        res.redirect(`${frontendUrl}?${type}_error=${encodeURIComponent(oauthError)}`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, oauthError));
         return;
       }
 
       if (!code || !state) {
-        res.redirect(`${frontendUrl}?${type}_error=missing_code_or_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "missing_code_or_state"));
         return;
       }
 
@@ -288,11 +293,12 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
       try {
         statePayload = decodeState(state);
       } catch {
-        res.redirect(`${frontendUrl}?${type}_error=invalid_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "invalid_state"));
         return;
       }
 
       const { userId, clientId, clientSecret, codeVerifier, redirectUri } = statePayload;
+      frontendUrl = resolveOAuthReturn(statePayload.returnTo);
 
       const tokenRes = await fetch(tokenUrl, {
         method: "POST",
@@ -303,7 +309,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
       if (!tokenRes.ok) {
         const text = await tokenRes.text();
         log.error(`[${type}-oauth] Browser callback token exchange failed: ${tokenRes.status} ${text}`);
-        res.redirect(`${frontendUrl}?${type}_error=token_exchange_failed`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "token_exchange_failed"));
         return;
       }
 
@@ -312,17 +318,17 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
       const user = await prisma.user.findUnique({ where: { id: userId } });
       if (!user) {
         log.error(`[${type}-oauth] User not found: ${userId}`);
-        res.redirect(`${frontendUrl}?${type}_error=user_not_found`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "user_not_found"));
         return;
       }
 
       await storeTokens(userId, clientId, clientSecret, tokens.access_token, tokens.refresh_token, tokens.expires_in);
 
       log.info(`[${type}-oauth] Stored ${label} credentials for user ${userId} via browser callback`);
-      res.redirect(`${frontendUrl}?${type}_connected=true`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_connected`, "true"));
     } catch (err) {
       log.error(`[${type}-oauth] browser callback error:`, err);
-      res.redirect(`${frontendUrl}?${type}_error=internal_error`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "internal_error"));
     }
   });
 

--- a/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
@@ -8,6 +8,7 @@ import { evictSession } from "../mcp/runner.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState } from "./oauth-state.js";
 import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
+import { oauthLimiter } from "../middleware/rate-limiters.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -200,7 +201,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
   const router = Router();
   router.use("/:userId", pinUserIdParam);
 
-  router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req, res) => {
+  router.post(`/:userId/oauth/${type}/authorize`, oauthLimiter, asyncHandler(async (req, res) => {
     const { userId } = req.params as { userId: string };
     const { redirectUri, scope, returnTo } = req.body as { redirectUri?: string; scope?: string; returnTo?: string };
 

--- a/apps/xyne-claw-auth/backend/src/lib/oauth-return.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/oauth-return.ts
@@ -1,0 +1,100 @@
+/**
+ * Post-OAuth return targets.
+ *
+ * Every OAuth callback used to redirect to a single global FRONTEND_URL (the
+ * claw SPA), so a flow started from Spaces finished on claw's home page and the
+ * user lost their place. The starting UI can now pass `returnTo`; the callback
+ * sends the browser back there instead.
+ *
+ * The value is a HINT, never trusted: it arrives from the browser and is acted
+ * on immediately after a credential is minted, so an unvalidated one is an open
+ * redirect handing an attacker the "connected" landing. Anything that isn't an
+ * allowed origin silently falls back to the old FRONTEND_URL behaviour.
+ */
+
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("oauth-return");
+
+function originOf(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Origins a post-OAuth redirect may target. */
+function allowedOrigins(): Set<string> {
+  const configured = (process.env["OAUTH_RETURN_ORIGINS"] ?? "")
+    .split(",")
+    .map((entry) => originOf(entry.trim()))
+    .filter((entry): entry is string => !!entry);
+
+  return new Set(
+    [
+      originOf(CONFIG.frontendUrl),
+      originOf(CONFIG.spacesAppUrl),
+      ...configured,
+    ].filter((entry): entry is string => !!entry),
+  );
+}
+
+/**
+ * Dev convenience: the local dashboard (:5173) is not any configured origin —
+ * SPACES_APP_URL points at the API (:3001) — so a localhost return would fall
+ * back to claw and the flow would look broken on every developer's machine.
+ * Production stays strictly on the allowlist.
+ */
+function isDevLoopback(origin: string): boolean {
+  if (process.env["NODE_ENV"] === "production") return false;
+  return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+}
+
+/** The default target — exactly what every callback did before `returnTo`. */
+export function defaultOAuthReturn(): string {
+  return process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+}
+
+/**
+ * Validate a client-supplied `returnTo`. Returns the default whenever it is
+ * absent, unparseable, or points somewhere we don't serve.
+ */
+export function resolveOAuthReturn(candidate: unknown): string {
+  if (typeof candidate !== "string" || candidate.trim().length === 0) {
+    return defaultOAuthReturn();
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate.trim());
+  } catch {
+    log.warn("[oauth-return] ignoring unparseable returnTo");
+    return defaultOAuthReturn();
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    log.warn(`[oauth-return] ignoring returnTo with protocol ${parsed.protocol}`);
+    return defaultOAuthReturn();
+  }
+  if (!allowedOrigins().has(parsed.origin) && !isDevLoopback(parsed.origin)) {
+    log.warn(`[oauth-return] ignoring returnTo outside the allowlist: ${parsed.origin}`);
+    return defaultOAuthReturn();
+  }
+  return parsed.toString();
+}
+
+/**
+ * Append the connected/error marker the UIs poll for. Uses URL rather than
+ * string concatenation because a returnTo legitimately carries its own query
+ * (e.g. /ai/library?tab=agents) and `?x=y` would corrupt it.
+ */
+export function withOAuthResult(base: string, key: string, value: string): string {
+  try {
+    const url = new URL(base);
+    url.searchParams.set(key, value);
+    return url.toString();
+  } catch {
+    return `${base}?${key}=${encodeURIComponent(value)}`;
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/main.ts
+++ b/apps/xyne-claw-auth/backend/src/main.ts
@@ -11,6 +11,7 @@ import { errorMiddleware } from "./lib/http.js";
 import { serversRouter } from "./routes/servers.js";
 import { connectionsRouter } from "./routes/connections.js";
 import { mcpRouter } from "./routes/mcp.js";
+import { connectorsInternalRouter } from "./routes/connectors-internal.js";
 import { awakeningRouter } from "./routes/awakening.js";
 import { ensureTickScheduler, closeAwakeningQueues } from "./queue/awakening-queue.js";
 import { initAwakeningTickWorker, closeAwakeningTickWorker } from "./queue/awakening-tick-worker.js";
@@ -233,6 +234,7 @@ app.use(`${BASE}/internal/artifact-apps`, requireStrictS2S, artifactAppsInternal
 app.use(`${BASE}/error-pipeline`, errorPipelineIngestRouter); // Grafana webhook ingest (JWT-authed inside)
 app.use(`${BASE}/internal/error-pipeline`, requireStrictS2S, errorPipelineInternalRouter); // run-result callback from xyne-claw (S2S only)
 app.use(`${BASE}/internal/tts`, requireStrictS2S, ttsRouter);
+app.use(`${BASE}/internal/connectors`, requireStrictS2S, connectorsInternalRouter); // connector availability lookup for xyne-claw (S2S only)
 // Generic live OAuth-token read for every connector — GET /users/:userId/oauth/:provider/token.
 // Mounted before the per-provider routers (which now only serve authorize/callback)
 // so it owns the `/token` path. Same requireAuth guard; the handler additionally

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -3926,6 +3926,129 @@ router.post(
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Agent-level GitHub Copilot device-code login. Mirrors the user-level flow in
+// settings.ts, but stores the token as an AGENT credential so every run of this
+// agent uses it, rather than binding it to the person who signed in.
+//
+// Note this spends the signing-in user's Copilot seat on behalf of everyone who
+// runs the agent — unlike Claude/ChatGPT team accounts, Copilot is licensed per
+// user. Owner-or-admin only, and the acting user is recorded on the credential.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AGENT_COPILOT_DEVICE_PREFIX = "gh-device-agent:";
+
+router.post(
+  "/:slug/provider-credentials/copilot/github-login",
+  requireAgentOwnerOrAdmin,
+  async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const agent = req.agentContext!.agent;
+      const ghRes = await fetch(GITHUB_DEVICE_CODE_URL, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: new URLSearchParams({ client_id: GITHUB_CLIENT_ID, scope: "read:user" }),
+      });
+      if (!ghRes.ok) {
+        const text = await ghRes.text().catch(() => "");
+        res.status(502).json({ success: false, error: `GitHub error: ${text.slice(0, 200)}` });
+        return;
+      }
+      const data = (await ghRes.json()) as {
+        device_code: string;
+        user_code: string;
+        verification_uri: string;
+        expires_in: number;
+        interval: number;
+      };
+      const redis = redisService.getConnection();
+      await redis.set(
+        `${AGENT_COPILOT_DEVICE_PREFIX}${agent.id}`,
+        JSON.stringify({ device_code: data.device_code, interval: data.interval }),
+        "EX",
+        DEVICE_CODE_TTL,
+      );
+      res.json({
+        success: true,
+        data: {
+          userCode: data.user_code,
+          verificationUri: data.verification_uri,
+          expiresIn: data.expires_in,
+          interval: data.interval,
+        },
+      });
+    } catch (err) {
+      log.error("[agents] copilot/github-login error:", err);
+      res.status(500).json({ success: false, error: "Failed to initiate GitHub login" });
+    }
+  },
+);
+
+router.post(
+  "/:slug/provider-credentials/copilot/github-poll",
+  requireAgentOwnerOrAdmin,
+  async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const agent = req.agentContext!.agent;
+      const requesterId = getRequesterId(req);
+      const key = `${AGENT_COPILOT_DEVICE_PREFIX}${agent.id}`;
+      const redis = redisService.getConnection();
+      const raw = await redis.get(key);
+      if (!raw) {
+        res.status(400).json({ success: false, error: "No pending login — start again" });
+        return;
+      }
+      const { device_code } = JSON.parse(raw) as { device_code: string };
+
+      const ghRes = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: new URLSearchParams({
+          client_id: GITHUB_CLIENT_ID,
+          device_code,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      });
+      const data = (await ghRes.json()) as {
+        access_token?: string;
+        error?: string;
+        error_description?: string;
+      };
+
+      if (data.access_token) {
+        const encrypted = encrypt(data.access_token, CONFIG.encryptionKey);
+        await agentProviderCredentialsRepository.upsert(agent.id, "copilot", {
+          encryptedKey: encrypted.ciphertext,
+          iv: encrypted.iv,
+          authTag: encrypted.authTag,
+          authType: "oauth_token",
+          baseUrl: "https://api.githubcopilot.com",
+          ...(requesterId ? { createdByUserId: requesterId } : {}),
+        });
+        await redis.del(key);
+        res.json({ success: true, data: { status: "approved" } });
+        return;
+      }
+      if (data.error === "authorization_pending") {
+        res.json({ success: true, data: { status: "pending" } });
+        return;
+      }
+      if (data.error === "slow_down") {
+        res.json({ success: true, data: { status: "slow_down" } });
+        return;
+      }
+      await redis.del(key);
+      res.status(400).json({
+        success: false,
+        error: data.error_description ?? data.error ?? "Authorization failed",
+      });
+    } catch (err) {
+      log.error("[agents] copilot/github-poll error:", err);
+      res.status(500).json({ success: false, error: "GitHub login failed" });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Agent-level Codex model list — mirror of `/settings/codex/models` but reads
 // the agent-scoped credential. ChatGPT OAuth tokens cannot hit OpenAI's
 // `/v1/models` (missing `api.model.read` scope, returns 403); Codex CLI works

--- a/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from "express";
 import { availableServerTypesSafe } from "../lib/connector-availability.js";
+import { prisma } from "../db.js";
 import { createLogger } from "../logger.js";
 
 const log = createLogger("connectors-internal");
@@ -34,5 +35,26 @@ connectorsInternalRouter.post("/available", async (req: Request, res: Response) 
     return;
   }
 
-  res.json({ success: true, connected: serverTypes.filter((t) => available.has(t)), known: true });
+  let existing: string[] = [];
+  try {
+    const rows = await prisma.mcpServer.findMany({
+      where: { type: { in: serverTypes }, enabled: true },
+      select: { type: true },
+    });
+    existing = rows.map((r) => r.type);
+  } catch (err) {
+    log.warn(
+      `[connectors-internal] catalog lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    res.json({ success: true, connected: serverTypes.filter((t) => available.has(t)), known: true });
+    return;
+  }
+
+  res.json({
+    success: true,
+    connected: serverTypes.filter((t) => available.has(t)),
+    existing: serverTypes.filter((t) => existing.includes(t)),
+    catalogKnown: true,
+    known: true,
+  });
 });

--- a/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
@@ -1,0 +1,38 @@
+import { Router, type Request, type Response } from "express";
+import { availableServerTypesSafe } from "../lib/connector-availability.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("connectors-internal");
+
+const MAX_TYPES = 12;
+
+export const connectorsInternalRouter = Router();
+
+connectorsInternalRouter.post("/available", async (req: Request, res: Response) => {
+  const body = (req.body ?? {}) as { userId?: unknown; serverTypes?: unknown };
+  const userId = typeof body.userId === "string" ? body.userId.trim() : "";
+  const serverTypes = Array.isArray(body.serverTypes)
+    ? [
+        ...new Set(
+          body.serverTypes
+            .filter((t): t is string => typeof t === "string")
+            .map((t) => t.trim().toLowerCase())
+            .filter((t) => t.length > 0),
+        ),
+      ].slice(0, MAX_TYPES)
+    : [];
+
+  if (!userId || serverTypes.length === 0) {
+    res.json({ success: true, connected: [], known: false });
+    return;
+  }
+
+  const available = await availableServerTypesSafe(userId, serverTypes);
+  if (!available) {
+    log.warn(`[connectors-internal] availability unknown for user ${userId}`);
+    res.json({ success: true, connected: [], known: false });
+    return;
+  }
+
+  res.json({ success: true, connected: serverTypes.filter((t) => available.has(t)), known: true });
+});

--- a/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
@@ -33,6 +33,7 @@ import {
   getDocuSignClientCredentials,
 } from "../lib/docusign-config.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
 
 import { createLogger } from "../logger.js";
@@ -157,7 +158,7 @@ export const docusignOAuthProvider: OAuthTokenProvider = {
  */
 router.post("/:userId/oauth/docusign/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
-  const { redirectUri } = req.body as { redirectUri?: string };
+  const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 
   const callbackUri = redirectUri ?? defaultCallbackUri();
 
@@ -168,7 +169,7 @@ router.post("/:userId/oauth/docusign/authorize", asyncHandler(async (req: Reques
   authUrl.searchParams.set("redirect_uri", callbackUri);
   authUrl.searchParams.set("response_type", "code");
   authUrl.searchParams.set("scope", DOCUSIGN_SCOPES);
-  authUrl.searchParams.set("state", signOAuthState(userId, { redirectUri: callbackUri }));
+  authUrl.searchParams.set("state", signOAuthState(userId, { redirectUri: callbackUri, returnTo: resolveOAuthReturn(returnTo) }));
 
   ok(res, { authUrl: authUrl.toString() });
 }));
@@ -217,7 +218,9 @@ router.post("/:userId/oauth/docusign/callback", asyncHandler(async (req: Request
 export const docusignCallbackRouter = Router();
 
 docusignCallbackRouter.get("/docusign/callback", async (req: Request, res: Response) => {
-  const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+  // Default until the state verifies below — an unverified state must never
+  // steer the redirect.
+  let frontendUrl = defaultOAuthReturn();
 
   try {
     const { code, state, error: oauthError } = req.query as {
@@ -228,12 +231,12 @@ docusignCallbackRouter.get("/docusign/callback", async (req: Request, res: Respo
 
     if (oauthError) {
       log.error(`[docusign-oauth] OAuth error: ${oauthError}`);
-      res.redirect(`${frontendUrl}?docusign_error=${encodeURIComponent(oauthError)}`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", oauthError));
       return;
     }
 
     if (!code || !state) {
-      res.redirect(`${frontendUrl}?docusign_error=missing_code_or_state`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", "missing_code_or_state"));
       return;
     }
 
@@ -243,30 +246,31 @@ docusignCallbackRouter.get("/docusign/callback", async (req: Request, res: Respo
     } catch (err) {
       const reason = err instanceof OAuthStateError ? err.reason : "malformed";
       log.error(`[docusign-oauth] state ${reason}`);
-      res.redirect(`${frontendUrl}?docusign_error=invalid_state`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", "invalid_state"));
       return;
     }
 
     const userId = verified.userId;
+    frontendUrl = resolveOAuthReturn(verified.extra?.["returnTo"]);
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
       log.error(`[docusign-oauth] User not found: ${userId}`);
-      res.redirect(`${frontendUrl}?docusign_error=user_not_found`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", "user_not_found"));
       return;
     }
 
     const redirectUri = (verified.extra?.["redirectUri"] as string | undefined) ?? defaultCallbackUri();
     const result = await exchangeAndStore(userId, code, redirectUri);
     if (!result.ok) {
-      res.redirect(`${frontendUrl}?docusign_error=${encodeURIComponent(result.code)}`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", result.code));
       return;
     }
 
     log.info(`[docusign-oauth] Stored DocuSign credentials for user ${userId} (accountId: ${result.accountId})`);
-    res.redirect(`${frontendUrl}?docusign_connected=true`);
+    res.redirect(withOAuthResult(frontendUrl, "docusign_connected", "true"));
   } catch (err) {
     log.error("[docusign-oauth] browser callback error:", err);
-    res.redirect(`${frontendUrl}?docusign_error=internal_error`);
+    res.redirect(withOAuthResult(frontendUrl, "docusign_error", "internal_error"));
   }
 });
 

--- a/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
@@ -34,6 +34,7 @@ import {
 } from "../lib/docusign-config.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
 import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
+import { oauthLimiter } from "../middleware/rate-limiters.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
 
 import { createLogger } from "../logger.js";
@@ -156,7 +157,7 @@ export const docusignOAuthProvider: OAuthTokenProvider = {
  * POST /:userId/oauth/docusign/authorize
  * Returns the DocuSign consent URL with an HMAC-signed `state`.
  */
-router.post("/:userId/oauth/docusign/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
+router.post("/:userId/oauth/docusign/authorize", oauthLimiter, asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
   const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 

--- a/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
@@ -25,6 +25,7 @@ import { CONFIG } from "../config.js";
 import { syncToolsForServer } from "../tool-sync.js";
 import { evictSession } from "../mcp/runner.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "../lib/oauth-token-endpoint.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
@@ -150,7 +151,7 @@ export const egnyteOAuthProvider: OAuthTokenProvider = {
  */
 router.post("/:userId/oauth/egnyte/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
-  const { redirectUri } = req.body as { redirectUri?: string };
+  const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 
   const envDomain = process.env["EGNYTE_DOMAIN"];
   if (!envDomain || envDomain.trim().length === 0) {
@@ -167,7 +168,7 @@ router.post("/:userId/oauth/egnyte/authorize", asyncHandler(async (req: Request<
   const callbackUri = redirectUri ?? defaultCallbackUri();
 
   // Encode the domain into the signed state so the callback can use it.
-  const state = signOAuthState(userId, { domain: normalizedDomain, redirectUri: callbackUri });
+  const state = signOAuthState(userId, { domain: normalizedDomain, redirectUri: callbackUri, returnTo: resolveOAuthReturn(returnTo) });
 
   const authUrl = new URL(egnyteAuthUrl(normalizedDomain));
   authUrl.searchParams.set("client_id", clientId);
@@ -228,7 +229,9 @@ router.post("/:userId/oauth/egnyte/callback", asyncHandler(async (req: Request<{
 export const egnyteCallbackRouter = Router();
 
 egnyteCallbackRouter.get("/egnyte/callback", async (req: Request, res: Response) => {
-  const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+  // Default until the state verifies below — an unverified state must never
+  // steer the redirect.
+  let frontendUrl = defaultOAuthReturn();
 
   try {
     const { code, state, error: oauthError } = req.query as {
@@ -239,12 +242,12 @@ egnyteCallbackRouter.get("/egnyte/callback", async (req: Request, res: Response)
 
     if (oauthError) {
       log.error(`[egnyte-oauth] OAuth error: ${oauthError}`);
-      res.redirect(`${frontendUrl}?egnyte_error=${encodeURIComponent(oauthError)}`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", oauthError));
       return;
     }
 
     if (!code || !state) {
-      res.redirect(`${frontendUrl}?egnyte_error=missing_code_or_state`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "missing_code_or_state"));
       return;
     }
 
@@ -254,37 +257,38 @@ egnyteCallbackRouter.get("/egnyte/callback", async (req: Request, res: Response)
     } catch (err) {
       const reason = err instanceof OAuthStateError ? err.reason : "malformed";
       log.error(`[egnyte-oauth] state ${reason}`);
-      res.redirect(`${frontendUrl}?egnyte_error=invalid_state`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "invalid_state"));
       return;
     }
 
     const userId = verified.userId;
+    frontendUrl = resolveOAuthReturn(verified.extra?.["returnTo"]);
     const domain = verified.extra?.["domain"] as string | undefined;
     const redirectUri = (verified.extra?.["redirectUri"] as string | undefined) ?? defaultCallbackUri();
 
     if (!domain) {
-      res.redirect(`${frontendUrl}?egnyte_error=missing_domain_in_state`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "missing_domain_in_state"));
       return;
     }
 
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
       log.error(`[egnyte-oauth] User not found: ${userId}`);
-      res.redirect(`${frontendUrl}?egnyte_error=user_not_found`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "user_not_found"));
       return;
     }
 
     const result = await exchangeAndStore(userId, code, domain, redirectUri);
     if (!result.ok) {
-      res.redirect(`${frontendUrl}?egnyte_error=${encodeURIComponent(result.code)}`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", result.code));
       return;
     }
 
     log.info(`[egnyte-oauth] Stored Egnyte credentials for user ${userId} (domain: ${domain}.egnyte.com)`);
-    res.redirect(`${frontendUrl}?egnyte_connected=true`);
+    res.redirect(withOAuthResult(frontendUrl, "egnyte_connected", "true"));
   } catch (err) {
     log.error("[egnyte-oauth] browser callback error:", err);
-    res.redirect(`${frontendUrl}?egnyte_error=internal_error`);
+    res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "internal_error"));
   }
 });
 

--- a/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
@@ -26,6 +26,7 @@ import { syncToolsForServer } from "../tool-sync.js";
 import { evictSession } from "../mcp/runner.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
 import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
+import { oauthLimiter } from "../middleware/rate-limiters.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "../lib/oauth-token-endpoint.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
@@ -149,7 +150,7 @@ export const egnyteOAuthProvider: OAuthTokenProvider = {
  * Body: { domain: string, redirectUri?: string }
  * Returns the Egnyte consent URL with an HMAC-signed `state` that includes the domain.
  */
-router.post("/:userId/oauth/egnyte/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
+router.post("/:userId/oauth/egnyte/authorize", oauthLimiter, asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
   const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 

--- a/apps/xyne-claw-auth/backend/src/routes/servers.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/servers.ts
@@ -56,11 +56,11 @@ type ConnectorMeta = {
   mode?: string;
 };
 
-function parseConnectorMeta(value: unknown): ConnectorMeta {
+export function parseConnectorMeta(value: unknown): ConnectorMeta {
   return isRecord(value) ? (value as ConnectorMeta) : {};
 }
 
-function isVisibleToUser(meta: ConnectorMeta, requesterId?: string): boolean {
+export function isVisibleToUser(meta: ConnectorMeta, requesterId?: string): boolean {
   const scope = meta.scope ?? "global";
   if (scope === "global") return true;
   return Boolean(requesterId && meta.ownerUserId === requesterId);

--- a/apps/xyne-claw-auth/backend/src/routes/settings.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/settings.ts
@@ -23,7 +23,7 @@ const log = createLogger("settings");
 
 const router = Router();
 
-const VALID_PROVIDERS = new Set(["spaces", "copilot", "claude", "codex", "litellm"]);
+const VALID_PROVIDERS = new Set(["spaces", "copilot", "claude", "codex", "openrouter", "litellm"]);
 
 const GITHUB_CLIENT_ID = "Ov23li8tweQw6odWQebz";
 const GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code";

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -25,6 +25,7 @@ import {
   agentRequestRepository,
 } from "../repositories/index.js";
 import { buildAvailableToolsCatalog } from "./tools.js";
+import { isVisibleToUser, parseConnectorMeta } from "./servers.js";
 import {
   identityFromAgentRow,
   identityFromDraftSpec,
@@ -6146,17 +6147,20 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       // Resolve every requested type against the catalog. The model supplies
       // names only — descriptions and display names come from the row, and an
       // unknown type is dropped rather than rendered as an empty card.
-      const rows = listAll
+      const candidates = listAll
         ? await prisma.mcpServer.findMany({
             where: { enabled: true },
-            select: { id: true, type: true, name: true, description: true },
+            select: { id: true, type: true, name: true, description: true, connectorMeta: true },
             orderBy: { name: "asc" },
-            take: MCP_SUGGEST_ROSTER_SAMPLE,
           })
         : await prisma.mcpServer.findMany({
             where: { type: { in: pendingConnectorSuggestions.serverTypes }, enabled: true },
-            select: { id: true, type: true, name: true, description: true },
+            select: { id: true, type: true, name: true, description: true, connectorMeta: true },
           });
+      const visibleRows = candidates.filter((row) =>
+        isVisibleToUser(parseConnectorMeta(row.connectorMeta), ctx.senderId),
+      );
+      const rows = listAll ? visibleRows.slice(0, MCP_SUGGEST_ROSTER_SAMPLE) : visibleRows;
       const byType = new Map(rows.map((row) => [row.type, row]));
 
       const connectedIds = await availableServerIds(

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -129,7 +129,7 @@ import type { TwinDelivery, UiWidget } from "xyne-claw-shared";
 import { isAgentInvocableBy } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 import { tools as xyneSpacesTools } from "../mcp/servers/xyne-spaces-tools.js";
-import { connectorTypesFromText, connectorTypesUserAskedToConnect } from "../lib/connector-hints.js";
+import { connectorTypesFromText, connectorTypesUserAskedFor } from "../lib/connector-hints.js";
 import { availableServerIds } from "../lib/connector-availability.js";
 
 const clog = createLogger("webhook");
@@ -6121,10 +6121,9 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
   let inferredTypes: string[] = [];
   if (!payload.pendingConnectorSuggestions) {
     try {
-      inferredTypes = connectorTypesFromText(ctx.rootTask ?? ctx.task ?? "").slice(
-        0,
-        MCP_SUGGEST_INFERRED_MAX,
-      );
+      inferredTypes = connectorTypesFromText(ctx.rootTask ?? ctx.task ?? "", {
+        includeKeywords: true,
+      }).slice(0, MCP_SUGGEST_INFERRED_MAX);
     } catch (err) {
       log.warn("[mcp-suggest] connector inference failed (non-fatal)", {
         error: err instanceof Error ? err.message : String(err),
@@ -6180,7 +6179,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       // request, which is exactly how an already-usable connector slipped
       // through. The server owns this fact like every other on the card.
       const askedToConnect = new Set(
-        connectorTypesUserAskedToConnect(ctx.rootTask ?? ctx.task ?? ""),
+        connectorTypesUserAskedFor(ctx.rootTask ?? ctx.task ?? ""),
       );
 
       const connectors = ordered

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -130,8 +130,8 @@ import type { TwinDelivery, UiWidget } from "xyne-claw-shared";
 import { isAgentInvocableBy } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 import { tools as xyneSpacesTools } from "../mcp/servers/xyne-spaces-tools.js";
-import { connectorTypesFromText, connectorTypesUserAskedFor } from "../lib/connector-hints.js";
-import { availableServerIds } from "../lib/connector-availability.js";
+import { connectorTypesFromText, connectorTypesUserAskedFor, wantsConnectorRoster } from "../lib/connector-hints.js";
+import { availabilityForServerIds } from "../lib/connector-availability.js";
 
 const clog = createLogger("webhook");
 const SDLC_AGENT_TOOL_PROFILE = buildSdlcAgentToolProfile(
@@ -4776,6 +4776,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // Connector cards to post alongside the reply, so the user can connect
     // without leaving the conversation.
     pendingConnectorSuggestions?: PendingConnectorSuggestions;
+    blockedConnectors?: string[];
   };
 
   const sessionId = payload.sessionId ?? "";
@@ -6132,9 +6133,16 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     }
   }
 
+  const rosterAsked =
+    !payload.pendingConnectorSuggestions && wantsConnectorRoster(ctx.rootTask ?? ctx.task ?? "");
+
   const pendingConnectorSuggestions: PendingConnectorSuggestions | undefined =
     payload.pendingConnectorSuggestions ??
-    (inferredTypes.length > 0 ? { serverTypes: inferredTypes, inferred: true } : undefined);
+    (rosterAsked
+      ? { serverTypes: [], listAll: true, inferred: true }
+      : inferredTypes.length > 0
+        ? { serverTypes: inferredTypes, inferred: true }
+        : undefined);
   if (pendingConnectorSuggestions && agentCardDeliverable) {
     try {
       // Roster mode: the user asked what exists, so the SERVER picks the sample
@@ -6163,10 +6171,11 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       const rows = listAll ? visibleRows.slice(0, MCP_SUGGEST_ROSTER_SAMPLE) : visibleRows;
       const byType = new Map(rows.map((row) => [row.type, row]));
 
-      const connectedIds = await availableServerIds(
+      const availability = await availabilityForServerIds(
         ctx.senderId,
         rows.map((r) => r.id),
       );
+      const blockedTypes = new Set(payload.blockedConnectors ?? []);
 
       // Roster mode is already ordered by the query; otherwise preserve the
       // model's ordering, since it ranked them by relevance.
@@ -6192,12 +6201,17 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
         // exceptions, both genuine user intent: roster mode ("what exists?"),
         // and the user naming a connector they want to connect, where a personal
         // connection is a legitimate want even under an org credential.
-        .filter((row) => listAll || askedToConnect.has(row.type) || !connectedIds.has(row.id))
+        .filter((row) => {
+          if (listAll || askedToConnect.has(row.type)) return true;
+          if (availability.personal.has(row.id)) return false;
+          if (availability.org.has(row.id)) return blockedTypes.has(row.type);
+          return true;
+        })
         .map((row) => ({
           serverType: row.type,
           name: row.name,
           ...(row.description ? { description: row.description } : {}),
-          connected: connectedIds.has(row.id),
+          connected: availability.personal.has(row.id) || availability.org.has(row.id),
         }));
 
       if (connectors.length === 0) {

--- a/apps/xyne-claw-auth/frontend/src/v3/components/MCPPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/MCPPageV3.tsx
@@ -554,16 +554,35 @@ export function MCPPageV3({ userId }: Props) {
   // collect their credential fields via the AddConnectionDialog first. The raw
   // connect() would post empty credentials, which the backend rejects — and the
   // sidebar swallows the error, so the button appears to "do nothing".
-  const requiresCredentials = useCallback((s: McpServer) => {
-    if (s.oauth) return false;
-    if (s.type === "google" || s.type === "microsoft" || s.type === "xyne-spaces") return false;
-    const hasFormFields = (s.credentialForm?.fields?.length ?? 0) > 0;
-    const hasSchema = !!s.credentialSchema && Object.keys(s.credentialSchema).length > 0;
-    return hasFormFields || hasSchema;
-  }, []);
+  const requiresCredentials = useCallback(
+    (s: McpServer, resolvedFields?: CredentialField[]) => {
+      if (s.oauth) return false;
+      if (s.type === "google" || s.type === "microsoft" || s.type === "xyne-spaces") return false;
+      if (resolvedFields) return resolvedFields.length > 0;
+      const hasFormFields = (s.credentialForm?.fields?.length ?? 0) > 0;
+      const hasSchema = !!s.credentialSchema && Object.keys(s.credentialSchema).length > 0;
+      return hasFormFields || hasSchema;
+    },
+    [],
+  );
+
+  const resolveCredentialFields = useCallback(
+    async (type: string): Promise<CredentialField[] | undefined> => {
+      const cached = credentialFields[type];
+      if (cached) return cached;
+      try {
+        const map = await getCredentialFields();
+        setCredentialFields(map);
+        return map[type];
+      } catch {
+        return undefined;
+      }
+    },
+    [credentialFields],
+  );
 
   const handleConnect = useCallback(async (server: McpServer) => {
-    if (requiresCredentials(server)) {
+    if (requiresCredentials(server, await resolveCredentialFields(server.type))) {
       setConnectServerId(server.id);
       setShowAddDialog(true);
       return;
@@ -577,7 +596,7 @@ export function MCPPageV3({ userId }: Props) {
         description: err instanceof Error ? err.message : undefined,
       });
     }
-  }, [requiresCredentials, connect, showSnackbar]);
+  }, [requiresCredentials, resolveCredentialFields, connect, showSnackbar]);
 
   // OAuth callback params
   useEffect(() => {

--- a/apps/xyne-claw/src/mcp.ts
+++ b/apps/xyne-claw/src/mcp.ts
@@ -96,6 +96,15 @@ export function applyTrustedMcpBindings(
   return bindings ? { ...params, ...bindings } : params;
 }
 
+export class McpAuthServiceError extends Error {
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "McpAuthServiceError";
+    this.status = status;
+  }
+}
+
 async function authFetch<T>(path: string, sessionToken: string, init?: RequestInit): Promise<T> {
   const url = `${SERVER.authServiceUrl}${path}`;
   const res = await fetch(url, {
@@ -109,7 +118,7 @@ async function authFetch<T>(path: string, sessionToken: string, init?: RequestIn
   });
   const body = (await res.json()) as AuthResponse<T>;
   if (!body.success || body.data === undefined) {
-    throw new Error(body.error ?? `Auth service error: ${res.status}`);
+    throw new McpAuthServiceError(body.error ?? `Auth service error: ${res.status}`, res.status);
   }
   return body.data;
 }
@@ -229,6 +238,27 @@ export async function injectForwardedFiles(
   return { params: rewritten, forwarded };
 }
 
+async function callMcpWithBlockedCapture<T>(
+  path: string,
+  sessionToken: string,
+  init: RequestInit,
+  serverType: string,
+  onConnectorBlocked?: (serverType: string, status: number) => void,
+): Promise<T> {
+  try {
+    return await authFetch<T>(path, sessionToken, init);
+  } catch (err) {
+    if (err instanceof McpAuthServiceError && isCredentialRejection(err.status)) {
+      onConnectorBlocked?.(serverType, err.status);
+    }
+    throw err;
+  }
+}
+
+function isCredentialRejection(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
 export async function loadMcpToolsForUser(
   sessionId: string,
   sessionToken: string,
@@ -248,6 +278,7 @@ export async function loadMcpToolsForUser(
   // execution identity stable across context compaction and prevents a model
   // from omitting or replacing trusted run bindings.
   trustedToolBindings?: TrustedMcpToolBindings,
+  onConnectorBlocked?: (serverType: string, status: number) => void,
 ): Promise<{
   groups: McpToolGroup[];
   cleanup: () => Promise<void>;
@@ -323,7 +354,7 @@ export async function loadMcpToolsForUser(
             }
           }
           callParams = applyTrustedMcpBindings(callParams, trustedBindings);
-          const result = await authFetch<{
+          const result = await callMcpWithBlockedCapture<{
             content: string;
             citations?: import("xyne-claw-shared").Citation[];
             pendingAction?: Record<string, unknown>;
@@ -345,6 +376,8 @@ export async function loadMcpToolsForUser(
                 agentSlug,
               }),
             },
+            server.serverType,
+            onConnectorBlocked,
           );
 
           if (result.pendingAction) {

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -3068,7 +3068,7 @@ async function processTask(
       allTools.push(buildDescribeAgentTool(describeAgentRef));
       // Same gate as describe-agent: a connector card is only worth posting
       // where a human is watching and can press Connect.
-      allTools.push(buildSuggestConnectorsTool(suggestConnectorsRef));
+      allTools.push(buildSuggestConnectorsTool(suggestConnectorsRef, userId));
     }
 
 

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -1738,6 +1738,7 @@ async function processTask(
   // the turn ends some other way.
   const describeAgentRef: DescribeAgentRef = {};
   const suggestConnectorsRef: SuggestConnectorsRef = {};
+  const blockedConnectors = new Set<string>();
   // Hoisted for the same reason: emit_brief (daily-brief mode's terminal tool)
   // fires abortRun, so the brief is recovered from ref.value in the catch block
   // and shipped as `dailyBrief` on the callback.
@@ -1945,6 +1946,7 @@ async function processTask(
       mcpOutputDir,
       (att) => pushAttachment(progressUrl, sessionId, att),
       trustedSdlcBindings,
+      (serverType) => blockedConnectors.add(serverType),
     );
     mcpGetAttachments = getMcpAttachments;
     // Expose the MCP-layer pendingActions getter to the catch handler so
@@ -4645,6 +4647,7 @@ async function processTask(
       ...(suggestConnectorsRef.value
         ? { pendingConnectorSuggestions: suggestConnectorsRef.value }
         : {}),
+      ...(blockedConnectors.size > 0 ? { blockedConnectors: [...blockedConnectors] } : {}),
       ...(proposeAgentRef.value || describeAgentRef.value
         ? { pendingAgentCard: proposeAgentRef.value ?? describeAgentRef.value }
         : {}),
@@ -4832,6 +4835,7 @@ async function processTask(
         ...(suggestConnectorsRef.value
           ? { pendingConnectorSuggestions: suggestConnectorsRef.value }
           : {}),
+        ...(blockedConnectors.size > 0 ? { blockedConnectors: [...blockedConnectors] } : {}),
         ...(pendingGoalSuggestion ? { pendingGoalSuggestion } : {}),
         ...(dedupedPendingActionsAtError.length > 0 ? { pendingActions: dedupedPendingActionsAtError } : {}),
         ...(attachmentsAtError.length > 0 ? { attachments: attachmentsAtError } : {}),

--- a/apps/xyne-claw/src/suggest-connectors.ts
+++ b/apps/xyne-claw/src/suggest-connectors.ts
@@ -18,6 +18,11 @@
  * catalog and drops anything it does not recognise. Nothing the model writes
  * reaches the card's title or description, so it cannot invent an integration
  * or misdescribe what one does.
+ *
+ * The tool checks the catalog BEFORE promising a card. It used to answer "cards
+ * will be shown" unconditionally, so a request for a connector we do not carry
+ * (prod: figma) had the model write "hit Connect on the card" over a card the
+ * server then silently dropped. Unknown types are now reported back instead.
  */
 
 import { Type } from "@sinclair/typebox";
@@ -48,9 +53,16 @@ const AVAILABILITY_TIMEOUT_MS = 2000;
 interface ConnectorAvailability {
   connected: string[];
   known: boolean;
+  existing: string[];
+  catalogKnown: boolean;
 }
 
-const UNKNOWN_AVAILABILITY: ConnectorAvailability = { connected: [], known: false };
+const UNKNOWN_AVAILABILITY: ConnectorAvailability = {
+  connected: [],
+  known: false,
+  existing: [],
+  catalogKnown: false,
+};
 
 async function fetchAvailability(
   userId: string | undefined,
@@ -66,11 +78,21 @@ async function fetchAvailability(
       signal: AbortSignal.timeout(AVAILABILITY_TIMEOUT_MS),
     });
     if (!res.ok) return UNKNOWN_AVAILABILITY;
-    const body = (await res.json()) as { connected?: unknown; known?: unknown };
+    const body = (await res.json()) as {
+      connected?: unknown;
+      known?: unknown;
+      existing?: unknown;
+      catalogKnown?: unknown;
+    };
     if (body.known !== true || !Array.isArray(body.connected)) return UNKNOWN_AVAILABILITY;
+    const catalogKnown = body.catalogKnown === true && Array.isArray(body.existing);
     return {
       connected: body.connected.filter((t): t is string => typeof t === "string"),
       known: true,
+      existing: catalogKnown
+        ? (body.existing as unknown[]).filter((t): t is string => typeof t === "string")
+        : [],
+      catalogKnown,
     };
   } catch (err) {
     log.warn(
@@ -102,20 +124,29 @@ export function buildSuggestConnectorsTool(
       "    GitHub or Bitbucket repo or PR, a Figma file, a Notion page, a Jira ticket.",
       "  • a task needs an account you have no working tools for (e.g. summarising a Google",
       "    Doc with no Google tools available),",
-      "  • the user asks to connect something by name (\"connect Figma\").",
+      "  • the user asks to connect something by name (\"connect Figma\"),",
+      "  • a tool you tried FAILED with a permission / auth error (401, 403, \"access denied\").",
+      "    That means the shared org account cannot reach THIS user\'s data, and their own",
+      "    connection is the fix. Call it even though tools for that service exist.",
       "",
       "Do NOT call it when:",
-      "  • you already have working tools for that service — an admin may have connected it",
-      "    org-wide, so tools can work without the user ever connecting anything,",
+      "  • you have working tools for that service and they are WORKING — an admin may have",
+      "    connected it org-wide, so tools can work without the user connecting anything,",
       "  • the user merely mentions a product by name, or the name appears in a task handed",
       "    to you by another agent,",
       "  • you are only explaining what a connector does.",
       "",
-      "The server resolves each type against the catalog, fills in the name, description and",
-      "connected state, and DROPS any connector that is already usable — including ones an",
-      "admin shared org-wide — unless the USER asked to connect it by name. It reads that",
-      "intent from the user\'s own message, not from you. So a card may not appear: never say",
-      "\"the card above\" or tell the user to press Connect. Say what you need and why.",
+      "The server resolves each type against the catalog and fills in the name, description",
+      "and connected state — nothing you write reaches the card. It DROPS a connector the",
+      "user has already connected themselves. One shared org-wide is dropped too, UNLESS a",
+      "tool call actually failed against it this turn, or the USER asked for it by name —",
+      "read from their own message, not from your claim.",
+      "",
+      "The tool result tells you exactly what will render. Follow it literally:",
+      "  • it names the connectors whose cards will appear → you may point at them,",
+      "  • it says a connector is NOT available → say so plainly; there is no card to press,",
+      "  • it says something is already connected → do not tell the user to connect it again.",
+      "Never refer to a card the result did not promise.",
       "",
       "This does not end your turn. Call it at most once per reply.",
     ].join("\n"),
@@ -181,17 +212,36 @@ export function buildSuggestConnectorsTool(
       }
 
       const title = typeof p["title"] === "string" ? p["title"].trim().slice(0, 120) : "";
-      ref.value = { serverTypes, ...(title ? { title } : {}), ...(listAll ? { listAll: true } : {}) };
+      const availability = listAll
+        ? UNKNOWN_AVAILABILITY
+        : await fetchAvailability(userId, serverTypes);
+
+      const renderable =
+        listAll || !availability.catalogKnown
+          ? serverTypes
+          : serverTypes.filter((t) => availability.existing.includes(t));
+
+      if (!listAll && availability.catalogKnown && renderable.length === 0) {
+        log.info(`[suggest-connectors] no catalog entry for: ${serverTypes.join(", ")}`);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `No connector is available for ${serverTypes.join(", ")}. NO card will be shown. Tell the user plainly that this connector is not available on Xyne yet — do NOT tell them to press Connect or refer to a card.`,
+            },
+          ],
+          details: { serverTypes, unavailable: serverTypes },
+        };
+      }
+
+      ref.value = { serverTypes: renderable, ...(title ? { title } : {}), ...(listAll ? { listAll: true } : {}) };
       log.info(
         listAll
           ? "[suggest-connectors] queued roster listing"
           : `[suggest-connectors] queued ${serverTypes.length}: ${serverTypes.join(", ")}`,
       );
 
-      const availability = listAll
-        ? UNKNOWN_AVAILABILITY
-        : await fetchAvailability(userId, serverTypes);
-      const connected = availability.connected.filter((t) => serverTypes.includes(t));
+      const connected = availability.connected.filter((t) => renderable.includes(t));
 
       const stateNote = connected.length
         ? ` ${connected.join(", ")} ${connected.length === 1 ? "is" : "are"} ALREADY CONNECTED and the card shows it that way — do NOT tell the user to press Connect or link an account for ${connected.length === 1 ? "it" : "them"}; say what you can already do with ${connected.length === 1 ? "it" : "them"}.`
@@ -205,10 +255,10 @@ export function buildSuggestConnectorsTool(
             type: "text" as const,
             text: listAll
               ? "A connector list with a Browse button will be shown with your reply. Do NOT list the connectors in your text — say at most one short line."
-              : `Connector cards for ${serverTypes.join(", ")} will be shown with your reply. Do NOT list or describe these connectors in your text — say at most one short line about why they help.${stateNote}`,
+              : `Connector cards for ${renderable.join(", ")} will be shown with your reply. Do NOT list or describe these connectors in your text — say at most one short line about why they help.${stateNote}`,
           },
         ],
-        details: { serverTypes, listAll, ...(availability.known ? { connected } : {}) },
+        details: { serverTypes: renderable, listAll, ...(availability.known ? { connected } : {}) },
       };
     },
   };

--- a/apps/xyne-claw/src/suggest-connectors.ts
+++ b/apps/xyne-claw/src/suggest-connectors.ts
@@ -23,6 +23,7 @@
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.js";
+import { SERVER } from "./config.js";
 
 const log = createLogger("suggest-connectors");
 
@@ -42,8 +43,47 @@ export interface SuggestConnectorsRef {
 }
 
 const MAX_SUGGESTIONS = 6;
+const AVAILABILITY_TIMEOUT_MS = 2000;
 
-export function buildSuggestConnectorsTool(ref: SuggestConnectorsRef): ToolDefinition {
+interface ConnectorAvailability {
+  connected: string[];
+  known: boolean;
+}
+
+const UNKNOWN_AVAILABILITY: ConnectorAvailability = { connected: [], known: false };
+
+async function fetchAvailability(
+  userId: string | undefined,
+  serverTypes: string[],
+): Promise<ConnectorAvailability> {
+  if (!userId || !SERVER.s2sKey || serverTypes.length === 0) return UNKNOWN_AVAILABILITY;
+  try {
+    const base = SERVER.authServiceUrl.replace(/\/$/, "");
+    const res = await fetch(`${base}/claw/api/v1/internal/connectors/available`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-s2s-key": SERVER.s2sKey },
+      body: JSON.stringify({ userId, serverTypes }),
+      signal: AbortSignal.timeout(AVAILABILITY_TIMEOUT_MS),
+    });
+    if (!res.ok) return UNKNOWN_AVAILABILITY;
+    const body = (await res.json()) as { connected?: unknown; known?: unknown };
+    if (body.known !== true || !Array.isArray(body.connected)) return UNKNOWN_AVAILABILITY;
+    return {
+      connected: body.connected.filter((t): t is string => typeof t === "string"),
+      known: true,
+    };
+  } catch (err) {
+    log.warn(
+      `[suggest-connectors] availability lookup failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return UNKNOWN_AVAILABILITY;
+  }
+}
+
+export function buildSuggestConnectorsTool(
+  ref: SuggestConnectorsRef,
+  userId?: string,
+): ToolDefinition {
   return {
     name: SUGGEST_CONNECTORS_TOOL_NAME,
     label: "Suggest Connectors",
@@ -148,16 +188,27 @@ export function buildSuggestConnectorsTool(ref: SuggestConnectorsRef): ToolDefin
           : `[suggest-connectors] queued ${serverTypes.length}: ${serverTypes.join(", ")}`,
       );
 
+      const availability = listAll
+        ? UNKNOWN_AVAILABILITY
+        : await fetchAvailability(userId, serverTypes);
+      const connected = availability.connected.filter((t) => serverTypes.includes(t));
+
+      const stateNote = connected.length
+        ? ` ${connected.join(", ")} ${connected.length === 1 ? "is" : "are"} ALREADY CONNECTED and the card shows it that way — do NOT tell the user to press Connect or link an account for ${connected.length === 1 ? "it" : "them"}; say what you can already do with ${connected.length === 1 ? "it" : "them"}.`
+        : availability.known
+          ? " None of them are connected yet, so each card carries a Connect button."
+          : "";
+
       return {
         content: [
           {
             type: "text" as const,
             text: listAll
               ? "A connector list with a Browse button will be shown with your reply. Do NOT list the connectors in your text — say at most one short line."
-              : `Connector cards for ${serverTypes.join(", ")} will be shown with your reply, each with a Connect button. Do NOT list or describe these connectors in your text — say at most one short line about why they help.`,
+              : `Connector cards for ${serverTypes.join(", ")} will be shown with your reply. Do NOT list or describe these connectors in your text — say at most one short line about why they help.${stateNote}`,
           },
         ],
-        details: { serverTypes, listAll },
+        details: { serverTypes, listAll, ...(availability.known ? { connected } : {}) },
       };
     },
   };

--- a/apps/xyne-claw/test/suggest-connectors-availability.test.ts
+++ b/apps/xyne-claw/test/suggest-connectors-availability.test.ts
@@ -90,3 +90,41 @@ test("skips the lookup entirely when no userId is wired through", async () => {
   expect(fetchSpy).not.toHaveBeenCalled();
   expect(ref.value).toEqual({ serverTypes: ["github"] });
 });
+
+test("refuses to promise a card for a connector the catalog does not have", async () => {
+  mockAvailability({ success: true, connected: [], known: true, existing: [], catalogKnown: true });
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["figma"] }, "user-1");
+
+  expect(ref.value).toBeUndefined();
+  expect(out.content[0]?.text).toContain("not available on Xyne yet");
+  expect(out.content[0]?.text).toContain("NO card will be shown");
+  expect(out.details?.["unavailable"]).toEqual(["figma"]);
+});
+
+test("keeps only the connectors that exist when some of them do", async () => {
+  mockAvailability({
+    success: true,
+    connected: [],
+    known: true,
+    existing: ["github"],
+    catalogKnown: true,
+  });
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["figma", "github"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["github"] });
+  expect(out.content[0]?.text).toContain("github");
+  expect(out.content[0]?.text).not.toContain("figma");
+});
+
+test("falls open to the old behaviour when the catalog answer is missing", async () => {
+  mockAvailability({ success: true, connected: [], known: true });
+
+  const ref: SuggestConnectorsRef = {};
+  await callTool(ref, { serverTypes: ["figma"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["figma"] });
+});

--- a/apps/xyne-claw/test/suggest-connectors-availability.test.ts
+++ b/apps/xyne-claw/test/suggest-connectors-availability.test.ts
@@ -1,0 +1,92 @@
+import { test, expect, vi, afterEach } from "vitest";
+
+vi.hoisted(() => {
+  process.env["XYNE_CLAW_S2S_KEY"] = "test-key";
+});
+
+import {
+  buildSuggestConnectorsTool,
+  type SuggestConnectorsRef,
+} from "../src/suggest-connectors.js";
+
+async function callTool(ref: SuggestConnectorsRef, params: unknown, userId?: string) {
+  const tool = buildSuggestConnectorsTool(ref, userId);
+  return (
+    tool as unknown as {
+      execute: (
+        id: string,
+        p: unknown,
+      ) => Promise<{ content: { text: string }[]; details?: Record<string, unknown> }>;
+    }
+  ).execute("tc-1", params);
+}
+
+function mockAvailability(body: unknown, ok = true): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok, json: async () => body }) as unknown as Response),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("tells the model when a connector is already connected", async () => {
+  mockAvailability({ success: true, connected: ["github"], known: true });
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["github"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["github"] });
+  expect(out.content[0]?.text).toContain("ALREADY CONNECTED");
+  expect(out.content[0]?.text).not.toContain("each card carries a Connect button");
+  expect(out.details?.["connected"]).toEqual(["github"]);
+});
+
+test("promises a Connect button only when the lookup says nothing is connected", async () => {
+  mockAvailability({ success: true, connected: [], known: true });
+
+  const out = await callTool({}, { serverTypes: ["figma"] }, "user-1");
+
+  expect(out.content[0]?.text).toContain("each card carries a Connect button");
+  expect(out.content[0]?.text).not.toContain("ALREADY CONNECTED");
+});
+
+test("stays silent about state when the lookup is unavailable", async () => {
+  mockAvailability({}, false);
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["notion"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["notion"] });
+  expect(out.content[0]?.text).not.toContain("ALREADY CONNECTED");
+  expect(out.content[0]?.text).not.toContain("Connect button");
+  expect(out.details?.["connected"]).toBeUndefined();
+});
+
+test("still queues the card when the lookup throws", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      throw new Error("connection refused");
+    }),
+  );
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["slack"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["slack"] });
+  expect(out.content[0]?.text).toContain("Connector cards for slack");
+});
+
+test("skips the lookup entirely when no userId is wired through", async () => {
+  const fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+
+  const ref: SuggestConnectorsRef = {};
+  await callTool(ref, { serverTypes: ["github"] });
+
+  expect(fetchSpy).not.toHaveBeenCalled();
+  expect(ref.value).toEqual({ serverTypes: ["github"] });
+});


### PR DESCRIPTION
POT for correct response when the MCP is already connected: https://drive.google.com/file/d/1lAbwOQkc6qfFTn6WycbLMo9gFw5VaBqY/view?usp=sharing
POT for add agents inside agents: https://drive.google.com/file/d/1sNkQZ2Dg0ml-DkVKmGgcAtAD-_63VvaQ/view?usp=sharing
POT for AI provider OAuth fix and displaying all the provider which we allow : 
https://drive.google.com/file/d/1j2dzHJem2sH0naxCtk3F4xC0p-RyIqVp/view?usp=sharing
POT for search fix in Agents hub: https://drive.google.com/file/d/1yEPBsTE4g_TNQasiK6ta3wbdU_zvWQDa/view


Services-Requiring-Redeployment:
  - dashboard
  - backend

## Type of Change

- [x] New feature
- [x] Enhancement
- [x] Bugfix

## Description

Agent Hub improvements across the AI library, plus connector fixes in claw. XYNE-61540.

**Agent-to-agent delegation** — an **Agents** row on the agent edit page picks another agent to delegate to; a new **Call graph** tab lets the owner approve, decline or revoke requests. claw-auth already had the grants and DMs — this wires the dashboard to them.

**Provider credentials** — "OAuth token" in Agent keys did nothing before. Codex and Claude now get the browser flow, Copilot an agent-scoped GitHub device flow. AI settings lists all five providers (adds OpenRouter + LiteLLM); OpenRouter also needed adding to the claw-auth allowlist.

**Connectors skipped their credentials dialog** — Connect decided from `mcp_servers.credentialForm`, but the dialog renders from the `/servers/credential-fields` registry. That column is unset in pre-prod for Amplitude, BigQuery, Asana and Bitbucket, so the dialog was skipped and Connect posted empty credentials → 400. Both now read the registry, resolved at click time. Fixed in Spaces and in claw's v3 page.

**Library search** — tabs matched `name + description` as one blob, so "test" returned an agent named `afd` described as "test". Name matches now rank first, descriptions only as fallback.

**Connector suggestions (claw)** — the card now shows only what you can actually use. Availability is split into your own connections vs the org's, so an org credential no longer hides the card when it can't do the job; that case is driven by real 401/403 failures, not the model's word. The tool also checks the catalog before promising a card — asking for a connector we don't carry (figma) used to produce "hit Connect on the card" over a card that never rendered. Plus: the server recognises "list all the connectors" itself, and 20 connectors that had no hints (reddit, sentry, jenkins, mongodb, miro…) are inferrable again.

**OAuth returns you to where you started** — every callback redirected to one global `FRONTEND_URL`, so a flow started in Spaces finished on claw's home page. The starting UI now passes `returnTo`, carried in the HMAC-signed state and validated against an origin allowlist before redirecting.

**Smaller fixes**

- Approving a drafted agent no longer waits for the conversation to be idle.
- Flow JSON artifacts get a top margin instead of sitting flush against the text above.
- OAuth `authorize` routes are rate limited with the existing `oauthLimiter`, closing a CodeQL finding. `/callback` routes are left alone on purpose — they mount without `requireAuth`, so the limiter would key on `req.ip`, and with no `trust proxy` every callback behind the ingress would share one bucket.

## Areas Touched

- [x] `apps/dashboard`
- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

No migration. Worth knowing operationally: `mcp_servers.credentialForm` is still NULL in pre-prod for the connectors above. The fix removes the UI's dependency on that column, so nothing is blocked on a backfill — but anything else reading the column directly still sees nothing there.

## Config, Environment & URLs

- [x] No config changes — **skip this section**

`OAUTH_RETURN_ORIGINS` is read by the claw-auth side in #1546, and is optional there. Nothing to set for this PR.

## API Contract

- [x] New endpoint

claw-auth, all additive:
- `POST /agents/:slug/provider-credentials/copilot/github-{login,poll}` — agent-scoped Copilot device flow.
- `POST /internal/connectors/available` — s2s-only; which of the given connector types a user has connected.
- `POST /users/:userId/oauth/:type/authorize` — accepts an optional `returnTo`. Callers that omit it are unaffected.

No existing contract changed.

---

## Rollout note

The claw half ships separately in #1546 (replaces #1527, closed). The OAuth return fix spans both: this PR sends `returnTo`, #1546 honours it. Either can merge first — without `returnTo` the callback behaves as today — but the fix needs both.

## How did you test it?

Manually against a local stack.

- Delegation: added an agent, approved the request from Call graph
- Agent keys: OAuth for Claude/Codex/Copilot; API-key path unchanged
- AI settings shows five providers; OpenRouter no longer 400s
- Library search: "test" returns only test-named agents; "pull request" still finds PR Reviewer via description
- Approved a drafted agent while another was mid-run
- "connect google" → card; re-asked once connected → correctly not offered
- "list all the connectors" → roster; reddit / sentry / jenkins now recognised
- Test suites compared against a clean `main` baseline: same failing files before and after, nothing regressed

**Not verified locally** — needs pre-prod or a second account:

- Credentials dialog: local rows have `credentialForm` populated, so the bug can't reproduce here. Worth clicking Connect on Amplitude once deployed.
- The org-blocked connector card: no org credentials in the local DB to trigger it.
- OAuth return: local Google/Microsoft blocked by an unrelated `redirect_uri_mismatch`. Use a dynamically-registered connector (Notion, Miro, Attio).

### Automated

- [x] Added / updated tests for this change <!-- apps/xyne-claw/test/suggest-connectors-availability.test.ts -->
- [x] Not covered by tests <!-- no runner configured for apps/dashboard; the rest is presentational + service wiring -->

### Manual

**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind


