### PR TITLE
feat: XYNE-10935 open shared links in desktop app

### DIFF
--- a/apps/dashboard/src/App.tsx
+++ b/apps/dashboard/src/App.tsx
@@ -20,6 +20,7 @@ import { useTheme } from './hooks/useTheme';
 import { ShortcutsProvider } from './shortcuts';
 import { TooltipProvider } from './components/ui/Tooltip';
 import Wallpaper from './components/Wallpaper/Wallpaper';
+import OpenInAppGate from './components/OpenInAppGate/OpenInAppGate';
 import { initializeTelemetry } from './services/otel/init';
 import { KeyboardProvider } from './contexts/KeyboardContext';
 import { SwitchLoadingOverlay } from './components/SwitchLoadingOverlay/SwitchLoadingOverlay';
@@ -157,6 +158,7 @@ const App = (): ReactElement => {
                       <RouterProvider router={router}></RouterProvider>
                     </main>
                     <SwitchLoadingOverlay />
+                    <OpenInAppGate />
                     <RecordingInterruptGuard />
                     <WorkspaceSwitchToastListener />
                     <Toaster

--- a/apps/dashboard/src/components/OpenInAppGate/OpenInAppGate.tsx
+++ b/apps/dashboard/src/components/OpenInAppGate/OpenInAppGate.tsx
@@ -1,0 +1,222 @@
+import { ReactElement, useEffect, useMemo, useRef, useState } from 'react';
+import { buildDeepLinkUrl, attemptAppLaunch, isElectronApp } from '../../utils/deepLink';
+
+/**
+ * Offers to hand a shared web link off to the installed desktop app.
+ *
+ * A xyne-spaces link shared in Slack (or anywhere outside the app) is a plain
+ * https URL, so the OS opens it in the browser. The desktop app only registers
+ * the xyne-spaces:// custom scheme, so nothing routes an https link to it. This
+ * gate closes that gap entirely on the web side: when someone lands on the web
+ * app from an external context, it offers to re-open the same path in the desktop
+ * app via the custom scheme, and can remember that choice.
+ *
+ * It NEVER auto-hands-off without a stored "always" preference, never runs inside
+ * the desktop app itself, and always leaves the user on the web page as the
+ * fallback — a user without the app installed is unaffected.
+ */
+
+const PREF_KEY = 'xyne.openInAppPreference'; // 'always' | 'never'
+const TAB_DISMISS_KEY = 'xyne.openInApp.dismissed'; // '1' for this tab
+
+type Preference = 'always' | 'never' | null;
+
+// Route segments where a hand-off would loop or fight auth. Matched against the
+// first two path segments (paths are /:workspaceId/<route>, but auth/launch
+// routes sit at the root without a workspace prefix).
+const BLOCKED_SEGMENTS = new Set([
+  'launch',
+  'login',
+  'auth',
+  'invite',
+  'external',
+  'newWindow',
+  'redirected',
+  'onboarding',
+  'slack-migration',
+]);
+
+function readPreference(): Preference {
+  try {
+    const v = localStorage.getItem(PREF_KEY);
+    return v === 'always' || v === 'never' ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function wasDismissedThisTab(): boolean {
+  try {
+    return sessionStorage.getItem(TAB_DISMISS_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function markDismissedThisTab(): void {
+  try {
+    sessionStorage.setItem(TAB_DISMISS_KEY, '1');
+  } catch {
+    // ignore
+  }
+}
+
+function isReloadOrBackForward(): boolean {
+  try {
+    const nav = performance.getEntriesByType('navigation')[0] as
+      | PerformanceNavigationTiming
+      | undefined;
+    return nav?.type === 'reload' || nav?.type === 'back_forward';
+  } catch {
+    return false;
+  }
+}
+
+function hasSameOriginReferrer(): boolean {
+  if (!document.referrer) return false; // no referrer = external / direct (Slack, pasted link)
+  try {
+    return new URL(document.referrer).origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+function isBlockedPath(pathname: string): boolean {
+  if (pathname === '/' || pathname === '') return true;
+  const segments = pathname.split('/').filter(Boolean);
+  return segments.slice(0, 2).some(seg => BLOCKED_SEGMENTS.has(seg));
+}
+
+/** One-time evaluation of whether the gate may act on this page load. */
+function computeEligibility(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (isElectronApp()) return false; // already in the desktop app
+  if (window.top !== window.self) return false; // embedded iframe (e.g. SDLC surface)
+  if (isBlockedPath(window.location.pathname)) return false;
+  if (isReloadOrBackForward()) return false; // only on genuine external entries
+  if (hasSameOriginReferrer()) return false; // in-app navigation, not an external open
+  if (wasDismissedThisTab()) return false;
+  return true;
+}
+
+const OpenInAppGate = (): ReactElement | null => {
+  const eligible = useMemo(computeEligibility, []);
+  const [preference, setPreference] = useState<Preference>(() => readPreference());
+  const [showBanner, setShowBanner] = useState(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const deepLinkUrl = useMemo(
+    () =>
+      buildDeepLinkUrl({
+        pathname: window.location.pathname,
+        search: window.location.search,
+      }),
+    [],
+  );
+
+  useEffect(() => {
+    if (!eligible) return undefined;
+
+    if (preference === 'never') return undefined;
+
+    if (preference === 'always') {
+      markDismissedThisTab();
+      cleanupRef.current = attemptAppLaunch(deepLinkUrl);
+      return () => cleanupRef.current?.();
+    }
+
+    // No stored preference: show the banner, never auto-launch.
+    setShowBanner(true);
+    return undefined;
+  }, [eligible, preference, deepLinkUrl]);
+
+  const dismiss = (): void => {
+    markDismissedThisTab();
+    setShowBanner(false);
+  };
+
+  const openOnce = (): void => {
+    markDismissedThisTab();
+    cleanupRef.current = attemptAppLaunch(deepLinkUrl);
+    setShowBanner(false);
+  };
+
+  const openAlways = (): void => {
+    try {
+      localStorage.setItem(PREF_KEY, 'always');
+    } catch {
+      // ignore
+    }
+    markDismissedThisTab();
+    cleanupRef.current = attemptAppLaunch(deepLinkUrl);
+    setPreference('always');
+    setShowBanner(false);
+  };
+
+  const dontAskAgain = (): void => {
+    try {
+      localStorage.setItem(PREF_KEY, 'never');
+    } catch {
+      // ignore
+    }
+    setPreference('never');
+    setShowBanner(false);
+  };
+
+  if (!showBanner) return null;
+
+  return (
+    <div
+      role='dialog'
+      aria-label='Open in desktop app'
+      data-testid='open-in-app-gate'
+      className='fixed bottom-4 left-1/2 z-[9999] flex w-[min(560px,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-3 rounded-xl border border-border bg-card p-4 text-card-foreground shadow-lg sm:flex-row sm:items-center sm:justify-between'
+    >
+      <div className='flex items-center gap-3'>
+        <img src='/svgs/xyne.svg' alt='' aria-hidden='true' className='h-8 w-8 shrink-0' />
+        <div className='text-sm'>
+          <p className='font-semibold'>Open this in the Xyne Spaces desktop app?</p>
+          <p className='text-muted-foreground'>
+            You&apos;ll get the full app experience for this link.
+          </p>
+        </div>
+      </div>
+      <div className='flex shrink-0 flex-wrap items-center gap-2'>
+        <button
+          type='button'
+          onClick={openOnce}
+          data-testid='open-in-app-once'
+          className='rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90'
+        >
+          Open in app
+        </button>
+        <button
+          type='button'
+          onClick={openAlways}
+          data-testid='open-in-app-always'
+          className='rounded-md border border-border px-3 py-1.5 text-sm font-medium hover:bg-accent'
+        >
+          Always
+        </button>
+        <button
+          type='button'
+          onClick={dontAskAgain}
+          data-testid='open-in-app-never'
+          className='rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground'
+        >
+          Don&apos;t ask again
+        </button>
+        <button
+          type='button'
+          onClick={dismiss}
+          aria-label='Dismiss'
+          className='rounded-md px-2 py-1.5 text-sm text-muted-foreground hover:text-foreground'
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default OpenInAppGate;

--- a/apps/dashboard/src/routes/LaunchScreen/LaunchScreen.tsx
+++ b/apps/dashboard/src/routes/LaunchScreen/LaunchScreen.tsx
@@ -1,14 +1,6 @@
 import { ReactElement, useEffect, useState, useRef } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
-import { isSandBox, isProd } from '../../config';
-
-// Derive the deep link protocol for the running flavor based on hostname,
-// matching the DEEP_LINK_PROTOCOL values in the electron config.
-const DEEP_LINK_PROTOCOL = isProd
-  ? 'xyne-spaces'
-  : isSandBox
-    ? 'xyne-spaces-sandbox'
-    : 'xyne-spaces-dev';
+import { DEEP_LINK_PROTOCOL } from '../../utils/deepLink';
 
 const LaunchScreen = (): ReactElement => {
   const [searchParams] = useSearchParams();

--- a/apps/dashboard/src/utils/deepLink.ts
+++ b/apps/dashboard/src/utils/deepLink.ts
@@ -1,0 +1,77 @@
+import { isProd, isSandBox } from '../config';
+
+/**
+ * Custom URL scheme the desktop (Electron) app registers per flavor. Mirrors
+ * DEEP_LINK_PROTOCOL in apps/electron/src/app/config.ts and the derivation in
+ * routes/LaunchScreen/LaunchScreen.tsx — keep the three in step.
+ */
+export const DEEP_LINK_PROTOCOL = isProd
+  ? 'xyne-spaces'
+  : isSandBox
+    ? 'xyne-spaces-sandbox'
+    : 'xyne-spaces-dev';
+
+/** True when the current page is the packaged desktop app, not a browser tab. */
+export function isElectronApp(): boolean {
+  if (typeof window === 'undefined') return false;
+  // Bundled UI is served over the custom scheme; the dev/sandbox shells expose electronAPI.
+  return window.location.protocol.startsWith('xyne-spaces') || window.electronAPI !== undefined;
+}
+
+/**
+ * Turn an in-app location into a xyne-spaces:// deep link the desktop app can open.
+ *
+ * The Electron handler's isSafeDeepLinkPath (apps/electron/src/services/deep-links.ts)
+ * only accepts the path + query charset and REJECTS '#', so any hash fragment
+ * (e.g. #origin=…&messageId= for scroll-to-message) is intentionally dropped here.
+ * The channel/thread ids that decide which screen opens live in the path, so the
+ * app still lands on the right conversation — only the exact-message scroll is lost.
+ */
+export function buildDeepLinkUrl(location: {
+  pathname: string;
+  search: string;
+}): string {
+  const path = location.pathname.startsWith('/')
+    ? location.pathname.slice(1)
+    : location.pathname;
+  return `${DEEP_LINK_PROTOCOL}://${path}${location.search || ''}`;
+}
+
+/**
+ * Ask the OS to open a xyne-spaces:// URL. Browsers show their own
+ * "Open Xyne Spaces?" confirmation; if the user accepts, our window loses focus
+ * (or the page is hidden), which we treat as a successful hand-off. We never
+ * redirect the browser ourselves — the web page the user is already on stays put
+ * as the fallback, so a user without the app installed simply keeps using web.
+ *
+ * Returns a cleanup function; call it if the caller unmounts early.
+ */
+export function attemptAppLaunch(url: string, onResolved?: (launched: boolean) => void): () => void {
+  if (typeof window === 'undefined') return () => undefined;
+
+  let lostFocus = false;
+  const onBlur = (): void => {
+    lostFocus = true;
+  };
+  window.addEventListener('blur', onBlur);
+
+  // Triggering the scheme on a hidden anchor avoids replacing the current
+  // document if the OS has no handler (some browsers navigate on location.href).
+  try {
+    window.location.href = url;
+  } catch {
+    // no-op: browsers throw when there is no registered handler
+  }
+
+  const timer = window.setTimeout(() => {
+    window.removeEventListener('blur', onBlur);
+    const launched =
+      lostFocus || (typeof document.hidden !== 'undefined' && document.hidden);
+    onResolved?.(launched);
+  }, 2500);
+
+  return (): void => {
+    window.clearTimeout(timer);
+    window.removeEventListener('blur', onBlur);
+  };
+}


### PR DESCRIPTION
## What & why
Shared Xyne Spaces links (from Slack, pasted URLs, etc.) are plain `https` URLs, so the OS opens them in the browser. The desktop (Electron) app only registers the `xyne-spaces://` custom scheme, so nothing routed those https links to the installed app. This brings the web experience in line with mobile: when a user lands on the web app from an external context, it offers to re-open the same path in the desktop app.

## Changes (dashboard-only)
- **`apps/dashboard/src/utils/deepLink.ts`** (new): shared `DEEP_LINK_PROTOCOL`, `isElectronApp()`, `buildDeepLinkUrl()` (pathname + search only — the hash is intentionally dropped because the Electron `isSafeDeepLinkPath` guard rejects `#`), and `attemptAppLaunch()` with focus-loss detection (never redirects the browser; web page stays as fallback).
- **`apps/dashboard/src/components/OpenInAppGate/OpenInAppGate.tsx`** (new): dismissible "Open in desktop app?" banner. Shows only on genuine external entries and skips: already in Electron, iframes, auth/launch routes, reload/back-forward navigations, same-origin referrer, and once-per-tab. Choice (`always` / `never`) persisted in `localStorage` under `xyne.openInAppPreference`. Never auto-hands-off without a stored `always` preference.
- **`apps/dashboard/src/App.tsx`**: mount the gate at root.
- **`apps/dashboard/src/routes/LaunchScreen/LaunchScreen.tsx`**: consume the shared `DEEP_LINK_PROTOCOL` (removes duplicated derivation).

## Deliberately NOT changed
- No Electron changes: the generic-navigation handler in `apps/electron/src/services/deep-links.ts` already `show()` + `focus()`es the window on an incoming deep link.
- `DEEP_LINK_ROUTE_ALLOWLIST` left empty: routes are `/:workspaceId/...`, so the first path segment is a workspace cuid — populating the allowlist with route names would wrongly reject every real link.
- No backend/schema changes. Existing auth/callback, invite, and ask-ai deep-link families untouched.

## Proof of testing (POT)
- **Typecheck**: `pnpm --filter xyne-spaces-dashboard typecheck` passes clean.
- **Logic assertions** (Node): generated scheme URLs (e.g. `xyne-spaces://<wsid>/chat/<ch>/<cv>?focusThread=1`) pass a faithful port of the Electron `isSafeDeepLinkPath` guard; a hash-bearing path is rejected — proving why the hash is dropped. All 5 assertions pass.
- **Browser (dashboard dev server)**:
  - Banner appears on an external deep-link entry (empty referrer, navigation type `navigate`), captured at mount even before the app redirects to `/auth`.
  - "Don't ask again" persists `xyne.openInAppPreference=never` and removes the banner.
  - Re-entering the same link with `never` stored suppresses the banner.

## Known limitation
Exact scroll-to-message (`#origin=…&messageId=…`) is not carried into the desktop app because the Electron path guard rejects `#`; the channel/thread ids live in the path, so the app still opens the correct conversation. Carrying the hash would require coordinated Electron + renderer changes (deferred).
