### PR TITLE
feat: XYNE always spill MCP results to file + forward via sandbox-copy-in contextPath

### DIFF
--- a/apps/xyne-claw/src/mcp.ts
+++ b/apps/xyne-claw/src/mcp.ts
@@ -399,11 +399,14 @@ export async function loadMcpToolsForUser(
           // result, return a small preview. Without this, MCP tools that
           // return tens-of-MB blobs (iswitch_list_resources, etc.) blow
           // through the LLM's context window in a single turn.
+          // forceFile: always keep the raw MCP result on disk so the agent can forward the whole file to a sandbox instead of retyping it.
           const promotedText = await promoteIfOversized(
             toolOutputDir,
             server.serverType,
             mcpTool.name,
             persistedAttachmentText ?? renderedContent,
+            undefined,
+            true,
           );
           return {
             content: [{ type: "text" as const, text: promotedText }],

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -1712,6 +1712,8 @@ export async function processTask(
     if (agentSlug) meta["agentSlug"] = agentSlug;
     if (channelId) meta["channelId"] = channelId;
     if (conversationId) meta["conversationId"] = conversationId;
+    // Root of this run's spilled tool-result / attachment files, so sandbox-copy-in can forward a whole MCP result file into a sandbox (contextPath).
+    meta["contextRoot"] = join(mcpOutputDir, ".context");
     if (taskCommand) meta["taskCommand"] = taskCommand.command;
     if (recordingFiles.length > 0) {
       // Server-authored metadata consumed only by analyze-skill-recording. The

--- a/apps/xyne-claw/src/tool-output.ts
+++ b/apps/xyne-claw/src/tool-output.ts
@@ -198,11 +198,28 @@ export async function promoteIfOversized(
   // retrieval tools keep their full result inline while bulk/file tools spill at
   // the small cap. Callers may pass an explicit value to override.
   inlineCapBytes?: number,
+  // When true, persist the raw result to a file even when it fits inline, and
+  // hand the model the path — so it can forward the whole file into a sandbox
+  // byte-for-byte (sandbox-copy-in contextPath) instead of retyping it.
+  forceFile = false,
 ): Promise<string> {
   const cap = inlineCapBytes ?? inlineCapForTool(toolName);
   const clean = stripControlChars(rawContent);
   if (clean.length <= cap) {
-    return clean;
+    if (!forceFile) return clean;
+    const dir = resolvePath(outputBaseDir, ".context", "tool-results");
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const absPath = joinPath(
+      dir,
+      `${category.replace(/[^a-zA-Z0-9_-]/g, "_")}-${toolName.replace(/[^a-zA-Z0-9_-]/g, "_")}-${stamp}.json`,
+    );
+    try {
+      await mkdir(dir, { recursive: true });
+      await writeFile(absPath, clean, { encoding: "utf8" });
+    } catch {
+      return clean;
+    }
+    return `${clean}\n\n[Full raw result also saved to ${absPath} — to use it in a sandbox, forward the whole file with sandbox-copy-in (contextPath) instead of pasting its content.]`;
   }
   // Reflow to line-structured form so the spilled file is readable/greppable by
   // the line-oriented read/grep tools (a minified single-line JSON payload is

--- a/apps/xyne-claw/src/tool-output.ts
+++ b/apps/xyne-claw/src/tool-output.ts
@@ -29,6 +29,7 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { join as joinPath, resolve as resolvePath } from "node:path";
+import { randomUUID } from "node:crypto";
 import { metric } from "./metrics.js";
 
 import { createLogger } from "./logger.js";
@@ -207,19 +208,24 @@ export async function promoteIfOversized(
   const clean = stripControlChars(rawContent);
   if (clean.length <= cap) {
     if (!forceFile) return clean;
-    const dir = resolvePath(outputBaseDir, ".context", "tool-results");
+    // Persist the RAW bytes (not the control-stripped inline copy) so a sandbox-copy-in
+    // forward is byte-identical; the random suffix avoids same-millisecond collisions.
+    const safeCat = category.replace(/[^a-zA-Z0-9_-]/g, "_");
+    const safeName = toolName.replace(/[^a-zA-Z0-9_-]/g, "_");
     const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const absPath = joinPath(
-      dir,
-      `${category.replace(/[^a-zA-Z0-9_-]/g, "_")}-${toolName.replace(/[^a-zA-Z0-9_-]/g, "_")}-${stamp}.json`,
-    );
+    const fileName = `${safeCat}-${safeName}-${stamp}-${randomUUID().slice(0, 8)}.json`;
+    const dir = resolvePath(outputBaseDir, ".context", "tool-results");
+    const absPath = joinPath(dir, fileName);
+    const relPath = joinPath("tool-results", fileName);
     try {
       await mkdir(dir, { recursive: true });
-      await writeFile(absPath, clean, { encoding: "utf8" });
-    } catch {
+      await writeFile(absPath, rawContent, { encoding: "utf8" });
+    } catch (err) {
+      log.warn(`[tool-output] ${safeCat}/${safeName} force-file write failed: ${err instanceof Error ? err.message : String(err)}`);
       return clean;
     }
-    return `${clean}\n\n[Full raw result also saved to ${absPath} — to use it in a sandbox, forward the whole file with sandbox-copy-in (contextPath) instead of pasting its content.]`;
+    metric.count("tool_output_spill", { category: safeCat, tool: safeName });
+    return `${clean}\n\n[Full raw result also saved — forward it into a sandbox with sandbox-copy-in contextPath: "${relPath}" instead of pasting its content.]`;
   }
   // Reflow to line-structured form so the spilled file is readable/greppable by
   // the line-oriented read/grep tools (a minified single-line JSON payload is

--- a/packages/xyne-claw-shared/src/tools/sandbox/copy-in.test.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/copy-in.test.ts
@@ -2,17 +2,18 @@ import { describe, it, expect } from "vitest";
 import { sandboxCopyIn } from "./tools.js";
 import type { ToolExecutionContext } from "../types.js";
 
-// A run context that has a materialized skills root + a plausible session owner.
+// A run context that can carry a materialized skills root and/or a .context root.
 // The path-confinement / validation branches all return BEFORE any sandbox
 // session lookup, so these cases never need a live SESSION_STORE entry.
-function ctx(skillsRoot: string | undefined): ToolExecutionContext {
+function ctx(opts: { skillsRoot?: string; contextRoot?: string } = {}): ToolExecutionContext {
   return {
     config: {},
     meta: {
       userId: "u1",
       conversationId: "c1",
       agentSlug: "a1",
-      ...(skillsRoot ? { skillsRoot } : {}),
+      ...(opts.skillsRoot ? { skillsRoot: opts.skillsRoot } : {}),
+      ...(opts.contextRoot ? { contextRoot: opts.contextRoot } : {}),
     },
   };
 }
@@ -23,10 +24,14 @@ describe("sandbox-copy-in tool definition", () => {
     expect(sandboxCopyIn.source).toBe("custom:sandbox");
   });
 
-  it("requires sessionId and skillPath", () => {
-    expect(sandboxCopyIn.inputSchema.required).toEqual(
-      expect.arrayContaining(["sessionId", "skillPath"]),
-    );
+  it("requires only sessionId (skillPath/contextPath are XOR, enforced at runtime)", () => {
+    expect(sandboxCopyIn.inputSchema.required).toEqual(["sessionId"]);
+  });
+
+  it("exposes both skillPath and contextPath inputs", () => {
+    const props = sandboxCopyIn.inputSchema.properties ?? {};
+    expect(props).toHaveProperty("skillPath");
+    expect(props).toHaveProperty("contextPath");
   });
 
   it("is NOT an approval-gated write tool (server-side copy, no user data mutation)", () => {
@@ -36,31 +41,45 @@ describe("sandbox-copy-in tool definition", () => {
   });
 });
 
-describe("sandbox-copy-in path confinement", () => {
+describe("sandbox-copy-in source selection (skillPath XOR contextPath)", () => {
+  const ROOT = "/data/session-skills/sess-123";
+
+  it("rejects when neither skillPath nor contextPath is given", async () => {
+    const out = await sandboxCopyIn.execute({ sessionId: "s" }, ctx({ skillsRoot: ROOT }));
+    expect(out.toLowerCase()).toContain("exactly one");
+  });
+
+  it("rejects when BOTH skillPath and contextPath are given", async () => {
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "s", skillPath: "slug/run.sh", contextPath: "tool-results/x.json" },
+      ctx({ skillsRoot: ROOT, contextRoot: "/data/sessions/c1/.context" }),
+    );
+    expect(out.toLowerCase()).toContain("exactly one");
+  });
+
+  it("treats a blank skillPath as 'not provided' (falls into the XOR error)", async () => {
+    const out = await sandboxCopyIn.execute({ sessionId: "s", skillPath: "   " }, ctx({ skillsRoot: ROOT }));
+    expect(out.toLowerCase()).toContain("exactly one");
+  });
+});
+
+describe("sandbox-copy-in path confinement (skillPath)", () => {
   const ROOT = "/data/session-skills/sess-123";
 
   it("refuses when no skills are materialized for the run", async () => {
     const out = await sandboxCopyIn.execute(
       { sessionId: "s", skillPath: "slug/scripts/run.sh" },
-      ctx(undefined),
+      ctx({}),
     );
     expect(out.toLowerCase()).toContain("no skills are materialized");
-  });
-
-  it("rejects an empty skillPath", async () => {
-    const out = await sandboxCopyIn.execute(
-      { sessionId: "s", skillPath: "   " },
-      ctx(ROOT),
-    );
-    expect(out.toLowerCase()).toContain("non-empty");
   });
 
   it("rejects '..' traversal that escapes the skills root", async () => {
     const out = await sandboxCopyIn.execute(
       { sessionId: "s", skillPath: "../../etc/passwd" },
-      ctx(ROOT),
+      ctx({ skillsRoot: ROOT }),
     );
-    expect(out.toLowerCase()).toContain("escapes the skill directory");
+    expect(out.toLowerCase()).toContain("escapes its root");
   });
 
   it("rejects a sibling-prefix escape (root-name is a prefix, not a parent)", async () => {
@@ -68,9 +87,9 @@ describe("sandbox-copy-in path confinement", () => {
     // starts with the root string — the separator check guards this.
     const out = await sandboxCopyIn.execute(
       { sessionId: "s", skillPath: "../sess-123-evil/secret" },
-      ctx(ROOT),
+      ctx({ skillsRoot: ROOT }),
     );
-    expect(out.toLowerCase()).toContain("escapes the skill directory");
+    expect(out.toLowerCase()).toContain("escapes its root");
   });
 
   it("neutralizes a leading '/' into the root instead of treating it as absolute", async () => {
@@ -79,7 +98,7 @@ describe("sandbox-copy-in path confinement", () => {
     // confinement and fails later on the missing session (safe outcome).
     const out = await sandboxCopyIn.execute(
       { sessionId: "no-such-session", skillPath: "/etc/shadow" },
-      ctx(ROOT),
+      ctx({ skillsRoot: ROOT }),
     );
     expect(out).toContain("no-such-session");
     expect(out.toLowerCase()).toContain("not found");
@@ -88,7 +107,7 @@ describe("sandbox-copy-in path confinement", () => {
   it("refuses paths that resolve to a credential file even inside the root", async () => {
     const out = await sandboxCopyIn.execute(
       { sessionId: "s", skillPath: "slug/.ssh/id_rsa" },
-      ctx(ROOT),
+      ctx({ skillsRoot: ROOT }),
     );
     expect(out.toLowerCase()).toContain("credential");
   });
@@ -98,7 +117,44 @@ describe("sandbox-copy-in path confinement", () => {
     // session lookup — proving the guards don't false-reject valid input.
     const out = await sandboxCopyIn.execute(
       { sessionId: "no-such-session", skillPath: "slug/scripts/run.sh" },
-      ctx(ROOT),
+      ctx({ skillsRoot: ROOT }),
+    );
+    expect(out).toContain("no-such-session");
+    expect(out.toLowerCase()).toContain("not found");
+  });
+});
+
+describe("sandbox-copy-in path confinement (contextPath)", () => {
+  const CTX_ROOT = "/data/sessions/c1/.context";
+
+  it("refuses when no .context root exists for the run", async () => {
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "s", contextPath: "tool-results/x.json" },
+      ctx({ skillsRoot: "/data/session-skills/sess-123" }),
+    );
+    expect(out.toLowerCase()).toContain(".context root");
+  });
+
+  it("rejects '..' traversal that escapes the .context root", async () => {
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "s", contextPath: "../../etc/passwd" },
+      ctx({ contextRoot: CTX_ROOT }),
+    );
+    expect(out.toLowerCase()).toContain("escapes its root");
+  });
+
+  it("refuses a credential file even inside the .context root", async () => {
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "s", contextPath: ".ssh/id_rsa" },
+      ctx({ contextRoot: CTX_ROOT }),
+    );
+    expect(out.toLowerCase()).toContain("credential");
+  });
+
+  it("passes confinement for a normal tool-results path, then fails only on the missing session", async () => {
+    const out = await sandboxCopyIn.execute(
+      { sessionId: "no-such-session", contextPath: "tool-results/juspay_alerts-x.json" },
+      ctx({ contextRoot: CTX_ROOT }),
     );
     expect(out).toContain("no-such-session");
     expect(out.toLowerCase()).toContain("not found");

--- a/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/sandbox/tools.ts
@@ -1155,9 +1155,10 @@ export const sandboxCopyIn: ToolDefinition = {
   slug: "sandbox-copy-in",
   name: "Sandbox Copy Skill File",
   description:
-    "Copy a companion file bundled with a loaded skill (a script or asset in the skill's folder) directly into a sandbox session, WITHOUT pasting its content. " +
-    "Prefer this over sandbox-write-file when a skill ships a script/binary you need to run in the sandbox: the file is streamed server-side, so large or binary files stay intact and don't bloat context. " +
-    "`skillPath` is relative to the skill directory shown in the skill's <location> (e.g. 'sandbox-record-video/scripts/recorder.mjs').",
+    "Copy a file directly into a sandbox session WITHOUT pasting its content — the bytes stream server-side, so large/binary files stay intact and don't bloat context. " +
+    "Pass EITHER `skillPath` (a companion file bundled with a loaded skill, relative to the skill's <location>, e.g. 'sandbox-record-video/scripts/recorder.mjs') " +
+    "OR `contextPath` (a spilled tool-result / attachment file under this run's .context, e.g. 'tool-results/<file>.json'). " +
+    "Prefer contextPath to forward a whole MCP result file into the sandbox byte-for-byte instead of retyping it with sandbox-write-file.",
   source: "custom:sandbox",
   configSchema: SANDBOX_CONFIG_SCHEMA,
   inputSchema: {
@@ -1172,35 +1173,48 @@ export const sandboxCopyIn: ToolDefinition = {
         description:
           "Path of the skill companion file RELATIVE to this run's session-skills root, e.g. '<skill-slug>/scripts/run.sh'. Leading '/' and '..' are rejected.",
       },
+      contextPath: {
+        type: "string",
+        description:
+          "Path of a spilled tool-result / attachment file RELATIVE to this run's .context root, e.g. 'tool-results/<file>.json'. Use this to forward a whole MCP result file into the sandbox. Leading '/' and '..' are rejected.",
+      },
       destPath: {
         type: "string",
-        description: "Absolute destination path inside the sandbox (default: /workspace/<basename of skillPath>).",
+        description: "Absolute destination path inside the sandbox (default: /workspace/<basename of source path>).",
       },
     },
-    required: ["sessionId", "skillPath"],
+    required: ["sessionId"],
   },
 
   async execute(params, context) {
     if (!context) return "Error: No execution context available.";
     const sessionId = params["sessionId"] as string;
-    const skillPathRaw = params["skillPath"] as string;
+    const skillPathRaw = params["skillPath"] as string | undefined;
+    const contextPathRaw = params["contextPath"] as string | undefined;
     const destPathRaw = params["destPath"] as string | undefined;
 
-    const skillsRoot = context.meta?.["skillsRoot"];
-    if (!skillsRoot) {
-      return "Error: No skills are materialized for this run (context.meta.skillsRoot is unset), so there is nothing to copy in. Use sandbox-write-file for ad-hoc content.";
+    // Exactly one source: a skill companion file (skillsRoot) or a spilled
+    // tool-result file (.context root). Each is confined to its own root.
+    const hasSkill = typeof skillPathRaw === "string" && skillPathRaw.trim().length > 0;
+    const hasContext = typeof contextPathRaw === "string" && contextPathRaw.trim().length > 0;
+    if (hasSkill === hasContext) {
+      return "Error: pass exactly one of skillPath (a loaded skill's companion file) or contextPath (a spilled tool-result file under .context).";
     }
-    if (typeof skillPathRaw !== "string" || skillPathRaw.trim().length === 0) {
-      return "Error: skillPath must be a non-empty path relative to the skill directory.";
+    const rootRaw = hasSkill ? context.meta?.["skillsRoot"] : context.meta?.["contextRoot"];
+    if (!rootRaw) {
+      return hasSkill
+        ? "Error: No skills are materialized for this run (context.meta.skillsRoot is unset). Use sandbox-write-file for ad-hoc content."
+        : "Error: No .context root for this run (context.meta.contextRoot is unset), so there is no tool-result file to copy in.";
     }
+    const relPath = (hasSkill ? skillPathRaw! : contextPathRaw!).trim();
 
-    // Confine the source to THIS run's session-skills root. Reject absolute
-    // inputs and any '..' traversal that escapes the root — otherwise this
-    // becomes an arbitrary pod-file / cross-session read primitive.
-    const rootAbs = resolve(skillsRoot);
-    const sourceAbs = resolve(join(rootAbs, skillPathRaw));
+    // Confine the source to its root. Reject absolute inputs and any '..'
+    // traversal that escapes it — otherwise this becomes an arbitrary
+    // pod-file / cross-session read primitive.
+    const rootAbs = resolve(rootRaw);
+    const sourceAbs = resolve(join(rootAbs, relPath));
     if (sourceAbs !== rootAbs && !sourceAbs.startsWith(rootAbs + sep)) {
-      return "Error: skillPath escapes the skill directory. Pass a path relative to the skill folder (no leading '/' and no '..').";
+      return "Error: path escapes its root. Pass a relative path (no leading '/' and no '..').";
     }
     if (isCredentialPath(sourceAbs)) {
       return JSON.stringify({ error: "Refused: path looks like a credential file" });
@@ -1222,14 +1236,14 @@ export const sandboxCopyIn: ToolDefinition = {
     try {
       const buf = await readFile(sourceAbs);
       await session.files.write(destPath, buf);
-      return JSON.stringify({ skillPath: skillPathRaw, destPath, bytes: buf.length, copied: true });
+      return JSON.stringify({ sourcePath: relPath, destPath, bytes: buf.length, copied: true });
     } catch (err) {
       if (isStaleSessionError(err)) {
         evictSession(session);
         return `Error: Session ${sessionId} died (sandbox pod replaced). Call sandbox-repo-setup to re-provision.`;
       }
       if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
-        return `Error: Skill file not found at '${skillPathRaw}'. Check the path relative to the skill's <location> directory.`;
+        return `Error: file not found at '${relPath}'. Check the path is relative to the ${hasSkill ? "skill's <location> directory" : "run's .context root"}.`;
       }
       return sandboxErr(err);
     }


### PR DESCRIPTION
## What
Makes the MCP tool-result → sandbox data path deterministic so the agent never has to re-type large blobs (root cause of the recurring bracket-count mismatches in the PI alerts bot).

Two small, connected changes:

1. **Always persist MCP results to a file + hand the agent the path.** `promoteIfOversized` gains a `forceFile` flag (passed `true` from the MCP execute path in `mcp.ts`). Even when a result fits inline, the raw bytes are written to `.context/tool-results/<server>-<tool>-<ts>.json` and the inline text gets a marker line pointing at the file. Over-cap results keep their existing preview+spill behaviour.
2. **Let the agent forward that file into a sandbox byte-for-byte.** `sandbox-copy-in` now accepts a `contextPath` (a file under this run's `.context` root) in addition to `skillPath`. Exactly one source is required; each is confined to its own root with the same `..`/absolute-path/credential rejection. The `.context` root is injected as `context.meta.contextRoot` in `routes/run.ts` (= `join(mcpOutputDir, ".context")`) and flows through the existing `toolMeta` spread in `custom-tools.ts`.

## Why
The agent was manually re-emitting large MCP data through `sandbox-write-file`, dropping/mismatching brackets. Now it forwards the whole result file server-side — no re-typing, byte-identical.

## Files
- `apps/xyne-claw/src/tool-output.ts` — `forceFile` param + always-write branch
- `apps/xyne-claw/src/mcp.ts` — pass `forceFile: true`
- `apps/xyne-claw/src/routes/run.ts` — inject `meta.contextRoot`
- `packages/xyne-claw-shared/src/tools/sandbox/tools.ts` — `sandbox-copy-in` accepts `contextPath`

## Testing
- `tsc --noEmit` clean on `packages/xyne-claw-shared`.
- `apps/xyne-claw` typecheck surfaces only pre-existing, unrelated errors (missing `zod`/`bullmq` modules, implicit-any in `main.ts`/`run-queue-worker.ts`/`pr-review-findings.ts`); none touch the four changed files.