### PR TITLE
fix: XYNE-61845 add workspaceId to Claw Spaces thread links

### DIFF
--- a/apps/xyne-claw-auth/frontend/src/components/ActivityTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/components/ActivityTab.tsx
@@ -4,7 +4,7 @@ import { listRuns, pollChatMessages, rateRun, exportSessionUrl, type AgentRun, t
 
 // In dev, VITE_XYNE_BACKEND_URL may be empty; in prod the dashboard is served off the same origin as this app.
 // Fall back to the current origin so the "Open thread" button always has a target.
-const SPACES_APP_URL = import.meta.env.VITE_XYNE_BACKEND_URL || (typeof window !== "undefined" ? window.location.origin : "");
+import { spacesThreadUrl } from "../lib/spacesLink";
 import { MessageBubble } from "./MessageBubble";
 import { ToolInvocationList } from "./ToolInvocationList";
 
@@ -856,7 +856,7 @@ function OpenSessionButton({ session }: { session: Session }) {
 
   if (source === "spaces" && session.latest.channelId && conversationId) {
     // Spaces dashboard route — from xyne-spaces/dashboard/src/routes/AppRoot.tsx: /chat/dir/:channelId/:conversationId
-    const threadUrl = `${SPACES_APP_URL}/chat/dir/${encodeURIComponent(session.latest.channelId)}/${encodeURIComponent(conversationId)}`;
+    const threadUrl = spacesThreadUrl(session.latest.channelId, conversationId);
     return (
       <a
         href={threadUrl}
@@ -1098,9 +1098,9 @@ function RunDetailDrawer({ run, onClose }: { run: AgentRun; onClose: () => void 
   // For runs that originated from a Spaces thread we link back to the source
   // conversation. Same URL shape used by the session-level OpenSessionButton
   // above — see Spaces dashboard route `/chat/dir/:channelId/:conversationId`.
-  const spacesThreadUrl =
+  const spacesThreadHref =
     run.triggerSource === "spaces" && run.channelId && run.conversationId
-      ? `${SPACES_APP_URL}/chat/dir/${encodeURIComponent(run.channelId)}/${encodeURIComponent(run.conversationId)}`
+      ? spacesThreadUrl(run.channelId, run.conversationId)
       : null;
 
   return (
@@ -1119,9 +1119,9 @@ function RunDetailDrawer({ run, onClose }: { run: AgentRun; onClose: () => void 
             </p>
           </div>
           <div className="flex items-center gap-2">
-            {spacesThreadUrl && (
+            {spacesThreadHref && (
               <a
-                href={spacesThreadUrl}
+                href={spacesThreadHref}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1 text-xs text-zinc-300 shadow-sm transition hover:border-zinc-600 hover:bg-zinc-800"

--- a/apps/xyne-claw-auth/frontend/src/hooks/useAuth.ts
+++ b/apps/xyne-claw-auth/frontend/src/hooks/useAuth.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { getMe, getLoginUrl, upsertUser } from "../lib/api";
+import { setSpacesWorkspaceId } from "../lib/spacesLink";
 import { frontendConfig } from "../lib/config";
 import type { User } from "../lib/types";
 
@@ -73,6 +74,9 @@ export function useAuth() {
 
       try {
         const user = await getMe();
+        // Cache the workspaceId so Spaces thread links carry the /:workspaceId
+        // route segment (the xyne_last_workspace cookie is httpOnly → unreadable).
+        setSpacesWorkspaceId(user.workspaceId);
         await upsertUser(user).catch(() => {});
         setState({ status: "authenticated", user });
       } catch {

--- a/apps/xyne-claw-auth/frontend/src/lib/spacesLink.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/spacesLink.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers for linking back into the Xyne Spaces dashboard from Claw.
+ *
+ * Spaces routes are mounted under a `/:workspaceId/*` layout (see
+ * xyne-spaces/apps/dashboard/src/routes/AppRoot.tsx). A cold page load in a new
+ * tab at `/chat/dir/:channelId/:conversationId` therefore does NOT match any
+ * route and fails — the in-app anchor fallback that prepends the default
+ * workspace only runs for same-origin SPA clicks, not fresh tab loads.
+ *
+ * The workspace pointer cookie (`xyne_last_workspace`) is set `httpOnly` by the
+ * Spaces backend, so the browser can't read it via `document.cookie` — the old
+ * cookie-based lookup always returned "". We instead cache the workspaceId from
+ * the authenticated user (GET /api/auth/validate, via getMe/useAuth) and use it
+ * to build every Spaces thread link.
+ */
+
+const SPACES_APP_URL =
+  import.meta.env.VITE_SPACES_APP_URL ||
+  import.meta.env.VITE_XYNE_BACKEND_URL ||
+  (import.meta.env.DEV ? "http://localhost:5173" : window.location.origin);
+
+let cachedWorkspaceId = "";
+
+/** Populate the cached workspaceId from the authenticated user (call after getMe). */
+export function setSpacesWorkspaceId(id: string | null | undefined): void {
+  if (id) cachedWorkspaceId = id;
+}
+
+export function getSpacesWorkspaceId(): string {
+  return cachedWorkspaceId;
+}
+
+/**
+ * Build a link to a Spaces conversation thread, including the `/:workspaceId`
+ * segment the dashboard router requires. Falls back to the workspace-less path
+ * only when the id is unknown (better than nothing, still hits the in-app
+ * default-workspace fallback for same-origin navigations).
+ */
+export function spacesThreadUrl(channelId: string, conversationId: string): string {
+  const base = cachedWorkspaceId ? `${SPACES_APP_URL}/${cachedWorkspaceId}` : SPACES_APP_URL;
+  return `${base}/chat/dir/${encodeURIComponent(channelId)}/${encodeURIComponent(conversationId)}`;
+}

--- a/apps/xyne-claw-auth/frontend/src/lib/types.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/types.ts
@@ -3,6 +3,10 @@ export interface User {
   readonly email: string;
   readonly name: string;
   readonly googleId: string;
+  /** Workspace the user is currently scoped to. Returned by GET /api/auth/validate
+   *  (see xyne-spaces/apps/backend/src/routes/auth.ts). Used to build Spaces
+   *  thread links that require the /:workspaceId route segment. */
+  readonly workspaceId?: string;
 }
 
 export interface McpServer {

--- a/apps/xyne-claw-auth/frontend/src/v3/components/home/HomeInsightStrip.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/home/HomeInsightStrip.tsx
@@ -21,10 +21,8 @@ import type { UserDashboardAgentRow } from "../../../lib/api";
 import type { AgentRunLight as AgentRun } from "../../../lib/api";
 import type { AgentLight } from "../../../lib/types";
 import { formatTimeAgo, truncate } from "./homeUtils";
+import { spacesThreadUrl } from "../../../lib/spacesLink";
 
-const SPACES_APP_URL =
-  import.meta.env.VITE_XYNE_BACKEND_URL ||
-  (import.meta.env.DEV ? "http://localhost:5173" : window.location.origin);
 
 interface HomeInsightStripProps {
   topAgentToday: UserDashboardAgentRow | null;
@@ -138,7 +136,7 @@ export function HomeInsightStrip({
     if (!lastRun) return;
     if (lastRun.channelId && lastRun.conversationId) {
       window.open(
-        `${SPACES_APP_URL}/chat/dir/${encodeURIComponent(lastRun.channelId)}/${encodeURIComponent(lastRun.conversationId)}`,
+        spacesThreadUrl(lastRun.channelId, lastRun.conversationId),
         "_blank",
       );
     } else {

--- a/apps/xyne-claw-auth/frontend/src/v3/components/home/RecentRunsCard.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/home/RecentRunsCard.tsx
@@ -33,24 +33,7 @@ import type { AgentLight } from "../../../lib/types";
 import type { AgentRun } from "../../../lib/api";
 import { Skeleton } from "../ui/Skeleton";
 import { formatTimeAgo, getInitials } from "./homeUtils";
-
-const SPACES_APP_URL =
-  import.meta.env.VITE_SPACES_APP_URL ||
-  import.meta.env.VITE_XYNE_BACKEND_URL ||
-  (import.meta.env.DEV ? "http://localhost:5173" : window.location.origin);
-
-function getSpacesWorkspaceId(): string {
-  return document.cookie
-    .split("; ")
-    .find((c) => c.startsWith("xyne_last_workspace="))
-    ?.split("=")[1] ?? "";
-}
-
-function spacesThreadUrl(channelId: string, conversationId: string): string {
-  const workspaceId = getSpacesWorkspaceId();
-  const base = workspaceId ? `${SPACES_APP_URL}/${workspaceId}` : SPACES_APP_URL;
-  return `${base}/chat/dir/${encodeURIComponent(channelId)}/${encodeURIComponent(conversationId)}`;
-}
+import { spacesThreadUrl } from "../../../lib/spacesLink";
 
 const COLLAPSED_COUNT = 4;
 

--- a/apps/xyne-claw-auth/frontend/src/v3/components/home/SessionDetailPanel.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/home/SessionDetailPanel.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useEffect, useRef } from "react";
+import { spacesThreadUrl } from "../../../lib/spacesLink";
 import {
   XIcon,
   ArrowSquareOutIcon,
@@ -22,9 +23,6 @@ import type { AgentRunLight as AgentRun } from "../../../lib/api";
 import { exportSessionUrl } from "../../../lib/api";
 import { formatTimeAgo } from "./homeUtils";
 
-const SPACES_APP_URL =
-  import.meta.env.VITE_XYNE_BACKEND_URL ||
-  (import.meta.env.DEV ? "http://localhost:5173" : window.location.origin);
 
 const AGENT_COLORS = [
   "#00E5FF","#00FF7F","#FFD700","#FF6B35",
@@ -96,7 +94,7 @@ export function SessionDetailPanel({ session, onClose }: SessionDetailPanelProps
     const run = session.first;
     if (run.channelId && run.conversationId) {
       window.open(
-        `${SPACES_APP_URL}/chat/dir/${encodeURIComponent(run.channelId)}/${encodeURIComponent(run.conversationId)}`,
+        spacesThreadUrl(run.channelId, run.conversationId),
         "_blank",
       );
     }


### PR DESCRIPTION
## 1. Problem Description
In Claw, clicking "Open session in chat" (and other "open thread in Spaces" links) opens `<SPACES_APP_URL>/chat/dir/<channelId>/<conversationId>`. The Spaces dashboard mounts all chat routes under a `/:workspaceId/*` layout (`apps/dashboard/src/routes/AppRoot.tsx`), so a cold new-tab load at a workspace-less path matches no route and fails. The in-app `App.tsx` fallback that prepends the default workspace only fires for same-origin anchor clicks, not `window.open` tabs.

## 2. How the issue was identified
Reported from Claw: clicking "Open session in chat" for a Spaces run fails because the URL has no workspace id. Tracing the link builders showed `RecentRunsCard.tsx` tried to prepend the workspace by reading the `xyne_last_workspace` cookie via `document.cookie`, but that cookie is set `httpOnly: true` by the Spaces backend (`authV2Controller.ts`), so JS can never read it — the prefix was always dropped. The other four link sites never attempted a prefix.

## 3. Solution implemented
Source `workspaceId` from the authenticated user (`getMe` → `GET /api/auth/validate`, which already returns `user.workspaceId`) via a new shared helper, and route all link sites through it:
- New `apps/xyne-claw-auth/frontend/src/lib/spacesLink.ts` — `spacesThreadUrl()` (bakes in the `/:workspaceId` segment) + a `setSpacesWorkspaceId()` cache.
- `hooks/useAuth.ts` caches `user.workspaceId` right after `getMe()`.
- `lib/types.ts` adds `workspaceId` to the `User` type.
- Updated `RecentRunsCard.tsx`, `SessionDetailPanel.tsx`, `HomeInsightStrip.tsx`, and `ActivityTab.tsx` (2 sites) to use the shared helper; removes 3 drifted copies of `SPACES_APP_URL`.

## 4. Documentation
N/A

## 5. DB Alter Details
N/A

## 6. Data fix Details
N/A

## 7. Environment variable Changes
N/A

## 8. Testing
`tsc -b` on the claw-auth frontend passes clean. Manual: open a Spaces-sourced session from Claw → the new tab now lands on `/<workspaceId>/chat/dir/<channelId>/<conversationId>` and resolves.

## 9. Services to which this change is to be deployed
xyne-claw-auth frontend.

## 10. Main PR link (if against a release branch)
N/A — this targets main.

Ticket: XYNE-61845