### PR TITLE
feat: reference thread files like mentions in the composer

### DIFF
--- a/apps/backend/src/apps/types/index.ts
+++ b/apps/backend/src/apps/types/index.ts
@@ -67,6 +67,8 @@ export interface AppMentionEventPayload {
     channelId: string;
     channelName?: string;
     attachments?: AppEventAttachment[];
+    /** Files referenced (tagged) from the thread, resolved and authorized server-side. */
+    referencedAttachments?: AppEventAttachment[];
     metadata?: Record<string, unknown>;
 }
 
@@ -87,6 +89,8 @@ export interface DMEventPayload {
     channelId: string;
     channelName?: string;
     attachments?: AppEventAttachment[];
+    /** Files referenced (tagged) from the thread, resolved and authorized server-side. */
+    referencedAttachments?: AppEventAttachment[];
     metadata?: Record<string, unknown>;
 }
 

--- a/apps/backend/src/apps/utils/fileReferenceUtils.test.ts
+++ b/apps/backend/src/apps/utils/fileReferenceUtils.test.ts
@@ -1,0 +1,152 @@
+import {
+  extractFileReferenceIds,
+  resolveReferencedAttachments,
+  mergeAttachments,
+  MAX_FILE_REFERENCES,
+  type ReferencedAttachmentRow,
+  type ReferencedAttachmentRepo,
+} from './fileReferenceUtils';
+
+const WS = 'ws_1';
+const CONV = 'conv_1';
+
+function row(overrides: Partial<ReferencedAttachmentRow> & { id: string }): ReferencedAttachmentRow {
+  return {
+    workspaceId: WS,
+    conversationId: CONV,
+    originalFilename: `${overrides.id}.pdf`,
+    mimetype: 'application/pdf',
+    size: 123,
+    url: `gs://bucket/${overrides.id}`,
+    isDeleted: false,
+    ...overrides,
+  };
+}
+
+function repoFrom(rows: ReferencedAttachmentRow[]): ReferencedAttachmentRepo {
+  const byId = new Map(rows.map(r => [r.id, r]));
+  return { findById: async (id: string) => byId.get(id) ?? null };
+}
+
+describe('extractFileReferenceIds', () => {
+  it('returns [] for empty / missing content', () => {
+    expect(extractFileReferenceIds(undefined)).toEqual([]);
+    expect(extractFileReferenceIds(null)).toEqual([]);
+    expect(extractFileReferenceIds('')).toEqual([]);
+    expect(extractFileReferenceIds('<p>no chips here</p>')).toEqual([]);
+  });
+
+  it('extracts the attachment id from a file-reference span', () => {
+    const html = '<p>see <span data-file-reference data-attachment-id="att_1" class="chip">@spec.pdf</span></p>';
+    expect(extractFileReferenceIds(html)).toEqual(['att_1']);
+  });
+
+  it('is tolerant of attribute order and extra attributes', () => {
+    const html =
+      '<span class="x" data-attachment-id="att_2" data-file-name="a.pdf" data-file-reference role="button">@a.pdf</span>';
+    expect(extractFileReferenceIds(html)).toEqual(['att_2']);
+  });
+
+  it('extracts multiple ids and de-duplicates preserving order', () => {
+    const html = [
+      '<span data-file-reference data-attachment-id="att_a">@a</span>',
+      '<span data-file-reference data-attachment-id="att_b">@b</span>',
+      '<span data-file-reference data-attachment-id="att_a">@a again</span>',
+    ].join(' ');
+    expect(extractFileReferenceIds(html)).toEqual(['att_a', 'att_b']);
+  });
+
+  it('ignores plain channel / user mention spans', () => {
+    const html =
+      '<span data-channel-mention data-channel-id="c1">#general</span>' +
+      '<span data-mention data-user-id="u1">@bob</span>';
+    expect(extractFileReferenceIds(html)).toEqual([]);
+  });
+
+  it('caps the number of extracted ids at MAX_FILE_REFERENCES', () => {
+    const html = Array.from({ length: MAX_FILE_REFERENCES + 5 }, (_, i) =>
+      `<span data-file-reference data-attachment-id="att_${i}">@f</span>`,
+    ).join('');
+    expect(extractFileReferenceIds(html)).toHaveLength(MAX_FILE_REFERENCES);
+  });
+});
+
+describe('resolveReferencedAttachments', () => {
+  const ctx = (repo: ReferencedAttachmentRepo) => ({ workspaceId: WS, conversationId: CONV, repo });
+
+  it('resolves a valid in-thread attachment to an AppEventAttachment', async () => {
+    const repo = repoFrom([row({ id: 'att_1', originalFilename: 'spec.pdf', size: 999 })]);
+    const out = await resolveReferencedAttachments(['att_1'], ctx(repo));
+    expect(out).toEqual([
+      { attachmentId: 'att_1', fileName: 'spec.pdf', fileSize: 999, mimeType: 'application/pdf', fileUrl: 'gs://bucket/att_1' },
+    ]);
+  });
+
+  it('drops ids that do not exist', async () => {
+    const repo = repoFrom([row({ id: 'att_1' })]);
+    const out = await resolveReferencedAttachments(['missing'], ctx(repo));
+    expect(out).toEqual([]);
+  });
+
+  it('drops attachments from a different workspace (cross-tenant guard)', async () => {
+    const repo = repoFrom([row({ id: 'att_1', workspaceId: 'ws_other' })]);
+    const out = await resolveReferencedAttachments(['att_1'], ctx(repo));
+    expect(out).toEqual([]);
+  });
+
+  it('drops attachments from a different conversation (cross-thread guard)', async () => {
+    const repo = repoFrom([row({ id: 'att_1', conversationId: 'conv_other' })]);
+    const out = await resolveReferencedAttachments(['att_1'], ctx(repo));
+    expect(out).toEqual([]);
+  });
+
+  it('drops soft-deleted attachments', async () => {
+    const repo = repoFrom([row({ id: 'att_1', isDeleted: true })]);
+    const out = await resolveReferencedAttachments(['att_1'], ctx(repo));
+    expect(out).toEqual([]);
+  });
+
+  it('drops attachments with no storage url yet', async () => {
+    const repo = repoFrom([row({ id: 'att_1', url: '' })]);
+    const out = await resolveReferencedAttachments(['att_1'], ctx(repo));
+    expect(out).toEqual([]);
+  });
+
+  it('survives repo errors on a single id without failing the batch', async () => {
+    const repo: ReferencedAttachmentRepo = {
+      findById: async (id: string) => {
+        if (id === 'boom') throw new Error('db down');
+        return row({ id });
+      },
+    };
+    const out = await resolveReferencedAttachments(['boom', 'att_ok'], ctx(repo));
+    expect(out.map(a => a.attachmentId)).toEqual(['att_ok']);
+  });
+
+  it('returns [] for an empty id list without touching the repo', async () => {
+    const findById = jest.fn();
+    const out = await resolveReferencedAttachments([], { workspaceId: WS, conversationId: CONV, repo: { findById } });
+    expect(out).toEqual([]);
+    expect(findById).not.toHaveBeenCalled();
+  });
+});
+
+describe('mergeAttachments', () => {
+  const a = { attachmentId: 'a', fileName: 'a', fileSize: 1, mimeType: 'x', fileUrl: 'u' };
+  const b = { attachmentId: 'b', fileName: 'b', fileSize: 1, mimeType: 'x', fileUrl: 'u' };
+  const aDup = { attachmentId: 'a', fileName: 'a-dup', fileSize: 2, mimeType: 'y', fileUrl: 'v' };
+
+  it('concatenates disjoint lists', () => {
+    expect(mergeAttachments([a], [b])).toEqual([a, b]);
+  });
+
+  it('de-duplicates by attachmentId, uploaded wins', () => {
+    expect(mergeAttachments([a], [aDup, b])).toEqual([a, b]);
+  });
+
+  it('handles undefined inputs', () => {
+    expect(mergeAttachments(undefined, [b])).toEqual([b]);
+    expect(mergeAttachments([a], undefined)).toEqual([a]);
+    expect(mergeAttachments(undefined, undefined)).toEqual([]);
+  });
+});

