### PR TITLE
fix: XYNE-61836 allow cross-org workspace members to read their workspace row (release-20260901)

### DIFF
--- a/packages/shared/src/zero/acl/tables/workspaces-acl.ts
+++ b/packages/shared/src/zero/acl/tables/workspaces-acl.ts
@@ -14,10 +14,16 @@ export class WorkspacesACL extends BaseQueryACL<'workspaces'> {
       return denyGuestSelect(query, 'id');
     }
 
+    // The caller's own workspace is always readable, even when their org_members row
+    // belongs to a different org than the one owning the workspace (cross-org members
+    // joined via users, e.g. external collaborators). Mirrors the Prisma WorkspacesACL.
     return query
       .where('status', '=', Status.ACTIVE)
-      .whereExists('orgMembers', (om) =>
-        om.where('memberId', '=', this.ctx.memberId)
+      .where(({ or, cmp, exists }) =>
+        or(
+          cmp('id', '=', this.ctx.workspaceId),
+          exists('orgMembers', (om) => om.where('memberId', '=', this.ctx.memberId)),
+        ),
       );
   }
 }


### PR DESCRIPTION
Cherry-pick of #1431 onto `release-20260901`.

`WorkspacesACL.canSelect` only granted workspace-row reads to members of the workspace's owning org, so external collaborators (active workspace members whose org differs from the workspace's owning org) never synced the workspace row over Zero — `workspace.orgId` stayed unresolved and the Apps page Org tab never loaded. Fix allows the caller's own workspace (`ctx.workspaceId` from the JWT) alongside the existing org-membership check, mirroring the Prisma-side `WorkspacesACL`. Purely additive — org members keep existing visibility.

See #1431 for full root-cause analysis (prod log evidence + DB verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)