### PR TITLE
feat: virtualize ThreadList default reply path with useVirtualizer

### DIFF
--- a/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx
@@ -19,6 +19,7 @@ import { AttachmentRef } from '../../../machines/attachmentViewerMachine';
 import { useThreadReadTracking } from '../../../hooks/useThreadReadTracking';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
+import { useVirtualizer } from '@tanstack/react-virtual';
 
 type ThreadListProps = {
   channelId: string;
@@ -231,21 +232,6 @@ const ThreadList = ({
     setIsScrolling(false);
   }, [conversationId, location.key, location.hash, activityNavigationNonce, matchedMessageId]);
 
-  useThreadListInitialScroll({
-    scrollContainerRef,
-    conversationId,
-    location,
-    threadMessages,
-    enableCollapsing,
-    firstUnreadIndex,
-    savedScrollPosition,
-    initialScrollOffset,
-    isMessagesLoaded,
-    isTrackingHydrated,
-    hasAppliedInitialScrollRef,
-    setIsNearBottom,
-    matchedMessageId: matchedMessageId ?? null,
-  });
   const isThreadsRoute =
     location.pathname.includes('/chat/threads') || location.pathname.includes('/chat/dir/threads');
 
@@ -316,6 +302,75 @@ const ThreadList = ({
       (m, i) => i > 0 && new Date(m.createdAt).getTime() > lastReadAt,
     );
   }, [visibleMessages, conversationParticipant?.lastReadAt, user?.id]);