--- a/apps/backend/src/apps/utils/fileReferenceUtils.ts
+++ b/apps/backend/src/apps/utils/fileReferenceUtils.ts
@@ -1,0 +1,142 @@
+import type { AppEventAttachment } from '@/apps/types';
+
+/**
+ * Maximum number of referenced (tagged) files we will resolve for a single
+ * message. This bounds the work done on the dispatch path and prevents a
+ * crafted message from forcing a large number of attachment lookups.
+ */
+export const MAX_FILE_REFERENCES = 10;
+
+/**
+ * Minimal shape of a stored attachment row that this module needs.
+ * Declared locally to avoid coupling to the Prisma client type and to keep
+ * the resolver easy to unit test with a fake repository.
+ */
+export interface ReferencedAttachmentRow {
+  id: string;
+  workspaceId: string;
+  conversationId: string | null;
+  originalFilename: string;
+  mimetype: string;
+  size: number;
+  url: string;
+  isDeleted?: boolean | null;
+}
+
+export interface ReferencedAttachmentRepo {
+  findById(id: string): Promise<ReferencedAttachmentRow | null>;
+}
+
+export interface ResolveReferencedAttachmentsContext {
+  workspaceId: string;
+  /** Conversation (thread) the triggering message belongs to. */
+  conversationId: string;
+  repo: ReferencedAttachmentRepo;
+}
+
+// A file-reference chip is serialized by the composer as
+//   <span data-file-reference data-attachment-id="..." ...>@name</span>
+// We locate each such span and pull the attachment id out of it. Attribute
+// order is not guaranteed, so we match the tag first, then the id within it.
+const FILE_REFERENCE_TAG_RE = /<span\b[^>]*\bdata-file-reference\b[^>]*>/gi;
+const ATTACHMENT_ID_RE = /\bdata-attachment-id\s*=\s*"([^"]+)"/i;
+
+/**
+ * Parse the stable attachment ids out of a message's HTML content.
+ *
+ * Returns a de-duplicated, order-preserving list of ids. The ids are
+ * client-supplied and MUST NOT be trusted for access — every id has to be
+ * re-authorized against the store via {@link resolveReferencedAttachments}.
+ */
+export function extractFileReferenceIds(content: string | null | undefined): string[] {
+  if (!content) return [];
+
+  const ids: string[] = [];
+  const seen = new Set<string>();
+
+  const tags = content.match(FILE_REFERENCE_TAG_RE);
+  if (!tags) return [];
+
+  for (const tag of tags) {
+    const match = tag.match(ATTACHMENT_ID_RE);
+    const id = match?.[1]?.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+    if (ids.length >= MAX_FILE_REFERENCES) break;
+  }
+
+  return ids;
+}
+
+/**
+ * Resolve and AUTHORIZE a list of client-supplied attachment ids into
+ * app-event attachments.
+ *
+ * An id survives only if the underlying attachment:
+ *   - exists and is not soft-deleted,
+ *   - belongs to the same workspace as the triggering message, and
+ *   - belongs to the same conversation (thread) as the triggering message.
+ *
+ * The conversation check is the boundary that stops a crafted message from
+ * tagging an arbitrary file elsewhere in the workspace. Ids that fail any
+ * check are silently dropped rather than throwing, so one bad reference never
+ * blocks delivery of the rest of the event.
+ */
+export async function resolveReferencedAttachments(
+  attachmentIds: string[],
+  ctx: ResolveReferencedAttachmentsContext,
+): Promise<AppEventAttachment[]> {
+  if (!attachmentIds.length) return [];
+
+  const { workspaceId, conversationId, repo } = ctx;
+  const bounded = attachmentIds.slice(0, MAX_FILE_REFERENCES);
+
+  const rows = await Promise.all(
+    bounded.map(id => repo.findById(id).catch(() => null)),
+  );
+
+  const resolved: AppEventAttachment[] = [];
+
+  for (const att of rows) {
+    if (!att) continue;
+    if (att.isDeleted) continue;
+    if (!att.url) continue;
+    if (workspaceId && att.workspaceId !== workspaceId) continue;
+    if (!att.conversationId || att.conversationId !== conversationId) continue;
+
+    resolved.push({
+      attachmentId: att.id,
+      fileName: att.originalFilename,
+      fileSize: att.size,
+      mimeType: att.mimetype,
+      fileUrl: att.url,
+    });
+  }
+
+  return resolved;
+}
+
+/**
+ * Merge referenced attachments into the list of attachments physically
+ * uploaded on the message, de-duplicating by attachment id. Uploaded
+ * attachments win on collision. This lets recipients (e.g. Claw) receive
+ * tagged files through the existing attachment pipeline with no change on
+ * their side, while {@link AppMentionEventPayload.referencedAttachments}
+ * preserves the provenance distinction.
+ */
+export function mergeAttachments(
+  uploaded: AppEventAttachment[] | undefined,
+  referenced: AppEventAttachment[] | undefined,
+): AppEventAttachment[] {
+  const out: AppEventAttachment[] = [];
+  const seen = new Set<string>();
+
+  for (const att of [...(uploaded ?? []), ...(referenced ?? [])]) {
+    if (seen.has(att.attachmentId)) continue;
+    seen.add(att.attachmentId);
+    out.push(att);
+  }
+
+  return out;
+}

