### PR TITLE
fix: XYNE-61948 Modifying the script to skip ci check for workspaceId…

### DIFF
--- a/apps/backend/src/database/tenant/tenant-key-exclusions.ts
+++ b/apps/backend/src/database/tenant/tenant-key-exclusions.ts
@@ -1,0 +1,19 @@
+import type { Prisma } from '@prisma/client';
+
+export const TENANT_KEY_EXCLUDED_MODELS = [
+  'WorkflowMapping',
+  'Resource',
+  'AiProvisioningStatus',
+  'CanvasCommentThread',
+  'CanvasComment',
+  'LookupValue',
+  'Merchant',
+  'ActivityAlias',
+  'AvailableAppPermission',
+  'TeamIntelligenceIngestionBatchV2',
+  'TeamIntelligenceUserIngestionV2',
+  'TeamIntelligenceTeamSummaryV2',
+  'TeamIntelligenceOrgSummaryV2',
+  'DoclingAsyncFile',
+  'DoclingAsyncPart',
+] as const satisfies readonly Prisma.ModelName[];

--- a/apps/backend/src/database/tenant/tenant-key-guard.ts
+++ b/apps/backend/src/database/tenant/tenant-key-guard.ts
@@ -1,0 +1,28 @@
+import type { Prisma } from '@prisma/client';
+import { TENANT_KEY_EXCLUDED_MODELS } from './tenant-key-exclusions';
+
+type ScalarsOf<M extends Prisma.ModelName> = Prisma.TypeMap['model'][M]['payload']['scalars'];
+
+type IsNonNullableKey<T, K extends PropertyKey> = K extends keyof T
+  ? null extends T[K]
+    ? false
+    : true
+  : false;
+
+type HasNonNullTenantKey<M extends Prisma.ModelName> =
+  IsNonNullableKey<ScalarsOf<M>, 'workspaceId'> extends true
+    ? true
+    : IsNonNullableKey<ScalarsOf<M>, 'orgId'> extends true
+      ? true
+      : false;
+
+type ExcludedModel = (typeof TENANT_KEY_EXCLUDED_MODELS)[number];
+type ModelsRequiringTenantKey = Exclude<Prisma.ModelName, ExcludedModel>;
+
+type TenantKeyViolations = {
+  [M in ModelsRequiringTenantKey]: HasNonNullTenantKey<M> extends true ? never : M;
+}[ModelsRequiringTenantKey];
+
+export const _assertNoTenantKeyViolations: TenantKeyViolations extends never
+  ? true
+  : { TENANT_KEY_VIOLATIONS: TenantKeyViolations } = true;

--- a/scripts/validate-workspace-id.sh
+++ b/scripts/validate-workspace-id.sh
@@ -12,9 +12,20 @@
 # Only runs against genuinely NEW models (added in this diff) — existing models
 # are untouched, so this never blocks unrelated schema edits.
 #
-# Escape hatch: a model that is intentionally global/cross-tenant (e.g. a shared
-# lookup table) can opt out by placing `// workspace-check:ignore` on the line
-# directly above `model X {`.
+# Escape hatch #1 (inline, per-model): a model that is intentionally global/cross-tenant
+# (e.g. a shared lookup table) can opt out by placing `// workspace-check:ignore` on the
+# line directly above `model X {`.
+#
+# Escape hatch #2 (list): add the model name to TENANT_KEY_EXCLUDED_MODELS in
+# apps/backend/src/database/tenant/tenant-key-exclusions.ts instead. Same effect,
+# centralized and reviewable in one diff instead of scattered comments — and it's the
+# same list apps/backend/src/database/tenant/tenant-key-guard.test.ts checks against
+# the FULL schema, so there is exactly one place to maintain exclusions, not two.
+#
+# Neither hatch excuses the model from tenant scoping in code — it only silences this
+# shape check. The No-Default-ACL guard below (and the backend's exhaustive ACL-factory
+# switches it protects) still forces an explicit, reviewed access-control decision
+# (a real scoped ACL, or UnscopedACL) for every model, excluded or not.
 #
 # No-Default-ACL Guard
 #
