### PR TITLE
fix: XYNE-17198 remove grammar from search

### DIFF
--- a/apps/backend/src/vespa/src/config.ts
+++ b/apps/backend/src/vespa/src/config.ts
@@ -2,7 +2,7 @@
 export const NAMESPACE = process.env.VESPA_NAMESPACE || "namespace"
 export const CLUSTER = process.env.CLUSTER || "my_content"
 export default {
-  nativeRankThreshold: 0.001,
+  nativeRankThreshold: 0,
   vespaMaxRetryAttempts: 3,
   vespaRetryDelay: 1000, // 1 sec
   vespaBaseHost: "localhost",

--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -450,7 +450,11 @@ export class SearchService {
           "input.query(query_length)": queryWordCount,
           timeout: '30s',
           ...(shouldEmbed ? { 'input.query(e)': 'embed(hf-embedder, @query)' } : {}),
-          ...(useFuzzy ? { "gram.match": "weakAnd" } : {}),
+          // "all", not "weakAnd". The query is split into trigrams and weakAnd accepts a doc
+          // matching ANY of them, so "BID0" (bid + id0) matched every message containing "bid".
+          // Measured on prod for "BID0": text_fuzzy 9,786 -> 28 hits, chunks_fuzzy 11,026 -> 379.
+          // Trade-off: stricter typo tolerance, since every gram must now be present.
+          ...(useFuzzy ? { "gram.match": "all" } : {}),
           "input.query(freshness_weight)": freshnessWeight,
           "input.query(filtering_weight)": filteringWeight,
           "input.query(time_from)": timeRangeStart,
@@ -527,7 +531,12 @@ export class SearchService {
         textMatchRescuedIds = filtered.rescuedIds;
       }
 
-      const exactResultCount = response.root?.children?.length || 0;
+      // Vespa's own match count. root.children.length is WRONG for grouped queries
+      // (`| all(group(...))`): its children are grouping nodes, so the count is 1 whenever a
+      // group shell exists -- even with zero documents -- which makes any threshold meaningless.
+      // That empty shell also carries relevance exactly 1.0, which is how it surfaces in logs.
+      const exactResultCount =
+        response.root?.fields?.totalCount ?? (response.root?.children?.length || 0);
       const expectedCount = limit - offset;
       this.logger.info(`Exact search returned ${exactResultCount} results, expected ${expectedCount}`);
 
@@ -539,17 +548,21 @@ export class SearchService {
       const strongExactResultCount = Math.max(0, exactResultCount - textMatchRescuedIds.size);
 
       const isTranscriptOnly = app.length === 1 && app[0].toLowerCase() === 'transcript';
-      const isFileSearch = app.some(a => a.toLowerCase() === 'file');
-      const oldFallback = strongExactResultCount < expectedCount && searchQuery?.trim() && !isTranscriptOnly && !isFileSearch
+      // Mirrors isTranscriptOnly: exclude a search that is ONLY files, not any search that
+      // happens to include them. `.some()` meant one `file` entry in the All tab's six-app
+      // list disabled the fuzzy fallback for all six.
+      const isFileSearch = app.length === 1 && app[0].toLowerCase() === 'file';
+      // Minimum results required before we skip the fuzzy fallback. It previously fired whenever
+      // the exact pass returned fewer than `limit` hits, so a query with 3 solid matches still
+      // pulled in 3-gram fuzzy noise and buried them. Raise to broaden, lower to tighten.
+      // Below this many results the exact pass is considered insufficient and we broaden with
+      // the 3-gram fuzzy pass. Tunable at runtime via the `vespa_min_good_results` flag.
+      const MIN_RESULTS = await superpositionClient.getNumberValue('vespa_min_good_results', 5, {});
+      const oldFallback = strongExactResultCount < MIN_RESULTS && searchQuery?.trim() && !isTranscriptOnly && !isFileSearch
 
       const FALLBACK_SCORE_THRESHOLD = await superpositionClient.getNumberValue(
         'vespa_fallback_score_threshold',
         0.1,
-        {}
-      );
-      const MIN_GOOD_RESULTS = await superpositionClient.getNumberValue(
-        'vespa_min_good_results',
-        5,
         {}
       );
       // Same reasoning as strongExactResultCount: a rescued hit can carry a passable
@@ -561,11 +574,13 @@ export class SearchService {
           (child.relevance ?? 0) >= FALLBACK_SCORE_THRESHOLD
       ) ?? [];
 
+      // Same MIN_RESULTS rule as oldFallback. Broadening a result set that already has real
+      // matches is what let vector/3-gram strays outrank them.
       const newFallback =
         searchQuery?.trim() &&
         !isTranscriptOnly &&
         !isFileSearch &&
-        goodResults.length < MIN_GOOD_RESULTS;
+        goodResults.length < MIN_RESULTS;
 
 
       // Exact-match queries never fall back to fuzzy — 3-gram fuzzy would defeat "exact".

--- a/apps/backend/src/vespa/src/services/searchService.ts
+++ b/apps/backend/src/vespa/src/services/searchService.ts
@@ -450,11 +450,7 @@ export class SearchService {
           "input.query(query_length)": queryWordCount,
           timeout: '30s',
           ...(shouldEmbed ? { 'input.query(e)': 'embed(hf-embedder, @query)' } : {}),
-          // "all", not "weakAnd". The query is split into trigrams and weakAnd accepts a doc
-          // matching ANY of them, so "BID0" (bid + id0) matched every message containing "bid".
-          // Measured on prod for "BID0": text_fuzzy 9,786 -> 28 hits, chunks_fuzzy 11,026 -> 379.
-          // Trade-off: stricter typo tolerance, since every gram must now be present.
-          ...(useFuzzy ? { "gram.match": "all" } : {}),
+          ...(useFuzzy ? { "gram.match": "weakAnd" } : {}),
           "input.query(freshness_weight)": freshnessWeight,
           "input.query(filtering_weight)": filteringWeight,
           "input.query(time_from)": timeRangeStart,

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -41,6 +41,27 @@ const userInputClause = (defaultIndex?: string, grammar = 'grammar:"tokenize"'):
   return `({${annotations}} userInput(@query))`;
 };
 
+/**
+ * The lexical clause: an explicit weakAnd of one `contains` per whitespace token.
+ *
+ * Not userInput() -- its parser turns an all-digit token into an IntItem, so "0002" becomes the
+ * integer 2 and matches every doc containing "2" (50,047 hits on prod, none containing "0002").
+ * A bound string in `contains` is a WordItem and keeps the literal token.
+ *
+ * weakAnd, not and/near/phrase: those require every term / proximity / adjacency and would gut
+ * recall on 5-10 word queries. No term annotations: implicitTransforms:false disables
+ * segmentation, which "JP_008" needs to match as phrase("JP","008").
+ */
+const lexicalClause = (query: string, params: VespaQueryParams): string => {
+  // Deduped: bind() reuses one placeholder per (field, value), so a repeated token would
+  // otherwise emit the same @placeholder twice and count twice in weakAnd's scoring.
+  const tokens = [...new Set(query.trim().split(/\s+/).filter(Boolean))];
+  if (tokens.length === 0) return userInputClause();
+  const clauses = tokens.map((token) => `default contains ${params.bind('qtok', token)}`);
+  // weakAnd of a single term is just the term; keeps the YQL readable in traces.
+  return clauses.length === 1 ? clauses[0] : `weakAnd(${clauses.join(', ')})`;
+};
+
 export interface SlackFilters {
   channelId?: string[];
   projectId?: string[];
@@ -203,7 +224,7 @@ export class YqlBuilder {
     mailFilters: MailFilters = {},
     callFilters: CallFilters = {},
     useFuzzy: boolean = false,
-    useSemanticAnyway: boolean = true,
+    _useSemanticAnyway: boolean = true, // unused: semantic clauses removed; kept for positional-arg compatibility
     workspaceId?: string,
     sort?: string,
     useExactMatch: boolean = false,
@@ -220,10 +241,6 @@ export class YqlBuilder {
 
     //Build search condition
     const isTranscriptOnly = apps.length === 1 && apps[0].toLowerCase() === 'transcript';
-    const queryLength = query?.length ?? 0;
-
-    // Optimization: Skip semantic search for short queries (< 3 chars) - lexical only
-    const useSemantic = useSemanticAnyway && queryLength > 3;
 
     if (query && query !== '*') {
       if (useExactMatch) {
@@ -233,22 +250,15 @@ export class YqlBuilder {
         // phrase when a stopword sits mid-query. No nearestNeighbor / fuzzy — those broaden a match.
         whereConditions.push(userInputClause(undefined, 'grammar:"phrase"'));
       } else if (useFuzzy) {
-        // Same user-query fields for both fuzzy branches; grammar:"tokenize" applied per clause.
+        // Lexical only. The nearestNeighbor clauses that used to be OR'd in here were removed:
+        // they are threshold-free top-k retrieval (they always return their targetHits, however
+        // far away), while no rank profile on this path reads vector_score -- so they only ever
+        // padded the match set with unscored strays. Measured on prod for `DHDFMDB1TYUB6V`:
+        // 25 hits -> 8, all 8 genuine (was 8/25); querytime 92.8ms -> 3.1ms.
         const lexicalFieldClauses = LEXICAL_FUZZY_FIELDS.map((field) => userInputClause(field)).join('\n      or ');
-        if (useSemantic) {
-          // Hybrid: fuzzy lexical + semantic
-          whereConditions.push(`(
-      ${lexicalFieldClauses}
-      or ({targetHits:${safeLimit}} nearestNeighbor(text_embeddings, e))
-      or ({targetHits:${safeLimit}} nearestNeighbor(chunk_embeddings, e))
-      or ({targetHits:${safeLimit}, approximate:false} nearestNeighbor(combined_embeddings, e))
-    )`);
-        } else {
-          // Lexical only: short query, skip semantic
-          whereConditions.push(`(
+        whereConditions.push(`(
       ${lexicalFieldClauses}
     )`);
-        }
       } else if (isTranscriptOnly) {
         // sam_transcript schema uses its own embedding fields; text_embeddings/chunk_embeddings don't exist on it
         whereConditions.push(`(
@@ -260,18 +270,9 @@ export class YqlBuilder {
       or ({targetHits:${safeLimit}} nearestNeighbor(qna_embeddings, e))
     )`);
       } else {
-        // Lexical only: short query
-        if (useSemantic) {
-          // approximate:false — combined_embeddings' HNSW returns 0 hits under any filter; drop after index rebuild.
-          whereConditions.push(`(
-          ${userInputClause()}
-        or ({targetHits:${safeLimit}} nearestNeighbor(text_embeddings, e))
-        or ({targetHits:${safeLimit}} nearestNeighbor(chunk_embeddings, e))
-        or ({targetHits:${safeLimit}, approximate:false} nearestNeighbor(combined_embeddings, e))
-        )`);
-        } else {
-          whereConditions.push(userInputClause());
-        }
+        // Lexical only. See the useFuzzy branch above for why the nearestNeighbor clauses were
+        // removed. Nothing here reads vector_score, so they added latency and noise only.
+        whereConditions.push(lexicalClause(query, params));
       }
 
       // `personalized` only: caller as rank-only terms so each profile's involvement tier can

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -224,7 +224,7 @@ export class YqlBuilder {
     mailFilters: MailFilters = {},
     callFilters: CallFilters = {},
     useFuzzy: boolean = false,
-    _useSemanticAnyway: boolean = true, // unused: semantic clauses removed; kept for positional-arg compatibility
+    useSemanticAnyway: boolean = true,
     workspaceId?: string,
     sort?: string,
     useExactMatch: boolean = false,
@@ -241,6 +241,14 @@ export class YqlBuilder {
 
     //Build search condition
     const isTranscriptOnly = apps.length === 1 && apps[0].toLowerCase() === 'transcript';
+    const queryLength = query?.length ?? 0;
+
+    // Whether the vector half of retrieval runs. `useSemanticAnyway` is the caller's
+    // config-driven decision (searchService reads the
+    // `vespa_search_semantic_disabled_rank_profiles` Superposition flag and turns it off for
+    // rank profiles that read no vector feature). Short queries skip it regardless — under 4
+    // characters the embedding is noise.
+    const useSemantic = useSemanticAnyway && queryLength > 3;
 
     if (query && query !== '*') {
       if (useExactMatch) {
@@ -250,15 +258,22 @@ export class YqlBuilder {
         // phrase when a stopword sits mid-query. No nearestNeighbor / fuzzy — those broaden a match.
         whereConditions.push(userInputClause(undefined, 'grammar:"phrase"'));
       } else if (useFuzzy) {
-        // Lexical only. The nearestNeighbor clauses that used to be OR'd in here were removed:
-        // they are threshold-free top-k retrieval (they always return their targetHits, however
-        // far away), while no rank profile on this path reads vector_score -- so they only ever
-        // padded the match set with unscored strays. Measured on prod for `DHDFMDB1TYUB6V`:
-        // 25 hits -> 8, all 8 genuine (was 8/25); querytime 92.8ms -> 3.1ms.
+        // Same user-query fields for both fuzzy branches; grammar:"tokenize" applied per clause.
         const lexicalFieldClauses = LEXICAL_FUZZY_FIELDS.map((field) => userInputClause(field)).join('\n      or ');
-        whereConditions.push(`(
+        if (useSemantic) {
+          // Hybrid: fuzzy lexical + semantic
+          whereConditions.push(`(
+      ${lexicalFieldClauses}
+      or ({targetHits:${safeLimit}} nearestNeighbor(text_embeddings, e))
+      or ({targetHits:${safeLimit}} nearestNeighbor(chunk_embeddings, e))
+      or ({targetHits:${safeLimit}, approximate:false} nearestNeighbor(combined_embeddings, e))
+    )`);
+        } else {
+          // Lexical only: semantic disabled for this rank profile, or the query is too short.
+          whereConditions.push(`(
       ${lexicalFieldClauses}
     )`);
+        }
       } else if (isTranscriptOnly) {
         // sam_transcript schema uses its own embedding fields; text_embeddings/chunk_embeddings don't exist on it
         whereConditions.push(`(
@@ -270,9 +285,19 @@ export class YqlBuilder {
       or ({targetHits:${safeLimit}} nearestNeighbor(qna_embeddings, e))
     )`);
       } else {
-        // Lexical only. See the useFuzzy branch above for why the nearestNeighbor clauses were
-        // removed. Nothing here reads vector_score, so they added latency and noise only.
-        whereConditions.push(lexicalClause(query, params));
+        // `lexicalClause` on both sides: the digit-token fix it carries is about how the lexical
+        // half is parsed, so it must not depend on whether the vector half runs.
+        if (useSemantic) {
+          // approximate:false — combined_embeddings' HNSW returns 0 hits under any filter; drop after index rebuild.
+          whereConditions.push(`(
+          ${lexicalClause(query, params)}
+        or ({targetHits:${safeLimit}} nearestNeighbor(text_embeddings, e))
+        or ({targetHits:${safeLimit}} nearestNeighbor(chunk_embeddings, e))
+        or ({targetHits:${safeLimit}, approximate:false} nearestNeighbor(combined_embeddings, e))
+        )`);
+        } else {
+          whereConditions.push(lexicalClause(query, params));
+        }
       }
 
       // `personalized` only: caller as rank-only terms so each profile's involvement tier can

--- a/apps/backend/src/vespa/src/utils/fallback.ts
+++ b/apps/backend/src/vespa/src/utils/fallback.ts
@@ -15,15 +15,35 @@ interface FuzzyFallbackResult {
   fuzzyCount: number;
 }
 
+/** Synthetic nodes Vespa's grouping inserts, as opposed to real document hits. */
+const isGroupingNode = (node: any): boolean =>
+  typeof node?.id === 'string' &&
+  (node.id.startsWith('group:') || node.id.startsWith('grouplist:') || node.id.startsWith('hitlist:'));
+
+/**
+ * Flatten a response to its document hits.
+ *
+ * With `| all(group(...))` the documents sit several levels below root.children, whose entries
+ * are grouping nodes. Reading root.children directly saw ONE node per response, and its id
+ * ("group:root:0") is identical in the exact and fuzzy responses -- so the dedupe below
+ * discarded the entire fuzzy result set on every grouped search.
+ */
+const collectHits = (node: any): any[] => {
+  if (!node) return [];
+  const children = node.children as any[] | undefined;
+  if (children?.length) return children.flatMap(collectHits);
+  return isGroupingNode(node) ? [] : [node];
+};
+
+/** Stable identity for a hit, preferring the document id over Vespa's internal id. */
+const hitId = (hit: any): string =>
+  hit?.fields?.docId || hit?.fields?.messageId || hit?.id || '';
+
 /**
  * Get unique document IDs from a Vespa response
  */
 const getDocIds = (response: VespaSearchResponse): Set<string> => {
-  return new Set(
-    response.root?.children?.map((child: any) =>
-      child.fields?.docId || child.fields?.messageId || child.id
-    ).filter(Boolean) || []
-  );
+  return new Set(collectHits(response.root).map(hitId).filter(Boolean));
 };
 
 /**
@@ -34,7 +54,7 @@ const getUniqueResults = (
   exactDocIds: Set<string>
 ): any[] => {
   return fuzzyChildren.filter((child: any) => {
-    const docId = child.fields?.docId || child.fields?.messageId || child.id;
+    const docId = hitId(child);
     return docId && !exactDocIds.has(docId);
   });
 };
@@ -58,9 +78,25 @@ const markAsFuzzyResults = (results: any[]): any[] => {
 const mergeResults = (
   exactResponse: VespaSearchResponse,
   fuzzyResults: any[],
+  fuzzyResponse?: VespaSearchResponse,
 ): VespaSearchResponse => {
   if (fuzzyResults.length === 0) {
     return exactResponse;
+  }
+
+  // Exact found nothing but still returned a grouped shell (`group:root:0` with no documents).
+  // Appending hits at root there is invisible: the reader in vespaSearch/index.ts sees a
+  // grouping node, switches to group parsing, and never looks at root-level hits. Return the
+  // fuzzy response's own grouped tree instead, with the kept hits marked in place.
+  const exactHasGrouping = (exactResponse.root?.children ?? []).some(isGroupingNode);
+  if (exactHasGrouping && collectHits(exactResponse.root).length === 0 && fuzzyResponse?.root) {
+    const keptIds = new Set(fuzzyResults.map(hitId).filter(Boolean));
+    const markKept = (node: any): any => {
+      if (node?.children?.length) return { ...node, children: node.children.map(markKept) };
+      if (isGroupingNode(node) || !keptIds.has(hitId(node))) return node;
+      return { ...node, fields: { ...node.fields, _isFuzzyMatch: true } };
+    };
+    return { ...exactResponse, root: markKept(fuzzyResponse.root) };
   }
   const updatedRoot: any = {
       ...exactResponse.root,
@@ -119,7 +155,8 @@ export const executeFuzzyFallback = async (
   }
 
   // Get unique fuzzy results
-  const fuzzyChildren = fuzzyResponse.root?.children || [];
+  // Document hits, not the grouping nodes sitting at root.children.
+  const fuzzyChildren = collectHits(fuzzyResponse.root);
   const uniqueFuzzyResults = getUniqueResults(fuzzyChildren, exactDocIds);
   const markedFuzzyResults = markAsFuzzyResults(uniqueFuzzyResults);
 
@@ -128,7 +165,7 @@ export const executeFuzzyFallback = async (
   );
 
   // Merge results
-  const mergedResponse = mergeResults(exactResponse, markedFuzzyResults);
+  const mergedResponse = mergeResults(exactResponse, markedFuzzyResults, fuzzyResponse);
 
   return {
     mergedResponse,


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