--- a/apps/backend/src/zero/side-effects/tables/messages-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/messages-handler.ts
@@ -40,6 +40,7 @@ import { Platform,
 import { handleEventSubscriptionsForUsers } from '@/apps/core/eventSubscriptionUtils';
 import { BaseAppEvent, AppEventType, AppMentionEventPayload, DMEventPayload, UserMentionedEventPayload } from '@/apps/types';
 import { MessageAttachmentRepository } from '@/database/repositories/messageAttachmentRepository';
+import { extractFileReferenceIds, resolveReferencedAttachments, mergeAttachments } from '@/apps/utils/fileReferenceUtils';
 import { syncMessageArtifact } from '@/database/repositories/messageArtifactRepository';
 import { ChannelRepository } from '@/database/repositories/channelRepository';
 import { InstalledAppsRepository } from '@/database/repositories/installedAppsRepository';
@@ -652,6 +653,29 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
         ? await messageAttachmentRepository.findByMessageId(messageId)
         : [];
 
+      const uploadedAppAttachments = attachments.map(att => ({
+        attachmentId: att.id,
+        fileName: att.originalFilename,
+        fileSize: att.size,
+        mimeType: att.mimetype,
+        fileUrl: att.url,
+      }));
+
+      // Resolve files the sender TAGGED from this thread. Ids come from the
+      // message body and are re-authorized here against workspace + thread.
+      const referencedAppAttachments = await resolveReferencedAttachments(
+        extractFileReferenceIds(content),
+        { workspaceId, conversationId, repo: messageAttachmentRepository },
+      ).catch(err => {
+        logger.error('[MessagesSideEffect] Failed to resolve referenced attachments', { error: err, messageId });
+        return [];
+      });
+
+      // Deliver tagged files through the existing attachment pipeline (so Claw
+      // and other apps need no change), while keeping provenance in
+      // referencedAttachments.
+      const mergedAppAttachments = mergeAttachments(uploadedAppAttachments, referencedAppAttachments);
+
       void this.handlleMessageAppEvents(AppEventType.APP_MENTION, {
         conversationId,
         messageId,
@@ -662,15 +686,8 @@ export class MessagesSideEffectHandler extends BaseSideEffectHandler {
         senderName,
         channelId,
         channelName: channel?.name ?? channelId,
-        ...(attachments.length > 0 && {
-          attachments: attachments.map(att => ({
-            attachmentId: att.id,
-            fileName: att.originalFilename,
-            fileSize: att.size,
-            mimeType: att.mimetype,
-            fileUrl: att.url,
-          })),
-        }),
+        ...(mergedAppAttachments.length > 0 && { attachments: mergedAppAttachments }),
+        ...(referencedAppAttachments.length > 0 && { referencedAttachments: referencedAppAttachments }),
       }, mentionedAppUsersIds);
     }
 

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -9,6 +9,9 @@ import React, {
   useImperativeHandle,
 } from 'react';
 import { withProfilerRef } from '../../../utils/withProfiler';
+import { queries } from '../../../zero/queries';
+import { useQuery as useZeroQuery } from '../../../hooks/useQuery';
+import type { FileReferenceItem } from '../../ui/Selectors/FileReferenceSelector';
 import { useZeroWithFallback as useZero } from '../../../hooks/useZeroWithFallback';
 import { toast } from 'sonner';
 import { useSummaryCache } from '../../../hooks/useSummaryQuery';
@@ -207,6 +210,35 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
     const [channelSearchQuery, setChannelSearchQuery] = useState('');
     const channelResults = useChannelSearch(channelSearchQuery, 10);
     const conversationId = conversation?.conversationId;
+
+    // Files already posted in this thread — the source list for the `~` file
+    // reference picker. We reuse the same named query the thread view uses, so
+    // the picker only ever offers files the user can already see, and the Zero
+    // permission layer gates access. Attachments are re-authorized server-side
+    // on send, so this list is a convenience, not a trust boundary.
+    const [threadMessagesForFiles] = useZeroQuery(
+      queries.conversationMessages({ conversationId: conversationId ?? '' }),
+      { enabled: !!conversationId },
+    );
+    const fileReferenceItems = useMemo<FileReferenceItem[]>(() => {
+      if (!conversationId || !threadMessagesForFiles) return [];
+      const seen = new Set<string>();
+      const items: FileReferenceItem[] = [];
+      for (const message of threadMessagesForFiles) {
+        const attachments = message.attachments;
+        if (!attachments) continue;
+        for (const att of attachments) {
+          if (!att.id || !att.originalFilename || att.isDeleted || seen.has(att.id)) continue;
+          seen.add(att.id);
+          items.push({
+            id: att.id,
+            name: att.originalFilename,
+            ...(att.mimetype != null && { mimeType: att.mimetype }),
+          });
+        }
+      }
+      return items;
+    }, [conversationId, threadMessagesForFiles]);
 
     // A thread is one incident's workspace, so it holds at most one open artifact
     // of a given command. The channel root is unrestricted — it has no
@@ -1157,6 +1189,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
               onMentionSearch={handleMentionSearch}
               channelItems={channelItems}
               onChannelSearch={handleChannelSearch}
+              fileReferenceItems={fileReferenceItems}
               onSendMessage={handleSendMessage}
               onContentChange={handleContentChange}
               onTyping={handleTyping}

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -43,6 +43,7 @@ import { toast } from 'sonner';
 import { EditorToolbar } from '../EditorToolbar';
 import { EmojiPickerButton } from '../EditorToolbar';
 import { MentionSelector } from '../Selectors';
+import { FileReferenceSelector } from '../Selectors';
 import { CommandSelector } from '../Selectors';
 import { EmojiSelector } from '../Selectors';
 import { AttachmentPreview } from '../files';
@@ -222,6 +223,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       channelItems = [],
       onChannelSearch,
       onChannelSelect,
+      fileReferenceItems = [],
       commandItems = [],
       onCommandSelect,
       isLoadingCommands = false,
@@ -1552,6 +1554,10 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
           {...(onChannelSearch && { onMentionSearch: onChannelSearch })}
           {...(onChannelSelect && { onMentionSelect: handleChannelSelect })}
         />
+
+        {features.mentions && (
+          <FileReferenceSelector editor={editor} fileItems={fileReferenceItems} />
+        )}
 
         {features.emojiPicker && (
           <EmojiSelector editor={editor} customEmojis={customEmojis ?? []} />

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -54,6 +54,7 @@ import { MentionExtension, mentionPluginKey } from '../TipTapExtensions';
 import { CommandsExtension, commandPluginKey } from '../TipTapExtensions';
 import { EmojiSelectorExtension, emojiSelectorPluginKey } from '../TipTapExtensions';
 import { ChannelMentionExtension, channelMentionPluginKey } from '../TipTapExtensions';
+import { FileReferenceExtension } from '../TipTapExtensions';
 import { TableExtensions } from '../TipTapExtensions';
 import { FormattingShortcutsExtension } from '../TipTapExtensions';
 import { ColonEmojiExtension } from '../TipTapExtensions/ColonEmojiExtension';
@@ -708,6 +709,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
           preserveThreadRoute,
         }),
         ChannelMentionExtension,
+        FileReferenceExtension,
         CommandsExtension,
         EmojiSelectorExtension,
         VoiceShimmerMark,

--- a/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.types.ts
@@ -36,6 +36,8 @@ export interface InputBoxProps {
   channelItems?: import('../Selectors/Selectors.types').ChannelResult[];
   onChannelSearch?: (query: string) => void;
   onChannelSelect?: (channel: import('../Selectors/Selectors.types').ChannelResult) => void;
+  /** Files from the current thread that can be tagged via the `~` reference picker. */
+  fileReferenceItems?: import('../Selectors/FileReferenceSelector').FileReferenceItem[];
   commandItems?: import('../Selectors/Selectors.types').CommandItem[];
   onCommandSelect?: (
     command: import('../Selectors/Selectors.types').CommandItem,

--- a/apps/dashboard/src/components/ui/Selectors/FileReferenceSelector.tsx
+++ b/apps/dashboard/src/components/ui/Selectors/FileReferenceSelector.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { PluginKey } from '@tiptap/pm/state';
+import type { Editor } from '@tiptap/react';
+import { FileText, FileImage, FileVideo, Paperclip } from 'lucide-react';
+import { detectFileReferenceTrigger, createVirtualAnchor } from './Selectors.utils';
+import { fileReferencePluginKey } from '../TipTapExtensions';
+import type { FileReferenceItem } from '../TipTapExtensions';
+import { BasePopoverSelector, type BaseSelectorPluginState } from './BasePopoverSelector';
+
+export type { FileReferenceItem };
+
+export interface FileReferenceSelectorProps {
+  editor: Editor | null;
+  fileItems: FileReferenceItem[];
+  onFileSelect?: (file: FileReferenceItem) => void;
+}
+
+const FileGlyph: React.FC<{ mimeType?: string | undefined }> = ({ mimeType }) => {
+  const cls = 'h-3.5 w-3.5 text-muted-foreground';
+  if (mimeType?.startsWith('image/')) return <FileImage className={cls} />;
+  if (mimeType?.startsWith('video/')) return <FileVideo className={cls} />;
+  if (mimeType === 'application/pdf' || mimeType?.startsWith('text/'))
+    return <FileText className={cls} />;
+  return <Paperclip className={cls} />;
+};
+
+/**
+ * FileReferenceSelector
+ *
+ * The `~`-triggered picker that lets a user tag an existing file from the
+ * current thread — the file analogue of the @-user and #-channel pickers.
+ * Items come from the thread's attachments (see ChatInput → conversationMessages).
+ * Selecting inserts a `fileReference` chip whose identity is the immutable
+ * attachmentId; the backend re-authorizes that id server-side, so the embedded
+ * id is display metadata, never a trusted grant.
+ *
+ * Filtering is local: the thread's file list is small and already client-side,
+ * so we match the `~query` against file names here instead of round-tripping.
+ */
+export const FileReferenceSelector: React.FC<FileReferenceSelectorProps> = ({
+  editor,
+  fileItems,
+  onFileSelect,
+}) => {
+  const [query, setQuery] = useState('');
+
+  const detectTriggerWithSearch = useCallback(
+    (ed: typeof editor) => {
+      if (!ed) return null;
+      const trigger = detectFileReferenceTrigger(ed);
+      if (trigger) {
+        setQuery(trigger.query.replace(/[.,!?:;)]*$/, ''));
+      }
+      return trigger;
+    },
+    [],
+  );
+
+  const filteredItems = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return fileItems.slice(0, 10);
+    return fileItems.filter(f => f.name.toLowerCase().includes(q)).slice(0, 10);
+  }, [fileItems, query]);
+
+  const handleSelect = useCallback(
+    (file: FileReferenceItem) => {
+      if (!editor) return;
+
+      const { state } = editor;
+      const { from, $from } = state.selection;
+      const textBefore = $from.parent.textBetween(0, $from.parentOffset, '\n', '\0');
+      const match = textBefore.match(/~([\w\s.-]*)$/);
+      if (!match) return;
+
+      const triggerStart = from - match[0].length;
+
+      editor
+        .chain()
+        .focus()
+        .deleteRange({ from: triggerStart, to: from })
+        .insertFileReference({
+          attachmentId: file.id,
+          fileName: file.name,
+          ...(file.mimeType !== undefined && { mimeType: file.mimeType }),
+        })
+        .insertContent(' ')
+        .run();
+
+      onFileSelect?.(file);
+    },
+    [editor, onFileSelect],
+  );
+
+  const renderItem = useCallback(
+    (item: FileReferenceItem, _index: number, isSelected: boolean) => (
+      <div
+        className={`flex items-center h-8 px-1 transition-all duration-200 ease-in active:scale-[0.98] ${
+          isSelected ? 'bg-accent' : ''
+        }`}
+      >
+        <div className='w-8 h-8 flex items-center justify-center flex-shrink-0'>
+          <FileGlyph mimeType={item.mimeType} />
+        </div>
+        <div className='flex-1 min-w-0 flex flex-col gap-0.5'>
+          <span className='text-sm font-medium text-foreground whitespace-nowrap overflow-hidden text-ellipsis'>
+            {item.name}
+          </span>
+        </div>
+      </div>
+    ),
+    [],
+  );
+
+  return (
+    <BasePopoverSelector<FileReferenceItem>
+      editor={editor}
+      pluginKey={fileReferencePluginKey as PluginKey<BaseSelectorPluginState<FileReferenceItem>>}
+      items={filteredItems}
+      detectTrigger={detectTriggerWithSearch}
+      getPosition={createVirtualAnchor}
+      onSelect={handleSelect}
+      renderItem={renderItem}
+      emptyMessage='No files in this thread'
+      className='w-80'
+      triggerChar='#'
+    />
+  );
+};

