### PR TITLE
fix: XYNE-62252 make ClickHouse MCP secure/verify credential-driven

### DIFF
--- a/apps/xyne-claw-auth/backend/src/mcp/adapters/clickhouse.ts
+++ b/apps/xyne-claw-auth/backend/src/mcp/adapters/clickhouse.ts
@@ -16,17 +16,30 @@ export const clickhouseAdapter: StdioMcpAdapter = {
     { name: "port", label: "Port", type: "text", placeholder: "8443", optional: true },
     { name: "user", label: "Username", type: "text", placeholder: "default", optional: true },
     { name: "password", label: "Password", type: "password", placeholder: "", optional: true },
+    { name: "secure", label: "Use TLS (secure)", type: "text", placeholder: "true", optional: true },
+    { name: "verify", label: "Verify TLS cert", type: "text", placeholder: "true", optional: true },
   ],
   buildCommand(credentials) {
-    const host = String(credentials["host"] ?? "").trim();
+    // Strip any scheme/trailing slash a user may have pasted into the host
+    // field (prevents the mangled `https://http://host:port` seen in logs).
+    const host = String(credentials["host"] ?? "")
+      .trim()
+      .replace(/^https?:\/\//i, "")
+      .replace(/\/+$/, "");
     const port = String(credentials["port"] ?? "").trim();
     const user = String(credentials["user"] ?? "").trim();
     const password = String(credentials["password"] ?? "");
 
-    // SECURE/VERIFY default on — the legacy connector hardcoded both to "true".
+    // SECURE/VERIFY default on (matches legacy behaviour) but are now
+    // credential-driven so plaintext-HTTP servers (e.g. port 8123) can opt out
+    // by setting secure="false". Only an explicit "false" disables them.
+    const secure =
+      String(credentials["secure"] ?? "true").trim().toLowerCase() === "false" ? "false" : "true";
+    const verify =
+      String(credentials["verify"] ?? "true").trim().toLowerCase() === "false" ? "false" : "true";
     const env: Record<string, string> = {
-      CLICKHOUSE_SECURE: "true",
-      CLICKHOUSE_VERIFY: "true",
+      CLICKHOUSE_SECURE: secure,
+      CLICKHOUSE_VERIFY: verify,
     };
     if (host) env["CLICKHOUSE_HOST"] = host;
     if (port) env["CLICKHOUSE_PORT"] = port; // legacy template appended a stray space; trimmed here


### PR DESCRIPTION
## Problem
The ClickHouse MCP adapter (`apps/xyne-claw-auth/backend/src/mcp/adapters/clickhouse.ts`) hardcoded `CLICKHOUSE_SECURE=true` and `CLICKHOUSE_VERIFY=true`. A plaintext-HTTP ClickHouse server (e.g. on port 8123) therefore cannot be reached: the `mcp-clickhouse` client forces a TLS handshake against a non-TLS port and fails with `[SSL: WRONG_VERSION_NUMBER]`. There was no way to disable TLS from stored credentials. Logs also showed a mangled `https://http://host:port` when a user pasted a scheme into the host field.

## Fix
- Make `secure` and `verify` credential-driven via two new optional credential fields. They still default to `true`, so existing connections are unchanged; only an explicit `secure="false"` / `verify="false"` disables them.
- Strip any `http(s)://` scheme and trailing slash from the host field to prevent the mangled URL.

## Impact / compatibility
- No behaviour change for existing connections (defaults remain true).
- Plaintext-8123 ClickHouse setups can now connect by setting `secure=false`.

## Validation
- `ts.transpileModule` on the changed file: 0 diagnostics.
