### PR TITLE
feat(artifact-apps): per-app key-value storage API (XYNE-61939)

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260902120000_artifact_app_records/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260902120000_artifact_app_records/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "artifact_app_records" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "appId" TEXT NOT NULL,
+    "baseKey" TEXT NOT NULL,
+    "dynamicKey" TEXT NOT NULL,
+    "owner" TEXT NOT NULL,
+    "value" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "artifact_app_records_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "artifact_app_records_workspaceId_appId_baseKey_owner_dynami_key" ON "artifact_app_records"("workspaceId", "appId", "baseKey", "owner", "dynamicKey");
+
+-- CreateIndex
+CREATE INDEX "artifact_app_records_workspaceId_appId_idx" ON "artifact_app_records"("workspaceId", "appId");

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1342,6 +1342,39 @@ model ArtifactAppAgentRun {
   @@map("artifact_app_agent_runs")
 }
 
+/// Small key-value storage an artifact app reads and writes through the host
+/// bridge — the app-facing "database" for apps that need to keep state
+/// (preferences, drafts, counters) beyond one session.
+///
+/// Two-level key: `baseKey` names a collection, `dynamicKey` a record in it.
+/// The value is an opaque JSON blob — it is never filterable, by design: every
+/// query the API accepts touches only the key columns, so a busy app cannot
+/// force a sequential scan over this shared table.
+model ArtifactAppRecord {
+  id          String   @id @default(cuid())
+  /// Denormalized tenant key, stamped from the parent app on insert — same
+  /// discipline as ArtifactAppVersion.
+  workspaceId String
+  appId       String
+  baseKey     String
+  dynamicKey  String
+  /// "global" — one row every viewer of the app shares — or the userId whose
+  /// private row this is. Stamped from the session, never from the request, and
+  /// reads always filter to ("global", caller), so one viewer can never reach
+  /// another's rows. A cuid can never equal the literal "global".
+  owner       String
+  value       Json
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  /// Doubles as the read index: every lookup filters workspaceId+appId+baseKey
+  /// (+owner) and walks dynamicKey in order, which is what makes prefix scans
+  /// and paging index-only. Also what `put` upserts against.
+  @@unique([workspaceId, appId, baseKey, owner, dynamicKey])
+  @@index([workspaceId, appId])
+  @@map("artifact_app_records")
+}
+
 /// A stable, revocable public link to the latest published HTML attachment in
 /// one Design Studio conversation. Only the bearer token hash is used for
 /// verification; its encrypted copy exists so

