### PR TITLE
fix: XYNE-62304 correct DmListItem attachment preview label

### DIFF
--- a/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
@@ -85,9 +85,7 @@ export const DmListItem = ({
 
     const rawContent =
       lastMessage.content ||
-      ('attachments' in lastMessage && lastMessage.attachments?.length
-        ? 'Sent an attachment'
-        : 'Message');
+      (lastMessage.hasAttachment ? 'Sent an attachment' : 'Message');
 
     return sanitizeHtmlString(rawContent);
   }, [lastMessage]);

--- a/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
@@ -84,8 +84,7 @@ export const DmListItem = ({
     }
 
     const rawContent =
-      lastMessage.content ||
-      (lastMessage.hasAttachment ? 'Sent an attachment' : 'Message');
+      lastMessage.content || (lastMessage.hasAttachment ? 'Sent an attachment' : 'Message');
 
     return sanitizeHtmlString(rawContent);
   }, [lastMessage]);


### PR DESCRIPTION
## 1. Problem Description
In `DmListItem` (DMs page), a DM whose latest message is attachment-only (empty text + `hasAttachment=true`) shows the generic label **"Message"** in the DM list preview instead of **"Sent an attachment"**.

## 2. How the issue was identified
The DM list renders each row's preview from the denormalized `initial_message_md` blob (via `dmChannelsLatestMessagesPaginated` → `parseInitialMessageMd`), which carries only `hasAttachment: boolean` — no `attachments` array. `DmListItem.tsx` computed its fallback as `'attachments' in lastMessage && lastMessage.attachments?.length ? 'Sent an attachment' : 'Message'`. Since the blob-rebuilt message never has an `attachments` property, that branch is always false and every attachment-only DM falls through to the literal "Message" (dead code).

## 3. Solution implemented
Change the fallback in `apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx` to read the boolean the blob actually carries:
`lastMessage.content || (lastMessage.hasAttachment ? 'Sent an attachment' : 'Message')`

## 4. Documentation
N/A

## 5. DB Alter Details
N/A

## 6. Data fix Details
N/A

## 7. Environment variable Changes
N/A

## 8. Testing
Verified end-to-end in a live dev sandbox with a seeded attachment-only DM (`content=''`, `hasAttachment=true`, real `initial_message_md` blob). DM list preview changed from "Message" (before) to "Sent an attachment" (after). Before/after screenshots captured as proof of testing.

## 9. Services to which this change is to be deployed
dashboard (frontend)

## 10. Main PR link (if raised against a release branch)
N/A — this PR targets `main`.

---
Ticket: XYNE-62304