### PR TITLE
fix: XYNE-61836 allow cross-org workspace members to read their workspace row

### DIFF
--- a/packages/shared/src/zero/acl/tables/workspaces-acl.ts
+++ b/packages/shared/src/zero/acl/tables/workspaces-acl.ts
@@ -14,10 +14,16 @@ export class WorkspacesACL extends BaseQueryACL<'workspaces'> {
       return denyGuestSelect(query, 'id');
     }
 
+    // The caller's own workspace is always readable, even when their org_members row
+    // belongs to a different org than the one owning the workspace (cross-org members
+    // joined via users, e.g. external collaborators). Mirrors the Prisma WorkspacesACL.
     return query
       .where('status', '=', Status.ACTIVE)
-      .whereExists('orgMembers', (om) =>
-        om.where('memberId', '=', this.ctx.memberId)
+      .where(({ or, cmp, exists }) =>
+        or(
+          cmp('id', '=', this.ctx.workspaceId),
+          exists('orgMembers', (om) => om.where('memberId', '=', this.ctx.memberId)),
+        ),
       );
   }
 }


### PR DESCRIPTION
## Problem

External collaborators — users who are active `MEMBER`s of a workspace but whose `org_members` row belongs to a different org than the one owning the workspace — could never sync the `workspaces` row over Zero. `WorkspacesACL.canSelect` only granted reads when the caller was a member of the workspace's **owning** org.

Symptom: for an affected user, the Apps page showed empty. Prod logs confirmed `getWorkspaceById` returned `rowCount: 0` on 100% of their query completions over 7 days (same-org members of the same workspace: 1), so `workspace.orgId` never resolved, `getOrgApps` was never enabled, and the Org Apps tab never loaded. DB checks confirmed the user's active workspace membership and the org mismatch.

## Fix

Allow the caller's own workspace alongside the existing org-membership check:

```ts
.where(({ or, cmp, exists }) =>
  or(
    cmp('id', '=', this.ctx.workspaceId),
    exists('orgMembers', (om) => om.where('memberId', '=', this.ctx.memberId)),
  ),
)
```

- `ctx.workspaceId` comes from the JWT (workspace-scoped session), so it can't be spoofed client-side.
- Mirrors the Prisma-side `WorkspacesACL` (`apps/backend/src/database/acl/tables/workspaces-acl.ts`), which already carries the same `OR { id: ctx.workspaceId }` clause.
- Purely additive: org members keep existing visibility; the only row a caller can gain is the workspace their session belongs to. Guest deny and ACTIVE filter unchanged.
- The Prisma ACL's third branch (`workspace_organizations`-linked orgs) is deliberately not ported: no Zero query can currently reach it (`getWorkspaceById` only queries the session's own workspace) and it would attach a doubly-nested EXISTS to every workspace sync.

## Testing

- `tsc --noEmit` on `@xyne/shared` passes.
- Pre-commit checks run manually (hook needs a tty): gitleaks, tenant-key/ACL-factory guards, dashboard lint, change analysis, schema-migration + enum guards — all green.
- Note for QA: after deploy, a cross-org member's Org Apps tab shows **their own org's** apps, not the host org's — correct per the apps ACL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)