### PR TITLE
feat: XYNE-61843 incremental app updates

### DIFF
--- a/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
@@ -72,6 +72,7 @@ import { CitationLink } from '../Chat/XyneAISidebar/components/CitationLink';
 import { useCitationDocs, panelDocFromCitation } from './citationDocs';
 import { MessageReactArtifacts, toArtifactRef } from './ReactArtifact';
 import { ArtifactRestoreNotice } from './ReactArtifact/ArtifactRestoreNotice';
+import { PromptMarkerRail, type PromptMarker } from './PromptMarkerRail';
 import type { ArtifactAppRestoreEvent } from '../../services/claw/artifactAppsService';
 import { useAppCreationModeSignal } from './ReactArtifact/appCreationModeContext';
 import { SidebarLeftClose, SidebarLeftOpen } from '@xyne/icons';
@@ -140,6 +141,9 @@ interface AIChatThreadProps {
 
 export interface AIChatThreadHandle {
   addFiles: (files: File[]) => void;
+  /** Submit `text` as a new turn with the composer's current context, leaving
+   *  whatever the user has drafted untouched. False if a reply is streaming. */
+  submitPrompt: (text: string) => boolean;
 }
 
 const toMessageAttachments = (attachments: AIComposerAttachment[]): MessageAttachment[] =>
@@ -1068,6 +1072,10 @@ function ChatMessageBubble({
 
   return (
     <div
+      // The rail measures these to place its ticks. Marking every message (not
+      // just user ones) keeps the attribute meaningful if the rail later shows
+      // answers too; it filters by type on its own side.
+      data-prompt-marker={isUser ? message.id : undefined}
       className={cn(
         'group w-full',
         isUser ? 'flex justify-end px-2 py-3 sm:px-4' : 'px-2 py-5 sm:px-4',
@@ -1408,6 +1416,7 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
       addFiles: (files: File[]): void => {
         composerRef.current?.addFiles(files);
       },
+      submitPrompt: (text: string): boolean => composerRef.current?.submitPrompt(text) ?? false,
     }),
     [],
   );
@@ -1904,10 +1913,17 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
   // on merely opening an old thread that happens to contain an app. The set
   // resets with the component (chatKey remounts on thread switch), so history
   // can never masquerade as live.
+  // Keyed by stableKey as well as id: a streaming message carries a temp id
+  // that is swapped for the server id at completion — which is exactly when its
+  // artifact attachment arrives. Recording only the temp id meant the finished
+  // message never matched, and the first build of every thread was reported as
+  // history rather than as a live generation.
   const streamedMessageIds = useRef(new Set<string>());
   useEffect(() => {
     for (const m of displayMessages) {
-      if (m.isStreaming) streamedMessageIds.current.add(m.id);
+      if (!m.isStreaming) continue;
+      streamedMessageIds.current.add(m.id);
+      if (m.stableKey) streamedMessageIds.current.add(m.stableKey);
     }
   }, [displayMessages]);
 
@@ -1926,7 +1942,12 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
           // this is the freshness signal: a versionId the loaded version list
           // does not contain means "a generation just landed — refetch".
           foundVersion = artifact.versionId ?? null;
-          generatedLive = Boolean(message && streamedMessageIds.current.has(message.id));
+          generatedLive = Boolean(
+            message &&
+            (streamedMessageIds.current.has(message.id) ||
+              (message.stableKey !== undefined &&
+                streamedMessageIds.current.has(message.stableKey))),
+          );
           break;
         }
       }
@@ -2226,6 +2247,17 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
     return byMessage;
   }, [appRestores, displayMessages]);
 
+  // Only prompts. The answers are what you scroll THROUGH; the questions are
+  // what you scroll TO — so marking both would bury the landmarks among the
+  // things being navigated.
+  const promptMarkers = useMemo<PromptMarker[]>(
+    () =>
+      displayMessages
+        .filter(m => m.type === 'user' && m.content.trim().length > 0)
+        .map(m => ({ id: m.id, text: m.content })),
+    [displayMessages],
+  );
+
   const title =
     messages.length > 0
       ? (messages.find(m => m.type === 'user')?.content.slice(0, 40) ?? 'New chat')
