### PR TITLE
fix: correct call duration for scheduled calls with multiple sessions (rejoin overwrote startedAt)

### DIFF
--- a/apps/backend/src/database/repositories/callRepository.activateScheduledCall.test.ts
+++ b/apps/backend/src/database/repositories/callRepository.activateScheduledCall.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression test for the "18 seconds vs 49 minute transcript" call-duration bug.
+ *
+ * A scheduled call's duration is derived as endedAt - startedAt. startedAt is set to the
+ * REAL first-join time by the first-activation branch of activateScheduledCall (correcting
+ * the schema's schedule-time default). When everyone leaves within the scheduled window the
+ * call reverts to SCHEDULED and can be rejoined. The rejoin branch used to overwrite
+ * startedAt with the reconnect time, collapsing the whole call's duration to the length of
+ * the last tiny reconnect — the reported bug (call showed 18s, transcript spanned 49m).
+ *
+ * These tests pin the fix: the rejoin branch must NOT write startedAt and must clear the
+ * stale endedAt, while genuine first-join branches must still set startedAt to `now`.
+ */
+
+// Enums are runtime values used inside the method; @xyne/shared ships ESM jest won't transform.
+jest.mock('@xyne/shared', () => ({
+  CallStatus: { SCHEDULED: 'SCHEDULED', ACTIVE: 'ACTIVE', ENDED: 'ENDED' },
+  CallType: { AUDIO: 'AUDIO', VIDEO: 'VIDEO', HEADLESS: 'HEADLESS' },
+  CallOrigin: { CHANNEL: 'CHANNEL', CONVERSATION: 'CONVERSATION' },
+  MessageType: { SYSTEM: 'SYSTEM', BOT: 'BOT' },
+  MessageArtifactStatus: { ACTIVE: 'ACTIVE', COMPLETED: 'COMPLETED' },
+  InvitationResponse: {},
+  MeetingStatus: {},
+  TagMethod: {},
+}));
+
+const dbMock = {
+  $transaction: jest.fn(),
+  call: { findUnique: jest.fn() },
+};
+jest.mock('../client', () => ({
+  DatabaseClient: { getInstance: () => dbMock },
+}));
+
+jest.mock('./index', () => ({ repositories: { channels: { getWorkspaceId: jest.fn() } } }));
+jest.mock('@/services/messageMetadataService', () => ({
+  messageMetadataService: { syncInitialMessageMd: jest.fn().mockResolvedValue(undefined) },
+}));
+jest.mock('@/services/callVespaQueue', () => ({
+  queueCallVespaFeed: jest.fn(),
+  queueCallVespaDelete: jest.fn(),
+  CallVespaFeedSource: { CallRepositoryActivateScheduledCall: 'activate' },
+}));
+jest.mock('@/zero/utils/systemMessagesUtils', () => ({
+  updateCallSystemMessageIfNeeded: jest.fn().mockResolvedValue(false),
+}));
+jest.mock('@/utils/callParticipantCountUtils', () => ({
+  refreshCallParticipantPreview: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('./messageArtifactRepository', () => ({
+  setSlashCommandArtifactLifecycle: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@/utils/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), debug: jest.fn(), warn: jest.fn() },
+}));
+jest.mock('@/database/tenant/workspace-utils', () => ({ resolveWorkspaceIdFromModel: jest.fn() }));
+jest.mock('@/utils/email', () => ({ normalizeEmailList: (x: unknown) => x }));
+
+import { CallRepository } from './callRepository';
+
+type UpdateArg = { where: unknown; data: Record<string, unknown> };
+
+/** Build a tx mock that records every call.update payload. */
+function makeTx(callRow: Record<string, unknown>) {
+  const callUpdates: UpdateArg[] = [];
+  const tx = {
+    call: {
+      findUnique: jest.fn().mockResolvedValue(callRow),
+      update: jest.fn((arg: UpdateArg) => {
+        callUpdates.push(arg);
+        return Promise.resolve({ ...callRow, ...arg.data });
+      }),
+    },
+    conversation: { create: jest.fn(), update: jest.fn() },
+    message: { create: jest.fn(), update: jest.fn() },
+  };
+  return { tx, callUpdates };
+}
+
+const ORIGINAL_STARTED = new Date('2025-09-02T12:59:29.000Z');
+const NOW = new Date('2025-09-02T13:50:15.500Z');
+
+describe('CallRepository.activateScheduledCall — startedAt handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    dbMock.call.findUnique.mockResolvedValue({ metadata: { conversationId: 'conv-1' } });
+  });
+
+  it('rejoin within the window preserves the original startedAt and clears the stale endedAt', async () => {
+    const callRow = {
+      id: 'call-1',
+      externalId: 'room-1',
+      workspaceId: 'ws-1',
+      channelId: 'chan-1',
+      callUpdatesChannel: null,
+      startedAt: ORIGINAL_STARTED,
+      endedAt: new Date('2025-09-02T13:49:50.000Z'), // written by the previous revert-to-SCHEDULED
+      // both keys present => rejoin branch
+      metadata: { conversationId: 'conv-1', systemMessageId: 'sys-1' },
+    };
+    const { tx, callUpdates } = makeTx(callRow);
+    dbMock.$transaction.mockImplementation((cb: (t: unknown) => unknown) => cb(tx));
+
+    const repo = new CallRepository();
+    await repo.activateScheduledCall({
+      call: callRow as never,
+      initiatorName: 'Utkarsh',
+      now: NOW,
+    });
+
+    expect(callUpdates).toHaveLength(1);
+    const data = callUpdates[0].data;
+    expect(data.status).toBe('ACTIVE');
+    // The bug: startedAt must NOT be overwritten on rejoin.
+    expect(data).not.toHaveProperty('startedAt');
+    // Re-open semantics: the stale endedAt from the previous revert is cleared.
+    expect(data.endedAt).toBeNull();
+  });
+
+  it('first join (no conversation yet) sets startedAt to the real first-join time', async () => {
+    const callRow = {
+      id: 'call-2',
+      externalId: 'room-2',
+      workspaceId: 'ws-1',
+      channelId: 'chan-1',
+      callUpdatesChannel: null,
+      startedAt: ORIGINAL_STARTED, // schema default (schedule time) — must be corrected to `now`
+      endedAt: null,
+      metadata: {}, // no conversationId => first-join branch
+    };
+    const { tx, callUpdates } = makeTx(callRow);
+    dbMock.$transaction.mockImplementation((cb: (t: unknown) => unknown) => cb(tx));
+
+    const repo = new CallRepository();
+    await repo.activateScheduledCall({
+      call: callRow as never,
+      initiatorName: 'Utkarsh',
+      now: NOW,
+    });
+
+    expect(callUpdates).toHaveLength(1);
+    const data = callUpdates[0].data;
+    expect(data.status).toBe('ACTIVE');
+    expect(data.startedAt).toBe(NOW);
+  });
+});

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -1339,12 +1339,22 @@ export class CallRepository {
           },
         });
       } else {
-        // Rejoin within the scheduled window — conversation already exists, just flip to ACTIVE
+        // Rejoin within the scheduled window — conversation already exists, just flip to ACTIVE.
+        //
+        // Do NOT overwrite startedAt here. It was set to the real first-join time by the
+        // first-activation branch above; a scheduled call's default startedAt (schedule time)
+        // has already been corrected at that point. Overwriting it with the reconnect time
+        // collapses the call's duration to the length of the latest tiny reconnect (this is
+        // the "18 seconds vs 49 minute transcript" bug). Preserving it keeps the call's
+        // duration spanning the whole scheduled-window envelope (first join -> last leave).
+        //
+        // Clear the stale endedAt that the previous session's revert-to-SCHEDULED wrote, since
+        // the call is live again; the final end path rewrites endedAt to the true last-leave time.
         await tx.call.update({
           where: { id: call.id },
           data: {
             status: CallStatus.ACTIVE,
-            startedAt: now,
+            endedAt: null,
             lastActivityAt: now,
             updatedAt: now,
           },


### PR DESCRIPTION
## 1. Problem Description
A scheduled call's duration is derived at read time as `endedAt - startedAt` (there is no stored duration column). Call `b94efffd-0b12-494f-8857-a16764d6b6aa` displayed a duration of **18 seconds** while its transcript spanned **~49 minutes**.

## 2. How the issue was identified
Root-caused via the LiveKit room-webhook timeline for that call:
1. `12:59:29` first human joins → call activates, `startedAt` correctly set to the real first-join time.
2. `13:49:50` last human leaves → within the scheduled window, so the call reverts to `SCHEDULED` and `endedAt` is written.
3. `13:50:13` someone briefly re-joins → `activateScheduledCall` takes the **rejoin branch**, which overwrote `startedAt` with the reconnect time (`13:50:15.5`).
4. `13:50:33` room finishes → `endedAt` rewritten to `13:50:33.586`.

Final stored state `startedAt=13:50:15.5`, `endedAt=13:50:33.586` → **18s**, even though the real session ran ~50 min. The transcript was correct; the duration was corrupted. The rejoin branch was treating a reconnect as a brand-new call start.

## 3. Solution implemented
In `activateScheduledCall`'s rejoin branch (`apps/backend/src/database/repositories/callRepository.ts`):
- Stop overwriting `startedAt` on rejoin. It was already set to the real first-join time by the first-activation branch (which also corrects the schema's schedule-time `@default(now())`), so the rejoin must preserve it. Duration now spans the whole first-join → last-leave envelope.
- Clear the stale `endedAt` that the previous revert-to-SCHEDULED wrote, since the call is live again; the final end path rewrites `endedAt` to the true last-leave time.

The first-join branches are unchanged and still set `startedAt = now`. No schema change, no data migration.

## 4. Documentation
N/A

## 5. DB Alter Details (if any)
N/A — no schema change.

## 6. Data fix Details (if any)
Optional one-off backfill: for calls whose stored `startedAt` is later than their first participant `joinedAt`, reset `startedAt = MIN(callParticipant.joinedAt)`. Not required for the code fix.

## 7. Environment variable Changes (if any)
N/A

## 8. Testing
Added `apps/backend/src/database/repositories/callRepository.activateScheduledCall.test.ts` (2 tests, passing):
- rejoin branch does NOT write `startedAt` and clears `endedAt`.
- genuine first-join still sets `startedAt = now`.

Run: `npx jest src/database/repositories/callRepository.activateScheduledCall.test.ts` in `apps/backend`.

## 9. Services to which this change is to be deployed
backend (API + worker — call webhook / side-effect paths).

## 10. Main PR link (if this PR is raised against a release branch)
N/A — raised against `main`.