### PR TITLE
XYNE-61705: Fix/search screen side panel

### DIFF
--- a/apps/dashboard/src/components/Activity/ActivitySupportTicket/ActivitySupportTicket.tsx
+++ b/apps/dashboard/src/components/Activity/ActivitySupportTicket/ActivitySupportTicket.tsx
@@ -23,6 +23,13 @@ const EMPTY_TICKET_FILTER = {
   createdAtEnd: undefined,
 } as const;
 
+interface ActivitySupportTicketProps {
+  // Show the in-list navigation chrome (back-to-list button + prev/next controls). The search
+  // pane sets this false: it has its own close header, no ticket list to page, and archive /
+  // mark-unread there must leave the pane in place rather than navigate away.
+  showAdjacentNav?: boolean;
+}
+
 /**
  * Renders a Support/Desk ticket detail INSIDE the Activity panel outlet, so
  * clicking a desk-channel mention in the Activity list keeps the list on the
@@ -34,7 +41,9 @@ const EMPTY_TICKET_FILTER = {
  *    redirect to the `:ticketId` form.
  *  - `ticket/:channelId/:ticketId`  — render `<SupportTicketDetail>` directly.
  */
-const ActivitySupportTicket = (): ReactElement => {
+const ActivitySupportTicket = ({
+  showAdjacentNav = true,
+}: ActivitySupportTicketProps): ReactElement => {
   const navigate = useNavigate();
   const { workspaceId, channelId, ticketId } = useParams<{
     workspaceId?: string;
@@ -60,6 +69,14 @@ const ActivitySupportTicket = (): ReactElement => {
     return <ActivityTicketResolver channelId={channelId} ticketBase={ticketBase} />;
   }
 
+  // On the Activity screen, back (and the post-archive / mark-unread return) goes to the activity
+  // list. In the search pane there's no list to return to and those actions must not dismiss the
+  // pane, so back is a no-op — SupportTicketDetail still needs a defined handler, otherwise
+  // goBackToTicketList falls through and navigates away.
+  const handleBack = showAdjacentNav
+    ? (): void => void navigate(activityBase)
+    : (): void => undefined;
+
   return (
     <SupportTicketDetail
       ticketFilter={EMPTY_TICKET_FILTER}
@@ -68,9 +85,8 @@ const ActivitySupportTicket = (): ReactElement => {
       channelPreference={channelPreferenceRows?.[0]}
       channelPreferenceLoaded={channelPreferenceDetails.type === 'complete'}
       navBasePath={ticketBase}
-      onBack={() => {
-        void navigate(activityBase);
-      }}
+      onBack={handleBack}
+      showAdjacentNav={showAdjacentNav}
     />
   );
 };

--- a/apps/dashboard/src/components/Chat/ChannelIcon/ChannelIcon.tsx
+++ b/apps/dashboard/src/components/Chat/ChannelIcon/ChannelIcon.tsx
@@ -1,11 +1,13 @@
 import { ChannelScopeType, ChannelVisibility, Channel } from '@xyne/shared';
 import { useAuthContextValues } from '../../../hooks/useAuth';
-import { Hashtag, LockClose } from '@xyne/icons';
+import { Hashtag, UserTwo } from '@xyne/icons';
+import ChatLock from '../../icons/ChatLock';
 import Avatar, { type AvatarSize } from '../../ui/Avatar/Avatar';
-import { getDMParticipantIdsToFetch } from '../ChatDirectory/ChatDirectory.utils';
+import { getDMParticipantIdsToFetch, isGroupDMChannel } from '../ChatDirectory/ChatDirectory.utils';
 
 interface ChannelIconProps {
-  channel: Channel;
+  // The channel to render an icon for. Undefined (e.g. not yet resolved) falls back to a hashtag.
+  channel: Channel | undefined;
   /**
    * Color class for the hashtag / lock glyphs. Defaults to `text-foreground`
    * (the header/info surfaces). The Cmd+K palette passes `text-muted-foreground`
@@ -26,14 +28,21 @@ const ChannelIcon = ({
 }: ChannelIconProps): React.ReactNode | null => {
   const context = useAuthContextValues();
 
-  if (
-    channel.scopeType === ChannelScopeType.DEFAULT ||
-    channel.scopeType === ChannelScopeType.GROUP_DM
-  ) {
-    if (channel.visibility === ChannelVisibility.PUBLIC) {
-      return <Hashtag size={16} className={glyphClassName} />;
-    }
-    return <LockClose size={16} className={glyphClassName} />;
+  if (!channel) return <Hashtag size={16} className={glyphClassName} />;
+
+  // Group DM → participant glyph with an "others" count badge (cmd+K's original design).
+  if (isGroupDMChannel(channel.scopeType)) {
+    const otherCount = getDMParticipantIdsToFetch(channel, context.userID).length;
+    return (
+      <div className='relative flex h-5 w-5 items-center justify-center'>
+        <UserTwo size={16} className={glyphClassName} />
+        {otherCount > 0 && (
+          <span className='absolute -bottom-0.5 -right-0.5 min-w-3 rounded-full bg-muted px-0.5 text-xs font-semibold leading-none text-muted-foreground'>
+            {otherCount}
+          </span>
+        )}
+      </div>
+    );
   }
 
   if (channel.scopeType === ChannelScopeType.DM) {
@@ -41,6 +50,16 @@ const ChannelIcon = ({
     const otherUserId = participantIds.find(id => id !== context.userID);
     return (
       <Avatar userId={otherUserId || context.userID} size={avatarSize} showActiveStatus={true} />
+    );
+  }
+
+  if (channel.scopeType === ChannelScopeType.DEFAULT) {
+    return channel.visibility === ChannelVisibility.PUBLIC ? (
+      <Hashtag size={16} className={glyphClassName} />
+    ) : (
+      <span className={glyphClassName}>
+        <ChatLock />
+      </span>
     );
   }
 

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -41,6 +41,7 @@ import {
 } from './ChatDirectory.utils';
 import { useChannelDisplayName } from '../../../hooks/useChannelDisplayName';
 import Avatar from '../../ui/Avatar/Avatar';
+import ChannelIcon from '../ChannelIcon/ChannelIcon';
 import Badge from '../../ui/Badge';
 import { DisplaySearchResult } from '../../../types/search';
 import {
@@ -2016,32 +2017,9 @@ const ChannelCommandMenu = ({
     setHoveredResult(null);
   }, []);
 
-  const getChannelIcon = (channel: Channel): ReactElement => {
-    if (isGroupDMChannel(channel.scopeType)) {
-      // Slack-style group icon: people glyph with participant count badge
-      const otherCount = getDMParticipantIdsToFetch(channel, currentUserID).length;
-      return (
-        <div className='relative flex h-5 w-5 items-center justify-center'>
-          <UserTwo size={16} className='text-muted-foreground' />
-          {otherCount > 0 && (
-            <span className='absolute -bottom-0.5 -right-0.5 min-w-3 rounded-full bg-muted px-0.5 text-xs font-semibold leading-none text-muted-foreground'>
-              {otherCount}
-            </span>
-          )}
-        </div>
-      );
-    }
-    if (isDMChannel(channel.scopeType)) {
-      const userIds = getDMParticipantIdsToFetch(channel, currentUserID);
-      if (userIds.length > 0 && userIds[0]) {
-        return <Avatar userId={userIds[0]} size='xs' />;
-      }
-    }
-    if (channel.visibility === ChannelVisibility.PRIVATE) {
-      return <Lock02Close size={16} />;
-    }
-    return <Hashtag size={16} />;
-  };
+  const getChannelIcon = (channel: Channel): ReactElement => (
+    <ChannelIcon channel={channel} glyphClassName='text-muted-foreground' avatarSize='xs' />
+  );
 
   /**
    * Channel tag for a ticket / file result row.

--- a/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
+++ b/apps/dashboard/src/components/Chat/ChatList/ChatListV4.tsx
@@ -226,7 +226,12 @@ const ChatListV4: React.FC<ChatListProps> = ({
   const { baseRoute } = useRouteContext();
   const { isEditingMessage, requestEdit } = useMessageEdit();
   const channelParticipation = useChannelParticipation(channelId);
-  const isMember = !!channelParticipation;
+  const isDmScope =
+    channelScopeType === ChannelScopeType.DM || channelScopeType === ChannelScopeType.GROUP_DM;
+  // A closed DM isn't in the seeded status map at mount, so participation is briefly undefined;
+  // treat an opened DM/group-DM as a member so ConversationsACL loads messages (its participant
+  // check still re-verifies real membership — a non-participant gets nothing, not a leak).
+  const isMember = !!channelParticipation || isDmScope;
   const channel = useVisibleChannel(channelId);
 
   const [newConversationsAnchor, setNewConversationsAnchor] = useState<Anchor | null>(
@@ -344,8 +349,14 @@ const ChatListV4: React.FC<ChatListProps> = ({
   // Container for the shared hover toolbar overlay (Slack pattern): one
   // toolbar for the whole list, positioned over the hovered row.
   const hoverToolbarContainerRef = useRef<HTMLDivElement>(null);
+  // Require resolved participation: while it's undefined, `?.conversationSeenCutoffAt !== null`
+  // is spuriously true and — now that DMs default isMember to true — would route to the cutoff
+  // path with a null anchor, skipping both load paths and leaving the list stuck empty.
   const shouldUseCutoffQuery =
-    channelParticipation?.conversationSeenCutoffAt !== null && isMember && !linkedConversationId;
+    !!channelParticipation &&
+    channelParticipation.conversationSeenCutoffAt !== null &&
+    isMember &&
+    !linkedConversationId;
 
   // ── TanStack Virtualizer ──────────────────────────────────────────────────────
   // anchorTo: 'end' replaces Virtuoso's firstItemIndex trick and alignToBottom.

--- a/apps/dashboard/src/components/Chat/ConversationPannel/ConversationPanelV2.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationPannel/ConversationPanelV2.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useCallback, useEffect, useRef, useMemo } from 'react';
+import { ReactElement, useCallback, useEffect, useRef, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { useRouteContext } from '../../../hooks/useRouteContext';
 import {
@@ -91,6 +91,7 @@ const ConversationPanelV2 = ({
   skipMarkAsRead = false,
   conversationIds,
   onOpenThread,
+  useLocalTabState = false,
 }: {
   channelId: string;
   previousChannelId: string | null;
@@ -106,6 +107,10 @@ const ConversationPanelV2 = ({
   // Used by read-only surfaces such as the Unreads inbox.
   hideComposer?: boolean;
   skipMarkAsRead?: boolean;
+  // When true (e.g. rendered in the search-results pane, which owns its own `?tab=`
+  // for the doc-type filter), keep the active tab in local state instead of the URL —
+  // otherwise a foreign `tab=all` matches no conversation tab and blanks the body.
+  useLocalTabState?: boolean;
 }): ReactElement => {
   const { baseRoute } = useRouteContext();
   const channel = useChannel(channelId);
@@ -148,7 +153,10 @@ const ConversationPanelV2 = ({
       ? activityNavigationState.linkedCutoffCreatedAt
       : null;
 
-  const tab = searchParams.get('tab') || getDefaultTab();
+  const [localTab, setLocalTab] = useState<string>(getDefaultTab());
+  const urlTab = searchParams.get('tab');
+  const urlTabOrDefault = urlTab && isValidTab(urlTab) ? urlTab : getDefaultTab();
+  const tab = useLocalTabState ? localTab : urlTabOrDefault;
   const ticketId = searchParams.get('ticketId');
   const conversationId = searchParams.get('conversationId');
   const canvasId = searchParams.get('canvasId');
@@ -221,11 +229,14 @@ const ConversationPanelV2 = ({
   // (context consumers) on each panel render.
   const handleTabChange = useCallback(
     (tab: string, e?: React.MouseEvent): void => {
-      if (isValidTab(tab)) {
+      if (!isValidTab(tab)) return;
+      if (useLocalTabState) {
+        setLocalTab(tab);
+      } else {
         standaloneNavigate(navigate, `${baseRoute}/${channelId}?tab=${tab}`, { event: e });
       }
     },
-    [isValidTab, navigate, baseRoute, channelId],
+    [isValidTab, navigate, baseRoute, channelId, useLocalTabState],
   );
 
   const conversationTabContextValue = useMemo(

--- a/apps/dashboard/src/components/Chat/ConversationPannel/ConversationPanelV2.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationPannel/ConversationPanelV2.tsx
@@ -154,11 +154,16 @@ const ConversationPanelV2 = ({
   const canvasId = searchParams.get('canvasId');
 
   const participationStatus = useGetChannelUserStatus(channelId);
+  // A closed/not-open DM is absent from the status map, so participation is briefly undefined;
+  // treat a DM/group-DM as member here too — otherwise the linked-message lookup returns nothing
+  // and the panel is stuck on "Messages are loading…". The query's ACL re-verifies real membership.
+  const isDmScope =
+    channel?.scopeType === ChannelScopeType.DM || channel?.scopeType === ChannelScopeType.GROUP_DM;
   const [initialMessageById] = useCachedQuery(
     queries.getConversationByIdWithChannel({
       conversationId: urlConversationId || '',
       channelId: channelId || '',
-      isMember: !!participationStatus,
+      isMember: !!participationStatus || isDmScope,
     }),
     { enabled: !!urlConversationId && !urlCreatedAtMatch && stateLinkedItemCreatedAt === null },
   );

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -5,7 +5,6 @@ import { ResizableGroup, Panel, Separator } from '../../ui/Resizable/Resizable';
 import {
   FileText,
   GitCompare,
-  Hash,
   Loader2,
   Mail,
   MessageCircle,
@@ -30,10 +29,8 @@ const utcToIst = (utcString?: string): string => {
     hour12: true,
   });
 };
-import ThreadMessages from '../ThreadPannel';
-import { UserProfile } from '../../ui/UserProfile/UserProfile';
 import { usePlatform } from '../../../hooks/usePlatform';
-import { useAuth, useAuthContextValues } from '../../../hooks/useAuth';
+import { useAuthContextValues } from '../../../hooks/useAuth';
 import {
   DEFAULT_SEARCH_FILTERS,
   type SearchResultsFilters,
@@ -50,7 +47,6 @@ import {
   useAllChannels,
   useUserChannelStatuses,
 } from '../../../hooks/useChannels';
-import ConversationPanelV2 from '../ConversationPannel/ConversationPanelV2';
 import { useSearchMetrics } from '../../../hooks/useSearchMetrics';
 import { useUser, useUsers } from '../../../hooks/useUsers';
 import {
@@ -69,7 +65,8 @@ import {
 } from '../ChatDirectory/ChannelCommandMenu.types';
 import { ChannelCategory } from '../ChatDirectory/ChatDirectory.types';
 import { Channel } from '@xyne/shared';
-import { navigateToSearchResult } from '../../../utils/searchNavigation';
+import { resolveOrCreateDmChannelId } from '../../../utils/searchNavigation';
+import { toast } from 'sonner';
 import Avatar from '../../ui/Avatar/Avatar';
 import { AnimatePresence, motion } from 'framer-motion';
 import { cn } from '../../../utils/classNames';
@@ -89,18 +86,10 @@ import {
 } from '@xyne/shared';
 import { TicketCardV2 } from '../../Tickets/TicketCardV2/TicketCardV2';
 import { isUserDeactivated } from '../../../utils/userDisplayName';
-
-type SidePanelState =
-  | { kind: 'thread'; thread: SearchResultsThread }
-  | { kind: 'profile'; userId: string }
-  | {
-      kind: 'channel';
-      channelId: string;
-      conversationId: string;
-      conversationCreatedAt?: number;
-      matchedMessageId?: string | null;
-    }
-  | null;
+import type { SidePanelState } from './SidePanel/PanelTypes';
+import { SearchResultsSidePanel } from './SidePanel/SidePanel';
+import { resolveResultClick } from './SidePanel/ResultClickResolver';
+import ChannelIcon from '../ChannelIcon/ChannelIcon';
 
 function parseDocTypeParam(value: string | null): SearchResultsFilters['docType'] | null {
   return value && (VALID_DOC_TYPES as string[]).includes(value)
@@ -623,13 +612,16 @@ const SearchResults = (): ReactElement => {
   ]);
   const searchRequestKey = JSON.stringify([query, filterKey]);
   const fullSearchKey = JSON.stringify([searchRequestKey, filters.sortBy]);
+  // Latest search key, read by async handlers to drop panels that resolve after a re-search.
+  const fullSearchKeyRef = useRef(fullSearchKey);
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: 0 });
   }, [query]);
 
-  // Reset auto-open and close stale panel whenever the search or any filter changes
+  // Close any open panel and refresh the async race key whenever the search or filters change
   useEffect(() => {
+    fullSearchKeyRef.current = fullSearchKey;
     setSelectedPanel(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fullSearchKey]);
@@ -656,6 +648,42 @@ const SearchResults = (): ReactElement => {
       });
     },
     [],
+  );
+  // Open a user's 1:1 DM chat in the right pane, creating the DM if it doesn't exist.
+  // Async; drops the result if the search changed while the DM was being created.
+  const openUserDm = useCallback(
+    (userId: string): void => {
+      const keyAtClick = fullSearchKeyRef.current;
+      void (async (): Promise<void> => {
+        try {
+          const channelId = await resolveOrCreateDmChannelId(userId, allChannelsForNav);
+          if (fullSearchKeyRef.current !== keyAtClick) return;
+          setSelectedPanel({ kind: 'channel', channelId });
+        } catch {
+          toast.error('Failed to open conversation');
+        }
+      })();
+    },
+    [allChannelsForNav],
+  );
+  // Single entry point for a result-card click: resolve what it should do, then do it.
+  const openResult = useCallback(
+    (result: DisplaySearchResult): void => {
+      const action = resolveResultClick(result, allChannelsForNav);
+      if (!action) return;
+      switch (action.kind) {
+        case 'panel':
+          setSelectedPanel(action.panel);
+          return;
+        case 'navigate':
+          void navigate(action.to, action.state ? { state: action.state } : undefined);
+          return;
+        case 'userDm':
+          openUserDm(action.userId);
+          return;
+      }
+    },
+    [allChannelsForNav, navigate, openUserDm],
   );
   const handleClosePanel = (): void => {
     setSelectedPanel(null);
@@ -793,7 +821,7 @@ const SearchResults = (): ReactElement => {
             results={results}
             loadMoreRef={loadMoreRef}
             selectedPanel={selectedPanel}
-            onSelectUser={handleSelectUser}
+            onOpenResult={openResult}
             channelData={allChannelsForNav}
             searchableChannels={allChannelsWithCategory}
             usersById={usersById}
@@ -897,7 +925,7 @@ interface ResultsBodyProps {
   results: DisplaySearchResult[];
   loadMoreRef: React.RefObject<HTMLDivElement | null>;
   selectedPanel: SidePanelState;
-  onSelectUser: (userId: string) => void;
+  onOpenResult: (result: DisplaySearchResult) => void;
   channelData: ReturnType<typeof useAllChannels>;
   searchableChannels: Array<{
     channel: Channel;
@@ -992,7 +1020,7 @@ function UserResultCard({
       data-track-category='SEARCH_RESULTS'
       data-track-name='OPEN_USER'
     >
-      <Avatar userId={result.id} size='md' showActiveStatus={false} />
+      <Avatar userId={result.id} size='md' showActiveStatus />
       <div className='min-w-0'>
         <div className='flex items-center gap-2 min-w-0'>
           <p
@@ -1042,7 +1070,7 @@ function ResultsBody({
   results,
   loadMoreRef,
   selectedPanel,
-  onSelectUser,
+  onOpenResult,
   channelData,
   searchableChannels,
   usersById,
@@ -1054,7 +1082,6 @@ function ResultsBody({
   docType,
   filteredLocalChannels,
 }: ResultsBodyProps): ReactElement {
-  const navigate = useNavigate();
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
   // `searchableNames` is already the rendered form: getDMNames(...).display for DMs
   // (participant names — `channel.name` is a participant id there) and [channel.name]
@@ -1091,9 +1118,9 @@ function ResultsBody({
   const renderCard = (result: DisplaySearchResult): ReactElement | null => {
     const key = `${result.type}-${result.id}`;
 
-    // User card — opens profile panel
+    // User card — opens the user's DM chat in the right pane.
     if (result.type === 'user') {
-      return <UserResultCard key={key} result={result} onSelectUser={onSelectUser} />;
+      return <UserResultCard key={key} result={result} onSelectUser={() => onOpenResult(result)} />;
     }
 
     // Channel card
@@ -1104,19 +1131,13 @@ function ResultsBody({
       return (
         <button
           key={key}
-          onClick={() =>
-            void navigate(isDeskChannel ? `/support/${channelId}` : `/chat/dir/${channelId}`)
-          }
+          onClick={() => onOpenResult(result)}
           className='w-full flex items-center gap-3 px-4 py-3 rounded-xl border border-border bg-card hover:bg-muted transition-colors text-left'
           data-track-category='SEARCH_RESULTS'
           data-track-name={isDeskChannel ? 'OPEN_DESK_CHANNEL' : 'OPEN_CHANNEL'}
         >
           <div className='flex items-center justify-center size-9 rounded-lg bg-muted shrink-0'>
-            {isDeskChannel ? (
-              <Mail className='size-4 text-muted-foreground' />
-            ) : (
-              <Hash className='size-4 text-muted-foreground' />
-            )}
+            <ChannelIcon channel={channel} glyphClassName='text-muted-foreground' avatarSize='md' />
           </div>
           <div className='min-w-0'>
             <p className='text-sm font-medium text-foreground truncate'>
@@ -1156,7 +1177,7 @@ function ResultsBody({
       return (
         <button
           key={key}
-          onClick={() => void navigateToSearchResult(result, navigate, channelData)}
+          onClick={() => onOpenResult(result)}
           className='w-full flex items-center gap-3 px-4 py-3 rounded-xl border border-border bg-card hover:bg-muted transition-colors text-left'
           data-track-category='SEARCH_RESULTS'
           data-track-name='OPEN_ATTACHMENT'
@@ -1205,7 +1226,7 @@ function ResultsBody({
       return (
         <button
           key={key}
-          onClick={() => void navigateToSearchResult(result, navigate, channelData)}
+          onClick={() => onOpenResult(result)}
           className='w-full flex items-start gap-3 px-4 py-3 rounded-xl border border-border bg-card hover:bg-muted transition-colors text-left'
           data-track-category='SEARCH_RESULTS'
           data-track-name='OPEN_MAIL'
@@ -1248,8 +1269,6 @@ function ResultsBody({
     const ctx = result.searchContext;
     if (!ctx?.channelId || !ctx?.conversationId) return null;
     const isTicket = result.type === 'ticket';
-    const isDeskTicket =
-      isTicket && isDeskChannelType(channelData?.find(c => c.id === ctx.channelId)?.type);
 
     // Ticket summary from the search fields — desk tickets render it as a compact
     // card; normal tickets serialize it into ticket_md so the message bubble shows
@@ -1272,9 +1291,11 @@ function ResultsBody({
         }
       : null;
 
-    // Desk tickets: their message-bound widget can't render (bot/AI initial
-    // message, missing ticket_md), so render a compact data-driven ticket card.
-    if (isDeskTicket && ticketSummary) {
+    // Tickets render as a compact data-driven ticket card. Desk tickets navigate to
+    // the support view; board tickets open their details in the right pane. Rendering
+    // both as TicketCardV2 (single onClick) avoids the message-bubble's embedded ticket
+    // widget fighting the card click for board tickets.
+    if (isTicket && ticketSummary) {
       return (
         <div
           key={key}
@@ -1286,7 +1307,7 @@ function ResultsBody({
             ticket={ticketSummary}
             isConversation
             width='max-w-none w-full'
-            onClick={() => void navigateToSearchResult(result, navigate, channelData)}
+            onClick={() => onOpenResult(result)}
           />
         </div>
       );
@@ -1626,18 +1647,30 @@ function MobileLayout({ selectedPanel, onClose, resultsColumn }: LayoutProps): R
   );
 }
 
+// Default pane split when a side panel is open. Desk tickets render a 3-column ticket view
+// (email thread + details/AI sidebar), so they open wider than other panes.
+const RESULTS_SIZE_FULL = '100%'; // no panel open
+const RESULTS_SIZE_WITH_PANEL = '55%';
+const RESULTS_MIN_SIZE = '30%';
+const SIDE_PANEL_SIZE = '45%';
+const SIDE_PANEL_MIN_SIZE = '25%';
+
+// Layout persistence key (ResizableGroup autoSaveId → localStorage). One split for every panel type —
+// a single consistent side-panel width avoids the results list reflowing when switching result types.
+const PANE_LAYOUT_ID = 'search-results-panel';
+
 function DesktopLayout({ selectedPanel, onClose, resultsColumn }: LayoutProps): ReactElement {
   return (
     <ResizableGroup
       orientation='horizontal'
       className='h-full'
-      autoSaveId='search-results-thread'
+      autoSaveId={PANE_LAYOUT_ID}
       panelIds={selectedPanel ? ['search-results', 'search-side-panel'] : ['search-results']}
     >
       <Panel
         id='search-results'
-        defaultSize={selectedPanel ? '60%' : '100%'}
-        minSize={selectedPanel ? '30%' : '100%'}
+        defaultSize={selectedPanel ? RESULTS_SIZE_WITH_PANEL : RESULTS_SIZE_FULL}
+        minSize={selectedPanel ? RESULTS_MIN_SIZE : RESULTS_SIZE_FULL}
       >
         <div className='h-full'>{resultsColumn}</div>
       </Panel>
@@ -1646,7 +1679,7 @@ function DesktopLayout({ selectedPanel, onClose, resultsColumn }: LayoutProps): 
           <Separator className='w-1 hover:bg-blue-50 active:bg-blue-100 transition-colors duration-200 cursor-col-resize flex items-center justify-center group'>
             <div className='w-[1px] h-full bg-border' />
           </Separator>
-          <Panel id='search-side-panel' defaultSize='40%' minSize='25%'>
+          <Panel id='search-side-panel' defaultSize={SIDE_PANEL_SIZE} minSize={SIDE_PANEL_MIN_SIZE}>
             <div className='h-full animate-slide-in-from-right'>
               <SearchResultsSidePanel panel={selectedPanel} onClose={onClose} />
             </div>
@@ -1657,61 +1690,5 @@ function DesktopLayout({ selectedPanel, onClose, resultsColumn }: LayoutProps): 
   );
 }
 
-function SearchResultsSidePanel({
-  panel,
-  onClose,
-}: {
-  panel: NonNullable<SidePanelState>;
-  onClose: () => void;
-}): ReactElement {
-  const { user: currentUser } = useAuth();
-  const navigate = useNavigate();
-
-  return (
-    <div className='h-full flex flex-col min-h-0 bg-background'>
-      {panel.kind === 'channel' ? (
-        <ConversationPanelV2
-          channelId={panel.channelId}
-          previousChannelId={null}
-          linkedConversationIdOverride={panel.conversationId}
-          linkedItemCreatedAtOverride={panel.conversationCreatedAt ?? null}
-          onClose={onClose}
-        />
-      ) : panel.kind === 'thread' ? (
-        <ThreadMessages
-          channelId={panel.thread.channelId}
-          conversationId={panel.thread.conversationId}
-          matchedMessageId={panel.thread.matchedMessageId ?? null}
-          showChannelLink
-          onChannelLinkClick={() =>
-            void navigate(
-              `/chat/dir/${panel.thread.channelId}#origin=${panel.thread.conversationId}`,
-            )
-          }
-          onClose={onClose}
-        />
-      ) : (
-        <>
-          <div className='flex items-center justify-end p-2 border-b border-border shrink-0'>
-            <button
-              onClick={onClose}
-              className='p-2 rounded-md hover:bg-accent'
-              aria-label='Close profile'
-              data-track-category='SEARCH_RESULTS'
-              data-track-name='CLOSE_PROFILE_PANEL'
-            >
-              <X size={18} />
-            </button>
-          </div>
-          <div className='flex-1 min-h-0 overflow-y-auto'>
-            <UserProfile
-              userId={panel.userId}
-              isOwnProfile={currentUser?.id === panel.userId}
-              className='border-0 rounded-none shadow-none'
-            />
-          </div>
-        </>
-      )}
-    </div>
-  );
-}
+// Side-panel rendering, click resolution, and panel types now live in ./SidePanel
+// (SidePanel, ResultClickResolver, PanelTypes).

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -283,6 +283,12 @@ const SearchResults = (): ReactElement => {
     for (const ch of regularChannels) {
       result.push({ channel: ch, category: ChannelCategory.CHANNELS, searchableNames: [ch.name] });
     }
+    // EMAIL/desk channels are excluded by groupChannelsByScope (they live in Desk). Re-include them
+    // as CHANNELS from the full set (useAllChannels) — like GlobalCommandMenu — since desk channels
+    // aren't in useAllVisibleChannels.
+    for (const ch of allChannelsForNav.filter(channel => isDeskChannelType(channel.type))) {
+      result.push({ channel: ch, category: ChannelCategory.CHANNELS, searchableNames: [ch.name] });
+    }
     for (const ch of dmChannels) {
       const dmNames = getDMNames(ch, currentUserId, usersById);
       result.push({
@@ -293,7 +299,7 @@ const SearchResults = (): ReactElement => {
       });
     }
     return result;
-  }, [starredChannels, regularChannels, dmChannels, currentUserId, usersById]);
+  }, [starredChannels, regularChannels, dmChannels, allChannelsForNav, currentUserId, usersById]);
 
   // Use the exact same hook as the popup modal — no separate search infrastructure
   const {

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResults.tsx
@@ -609,8 +609,6 @@ const SearchResults = (): ReactElement => {
     });
   }, [baseResults, filters.sortBy, isChannelsMode]);
 
-  const autoOpenedResultKeyRef = useRef<string | null>(null);
-  const hasManualPanelSelectionRef = useRef(false);
   const filterKey = JSON.stringify([
     filters.docType,
     filters.fromUserIds,
@@ -632,18 +630,14 @@ const SearchResults = (): ReactElement => {
 
   // Reset auto-open and close stale panel whenever the search or any filter changes
   useEffect(() => {
-    autoOpenedResultKeyRef.current = null;
-    hasManualPanelSelectionRef.current = false;
     setSelectedPanel(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fullSearchKey]);
 
   const handleSelectThread = useCallback((thread: SearchResultsThread) => {
-    hasManualPanelSelectionRef.current = true;
     setSelectedPanel({ kind: 'thread', thread });
   }, []);
   const handleSelectUser = useCallback((userId: string) => {
-    hasManualPanelSelectionRef.current = true;
     setSelectedPanel({ kind: 'profile', userId });
   }, []);
   const handleSelectChannelContext = useCallback(
@@ -653,7 +647,6 @@ const SearchResults = (): ReactElement => {
       conversationCreatedAt?: number,
       matchedMessageId?: string | null,
     ) => {
-      hasManualPanelSelectionRef.current = true;
       setSelectedPanel({
         kind: 'channel',
         channelId,
@@ -665,80 +658,8 @@ const SearchResults = (): ReactElement => {
     [],
   );
   const handleClosePanel = (): void => {
-    hasManualPanelSelectionRef.current = true;
     setSelectedPanel(null);
   };
-
-  // Auto-open the first result once results arrive for a new search (desktop only)
-  useEffect(() => {
-    if (isMobile || isLoading) return;
-    if (hasManualPanelSelectionRef.current) return;
-
-    const autoOpenableTypes =
-      filters.docType === 'messages'
-        ? new Set<DisplaySearchResult['type']>(['conversation'])
-        : filters.docType === 'tickets'
-          ? new Set<DisplaySearchResult['type']>(['ticket'])
-          : filters.docType === 'all'
-            ? new Set<DisplaySearchResult['type']>(['conversation', 'ticket'])
-            : null;
-
-    // Files and other non-message tabs do not have a meaningful thread to preview.
-    if (!autoOpenableTypes) return;
-
-    const first = results.find(result => {
-      if (!autoOpenableTypes.has(result.type)) return false;
-      const resultContext = result.searchContext;
-      if (!resultContext?.channelId || !resultContext.conversationId) return false;
-      return !(
-        resultContext.subApp === 'DESK' ||
-        (result.type === 'ticket' &&
-          isDeskChannelType(allChannelsForNav.find(c => c.id === resultContext.channelId)?.type))
-      );
-    });
-
-    if (!first) {
-      // A completed search with no previewable result must not retain a stale panel.
-      if (autoOpenedResultKeyRef.current !== null) {
-        autoOpenedResultKeyRef.current = null;
-        setSelectedPanel(null);
-      }
-      return;
-    }
-
-    const ctx = first.searchContext;
-    if (!ctx?.channelId || !ctx?.conversationId) return;
-    const resultKey = JSON.stringify([
-      fullSearchKey,
-      first.type,
-      first.id,
-      ctx.channelId,
-      ctx.conversationId,
-      ctx.messageId,
-    ]);
-    if (autoOpenedResultKeyRef.current === resultKey) return;
-    autoOpenedResultKeyRef.current = resultKey;
-
-    // Mirror the click-handler routing: open thread panel for any conversation with
-    // replies (replyCount > 0), channel context for standalone messages.
-    if (ctx.replyCount && ctx.replyCount > 0) {
-      setSelectedPanel({
-        kind: 'thread',
-        thread: {
-          channelId: ctx.channelId,
-          conversationId: ctx.conversationId,
-          matchedMessageId: ctx.messageId ?? null,
-        },
-      });
-    } else {
-      setSelectedPanel({
-        kind: 'channel',
-        channelId: ctx.channelId,
-        conversationId: ctx.conversationId,
-        matchedMessageId: ctx.messageId ?? null,
-      });
-    }
-  }, [results, isMobile, isLoading, filters.docType, fullSearchKey, allChannelsForNav]);
 
   const contextValue = useMemo(
     () => ({

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchResultsContext.ts
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchResultsContext.ts
@@ -4,6 +4,9 @@ export type SearchResultsThread = {
   channelId: string;
   conversationId: string;
   matchedMessageId?: string | null;
+  // Present when the thread is a board ticket — lets ThreadMessages show the Details/RCA tabs
+  // immediately instead of waiting to derive the ticket from the conversation.
+  ticketId?: string | null;
 };
 
 export const SearchResultsContext = createContext<{

--- a/apps/dashboard/src/components/Chat/SearchResults/SidePanel/PanelTypes.ts
+++ b/apps/dashboard/src/components/Chat/SearchResults/SidePanel/PanelTypes.ts
@@ -1,0 +1,50 @@
+import type { SearchResultsThread } from '../SearchResultsContext';
+
+// Right-pane state for the full-screen search view. Each variant is a named type so its
+// renderer in PANEL_RENDERERS (SidePanel.tsx) can type its props explicitly — no
+// Extract/mapped-type gymnastics. New surfaces are added as a variant here + a renderer.
+export type ThreadPanelState = { kind: 'thread'; thread: SearchResultsThread };
+
+export type ProfilePanelState = { kind: 'profile'; userId: string };
+
+export type ChannelPanelState = {
+  kind: 'channel';
+  channelId: string;
+  // Optional: a plain channel/DM opens without anchoring to a specific message.
+  conversationId?: string;
+  conversationCreatedAt?: number;
+  matchedMessageId?: string | null;
+};
+
+export type CanvasPanelState = { kind: 'canvas'; canvasId: string };
+
+export type AttachmentPanelState = {
+  kind: 'attachment';
+  attachmentId: string;
+  fileName: string;
+  mimeType: string;
+  fileSize: number;
+};
+
+// A desk/support ticket (or desk mail) hosted in the pane. SupportTicketDetail is URL-driven, so
+// DeskTicketPanel replays these into a synthetic route location (see SidePanel.tsx).
+export type DeskTicketPanelState = {
+  kind: 'deskTicket';
+  title: string; // mail subject / ticket title, shown in the pane header
+  channelId: string;
+  ticketXyneId: string; // ticket public id → synthetic URL :ticketId
+  ticketId: string; // db id → router state (SupportTicketDetail reads location.state.ticketId)
+  conversationId: string;
+  mailId?: string; // desk-mail only → ?mail= deep-link scroll target
+};
+
+export type SidePanelState =
+  | ThreadPanelState
+  | ProfilePanelState
+  | ChannelPanelState
+  | CanvasPanelState
+  | AttachmentPanelState
+  | DeskTicketPanelState
+  | null;
+
+export type PanelKind = NonNullable<SidePanelState>['kind'];

--- a/apps/dashboard/src/components/Chat/SearchResults/SidePanel/ResultClickResolver.ts
+++ b/apps/dashboard/src/components/Chat/SearchResults/SidePanel/ResultClickResolver.ts
@@ -1,0 +1,188 @@
+import { isDeskChannelType, type Channel } from '@xyne/shared';
+import type { DisplaySearchResult, DisplayEntityType } from '../../../../types/search';
+import type { SidePanelState } from './PanelTypes';
+
+// ————————————————————————————————————————————————————————————————
+// Public contracts
+// ————————————————————————————————————————————————————————————————
+
+// A click on a search result resolves to exactly one of these. Navigation (desk) is a
+// first-class variant — desk routes away, it doesn't render a pane.
+export type ResultClickAction =
+  | { kind: 'panel'; panel: NonNullable<SidePanelState> } // open this pane
+  | { kind: 'navigate'; to: string; state?: unknown } // route away (desk /support, …)
+  | { kind: 'userDm'; userId: string }; // user → resolve/create DM, then open (async)
+
+// ————————————————————————————————————————————————————————————————
+// Public API
+// ————————————————————————————————————————————————————————————————
+
+// The single source of truth for search-result clicks — one Map lookup.
+export function resolveResultClick(
+  result: DisplaySearchResult,
+  channels: readonly Channel[],
+): ResultClickAction | null {
+  return RESULT_CLICK_RESOLVERS[result.type](result, channels);
+}
+
+// ————————————————————————————————————————————————————————————————
+// Registry (bindings)
+// ————————————————————————————————————————————————————————————————
+
+// Contract: every resolver maps a result (+ the user's channels) to one action, or null when
+// the result isn't routable from this screen.
+type ResultClickResolver = (
+  result: DisplaySearchResult,
+  channels: readonly Channel[],
+) => ResultClickAction | null;
+
+// Keys: DisplayEntityType (result.type). type → resolver, bound in one block. The Record is
+// total, so a new entity type won't compile until it's registered here — no silent fallthrough.
+const RESULT_CLICK_RESOLVERS: Record<DisplayEntityType, ResultClickResolver> = {
+  user: result => ({ kind: 'userDm', userId: result.id }),
+  channel: resolveChannelClick,
+  ticket: resolveTicketClick,
+  conversation: resolveConversationClick,
+  attachment: resolveAttachmentClick,
+  collection: () => null, // knowledge-base docs aren't surfaced on this screen
+};
+
+// ————————————————————————————————————————————————————————————————
+// Internal — click resolvers
+// ————————————————————————————————————————————————————————————————
+
+const SUPPORT_ROUTE = '/support';
+const CHAT_DIR_ROUTE = '/chat/dir';
+const DEFAULT_ATTACHMENT_MIME_TYPE = 'application/octet-stream';
+
+// Vespa wraps query matches in <hi> tags; strip them before the name is shown in the pane
+// header or used for file-type detection — a highlighted ".md" would break extension matching.
+const stripHighlightTags = (value: string): string => value.replace(/<\/?hi>/gi, '');
+
+// True when the channel is an EMAIL/Desk channel — those route to /support, not a pane.
+const isDeskChannel = (channels: readonly Channel[], channelId?: string): boolean =>
+  isDeskChannelType(channels.find(channel => channel.id === channelId)?.type);
+
+// Normal channel/DM → chat pane; desk (EMAIL) channel → Support view.
+function resolveChannelClick(
+  result: DisplaySearchResult,
+  channels: readonly Channel[],
+): ResultClickAction {
+  const channelId = result.searchContext?.channelId ?? result.id;
+  return isDeskChannel(channels, channelId)
+    ? { kind: 'navigate', to: `${SUPPORT_ROUTE}/${channelId}` }
+    : { kind: 'panel', panel: { kind: 'channel', channelId } };
+}
+
+// Desk ticket → desk-ticket pane (SupportTicketDetail); board ticket → thread pane (full ticket view).
+function resolveTicketClick(
+  result: DisplaySearchResult,
+  channels: readonly Channel[],
+): ResultClickAction | null {
+  const searchContext = result.searchContext;
+  if (!searchContext?.channelId || !searchContext.conversationId) return null;
+  if (isDeskChannel(channels, searchContext.channelId) && searchContext.xyneId) {
+    return {
+      kind: 'panel',
+      panel: {
+        kind: 'deskTicket',
+        title: stripHighlightTags(result.title),
+        channelId: searchContext.channelId,
+        ticketXyneId: searchContext.xyneId,
+        ticketId: searchContext.ticketId ?? result.id,
+        conversationId: searchContext.conversationId,
+      },
+    };
+  }
+  return {
+    kind: 'panel',
+    panel: {
+      kind: 'thread',
+      thread: {
+        channelId: searchContext.channelId,
+        conversationId: searchContext.conversationId,
+        ticketId: searchContext.ticketId ?? result.id,
+      },
+    },
+  };
+}
+
+// Desk mail → desk-ticket pane (its ticket, scrolled to the mail); regular message → thread or channel pane.
+function resolveConversationClick(result: DisplaySearchResult): ResultClickAction | null {
+  const searchContext = result.searchContext;
+  if (searchContext?.subApp === 'DESK') {
+    if (!searchContext.channelId || !searchContext.xyneId || !searchContext.conversationId) {
+      return null;
+    }
+    return {
+      kind: 'panel',
+      panel: {
+        kind: 'deskTicket',
+        title: stripHighlightTags(result.title),
+        channelId: searchContext.channelId,
+        ticketXyneId: searchContext.xyneId,
+        ticketId: searchContext.ticketId ?? result.id,
+        conversationId: searchContext.conversationId,
+        ...(searchContext.mailId && { mailId: searchContext.mailId }),
+      },
+    };
+  }
+  if (!searchContext?.channelId || !searchContext.conversationId) return null;
+  // Mirrors the message card: replies → thread pane, standalone → channel pane.
+  const anchor = {
+    channelId: searchContext.channelId,
+    conversationId: searchContext.conversationId,
+    matchedMessageId: searchContext.messageId ?? null,
+  };
+  return searchContext.replyCount && searchContext.replyCount > 0
+    ? { kind: 'panel', panel: { kind: 'thread', thread: anchor } }
+    : { kind: 'panel', panel: { kind: 'channel', ...anchor } };
+}
+
+function resolveAttachmentClick(result: DisplaySearchResult): ResultClickAction | null {
+  const searchContext = result.searchContext;
+  // subApp casing is inconsistent from the backend, so normalize.
+  const subApp = searchContext?.subApp?.toUpperCase();
+  if (subApp === 'CANVAS') {
+    return { kind: 'panel', panel: { kind: 'canvas', canvasId: result.id } };
+  }
+  // Call recordings/transcripts aren't downloadable attachments (they live at /calls/recordings/{id},
+  // not /attachments/{id}/download). Open the focused reply thread where the call was shared (CallBubble
+  // renders inline) — the `thread` pane, not the `channel` container view. Falls back to the channel
+  // when there's no conversation to anchor a thread to.
+  if (subApp === 'TRANSCRIPT') {
+    const { channelId, conversationId, messageId } = searchContext ?? {};
+    if (channelId && conversationId) {
+      return {
+        kind: 'panel',
+        panel: {
+          kind: 'thread',
+          thread: { channelId, conversationId, matchedMessageId: messageId ?? null },
+        },
+      };
+    }
+    return channelId ? { kind: 'panel', panel: { kind: 'channel', channelId } } : null;
+  }
+  // A file-backed attachment previews in the pane via its id. originalUrl/internalUrl are internal
+  // storage keys (e.g. "attachments/CONVERSATION/temp/…"), not openable URLs — never window.open them.
+  if (searchContext?.attachmentId) {
+    return {
+      kind: 'panel',
+      panel: {
+        kind: 'attachment',
+        attachmentId: searchContext.attachmentId,
+        fileName: stripHighlightTags(searchContext.fileName ?? result.title),
+        mimeType: searchContext.mimeType ?? DEFAULT_ATTACHMENT_MIME_TYPE,
+        fileSize: searchContext.fileSize ?? 0,
+      },
+    };
+  }
+  // No stored file id — open the channel where it was shared (mirrors navigateToAttachment).
+  return searchContext?.channelId
+    ? {
+        kind: 'navigate',
+        to: `${CHAT_DIR_ROUTE}/${searchContext.channelId}`,
+        state: { attachmentId: searchContext.attachmentId ?? result.id, openAttachment: true },
+      }
+    : null;
+}

--- a/apps/dashboard/src/components/Chat/SearchResults/SidePanel/SidePanel.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SidePanel/SidePanel.tsx
@@ -1,0 +1,251 @@
+import { ReactElement } from 'react';
+import { useNavigate, useLocation, Routes, Route } from 'react-router-dom';
+import { X } from 'lucide-react';
+import ThreadMessages from '../../ThreadPannel';
+import { UserProfile } from '../../../ui/UserProfile/UserProfile';
+import ConversationPanelV2 from '../../ConversationPannel/ConversationPanelV2';
+import CanvasScreen from '../../../Canvas/CanvasScreen';
+import ActivitySupportTicket from '../../../Activity/ActivitySupportTicket/ActivitySupportTicket';
+import { AttachmentPreviewPane } from '../../../FileViewer/AttachmentPreviewPane';
+import { useAuth } from '../../../../hooks/useAuth';
+import type {
+  SidePanelState,
+  ThreadPanelState,
+  ProfilePanelState,
+  ChannelPanelState,
+  CanvasPanelState,
+  AttachmentPanelState,
+  DeskTicketPanelState,
+} from './PanelTypes';
+
+// ————————————————————————————————————————————————————————————————
+// Public API
+// ————————————————————————————————————————————————————————————————
+
+// Every side-panel component is closable — the one shared prop across the whole family.
+// Each specific panel adds its own `panel` variant on top (below).
+interface BasePanelProps {
+  onClose: () => void;
+}
+
+interface SearchResultsSidePanelProps extends BasePanelProps {
+  panel: NonNullable<SidePanelState>;
+}
+
+// Renders the right-pane content for the selected panel, dispatching on its `kind`.
+export function SearchResultsSidePanel({
+  panel,
+  onClose,
+}: SearchResultsSidePanelProps): ReactElement {
+  // Single cast at the dispatch boundary is the standard idiom for a registry over a
+  // discriminated union — each renderer is typed to its own panel variant in PANEL_RENDERERS.
+  const Renderer = PANEL_RENDERERS[panel.kind] as (
+    props: SearchResultsSidePanelProps,
+  ) => ReactElement;
+  return (
+    <div className='h-full flex flex-col min-h-0 bg-background'>
+      <Renderer panel={panel} onClose={onClose} />
+    </div>
+  );
+}
+
+// ————————————————————————————————————————————————————————————————
+// Registry (bindings)
+// ————————————————————————————————————————————————————————————————
+
+// Keys: SidePanelState's `kind`. Each entry is a component typed to its own named panel-props
+// interface (defined directly above each component below) — no mapped types, no React.FC.
+type PanelRegistry = {
+  channel: (props: ChannelPanelProps) => ReactElement;
+  thread: (props: ThreadPanelProps) => ReactElement;
+  profile: (props: ProfilePanelProps) => ReactElement;
+  canvas: (props: CanvasPanelProps) => ReactElement;
+  attachment: (props: AttachmentPanelProps) => ReactElement;
+  deskTicket: (props: DeskTicketPanelProps) => ReactElement;
+};
+
+// kind → renderer. New panel kinds plug in here (mirrors the SidePanelState union).
+const PANEL_RENDERERS: PanelRegistry = {
+  channel: ChannelPanel,
+  thread: ThreadPanel,
+  profile: ProfilePanel,
+  canvas: CanvasPanel,
+  attachment: AttachmentPanel,
+  deskTicket: DeskTicketPanel,
+};
+
+// ————————————————————————————————————————————————————————————————
+// Internal — panel renderer components
+// ————————————————————————————————————————————————————————————————
+
+interface PanelCloseHeaderProps extends BasePanelProps {
+  label: string;
+  trackName: string;
+  title?: string;
+}
+
+// Shared close-header for panels whose content component has no close affordance
+// of its own (profile / canvas / attachment). Channel and thread panels own their
+// headers (via ConversationPanelV2 / ThreadMessages) and don't use this.
+function PanelCloseHeader({
+  label,
+  trackName,
+  onClose,
+  title,
+}: PanelCloseHeaderProps): ReactElement {
+  return (
+    <div className='flex items-center justify-between gap-2 p-2 border-b border-border shrink-0'>
+      {title ? (
+        <span className='truncate px-1 text-sm font-medium text-foreground'>{title}</span>
+      ) : (
+        <span />
+      )}
+      <button
+        onClick={onClose}
+        className='p-2 rounded-md hover:bg-accent shrink-0'
+        aria-label={label}
+        data-track-category='SEARCH_RESULTS'
+        data-track-name={trackName}
+      >
+        <X size={18} />
+      </button>
+    </div>
+  );
+}
+
+interface ChannelPanelProps extends BasePanelProps {
+  panel: ChannelPanelState;
+}
+
+function ChannelPanel({ panel, onClose }: ChannelPanelProps): ReactElement {
+  return (
+    <ConversationPanelV2
+      channelId={panel.channelId}
+      previousChannelId={null}
+      useLocalTabState
+      {...(panel.conversationId !== undefined && {
+        linkedConversationIdOverride: panel.conversationId,
+      })}
+      linkedItemCreatedAtOverride={panel.conversationCreatedAt ?? null}
+      onClose={onClose}
+    />
+  );
+}
+
+interface ThreadPanelProps extends BasePanelProps {
+  panel: ThreadPanelState;
+}
+
+function ThreadPanel({ panel, onClose }: ThreadPanelProps): ReactElement {
+  const navigate = useNavigate();
+  return (
+    <ThreadMessages
+      channelId={panel.thread.channelId}
+      conversationId={panel.thread.conversationId}
+      matchedMessageId={panel.thread.matchedMessageId ?? null}
+      {...(panel.thread.ticketId && { ticketId: panel.thread.ticketId })}
+      showChannelLink
+      onChannelLinkClick={() =>
+        void navigate(`/chat/dir/${panel.thread.channelId}#origin=${panel.thread.conversationId}`)
+      }
+      onClose={onClose}
+    />
+  );
+}
+
+interface ProfilePanelProps extends BasePanelProps {
+  panel: ProfilePanelState;
+}
+
+function ProfilePanel({ panel, onClose }: ProfilePanelProps): ReactElement {
+  const { user: currentUser } = useAuth();
+  return (
+    <>
+      <PanelCloseHeader label='Close profile' trackName='CLOSE_PROFILE_PANEL' onClose={onClose} />
+      <div className='flex-1 min-h-0 overflow-y-auto'>
+        <UserProfile
+          userId={panel.userId}
+          isOwnProfile={currentUser?.id === panel.userId}
+          className='border-0 rounded-none shadow-none'
+        />
+      </div>
+    </>
+  );
+}
+
+interface CanvasPanelProps extends BasePanelProps {
+  panel: CanvasPanelState;
+}
+
+function CanvasPanel({ panel, onClose }: CanvasPanelProps): ReactElement {
+  return (
+    <>
+      <PanelCloseHeader label='Close canvas' trackName='CLOSE_CANVAS_PANEL' onClose={onClose} />
+      <div className='flex-1 min-h-0 overflow-hidden'>
+        <CanvasScreen canvasId={panel.canvasId} />
+      </div>
+    </>
+  );
+}
+
+interface AttachmentPanelProps extends BasePanelProps {
+  panel: AttachmentPanelState;
+}
+
+function AttachmentPanel({ panel, onClose }: AttachmentPanelProps): ReactElement {
+  return (
+    <>
+      <PanelCloseHeader
+        label='Close attachment'
+        trackName='CLOSE_ATTACHMENT_PANEL'
+        title={panel.fileName}
+        onClose={onClose}
+      />
+      <AttachmentPreviewPane
+        attachmentId={panel.attachmentId}
+        fileName={panel.fileName}
+        mimeType={panel.mimeType}
+        fileSize={panel.fileSize}
+      />
+    </>
+  );
+}
+
+interface DeskTicketPanelProps extends BasePanelProps {
+  panel: DeskTicketPanelState;
+}
+
+// Hosts the desk ticket the /chat/activity/ticket route renders, but in the pane. SupportTicketDetail is
+// URL-driven, so we replay the ids into a synthetic child location: `<Routes location>` scopes its
+// useParams/useSearchParams/location.state, while useNavigate keeps hitting the real router — so the rare
+// in-ticket edit navigations (e.g. unmerge) open the full app instead of blanking the pane.
+function DeskTicketPanel({ panel, onClose }: DeskTicketPanelProps): ReactElement {
+  const { pathname } = useLocation();
+  const ticketLocation = {
+    pathname: `${pathname}/ticket/${panel.channelId}/${panel.ticketXyneId}`,
+    search: panel.mailId ? `?mail=${panel.mailId}` : '',
+    hash: '',
+    state: { conversationId: panel.conversationId, ticketId: panel.ticketId },
+    key: panel.ticketXyneId,
+  };
+  return (
+    <>
+      <PanelCloseHeader
+        label='Close ticket'
+        trackName='CLOSE_DESK_TICKET_PANEL'
+        title={panel.title}
+        onClose={onClose}
+      />
+      <div className='flex-1 min-h-0 overflow-hidden'>
+        {/* RR's dev "descendant <Routes> … no trailing *" warning is a false positive here — the
+            location is synthetic and never navigated to, so the child always matches. */}
+        <Routes location={ticketLocation}>
+          <Route
+            path='ticket/:channelId/:ticketId'
+            element={<ActivitySupportTicket showAdjacentNav={false} />}
+          />
+        </Routes>
+      </div>
+    </>
+  );
+}

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPicker.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ContextPicker.tsx
@@ -1,22 +1,16 @@
 import { useEffect, useMemo, useRef, useState, type ComponentType, type ReactElement } from 'react';
 import { Command } from 'cmdk';
 import { FileText, Hashtag, MicOn, PhoneDefault, TicketToken } from '@xyne/icons';
-import { Hash, Loader2, Lock, Users } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import type { Channel } from '@xyne/shared';
-import { ChannelVisibility, isDeskChannelType } from '@xyne/shared';
-import Avatar from '../../../ui/Avatar/Avatar';
+import { isDeskChannelType } from '@xyne/shared';
+import ChannelIcon from '../../ChannelIcon/ChannelIcon';
 import { useSearchMetrics } from '../../../../hooks/useSearchMetrics';
 import { TabType } from '../../ChatDirectory/ChannelCommandMenu.types';
 import { ChannelCommandItem } from '../../ChatDirectory/ChannelCommandMenu';
 import SearchResultItem from '../../ChatDirectory/SearchResultItem';
 import { ChannelCategory } from '../../ChatDirectory/ChatDirectory.types';
-import {
-  groupChannelsByScope,
-  getDMNames,
-  isDMChannel,
-  isGroupDMChannel,
-  getDMParticipantIdsToFetch,
-} from '../../ChatDirectory/ChatDirectory.utils';
+import { groupChannelsByScope, getDMNames } from '../../ChatDirectory/ChatDirectory.utils';
 import {
   useAllChannels,
   useAllVisibleChannels,
@@ -275,33 +269,9 @@ export const ContextPicker = ({
 
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
 
-  // Same avatar/lock/hash logic as ChannelCommandMenu's getChannelIcon — that
-  // one is a closure inside the menu component, so it can't be imported.
-  const getChannelIcon = (channel: Channel): ReactElement => {
-    if (isGroupDMChannel(channel.scopeType)) {
-      const otherCount = getDMParticipantIdsToFetch(channel, currentUserID).length;
-      return (
-        <div className='relative flex h-5 w-5 items-center justify-center'>
-          <Users size={16} className='text-muted-foreground' />
-          {otherCount > 0 && (
-            <span className='absolute -bottom-0.5 -right-0.5 min-w-3 rounded-full bg-muted px-0.5 text-xs font-semibold leading-none text-muted-foreground'>
-              {otherCount}
-            </span>
-          )}
-        </div>
-      );
-    }
-    if (isDMChannel(channel.scopeType)) {
-      const userIds = getDMParticipantIdsToFetch(channel, currentUserID);
-      if (userIds.length > 0 && userIds[0]) {
-        return <Avatar userId={userIds[0]} size='sm' />;
-      }
-    }
-    if (channel.visibility === ChannelVisibility.PRIVATE) {
-      return <Lock size={14} />;
-    }
-    return <Hash size={14} />;
-  };
+  const getChannelIcon = (channel: Channel): ReactElement => (
+    <ChannelIcon channel={channel} glyphClassName='text-muted-foreground' avatarSize='sm' />
+  );
 
   // CHANNELS tab renders the local corpus grouped by category, like the menu.
   const groupedChannels = useMemo(() => {

--- a/apps/dashboard/src/components/FileViewer/AttachmentPreviewPane.tsx
+++ b/apps/dashboard/src/components/FileViewer/AttachmentPreviewPane.tsx
@@ -1,0 +1,40 @@
+import { ReactElement } from 'react';
+import { SlideContent, type FileItem } from './FileViewerModal';
+import { FileSearchProvider, FileSearchControls } from './search';
+
+interface AttachmentPreviewPaneProps {
+  attachmentId: string;
+  fileName: string;
+  mimeType: string;
+  fileSize: number;
+}
+
+// Prop-driven single-file preview for the search right-pane. Reuses the modal's
+// inner viewer (SlideContent) without the gallery / actor / modal shell. Search
+// results carry the attachment metadata but not the download URL, so build it here.
+export function AttachmentPreviewPane({
+  attachmentId,
+  fileName,
+  mimeType,
+  fileSize,
+}: AttachmentPreviewPaneProps): ReactElement {
+  const file: FileItem = {
+    fileName,
+    fileUrl: `${ATTACHMENT_DOWNLOAD_ROUTE}/${attachmentId}/download`,
+    mimeType,
+    fileSize,
+    attachmentId,
+  };
+  return (
+    <FileSearchProvider resetKey={attachmentId}>
+      <div className='flex-1 min-h-0 flex flex-col overflow-hidden'>
+        <FileSearchControls />
+        <div className='flex-1 min-h-0 overflow-auto flex items-center justify-center p-3'>
+          <SlideContent file={file} isActive />
+        </div>
+      </div>
+    </FileSearchProvider>
+  );
+}
+
+const ATTACHMENT_DOWNLOAD_ROUTE = '/attachments';

--- a/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
+++ b/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
@@ -110,7 +110,7 @@ const SlidePlaceholder: React.FC<{ file: FileItem }> = ({ file }) => {
 };
 
 // Individual slide component - fetches its own file
-const SlideContent: React.FC<{
+export const SlideContent: React.FC<{
   file: FileItem;
   isActive: boolean;
   disableGestures?: boolean;

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -4136,6 +4136,11 @@ type SupportTicketDetailProps = {
     title: string;
     lastEmailAt?: number | null;
   }>;
+  /**
+   * Show the prev/next adjacent-ticket controls (chevrons + j/k shortcuts). Defaults to shown;
+   * the search-results pane disables them since there's no ticket list to page through there.
+   */
+  showAdjacentNav?: boolean;
 };
 
 type TicketReplyKind = 'app' | 'channel';
@@ -4160,6 +4165,7 @@ export const SupportTicketDetail = ({
   navBasePath,
   onBack,
   navTickets,
+  showAdjacentNav = true,
 }: SupportTicketDetailProps): ReactElement => {
   const {
     workspaceId: routeWorkspaceId,
@@ -4624,6 +4630,7 @@ export const SupportTicketDetail = ({
       scope: 'global',
       description: 'Next ticket',
       category: 'Support',
+      enabled: showAdjacentNav,
     },
   );
   useShortcut(
@@ -4635,6 +4642,7 @@ export const SupportTicketDetail = ({
       scope: 'global',
       description: 'Previous ticket',
       category: 'Support',
+      enabled: showAdjacentNav,
     },
   );
   useShortcut(
@@ -4803,22 +4811,26 @@ export const SupportTicketDetail = ({
           <div className='h-full flex flex-col overflow-hidden relative'>
             <div className='w-full px-6 py-4 flex flex-col gap-2.5 flex-shrink-0 sticky top-0 bg-background z-10 border-b border-border'>
               <div className='flex flex-wrap items-center gap-2 min-w-0 overflow-hidden'>
-                <button
-                  type='button'
-                  onClick={() => {
-                    if (onBack) {
-                      onBack();
-                      return;
-                    }
-                    goBackToTicketList();
-                  }}
-                  className='p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0'
-                  aria-label='Back to ticket list'
-                  data-track-category='Support'
-                  data-track-name='BackToList'
-                >
-                  <ArrowLeft size={18} />
-                </button>
+                {/* Hidden in the search-results pane (showAdjacentNav=false): it hosts the ticket
+                    with its own close header and has no ticket list to return to. */}
+                {showAdjacentNav && (
+                  <button
+                    type='button'
+                    onClick={() => {
+                      if (onBack) {
+                        onBack();
+                        return;
+                      }
+                      goBackToTicketList();
+                    }}
+                    className='p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0'
+                    aria-label='Back to ticket list'
+                    data-track-category='Support'
+                    data-track-name='BackToList'
+                  >
+                    <ArrowLeft size={18} />
+                  </button>
+                )}
                 <span className='bg-border py-[3px] px-3 flex items-center justify-center text-xs text-foreground rounded-md font-mono shrink-0 whitespace-nowrap'>
                   {ticketIdParam}
                 </span>
@@ -4840,52 +4852,56 @@ export const SupportTicketDetail = ({
 
                 {/* Prev/Next + Status pill + ··· overflow menu */}
                 <div className='flex items-center gap-1.5 min-w-0 shrink-0'>
-                  <div className='flex items-center gap-0.5'>
-                    <Tooltip
-                      side='bottom'
-                      delayDuration={300}
-                      content={
-                        <span className='flex items-center gap-2'>
-                          Previous ticket
-                          <kbd className='px-1 py-px rounded bg-background/15 border border-background/20 text-[10px] font-mono uppercase'>
-                            K
-                          </kbd>
-                        </span>
-                      }
-                    >
-                      <button
-                        type='button'
-                        onClick={() => void navigateAdjacent('backward')}
-                        className='p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
-                        data-track-category='Support'
-                        data-track-name='PrevTicket'
+                  {/* Adjacent-ticket paging — hidden in the search-results pane (no ticket list
+                      to page through); the status pill + overflow menu below stay visible. */}
+                  {showAdjacentNav && (
+                    <div className='flex items-center gap-0.5'>
+                      <Tooltip
+                        side='bottom'
+                        delayDuration={300}
+                        content={
+                          <span className='flex items-center gap-2'>
+                            Previous ticket
+                            <kbd className='px-1 py-px rounded bg-background/15 border border-background/20 text-[10px] font-mono uppercase'>
+                              K
+                            </kbd>
+                          </span>
+                        }
                       >
-                        <ChevronUp size={16} />
-                      </button>
-                    </Tooltip>
-                    <Tooltip
-                      side='bottom'
-                      delayDuration={300}
-                      content={
-                        <span className='flex items-center gap-2'>
-                          Next ticket
-                          <kbd className='px-1 py-px rounded bg-background/15 border border-background/20 text-[10px] font-mono uppercase'>
-                            J
-                          </kbd>
-                        </span>
-                      }
-                    >
-                      <button
-                        type='button'
-                        onClick={() => void navigateAdjacent('forward')}
-                        className='p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
-                        data-track-category='Support'
-                        data-track-name='NextTicket'
+                        <button
+                          type='button'
+                          onClick={() => void navigateAdjacent('backward')}
+                          className='p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+                          data-track-category='Support'
+                          data-track-name='PrevTicket'
+                        >
+                          <ChevronUp size={16} />
+                        </button>
+                      </Tooltip>
+                      <Tooltip
+                        side='bottom'
+                        delayDuration={300}
+                        content={
+                          <span className='flex items-center gap-2'>
+                            Next ticket
+                            <kbd className='px-1 py-px rounded bg-background/15 border border-background/20 text-[10px] font-mono uppercase'>
+                              J
+                            </kbd>
+                          </span>
+                        }
                       >
-                        <ChevronDown size={16} />
-                      </button>
-                    </Tooltip>
-                  </div>
+                        <button
+                          type='button'
+                          onClick={() => void navigateAdjacent('forward')}
+                          className='p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors'
+                          data-track-category='Support'
+                          data-track-name='NextTicket'
+                        >
+                          <ChevronDown size={16} />
+                        </button>
+                      </Tooltip>
+                    </div>
+                  )}
                   {/* Status pill */}
                   {ticket && (
                     <div className='border border-border rounded-md overflow-hidden shrink-0'>

--- a/apps/dashboard/src/utils/searchNavigation.ts
+++ b/apps/dashboard/src/utils/searchNavigation.ts
@@ -89,13 +89,27 @@ export const navigateToSearchResult = async (
 };
 
 /**
- * Navigate to a user (create or open DM channel)
- *
- * Logic:
- * 1. Check if DM channel already exists with this user
- * 2. If exists, navigate to it
- * 3. If not, create new DM channel and navigate
+ * Resolve the 1:1 DM channel id for a user — returns the existing DM if there is
+ * one, otherwise creates it. Shared by navigateToUser (navigates to it) and the
+ * full-screen search pane (opens the chat in-pane) so both take the same path.
  */
+export const resolveOrCreateDmChannelId = async (
+  userId: string,
+  channelData: Channel[],
+): Promise<string> => {
+  const existingDmChannel = channelData.find(
+    channel =>
+      channel.scopeType === ChannelScopeType.DM &&
+      channel.participants?.length === 2 &&
+      channel.participants?.some(p => p.userId === userId),
+  );
+  if (existingDmChannel) return existingDmChannel.id;
+
+  const dmResponse = await channelService.createDm({ participantIds: [userId] });
+  return dmResponse.id;
+};
+
+/** Open (or create) the user's 1:1 DM and navigate to it. */
 export const navigateToUser = async (
   result: DisplaySearchResult,
   navigate: NavigateFunction,
@@ -109,33 +123,16 @@ export const navigateToUser = async (
     return;
   }
 
-  // Look for existing 1:1 DM channel with this user
-  const existingDmChannel = channelData.find(channel => {
-    // Check if it's a 1:1 DM channel (scopeType DM with exactly 2 participants)
-    // and if the searched user is the other participant
-    return (
-      channel.scopeType === ChannelScopeType.DM &&
-      channel.participants?.length === 2 &&
-      channel.participants?.some(p => p.userId === result.id)
-    );
-  });
-
-  if (existingDmChannel) {
-    void navigate(`/chat/dir/${existingDmChannel.id}`);
-  } else {
-    try {
-      const dmResponse = await channelService.createDm({
-        participantIds: [result.id],
-      });
-      void navigate(`/chat/dir/${dmResponse.id}`);
-    } catch (error) {
-      logger.error(LogEvent.FRONTEND_ERROR, {
-        type: 'migrated_console_error',
-        message: String('[SEARCH-NAVIGATION] Failed to create DM:'),
-        error: error,
-      });
-      throw new Error('Failed to start conversation with user');
-    }
+  try {
+    const channelId = await resolveOrCreateDmChannelId(result.id, channelData);
+    void navigate(`/chat/dir/${channelId}`);
+  } catch (error) {
+    logger.error(LogEvent.FRONTEND_ERROR, {
+      type: 'migrated_console_error',
+      message: String('[SEARCH-NAVIGATION] Failed to create DM:'),
+      error: error,
+    });
+    throw new Error('Failed to start conversation with user');
   }
 };
 


### PR DESCRIPTION
  ## Type of Change

  - [x] Bugfix
  - [x] New feature
  - [x] Enhancement
  - [ ] Refactoring
  - [ ] Dependency updates
  - [ ] Documentation
  - [ ] CI/CD

  ## Description

  XYNE-61705 — Make every result on the full-screen Search-Results screen open in the
  right-side pane instead of navigating away, matching cmd+K.

  Adds a `SidePanel/` registry (discriminated-union panel state + a per-entity click
  resolver). Click behavior by result type:

  - Board ticket → thread pane (full ticket view, Details/RCA tabs)
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 09 45 AM" src="https://github.com/user-attachments/assets/739b5655-49c6-42e5-9b56-fb8ddc677017" />

  - DMs / Channels / Group DMs / Starred → channel pane
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 15 45 AM" src="https://github.com/user-attachments/assets/03f8e526-4f75-40d3-a029-5a1c9a6e10b2" />

  - Messages (in any of the above) → thread pane (replies)
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 10 30 AM" src="https://github.com/user-attachments/assets/0a126a47-04bf-4277-8950-47184978e1ee" />
 or channel pane (standalone)
  - Users → open/create the 1:1 DM in the pane
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 11 43 AM" src="https://github.com/user-attachments/assets/b197e3d5-17cc-4e14-a93e-8af7c55599a1" />

  - Canvas → canvas pane
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 08 28 AM" src="https://github.com/user-attachments/assets/e2bc8a14-5f92-4fc9-a19e-9c2ce0b3c3c5" />

  - Attachments / Files → in-pane file preview (AttachmentPreviewPane)
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 07 57 AM" src="https://github.com/user-attachments/assets/4a0216fc-ce4b-4d8a-b890-f0210d9f38f8" />

  - Recordings/Call → thread pane where the call was shared
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 13 32 AM" src="https://github.com/user-attachments/assets/482f039d-7228-4abe-aa03-93e9418d4ed0" />

  - Desk ticket → SupportTicketDetail hosted in the pane (via `<Routes location>`)
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 09 45 AM" src="https://github.com/user-attachments/assets/d2896cd2-174e-4c19-8720-75b5b14752b9" />

  - Desk mail / email → SupportTicketDetail in the pane, scrolled to the target email
<img width="1728" height="1117" alt="Screenshot 2026-09-03 at 11 14 36 AM" src="https://github.com/user-attachments/assets/61712c01-b2f1-4c90-a8a3-32051939c02c" />

  - Support / desk channel → navigates to `/support` (bare desk channel has no ticket to embed)

https://github.com/user-attachments/assets/f51f90cc-0cb7-4264-8dcc-49ca8b3542a8



  Supporting fixes required to host these views in a pane:
  - Closed DM/group-DM opened blank — participation is briefly undefined at mount, so
    ConversationsACL loaded nothing; now treats an opened DM as a member (ACL still
    re-verifies), with a guard so DMs don't fall into the cutoff path with a null anchor.
  - ConversationPanelV2 keeps its active tab in local state in the pane so the screen's
    own `?tab=` filter no longer blanks the conversation body.
  - Desk ticket detail made embeddable (onBack / showAdjacentNav suppress the back button,
    prev/next chevrons, and j/k shortcuts).
  - Unified all channel icons behind a single shared ChannelIcon (removes two duplicate
    getChannelIcon copies); desk channels now surface in the channel list (matches cmd+K).
  - Stopped auto-opening a preview in the side panel.

  ## Areas Touched

  - [ ] `apps/backend` (API / worker)
  - [x] `apps/dashboard`
  - [ ] `apps/electron`
  - [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
  - [ ] `packages/shared` or another shared package
  - [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

 - [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

 - [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- why? -->

### Manual

**Users**
- [x] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [x] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [x] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [x] Web browser
- [x] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