@@ -2256,107 +2288,114 @@ export const AIChatThread = forwardRef<AIChatThreadHandle, AIChatThreadProps>(fu
           sidebarCollapsed={sidebarCollapsed}
         />
 
-        {/* Messages area — tabIndex enables keyboard scroll (PageUp/Home/ArrowUp)
-          which the auto-scroll effect listens for to unstick from bottom. */}
-        <div
-          ref={scrollRef}
-          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-          tabIndex={0}
-          className='relative flex-1 overflow-y-auto px-2 py-6 focus:outline-none sm:px-4'
-          role='log'
-          aria-live='polite'
-          aria-label='Chat messages'
-        >
-          <div ref={contentRef} className='mx-auto flex max-w-3xl flex-col'>
-            <ConversationToolInvocationsContext.Provider value={conversationToolInvocations}>
-              {displayMessages.map((message, idx) => {
-                const feedbackValue: FeedbackValue =
-                  message.feedback === 1 ? 'LIKE' : message.feedback === 2 ? 'DISLIKE' : null;
-                const botTurnIndex =
-                  message.type === 'bot'
-                    ? displayMessages.slice(0, idx + 1).filter(m => m.type === 'bot').length - 1
-                    : -1;
-                // Branching is disabled for legacy conversations (no parentId).
-                const branchEnabled = !isLegacyConversation;
-                const isLatestUserMessage = idx === lastUserIndex;
-                const isLatestBotMessage = idx === lastBotIndex;
-                const siblingCount = siblingCountById.get(message.id) ?? 1;
-                const branchInfo =
-                  branchEnabled && siblingCount > 1
-                    ? { index: siblingIndexById.get(message.id) ?? 0, total: siblingCount }
-                    : undefined;
-                const restoresHere = restoresByMessageId.get(message.id);
-                return (
-                  // Stable key so the bubble doesn't remount when the id swaps
-                  // temp→server at completion (which would kill the reasoning
-                  // section's transitions).
-                  <Fragment key={message.stableKey ?? message.id}>
-                    <ChatMessageBubble
-                      message={message}
-                      onCopy={() => {
-                        void navigator.clipboard.writeText(
-                          message.content || message.streamingContent || '',
-                        );
-                      }}
-                      onFeedback={(id, type) => {
-                        void handleFeedback(id, type);
-                      }}
-                      feedbackValue={feedbackValue}
-                      isV2={isV2}
-                      onRatingChange={handleRatingChange}
-                      onDebug={
-                        isV2 && message.type === 'bot'
-                          ? () => {
-                              setDebugTurnIndex(botTurnIndex);
-                              // Pin to this message's run when known (branching-safe);
-                              // null falls back to turn-index for unlinked live runs.
-                              setDebugSessionId(message.debugSessionId ?? null);
-                              setDebugFocusToolCallId(null);
-                              setShowDebugger(true);
-                            }
-                          : undefined
-                      }
-                      onOpenToolDebug={
-                        isV2 && message.type === 'bot'
-                          ? (toolCallId: string) => {
-                              setDebugTurnIndex(botTurnIndex);
-                              setDebugSessionId(message.debugSessionId ?? null);
-                              setDebugFocusToolCallId(toolCallId);
-                              setShowDebugger(true);
-                            }
-                          : undefined
-                      }
-                      onEditSubmit={
-                        branchEnabled && isLatestUserMessage
-                          ? (newContent: string) => void handleEditMessage(message.id, newContent)
-                          : undefined
-                      }
-                      onRegenerate={
-                        branchEnabled && isLatestBotMessage && !message.isStreaming
-                          ? () => void handleRegenerate()
-                          : undefined
-                      }
-                      onFollowUpSuggestionClick={
-                        isV2 && isLatestBotMessage && !message.isStreaming
-                          ? handleFollowUpSuggestion
-                          : undefined
-                      }
-                      branchInfo={branchInfo}
-                      onBranchNavigate={
-                        branchInfo
-                          ? (direction: 'prev' | 'next') =>
-                              handleBranchNavigate(message.id, direction)
-                          : undefined
-                      }
-                    />
-                    {restoresHere?.map(event => (
-                      <ArtifactRestoreNotice key={event.id} event={event} />
-                    ))}
-                  </Fragment>
-                );
-              })}
-            </ConversationToolInvocationsContext.Provider>
-            <div ref={tailRef} />
+        {/* Non-scrolling frame around the scroller. The prompt rail lives HERE,
+          as a sibling of the scroll area rather than inside it — anything
+          positioned inside an overflow container scrolls away with the content,
+          so the rail has to be anchored to the frame that stays put. */}
+        <div className='relative min-h-0 flex-1'>
+          <PromptMarkerRail markers={promptMarkers} scrollRef={scrollRef} />
+          {/* Messages area — tabIndex enables keyboard scroll (PageUp/Home/ArrowUp)
+            which the auto-scroll effect listens for to unstick from bottom. */}
+          <div
+            ref={scrollRef}
+            // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+            tabIndex={0}
+            className='relative h-full overflow-y-auto px-2 py-6 focus:outline-none sm:px-4'
+            role='log'
+            aria-live='polite'
+            aria-label='Chat messages'
+          >
+            <div ref={contentRef} className='mx-auto flex max-w-3xl flex-col'>
+              <ConversationToolInvocationsContext.Provider value={conversationToolInvocations}>
+                {displayMessages.map((message, idx) => {
+                  const feedbackValue: FeedbackValue =
+                    message.feedback === 1 ? 'LIKE' : message.feedback === 2 ? 'DISLIKE' : null;
+                  const botTurnIndex =
+                    message.type === 'bot'
+                      ? displayMessages.slice(0, idx + 1).filter(m => m.type === 'bot').length - 1
+                      : -1;
+                  // Branching is disabled for legacy conversations (no parentId).
+                  const branchEnabled = !isLegacyConversation;
+                  const isLatestUserMessage = idx === lastUserIndex;
+                  const isLatestBotMessage = idx === lastBotIndex;
+                  const siblingCount = siblingCountById.get(message.id) ?? 1;
+                  const branchInfo =
+                    branchEnabled && siblingCount > 1
+                      ? { index: siblingIndexById.get(message.id) ?? 0, total: siblingCount }
+                      : undefined;
+                  const restoresHere = restoresByMessageId.get(message.id);
+                  return (
+                    // Stable key so the bubble doesn't remount when the id swaps
+                    // temp→server at completion (which would kill the reasoning
+                    // section's transitions).
+                    <Fragment key={message.stableKey ?? message.id}>
+                      <ChatMessageBubble
+                        message={message}
+                        onCopy={() => {
+                          void navigator.clipboard.writeText(
+                            message.content || message.streamingContent || '',
+                          );
+                        }}
+                        onFeedback={(id, type) => {
+                          void handleFeedback(id, type);
+                        }}
+                        feedbackValue={feedbackValue}
+                        isV2={isV2}
+                        onRatingChange={handleRatingChange}
+                        onDebug={
+                          isV2 && message.type === 'bot'
+                            ? () => {
+                                setDebugTurnIndex(botTurnIndex);
+                                // Pin to this message's run when known (branching-safe);
+                                // null falls back to turn-index for unlinked live runs.
+                                setDebugSessionId(message.debugSessionId ?? null);
+                                setDebugFocusToolCallId(null);
+                                setShowDebugger(true);
+                              }
+                            : undefined
+                        }
+                        onOpenToolDebug={
+                          isV2 && message.type === 'bot'
+                            ? (toolCallId: string) => {
+                                setDebugTurnIndex(botTurnIndex);
+                                setDebugSessionId(message.debugSessionId ?? null);
+                                setDebugFocusToolCallId(toolCallId);
+                                setShowDebugger(true);
+                              }
+                            : undefined
+                        }
+                        onEditSubmit={
+                          branchEnabled && isLatestUserMessage
+                            ? (newContent: string) => void handleEditMessage(message.id, newContent)
+                            : undefined
+                        }
+                        onRegenerate={
+                          branchEnabled && isLatestBotMessage && !message.isStreaming
+                            ? () => void handleRegenerate()
+                            : undefined
+                        }
+                        onFollowUpSuggestionClick={
+                          isV2 && isLatestBotMessage && !message.isStreaming
+                            ? handleFollowUpSuggestion
+                            : undefined
+                        }
+                        branchInfo={branchInfo}
+                        onBranchNavigate={
+                          branchInfo
+                            ? (direction: 'prev' | 'next') =>
+                                handleBranchNavigate(message.id, direction)
+                            : undefined
+                        }
+                      />
+                      {restoresHere?.map(event => (
+                        <ArtifactRestoreNotice key={event.id} event={event} />
+                      ))}
+                    </Fragment>
+                  );
+                })}
+              </ConversationToolInvocationsContext.Provider>
+              <div ref={tailRef} />
+            </div>
           </div>
         </div>
 

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -65,6 +65,10 @@ export interface AIComposerHandle {
   clearContent: () => void;
   focus: () => void;
   setPrompt: (value: string) => void;
+  /** Submit `text` as its own turn, carrying the composer's current context
+   *  (agent, model, toggles) but not its draft or attachments — those stay
+   *  put. False when refused because a reply is still streaming. */
+  submitPrompt: (text: string) => boolean;
   /** REPLACE the composer's editable context with these items (empty clears it).
    *  Used on chat switch to carry the opened conversation's last-turn context
    *  into the composer. */
@@ -490,6 +494,13 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
         setValue(nextValue);
         window.setTimeout(() => textareaRef.current?.focus(), 0);
       },
+      submitPrompt: (text: string): boolean => {
+        if (pending) return false;
+        const trimmed = text.trim();
+        if (!trimmed) return false;
+        onSubmit?.(trimmed, undefined, buildContext());
+        return true;
+      },
       setContext: (items: AttachedContextItem[]): void => {
         const next = attachedContextToSelections(items);
         setSelections({
@@ -504,7 +515,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
         setFolderScopes(next.folderScopes);
       },
     }),
-    [handleFilesAdded],
+    [handleFilesAdded, pending, onSubmit, buildContext],
   );
 
   const submit = (): void => {

--- a/apps/dashboard/src/components/AIScreen/PromptMarkerRail.tsx
+++ b/apps/dashboard/src/components/AIScreen/PromptMarkerRail.tsx
@@ -1,0 +1,157 @@
+/**
+ * A scroll rail marking where each of your prompts sits in the conversation.
+ *
+ * Long agent turns push a thread to many screens tall, and the only landmarks
+ * in it are the things YOU said — the answers are what you are scrolling
+ * through, not what you are looking for. So the rail marks user prompts only:
+ * one tick per turn.
+ *
+ * The ticks are EVENLY SPACED and centred as a group, not positioned
+ * proportionally to where each message sits. Proportional placement sounds more
+ * honest but reads worse: one long agent turn pushes its neighbours into a
+ * cluster of overlapping ticks with a wide empty gap beside it, and the ticks
+ * stop being clickable. An even list is a table of contents rather than a
+ * scrollbar — the ordering is the information, and every tick keeps the same
+ * hit area no matter how long the answers run.
+ *
+ * Which tick is CURRENT is still measured from the DOM, because a message's
+ * height is not knowable up front: markdown, artifacts, tool blocks and images
+ * all settle after mount, and a streaming answer grows continuously.
+ */
+
+import { useCallback, useEffect, useState, type ReactElement, type RefObject } from 'react';
+
+export interface PromptMarker {
+  id: string;
+  /** The prompt text, used for the hover preview. */
+  text: string;
+}
+
+/** Enough to recognise a turn without turning the rail into a reading surface. */
+const PREVIEW_CHARS = 140;
+
+export const PromptMarkerRail = ({
+  markers,
+  scrollRef,
+}: {
+  markers: PromptMarker[];
+  /** The scroll container the ticks are measured against. */
+  scrollRef: RefObject<HTMLDivElement | null>;
+}): ReactElement | null => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [hoverId, setHoverId] = useState<string | null>(null);
+
+  // Which tick reads as "you are here": the last prompt whose message sits at
+  // or above the middle of the viewport. Middle rather than top, so a prompt
+  // scrolled just past the top edge still counts as the one you are reading
+  // under. Measured live off the DOM — the rail's own layout says nothing about
+  // where anything actually is.
+  useEffect(() => {
+    const scroll = scrollRef.current;
+    if (!scroll) return;
+
+    const sync = (): void => {
+      const mid = scroll.scrollTop + scroll.clientHeight / 2;
+      let current: string | null = null;
+      for (const marker of markers) {
+        const el = scroll.querySelector<HTMLElement>(
+          `[data-prompt-marker="${CSS.escape(marker.id)}"]`,
+        );
+        if (!el) continue;
+        if (el.offsetTop <= mid) current = marker.id;
+        else break;
+      }
+      setActiveId(current);
+    };
+
+    sync();
+    scroll.addEventListener('scroll', sync, { passive: true });
+    // Content settles and grows after mount, which moves every message without
+    // a scroll event ever firing.
+    const ro = new ResizeObserver(sync);
+    ro.observe(scroll);
+    return () => {
+      scroll.removeEventListener('scroll', sync);
+      ro.disconnect();
+    };
+  }, [markers, scrollRef]);
+
+  const jumpTo = useCallback(
+    (id: string): void => {
+      const scroll = scrollRef.current;
+      const el = scroll?.querySelector<HTMLElement>(`[data-prompt-marker="${CSS.escape(id)}"]`);
+      el?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+    },
+    [scrollRef],
+  );
+
+  // One prompt is not a map. The rail earns its space only once a thread has
+  // somewhere to navigate to.
+  if (markers.length < 2) return null;
+
+  return (
+    <div
+      // Centred as a group on the left edge. `pointer-events-none` so the rail
+      // never steals a click from the transcript beneath it; the ticks take the
+      // pointer back individually.
+      className='pointer-events-none absolute inset-y-0 left-0 z-20 hidden w-8 items-center md:flex'
+    >
+      <div
+        // `pointer-events-auto` here is what lets the 2px gap exist without
+        // the preview blinking. The rail wrapper is pointer-events-none, so an
+        // un-owned gap passes the pointer through to the transcript below —
+        // which is OUTSIDE this subtree, firing the group's mouseleave and
+        // clearing hover mid-travel. Owning the column makes the gap part of
+        // the group, so crossing it keeps the last tick previewed.
+        className='pointer-events-auto flex w-full flex-col items-start gap-[2px] py-2'
+        role='navigation'
+        aria-label='Your prompts'
+        onMouseLeave={() => setHoverId(null)}
+      >
+        {markers.map(marker => {
+          const isActive = marker.id === activeId;
+          const isHover = marker.id === hoverId;
+          return (
+            <button
+              key={marker.id}
+              type='button'
+              onClick={() => jumpTo(marker.id)}
+              onMouseEnter={() => setHoverId(marker.id)}
+              onFocus={() => setHoverId(marker.id)}
+              onBlur={() => setHoverId(current => (current === marker.id ? null : current))}
+              aria-label={truncate(marker.text)}
+              aria-current={isActive ? 'true' : undefined}
+              // A 2px line is not a hit target: the button owns a taller band
+              // with the tick drawn centred inside it. The bands touch, so the
+              // pointer is never off a tick while travelling the rail.
+              className='pointer-events-auto flex h-2 w-full items-center pl-1 focus:outline-none'
+              data-track-category='AskAI'
+              data-track-name='PromptMarkerJump'
+            >
+              <span
+                className={`block h-[2px] rounded-full transition-all ${
+                  isActive
+                    ? 'w-5 bg-foreground'
+                    : isHover
+                      ? 'w-4 bg-muted-foreground'
+                      : 'w-2.5 bg-border'
+                }`}
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      {hoverId !== null && (
+        <div className='pointer-events-none absolute left-8 top-1/2 z-30 w-64 -translate-y-1/2 rounded-xl border border-border bg-popover px-3 py-2 text-xs leading-relaxed text-popover-foreground shadow-lg'>
+          {truncate(markers.find(m => m.id === hoverId)?.text ?? '')}
+        </div>
+      )}
+    </div>
+  );
+};
+
+function truncate(text: string): string {
+  const clean = text.trim().replace(/\s+/g, ' ');
+  return clean.length > PREVIEW_CHARS ? `${clean.slice(0, PREVIEW_CHARS)}…` : clean;
+}

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactCodeView.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactCodeView.tsx
@@ -2,7 +2,23 @@ import { useMemo, useState, type ReactElement } from 'react';
 import { FileTree, useFileTree } from '@pierre/trees/react';
 import { File } from '@pierre/diffs/react';
 import type { ReactArtifactPayload } from './ReactArtifact.types';
-import { sandpackThemeName, toProjectFiles } from './ReactArtifact.utils';
+import { toProjectFiles } from './ReactArtifact.utils';
+import { useDiffsTheme } from '../../flowUI/nodes/useDiffsTheme';
+
+/** Sandpack addresses project files absolutely (`/App.tsx`), but the tree splits
+ *  on `/` — a leading slash makes an empty first segment, so every file lands
+ *  under a directory whose name is `''` and the panel opens on a single blank
+ *  chevron row. Template files like `tsconfig.json` arrive without the slash, so
+ *  this is not reversible by prefixing; callers map back through
+ *  `projectPathByTreePath`. */
+const toTreePath = (path: string): string => (path.startsWith('/') ? path.slice(1) : path);
+
+/** The search field otherwise sits flush against the top of the panel. Injected
+ *  through the tree's own `unsafeCSS` because the row lives in a shadow root
+ *  that outside stylesheets cannot reach; `--trees-padding-inline` is the same
+ *  16px the row already uses horizontally. */
+const SEARCH_ROW_CSS =
+  '[data-file-tree-search-container] { padding-block-start: var(--trees-padding-inline); }';
 
 /**
  * Source browser for a generated app: a file tree on the left, the selected
@@ -16,7 +32,7 @@ import { sandpackThemeName, toProjectFiles } from './ReactArtifact.utils';
  */
 export function ArtifactCodeView({ payload }: { payload: ReactArtifactPayload }): ReactElement {
   const [selected, setSelected] = useState<string>(payload.entry);
-  const themeType = useMemo(() => sandpackThemeName(), []);
+  const { themeType } = useDiffsTheme();
 
   // The full project as the bundler sees it: template files (package.json,
   // tsconfig) + injected preamble + the agent's own source.
@@ -31,16 +47,24 @@ export function ArtifactCodeView({ payload }: { payload: ReactArtifactPayload })
     return all.sort((a, b) => rank(a) - rank(b) || a.localeCompare(b));
   }, [projectFiles, authored]);
 
+  const treePaths = useMemo(() => paths.map(toTreePath), [paths]);
+
+  const projectPathByTreePath = useMemo(() => new Map(paths.map(p => [toTreePath(p), p])), [paths]);
+
   const { model } = useFileTree({
-    paths,
-    initialSelectedPaths: [payload.entry],
+    paths: treePaths,
+    initialSelectedPaths: [toTreePath(payload.entry)],
     search: true,
-    // Directories collapse to nothing useful in a 2–7 file project, so keep the
-    // whole tree open rather than making the reader drill in.
+    unsafeCSS: SEARCH_ROW_CSS,
+    // Depth 2, not 1: a folder holding nothing but one folder renders as a
+    // single flattened row (`components/ui`), so the tree's top row can be two
+    // nodes deep. Anything below what the panel shows at the top stays shut.
+    initialExpansion: 2,
     onSelectionChange: (selectedPaths: readonly string[]) => {
       const next = selectedPaths[0];
+      const path = next ? projectPathByTreePath.get(next) : undefined;
       // Directory rows report as selected too; ignore anything that isn't a file.
-      if (next && projectFiles[next]) setSelected(next);
+      if (path && projectFiles[path]) setSelected(path);
     },
   });
 
@@ -53,7 +77,15 @@ export function ArtifactCodeView({ payload }: { payload: ReactArtifactPayload })
   return (
     <div className='flex h-full min-h-0'>
       <div className='w-56 shrink-0 overflow-auto border-r border-border'>
-        <FileTree model={model} style={{ height: '100%' }} />
+        <FileTree
+          model={model}
+          // `@pierre/trees` takes no theme prop: its shadow stylesheet derives
+          // every color through `light-dark()` under `:host { color-scheme:
+          // light dark }`, so the tree follows the OS preference instead of
+          // ours. Pinning `color-scheme` on the host beats that rule (outer-tree
+          // declarations win) and lands `light-dark()` on the editor's side.
+          style={{ height: '100%', colorScheme: themeType }}
+        />
       </div>
       <div className='min-w-0 flex-1 overflow-auto'>
         {file && (

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactErrorOverlay.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactErrorOverlay.tsx
@@ -127,10 +127,7 @@ export const ArtifactErrorOverlay = ({
     return (): void => window.clearTimeout(timer);
   }, [copied]);
 
-  const error = useMemo(
-    () => appError ?? fromSandpack(sandpack.error),
-    [appError, sandpack.error],
-  );
+  const error = useMemo(() => appError ?? fromSandpack(sandpack.error), [appError, sandpack.error]);
   if (!error || dismissed) return null;
 
   const text = describeArtifactError(error);

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactErrorOverlay.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ArtifactErrorOverlay.tsx
@@ -1,0 +1,219 @@
+/**
+ * Covers the frame when the app breaks, with the error and a way to act on it.
+ *
+ * Two sources feed it. `sandpack.error` is the bundler's report — a file that
+ * does not compile, a dependency that will not resolve, a throw its own window
+ * handler saw — and carries no component stack. The app's own report comes over
+ * postMessage from the boundary the synthesized entry wraps the root in
+ * (xyneDataRuntime.source.ts) and does, so it wins when both arrive. Both clear
+ * on `start`: a rebuild — the next version landing in the pane, a refresh — is
+ * a fresh chance, and a stale error over a working app would be worse than none.
+ *
+ * Replaces Sandpack's own error overlay (`showSandpackErrorOverlay={false}` on
+ * the preview), which shows the same text and offers nothing to do about it.
+ * Bundler timeouts are deliberately not routed here: that is Sandpack's
+ * `LoadingOverlay`, with its Restart button, and not something the agent can
+ * fix.
+ *
+ * "Fix with AI" sends `fix: <error>` into the thread as a new turn, so the agent
+ * repairs the app on its next cycle from the same text a person would have
+ * pasted. It is only offered where there is a thread to send to — see
+ * `AppCreationModeSignal.submitPrompt`.
+ *
+ * One request per error, enforced here rather than left to the composer. The
+ * composer refuses a second send only once a reply is streaming, which leaves
+ * both a race (the click before `pending` flips) and a gap (an agent that
+ * answers without rebuilding), and either way a live-looking button after the
+ * request is already in the thread reads as "that did nothing". The rearm is
+ * the bundler's `start`: a new build is a new chance to fail, and its error is
+ * a new error.
+ */
+
+import { useEffect, useMemo, useState, type MutableRefObject, type ReactElement } from 'react';
+import { useSandpack } from '@codesandbox/sandpack-react';
+import { AlertTriangle, Check, Copy, Loader2, Sparkles, X } from 'lucide-react';
+import { isAppArtifactMessage } from './artifactData.constants';
+import { useAppCreationModeSignal } from './appCreationModeContext';
+import type { PreviewClientRef } from './useArtifactDataBridge';
+
+interface ArtifactRenderError {
+  message: string;
+  /** `path:line:column`, when the bundler knows it and the message doesn't already say. */
+  location?: string;
+  componentStack?: string;
+}
+
+/** Lines of component stack worth sending: the leaf and its nearest ancestors
+ *  name the culprit; the rest is the app's shell, repeated on every error. */
+const COMPONENT_STACK_LINES = 6;
+
+/** The error as text — what gets copied, and what the agent is sent. */
+export function describeArtifactError(error: ArtifactRenderError): string {
+  const lines = [error.message];
+  if (error.location) lines.push(`at ${error.location}`);
+  if (error.componentStack) {
+    const frames = error.componentStack
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .slice(0, COMPONENT_STACK_LINES);
+    if (frames.length > 0) lines.push('Component stack:', ...frames.map(frame => `  ${frame}`));
+  }
+  return lines.join('\n');
+}
+
+/** Sandpack's own report, in the same shape as the app's. */
+function fromSandpack(
+  error: { message: string; path?: string; line?: number; column?: number } | null,
+): ArtifactRenderError | null {
+  if (!error) return null;
+  const message = error.message.trim() || 'Unknown error';
+  const location =
+    error.path && !message.includes(error.path)
+      ? [error.path, error.line, error.column].filter(part => part !== undefined).join(':')
+      : undefined;
+  return { message, ...(location ? { location } : {}) };
+}
+
+export const ArtifactErrorOverlay = ({
+  fill,
+  previewRef,
+}: {
+  fill: boolean;
+  /** Identifies our iframe: several artifacts can be mounted at once and they
+   *  all post to this same window. */
+  previewRef: MutableRefObject<PreviewClientRef | null>;
+}): ReactElement | null => {
+  const { sandpack, listen } = useSandpack();
+  const { submitPrompt } = useAppCreationModeSignal();
+  const [appError, setAppError] = useState<ArtifactRenderError | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [refused, setRefused] = useState(false);
+  const [requested, setRequested] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = listen(message => {
+      if (message.type !== 'start') return;
+      setAppError(null);
+      setDismissed(false);
+      setRefused(false);
+      setRequested(false);
+    });
+    const onMessage = (event: MessageEvent): void => {
+      if (!isAppArtifactMessage(event.data) || event.data.type !== 'error') return;
+      const target = previewRef.current?.getClient()?.iframe?.contentWindow ?? null;
+      if (!target || event.source !== target) return;
+      const { message, componentStack } = event.data;
+      const next: ArtifactRenderError = {
+        message: message?.trim() || 'Unknown error',
+        ...(componentStack ? { componentStack } : {}),
+      };
+      // React (dev) raises a boundary-caught error on `window` first and in
+      // componentDidCatch second, so one failure arrives twice. Keep the first
+      // report unless the later one is the richer of the two.
+      setAppError(prev => (prev && !next.componentStack ? prev : next));
+    };
+    window.addEventListener('message', onMessage);
+    return (): void => {
+      unsubscribe();
+      window.removeEventListener('message', onMessage);
+    };
+  }, [listen, previewRef]);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1500);
+    return (): void => window.clearTimeout(timer);
+  }, [copied]);
+
+  const error = useMemo(
+    () => appError ?? fromSandpack(sandpack.error),
+    [appError, sandpack.error],
+  );
+  if (!error || dismissed) return null;
+
+  const text = describeArtifactError(error);
+
+  return (
+    <div
+      className={`absolute inset-0 z-30 flex items-center justify-center p-4 ${
+        fill ? 'bg-background' : 'bg-card'
+      }`}
+      role='alert'
+    >
+      <div className='flex w-full max-w-md flex-col gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4'>
+        <div className='flex items-start gap-2'>
+          <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0 text-destructive' aria-hidden='true' />
+          <div className='min-w-0 flex-1'>
+            <p className='text-sm font-medium text-foreground'>This app hit an error</p>
+            <pre className='mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words font-mono text-xs text-muted-foreground'>
+              {text}
+            </pre>
+          </div>
+          <button
+            type='button'
+            onClick={() => setDismissed(true)}
+            className='-mr-1 -mt-1 shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
+            aria-label='Dismiss'
+            title='Dismiss and show the app anyway'
+            data-track-category='AskAI'
+            data-track-name='ReactArtifactDismissError'
+          >
+            <X className='h-4 w-4' aria-hidden='true' />
+          </button>
+        </div>
+        <div className='flex flex-wrap items-center gap-2'>
+          {submitPrompt && (
+            <button
+              type='button'
+              disabled={requested}
+              onClick={() => {
+                if (requested) return;
+                const sent = submitPrompt(`fix: ${text}`);
+                setRequested(sent);
+                setRefused(!sent);
+              }}
+              className='flex items-center gap-1.5 rounded-md bg-primary px-2.5 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-60'
+              data-track-category='AskAI'
+              data-track-name='ReactArtifactFixWithAI'
+            >
+              {requested ? (
+                <>
+                  <Loader2 className='h-3.5 w-3.5 animate-spin' aria-hidden='true' />
+                  Fix requested
+                </>
+              ) : (
+                <>
+                  <Sparkles className='h-3.5 w-3.5' aria-hidden='true' />
+                  Fix with AI
+                </>
+              )}
+            </button>
+          )}
+          <button
+            type='button'
+            onClick={() => {
+              void navigator.clipboard.writeText(text).then(() => setCopied(true));
+            }}
+            className='flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-accent'
+            data-track-category='AskAI'
+            data-track-name='ReactArtifactCopyError'
+          >
+            {copied ? (
+              <Check className='h-3.5 w-3.5 text-emerald-500' aria-hidden='true' />
+            ) : (
+              <Copy className='h-3.5 w-3.5' aria-hidden='true' />
+            )}
+            {copied ? 'Copied' : 'Copy error'}
+          </button>
+          {refused && (
+            <span className='text-xs text-muted-foreground'>
+              Wait for the current reply to finish, then try again.
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/MessageReactArtifacts.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/MessageReactArtifacts.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useMemo, useState, type ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import type { Message } from '../../Chat/XyneAISidebar/utils/XyneAITypes';
 import { ReactArtifactView } from './ReactArtifactView';
 import { ReactArtifactDialog } from './ReactArtifactDialog';
 import { toArtifactRef, type ReactArtifactRef } from './ReactArtifact.types';
-import { useIsShownInPane } from './appCreationModeContext';
+import { useAppCreationModeSignal, useIsShownInPane } from './appCreationModeContext';
 import { ArtifactPaneReference } from './ArtifactPaneReference';
 import { saveArtifactApp } from '../../../services/claw/artifactAppsService';
 import { clawErrorText } from '../../../services/claw/clawRequest';
@@ -92,6 +92,18 @@ export function MessageReactArtifacts({ message }: { message: Message }): ReactE
  * One artifact in the transcript — live, or a reference when App Creation mode
  * is already running this app in the pane. Split into its own component because
  * the decision needs a hook, and hooks cannot be called inside a `.map`.
+ *
+ * This card is also what OPENS the mode. It mounts exactly when a build appears
+ * in the thread — on history load and on every new generation — so a
+ * mount-once request here fires at precisely the moments the pane should open,
+ * with the app id and version in hand and nothing to infer. Once per mount is
+ * what lets a close stick: an existing card never asks again, and only the
+ * next build's fresh card reopens the pane.
+ *
+ * Expand follows the same logic. For an app this thread owns, "expand" means
+ * the pane — that is the full-size surface — so it enters the mode rather than
+ * opening a second copy in a dialog. The dialog survives only for artifacts
+ * that predate session-scoping and have no app to open.
  */
 function ArtifactCard({
   artifact,
@@ -105,13 +117,26 @@ function ArtifactCard({
   saveState: SaveState;
 }): ReactElement {
   const shownInPane = useIsShownInPane(artifact.savedAppId);
+  const { active, enterForApp } = useAppCreationModeSignal();
+  const { savedAppId, versionId } = artifact;
+
+  const asked = useRef(false);
+  useEffect(() => {
+    if (asked.current) return;
+    asked.current = true;
+    if (!savedAppId || active) return;
+    enterForApp(savedAppId, versionId ?? null);
+  }, [savedAppId, versionId, active, enterForApp]);
 
   if (shownInPane) return <ArtifactPaneReference artifact={artifact} />;
+
+  const expand = savedAppId ? (): void => enterForApp(savedAppId, versionId ?? null) : onExpand;
 
   return (
     <ReactArtifactView
       artifact={artifact}
-      onExpand={onExpand}
+      onExpand={expand}
+      expandLabel={savedAppId ? 'Open in the app panel' : 'Open full screen'}
       {...(onSave ? { onSave } : {})}
       saveState={saveState}
     />

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifact.types.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifact.types.ts
@@ -61,6 +61,9 @@ export interface ReactArtifactViewProps {
   fill?: boolean;
   /** Shows an expand affordance when the artifact can also open full-screen. */
   onExpand?: (artifact: ReactArtifactRef) => void;
+  /** Accessible name for the expand control — it opens the pane for a saved
+   *  app and a dialog for anything else, and the label should say which. */
+  expandLabel?: string;
   /** Shows a close affordance; set when rendered inside the full-screen dialog. */
   onClose?: () => void;
   /**

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifact.utils.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifact.utils.ts
@@ -152,7 +152,8 @@ export function toSandpackFiles(
   // Injected AFTER the agent's files, deliberately overwriting — the opposite of
   // the preamble rule above. The bridge endpoint must be ours: a payload saved
   // before this path was reserved could otherwise ship its own /lib/xyne-data.
-  // Always injected, so a stray import can never break the build.
+  // Always injected: the synthesized entry imports it for the root boundary,
+  // and a stray import from agent code can never break the build.
   files[XYNE_DATA_RUNTIME_PATH] = { code: XYNE_DATA_RUNTIME_CODE, hidden: true };
 
   if (!files[SANDPACK_ENTRY]) {
@@ -160,6 +161,7 @@ export function toSandpackFiles(
       code: [
         "import { StrictMode } from 'react';",
         "import { createRoot } from 'react-dom/client';",
+        "import { XyneErrorBoundary } from './lib/xyne-data';",
         `import Root from '${toModuleSpecifier(payload.entry)}';`,
         '',
         '// Install the theme BEFORE Tailwind compiles. A static',
@@ -172,7 +174,17 @@ export function toSandpackFiles(
         '',
         'function mount() {',
         "  const el = document.getElementById('root');",
-        '  if (el) createRoot(el).render(<StrictMode><Root /></StrictMode>);',
+        '  // The boundary reports a throw during render to the host, which is',
+        '  // what turns a blank frame into an error the agent can be asked to fix.',
+        '  if (el) {',
+        '    createRoot(el).render(',
+        '      <StrictMode>',
+        '        <XyneErrorBoundary>',
+        '          <Root />',
+        '        </XyneErrorBoundary>',
+        '      </StrictMode>,',
+        '    );',
+        '  }',
         '}',
         '',
         '// Mount after Tailwind has generated its stylesheet so the first paint is',

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifactView.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifactView.tsx
@@ -36,6 +36,7 @@ import { useArtifactAgentBridge } from './useArtifactAgentBridge';
 import { useArtifactDirectoryBridge } from './useArtifactDirectoryBridge';
 import { ArtifactSavedIndicator } from './ArtifactSavedIndicator';
 import { ArtifactBootOverlay } from './ArtifactBootOverlay';
+import { ArtifactErrorOverlay } from './ArtifactErrorOverlay';
 import { AppLoaderMark } from '../../AppLoader/AppLoaderMark';
 import { useAuthContextValues } from '../../../hooks/useAuth';
 import { TOP_BAR_HEIGHT_CLASS } from '../../AppNavigator/topBarHeight';
@@ -156,9 +157,16 @@ const ArtifactSandpack = memo(
     return (
       <SandpackProvider template='react-ts' theme={theme} files={files} customSetup={customSetup}>
         <SandpackLayout>
-          <SandpackPreview ref={previewRef} showOpenInCodeSandbox={false} />
+          {/* Sandpack's error overlay is replaced by ArtifactErrorOverlay below,
+              which shows the same failure with a way to act on it. */}
+          <SandpackPreview
+            ref={previewRef}
+            showOpenInCodeSandbox={false}
+            showSandpackErrorOverlay={false}
+          />
         </SandpackLayout>
         <ArtifactBootOverlay fill={fill} />
+        <ArtifactErrorOverlay fill={fill} previewRef={previewRef} />
       </SandpackProvider>
     );
   },
@@ -179,6 +187,7 @@ export const ReactArtifactView = ({
   artifact,
   fill = false,
   onExpand,
+  expandLabel = 'Open full screen',
   onClose,
   titleSlot,
   onSave,
@@ -380,7 +389,8 @@ export const ReactArtifactView = ({
               type='button'
               onClick={() => onExpand(artifact)}
               className='shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground'
-              aria-label='Open full screen'
+              aria-label={expandLabel}
+              title={expandLabel}
               data-track-category='AskAI'
               data-track-name='ReactArtifactExpand'
             >

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/appCreationModeContext.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/appCreationModeContext.ts
@@ -36,6 +36,23 @@ export interface AppCreationModeSignal {
   restoreVersion: (versionId: string) => void;
   /** True while a restore is in flight, so cards can disable themselves. */
   restoring: boolean;
+  /**
+   * Enter App Creation mode for a specific app, from the card that knows it.
+   *
+   * The card is the one component that holds the app id, the version id, and
+   * the fact that a build is on screen — all at once, with no intermediate
+   * state. Routing entry through it, rather than through a scan of the message
+   * list that reports upward into screen state and then into a URL effect,
+   * removes every link in the chain that used to make entry order-dependent.
+   */
+  enterForApp: (appId: string, versionId: string | null) => void;
+  /**
+   * Send a message into the thread this app belongs to, as if typed into its
+   * composer. Returns false when the thread refused it (a reply is still
+   * streaming). Null where there is no thread — the Library's app screen —
+   * which is what hides "Fix with AI" there.
+   */
+  submitPrompt: ((text: string) => boolean) | null;
 }
 
 const AppCreationModeContext = createContext<AppCreationModeSignal>({
@@ -47,6 +64,8 @@ const AppCreationModeContext = createContext<AppCreationModeSignal>({
   viewVersion: () => undefined,
   restoreVersion: () => undefined,
   restoring: false,
+  enterForApp: () => undefined,
+  submitPrompt: null,
 });
 
 export const AppCreationModeProvider = AppCreationModeContext.Provider;

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/artifactData.constants.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/artifactData.constants.ts
@@ -185,7 +185,7 @@ export interface HostAgentStateMessage {
 export interface AppArtifactMessage {
   source: 'xyne-artifact';
   v: number;
-  type: 'ready' | 'refresh' | 'mutate' | 'agent-run' | 'agent-cancel' | 'agent-attach';
+  type: 'ready' | 'refresh' | 'mutate' | 'agent-run' | 'agent-cancel' | 'agent-attach' | 'error';
   /** `refresh`: which requirement (omitted = all). */
   name?: string;
   /** `mutate` only. */
@@ -196,6 +196,11 @@ export interface AppArtifactMessage {
   /** `agent-run` only. */
   prompt?: string;
   agentSlug?: string;
+  /** `error` only: an uncaught failure inside the app, reported so the host can
+   *  show it and offer a fix. `componentStack` comes from the root boundary. */
+  message?: string;
+  stack?: string;
+  componentStack?: string;
 }
 
 export function isAppArtifactMessage(value: unknown): value is AppArtifactMessage {
@@ -203,6 +208,7 @@ export function isAppArtifactMessage(value: unknown): value is AppArtifactMessag
   const msg = value as Partial<AppArtifactMessage>;
   if (msg.source !== 'xyne-artifact') return false;
   if (msg.type === 'ready' || msg.type === 'refresh') return true;
+  if (msg.type === 'error') return typeof msg.message === 'string';
   if (msg.type === 'agent-attach' || msg.type === 'agent-cancel') {
     return typeof msg.runKey === 'string';
   }

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/sandpackOverrides.css
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/sandpackOverrides.css
@@ -41,8 +41,9 @@
    turn it off — and ArtifactBootOverlay draws the Xyne mark over the same
    frame. Without this, theirs fades out over 400ms starting at `done` while
    ours unmounts instantly, flashing the CodeSandbox loader on every boot.
-   Scoped to `.sp-loading`: the timeout and runtime-error overlays use
-   `.sp-error` and must stay visible. */
+   Scoped to `.sp-loading`: the bundler-timeout overlay uses `.sp-error` and
+   must stay visible. (The runtime-error overlay is turned off by prop and
+   replaced by ArtifactErrorOverlay.) */
 .xyne-artifact-sandpack .sp-overlay.sp-loading {
   display: none;
 }

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/useAppCreationMode.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/useAppCreationMode.ts
@@ -90,14 +90,32 @@ export function useAppCreationMode(
     [setSearchParams],
   );
 
+  // Whether the mode SHOULD be on, independent of whether the URL says so yet.
+  //
+  // Entry used to be a single `setMode(true)`, and it was order-dependent. The
+  // artifact lands at stream completion — the same instant the draft acquires
+  // its server id — so two URL writers fired in one commit: this hook adding
+  // `?mode=create-app`, and AIScreen navigating to `/chat/<id>` carrying the
+  // *rendered* `location.search`, which did not have the param yet. Both built
+  // on a stale location; whichever landed second could drop the other's write.
+  // Entry worked or did not depending on effect order.
+  //
+  // So entry is now an intent that is re-asserted until the URL agrees. If a
+  // racing navigate strips the param, the effect below sees `modeOn` false with
+  // the intent still set and writes it again — onto the pathname that has now
+  // settled. It converges in one extra render regardless of who wrote last.
+  const wantMode = useRef(false);
+  useEffect(() => {
+    if (wantMode.current && !modeOn && conversationId) setMode(true);
+  }, [modeOn, conversationId, setMode]);
+
   // Leaving a thread drops everything thread-specific. Without this the pane
   // keeps showing the previous chat's app and a pinned version leaks across.
   const lastConversation = useRef<string | null>(conversationId);
-  const autoEnteredFor = useRef<string | null>(null);
   useEffect(() => {
     if (lastConversation.current === conversationId) return;
     lastConversation.current = conversationId;
-    autoEnteredFor.current = null;
+    wantMode.current = false;
     setPinnedVersionId(null);
   }, [conversationId]);
 
@@ -106,22 +124,18 @@ export function useAppCreationMode(
   // lingering param kept mode-derived layout (the collapsed sidebar) armed on
   // /ai/chat/new. The next thread that generates an app re-enters on its own.
   useEffect(() => {
-    if (!conversationId && modeOn) setMode(false);
+    if (!conversationId && modeOn) {
+      wantMode.current = false;
+      setMode(false);
+    }
   }, [conversationId, modeOn, setMode]);
 
-  // Auto-enter ONCE per conversation. Tracking it per conversation is what lets
-  // an explicit close stick: closing marks this thread handled, so a later
-  // generation reopens nothing, while switching threads starts fresh.
-  useEffect(() => {
-    if (!appId) return;
-    // Wait for the conversation to be named. `autoEnteredFor` starts as null and
-    // a fresh chat's conversationId is also null, so acting here would compare
-    // null === null and mark the thread handled before it even has an identity.
-    if (!conversationId) return;
-    if (autoEnteredFor.current === conversationId) return;
-    autoEnteredFor.current = conversationId;
-    if (!modeOn) setMode(true);
-  }, [appId, conversationId, modeOn, setMode]);
+  // Entry itself is driven by the artifact cards: each one, on mount, asks for
+  // the mode via `enterForApp` (see appCreationModeContext). A card mounts
+  // exactly when a build appears in the thread — on history load, and on every
+  // new generation — which is precisely the set of moments the mode should
+  // open. The card mounts once, so an explicit close sticks until the NEXT
+  // build lands, at which point the new card asks again.
 
   const { data } = useQuery({
     queryKey: ['artifact-app', appId],
@@ -166,12 +180,16 @@ export function useAppCreationMode(
     [appId, restore],
   );
 
-  const open = useCallback(() => setMode(true), [setMode]);
+  const open = useCallback(() => {
+    wantMode.current = true;
+    setMode(true);
+  }, [setMode]);
   const exit = useCallback(() => {
-    // Mark handled so the next generation does not reopen what was just closed.
-    autoEnteredFor.current = conversationId;
+    // Dropping the intent is what makes a close stick: nothing re-asserts the
+    // param until a new build's card asks for the mode again.
+    wantMode.current = false;
     setMode(false);
-  }, [setMode, conversationId]);
+  }, [setMode]);
   const headVersionId = data?.app.headVersionId ?? null;
 
   const viewVersion = useCallback(

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/xyneDataRuntime.source.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/xyneDataRuntime.source.ts
@@ -65,7 +65,12 @@ function errorText(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (typeof error === 'string') return error;
   // A rejection with a plain `{ message }` — common from fetch wrappers.
-  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
     return error.message;
   }
   return '';

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/xyneDataRuntime.source.ts
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/xyneDataRuntime.source.ts
@@ -12,7 +12,15 @@
  * as the current viewer and posts snapshots in over postMessage.
  */
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import {
+  Component,
+  useCallback,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+  type ErrorInfo,
+  type ReactNode,
+} from 'react';
 
 const PROTOCOL_VERSION = 1;
 
@@ -51,6 +59,56 @@ const refreshFns: Record<string, () => void> = {};
 function post(message: Record<string, unknown>): void {
   if (window.parent === window) return;
   window.parent.postMessage({ source: 'xyne-artifact', v: PROTOCOL_VERSION, ...message }, '*');
+}
+
+function errorText(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  // A rejection with a plain `{ message }` — common from fetch wrappers.
+  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+    return error.message;
+  }
+  return '';
+}
+
+/**
+ * Tells the host the app broke. The bundler reports some of this on its own,
+ * but its report has no component stack and misses anything a boundary
+ * swallows — so the app reports its own failures too, and the host shows
+ * whichever it holds (see ArtifactErrorOverlay).
+ */
+function reportError(error: unknown, componentStack?: string): void {
+  post({
+    type: 'error',
+    message: errorText(error) || 'Unknown error',
+    ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+    ...(componentStack ? { componentStack } : {}),
+  });
+}
+
+window.addEventListener('error', event => reportError(event.error ?? event.message));
+window.addEventListener('unhandledrejection', event => reportError(event.reason));
+
+/**
+ * Wraps the app's root. Placed by the synthesized entry, not by agent code, so
+ * every app has one whether or not the agent thought to add its own. Renders
+ * nothing once it has caught: the host's overlay is the failure UI, and a
+ * second message inside the frame would only compete with it.
+ */
+export class XyneErrorBoundary extends Component<{ children?: ReactNode }, { failed: boolean }> {
+  override state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    reportError(error, info.componentStack ?? undefined);
+  }
+
+  override render(): ReactNode {
+    return this.state.failed ? null : this.props.children;
+  }
 }
 
 window.addEventListener('message', (event: MessageEvent) => {

--- a/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
+++ b/apps/dashboard/src/routes/AIScreen/AIScreen.tsx
@@ -323,6 +323,27 @@ const AIScreen = (): ReactElement => {
     },
     [appModeCollapseSidebar],
   );
+  // Entry from a card. Sets the app and opens the mode together, so the pane
+  // never depends on the message-list scan having reported the app first —
+  // that chain (scan → onAppChange → state → hook effect) was the part that
+  // made entry a coin flip. The scan still runs, for clearing on thread switch
+  // and for the freshness signal, but it is no longer on the entry path.
+  const { open: openAppMode } = appMode;
+  const enterForApp = useCallback(
+    (id: string, versionId: string | null) => {
+      setAppId(id);
+      if (versionId) setLatestVersionId(versionId);
+      openAppMode();
+    },
+    [openAppMode],
+  );
+  // Routed through the thread's handle rather than a composer ref of its own:
+  // the thread owns submit (draft recovery, branch parenting), so a fix request
+  // takes exactly the path a typed message does.
+  const submitPrompt = useCallback(
+    (text: string): boolean => chatThreadRef.current?.submitPrompt(text) ?? false,
+    [],
+  );
   // A fresh object here re-renders every context consumer — that is every
   // artifact card in the transcript — on each AIScreen render.
   const appModeSignal = useMemo(
@@ -335,6 +356,8 @@ const AIScreen = (): ReactElement => {
       viewVersion: appMode.viewVersion,
       restoreVersion: appMode.restoreVersion,
       restoring: appMode.restoring,
+      enterForApp,
+      submitPrompt,
     }),
     [
       appMode.active,
@@ -345,6 +368,8 @@ const AIScreen = (): ReactElement => {
       appMode.viewVersion,
       appMode.restoreVersion,
       appMode.restoring,
+      enterForApp,
+      submitPrompt,
     ],
   );
   // Likewise a fresh element remounts the pane's subtree each render.

--- a/apps/xyne-claw-auth/backend/src/main.ts
+++ b/apps/xyne-claw-auth/backend/src/main.ts
@@ -46,6 +46,7 @@ import { artifactAppAgentsRouter } from "./routes/artifact-app-agents.js";
 import { designSharesRouter, publicDesignSharesRouter } from "./routes/design-shares.js";
 import { sessionsArchiveRouter } from "./routes/sessions-archive.js";
 import { experimentsInternalRouter } from "./routes/experiments-internal.js";
+import { artifactAppsInternalRouter } from "./routes/artifact-apps-internal.js";
 import { errorPipelineIngestRouter, errorPipelineInternalRouter } from "./routes/error-pipeline.js";
 import { ERROR_PIPELINE } from "./config.js";
 import { runner as errorPipelineRunner } from "./error-pipeline/runner/runner.js";
@@ -228,6 +229,7 @@ app.use(`${BASE}/internal/twin-draft`, requireInternalS2S, twinDraftInternalRout
 app.use(`${BASE}/internal/attachments`, requireInternalS2S, attachmentsInternalRouter); // Spaces → extract document text via claw's converters (INTERNAL_S2S_KEY)
 app.use(`${BASE}/internal/sessions`, requireStrictS2S, sessionsArchiveRouter);     // archive/restore session JSONLs to GCS — S2S only (transcripts)
 app.use(`${BASE}/internal/experiments`, requireStrictS2S, experimentsInternalRouter);
+app.use(`${BASE}/internal/artifact-apps`, requireStrictS2S, artifactAppsInternalRouter); // create-app reads the conversation's head build before an incremental update
 app.use(`${BASE}/error-pipeline`, errorPipelineIngestRouter); // Grafana webhook ingest (JWT-authed inside)
 app.use(`${BASE}/internal/error-pipeline`, requireStrictS2S, errorPipelineInternalRouter); // run-result callback from xyne-claw (S2S only)
 app.use(`${BASE}/internal/tts`, requireStrictS2S, ttsRouter);

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-app-agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-app-agents.ts
@@ -570,7 +570,8 @@ async function dispatchRun(input: {
 }
 
 /**
- * Remove create-app from the agent's selected custom tools before dispatch.
+ * Remove create-app and its read-back tool from the agent's selected custom
+ * tools before dispatch.
  *
  * This is the WEAKER half of the recursion guard and cannot stand alone: an
  * agent with no `tools` key gets every tool by default (see parseToolsConfig),
@@ -586,7 +587,7 @@ function stripCreateApp(config: unknown): unknown {
     ...(cfg as object),
     tools: {
       ...(cfg?.tools as object),
-      custom: custom.filter((s) => s !== "create-app" && s !== "schedule-task"),
+      custom: custom.filter((s) => s !== "create-app" && s !== "read-app-file" && s !== "schedule-task"),
     },
   };
 }

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-apps-internal.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-apps-internal.ts
@@ -1,0 +1,96 @@
+/**
+ * S2S read-back of a conversation's current app, for the `create-app` tool.
+ *
+ * The tool runs in xyne-claw, which is stateless and has no database — it is a
+ * pure validator by design. But an *incremental* update has to start from the
+ * code that is already there, and the agent never sees that code: the tool
+ * result carries only the manifest (file paths), while the bytes go to GCS. So
+ * every "change the header colour" regenerated the whole project from
+ * conversational memory — thousands of output tokens, truncation on large apps,
+ * and bugs from two iterations ago quietly reappearing.
+ *
+ * This is the read half that closes that gap. It is keyed by CONVERSATION, not
+ * by app id, because that is the only identifier the tool has: Step 1 made a
+ * conversation own exactly one app, which is what lets `:convId` be
+ * unambiguous.
+ *
+ * Strictly S2S and strictly read-only. It serves HEAD — the version the owner
+ * and the agent are working on, which is what makes "restore v2, now add X"
+ * edit v2 rather than the newest build.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { prisma } from "../db.js";
+import { gcsService } from "../services/storageService.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("artifact-apps-internal");
+export const artifactAppsInternalRouter: Router = Router();
+
+/**
+ * Resolve a conversation to the app version the agent should build on.
+ *
+ * Head, not newest: `headVersionId` moves backward on restore, and an update
+ * that silently based on the highest version number would undo the rollback the
+ * user just performed. Falls back to the newest version only for apps created
+ * before head tracking existed.
+ */
+async function resolveHeadVersion(conversationId: string) {
+  const app = await prisma.artifactApp.findUnique({ where: { conversationId } });
+  if (!app || app.isArchived) return null;
+
+  const version = app.headVersionId
+    ? await prisma.artifactAppVersion.findUnique({ where: { id: app.headVersionId } })
+    : await prisma.artifactAppVersion.findFirst({
+        where: { appId: app.id },
+        orderBy: { versionNumber: "desc" },
+      });
+
+  if (!version || version.appId !== app.id) return null;
+  return { app, version };
+}
+
+/**
+ * GET /by-conversation/:convId/payload — the full project the agent should edit.
+ *
+ * Returns the stored payload verbatim (it was canonicalized through
+ * `buildReactArtifact` before being written, so it is already exactly what the
+ * validator approved) plus the identifiers the caller needs to reason about
+ * what it is holding.
+ */
+artifactAppsInternalRouter.get(
+  "/by-conversation/:convId/payload",
+  async (req: Request<{ convId: string }>, res: Response): Promise<void> => {
+    const found = await resolveHeadVersion(req.params.convId);
+    if (!found) {
+      res.status(404).json({ success: false, error: "No app for this conversation" });
+      return;
+    }
+    const { app, version } = found;
+
+    let raw: Buffer;
+    try {
+      raw = await gcsService.getFileBuffer(version.storagePath);
+    } catch (err) {
+      log.error(`failed reading head payload app=${app.id} version=${version.id}: ${String(err)}`);
+      res.status(502).json({ success: false, error: "Could not read the current app" });
+      return;
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw.toString("utf8"));
+    } catch {
+      res.status(502).json({ success: false, error: "Stored app payload is not valid JSON" });
+      return;
+    }
+
+    res.json({
+      success: true,
+      appId: app.id,
+      versionId: version.id,
+      versionNumber: version.versionNumber,
+      payload,
+    });
+  },
+);

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -267,6 +267,27 @@ function dedupeToolsByName(tools: ToolDefinition[]): ToolDefinition[] {
 }
 
 /** Snapshot for shutdown/drain forensics — one line per still-active run. */
+/**
+ * `read-app-file` rides on `create-app` selection.
+ *
+ * The two are one feature. `create-app` writes a project but hands back only a
+ * manifest — file paths, never contents — so without the read half an
+ * incremental update is authored from memory, which is how earlier features get
+ * silently dropped. Registering a new tool does NOT add it to agents that
+ * already have a saved `tools.custom` list, so fractal-agent held `create-app`
+ * while never being offered its reader (observed 2026-09-02: an explicit "read
+ * the code and tell me…" turn made zero tool calls and answered from context).
+ *
+ * Pairing at resolution time rather than per-agent means no saved selection has
+ * to be migrated and no new agent can be configured into the same half-state.
+ * Mirrors the sandbox → playwright hoist below.
+ */
+function expandCustomSelection(custom: string[] | undefined): Set<string> {
+  const selected = new Set(custom ?? []);
+  if (selected.has("create-app")) selected.add("read-app-file");
+  return selected;
+}
+
 export function describeActiveRuns(): Array<{ sessionId: string; agentSlug: string; userId: string; ageS: number }> {
   const now = Date.now();
   return [...activeRuns.entries()].map(([sessionId, a]) => ({
@@ -1017,8 +1038,16 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
           : processTaskError !== undefined
             ? String(processTaskError)
             : "Run ended without emitting a result (likely session-locked or silent early-return — check claw logs for this sessionId)";
-        const status: "completed" | "failed" | "cancelled" = processTaskError ? "failed" : "completed";
-        emitter.forceDone(sessionId, status, reason);
+        // Reaching here means the emitter never wrote a done frame — the run
+        // produced NO result. That is a failure whether or not something was
+        // thrown: a loop that gives up after every LLM turn 429s throws
+        // nothing, yet used to finalize as "completed" with a zero-length
+        // answer. Eight consecutive runs reported success that way on
+        // 2026-09-02 while the LiteLLM key was rate-limited, which is why the
+        // outage read as "the agent silently does nothing" for hours. The
+        // `reason` string above already describes a failure; the status now
+        // agrees with it.
+        emitter.forceDone(sessionId, "failed", reason);
       }
       const terminal = emitter.terminalPayload();
       if (terminal && emitter.deliveryFailed() && typeof callbackUrl === "string" && callbackUrl.trim()) {
@@ -2544,7 +2573,7 @@ async function processTask(
       if (!cfg) return tools;
       const allowedSubagents = new Set(cfg.subagents ?? []);
       const allowedDirect = cfg.direct ?? [];
-      const allowedCustom = new Set(cfg.custom ?? []);
+      const allowedCustom = expandCustomSelection(cfg.custom);
       const allowedGatewayServices = new Set(cfg.gateway ?? []);
       return tools.filter((t) => {
         if (sets.subagentTools.some((s) => s.name === t.name)) {
@@ -2818,7 +2847,7 @@ async function processTask(
     if (toolsConfigEarly) {
       const allowedSubagents = new Set(toolsConfigEarly.subagents ?? []);
       const allowedDirect = toolsConfigEarly.direct ?? [];
-      const allowedCustom = new Set(toolsConfigEarly.custom ?? []);
+      const allowedCustom = expandCustomSelection(toolsConfigEarly.custom);
       const allowedGatewayServices = new Set(toolsConfigEarly.gateway ?? []);
 
       allTools = allTools.filter((t) => {
@@ -3244,9 +3273,17 @@ async function processTask(
       eventType === "artifact_app" || (conversationId?.startsWith("app_") ?? false);
     if (isArtifactAppRun) {
       const before = allTools.length;
-      allTools = allTools.filter((t) => t.name !== "create-app" && t.name !== "schedule-task");
+      // read-app-file goes with create-app: it is keyed by conversation, and an
+      // app-invoked run carries the `app_` conversation of the app itself, so
+      // leaving it in would let an app read its own source back.
+      allTools = allTools.filter(
+        (t) =>
+          t.name !== "create-app" && t.name !== "read-app-file" && t.name !== "schedule-task",
+      );
       if (allTools.length !== before) {
-        log("Artifact-app run — create-app + schedule-task removed (self-replication ban)");
+        log(
+          "Artifact-app run — create-app + read-app-file + schedule-task removed (self-replication ban)",
+        );
       }
     }
 

--- a/packages/xyne-claw-shared/src/tools/react-artifact/index.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/index.ts
@@ -1,8 +1,10 @@
 export {
   createReactArtifactTool,
   buildReactArtifact,
+  mergeArtifactParams,
   formatReactArtifactResult,
 } from "./tools.js";
+export { readArtifactAppFileTool } from "./readTool.js";
 export type {
   ReactArtifactFile,
   ReactArtifactDataRequirement,

--- a/packages/xyne-claw-shared/src/tools/react-artifact/readTool.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/readTool.ts
@@ -1,0 +1,158 @@
+/**
+ * read-app-file — the read half of incremental updates.
+ *
+ * `create-app` hands back only a manifest: file *paths*, never contents. The
+ * bytes go straight to object storage. So an agent asked to "change the header
+ * colour" could not see the header — it rewrote all fifteen files from its
+ * memory of the conversation, which is how features silently disappeared and
+ * bugs fixed two versions ago came back.
+ *
+ * This closes that loop. Read the files you intend to change, then send only
+ * those back through `create-app` with `mode: "update"`.
+ *
+ * Reads HEAD, the same build `create-app` merges onto, so the code you read is
+ * exactly the code your patch lands on. Both go through one S2S route in
+ * claw-auth, keyed by conversation — Step 1 made a conversation own exactly one
+ * app, which is what makes that key unambiguous.
+ */
+
+import type { ToolDefinition, ToolExecutionContext } from "../types.js";
+import { REACT_ARTIFACT_CONFIG_SCHEMA } from "./tools.js";
+import type { ReactArtifactFile, ReactArtifactPayload } from "./tools.js";
+
+const READ_TIMEOUT_MS = 15_000;
+
+/** A single file's content is capped well below the runtime's tool-result
+ *  truncation so a large file arrives whole rather than silently clipped. */
+const MAX_CONTENT_CHARS = 48_000;
+
+interface HeadApp {
+  payload: ReactArtifactPayload;
+  versionNumber: number;
+}
+
+async function fetchHead(
+  context?: ToolExecutionContext,
+): Promise<{ ok: true; head: HeadApp } | { ok: false; error: string }> {
+  const conversationId = context?.meta?.["conversationId"];
+  if (!conversationId) {
+    return { ok: false, error: "Error: this run has no conversation, so there is no app to read." };
+  }
+
+  const authUrl = context?.config?.["XYNE_CLAW_AUTH_URL"] ?? "http://localhost:3003";
+  const s2sKey = context?.config?.["XYNE_CLAW_S2S_KEY"] ?? "";
+  const url = `${authUrl}/claw/api/v1/internal/artifact-apps/by-conversation/${encodeURIComponent(conversationId)}/payload`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { ...(s2sKey ? { "x-s2s-key": s2sKey } : {}) },
+      signal: AbortSignal.timeout(READ_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `Error: could not read the app (${message}). Retry.` };
+  }
+
+  if (res.status === 404) {
+    return {
+      ok: false,
+      error:
+        'Error: this conversation has no app yet. Build one first with create-app and `mode: "create"`.',
+    };
+  }
+  if (!res.ok) {
+    return { ok: false, error: `Error: could not read the app (HTTP ${res.status}). Retry.` };
+  }
+
+  let body: { payload?: unknown; versionNumber?: unknown };
+  try {
+    body = (await res.json()) as { payload?: unknown; versionNumber?: unknown };
+  } catch {
+    return { ok: false, error: "Error: the app came back unreadable. Retry." };
+  }
+
+  const payload = body.payload as ReactArtifactPayload | undefined;
+  if (!payload || !Array.isArray(payload.files)) {
+    return { ok: false, error: "Error: the app has no readable files." };
+  }
+
+  return {
+    ok: true,
+    head: { payload, versionNumber: typeof body.versionNumber === "number" ? body.versionNumber : 0 },
+  };
+}
+
+/** The listing shown when no path is given: enough to decide what to read next
+ *  without pulling every file's contents into the context window. */
+function formatListing(head: HeadApp): string {
+  const { payload } = head;
+  const lines = payload.files.map((f: ReactArtifactFile) => {
+    const bytes = Buffer.byteLength(f.content ?? "", "utf8");
+    const entry = f.path === payload.entry ? "  (entry)" : "";
+    return `  ${f.path}  —  ${bytes} bytes${entry}`;
+  });
+  const deps = Object.keys(payload.dependencies ?? {});
+  return (
+    `"${payload.title}" — version ${head.versionNumber}, ${payload.files.length} file(s):\n` +
+    `${lines.join("\n")}\n` +
+    `dependencies: ${deps.length ? deps.join(", ") : "(none)"}\n\n` +
+    "Read the files you intend to change, then call create-app with " +
+    '`mode: "update"` and only those files.'
+  );
+}
+
+export const readArtifactAppFileTool: ToolDefinition = {
+  slug: "read-app-file",
+  name: "Read app file",
+  source: "custom:react-artifact",
+  configSchema: REACT_ARTIFACT_CONFIG_SCHEMA,
+  description:
+    "Read the current source of the app this conversation has already built. Call with no `path` to " +
+    "list its files, then with a `path` to read one.\n\n" +
+    "ALWAYS read before you change. create-app returns only file paths, never contents, so this is " +
+    "the only way to see the code you are editing — without it you are rewriting from memory, which " +
+    "is how earlier features get dropped. Read the files you intend to change, then send just those " +
+    'back through create-app with `mode: "update"`.\n\n' +
+    "Reads the version the app is currently on, which is the same build your update merges onto — " +
+    "including after the user has rolled back to an earlier version.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description:
+          'Exact file path to read, e.g. "/App.tsx". Omit to list every file with its size.',
+      },
+    },
+    required: [],
+  },
+  execute: async (
+    params: Record<string, unknown>,
+    context?: ToolExecutionContext,
+  ): Promise<string> => {
+    const result = await fetchHead(context);
+    if (!result.ok) return result.error;
+    const { head } = result;
+
+    const raw = params["path"];
+    const path = typeof raw === "string" ? raw.trim() : "";
+    if (!path) return formatListing(head);
+
+    const file = head.payload.files.find((f: ReactArtifactFile) => f.path === path);
+    if (!file) {
+      const known = head.payload.files.map((f: ReactArtifactFile) => f.path).join(", ");
+      return `Error: no file at "${path}". The app has: ${known}.`;
+    }
+
+    const content = file.content ?? "";
+    if (content.length > MAX_CONTENT_CHARS) {
+      return (
+        `${path} (truncated at ${MAX_CONTENT_CHARS} of ${content.length} characters — ` +
+        "this file is too large to edit safely; consider splitting it):\n\n" +
+        content.slice(0, MAX_CONTENT_CHARS)
+      );
+    }
+    return `${path}:\n\n${content}`;
+  },
+};

--- a/packages/xyne-claw-shared/src/tools/react-artifact/tools.test.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildReactArtifact,
   formatReactArtifactResult,
+  mergeArtifactParams,
   createReactArtifactTool,
   type ReactArtifactPayload,
   type ReactArtifactManifest,
@@ -537,5 +538,179 @@ describe("session scoping guidance", () => {
 
   it("warns against dropping earlier work on an update", () => {
     expect(createReactArtifactTool.description).toMatch(/do not drop features you built/i);
+  });
+});
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Incremental updates (Step 2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function baseApp(overrides: Partial<ReactArtifactPayload> = {}): ReactArtifactPayload {
+  return {
+    version: 1,
+    title: "Ticket dashboard",
+    entry: "/App.tsx",
+    template: "react-ts",
+    files: [
+      { path: "/App.tsx", content: "export default () => <Chart />;" },
+      { path: "/Chart.tsx", content: "export const Chart = () => <div>chart</div>;" },
+      { path: "/theme.css", content: ".a{color:red}" },
+    ],
+    dependencies: { recharts: "latest" },
+    dataRequirements: [],
+    ...overrides,
+  };
+}
+
+describe("mergeArtifactParams", () => {
+  it("replaces only the files sent and inherits the rest", () => {
+    const merged = mergeArtifactParams(baseApp(), {
+      files: [{ path: "/Chart.tsx", content: "export const Chart = () => <div>NEW</div>;" }],
+    });
+
+    const files = merged["files"] as Array<{ path: string; content: string }>;
+    expect(files).toHaveLength(3);
+    expect(files.find((f) => f.path === "/Chart.tsx")?.content).toContain("NEW");
+    expect(files.find((f) => f.path === "/App.tsx")?.content).toContain("<Chart />");
+    expect(merged["title"]).toBe("Ticket dashboard");
+    expect(merged["entry"]).toBe("/App.tsx");
+    expect(merged["dependencies"]).toEqual({ recharts: "latest" });
+  });
+
+  it("adds a file that is not in the base", () => {
+    const merged = mergeArtifactParams(baseApp(), {
+      files: [{ path: "/Legend.tsx", content: "export const Legend = () => null;" }],
+    });
+    expect((merged["files"] as unknown[]).length).toBe(4);
+  });
+
+  it("removes files named in deleteFiles", () => {
+    const merged = mergeArtifactParams(baseApp(), {
+      files: [{ path: "/App.tsx", content: "export default () => null;" }],
+      deleteFiles: ["/Chart.tsx"],
+    });
+    const paths = (merged["files"] as Array<{ path: string }>).map((f) => f.path);
+    expect(paths).toEqual(["/App.tsx", "/theme.css"]);
+  });
+
+  it("rejects deleting a file the app does not have", () => {
+    expect(() =>
+      mergeArtifactParams(baseApp(), { files: [], deleteFiles: ["/nope.tsx"] }),
+    ).toThrow(/has no such file/i);
+  });
+
+  it("rejects deleting every file", () => {
+    expect(() =>
+      mergeArtifactParams(baseApp(), {
+        files: [],
+        deleteFiles: ["/App.tsx", "/Chart.tsx", "/theme.css"],
+      }),
+    ).toThrow(/cannot delete every file/i);
+  });
+
+  it("allows a delete-only turn", () => {
+    const merged = mergeArtifactParams(baseApp(), { deleteFiles: ["/theme.css"] });
+    expect((merged["files"] as Array<{ path: string }>).map((f) => f.path)).toEqual([
+      "/App.tsx",
+      "/Chart.tsx",
+    ]);
+  });
+
+  it("re-sending a deleted path keeps the file — deletions apply first", () => {
+    const merged = mergeArtifactParams(baseApp(), {
+      files: [{ path: "/Chart.tsx", content: "resurrected" }],
+      deleteFiles: ["/Chart.tsx"],
+    });
+    const chart = (merged["files"] as Array<{ path: string; content: string }>).find(
+      (f) => f.path === "/Chart.tsx",
+    );
+    expect(chart?.content).toBe("resurrected");
+  });
+
+  it("inherits dependencies when omitted and replaces them when sent", () => {
+    expect(mergeArtifactParams(baseApp(), { files: [] })["dependencies"]).toEqual({
+      recharts: "latest",
+    });
+    expect(
+      mergeArtifactParams(baseApp(), { files: [], dependencies: { "date-fns": "latest" } })[
+        "dependencies"
+      ],
+    ).toEqual({ "date-fns": "latest" });
+  });
+
+  it("never inherits the summary — it describes this turn", () => {
+    const merged = mergeArtifactParams(baseApp(), { files: [] });
+    expect(merged["summary"]).toBeUndefined();
+  });
+
+  it("blocks a reserved path arriving through deleteFiles", () => {
+    expect(() =>
+      mergeArtifactParams(baseApp(), { files: [], deleteFiles: ["/components/ui/card.tsx"] }),
+    ).toThrow();
+  });
+
+  it("the merged whole is re-validated, so a patch cannot orphan the entry", () => {
+    const merged = mergeArtifactParams(baseApp(), { deleteFiles: ["/App.tsx"] });
+    expect(() => buildReactArtifact(merged)).toThrow(/entry/i);
+  });
+});
+
+describe("createReactArtifactTool update mode", () => {
+  it("rejects an unknown mode", async () => {
+    expect(await run(validParams({ mode: "patch" }))).toMatch(/`mode` must be/);
+  });
+
+  it("still builds normally in the default (create) mode", async () => {
+    expect(await run(validParams())).toContain("REACT_ARTIFACT_START");
+  });
+
+  it("update without a conversation steers back to create rather than rebuilding", async () => {
+    const result = await run(validParams({ mode: "update" }));
+    expect(result).toMatch(/no conversation/i);
+    expect(result).toMatch(/mode: "create"/);
+    expect(result).not.toContain("REACT_ARTIFACT_START");
+  });
+});
+
+describe("readArtifactAppFileTool", () => {
+  it("is registered with a read-only shape", async () => {
+    const { readArtifactAppFileTool } = await import("./readTool.js");
+    expect(readArtifactAppFileTool.slug).toBe("read-app-file");
+    expect(readArtifactAppFileTool.isWriteTool).toBeFalsy();
+    expect(readArtifactAppFileTool.inputSchema.required ?? []).toEqual([]);
+  });
+
+  it("reports plainly when the run has no conversation", async () => {
+    const { readArtifactAppFileTool } = await import("./readTool.js");
+    expect(await readArtifactAppFileTool.execute({})).toMatch(/no conversation/i);
+  });
+});
+
+describe("create-app description teaches incremental updates", () => {
+  it("tells the model to read before changing and to send only changed files", () => {
+    expect(createReactArtifactTool.description).toContain("read-app-file");
+    expect(createReactArtifactTool.description).toMatch(/mode: "update"/);
+    expect(createReactArtifactTool.description).toMatch(/ONLY the files you changed/i);
+  });
+});
+
+describe("S2S config is actually reachable at runtime", () => {
+  // xyne-claw builds tool context with resolveToolConfig(tool.configSchema, …),
+  // so an undeclared key is simply absent — the read-back then goes out with no
+  // x-s2s-key and claw-auth returns 401. That failure is silent: the tool falls
+  // back to advising a full rebuild, which looks like the model choosing badly
+  // rather than a misconfiguration.
+  it("create-app declares the auth URL and S2S key it reads", () => {
+    const keys = Object.keys(createReactArtifactTool.configSchema ?? {});
+    expect(keys).toContain("XYNE_CLAW_AUTH_URL");
+    expect(keys).toContain("XYNE_CLAW_S2S_KEY");
+  });
+
+  it("read-app-file declares them too", async () => {
+    const { readArtifactAppFileTool } = await import("./readTool.js");
+    const keys = Object.keys(readArtifactAppFileTool.configSchema ?? {});
+    expect(keys).toContain("XYNE_CLAW_AUTH_URL");
+    expect(keys).toContain("XYNE_CLAW_S2S_KEY");
   });
 });

--- a/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
@@ -108,6 +108,32 @@ const RESERVED_PATH_PREFIXES = ["/components/ui/", "/lib/utils", "/lib/xyne-data
 const MAX_DECLARED_AGENTS = 4;
 const AGENT_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
+/**
+ * Config keys these tools receive at execution time.
+ *
+ * This block is load-bearing, not boilerplate: xyne-claw builds each tool's
+ * context with `resolveToolConfig(tool.configSchema, config)`, so a tool that
+ * declares no schema is handed an EMPTY config object. Without it the S2S key
+ * is undefined, the read-back goes out unauthenticated, and claw-auth answers
+ * 401 — which is exactly how incremental updates silently degraded into full
+ * rebuilds (observed 2026-09-02: every `mode:"update"` returned
+ * "could not load the current app (HTTP 401)").
+ */
+export const REACT_ARTIFACT_CONFIG_SCHEMA = {
+  XYNE_CLAW_AUTH_URL: {
+    label: "Claw Auth Service URL",
+    default: "http://localhost:3003",
+    required: true as const,
+    placeholder: "http://localhost:3003",
+  },
+  XYNE_CLAW_S2S_KEY: {
+    label: "Claw S2S Key (reads the conversation's current app before an update)",
+    default: "",
+    required: false as const,
+    placeholder: "Shared secret between xyne-claw and xyne-claw-auth",
+  },
+};
+
 export interface ReactArtifactFile {
   path: string;
   content: string;
@@ -426,6 +452,95 @@ function parseAgents(raw: unknown): string[] {
   return agents;
 }
 
+/**
+ * Fold an incremental update onto the project the conversation already has.
+ *
+ * Produces raw params, NOT a payload, so the merged whole then goes through
+ * `buildReactArtifact` unchanged. That ordering is the point: a patch must not
+ * be able to reach storage past validation that a full build would have failed —
+ * entry still present, path rules, per-file and total size limits all apply to
+ * the RESULT, not to the handful of files the model happened to send.
+ *
+ * Merge rules:
+ *  - `files` replace by path; everything untouched is inherited.
+ *  - `deleteFiles` removes, since a patch cannot express absence.
+ *  - Every other field is replace-if-present, inherit otherwise — the model
+ *    sends `dependencies` only when they changed, and omitting them must not
+ *    silently uninstall the project's packages.
+ *  - `summary` is the exception: it describes THIS turn, so it is never
+ *    inherited.
+ *
+ * Exported for unit tests; `execute` is the only production caller.
+ */
+export function mergeArtifactParams(
+  base: ReactArtifactPayload,
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const deletions = parseDeleteFiles(params["deleteFiles"]);
+
+  const byPath = new Map<string, ReactArtifactFile>();
+  for (const file of base.files) byPath.set(file.path, file);
+
+  // Deletions first, so re-sending a path you also deleted is a no-op rather
+  // than order-dependent.
+  for (const path of deletions) {
+    if (!byPath.has(path)) {
+      fail(`Cannot delete "${path}": the app has no such file. Current files: ${base.files.map((f) => f.path).join(", ")}.`);
+    }
+    byPath.delete(path);
+  }
+
+  const incoming = params["files"];
+  if (incoming !== undefined && incoming !== null) {
+    if (!Array.isArray(incoming)) {
+      fail("`files` must be an array of {path, content}.");
+    }
+    for (const entry of incoming) {
+      const path = asString((entry as ReactArtifactFile | undefined)?.path).trim();
+      const content = asString((entry as ReactArtifactFile | undefined)?.content);
+      if (!path) fail("Every file needs a non-empty `path`.");
+      byPath.set(path, { path, content });
+    }
+  }
+
+  if (byPath.size === 0) {
+    fail("An update cannot delete every file. Send at least one file, or use mode \"create\" to start over.");
+  }
+
+  const has = (key: string): boolean => params[key] !== undefined && params[key] !== null;
+
+  return {
+    title: has("title") ? params["title"] : base.title,
+    entry: has("entry") ? params["entry"] : base.entry,
+    files: [...byPath.values()],
+    dependencies: has("dependencies") ? params["dependencies"] : base.dependencies,
+    dataRequirements: has("dataRequirements") ? params["dataRequirements"] : base.dataRequirements,
+    writes: has("writes") ? params["writes"] : base.writes,
+    invokesAgents: has("invokesAgents") ? params["invokesAgents"] : base.invokesAgents,
+    agents: has("agents") ? params["agents"] : base.agents,
+    // Describes this turn's change, so never inherited.
+    ...(has("summary") ? { summary: params["summary"] } : {}),
+  };
+}
+
+/** Paths an update removes. Validated like any other path so a traversal or a
+ *  reserved prefix cannot slip in through the delete channel. */
+function parseDeleteFiles(raw: unknown): string[] {
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) fail("`deleteFiles` must be an array of file paths.");
+  if (raw.length > MAX_FILES) {
+    fail(`Too many deletions: ${raw.length}. The limit is ${MAX_FILES}.`);
+  }
+  const paths: string[] = [];
+  for (const entry of raw) {
+    const path = asString(entry).trim();
+    if (!path) fail("`deleteFiles` entries must be non-empty file paths.");
+    validatePath(path);
+    if (!paths.includes(path)) paths.push(path);
+  }
+  return paths;
+}
+
 export interface BuiltReactArtifact {
   payload: ReactArtifactPayload;
   manifest: ReactArtifactManifest;
@@ -488,6 +603,88 @@ export function buildReactArtifact(params: Record<string, unknown>): BuiltReactA
   return { payload, manifest, summary };
 }
 
+/** How long to wait for claw-auth when reading the current build. Generous:
+ *  this is one small GCS-backed read on the internal network, and timing out
+ *  early would push the model into a needless full rebuild. */
+const READ_BACK_TIMEOUT_MS = 15_000;
+
+type ReadBackResult =
+  | { ok: true; payload: ReactArtifactPayload; versionNumber: number }
+  | { ok: false; error: string };
+
+/**
+ * Fetch the build this conversation is currently on, so an update can be folded
+ * onto it.
+ *
+ * Every failure here returns a RETRYABLE error and never falls back to treating
+ * the call as a create. A silent full rebuild is precisely the behaviour Step 2
+ * exists to remove: it would discard the user's current app and re-imagine it
+ * from conversational memory at the exact moment we know we cannot see it.
+ */
+async function readConversationApp(context?: ToolExecutionContext): Promise<ReadBackResult> {
+  const conversationId = context?.meta?.["conversationId"];
+  if (!conversationId) {
+    return {
+      ok: false,
+      error:
+        'Error: `mode: "update"` needs a conversation that already owns an app, and this run has no conversation. Call create-app with `mode: "create"`.',
+    };
+  }
+
+  const authUrl = context?.config?.["XYNE_CLAW_AUTH_URL"] ?? "http://localhost:3003";
+  const s2sKey = context?.config?.["XYNE_CLAW_S2S_KEY"] ?? "";
+  const url = `${authUrl}/claw/api/v1/internal/artifact-apps/by-conversation/${encodeURIComponent(conversationId)}/payload`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { ...(s2sKey ? { "x-s2s-key": s2sKey } : {}) },
+      signal: AbortSignal.timeout(READ_BACK_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `Error: could not load the current app (${message}). This is temporary — retry the same update. Do not rebuild the whole project unless the user asks for a fresh one.`,
+    };
+  }
+
+  if (res.status === 404) {
+    return {
+      ok: false,
+      error:
+        'Error: this conversation has no app yet, so there is nothing to update. Call create-app with `mode: "create"`.',
+    };
+  }
+  if (!res.ok) {
+    return {
+      ok: false,
+      error: `Error: could not load the current app (HTTP ${res.status}). This is temporary — retry the same update rather than rebuilding the project.`,
+    };
+  }
+
+  let body: { payload?: unknown; versionNumber?: unknown };
+  try {
+    body = (await res.json()) as { payload?: unknown; versionNumber?: unknown };
+  } catch {
+    return { ok: false, error: "Error: the current app came back unreadable. Retry the same update." };
+  }
+
+  const payload = body.payload as ReactArtifactPayload | undefined;
+  if (!payload || !Array.isArray(payload.files) || payload.files.length === 0) {
+    return {
+      ok: false,
+      error: "Error: the current app has no readable files. Retry, or call create-app with `mode: \"create\"`.",
+    };
+  }
+
+  return {
+    ok: true,
+    payload,
+    versionNumber: typeof body.versionNumber === "number" ? body.versionNumber : 0,
+  };
+}
+
 /** Serialize a built artifact into the marker string the claw runtime parses. */
 export function formatReactArtifactResult(built: BuiltReactArtifact): string {
   const data = Buffer.from(JSON.stringify(built.payload), "utf8").toString("base64");
@@ -506,17 +703,29 @@ export const createReactArtifactTool: ToolDefinition = {
   // custom-tool palette — a tool declared builtin is silently absent from the
   // model's tool list no matter what the agent config selects.
   source: "custom:react-artifact",
+  configSchema: REACT_ARTIFACT_CONFIG_SCHEMA,
   description:
     "Build a small, self-contained React app that the user can view and interact with, instead of " +
     "describing a UI in prose. Use it when the answer is better shown than told — a dashboard, a chart, " +
     "a comparison table, an interactive explainer. Write TypeScript React (.tsx) and default-export a " +
     "component from the `entry` file.\n\n" +
     "ONE APP PER CONVERSATION — this thread has a single app. Your FIRST call creates it; " +
-    "every later call REPLACES its contents as a new version of that same app. So when asked " +
-    "to change or fix something, re-send the whole project with the change applied — do not " +
-    "announce a new app, do not rename it unless asked, and do not drop features you built " +
-    "earlier just because the latest message did not mention them. Users can roll back to any " +
-    "earlier version, so a mistake is recoverable — but a silent regression is not obvious.\n\n" +
+    "every later call produces a new version of that same app. Do not announce a new app and do " +
+    "not rename it unless asked.\n\n" +
+    "CHANGING AN EXISTING APP — use `mode: \"update\"` and send ONLY the files you changed:\n" +
+    "  1. Call `read-app-file` with no path to list the current files, then with a path to read " +
+    "each file you intend to change. You cannot edit code you have not read — you do not " +
+    "otherwise see the app you built, and guessing at it from memory is how features silently " +
+    "disappear.\n" +
+    "  2. Call create-app with `mode: \"update\"` and `files` containing just the changed files. " +
+    "Use `deleteFiles` to remove one. Everything you omit — other files, title, entry, " +
+    "dependencies, dataRequirements — is inherited unchanged.\n" +
+    "Each file you send REPLACES that file whole, so write it out complete: do not drop features " +
+    "you built earlier just because the latest message did not mention them.\n" +
+    "Sending the whole project on every tweak is slow, truncates large apps, and reintroduces " +
+    "bugs you already fixed. Only use `mode: \"create\"` for the first build, or when the user " +
+    "genuinely wants a different app. Users can roll back to any earlier version, so a mistake " +
+    "is recoverable — but a silent regression is not obvious.\n\n" +
     "DESIGN SYSTEM — the project is preloaded with Tailwind v4 and the shadcn/ui base set. Do NOT " +
     "write these yourself and do NOT list them in `dependencies`; they are injected for you:\n" +
     `  • shadcn/ui components at /components/ui/<name>: ${SHADCN_UI_COMPONENTS.join(", ")}\n` +
@@ -619,6 +828,18 @@ export const createReactArtifactTool: ToolDefinition = {
   inputSchema: {
     type: "object",
     properties: {
+      mode: {
+        type: "string",
+        enum: ["create", "update"],
+        description:
+          'Defaults to "create". Use "update" to change an app this conversation already built: send ONLY the files you changed and the tool merges them onto the current build. Every other field you omit is inherited.',
+      },
+      deleteFiles: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          'Paths to remove, e.g. ["/OldChart.tsx"]. Only meaningful with mode "update" — a patch cannot express a deletion any other way.',
+      },
       title: {
         type: "string",
         description: "Short, user-facing name for the app, e.g. \"Weekly ticket volume\".",
@@ -713,14 +934,32 @@ export const createReactArtifactTool: ToolDefinition = {
         },
       },
     },
-    required: ["title", "entry", "files"],
+    // `title` and `entry` are required for a CREATE and inherited on an UPDATE,
+    // which a static schema cannot express — `buildReactArtifact` fails with an
+    // actionable message when a create omits them.
+    required: ["files"],
   },
   execute: async (
     params: Record<string, unknown>,
-    _context?: ToolExecutionContext,
+    context?: ToolExecutionContext,
   ): Promise<string> => {
     try {
-      return formatReactArtifactResult(buildReactArtifact(params));
+      const mode = asString(params["mode"]).trim() || "create";
+      if (mode !== "create" && mode !== "update") {
+        return 'Error: `mode` must be "create" or "update".';
+      }
+
+      if (mode === "create") {
+        return formatReactArtifactResult(buildReactArtifact(params));
+      }
+
+      const base = await readConversationApp(context);
+      if (!base.ok) return base.error;
+
+      // Merge first, then validate the WHOLE — never the fragment.
+      return formatReactArtifactResult(
+        buildReactArtifact(mergeArtifactParams(base.payload, params)),
+      );
     } catch (err) {
       if (err instanceof ValidationError) {
         return `Error: ${err.message} Fix the input and call create-app again.`;

--- a/packages/xyne-claw-shared/src/tools/registry.ts
+++ b/packages/xyne-claw-shared/src/tools/registry.ts
@@ -135,6 +135,7 @@ register(researchAgent.reviewPullRequest);
 register(createPpt.createPptTool);
 register(createPpt.editPptTool);
 register(reactArtifact.createReactArtifactTool);
+register(reactArtifact.readArtifactAppFileTool);
 
 // Register create-html-report tool — renders a markdown report into a
 // standalone HTML file and attaches it, leaving a short summary inline in


### PR DESCRIPTION
Step 2 of the artifact-app lifecycle plan: `create-app` can now **edit** an app instead of re-imagining it.

## The problem

The agent never saw the code it wrote. `create-app` returns only a manifest — file *paths*, never contents — so "make the header blue" regenerated all 15 files from conversational memory: ~10–16k output tokens, truncation on large apps, and bugs fixed two versions ago quietly returning.

## What landed

| Piece | Detail |
|---|---|
| `mode: "update"` + `deleteFiles` | Send only what changed; `deleteFiles` because a patch cannot express absence |
| `read-app-file` | New tool — list files, or read one. The read half that makes editing possible |
| S2S read-back route | `GET /internal/artifact-apps/by-conversation/:convId/payload`, `requireStrictS2S`, read-only |
| Merge + revalidate | Merge produces raw *params*, then the untouched `buildReactArtifact` validates the **whole** result — a patch cannot slip past validation a full build would fail |

Nothing downstream changed: the attachment still carries the complete project, versioning is untouched, the renderer is oblivious. Only the model's *output* shrinks.

## Verified live, not just unit-tested

| Check | Result |
|---|---|
| Payload on a real patch | **12,590 → 3,787 chars (−70%)** on a 2-file app |
| `read-app-file` called before editing | ✅ 5 consecutive turns |
| `deleteFiles` | ✅ removed a file and inlined it, landed a new version |
| Merge bases on **head**, not newest | ✅ verified through 3 break/fix cycles |
| Content dedup | ✅ 3 repairs each converged byte-for-byte on v1, reusing it instead of creating duplicates |

308 unit tests pass; `xyne-claw-shared`, `xyne-claw` and `xyne-claw-auth` all typecheck clean.

## Fixes found while testing

- **`read-app-file` was never offered to agents.** Registering a tool does not add it to an agent's saved `tools.custom`, so `fractal-agent` held `create-app` without its reader. Now paired at resolution time (`expandCustomSelection`) at both gate sites, so no saved config needs migrating.
- **`configSchema` was missing on both tools.** `resolveToolConfig` only sources env for *declared* keys, so the S2S key was empty and every read-back 401'd — silently degrading updates into full rebuilds. Declared, with a regression test.
- **A run producing no result finalized as `completed`.** It now reports `failed`; that status is what made a rate-limit outage read as "the agent does nothing" for hours.

## Also in this commit

App Creation mode entry made deterministic (it was a race between two URL writers), the artifact card de-boxed, a duplicate `artifact.json` attachment row removed, the Sandpack boot loader, the file-tree light/dark fix, and a prompt-marker rail in the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)