### PR TITLE
fix: XYNE-62291 close sidebar quick-nav hover card on navigation

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
@@ -244,6 +244,10 @@ const AppSidebar = (): ReactElement => {
     PreferenceSection | undefined
   >(undefined);
 
+  useEffect(() => {
+    setOpenQuickMenu(null);
+  }, [activeRoute]);
+
   const handleOpenPreferences = (): void => {
     setIsSettingsPopoverOpen(false);
     setPreferencesInitialSection(undefined);

--- a/apps/dashboard/src/components/AppSidebar/RailQuickNav.tsx
+++ b/apps/dashboard/src/components/AppSidebar/RailQuickNav.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, type ReactElement, type ReactNode } from 'react';
+import { cloneElement, useEffect, type ReactElement, type ReactNode } from 'react';
 import { HoverCard } from '../ui/HoverCard';
 import { Tooltip } from '../ui/Tooltip/Tooltip';
 
@@ -26,13 +26,22 @@ export const RailQuickNavEntry = ({
   open,
   onOpenChange,
 }: {
-  trigger: ReactElement<{ onFocus?: (event: React.FocusEvent) => void }>;
+  trigger: ReactElement<{
+    onFocus?: (event: React.FocusEvent) => void;
+    onClick?: (event: React.MouseEvent) => void;
+  }>;
   menu: ReactNode;
   tooltip: ReactNode;
   showQuickMenu: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }): ReactElement => {
+  useEffect(() => {
+    if (!showQuickMenu && open) {
+      onOpenChange(false);
+    }
+  }, [showQuickMenu, open, onOpenChange]);
+
   if (!showQuickMenu) {
     return (
       <Tooltip content={tooltip} side='right' delayDuration={0}>
@@ -51,7 +60,13 @@ export const RailQuickNavEntry = ({
       openDelay={200}
       closeDelay={120}
       className='w-56 rounded-xl p-1.5'
-      trigger={cloneElement(trigger, { onFocus: event => event.preventDefault() })}
+      trigger={cloneElement(trigger, {
+        onFocus: event => event.preventDefault(),
+        onClick: event => {
+          trigger.props.onClick?.(event);
+          onOpenChange(false);
+        },
+      })}
     >
       {menu}
     </HoverCard>


### PR DESCRIPTION
The sidebar quick-access hover card sometimes stayed open with the pointer nowhere near it — most easily reproduced by tapping between Xyne AI and DMs.

`AppSidebar` controls the card's `open` state by path. Clicking a rail item makes it active, which drops the hover card branch entirely, and Radix fires no close event on unmount — so the path stayed parked in `openQuickMenu` and the card re-opened, already open, the next time that item stopped being active.

Cleared in three places:
- `AppSidebar` — reset `openQuickMenu` on route change
- `RailQuickNavEntry` — notify close when it stops rendering the card
- `RailQuickNavEntry` — close on trigger click (the trigger's own `onClick` still runs first)

