### PR TITLE
feat(artifact-apps): bare-Bearer auth bridge for storage routes (XYNE-61939)

### DIFF
--- a/apps/xyne-claw-auth/backend/src/http/routes.ts
+++ b/apps/xyne-claw-auth/backend/src/http/routes.ts
@@ -31,7 +31,7 @@ import { dashboardRouter } from "../routes/dashboard.js";
 import { agentChatRouter, agentChatInternalRouter } from "../routes/agent-chat.js";
 import { artifactAppsRouter } from "../routes/artifact-apps.js";
 import { artifactAppAgentsRouter } from "../routes/artifact-app-agents.js";
-import { artifactAppStorageRouter } from "../routes/artifact-app-storage.js";
+import { artifactAppStorageRouter, storageBearerAuthBridge } from "../routes/artifact-app-storage.js";
 import { designSharesRouter, publicDesignSharesRouter } from "../routes/design-shares.js";
 import { sessionsArchiveRouter } from "../routes/sessions-archive.js";
 import { experimentsInternalRouter } from "../routes/experiments-internal.js";
@@ -156,7 +156,10 @@ function mountCoreApi(app: Express): void {
   app.use(`${BASE}/agent-chat`, requireAuth, requireNoAccessToken, agentChatRouter);
   app.use(`${BASE}/artifact-apps`, requireAuth, artifactAppsRouter);
   app.use(`${BASE}/artifact-app-agents`, requireAuth, artifactAppAgentsRouter);
-  app.use(`${BASE}/artifact-app-storage`, requireAuth, artifactAppStorageRouter);
+  // storageBearerAuthBridge runs first: bare-Bearer SDK calls get the token's
+  // own workspaceId claim turned into the cookie form requireAuth expects.
+  // Scoped to this path only — requireAuth itself is untouched.
+  app.use(`${BASE}/artifact-app-storage`, storageBearerAuthBridge, requireAuth, artifactAppStorageRouter);
   app.use(`${BASE}/design-shares`, requireAuth, requireNoAccessToken, designSharesRouter);
   app.use(`${BASE}/daily-brief`, requireAuth, requireNoAccessToken, dailyBriefRouter);
   app.use(`${BASE}/internal/agent-chat`, requireStrictS2S, agentChatInternalRouter); // progress/callback from xyne-claw

--- a/apps/xyne-claw-auth/backend/src/routes/artifact-app-storage.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/artifact-app-storage.ts
@@ -41,7 +41,7 @@
  * SAVED apps — an unsaved chat artifact has no stable id to key records on.
  */
 
-import { Router, type Request, type Response } from "express";
+import { Router, type NextFunction, type Request, type Response } from "express";
 import { z } from "zod";
 import { prisma } from "../db.js";
 import { redisService } from "../redis.js";
@@ -51,6 +51,59 @@ import { createLogger } from "../logger.js";
 
 const log = createLogger("artifact-app-storage");
 export const artifactAppStorageRouter: Router = Router();
+
+/**
+ * Storage-only Bearer bridge, mounted BEFORE requireAuth on this router's
+ * path (see http/routes.ts) and nowhere else — requireAuth itself is shared
+ * by every route in the service and stays untouched.
+ *
+ * An SDK client sends only `Authorization: Bearer <workspace JWT>`. Spaces'
+ * auth wants that token in a cookie whose NAME embeds the workspaceId
+ * (`xyne_ws_<id>_token`), so this synthesizes the cookie header from the
+ * token's own workspaceId claim and lets requireAuth's normal cookie path do
+ * the rest. The claim is decoded WITHOUT verification — safe, because it is
+ * only a routing hint: it selects which cookie slot Spaces verifies, and the
+ * signature check still happens there. A tampered claim just misroutes the
+ * caller's own request into a slot that fails verification.
+ *
+ * Strictly additive: it acts only when the request has NO cookie header —
+ * which today could never authenticate — and a non-JWT bearer (xyne_cli_*,
+ * xyne_svc_*) doesn't decode, so CLI/service tokens fall through untouched.
+ */
+export function storageBearerAuthBridge(req: Request, _res: Response, next: NextFunction): void {
+  if (!req.headers.cookie) {
+    const match = /^Bearer\s+(.+)$/i.exec(req.headers.authorization ?? "");
+    const token = match?.[1]?.trim();
+    const workspaceId = token ? workspaceIdFromJwt(token) : undefined;
+    if (token && workspaceId) {
+      req.headers.cookie = `xyne_last_workspace=${workspaceId}; xyne_ws_${workspaceId}_token=${token}`;
+      if (typeof req.headers["x-workspace-id"] !== "string" || !req.headers["x-workspace-id"].trim()) {
+        req.headers["x-workspace-id"] = workspaceId;
+      }
+    }
+  }
+  next();
+}
+
+/** The workspaceId claim of a Spaces workspace JWT, undefined for anything
+ *  that isn't a decodable JWT. Charset-restricted because the value is
+ *  embedded into the synthesized Cookie header above. */
+function workspaceIdFromJwt(token: string): string | undefined {
+  const parts = token.split(".");
+  if (parts.length !== 3) return undefined;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString("utf8")) as {
+      workspaceId?: unknown;
+    };
+    const workspaceId = payload.workspaceId;
+    if (typeof workspaceId === "string" && /^[A-Za-z0-9_-]{1,64}$/.test(workspaceId)) {
+      return workspaceId;
+    }
+  } catch {
+    /* not decodable — not a workspace JWT */
+  }
+  return undefined;
+}
 
 const VISIBILITY_WORKSPACE = "WORKSPACE";
 


### PR DESCRIPTION
## What

Follow-up to the merged #1462 (this commit was pushed to that branch after the merge, so it needs its own PR).

Lets SDK clients call the storage API with only `Authorization: Bearer <workspace JWT>` — no workspaceId parameter, no synthesized cookie:

- New `storageBearerAuthBridge` middleware in `artifact-app-storage.ts`, mounted **only on the storage path**, ahead of `requireAuth` — the shared auth middleware itself is untouched.
- When a request has **no cookie header** (previously a guaranteed 401), it decodes the `workspaceId` claim from the Bearer JWT and rewrites the token into the `xyne_ws_<id>_token` cookie form `requireAuth`'s normal path already verifies against the Spaces backend.
- The claim is a routing hint only: signature verification still happens at Spaces, and the storage ACL derives its workspace from the `artifact_apps` row — a tampered claim just fails the caller's own auth. CLI/service bearers (`xyne_cli_…`) don't decode as JWTs and fall through untouched. The claim value is charset-restricted before being embedded in the cookie header.

## Pairing

SDK side (drops the `workspaceId` option, pure Bearer): juspay/xyne-spaces-private#259 — merge this first or bare-Bearer SDK calls 401.

## Validation

`tsc --noEmit` clean; exercised end-to-end against a local claw-auth via the CRUD test page (connect with token + app id only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dbikGSSdDEpDWMGk9QbCm