### PR TITLE
fix: XYNE-61571 open the discussion with a newly created artifact

### DIFF
--- a/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
+++ b/apps/dashboard/src/routes/SdlcScreen/SdlcScreen.tsx
@@ -1343,10 +1343,11 @@ export default function SdlcScreen(): ReactElement {
     resetArtifactDialog();
     const newCanvasId = response.data.artifact.canvasId;
     setRelatedSourceId(null);
-    navigateWithinSdlc(
-      `/sdlc/${channelId}/artifacts`,
-      `?type=${encodeURIComponent(folder.id)}&canvas=${encodeURIComponent(newCanvasId)}`,
-    );
+    // Same search as opening an artifact from the list, so a new artifact lands
+    // with its discussion open rather than only doing so once reopened.
+    const search = canvasSearch(newCanvasId, true);
+    search.set('type', folder.id);
+    navigateWithinSdlc(`/sdlc/${channelId}/artifacts`, `?${search.toString()}`);
   };
 
   const createArtifactType = async (): Promise<void> => {


### PR DESCRIPTION
## What

Creating a blank artifact in SDLC opened the canvas with the conversation panel **closed**. Opening that same artifact from the list opened it **with** the discussion, so the panel appeared only once you left and came back.

## Why

Every other route into an artifact goes through `canvasSearch(canvasId, true)`, which sets `canvas`, `discussion=1` and `chat=conversations`. `createBlankArtifact` built its own query string instead:

```ts
`?type=${encodeURIComponent(folder.id)}&canvas=${encodeURIComponent(newCanvasId)}`
```

`sdlcChatLayout` reads exactly one thing to decide whether the panel is open:

```ts
const panelOpen = input.discussionParam === '1';
```

so the hand-built URL could never open it.

## Fix

Build the search with the same helper the click path uses, keeping the known folder id:

```ts
const search = canvasSearch(newCanvasId, true);
search.set('type', folder.id);
navigateWithinSdlc(`/sdlc/${channelId}/artifacts`, `?${search.toString()}`);
```

This mirrors `openArtifactCanvas`, which does the same thing but resolves its folder by lookup — not usable here, since a just-created canvas is not in `typeFolders` yet.

## Testing

Confirmed working in the SDLC app by the reporter: a newly created artifact now opens with the conversation panel.

I could not reproduce it locally — no SDLC repo in the local database is bound to a channel (`repos.channelId` is empty), so the screen has no route. What I did verify here is the mechanism, driving the real `sdlcChatLayout` with the two URLs each code path produces:

```
creation URL BEFORE : type=folder-1&canvas=canvas-1
  panelOpen = false
creation URL AFTER  : canvas=canvas-1&discussion=1&chat=conversations&type=folder-1
  panelOpen = true,  activeTab = conversations
```

Adding these params is safe: the deep-link cleanup effect only strips `discussion`/`chat` when a `conversation` id is also set (`shouldCloseInvalidSdlcConversationDeepLink`), which this URL does not set.

Dashboard typecheck 0 errors, eslint 0 errors, full pre-commit suite passed.

## Not included

`openWikiPage` (`SdlcScreen.tsx:1054`) hand-builds `?canvas=…` the same way and also omits the discussion params, even though wiki pages resolve a discussion context. Same bug, different entry point — left out because only the artifact path was reported. Happy to fold it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPBJtAza2gBg54qfRDv3t7
