### PR TITLE
fix: XYNE-61829 added new section in dm and optimized the search

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -243,6 +243,7 @@ const ChatDirectory = ({
   const prefetchRecap = usePrefetchRecap();
   const [showAddChannelForm, setShowAddChannelForm] = useState(false);
   const [showAddSectionForm, setShowAddSectionForm] = useState(false);
+  const [addSectionSource, setAddSectionSource] = useState<'channels' | 'dms'>('channels');
   const [sectionToRename, setSectionToRename] = useState<ChannelSection | null>(null);
   const [sectionToDelete, setSectionToDelete] = useState<ChannelSection | null>(null);
   const [sectionToManage, setSectionToManage] = useState<ChannelSection | null>(null);
@@ -935,7 +936,10 @@ const ChatDirectory = ({
                     onRename={setSectionToRename}
                     onDelete={setSectionToDelete}
                     onManageChannels={setSectionToManage}
-                    onCreateSection={() => setShowAddSectionForm(true)}
+                    onCreateSection={() => {
+                      setAddSectionSource('channels');
+                      setShowAddSectionForm(true);
+                    }}
                     onMoveChannelToSection={moveChannelToSection}
                     onSetSortOrder={(sectionId, order) => {
                       void zero.mutate(
@@ -1080,7 +1084,10 @@ const ChatDirectory = ({
                             label: 'New section',
                             icon: FolderPlus,
                             trackName: 'CREATE_NEW_SECTION',
-                            onSelect: () => setShowAddSectionForm(true),
+                            onSelect: () => {
+                              setAddSectionSource('channels');
+                              setShowAddSectionForm(true);
+                            },
                           },
                         ]}
                       />
@@ -1170,6 +1177,15 @@ const ChatDirectory = ({
                           trackName: 'CREATE_DIRECT_MESSAGE',
                           onSelect: handleAddDirectMessage,
                         },
+                        {
+                          label: 'New section',
+                          icon: FolderPlus,
+                          trackName: 'CREATE_NEW_SECTION',
+                          onSelect: () => {
+                            setAddSectionSource('dms');
+                            setShowAddSectionForm(true);
+                          },
+                        },
                       ]}
                     />
                   </div>
@@ -1245,6 +1261,7 @@ const ChatDirectory = ({
               channels={sectionableChannels}
               existingNames={(channelSections ?? []).map(s => s.name)}
               lastSectionPosition={lastSectionPosition}
+              prioritizeType={addSectionSource === 'dms' ? 'dm' : 'channel'}
               onClose={() => setShowAddSectionForm(false)}
             />
           )}

--- a/apps/dashboard/src/components/Chat/CreateSectionDialog/CreateSectionDialog.tsx
+++ b/apps/dashboard/src/components/Chat/CreateSectionDialog/CreateSectionDialog.tsx
@@ -28,6 +28,7 @@ interface CreateSectionDialogProps {
   channels: VisibleChannel[];
   existingNames: string[];
   lastSectionPosition: string | null;
+  prioritizeType?: 'dm' | 'channel';
   onClose: () => void;
 }
 
@@ -71,6 +72,7 @@ export const CreateSectionDialog = ({
   channels,
   existingNames,
   lastSectionPosition,
+  prioritizeType = 'channel',
   onClose,
 }: CreateSectionDialogProps): ReactElement => {
   const zero = useZero();
@@ -144,15 +146,24 @@ export const CreateSectionDialog = ({
     const base = !q
       ? channels
       : channels.filter(c => getDMSearchableName(c, userMap, userID).toLowerCase().includes(q));
+    const preferDM = prioritizeType === 'dm';
     return [...base].sort((a, b) => {
       const aSelected = selected.has(a.id) ? 0 : 1;
       const bSelected = selected.has(b.id) ? 0 : 1;
-      return aSelected - bSelected;
+      if (aSelected !== bSelected) return aSelected - bSelected;
+      const aIsDM = isDMChannel(a.scopeType);
+      const bIsDM = isDMChannel(b.scopeType);
+      if (aIsDM === bIsDM) return 0;
+      if (preferDM) return aIsDM ? -1 : 1;
+      return aIsDM ? 1 : -1;
     });
-  }, [channels, filter, selected, userMap, userID]);
+  }, [channels, filter, selected, userMap, userID, prioritizeType]);
 
   const allFilteredSelected =
     filteredChannels.length > 0 && filteredChannels.every(c => selected.has(c.id));
+
+  const itemLabel = 'channels & DMs';
+  const itemLabelTitle = 'Channels & DMs';
 
   const toggleChannel = (id: string): void => {
     setSelected(prev => {
@@ -290,7 +301,7 @@ export const CreateSectionDialog = ({
                   !!nameError && 'pointer-events-none',
                 )}
               >
-                Create and Add Channels
+                Create and Add {itemLabelTitle}
               </Button>
             </span>
           </Tooltip>
@@ -303,7 +314,7 @@ export const CreateSectionDialog = ({
     <div className='space-y-4 p-4' data-testid='create-section-step2'>
       <div className='flex items-start justify-between gap-2'>
         <div>
-          <div className='text-xl font-medium text-foreground'>Add channels</div>
+          <div className='text-xl font-medium text-foreground'>Add {itemLabel}</div>
           <div className='flex items-center gap-1 text-sm text-muted-foreground'>
             {emoji.trim() && renderEmoji(emoji.trim(), 'size-4')}
             <span>{trimmedName}</span>
@@ -343,7 +354,7 @@ export const CreateSectionDialog = ({
         <div className='max-h-64 overflow-y-auto'>
           {filteredChannels.length === 0 ? (
             <div className='px-3 py-6 text-center text-sm text-muted-foreground'>
-              No channels found
+              No {itemLabel} found
             </div>
           ) : (
             filteredChannels.map(channel => (
@@ -382,7 +393,7 @@ export const CreateSectionDialog = ({
             disabled={selected.size === 0}
             className='bg-action-primary text-action-primary-foreground hover:bg-action-primary/90'
           >
-            Add Channels
+            Add {itemLabelTitle}
           </Button>
         </div>
       </div>


### PR DESCRIPTION


https://github.com/user-attachments/assets/8833afb3-2b99-4fce-95b3-187812f98fea

Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
