### PR TITLE
fix: XYNE-1315 denormalise the linked ticket's assignee onto mail

### DIFF
--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -467,6 +467,7 @@ export interface VespaMailDocument extends VespaDocument {
   xyneId?: string;
   /** Project.code of the linked ticket — the "<code>" half of xyneId. */
   projectCode?: string;
+  assignedTo?: string;
   ticketFormFields?: TicketFormFields;
   ticketFormFieldValues?: string[]; // Indexed copy used for Desk/All lexical search.
   subject: string;

--- a/apps/backend/src/workers/handlers/mailAssignedToSync.ts
+++ b/apps/backend/src/workers/handlers/mailAssignedToSync.ts
@@ -1,0 +1,69 @@
+import { db } from '@/database/client';
+import { logger } from '@/utils/logger';
+import vespaClient from '@/vespa/client';
+import { mailSchema, VespaDocType } from '@/vespa/src/types';
+import type { VespaJobType } from '@/zero/vespa-injection/core/types';
+
+type MailAssignedToSyncContext = {
+  docId: string;
+  jobType: VespaJobType;
+  mappedData?: Record<string, unknown> | null;
+};
+
+/**
+ * Keep `mail.assignedTo` in step with the ticket it was denormalised from — mapEmail only
+ * runs when the mail changes, so a reassignment would leave indexed mails on the old value.
+ *
+ * Runs off the ticket's Vespa write, so it covers every path that reindexes a ticket. Partial
+ * updates only: re-feeding mail would re-run the hf-embedder over subject/chunks.
+ */
+export async function runMailAssignedToSync(ctx: MailAssignedToSyncContext): Promise<void> {
+  if (ctx.jobType !== 'feed') return;
+
+  const mapped = ctx.mappedData;
+  if (!mapped) return;
+
+  const convId = typeof mapped.convId === 'string' ? mapped.convId : '';
+  if (!convId) return;
+
+  // mapTicket writes '' when unassigned, mapEmail drops the key — normalise both to undefined.
+  const assignedTo =
+    typeof mapped.assignedTo === 'string' && mapped.assignedTo ? mapped.assignedTo : undefined;
+
+  try {
+    const emails = await db.email.findMany({
+      where: { conversationId: convId },
+      select: { id: true },
+    });
+    if (emails.length === 0) return;
+
+    // Most ticket feeds carry no assignee change, so read one mail doc before writing all of them.
+    const indexed = await vespaClient.crudService.getDocument(emails[0].id, mailSchema);
+    const indexedFields = indexed?.fields as Record<string, unknown> | undefined;
+    const indexedAssignedTo =
+      typeof indexedFields?.assignedTo === 'string' && indexedFields.assignedTo
+        ? indexedFields.assignedTo
+        : undefined;
+    if (indexedAssignedTo === assignedTo) return;
+
+    const results = await vespaClient.crudService.update(
+      emails.map((email) => ({
+        docId: email.id,
+        fields: {
+          docType: VespaDocType.MAIL,
+          docId: email.id,
+          assignedTo: assignedTo ?? '',
+        },
+      })),
+      mailSchema,
+    );
+
+    const failed = results.filter((result) => !result.success).length;
+    logger.info(
+      `[MAIL_ASSIGNEE_SYNC] ticket ${ctx.docId}: assignedTo "${indexedAssignedTo ?? ''}" -> "${assignedTo ?? ''}" on ${emails.length - failed}/${emails.length} mail docs`,
+    );
+  } catch (error) {
+    // Best-effort: the ticket write already succeeded and must not be failed by this.
+    logger.error(`[MAIL_ASSIGNEE_SYNC] Failed for ticket ${ctx.docId} (conversation ${convId}):`, error);
+  }
+}

--- a/apps/backend/src/workers/vespaPostIngestHooks.ts
+++ b/apps/backend/src/workers/vespaPostIngestHooks.ts
@@ -2,6 +2,7 @@ import type { InsertDocument, VespaSchema } from '@/vespa/src/types';
 import { ticketSchema } from '@/vespa/src/types';
 import type { VespaJobType } from '@/zero/vespa-injection/core/types';
 import { runTicketDescriptionCleanOnCompletion } from './handlers/ticketDescriptionCleanOnCompletion';
+import { runMailAssignedToSync } from './handlers/mailAssignedToSync';
 
 export type VespaPostIngestContext = {
   schema: VespaSchema;
@@ -14,12 +15,22 @@ export type VespaPostIngestContext = {
 class VespaPostIngestHooks {
   async run(ctx: VespaPostIngestContext): Promise<void> {
     if (ctx.schema !== ticketSchema) return;
-    await runTicketDescriptionCleanOnCompletion({
-      docId: ctx.docId,
-      jobType: ctx.jobType,
-      mappedData: ctx.mappedData as Record<string, unknown>,
-      userId: ctx.userId,
-    });
+    // allSettled so one hook throwing does not skip the others; first rejection still re-thrown.
+    const outcomes = await Promise.allSettled([
+      runTicketDescriptionCleanOnCompletion({
+        docId: ctx.docId,
+        jobType: ctx.jobType,
+        mappedData: ctx.mappedData as Record<string, unknown>,
+        userId: ctx.userId,
+      }),
+      runMailAssignedToSync({
+        docId: ctx.docId,
+        jobType: ctx.jobType,
+        mappedData: ctx.mappedData as Record<string, unknown>,
+      }),
+    ]);
+    const rejected = outcomes.find((outcome) => outcome.status === 'rejected');
+    if (rejected) throw (rejected as PromiseRejectedResult).reason;
   }
 }
 

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -1444,7 +1444,7 @@ export const mapEmail = async (email: Email, workspaceId?: string, orgId?: strin
 
   const ticket = await db.ticket.findFirst({
     where: { conversationId: email.conversationId },
-    select: { id: true, xyneId: true, project: { select: { code: true } } },
+    select: { id: true, xyneId: true, assignedTo: true, project: { select: { code: true } } },
   });
   const ticketFormFields = ticket ? await loadTicketFormFields(ticket.id) : [];
 
@@ -1506,6 +1506,7 @@ export const mapEmail = async (email: Email, workspaceId?: string, orgId?: strin
     mailId: email.externalMessageId || undefined,
     xyneId: ticket?.xyneId ?? undefined,
     projectCode: ticket?.project?.code ?? undefined,
+    assignedTo: ticket?.assignedTo ?? undefined,
     ticketFormFields,
     ticketFormFieldValues: Array.from(new Set(ticketFormFields.map(field => field.fieldValue))),
     subject: email.subject,

--- a/vespa-core/vespa/common/schemas/mail.sd
+++ b/vespa-core/vespa/common/schemas/mail.sd
@@ -51,6 +51,12 @@ schema mail {
       index: enable-bm25
     }
 
+    # Assignee of the linked ticket, denormalised. Mirrors ticket.sd's assignedTo.
+    field assignedTo type string {
+      indexing: index | attribute | summary
+      index: enable-bm25
+    }
+
     field channelRef type reference<chat_container> {
       indexing: attribute
     }
@@ -251,7 +257,7 @@ schema mail {
   }
 
   fieldset default {
-    fields: subject, app, entity, chunks, attachmentFilenames, from, to, cc, bcc, labels, entityPeople, entityProducts, entityMerchants, xyneId, ticketFormFieldValues
+    fields: subject, app, entity, chunks, attachmentFilenames, from, to, cc, bcc, labels, entityPeople, entityProducts, entityMerchants, xyneId, ticketFormFieldValues, assignedTo
   }
 
   fieldset autocomplete {
@@ -337,6 +343,7 @@ schema mail {
     summary entity {}
     summary permissions {}
     summary mailId {}
+    summary assignedTo {}
   }
 
 


### PR DESCRIPTION
## Type of Change
- [x] Enhancement

## Description
XYNE-1315. mapEmail already resolves the linked ticket for xyneId/projectCode;
it now also selects the assignee and writes it onto the mail doc. Because a
ticket update does not re-feed its mails, a post-ingest hook pushes the assignee
onto the conversation's mail docs whenever the indexed value disagrees — a
partial update, never a re-feed (a re-feed re-runs the hf-embedder over
subject/chunks).

Schema half: vespa-core fix/XYNE-1315-mail-assigned-to

## Areas Touched
- [x] `apps/backend` (API / worker)

## Zero (Sync) Changes
- [x] No Zero changes

## Schema & Data Changes
- [x] No schema changes (Prisma untouched)
Vespa mail.sd gains `assignedTo`. Rollout: Vespa schema → backend → backfill.
Backend-first makes Vespa 400 the whole document and stops all mail indexing.
Existing mail docs carry no value until backfilled.

## API Contract
- [x] No API changes

## How did you test it?
- Backend typecheck + build green via pre-commit hook.
- Queried local Vespa for `assignedTo` on the mail schema: field resolves.
NOT verified: the post-ingest propagation against a live reassignment, and the
schema against current vespa-core main (container down, see below).

### Automated
- [x] Not covered by tests

## Checklist
- [x] Reviewed my own diff; scoped to one thing
- [x] Backend `typecheck` + `build` pass
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [x] No debug logging left behind