--- a/apps/dashboard/src/components/ui/Selectors/Selectors.utils.ts
+++ b/apps/dashboard/src/components/ui/Selectors/Selectors.utils.ts
@@ -105,6 +105,30 @@ export const detectRecipientTrigger = (editor: Editor): TriggerMatch | null => {
   };
 };
 
+/**
+ * Detects `~query` before the cursor for the thread-file reference picker.
+ * `~` is used because @, #, /, :, and + are already claimed by other selectors.
+ * Mirrors detectMentionTrigger: closes on `~ ` or a double space.
+ */
+export const detectFileReferenceTrigger = (editor: Editor): TriggerMatch | null => {
+  const { from } = editor.state.selection;
+  const textBefore = getTextBeforeCursor(editor);
+  const fileMatch = textBefore.match(/(?:^|[\s\u200B(])~([\w\s.-]*)$/);
+
+  if (textBefore.match(/~ $/) || textBefore.match(/~[\w\s.-]* {2}$/)) {
+    return null;
+  }
+
+  if (!fileMatch || fileMatch[1] === undefined) return null;
+
+  return {
+    query: fileMatch[1],
+    match: fileMatch,
+    triggerStart: from - fileMatch[0].length,
+    triggerEnd: from,
+  };
+};
+
 export const getAbsolutePosition = (editor: Editor, pos: number): EditorPosition | null => {
   const { view } = editor;
   const coords = view.coordsAtPos(pos);

--- a/apps/dashboard/src/components/ui/Selectors/index.ts
+++ b/apps/dashboard/src/components/ui/Selectors/index.ts
@@ -9,6 +9,8 @@ export { createSelectorPlugin } from './BaseSelectorPlugin';
 export type { BaseSelectorPluginConfig } from './BaseSelectorPlugin';
 
 export { MentionSelector } from './MentionSelector';
+export { FileReferenceSelector } from './FileReferenceSelector';
+export type { FileReferenceItem, FileReferenceSelectorProps } from './FileReferenceSelector';
 export { CommandSelector } from './CommandSelector';
 export { EmojiSelector } from './EmojiSelector';
 
@@ -21,6 +23,7 @@ export {
   detectChannelTrigger,
   detectEmojiTrigger,
   detectRecipientTrigger,
+  detectFileReferenceTrigger,
   getAbsolutePosition,
   getTextBeforeCursor,
   createVirtualAnchor,

--- a/apps/dashboard/src/components/ui/TipTapExtensions/FileReferenceExtension.ts
+++ b/apps/dashboard/src/components/ui/TipTapExtensions/FileReferenceExtension.ts
@@ -1,0 +1,181 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+
+/**
+ * FileReferenceExtension
+ *
+ * An inline, atomic node that lets a user reference (tag) an EXISTING file
+ * from the current thread — the file-equivalent of a channel/user mention.
+ *
+ * The node's identity is the immutable `attachmentId`; `fileName` and
+ * `mimeType` are display-only metadata. The chip serializes to
+ *   <span data-file-reference data-attachment-id="..." data-file-name="..." ...>@name</span>
+ * which the backend parses (see fileReferenceUtils.extractFileReferenceIds)
+ * and RE-AUTHORIZES server-side — the embedded id is never trusted for access.
+ *
+ * This extension intentionally ships only the node + insert command; the
+ * suggestion picker that populates it from the thread's attachments is wired
+ * separately in the composer.
+ */
+export interface FileReferenceOptions {
+  HTMLAttributes: Record<string, unknown>;
+}
+
+export interface FileReferenceAttributes {
+  attachmentId: string;
+  fileName: string;
+  mimeType?: string;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    fileReference: {
+      insertFileReference: (attributes: FileReferenceAttributes) => ReturnType;
+      removeFileReference: () => ReturnType;
+    };
+  }
+}
+
+const ZWSP = '\u200B'; // Zero-width space guard, matching other mention nodes
+
+export const FileReferenceExtension = Node.create<FileReferenceOptions>({
+  name: 'fileReference',
+
+  group: 'inline',
+
+  inline: true,
+
+  selectable: false,
+
+  atom: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    return {
+      attachmentId: {
+        default: null,
+        parseHTML: (element: HTMLElement): string | null =>
+          element.getAttribute('data-attachment-id'),
+        renderHTML: (attributes: Record<string, unknown>): Record<string, string> => {
+          if (!attributes['attachmentId']) return {};
+          return { 'data-attachment-id': attributes['attachmentId'] as string };
+        },
+      },
+      fileName: {
+        default: null,
+        parseHTML: (element: HTMLElement): string | null =>
+          element.getAttribute('data-file-name'),
+        renderHTML: (attributes: Record<string, unknown>): Record<string, string> => {
+          if (!attributes['fileName']) return {};
+          return { 'data-file-name': attributes['fileName'] as string };
+        },
+      },
+      mimeType: {
+        default: null,
+        parseHTML: (element: HTMLElement): string | null =>
+          element.getAttribute('data-mime-type'),
+        renderHTML: (attributes: Record<string, unknown>): Record<string, string> => {
+          if (!attributes['mimeType']) return {};
+          return { 'data-mime-type': attributes['mimeType'] as string };
+        },
+      },
+    };
+    /* eslint-enable @typescript-eslint/naming-convention */
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'span[data-file-reference]',
+      },
+    ];
+  },
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  renderHTML({ node, HTMLAttributes }): [string, Record<string, string | undefined>, string] {
+    const attrs = node.attrs as Record<string, unknown>;
+    const fileName = (attrs['fileName'] as string) ?? 'file';
+
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const dataAttributes: Record<string, string> = {
+      'data-file-reference': '',
+      'data-attachment-id': (attrs['attachmentId'] as string) ?? '',
+      'data-file-name': fileName,
+    };
+    if (attrs['mimeType']) {
+      dataAttributes['data-mime-type'] = attrs['mimeType'] as string;
+    }
+
+    return [
+      'span',
+      mergeAttributes(
+        {
+          ...dataAttributes,
+          class: 'chat-input-file-reference',
+          contenteditable: 'false',
+          role: 'button',
+          'aria-label': `Reference file ${fileName}`,
+          tabindex: '-1',
+        },
+        this.options.HTMLAttributes,
+        HTMLAttributes,
+      ),
+      `📎${fileName}`,
+    ];
+    /* eslint-enable @typescript-eslint/naming-convention */
+  },
+
+  renderText({ node }): string {
+    const attrs = node.attrs as Record<string, unknown>;
+    const fileName = (attrs['fileName'] as string) ?? 'file';
+    return `📎${fileName}`;
+  },
+
+  addCommands() {
+    return {
+      insertFileReference:
+        attributes =>
+        ({ chain }): boolean => {
+          return chain()
+            .insertContent([
+              { type: 'text', text: ZWSP },
+              { type: this.name, attrs: attributes },
+              { type: 'text', text: ZWSP },
+            ])
+            .run();
+        },
+      removeFileReference:
+        () =>
+        ({ tr, state }): boolean => {
+          const { selection } = state;
+          const { $from } = selection;
+
+          let foundNode: ProseMirrorNode | undefined;
+          let foundPos: number | undefined;
+
+          state.doc.nodesBetween($from.pos - 1, $from.pos + 1, (node, pos): boolean => {
+            if (node.type.name === this.name) {
+              foundNode = node;
+              foundPos = pos;
+              return false;
+            }
+            return true;
+          });
+
+          if (foundNode && foundPos !== undefined) {
+            const fileName = (foundNode.attrs['fileName'] as string) ?? 'file';
+            tr.replaceWith(foundPos, foundPos + foundNode.nodeSize, state.schema.text(`📎${fileName}`));
+            return true;
+          }
+
+          return false;
+        },
+    };
+  },
+});