--- a/apps/xyne-claw-auth/backend/src/http/parsers.ts
+++ b/apps/xyne-claw-auth/backend/src/http/parsers.ts
@@ -1,6 +1,25 @@
-import express, { type Express } from "express";
+import express, { type Express, type NextFunction, type Request, type Response } from "express";
+
+/** Storage values are capped at 64KB AFTER parsing (the authoritative check,
+ *  in routes/artifact-app-storage.ts). This guard runs BEFORE the global 50MB
+ *  json parser so an oversized body is refused without being buffered at all —
+ *  a router-level limit could not do that, because by the time a router runs
+ *  the global parser has already consumed the stream. Best-effort: a chunked
+ *  request without Content-Length falls through to the post-parse check. */
+const STORAGE_PATH = "/claw/api/v1/artifact-app-storage";
+const STORAGE_MAX_BODY_BYTES = 128 * 1024;
+
+function storageBodyGuard(req: Request, res: Response, next: NextFunction): void {
+  const length = Number(req.headers["content-length"]);
+  if (Number.isFinite(length) && length > STORAGE_MAX_BODY_BYTES) {
+    res.status(413).json({ success: false, error: `Request body must be under ${STORAGE_MAX_BODY_BYTES / 1024}KB` });
+    return;
+  }
+  next();
+}
 
 export function installParsers(app: Express): void {
+  app.use(STORAGE_PATH, storageBodyGuard);
   // Capture the raw request body so verify-spaces-signature middleware can
   // HMAC-check inbound webhook bodies. express.json() consumes the stream
   // otherwise; the verify callback gets the buffer before parsing.

--- a/apps/xyne-claw-auth/backend/src/http/routes.ts
+++ b/apps/xyne-claw-auth/backend/src/http/routes.ts
@@ -31,6 +31,7 @@ import { dashboardRouter } from "../routes/dashboard.js";
 import { agentChatRouter, agentChatInternalRouter } from "../routes/agent-chat.js";
 import { artifactAppsRouter } from "../routes/artifact-apps.js";
 import { artifactAppAgentsRouter } from "../routes/artifact-app-agents.js";
+import { artifactAppStorageRouter } from "../routes/artifact-app-storage.js";
 import { designSharesRouter, publicDesignSharesRouter } from "../routes/design-shares.js";
 import { sessionsArchiveRouter } from "../routes/sessions-archive.js";
 import { experimentsInternalRouter } from "../routes/experiments-internal.js";
@@ -154,6 +155,7 @@ function mountCoreApi(app: Express): void {
   app.use(`${BASE}/agent-chat`, requireAuth, requireNoAccessToken, agentChatRouter);
   app.use(`${BASE}/artifact-apps`, requireAuth, artifactAppsRouter);
   app.use(`${BASE}/artifact-app-agents`, requireAuth, artifactAppAgentsRouter);
+  app.use(`${BASE}/artifact-app-storage`, requireAuth, artifactAppStorageRouter);
   app.use(`${BASE}/design-shares`, requireAuth, requireNoAccessToken, designSharesRouter);
   app.use(`${BASE}/daily-brief`, requireAuth, requireNoAccessToken, dailyBriefRouter);
   app.use(`${BASE}/internal/agent-chat`, requireStrictS2S, agentChatInternalRouter); // progress/callback from xyne-claw

--- a/apps/xyne-claw-auth/backend/src/lib/spaces-db.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/spaces-db.ts
@@ -177,6 +177,7 @@ export type SpacesAuthCaller =
   | "awakening"
   | "artifact-apps"
   | "artifact-app-agents"
+  | "artifact-app-storage"
   | "unknown";
 
 export async function getSpacesAuthForUser(

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-app-storage.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-app-storage.ts
@@ -1,0 +1,366 @@
+/**
+ * Key-value storage for artifact apps.
+ *
+ * An app is a React project in a bundler-origin iframe with no cookies and no
+ * network; it asks the dashboard, which calls this router as the viewer. The
+ * design constraint everything below serves: the table is SHARED by every app,
+ * so no request may ever touch anything but the indexed key columns.
+ *
+ *  - **The value is opaque.** Reads and writes address records by
+ *    (baseKey, dynamicKey) only. There is no filter on `value` and the schemas
+ *    are `.strict()`, so "can't query the blob" holds by construction — an
+ *    unknown field is a 400, not a silently ignored (or worse, forwarded) key.
+ *
+ *  - **Scope is enforced here, not in app code.** App code is model-authored
+ *    and runs in the viewer's browser; anything it "hides" client-side is
+ *    readable by any viewer with devtools. `owner` is stamped from the session
+ *    and reads filter to ("global", caller), so a user-scoped record is private
+ *    no matter what the app does. A user row SHADOWS a global row with the same
+ *    key on point reads — "default settings, overridden per user" for free.
+ *
+ *  - **Every read is bounded.** `limit` is capped, `offset` is capped (a large
+ *    OFFSET still walks the index), keys are length-capped, and list order is
+ *    dynamicKey only — all of it inside the unique index, so the worst request
+ *    is an index range scan.
+ *
+ * The app ACL is the same predicate the payload read and agent dispatch use:
+ * the owner, or anyone in the workspace once published. Storage exists only for
+ * SAVED apps — an unsaved chat artifact has no stable id to key records on.
+ */
+
+import { Router, type Request, type Response } from "express";
+import { z } from "zod";
+import { prisma } from "../db.js";
+import { redisService } from "../redis.js";
+import { getRequesterId } from "../middleware/agent-acl.js";
+import { getWorkspaceIdForUser } from "../lib/spaces-db.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("artifact-app-storage");
+export const artifactAppStorageRouter: Router = Router();
+
+const VISIBILITY_WORKSPACE = "WORKSPACE";
+
+/** The one owner value that is not a user id. A cuid can never collide with it. */
+const GLOBAL_OWNER = "global";
+
+const MAX_VALUE_BYTES = 64 * 1024;
+const MAX_LIST_LIMIT = 100;
+const MAX_OFFSET = 10_000;
+const MAX_BATCH_KEYS = 50;
+/** Soft cap per app, checked only when a `put` would create a new record —
+ *  an app at the cap can still update and delete its way back under it. */
+const MAX_RECORDS_PER_APP = 20_000;
+
+/** Writes a viewer may make per hour across every app. A runaway-loop guard,
+ *  not a permission — mirrors artifact-app-agents' run quota. */
+const WRITES_PER_HOUR = 2_000;
+const RATE_WINDOW_SECONDS = 3600;
+
+const baseKey = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/, "baseKey must be 1-64 chars of letters, digits, . _ -");
+const dynamicKey = z.string().min(1).max(256);
+const scopeRead = z.enum(["user", "global", "any"]).default("any");
+const scopeWrite = z.enum(["user", "global"]).default("user");
+
+/**
+ * The fetch contract. `.strict()` throughout: these schemas ARE the query
+ * language, and anything they do not name does not reach Prisma.
+ */
+const querySchema = z
+  .object({
+    appId: z.string().min(1),
+    baseKey,
+    op: z.enum(["get", "list"]),
+    /** get: one key, or a batch. Exactly one of the two. */
+    key: dynamicKey.optional(),
+    keys: z.array(dynamicKey).min(1).max(MAX_BATCH_KEYS).optional(),
+    /** list: dynamicKey prefix filter. */
+    prefix: z.string().max(256).optional(),
+    scope: scopeRead,
+    order: z.enum(["asc", "desc"]).default("asc"),
+    limit: z.number().int().min(1).max(MAX_LIST_LIMIT).default(50),
+    offset: z.number().int().min(0).max(MAX_OFFSET).default(0),
+  })
+  .strict();
+
+const putSchema = z
+  .object({
+    appId: z.string().min(1),
+    baseKey,
+    key: dynamicKey,
+    /** Opaque JSON. Size-capped below — zod cannot see serialized size. */
+    value: z.unknown(),
+    scope: scopeWrite,
+  })
+  .strict();
+
+const deleteSchema = z
+  .object({
+    appId: z.string().min(1),
+    baseKey,
+    key: dynamicKey,
+    scope: scopeWrite,
+  })
+  .strict();
+
+function badRequest(res: Response, parsed: z.ZodSafeParseError<unknown>): void {
+  res.status(400).json({ success: false, error: "ValidationError", details: parsed.error.flatten() });
+}
+
+/**
+ * Same read rule as `GET /artifact-apps/:id/payload` and artifact-app-agents:
+ * the owner, or anyone in the workspace once published.
+ */
+async function resolveApp(
+  appId: string,
+  requesterId: string,
+): Promise<{ ok: true; workspaceId: string } | { ok: false; status: number; error: string }> {
+  const app = await prisma.artifactApp.findUnique({
+    where: { id: appId },
+    select: { workspaceId: true, ownerUserId: true, visibility: true, isArchived: true },
+  });
+  if (!app || app.isArchived) return { ok: false, status: 404, error: "App not found" };
+
+  if (app.ownerUserId !== requesterId) {
+    const workspaceId = await getWorkspaceIdForUser(requesterId, "artifact-app-storage");
+    const sameWorkspace = workspaceId !== null && workspaceId === app.workspaceId;
+    if (!sameWorkspace || app.visibility !== VISIBILITY_WORKSPACE) {
+      return { ok: false, status: 403, error: "Forbidden" };
+    }
+  }
+  return { ok: true, workspaceId: app.workspaceId };
+}
+
+/** Owners a read may touch. Never anything but the caller's row and the shared one. */
+function readOwners(scope: "user" | "global" | "any", requesterId: string): string[] {
+  if (scope === "user") return [requesterId];
+  if (scope === "global") return [GLOBAL_OWNER];
+  return [GLOBAL_OWNER, requesterId];
+}
+
+interface RecordRow {
+  dynamicKey: string;
+  owner: string;
+  value: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** The wire shape. `owner` is collapsed to a scope so a user id never leaves. */
+function toWire(row: RecordRow): {
+  key: string;
+  scope: "user" | "global";
+  value: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+} {
+  return {
+    key: row.dynamicKey,
+    scope: row.owner === GLOBAL_OWNER ? "global" : "user",
+    value: row.value,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+/** For one dynamicKey, the row the app should see: the user's shadows the global. */
+function shadow(rows: RecordRow[]): RecordRow | null {
+  return rows.find((r) => r.owner !== GLOBAL_OWNER) ?? rows[0] ?? null;
+}
+
+async function overWriteQuota(userId: string): Promise<boolean> {
+  try {
+    const redis = redisService.getConnection();
+    const key = `artifact-app-storage:rate:${userId}`;
+    const count = await redis.incr(key);
+    if (count === 1) await redis.expire(key, RATE_WINDOW_SECONDS);
+    return count > WRITES_PER_HOUR;
+  } catch (err) {
+    // Redis down must not take the feature down; the other caps still hold.
+    log.warn(`rate limit check failed for ${userId}: ${String(err)}`);
+    return false;
+  }
+}
+
+const recordSelect = { dynamicKey: true, owner: true, value: true, createdAt: true, updatedAt: true } as const;
+
+/** POST /query — the only read. `op` picks point-get or bounded list. */
+artifactAppStorageRouter.post("/query", async (req: Request, res: Response): Promise<void> => {
+  const requesterId = getRequesterId(req);
+  if (!requesterId) {
+    res.status(401).json({ success: false, error: "Unauthorized" });
+    return;
+  }
+
+  const parsed = querySchema.safeParse(req.body);
+  if (!parsed.success) return badRequest(res, parsed);
+  const q = parsed.data;
+
+  if (q.op === "get" && !q.key && !q.keys) {
+    res.status(400).json({ success: false, error: "op \"get\" needs key or keys" });
+    return;
+  }
+  if (q.op === "get" && q.key && q.keys) {
+    res.status(400).json({ success: false, error: "Pass key or keys, not both" });
+    return;
+  }
+
+  const resolved = await resolveApp(q.appId, requesterId);
+  if (!resolved.ok) {
+    res.status(resolved.status).json({ success: false, error: resolved.error });
+    return;
+  }
+
+  const base = {
+    workspaceId: resolved.workspaceId,
+    appId: q.appId,
+    baseKey: q.baseKey,
+    owner: { in: readOwners(q.scope, requesterId) },
+  };
+
+  if (q.op === "get") {
+    const wanted = q.keys ?? [q.key as string];
+    const rows = await prisma.artifactAppRecord.findMany({
+      where: { ...base, dynamicKey: { in: wanted } },
+      select: recordSelect,
+    });
+    const byKey = new Map<string, RecordRow[]>();
+    for (const row of rows) {
+      const bucket = byKey.get(row.dynamicKey) ?? [];
+      bucket.push(row);
+      byKey.set(row.dynamicKey, bucket);
+    }
+    if (q.key !== undefined) {
+      const row = shadow(byKey.get(q.key) ?? []);
+      res.json({ success: true, record: row ? toWire(row) : null });
+      return;
+    }
+    const records = wanted
+      .map((k) => shadow(byKey.get(k) ?? []))
+      .filter((r): r is RecordRow => r !== null)
+      .map(toWire);
+    res.json({ success: true, records });
+    return;
+  }
+
+  // list. limit+1 answers hasMore without a count; ties across owners break on
+  // owner so the order is total and offset paging never skips or repeats.
+  const rows = await prisma.artifactAppRecord.findMany({
+    where: { ...base, ...(q.prefix ? { dynamicKey: { startsWith: q.prefix } } : {}) },
+    orderBy: [{ dynamicKey: q.order }, { owner: q.order }],
+    skip: q.offset,
+    take: q.limit + 1,
+    select: recordSelect,
+  });
+  res.json({
+    success: true,
+    records: rows.slice(0, q.limit).map(toWire),
+    hasMore: rows.length > q.limit,
+  });
+});
+
+/** POST /put — upsert one record. The unique index is what makes this atomic. */
+artifactAppStorageRouter.post("/put", async (req: Request, res: Response): Promise<void> => {
+  const requesterId = getRequesterId(req);
+  if (!requesterId) {
+    res.status(401).json({ success: false, error: "Unauthorized" });
+    return;
+  }
+
+  const parsed = putSchema.safeParse(req.body);
+  if (!parsed.success) return badRequest(res, parsed);
+  const body = parsed.data;
+
+  if (body.value === undefined) {
+    res.status(400).json({ success: false, error: "value is required" });
+    return;
+  }
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(body.value);
+  } catch {
+    res.status(400).json({ success: false, error: "value must be JSON-serializable" });
+    return;
+  }
+  if (serialized === undefined || Buffer.byteLength(serialized, "utf8") > MAX_VALUE_BYTES) {
+    res.status(413).json({ success: false, error: `value must serialize to at most ${MAX_VALUE_BYTES / 1024}KB of JSON` });
+    return;
+  }
+
+  const resolved = await resolveApp(body.appId, requesterId);
+  if (!resolved.ok) {
+    res.status(resolved.status).json({ success: false, error: resolved.error });
+    return;
+  }
+
+  if (await overWriteQuota(requesterId)) {
+    res.status(429).json({ success: false, error: "Too many storage writes recently. Try again later." });
+    return;
+  }
+
+  const owner = body.scope === "global" ? GLOBAL_OWNER : requesterId;
+  const uniqueKey = {
+    workspaceId: resolved.workspaceId,
+    appId: body.appId,
+    baseKey: body.baseKey,
+    owner,
+    dynamicKey: body.key,
+  };
+
+  // Soft cap, paid only on a CREATE: an existing key updates in place freely.
+  // The count/create race can overshoot by a few rows; that is fine for a guard
+  // whose job is stopping unbounded growth, not enforcing an exact number.
+  const exists = await prisma.artifactAppRecord.findUnique({
+    where: { workspaceId_appId_baseKey_owner_dynamicKey: uniqueKey },
+    select: { id: true },
+  });
+  if (!exists) {
+    const total = await prisma.artifactAppRecord.count({
+      where: { workspaceId: resolved.workspaceId, appId: body.appId },
+    });
+    if (total >= MAX_RECORDS_PER_APP) {
+      res.status(403).json({ success: false, error: "This app has reached its storage limit. Delete records to add more." });
+      return;
+    }
+  }
+
+  const valueJson = JSON.parse(serialized) as object;
+  const row = await prisma.artifactAppRecord.upsert({
+    where: { workspaceId_appId_baseKey_owner_dynamicKey: uniqueKey },
+    create: { ...uniqueKey, value: valueJson },
+    update: { value: valueJson },
+    select: recordSelect,
+  });
+  res.json({ success: true, record: toWire(row) });
+});
+
+/** POST /delete — remove one record the caller may write. */
+artifactAppStorageRouter.post("/delete", async (req: Request, res: Response): Promise<void> => {
+  const requesterId = getRequesterId(req);
+  if (!requesterId) {
+    res.status(401).json({ success: false, error: "Unauthorized" });
+    return;
+  }
+
+  const parsed = deleteSchema.safeParse(req.body);
+  if (!parsed.success) return badRequest(res, parsed);
+  const body = parsed.data;
+
+  const resolved = await resolveApp(body.appId, requesterId);
+  if (!resolved.ok) {
+    res.status(resolved.status).json({ success: false, error: resolved.error });
+    return;
+  }
+
+  const owner = body.scope === "global" ? GLOBAL_OWNER : requesterId;
+  const { count } = await prisma.artifactAppRecord.deleteMany({
+    where: {
+      workspaceId: resolved.workspaceId,
+      appId: body.appId,
+      baseKey: body.baseKey,
+      owner,
+      dynamicKey: body.key,
+    },
+  });
+  res.json({ success: true, deleted: count > 0 });
+});

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-app-storage.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-app-storage.ts
@@ -16,7 +16,20 @@
  *    readable by any viewer with devtools. `owner` is stamped from the session
  *    and reads filter to ("global", caller), so a user-scoped record is private
  *    no matter what the app does. A user row SHADOWS a global row with the same
- *    key on point reads — "default settings, overridden per user" for free.
+ *    key on POINT reads only — "default settings, overridden per user" for
+ *    free. `list` is deliberately raw: it returns both rows (each carries its
+ *    scope) because offset pagination cannot collapse a pair split across two
+ *    pages without lying about completeness. Clients that want the collapsed
+ *    view filter on scope, or list 'user' and 'global' separately.
+ *
+ *  - **Global rows are shared-WRITE, not just shared-read — deliberately.**
+ *    Any user who can open the app can put/delete scope:"global" records,
+ *    last-write-wins; that is what makes shared app state (a common board
+ *    config, a team counter) possible without a server component. Per-user
+ *    data belongs in scope:"user", which nobody else can touch. If a future
+ *    app needs owner-only shared state, gate it here (resolveApp already
+ *    fetches ownerUserId; compare it against the requester) — do not trust
+ *    app-side checks for it.
  *
  *  - **Every read is bounded.** `limit` is capped, `offset` is capped (a large
  *    OFFSET still walks the index), keys are length-capped, and list order is
@@ -245,6 +258,8 @@ artifactAppStorageRouter.post("/query", async (req: Request, res: Response): Pro
 
   // list. limit+1 answers hasMore without a count; ties across owners break on
   // owner so the order is total and offset paging never skips or repeats.
+  // No shadow-collapse here (see header): under scope "any" a key with both a
+  // user and a global row yields TWO records, distinguished by their scope.
   const rows = await prisma.artifactAppRecord.findMany({
     where: { ...base, ...(q.prefix ? { dynamicKey: { startsWith: q.prefix } } : {}) },
     orderBy: [{ dynamicKey: q.order }, { owner: q.order }],


### PR DESCRIPTION
## What

Adds a small storage layer for artifact apps, served by xyne-claw-auth at `/claw/api/v1/artifact-app-storage`.

- **New table `artifact_app_records`** — two-level key (`baseKey` collection + `dynamicKey` record), `owner` column holding `"global"` or a userId (sentinel avoids the Postgres NULLs-are-distinct unique-index trap), opaque `jsonb` value. The unique index `(workspaceId, appId, baseKey, owner, dynamicKey)` doubles as the read/list index and the upsert target.
- **Three endpoints** (`/query`, `/put`, `/delete`) behind `requireAuth`, validated by zod `.strict()` schemas — records are addressed by key/prefix/scope only; there is deliberately no filtering on values, so no request can escape the compound index.
- **Scope enforced server-side**: `user` rows are private to the caller (stamped from the verified session, never the body), `global` rows are shared per app; reads filter to `(global, caller)` and a user row shadows a global row on point gets. Another user's row is unaddressable by construction.
- **App ACL** mirrors artifact-app-agents: owner, or workspace member once the app is published (`visibility = WORKSPACE`).
- **Caps**: values ≤ 64KB JSON, list pages ≤ 100, offset ≤ 10k, batch get ≤ 50 keys, 20k records/app (blocks creates only), 2k writes/hour/user via Redis.

## Validation

- `prisma validate` + `tsc --noEmit` clean (only pre-existing unrelated errors remain).
- Pre-commit checks run manually (hook needs a TTY): gitleaks clean, tenant-key guard passed (`ArtifactAppRecord` has non-nullable `workspaceId`), schema↔migration validation passed, no enum changes.
- Exercised end-to-end against a local claw-auth: put/get/list/delete in both scopes, user-shadows-global, cross-user 403 on a PRIVATE app.

## Notes

- Run `prisma migrate deploy` in claw-auth on deploy (`20260902120000_artifact_app_records`).
- No FK to `artifact_apps` by request — a hard app delete should also `deleteMany` its records (apps are archived, not deleted, today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dbikGSSdDEpDWMGk9QbCm