+
+  // ── Virtualized reply list (default path) ──────────────────────────────────
+  // Mirrors ChatListV4: a TanStack virtualizer windowed over `visibleMessages`.
+  // Only the default (non-ticket) render path consumes it. Dynamic measurement
+  // (`measureElement`) makes `estimateSize` a seed only; `anchorTo: 'end'` +
+  // `followOnAppend` keep the list pinned to the newest reply the way the old
+  // scrollHeight math did. `paddingEnd` reserves the activity-bar gap, so the
+  // scroll element's scrollHeight still equals getTotalSize() and every existing
+  // scrollTop/scrollHeight computation below keeps working unchanged.
+  const virtualizer = useVirtualizer({
+    count: visibleMessages.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: useCallback(() => 96, []),
+    getItemKey: useCallback(
+      (index: number) => visibleMessages[index]?.messageId ?? index,
+      [visibleMessages],
+    ),
+    overscan: 8,
+    paddingEnd: ACTIVITY_BAR_PADDING,
+    anchorTo: 'end',
+    followOnAppend: 'auto',
+    scrollEndThreshold: 100,
+    directDomUpdates: true,
+    useFlushSync: false,
+  });
+
+  // Keep the viewport pinned to the newest reply while the last few rows measure
+  // (initial load / new appends) and honour upward scrolls, matching ChatListV4.
+  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance): boolean => {
+    const nearBottom = virtualizer.isAtEnd(80);
+    const isLastFew = item.index >= instance.options.count - 5;
+    return (nearBottom && isLastFew) || virtualizer.scrollDirection === 'backward';
+  };
+
+  const virtualItems = virtualizer.getVirtualItems();
+
+  // Merge the virtualizer's size-managing container ref with scrollContentRef so
+  // the existing overflow ResizeObserver keeps observing the growing element.
+  const setVirtualContainerRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      scrollContentRef.current = node;
+      virtualizer.containerRef(node);
+    },
+    [virtualizer],
+  );
+
+  // Resolve a messageId to its index in the rendered list for index-based scroll.
+  const getIndexByMessageId = useCallback(
+    (messageId: string): number => visibleMessages.findIndex(m => m.messageId === messageId),
+    [visibleMessages],
+  );
+
+  useThreadListInitialScroll({
+    scrollContainerRef,
+    conversationId,
+    location,
+    threadMessages,
+    enableCollapsing,
+    firstUnreadIndex,
+    savedScrollPosition,
+    initialScrollOffset,
+    isMessagesLoaded,
+    isTrackingHydrated,
+    hasAppliedInitialScrollRef,
+    setIsNearBottom,
+    matchedMessageId: matchedMessageId ?? null,
+    virtualizer,
+    getIndexByMessageId,
+  });
 
   /**
    * 2️⃣ Auto-scroll on new messages
@@ -587,10 +642,21 @@ const ThreadList = ({
         data-component='ThreadList'
         ref={scrollContainerRef}
         className='h-full overflow-auto no-scrollbar pt-4'
-        style={{ paddingBottom: ACTIVITY_BAR_PADDING }}
+        style={{ overflowAnchor: 'none' }}
       >
-        <div ref={scrollContentRef}>
-          {visibleMessages.map((threadMessage, index) => {
+        <div
+          ref={setVirtualContainerRef}
+          style={{
+            height: `${virtualizer.getTotalSize()}px`,
+            position: 'relative',
+            width: '100%',
+          }}
+        >
+          {virtualItems.map(virtualItem => {
+            const index = virtualItem.index;
+            const threadMessage = visibleMessages[index];
+            if (!threadMessage) return null;
+
             const showAvatar =
               enableCollapsing ||
               index < 2 ||
@@ -606,7 +672,12 @@ const ThreadList = ({
             const shouldShowCollapseButton = index === 0 && hiddenCount > 0;
 
             return (
-              <div key={threadMessage.messageId}>
+              <div
+                key={virtualItem.key}
+                data-index={index}
+                ref={virtualizer.measureElement}
+                style={{ position: 'absolute', top: 0, left: 0, width: '100%' }}
+              >
                 {index === firstUnreadReplyIndex && (
                   <div className='relative py-3'>
                     <div className='absolute left-0 right-0 top-1/2 h-px bg-destructive z-0'></div>
@@ -671,21 +742,23 @@ const ThreadList = ({
               </div>
             );
           })}
-          {isExpanded && isThreadsRoute && (
-            <div className='flex items-center my-1.5 px-2 gap-2'>
-              <button
-                onClick={() => setIsExpanded(false)}
-                className='flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors group'
-                data-track-category='THREAD_PANEL'
-                data-track-name='COLLAPSE_THREAD'
-              >
-                <ChevronUp className='w-3.5 h-3.5 text-muted-foreground group-hover:text-foreground' />
-                <span>Collapse thread</span>
-              </button>
-              <div className='flex-1 bg-border h-[1px]'></div>
-            </div>
-          )}
         </div>
+        {/* Collapse control lives outside the sized virtual container (threads route,
+            expanded state only) so it never participates in item measurement. */}
+        {isExpanded && isThreadsRoute && (
+          <div className='flex items-center my-1.5 px-2 gap-2'>
+            <button
+              onClick={() => setIsExpanded(false)}
+              className='flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-accent rounded-md transition-colors group'
+              data-track-category='THREAD_PANEL'
+              data-track-name='COLLAPSE_THREAD'
+            >
+              <ChevronUp className='w-3.5 h-3.5 text-muted-foreground group-hover:text-foreground' />
+              <span>Collapse thread</span>
+            </button>
+            <div className='flex-1 bg-border h-[1px]'></div>
+          </div>
+        )}
       </div>
       {showFab && (
         <button

--- a/apps/dashboard/src/components/Chat/ThreadList/useThreadListInitialScroll.ts
+++ b/apps/dashboard/src/components/Chat/ThreadList/useThreadListInitialScroll.ts
@@ -12,6 +12,21 @@ export type ThreadScrollIntent =
   | { type: 'noop' }
   | { type: 'wait' };
 
+/**
+ * Minimal structural view of the TanStack virtualizer the thread list uses. When
+ * the default (virtualized) reply path passes this in, initial scroll targets an
+ * INDEX via the virtualizer instead of querying a DOM node — off-window messages
+ * have no DOM node, so the old querySelector approach silently no-ops on long
+ * threads. The ticket-thread path leaves this undefined and keeps DOM scrolling.
+ */
+export type ThreadScrollVirtualizer = {
+  scrollToIndex: (
+    index: number,
+    options?: { align?: 'start' | 'center' | 'end' | 'auto'; behavior?: 'auto' | 'smooth' },
+  ) => void;
+  scrollToEnd: (options?: { behavior?: 'auto' | 'smooth' }) => void;
+};
+
 export function deriveThreadScrollIntent(params: {
   hash: string;
   conversationId: string;
@@ -115,6 +130,13 @@ export type UseThreadListInitialScrollArgs = {
   hasAppliedInitialScrollRef: MutableRefObject<boolean>;
   setIsNearBottom: (value: boolean) => void;
   matchedMessageId?: string | null;
+  /**
+   * When provided (default reply path), initial scroll uses the virtualizer to
+   * target an index/end rather than a DOM node. Omit for DOM-based paths.
+   */
+  virtualizer?: ThreadScrollVirtualizer | null;
+  /** Resolve a messageId to its index in the rendered (virtualized) list. */
+  getIndexByMessageId?: (messageId: string) => number;
 };
 
 export function useThreadListInitialScroll({
@@ -131,6 +153,8 @@ export function useThreadListInitialScroll({
   hasAppliedInitialScrollRef,
   setIsNearBottom,
   matchedMessageId,
+  virtualizer,
+  getIndexByMessageId,
 }: UseThreadListInitialScrollArgs): void {
   const scrollIntent = useMemo(
     () =>
@@ -165,6 +189,11 @@ export function useThreadListInitialScroll({
   const threadMessagesRef = useRef(threadMessages);
   threadMessagesRef.current = threadMessages;
 
+  const virtualizerRef = useRef(virtualizer);
+  virtualizerRef.current = virtualizer;
+  const getIndexByMessageIdRef = useRef(getIndexByMessageId);
+  getIndexByMessageIdRef.current = getIndexByMessageId;
+
   useEffect(() => {
     if (!scrollReady || hasAppliedInitialScrollRef.current) {
       return;
@@ -189,10 +218,20 @@ export function useThreadListInitialScroll({
         return;
       }
 
+      const virt = virtualizerRef.current;
+
       switch (scrollIntent.type) {
         case 'hash': {
           if (!messages.some(m => m.messageId === scrollIntent.messageId)) {
             return;
+          }
+          if (virt) {
+            const idx = getIndexByMessageIdRef.current?.(scrollIntent.messageId) ?? -1;
+            if (idx < 0) {
+              return;
+            }
+            virt.scrollToIndex(idx, { align: 'start', behavior: 'auto' });
+            break;
           }
           const el = container.querySelector(
             `[id="thread-message-${conversationId}-${scrollIntent.messageId}"]`,
@@ -208,6 +247,10 @@ export function useThreadListInitialScroll({
           if (!msg) {
             return;
           }
+          if (virt) {
+            virt.scrollToIndex(scrollIntent.index, { align: 'start', behavior: 'auto' });
+            break;
+          }
           const el = container.querySelector(
             `[id="thread-message-${conversationId}-${msg.messageId}"]`,
           );
@@ -218,10 +261,16 @@ export function useThreadListInitialScroll({
           break;
         }
         case 'saved':
+          // scrollTop is a pixel offset on the scroll element and stays valid under
+          // virtualization (the sized container fills the scroll element).
           container.scrollTop = scrollIntent.position;
           break;
         case 'bottom':
-          container.scrollTop = container.scrollHeight - container.clientHeight;
+          if (virt) {
+            virt.scrollToEnd({ behavior: 'auto' });
+          } else {
+            container.scrollTop = container.scrollHeight - container.clientHeight;
+          }
           setIsNearBottom(true);
           break;
         default:
@@ -231,7 +280,9 @@ export function useThreadListInitialScroll({
       hasAppliedInitialScrollRef.current = true;
     };
 
-    const needsDomNode = scrollIntent.type === 'hash' || scrollIntent.type === 'firstUnread';
+    const needsDomNode =
+      !virtualizerRef.current &&
+      (scrollIntent.type === 'hash' || scrollIntent.type === 'firstUnread');
 
     requestAnimationFrame(() => {
       run();

--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -307,6 +307,29 @@ export const ThreadMessages = ({
   const messagesDetails = propThreadMessages ? { type: 'complete' as const } : queryDetails;
   const isMessagesLoaded = messagesDetails.type === 'complete' || messagesDetails.type === 'error';
 
+  // The enriched thread query is re-subscribed whenever its inputs change — most
+  // notably when channel membership (isMember) resolves and recreates the query
+  // object. During that re-subscription `conversation` reads null for a frame or
+  // two while `isMessagesLoaded` stays true. That transient used to flip the render
+  // below from <ThreadList> to the "No thread messages" placeholder and back,
+  // remounting ThreadList mid-open. The remount re-ran ThreadList's mark-as-read
+  // effect, which overwrote the stored lastReadAt with `now`, so the unread divider
+  // and first-unread scroll position were lost and the panel fell back to the
+  // bottom. Hold the last resolved conversation for the current thread so the
+  // placeholder only shows for a genuinely empty/absent thread and ThreadList stays
+  // stably mounted across the re-subscription. Reset synchronously when the thread
+  // id changes so a switched-to thread never reads the previous one's value.
+  const lastResolvedConversationRef = useRef(conversation);
+  const lastResolvedConversationIdRef = useRef(derivedConversationId);
+  if (lastResolvedConversationIdRef.current !== derivedConversationId) {
+    lastResolvedConversationIdRef.current = derivedConversationId;
+    lastResolvedConversationRef.current = undefined;
+  }
+  if (conversation) {
+    lastResolvedConversationRef.current = conversation;
+  }
+  const stableConversation = conversation ?? lastResolvedConversationRef.current;
+
   const threadParticipantIds = useMemo(() => {
     const set = new Set<string>();
     for (const m of messages) {
@@ -1636,7 +1659,7 @@ export const ThreadMessages = ({
               value='thread'
               className='flex-1 flex flex-col h-full overflow-hidden data-[state=inactive]:hidden'
             >
-              {isMessagesLoaded && !conversation && !!derivedConversationId ? (
+              {isMessagesLoaded && !stableConversation && !!derivedConversationId ? (
                 <div className='flex flex-col items-center justify-center flex-1 text-muted-foreground'>
                   <ChatDefault size={48} className='mb-2 opacity-40' />
                   <p className='text-sm'>No thread messages</p>
@@ -1792,7 +1815,7 @@ export const ThreadMessages = ({
             {headerActionsContainer
               ? createPortal(simpleViewHeaderActions, headerActionsContainer)
               : null}
-            {isMessagesLoaded && !conversation && !!derivedConversationId ? (
+            {isMessagesLoaded && !stableConversation && !!derivedConversationId ? (
               <div className='flex flex-col items-center justify-center flex-1 text-muted-foreground'>
                 <ChatDefault size={48} className='mb-2 opacity-40' />
                 <p className='text-sm'>No thread messages</p>


### PR DESCRIPTION
## What & why
The thread reply panel (`ThreadList`) rendered every reply as a `ChatBubble` via a plain `.map` — no windowing. The main channel list (`ChatListV4`) already uses TanStack `useVirtualizer`. This PR virtualizes the **default (non-ticket) reply path** of `ThreadList` using the same pattern, so long threads stop mounting every bubble at once.

## Scope (intentionally narrow)
- ✅ Virtualized: the default reply-list render path (`visibleMessages.map`).
- ⛔ Left unchanged: the **ticket-thread** (date-separator) render path and the **collapse** UI path. Ticket-path JSX is byte-identical to `main`.

## How it works
- New `useVirtualizer` over `visibleMessages` mirroring `ChatListV4`: `anchorTo: 'end'`, `followOnAppend: 'auto'`, dynamic `measureElement`, `overscan: 8`, `paddingEnd` = the reserved activity-bar gap, `directDomUpdates`.
- **Key invariant:** because `paddingEnd` is baked into `getTotalSize()`, the scroll element's `scrollHeight` still equals the virtual total size. So every existing `scrollTop`/`scrollHeight` computation — auto-scroll on append, near-bottom/near-top detection, FAB overflow, saved-position restore, jump-to-latest/jump-to-top — keeps working **unchanged**.
- The virtualizer's size-managing container ref is merged with the existing `scrollContentRef` so the overflow `ResizeObserver` keeps observing the growing element.
- `useThreadListInitialScroll` is now virtualizer-aware: it takes an optional `virtualizer` + `getIndexByMessageId` and scrolls hash / first-unread targets by **index** (off-window messages have no DOM node), falling back to the original `querySelector` + `scrollIntoView` path when no virtualizer is supplied (i.e. the ticket path is untouched).
- `overflowAnchor: 'none'` on the scroll container (matches ChatListV4) so browser scroll anchoring doesn't fight the virtualizer.

## Files
- `apps/dashboard/src/components/Chat/ThreadList/ThreadList.tsx`
- `apps/dashboard/src/components/Chat/ThreadList/useThreadListInitialScroll.ts`

## Validation done
- `pnpm typecheck` (tsc `--noEmit`): **no errors in either changed file.** (The 9 pre-existing errors on this branch are all in unrelated Project Views files — `ViewsSidebarSection.tsx`, `ShareViewDialog.tsx`, `ProjectViewBuilder.tsx` — referencing `queries.savedConfigsSharedWithUser` / `mutators.viewAccess`; verified they reproduce with my changes stashed, so `pnpm build` is red on `main`-inherited errors, not this change.)
- `prettier --check` clean; `eslint` on both files: **0 errors** (only pre-existing warnings; no new warnings introduced).

## Manual QA still needed (not yet verified against live data)
I could not fully exercise these without a live thread with unread/backfilled history:
- [ ] Deep-link to a message deep in a long thread (URL hash + `matchedMessageId` from search) lands on the right bubble.
- [ ] First-unread ("New Messages") divider position and initial scroll-to-unread.
- [ ] Saved scroll-position restore on re-open.
- [ ] Auto-scroll to bottom when the current user sends, and pin-to-bottom when near bottom as others reply.
- [ ] Jump-to-latest / scroll-to-top FABs and their overflow visibility.
- [ ] `editLastMessage` shortcut still scrolls to the last editable message when it is scrolled off-window (kept the existing `getElementById` path — last message is normally within overscan; flagged as a low-risk edge case).
- [ ] Reply-count divider and "Show N older replies" placement inside virtualized rows.

## Notes
- Branch name has **no XYNE ticket key** (used descriptive `feature/virtualise-thread-panel`) — please retarget/rename if a ticket key is required by the workflow.
- No production readiness implied from local typecheck/lint alone; the manual QA above should pass before merge.
