### PR TITLE
fix: XYNE-62291 close sidebar quick-nav hover card on navigation

### DIFF
--- a/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
+++ b/apps/dashboard/src/components/AppSidebar/AppSidebar.tsx
@@ -239,6 +239,10 @@ const AppSidebar = (): ReactElement => {
     PreferenceSection | undefined
   >(undefined);
 
+  useEffect(() => {
+    setOpenQuickMenu(null);
+  }, [activeRoute]);
+
   const handleOpenPreferences = (): void => {
     setIsSettingsPopoverOpen(false);
     setPreferencesInitialSection(undefined);

--- a/apps/dashboard/src/components/AppSidebar/RailQuickNav.tsx
+++ b/apps/dashboard/src/components/AppSidebar/RailQuickNav.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, type ReactElement, type ReactNode } from 'react';
+import { cloneElement, useEffect, type ReactElement, type ReactNode } from 'react';
 import { HoverCard } from '../ui/HoverCard';
 import { Tooltip } from '../ui/Tooltip/Tooltip';
 
@@ -26,13 +26,22 @@ export const RailQuickNavEntry = ({
   open,
   onOpenChange,
 }: {
-  trigger: ReactElement<{ onFocus?: (event: React.FocusEvent) => void }>;
+  trigger: ReactElement<{
+    onFocus?: (event: React.FocusEvent) => void;
+    onClick?: (event: React.MouseEvent) => void;
+  }>;
   menu: ReactNode;
   tooltip: ReactNode;
   showQuickMenu: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }): ReactElement => {
+  useEffect(() => {
+    if (!showQuickMenu && open) {
+      onOpenChange(false);
+    }
+  }, [showQuickMenu, open, onOpenChange]);
+
   if (!showQuickMenu) {
     return (
       <Tooltip content={tooltip} side='right' delayDuration={0}>
@@ -51,7 +60,13 @@ export const RailQuickNavEntry = ({
       openDelay={200}
       closeDelay={120}
       className='w-56 rounded-xl p-1.5'
-      trigger={cloneElement(trigger, { onFocus: event => event.preventDefault() })}
+      trigger={cloneElement(trigger, {
+        onFocus: event => event.preventDefault(),
+        onClick: event => {
+          trigger.props.onClick?.(event);
+          onOpenChange(false);
+        },
+      })}
     >
       {menu}
     </HoverCard>


### PR DESCRIPTION
Cherry-pick of #1487 (commit cdd739f) onto release-20260903.

Fixes the sidebar quick-access hover card staying open with the pointer nowhere near it (reproduced by switching between Xyne AI and DMs). Cleared in three places: AppSidebar resets openQuickMenu on route change; RailQuickNavEntry notifies close when it stops rendering the card; and RailQuickNavEntry closes on trigger click.