### PR TITLE
fix: XYNE-61758 reject empty attachment objects instead of serving 200 with 0 bytes

### DIFF
--- a/apps/backend/src/controllers/attachmentController.ts
+++ b/apps/backend/src/controllers/attachmentController.ts
@@ -305,6 +305,19 @@ export class AttachmentController {
 
       const buffer = await service.getFileBuffer(filePath);
 
+      // Guard: a zero-byte / empty storage object must never be served as a valid
+      // 200. Otherwise the client builds a 0-byte File, the image decoder fails,
+      // and the viewer shows "Failed to load image" (XYNE-61758). Treat an empty
+      // object as a missing/corrupt file so the client can show a clear error and
+      // retry, instead of silently caching a broken preview.
+      if (!buffer || buffer.length === 0) {
+        logger.error(
+          `Empty storage object for attachment ${attachmentId} at path: ${filePath} (0 bytes)`,
+        );
+        res.status(404).json({ error: 'Attachment file is empty or unavailable' });
+        return;
+      }
+
       // Set response headers (safe disposition/type to prevent stored XSS)
       res.setHeader('Content-Length', buffer.length);
       setSafeDownloadHeaders(res, {

--- a/apps/dashboard/src/components/FileViewer/ImageViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/ImageViewer.tsx
@@ -54,6 +54,13 @@ const ImageViewer: React.FC<BaseViewerProps> = ({
       return () => {};
     }
 
+    // An empty (0-byte) File can never decode into an image — fail fast with a
+    // clear message instead of waiting for the <img> onerror (XYNE-61758).
+    if (source.size === 0) {
+      setImageError(true);
+      return () => {};
+    }
+
     const url = URL.createObjectURL(source);
     setImageError(false);
     setImageUrl(url);
@@ -200,8 +207,8 @@ const ImageViewer: React.FC<BaseViewerProps> = ({
     return (
       <div className='flex items-center justify-center h-full'>
         <div className='text-center text-muted'>
-          <p className='text-lg font-semibold mb-2 text-white'>Failed to load image</p>
-          <p className='text-sm text-muted-foreground'>The image could not be displayed</p>
+          <p className='text-lg font-semibold mb-2 text-white'>Couldn&apos;t load image</p>
+          <p className='text-sm text-muted-foreground'>The file may be missing or empty</p>
         </div>
       </div>
     );

--- a/apps/dashboard/src/services/clients/fileFetchService.ts
+++ b/apps/dashboard/src/services/clients/fileFetchService.ts
@@ -42,6 +42,9 @@ export const fetchFile = async (
       });
 
       const blob: Blob = response.data;
+      if (!blob || blob.size === 0) {
+        throw new Error('The file is empty or unavailable');
+      }
       return new File([blob], fileName, { type: mimeType });
     },
     staleTime: 10 * 60 * 1000,
@@ -122,7 +125,11 @@ export const createPreviewUrl = async (
         responseType: 'blob',
         signal,
       });
-      return response.data as Blob;
+      const blob = response.data as Blob;
+      if (!blob || blob.size === 0) {
+        throw new Error('The file is empty or unavailable');
+      }
+      return blob;
     },
     staleTime: 10 * 60 * 1000,
   });


### PR DESCRIPTION
## Problem
Ticket XYNE-61758: an image attachment (`pasted-image-1788325660552.jpg`) rendered as "Failed to load image" for multiple users. Root cause: the attachment is stored in GCS as a **zero-byte object**, but the backend `downloadAttachment()` handler streamed `getFileBuffer()` and set `Content-Length` from `buffer.length` with **no empty/exists guard** — so a 0-byte object was served as a valid **HTTP 200 with an empty body**. The client then built a 0-byte `File`, the image decoder failed, and `ImageViewer` showed a misleading generic error.

## Fix
- **Backend** (`apps/backend/src/controllers/attachmentController.ts`): return `404 { error: 'Attachment file is empty or unavailable' }` when the fetched buffer is 0 bytes, instead of a 200 with 0 bytes (mirrors the `fileExists` guard the thumbnail/ranged handlers already have).
- **Frontend fetch layer** (`apps/dashboard/src/services/clients/fileFetchService.ts`): `fetchFile` and `createPreviewUrl` now throw on an empty blob so React Query surfaces an error state instead of caching a broken 0-byte File/Blob.
- **ImageViewer** (`apps/dashboard/src/components/FileViewer/ImageViewer.tsx`): fail fast on a 0-byte `File` and show a clearer, actionable message — "Couldn't load image / The file may be missing or empty".

## Validation
- Backend `tsc --noEmit` passes.
- Before/after proof-of-test videos recorded showing the empty object served as 200+0 bytes → broken tile (before) vs 404 + clear message (after), with the healthy image still rendering in both.

Ticket: XYNE-61758