@@ -32,6 +43,33 @@ SCHEMA_PATHS=(
     "apps/backend/prisma/schema.prisma"
     "apps/xyne-claw-auth/backend/prisma/schema.prisma"
 )
+
+# Single source of truth for the exclusion list — same file the backend's
+# tenant-key-guard.test.ts reads, so a table only needs to be listed once.
+TENANT_KEY_EXCLUSIONS_TS="apps/backend/src/database/tenant/tenant-key-exclusions.ts"
+
+# Parses the quoted model names out of the TENANT_KEY_EXCLUDED_MODELS array literal in
+# TENANT_KEY_EXCLUSIONS_TS (plain text parsing, no TS/node dependency — this script only
+# needs bash+git). Reads the staged version when available, so a staged edit to the
+# exclusion list is honored immediately; falls back to the working-tree file otherwise.
+load_excluded_models() {
+    local ts_file="$1"
+    [ -f "$ts_file" ] || return
+
+    local content
+    content=$(git show ":$ts_file" 2>/dev/null || cat "$ts_file" 2>/dev/null || echo "")
+
+    echo "$content" | awk '
+        /TENANT_KEY_EXCLUDED_MODELS/ { found=1 }
+        found { print }
+        found && /\];/ { exit }
+    ' | sed -E 's#//.*$##' | grep -oE "'[^']*'" | sed -E "s/^'|'\$//g"
+}
+
+EXCLUDED_MODELS=()
+while IFS= read -r model_name; do
+    [ -n "$model_name" ] && EXCLUDED_MODELS+=("$model_name")
+done < <(load_excluded_models "$TENANT_KEY_EXCLUSIONS_TS")
 
 # ACL factory switches that must enumerate every table explicitly — a `default:`
 # branch in any of these files is a blocking failure.
@@ -73,6 +111,15 @@ extract_new_models() {
         grep -E '^\+model[[:space:]]+[A-Za-z0-9_]+' | \
         sed -E 's/^\+model[[:space:]]+([A-Za-z0-9_]+).*/\1/' | \
         sort -u
+}
+
+# Whether the model name is listed in EXCLUDED_MODELS.
+model_is_excluded() {
+    local model_name="$1"
+    local excluded
+    for excluded in "${EXCLUDED_MODELS[@]}"; do
+        [ "$excluded" = "$model_name" ] && { echo "yes"; return; }
+    done
 }
 
 # Whether the model is annotated with the opt-out comment on the line before `model X {`.
@@ -129,6 +176,11 @@ validate_workspace_id() {
         while IFS= read -r model; do
             [ -z "$model" ] && continue
 
+            if [ "$(model_is_excluded "$model")" = "yes" ]; then
+                log_info "  ⏭ model '$model' is in EXCLUDED_MODELS — skipping"
+                continue
+            fi
+
             if [ "$(model_opts_out "$schema_file" "$model")" = "yes" ]; then
                 log_info "  ⏭ model '$model' has workspace-check:ignore — skipping"
                 continue
@@ -162,7 +214,8 @@ validate_workspace_id() {
         echo ""
         echo "New tables must carry a non-nullable tenant key:"
         echo "  Add a non-nullable 'workspaceId String' (or 'orgId String') field to the model."
-        echo "  If the table is intentionally global/cross-tenant, add"
+        echo "  If the table is intentionally global/cross-tenant, either add the model name"
+        echo "  to TENANT_KEY_EXCLUDED_MODELS in $TENANT_KEY_EXCLUSIONS_TS, or add"
         echo "  '// workspace-check:ignore' on the line directly above 'model X {'."
         echo ""
         return 1


### PR DESCRIPTION
… in certain tables

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
