### PR TITLE
fix: XYNE-58075 shortcut api call fix

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -96,6 +96,7 @@ import type { ReminderMenuOption, ReminderTimeOption } from '../utils/bookmarkUt
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../ui/Select';
 import { DatePicker } from '../../ui/DatePicker/DatePicker';
 import { appsService, type AppShortcutWithApp } from '../../../services/Apps/appsService';
+import { useChannelShortcuts } from '../../../hooks/useChannelAppCommands';
 import { ShortcutPickerModal } from '../../Apps/ShortcutPickerModal/ShortcutPickerModal';
 import { sendRecordingEvent, useRecordingStore } from '../../../hooks/useRecordingStore';
 import { getRecordingDefaultLayout } from '../../../hooks/useRecordingDefaultLayout';
@@ -196,14 +197,8 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
   const sender = useUser(message.senderId);
 
   // Message shortcuts — fetched per channel, used by HoverActionsToolbar
-  const [messageShortcuts, setMessageShortcuts] = useState<AppShortcutWithApp[]>([]);
+  const messageShortcuts = useChannelShortcuts(channelId, 'MESSAGE');
   const [shortcutModalOpen, setShortcutModalOpen] = useState(false);
-  useEffect(() => {
-    appsService
-      .getChannelShortcuts(channelId, { type: 'MESSAGE' })
-      .then(setMessageShortcuts)
-      .catch(() => undefined);
-  }, [channelId]);
 
   const messageConversationId = message.conversationId;
 

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -72,7 +72,7 @@ import { useThreadBroadcastMentions } from '../../../hooks/useThreadBroadcastMen
 import { useSelector } from '@xstate/react';
 import { xyneAIActor } from '../../../machines/xyneAIMachine';
 import { appsService } from '../../../services/Apps/appsService';
-import type { AppShortcutWithApp } from '../../../services/Apps/appsService';
+import { useChannelCommands, useChannelShortcuts } from '../../../hooks/useChannelAppCommands';
 import { ShortcutPickerModal } from '../../Apps/ShortcutPickerModal/ShortcutPickerModal';
 import { Tooltip } from '../../ui/Tooltip/Tooltip';
 import type { CommandItem } from '../../ui/Selectors/Selectors.types';
@@ -224,49 +224,36 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
       [conversationId, openArtifacts],
     );
 
-    // Slash commands for this channel — filtered by context (thread vs chat)
-    const [channelCommands, setChannelCommands] = useState<CommandItem[]>(
-      SLASH_COMMAND_ARTIFACT_COMMAND_ITEMS,
-    );
     // Registry command id of the artifact currently being drafted, if any.
     const [activeArtifactCommand, setActiveArtifactCommand] = useState<string | null>(null);
-    // Global shortcuts for this channel
-    const [globalShortcuts, setGlobalShortcuts] = useState<AppShortcutWithApp[]>([]);
     const [shortcutModalOpen, setShortcutModalOpen] = useState(false);
-    useEffect(() => {
-      const isThread = !!conversation?.conversationId;
-      const filter: { commandAccessibility?: CommandAccessibility } = isThread
-        ? { commandAccessibility: CommandAccessibility.THREAD }
-        : { commandAccessibility: CommandAccessibility.CHAT };
-      appsService
-        .getChannelCommands(channelId, filter)
-        .then(cmds =>
-          setChannelCommands([
-            ...SLASH_COMMAND_ARTIFACT_COMMAND_ITEMS,
-            ...cmds
-              .filter(
-                c =>
-                  !SLASH_COMMAND_ARTIFACT_COMMAND_ITEMS.some(
-                    artifact => artifact.name === c.commandName.toLowerCase(),
-                  ),
-              )
-              .map(c => ({
-                id: c.id,
-                name: c.commandName,
-                description: c.description,
-                kind: 'app' as const,
-              })),
-          ]),
-        )
-        .catch(() => {
-          setChannelCommands(SLASH_COMMAND_ARTIFACT_COMMAND_ITEMS);
-        });
-      // Fetch global shortcuts (not filtered by thread/chat)
-      appsService
-        .getChannelShortcuts(channelId, { type: 'GLOBAL' })
-        .then(setGlobalShortcuts)
-        .catch(() => undefined);
-    }, [channelId, conversation?.conversationId]);
+
+    // Slash commands for this channel — filtered by context (thread vs chat).
+    // Global shortcuts are not filtered by thread/chat.
+    const appCommands = useChannelCommands(
+      channelId,
+      conversation?.conversationId ? CommandAccessibility.THREAD : CommandAccessibility.CHAT,
+    );
+    const globalShortcuts = useChannelShortcuts(channelId, 'GLOBAL');
+    const channelCommands = useMemo<CommandItem[]>(
+      () => [
+        ...SLASH_COMMAND_ARTIFACT_COMMAND_ITEMS,
+        ...appCommands
+          .filter(
+            c =>
+              !SLASH_COMMAND_ARTIFACT_COMMAND_ITEMS.some(
+                artifact => artifact.name === c.commandName.toLowerCase(),
+              ),
+          )
+          .map(c => ({
+            id: c.id,
+            name: c.commandName,
+            description: c.description,
+            kind: 'app' as const,
+          })),
+      ],
+      [appCommands],
+    );
 
     // Hide, don't just reject: an artifact the user cannot post here should not
     // be offered. The send guards below still fire, because the command can also

--- a/apps/dashboard/src/hooks/useChannelAppCommands.ts
+++ b/apps/dashboard/src/hooks/useChannelAppCommands.ts
@@ -1,0 +1,43 @@
+import { useQuery } from '@tanstack/react-query';
+import { CommandAccessibility } from '@xyne/shared';
+import {
+  appsService,
+  type AppCommand,
+  type AppShortcutWithApp,
+  type ShortcutType,
+} from '../services/Apps/appsService';
+
+const EMPTY_COMMANDS: AppCommand[] = [];
+const EMPTY_SHORTCUTS: AppShortcutWithApp[] = [];
+
+/**
+ * Channel commands/shortcuts are read from components that mount constantly —
+ * every message row in the virtualized chat list, every composer in a
+ * virtualized thread-card list. Fetching them in a `useEffect` meant one request
+ * per mount, so scrolling flooded `/apps/channel/:id/commands`. Going through
+ * react-query dedupes concurrent mounts onto a single request and keeps the
+ * result cached across unmount/remount (staleTime is 5min by default).
+ */
+export function useChannelCommands(
+  channelId: string | undefined,
+  commandAccessibility: CommandAccessibility,
+): AppCommand[] {
+  const { data } = useQuery({
+    queryKey: ['channel-commands', channelId, commandAccessibility],
+    queryFn: () => appsService.getChannelCommands(channelId ?? '', { commandAccessibility }),
+    enabled: !!channelId,
+  });
+  return data ?? EMPTY_COMMANDS;
+}
+
+export function useChannelShortcuts(
+  channelId: string | undefined,
+  type: ShortcutType,
+): AppShortcutWithApp[] {
+  const { data } = useQuery({
+    queryKey: ['channel-shortcuts', channelId, type],
+    queryFn: () => appsService.getChannelShortcuts(channelId ?? '', { type }),
+    enabled: !!channelId,
+  });
+  return data ?? EMPTY_SHORTCUTS;
+}


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
