### PR TITLE
fix: XYNE-61888 open links in external browser by default

### DIFF
--- a/apps/dashboard/src/types/browserSettings.ts
+++ b/apps/dashboard/src/types/browserSettings.ts
@@ -5,5 +5,5 @@ export interface BrowserSettings {
 
 export const defaultBrowserSettings: BrowserSettings = {
   popups: true,
-  openLinksExternally: false,
+  openLinksExternally: true,
 };

--- a/apps/dashboard/src/utils/openLink.ts
+++ b/apps/dashboard/src/utils/openLink.ts
@@ -18,7 +18,7 @@ export const subscribeLinkOpenPref = (listener: () => void): (() => void) => {
 };
 
 export const getLinkOpenExternalDefault = (): boolean =>
-  localStorage.getItem(LINK_OPEN_EXTERNAL_KEY) === 'true';
+  localStorage.getItem(LINK_OPEN_EXTERNAL_KEY) !== 'false';
 
 const syncLinkOpenPrefToMain = (value: boolean): void => {
   if (!isElectronApp()) return;

--- a/apps/electron/src/services/browser-settings.ts
+++ b/apps/electron/src/services/browser-settings.ts
@@ -7,7 +7,7 @@ export interface BrowserSettings {
 
 const defaultSettings: BrowserSettings = {
   popups: true,
-  openLinksExternally: false,
+  openLinksExternally: true,
 };
 
 class BrowserSettingsService {


### PR DESCRIPTION
## Type of Change

- [x] Enhancement

## Description

XYNE-61888 — the **Open links in external browser** preference (Settings → Preferences) already existed; it just defaulted to *off*, so a plain click landed in the in-app browser panel. This flips the default so a user who has never touched the toggle gets the system browser.

Three places encoded the old default:

| File | Change |
|---|---|
| `apps/dashboard/src/utils/openLink.ts:21` | unset `localStorage` now resolves to `true` — reads `!== 'false'` instead of `=== 'true'` |
| `apps/electron/src/services/browser-settings.ts:10` | main-process `electron-store` default → `true` |
| `apps/dashboard/src/types/browserSettings.ts:8` | renderer mirror of the same default → `true` |

**Why `!== 'false'` and not the inverse of `=== 'true'`:** `setLinkOpenExternalDefault` persists the literal `'true'`/`'false'`, so the three states stay distinct — never-touched (`null`) flips to external, explicitly-on stays on, and anyone who *deliberately* switched the toggle off keeps the in-app panel. A blunt default-true that ignored a stored `'false'` would silently override their choice.

**Behaviour after this change** — `wantsExternal` is `externalDefault !== modifier`, so:
- plain click → system browser
- ⌘/Ctrl-click → in-app browser panel

The Preferences copy already had strings for both directions, so no UI edit was needed. `apps/electron/src/window/manager.ts:118` uses the same `prefExternal !== modifier` shape (with `disposition === 'background-tab'` as the modifier), so links originating *inside* webviews flip consistently.

**Existing installs:** they already have `browserSettings.openLinksExternally: false` persisted in `electron-store`, so the main-process default alone would not reach them — but `openLink.ts:28` pushes the renderer's resolved value into main on every boot, so they self-heal to `true` as soon as the renderer mounts. The only stale window is main-process link handling before the renderer loads.

## Areas Touched

- [x] `apps/dashboard`
- [x] `apps/electron`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Pre-commit hook could not run in this environment (`.husky/pre-commit` opens `/dev/tty`), so its checks were run manually instead — all passed:

- `gitleaks git --staged` — no leaks
- `scripts/validate-workspace-id.sh` — no new models, no `default:` in ACL factory
- `scripts/validate-schema-migrations.sh` — no schema changes
- `scripts/change-analysis.sh` — dashboard flagged for redeploy (footer on the commit)
- `pnpm run test:enum` — enum guard passed
- `apps/dashboard` `pnpm run lint:errors-only` — clean

**Not run:** dashboard `typecheck` / `build` and backend checks. Every edit is `boolean` → `boolean` against an explicitly typed const, so no type can narrow differently, but a reviewer may want CI to confirm.

**Not manually exercised yet** — worth a reviewer check on desktop: plain click opens the system browser, ⌘-click opens the in-app panel, and the Settings toggle still round-trips both ways.

### Automated

- [x] Not covered by tests <!-- default-value flip; no existing suite covers link routing -->

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Dashboard `lint:errors-only` passes (`typecheck` / `build` not run locally — see above)
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [x] No debug logging or commented-out code left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)
