### PR TITLE
fix: XYNE-60866 revert native-button conversions to raw <button>

### DIFF
--- a/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIChatThread.tsx
@@ -69,7 +69,7 @@ import {
   resolveCitationIconUrl,
 } from '../Chat/XyneAISidebar/utils/clawCitationUrl';
 import { CitationLink } from '../Chat/XyneAISidebar/components/CitationLink';
-import { Button } from '../ui/Button/Button';
+
 import { useCitationDocs, panelDocFromCitation } from './citationDocs';
 import { MessageReactArtifacts, toArtifactRef } from './ReactArtifact';
 import { ArtifactRestoreNotice } from './ReactArtifact/ArtifactRestoreNotice';
@@ -1147,9 +1147,8 @@ function ChatMessageBubble({
                     >
                       Cancel
                     </button>
-                    <Button
-                      variant='ghost'
-                      trackId='ai_chat_edit_submit'
+                    <button
+                      data-ph-capture-attribute-track-id='ai_chat_edit_submit'
                       type='button'
                       onClick={() => {
                         if (editText.trim()) {
@@ -1163,7 +1162,7 @@ function ChatMessageBubble({
                       data-track-name='EDIT_SUBMIT'
                     >
                       Send
-                    </Button>
+                    </button>
                   </div>
                 </div>
               ) : (
@@ -1360,9 +1359,8 @@ function ChatMessageBubble({
               {/* Regenerate — re-runs the last user query as a new bot sibling.
                   Only wired on the latest bot message. */}
               {onRegenerate && (
-                <Button
-                  variant='ghost'
-                  trackId='ai_chat_regenerate'
+                <button
+                  data-ph-capture-attribute-track-id='ai_chat_regenerate'
                   type='button'
                   onClick={onRegenerate}
                   title='Regenerate response'
@@ -1371,7 +1369,7 @@ function ChatMessageBubble({
                   data-track-name='REGENERATE_MESSAGE'
                 >
                   <RefreshCw className='h-3.5 w-3.5' aria-hidden strokeWidth={1.75} />
-                </Button>
+                </button>
               )}
               {/* Branch switcher for bot-response versions (created via regenerate). */}
               {branchInfo && onBranchNavigate && (

--- a/apps/dashboard/src/components/AIScreen/AIComposer.tsx
+++ b/apps/dashboard/src/components/AIScreen/AIComposer.tsx
@@ -36,7 +36,7 @@ import { ModelThinkingSelector, formatModelLabel } from './ModelThinkingSelector
 import { fetchClawAgentModels } from '../../services/clawAgentModelsService';
 import { ComposerCollectionPicker } from './ComposerCollectionPicker';
 import { ComposerVoiceButton } from './ComposerVoiceButton';
-import { Button } from '../ui/Button/Button';
+
 import { cn } from '../../utils/classNames';
 import { apiInstance } from '../../services/clients/apiClient';
 import {
@@ -970,9 +970,8 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
                   <Square className='h-2.5 w-2.5 fill-current' aria-hidden strokeWidth={0} />
                 </button>
               ) : (
-                <Button
-                  variant='ghost'
-                  trackId='ai_composer_send'
+                <button
+                  data-ph-capture-attribute-track-id='ai_composer_send'
                   type='submit'
                   disabled={!canSend}
                   aria-label='Send'
@@ -984,7 +983,7 @@ export const AIComposer = forwardRef<AIComposerHandle, AIComposerProps>(function
                   )}
                 >
                   <ArrowUp className='h-4 w-4' aria-hidden strokeWidth={2.25} />
-                </Button>
+                </button>
               )}
             </div>
           </div>

--- a/apps/dashboard/src/components/AIScreen/AskAiRatingButtons.tsx
+++ b/apps/dashboard/src/components/AIScreen/AskAiRatingButtons.tsx
@@ -1,7 +1,7 @@
 import { logger, Event as LogEvent } from '../../utils/logger';
 import { useEffect, useState, type ReactElement } from 'react';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
-import { Button } from '../ui/Button/Button';
+
 import { cn } from '../../utils/classNames';
 import { rateV2Message } from '../../services/XyneAI/XyneAISessionsV2Service';
 
@@ -82,9 +82,8 @@ export function AskAiRatingButtons({
 
   return (
     <span className={cn('inline-flex items-center gap-0.5', className)}>
-      <Button
-        variant='ghost'
-        trackId='ask_ai_rate_up'
+      <button
+        data-ph-capture-attribute-track-id='ask_ai_rate_up'
         type='button'
         onClick={(): void => {
           setShowComment(false);
@@ -106,10 +105,9 @@ export function AskAiRatingButtons({
           fill={isUp ? 'currentColor' : 'none'}
           fillOpacity={isUp ? 0.3 : 1}
         />
-      </Button>
-      <Button
-        variant='ghost'
-        trackId='ask_ai_rate_down'
+      </button>
+      <button
+        data-ph-capture-attribute-track-id='ask_ai_rate_down'
         type='button'
         onClick={(): void => {
           setShowComment(true);
@@ -131,7 +129,7 @@ export function AskAiRatingButtons({
           fill={isDown ? 'currentColor' : 'none'}
           fillOpacity={isDown ? 0.3 : 1}
         />
-      </Button>
+      </button>
       {showComment && isDown && (
         <span className='ml-1 inline-flex items-center gap-1'>
           <input
@@ -151,10 +149,8 @@ export function AskAiRatingButtons({
               if (e.key === 'Escape') setShowComment(false);
             }}
           />
-          <Button
-            variant='ghost'
-            size='inline'
-            trackId='ask_ai_rate_comment_save'
+          <button
+            data-ph-capture-attribute-track-id='ask_ai_rate_comment_save'
             type='button'
             onClick={(): void => {
               void submit('down', commentText);
@@ -166,7 +162,7 @@ export function AskAiRatingButtons({
             className='rounded-md bg-secondary px-2 py-0.5 text-[11px] text-foreground transition-colors hover:bg-muted'
           >
             Save
-          </Button>
+          </button>
         </span>
       )}
     </span>

--- a/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifactView.tsx
+++ b/apps/dashboard/src/components/AIScreen/ReactArtifact/ReactArtifactView.tsx
@@ -21,7 +21,7 @@ import {
   Sparkles,
   X,
 } from 'lucide-react';
-import { Button } from '../../ui/Button/Button';
+
 import { SandpackProvider, SandpackLayout, SandpackPreview } from '@codesandbox/sandpack-react';
 import {
   loadArtifactPayload,
@@ -351,9 +351,8 @@ export const ReactArtifactView = ({
             <ArtifactSavedIndicator appId={savedAppId} {...(versionId ? { versionId } : {})} />
           )}
           {payload.dataRequirements?.some(r => r.source) && (
-            <Button
-              variant='ghost'
-              trackId='react_artifact_refresh_data'
+            <button
+              data-ph-capture-attribute-track-id='react_artifact_refresh_data'
               type='button'
               onClick={() => {
                 setRefreshingData(true);
@@ -370,12 +369,11 @@ export const ReactArtifactView = ({
                 className={`h-3.5 w-3.5 ${refreshingData ? 'animate-spin' : ''}`}
                 aria-hidden='true'
               />
-            </Button>
+            </button>
           )}
           {onSave && (
-            <Button
-              variant='ghost'
-              trackId='react_artifact_save'
+            <button
+              data-ph-capture-attribute-track-id='react_artifact_save'
               type='button'
               onClick={() => onSave(artifact)}
               disabled={saveState !== 'idle'}
@@ -392,7 +390,7 @@ export const ReactArtifactView = ({
               ) : (
                 <Save className='h-3.5 w-3.5' aria-hidden='true' />
               )}
-            </Button>
+            </button>
           )}
           {onExpand && (
             <button

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -60,7 +60,6 @@ import {
   NotificationBellOn,
 } from '@xyne/icons';
 import { Tooltip } from '../../ui/Tooltip/Tooltip';
-import { Button } from '../../ui/Button/Button';
 
 type ActivityTab =
   | 'all'
@@ -1002,10 +1001,9 @@ const ActivityListView = (): ReactElement => {
               {showMobileMenu && (
                 <div className='absolute right-0 top-full mt-1 bg-popover border border-border rounded-lg shadow-lg py-1 min-w-[200px] z-50'>
                   {/* Mark as Read */}
-                  <Button
-                    variant='ghost'
-                    trackId='mark_tab_as_read'
-                    trackProps={{ tab: activeTab }}
+                  <button
+                    data-ph-capture-attribute-track-id='mark_tab_as_read'
+                    data-ph-capture-attribute-tab={activeTab}
                     onClick={() => {
                       markActiveTabUnread();
                       setShowMobileMenu(false);
@@ -1021,7 +1019,7 @@ const ActivityListView = (): ReactElement => {
                   >
                     <MarkAsRead size={16} />
                     <span>Mark as read</span>
-                  </Button>
+                  </button>
 
                   {/* Divider */}
                   <div className='border-t border-border my-1'></div>

--- a/apps/dashboard/src/components/AppSidebar/UpdateStatusModal.tsx
+++ b/apps/dashboard/src/components/AppSidebar/UpdateStatusModal.tsx
@@ -463,17 +463,16 @@ export const UpdateStatusModal: React.FC<UpdateStatusModalProps> = ({
               />
 
               {isEditingMode && (
-                <Button
-                  variant='ghost'
+                <button
                   onClick={handleClearStatus}
-                  trackId='clear_user_status'
+                  data-ph-capture-attribute-track-id='clear_user_status'
                   className='h-auto p-0 flex-shrink-0 flex items-center gap-1 text-muted-foreground hover:text-muted-foreground hover:bg-transparent'
                   data-track-category='Update_User_Status_Modal'
                   data-track-name='Clear_Status_In_Modal'
                 >
                   <span className='text-xs opacity-60'>(Clear status)</span>
                   <X className='size-4' />
-                </Button>
+                </button>
               )}
             </div>
 

--- a/apps/dashboard/src/components/AppSidebar/WorkspaceInviteDialog.tsx
+++ b/apps/dashboard/src/components/AppSidebar/WorkspaceInviteDialog.tsx
@@ -4,7 +4,7 @@ import { CheckTickSingle, CopyDefault } from '@xyne/icons';
 import { WorkspaceRole } from '@xyne/shared';
 import { toast } from 'sonner';
 import Dialog from '../ui/Dialog';
-import { Button } from '../ui/Button/Button';
+
 import { apiInstance } from '../../services/clients/apiClient';
 import { cn } from '../../utils/classNames';
 
@@ -206,17 +206,16 @@ export const WorkspaceInviteDialog = ({
               data-track-category='WorkspaceInviteDialog'
               data-track-name='EmailsInput'
             />
-            <Button
+            <button
               type='submit'
-              variant='ghost'
-              trackId='invite_workspace_member'
+              data-ph-capture-attribute-track-id='invite_workspace_member'
               disabled={isInviting || !emailsInput.trim()}
               className='h-10 shrink-0 rounded-[12px] bg-[#ff6368] px-6 text-[15px] font-semibold text-white transition-colors hover:bg-[#f2555b] disabled:cursor-not-allowed disabled:opacity-70'
               data-track-category='WorkspaceInviteDialog'
               data-track-name='InviteByEmail'
             >
               {isInviting ? 'Inviting...' : 'Invite'}
-            </Button>
+            </button>
           </div>
         </div>
 

--- a/apps/dashboard/src/components/AppSidebar/WorkspaceSwitcher.tsx
+++ b/apps/dashboard/src/components/AppSidebar/WorkspaceSwitcher.tsx
@@ -14,7 +14,6 @@ import {
 import { queryClient } from '../../services/clients/queryClient';
 import { useCanCreateWorkspace } from '../../hooks/usePermissions';
 import { confirmRecordingInterrupt } from '../Recording/RecordingInterruptGuard/RecordingInterruptGuard';
-import { Button } from '../ui/Button/Button';
 
 type CreateWorkspaceType = (typeof WorkspaceType)[keyof typeof WorkspaceType];
 
@@ -339,11 +338,10 @@ export const WorkspaceSwitcher: React.FC = () => {
                 const isSwitching = switching === ws.id;
                 const count = activityCounts.get(ws.id) || 0;
                 return (
-                  <Button
+                  <button
                     key={ws.id}
-                    variant='ghost'
                     onClick={() => void handleSwitch(ws.id)}
-                    trackId='switch_workspace'
+                    data-ph-capture-attribute-track-id='switch_workspace'
                     disabled={isSwitching}
                     data-track-category='Workspace_Switcher'
                     data-track-name='Switch_Workspace'
@@ -372,7 +370,7 @@ export const WorkspaceSwitcher: React.FC = () => {
                         <Check size={14} className='text-green-500' />
                       ) : null}
                     </div>
-                  </Button>
+                  </button>
                 );
               })
             )}
@@ -421,11 +419,10 @@ export const WorkspaceSwitcher: React.FC = () => {
                       const isSwitching = switching === ws.id;
                       const count = activityCounts.get(ws.id) || 0;
                       return (
-                        <Button
+                        <button
                           key={ws.id}
-                          variant='ghost'
                           onClick={() => void handleSwitch(ws.id)}
-                          trackId='switch_workspace_signin'
+                          data-ph-capture-attribute-track-id='switch_workspace_signin'
                           disabled={isSwitching}
                           data-track-category='Workspace_Switcher'
                           data-track-name='Switch_Workspace_SignIn'
@@ -455,7 +452,7 @@ export const WorkspaceSwitcher: React.FC = () => {
                               <Check size={12} className='text-green-500' />
                             ) : null}
                           </div>
-                        </Button>
+                        </button>
                       );
                     })
                   )}
@@ -483,17 +480,16 @@ export const WorkspaceSwitcher: React.FC = () => {
                     autoFocus
                   />
                   <div className='flex gap-2'>
-                    <Button
+                    <button
                       type='submit'
-                      variant='ghost'
-                      trackId='create_workspace'
+                      data-ph-capture-attribute-track-id='create_workspace'
                       disabled={creating || !workspaceName.trim()}
                       data-track-category='Workspace_Switcher'
                       data-track-name='Create_Workspace'
                       className='h-auto flex-1 py-1.5 text-xs font-medium bg-primary text-primary-foreground rounded-md disabled:opacity-50 hover:bg-primary hover:opacity-90'
                     >
                       {creating ? 'Creating…' : 'Create'}
-                    </Button>
+                    </button>
                     <button
                       type='button'
                       onClick={() => {

--- a/apps/dashboard/src/components/Apps/ShortcutPickerModal/ShortcutPickerModal.tsx
+++ b/apps/dashboard/src/components/Apps/ShortcutPickerModal/ShortcutPickerModal.tsx
@@ -154,11 +154,10 @@ export const ShortcutPickerModal: React.FC<ShortcutPickerModalProps> = ({
                   {appName}
                 </p>
                 {appShortcuts.map(shortcut => (
-                  <Button
+                  <button
                     key={shortcut.commandName}
-                    variant='ghost'
                     type='button'
-                    trackId='run_shortcut'
+                    data-ph-capture-attribute-track-id='run_shortcut'
                     disabled={dispatching === shortcut.commandName}
                     onClick={() => void handleSelect(shortcut)}
                     data-track-category='shortcut-picker'
@@ -181,7 +180,7 @@ export const ShortcutPickerModal: React.FC<ShortcutPickerModalProps> = ({
                     {dispatching === shortcut.commandName && (
                       <span className='text-xs text-muted-foreground self-center'>Running…</span>
                     )}
-                  </Button>
+                  </button>
                 ))}
               </div>
             ))

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/RunAgentStepForm.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/RunAgentStepForm.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Sparkles, X } from 'lucide-react';
-import { Button } from '../../../ui/Button/Button';
+
 import { Combobox } from '../../../ui/Combobox/Combobox';
 import { AutomationRichTextField } from '../SchemaForm/AutomationRichTextField';
 import { SchemaJsonEditor, type SchemaTree } from '../SchemaForm/SchemaJsonEditor';
@@ -141,10 +141,9 @@ export function RunAgentStepForm({
         ) : agentsError ? (
           <div className='flex items-center gap-2 text-xs text-red-600'>
             <span>Couldn&apos;t reach claw — agents unavailable.</span>
-            <Button
+            <button
               type='button'
-              variant='ghost'
-              trackId='run_agent_step_agents_retry'
+              data-ph-capture-attribute-track-id='run_agent_step_agents_retry'
               data-track-category='automation-builder'
               data-track-name='run-agent-step-agents-retry'
               onClick={() => {
@@ -153,7 +152,7 @@ export function RunAgentStepForm({
               className='underline hover:no-underline'
             >
               Retry
-            </Button>
+            </button>
           </div>
         ) : (
           <Combobox

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/TemplateAttachmentsField.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/StepCard/TemplateAttachmentsField.tsx
@@ -17,7 +17,7 @@ import remarkGfm from 'remark-gfm';
 import { toast } from 'sonner';
 import { Dialog } from '../../../ui/Dialog/Dialog';
 import { Popover } from '../../../ui/Popover/Popover';
-import { Button } from '../../../ui/Button/Button';
+
 import { cn } from '../../../../utils/classNames';
 import {
   fetchAutomationTemplateContent,
@@ -474,19 +474,18 @@ export function TemplateAttachmentsField({
             >
               Cancel
             </button>
-            <Button
-              variant='ghost'
+            <button
               type='button'
               data-track-category='automation-builder'
               data-track-name='template-editor-apply'
-              trackId='automation_template_save'
+              data-ph-capture-attribute-track-id='automation_template_save'
               disabled={editorLoading || editorSaving}
               onClick={() => void saveEditor()}
               className='flex h-9 items-center gap-2 rounded-md bg-foreground px-3 text-sm text-background hover:opacity-90 disabled:opacity-50'
             >
               {editorSaving ? <Loader2 className='size-3.5 animate-spin' /> : null}
               {editorSession?.kind === 'new' ? 'Create and attach' : 'Apply changes'}
-            </Button>
+            </button>
           </div>
         </div>
       </Dialog>

--- a/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
@@ -145,10 +145,9 @@ export function RunHistory({
         {isError ? (
           <div className='py-16 text-center text-sm text-red-600'>
             Failed to load runs.
-            <Button
-              variant='ghost'
+            <button
               type='button'
-              trackId='automation_run_history_retry'
+              data-ph-capture-attribute-track-id='automation_run_history_retry'
               data-track-category='automation-runs'
               data-track-name='run-history-retry'
               onClick={() => {
@@ -157,7 +156,7 @@ export function RunHistory({
               className='ml-2 underline hover:no-underline'
             >
               Retry
-            </Button>
+            </button>
           </div>
         ) : isLoading ? (
           <div className='flex flex-col'>

--- a/apps/dashboard/src/components/Automation/AutomationVersions/VersionHistory/VersionHistory.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationVersions/VersionHistory/VersionHistory.tsx
@@ -79,10 +79,9 @@ export function VersionHistory({
         {isError ? (
           <div className='py-16 text-center text-sm text-red-600'>
             Failed to load version history.
-            <Button
-              variant='ghost'
+            <button
               type='button'
-              trackId='automation_version_history_retry'
+              data-ph-capture-attribute-track-id='automation_version_history_retry'
               data-track-category='automation-versions'
               data-track-name='version-history-retry'
               onClick={() => {
@@ -91,7 +90,7 @@ export function VersionHistory({
               className='ml-2 underline hover:no-underline'
             >
               Retry
-            </Button>
+            </button>
           </div>
         ) : isLoading ? (
           <div className='flex flex-col'>

--- a/apps/dashboard/src/components/BrowserPanel/BrowserSettingsMenu.tsx
+++ b/apps/dashboard/src/components/BrowserPanel/BrowserSettingsMenu.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Settings, Shield } from 'lucide-react';
 import Popover from '../ui/Popover';
-import { Button } from '../ui/Button/Button';
+
 import { Switch } from '../ui/Switch';
 import { useSelector } from '@xstate/react';
 import { browserPanelActor } from '../../machines/browserPanelMachine';
@@ -69,18 +69,17 @@ export const BrowserSettingsMenu: React.FC<BrowserSettingsMenuProps> = ({ isOpen
 
         <div className='h-px bg-border my-1' />
 
-        <Button
-          variant='ghost'
+        <button
           onClick={() => {
             void handleClearSiteData();
           }}
-          trackId='clear_site_data'
+          data-ph-capture-attribute-track-id='clear_site_data'
           className='h-auto w-full justify-start text-left text-sm text-red-500 hover:bg-red-500/10 hover:text-red-500 px-2 py-1.5 rounded-md transition-colors font-medium border border-transparent hover:border-red-500/20'
           data-track-category='browser_settings'
           data-track-name='clear_site_data'
         >
           Clear Site Data
-        </Button>
+        </button>
       </div>
     </Popover>
   );

--- a/apps/dashboard/src/components/Call/CallChatPanel/CallChatPanel.tsx
+++ b/apps/dashboard/src/components/Call/CallChatPanel/CallChatPanel.tsx
@@ -4,7 +4,7 @@ import { X, Send, User } from 'lucide-react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '../../../utils/classNames';
-import { Button } from '../../ui/Button/Button';
+
 import { useCallChat } from '../hooks/useCallChat';
 import type { ChatMessage } from '../hooks/useCallChat';
 
@@ -241,11 +241,10 @@ export function CallChatPanel({
               target.style.height = `${Math.min(target.scrollHeight, 128)}px`;
             }}
           />
-          <Button
-            variant='ghost'
+          <button
             onClick={() => void handleSend()}
             disabled={!input.trim() || isSending}
-            trackId='send_call_chat_message'
+            data-ph-capture-attribute-track-id='send_call_chat_message'
             data-track-category='CALLS'
             data-track-name='SEND_CALL_CHAT_MESSAGE'
             className={cn(
@@ -256,7 +255,7 @@ export function CallChatPanel({
             )}
           >
             <Send size={16} />
-          </Button>
+          </button>
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
+++ b/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
@@ -53,7 +53,7 @@ import {
 } from '../../ui/dropdown-menu';
 import Tooltip from '../../ui/Tooltip';
 import { ShortcutHint } from '../../ui/ShortcutHint';
-import { Button } from '../../ui/Button/Button';
+
 import { XyneTelepresenceIcon } from '../../../assets/icons/XyneTelepresenceIcon';
 
 interface ActiveCallForControls {
@@ -926,22 +926,21 @@ export function CallControls({
                 )}
               >
                 {REACTION_EMOJIS.map(emoji => (
-                  <Button
+                  <button
                     key={emoji}
-                    variant='ghost'
                     onClick={() => {
                       onSendReaction(emoji);
                       setShowReactionPicker(false);
                     }}
                     className='text-2xl p-2 rounded-xl hover:bg-[#202224] transition-colors duration-150 hover:scale-125 transform'
                     title={emoji}
-                    trackId='send_reaction'
+                    data-ph-capture-attribute-track-id='send_reaction'
                     data-track-category='CALLS'
                     data-track-name='SEND_REACTION'
                     data-track-metadata={JSON.stringify({ emoji, callId })}
                   >
                     {emoji}
-                  </Button>
+                  </button>
                 ))}
               </div>
             )}
@@ -1129,14 +1128,13 @@ export function CallControls({
         )}
 
         {/* Disconnect Button */}
-        <Button
-          variant='ghost'
+        <button
           onClick={onDisconnect}
           className={cn(buttonClasses, 'bg-red-600 hover:bg-red-700 text-white shadow-red-900/40')}
           style={hasCustomSizing ? { padding: `${buttonPadding}px` } : undefined}
           title='Leave call'
           data-testid='end-call-button'
-          trackId='end_call'
+          data-ph-capture-attribute-track-id='end_call'
           data-track-category='CALLS'
           data-track-name='END_CALL'
           data-track-metadata={JSON.stringify({ callId })}
@@ -1147,7 +1145,7 @@ export function CallControls({
               hasCustomSizing ? { width: `${iconSize}px`, height: `${iconSize}px` } : undefined
             }
           />
-        </Button>
+        </button>
       </div>
     </>
   );

--- a/apps/dashboard/src/components/Call/CallModals/ControlRequestDialog.tsx
+++ b/apps/dashboard/src/components/Call/CallModals/ControlRequestDialog.tsx
@@ -1,6 +1,5 @@
 import { Bot, Check, XCircle } from 'lucide-react';
 import { Dialog } from '../../ui/Dialog/Dialog';
-import { Button } from '../../ui/Button/Button';
 
 interface ControlRequestDialogProps {
   isOpen: boolean;
@@ -38,23 +37,21 @@ export function ControlRequestDialog({
         </p>
 
         <div className='flex gap-3'>
-          <Button
-            variant='ghost'
+          <button
             onClick={onApprove}
             className='flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl bg-green-600 hover:bg-green-700 text-white font-medium transition-all duration-200 shadow-lg hover:shadow-xl'
-            trackId='approve_control_request'
+            data-ph-capture-attribute-track-id='approve_control_request'
             data-track-category='CALLS'
             data-track-name='APPROVE_CONTROL_REQUEST'
             data-track-metadata={JSON.stringify({ requesterName })}
           >
             <Check className='w-5 h-5' />
             Approve
-          </Button>
-          <Button
-            variant='ghost'
+          </button>
+          <button
             onClick={onDeny}
             className='flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl bg-gray-600 hover:bg-gray-700 dark:bg-gray-700 dark:hover:bg-gray-600 text-white font-medium transition-all duration-200 shadow-lg hover:shadow-xl'
-            trackId='deny_control_request'
+            data-ph-capture-attribute-track-id='deny_control_request'
             data-track-event='BUTTON_CLICK'
             data-track-category='CALLS'
             data-track-name='DENY_CONTROL_REQUEST'
@@ -62,7 +59,7 @@ export function ControlRequestDialog({
           >
             <XCircle className='w-5 h-5' />
             Deny
-          </Button>
+          </button>
         </div>
       </div>
     </Dialog>

--- a/apps/dashboard/src/components/Call/CallTriggerModal/CallCard.tsx
+++ b/apps/dashboard/src/components/Call/CallTriggerModal/CallCard.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, Fragment } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Users } from 'lucide-react';
 import { cn } from '../../../utils/classNames';
-import { Button } from '../../ui/Button/Button';
+
 import AvatarGroup from '../../ui/Avatar/AvatarGroup';
 import { useUsers } from '../../../hooks/useUsers';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
@@ -229,12 +229,11 @@ export const CallCard: React.FC<CallCardProps> = ({
               {!isMobileLiveCall && callDuration && (
                 <div className='text-xs text-muted-foreground'>{callDuration}</div>
               )}
-              <Button
-                variant='ghost'
+              <button
                 className='p-0 h-auto hover:bg-transparent'
                 onClick={handleLeaveCall}
                 data-track-category='CALLS'
-                trackId='leave_call'
+                data-ph-capture-attribute-track-id='leave_call'
                 data-track-name='LeaveCall'
                 data-track-metadata={JSON.stringify({
                   callId: call.externalId,
@@ -249,7 +248,7 @@ export const CallCard: React.FC<CallCardProps> = ({
                 >
                   Leave
                 </span>
-              </Button>
+              </button>
             </>
           ) : (
             <CallJoinButton

--- a/apps/dashboard/src/components/Call/CallTriggerModal/CallTriggerModal.tsx
+++ b/apps/dashboard/src/components/Call/CallTriggerModal/CallTriggerModal.tsx
@@ -3,7 +3,7 @@ import type { SdlcCallLink } from '@xyne/shared';
 import { Headphones, ChevronDown } from '@xyne/icons';
 import { Popover } from '../../ui/Popover/Popover';
 import { Drawer } from '../../ui/Drawer/Drawer';
-import { Button } from '../../ui/Button/Button';
+
 import { cn } from '../../../utils/classNames';
 import { ChannelScopeType } from '@xyne/shared';
 import { CallTrigger } from '../CallTrigger/CallTrigger';
@@ -223,12 +223,11 @@ export const CallTriggerModal: React.FC<CallTriggerModalProps> = ({
           >
             Other Options
           </div>
-          <Button
-            variant='ghost'
+          <button
             className='flex items-center gap-3 w-full h-auto justify-start px-6 py-4 rounded-lg hover:bg-muted transition-colors'
             onClick={() => handleCallAction(handleInitiateCall)}
             data-track-category='CALLS'
-            trackId='start_call_now'
+            data-ph-capture-attribute-track-id='start_call_now'
             data-track-name='StartCallNow'
             data-track-metadata={JSON.stringify({ channelId, targetUserIds })}
           >
@@ -236,7 +235,7 @@ export const CallTriggerModal: React.FC<CallTriggerModalProps> = ({
               <Headphones className='w-5 h-5 text-foreground' />
             </div>
             <span className='text-sm font-semibold text-foreground'>Start call now</span>
-          </Button>
+          </button>
         </div>
       )}
     </div>

--- a/apps/dashboard/src/components/Call/CallWhiteboard/CallWhiteboard.tsx
+++ b/apps/dashboard/src/components/Call/CallWhiteboard/CallWhiteboard.tsx
@@ -3,7 +3,7 @@ import type { Room } from 'livekit-client';
 import { Brush, Eraser, Plus, Trash2, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '../../../utils/classNames';
-import { Button } from '../../ui/Button/Button';
+
 import { callService } from '../../../services/Call/callService';
 import { logger, Logger } from '../../../utils/logger';
 import {
@@ -728,32 +728,30 @@ export function CallWhiteboard({
                   >
                     Cancel
                   </button>
-                  <Button
+                  <button
                     type='button'
-                    variant='ghost'
                     onClick={handleDeleteAndSavePage}
                     disabled={!callId || !activePageHasContent || isSavingBeforeDelete}
                     className='rounded-lg border border-gray-900 px-3 py-2 text-sm font-medium text-gray-900 transition-colors hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50'
-                    trackId='whiteboard_delete_page_save_confirm'
+                    data-ph-capture-attribute-track-id='whiteboard_delete_page_save_confirm'
                     data-track-category='CALLS'
                     data-track-name='Whiteboard_Delete_Page_Save_Confirm'
                     data-track-metadata={JSON.stringify({ pageId: activePageId })}
                   >
                     {isSavingBeforeDelete ? 'Saving...' : 'Save & delete'}
-                  </Button>
-                  <Button
+                  </button>
+                  <button
                     type='button'
-                    variant='ghost'
                     onClick={handleDeletePage}
                     disabled={isSavingBeforeDelete}
                     className='rounded-lg bg-red-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50'
-                    trackId='whiteboard_delete_page_confirm'
+                    data-ph-capture-attribute-track-id='whiteboard_delete_page_confirm'
                     data-track-category='CALLS'
                     data-track-name='Whiteboard_Delete_Page_Confirm'
                     data-track-metadata={JSON.stringify({ pageId: activePageId })}
                   >
                     Delete
-                  </Button>
+                  </button>
                 </div>
               </div>
             </div>

--- a/apps/dashboard/src/components/Call/IncomingCall/IncomingCallActions.tsx
+++ b/apps/dashboard/src/components/Call/IncomingCall/IncomingCallActions.tsx
@@ -1,6 +1,5 @@
 import { Phone, X } from 'lucide-react';
 import type { ReactElement } from 'react';
-import { Button } from '../../ui/Button/Button';
 
 interface IncomingCallActionsProps {
   callId: string;
@@ -47,19 +46,18 @@ export function IncomingCallActions({
   return (
     <div className='flex items-start justify-center gap-6'>
       <div className='flex flex-col items-center'>
-        <Button
+        <button
           type='button'
-          variant='ghost'
           onClick={onReject}
           aria-label='Decline call'
           className={`${CIRCLE} ${DECLINE_COLORS}`}
-          trackId='reject_incoming_call'
+          data-ph-capture-attribute-track-id='reject_incoming_call'
           data-track-category='CALLS_NOTIFICATIONS'
           data-track-name='REJECT_INCOMING_CALL'
           data-track-metadata={trackMetadata}
         >
           <X className='h-[22px] w-[22px]' strokeWidth={2} />
-        </Button>
+        </button>
         {/* The Switch-call pill carries its label inline, so a lone caption
             under the circle beside it reads as a stray. The button keeps its
             aria-label either way. */}
@@ -67,38 +65,36 @@ export function IncomingCallActions({
       </div>
 
       {isInActiveCall ? (
-        <Button
+        <button
           type='button'
-          variant='ghost'
           onClick={onAccept}
           className={
             'flex h-14 cursor-pointer items-center gap-[9px] rounded-full border-none ' +
             'px-[26px] text-sm font-semibold transition-colors duration-[120ms] ease-out ' +
             `focus-visible:outline-none ${ACCEPT_COLORS}`
           }
-          trackId='accept_incoming_call'
+          data-ph-capture-attribute-track-id='accept_incoming_call'
           data-track-category='CALLS_NOTIFICATIONS'
           data-track-name='ACCEPT_INCOMING_CALL'
           data-track-metadata={trackMetadata}
         >
           <Phone className='h-[22px] w-[22px]' strokeWidth={2} />
           <span>Switch call</span>
-        </Button>
+        </button>
       ) : (
         <div className='flex flex-col items-center'>
-          <Button
+          <button
             type='button'
-            variant='ghost'
             onClick={onAccept}
             aria-label='Accept call'
             className={`${CIRCLE} ${ACCEPT_COLORS}`}
-            trackId='accept_incoming_call'
+            data-ph-capture-attribute-track-id='accept_incoming_call'
             data-track-category='CALLS_NOTIFICATIONS'
             data-track-name='ACCEPT_INCOMING_CALL'
             data-track-metadata={trackMetadata}
           >
             <Phone className='h-[22px] w-[22px]' strokeWidth={2} />
-          </Button>
+          </button>
           <span className={LABEL}>Accept</span>
         </div>
       )}

--- a/apps/dashboard/src/components/Call/ParticipantsSidebar/ParticipantsSidebar.tsx
+++ b/apps/dashboard/src/components/Call/ParticipantsSidebar/ParticipantsSidebar.tsx
@@ -20,7 +20,7 @@ import { useUser } from '../../../hooks/useUsers';
 import { useAuth } from '../../../hooks/useAuth';
 import { InvitationResponse, type CallParticipantMetadata } from '@xyne/shared';
 import Avatar from '../../ui/Avatar/Avatar';
-import { Button } from '../../ui/Button/Button';
+
 import { InviteToCallModal } from '../CallModals/InviteToCallModal';
 import { callService } from '../../../services/Call/callService';
 import { getUserDisplayName, isUserDeactivated } from '../../../utils/userDisplayName';
@@ -276,8 +276,7 @@ function ParticipantItem({
       )}
       {/* Mute/Unmute button - always visible for host */}
       {canMute && (
-        <Button
-          variant='ghost'
+        <button
           onClick={() => void onMuteParticipant(userId)}
           disabled={isMutingThis || !isMicrophoneEnabled}
           className={`p-1.5 rounded-md transition-colors disabled:cursor-not-allowed ${
@@ -285,7 +284,7 @@ function ParticipantItem({
               ? 'text-red-500 bg-red-50'
               : 'hover:bg-secondary text-muted-foreground hover:text-foreground'
           }`}
-          trackId='mute_participant'
+          data-ph-capture-attribute-track-id='mute_participant'
           data-track-category='CALLS'
           data-track-name='MUTE_PARTICIPANT'
           data-track-metadata={JSON.stringify({ callId, participantUserId: userId })}
@@ -298,15 +297,14 @@ function ParticipantItem({
           ) : (
             <Mic size={16} />
           )}
-        </Button>
+        </button>
       )}
       {canRemove && (
-        <Button
-          variant='ghost'
+        <button
           onClick={() => void onRemoveParticipant(userId, participantName)}
           disabled={isRemovingThis}
           className='p-1.5 rounded-md transition-colors disabled:cursor-not-allowed text-muted-foreground hover:bg-red-50 hover:text-red-600'
-          trackId='remove_participant'
+          data-ph-capture-attribute-track-id='remove_participant'
           data-track-category='CALLS'
           data-track-name='REMOVE_PARTICIPANT'
           data-track-metadata={JSON.stringify({ callId, participantUserId: userId })}
@@ -317,7 +315,7 @@ function ParticipantItem({
           ) : (
             <UserX size={16} />
           )}
-        </Button>
+        </button>
       )}
     </div>
   );
@@ -366,13 +364,12 @@ function RequestedParticipantItem({
       </div>
       {canActOnRequest && (
         <div className='flex items-center gap-1.5 shrink-0'>
-          <Button
-            variant='ghost'
+          <button
             onClick={() => onApprove(participant.id)}
             disabled={approvingId === participant.id}
             className='inline-flex items-center justify-center w-7 h-7 rounded-md bg-green-600 text-white hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
             title='Admit'
-            trackId='approve_lobby_request'
+            data-ph-capture-attribute-track-id='approve_lobby_request'
             data-track-category='CALLS'
             data-track-name='APPROVE_LOBBY_REQUEST'
           >
@@ -381,14 +378,13 @@ function RequestedParticipantItem({
             ) : (
               <Check size={14} />
             )}
-          </Button>
-          <Button
-            variant='ghost'
+          </button>
+          <button
             onClick={() => onReject(participant.id)}
             disabled={rejectingId === participant.id}
             className='inline-flex items-center justify-center w-7 h-7 rounded-md bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
             title='Decline'
-            trackId='reject_lobby_request'
+            data-ph-capture-attribute-track-id='reject_lobby_request'
             data-track-category='CALLS'
             data-track-name='REJECT_LOBBY_REQUEST'
           >
@@ -397,7 +393,7 @@ function RequestedParticipantItem({
             ) : (
               <XIcon size={14} />
             )}
-          </Button>
+          </button>
         </div>
       )}
     </div>
@@ -632,21 +628,20 @@ export function ParticipantsSidebar({
           </div>
           <div className='flex items-center gap-2'>
             {isHost && contributors.length > 1 && (
-              <Button
-                variant='ghost'
+              <button
                 onClick={() => void handleMuteAll()}
                 disabled={isMuting}
                 className='flex items-center gap-2 px-3 py-1.5 rounded-lg bg-card hover:bg-accent text-foreground border border-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
                 title='Mute all participants'
                 data-testid='mute-all-button'
-                trackId='mute_all_participants'
+                data-ph-capture-attribute-track-id='mute_all_participants'
                 data-track-category='CALLS'
                 data-track-name='MUTE_ALL_PARTICIPANTS'
                 data-track-metadata={JSON.stringify({ callId })}
               >
                 <MicOff size={16} />
                 <span className='text-sm font-medium'>{isMuting ? 'Muting...' : 'Mute All'}</span>
-              </Button>
+              </button>
             )}
             {!hideInvite && (
               <button

--- a/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGrouped.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGrouped.tsx
@@ -6,7 +6,7 @@ import { mutators } from '../../../zero/mutators';
 import { v4 as uuidv4 } from 'uuid';
 import { toast } from 'sonner';
 import Input from '../../ui/Input';
-import { Button } from '../../ui/Button/Button';
+
 import { Dialog } from '../../ui/Dialog';
 import { CanvasDeleteModal } from '../CanvasDeleteModal';
 import { canvasService } from '../../../services/Canvas/canvasService';
@@ -594,39 +594,37 @@ export const CanvasListGrouped: React.FC<CanvasListGroupedProps> = ({
             )}
           </div>
 
-          <Button
-            variant='ghost'
+          <button
             className='w-full flex items-center gap-2 rounded-md border border-border px-3 py-2 text-left text-foreground hover:bg-accent disabled:opacity-50'
             onClick={() =>
               channelCreateTarget && void handleCreateCanvasInChannel(channelCreateTarget)
             }
             disabled={isCreatingCanvas || !channelCreateTarget || !!channelCreateTarget?.isArchived}
-            trackId='create_canvas_in_channel_root'
+            data-ph-capture-attribute-track-id='create_canvas_in_channel_root'
             data-track-category='CANVAS'
             data-track-name='CREATE_CANVAS_IN_CHANNEL_ROOT'
           >
             <FileText className='w-4 h-4 text-muted-foreground shrink-0' />
             <span className='text-sm'>Create in channel</span>
-          </Button>
+          </button>
 
           <div className='space-y-2'>
             <div className='text-sm font-medium text-foreground'>Folders</div>
             {channelFoldersForTarget.length > 0 ? (
               <div className='space-y-1'>
                 {channelFoldersForTarget.map(folder => (
-                  <Button
+                  <button
                     key={folder.id}
-                    variant='ghost'
                     className='w-full flex items-center gap-2 rounded-md border border-border px-3 py-2 text-left text-foreground hover:bg-accent disabled:opacity-50'
                     onClick={() => handleCreateCanvasInChannelFolder(folder)}
                     disabled={isCreatingCanvas}
-                    trackId='create_canvas_in_channel_folder'
+                    data-ph-capture-attribute-track-id='create_canvas_in_channel_folder'
                     data-track-category='CANVAS'
                     data-track-name='CREATE_CANVAS_IN_CHANNEL_FOLDER'
                   >
                     <Folder className='w-4 h-4 text-amber-500 shrink-0' />
                     <span className='text-sm truncate'>{folder.name}</span>
-                  </Button>
+                  </button>
                 ))}
               </div>
             ) : (
@@ -649,17 +647,16 @@ export const CanvasListGrouped: React.FC<CanvasListGroupedProps> = ({
                 placeholder='Folder name'
                 className='h-9 flex-1'
               />
-              <Button
-                variant='ghost'
+              <button
                 className='inline-flex items-center justify-center rounded-md bg-foreground px-3 py-2 text-sm font-medium text-background hover:opacity-90 disabled:opacity-50'
                 onClick={handleCreateChannelFolder}
                 disabled={!channelCreateTarget || !!channelCreateTarget?.isArchived}
-                trackId='create_channel_canvas_folder'
+                data-ph-capture-attribute-track-id='create_channel_canvas_folder'
                 data-track-category='CANVAS'
                 data-track-name='CREATE_CHANNEL_CANVAS_FOLDER'
               >
                 Create
-              </Button>
+              </button>
             </div>
           </div>
         </div>

--- a/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGroupedContent.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasListGrouped/CanvasListGroupedContent.tsx
@@ -22,7 +22,7 @@ import {
   DropdownMenuTrigger,
 } from '../../ui/dropdown-menu';
 import Input from '../../ui/Input';
-import { Button } from '../../ui/Button/Button';
+
 import { CanvasRow, HighlightedText } from '../CanvasRow';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { queries } from '../../../zero/queries';
@@ -270,18 +270,17 @@ const FolderGroupSection: React.FC<FolderGroupSectionProps> = ({
               </span>
             </button>
           )}
-          <Button
-            variant='ghost'
+          <button
             className={HOVER_ACTION_CLASS}
             onClick={() => void onCreateCanvasInFolder(folderGroup.folder)}
             disabled={isCreatingCanvas}
             title='Create canvas in folder'
-            trackId='create_canvas_in_folder'
+            data-ph-capture-attribute-track-id='create_canvas_in_folder'
             data-track-category='CANVAS'
             data-track-name='CREATE_CANVAS_IN_FOLDER'
           >
             <PlusDefault size={14} />
-          </Button>
+          </button>
           {canRenameFolder && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/apps/dashboard/src/components/Canvas/CanvasRow.tsx
+++ b/apps/dashboard/src/components/Canvas/CanvasRow.tsx
@@ -19,7 +19,7 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import { Dialog } from '../ui/Dialog';
-import { Button } from '../ui/Button/Button';
+
 import { Tooltip } from '../ui/Tooltip/Tooltip';
 import { CanvasShareModal } from './CanvasShareModal';
 import { cn } from '../../utils/classNames';
@@ -145,8 +145,7 @@ export const CanvasRow: React.FC<CanvasRowProps> = ({
           </button>
 
           {canToggleStar && (
-            <Button
-              variant='ghost'
+            <button
               className={cn(
                 'items-center justify-center p-1 rounded-md shrink-0 hover:bg-sidebar-accent',
                 // Display (not opacity) so a hidden control reserves no width and
@@ -158,7 +157,7 @@ export const CanvasRow: React.FC<CanvasRowProps> = ({
                 onToggleStar?.(canvas);
               }}
               title={canvas.isStarred ? 'Unstar canvas' : 'Star canvas'}
-              trackId='toggle_canvas_star'
+              data-ph-capture-attribute-track-id='toggle_canvas_star'
               data-track-category='CANVAS'
               data-track-name='TOGGLE_CANVAS_STAR'
             >
@@ -167,7 +166,7 @@ export const CanvasRow: React.FC<CanvasRowProps> = ({
                 variant={canvas.isStarred ? 'Solid' : 'Stroke'}
                 {...(canvas.isStarred ? { className: 'text-status-pending' } : {})}
               />
-            </Button>
+            </button>
           )}
 
           <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>

--- a/apps/dashboard/src/components/Canvas/ChannelCanvasList/ChannelCanvasList.tsx
+++ b/apps/dashboard/src/components/Canvas/ChannelCanvasList/ChannelCanvasList.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { ChevronDown, ChevronRight, FileText, Folder, Plus, Search } from 'lucide-react';
 import type { Canvas, CanvasFolder } from '../Canvas.types';
 import Input from '../../ui/Input';
-import { Button } from '../../ui/Button/Button';
+
 import { Dialog } from '../../ui/Dialog';
 import { CanvasDeleteModal } from '../CanvasDeleteModal';
 import { CanvasRow } from '../CanvasRow';
@@ -252,19 +252,18 @@ export const ChannelCanvasList: React.FC<ChannelCanvasListProps> = ({
                         </span>
                       </button>
                       {onCreateCanvasInFolder && (
-                        <Button
-                          variant='ghost'
+                        <button
                           className='p-1 opacity-70 group-hover:opacity-100 hover:bg-muted rounded transition-all disabled:opacity-40'
                           onClick={() => onCreateCanvasInFolder(folderGroup.folder)}
                           disabled={isCreatingCanvas}
                           title='Create canvas in folder'
                           data-testid={`channel-folder-create-canvas-${folderGroup.folder.id}`}
-                          trackId='create_canvas_in_channel_folder'
+                          data-ph-capture-attribute-track-id='create_canvas_in_channel_folder'
                           data-track-category='CANVAS'
                           data-track-name='Create_Canvas_In_Channel_Folder'
                         >
                           <Plus className='w-4 h-4 text-muted-foreground' />
-                        </Button>
+                        </button>
                       )}
                     </div>
                     {!isCollapsed &&

--- a/apps/dashboard/src/components/Chat/AboutChannel/NotificationsTab.tsx
+++ b/apps/dashboard/src/components/Chat/AboutChannel/NotificationsTab.tsx
@@ -4,7 +4,7 @@ import { Channel, NotificationLevel, ChannelScopeType } from '@xyne/shared';
 import { mutators } from '../../../zero/mutators';
 import { Monitor, Smartphone } from 'lucide-react';
 import * as Switch from '@radix-ui/react-switch';
-import { Button } from '../../ui/Button';
+
 import { cn } from '../../../utils/classNames';
 import { useGlobalNotificationSettings } from '../../../hooks/useGlobalNotificationSettings';
 import { useQuery } from '../../../hooks/useQuery';
@@ -154,13 +154,12 @@ const NotificationsTab = ({ channel, isParticipant }: NotificationsTabProps): Re
             {!channelIsDM && desktopEnabled && (
               <div className='grid grid-cols-2 gap-2 pl-6'>
                 {CHANNEL_LEVEL_OPTIONS.map(opt => (
-                  <Button
+                  <button
                     key={opt.value}
-                    variant='ghost'
                     disabled={!settingsReady}
                     onClick={() => setNotificationLevel('desktop', opt.value)}
                     data-track-category='NOTIFICATIONS'
-                    trackId={`set_desktop_notification_level_${opt.value.toLowerCase()}`}
+                    data-ph-capture-attribute-track-id={`set_desktop_notification_level_${opt.value.toLowerCase()}`}
                     data-track-name={`set_desktop_level_${opt.value.toLowerCase()}`}
                     className={cn(
                       'px-2 py-1.5 text-xs rounded-md border transition-colors',
@@ -171,7 +170,7 @@ const NotificationsTab = ({ channel, isParticipant }: NotificationsTabProps): Re
                     )}
                   >
                     {opt.label}
-                  </Button>
+                  </button>
                 ))}
               </div>
             )}
@@ -208,13 +207,12 @@ const NotificationsTab = ({ channel, isParticipant }: NotificationsTabProps): Re
             {!channelIsDM && mobileEnabled && (
               <div className='grid grid-cols-2 gap-2 pl-6'>
                 {CHANNEL_LEVEL_OPTIONS.map(opt => (
-                  <Button
+                  <button
                     key={opt.value}
-                    variant='ghost'
                     disabled={!settingsReady}
                     onClick={() => setNotificationLevel('mobile', opt.value)}
                     data-track-category='NOTIFICATIONS'
-                    trackId={`set_mobile_notification_level_${opt.value.toLowerCase()}`}
+                    data-ph-capture-attribute-track-id={`set_mobile_notification_level_${opt.value.toLowerCase()}`}
                     data-track-name={`set_mobile_level_${opt.value.toLowerCase()}`}
                     className={cn(
                       'px-2 py-1.5 text-xs rounded-md border transition-colors',
@@ -225,7 +223,7 @@ const NotificationsTab = ({ channel, isParticipant }: NotificationsTabProps): Re
                     )}
                   >
                     {opt.label}
-                  </Button>
+                  </button>
                 ))}
               </div>
             )}

--- a/apps/dashboard/src/components/Chat/BookmarkItem/BookmarkItem.tsx
+++ b/apps/dashboard/src/components/Chat/BookmarkItem/BookmarkItem.tsx
@@ -276,20 +276,19 @@ export const BookmarkItem = ({
       {isActionToolbarVisible && (
         <div className='absolute top-2 right-2 z-10 flex items-center gap-1 bg-card border border-border rounded-md shadow-sm p-1'>
           <Tooltip content='Mark as done'>
-            <Button
-              variant='ghost'
+            <button
               type='button'
               onClick={handleRemoveBookmark}
               className='p-1.5 rounded hover:bg-accent transition-colors duration-150'
               aria-label='Mark as done'
               data-testid='bookmark-mark-as-done-btn'
-              trackId='mark_bookmark_done'
+              data-ph-capture-attribute-track-id='mark_bookmark_done'
               data-track-category='CHAT_BOOKMARK'
               data-track-name='Mark_Bookmark_Done'
               data-track-metadata={JSON.stringify({ entityId })}
             >
               <Check size={16} className='text-muted-foreground' strokeWidth={1.33} />
-            </Button>
+            </button>
           </Tooltip>
           <Tooltip content={reminderActionLabel}>
             <div>

--- a/apps/dashboard/src/components/Chat/CallSettings/CallSummaryConfig.tsx
+++ b/apps/dashboard/src/components/Chat/CallSettings/CallSummaryConfig.tsx
@@ -6,7 +6,7 @@ import { useZero } from '../../../hooks/useZero';
 import { mutators } from '../../../zero/mutators';
 import { callSummaryApi } from '../../../api/callSummaryApi';
 import { Dialog } from '../../ui/Dialog/Dialog';
-import { Button } from '../../ui/Button/Button';
+
 import { SummaryCanvasPreview } from './SummaryCanvasPreview';
 
 const AI_WORDS = [
@@ -272,14 +272,13 @@ export const CallSummaryConfig: React.FC<CallSummaryConfigProps> = ({
                     data-track-category='CallSummary'
                     data-track-name='EditWithAIInput'
                   />
-                  <Button
-                    variant='ghost'
+                  <button
                     type='button'
                     onClick={() => void handleEditWithAI()}
                     disabled={!aiInstruction.trim() || aiLoading}
                     aria-label='Edit with AI'
                     className='absolute right-1.5 top-1/2 -translate-y-1/2 inline-flex h-7 w-7 items-center justify-center rounded-[8px] text-primary hover:bg-muted/60 disabled:pointer-events-none disabled:opacity-40'
-                    trackId='edit_call_summary_with_ai'
+                    data-ph-capture-attribute-track-id='edit_call_summary_with_ai'
                     data-track-category='CallSummary'
                     data-track-name='EditWithAI'
                   >
@@ -288,7 +287,7 @@ export const CallSummaryConfig: React.FC<CallSummaryConfigProps> = ({
                     ) : (
                       <SendHorizontal size={16} />
                     )}
-                  </Button>
+                  </button>
                 </div>
               </div>
               <div className='flex flex-1 items-center justify-center gap-4'>
@@ -302,18 +301,17 @@ export const CallSummaryConfig: React.FC<CallSummaryConfigProps> = ({
                 >
                   Reset to default
                 </button>
-                <Button
-                  variant='default'
+                <button
                   type='button'
                   onClick={() => void handleSave()}
                   disabled={!dirty || saving}
                   className='inline-flex items-center rounded-[10px] bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50'
-                  trackId='save_call_summary_prompt'
+                  data-ph-capture-attribute-track-id='save_call_summary_prompt'
                   data-track-category='CallSummary'
                   data-track-name='SaveCallSummary'
                 >
                   {saving ? 'Saving…' : 'Save'}
-                </Button>
+                </button>
               </div>
             </div>
           )}

--- a/apps/dashboard/src/components/Chat/ChannelInformation/ChannelSettings.tsx
+++ b/apps/dashboard/src/components/Chat/ChannelInformation/ChannelSettings.tsx
@@ -402,18 +402,17 @@ export const ChannelSettings: React.FC<ChannelSettingsProps> = ({
                     <p className='text-sm text-muted-foreground'>
                       Anyone in your workspace will be able to find and join this channel.
                     </p>
-                    <Button
-                      variant='ghost'
+                    <button
                       type='button'
                       onClick={handleMakePublic}
-                      trackId='make_channel_public'
+                      data-ph-capture-attribute-track-id='make_channel_public'
                       className='mt-1 inline-flex items-center self-start rounded-[8px] border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground hover:bg-accent'
                       data-track-category='CHANNEL_SETTINGS'
                       data-track-name='MakeChannelPublic'
                       data-track-metadata={JSON.stringify({ channelId: channel.id })}
                     >
                       Change to public
-                    </Button>
+                    </button>
                   </>
                 ) : (
                   <p className='text-sm text-muted-foreground'>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelItemV2.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelItemV2.tsx
@@ -28,7 +28,7 @@ import { useGetChannelUserStatus } from '../../../hooks/useChannels';
 import Badge from '../../ui/Badge';
 import Avatar from '../../ui/Avatar/Avatar';
 import Tooltip from '../../ui/Tooltip';
-import { Button } from '../../ui/Button/Button';
+
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -313,12 +313,11 @@ const ChannelItemV2 = memo(
             </DropdownMenu>
           )}
           {shouldShowCloseButton && (
-            <Button
-              variant='ghost'
+            <button
               type='button'
               className='group-hover:block hidden p-1 rounded-md -blue'
               onClick={handleCloseDm}
-              trackId='close_dm_channel'
+              data-ph-capture-attribute-track-id='close_dm_channel'
               data-track-category='CHAT_SIDEBAR'
               data-track-name='CLOSE_DM_CHANNEL'
               data-track-metadata={JSON.stringify({
@@ -327,7 +326,7 @@ const ChannelItemV2 = memo(
               })}
             >
               <MultipleCrossCancelDefault size={14} className='shrink-0' />
-            </Button>
+            </button>
           )}
         </div>
       </Link>

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChatDirectory.tsx
@@ -64,7 +64,6 @@ import { AddPeopleForm } from '../AddPeopleForm/AddPeopleForm';
 import Badge from '../../ui/Badge';
 import Avatar from '../../ui/Avatar/Avatar';
 import Dialog, { cn } from '../../ui/Dialog';
-import { Button } from '../../ui/Button';
 
 import { useZero } from '../../../hooks/useZero';
 import { mutators } from '../../../zero/mutators';
@@ -1334,16 +1333,15 @@ const ChatDirectory = ({
               >
                 Cancel
               </button>
-              <Button
-                variant='ghost'
+              <button
                 onClick={handleConfirmDeleteSection}
-                trackId='delete_channel_section'
+                data-ph-capture-attribute-track-id='delete_channel_section'
                 data-track-category='CHAT_SIDEBAR'
                 data-track-name='CONFIRM_DELETE_SECTION'
                 className='inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors'
               >
                 Delete
-              </Button>
+              </button>
             </div>
           </div>
         </Dialog>

--- a/apps/dashboard/src/components/Chat/ChatInput/AgentProgressIndicator.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/AgentProgressIndicator.tsx
@@ -6,7 +6,6 @@ import { useAgentProgress } from '../../../hooks/useAgentProgress';
 import { useAuth } from '../../../hooks/useAuth';
 import { apiInstance } from '../../../services/clients/apiClient';
 import { AgentSpinner } from '../../ui/AgentSpinner';
-import { Button } from '../../ui/Button/Button';
 
 const rowStyle: CSSProperties = {
   display: 'inline-flex',
@@ -90,18 +89,17 @@ export function AgentProgressIndicator({
         ))}
       </div>
       {myAgent && (
-        <Button
-          variant='ghost'
+        <button
           type='button'
           onClick={() => void handleAbortAgent()}
           className='p-1 rounded-full bg-red-500 text-white hover:bg-red-600 transition-colors shrink-0'
           aria-label='Stop agent'
-          trackId='stop_agent'
+          data-ph-capture-attribute-track-id='stop_agent'
           data-track-category='CHAT_INPUT'
           data-track-name='STOP_AGENT'
         >
           <Square className='h-3 w-3 fill-current' />
-        </Button>
+        </button>
       )}
     </div>
   );

--- a/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatInput/ChatInput.tsx
@@ -14,7 +14,7 @@ import { toast } from 'sonner';
 import { useSummaryCache } from '../../../hooks/useSummaryQuery';
 
 import { InputBox } from '../../ui/InputBox';
-import { Button } from '../../ui/Button/Button';
+
 import {
   MessageType,
   ChannelScopeType,
@@ -1091,8 +1091,7 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
                       : "You're offline. Messages will be saved as drafts until you reconnect."}
                   </span>
                 </div>
-                <Button
-                  variant='ghost'
+                <button
                   type='button'
                   onClick={refreshConnection}
                   disabled={isReconnecting}
@@ -1101,12 +1100,12 @@ const ChatInputInner = forwardRef<InputBoxHandle, ChatInputProps>(
                       ? 'text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-950 cursor-wait'
                       : 'text-amber-800 dark:text-amber-200 bg-amber-100 dark:bg-amber-900 hover:bg-amber-200 dark:hover:bg-amber-800'
                   }`}
-                  trackId='reconnect_zero'
+                  data-ph-capture-attribute-track-id='reconnect_zero'
                   data-track-category='CHAT_INPUT'
                   data-track-name='RECONNECT_ZERO'
                 >
                   {isReconnecting ? 'Reconnecting...' : 'Reconnect'}
-                </Button>
+                </button>
               </div>
             )}
             {isReconnected && (

--- a/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
+++ b/apps/dashboard/src/components/Chat/ChatListItem/ChatListItem.tsx
@@ -11,7 +11,7 @@ import { getInitialMessageFromConversation } from '../../../utils/conversationMe
 import { useAuth } from '../../../hooks/useAuth';
 import { useZero } from '../../../hooks/useZero';
 import { useShowThreadTags } from '../../../hooks/useShowThreadTags';
-import { Button } from '../../ui/Button/Button';
+
 import {
   usePendingStatusByMessageId,
   usePendingByMessageId,
@@ -127,28 +127,26 @@ const ChatListItemComponent = ({
       {pendingStatus === 'failed' && pendingEntry && (
         <div className='flex items-center gap-3 pl-12 pt-1 text-xs text-red-500'>
           <span>Failed to send.</span>
-          <Button
-            variant='ghost'
+          <button
             type='button'
-            trackId='retry_failed_send'
+            data-ph-capture-attribute-track-id='retry_failed_send'
             data-track-category='PENDING_MESSAGE'
             data-track-name='retry_failed_send'
             className='font-medium underline hover:opacity-80'
             onClick={() => firePendingMutator(zero, pendingEntry)}
           >
             Retry
-          </Button>
-          <Button
-            variant='ghost'
+          </button>
+          <button
             type='button'
-            trackId='delete_failed_send'
+            data-ph-capture-attribute-track-id='delete_failed_send'
             data-track-category='PENDING_MESSAGE'
             data-track-name='delete_failed_send'
             className='font-medium underline hover:opacity-80'
             onClick={() => removePending(pendingEntry.messageId)}
           >
             Delete
-          </Button>
+          </button>
         </div>
       )}
     </div>

--- a/apps/dashboard/src/components/Chat/ConversationHeaderMobile/ConversationHeaderMobile.tsx
+++ b/apps/dashboard/src/components/Chat/ConversationHeaderMobile/ConversationHeaderMobile.tsx
@@ -33,7 +33,6 @@ import { isOneToOneDMChannel } from '../ChatDirectory/ChatDirectory.utils';
 import { isStatusExpired } from '../../../utils/statusUtils';
 import { StatusIndicator } from '../../ui/StatusIndicator';
 import { XyneAIStar } from '../../icons/xyne-ai';
-import { Button } from '../../ui/Button';
 
 interface ConversationHeaderMobileProps {
   channelId: string;
@@ -189,10 +188,9 @@ const ConversationHeaderMobile = ({
                 <UserPlus size={16} />
                 <span className='text-sm font-medium text-foreground'>Add</span>
               </button>
-              <Button
-                variant='ghost'
+              <button
                 onClick={handleStarToggle}
-                trackId='toggle_star_channel'
+                data-ph-capture-attribute-track-id='toggle_star_channel'
                 className={cn(
                   'w-full border flex items-center justify-center gap-2 rounded-lg py-1.5 px-2 h-[34px] transition-all duration-100',
                   isStarred ? 'bg-muted border-border' : 'bg-background border-border',
@@ -212,7 +210,7 @@ const ConversationHeaderMobile = ({
                 <span className='text-sm font-medium text-foreground'>
                   {isStarred ? 'Unstar' : 'Star'}
                 </span>
-              </Button>
+              </button>
               <button
                 onClick={(): void => void navigate('/chat/search')}
                 disabled={true}

--- a/apps/dashboard/src/components/Chat/DelayedMessageDropdown/DelayedMessageEditModal.tsx
+++ b/apps/dashboard/src/components/Chat/DelayedMessageDropdown/DelayedMessageEditModal.tsx
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 import type { DelayedMessage } from '@xyne/shared';
 import { Dialog } from '../../ui/Dialog/Dialog';
 import { InputBox } from '../../ui/InputBox';
-import { Button } from '../../ui/Button';
+
 import { useZero } from '../../../hooks/useZero';
 import { mutators } from '../../../zero/mutators';
 import { sanitizeHtmlContent } from '../ChatInput/ChatInput.utils';
@@ -136,11 +136,10 @@ export const DelayedMessageEditModal = ({
           >
             Cancel
           </button>
-          <Button
-            variant='default'
+          <button
             type='button'
             onClick={() => void handleSave()}
-            trackId='edit_scheduled_message'
+            data-ph-capture-attribute-track-id='edit_scheduled_message'
             disabled={isSaving || !hasContent}
             className='text-sm font-medium px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors inline-flex items-center gap-2'
             data-track-category='delayed-messages'
@@ -148,7 +147,7 @@ export const DelayedMessageEditModal = ({
           >
             {isSaving && <Loader2 size={14} className='animate-spin' />}
             Save
-          </Button>
+          </button>
         </div>
       </div>
     </Dialog>

--- a/apps/dashboard/src/components/Chat/DelayedMessagesPanel/DelayedMessagesPanel.tsx
+++ b/apps/dashboard/src/components/Chat/DelayedMessagesPanel/DelayedMessagesPanel.tsx
@@ -17,7 +17,6 @@ import { MessageCard } from '../MessageCard';
 import { RecipientAvatar, useRecipientName } from '../MessageCard/avatarHelpers';
 import { ScheduleMessageDialog } from '../../ui/ScheduleMessageDialog/ScheduleMessageDialog';
 import { useUserDelayedMessages } from '../../../hooks/useUserDelayedMessages';
-import { Button } from '../../ui/Button';
 
 type DelayedMessageWithAttachments = DelayedMessage & {
   attachments?: readonly MessageAttachment[] | undefined;
@@ -236,11 +235,10 @@ const DelayedMessageRow = ({
               >
                 Cancel
               </button>
-              <Button
-                variant='default'
+              <button
                 type='button'
                 onClick={() => void performSendNow()}
-                trackId='send_now_scheduled_message'
+                data-ph-capture-attribute-track-id='send_now_scheduled_message'
                 disabled={isSendNowLoading}
                 className='text-sm font-medium px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors disabled:opacity-50 inline-flex items-center justify-center gap-2'
                 data-track-category='delayed-messages'
@@ -248,7 +246,7 @@ const DelayedMessageRow = ({
               >
                 {isSendNowLoading ? <Loader2 size={14} className='animate-spin' /> : null}
                 Send now
-              </Button>
+              </button>
             </div>
           </div>
         </Dialog>
@@ -295,17 +293,16 @@ const DelayedMessageRow = ({
               >
                 Cancel
               </button>
-              <Button
-                variant='ghost'
+              <button
                 type='button'
                 onClick={() => void handleConfirmDelete()}
-                trackId='delete_scheduled_message'
+                data-ph-capture-attribute-track-id='delete_scheduled_message'
                 className='text-sm font-bold px-4 py-2 rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors'
                 data-track-category='delayed-messages'
                 data-track-name='confirm-delete-scheduled'
               >
                 Delete message
-              </Button>
+              </button>
             </div>
           </div>
         </Dialog>

--- a/apps/dashboard/src/components/Chat/DraftsPanel/DraftsPanel.tsx
+++ b/apps/dashboard/src/components/Chat/DraftsPanel/DraftsPanel.tsx
@@ -11,7 +11,7 @@ import type { Conversation, MessageAttachment } from '@xyne/shared';
 import { removeDraft, useDraftAttachments } from '../../../hooks/useDraft';
 import { formatDistanceToNow } from 'date-fns';
 import { Dialog } from '../../ui/Dialog/Dialog';
-import { Button } from '../../ui/Button/Button';
+
 import { MessageCard, RecipientAvatar, useRecipientName } from '../MessageCard';
 import { ScheduleMessageDialog } from '../../ui/ScheduleMessageDialog/ScheduleMessageDialog';
 
@@ -232,17 +232,16 @@ const DraftRow = ({ draft }: { draft: DraftWithAttachments }): ReactElement => {
               >
                 Cancel
               </button>
-              <Button
-                variant='ghost'
+              <button
                 type='button'
                 onClick={() => void performDelete()}
                 className='text-sm font-bold px-4 py-2 rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors'
                 data-track-category='DRAFTS_PANEL'
                 data-track-name='confirm-delete-draft'
-                trackId='delete_draft'
+                data-ph-capture-attribute-track-id='delete_draft'
               >
                 Delete Draft
-              </Button>
+              </button>
             </div>
           </div>
         </Dialog>
@@ -288,17 +287,16 @@ const DraftRow = ({ draft }: { draft: DraftWithAttachments }): ReactElement => {
               >
                 Cancel
               </button>
-              <Button
-                variant='ghost'
+              <button
                 type='button'
                 onClick={() => void performSend()}
                 className='text-sm font-medium px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors'
                 data-track-category='DRAFTS_PANEL'
                 data-track-name='confirm-send-draft'
-                trackId='send_draft'
+                data-ph-capture-attribute-track-id='send_draft'
               >
                 Send now
-              </Button>
+              </button>
             </div>
           </div>
         </Dialog>

--- a/apps/dashboard/src/components/Chat/Info/Info.tsx
+++ b/apps/dashboard/src/components/Chat/Info/Info.tsx
@@ -342,9 +342,7 @@ const Info = ({
 
       {/* HeaderLinkItems */}
       <div className='flex justify-between px-4 mb-4 gap-x-3 overflow-x-auto no-scrollbar'>
-        <Button
-          variant='ghost'
-          size='inline'
+        <button
           onClick={handleStarToggle}
           className={[
             headerLinkContainerStyle,
@@ -356,7 +354,7 @@ const Info = ({
             isStarred: channelUserStatus?.isStarred,
             channelId: channel.id,
           })}
-          trackId='toggle_channel_star'
+          data-ph-capture-attribute-track-id='toggle_channel_star'
         >
           {channelUserStatus?.isStarred ? (
             <LucideStar size={16} className='text-status-pending' fill='currentColor' />
@@ -368,7 +366,7 @@ const Info = ({
           >
             Starred
           </div>
-        </Button>
+        </button>
         {showAddPeopleButton && (
           <button
             onClick={handleAddPeopleClick}
@@ -420,19 +418,17 @@ const Info = ({
           </button>
         )}
         {isParticipant && !isDM && !isGroupDM && (
-          <Button
-            variant='ghost'
-            size='inline'
+          <button
             onClick={handleLeaveChannel}
             className={headerLinkContainerStyle}
             data-track-category='CHAT_INFO'
             data-track-name='LEAVE_CHANNEL'
             data-track-metadata={JSON.stringify({ channelId: channel.id })}
-            trackId='leave_channel'
+            data-ph-capture-attribute-track-id='leave_channel'
           >
             <LucideLogOut size={16} className='text-destructive' />
             <div className='text-destructive text-[13px]'>Leave</div>
-          </Button>
+          </button>
         )}
       </div>
       <Tabs.Root
@@ -663,31 +659,29 @@ const ParticipantListItem = ({
               <div>
                 {canManageThisUser &&
                   (isAdmin ? (
-                    <Button
-                      variant='ghost'
+                    <button
                       className={popoverStyle}
                       onClick={() => onRemoveAdmin(participant.userId)}
                       data-track-category='CHAT_INFO'
                       data-track-name='REMOVE_ADMIN'
                       data-track-metadata={JSON.stringify({ userId: participant.userId })}
-                      trackId='remove_channel_admin'
+                      data-ph-capture-attribute-track-id='remove_channel_admin'
                     >
                       <LucideUserMinus size={14} />
                       <span className='text-[14px] text-foreground'>Remove admin</span>
-                    </Button>
+                    </button>
                   ) : (
-                    <Button
-                      variant='ghost'
+                    <button
                       className={popoverStyle}
                       onClick={() => onMakeAdmin(participant.userId)}
                       data-track-category='CHAT_INFO'
                       data-track-name='MAKE_ADMIN'
                       data-track-metadata={JSON.stringify({ userId: participant.userId })}
-                      trackId='make_channel_admin'
+                      data-ph-capture-attribute-track-id='make_channel_admin'
                     >
                       <LucideUser size={14} />
                       <span className='text-[14px] text-foreground'>Make admin</span>
-                    </Button>
+                    </button>
                   ))}
                 {canRemoveThisUser && (
                   <button

--- a/apps/dashboard/src/components/Chat/LinksTab/LinksTab.tsx
+++ b/apps/dashboard/src/components/Chat/LinksTab/LinksTab.tsx
@@ -8,7 +8,6 @@ import { useZero } from '../../../hooks/useZero';
 import type { Link } from '@xyne/shared';
 import { LinkVisibility } from '@xyne/shared';
 import Dialog from '../../ui/Dialog';
-import Button from '../../ui/Button';
 import { browserPanelActor } from '../../../machines/browserPanelMachine';
 import { xyneAIActor } from '../../../machines/xyneAIMachine';
 import { useSearchParams, useNavigate } from 'react-router-dom';
@@ -394,14 +393,15 @@ const LinksTab: React.FC<LinksTabProps> = ({ channelId }) => {
                 >
                   Cancel
                 </button>
-                <Button
+                <button
                   type='submit'
-                  variant='ghost'
                   className='flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium'
-                  trackId={linkToEdit ? 'update_channel_link' : 'create_channel_link'}
+                  data-ph-capture-attribute-track-id={
+                    linkToEdit ? 'update_channel_link' : 'create_channel_link'
+                  }
                 >
                   {linkToEdit ? 'Update Link' : 'Add Link'}
-                </Button>
+                </button>
               </div>
             </form>
           </div>
@@ -513,17 +513,16 @@ const LinksTab: React.FC<LinksTabProps> = ({ channelId }) => {
             >
               Cancel
             </button>
-            <Button
+            <button
               type='button'
-              variant='ghost'
               onClick={confirmDelete}
               className='flex-1 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm font-medium'
               data-track-category='CHANNEL_LINKS'
               data-track-name='ConfirmDeleteLink'
-              trackId='delete_channel_link'
+              data-ph-capture-attribute-track-id='delete_channel_link'
             >
               Delete Link
-            </Button>
+            </button>
           </div>
         </div>
       </Dialog>

--- a/apps/dashboard/src/components/Chat/MessageAttachment/DownloadButton.tsx
+++ b/apps/dashboard/src/components/Chat/MessageAttachment/DownloadButton.tsx
@@ -3,7 +3,6 @@ import { Download, Loader2 } from 'lucide-react';
 import { downloadAttachment } from './utils';
 import { toast } from 'sonner';
 import { cn } from '../../../utils/classNames';
-import { Button } from '../../ui/Button/Button';
 
 type DownloadButtonVariant = 'default' | 'overlay';
 
@@ -68,12 +67,11 @@ export const DownloadButton = memo<DownloadButtonProps>(
     const buttonLabel = isDownloading ? 'Downloading...' : `Download ${fileName}`;
 
     return (
-      <Button
-        variant='ghost'
+      <button
         type='button'
         onClick={e => void handleDownload(e)}
         disabled={isDownloading}
-        trackId='download_attachment'
+        data-ph-capture-attribute-track-id='download_attachment'
         className={`p-2 rounded-md text-foreground transition-colors duration-200 disabled:opacity-50 ${VARIANT_STYLES[variant]}`}
         title={buttonLabel}
         aria-label={buttonLabel}
@@ -93,7 +91,7 @@ export const DownloadButton = memo<DownloadButtonProps>(
             {showLabel && <span className={cn('ml-2 text-sm', className)}>Download</span>}
           </div>
         )}
-      </Button>
+      </button>
     );
   },
 );

--- a/apps/dashboard/src/components/Chat/MessageAttachment/MessageAttachment.tsx
+++ b/apps/dashboard/src/components/Chat/MessageAttachment/MessageAttachment.tsx
@@ -48,7 +48,7 @@ import { useZero } from '../../../hooks/useZero';
 import { mutators } from '../../../zero/mutators';
 import { DownloadButton } from './DownloadButton';
 import { DeleteButton } from './DeleteButton';
-import { Button } from '../../ui/Button/Button';
+
 import { CopyCopied, CopyDefault } from '@xyne/icons';
 import { useClipboard } from '../../../hooks/useClipboard';
 import axios from 'axios';
@@ -643,14 +643,13 @@ const InlineTextFile: React.FC<{
             <span className='truncate max-w-md'>{formatFileName(fileName)}</span>
             <span className='ml-1 text-xs text-muted-foreground'>(click to view)</span>
           </button>
-          <Button
-            variant='ghost'
+          <button
             type='button'
             onClick={e => {
               e.stopPropagation();
               void downloadAttachment(attachmentId, fileName);
             }}
-            trackId='download_text_file'
+            data-ph-capture-attribute-track-id='download_text_file'
             className='p-2 hover:bg-accent rounded-lg transition-colors'
             title='Download file'
             data-track-category='MESSAGE'
@@ -658,7 +657,7 @@ const InlineTextFile: React.FC<{
             data-track-metadata={JSON.stringify({ fileName, attachmentId })}
           >
             <Download className='h-4 w-4 text-muted-foreground' />
-          </Button>
+          </button>
           {extraActions}
         </div>
       </div>
@@ -683,14 +682,13 @@ const InlineTextFile: React.FC<{
             {isExpanded ? '[Hide]' : '[View]'}
           </span>
         </button>
-        <Button
-          variant='ghost'
+        <button
           type='button'
           onClick={e => {
             e.stopPropagation();
             void downloadAttachment(attachmentId, fileName);
           }}
-          trackId='download_text_file_inline'
+          data-ph-capture-attribute-track-id='download_text_file_inline'
           className='p-2 hover:bg-accent rounded-lg transition-colors'
           title='Download file'
           data-track-category='MESSAGE'
@@ -698,7 +696,7 @@ const InlineTextFile: React.FC<{
           data-track-metadata={JSON.stringify({ fileName, attachmentId })}
         >
           <Download className='h-4 w-4 text-muted-foreground' />
-        </Button>
+        </button>
         {extraActions}
       </div>
 
@@ -809,14 +807,13 @@ const InlineCodeFile: React.FC<{
           <span className='truncate max-w-md'>{formatFileName(fileName)}</span>
           <span className='ml-1 text-xs text-muted-foreground'>[View]</span>
         </button>
-        <Button
-          variant='ghost'
+        <button
           type='button'
           onClick={e => {
             e.stopPropagation();
             void downloadAttachment(attachmentId, fileName);
           }}
-          trackId='download_code_file'
+          data-ph-capture-attribute-track-id='download_code_file'
           className='p-2 hover:bg-accent rounded-lg transition-colors'
           title='Download file'
           data-track-category='MESSAGE'
@@ -824,7 +821,7 @@ const InlineCodeFile: React.FC<{
           data-track-metadata={JSON.stringify({ fileName, attachmentId })}
         >
           <Download className='h-4 w-4 text-muted-foreground' />
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/Chat/Nudges/SurfaceNudgeCard.tsx
+++ b/apps/dashboard/src/components/Chat/Nudges/SurfaceNudgeCard.tsx
@@ -358,17 +358,16 @@ export const SurfaceNudgeCard: React.FC<SurfaceNudgeCardProps> = ({
             {getNudgeKindLabel(nudge.nudgeKind)}
           </span>
           {isScheduleCall && canDismiss && (
-            <Button
-              variant='ghost'
+            <button
               onClick={handleDismiss}
               disabled={isActing}
-              trackId='dismiss_schedule_call_nudge'
+              data-ph-capture-attribute-track-id='dismiss_schedule_call_nudge'
               data-track-category='NUDGES'
               data-track-name='dismiss_schedule_call_nudge'
               className='p-0.5 text-muted-foreground hover:text-foreground rounded-md hover:bg-muted/50 disabled:opacity-50'
             >
               <X className='h-3.5 w-3.5' />
-            </Button>
+            </button>
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Chat/SlashCommandArtifactBanner.tsx
+++ b/apps/dashboard/src/components/Chat/SlashCommandArtifactBanner.tsx
@@ -17,7 +17,6 @@ import {
 } from './SlashCommandArtifactSideEffects';
 import { buildSlashCommandArtifactRoute } from './SlashCommandArtifacts';
 import { isDMChannel } from './ChatDirectory/ChatDirectory.utils';
-import { Button } from '../ui/Button/Button';
 
 export const getVisibleSlashCommandArtifactBanners = (
   items: readonly SlashCommandArtifactBannerItem[],
@@ -183,9 +182,8 @@ export const SlashCommandArtifactBanner = (): React.JSX.Element | null => {
               </button>
 
               {item.activeCallExternalId && (
-                <Button
+                <button
                   type='button'
-                  variant='ghost'
                   onClick={() => {
                     if (!isInThisCall) {
                       setIsOpen(false);
@@ -198,7 +196,7 @@ export const SlashCommandArtifactBanner = (): React.JSX.Element | null => {
                     }
                   }}
                   disabled={isInThisCall}
-                  trackId='join_call_from_banner'
+                  data-ph-capture-attribute-track-id='join_call_from_banner'
                   className='flex h-[30px] shrink-0 items-center gap-1.5 rounded-lg bg-orange-500 px-2.5 text-xs font-semibold text-white hover:bg-orange-600 disabled:cursor-default disabled:opacity-70'
                   data-track-category='SLASH_COMMAND_ARTIFACT'
                   data-track-name='JOIN_CALL_FROM_BANNER'
@@ -210,7 +208,7 @@ export const SlashCommandArtifactBanner = (): React.JSX.Element | null => {
                 >
                   <Phone className='size-3' />
                   {isInThisCall ? 'In call' : 'Join call'}
-                </Button>
+                </button>
               )}
             </div>
 

--- a/apps/dashboard/src/components/Chat/SlashCommandArtifacts.tsx
+++ b/apps/dashboard/src/components/Chat/SlashCommandArtifacts.tsx
@@ -28,7 +28,6 @@ import { useZero } from '../../hooks/useZero';
 import { mutators } from '../../zero/mutators';
 import { useFlow } from '../flowUI/FlowContext';
 import { useActiveSlashCommandArtifact } from './SlashCommandArtifactSideEffects';
-import { Button } from '../ui/Button/Button';
 
 /**
  * Composer entry for a slash-command artifact. Presentation and side-effect
@@ -444,16 +443,15 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
           </span>
         )}
         {canCloseArtifact && (
-          <Button
+          <button
             type='button'
-            variant='ghost'
             onClick={event => {
               event.preventDefault();
               event.stopPropagation();
               void handleCloseArtifact();
             }}
             disabled={isClosing}
-            trackId='close_slash_command_artifact'
+            data-ph-capture-attribute-track-id='close_slash_command_artifact'
             className='-mr-1 ml-auto flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60'
             aria-label={`Close this ${definition.bodyNoun}`}
             title={`Close this ${definition.bodyNoun}`}
@@ -463,7 +461,7 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
             data-track-metadata={trackingMetadata}
           >
             <X className='size-4' />
-          </Button>
+          </button>
         )}
       </div>
 
@@ -483,16 +481,15 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
                 Call ended{endedDuration ? ` · lasted ${endedDuration}` : ''} · {joinedCount} joined
               </span>
             </div>
-            <Button
+            <button
               type='button'
-              variant='ghost'
               onClick={event => {
                 event.preventDefault();
                 event.stopPropagation();
                 startNewCall();
               }}
               disabled={isInCall || !canActOnArtifact}
-              trackId='start_new_call_from_artifact'
+              data-ph-capture-attribute-track-id='start_new_call_from_artifact'
               className='inline-flex h-10 items-center gap-2 rounded-lg border border-border bg-background px-4 text-sm font-semibold hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60'
               data-prevent-thread
               data-track-category='SLASH_COMMAND_ARTIFACT'
@@ -501,7 +498,7 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
             >
               <Phone className='size-4' />
               Start a new call
-            </Button>
+            </button>
           </>
         ) : resolvedState === 'active' ? (
           <>
@@ -535,16 +532,15 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
             </button>
           </>
         ) : (
-          <Button
+          <button
             type='button'
-            variant='ghost'
             onClick={event => {
               event.preventDefault();
               event.stopPropagation();
               startNewCall();
             }}
             disabled={!canActOnArtifact || isInCall}
-            trackId='start_call_from_artifact'
+            data-ph-capture-attribute-track-id='start_call_from_artifact'
             className='inline-flex h-10 items-center gap-2 rounded-lg bg-foreground px-4 text-sm font-semibold text-background transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60'
             data-prevent-thread
             data-track-category='SLASH_COMMAND_ARTIFACT'
@@ -553,7 +549,7 @@ export const SlashCommandArtifactCard: React.FC<SlashCommandArtifactCardProps> =
           >
             <Phone className='size-4' />
             Start call
-          </Button>
+          </button>
         )}
       </div>
 

--- a/apps/dashboard/src/components/Chat/TwinReplyDraft/ThreadAssistDock.tsx
+++ b/apps/dashboard/src/components/Chat/TwinReplyDraft/ThreadAssistDock.tsx
@@ -827,18 +827,17 @@ function ReplyCard({
               />
             )}
             <Tooltip content='Discard draft' side='top'>
-              <Button
-                variant='ghost'
+              <button
                 onClick={() => void decline()}
                 disabled={loading}
-                trackId='twin_decline_draft'
+                data-ph-capture-attribute-track-id='twin_decline_draft'
                 aria-label='Discard draft'
                 data-track-category='twin-dock'
                 data-track-name='decline'
                 className='flex items-center justify-center px-[9px] py-1.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50'
               >
                 <ChatCancel size={14} />
-              </Button>
+              </button>
             </Tooltip>
             {hasReply && (
               <Tooltip content={editing ? 'Cancel edit' : 'Edit draft'} side='top'>

--- a/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
+++ b/apps/dashboard/src/components/Chat/UserThreads/UserThreads.tsx
@@ -25,7 +25,6 @@ import {
 } from '../../../services/Chat/conversationService';
 import { useUnreadThreadConversationIds } from '../../../hooks/useUnreadThreadsCount';
 import { TwinDraftIndicator } from '../TwinReplyDraft/TwinDraftIndicator';
-import { Button } from '../../ui/Button/Button';
 
 const PAGE_SIZE = 10;
 const THREAD_LIST_SORT_STORAGE_PREFIX = 'xyne:user-threads-sort';
@@ -333,16 +332,15 @@ const UserThreads = (): ReactElement => {
         <div className='flex min-h-10 justify-center py-4'>
           {isLoadingMore && <Loader2 className='animate-spin text-muted-foreground' />}
           {loadError && hasConversations && (
-            <Button
-              variant='link'
+            <button
               className='text-sm text-primary hover:underline'
               onClick={retryLoad}
-              trackId='retry_thread_list_page'
+              data-ph-capture-attribute-track-id='retry_thread_list_page'
               data-track-category='USER_THREADS'
               data-track-name='RETRY_THREAD_LIST_PAGE'
             >
               Try loading more again
-            </Button>
+            </button>
           )}
         </div>
       ),
@@ -401,16 +399,15 @@ const UserThreads = (): ReactElement => {
           ) : loadError && !hasConversations ? (
             <div className='flex h-full flex-col items-center justify-center gap-3 p-8 text-center'>
               <p className='text-muted-foreground'>{loadError}</p>
-              <Button
-                variant='link'
+              <button
                 className='text-sm text-primary hover:underline'
                 onClick={retryLoad}
-                trackId='retry_thread_list'
+                data-ph-capture-attribute-track-id='retry_thread_list'
                 data-track-category='USER_THREADS'
                 data-track-name='RETRY_THREAD_LIST'
               >
                 Try again
-              </Button>
+              </button>
             </div>
           ) : !hasConversations ? (
             <div className='flex flex-col items-center justify-center h-full p-8 text-center'>

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ActivityConfigDialog.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ActivityConfigDialog.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable local-rules/require-tracking-on-click */
 import { ReactElement, useState, useCallback, useEffect } from 'react';
 import { X, AlertTriangle, Pencil } from 'lucide-react';
-import { Button } from '../../../ui/Button/Button';
 
 interface ActivityConfigDialogProps {
   isOpen: boolean;
@@ -222,17 +221,16 @@ export const ActivityConfigDialog = ({
           >
             Cancel
           </button>
-          <Button
-            variant='ghost'
+          <button
             onClick={handleSave}
-            trackId='save_activity_config'
+            data-ph-capture-attribute-track-id='save_activity_config'
             data-track-category='XYNE_AI_SIDEBAR'
             data-track-name='SAVE_ACTIVITY_CONFIG'
             className='px-4 py-2 text-sm font-medium text-action-primary-foreground bg-action-primary rounded-md hover:bg-action-primary/90 transition-colors'
             type='button'
           >
             {hasExistingAlias ? 'Update' : 'Save'}
-          </Button>
+          </button>
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/AliasManager.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/AliasManager.tsx
@@ -2,7 +2,6 @@
 import { ReactElement, useState, useCallback } from 'react';
 import { X, Trash2, Edit2, Ban } from 'lucide-react';
 import type { ActivityAlias } from '../../../../hooks/useActivityAliases';
-import { Button } from '../../../ui/Button/Button';
 
 interface AliasManagerProps {
   isOpen: boolean;
@@ -136,17 +135,16 @@ export const AliasManager = ({
                           </button>
                           {confirmDeleteId === alias.id ? (
                             <div className='flex items-center gap-1'>
-                              <Button
-                                variant='ghost'
+                              <button
                                 onClick={() => handleConfirmDelete(alias.id)}
-                                trackId='confirm_delete_alias'
+                                data-ph-capture-attribute-track-id='confirm_delete_alias'
                                 data-track-category='XYNE_AI_SIDEBAR'
                                 data-track-name='CONFIRM_DELETE_ALIAS'
                                 className='px-2 py-1 text-xs font-medium text-destructive-foreground bg-destructive rounded hover:bg-destructive/90 transition-colors'
                                 type='button'
                               >
                                 Confirm
-                              </Button>
+                              </button>
                               <button
                                 onClick={handleCancelDelete}
                                 data-track-category='XYNE_AI_SIDEBAR'

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/ConversationHistory.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/ConversationHistory.tsx
@@ -8,7 +8,6 @@ import { XyneDelete } from '../../../icons/xyne-ai';
 import { formatRelativeTime } from '../../../../utils/dateUtils';
 import { AgentSelector } from './AgentSelector';
 import type { AgentOption } from './AgentSelector';
-import { Button } from '../../../ui/Button/Button';
 
 interface ConversationHistoryProps {
   conversations: ConversationHistoryType[];
@@ -540,14 +539,13 @@ const ConversationItem = ({
           description='Manage this conversation'
         >
           <div className='flex flex-col bg-popover rounded-t-[20px] overflow-hidden'>
-            <Button
-              variant='ghost'
+            <button
               onClick={e => {
                 e.stopPropagation();
                 onDelete();
                 setOpenDropdownId(null);
               }}
-              trackId='delete_conversation'
+              data-ph-capture-attribute-track-id='delete_conversation'
               className='w-full px-4 py-4 text-left text-sm active:bg-accent flex items-center gap-3 text-destructive touch-manipulation'
               data-track-category='XyneAI'
               data-track-name='DELETE_CONVERSATION'
@@ -555,7 +553,7 @@ const ConversationItem = ({
             >
               <XyneDelete color='currentColor' />
               <span>Delete</span>
-            </Button>
+            </button>
           </div>
         </Drawer>
       ) : (
@@ -576,14 +574,13 @@ const ConversationItem = ({
           }
           className='w-48 p-0 bg-popover border border-border rounded-lg shadow-lg'
         >
-          <Button
-            variant='ghost'
+          <button
             onClick={e => {
               e.stopPropagation();
               onDelete();
               setOpenDropdownId(null);
             }}
-            trackId='delete_conversation'
+            data-ph-capture-attribute-track-id='delete_conversation'
             className='w-full px-4 py-2 text-left text-sm hover:bg-accent flex items-center gap-2 text-destructive'
             data-track-category='XyneAI'
             data-track-name='DELETE_DESKTOP'
@@ -591,7 +588,7 @@ const ConversationItem = ({
           >
             <XyneDelete color='currentColor' />
             <span>Delete</span>
-          </Button>
+          </button>
         </Popover>
       )}
     </div>

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/MessageItem.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/MessageItem.tsx
@@ -90,7 +90,6 @@ import { respondToPendingAction } from '../../../../services/XyneAI/XyneAIPendin
 import { Link2 } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { AskAiRatingButtons } from '../../../AIScreen/AskAiRatingButtons';
-import { Button } from '../../../ui/Button/Button';
 
 /**
  * v3-style inline citation chip for `[clf-<toolCallId>#<chunkIndex>]` tokens.
@@ -1373,17 +1372,21 @@ export const MessageItem = React.memo(
                   >
                     Cancel
                   </button>
-                  <Button
-                    variant='ghost'
-                    onClick={submitEdit}
-                    trackId='edit_message_submit'
+                  <button
+                    onClick={() => {
+                      if (editText.trim()) {
+                        onEditSubmit?.(editText.trim());
+                        setIsEditing(false);
+                      }
+                    }}
+                    data-ph-capture-attribute-track-id='edit_message_submit'
                     disabled={!editText.trim()}
                     className="px-3 py-1.5 text-xs font-medium rounded-full bg-foreground text-background hover:opacity-90 transition-opacity disabled:opacity-50 font-['Inter']"
                     data-track-category='XyneAI'
                     data-track-name='EDIT_SUBMIT'
                   >
                     Send
-                  </Button>
+                  </button>
                 </div>
               </div>
             ) : message.type === 'user' ? (
@@ -2679,10 +2682,9 @@ const MessageActions = ({
 
       {/* Regenerate Button - only on the latest bot message */}
       {onRegenerate && (
-        <Button
-          variant='ghost'
+        <button
           onClick={onRegenerate}
-          trackId='regenerate_message'
+          data-ph-capture-attribute-track-id='regenerate_message'
           className='p-1.5 rounded transition-colors hover:bg-accent'
           title='Regenerate response'
           data-track-category='XyneAI'
@@ -2690,7 +2692,7 @@ const MessageActions = ({
           data-track-metadata={JSON.stringify({ messageId: message.id })}
         >
           <RefreshCw size={16} className='text-current' />
-        </Button>
+        </button>
       )}
 
       {isV2 ? (
@@ -2705,10 +2707,9 @@ const MessageActions = ({
       ) : (
         <>
           {/* Like Button */}
-          <Button
-            variant='ghost'
+          <button
             onClick={() => onFeedback(message.id, 'LIKE')}
-            trackId='like_message'
+            data-ph-capture-attribute-track-id='like_message'
             className='p-1.5 rounded transition-colors hover:bg-accent'
             title='Like'
             data-track-category='XyneAI'
@@ -2746,13 +2747,12 @@ const MessageActions = ({
                 </clipPath>
               </defs>
             </svg>
-          </Button>
+          </button>
 
           {/* Dislike Button */}
-          <Button
-            variant='ghost'
+          <button
             onClick={() => onFeedback(message.id, 'DISLIKE')}
-            trackId='dislike_message'
+            data-ph-capture-attribute-track-id='dislike_message'
             className='p-1.5 rounded transition-colors hover:bg-accent'
             title='Dislike'
             data-track-category='XyneAI'
@@ -2795,7 +2795,7 @@ const MessageActions = ({
                 </clipPath>
               </defs>
             </svg>
-          </Button>
+          </button>
         </>
       )}
       {/* Participants avatars - shown for Summarizer messages */}

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/PendingActionBlock.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/PendingActionBlock.tsx
@@ -6,7 +6,6 @@ import {
   getStoredPendingActionResolution,
   subscribeToPendingActionResolutions,
 } from '../../../../services/XyneAI/XyneAIPendingActionStore';
-import { Button } from '../../../ui/Button/Button';
 
 interface PendingActionBlockProps {
   actions: PendingAction[];
@@ -143,10 +142,9 @@ function PendingActionItem({
 
       {/* Action buttons */}
       <div className='flex items-center gap-2'>
-        <Button
-          variant='ghost'
+        <button
           onClick={() => void handleApprove()}
-          trackId='approve_pending_action'
+          data-ph-capture-attribute-track-id='approve_pending_action'
           disabled={state === 'running'}
           className='inline-flex items-center gap-1 rounded bg-emerald-600 px-2.5 py-1 text-[10px] font-medium text-white transition hover:bg-emerald-700 disabled:opacity-50'
           type='button'
@@ -159,11 +157,10 @@ function PendingActionItem({
             <Check size={10} />
           )}
           Approve
-        </Button>
-        <Button
-          variant='ghost'
+        </button>
+        <button
           onClick={() => void handleDecline()}
-          trackId='decline_pending_action'
+          data-ph-capture-attribute-track-id='decline_pending_action'
           disabled={state === 'running'}
           className='inline-flex items-center gap-1 rounded bg-secondary px-2.5 py-1 text-[10px] text-secondary-foreground transition hover:bg-secondary/80 disabled:opacity-50'
           type='button'
@@ -172,7 +169,7 @@ function PendingActionItem({
         >
           <X size={10} />
           Decline
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/SettingsModal.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/SettingsModal.tsx
@@ -3,7 +3,6 @@ import { apiInstance } from '../../../../services/clients/apiClient';
 import { toast } from 'sonner';
 import { Edit2, Trash2, Plus, Eye, X } from 'lucide-react';
 import { usePlatform } from '../../../../hooks/usePlatform';
-import { Button } from '../../../ui/Button/Button';
 
 interface Skill {
   name: string;
@@ -661,19 +660,18 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps): ReactEle
                           >
                             <Edit2 size={16} />
                           </button>
-                          <Button
-                            variant='ghost'
+                          <button
                             onClick={() => {
                               void handleDeleteSkill(skill.name);
                             }}
-                            trackId='delete_skill'
+                            data-ph-capture-attribute-track-id='delete_skill'
                             className='p-1.5 rounded-md hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors'
                             title='Delete'
                             data-track-category='XyneAI'
                             data-track-name='DeleteSkill'
                           >
                             <Trash2 size={16} />
-                          </Button>
+                          </button>
                         </div>
                       )}
                     </div>
@@ -689,17 +687,16 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps): ReactEle
           {activeTab === 'custom' ? (
             // Custom Instructions Footer
             <>
-              <Button
-                variant='ghost'
+              <button
                 onClick={() => void handleClearInstruction()}
-                trackId='clear_custom_instructions'
+                data-ph-capture-attribute-track-id='clear_custom_instructions'
                 className='px-4 py-2 text-sm font-medium text-destructive hover:text-destructive hover:bg-destructive/10 rounded-lg transition-colors'
                 disabled={isSavingInstruction || isLoadingInstruction || !instruction}
                 data-track-category='XyneAI'
                 data-track-name='ClearCustomInstructions'
               >
                 Clear
-              </Button>
+              </button>
               <div className='flex gap-2'>
                 <button
                   onClick={onClose}
@@ -710,10 +707,9 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps): ReactEle
                 >
                   Cancel
                 </button>
-                <Button
-                  variant='ghost'
+                <button
                   onClick={() => void handleSaveInstruction()}
-                  trackId='save_custom_instructions'
+                  data-ph-capture-attribute-track-id='save_custom_instructions'
                   className='px-4 py-2 text-sm font-medium text-action-primary-foreground bg-action-primary hover:bg-action-primary/90 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
                   disabled={
                     isSavingInstruction ||
@@ -724,7 +720,7 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps): ReactEle
                   data-track-name='SaveCustomInstructions'
                 >
                   {isSavingInstruction ? 'Saving...' : 'Save'}
-                </Button>
+                </button>
               </div>
             </>
           ) : previewingSkill ? (
@@ -752,17 +748,18 @@ export const SettingsModal = ({ isOpen, onClose }: SettingsModalProps): ReactEle
               >
                 Cancel
               </button>
-              <Button
-                variant='ghost'
+              <button
                 onClick={() => void handleSaveSkill()}
-                trackId={editingSkillName ? 'update_skill' : 'create_skill'}
+                data-ph-capture-attribute-track-id={
+                  editingSkillName ? 'update_skill' : 'create_skill'
+                }
                 className='px-4 py-2 text-sm font-medium text-action-primary-foreground bg-action-primary hover:bg-action-primary/90 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
                 disabled={isSavingSkill || !skillName.trim() || !!nameError}
                 data-track-category='XyneAI'
                 data-track-name={editingSkillName ? 'UpdateSkill' : 'CreateSkill'}
               >
                 {isSavingSkill ? 'Saving...' : editingSkillName ? 'Update' : 'Save'}
-              </Button>
+              </button>
             </>
           ) : (
             // Skills List Footer

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/XyneAIInputBox.tsx
@@ -80,7 +80,6 @@ import type { Channel } from '@xyne/shared';
 import { ChannelVisibility } from '@xyne/shared';
 import type { DisplaySearchResult } from '../../../../types/search';
 import { TabType } from '../../ChatDirectory/ChannelCommandMenu.types';
-import { Button } from '../../../ui/Button/Button';
 
 // Browser context interface
 export interface BrowserContext {
@@ -1951,10 +1950,11 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
                     disabled={isStreaming}
                     onStateChange={({ isRecording }) => setIsVoiceRecording(isRecording)}
                   />
-                  <Button
-                    variant='ghost'
+                  <button
                     onClick={isStreaming ? onAbort : onSubmit}
-                    trackId={isStreaming ? 'abort_message' : 'submit_message'}
+                    data-ph-capture-attribute-track-id={
+                      isStreaming ? 'abort_message' : 'submit_message'
+                    }
                     disabled={!isStreaming && !inputValue.trim()}
                     className={`rounded-full transition-colors shrink-0 p-2 ${
                       isStreaming
@@ -1971,7 +1971,7 @@ export const XyneAIInputBox = forwardRef<XyneAIInputBoxHandle, XyneAIInputBoxPro
                     ) : (
                       <ArrowUp className='w-4 h-4' />
                     )}
-                  </Button>
+                  </button>
                 </div>
               </div>
             )}

--- a/apps/dashboard/src/components/Claw/ClawChat/Composer.tsx
+++ b/apps/dashboard/src/components/Claw/ClawChat/Composer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ReactElement } from 'react';
 import { ArrowUp, Square } from 'lucide-react';
-import { Button } from '../../ui/Button/Button';
+
 import { cn } from '../../../utils/classNames';
 import { MAX_TEXTAREA_HEIGHT_PX } from './clawChat.constants';
 
@@ -79,13 +79,12 @@ export function Composer({ isStreaming, onSend, onStop }: ComposerProps): ReactE
             <Square className='size-3 fill-current' />
           </button>
         ) : (
-          <Button
-            variant='ghost'
+          <button
             type='button'
             onClick={handleSubmit}
             disabled={!canSend}
             aria-label='Send message'
-            trackId='claw_send_message'
+            data-ph-capture-attribute-track-id='claw_send_message'
             data-track-category='CLAW_CHAT'
             data-track-name='SEND_MESSAGE'
             className={cn(
@@ -96,7 +95,7 @@ export function Composer({ isStreaming, onSend, onStop }: ComposerProps): ReactE
             )}
           >
             <ArrowUp className='size-4' />
-          </Button>
+          </button>
         )}
       </div>
     </div>

--- a/apps/dashboard/src/components/Claw/ClawChat/MessageBubble.tsx
+++ b/apps/dashboard/src/components/Claw/ClawChat/MessageBubble.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import { motion } from 'framer-motion';
-import { Button } from '../../ui/Button/Button';
+
 import { cn } from '../../../utils/classNames';
 import type { Message } from '../../Chat/XyneAISidebar/utils/XyneAITypes';
 import { ActivityBlock } from '../../Chat/XyneAISidebar/components/ActivityBlock';
@@ -51,17 +51,16 @@ export function MessageBubble({ message, onRetry }: MessageBubbleProps): ReactEl
               <span className='font-medium'>{message.errorInfo.title}</span>
               <span className='text-destructive/90'>{message.errorInfo.message}</span>
               {onRetry && message.errorInfo.retryable !== false && (
-                <Button
-                  variant='ghost'
+                <button
                   type='button'
                   onClick={onRetry}
-                  trackId='claw_retry_message'
+                  data-ph-capture-attribute-track-id='claw_retry_message'
                   data-track-category='CLAW_CHAT'
                   data-track-name='RETRY_MESSAGE'
                   className='self-start text-xs font-medium underline underline-offset-2 hover:opacity-80'
                 >
                   Try again
-                </Button>
+                </button>
               )}
             </div>
           </div>

--- a/apps/dashboard/src/components/ClawAgents/ToolboxPicker/ToolboxPicker.tsx
+++ b/apps/dashboard/src/components/ClawAgents/ToolboxPicker/ToolboxPicker.tsx
@@ -17,7 +17,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
 import { Sparkles, ChevronRight, Loader2, Check, X, Info } from 'lucide-react';
 import { suggestTools } from '@/services/claw/clawToolsService';
-import { Button } from '@/components/ui/Button';
+
 import { Dialog } from '@/components/ui/Dialog';
 import type {
   AvailableTools,
@@ -673,17 +673,16 @@ export function ToolboxPicker({
           <span className='min-w-0 flex-1 truncate'>
             Couldn&apos;t suggest tools — {suggestionError}
           </span>
-          <Button
+          <button
             type='button'
-            variant='ghost'
-            trackId='claw_toolbox_resuggest'
+            data-ph-capture-attribute-track-id='claw_toolbox_resuggest'
             data-track-category='Claw Agents'
             data-track-name='Re-suggest tools'
             onClick={reRollSuggestion}
             className='shrink-0 font-medium underline-offset-2 hover:underline'
           >
             Try again
-          </Button>
+          </button>
           <button
             type='button'
             data-track-category='Claw Agents'
@@ -848,17 +847,16 @@ export function ToolboxPicker({
                 >
                   <Sparkles size={12} /> Accept all {total}
                 </button>
-                <Button
+                <button
                   type='button'
-                  variant='ghost'
-                  trackId='claw_toolbox_resuggest'
+                  data-ph-capture-attribute-track-id='claw_toolbox_resuggest'
                   data-track-category='Claw Agents'
                   data-track-name='Re-suggest tools'
                   onClick={reRollSuggestion}
                   className='rounded bg-muted px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted/70'
                 >
                   Re-suggest
-                </Button>
+                </button>
               </div>
             </div>
           );
@@ -868,17 +866,16 @@ export function ToolboxPicker({
         <div className='flex items-center gap-2 rounded-md bg-emerald-500/10 px-2.5 py-1.5 text-[12px] text-emerald-600 dark:text-emerald-400'>
           <Check size={13} className='shrink-0' />
           <span className='flex-1'>Suggestions applied</span>
-          <Button
+          <button
             type='button'
-            variant='ghost'
-            trackId='claw_toolbox_resuggest'
+            data-ph-capture-attribute-track-id='claw_toolbox_resuggest'
             data-track-category='Claw Agents'
             data-track-name='Re-suggest tools'
             onClick={reRollSuggestion}
             className='shrink-0 font-medium underline-offset-2 hover:underline'
           >
             Re-suggest
-          </Button>
+          </button>
         </div>
       )}
     </div>
@@ -942,10 +939,9 @@ export function ToolboxPicker({
           >
             Cancel
           </button>
-          <Button
+          <button
             type='button'
-            variant='ghost'
-            trackId='claw_toolbox_suggest_submit'
+            data-ph-capture-attribute-track-id='claw_toolbox_suggest_submit'
             data-track-category='Claw Agents'
             data-track-name='Submit suggest tools'
             onClick={submitRefine}
@@ -953,7 +949,7 @@ export function ToolboxPicker({
             className='inline-flex items-center gap-1.5 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-foreground/90 disabled:opacity-40 disabled:cursor-not-allowed'
           >
             <Sparkles size={14} /> Suggest
-          </Button>
+          </button>
         </div>
       </Dialog>
     </>

--- a/apps/dashboard/src/components/ClawAgents/digitalTwin/CandidateRow.tsx
+++ b/apps/dashboard/src/components/ClawAgents/digitalTwin/CandidateRow.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useState } from 'react';
 import { Check, Loader2, Pencil, X } from 'lucide-react';
 import { toast } from 'sonner';
-import { Button } from '@/components/ui/Button/Button';
+
 import { Tooltip } from '@/components/ui/Tooltip/Tooltip';
 import { cn } from '@/utils/classNames';
 import { usePatchDigitalTwinCandidate } from '@/hooks/useClawDigitalTwin';
@@ -108,11 +108,10 @@ export const CandidateRow = ({
         {editing ? (
           <>
             <Tooltip side='top' content='Save edit'>
-              <Button
-                variant='ghost'
+              <button
                 type='button'
                 onClick={() => void handleSave()}
-                trackId='digital_twin_save_candidate_edit'
+                data-ph-capture-attribute-track-id='digital_twin_save_candidate_edit'
                 data-track-category='Claw Agents'
                 data-track-name='Digital Twin save candidate edit'
                 disabled={isBusy}
@@ -123,7 +122,7 @@ export const CandidateRow = ({
                 ) : (
                   <Check className='size-3.5' />
                 )}
-              </Button>
+              </button>
             </Tooltip>
             <Tooltip side='top' content='Cancel'>
               <button
@@ -162,11 +161,10 @@ export const CandidateRow = ({
               </button>
             </Tooltip>
             <Tooltip side='top' content={isDirty ? 'Save & approve' : 'Approve'}>
-              <Button
-                variant='ghost'
+              <button
                 type='button'
                 onClick={() => void handleApprove()}
-                trackId='digital_twin_approve_candidate'
+                data-ph-capture-attribute-track-id='digital_twin_approve_candidate'
                 data-track-category='Claw Agents'
                 data-track-name='Digital Twin approve candidate'
                 disabled={isBusy}
@@ -177,14 +175,13 @@ export const CandidateRow = ({
                 ) : (
                   <Check className='size-3.5' />
                 )}
-              </Button>
+              </button>
             </Tooltip>
             <Tooltip side='top' content='Reject'>
-              <Button
-                variant='ghost'
+              <button
                 type='button'
                 onClick={() => void handleReject()}
-                trackId='digital_twin_reject_candidate'
+                data-ph-capture-attribute-track-id='digital_twin_reject_candidate'
                 data-track-category='Claw Agents'
                 data-track-name='Digital Twin reject candidate'
                 disabled={isBusy}
@@ -198,7 +195,7 @@ export const CandidateRow = ({
                 ) : (
                   <X className='size-3.5' />
                 )}
-              </Button>
+              </button>
             </Tooltip>
           </>
         )}

--- a/apps/dashboard/src/components/ClawAgents/digitalTwin/DigitalTwinBanner.tsx
+++ b/apps/dashboard/src/components/ClawAgents/digitalTwin/DigitalTwinBanner.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react';
 import { AlertTriangle, Brain, CheckCircle2, Info, Loader2, XCircle } from 'lucide-react';
-import { Button } from '@/components/ui/Button/Button';
+
 import { Tooltip } from '@/components/ui/Tooltip/Tooltip';
 import { cn } from '@/utils/classNames';
 import type { DigitalTwinStatus } from '@/services/claw/digitalTwinTypes';
@@ -65,18 +65,17 @@ export const DigitalTwinBanner = ({
               </p>
             </div>
           </div>
-          <Button
-            variant='ghost'
+          <button
             type='button'
             onClick={onEnable}
-            trackId='digital_twin_enable'
+            data-ph-capture-attribute-track-id='digital_twin_enable'
             data-track-category='Claw Agents'
             data-track-name='Digital Twin enable'
             className='mt-3.5 flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-600 px-3.5 py-2 text-[13px] font-semibold text-white transition hover:bg-emerald-600/90'
           >
             <Brain className='size-4' />
             Enable Digital Twin
-          </Button>
+          </button>
         </div>
       </div>
     );
@@ -116,17 +115,16 @@ export const DigitalTwinBanner = ({
               <span className='text-xs font-semibold text-foreground'>Backfill stalled</span>
               <span className='text-[11px] text-muted-foreground'>No progress in 30 s</span>
             </div>
-            <Button
-              variant='ghost'
+            <button
               type='button'
               onClick={onDisable}
-              trackId='digital_twin_disable_and_retry_backfill'
+              data-ph-capture-attribute-track-id='digital_twin_disable_and_retry_backfill'
               data-track-category='Claw Agents'
               data-track-name='Digital Twin disable and retry backfill'
               className='rounded-lg border border-border bg-card px-2.5 py-1 text-[11px] font-semibold text-foreground transition hover:bg-muted'
             >
               Disable &amp; retry
-            </Button>
+            </button>
           </div>
         )}
 

--- a/apps/dashboard/src/components/ClawAgents/digitalTwin/MemoryCard.tsx
+++ b/apps/dashboard/src/components/ClawAgents/digitalTwin/MemoryCard.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useState } from 'react';
 import { Trash2 } from 'lucide-react';
-import { Button } from '@/components/ui/Button/Button';
+
 import type { MemoryBankMemory } from '@/services/claw/digitalTwinTypes';
 import { CategoryBadge } from './CategoryBadge';
 import { fmtRelative } from './format';
@@ -74,11 +74,10 @@ export const MemoryCard = ({
           )}
         </div>
         {onDelete && (
-          <Button
-            variant='ghost'
+          <button
             type='button'
             onClick={() => onDelete(memory.hindsightMemoryId)}
-            trackId='digital_twin_delete_memory'
+            data-ph-capture-attribute-track-id='digital_twin_delete_memory'
             data-track-category='Claw Agents'
             data-track-name='Digital Twin delete memory'
             className='shrink-0 text-muted-foreground transition-colors hover:text-destructive'
@@ -86,7 +85,7 @@ export const MemoryCard = ({
             aria-label='Delete memory'
           >
             <Trash2 className='size-3.5' />
-          </Button>
+          </button>
         )}
       </div>
     </div>

--- a/apps/dashboard/src/components/DynamicDashboard/DataSourcesAdminModal.tsx
+++ b/apps/dashboard/src/components/DynamicDashboard/DataSourcesAdminModal.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../services/DynamicDashboard/dataSourcesAdminService';
 import Input from '../ui/Input';
 import { Textarea } from '../ui/Textarea';
-import { Button } from '../ui/Button/Button';
+
 import { CaCertificateField } from './CaCertificateField';
 import { SOURCE_TYPES, type SourceType } from './dataSources.constants';
 import {
@@ -577,12 +577,11 @@ export const DataSourcesAdminModal = ({ onClose }: DataSourcesAdminModalProps): 
         >
           Previous
         </button>
-        <Button
-          variant='default'
+        <button
           type='button'
           onClick={() => void handleSave()}
           disabled={!canSave}
-          trackId='create_data_source'
+          data-ph-capture-attribute-track-id='create_data_source'
           data-track-category='DATA_SOURCE'
           data-track-name='Wizard_Save_Ingest'
           className={`inline-flex items-center gap-1.5 h-9 px-5 rounded-lg text-[13px] leading-[18px] font-medium text-white transition-colors ${
@@ -599,7 +598,7 @@ export const DataSourcesAdminModal = ({ onClose }: DataSourcesAdminModalProps): 
           ) : (
             'Save & Ingest'
           )}
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/DynamicDashboard/DatabaseVisualizer/DatabaseVisualizerDialog.tsx
+++ b/apps/dashboard/src/components/DynamicDashboard/DatabaseVisualizer/DatabaseVisualizerDialog.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 
 import { useQuery } from '@tanstack/react-query';
 import { AlertCircle, Loader2, RefreshCw, Search, Trash2, X } from 'lucide-react';
 import { Dialog } from '../../ui/Dialog';
-import { Button } from '../../ui/Button/Button';
+
 import { SegmentedToggle } from '../../ui/SegmentedToggle/SegmentedToggle';
 import { listDataSources } from '../../../services/DynamicDashboard/dataSourcesService';
 import { dataSourceKeys, useDataSourceMutations } from '../../../hooks/useDataSources';
@@ -254,19 +254,18 @@ export function DatabaseVisualizerDialog({
             >
               Cancel
             </button>
-            <Button
-              variant='default'
+            <button
               type='button'
               onClick={onRefreshConfirmed}
               disabled={refreshMutation.isPending}
-              trackId='reingest_data_source'
+              data-ph-capture-attribute-track-id='reingest_data_source'
               data-track-category='DYNAMIC_DASHBOARD'
               data-track-name='Db_Viz_Refresh_Source_Confirm'
               className='h-9 px-3 rounded-lg text-sm font-medium text-primary-foreground bg-primary hover:bg-primary/90 transition-colors disabled:opacity-50 inline-flex items-center gap-1.5'
             >
               {refreshMutation.isPending && <Loader2 size={13} className='animate-spin' />}
               Re-ingest
-            </Button>
+            </button>
           </div>
         </div>
       </Dialog>
@@ -299,19 +298,18 @@ export function DatabaseVisualizerDialog({
             >
               Cancel
             </button>
-            <Button
-              variant='destructive'
+            <button
               type='button'
               onClick={onDeleteConfirmed}
               disabled={deleteMutation.isPending}
-              trackId='delete_data_source'
+              data-ph-capture-attribute-track-id='delete_data_source'
               data-track-category='DYNAMIC_DASHBOARD'
               data-track-name='Db_Viz_Delete_Source_Confirm'
               className='h-9 px-3 rounded-lg text-sm font-medium text-white bg-rose-600 hover:bg-rose-700 transition-colors disabled:opacity-50 inline-flex items-center gap-1.5'
             >
               {deleteMutation.isPending && <Loader2 size={13} className='animate-spin' />}
               Delete
-            </Button>
+            </button>
           </div>
         </div>
       </Dialog>

--- a/apps/dashboard/src/components/DynamicDashboard/ai/DrillResultBubble.tsx
+++ b/apps/dashboard/src/components/DynamicDashboard/ai/DrillResultBubble.tsx
@@ -4,7 +4,6 @@ import { Check, Plus } from 'lucide-react';
 import type { QueryVisualizationType } from '@xyne/shared';
 import { previewQueryPlan } from '../../../services/DynamicDashboard/previewService';
 import { getRendererForType } from '../ComponentGrid/renderers';
-import { Button } from '../../ui/Button/Button';
 
 export interface DrillResultBubbleProps {
   title: string;
@@ -48,11 +47,10 @@ export const DrillResultBubble = ({
       {query.data && !Renderer && (
         <div className='text-xs text-muted-foreground'>No preview available for {visualType}.</div>
       )}
-      <Button
-        variant='ghost'
+      <button
         type='button'
         disabled={added || adding}
-        trackId='add_drill_to_dashboard'
+        data-ph-capture-attribute-track-id='add_drill_to_dashboard'
         onClick={() => {
           setAdding(true);
           void onAdd({ title, visualType, queryPlan })
@@ -66,7 +64,7 @@ export const DrillResultBubble = ({
       >
         {added ? <Check size={12} /> : <Plus size={12} />}
         {added ? 'Added to dashboard' : adding ? 'Adding…' : 'Add to dashboard'}
-      </Button>
+      </button>
     </div>
   );
 };

--- a/apps/dashboard/src/components/DynamicDashboard/componentEditor/ComponentEditorHeader.tsx
+++ b/apps/dashboard/src/components/DynamicDashboard/componentEditor/ComponentEditorHeader.tsx
@@ -1,6 +1,5 @@
 import { LayoutDashboard, Loader2, RefreshCw } from 'lucide-react';
 import type { ReactElement } from 'react';
-import { Button } from '../../ui/Button/Button';
 
 interface ComponentEditorHeaderProps {
   dashboardName: string;
@@ -33,12 +32,11 @@ export const ComponentEditorHeader = ({
       <span className='font-medium text-xyne-gray-900 truncate'>{title.trim() || 'Untitled'}</span>
     </div>
     <div className='flex items-center gap-1.5'>
-      <Button
-        variant='ghost'
+      <button
         type='button'
         onClick={onRefresh}
         disabled={isPreviewing || !planIsValid}
-        trackId='refresh_component_preview'
+        data-ph-capture-attribute-track-id='refresh_component_preview'
         className='inline-flex items-center gap-1.5 h-8 px-3 rounded-lg border border-xyne-gray-200 bg-white text-[13px] leading-[18px] font-medium text-xyne-gray-900 transition-colors hover:bg-xyne-gray-50 disabled:opacity-50 disabled:cursor-not-allowed'
         data-track-category='COMPONENT_EDITOR'
         data-track-name='Refresh_Preview_Click'
@@ -48,7 +46,7 @@ export const ComponentEditorHeader = ({
           className={`text-xyne-gray-600 ${isPreviewing ? 'animate-spin' : ''}`}
         />
         {isPreviewing ? 'Running…' : 'Refresh'}
-      </Button>
+      </button>
       <button
         type='button'
         onClick={onCancel}
@@ -58,19 +56,18 @@ export const ComponentEditorHeader = ({
       >
         Cancel
       </button>
-      <Button
-        variant='default'
+      <button
         type='button'
         onClick={onSave}
         disabled={isSaving || !planIsValid || hasPreviewError}
-        trackId='save_component'
+        data-ph-capture-attribute-track-id='save_component'
         className='inline-flex items-center h-8 px-4 rounded-lg bg-xyne-primary-500 text-[13px] leading-[18px] font-medium text-white transition-colors hover:bg-xyne-primary-600 disabled:bg-xyne-gray-300 disabled:text-white disabled:cursor-not-allowed'
         data-track-category='COMPONENT_EDITOR'
         data-track-name='Save_Click'
       >
         {isSaving ? <Loader2 size={14} className='mr-1.5 animate-spin' /> : null}
         {isSaving ? 'Saving…' : 'Save'}
-      </Button>
+      </button>
     </div>
   </div>
 );

--- a/apps/dashboard/src/components/ElectronUpdateNudge/ElectronUpdateNudge.tsx
+++ b/apps/dashboard/src/components/ElectronUpdateNudge/ElectronUpdateNudge.tsx
@@ -4,7 +4,6 @@ import { useSelector } from '@xstate/react';
 import { RefreshCw, X } from 'lucide-react';
 import { callActor } from '../../machines/callMachine';
 import { roomActor } from '../../machines/roomMachine';
-import { Button } from '../ui/Button/Button';
 
 // Kill switch for the Electron auto-update nudge. While false the component is
 // fully inert: no event listener is registered and nothing is rendered.
@@ -404,18 +403,17 @@ export const ElectronUpdateNudge = (): ReactElement | null => {
         <p className='shrink-0 text-xs font-semibold text-foreground'>{title}</p>
         <p className='truncate text-xs text-muted-foreground'>{message}</p>
       </div>
-      <Button
+      <button
         type='button'
-        variant='ghost'
         onClick={() => applyUpdate('manual')}
         disabled={activationBlocked}
         className='h-auto shrink-0 rounded-md bg-primary px-2.5 py-1.5 text-xs font-semibold text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50'
-        trackId='electron_apply_update'
+        data-ph-capture-attribute-track-id='electron_apply_update'
         data-track-category='ElectronUpdate'
         data-track-name='UpdateNow'
       >
         Update now
-      </Button>
+      </button>
       {!nudge.autoApprovalRequired && (
         <button
           type='button'

--- a/apps/dashboard/src/components/FileViewer/CodeViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/CodeViewer.tsx
@@ -4,7 +4,6 @@ import hljs from 'highlight.js';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import ReadmeViewer from './ReadmeViewer';
 import { injectMarks, useLineSearch, useMatchScroll } from './search';
-import { Button } from '../ui/Button/Button';
 
 // Static lookup map — O(1) vs sequential if-chain
 const EXTENSION_TO_LANGUAGE: Record<string, string> = {
@@ -77,16 +76,15 @@ const ErrorDisplay: React.FC<{ error: string; canRetry?: boolean; onRetry?: () =
       <p className='text-red-800 dark:text-red-200 font-semibold mb-2'>Unable to display file</p>
       <p className='text-red-600 dark:text-red-300 text-sm mb-3'>{error}</p>
       {canRetry && onRetry && (
-        <Button
+        <button
           onClick={onRetry}
-          variant='ghost'
           className='px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700 transition-colors'
           data-track-category='FileViewer'
           data-track-name='RetryLoadCode'
-          trackId='retry_load_code'
+          data-ph-capture-attribute-track-id='retry_load_code'
         >
           Try Again
-        </Button>
+        </button>
       )}
     </div>
   </div>

--- a/apps/dashboard/src/components/FileViewer/DocxViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/DocxViewer.tsx
@@ -4,7 +4,6 @@ import { BaseViewerProps } from './utils';
 import { usePlatform } from '../../hooks/usePlatform';
 import { useMobileZoom } from '../../hooks/useMobileZoom';
 import { useDomSearch } from './search';
-import { Button } from '../ui/Button/Button';
 
 /**
  * Standard US Letter page width in pixels at 96 DPI.
@@ -136,17 +135,16 @@ export const DocxViewer: React.FC<BaseViewerProps> = ({ source, searchable }) =>
           <div className='bg-red-100 dark:bg-red-900 p-4 rounded shadow'>
             <p className='text-red-700 dark:text-red-300 font-semibold'>Error loading document</p>
             <p className='text-red-600 dark:text-red-400 text-sm'>{error}</p>
-            <Button
+            <button
               onClick={() => void loadDocument()}
-              variant='ghost'
               className='mt-2 px-3 py-1 bg-red-600 dark:bg-red-700 text-white text-sm rounded hover:bg-red-700 dark:hover:bg-red-600 transition-colors'
               data-track-category='FileViewer'
               data-track-name='RETRY_LOAD_DOCUMENT'
               data-track-metadata={JSON.stringify({ fileType: 'docx', source })}
-              trackId='retry_load_document'
+              data-ph-capture-attribute-track-id='retry_load_document'
             >
               Retry
-            </Button>
+            </button>
           </div>
         </div>
       )}

--- a/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
+++ b/apps/dashboard/src/components/FileViewer/FileViewerModal.tsx
@@ -25,7 +25,6 @@ import {
 } from '../../machines/attachmentViewerMachine';
 import { ZoomState } from './utils';
 import { FileSearchControls, FileSearchProvider, useFileSearchContext } from './search';
-import { Button } from '../ui/Button/Button';
 
 export interface FileItem {
   fileName: string;
@@ -250,17 +249,16 @@ const ErrorState: React.FC<{
       <div className='text-red-300 text-sm mb-4'>{error}</div>
     </div>
     <div className='flex gap-2'>
-      <Button
+      <button
         onClick={onRetry}
-        variant='ghost'
         className='px-4 py-2 bg-background/10 text-white rounded hover:bg-background/20 transition-colors text-sm backdrop-blur-sm'
         data-track-category='FileViewer'
         data-track-name='RETRY_LOAD_FILE'
         data-track-metadata={JSON.stringify({ error })}
-        trackId='retry_load_file'
+        data-ph-capture-attribute-track-id='retry_load_file'
       >
         Try Again
-      </Button>
+      </button>
       <button
         onClick={onDownload}
         className='px-4 py-2 bg-background/10 text-white rounded hover:bg-background/20 flex items-center gap-2 transition-colors text-sm backdrop-blur-sm'

--- a/apps/dashboard/src/components/FileViewer/HtmlViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/HtmlViewer.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useCallback, memo } from 'react';
 import { BaseViewerProps } from './utils';
-import { Button } from '../ui/Button/Button';
 
 const declaresEncoding = async (file: Blob): Promise<boolean> => {
   const head = new Uint8Array(await file.slice(0, 1024).arrayBuffer());
@@ -63,16 +62,15 @@ const HtmlViewer: React.FC<BaseViewerProps> = memo(({ source }) => {
             Unable to display file
           </p>
           <p className='text-red-600 dark:text-red-300 text-sm mb-3'>{error}</p>
-          <Button
+          <button
             onClick={() => void loadFile()}
-            variant='ghost'
             className='px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700 transition-colors'
             data-track-category='FileViewer'
             data-track-name='RetryLoadHtml'
-            trackId='retry_load_html'
+            data-ph-capture-attribute-track-id='retry_load_html'
           >
             Try Again
-          </Button>
+          </button>
         </div>
       </div>
     );

--- a/apps/dashboard/src/components/FileViewer/TxtViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/TxtViewer.tsx
@@ -3,7 +3,6 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { BaseViewerProps } from './utils';
 import { HighlightedText } from './search/HighlightedText';
 import { useLineSearch, useMatchScroll } from './search';
-import { Button } from '../ui/Button/Button';
 
 // Reusable Loading Component
 const LoadingSpinner: React.FC = () => (
@@ -26,16 +25,15 @@ const ErrorDisplay: React.FC<{ error: string; canRetry?: boolean; onRetry?: () =
       <p className='text-red-800 dark:text-red-200 font-semibold mb-2'>Unable to display file</p>
       <p className='text-red-600 dark:text-red-300 text-sm mb-3'>{error}</p>
       {canRetry && onRetry && (
-        <Button
+        <button
           onClick={onRetry}
-          variant='ghost'
           className='px-3 py-1 bg-red-600 text-white text-sm rounded hover:bg-red-700 transition-colors'
           data-track-category='FileViewer'
           data-track-name='RetryLoadTxt'
-          trackId='retry_load_txt'
+          data-ph-capture-attribute-track-id='retry_load_txt'
         >
           Try Again
-        </Button>
+        </button>
       )}
     </div>
   </div>

--- a/apps/dashboard/src/components/Memory/MemoryCompareCard.tsx
+++ b/apps/dashboard/src/components/Memory/MemoryCompareCard.tsx
@@ -4,7 +4,6 @@ import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessa
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Pencil, Trash2, Check, X } from 'lucide-react';
-import { Button } from '../ui/Button/Button';
 
 const markdownPlugins = [remarkGfm];
 
@@ -193,18 +192,17 @@ const MemoryCompareCard: React.FC<MemoryCompareCardProps> = ({
           {showDeleteConfirm && (
             <div className='flex items-center gap-1'>
               <span className='text-xs text-red-600'>Delete?</span>
-              <Button
-                variant='ghost'
+              <button
                 onClick={handleDelete}
                 disabled={isDeleting}
                 className='h-auto p-1 text-red-600 hover:bg-red-100 dark:hover:bg-red-950 rounded transition-colors disabled:opacity-50'
                 title='Confirm delete'
-                trackId='memory_confirm_delete_document'
+                data-ph-capture-attribute-track-id='memory_confirm_delete_document'
                 data-track-category='Memory'
                 data-track-name='ConfirmDeleteDocument'
               >
                 <Check size={14} />
-              </Button>
+              </button>
               <button
                 onClick={() => setShowDeleteConfirm(false)}
                 className='p-1 text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors'
@@ -471,18 +469,17 @@ const EditableSection: React.FC<{
             </span>
           )}
           <div className='ml-auto flex items-center gap-0.5'>
-            <Button
-              variant='ghost'
+            <button
               onClick={onSave}
               disabled={isUpdating}
               className='h-auto p-0.5 text-green-600 hover:text-green-700 rounded transition-colors disabled:opacity-50'
               title='Save'
-              trackId='memory_save_field_edit'
+              data-ph-capture-attribute-track-id='memory_save_field_edit'
               data-track-category='Memory'
               data-track-name='SaveEdit'
             >
               <Check size={12} />
-            </Button>
+            </button>
             <button
               onClick={onCancel}
               className='p-0.5 text-muted-foreground hover:text-foreground rounded transition-colors'
@@ -568,18 +565,17 @@ const EditableMetadataRow: React.FC<{
               data-track-category='Memory'
               data-track-name='MetadataInput'
             />
-            <Button
-              variant='ghost'
+            <button
               onClick={onSave}
               disabled={isUpdating}
               className='h-auto p-0.5 text-green-600 hover:text-green-700 rounded disabled:opacity-50'
               title='Save'
-              trackId='memory_save_metadata_edit'
+              data-ph-capture-attribute-track-id='memory_save_metadata_edit'
               data-track-category='Memory'
               data-track-name='SaveMetadataEdit'
             >
               <Check size={12} />
-            </Button>
+            </button>
             <button
               onClick={onCancel}
               className='p-0.5 text-muted-foreground hover:text-foreground rounded'
@@ -680,18 +676,17 @@ const ReviewStatusRow: React.FC<{
                 </button>
               );
             })}
-            <Button
-              variant='ghost'
+            <button
               onClick={onSave}
               disabled={isUpdating}
               className='h-auto p-0.5 text-green-600 hover:text-green-700 rounded disabled:opacity-50'
               title='Save'
-              trackId='memory_save_status_edit'
+              data-ph-capture-attribute-track-id='memory_save_status_edit'
               data-track-category='Memory'
               data-track-name='SaveStatusEdit'
             >
               <Check size={12} />
-            </Button>
+            </button>
             <button
               onClick={onCancel}
               className='p-0.5 text-muted-foreground hover:text-foreground rounded'

--- a/apps/dashboard/src/components/Memory/MemoryHeader.tsx
+++ b/apps/dashboard/src/components/Memory/MemoryHeader.tsx
@@ -7,7 +7,6 @@ import { useUploadDocuments, useCleanupAllVespaMemory } from '../../hooks/useMem
 import { useIsMemoryAdmin } from '../../hooks/usePermissions';
 import { usePlatform } from '../../hooks/usePlatform';
 import Dialog from '../ui/Dialog';
-import { Button } from '../ui/Button/Button';
 
 interface MemoryHeaderProps {
   filters: MemoryFilters;
@@ -252,17 +251,16 @@ const MemoryHeader: React.FC<MemoryHeaderProps> = ({ filters, onFiltersChange })
             >
               Cancel
             </button>
-            <Button
-              variant='ghost'
+            <button
               onClick={handleUploadSubmit}
               disabled={uploadMutation.isPending || !repoUrl.trim()}
               className='h-auto px-4 py-2 text-sm font-medium rounded-md bg-purple-600 text-white hover:bg-purple-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
-              trackId='memory_upload_documents'
+              data-ph-capture-attribute-track-id='memory_upload_documents'
               data-track-category='Memory'
               data-track-name='ConfirmUploadDocuments'
             >
               {uploadMutation.isPending ? 'Uploading…' : 'Upload'}
-            </Button>
+            </button>
           </div>
         </div>
       </Dialog>
@@ -285,17 +283,16 @@ const MemoryHeader: React.FC<MemoryHeaderProps> = ({ filters, onFiltersChange })
             >
               Cancel
             </button>
-            <Button
-              variant='ghost'
+            <button
               onClick={handleCleanupConfirm}
               disabled={cleanupMutation.isPending}
               className='h-auto px-4 py-2 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
-              trackId='memory_cleanup_all_vespa'
+              data-ph-capture-attribute-track-id='memory_cleanup_all_vespa'
               data-track-category='Memory'
               data-track-name='ConfirmCleanupVespaMemory'
             >
               {cleanupMutation.isPending ? 'Deleting…' : 'Delete All'}
-            </Button>
+            </button>
           </div>
         </div>
       </Dialog>

--- a/apps/dashboard/src/components/Memory/MemoryTable.tsx
+++ b/apps/dashboard/src/components/Memory/MemoryTable.tsx
@@ -27,7 +27,7 @@ import type {
   MemoryFilters,
 } from '../../types/memory';
 import Dialog from '../ui/Dialog';
-import { Button } from '../ui/Button/Button';
+
 import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -529,8 +529,7 @@ const MemoryTable: React.FC<MemoryTableProps> = ({ filters, enableCompare = fals
               {filters.sessionIdFilter.trim()}
             </span>
           </span>
-          <Button
-            variant='ghost'
+          <button
             onClick={() => {
               const sessionId = filters.sessionIdFilter.trim();
               deleteSessionMutation.mutate([sessionId], {
@@ -543,13 +542,13 @@ const MemoryTable: React.FC<MemoryTableProps> = ({ filters, enableCompare = fals
             disabled={deleteSessionMutation.isPending}
             className='h-auto flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded border border-red-300 text-red-600 hover:bg-red-50 dark:hover:bg-red-950/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
             title='Delete all Vespa memory docs for this session'
-            trackId='memory_delete_session'
+            data-ph-capture-attribute-track-id='memory_delete_session'
             data-track-category='Memory'
             data-track-name='DeleteSession'
           >
             <Trash2 size={12} />
             {deleteSessionMutation.isPending ? 'Deleting…' : 'Delete Session'}
-          </Button>
+          </button>
         </div>
       )}
 

--- a/apps/dashboard/src/components/RecapPanel/RecapPanel.tsx
+++ b/apps/dashboard/src/components/RecapPanel/RecapPanel.tsx
@@ -27,7 +27,6 @@ import { useCacConfig } from '@xyne/shared/hooks';
 import { xyneAIActor, type ThreadInfo } from '../../machines/xyneAIMachine';
 import { XyneAIStar } from '../icons/xyne-ai';
 import { Tooltip } from '../ui/Tooltip';
-import { Button } from '../ui/Button/Button';
 
 type RecapTab = 'channel' | 'project';
 
@@ -549,8 +548,7 @@ const RecapPanel = (): ReactElement => {
                 </Tooltip>
               )}
               {!isHistoricalView && (
-                <Button
-                  variant='ghost'
+                <button
                   onClick={() => void handleToggleRead(card.channelId, isRead)}
                   className={`flex items-center gap-1.5 text-xs font-medium transition-colors px-2.5 py-1 rounded-md border ${
                     isRead
@@ -559,7 +557,9 @@ const RecapPanel = (): ReactElement => {
                   }`}
                   data-track-category='RECAP_PANEL'
                   data-track-name={isRead ? 'MARK_AS_UNREAD' : 'MARK_AS_READ'}
-                  trackId={isRead ? 'mark_recap_unread' : 'mark_recap_read'}
+                  data-ph-capture-attribute-track-id={
+                    isRead ? 'mark_recap_unread' : 'mark_recap_read'
+                  }
                 >
                   {isRead ? (
                     <>
@@ -572,7 +572,7 @@ const RecapPanel = (): ReactElement => {
                       <span>Mark as read</span>
                     </>
                   )}
-                </Button>
+                </button>
               )}
             </div>
           </div>
@@ -626,18 +626,17 @@ const RecapPanel = (): ReactElement => {
                   </span>
                 </div>
                 {!isHistoricalView && (
-                  <Button
-                    variant='ghost'
+                  <button
                     onClick={handleMarkAllAsRead}
                     className='flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium text-green-600 bg-green-500/10 hover:bg-green-500/20 rounded-md border border-green-500/30 transition-colors'
                     title='Mark all as read'
                     data-track-category='RECAP_PANEL'
                     data-track-name='MARK_ALL_AS_READ'
-                    trackId='mark_all_recap_read'
+                    data-ph-capture-attribute-track-id='mark_all_recap_read'
                   >
                     <CheckCheck size={12} />
                     <span>Mark all as read</span>
-                  </Button>
+                  </button>
                 )}
               </div>
               {unreadCards.map(card => (

--- a/apps/dashboard/src/components/Recording/RecordingOverlay/RecordingOverlay.tsx
+++ b/apps/dashboard/src/components/Recording/RecordingOverlay/RecordingOverlay.tsx
@@ -279,17 +279,16 @@ export function RecordingOverlay(): React.ReactElement | null {
                 )}
               </button>
 
-              <Button
-                variant='ghost'
+              <button
                 onClick={handleStop}
                 disabled={isStarting}
                 className='flex items-center justify-center w-10 h-10 rounded-full bg-destructive hover:bg-destructive/85 transition-colors'
                 data-track-category='RecordingOverlay'
                 data-track-name='stop_recording'
-                trackId='stop_recording'
+                data-ph-capture-attribute-track-id='stop_recording'
               >
                 <Square className='w-4 h-4 text-destructive-foreground fill-current' />
-              </Button>
+              </button>
             </div>
           </div>
 

--- a/apps/dashboard/src/components/Release/QAOwnerPicker.tsx
+++ b/apps/dashboard/src/components/Release/QAOwnerPicker.tsx
@@ -6,7 +6,6 @@ import { useZero } from '../../hooks/useZero';
 import { mutators } from '../../zero/mutators';
 import { cn } from '../../utils/classNames';
 import { Popover } from '../ui/Popover/Popover';
-import { Button } from '../ui/Button/Button';
 
 interface QAOwnerPickerProps {
   artId: string | null;
@@ -86,22 +85,20 @@ export const QAOwnerPicker = ({
       />
       <div className='max-h-48 overflow-y-auto p-1'>
         {testedBy && (
-          <Button
-            variant='ghost'
+          <button
             type='button'
             className='w-full rounded-sm px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted'
             onClick={() => handleSelect(null)}
             data-track-category='Release'
             data-track-name='CLEAR_QA_OWNER'
-            trackId='clear_qa_owner'
+            data-ph-capture-attribute-track-id='clear_qa_owner'
           >
             Clear
-          </Button>
+          </button>
         )}
         {filtered.map(u => (
-          <Button
+          <button
             key={u.id}
-            variant='ghost'
             type='button'
             className={cn(
               'w-full truncate rounded-sm px-2 py-1.5 text-left text-xs transition-colors hover:bg-muted',
@@ -110,10 +107,10 @@ export const QAOwnerPicker = ({
             onClick={() => handleSelect(u.id)}
             data-track-category='Release'
             data-track-name='SELECT_QA_OWNER'
-            trackId='select_qa_owner'
+            data-ph-capture-attribute-track-id='select_qa_owner'
           >
             {u.name ?? u.email}
-          </Button>
+          </button>
         ))}
         {filtered.length === 0 && (
           <p className='px-2 py-1.5 text-xs text-muted-foreground'>No users found</p>

--- a/apps/dashboard/src/components/Release/ReleaseStagePicker.tsx
+++ b/apps/dashboard/src/components/Release/ReleaseStagePicker.tsx
@@ -8,7 +8,6 @@ import { getStageColor } from '../../routes/KanbanBoardScreen/KanbanBoardScreen.
 import { surfaceMutationError } from '../../utils/zeroMutationToast';
 import { cn } from '../../utils/classNames';
 import { StagePicker } from '../Tickets/TicketListView/StagePicker';
-import { Button } from '../ui/Button/Button';
 
 export interface ReleaseStageOption {
   name: string;
@@ -132,9 +131,8 @@ export function ReleaseStagePicker({
           </div>
         ) : (
           stages.map(stage => (
-            <Button
+            <button
               key={stage.name}
-              variant='ghost'
               type='button'
               onClick={e => {
                 e.stopPropagation();
@@ -146,14 +144,14 @@ export function ReleaseStagePicker({
               )}
               data-track-category='Release'
               data-track-name='SelectRowStage'
-              trackId='select_release_stage'
+              data-ph-capture-attribute-track-id='select_release_stage'
             >
               <span
                 className='inline-block w-1.5 h-1.5 rounded-full'
                 style={{ backgroundColor: getStageColor(stage.name) }}
               />
               <span className='text-foreground'>{stage.name}</span>
-            </Button>
+            </button>
           ))
         )}
       </div>

--- a/apps/dashboard/src/components/ScreenPicker/ScreenPickerModal.tsx
+++ b/apps/dashboard/src/components/ScreenPicker/ScreenPickerModal.tsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { Monitor, AppWindow, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '../../utils/classNames';
-import { Button } from '../ui/Button/Button';
+
 import { useTheme } from '../../hooks/useTheme';
 import { MACOS_PRIVACY_URLS } from '../../constants/permissions';
 import type { ScreenSource } from '../../types/electron';
@@ -266,11 +266,10 @@ export function ScreenPickerModal(): React.ReactElement | null {
             >
               Cancel
             </button>
-            <Button
-              variant='ghost'
+            <button
               onClick={handleShare}
               disabled={!selectedId}
-              trackId='share_screen'
+              data-ph-capture-attribute-track-id='share_screen'
               data-track-category='screen-picker'
               data-track-name='share'
               className={cn(
@@ -281,7 +280,7 @@ export function ScreenPickerModal(): React.ReactElement | null {
               )}
             >
               Share
-            </Button>
+            </button>
           </div>
         </div>
       </div>

--- a/apps/dashboard/src/components/Settings/IntentSuggestionsToggle.tsx
+++ b/apps/dashboard/src/components/Settings/IntentSuggestionsToggle.tsx
@@ -1,6 +1,6 @@
 import { useEffect, type ReactElement } from 'react';
 import { Switch } from '../ui/Switch';
-import { Button } from '../ui/Button/Button';
+
 import { useIntentSuggestionsEnabled } from '../../hooks/useIntentSuggestionsEnabled';
 import { useIntentModelStatus } from '../../hooks/useIntentModelStatus';
 
@@ -97,17 +97,16 @@ function ModelStatusRow({
               Suggestions stay off until this succeeds. Nothing else is affected.
             </p>
           </div>
-          <Button
+          <button
             type='button'
-            variant='ghost'
             onClick={onRetry}
-            trackId='retry_intent_model_download'
+            data-ph-capture-attribute-track-id='retry_intent_model_download'
             data-track-category='Settings'
             data-track-name='Intent suggestions: retry model download'
             className='shrink-0 rounded-md border border-border px-2.5 py-1 text-xs font-medium text-foreground hover:bg-muted'
           >
             Retry
-          </Button>
+          </button>
         </div>
       </div>
     );

--- a/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
+++ b/apps/dashboard/src/components/Settings/Preferences/Preferences.tsx
@@ -276,18 +276,17 @@ const NotificationKeywordsCard: FC = () => {
           {keywords.map(keyword => (
             <Badge key={keyword} variant='primary' className='flex items-center gap-1.5 pr-1'>
               <span className='text-xs'>{keyword}</span>
-              <Button
+              <button
                 type='button'
-                variant='ghost'
                 onClick={() => removeKeyword(keyword)}
-                trackId='remove_notification_keyword'
+                data-ph-capture-attribute-track-id='remove_notification_keyword'
                 className='rounded-full p-0.5 transition-colors'
                 aria-label={`Remove ${keyword}`}
                 data-track-category='PREFERENCES'
                 data-track-name='RemoveNotificationKeyword'
               >
                 <X className='h-3 w-3' />
-              </Button>
+              </button>
             </Badge>
           ))}
         </div>
@@ -337,12 +336,11 @@ const NotificationsSection: FC<{ state: PreferencesState }> = () => {
           </div>
           <div className='flex gap-2'>
             {GLOBAL_NOTIFICATION_LEVELS.map(level => (
-              <Button
+              <button
                 key={level.value}
-                variant='ghost'
                 onClick={() => settings.update({ globalDesktopNotificationLevel: level.value })}
-                trackId='set_global_desktop_notification_level'
-                trackProps={{ level: level.value }}
+                data-ph-capture-attribute-track-id='set_global_desktop_notification_level'
+                data-ph-capture-attribute-level={level.value}
                 data-track-category='PREFERENCES'
                 data-track-name={`SetGlobalDesktopLevel_${level.value}`}
                 className={cn(
@@ -353,7 +351,7 @@ const NotificationsSection: FC<{ state: PreferencesState }> = () => {
                 )}
               >
                 {level.label}
-              </Button>
+              </button>
             ))}
           </div>
         </div>
@@ -366,12 +364,11 @@ const NotificationsSection: FC<{ state: PreferencesState }> = () => {
           </div>
           <div className='flex gap-2'>
             {GLOBAL_NOTIFICATION_LEVELS.map(level => (
-              <Button
+              <button
                 key={level.value}
-                variant='ghost'
                 onClick={() => settings.update({ globalMobileNotificationLevel: level.value })}
-                trackId='set_global_mobile_notification_level'
-                trackProps={{ level: level.value }}
+                data-ph-capture-attribute-track-id='set_global_mobile_notification_level'
+                data-ph-capture-attribute-level={level.value}
                 data-track-category='PREFERENCES'
                 data-track-name={`SetGlobalMobileLevel_${level.value}`}
                 className={cn(
@@ -382,7 +379,7 @@ const NotificationsSection: FC<{ state: PreferencesState }> = () => {
                 )}
               >
                 {level.label}
-              </Button>
+              </button>
             ))}
           </div>
         </div>

--- a/apps/dashboard/src/components/Settings/Settings.tsx
+++ b/apps/dashboard/src/components/Settings/Settings.tsx
@@ -195,13 +195,12 @@ const Settings = ({
             className='w-40 p-1'
           >
             <div className='space-y-0.5'>
-              <Button
-                variant='ghost'
+              <button
                 onClick={() => {
                   setLivePresenceStatus('ONLINE');
                   setPresencePopoverOpen(false);
                 }}
-                trackId='set_presence_online'
+                data-ph-capture-attribute-track-id='set_presence_online'
                 className='w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded-md hover:bg-muted transition-colors text-left'
                 data-track-category='Settings'
                 data-track-name='SetPresenceOnline'
@@ -211,14 +210,13 @@ const Settings = ({
                 {livePresenceStatus !== 'AWAY' && (
                   <Check className='size-3 ml-auto text-muted-foreground' />
                 )}
-              </Button>
-              <Button
-                variant='ghost'
+              </button>
+              <button
                 onClick={() => {
                   setLivePresenceStatus('AWAY');
                   setPresencePopoverOpen(false);
                 }}
-                trackId='set_presence_away'
+                data-ph-capture-attribute-track-id='set_presence_away'
                 className='w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded-md hover:bg-muted transition-colors text-left'
                 data-track-category='Settings'
                 data-track-name='SetPresenceAway'
@@ -228,7 +226,7 @@ const Settings = ({
                 {livePresenceStatus === 'AWAY' && (
                   <Check className='size-3 ml-auto text-muted-foreground' />
                 )}
-              </Button>
+              </button>
             </div>
           </Popover>
         </div>
@@ -353,22 +351,21 @@ const Settings = ({
             {!showCustomDatePicker ? (
               <div className='space-y-0.5'>
                 {pauseOptions.map(option => (
-                  <Button
+                  <button
                     key={option.minutes}
-                    variant='ghost'
                     onClick={e => {
                       e.stopPropagation();
                       handlePauseNotifications(option.minutes);
                     }}
-                    trackId='pause_notifications'
-                    trackProps={{ duration: option.minutes }}
+                    data-ph-capture-attribute-track-id='pause_notifications'
+                    data-ph-capture-attribute-duration={option.minutes}
                     className='w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded-md hover:bg-accent transition-colors text-left'
                     data-track-category='Settings'
                     data-track-name='PauseNotifications'
                     data-track-metadata={JSON.stringify({ duration: option.minutes })}
                   >
                     <span>{option.label}</span>
-                  </Button>
+                  </button>
                 ))}
                 <button
                   onClick={e => {

--- a/apps/dashboard/src/components/Settings/Views/ProfileView.tsx
+++ b/apps/dashboard/src/components/Settings/Views/ProfileView.tsx
@@ -267,13 +267,12 @@ const ProfileView = ({
             {isPresenceDropdownOpen && (
               <div className='absolute left-0 top-full mt-1 w-40 p-1 bg-background rounded-md border shadow-md z-10'>
                 <div className='space-y-0.5'>
-                  <Button
-                    variant='ghost'
+                  <button
                     onClick={() => {
                       setLivePresenceStatus('ONLINE');
                       setIsPresenceDropdownOpen(false);
                     }}
-                    trackId='set_presence_online'
+                    data-ph-capture-attribute-track-id='set_presence_online'
                     className='w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded-md hover:bg-muted transition-colors text-left'
                     data-track-category='PROFILE'
                     data-track-name='SetPresenceOnline'
@@ -284,14 +283,13 @@ const ProfileView = ({
                     {livePresenceStatus !== 'AWAY' && (
                       <Check className='size-3 ml-auto text-muted-foreground' />
                     )}
-                  </Button>
-                  <Button
-                    variant='ghost'
+                  </button>
+                  <button
                     onClick={() => {
                       setLivePresenceStatus('AWAY');
                       setIsPresenceDropdownOpen(false);
                     }}
-                    trackId='set_presence_away'
+                    data-ph-capture-attribute-track-id='set_presence_away'
                     className='w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded-md hover:bg-muted transition-colors text-left'
                     data-track-category='PROFILE'
                     data-track-name='SetPresenceAway'
@@ -302,7 +300,7 @@ const ProfileView = ({
                     {livePresenceStatus === 'AWAY' && (
                       <Check className='size-3 ml-auto text-muted-foreground' />
                     )}
-                  </Button>
+                  </button>
                 </div>
               </div>
             )}
@@ -432,22 +430,21 @@ const ProfileView = ({
             {!showCustomDatePicker ? (
               <div className='space-y-0.5'>
                 {pauseOptions.map(option => (
-                  <Button
+                  <button
                     key={option.minutes}
-                    variant='ghost'
                     onClick={e => {
                       e.stopPropagation();
                       handlePauseNotifications(option.minutes);
                     }}
-                    trackId='pause_notifications'
-                    trackProps={{ duration: option.minutes }}
+                    data-ph-capture-attribute-track-id='pause_notifications'
+                    data-ph-capture-attribute-duration={option.minutes}
                     className='w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded-md hover:bg-accent transition-colors text-left'
                     data-track-category='PROFILE'
                     data-track-name='PauseNotifications'
                     data-track-metadata={JSON.stringify({ duration: option.minutes })}
                   >
                     <span>{option.label}</span>
-                  </Button>
+                  </button>
                 ))}
                 <button
                   onClick={e => {

--- a/apps/dashboard/src/components/Settings/VoiceSignatureModal/VoiceSignatureModal.tsx
+++ b/apps/dashboard/src/components/Settings/VoiceSignatureModal/VoiceSignatureModal.tsx
@@ -223,17 +223,16 @@ export const VoiceSignatureModal: React.FC<VoiceSignatureModalProps> = ({
                   <CheckCircle2 className='size-4 text-green-500 flex-shrink-0' />
                   <p className='text-xs font-medium text-foreground'>Voice signature stored</p>
                 </div>
-                <Button
-                  variant='ghost'
-                  trackId='delete_voice_signature'
-                  trackAction={handleDelete}
+                <button
+                  data-ph-capture-attribute-track-id='delete_voice_signature'
+                  onClick={() => void handleDelete()}
                   data-track-category='voice-signature'
                   data-track-name='delete-signature'
                   className='flex items-center gap-1 text-xs text-destructive hover:text-destructive/80 transition-colors'
                 >
                   <Trash2 className='size-3' />
                   Remove
-                </Button>
+                </button>
               </div>
             )}
 

--- a/apps/dashboard/src/components/SummaryTemplateMenu/SummaryTemplateMenu.tsx
+++ b/apps/dashboard/src/components/SummaryTemplateMenu/SummaryTemplateMenu.tsx
@@ -19,7 +19,7 @@ import {
 import { XyneAIStar } from '@/components/icons/xyne-ai';
 import { cn } from '../../utils/classNames';
 import { Tooltip } from '../ui/Tooltip';
-import { Button } from '../ui/Button/Button';
+
 import type { SummaryTemplateMenuProps, SummaryTemplateOption } from './SummaryTemplateMenu.types';
 import {
   getSummaryTemplateLabel,
@@ -125,23 +125,22 @@ export function SummaryTemplateMenu({
             {label}
           </span>
         </span>
-        <Button
+        <button
           type='button'
-          variant='ghost'
           disabled={isRegenerating || !canRegenerate}
           onClick={() => {
             onRequestClose();
             onRegenerate();
           }}
-          trackId='regenerate_selected_summary_template'
-          trackProps={{ 'track-category': trackCategory }}
+          data-ph-capture-attribute-track-id='regenerate_selected_summary_template'
+          data-ph-capture-attribute-track-category={trackCategory}
           aria-label={`Regenerate with ${fullLabel}`}
           className='flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50'
           data-track-category={trackCategory}
           data-track-name='regenerate_selected_summary_template'
         >
           <Refresh strokeWidth={2.5} className={cn('size-4', isRegenerating && 'animate-spin')} />
-        </Button>
+        </button>
         <span className='flex w-5 shrink-0 items-center justify-center'>
           <CheckTickSingle
             strokeWidth={2.5}
@@ -164,10 +163,9 @@ export function SummaryTemplateMenu({
             .map(template => {
               const isTemplateRegenerating = activeRegeneratingTemplateId === template.id;
               return (
-                <Button
+                <button
                   key={template.id}
                   type='button'
-                  variant='ghost'
                   aria-disabled={isDisabledDuringRegeneration}
                   tabIndex={isDisabledDuringRegeneration ? -1 : undefined}
                   onClick={() => {
@@ -175,8 +173,8 @@ export function SummaryTemplateMenu({
                     onRequestClose();
                     onSelectTemplate(template.id);
                   }}
-                  trackId='select_summary_template'
-                  trackProps={{ trackCategory }}
+                  data-ph-capture-attribute-track-id='select_summary_template'
+                  data-ph-capture-attribute-trackCategory={trackCategory}
                   title={isTemplateRegenerating ? regeneratingTooltipContent : template.name}
                   className={cn(
                     'flex w-full items-center gap-3 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors',
@@ -200,7 +198,7 @@ export function SummaryTemplateMenu({
                   <span className='min-w-0 flex-1 truncate'>
                     {truncateTemplateName(template.name)}
                   </span>
-                </Button>
+                </button>
               );
             })
         )}

--- a/apps/dashboard/src/components/Tickets/RCAPanelView/RCAPanelView.tsx
+++ b/apps/dashboard/src/components/Tickets/RCAPanelView/RCAPanelView.tsx
@@ -238,18 +238,17 @@ export const RCAPanelView = ({ ticketId }: RCAPanelViewProps): React.ReactElemen
             Create a Root Cause Analysis to track the incident.
           </p>
         </div>
-        <Button
+        <button
           type='button'
-          variant='ghost'
           className='px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50'
           onClick={() => void handleCreateRCA()}
           disabled={isCreatingRCA}
-          trackId='rca_start_from_panel'
+          data-ph-capture-attribute-track-id='rca_start_from_panel'
           data-track-category='RCA'
           data-track-name='StartRCAFromPanel'
         >
           {isCreatingRCA ? 'Creating...' : 'Start RCA'}
-        </Button>
+        </button>
       </div>
     );
   } else if (isReadOnlyView) {

--- a/apps/dashboard/src/components/Tickets/TicketDetails/AIClassificationPanel.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/AIClassificationPanel.tsx
@@ -13,7 +13,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '../../ui/Select/Select';
-import { Button } from '../../ui/Button/Button';
 
 interface UserGroupOption {
   id: string;
@@ -240,17 +239,16 @@ export const AIClassificationPanel: React.FC<AIClassificationPanelProps> = ({
                 </div>
               </div>
               <div className='flex gap-2'>
-                <Button
-                  trackAction={() => handleSave()}
-                  trackId='save_classification_override'
+                <button
+                  onClick={() => void handleSave()}
+                  data-ph-capture-attribute-track-id='save_classification_override'
                   disabled={isSaving || !editCategory}
-                  variant='ghost'
                   className='text-xs px-3 py-1 rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50'
                   data-track-category='AIClassification'
                   data-track-name='SaveClassificationOverride'
                 >
                   {isSaving ? 'Saving...' : 'Save'}
-                </Button>
+                </button>
                 <button
                   onClick={() => {
                     setIsEditing(false);
@@ -293,17 +291,16 @@ export const AIClassificationPanel: React.FC<AIClassificationPanelProps> = ({
                         data-track-category='AIClassification'
                         data-track-name='RawFieldInput'
                       />
-                      <Button
-                        trackAction={() => handleSaveField(key)}
-                        trackId='save_raw_classification_field'
+                      <button
+                        onClick={() => void handleSaveField(key)}
+                        data-ph-capture-attribute-track-id='save_raw_classification_field'
                         disabled={savingField}
-                        variant='ghost'
                         className='text-xs px-2 py-0.5 rounded bg-primary text-primary-foreground disabled:opacity-50'
                         data-track-category='AIClassification'
                         data-track-name='SaveRawField'
                       >
                         {savingField ? '…' : '✓'}
-                      </Button>
+                      </button>
                       <button
                         onClick={() => setEditingField(null)}
                         className='text-xs px-2 py-0.5 rounded border border-border hover:bg-muted'

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -2987,32 +2987,30 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
             )}
           </div>
           {onUnmerge && (
-            <Button
+            <button
               type='button'
-              variant='ghost'
               onClick={onUnmerge}
-              trackId='unmerge_ticket'
+              data-ph-capture-attribute-track-id='unmerge_ticket'
               className='text-sm text-primary hover:text-primary/80 font-medium whitespace-nowrap'
               data-track-category='Tickets'
               data-track-name='UnmergeTicket'
             >
               Unmerge
-            </Button>
+            </button>
           )}
           {allowEdit && (
-            <Button
+            <button
               type='button'
-              variant='ghost'
               className='absolute right-[-20px] top-1/2 -translate-y-1/2 text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100'
               onClick={() => handleRemoveReference(reference.id)}
-              trackId='remove_ticket_reference'
+              data-ph-capture-attribute-track-id='remove_ticket_reference'
               aria-label='Remove reference'
               data-track-category='Tickets'
               data-track-name='RemoveReference'
               data-track-metadata={JSON.stringify({ referenceId: reference.id })}
             >
               <X size={14} />
-            </Button>
+            </button>
           )}
         </div>
       </div>
@@ -3690,10 +3688,9 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                             <div className={`w-2 h-2 rounded-full ${color.bg}`}></div>
                             {tag.tagName}
                             {
-                              <Button
-                                variant='ghost'
+                              <button
                                 onClick={() => void handleRemoveTag(tag.id)}
-                                trackId='remove_ticket_tag'
+                                data-ph-capture-attribute-track-id='remove_ticket_tag'
                                 className={`ml-1 p-0.5 rounded transition-colors`}
                                 aria-label='Remove label'
                                 data-track-category='Tickets'
@@ -3704,7 +3701,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                                 })}
                               >
                                 <X size={12} />
-                              </Button>
+                              </button>
                             }
                           </span>
                         );
@@ -3742,10 +3739,9 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                       {/* Tag List */}
                       <div className='max-h-48 overflow-y-auto'>
                         {tagSearchQuery.trim() && !exactMatch && (
-                          <Button
-                            variant='ghost'
+                          <button
                             onClick={() => void handleToggleTag(tagSearchQuery)}
-                            trackId='create_ticket_tag'
+                            data-ph-capture-attribute-track-id='create_ticket_tag'
                             className='w-full text-left px-3 py-2 text-sm hover:bg-muted flex items-center gap-2 border-b border-border'
                             data-track-category='Tickets'
                             data-track-name='CreateTag'
@@ -3755,18 +3751,17 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                             <span className='text-foreground font-medium'>
                               Create &quot;{tagSearchQuery.trim()}&quot;
                             </span>
-                          </Button>
+                          </button>
                         )}
 
                         {filteredTags.map(tagName => {
                           const isSelected = selectedTagNames.has(tagName);
 
                           return (
-                            <Button
+                            <button
                               key={tagName}
-                              variant='ghost'
                               onClick={() => void handleToggleTag(tagName)}
-                              trackId='toggle_ticket_tag'
+                              data-ph-capture-attribute-track-id='toggle_ticket_tag'
                               className='w-full px-3 py-2 text-sm flex items-center justify-between hover:bg-muted'
                               data-track-category='Tickets'
                               data-track-name='ToggleTag'
@@ -3785,7 +3780,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                                   <Check size={14} />
                                 </span>
                               )}
-                            </Button>
+                            </button>
                           );
                         })}
                       </div>
@@ -4420,8 +4415,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                                 </button>
                               )}
                               {isDraft && !item.formId && (
-                                <Button
-                                  variant='ghost'
+                                <button
                                   onClick={() => {
                                     void zero.mutate(
                                       mutators.ticketStageRequest.upsert({
@@ -4436,14 +4430,14 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                                     );
                                     toast.success('Request submitted for approval');
                                   }}
-                                  trackId='submit_stage_request'
+                                  data-ph-capture-attribute-track-id='submit_stage_request'
                                   className='text-sm text-foreground hover:text-muted-foreground font-medium whitespace-nowrap'
                                   data-track-category='Tickets'
                                   data-track-name='SubmitStageRequest'
                                   data-track-metadata={JSON.stringify({ stageId: item.stageId })}
                                 >
                                   Submit Request
-                                </Button>
+                                </button>
                               )}
                               {isSubmitted && item.formId && (
                                 <>
@@ -4609,8 +4603,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                                 </button>
                               )}
                               {isRejected && !item.formId && (
-                                <Button
-                                  variant='ghost'
+                                <button
                                   onClick={() => {
                                     void zero.mutate(
                                       mutators.ticketStageRequest.upsert({
@@ -4625,14 +4618,14 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                                     );
                                     toast.success('Stage change request resubmitted for approval');
                                   }}
-                                  trackId='resubmit_stage_request'
+                                  data-ph-capture-attribute-track-id='resubmit_stage_request'
                                   className='text-sm text-foreground hover:text-muted-foreground font-medium whitespace-nowrap'
                                   data-track-category='Tickets'
                                   data-track-name='ResubmitStageRequest'
                                   data-track-metadata={JSON.stringify({ stageId: item.stageId })}
                                 >
                                   Resubmit request
-                                </Button>
+                                </button>
                               )}
                             </>
                           ) : (

--- a/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketFilters/TicketFiltersDropdown.tsx
@@ -1005,17 +1005,16 @@ export const TicketFiltersDropdown = ({
                       >
                         Cancel
                       </button>
-                      <Button
-                        variant='ghost'
+                      <button
                         data-track-category='saved-views'
                         data-track-name='confirm-save-view'
-                        trackId='save_ticket_view'
+                        data-ph-capture-attribute-track-id='save_ticket_view'
                         onClick={handleSaveView}
                         disabled={!viewName.trim() || isSaving}
                         className='text-sm font-semibold px-4 h-8 rounded-[8px] bg-primary text-white disabled:opacity-50 disabled:cursor-not-allowed'
                       >
                         Save
-                      </Button>
+                      </button>
                     </div>
                   </div>
                 </Popover.Content>

--- a/apps/dashboard/src/components/Tickets/TicketListView/AssigneePicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/AssigneePicker.tsx
@@ -11,7 +11,6 @@ import { cn } from '../../../utils/classNames';
 import { useChannelAssignGate } from '../../../hooks/useChannelAssignGate';
 import { channelMembersFirst, currentUserFirst } from '../../../utils/channelMembersFirst';
 import { surfaceMutationError } from '../../../utils/zeroMutationToast';
-import { Button } from '../../ui/Button/Button';
 
 interface AssigneePickerProps {
   ticketId: string;
@@ -142,10 +141,9 @@ export function AssigneePicker({
           </div>
         </div>
         <div className='overflow-y-auto flex-1'>
-          <Button
-            variant='ghost'
+          <button
             type='button'
-            trackId='ticket_unassign_row'
+            data-ph-capture-attribute-track-id='ticket_unassign_row'
             onClick={e => {
               e.stopPropagation();
               assign(null);
@@ -161,13 +159,12 @@ export function AssigneePicker({
               <X className='w-3 h-3 text-muted-foreground' />
             </span>
             <span className='text-foreground'>Unassigned</span>
-          </Button>
+          </button>
           {filteredUsers.map(user => (
-            <Button
+            <button
               key={user.id}
-              variant='ghost'
               type='button'
-              trackId='ticket_assign_row'
+              data-ph-capture-attribute-track-id='ticket_assign_row'
               onClick={e => {
                 e.stopPropagation();
                 handleSelectUser(user);
@@ -193,7 +190,7 @@ export function AssigneePicker({
                   Not in channel
                 </span>
               )}
-            </Button>
+            </button>
           ))}
           {filteredUsers.length === 0 && (
             <div className='px-3 py-3 text-xs text-muted-foreground text-center'>

--- a/apps/dashboard/src/components/Tickets/TicketListView/PriorityPicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/PriorityPicker.tsx
@@ -6,7 +6,6 @@ import { mutators } from '../../../zero/mutators';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
 import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 import { cn } from '../../../utils/classNames';
-import { Button } from '../../ui/Button/Button';
 
 interface PriorityPickerProps {
   ticketId: string;
@@ -81,11 +80,10 @@ export function PriorityPicker({
     >
       <div className='flex flex-col'>
         {PRIORITIES.map(p => (
-          <Button
+          <button
             key={p}
-            variant='ghost'
             type='button'
-            trackId='ticket_set_priority_row'
+            data-ph-capture-attribute-track-id='ticket_set_priority_row'
             onClick={e => {
               e.stopPropagation();
               setPriority(p);
@@ -99,7 +97,7 @@ export function PriorityPicker({
           >
             {getPriorityIcon(p)}
             <span className='text-foreground'>{label(p)}</span>
-          </Button>
+          </button>
         ))}
       </div>
     </Popover>

--- a/apps/dashboard/src/components/Tickets/TicketListView/StagePicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/StagePicker.tsx
@@ -18,7 +18,6 @@ import { getReachableStageIds, findMatchingTransition } from '../../../utils/sta
 import { StageFormModal } from '../StageFormModal/StageFormModal';
 import type { StageVisitEta } from '../StageFormFields/useStageForm';
 import type { Stage } from '../../../routes/KanbanBoardScreen/KanbanBoardScreen.types';
-import { Button } from '../../ui/Button/Button';
 
 interface StagePickerProps {
   ticketId: string;
@@ -663,11 +662,10 @@ export function StagePicker({
       >
         <div className='flex flex-col'>
           {reachableStages.map(stage => (
-            <Button
+            <button
               key={stage}
-              variant='ghost'
               type='button'
-              trackId='ticket_set_stage_row'
+              data-ph-capture-attribute-track-id='ticket_set_stage_row'
               onClick={e => {
                 e.stopPropagation();
                 setStage(stage);
@@ -684,7 +682,7 @@ export function StagePicker({
                 style={{ backgroundColor: getStageColor(stage) }}
               />
               <span className='text-foreground'>{stage}</span>
-            </Button>
+            </button>
           ))}
         </div>
       </Popover>

--- a/apps/dashboard/src/components/Tickets/TicketTable/TagSelector.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TagSelector.tsx
@@ -6,7 +6,6 @@ import {
   PlusDefault as Plus,
 } from '@xyne/icons';
 import { cn } from '../../../utils/classNames';
-import { Button } from '../../ui/Button/Button';
 
 interface TagSelectorProps {
   availableTags: string[];
@@ -167,10 +166,9 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
                 const selected = selectedTags.includes(tag);
                 const active = i === activeIdx;
                 return (
-                  <Button
+                  <button
                     key={tag}
-                    variant='ghost'
-                    trackId='ticket_toggle_tag'
+                    data-ph-capture-attribute-track-id='ticket_toggle_tag'
                     onClick={() => {
                       toggle(tag);
                       setSearch('');
@@ -188,7 +186,7 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
                       {tag}
                     </div>
                     {selected && <Check className='size-4 text-blue-600' />}
-                  </Button>
+                  </button>
                 );
               })
             ) : search.trim() ? (
@@ -203,9 +201,8 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
 
             {canCreate && (
               <div className='border-t border-border mt-1 pt-1'>
-                <Button
-                  variant='ghost'
-                  trackId='ticket_create_tag'
+                <button
+                  data-ph-capture-attribute-track-id='ticket_create_tag'
                   onClick={create}
                   onMouseEnter={() => setActiveIdx(filtered.length)}
                   className={`flex items-center gap-2 w-full px-3 py-2 text-sm rounded font-medium ${
@@ -217,7 +214,7 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
                 >
                   <Plus className='size-4' />
                   Create {search.trim()}
-                </Button>
+                </button>
               </div>
             )}
           </div>

--- a/apps/dashboard/src/components/ZeroConnectionStatus/ZeroConnectionFailureModal.tsx
+++ b/apps/dashboard/src/components/ZeroConnectionStatus/ZeroConnectionFailureModal.tsx
@@ -1,6 +1,5 @@
 import { ReactElement } from 'react';
 import { RefreshCw, X } from 'lucide-react';
-import { Button } from '../ui/Button/Button';
 import { isElectronApp } from '../../utils/electronApp';
 import { logger, Event as LoggerEvent } from '../../utils/logger';
 import { useAuth } from '@/hooks/useAuth';
@@ -79,17 +78,16 @@ export const ZeroConnectionFailureModal = ({
         </p>
 
         {/* Refresh Button — behaviour differs between Electron and web */}
-        <Button
-          variant='ghost'
+        <button
           onClick={handleRefresh}
-          trackId='reload_app_on_connection_failure'
+          data-ph-capture-attribute-track-id='reload_app_on_connection_failure'
           className='w-full py-3 px-4 rounded-lg font-medium flex items-center justify-center gap-2 transition-all duration-200 bg-blue-600 hover:bg-blue-700 text-white shadow-md hover:shadow-lg'
           data-track-category='ZERO_CONNECTION'
           data-track-name='RELOAD_APP_ON_CONNECTION_FAILURE'
         >
           <RefreshCw className='w-5 h-5' strokeWidth={2.5} />
           <span>{isElectron ? 'Reload App' : 'Refresh Connection'}</span>
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/ZeroConnectionStatus/ZeroConnectionStatus.tsx
+++ b/apps/dashboard/src/components/ZeroConnectionStatus/ZeroConnectionStatus.tsx
@@ -8,7 +8,6 @@ import {
   type PikaStyle,
 } from '@xyne/icons';
 import { Tooltip } from '../ui/Tooltip/Tooltip';
-import { Button } from '../ui/Button/Button';
 import { cn } from '../../utils/classNames';
 import { logger, Event as LoggerEvent } from '../../utils/logger';
 import { stateMachineActor } from '../../machines/stateMachine';
@@ -103,11 +102,10 @@ export const ZeroConnectionStatus = ({
   return (
     <Tooltip content={tooltip} side='right' delayDuration={0}>
       {status.actionable ? (
-        <Button
+        <button
           type='button'
-          variant='ghost'
           onClick={refreshConnection}
-          trackId='reconnect_zero_connection'
+          data-ph-capture-attribute-track-id='reconnect_zero_connection'
           aria-label={`Connection status: ${status.label}. ${status.hint ?? ''}`.trim()}
           data-testid='zero-connection-status'
           data-connection-state={connectionState.name}
@@ -116,7 +114,7 @@ export const ZeroConnectionStatus = ({
           className={cn(shell, 'cursor-pointer hover:bg-sidebar-accent')}
         >
           {icon}
-        </Button>
+        </button>
       ) : (
         <div
           role='status'

--- a/apps/dashboard/src/components/flowUI/nodes/CallScheduleNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/CallScheduleNode.tsx
@@ -12,7 +12,6 @@ import {
 import { formatTimeAmPm } from '../../../utils/dateUtils';
 import type { FlowComponent, CallScheduleProps, CallSlot, DurationMinutes } from '@xyne/shared';
 import { cn } from '../../../utils/classNames';
-import { Button } from '../../ui/Button/Button';
 
 /**
  * Call-schedule artifact — an interactive scheduling proposal.
@@ -164,9 +163,8 @@ const ProposedCall: React.FC<{
       </div>
 
       <div className='flex items-center gap-2 border-t border-border bg-foreground/[0.03] px-4 py-3'>
-        <Button
+        <button
           type='button'
-          variant='ghost'
           disabled={state.submitting}
           onClick={() => void approve()}
           className={cn(
@@ -176,11 +174,11 @@ const ProposedCall: React.FC<{
           )}
           data-track-category='CALL_SCHEDULE_ARTIFACT'
           data-track-name='CLICK_APPROVE'
-          trackId='call_schedule_approve'
+          data-ph-capture-attribute-track-id='call_schedule_approve'
         >
           {inFlight && <Spinner size={14} className='animate-spin' />}
           Approve
-        </Button>
+        </button>
         {/* v1: inert placeholder — no backend manual-scheduler yet. */}
         <button
           type='button'

--- a/apps/dashboard/src/components/flowUI/nodes/McpConfigureNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/McpConfigureNode.tsx
@@ -5,7 +5,6 @@ import { McpServerIcon } from '../../ClawAgents/McpServerIcon';
 import type { McpServer } from '@/services/claw/clawMcpTypes';
 import { cn } from '../../../utils/classNames';
 import { useFlow } from '../FlowContext';
-import { Button } from '../../ui/Button/Button';
 
 interface McpConfigureNodeProps {
   node: FlowComponent;
@@ -147,9 +146,8 @@ export const McpConfigureNode: React.FC<McpConfigureNodeProps> = ({ node }) => {
       </div>
 
       <div className='mt-3 flex justify-end'>
-        <Button
+        <button
           type='button'
-          variant='ghost'
           onClick={() => {
             void onSubmit();
           }}
@@ -160,11 +158,11 @@ export const McpConfigureNode: React.FC<McpConfigureNodeProps> = ({ node }) => {
           )}
           data-track-category='MCP_CONFIGURE_ARTIFACT'
           data-track-name='MCP_CONFIGURE_SUBMIT'
-          trackId='mcp_configure_submit'
+          data-ph-capture-attribute-track-id='mcp_configure_submit'
         >
           <KeyRound size={14} strokeWidth={2} />
           {isSubmitting ? 'Configuring' : 'Configure'}
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/flowUI/nodes/PlanNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/PlanNode.tsx
@@ -12,7 +12,6 @@ import { useAgentProgress } from '../../../hooks/useAgentProgress';
 import { cn } from '../../../utils/classNames';
 import { MarkdownMessageRenderer } from '../../ui/MessageBubble/MarkdownMessageRenderer';
 import { createMarkdownComponents } from '../../../utils/markdownComponents';
-import { Button } from '../../ui/Button/Button';
 
 /**
  * Plan artifact — an agent-authored, interactive plan card.
@@ -170,9 +169,8 @@ const ProposedPlan: React.FC<{
   // preview footer (submit() closes the preview on a decision).
   const actionControls = (
     <div className='flex flex-wrap items-center gap-2'>
-      <Button
+      <button
         type='button'
-        variant='ghost'
         onClick={() => void submit('plan-approve')}
         disabled={includedIds.size === 0 || locked || agentRunning}
         className={cn(
@@ -182,14 +180,13 @@ const ProposedPlan: React.FC<{
         )}
         data-track-category='PLAN_ARTIFACT'
         data-track-name='CLICK_APPROVE'
-        trackId='plan_approve'
+        data-ph-capture-attribute-track-id='plan_approve'
       >
         {(pending === 'approve' || agentRunning) && <Spinner size={14} className='animate-spin' />}
         {approveLabel}
-      </Button>
-      <Button
+      </button>
+      <button
         type='button'
-        variant='ghost'
         onClick={() => void submit('plan-reject')}
         disabled={locked || agentRunning}
         className={cn(
@@ -200,11 +197,11 @@ const ProposedPlan: React.FC<{
         )}
         data-track-category='PLAN_ARTIFACT'
         data-track-name='CLICK_REJECT'
-        trackId='plan_reject'
+        data-ph-capture-attribute-track-id='plan_reject'
       >
         {pending === 'reject' && <Spinner size={14} className='animate-spin' />}
         {rejectLabel}
-      </Button>
+      </button>
       {agentRunning && (
         <span className='text-xs text-muted-foreground'>Approve once it finishes.</span>
       )}

--- a/apps/dashboard/src/components/flowUI/nodes/PrApprovalNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/PrApprovalNode.tsx
@@ -8,7 +8,6 @@ import type {
   PrApprovalOutcome,
 } from '@xyne/shared';
 import { cn } from '../../../utils/classNames';
-import { Button } from '../../ui/Button/Button';
 
 /**
  * PR approval artifact — an interactive human-in-the-loop (HITL) gate.
@@ -175,9 +174,8 @@ const Actions: React.FC = () => {
 
   return (
     <div className='flex items-center gap-1.5'>
-      <Button
+      <button
         type='button'
-        variant='ghost'
         disabled={state.submitting}
         onClick={() => void run('approved', APPROVE_ACTION_ID)}
         className={cn(
@@ -187,14 +185,13 @@ const Actions: React.FC = () => {
         )}
         data-track-category='PR_APPROVAL_ARTIFACT'
         data-track-name='CLICK_APPROVE'
-        trackId='pr_approval_approve'
+        data-ph-capture-attribute-track-id='pr_approval_approve'
       >
         {inFlight === 'approved' && <Spinner size={14} className='animate-spin' />}
         Approve
-      </Button>
-      <Button
+      </button>
+      <button
         type='button'
-        variant='ghost'
         disabled={state.submitting}
         onClick={() => void run('denied', DENY_ACTION_ID)}
         className={cn(
@@ -204,11 +201,11 @@ const Actions: React.FC = () => {
         )}
         data-track-category='PR_APPROVAL_ARTIFACT'
         data-track-name='CLICK_DENY'
-        trackId='pr_approval_deny'
+        data-ph-capture-attribute-track-id='pr_approval_deny'
       >
         {inFlight === 'denied' && <Spinner size={14} className='animate-spin' />}
         Deny
-      </Button>
+      </button>
     </div>
   );
 };

--- a/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/UserQuestionNode.tsx
@@ -5,7 +5,7 @@ import { useFlow } from '../FlowContext';
 import Avatar from '../../ui/Avatar/Avatar';
 import { useUser } from '../../../hooks/useUsers';
 import { cn } from '../../../utils/classNames';
-import { Button } from '../../ui/Button/Button';
+
 import type { FlowAction, FlowComponent, UserQuestionItem, UserQuestionOption } from '@xyne/shared';
 
 interface UserQuestionNodeProps {
@@ -364,18 +364,17 @@ export const UserQuestionNode: React.FC<UserQuestionNodeProps> = ({ node }) => {
               <span className='px-1'>Back</span>
             </button>
           )}
-          <Button
+          <button
             type='button'
-            variant='ghost'
             data-track-category='USER_QUESTION_ARTIFACT'
             data-track-name={isLast ? 'SUBMIT_ANSWERS' : 'NEXT_QUESTION'}
             onClick={advance}
             disabled={disabled}
             className='flex h-7 items-center rounded-lg border border-foreground/10 bg-background px-1.5 text-sm font-semibold leading-5 text-foreground transition-colors hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:opacity-60'
-            trackId='user_question_submit'
+            data-ph-capture-attribute-track-id='user_question_submit'
           >
             <span className='px-1'>{isLast ? 'Submit' : 'Next'}</span>
-          </Button>
+          </button>
         </div>
       </footer>
     </section>

--- a/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/agent/DraftAgentCard.tsx
@@ -8,7 +8,6 @@ import { AuditLine, CardShell, Mention, StatusChip } from '../cardPrimitives';
 import Avatar from '../../../ui/Avatar/Avatar';
 import { AgentPreview, InsideAgentPreviewContext } from './AgentPreview';
 import { ChatWithAgentButton } from './ChatWithAgentButton';
-import { Button } from '../../../ui/Button/Button';
 
 /**
  * The `agent` artifact's DRAFT variant — an agent an agent proposed, awaiting
@@ -154,19 +153,18 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
   // expanded preview footer (submit() closes the preview on a decision).
   const actionControls = (
     <div className='flex w-full items-center justify-between gap-3'>
-      <Button
+      <button
         type='button'
-        variant='ghost'
         onClick={() => void submit('agent-draft-decline')}
         disabled={locked}
         className={cn(ghostButton, 'px-2.5')}
         data-track-category='AGENT_ARTIFACT'
         data-track-name='CLICK_DECLINE'
-        trackId='agent_draft_decline'
+        data-ph-capture-attribute-track-id='agent_draft_decline'
       >
         {pending === 'reject' && <Spinner size={14} className='animate-spin' />}
         {pending === 'reject' ? 'Declining…' : 'Decline'}
-      </Button>
+      </button>
 
       <div className='flex shrink-0 items-center gap-2'>
         {agentRunning && (
@@ -188,21 +186,20 @@ export const DraftAgentCard: React.FC<{ node: FlowComponent; props: AgentDraftPr
         >
           Edit
         </button>
-        <Button
+        <button
           type='button'
-          variant='ghost'
           onClick={() => void submit('agent-draft-approve')}
           disabled={locked || agentRunning}
           className={cn(primaryButton, 'px-2.5')}
           data-track-category='AGENT_ARTIFACT'
           data-track-name='CLICK_APPROVE'
-          trackId='agent_draft_approve'
+          data-ph-capture-attribute-track-id='agent_draft_approve'
         >
           {(pending === 'approve' || agentRunning) && (
             <Spinner size={14} className='animate-spin' />
           )}
           {approveLabel}
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/knowledgeBase/upload/ShareCollectionModal.tsx
+++ b/apps/dashboard/src/components/knowledgeBase/upload/ShareCollectionModal.tsx
@@ -891,18 +891,17 @@ export const ShareCollectionModal = ({
                         <div className='flex items-center gap-1 pr-1'>
                           <span className='text-xs text-muted-foreground'>Viewer</span>
                           {collectionRole === 'OWNER' && (
-                            <Button
-                              variant='ghost'
+                            <button
                               type='button'
                               onClick={() => handleRemoveAccess(row)}
-                              trackId='remove_collection_access'
+                              data-ph-capture-attribute-track-id='remove_collection_access'
                               aria-label={`Remove ${row.channel?.name || 'channel'} access`}
                               data-track-category='knowledge-base'
                               data-track-name='access-remove-channel'
                               className='p-1 rounded-md text-muted-foreground hover:bg-muted hover:text-red-600'
                             >
                               <X size={14} />
-                            </Button>
+                            </button>
                           )}
                         </div>
                       ) : locked ? (

--- a/apps/dashboard/src/components/knowledgeBase/viewer/FileViewerPanel.tsx
+++ b/apps/dashboard/src/components/knowledgeBase/viewer/FileViewerPanel.tsx
@@ -373,13 +373,12 @@ export const FileViewerPanel: React.FC<{
           </button>
         </Tooltip>
 
-        <Button
-          variant='ghost'
+        <button
           type='button'
           onClick={() => {
             void handleDownload();
           }}
-          trackId='download_document'
+          data-ph-capture-attribute-track-id='download_document'
           aria-label='Download'
           title='Download'
           className='grid h-8 w-8 place-items-center rounded-md text-muted-foreground transition hover:bg-secondary hover:text-foreground'
@@ -387,7 +386,7 @@ export const FileViewerPanel: React.FC<{
           data-track-name='file-viewer-download'
         >
           <Download className='h-4 w-4' strokeWidth={1.75} />
-        </Button>
+        </button>
       </div>
 
       <div className='flex min-w-0 items-center gap-2 px-5 py-2.5'>

--- a/apps/dashboard/src/components/knowledgeBaseV2/components/NameDialogV2.tsx
+++ b/apps/dashboard/src/components/knowledgeBaseV2/components/NameDialogV2.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Button } from '../../ui/Button/Button';
 
 interface NameDialogV2Props {
   open: boolean;
@@ -103,17 +102,16 @@ export const NameDialogV2: React.FC<NameDialogV2Props> = ({
             >
               Cancel
             </button>
-            <Button
+            <button
               type='submit'
-              variant='ghost'
               disabled={!name.trim() || submitting}
               className='rounded-lg bg-muted-foreground px-4 py-2 text-sm font-medium text-background transition hover:bg-muted-foreground/90 disabled:opacity-50'
               data-track-category='knowledge-base'
               data-track-name='name-dialog-submit'
-              trackId='kb_name_dialog_submit'
+              data-ph-capture-attribute-track-id='kb_name_dialog_submit'
             >
               {submitting ? (submittingLabel ?? 'Creating...') : submitLabel}
-            </Button>
+            </button>
           </div>
         </form>
       </div>

--- a/apps/dashboard/src/components/tags/TagsBadge.tsx
+++ b/apps/dashboard/src/components/tags/TagsBadge.tsx
@@ -1,7 +1,7 @@
 import { ChevronDown, Loader2, Plus, Tag, X } from 'lucide-react';
 import { JSX, useState } from 'react';
 import { cn } from '../../utils/classNames';
-import { Button } from '../ui/Button/Button';
+
 import { Popover } from '../ui/Popover/Popover';
 import { useTagEditor, useEntityTags } from '../../hooks/useSourceTags';
 import type { TagGroup } from '../../api/tagsApi';
@@ -139,12 +139,11 @@ export const TagEditorContent = ({
                   const isMutating = mutating.has(key);
                   const wouldExceedMax = !isActive && atMax;
                   return (
-                    <Button
+                    <button
                       key={allowedTag}
-                      variant='ghost'
                       type='button'
                       disabled={isMutating || wouldExceedMax}
-                      trackId='toggle_tag'
+                      data-ph-capture-attribute-track-id='toggle_tag'
                       data-track-category='Support'
                       data-track-name='ToggleTag'
                       onClick={() => {
@@ -165,7 +164,7 @@ export const TagEditorContent = ({
                       {isMutating ? <Loader2 size={9} className='animate-spin' /> : null}
                       {allowedTag}
                       {isActive && !isMutating && <X size={9} />}
-                    </Button>
+                    </button>
                   );
                 })}
               </div>
@@ -183,11 +182,10 @@ export const TagEditorContent = ({
                           style={{ backgroundColor: safeColor(group.color) }}
                         >
                           {t.tag}
-                          <Button
-                            variant='ghost'
+                          <button
                             type='button'
                             disabled={isMutating}
-                            trackId='remove_tag'
+                            data-ph-capture-attribute-track-id='remove_tag'
                             data-track-category='Support'
                             data-track-name='RemoveTag'
                             onClick={() => {
@@ -201,7 +199,7 @@ export const TagEditorContent = ({
                             ) : (
                               <X size={9} />
                             )}
-                          </Button>
+                          </button>
                         </span>
                       );
                     })}
@@ -224,11 +222,10 @@ export const TagEditorContent = ({
                     {isDropdownOpen && (
                       <div className='absolute top-5 left-0 z-50 bg-popover border border-border rounded-md shadow-lg py-1 min-w-[140px] max-h-48 overflow-y-auto'>
                         {availableToAdd.map(t => (
-                          <Button
+                          <button
                             key={t}
-                            variant='ghost'
                             type='button'
-                            trackId='add_tag'
+                            data-ph-capture-attribute-track-id='add_tag'
                             data-track-category='Support'
                             data-track-name='AddTag'
                             onClick={() => {
@@ -238,7 +235,7 @@ export const TagEditorContent = ({
                             className='w-full text-left px-3 py-1.5 text-xs hover:bg-muted transition-colors'
                           >
                             {t}
-                          </Button>
+                          </button>
                         ))}
 
                         {opts?.isNewTagAllowed && (

--- a/apps/dashboard/src/components/tags/ThreadTags.tsx
+++ b/apps/dashboard/src/components/tags/ThreadTags.tsx
@@ -9,7 +9,6 @@ import { useThreadTypeVocabulary } from '../../hooks/useThreadTypeVocabulary';
 import { useMyPendingTags } from '../../hooks/useTagReview';
 import { mutators } from '../../zero/mutators';
 import { Tooltip } from '../ui/Tooltip/Tooltip';
-import { Button } from '../ui/Button/Button';
 import { cn } from '../../utils/classNames';
 import { colorForTagName } from './tagColors';
 
@@ -208,11 +207,10 @@ export const ThreadTags = ({
             >
               {entry?.label ?? tag.name}
               {canEdit && (
-                <Button
-                  variant='ghost'
+                <button
                   type='button'
                   aria-label={`Remove ${entry?.label ?? tag.name}`}
-                  trackId='remove_thread_tag'
+                  data-ph-capture-attribute-track-id='remove_thread_tag'
                   // Width reserved, only opacity changes, so the chip does not resize under
                   // the cursor. stopPropagation because the row opens the thread on click.
                   onClick={event => {
@@ -224,7 +222,7 @@ export const ThreadTags = ({
                   data-track-name='RemoveThreadTag'
                 >
                   <X className='size-2.5' />
-                </Button>
+                </button>
               )}
             </span>
           </Tooltip>

--- a/apps/dashboard/src/components/xyne-desk/AIComposerPanel/AIComposerPanel.tsx
+++ b/apps/dashboard/src/components/xyne-desk/AIComposerPanel/AIComposerPanel.tsx
@@ -13,7 +13,7 @@ import {
   ExternalLink,
 } from 'lucide-react';
 import { XyneAIStar } from '../../icons/xyne-ai';
-import { Button } from '../../ui/Button/Button';
+
 import type { AIRefineQuickAction } from '../../../hooks/useDeskAIDraft';
 
 export interface AIQuickRewriteAction {
@@ -153,19 +153,18 @@ export const AIComposerPanel = ({
               data-track-category='Support'
               data-track-name='AIComposerTextareaKeydown'
             />
-            <Button
+            <button
               type='button'
-              variant='ghost'
               onClick={submitInput}
               disabled={disabled || !value.trim()}
-              trackId='submit_ask_ai_instruction'
+              data-ph-capture-attribute-track-id='submit_ask_ai_instruction'
               className='p-1 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors shrink-0 mb-0.5'
               aria-label='Submit'
               data-track-category='Support'
               data-track-name='SubmitAskAIInstruction'
             >
               <ArrowRight size={14} />
-            </Button>
+            </button>
           </div>
         </div>
       </div>
@@ -249,17 +248,16 @@ export const AIRefineDropdown = ({
                   </p>
                 </div>
                 {QUICK_REWRITE_ACTIONS.map(action => (
-                  <Button
+                  <button
                     key={action.id}
                     type='button'
-                    variant='ghost'
                     disabled={disabled}
                     onClick={() => {
                       onQuickRewrite(action.id);
                       setOpen(false);
                     }}
-                    trackId='ai_quick_rewrite'
-                    trackProps={{ action: action.id }}
+                    data-ph-capture-attribute-track-id='ai_quick_rewrite'
+                    data-ph-capture-attribute-action={action.id}
                     className='w-full flex items-center gap-2.5 px-3 py-1.5 text-sm text-foreground hover:bg-muted transition-colors disabled:opacity-50'
                     data-track-category='Support'
                     data-track-name='QuickRewrite'
@@ -267,7 +265,7 @@ export const AIRefineDropdown = ({
                   >
                     <span className='text-muted-foreground'>{action.icon}</span>
                     <span>{action.label}</span>
-                  </Button>
+                  </button>
                 ))}
 
                 <div className='border-t border-border my-1' />
@@ -296,15 +294,14 @@ export const AIRefineDropdown = ({
               <span>Help me draft</span>
             </button>
             {onRerunDraft && (
-              <Button
+              <button
                 type='button'
-                variant='ghost'
                 disabled={disabled}
                 onClick={() => {
                   onRerunDraft();
                   setOpen(false);
                 }}
-                trackId='ai_rerun_draft'
+                data-ph-capture-attribute-track-id='ai_rerun_draft'
                 className='w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors disabled:opacity-50'
                 title={agentName ? `Rerun draft with ${agentName}` : 'Rerun draft'}
                 data-track-category='Support'
@@ -314,7 +311,7 @@ export const AIRefineDropdown = ({
                   <RefreshCw size={14} />
                 </span>
                 <span>Rerun draft</span>
-              </Button>
+              </button>
             )}
             {showSeeSources && onSeeSources && (
               <button

--- a/apps/dashboard/src/components/xyne-desk/ConversationLabels/ConversationLabels.tsx
+++ b/apps/dashboard/src/components/xyne-desk/ConversationLabels/ConversationLabels.tsx
@@ -7,7 +7,7 @@ import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { queries } from '../../../zero/queries';
 import { mutators } from '../../../zero/mutators';
 import { Popover } from '../../ui/Popover/Popover';
-import { Button } from '../../ui/Button/Button';
+
 import { cn } from '../../../utils/classNames';
 
 export type ConversationLabelSlot = 'chips' | 'picker' | 'inline-picker';
@@ -166,12 +166,11 @@ export const ConversationLabels = ({
         const selected = appliedNames.has(label.name.toLowerCase());
         const color = label.color ?? colorForName(label.name);
         return (
-          <Button
+          <button
             key={label.id}
             type='button'
-            variant='ghost'
             onClick={() => toggleByName(label.id, label.name, color)}
-            trackId='toggle_conversation_label'
+            data-ph-capture-attribute-track-id='toggle_conversation_label'
             className='flex items-center justify-between w-full px-2 py-1.5 text-sm rounded text-left hover:bg-muted text-foreground'
             data-track-category='Support'
             data-track-name='ToggleConversationLabel'
@@ -181,7 +180,7 @@ export const ConversationLabels = ({
               <span className='truncate'>{label.name}</span>
             </span>
             {selected && <Check className='size-4 text-foreground shrink-0' />}
-          </Button>
+          </button>
         );
       })}
       {filtered.length === 0 && !canCreate && (
@@ -189,18 +188,17 @@ export const ConversationLabels = ({
       )}
       {canCreate && (
         <div className='border-t border-border mt-1 pt-1'>
-          <Button
+          <button
             type='button'
-            variant='ghost'
             onClick={createAndApply}
-            trackId='create_conversation_label'
+            data-ph-capture-attribute-track-id='create_conversation_label'
             className='flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded font-medium text-foreground hover:bg-muted'
             data-track-category='Support'
             data-track-name='CreateConversationLabel'
           >
             <Plus className='size-4' />
             Create &ldquo;{search.trim()}&rdquo;
-          </Button>
+          </button>
         </div>
       )}
     </div>
@@ -223,18 +221,17 @@ export const ConversationLabels = ({
             >
               <span className='size-2 rounded-full shrink-0' style={{ backgroundColor: color }} />
               <span className='truncate max-w-[140px]'>{mapping.labelName}</span>
-              <Button
+              <button
                 type='button'
-                variant='ghost'
                 aria-label={`Remove ${mapping.labelName}`}
                 onClick={() => void removeLabel(mapping.labelId)}
-                trackId='remove_conversation_label'
+                data-ph-capture-attribute-track-id='remove_conversation_label'
                 className='hover:bg-muted rounded-full p-0.5'
                 data-track-category='Support'
                 data-track-name='RemoveConversationLabel'
               >
                 <X className='size-2.5' />
-              </Button>
+              </button>
             </span>
           );
         })}

--- a/apps/dashboard/src/components/xyne-desk/DeskFolders/DeskLabelsSidebar.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskFolders/DeskLabelsSidebar.tsx
@@ -8,7 +8,7 @@ import { mutators } from '../../../zero/mutators';
 import { useZero } from '../../../hooks/useZero';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { Dialog } from '../../ui/Dialog/Dialog';
-import { Button } from '../../ui/Button/Button';
+
 import { cn } from '../../../utils/classNames';
 import {
   deleteConversationLabel,
@@ -263,18 +263,17 @@ export const DeskLabelsSidebar = ({
             >
               Cancel
             </button>
-            <Button
+            <button
               type='button'
-              variant='default'
               onClick={() => void handleCreate()}
               disabled={!newName.trim()}
-              trackId='create_desk_label'
+              data-ph-capture-attribute-track-id='create_desk_label'
               className='text-sm font-medium px-4 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm disabled:opacity-50 disabled:pointer-events-none transition-colors'
               data-track-category='Support'
               data-track-name='ConfirmCreateLabel'
             >
               Create
-            </Button>
+            </button>
           </div>
         </div>
       </Dialog>
@@ -312,19 +311,18 @@ export const DeskLabelsSidebar = ({
               >
                 Cancel
               </button>
-              <Button
+              <button
                 type='button'
-                variant='destructive'
                 onClick={() => void confirmDelete()}
                 disabled={deleteSubmitting}
-                trackId='delete_desk_label'
+                data-ph-capture-attribute-track-id='delete_desk_label'
                 className='inline-flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 disabled:pointer-events-none transition-colors'
                 data-track-category='Support'
                 data-track-name='ConfirmDeleteLabel'
               >
                 {deleteSubmitting && <Loader2 className='size-4 animate-spin' />}
                 Delete
-              </Button>
+              </button>
             </div>
           </div>
         )}

--- a/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskConnectionCard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskConnectionCard.tsx
@@ -78,11 +78,10 @@ export const DeskConnectionCard = ({
           </button>
         ) : (
           onReconnect && (
-            <Button
+            <button
               type='button'
-              variant='ghost'
-              trackId='desk_reconnect_integration'
-              trackAction={handleReconnect}
+              data-ph-capture-attribute-track-id='desk_reconnect_integration'
+              onClick={() => void handleReconnect()}
               disabled={isReconnecting}
               className={cn(
                 'inline-flex shrink-0 items-center gap-1.5 px-3 py-1.5 text-sm font-medium',
@@ -94,7 +93,7 @@ export const DeskConnectionCard = ({
             >
               <Plug size={14} className='shrink-0' />
               {isReconnecting ? 'Reconnecting…' : 'Reconnect'}
-            </Button>
+            </button>
           )
         )}
       </div>

--- a/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskConnectionCard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskConnectionCard.tsx
@@ -1,7 +1,6 @@
 import { ReactElement, useState } from 'react';
 import { Plug, Unplug } from 'lucide-react';
 import { DisconnectConfirmDialog } from '../DisconnectConfirmDialog';
-import Button from '../../ui/Button';
 import { cn } from '../../../utils/classNames';
 
 interface DeskConnectionCardProps {

--- a/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskIntegrationCard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskIntegrationCard/DeskIntegrationCard.tsx
@@ -100,8 +100,7 @@ export const DeskIntegrationCard = ({
           </button>
         )}
         {canManage && !isConnected && (
-          <Button
-            variant='ghost'
+          <button
             type='button'
             onClick={() => void handleReconnect()}
             disabled={isReconnecting || isDisconnecting}
@@ -112,11 +111,11 @@ export const DeskIntegrationCard = ({
             )}
             data-track-category='desk-integration'
             data-track-name='connect'
-            trackId='desk_integration_reconnect'
+            data-ph-capture-attribute-track-id='desk_integration_reconnect'
           >
             <Plug size={14} className='shrink-0' />
             {isReconnecting ? 'Redirecting…' : 'Connect'}
-          </Button>
+          </button>
         )}
       </div>
 

--- a/apps/dashboard/src/components/xyne-desk/DeskReplyComposer/SocialMediaReplyComposer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskReplyComposer/SocialMediaReplyComposer.tsx
@@ -3,7 +3,6 @@ import { ArrowUp, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { apiInstance } from '../../../services/clients/apiClient';
 import { useEmailDraftOperations, type EmailDraftRecord } from '../../../hooks/useEmailDraft';
-import { Button } from '../../ui/Button/Button';
 
 interface SocialMediaReplyComposerProps {
   conversationId: string;
@@ -103,8 +102,7 @@ export const SocialMediaReplyComposer = ({
               {content.length}/{maxLength}
             </span>
           )}
-          <Button
-            variant='ghost'
+          <button
             type='button'
             onClick={() => void handleSend()}
             disabled={!canSend}
@@ -116,10 +114,10 @@ export const SocialMediaReplyComposer = ({
             data-track-category={trackingCategory}
             data-track-name='send-reply'
             aria-label='Send reply'
-            trackId='desk_send_social_reply'
+            data-ph-capture-attribute-track-id='desk_send_social_reply'
           >
             {sending ? <Loader2 size={16} className='animate-spin' /> : <ArrowUp size={16} />}
-          </Button>
+          </button>
         </div>
       </div>
     </div>

--- a/apps/dashboard/src/components/xyne-desk/DeskReport/DeskReportPanel.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskReport/DeskReportPanel.tsx
@@ -5,7 +5,6 @@ import { Dialog } from '../../ui/Dialog/Dialog';
 import { cn } from '../../../utils/classNames';
 import { apiInstance, BASE_URL } from '../../../services/clients/apiClient';
 import { showDownloadCompleteToast } from '../../../utils/downloadToast';
-import { Button } from '../../ui/Button/Button';
 
 export interface DeskReportPanelProps {
   open: boolean;
@@ -192,22 +191,21 @@ export const DeskReportPanel: React.FC<DeskReportPanelProps> = ({
                 </button>
               )}
               {canGenerate && (
-                <Button
-                  variant='ghost'
+                <button
                   type='button'
                   onClick={() => void handleGenerateNow()}
                   disabled={submitting || report?.generating}
                   className='flex items-center gap-1.5 rounded-[8px] bg-desk-accent px-3 py-1.5 text-sm font-medium text-white disabled:opacity-60'
                   data-track-category='DeskReport'
                   data-track-name='GenerateNow'
-                  trackId='desk_report_generate'
+                  data-ph-capture-attribute-track-id='desk_report_generate'
                 >
                   <RefreshCw
                     size={14}
                     className={submitting || report?.generating ? 'animate-spin' : ''}
                   />
                   {submitting || report?.generating ? 'Generating…' : 'Generate now'}
-                </Button>
+                </button>
               )}
             </div>
           </div>

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/AIClassificationConfig.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/AIClassificationConfig.tsx
@@ -8,7 +8,6 @@ import {
   SelectValue,
 } from '../../ui/Select/Select';
 import { TestClassificationForm } from './TestClassificationForm';
-import { Button } from '../../ui/Button/Button';
 import type {
   ClassificationMapping,
   SaveMappingPayload,
@@ -386,18 +385,17 @@ export const AIClassificationConfig: React.FC<AIClassificationConfigProps> = ({
                     </SelectContent>
                   </Select>
                   <div className='flex flex-row items-center justify-center gap-2 pt-1'>
-                    <Button
-                      variant='ghost'
+                    <button
                       type='button'
                       onClick={handleSaveEditRule}
                       disabled={!editCategory.trim() || !editUserGroup}
                       className='text-xs font-medium text-desk-accent disabled:opacity-50 disabled:cursor-not-allowed'
                       data-track-category='DeskSettings'
                       data-track-name='SaveEditRule'
-                      trackId='desk_classification_rule_update'
+                      data-ph-capture-attribute-track-id='desk_classification_rule_update'
                     >
                       Save
-                    </Button>
+                    </button>
                     <button
                       type='button'
                       onClick={cancelEditRule}
@@ -437,18 +435,17 @@ export const AIClassificationConfig: React.FC<AIClassificationConfigProps> = ({
                     >
                       Edit
                     </button>
-                    <Button
-                      variant='ghost'
+                    <button
                       type='button'
                       onClick={() => handleDeleteRule(mapping.id)}
                       className='text-red-500 hover:text-red-600 transition-colors'
                       title='Delete rule'
                       data-track-category='DeskSettings'
                       data-track-name='DeleteClassificationRule'
-                      trackId='desk_classification_rule_delete'
+                      data-ph-capture-attribute-track-id='desk_classification_rule_delete'
                     >
                       <Trash2 size={14} />
-                    </Button>
+                    </button>
                   </div>
                 )}
               </div>
@@ -534,18 +531,17 @@ export const AIClassificationConfig: React.FC<AIClassificationConfigProps> = ({
               >
                 Cancel
               </button>
-              <Button
-                variant='ghost'
+              <button
                 type='button'
                 onClick={handleAddRule}
                 disabled={!newCategory.trim() || !newUserGroup}
                 className='rounded-[10px] bg-desk-accent px-[12px] py-[6px] text-sm font-medium text-white transition-colors hover:bg-desk-accent-hover disabled:cursor-not-allowed disabled:opacity-50'
                 data-track-category='DeskSettings'
                 data-track-name='ConfirmAddRule'
-                trackId='desk_classification_rule_create'
+                data-ph-capture-attribute-track-id='desk_classification_rule_create'
               >
                 Add Rule
-              </Button>
+              </button>
             </div>
           </div>
         )}

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/DeskSettings.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/DeskSettings.tsx
@@ -10,7 +10,6 @@ import { AutomationTab } from './tabs/AutomationTab';
 import { AIFeaturesTab } from './tabs/AIFeaturesTab';
 import { MetricsTab } from './tabs/MetricsTab';
 import { Inbox, Route, Zap, Bot, X, BarChart3 } from 'lucide-react';
-import { Button } from '../../ui/Button/Button';
 
 /** Props for the DeskSettings modal component */
 export interface DeskSettingsProps {
@@ -229,8 +228,7 @@ export const DeskSettings: React.FC<DeskSettingsProps> = ({ open, onClose, chann
                   >
                     Cancel
                   </button>
-                  <Button
-                    variant='ghost'
+                  <button
                     type='button'
                     onClick={() => void save()}
                     disabled={saving || !!saveBlockedReason}
@@ -238,10 +236,10 @@ export const DeskSettings: React.FC<DeskSettingsProps> = ({ open, onClose, chann
                     className='rounded-[10px] border border-desk-accent bg-desk-accent px-3 py-1.5 text-sm font-medium text-white shadow-sm hover:opacity-90 focus:outline-none focus-visible:ring-1 focus-visible:ring-desk-accent disabled:cursor-not-allowed disabled:opacity-50'
                     data-track-category='DeskSettings'
                     data-track-name='SaveAll'
-                    trackId='desk_settings_save'
+                    data-ph-capture-attribute-track-id='desk_settings_save'
                   >
                     {saving ? 'Saving…' : 'Save changes'}
-                  </Button>
+                  </button>
                 </div>
               </div>
             )}

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/InlineSignatureEditor.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/InlineSignatureEditor.tsx
@@ -8,7 +8,6 @@ import Underline from '@tiptap/extension-underline';
 import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
 import { EditorToolbar } from '../../ui/EditorToolbar/EditorToolbar';
-import { Button } from '../../ui/Button/Button';
 import SignatureIcon from '../../icons/SignatureIcon';
 
 const ALLOWED_PASTE_IMAGE_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
@@ -126,18 +125,17 @@ export const InlineSignatureEditor: React.FC<InlineSignatureEditorProps> = ({
         >
           Cancel
         </button>
-        <Button
+        <button
           type='button'
-          variant='ghost'
-          trackId='save_signature'
-          trackAction={handleSave}
+          onClick={() => void handleSave()}
+          data-ph-capture-attribute-track-id='save_signature'
           disabled={isSaving || name.trim() === ''}
-          className='h-auto rounded-[10px] bg-desk-accent px-[12px] py-[6px] text-sm font-medium text-white transition-colors hover:bg-desk-accent-hover disabled:cursor-not-allowed disabled:opacity-50'
+          className='rounded-[10px] bg-desk-accent px-[12px] py-[6px] text-sm font-medium text-white transition-colors hover:bg-desk-accent-hover disabled:cursor-not-allowed disabled:opacity-50'
           data-track-category='DeskSettings'
           data-track-name='SaveSignature'
         >
           {isSaving ? 'Saving…' : initial?.id ? 'Save' : 'Add Signature'}
-        </Button>
+        </button>
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/TagGenerationConfig.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/TagGenerationConfig.tsx
@@ -21,7 +21,6 @@ import type {
 } from '../../../api/tagsConfigApi';
 import { TestClassificationForm } from './TestClassificationForm';
 import { TagChip, CategoryLabel } from '../../tags/TagsBadge';
-import { Button } from '../../ui/Button/Button';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -384,11 +383,9 @@ export const TagGenerationConfig: React.FC<TagGenerationConfigProps> = ({
                   >
                     <Pencil size={14} />
                   </button>
-                  <Button
+                  <button
                     type='button'
-                    variant='ghost'
-                    size='icon'
-                    trackId='delete_tag_category'
+                    data-ph-capture-attribute-track-id='delete_tag_category'
                     className='size-auto p-0 text-desk-muted hover:bg-transparent hover:text-destructive'
                     onClick={() => void handleDelete(name)}
                     disabled={editingName !== null || isSaving}
@@ -396,7 +393,7 @@ export const TagGenerationConfig: React.FC<TagGenerationConfigProps> = ({
                     data-track-name='DeleteTagCategory'
                   >
                     <Trash2 size={14} />
-                  </Button>
+                  </button>
                 </div>
               )}
             </div>
@@ -610,10 +607,9 @@ export const TagGenerationConfig: React.FC<TagGenerationConfigProps> = ({
 
             {/* Save / Cancel */}
             <div className='flex items-center gap-2'>
-              <Button
+              <button
                 type='button'
-                variant='ghost'
-                trackId='save_tag_category'
+                data-ph-capture-attribute-track-id='save_tag_category'
                 className='h-auto rounded-[10px] bg-desk-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-desk-accent disabled:opacity-50'
                 onClick={() => void handleSave()}
                 disabled={fieldDisabled}
@@ -621,7 +617,7 @@ export const TagGenerationConfig: React.FC<TagGenerationConfigProps> = ({
                 data-track-name='SaveTagCategory'
               >
                 Save
-              </Button>
+              </button>
               <button
                 type='button'
                 className='rounded-[10px] border border-border px-3 py-1.5 text-sm font-medium text-foreground'

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/TestClassificationForm.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/TestClassificationForm.tsx
@@ -1,6 +1,5 @@
 import { Play } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { Button } from '../../ui/Button/Button';
 
 export interface TestClassificationFormProps {
   title: string;
@@ -76,10 +75,9 @@ export const TestClassificationForm: React.FC<TestClassificationFormProps> = ({
           data-track-name={bodyTrackName}
         />
       </div>
-      <Button
+      <button
         type='button'
-        variant='ghost'
-        trackId='run_classification_preview'
+        data-ph-capture-attribute-track-id='run_classification_preview'
         onClick={onRunPreview}
         disabled={isPreviewing || !subjectValue.trim() || !bodyValue.trim()}
         className='flex h-auto items-center gap-1.5 rounded-lg bg-desk-accent px-3 py-1.5 text-sm text-white transition-colors hover:bg-desk-accent-hover disabled:cursor-not-allowed disabled:opacity-50'
@@ -88,7 +86,7 @@ export const TestClassificationForm: React.FC<TestClassificationFormProps> = ({
       >
         <Play size={14} />
         {isPreviewing ? runningButtonLabel : runButtonLabel}
-      </Button>
+      </button>
 
       {children}
     </div>

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AIFeaturesTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/AIFeaturesTab.tsx
@@ -12,7 +12,7 @@ import { useClawAgentDetail } from '../../../../hooks/useClawAgentDetail';
 import type { ChannelClawAgent } from '../../../../hooks/useChannelClawAgents';
 import { useUserGroups } from '../../../../hooks/useUserGroup';
 import { apiInstance } from '../../../../services/clients/apiClient';
-import { Button } from '../../../ui/Button/Button';
+
 import KnowledgeTab from '../../../../routes/ClawAgentsScreen/tabs/KnowledgeTab';
 import type { useDeskSettingsForm } from '../useDeskSettingsForm';
 import type { AIFeaturesSubTabId } from '../DeskSettings';
@@ -679,10 +679,9 @@ const AiSyncSection: React.FC<AiSyncSectionProps> = ({
 
       <MaybeTooltip side='bottom'>
         <span className='inline-flex self-start'>
-          <Button
+          <button
             type='button'
-            variant='ghost'
-            trackId='run_ai_sync'
+            data-ph-capture-attribute-track-id='run_ai_sync'
             className='inline-flex h-auto items-center justify-center gap-2 rounded-[10px] border border-border bg-background px-4 py-2 text-sm font-medium text-foreground shadow-sm hover:bg-muted/40 focus:outline-none focus-visible:ring-1 focus-visible:ring-desk-accent disabled:cursor-not-allowed disabled:opacity-50'
             onClick={() => {
               void handleRunSync();
@@ -693,7 +692,7 @@ const AiSyncSection: React.FC<AiSyncSectionProps> = ({
           >
             {syncLoading ? <Loader2 size={14} className='animate-spin' /> : <Sparkles size={14} />}
             {inCooldown ? 'AI Sync ran recently — wait a few minutes' : 'Run AI Sync'}
-          </Button>
+          </button>
         </span>
       </MaybeTooltip>
     </div>

--- a/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/InboxTab.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DeskSettings/tabs/InboxTab.tsx
@@ -10,7 +10,6 @@ import { SocialMediaDeskIntegrationCard } from '../../DeskIntegrationCard/Social
 import { ConnectedAppsSection } from '../ConnectedAppsSection';
 import { InlineSignatureEditor } from '../InlineSignatureEditor';
 import { Switch } from '../../../ui/Switch';
-import { Button } from '../../../ui/Button/Button';
 import { matchesUserQuery } from '../../../../utils/userDisplayName';
 import { useChannelApps } from '../../../../hooks/useChannelApps';
 import { useUsers } from '../../../../hooks/useUsers';
@@ -481,11 +480,9 @@ export const InboxTab: React.FC<InboxTabProps> = ({ channelId, form, signatures 
                     </div>
                     <div className='flex items-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity shrink-0'>
                       {!sig.isDefault && (
-                        <Button
+                        <button
                           type='button'
-                          variant='ghost'
-                          size='sm'
-                          trackId='set_default_signature'
+                          data-ph-capture-attribute-track-id='set_default_signature'
                           onClick={() =>
                             zero.mutate(
                               mutators.emailSignature.setDefault({
@@ -499,7 +496,7 @@ export const InboxTab: React.FC<InboxTabProps> = ({ channelId, form, signatures 
                           data-track-name='SetDefaultSignature'
                         >
                           Set as default
-                        </Button>
+                        </button>
                       )}
                       <button
                         type='button'
@@ -515,11 +512,9 @@ export const InboxTab: React.FC<InboxTabProps> = ({ channelId, form, signatures 
                       >
                         <Pencil size={16} />
                       </button>
-                      <Button
+                      <button
                         type='button'
-                        variant='ghost'
-                        size='icon'
-                        trackId='delete_signature'
+                        data-ph-capture-attribute-track-id='delete_signature'
                         onClick={() => zero.mutate(mutators.emailSignature.delete({ id: sig.id }))}
                         className='size-auto p-0 text-desk-muted transition-colors hover:bg-transparent hover:text-red-500'
                         title='Delete signature'
@@ -528,7 +523,7 @@ export const InboxTab: React.FC<InboxTabProps> = ({ channelId, form, signatures 
                         data-track-name='DeleteSignature'
                       >
                         <Trash2 size={16} />
-                      </Button>
+                      </button>
                     </div>
                   </div>
                 ))}

--- a/apps/dashboard/src/components/xyne-desk/DraftCard/DraftCard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/DraftCard/DraftCard.tsx
@@ -28,7 +28,6 @@ import remarkBreaks from 'remark-breaks';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { RefineInput } from '../RefineInput/RefineInput';
-import { Button } from '../../ui/Button/Button';
 import { aiMarkdownProseClassName } from '../../../utils/markdownStyles';
 import { cn } from '../../../utils/classNames';
 import type { AIRefineQuickAction } from '../../../hooks/useDeskAIDraft';
@@ -500,10 +499,9 @@ export const DraftCard = ({
             </button>
           )}
           <div className={cn('relative flex items-center', !onSeeSources && 'ml-auto')}>
-            <Button
+            <button
               type='button'
-              variant='default'
-              trackId='accept_ai_draft'
+              data-ph-capture-attribute-track-id='accept_ai_draft'
               onClick={onAccept}
               disabled={!draftContent || isStreaming}
               className='inline-flex items-center justify-center h-8 px-4 rounded-full bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-colors'
@@ -513,7 +511,7 @@ export const DraftCard = ({
               data-track-name='AcceptDraft'
             >
               Insert
-            </Button>
+            </button>
           </div>
         </div>
       </div>

--- a/apps/dashboard/src/components/xyne-desk/EmailComposer/EmailComposer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailComposer/EmailComposer.tsx
@@ -79,7 +79,6 @@ import { RecipientPillExtension } from '../../ui/TipTapExtensions';
 import { Popover } from '../../ui/Popover/Popover';
 import { RecipientMentionSelector } from './RecipientMentionSelector';
 import { RecipientField as RecipientFieldRow } from './RecipientField';
-import { Button } from '../../ui/Button/Button';
 
 import {
   buildContactPool,
@@ -2179,15 +2178,14 @@ export const EmailComposer = ({
                   >
                     Back to edit
                   </button>
-                  <Button
+                  <button
                     type='button'
-                    variant='default'
                     onClick={runSendEmail}
                     disabled={isSending}
                     className='inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60'
                     data-track-category='Support'
                     data-track-name='ConfirmTwoStepSend'
-                    trackId='send_email_confirm'
+                    data-ph-capture-attribute-track-id='send_email_confirm'
                   >
                     {isSending ? (
                       <Loader2 size={14} className='animate-spin' />
@@ -2195,7 +2193,7 @@ export const EmailComposer = ({
                       <Send size={14} />
                     )}
                     {isSending ? 'Sending…' : 'Send email'}
-                  </Button>
+                  </button>
                 </div>
               </div>
             </div>
@@ -2429,9 +2427,8 @@ export const EmailComposer = ({
                         </button>
                       )}
                       {onClose && features.showDiscardButton && (
-                        <Button
+                        <button
                           type='button'
-                          variant='ghost'
                           onMouseDown={() => {
                             if (!isComposeMode) suppressNextReplyAutosaveRef.current = true;
                           }}
@@ -2500,10 +2497,10 @@ export const EmailComposer = ({
                           title='Discard draft'
                           data-track-category='Support'
                           data-track-name='DiscardComposerDraft'
-                          trackId='discard_composer_draft'
+                          data-ph-capture-attribute-track-id='discard_composer_draft'
                         >
                           <Trash2 size={14} />
-                        </Button>
+                        </button>
                       )}
                       {onClose && features.showMinimizeButton && (
                         <button
@@ -2633,9 +2630,8 @@ export const EmailComposer = ({
                 side='bottom'
                 delayDuration={300}
               >
-                <Button
+                <button
                   type='button'
-                  variant='ghost'
                   onClick={() => {
                     void (async (): Promise<void> => {
                       const suggested = await subjectAI.generate(stripHtml(emailContent));
@@ -2647,14 +2643,14 @@ export const EmailComposer = ({
                   aria-label='Suggest subject with AI'
                   data-track-category='Support'
                   data-track-name='SuggestComposeSubject'
-                  trackId='generate_compose_subject'
+                  data-ph-capture-attribute-track-id='generate_compose_subject'
                 >
                   {subjectAI.isGenerating ? (
                     <RefreshCw size={14} className='animate-spin' />
                   ) : (
                     <Wand2 size={14} />
                   )}
-                </Button>
+                </button>
               </Tooltip>
             )}
           </div>
@@ -3030,8 +3026,7 @@ export const EmailComposer = ({
                   </button>
                 </Tooltip>
               )}
-              <Button
-                variant='default'
+              <button
                 className='size-8 flex items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed transition-colors'
                 onClick={runSendEmail}
                 disabled={
@@ -3051,14 +3046,14 @@ export const EmailComposer = ({
                   conversationId,
                   attachmentCount: attachments.length,
                 })}
-                trackId='send_email'
+                data-ph-capture-attribute-track-id='send_email'
               >
                 {isSending ? (
                   <RefreshCw size={16} className='animate-spin' />
                 ) : (
                   <ArrowUp size={16} />
                 )}
-              </Button>
+              </button>
             </div>
           </div>
         )}

--- a/apps/dashboard/src/components/xyne-desk/RefineInput/RefineInput.tsx
+++ b/apps/dashboard/src/components/xyne-desk/RefineInput/RefineInput.tsx
@@ -1,6 +1,5 @@
 import { useState, forwardRef } from 'react';
 import { ArrowRight } from 'lucide-react';
-import { Button } from '../../ui/Button/Button';
 
 interface RefineInputProps {
   onSubmit: (instruction: string) => void;
@@ -41,19 +40,18 @@ export const RefineInput = forwardRef<HTMLInputElement, RefineInputProps>(
           data-track-category='AIDraft'
           data-track-name='RefineInput'
         />
-        <Button
+        <button
           type='button'
-          variant='ghost'
           onClick={handleSubmit}
           disabled={disabled || !value.trim()}
           className='absolute right-1 top-1/2 -translate-y-1/2 p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed transition-colors'
           aria-label='Send refinement'
           data-track-category='AIDraft'
           data-track-name='SubmitRefinement'
-          trackId='refine_draft'
+          data-ph-capture-attribute-track-id='refine_draft'
         >
           <ArrowRight size={14} />
-        </Button>
+        </button>
       </div>
     );
   },

--- a/apps/dashboard/src/components/xyne-desk/SlaSettings/SlaSettings.tsx
+++ b/apps/dashboard/src/components/xyne-desk/SlaSettings/SlaSettings.tsx
@@ -6,7 +6,6 @@ import type { BoardSlaPolicy } from '../../../hooks/useChannelSlaPolicy';
 import { getPriorityIcon } from '../../Tickets/TicketCard/TicketCard.utils';
 import { TicketPriority } from '@xyne/shared';
 import * as Select from '@radix-ui/react-select';
-import { Button } from '../../ui/Button/Button';
 
 const PRIORITIES = [
   TicketPriority.CRITICAL,
@@ -243,9 +242,8 @@ export const SlaSettings: React.FC<SlaSettingsProps> = ({ boardId, disabled = fa
               <div className='flex items-center justify-between px-4 py-3'>
                 <div className='flex items-center gap-3'>
                   {/* Toggle */}
-                  <Button
+                  <button
                     type='button'
-                    variant='ghost'
                     role='switch'
                     aria-checked={isActive}
                     onClick={() => !disabled && handleToggleActive(priority)}
@@ -258,7 +256,7 @@ export const SlaSettings: React.FC<SlaSettingsProps> = ({ boardId, disabled = fa
                     data-track-category='BOARD_SLA_SETTINGS'
                     data-track-name='TOGGLE_SLA_PRIORITY'
                     data-track-metadata={JSON.stringify({ priority })}
-                    trackId='toggle_sla_priority'
+                    data-ph-capture-attribute-track-id='toggle_sla_priority'
                   >
                     <span
                       className={cn(
@@ -266,7 +264,7 @@ export const SlaSettings: React.FC<SlaSettingsProps> = ({ boardId, disabled = fa
                         isActive ? 'translate-x-4' : 'translate-x-0',
                       )}
                     />
-                  </Button>
+                  </button>
 
                   <div className='flex items-center gap-2'>
                     {getPriorityIcon(priority as TicketPriority)}
@@ -533,19 +531,18 @@ export const SlaSettings: React.FC<SlaSettingsProps> = ({ boardId, disabled = fa
 
                   {/* Save */}
                   <div className='flex justify-end'>
-                    <Button
+                    <button
                       type='button'
-                      variant='ghost'
                       onClick={() => handleSave(priority)}
                       disabled={disabled || !boardId}
                       className='px-3 py-1.5 text-sm font-medium text-white bg-[#6276be] rounded-lg hover:bg-[#4f62a8] dark:hover:bg-[#7986d0] disabled:opacity-50 disabled:cursor-not-allowed transition-colors'
                       data-track-category='BOARD_SLA_SETTINGS'
                       data-track-name='SAVE_SLA_POLICY'
                       data-track-metadata={JSON.stringify({ priority })}
-                      trackId='save_sla_policy'
+                      data-ph-capture-attribute-track-id='save_sla_policy'
                     >
                       Save
-                    </Button>
+                    </button>
                   </div>
                 </div>
               )}

--- a/apps/dashboard/src/components/xyne-desk/SlackThread/SlackComposer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/SlackThread/SlackComposer.tsx
@@ -20,7 +20,6 @@ import { MentionExtension, mentionPluginKey } from '../../ui/TipTapExtensions';
 import { MentionSelector } from '../../ui/Selectors';
 import { useComposerDragDrop } from '../EmailComposer/useComposerDragDrop';
 import { uploadComposerAttachments } from '../EmailComposer/composerAttachmentUpload';
-import { Button } from '../../ui/Button/Button';
 
 const lowlight = createLowlight(all);
 
@@ -268,34 +267,32 @@ const SlackComposer = ({
             <>
               <span className='inline-block size-1.5 rounded-full bg-green-500' />
               <span>Replying as you</span>
-              <Button
+              <button
                 type='button'
-                variant='ghost'
                 onClick={handleDisconnect}
                 disabled={disconnectMutation.isPending}
                 className='text-xs text-muted-foreground underline hover:text-foreground cursor-pointer'
                 data-track-category='slack-composer'
                 data-track-name='disconnect-slack-user'
-                trackId='disconnect_slack_user'
+                data-ph-capture-attribute-track-id='disconnect_slack_user'
               >
                 Disconnect
-              </Button>
+              </button>
             </>
           ) : (
             <>
               <span className='inline-block size-1.5 rounded-full bg-muted-foreground' />
               <span>Replying as Xyne Bot</span>
-              <Button
+              <button
                 type='button'
-                variant='ghost'
                 onClick={handleConnect}
                 className='text-xs text-primary underline hover:text-primary/80 cursor-pointer'
                 data-track-category='slack-composer'
                 data-track-name='connect-slack-user'
-                trackId='connect_slack_user'
+                data-ph-capture-attribute-track-id='connect_slack_user'
               >
                 Connect your Slack
-              </Button>
+              </button>
             </>
           )}
         </div>
@@ -408,9 +405,8 @@ const SlackComposer = ({
           {(() => {
             const canSend = (!!content || attachments.length > 0) && !sending && !uploading;
             return (
-              <Button
+              <button
                 type='button'
-                variant='ghost'
                 onClick={() => void handleSend()}
                 disabled={!canSend}
                 className={`p-2 rounded-md transition-all ${
@@ -421,10 +417,10 @@ const SlackComposer = ({
                 data-track-category='slack-composer'
                 data-track-name='send-reply'
                 aria-label='Send reply'
-                trackId='send_slack_reply'
+                data-ph-capture-attribute-track-id='send_slack_reply'
               >
                 {sending ? <Loader2 size={16} className='animate-spin' /> : <ArrowUp size={16} />}
-              </Button>
+              </button>
             );
           })()}
         </div>

--- a/apps/dashboard/src/components/xyne-desk/WorkspaceOzonetelCard/WorkspaceOzonetelCard.tsx
+++ b/apps/dashboard/src/components/xyne-desk/WorkspaceOzonetelCard/WorkspaceOzonetelCard.tsx
@@ -18,7 +18,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { getApiErrorMessage } from '../../../utils/apiError';
 import { cn } from '../../../utils/classNames';
 import { useAllChannels } from '../../../hooks/useChannels';
-import { Button } from '../../ui/Button/Button';
 
 const inputClass =
   'w-full rounded-[10px] border border-border bg-background px-3 py-1.5 text-sm text-foreground shadow-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-desk-accent';
@@ -661,18 +660,17 @@ export const WorkspaceOzonetelCard = (): ReactElement => {
             </p>
             <div className='flex flex-wrap items-center gap-3'>
               {mutation.isSuccess ? <span className='text-sm text-green-600'>Saved</span> : null}
-              <Button
+              <button
                 type='button'
-                variant='ghost'
                 onClick={onSave}
                 disabled={!canSave || mutation.isPending}
                 className='rounded-[12px] border border-desk-accent bg-desk-accent px-4 py-2 text-sm font-medium text-white shadow-sm transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50'
                 data-track-category='workspace-ozonetel'
                 data-track-name='SaveConfig'
-                trackId='save_ozonetel_config'
+                data-ph-capture-attribute-track-id='save_ozonetel_config'
               >
                 {mutation.isPending ? 'Saving…' : 'Save Ozonetel config'}
-              </Button>
+              </button>
             </div>
           </div>
         </div>
@@ -758,9 +756,8 @@ function ActionButton({
   trackId?: string;
 }): ReactElement {
   return (
-    <Button
+    <button
       type='button'
-      variant='ghost'
       onClick={onClick}
       disabled={disabled}
       className={cn(
@@ -772,7 +769,7 @@ function ActionButton({
       {...(trackId ? { trackId } : {})}
     >
       {label}
-    </Button>
+    </button>
   );
 }
 


### PR DESCRIPTION
The mixpanel->posthog migration replaced 216 native <button> elements with the <Button> component. <Button>'s cva defaults (fixed h-9/px-4, forced size-4 icons via [&_svg:not([class*="size-"])]:size-4, justify-center) layer on top of each button's own className and visibly shrank/padded controls — the call-end button, channel star/leave, and status toggles among them.

Revert those conversions to raw <button>, preserving PostHog autocapture (the allowlist keys on native `button` + the data attrs, so every click is still captured):
- trackId           -> data-ph-capture-attribute-track-id
- trackProps={{k}}  -> data-ph-capture-attribute-k
- trackAction       -> onClick (the 5 converted sites; spinner/double-submit
  guard is dropped there)
- drop variant/size/loading and now-unused Button imports

Pre-existing <Button> usages that the PR only annotated with trackId, and the genuinely-new <Button> elements (send-draft, save-form, disconnect, reconnect), are left intact — they never regressed.

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
