### PR TITLE
fix: shared links use canonical host so mobile deep links open in the app

### DIFF
--- a/apps/dashboard/src/hooks/useShareableOrigin.ts
+++ b/apps/dashboard/src/hooks/useShareableOrigin.ts
@@ -1,5 +1,24 @@
 import { useParams } from 'react-router-dom';
 
+/**
+ * The dashboard is served from `app.spaces[.sandbox].xyne.juspay.net`, but the
+ * mobile app only claims the app-less host (`spaces[.sandbox].xyne.juspay.net`)
+ * for iOS Universal Links / Android App Links. A shared link built on the
+ * `app.` host is not a registered universal-link host, so the OS opens it in the
+ * browser instead of routing it into the app. Normalising the origin to the
+ * canonical host keeps copied links openable in the mobile app.
+ *
+ * Hosts that are not `app.spaces.*` (e.g. `localhost:5173` in dev) are returned
+ * unchanged.
+ */
+export function canonicalShareOrigin(): string {
+  if (typeof window === 'undefined') return 'https://spaces.xyne.juspay.net';
+
+  const { protocol, host } = window.location;
+  const canonicalHost = host.startsWith('app.spaces.') ? host.slice('app.'.length) : host;
+  return `${protocol}//${canonicalHost}`;
+}
+
 /** Add the active workspace segment to a same-origin app URL when missing. */
 export function withWorkspacePrefix(url: string, workspaceId?: string): string {
   if (!url || !workspaceId || typeof window === 'undefined') return url;
@@ -20,7 +39,9 @@ export function withWorkspacePrefix(url: string, workspaceId?: string): string {
 
 /**
  * Returns the base URL to use when constructing shareable/copyable links.
- * Automatically includes the current workspace segment when inside `/:workspaceId` context.
+ * Uses the canonical (app-less) host so links open in the mobile app, and
+ * automatically includes the current workspace segment when inside
+ * `/:workspaceId` context.
  *
  * Usage:
  *   const shareableOrigin = useShareableOrigin();
@@ -28,5 +49,6 @@ export function withWorkspacePrefix(url: string, workspaceId?: string): string {
  */
 export function useShareableOrigin(): string {
   const { workspaceId } = useParams<{ workspaceId?: string }>();
-  return workspaceId ? `${window.location.origin}/${workspaceId}` : window.location.origin;
+  const origin = canonicalShareOrigin();
+  return workspaceId ? `${origin}/${workspaceId}` : origin;
 }


### PR DESCRIPTION
## Problem
Message/copy links shared from the dashboard are built on `app.spaces.xyne.juspay.net` (the dashboard's own origin). The mobile app only claims the app-less host `spaces.xyne.juspay.net` for iOS Universal Links / Android App Links, so the OS never routes an `app.spaces…` link into the app and opens it in the browser instead. The mobile-side normalisation added in #162 rewrites `app.spaces → spaces` only after the OS hands the link to the app, which never happens for an unregistered host — so the browser-open persists.

## Fix
`apps/dashboard/src/hooks/useShareableOrigin.ts` now normalises the origin: if the current host starts with `app.spaces.` it strips the leading `app.` (handles both prod `app.spaces.xyne.juspay.net` and sandbox `app.spaces.sandbox.xyne.juspay.net`); other hosts (e.g. `localhost:5173` in dev) are returned unchanged. Every copy-link consumer flows through this hook, so all shared links now use the canonical host the mobile app claims.

## Template
1. Problem Description: Shared message links open in the mobile browser instead of the app because they use the `app.spaces.*` host, which is not a registered universal/app-link host.
2. How the issue was identified: User report — opening a shared chat link on mobile launched the browser, not the app. Traced to link generation host vs the app's registered associated-domains/intent-filter host.
3. Solution implemented: Normalise the shareable-link origin to the canonical app-less host in `useShareableOrigin.ts` (strip leading `app.` from `app.spaces.*`).
4. Documentation: N/A
5. DB Alter Details: N/A
6. Data fix Details: N/A
7. Environment variable Changes: N/A
8. Testing: Verify a copied chat link uses `https://spaces.xyne.juspay.net/...`; in dev the host stays `localhost:5173`. Open the copied link on a production mobile build and confirm it opens in-app. Note: mobile `associatedDomains` is only set on the production variant, so links only open in-app on production builds.
9. Services to deploy: dashboard (web).
10. Main PR link (if against a release branch): N/A