--- a/apps/dashboard/src/components/ui/TipTapExtensions/FileReferenceExtension.ts
+++ b/apps/dashboard/src/components/ui/TipTapExtensions/FileReferenceExtension.ts
@@ -1,5 +1,9 @@
 import { Node, mergeAttributes } from '@tiptap/core';
+import { PluginKey } from '@tiptap/pm/state';
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import type { EditorView } from '@tiptap/pm/view';
+import type { BaseSelectorPluginState } from '../Selectors';
+import { createSelectorPlugin } from '../Selectors';
 
 /**
  * FileReferenceExtension
@@ -35,6 +39,19 @@ declare module '@tiptap/core' {
     };
   }
 }
+
+/** One selectable file in the thread-file reference picker. */
+export interface FileReferenceItem {
+  id: string;
+  name: string;
+  mimeType?: string;
+}
+
+export type FileReferencePluginState = BaseSelectorPluginState<FileReferenceItem>;
+
+export const fileReferencePluginKey = new PluginKey<FileReferencePluginState>(
+  'fileReferenceSelector',
+);
 
 const ZWSP = '\u200B'; // Zero-width space guard, matching other mention nodes
 
@@ -135,6 +152,36 @@ export const FileReferenceExtension = Node.create<FileReferenceOptions>({
     const attrs = node.attrs as Record<string, unknown>;
     const fileName = (attrs['fileName'] as string) ?? 'file';
     return `📎${fileName}`;
+  },
+
+  addProseMirrorPlugins() {
+    const extensionName = this.name;
+
+    return [
+      createSelectorPlugin<FileReferenceItem>({
+        pluginKey: fileReferencePluginKey,
+        customKeyHandler: (view: EditorView, event: KeyboardEvent): boolean => {
+          const { state, dispatch } = view;
+          const { selection } = state;
+          const { $from } = selection;
+          const nodeBefore = $from.nodeBefore;
+
+          // Backspace at the right ZWSP guard deletes the whole chip, matching
+          // channel/user mentions, so a reference never leaves a half-deleted node.
+          if (event.key === 'Backspace' && nodeBefore && nodeBefore.text === ZWSP) {
+            const posBeforeZwsp = $from.pos - 1;
+            const maybeChip = state.doc.nodeAt(posBeforeZwsp - 1);
+            if (maybeChip && maybeChip.type.name === extensionName) {
+              event.preventDefault();
+              const tr = state.tr.delete(posBeforeZwsp - 1, $from.pos);
+              dispatch(tr);
+              return true;
+            }
+          }
+          return false;
+        },
+      }),
+    ];
   },
 
   addCommands() {

--- a/apps/dashboard/src/components/ui/TipTapExtensions/index.ts
+++ b/apps/dashboard/src/components/ui/TipTapExtensions/index.ts
@@ -21,6 +21,9 @@ export type {
   ChannelResult,
 } from './ChannelMentionExtension';
 
+export { FileReferenceExtension } from './FileReferenceExtension';
+export type { FileReferenceOptions, FileReferenceAttributes } from './FileReferenceExtension';
+
 export { MentionNodeView } from './MentionNodeView';
 
 export {

--- a/apps/dashboard/src/components/ui/TipTapExtensions/index.ts
+++ b/apps/dashboard/src/components/ui/TipTapExtensions/index.ts
@@ -21,8 +21,13 @@ export type {
   ChannelResult,
 } from './ChannelMentionExtension';
 
-export { FileReferenceExtension } from './FileReferenceExtension';
-export type { FileReferenceOptions, FileReferenceAttributes } from './FileReferenceExtension';
+export { FileReferenceExtension, fileReferencePluginKey } from './FileReferenceExtension';
+export type {
+  FileReferenceOptions,
+  FileReferenceAttributes,
+  FileReferenceItem,
+  FileReferencePluginState,
+} from './FileReferenceExtension';
 
 export { MentionNodeView } from './MentionNodeView';
 

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -4785,3 +4785,36 @@ img.inline-emoji,
 [data-testid="virtuoso-item-list"] [data-index]:has([data-input-id]) {
   z-index: 10;
 }
+
+/* File References (tagged existing thread files) */
+.chat-input-field .chat-input-file-reference,
+.chat-input-field span[data-file-reference],
+.chat-input-field .ProseMirror .chat-input-file-reference,
+.chat-input-field .ProseMirror span[data-file-reference],
+.ProseMirror .chat-input-file-reference,
+.ProseMirror span[data-file-reference],
+span[data-file-reference].chat-input-file-reference,
+span.chat-input-file-reference[data-file-reference] {
+  color: #6d28d9 !important;
+  background-color: rgba(109, 40, 217, 0.08) !important;
+  font-weight: 400 !important;
+  cursor: pointer !important;
+  position: relative !important;
+  display: inline !important;
+  white-space: nowrap !important;
+  text-decoration: none !important;
+  max-width: none !important;
+  vertical-align: baseline !important;
+  line-height: inherit !important;
+  padding: 2px 4px !important;
+  border-radius: 4px !important;
+}
+
+.chat-input-field .chat-input-file-reference:hover,
+.chat-input-field span[data-file-reference]:hover,
+.ProseMirror .chat-input-file-reference:hover,
+.ProseMirror span[data-file-reference]:hover,
+span[data-file-reference].chat-input-file-reference:hover {
+  color: #5b21b6 !important;
+  background-color: rgba(109, 40, 217, 0.14) !important;
+}


### PR DESCRIPTION
## What & why
Lets a user reference (tag) an existing file from the current thread the same way channels and people are mentioned. This makes it easy to point a message — or a Claw agent — at a specific file already shared in the thread, instead of re-uploading it.

> No linked ticket — no XYNE key was available when this was raised. Happy to attach one.

## Changes
**Dashboard (composer)**
- New `FileReferenceExtension` TipTap node (inline, atomic) with `insertFileReference` / `removeFileReference` commands. Serializes to `<span data-file-reference data-attachment-id="…" data-file-name="…" data-mime-type="…">📎name</span>`.
- Registered the node in the message composer (`InputBox`) and exported it from the TipTap extensions barrel.
- Chip styling in `global.css` (mirrors the channel/user mention styling).

**Backend**
- New `apps/backend/src/apps/utils/fileReferenceUtils.ts`:
  - `extractFileReferenceIds(html)` — parses the tagged attachment ids out of the message HTML, de-dupes, caps at `MAX_FILE_REFERENCES` (10).
  - `resolveReferencedAttachments(ids, ctx)` — **re-authorizes every id server-side**: attachment must exist, not be soft-deleted, have a storage URL, and match the message's `workspaceId` **and** `conversationId` (thread). Bad references are dropped, never thrown.
  - `mergeAttachments(uploaded, referenced)` — de-dupes by attachmentId, uploaded wins.
- Added optional `referencedAttachments` to `AppMentionEventPayload` / `DMEventPayload`.
- Wired the resolver into the app-mention dispatch path in `messages-handler.ts`: resolved referenced files are merged into the existing `attachments` array (so apps like Claw need no changes) while `referencedAttachments` preserves provenance.

## Security
The attachment id embedded in the composer HTML is **never trusted for access**. It is re-authorized against the message's workspace + conversation before delivery, so a client cannot tag an arbitrary workspace file into a thread it doesn't belong to. One bad/forged reference is silently dropped and never blocks message delivery.

## Testing
- 17 backend unit tests (`fileReferenceUtils.test.ts`) covering extraction (attr order, dedupe, cap, ignoring channel/user mentions), the cross-tenant / cross-thread / soft-deleted / no-url / forged-id guards, per-id error isolation, and the dedupe merge — all pass.
- `tsc --noEmit` clean for both backend and dashboard.
- End-to-end composer→backend loop verified in a headless browser: the real `FileReferenceExtension` produces the HTML and the real `extractFileReferenceIds` parses back `["att_5f3a91","att_8b1c02"]` with zero console errors (recording attached in the thread).

## Notes / follow-ups
- The suggestion picker that populates the chip from the thread's attachments is intentionally a follow-up; this PR ships the node, the insert command, and the full authorize+deliver backend path.
- Only the primary APP_MENTION dispatch path is wired; the other mention build sites can adopt the same helper next.

## Update: composer picker UI + genuine end-to-end verification

The composer now has a real inline file-reference picker, added in commit 6aad6770 ("feat: thread-file reference picker in composer").

How it works for users:
- In a thread composer, type `~` to open a picker listing the files actually attached to that thread (backed by the existing Selectors framework, modeled on the channel/people mention popover).
- Selecting a file inserts an inline chip carrying `data-attachment-id`, `data-file-name`, and `data-mime-type`.
- On send, those referenced attachment IDs are extracted, re-resolved and re-authorized server-side, then merged (deduped) into the message `attachments` array so Claw agents receive the referenced thread files.

Verified end-to-end in the real dashboard (not a harness): logged into a seeded thread with 3 attachments (design-spec.pdf, launch-demo.mp4, pricing-sheet.xlsx), typed `~`, the picker listed all 3 real thread files, selected design-spec.pdf, and the composer produced a live chip `<span data-file-reference data-attachment-id="seedatt0001" data-file-name="design-spec.pdf" data-mime-type="application/pdf">📎design-spec.pdf</span>`. Backend merge path is covered by 17 passing Jest unit tests in fileReferenceUtils.test.ts; backend and frontend typechecks pass.