### PR TITLE
feat: XYNE-61843 incremental app updates

### DIFF
--- a/apps/xyne-claw-auth/backend/src/http/routes.ts
+++ b/apps/xyne-claw-auth/backend/src/http/routes.ts
@@ -34,6 +34,7 @@ import { artifactAppAgentsRouter } from "../routes/artifact-app-agents.js";
 import { designSharesRouter, publicDesignSharesRouter } from "../routes/design-shares.js";
 import { sessionsArchiveRouter } from "../routes/sessions-archive.js";
 import { experimentsInternalRouter } from "../routes/experiments-internal.js";
+import { artifactAppsInternalRouter } from "../routes/artifact-apps-internal.js";
 import { errorPipelineIngestRouter, errorPipelineInternalRouter } from "../routes/error-pipeline.js";
 import { googleOAuthRouter, googleCallbackRouter } from "../routes/google-oauth.js";
 import { microsoftOAuthRouter, microsoftCallbackRouter } from "../routes/microsoft-oauth.js";
@@ -161,6 +162,7 @@ function mountCoreApi(app: Express): void {
   app.use(`${BASE}/internal/attachments`, requireInternalS2S, attachmentsInternalRouter); // Spaces → extract document text via claw's converters (INTERNAL_S2S_KEY)
   app.use(`${BASE}/internal/sessions`, requireStrictS2S, sessionsArchiveRouter);     // archive/restore session JSONLs to GCS — S2S only (transcripts)
   app.use(`${BASE}/internal/experiments`, requireStrictS2S, experimentsInternalRouter);
+  app.use(`${BASE}/internal/artifact-apps`, requireStrictS2S, artifactAppsInternalRouter); // create-app reads the conversation's head build before an incremental update
   app.use(`${BASE}/error-pipeline`, errorPipelineIngestRouter); // Grafana webhook ingest (JWT-authed inside)
   app.use(`${BASE}/internal/error-pipeline`, requireStrictS2S, errorPipelineInternalRouter); // run-result callback from xyne-claw (S2S only)
   app.use(`${BASE}/internal/tts`, requireStrictS2S, ttsRouter);

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-app-agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-app-agents.ts
@@ -570,7 +570,8 @@ async function dispatchRun(input: {
 }
 
 /**
- * Remove create-app from the agent's selected custom tools before dispatch.
+ * Remove create-app and its read-back tool from the agent's selected custom
+ * tools before dispatch.
  *
  * This is the WEAKER half of the recursion guard and cannot stand alone: an
  * agent with no `tools` key gets every tool by default (see parseToolsConfig),
@@ -586,7 +587,7 @@ function stripCreateApp(config: unknown): unknown {
     ...(cfg as object),
     tools: {
       ...(cfg?.tools as object),
-      custom: custom.filter((s) => s !== "create-app" && s !== "schedule-task"),
+      custom: custom.filter((s) => s !== "create-app" && s !== "read-app-file" && s !== "schedule-task"),
     },
   };
 }

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-apps-internal.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-apps-internal.ts
@@ -1,0 +1,96 @@
+/**
+ * S2S read-back of a conversation's current app, for the `create-app` tool.
+ *
+ * The tool runs in xyne-claw, which is stateless and has no database — it is a
+ * pure validator by design. But an *incremental* update has to start from the
+ * code that is already there, and the agent never sees that code: the tool
+ * result carries only the manifest (file paths), while the bytes go to GCS. So
+ * every "change the header colour" regenerated the whole project from
+ * conversational memory — thousands of output tokens, truncation on large apps,
+ * and bugs from two iterations ago quietly reappearing.
+ *
+ * This is the read half that closes that gap. It is keyed by CONVERSATION, not
+ * by app id, because that is the only identifier the tool has: Step 1 made a
+ * conversation own exactly one app, which is what lets `:convId` be
+ * unambiguous.
+ *
+ * Strictly S2S and strictly read-only. It serves HEAD — the version the owner
+ * and the agent are working on, which is what makes "restore v2, now add X"
+ * edit v2 rather than the newest build.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { prisma } from "../db.js";
+import { gcsService } from "../services/storageService.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("artifact-apps-internal");
+export const artifactAppsInternalRouter: Router = Router();
+
+/**
+ * Resolve a conversation to the app version the agent should build on.
+ *
+ * Head, not newest: `headVersionId` moves backward on restore, and an update
+ * that silently based on the highest version number would undo the rollback the
+ * user just performed. Falls back to the newest version only for apps created
+ * before head tracking existed.
+ */
+async function resolveHeadVersion(conversationId: string) {
+  const app = await prisma.artifactApp.findUnique({ where: { conversationId } });
+  if (!app || app.isArchived) return null;
+
+  const version = app.headVersionId
+    ? await prisma.artifactAppVersion.findUnique({ where: { id: app.headVersionId } })
+    : await prisma.artifactAppVersion.findFirst({
+        where: { appId: app.id },
+        orderBy: { versionNumber: "desc" },
+      });
+
+  if (!version || version.appId !== app.id) return null;
+  return { app, version };
+}
+
+/**
+ * GET /by-conversation/:convId/payload — the full project the agent should edit.
+ *
+ * Returns the stored payload verbatim (it was canonicalized through
+ * `buildReactArtifact` before being written, so it is already exactly what the
+ * validator approved) plus the identifiers the caller needs to reason about
+ * what it is holding.
+ */
+artifactAppsInternalRouter.get(
+  "/by-conversation/:convId/payload",
+  async (req: Request<{ convId: string }>, res: Response): Promise<void> => {
+    const found = await resolveHeadVersion(req.params.convId);
+    if (!found) {
+      res.status(404).json({ success: false, error: "No app for this conversation" });
+      return;
+    }
+    const { app, version } = found;
+
+    let raw: Buffer;
+    try {
+      raw = await gcsService.getFileBuffer(version.storagePath);
+    } catch (err) {
+      log.error(`failed reading head payload app=${app.id} version=${version.id}: ${String(err)}`);
+      res.status(502).json({ success: false, error: "Could not read the current app" });
+      return;
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw.toString("utf8"));
+    } catch {
+      res.status(502).json({ success: false, error: "Stored app payload is not valid JSON" });
+      return;
+    }
+
+    res.json({
+      success: true,
+      appId: app.id,
+      versionId: version.id,
+      versionNumber: version.versionNumber,
+      payload,
+    });
+  },
+);

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -297,6 +297,27 @@ function dedupeToolsByName(tools: ToolDefinition[]): ToolDefinition[] {
 }
 
 /** Snapshot for shutdown/drain forensics — one line per still-active run. */
+/**
+ * `read-app-file` rides on `create-app` selection.
+ *
+ * The two are one feature. `create-app` writes a project but hands back only a
+ * manifest — file paths, never contents — so without the read half an
+ * incremental update is authored from memory, which is how earlier features get
+ * silently dropped. Registering a new tool does NOT add it to agents that
+ * already have a saved `tools.custom` list, so fractal-agent held `create-app`
+ * while never being offered its reader (observed 2026-09-02: an explicit "read
+ * the code and tell me…" turn made zero tool calls and answered from context).
+ *
+ * Pairing at resolution time rather than per-agent means no saved selection has
+ * to be migrated and no new agent can be configured into the same half-state.
+ * Mirrors the sandbox → playwright hoist below.
+ */
+function expandCustomSelection(custom: string[] | undefined): Set<string> {
+  const selected = new Set(custom ?? []);
+  if (selected.has("create-app")) selected.add("read-app-file");
+  return selected;
+}
+
 export function describeActiveRuns(): Array<{ sessionId: string; agentSlug: string; userId: string; ageS: number }> {
   const now = Date.now();
   return [...activeRuns.entries()].map(([sessionId, a]) => ({
@@ -925,8 +946,16 @@ router.post("/run", validateS2SKey, async (req, res: Response) => {
           : processTaskError !== undefined
             ? String(processTaskError)
             : "Run ended without emitting a result (likely session-locked or silent early-return — check claw logs for this sessionId)";
-        const status: "completed" | "failed" | "cancelled" = processTaskError || activeRun.handoffCapFired ? "failed" : "completed";
-        emitter.forceDone(sessionId, status, reason);
+        // Reaching here means the emitter never wrote a done frame — the run
+        // produced NO result. That is a failure whether or not something was
+        // thrown: a loop that gives up after every LLM turn 429s throws
+        // nothing, yet used to finalize as "completed" with a zero-length
+        // answer. Eight consecutive runs reported success that way on
+        // 2026-09-02 while the LiteLLM key was rate-limited, which is why the
+        // outage read as "the agent silently does nothing" for hours. The
+        // `reason` string above already describes a failure; the status now
+        // agrees with it.
+        emitter.forceDone(sessionId, "failed", reason);
       }
       const terminal = emitter.terminalPayload();
       if (terminal && emitter.deliveryFailed() && typeof callbackUrl === "string" && callbackUrl.trim()) {
@@ -2374,7 +2403,7 @@ export async function processTask(
       if (!cfg) return tools;
       const allowedSubagents = new Set(cfg.subagents ?? []);
       const allowedDirect = cfg.direct ?? [];
-      const allowedCustom = new Set(cfg.custom ?? []);
+      const allowedCustom = expandCustomSelection(cfg.custom);
       const allowedGatewayServices = new Set(cfg.gateway ?? []);
       return tools.filter((t) => {
         if (sets.subagentTools.some((s) => s.name === t.name)) {
@@ -2648,7 +2677,7 @@ export async function processTask(
     if (toolsConfigEarly) {
       const allowedSubagents = new Set(toolsConfigEarly.subagents ?? []);
       const allowedDirect = toolsConfigEarly.direct ?? [];
-      const allowedCustom = new Set(toolsConfigEarly.custom ?? []);
+      const allowedCustom = expandCustomSelection(toolsConfigEarly.custom);
       const allowedGatewayServices = new Set(toolsConfigEarly.gateway ?? []);
 
       allTools = allTools.filter((t) => {
@@ -3074,9 +3103,17 @@ export async function processTask(
       eventType === "artifact_app" || (conversationId?.startsWith("app_") ?? false);
     if (isArtifactAppRun) {
       const before = allTools.length;
-      allTools = allTools.filter((t) => t.name !== "create-app" && t.name !== "schedule-task");
+      // read-app-file goes with create-app: it is keyed by conversation, and an
+      // app-invoked run carries the `app_` conversation of the app itself, so
+      // leaving it in would let an app read its own source back.
+      allTools = allTools.filter(
+        (t) =>
+          t.name !== "create-app" && t.name !== "read-app-file" && t.name !== "schedule-task",
+      );
       if (allTools.length !== before) {
-        log("Artifact-app run — create-app + schedule-task removed (self-replication ban)");
+        log(
+          "Artifact-app run — create-app + read-app-file + schedule-task removed (self-replication ban)",
+        );
       }
     }
 

--- a/packages/xyne-claw-shared/src/tools/react-artifact/index.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/index.ts
@@ -1,8 +1,10 @@
 export {
   createReactArtifactTool,
   buildReactArtifact,
+  mergeArtifactParams,
   formatReactArtifactResult,
 } from "./tools.js";
+export { readArtifactAppFileTool } from "./readTool.js";
 export type {
   ReactArtifactFile,
   ReactArtifactDataRequirement,

--- a/packages/xyne-claw-shared/src/tools/react-artifact/readTool.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/readTool.ts
@@ -1,0 +1,158 @@
+/**
+ * read-app-file — the read half of incremental updates.
+ *
+ * `create-app` hands back only a manifest: file *paths*, never contents. The
+ * bytes go straight to object storage. So an agent asked to "change the header
+ * colour" could not see the header — it rewrote all fifteen files from its
+ * memory of the conversation, which is how features silently disappeared and
+ * bugs fixed two versions ago came back.
+ *
+ * This closes that loop. Read the files you intend to change, then send only
+ * those back through `create-app` with `mode: "update"`.
+ *
+ * Reads HEAD, the same build `create-app` merges onto, so the code you read is
+ * exactly the code your patch lands on. Both go through one S2S route in
+ * claw-auth, keyed by conversation — Step 1 made a conversation own exactly one
+ * app, which is what makes that key unambiguous.
+ */
+
+import type { ToolDefinition, ToolExecutionContext } from "../types.js";
+import { REACT_ARTIFACT_CONFIG_SCHEMA } from "./tools.js";
+import type { ReactArtifactFile, ReactArtifactPayload } from "./tools.js";
+
+const READ_TIMEOUT_MS = 15_000;
+
+/** A single file's content is capped well below the runtime's tool-result
+ *  truncation so a large file arrives whole rather than silently clipped. */
+const MAX_CONTENT_CHARS = 48_000;
+
+interface HeadApp {
+  payload: ReactArtifactPayload;
+  versionNumber: number;
+}
+
+async function fetchHead(
+  context?: ToolExecutionContext,
+): Promise<{ ok: true; head: HeadApp } | { ok: false; error: string }> {
+  const conversationId = context?.meta?.["conversationId"];
+  if (!conversationId) {
+    return { ok: false, error: "Error: this run has no conversation, so there is no app to read." };
+  }
+
+  const authUrl = context?.config?.["XYNE_CLAW_AUTH_URL"] ?? "http://localhost:3003";
+  const s2sKey = context?.config?.["XYNE_CLAW_S2S_KEY"] ?? "";
+  const url = `${authUrl}/claw/api/v1/internal/artifact-apps/by-conversation/${encodeURIComponent(conversationId)}/payload`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { ...(s2sKey ? { "x-s2s-key": s2sKey } : {}) },
+      signal: AbortSignal.timeout(READ_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `Error: could not read the app (${message}). Retry.` };
+  }
+
+  if (res.status === 404) {
+    return {
+      ok: false,
+      error:
+        'Error: this conversation has no app yet. Build one first with create-app and `mode: "create"`.',
+    };
+  }
+  if (!res.ok) {
+    return { ok: false, error: `Error: could not read the app (HTTP ${res.status}). Retry.` };
+  }
+
+  let body: { payload?: unknown; versionNumber?: unknown };
+  try {
+    body = (await res.json()) as { payload?: unknown; versionNumber?: unknown };
+  } catch {
+    return { ok: false, error: "Error: the app came back unreadable. Retry." };
+  }
+
+  const payload = body.payload as ReactArtifactPayload | undefined;
+  if (!payload || !Array.isArray(payload.files)) {
+    return { ok: false, error: "Error: the app has no readable files." };
+  }
+
+  return {
+    ok: true,
+    head: { payload, versionNumber: typeof body.versionNumber === "number" ? body.versionNumber : 0 },
+  };
+}
+
+/** The listing shown when no path is given: enough to decide what to read next
+ *  without pulling every file's contents into the context window. */
+function formatListing(head: HeadApp): string {
+  const { payload } = head;
+  const lines = payload.files.map((f: ReactArtifactFile) => {
+    const bytes = Buffer.byteLength(f.content ?? "", "utf8");
+    const entry = f.path === payload.entry ? "  (entry)" : "";
+    return `  ${f.path}  —  ${bytes} bytes${entry}`;
+  });
+  const deps = Object.keys(payload.dependencies ?? {});
+  return (
+    `"${payload.title}" — version ${head.versionNumber}, ${payload.files.length} file(s):\n` +
+    `${lines.join("\n")}\n` +
+    `dependencies: ${deps.length ? deps.join(", ") : "(none)"}\n\n` +
+    "Read the files you intend to change, then call create-app with " +
+    '`mode: "update"` and only those files.'
+  );
+}
+
+export const readArtifactAppFileTool: ToolDefinition = {
+  slug: "read-app-file",
+  name: "Read app file",
+  source: "custom:react-artifact",
+  configSchema: REACT_ARTIFACT_CONFIG_SCHEMA,
+  description:
+    "Read the current source of the app this conversation has already built. Call with no `path` to " +
+    "list its files, then with a `path` to read one.\n\n" +
+    "ALWAYS read before you change. create-app returns only file paths, never contents, so this is " +
+    "the only way to see the code you are editing — without it you are rewriting from memory, which " +
+    "is how earlier features get dropped. Read the files you intend to change, then send just those " +
+    'back through create-app with `mode: "update"`.\n\n' +
+    "Reads the version the app is currently on, which is the same build your update merges onto — " +
+    "including after the user has rolled back to an earlier version.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description:
+          'Exact file path to read, e.g. "/App.tsx". Omit to list every file with its size.',
+      },
+    },
+    required: [],
+  },
+  execute: async (
+    params: Record<string, unknown>,
+    context?: ToolExecutionContext,
+  ): Promise<string> => {
+    const result = await fetchHead(context);
+    if (!result.ok) return result.error;
+    const { head } = result;
+
+    const raw = params["path"];
+    const path = typeof raw === "string" ? raw.trim() : "";
+    if (!path) return formatListing(head);
+
+    const file = head.payload.files.find((f: ReactArtifactFile) => f.path === path);
+    if (!file) {
+      const known = head.payload.files.map((f: ReactArtifactFile) => f.path).join(", ");
+      return `Error: no file at "${path}". The app has: ${known}.`;
+    }
+
+    const content = file.content ?? "";
+    if (content.length > MAX_CONTENT_CHARS) {
+      return (
+        `${path} (truncated at ${MAX_CONTENT_CHARS} of ${content.length} characters — ` +
+        "this file is too large to edit safely; consider splitting it):\n\n" +
+        content.slice(0, MAX_CONTENT_CHARS)
+      );
+    }
+    return `${path}:\n\n${content}`;
+  },
+};

--- a/packages/xyne-claw-shared/src/tools/react-artifact/tools.test.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/tools.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildReactArtifact,
   formatReactArtifactResult,
+  mergeArtifactParams,
   createReactArtifactTool,
   type ReactArtifactPayload,
   type ReactArtifactManifest,
@@ -537,5 +538,179 @@ describe("session scoping guidance", () => {
 
   it("warns against dropping earlier work on an update", () => {
     expect(createReactArtifactTool.description).toMatch(/do not drop features you built/i);
+  });
+});
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Incremental updates (Step 2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function baseApp(overrides: Partial<ReactArtifactPayload> = {}): ReactArtifactPayload {
+  return {
+    version: 1,
+    title: "Ticket dashboard",
+    entry: "/App.tsx",
+    template: "react-ts",
+    files: [
+      { path: "/App.tsx", content: "export default () => <Chart />;" },
+      { path: "/Chart.tsx", content: "export const Chart = () => <div>chart</div>;" },
+      { path: "/theme.css", content: ".a{color:red}" },
+    ],
+    dependencies: { recharts: "latest" },
+    dataRequirements: [],
+    ...overrides,
+  };
+}
+
+describe("mergeArtifactParams", () => {
+  it("replaces only the files sent and inherits the rest", () => {
+    const merged = mergeArtifactParams(baseApp(), {
+      files: [{ path: "/Chart.tsx", content: "export const Chart = () => <div>NEW</div>;" }],
+    });
+
+    const files = merged["files"] as Array<{ path: string; content: string }>;
+    expect(files).toHaveLength(3);
+    expect(files.find((f) => f.path === "/Chart.tsx")?.content).toContain("NEW");
+    expect(files.find((f) => f.path === "/App.tsx")?.content).toContain("<Chart />");
+    expect(merged["title"]).toBe("Ticket dashboard");
+    expect(merged["entry"]).toBe("/App.tsx");
+    expect(merged["dependencies"]).toEqual({ recharts: "latest" });
+  });
+
+  it("adds a file that is not in the base", () => {
+    const merged = mergeArtifactParams(baseApp(), {
+      files: [{ path: "/Legend.tsx", content: "export const Legend = () => null;" }],
+    });
+    expect((merged["files"] as unknown[]).length).toBe(4);
+  });
+
+  it("removes files named in deleteFiles", () => {
+    const merged = mergeArtifactParams(baseApp(), {
+      files: [{ path: "/App.tsx", content: "export default () => null;" }],
+      deleteFiles: ["/Chart.tsx"],
+    });
+    const paths = (merged["files"] as Array<{ path: string }>).map((f) => f.path);
+    expect(paths).toEqual(["/App.tsx", "/theme.css"]);
+  });
+
+  it("rejects deleting a file the app does not have", () => {
+    expect(() =>
+      mergeArtifactParams(baseApp(), { files: [], deleteFiles: ["/nope.tsx"] }),
+    ).toThrow(/has no such file/i);
+  });
+
+  it("rejects deleting every file", () => {
+    expect(() =>
+      mergeArtifactParams(baseApp(), {
+        files: [],
+        deleteFiles: ["/App.tsx", "/Chart.tsx", "/theme.css"],
+      }),
+    ).toThrow(/cannot delete every file/i);
+  });
+
+  it("allows a delete-only turn", () => {
+    const merged = mergeArtifactParams(baseApp(), { deleteFiles: ["/theme.css"] });
+    expect((merged["files"] as Array<{ path: string }>).map((f) => f.path)).toEqual([
+      "/App.tsx",
+      "/Chart.tsx",
+    ]);
+  });
+
+  it("re-sending a deleted path keeps the file — deletions apply first", () => {
+    const merged = mergeArtifactParams(baseApp(), {
+      files: [{ path: "/Chart.tsx", content: "resurrected" }],
+      deleteFiles: ["/Chart.tsx"],
+    });
+    const chart = (merged["files"] as Array<{ path: string; content: string }>).find(
+      (f) => f.path === "/Chart.tsx",
+    );
+    expect(chart?.content).toBe("resurrected");
+  });
+
+  it("inherits dependencies when omitted and replaces them when sent", () => {
+    expect(mergeArtifactParams(baseApp(), { files: [] })["dependencies"]).toEqual({
+      recharts: "latest",
+    });
+    expect(
+      mergeArtifactParams(baseApp(), { files: [], dependencies: { "date-fns": "latest" } })[
+        "dependencies"
+      ],
+    ).toEqual({ "date-fns": "latest" });
+  });
+
+  it("never inherits the summary — it describes this turn", () => {
+    const merged = mergeArtifactParams(baseApp(), { files: [] });
+    expect(merged["summary"]).toBeUndefined();
+  });
+
+  it("blocks a reserved path arriving through deleteFiles", () => {
+    expect(() =>
+      mergeArtifactParams(baseApp(), { files: [], deleteFiles: ["/components/ui/card.tsx"] }),
+    ).toThrow();
+  });
+
+  it("the merged whole is re-validated, so a patch cannot orphan the entry", () => {
+    const merged = mergeArtifactParams(baseApp(), { deleteFiles: ["/App.tsx"] });
+    expect(() => buildReactArtifact(merged)).toThrow(/entry/i);
+  });
+});
+
+describe("createReactArtifactTool update mode", () => {
+  it("rejects an unknown mode", async () => {
+    expect(await run(validParams({ mode: "patch" }))).toMatch(/`mode` must be/);
+  });
+
+  it("still builds normally in the default (create) mode", async () => {
+    expect(await run(validParams())).toContain("REACT_ARTIFACT_START");
+  });
+
+  it("update without a conversation steers back to create rather than rebuilding", async () => {
+    const result = await run(validParams({ mode: "update" }));
+    expect(result).toMatch(/no conversation/i);
+    expect(result).toMatch(/mode: "create"/);
+    expect(result).not.toContain("REACT_ARTIFACT_START");
+  });
+});
+
+describe("readArtifactAppFileTool", () => {
+  it("is registered with a read-only shape", async () => {
+    const { readArtifactAppFileTool } = await import("./readTool.js");
+    expect(readArtifactAppFileTool.slug).toBe("read-app-file");
+    expect(readArtifactAppFileTool.isWriteTool).toBeFalsy();
+    expect(readArtifactAppFileTool.inputSchema.required ?? []).toEqual([]);
+  });
+
+  it("reports plainly when the run has no conversation", async () => {
+    const { readArtifactAppFileTool } = await import("./readTool.js");
+    expect(await readArtifactAppFileTool.execute({})).toMatch(/no conversation/i);
+  });
+});
+
+describe("create-app description teaches incremental updates", () => {
+  it("tells the model to read before changing and to send only changed files", () => {
+    expect(createReactArtifactTool.description).toContain("read-app-file");
+    expect(createReactArtifactTool.description).toMatch(/mode: "update"/);
+    expect(createReactArtifactTool.description).toMatch(/ONLY the files you changed/i);
+  });
+});
+
+describe("S2S config is actually reachable at runtime", () => {
+  // xyne-claw builds tool context with resolveToolConfig(tool.configSchema, …),
+  // so an undeclared key is simply absent — the read-back then goes out with no
+  // x-s2s-key and claw-auth returns 401. That failure is silent: the tool falls
+  // back to advising a full rebuild, which looks like the model choosing badly
+  // rather than a misconfiguration.
+  it("create-app declares the auth URL and S2S key it reads", () => {
+    const keys = Object.keys(createReactArtifactTool.configSchema ?? {});
+    expect(keys).toContain("XYNE_CLAW_AUTH_URL");
+    expect(keys).toContain("XYNE_CLAW_S2S_KEY");
+  });
+
+  it("read-app-file declares them too", async () => {
+    const { readArtifactAppFileTool } = await import("./readTool.js");
+    const keys = Object.keys(readArtifactAppFileTool.configSchema ?? {});
+    expect(keys).toContain("XYNE_CLAW_AUTH_URL");
+    expect(keys).toContain("XYNE_CLAW_S2S_KEY");
   });
 });

--- a/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/react-artifact/tools.ts
@@ -108,6 +108,32 @@ const RESERVED_PATH_PREFIXES = ["/components/ui/", "/lib/utils", "/lib/xyne-data
 const MAX_DECLARED_AGENTS = 4;
 const AGENT_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
+/**
+ * Config keys these tools receive at execution time.
+ *
+ * This block is load-bearing, not boilerplate: xyne-claw builds each tool's
+ * context with `resolveToolConfig(tool.configSchema, config)`, so a tool that
+ * declares no schema is handed an EMPTY config object. Without it the S2S key
+ * is undefined, the read-back goes out unauthenticated, and claw-auth answers
+ * 401 — which is exactly how incremental updates silently degraded into full
+ * rebuilds (observed 2026-09-02: every `mode:"update"` returned
+ * "could not load the current app (HTTP 401)").
+ */
+export const REACT_ARTIFACT_CONFIG_SCHEMA = {
+  XYNE_CLAW_AUTH_URL: {
+    label: "Claw Auth Service URL",
+    default: "http://localhost:3003",
+    required: true as const,
+    placeholder: "http://localhost:3003",
+  },
+  XYNE_CLAW_S2S_KEY: {
+    label: "Claw S2S Key (reads the conversation's current app before an update)",
+    default: "",
+    required: false as const,
+    placeholder: "Shared secret between xyne-claw and xyne-claw-auth",
+  },
+};
+
 export interface ReactArtifactFile {
   path: string;
   content: string;
@@ -426,6 +452,95 @@ function parseAgents(raw: unknown): string[] {
   return agents;
 }
 
+/**
+ * Fold an incremental update onto the project the conversation already has.
+ *
+ * Produces raw params, NOT a payload, so the merged whole then goes through
+ * `buildReactArtifact` unchanged. That ordering is the point: a patch must not
+ * be able to reach storage past validation that a full build would have failed —
+ * entry still present, path rules, per-file and total size limits all apply to
+ * the RESULT, not to the handful of files the model happened to send.
+ *
+ * Merge rules:
+ *  - `files` replace by path; everything untouched is inherited.
+ *  - `deleteFiles` removes, since a patch cannot express absence.
+ *  - Every other field is replace-if-present, inherit otherwise — the model
+ *    sends `dependencies` only when they changed, and omitting them must not
+ *    silently uninstall the project's packages.
+ *  - `summary` is the exception: it describes THIS turn, so it is never
+ *    inherited.
+ *
+ * Exported for unit tests; `execute` is the only production caller.
+ */
+export function mergeArtifactParams(
+  base: ReactArtifactPayload,
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const deletions = parseDeleteFiles(params["deleteFiles"]);
+
+  const byPath = new Map<string, ReactArtifactFile>();
+  for (const file of base.files) byPath.set(file.path, file);
+
+  // Deletions first, so re-sending a path you also deleted is a no-op rather
+  // than order-dependent.
+  for (const path of deletions) {
+    if (!byPath.has(path)) {
+      fail(`Cannot delete "${path}": the app has no such file. Current files: ${base.files.map((f) => f.path).join(", ")}.`);
+    }
+    byPath.delete(path);
+  }
+
+  const incoming = params["files"];
+  if (incoming !== undefined && incoming !== null) {
+    if (!Array.isArray(incoming)) {
+      fail("`files` must be an array of {path, content}.");
+    }
+    for (const entry of incoming) {
+      const path = asString((entry as ReactArtifactFile | undefined)?.path).trim();
+      const content = asString((entry as ReactArtifactFile | undefined)?.content);
+      if (!path) fail("Every file needs a non-empty `path`.");
+      byPath.set(path, { path, content });
+    }
+  }
+
+  if (byPath.size === 0) {
+    fail("An update cannot delete every file. Send at least one file, or use mode \"create\" to start over.");
+  }
+
+  const has = (key: string): boolean => params[key] !== undefined && params[key] !== null;
+
+  return {
+    title: has("title") ? params["title"] : base.title,
+    entry: has("entry") ? params["entry"] : base.entry,
+    files: [...byPath.values()],
+    dependencies: has("dependencies") ? params["dependencies"] : base.dependencies,
+    dataRequirements: has("dataRequirements") ? params["dataRequirements"] : base.dataRequirements,
+    writes: has("writes") ? params["writes"] : base.writes,
+    invokesAgents: has("invokesAgents") ? params["invokesAgents"] : base.invokesAgents,
+    agents: has("agents") ? params["agents"] : base.agents,
+    // Describes this turn's change, so never inherited.
+    ...(has("summary") ? { summary: params["summary"] } : {}),
+  };
+}
+
+/** Paths an update removes. Validated like any other path so a traversal or a
+ *  reserved prefix cannot slip in through the delete channel. */
+function parseDeleteFiles(raw: unknown): string[] {
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) fail("`deleteFiles` must be an array of file paths.");
+  if (raw.length > MAX_FILES) {
+    fail(`Too many deletions: ${raw.length}. The limit is ${MAX_FILES}.`);
+  }
+  const paths: string[] = [];
+  for (const entry of raw) {
+    const path = asString(entry).trim();
+    if (!path) fail("`deleteFiles` entries must be non-empty file paths.");
+    validatePath(path);
+    if (!paths.includes(path)) paths.push(path);
+  }
+  return paths;
+}
+
 export interface BuiltReactArtifact {
   payload: ReactArtifactPayload;
   manifest: ReactArtifactManifest;
@@ -488,6 +603,88 @@ export function buildReactArtifact(params: Record<string, unknown>): BuiltReactA
   return { payload, manifest, summary };
 }
 
+/** How long to wait for claw-auth when reading the current build. Generous:
+ *  this is one small GCS-backed read on the internal network, and timing out
+ *  early would push the model into a needless full rebuild. */
+const READ_BACK_TIMEOUT_MS = 15_000;
+
+type ReadBackResult =
+  | { ok: true; payload: ReactArtifactPayload; versionNumber: number }
+  | { ok: false; error: string };
+
+/**
+ * Fetch the build this conversation is currently on, so an update can be folded
+ * onto it.
+ *
+ * Every failure here returns a RETRYABLE error and never falls back to treating
+ * the call as a create. A silent full rebuild is precisely the behaviour Step 2
+ * exists to remove: it would discard the user's current app and re-imagine it
+ * from conversational memory at the exact moment we know we cannot see it.
+ */
+async function readConversationApp(context?: ToolExecutionContext): Promise<ReadBackResult> {
+  const conversationId = context?.meta?.["conversationId"];
+  if (!conversationId) {
+    return {
+      ok: false,
+      error:
+        'Error: `mode: "update"` needs a conversation that already owns an app, and this run has no conversation. Call create-app with `mode: "create"`.',
+    };
+  }
+
+  const authUrl = context?.config?.["XYNE_CLAW_AUTH_URL"] ?? "http://localhost:3003";
+  const s2sKey = context?.config?.["XYNE_CLAW_S2S_KEY"] ?? "";
+  const url = `${authUrl}/claw/api/v1/internal/artifact-apps/by-conversation/${encodeURIComponent(conversationId)}/payload`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: { ...(s2sKey ? { "x-s2s-key": s2sKey } : {}) },
+      signal: AbortSignal.timeout(READ_BACK_TIMEOUT_MS),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      error: `Error: could not load the current app (${message}). This is temporary — retry the same update. Do not rebuild the whole project unless the user asks for a fresh one.`,
+    };
+  }
+
+  if (res.status === 404) {
+    return {
+      ok: false,
+      error:
+        'Error: this conversation has no app yet, so there is nothing to update. Call create-app with `mode: "create"`.',
+    };
+  }
+  if (!res.ok) {
+    return {
+      ok: false,
+      error: `Error: could not load the current app (HTTP ${res.status}). This is temporary — retry the same update rather than rebuilding the project.`,
+    };
+  }
+
+  let body: { payload?: unknown; versionNumber?: unknown };
+  try {
+    body = (await res.json()) as { payload?: unknown; versionNumber?: unknown };
+  } catch {
+    return { ok: false, error: "Error: the current app came back unreadable. Retry the same update." };
+  }
+
+  const payload = body.payload as ReactArtifactPayload | undefined;
+  if (!payload || !Array.isArray(payload.files) || payload.files.length === 0) {
+    return {
+      ok: false,
+      error: "Error: the current app has no readable files. Retry, or call create-app with `mode: \"create\"`.",
+    };
+  }
+
+  return {
+    ok: true,
+    payload,
+    versionNumber: typeof body.versionNumber === "number" ? body.versionNumber : 0,
+  };
+}
+
 /** Serialize a built artifact into the marker string the claw runtime parses. */
 export function formatReactArtifactResult(built: BuiltReactArtifact): string {
   const data = Buffer.from(JSON.stringify(built.payload), "utf8").toString("base64");
@@ -506,17 +703,29 @@ export const createReactArtifactTool: ToolDefinition = {
   // custom-tool palette — a tool declared builtin is silently absent from the
   // model's tool list no matter what the agent config selects.
   source: "custom:react-artifact",
+  configSchema: REACT_ARTIFACT_CONFIG_SCHEMA,
   description:
     "Build a small, self-contained React app that the user can view and interact with, instead of " +
     "describing a UI in prose. Use it when the answer is better shown than told — a dashboard, a chart, " +
     "a comparison table, an interactive explainer. Write TypeScript React (.tsx) and default-export a " +
     "component from the `entry` file.\n\n" +
     "ONE APP PER CONVERSATION — this thread has a single app. Your FIRST call creates it; " +
-    "every later call REPLACES its contents as a new version of that same app. So when asked " +
-    "to change or fix something, re-send the whole project with the change applied — do not " +
-    "announce a new app, do not rename it unless asked, and do not drop features you built " +
-    "earlier just because the latest message did not mention them. Users can roll back to any " +
-    "earlier version, so a mistake is recoverable — but a silent regression is not obvious.\n\n" +
+    "every later call produces a new version of that same app. Do not announce a new app and do " +
+    "not rename it unless asked.\n\n" +
+    "CHANGING AN EXISTING APP — use `mode: \"update\"` and send ONLY the files you changed:\n" +
+    "  1. Call `read-app-file` with no path to list the current files, then with a path to read " +
+    "each file you intend to change. You cannot edit code you have not read — you do not " +
+    "otherwise see the app you built, and guessing at it from memory is how features silently " +
+    "disappear.\n" +
+    "  2. Call create-app with `mode: \"update\"` and `files` containing just the changed files. " +
+    "Use `deleteFiles` to remove one. Everything you omit — other files, title, entry, " +
+    "dependencies, dataRequirements — is inherited unchanged.\n" +
+    "Each file you send REPLACES that file whole, so write it out complete: do not drop features " +
+    "you built earlier just because the latest message did not mention them.\n" +
+    "Sending the whole project on every tweak is slow, truncates large apps, and reintroduces " +
+    "bugs you already fixed. Only use `mode: \"create\"` for the first build, or when the user " +
+    "genuinely wants a different app. Users can roll back to any earlier version, so a mistake " +
+    "is recoverable — but a silent regression is not obvious.\n\n" +
     "DESIGN SYSTEM — the project is preloaded with Tailwind v4 and the shadcn/ui base set. Do NOT " +
     "write these yourself and do NOT list them in `dependencies`; they are injected for you:\n" +
     `  • shadcn/ui components at /components/ui/<name>: ${SHADCN_UI_COMPONENTS.join(", ")}\n` +
@@ -619,6 +828,18 @@ export const createReactArtifactTool: ToolDefinition = {
   inputSchema: {
     type: "object",
     properties: {
+      mode: {
+        type: "string",
+        enum: ["create", "update"],
+        description:
+          'Defaults to "create". Use "update" to change an app this conversation already built: send ONLY the files you changed and the tool merges them onto the current build. Every other field you omit is inherited.',
+      },
+      deleteFiles: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          'Paths to remove, e.g. ["/OldChart.tsx"]. Only meaningful with mode "update" — a patch cannot express a deletion any other way.',
+      },
       title: {
         type: "string",
         description: "Short, user-facing name for the app, e.g. \"Weekly ticket volume\".",
@@ -713,14 +934,32 @@ export const createReactArtifactTool: ToolDefinition = {
         },
       },
     },
-    required: ["title", "entry", "files"],
+    // `title` and `entry` are required for a CREATE and inherited on an UPDATE,
+    // which a static schema cannot express — `buildReactArtifact` fails with an
+    // actionable message when a create omits them.
+    required: ["files"],
   },
   execute: async (
     params: Record<string, unknown>,
-    _context?: ToolExecutionContext,
+    context?: ToolExecutionContext,
   ): Promise<string> => {
     try {
-      return formatReactArtifactResult(buildReactArtifact(params));
+      const mode = asString(params["mode"]).trim() || "create";
+      if (mode !== "create" && mode !== "update") {
+        return 'Error: `mode` must be "create" or "update".';
+      }
+
+      if (mode === "create") {
+        return formatReactArtifactResult(buildReactArtifact(params));
+      }
+
+      const base = await readConversationApp(context);
+      if (!base.ok) return base.error;
+
+      // Merge first, then validate the WHOLE — never the fragment.
+      return formatReactArtifactResult(
+        buildReactArtifact(mergeArtifactParams(base.payload, params)),
+      );
     } catch (err) {
       if (err instanceof ValidationError) {
         return `Error: ${err.message} Fix the input and call create-app again.`;

--- a/packages/xyne-claw-shared/src/tools/registry.ts
+++ b/packages/xyne-claw-shared/src/tools/registry.ts
@@ -135,6 +135,7 @@ register(researchAgent.reviewPullRequest);
 register(createPpt.createPptTool);
 register(createPpt.editPptTool);
 register(reactArtifact.createReactArtifactTool);
+register(reactArtifact.readArtifactAppFileTool);
 
 // Register create-html-report tool — renders a markdown report into a
 // standalone HTML file and attaches it, leaving a short summary inline in


### PR DESCRIPTION
Backport of the **claw half** of #1434 — claw-auth, xyne-claw and xyne-claw-shared. Dashboard changes deliberately excluded, matching the previous artifact-app backports. 9 of the 24 files from the merged commit.

## What it does

`create-app` gains `mode: "update"` and `deleteFiles`. The agent sends only the files it changed; the tool fetches the conversation's **head** build over a new S2S route, merges, and re-validates the **whole** result through the untouched `buildReactArtifact` — so a patch cannot slip past validation a full build would have failed. A companion `read-app-file` tool gives the agent the code it is editing, which `create-app` never returned.

Nothing downstream changes: the attachment still carries the complete project, versioning is untouched, the renderer is oblivious. Only the model's *output* shrinks.

| File | Purpose |
|---|---|
| `routes/artifact-apps-internal.ts` (new) | S2S read-back, `requireStrictS2S`, read-only |
| `http/routes.ts` | Mounts it |
| `tools/react-artifact/tools.ts` | `mode`, `deleteFiles`, `mergeArtifactParams`, `configSchema` |
| `tools/react-artifact/readTool.ts` (new) | `read-app-file` |
| `routes/run.ts` | Pairs `read-app-file` with `create-app`; recursion guard; empty-run status |
| `routes/artifact-app-agents.ts` | Recursion guard at dispatch |

## Two conflicts, resolved against this branch

- **`main.ts` is refactored here** — routes are mounted from `http/routes.ts`, not `main.ts` (which is 52 lines on this branch vs ~350 on main). The internal router is registered there instead. A straight 3-way apply produced a 300-line conflict; this was done surgically.
- **`run.ts`** had `processTaskError || activeRun.handoffCapFired ? "failed" : "completed"`. The new code makes that branch unconditionally `"failed"` — reaching it means the emitter never wrote a done frame, so the run produced nothing either way. **`handoffCapFired` is subsumed, not dropped.**

## Verification

- `xyne-claw-shared`, `xyne-claw`, `xyne-claw-auth` — all typecheck **clean**
- **318 tests pass**

First typecheck showed errors in `design-shares.ts` and `run-queue-worker.ts` — stale Prisma client and a missing `bullmq` dep for this branch, cleared by `pnpm install` + `prisma generate`. Neither is related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)