### PR TITLE
fix: agent runs, post diff

### DIFF
--- a/apps/xyne-claw-auth/backend/prisma/migrations/20260903120000_agent_runs_listing_indexes/migration.sql
+++ b/apps/xyne-claw-auth/backend/prisma/migrations/20260903120000_agent_runs_listing_indexes/migration.sql
@@ -1,0 +1,33 @@
+-- agent_runs (userId, startedAt) and (orgId, startedAt) listing indexes.
+--
+-- GET /runs/paged orders every branch by startedAt DESC over a bounded date
+-- window, with either userId (scope=own) or orgId (scope=all, cross-agent) as
+-- the leading equality. Neither shape has a usable index today:
+--   * @@index([userId, status, startedAt]) puts status BETWEEN the equality
+--     and the sort column, so a query with no status equality comes back
+--     ordered by (status, startedAt) and must sort the user's whole history.
+--   * @@index([orgId]) is single-column, so a cross-agent org listing top-N
+--     sorts every run the org has ever made.
+-- With these two, LIMIT/OFFSET paging is an index-ordered scan, and the
+-- sibling COUNT(*) rides the same index range.
+--
+-- ⚠ PROD APPLY NOTE: migrations are applied MANUALLY in SQL studio (no
+-- _prisma_migrations baseline). Plain CREATE INDEX takes a write lock on
+-- agent_runs for the build duration — on the live table, run the CONCURRENTLY
+-- variant instead (it cannot run inside a transaction; execute each as a
+-- single standalone statement):
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS
+--     "agent_runs_userId_startedAt_idx" ON "agent_runs" ("userId", "startedAt");
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS
+--     "agent_runs_orgId_startedAt_idx"  ON "agent_runs" ("orgId",  "startedAt");
+--
+-- The non-concurrent statements below are for fresh/dev databases where
+-- `prisma migrate` runs this file inside a transaction (CONCURRENTLY is
+-- illegal there). Both are guarded — IF NOT EXISTS makes a re-run a no-op
+-- either way, and the index names match what Prisma derives from
+-- @@index([userId, startedAt]) / @@index([orgId, startedAt]) so drift checks
+-- stay clean.
+
+CREATE INDEX IF NOT EXISTS "agent_runs_userId_startedAt_idx" ON "agent_runs" ("userId", "startedAt");
+CREATE INDEX IF NOT EXISTS "agent_runs_orgId_startedAt_idx"  ON "agent_runs" ("orgId",  "startedAt");

--- a/apps/xyne-claw-auth/backend/prisma/schema.prisma
+++ b/apps/xyne-claw-auth/backend/prisma/schema.prisma
@@ -1074,6 +1074,8 @@ model AgentRun {
   ///   "agent_runs_completedAt_triggerSource_idx"
   ///   ON "agent_runs" ("completedAt", "triggerSource");
   @@index([completedAt, triggerSource])
+  @@index([userId, startedAt])
+  @@index([orgId, startedAt])
   @@map("agent_runs")
 }
 

--- a/apps/xyne-claw-auth/backend/src/repositories/agentRunRepository.ts
+++ b/apps/xyne-claw-auth/backend/src/repositories/agentRunRepository.ts
@@ -133,6 +133,127 @@ export interface FinalizeRunInput {
   fastMode?: boolean | null;
 }
 
+/**
+ * Filter shape shared by the two paged run listings (GET /runs/paged) that back
+ * the agent Activity tab and the admin cross-agent Runs page.
+ *
+ * `orgId` is REQUIRED whenever `scope === "all"`. The route asserts it and
+ * fails the request closed; `buildRunListWhere` asserts it again, because an
+ * undefined org silently WIDENS a scope=all query to every tenant instead of
+ * narrowing it — the one failure mode here that leaks across organisations.
+ * `userId` is a scope=all-only ADDITIONAL filter: under scope=own the
+ * requester's own id is the only scope there is.
+ */
+export interface RunListFilter {
+  requesterId: string;
+  scope: "own" | "all";
+  orgId?: string;
+  agentSlug?: string;
+  userId?: string;
+  status?: string;
+  from: Date;
+  to: Date;
+  /** Case-insensitive sessionId PREFIX. When set the date window is dropped —
+   *  see buildRunListWhere. */
+  sessionIdPrefix?: string;
+  /** True only when the route proved the caller is a CLAW_ADMIN, i.e. entitled
+   *  to the CROSS-AGENT listing. Never used to widen the row query — only
+   *  `listPagedFacets` reads it, to decide whether dropping `agentSlug` is a
+   *  dropdown fix or a privilege escalation. See the comment there. */
+  admin?: boolean;
+}
+
+/**
+ * Single source of truth for the paged-listing WHERE clause. `listPaged` and
+ * `listPagedFacets` MUST both go through it.
+ *
+ * The `usedUserToken` OR-guard is already triplicated across `listAllForAgent`,
+ * `listByConversation` and `listSessionAclForConversation`; a fourth hand-rolled
+ * copy that drifts is exactly how a run which fetched another user's private
+ * OAuth token becomes readable by a different admin. One builder, two callers,
+ * nothing to drift.
+ */
+function buildRunListWhere(f: RunListFilter): Prisma.AgentRunWhereInput {
+  // Half-open window: `lt` on the upper bound so a caller passing an exact
+  // day boundary as both `to` of one page and `from` of the next can't
+  // double-count the run that started on the tick.
+  //
+  // A sessionId lookup DROPS the window entirely. A session id names one run
+  // that already exists; intersecting it with "the last 30 days" makes the
+  // search silently fail for the older run the user is holding an id for,
+  // which reads as "search is broken" rather than "your date filter excluded
+  // it". Scope/org/usedUserToken still apply below, so this widens what you
+  // can FIND, never what you are allowed to see.
+  const idLookup = !!f.sessionIdPrefix;
+  const window = idLookup
+    ? { sessionId: { startsWith: f.sessionIdPrefix as string, mode: "insensitive" as const } }
+    : { startedAt: { gte: f.from, lt: f.to } };
+
+  if (f.scope === "own") {
+    // No orgId predicate — userId already implies the org, and adding one
+    // would diverge from listByUser / listByUserLight / searchByUser for no
+    // gain while pushing the query off the (userId, startedAt) index.
+    return {
+      userId: f.requesterId,
+      ...window,
+      ...(f.status ? { status: f.status } : {}),
+      ...(f.agentSlug ? { agentSlug: f.agentSlug } : {}),
+    };
+  }
+
+  if (!f.orgId) {
+    // Never degrade to "no org predicate": that returns every organisation's
+    // runs — task text and conversationIds included — to one org's admin.
+    throw new Error("buildRunListWhere: orgId is required for scope=all");
+  }
+  return {
+    ...(f.agentSlug ? { agentSlug: f.agentSlug } : {}),
+    orgId: f.orgId,
+    ...window,
+    ...(f.status ? { status: f.status } : {}),
+    AND: [
+      // The user filter is an ADDITIONAL term, never a replacement for the
+      // token guard below: "show me Asha's runs" must not hand over the ones
+      // Asha ran under her own OAuth token (mail/calendar/drive content).
+      ...(f.userId ? [{ userId: f.userId }] : []),
+      { OR: [{ userId: f.requesterId }, { usedUserToken: false }] },
+    ],
+  };
+}
+
+/**
+ * Deliberately light projection for the paged listings — same discipline as
+ * `listByUserLight`, for the same reason.
+ *
+ * `toolInvocations` is EXCLUDED and must stay excluded: it is JSON, routinely
+ * hundreds of KB per row, and 50 rows of it is precisely the payload disaster
+ * `listByUserLight` was created to prevent. `result`, `error`, `toolsUsed` and
+ * the whole latency block are excluded too — no list row renders them, and a
+ * caller that genuinely needs them already has `getRun`. `usedUserToken` is an
+ * ACL input, not a client field, so it is never selected.
+ */
+const RUN_LIST_SELECT = {
+  id: true,
+  sessionId: true,
+  userId: true,
+  agentSlug: true,
+  triggerSource: true,
+  status: true,
+  task: true,
+  conversationId: true,
+  channelId: true,
+  startedAt: true,
+  completedAt: true,
+  tokensIn: true,
+  tokensOut: true,
+  rating: true,
+} satisfies Prisma.AgentRunSelect;
+
+/** Upper bound on task text shipped per list row. Not `listByAgentSlug`'s 240:
+ *  the UI-only search matches on task text, and a 240-char cap would make that
+ *  search a lie for long prompts. 2000 x 100 rows is ~200 KB worst case. */
+const RUN_LIST_TASK_CAP = 2000;
+
 export const agentRunRepository = {
   start: async (input: StartRunInput) => {
     // Stamp the agent's active prompt version so quality/latency can later be
@@ -841,6 +962,129 @@ export const agentRunRepository = {
       orderBy: { startedAt: "desc" },
       take: opts?.limit ?? 20,
     }),
+
+  /**
+   * Paged + counted run listing behind GET /runs/paged. Serves BOTH the agent
+   * Activity tab (scope=all + agentSlug) and the admin cross-agent Runs page
+   * (scope=all, no agentSlug), plus every user's own history (scope=own).
+   *
+   * OFFSET rather than a keyset cursor on purpose: the product requirement is a
+   * denominator ("1-50 of 1,284") and Prev as well as Next, neither of which a
+   * forward-only cursor gives. With the (userId|orgId, startedAt) composites and
+   * the route's mandatory bounded date window, LIMIT/OFFSET is an index-ordered
+   * scan skipping k index tuples, not a sort — and the route caps offset at
+   * 10000 so the deep-page cost stays bounded.
+   *
+   * `total` is a COUNT over the IDENTICAL where clause, issued in the same
+   * Promise.all so it rides the same index range.
+   */
+  listPaged: async (f: RunListFilter, page: { limit: number; offset: number }) => {
+    const where = buildRunListWhere(f);
+    const [rows, total] = await Promise.all([
+      prisma.agentRun.findMany({
+        where,
+        select: RUN_LIST_SELECT,
+        // The `id` tiebreaker is mandatory, not cosmetic: startedAt has ms
+        // resolution and batch-created runs genuinely tie, and OFFSET paging
+        // over a non-deterministic order both skips and duplicates rows across
+        // page boundaries.
+        orderBy: [{ startedAt: "desc" }, { id: "desc" }],
+        take: page.limit,
+        skip: page.offset,
+      }),
+      prisma.agentRun.count({ where }),
+    ]);
+    const capped = rows.map((r) => ({
+      ...r,
+      task: r.task.length <= RUN_LIST_TASK_CAP ? r.task : r.task.slice(0, RUN_LIST_TASK_CAP),
+      userName: null as string | null,
+      userEmail: null as string | null,
+    }));
+    // Only the elevated listing shows other people's runs, so only it needs
+    // names. Under scope=own every row is the requester's own and the extra
+    // round-trip would buy nothing.
+    if (f.scope !== "all") return { rows: capped, total };
+    const userIds = [...new Set(capped.map((r) => r.userId))];
+    const users =
+      userIds.length === 0
+        ? []
+        : await prisma.user.findMany({
+            where: { id: { in: userIds } },
+            select: { id: true, email: true, name: true },
+          });
+    const userMap = new Map(users.map((u) => [u.id, u]));
+    return {
+      rows: capped.map((r) => {
+        const u = userMap.get(r.userId);
+        return { ...r, userName: u?.name ?? null, userEmail: u?.email ?? null };
+      }),
+      total,
+    };
+  },
+
+  /**
+   * Facet counts for the filter dropdowns of the same listing, in ONE groupBy.
+   *
+   * The userId predicate is ALWAYS dropped, and agentSlug is dropped only for
+   * callers whose grant already covers every agent: a facet list built from the
+   * already-filtered set collapses to the single option the user just picked,
+   * so the dropdown can never be changed again (same reasoning as the facet
+   * comment in AdminPageV3). Everything else — the org predicate, the date
+   * window, the status filter and the `usedUserToken` OR — is RETAINED, because
+   * the facets carry exactly the same ACL as the rows: without the OR the user
+   * dropdown becomes an org directory leak, listing names and emails of people
+   * whose every run is token-hidden.
+   */
+  listPagedFacets: async (f: RunListFilter) => {
+    // agentSlug may only be dropped when the caller could have asked for the
+    // cross-agent listing anyway — a CLAW_ADMIN, or scope=own where the where
+    // clause is pinned to the requester's own rows. An agent OWNER/CONTRIBUTOR
+    // reaches scope=all through the R2 gate with a grant that covers exactly
+    // ONE agent; dropping their agentSlug turns the facets into an org-wide
+    // user roster (name + email + run count of everyone in the org) plus the
+    // org's full agent inventory. It also makes the dropdown lie, offering
+    // users whose runs of THIS agent number zero.
+    const dropAgentSlug = f.admin === true || f.scope === "own";
+    // Destructured rather than spread-with-undefined: exactOptionalPropertyTypes
+    // rejects `{ ...f, agentSlug: undefined }` against `agentSlug?: string`.
+    const { agentSlug: droppedAgentSlug, userId: _droppedUserId, ...rest } = f;
+    const unfaceted: RunListFilter = dropAgentSlug
+      ? rest
+      : { ...rest, ...(droppedAgentSlug ? { agentSlug: droppedAgentSlug } : {}) };
+    const grouped = await prisma.agentRun.groupBy({
+      by: ["agentSlug", "userId"],
+      where: buildRunListWhere(unfaceted),
+      _count: { _all: true },
+    });
+    const agentCounts = new Map<string, number>();
+    const userCounts = new Map<string, number>();
+    for (const g of grouped) {
+      agentCounts.set(g.agentSlug, (agentCounts.get(g.agentSlug) ?? 0) + g._count._all);
+      userCounts.set(g.userId, (userCounts.get(g.userId) ?? 0) + g._count._all);
+    }
+    const agents = [...agentCounts.entries()]
+      .map(([agentSlug, count]) => ({ agentSlug, count }))
+      .sort((a, b) => b.count - a.count || a.agentSlug.localeCompare(b.agentSlug));
+    const users: Array<{ userId: string; name: string | null; email: string | null; count: number }> = [];
+    // scope=own has exactly one possible user (the requester); shipping a roster
+    // to a caller who passed no elevation check is the leak R5 exists to stop.
+    if (f.scope !== "all") return { agents, users };
+    const userIds = [...userCounts.keys()];
+    const hydrated =
+      userIds.length === 0
+        ? []
+        : await prisma.user.findMany({
+            where: { id: { in: userIds } },
+            select: { id: true, email: true, name: true },
+          });
+    const userMap = new Map(hydrated.map((u) => [u.id, u]));
+    for (const [userId, count] of userCounts) {
+      const u = userMap.get(userId);
+      users.push({ userId, name: u?.name ?? null, email: u?.email ?? null, count });
+    }
+    users.sort((a, b) => b.count - a.count || (a.name ?? a.userId).localeCompare(b.name ?? b.userId));
+    return { agents, users };
+  },
 
   /**
    * Aggregate rating stats per agent within a window. Null cutoff = all time.
@@ -1662,3 +1906,8 @@ export const agentRunRepository = {
     }));
   },
 };
+
+/** One row of the paged listing — the light projection plus the userName /
+ *  userEmail hydrated only under scope=all. Derived from the method so the
+ *  select clause stays the single definition of the shape. */
+export type AgentRunListRow = Awaited<ReturnType<typeof agentRunRepository.listPaged>>["rows"][number];

--- a/apps/xyne-claw-auth/backend/src/routes/runs.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/runs.ts
@@ -154,6 +154,184 @@ router.get("/search", asyncHandler(async (req: Request, res: Response) => {
   ok(res, data);
 }));
 
+const RUN_PAGED_DAY_MS = 24 * 60 * 60 * 1000;
+const RUN_PAGED_STATUSES = ["running", "completed", "failed", "cancelled"];
+
+/** Read a query param that must be a single string, treating "" as absent.
+ *
+ *  Express parses a REPEATED param (`?from=a&from=b`) into an ARRAY, and every
+ *  `typeof x === "string"` guard silently reads that as "not provided". For
+ *  `from`/`to` that lands on the 30-day default, so `?from=X&from=Y` returns
+ *  THIRTY DAYS of runs under a 200 — more than was asked for, which is the
+ *  dangerous direction and the exact widening parseRunWindowParam exists to
+ *  stop. For `status` it drops the filter; for `agentSlug` it flips an R2
+ *  single-agent request into the R3 cross-agent branch. Reject, never coerce. */
+function singleStringParam(raw: unknown, name: string): string | undefined {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "string") throw badRequest(`${name} must be a single value`);
+  return raw === "" ? undefined : raw;
+}
+
+/** Parse a `from` / `to` query param as an ISO datetime. Rejects rather than
+ *  coerces: a typo'd date silently falling back to "last 30 days" hands the
+ *  caller a window they did not ask for and calls it their answer. */
+function parseRunWindowParam(raw: unknown, fallbackMs: number, name: string): Date {
+  const value = singleStringParam(raw, name);
+  if (value === undefined) return new Date(fallbackMs);
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) throw badRequest(`${name} must be an ISO datetime`);
+  return new Date(ms);
+}
+
+// GET /runs/paged — offset-paged, ACL-filtered run listing that also returns a
+// total (and optional facet counts) so the UI can render "1–50 of 1,284" plus
+// Previous/Next instead of a silently-capped list.
+//
+// One endpoint, two surfaces: the agent Activity tab (scope=all + agentSlug)
+// and the admin cross-agent Runs page (scope=all, no agentSlug), plus any
+// user's own history (scope=own, the default). Purely ADDITIVE — GET /runs,
+// /runs/light and /runs/search keep their existing shapes, so ChatPageV3's
+// listRuns is unaffected.
+//
+// Response is FLAT: ok(res, rows, extra) puts `total`/`limit`/`offset` as
+// SIBLINGS of `data`, the envelope the v3 client already parses for the admin
+// audit-log listing.
+//
+// orgScope=all is deliberately NOT supported. An all-orgs listing ordered by
+// startedAt desc has no leading equality to anchor on (there is no bare
+// startedAt index), so it would seq-scan agent_runs. The org is always the
+// requester's server-derived org.
+//
+// The router mount supplies only requireAuth + allowReadAccessToken("runs:read")
+// — no admin gate — and that read token grants any CLI/service bearer access to
+// every GET on this router. So nothing is assumed from the mount: each
+// elevation below is re-checked here.
+//
+// Must be declared BEFORE /:sessionId, or Express matches "paged" as a
+// sessionId and this route becomes unreachable.
+router.get("/paged", asyncHandler(async (req: Request, res: Response) => {
+  const requesterId = requireRequester(req);
+
+  const scopeRaw = singleStringParam(req.query["scope"], "scope") ?? "own";
+  if (scopeRaw !== "own" && scopeRaw !== "all") throw badRequest("scope must be own or all");
+  const scope: "own" | "all" = scopeRaw;
+
+  // Absent agentSlug means a CROSS-AGENT listing, which is a different (and
+  // more privileged) query shape — not "no filter applied".
+  const agentSlug = singleStringParam(req.query["agentSlug"], "agentSlug");
+
+  const userIdFilter = singleStringParam(req.query["userId"], "userId");
+  // Reject, never silently ignore. Honouring `userId` under scope=own would
+  // turn an endpoint with no elevation check into "any runs:read token reads
+  // any user's runs"; ignoring it would answer a question nobody asked while
+  // looking like it answered theirs.
+  if (userIdFilter && scope !== "all") throw badRequest("userId filter requires scope=all");
+
+  const status = singleStringParam(req.query["status"], "status");
+  if (status && !RUN_PAGED_STATUSES.includes(status)) {
+    throw badRequest(`status must be one of ${RUN_PAGED_STATUSES.join(", ")}`);
+  }
+
+  // A session id is an exact handle on ONE run, so searching by it is a server
+  // lookup rather than a filter over whatever page the client happens to hold —
+  // `sessionId` is @unique, so this is a single index probe. Prefix (not exact)
+  // so a user pasting the short id the UI shows still lands on the run.
+  const sessionIdPrefix = singleStringParam(req.query["sessionId"], "sessionId");
+  if (sessionIdPrefix !== undefined && sessionIdPrefix.length < 4) {
+    throw badRequest("sessionId must be at least 4 characters");
+  }
+
+  const now = Date.now();
+  const from = parseRunWindowParam(req.query["from"], now - 30 * RUN_PAGED_DAY_MS, "from");
+  const to = parseRunWindowParam(req.query["to"], now, "to");
+  if (to.getTime() <= from.getTime()) throw badRequest("to must be after from");
+  // The window cap is what bounds both the index range scan and the sibling
+  // COUNT(*); without it an unbounded `total` walks the whole table.
+  if (to.getTime() - from.getTime() > 366 * RUN_PAGED_DAY_MS) throw badRequest("date range may not exceed 366 days");
+
+  // Clamp in /runs/light's form, NOT /runs' Math.min(parseInt || 50, 200):
+  // that one lets limit=-5 through as a negative Prisma `take`, which does not
+  // error — it silently returns the OLDEST rows.
+  const limit = typeof req.query["limit"] === "string"
+    ? Math.min(Math.max(parseInt(req.query["limit"], 10) || 50, 1), 100)
+    : 50;
+  const offset = typeof req.query["offset"] === "string" ? Math.max(parseInt(req.query["offset"], 10) || 0, 0) : 0;
+  // Hard ceiling rather than a clamp: paging past 10k rows means the caller
+  // wants a query, not a scroll, and deep OFFSET is where index-ordered paging
+  // stops being cheap.
+  if (offset > 10000) throw badRequest("offset may not exceed 10000");
+  const wantFacets = req.query["facets"] === "1";
+
+  // R1 (scope=own) needs nothing further — the repository hard-scopes the
+  // where clause to requesterId and adds no orgId predicate, matching
+  // listByUser / listByUserLight / searchByUser.
+  let orgId: string | undefined;
+  // Hoisted out of the R2 branch because listPagedFacets needs it: only an
+  // admin's grant spans every agent, so only an admin may have `agentSlug`
+  // dropped from the facet where clause (see the comment there).
+  let admin = false;
+  if (scope === "all" && agentSlug) {
+    // R2 — single-agent "All Runs": the same gate as GET /runs?scope=all.
+    const headerOrgId = getOrgId(req);
+    if (!headerOrgId) {
+      log.warn(`[runs/paged] orgId is required userId=${requesterId} agentSlug=${agentSlug}`);
+      throw badRequest("orgId is required");
+    }
+    const access = await getAgentEditAccess(requesterId, agentSlug, headerOrgId);
+    if (!access) {
+      // 404, not an empty list: a silent empty result turns a slug typo into a
+      // shrug and lets an attacker probe other orgs' slugs for free.
+      log.warn(`[runs/paged] agent org-scoped miss userId=${requesterId} agentSlug=${agentSlug} orgId=${headerOrgId}`);
+      throw notFound("Agent not found");
+    }
+    admin = await isClawAdmin(requesterId);
+    if (!admin && !access.canEdit) {
+      log.warn(`[runs/paged] denied userId=${requesterId} agentSlug=${agentSlug} orgId=${headerOrgId}`);
+      throw forbidden("Only admins, the owner, or contributors can view all runs for this agent");
+    }
+    // Query with the AGENT's org, not the header's — an agent resolved in one
+    // org listed against another org's runs is a cross-tenant leak.
+    orgId = access.agent.orgId;
+  } else if (scope === "all") {
+    // R3 — cross-agent, all-user listing: CLAW_ADMIN only. There is no agent
+    // to derive contributor access from, so admin is the only door.
+    if (!(await isClawAdmin(requesterId))) throw forbidden("CLAW_ADMIN role required for cross-agent all-user runs");
+    admin = true;
+    // getOrgId reads x-org-id, which requireAuth strips from the client and
+    // re-stamps from user.orgId — trustworthy, but best-effort, and it can
+    // legitimately be undefined. FAIL CLOSED: there is no "then omit the orgId
+    // predicate" fallback, because omitting it returns EVERY organisation's
+    // runs (task text + conversationIds) to one org's admin.
+    const headerOrgId = getOrgId(req);
+    if (!headerOrgId) {
+      log.warn(`[runs/paged] orgId is required for cross-agent listing userId=${requesterId}`);
+      throw badRequest("orgId is required");
+    }
+    orgId = headerOrgId;
+  }
+
+  // R4 (the usedUserToken OR on both scope=all branches) and R5 (facets carry
+  // the same ACL) live in the repository's shared buildRunListWhere, so the two
+  // queries below cannot disagree about who may see what.
+  const filter = {
+    requesterId,
+    scope,
+    ...(orgId ? { orgId } : {}),
+    ...(agentSlug ? { agentSlug } : {}),
+    ...(userIdFilter ? { userId: userIdFilter } : {}),
+    ...(status ? { status } : {}),
+    ...(sessionIdPrefix ? { sessionIdPrefix } : {}),
+    ...(admin ? { admin: true } : {}),
+    from,
+    to,
+  };
+  const [page, facets] = await Promise.all([
+    agentRunRepository.listPaged(filter, { limit, offset }),
+    wantFacets ? agentRunRepository.listPagedFacets(filter) : Promise.resolve(null),
+  ]);
+  ok(res, page.rows, { total: page.total, limit, offset, ...(facets ? { facets } : {}) });
+}));
+
 // GET /runs/by-agent/:slug — cross-user run history for one agent.
 //
 // Powers the `get-agent-runs` system tool. S2S-gated so it's only reachable

--- a/apps/xyne-claw-auth/backend/src/services/dailyBrief.ts
+++ b/apps/xyne-claw-auth/backend/src/services/dailyBrief.ts
@@ -26,6 +26,8 @@ import { consumeClawStream } from "../lib/consume-claw-stream.js";
 import { buildThreadCitationMeta } from "../lib/citations.js";
 import { formatDayIST } from "../lib/ist-time.js";
 import {
+  agentRunRepository,
+  chatMessageRepository,
   generatedContentRepository,
   userAgentInstructionRepository,
   DAILY_BRIEF_KIND,
@@ -168,6 +170,71 @@ export async function generateDailyBrief(
   });
 
   let sessionId: string | undefined;
+
+  // The brief conversation has to read back as an ordinary chat session in
+  // /v3/chat, which projects ONE path down the message tree: an assistant row is
+  // only on that path when its parentId points at the user row. persistRunStart
+  // would create the user message for us but does not hand back its id, so make
+  // it here (and tell the run to skip its own) to keep the two linked.
+  let userMessageId: string | null = null;
+  try {
+    const userMsg = await chatMessageRepository.create({
+      conversationId,
+      agentSlug,
+      userId,
+      role: "user",
+      content: BRIEF_TASK,
+      status: "completed",
+      orgId,
+    });
+    userMessageId = userMsg.id;
+  } catch (msgErr) {
+    log.warn(`[daily-brief] failed to persist user message for ${userId}: ${errMsg(msgErr)}`);
+  }
+
+  /**
+   * Close the chat turn the same way an interactive run does.
+   *
+   * Nothing else does this on the brief path: generateDailyBrief consumes the
+   * SSE stream itself rather than registering a callbackUrl, so the /callback
+   * machinery that normally writes the assistant row and finalizes the AgentRun
+   * never fires. Without this the conversation holds only the user message and
+   * the run sits at "running" forever.
+   */
+  const closeBriefTurn = async (
+    status: "completed" | "failed",
+    content: string,
+    toolInvocations?: unknown,
+  ): Promise<void> => {
+    let assistantMessageId: string | undefined;
+    try {
+      const assistantMsg = await chatMessageRepository.create({
+        conversationId,
+        agentSlug,
+        userId,
+        role: "assistant",
+        content,
+        status,
+        orgId,
+        parentId: userMessageId,
+      });
+      assistantMessageId = assistantMsg.id;
+    } catch (msgErr) {
+      log.warn(`[daily-brief] failed to persist assistant message for ${userId}: ${errMsg(msgErr)}`);
+    }
+    if (!sessionId) return;
+    try {
+      await agentRunRepository.finalize(sessionId, {
+        status,
+        ...(status === "completed" ? { result: content } : { error: content }),
+        ...(toolInvocations !== undefined ? { toolInvocations } : {}),
+        ...(assistantMessageId ? { chatMessageId: assistantMessageId } : {}),
+      });
+    } catch (runErr) {
+      log.warn(`[daily-brief] failed to finalize run ${sessionId}: ${errMsg(runErr)}`);
+    }
+  };
+
   try {
     const streamResult = await consumeClawStream({
       url: `${CONFIG.internalUrl}/claw/api/v1/internal/run`,
@@ -181,6 +248,8 @@ export async function generateDailyBrief(
         mode: "daily_brief",
         eventType: "daily_brief",
         conversationId,
+        // We already wrote the user row above, parented correctly.
+        __skipUserMessagePersist: true,
         ...(briefInstructions ? { additionalInstructions: briefInstructions } : {}),
       },
       handlers: {
@@ -212,6 +281,11 @@ export async function generateDailyBrief(
         `[daily-brief] run for ${userId} finished without a dailyBrief payload (lastEvent=${streamResult.lastEventName}, error=${streamResult.errorReason ?? "none"})`,
       );
       await generatedContentRepository.markFailed(userId, DAILY_BRIEF_KIND, dateBucket);
+      await closeBriefTurn(
+        "failed",
+        "The brief run finished without producing a brief. Please try regenerating it.",
+        done?.toolInvocations,
+      );
       recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt, attempt);
       return null;
     }
@@ -233,6 +307,7 @@ export async function generateDailyBrief(
       sessionId: sessionId ?? null,
       generatedAt,
     });
+    await closeBriefTurn("completed", content, done?.toolInvocations);
     log.info(`[daily-brief] generated + persisted for ${userId} (session=${sessionId ?? "?"})`);
     recordDailyBriefGenerated(trigger, "ready", Date.now() - startedAt, attempt);
     if (trigger === "scheduled") recordScheduledDeliveryDelay(dateBucket, generatedAt);
@@ -240,6 +315,7 @@ export async function generateDailyBrief(
   } catch (err) {
     log.error(`[daily-brief] generation failed for ${userId}:`, errMsg(err));
     await generatedContentRepository.markFailed(userId, DAILY_BRIEF_KIND, dateBucket).catch(() => {});
+    await closeBriefTurn("failed", `The brief could not be generated: ${errMsg(err)}`).catch(() => {});
     recordDailyBriefGenerated(trigger, "failed", Date.now() - startedAt, attempt);
     return null;
   }

--- a/apps/xyne-claw-auth/backend/src/services/twinResponseFeedback.test.ts
+++ b/apps/xyne-claw-auth/backend/src/services/twinResponseFeedback.test.ts
@@ -48,17 +48,29 @@ describe("renderTwinFeedbackRecord", () => {
     expect(r.text).toContain("yep looking now, will ping in 10");
   });
 
-  it("declined → negative signal, tells the twin to avoid this", () => {
+  // The two negative outcomes are the ones that degraded the twin: phrased as
+  // "avoid this sender/topic" they fed the curator's triage facet, which feeds
+  // the respond/ignore gate, so a run of declines trained the twin into silence
+  // instead of into a better voice. These assertions pin the reframing.
+  it("declined → draft-quality feedback, never a reason to stop replying", () => {
     const r = row({ status: "declined", draftMessage: "No worries, I'll handle it." });
     expect(r.text).toContain("DECLINED");
-    expect(r.text).toContain("NOT how they would respond");
     expect(r.text).toContain("No worries, I'll handle it.");
+    expect(r.text).toMatch(/VOICE/);
+    expect(r.text).toContain("sounds more like the user");
+    // The load-bearing part: no suppression instruction, and an explicit
+    // triage opt-out for the curator.
+    expect(r.text).toMatch(/do NOT emit a respond-vs-ignore \(triage\) pattern/i);
+    expect(r.text).not.toMatch(/avoid this kind of response/i);
   });
 
-  it("ignored → weak/negative signal", () => {
+  it("expired approval → weak, and never the word IGNORED", () => {
     const r = row({ status: "ignored" });
-    expect(r.text).toContain("IGNORED");
     expect(r.text.toLowerCase()).toContain("weak");
+    expect(r.text).toMatch(/never emit a respond-vs-ignore \(triage\) pattern/i);
+    // "IGNORED" is the curator's documented cue to mine a real non-response
+    // into a triage pattern. An expired approval DM is not that.
+    expect(r.text).not.toContain("IGNORED");
   });
 
   it("notes an emoji reaction when the delivery included one", () => {

--- a/apps/xyne-claw-auth/backend/src/services/twinResponseFeedback.ts
+++ b/apps/xyne-claw-auth/backend/src/services/twinResponseFeedback.ts
@@ -164,11 +164,22 @@ export function renderTwinFeedbackRecord(row: {
       body = `The Digital Twin proposed${reactNote}:\n"${draft}"\nThe user EDITED it before posting, to:\n"${final}"\nLearn from what the user changed — that delta is how their real voice differs from the draft.`;
       break;
     case "declined":
-      body = `The Digital Twin proposed a reply${reactNote}:\n"${draft}"\nThe user DECLINED it — this is NOT how they would respond here. Avoid this kind of response for this sender/topic.`;
+      // Phrased hard against a TRIAGE reading. The earlier wording ("avoid this
+      // kind of response for this sender/topic") was a suppression instruction:
+      // the curator's triage facet feeds the respond/ignore gate, so every
+      // decline taught the twin to stop drafting for that sender — and a run of
+      // declines silently trained it into permanent silence. A decline is
+      // feedback on the WORDS, not on whether the message deserved a reply.
+      body = `The Digital Twin drafted this reply${reactNote} on the user's behalf:\n"${draft}"\nThe user DECLINED the draft — the wording did not sound like them. This is feedback about the twin's VOICE, not about whether this message deserved a reply: the user was asked to approve a draft, and rejected THE DRAFT. Infer what about the phrasing, tone, length or register was wrong, so the next draft for a message like this sounds more like the user. Do NOT conclude that the user avoids this sender, channel, or topic, and do NOT emit a respond-vs-ignore (triage) pattern from this record — a rejected draft is not evidence of silence.`;
       break;
     case "ignored":
     default:
-      body = `The Digital Twin proposed a reply${reactNote}:\n"${draft}"\nThe user IGNORED the suggestion (took no action) — the proposal wasn't compelling enough to act on. Treat this as weak/negative signal for responding this way.`;
+      // Never say "IGNORED" here. That token is the curator's documented cue to
+      // mine a genuine non-response into a triage pattern, and this row is not
+      // that: it is auto-assigned after a 12h grace, so it mostly means the user
+      // did not open the approval DM in time. It is the highest-volume outcome,
+      // which made it the biggest single source of trigger suppression.
+      body = `The Digital Twin drafted this reply${reactNote} on the user's behalf:\n"${draft}"\nThe user did not act on the approval prompt within the grace window, so it expired undecided. This is a WEAK signal about the draft and NOT a decision by the user: an unopened approval says nothing about whether they wanted to reply. Prefer emitting nothing from this record. Never read it as the user staying silent on this sender, channel or topic, and never emit a respond-vs-ignore (triage) pattern from it.`;
       break;
   }
   return {

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -3989,6 +3989,127 @@ export async function getRun(userId: string, sessionId: string): Promise<AgentRu
   return data.data;
 }
 
+// ── Paged run listing (GET /runs/paged) ──────────────────────────────
+
+/**
+ * One row of the paged listing. A deliberate light projection: no
+ * `toolInvocations` (JSON, often hundreds of KB per row), no `result`/`error`,
+ * no latency block — nothing a list row renders. Use `getRun` when the heavy
+ * fields are actually needed.
+ *
+ * The field set is a structural SUBSET of `AgentRun`, so a full `AgentRun` is
+ * assignable to it. That is what lets one shared `RunRow` component render
+ * rows from `listRuns`, `listRunsPaged`, and `getRun` alike.
+ */
+export interface AgentRunListItem {
+  id: string;
+  sessionId: string;
+  userId: string;
+  agentSlug: string;
+  triggerSource: AgentRun["triggerSource"];
+  status: AgentRun["status"];
+  /** Capped at 2000 chars server-side — long enough that the UI-only task
+   *  search isn't lying about what it matched. */
+  task: string;
+  conversationId: string | null;
+  channelId: string | null;
+  startedAt: string;
+  completedAt: string | null;
+  tokensIn: number | null;
+  tokensOut: number | null;
+  rating: "up" | "down" | null;
+  /** Hydrated only by scope=all — null/absent otherwise. */
+  userName?: string | null;
+  userEmail?: string | null;
+}
+
+export interface RunAgentFacet {
+  agentSlug: string;
+  count: number;
+}
+
+export interface RunUserFacet {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  count: number;
+}
+
+export interface AgentRunListPage {
+  rows: AgentRunListItem[];
+  total: number;
+  limit: number;
+  offset: number;
+  /** Present only when the caller asked for `facets`. `users` is always `[]`
+   *  under scope=own — the server never ships an org's roster to a caller that
+   *  passed no elevation check. */
+  facets?: { agents: RunAgentFacet[]; users: RunUserFacet[] };
+}
+
+export interface AgentRunListQuery {
+  scope?: "own" | "all";
+  /** Omit for a CROSS-AGENT listing (scope=all + no slug requires CLAW_ADMIN). */
+  agentSlug?: string;
+  /** scope=all only — sending it with scope=own is a 400, not a silent ignore. */
+  userId?: string;
+  status?: string;
+  /** Case-insensitive sessionId PREFIX, min 4 chars. Setting it makes the
+   *  server IGNORE from/to — an id names one run, so intersecting it with a
+   *  date window just hides the run the caller already identified. Scope and
+   *  org ACL still apply. */
+  sessionId?: string;
+  /** ISO datetimes. Server defaults to the last 30 days and rejects a range
+   *  wider than 366 days. Ignored when `sessionId` is set. */
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+  facets?: boolean;
+}
+
+/**
+ * Offset-paged run listing with an exact `total`, backing both the agent
+ * Activity tab and the admin Runs page.
+ *
+ * The wire shape is FLAT — `{ success, data: rows, total, limit, offset,
+ * facets? }`, with `total` a SIBLING of `data` rather than nested inside it —
+ * the same envelope `listAuditLogsPaged` parses. Do NOT copy
+ * `listAdminScheduledJobs`' nested `data.rows` parser here: against this
+ * endpoint it yields `undefined` rows.
+ */
+export async function listRunsPaged(requesterId: string, q: AgentRunListQuery): Promise<AgentRunListPage> {
+  const qs = new URLSearchParams();
+  if (q.scope) qs.set("scope", q.scope);
+  if (q.agentSlug) qs.set("agentSlug", q.agentSlug);
+  if (q.userId) qs.set("userId", q.userId);
+  if (q.status) qs.set("status", q.status);
+  if (q.sessionId) qs.set("sessionId", q.sessionId);
+  if (q.from) qs.set("from", q.from);
+  if (q.to) qs.set("to", q.to);
+  if (q.limit != null) qs.set("limit", String(q.limit));
+  if (q.offset != null) qs.set("offset", String(q.offset));
+  if (q.facets) qs.set("facets", "1");
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  const data = await request<{
+    success: boolean;
+    data: AgentRunListItem[];
+    total: number;
+    limit: number;
+    offset: number;
+    facets?: { agents: RunAgentFacet[]; users: RunUserFacet[] };
+  }>(
+    `${AUTH_API_URL}/api/v1/runs/paged${suffix}`,
+    { headers: { "x-user-id": requesterId } },
+  );
+  return {
+    rows: data.data,
+    total: data.total,
+    limit: data.limit,
+    offset: data.offset,
+    ...(data.facets ? { facets: data.facets } : {}),
+  };
+}
+
 // ── Subagents (admin) ────────────────────────────────────────────────
 
 export interface SubagentShareEntry {

--- a/apps/xyne-claw-auth/frontend/src/v3/AppV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/AppV3.tsx
@@ -30,6 +30,7 @@ import { WorkflowsPageV3 } from "./components/WorkflowsPageV3";
 import { DigitalTwinPageV3 } from "./components/digital-twin/DigitalTwinPageV3";
 import { AdminPageV3 } from "./components/AdminPageV3";
 import { MetricsPageV3 } from "./components/MetricsPageV3";
+import { RunsPageV3 } from "./components/RunsPageV3";
 import { EvalsPageV3 } from "./components/EvalsPageV3";
 import { SearchEvalsPageV3 } from "./components/SearchEvalsPageV3";
 import { EntityTypesPageV3 } from "./components/EntityTypesPageV3";
@@ -207,6 +208,14 @@ export function AppV3() {
                 )
               }
             />
+            {/* Ungated: a non-admin gets their own runs, which is the point of
+                the page. The only elevated control ("All users") is hidden by
+                isAdmin in the component and re-checked server-side. */}
+            <Route path="/v3/runs" element={
+              <div className="flex flex-1 flex-col overflow-hidden rounded-xl bg-xyne-surface shadow-sm">
+                <RunsPageV3 userId={userId} />
+              </div>
+            } />
             <Route path="/v3/metrics" element={
               <div className="flex flex-1 flex-col overflow-hidden rounded-xl bg-xyne-surface shadow-sm">
                 <MetricsPageV3 userId={userId} />

--- a/apps/xyne-claw-auth/frontend/src/v3/ShellV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/ShellV3.tsx
@@ -40,6 +40,7 @@ import {
   CaretRightIcon,
   DotsThreeVerticalIcon,
   ArrowUUpLeftIcon,
+  ClockCounterClockwiseIcon,
 } from "@phosphor-icons/react";
 import { useAuth } from "../hooks/useAuth";
 import { useTheme } from "./hooks/useTheme";
@@ -122,6 +123,9 @@ const SIDEBAR_GROUPS: SidebarGroupConfig[] = [
   {
     label: "Observe",
     items: [
+      // Runs leads the group on purpose: it is the only Observe item every user
+      // can act on (their own sessions), so it reads before the aggregate views.
+      { label: "Runs", path: "/v3/runs", icon: ClockCounterClockwiseIcon },
       { label: "Metrics", path: "/v3/metrics", icon: ChartBarIcon },
       { label: "Evals", path: "/v3/evals", icon: FlaskIcon },
       { label: "Search Evals", path: "/v3/search-evals", icon: MagnifyingGlassIcon },

--- a/apps/xyne-claw-auth/frontend/src/v3/components/RunsPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/RunsPageV3.tsx
@@ -1,0 +1,489 @@
+/**
+ * RunsPageV3 — Observe ▸ Runs: every session, across every agent.
+ *
+ * This is the cross-agent listing the product did not have: the agent detail
+ * Activity tab can only ever answer "what did THIS agent do", so answering
+ * "what have I run today" meant opening agents one at a time.
+ *
+ * Two audiences, one page:
+ *   - everyone   → their own runs across all agents (scope=own)
+ *   - CLAW_ADMIN → the "All users" switch flips to scope=all, org-scoped, plus
+ *                  a user filter. The switch is hidden for non-admins here and
+ *                  independently re-checked server-side, so hiding it is a UI
+ *                  affordance, not the access control.
+ */
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { ClockCounterClockwiseIcon, ClockIcon, ArrowClockwiseIcon } from "@phosphor-icons/react";
+import { useAdminStatus } from "../hooks/useAdminStatus";
+import { PageLayout } from "./ui/PageLayout";
+import { PageHeader } from "./ui/PageHeader";
+import { SelectField } from "./ui/SelectField";
+import { Search } from "./ui/Search";
+import { Switch } from "./ui/Switch";
+import { Button } from "./ui/Button";
+import { Skeleton } from "./ui/Skeleton";
+import { Tooltip } from "./ui/Tooltip";
+import { useSnackbar } from "./ui/Snackbar";
+import { RunRow } from "./runs/RunRow";
+import { RunDateRangeFilter } from "./runs/RunDateRangeFilter";
+import { RunListFooter } from "./runs/RunListFooter";
+import { looksLikeSessionId, runOwnerLabel, rangeToIso, type RunRangePreset } from "../lib/runFormat";
+import {
+  listAgents,
+  listRunsPaged,
+  type AgentRunListItem,
+  type AgentRunListPage,
+  type RunAgentFacet,
+  type RunUserFacet,
+} from "../../lib/api";
+
+type RunPageSize = 25 | 50 | 100;
+
+const EMPTY_PAGE: AgentRunListPage = { rows: [], total: 0, limit: 50, offset: 0 };
+
+export function RunsPageV3({ userId }: { userId: string }) {
+  const { isAdmin } = useAdminStatus();
+  const { show: showSnackbar } = useSnackbar();
+  const navigate = useNavigate();
+
+  const [page, setPage] = useState<AgentRunListPage>(EMPTY_PAGE);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState("");
+
+  const [offset, setOffset] = useState(0);
+  const [pageSize, setPageSize] = useState<RunPageSize>(50);
+  const [preset, setPreset] = useState<RunRangePreset>("30d");
+  const [customFrom, setCustomFrom] = useState("");
+  const [customTo, setCustomTo] = useState("");
+  const [agentFilter, setAgentFilter] = useState("");
+  const [status, setStatus] = useState("");
+  const [allUsers, setAllUsers] = useState(false);
+  const [userFilter, setUserFilter] = useState("");
+
+  // Facet option lists. They are merged stickily (see `load`) rather than
+  // replaced per request, because facets are only asked for on page 1 — paging
+  // forward must not empty the dropdowns the user is filtering with.
+  const [agentOptions, setAgentOptions] = useState<RunAgentFacet[]>([]);
+  const [userOptions, setUserOptions] = useState<RunUserFacet[]>([]);
+  const [agentNames, setAgentNames] = useState<Map<string, string>>(new Map());
+
+  const [query, setQuery] = useState("");
+
+  // A role flip (or an admin check that resolves to false after first paint)
+  // must not leave an elevated request in flight: without this reset, `allUsers`
+  // would still be true and every load would ask for scope=all and 403.
+  useEffect(() => {
+    if (!isAdmin) {
+      setAllUsers(false);
+      setUserFilter("");
+      setUserOptions([]);
+    }
+  }, [isAdmin]);
+
+  // Slug → display name for the agent column/filter. The facets only carry
+  // slugs; the roster is fetched once so rows can read "Support triage" instead
+  // of "support-triage-v2". Failure is non-fatal — labels fall back to the slug.
+  useEffect(() => {
+    let cancelled = false;
+    listAgents(userId, isAdmin)
+      .then((rows) => {
+        if (cancelled) return;
+        setAgentNames(new Map(rows.map((a) => [a.slug, a.name])));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, isAdmin]);
+
+  const agentLabel = useCallback(
+    (slug: string) => agentNames.get(slug) ?? slug,
+    [agentNames],
+  );
+
+  // Debounced, id-shaped slice of the search box. Text queries stay entirely
+  // client-side (the product decision was UI-only search for now); only a
+  // session id round-trips, because that is the one query the loaded page
+  // genuinely cannot answer.
+  const [idSearch, setIdSearch] = useState("");
+  useEffect(() => {
+    const next = looksLikeSessionId(query) ? query.trim() : "";
+    if (next === idSearch) return;
+    const t = window.setTimeout(() => setIdSearch(next), 250);
+    return () => window.clearTimeout(t);
+  }, [query, idSearch]);
+
+  // A new id search restarts paging: staying on offset=120 while the result set
+  // collapses to one row shows an empty page with a non-zero total.
+  useEffect(() => {
+    setOffset(0);
+  }, [idSearch]);
+
+  const load = useCallback(
+    async (opts?: { quiet?: boolean; cancelled?: () => boolean }) => {
+      opts?.quiet ? setRefreshing(true) : setLoading(true);
+      try {
+        const { from, to } = rangeToIso(preset, customFrom, customTo);
+        // A session-id-shaped query is answered by the SERVER, not by filtering
+        // the page we happen to hold: the run being hunted is usually on some
+        // other page (or outside the date window), which is exactly why the
+        // client-only version read as "session id search is broken".
+        const idQuery = idSearch || undefined;
+        const res = await listRunsPaged(userId, {
+          // `scope` and `agentSlug` are independent on /runs/paged: scope=all
+          // with no slug is the cross-agent admin listing. (The older `listRuns`
+          // couples them and silently downgrades to own-runs without a slug —
+          // do not "simplify" this back onto that call.)
+          scope: isAdmin && allUsers ? "all" : "own",
+          ...(agentFilter ? { agentSlug: agentFilter } : {}),
+          ...(status ? { status } : {}),
+          ...(isAdmin && allUsers && userFilter ? { userId: userFilter } : {}),
+          ...(idQuery ? { sessionId: idQuery } : {}),
+          from,
+          to,
+          limit: pageSize,
+          offset,
+          // Facets are a second aggregate query over the same window; asking for
+          // them on every page-forward would double the cost for a list that
+          // cannot change while paging.
+          ...(offset === 0 ? { facets: true } : {}),
+        });
+        // Filter changes fire in bursts (a click on a preset pill re-runs this
+        // immediately); without the guard a slow earlier response can land after
+        // a faster later one and repaint stale rows.
+        if (opts?.cancelled?.()) return;
+        setPage(res);
+        setError("");
+        if (res.facets) {
+          setAgentOptions(res.facets.agents);
+          // `users` is [] under scope=own — keeping the previous list means
+          // toggling "All users" off and on again doesn't blank the dropdown.
+          if (res.facets.users.length) setUserOptions(res.facets.users);
+        }
+      } catch (err) {
+        if (opts?.cancelled?.()) return;
+        const message = err instanceof Error ? err.message : "Failed to load runs";
+        setError(message);
+        setPage(EMPTY_PAGE);
+        showSnackbar({ variant: "error", title: message });
+      } finally {
+        if (opts?.cancelled?.()) return;
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [
+      userId,
+      isAdmin,
+      allUsers,
+      agentFilter,
+      status,
+      userFilter,
+      preset,
+      customFrom,
+      customTo,
+      pageSize,
+      offset,
+      // Only the DEBOUNCED id query is a dep. Depending on `query` itself would
+      // refetch on every keystroke; depending on neither would leave a pasted
+      // session id filtering only the page already on screen — the original bug.
+      idSearch,
+      showSnackbar,
+    ],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void load({ cancelled: () => cancelled });
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
+
+  // Two different searches share one box:
+  //   * session id  → answered by the server (see `idSearch`), so the rows we
+  //                   were handed ARE the result. Filtering them again here
+  //                   would be a no-op at best and, on a partial prefix, would
+  //                   re-hide rows the server correctly matched.
+  //   * free text   → UI-only by design, so it can only see this page. The
+  //                   banner under the filter bar says so rather than letting a
+  //                   match count imply the whole history was searched.
+  const visibleRuns = useMemo(() => {
+    if (idSearch) return page.rows;
+    const q = query.trim().toLowerCase();
+    if (!q) return page.rows;
+    return page.rows.filter((run) => {
+      if (run.sessionId.toLowerCase().includes(q)) return true;
+      if (run.task.toLowerCase().includes(q)) return true;
+      return allUsers ? runOwnerLabel(run).toLowerCase().includes(q) : false;
+    });
+  }, [page.rows, query, allUsers, idSearch]);
+
+  const agentSelectOptions = useMemo(
+    () => [
+      { value: "", label: `All agents (${agentOptions.length})` },
+      ...agentOptions.map((a) => ({
+        value: a.agentSlug,
+        label: `${agentLabel(a.agentSlug)} (${a.count})`,
+      })),
+    ],
+    [agentOptions, agentLabel],
+  );
+
+  const userSelectOptions = useMemo(
+    () => [
+      { value: "", label: `All users (${userOptions.length})` },
+      ...userOptions.map((u) => ({
+        value: u.userId,
+        label: `${u.name || u.email || `user ${u.userId.slice(0, 8)}`} (${u.count})`,
+      })),
+    ],
+    [userOptions],
+  );
+
+  const filterBar = (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <RunDateRangeFilter
+          preset={preset}
+          customFrom={customFrom}
+          customTo={customTo}
+          onChange={(next) => {
+            setOffset(0);
+            setPreset(next.preset);
+            setCustomFrom(next.customFrom);
+            setCustomTo(next.customTo);
+          }}
+        />
+
+        <SelectField
+          className="w-[220px]"
+          value={agentFilter}
+          options={agentSelectOptions}
+          onValueChange={(v) => {
+            setOffset(0);
+            setAgentFilter(v ?? "");
+          }}
+        />
+
+        <SelectField
+          className="w-[150px]"
+          value={status}
+          options={[
+            { value: "", label: "All statuses" },
+            { value: "running", label: "Running" },
+            { value: "completed", label: "Completed" },
+            { value: "failed", label: "Failed" },
+            { value: "cancelled", label: "Cancelled" },
+          ]}
+          onValueChange={(v) => {
+            setOffset(0);
+            setStatus(v ?? "");
+          }}
+        />
+
+        {isAdmin && (
+          <Tooltip content="Show every user's runs in your organization. Runs that used a user's private token are hidden.">
+            <label className="flex cursor-pointer items-center gap-2 text-[12px] text-xyne-fg-secondary">
+              <Switch
+                checked={allUsers}
+                ariaLabel="All users"
+                onChange={(v) => {
+                  setOffset(0);
+                  setAllUsers(v);
+                  // The user filter belongs to the elevated listing only —
+                  // leaving it set would send `userId` with scope=own, a 400.
+                  if (!v) setUserFilter("");
+                }}
+              />
+              All users
+            </label>
+          </Tooltip>
+        )}
+
+        {isAdmin && allUsers && (
+          <SelectField
+            className="w-[220px]"
+            value={userFilter}
+            options={userSelectOptions}
+            onValueChange={(v) => {
+              setOffset(0);
+              setUserFilter(v ?? "");
+            }}
+          />
+        )}
+
+        <Search
+          className="min-w-[240px] flex-1"
+          value={query}
+          onChange={setQuery}
+          placeholder="Filter this page (session id or task)…"
+          data-id="runs-search"
+        />
+
+        <SelectField
+          className="w-[100px]"
+          value={String(pageSize)}
+          options={[25, 50, 100].map((n) => ({ value: String(n), label: String(n) }))}
+          onValueChange={(v) => {
+            setOffset(0);
+            setPageSize(Number(v ?? 50) as RunPageSize);
+          }}
+        />
+      </div>
+
+      {idSearch !== "" ? (
+        <p className="text-[11px] text-xyne-fg-tertiary">
+          Searching every run you can see for session id <span className="font-mono">{idSearch}</span> —
+          the date filter does not apply to an id lookup.
+        </p>
+      ) : query.trim() !== "" ? (
+        <p className="text-[11px] text-xyne-fg-tertiary">
+          Filtering the {page.rows.length} runs on this page — {visibleRuns.length} match. This does not
+          search the other {Math.max(0, page.total - page.rows.length)} runs in range; narrow the date,
+          agent or user filter instead. Paste a session id to search all runs.
+        </p>
+      ) : null}
+    </div>
+  );
+
+  let body: ReactNode;
+  if (error) {
+    body = (
+      <div className="p-6">
+        <div className="rounded-xl bg-red-500/10 text-red-500 p-4 text-[13px]">{error}</div>
+      </div>
+    );
+  } else if (loading) {
+    // Skeleton mirrors the real RunRow layout so the transition doesn't jitter.
+    body = (
+      <div className="flex flex-col gap-2 p-6">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-3 rounded-lg border border-xyne-border-subtle px-4 py-3"
+          >
+            <Skeleton className="h-[22px] w-[22px] shrink-0 rounded-full" />
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <Skeleton className="h-3 w-[60%] rounded" />
+              <Skeleton className="h-2.5 w-[40%] rounded" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  } else if (page.rows.length === 0) {
+    body = (
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 pt-10 pb-28 text-center">
+        <ClockIcon size={32} className="text-xyne-fg-muted" />
+        <p className="text-[14px] font-medium text-xyne-fg-secondary">No runs in this range</p>
+        <p className="max-w-[320px] text-[13px] text-xyne-fg-tertiary">
+          {allUsers
+            ? "No user in your organization ran an agent inside the selected window."
+            : "You haven't run an agent inside the selected window."}
+        </p>
+        {preset !== "365d" && (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => {
+              setOffset(0);
+              setPreset("365d");
+            }}
+          >
+            Widen to 1 year
+          </Button>
+        )}
+      </div>
+    );
+  } else if (visibleRuns.length === 0) {
+    body = (
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 pt-10 pb-28 text-center">
+        <ClockIcon size={32} className="text-xyne-fg-muted" />
+        <p className="text-[14px] font-medium text-xyne-fg-secondary">
+          {idSearch ? "No run with that session id" : "No runs match on this page"}
+        </p>
+        <p className="max-w-[320px] text-[13px] text-xyne-fg-tertiary">
+          {idSearch
+            ? "That id was searched across every run you can see, ignoring the date filter — nothing matched it."
+            : `Text search only looks at the ${page.rows.length} runs currently loaded. Clear it, narrow the date/agent/user filter, or paste a session id to search all runs.`}
+        </p>
+      </div>
+    );
+  } else {
+    body = (
+      <div className="flex flex-col gap-2 p-6">
+        {visibleRuns.map((run) => (
+          <div key={run.sessionId}>
+            <div className="min-w-0 flex-1">
+              <RunRow
+                run={run}
+                showOwner={allUsers}
+                // Cross-agent listing, so each row names its own agent. RunRow
+                // renders it inside the card; the Activity tab omits the prop
+                // because every row there is the same agent.
+                agentLabel={agentLabel(run.agentSlug)}
+                // Opens the in-app conversation replay. Needs a conversationId —
+                // API/scheduled runs without one stay non-clickable. Another
+                // user's run carries &allRuns=1 so the chat view opts into the
+                // cross-user read path (the backend gates that on admin + flag).
+                onOpen={
+                  run.conversationId
+                    ? () =>
+                        navigate(
+                          `/v3/chat?agent=${encodeURIComponent(run.agentSlug)}&conversation=${encodeURIComponent(run.conversationId!)}${
+                            run.userId !== userId ? "&allRuns=1" : ""
+                          }`,
+                        )
+                    : undefined
+                }
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <PageLayout
+      header={
+        <PageHeader
+          title="Runs"
+          description={
+            isAdmin && allUsers
+              ? "Every run in your organization, newest first."
+              : "Every session you've run, newest first."
+          }
+          icon={<ClockCounterClockwiseIcon size={22} weight="duotone" className="text-xyne-fg-muted" />}
+          actions={
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={refreshing || loading}
+              leadingIcon={<ArrowClockwiseIcon size={14} className={refreshing ? "animate-spin" : ""} />}
+              onClick={() => void load({ quiet: true })}
+            >
+              Refresh
+            </Button>
+          }
+        />
+      }
+      filterTab={filterBar}
+      body={body}
+      footer={
+        <div className="px-6 py-3">
+          <RunListFooter
+            total={page.total}
+            limit={pageSize}
+            offset={offset}
+            loading={loading || refreshing}
+            onOffsetChange={setOffset}
+          />
+        </div>
+      }
+    />
+  );
+}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/RunHistoryTab.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/agent-detail/tabs/RunHistoryTab.tsx
@@ -1,17 +1,15 @@
-import { useState, useEffect, useMemo, type ReactNode } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  CircleDashedIcon,
-  CheckCircleIcon,
-  XCircleIcon,
-  MinusCircleIcon,
-  ClockIcon,
-  CaretRightIcon,
-} from "@phosphor-icons/react";
-import { listRuns } from "../../../../lib/api";
-import type { AgentRun } from "../../../../lib/api";
+import { ClockIcon } from "@phosphor-icons/react";
+import { listRunsPaged } from "../../../../lib/api";
+import type { AgentRunListPage, RunUserFacet } from "../../../../lib/api";
 import { Skeleton } from "../../ui/Skeleton";
-import { formatTimeAgo, formatDuration, truncate } from "../../home/homeUtils";
+import { Button } from "../../ui/Button";
+import { SelectField } from "../../ui/SelectField";
+import { RunRow } from "../../runs/RunRow";
+import { RunDateRangeFilter } from "../../runs/RunDateRangeFilter";
+import { RunListFooter } from "../../runs/RunListFooter";
+import { runOwnerLabel, rangeToIso, type RunRangePreset } from "../../../lib/runFormat";
 
 interface Props {
   agentSlug: string;
@@ -19,223 +17,223 @@ interface Props {
   canViewAllRuns: boolean;
 }
 
-// Status icon size bumped from 16 → 22 and switched to filled weight so it
-// reads as a real status anchor (replaces the old text "completed" badge).
-function StatusIcon({ status }: { status: AgentRun["status"] }) {
-  switch (status) {
-    case "running":
-      return <CircleDashedIcon size={22} className="animate-spin text-xyne-info" />;
-    case "completed":
-      return <CheckCircleIcon size={22} weight="fill" className="text-xyne-success" />;
-    case "failed":
-      return <XCircleIcon size={22} weight="fill" className="text-xyne-error" />;
-    case "cancelled":
-      return <MinusCircleIcon size={22} weight="fill" className="text-xyne-fg-muted" />;
-  }
-}
+const PAGE_SIZE = 25;
 
-// Human label for a run's owner — real name/email if the admin All-Runs listing
-// hydrated it, else a short id. Shared by the row and the user-filter dropdown
-// so a user reads the same everywhere.
-function runOwnerLabel(run: AgentRun): string {
-  return run.userName || run.userEmail || `user ${run.userId.slice(0, 8)}`;
-}
-
-function triggerLabel(source: AgentRun["triggerSource"]): string {
-  return source === "spaces"
-    ? "Spaces"
-    : source === "scheduled"
-      ? "Scheduled"
-      : source === "chat"
-        ? "Chat"
-        : source === "automation"
-          ? "Automation"
-          : "API";
-}
-
-function RunRow({ run, showOwner, onOpen }: { run: AgentRun; showOwner?: boolean; onOpen?: () => void }) {
-  const duration =
-    run.completedAt
-      ? formatDuration(run.startedAt, run.completedAt)
-      : run.status === "running"
-        ? "Running…"
-        : null;
-
-  const tokens =
-    run.tokensIn != null || run.tokensOut != null
-      ? `${run.tokensIn ?? 0} → ${run.tokensOut ?? 0} tok`
-      : null;
-
-  // Collected meta facts rendered on the second line with `·` separators
-  // — e.g. "Chat · 1d ago · 7s · 27994 → 336 tok".
-  const metaParts = [
-    // In admin "All Runs" mode, lead with the owning user so runs are
-    // attributable — real name/email when the scope=all listing hydrated it,
-    // falling back to a short id.
-    showOwner ? runOwnerLabel(run) : null,
-    triggerLabel(run.triggerSource),
-    formatTimeAgo(run.startedAt),
-    duration,
-    tokens,
-  ].filter((p): p is string => !!p);
-
-  const clickable = !!onOpen;
-  return (
-    <div
-      onClick={onOpen}
-      role={clickable ? "button" : undefined}
-      tabIndex={clickable ? 0 : undefined}
-      onKeyDown={
-        clickable
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onOpen?.();
-              }
-            }
-          : undefined
-      }
-      className={`group flex items-center gap-3 rounded-lg border border-xyne-border-subtle px-4 py-3 transition-colors hover:bg-xyne-surface-subtle hover:border-xyne-border ${
-        clickable ? "cursor-pointer" : ""
-      }`}
-    >
-      <StatusIcon status={run.status} />
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-[13px] font-medium text-xyne-fg-primary">
-          {truncate(run.task, 80)}
-        </span>
-        <div className="flex items-center flex-wrap gap-x-1.5 text-[11px] text-xyne-fg-tertiary">
-          {metaParts.map((part, i) => (
-            <span key={i} className="inline-flex items-center gap-1.5">
-              {i > 0 && <span className="text-xyne-fg-muted">·</span>}
-              {part}
-            </span>
-          ))}
-        </div>
-      </div>
-      {clickable && (
-        <CaretRightIcon
-          size={16}
-          className="shrink-0 text-xyne-fg-muted opacity-0 transition-opacity group-hover:opacity-100"
-        />
-      )}
-    </div>
-  );
-}
+// Sentinel page so every consumer below reads `page.rows` / `page.total`
+// unconditionally — a nullable page would force a null-guard at each of the
+// four render branches and at the footer.
+const EMPTY_RUN_PAGE: AgentRunListPage = { rows: [], total: 0, limit: PAGE_SIZE, offset: 0 };
 
 export function RunHistoryTab({ agentSlug, userId, canViewAllRuns }: Props) {
   const navigate = useNavigate();
-  const [runs, setRuns] = useState<AgentRun[]>([]);
+  const [page, setPage] = useState<AgentRunListPage>(EMPTY_RUN_PAGE);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  // Without this the bare catch below turns every 400/403/5xx into
+  // EMPTY_RUN_PAGE, and the empty-state branches then assert "This agent
+  // hasn't been executed yet" about a request the server REFUSED. On an audit
+  // surface a refusal and a genuinely empty result must never render alike.
+  const [error, setError] = useState("");
   // Elevated view: admins, owners, and contributors can show every user's runs
   // of this agent. The server ACL-filters by usedUserToken, so other users'
   // runs that touched their private token are never returned.
   const [allUsers, setAllUsers] = useState(false);
-  // "All Runs" filters (client-side over the loaded set).
-  const [userFilter, setUserFilter] = useState<string>(""); // "" = every user
+  const [offset, setOffset] = useState(0);
+  const [preset, setPreset] = useState<RunRangePreset>("30d");
+  const [customFrom, setCustomFrom] = useState("");
+  const [customTo, setCustomTo] = useState("");
+  // "" = every user. Server-side now: the old client-side variant could only
+  // filter whatever the single fetch happened to have loaded.
+  const [userFilter, setUserFilter] = useState("");
+  const [userOptions, setUserOptions] = useState<RunUserFacet[]>([]);
+  // Free text stays client-side and therefore only ever covers the current page
+  // — A6's hint below says so out loud.
   const [query, setQuery] = useState("");
+
+  // First load paints skeletons; every later filter-driven refetch is "quiet"
+  // so the list doesn't collapse to skeletons on each keystroke of the date
+  // inputs. Ref, not state, so flipping it never schedules a render of its own.
+  const loadedOnce = useRef(false);
 
   useEffect(() => {
     if (canViewAllRuns) return;
     setAllUsers(false);
     setUserFilter("");
     setQuery("");
+    setOffset(0);
+    setUserOptions([]);
   }, [canViewAllRuns]);
 
+  // `isCancelled` is threaded in from the effect rather than read off a ref:
+  // the effect's cleanup runs before the next effect, so the flag it closes
+  // over is exactly "a newer request has started" — without it, toggling
+  // filters quickly can land an older response on top of a newer one.
+  const load = useCallback(
+    async (quiet: boolean, isCancelled: () => boolean) => {
+      if (quiet) setRefreshing(true);
+      else setLoading(true);
+      const { from, to } = rangeToIso(preset, customFrom, customTo);
+      try {
+        const res = await listRunsPaged(userId, {
+          agentSlug,
+          scope: allUsers ? "all" : "own",
+          ...(allUsers && userFilter ? { userId: userFilter } : {}),
+          from,
+          to,
+          limit: PAGE_SIZE,
+          offset,
+          // One extra groupBy, paid only on the first page: the option list is
+          // invariant across pages of the same filter set.
+          ...(allUsers && offset === 0 ? { facets: true } : {}),
+        });
+        if (isCancelled()) return;
+        setPage(res);
+        // Overwrite only when the response actually carried facets, otherwise
+        // paging (or selecting a user, which narrows the counts) would collapse
+        // the dropdown to the single option still present in the result.
+        if (res.facets) setUserOptions(res.facets.users);
+        setError("");
+      } catch (err) {
+        if (isCancelled()) return;
+        setError(err instanceof Error ? err.message : "Failed to load runs");
+        setPage(EMPTY_RUN_PAGE);
+      } finally {
+        if (!isCancelled()) {
+          loadedOnce.current = true;
+          setLoading(false);
+          setRefreshing(false);
+        }
+      }
+    },
+    [agentSlug, userId, allUsers, offset, preset, customFrom, customTo, userFilter],
+  );
+
   useEffect(() => {
-    setLoading(true);
-    // Pull a bigger pool in All-Runs mode so the user/text filter has something
-    // meaningful to work over (server caps at 200).
-    listRuns(userId, { agentSlug, limit: allUsers ? 200 : 50, allUsers })
-      .then(setRuns)
-      .catch(() => setRuns([]))
-      .finally(() => setLoading(false));
-  }, [agentSlug, userId, allUsers]);
+    let cancelled = false;
+    void load(loadedOnce.current, () => cancelled);
+    return () => {
+      cancelled = true;
+    };
+  }, [load]);
 
-  // Distinct owners present in the loaded rows — drives the dropdown so its
-  // options always match what's actually filterable.
-  const userOptions = useMemo(() => {
-    const m = new Map<string, string>();
-    for (const r of runs) if (!m.has(r.userId)) m.set(r.userId, runOwnerLabel(r));
-    return [...m.entries()]
-      .map(([id, label]) => ({ id, label }))
-      .sort((a, b) => a.label.localeCompare(b.label));
-  }, [runs]);
-
-  // Apply the user + free-text filters (only meaningful in All-Runs mode; the
-  // controls are hidden otherwise so the state stays inert).
+  // Free-text filter over THIS page only — never the full `page.total`.
   const visibleRuns = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return runs.filter((r) => {
-      if (userFilter && r.userId !== userFilter) return false;
-      if (q && !`${r.task} ${runOwnerLabel(r)}`.toLowerCase().includes(q)) return false;
-      return true;
-    });
-  }, [runs, userFilter, query]);
+    if (!q) return page.rows;
+    return page.rows.filter((r) =>
+      `${r.sessionId} ${r.task} ${runOwnerLabel(r)}`.toLowerCase().includes(q),
+    );
+  }, [page.rows, query]);
 
-  // Elevated toggle — rendered above the body so it's reachable even when YOUR
-  // own runs are empty (the common "No runs yet" case).
-  const allRunsToggle = canViewAllRuns ? (
+  const userSelectOptions = useMemo(
+    () => [
+      { value: "", label: `All users (${userOptions.length})` },
+      ...userOptions.map((u) => ({
+        value: u.userId,
+        label: `${u.name || u.email || `user ${u.userId.slice(0, 8)}`} (${u.count})`,
+      })),
+    ],
+    [userOptions],
+  );
+
+  // Filters live above the body so they're reachable even when the result set
+  // is empty (the common "No runs yet" case).
+  const controls = (
     <div className="flex flex-col gap-2.5 border-b border-xyne-border-subtle px-6 py-2.5">
-      <div className="flex items-center justify-end gap-2">
-        <span className="text-[12px] text-xyne-fg-tertiary">All Runs</span>
-        <label
-          className="flex items-center gap-2 select-none"
-          title="Show every user's runs of this agent. Runs that used a user's private token are hidden."
-        >
-          <input
-            type="checkbox"
-            checked={allUsers}
-            onChange={(e) => {
-              setAllUsers(e.target.checked);
-              if (!e.target.checked) {
-                setUserFilter("");
-                setQuery("");
-              }
-            }}
-            className="h-4 w-4 cursor-pointer accent-xyne-accent"
-            aria-label="Show all users' runs"
-          />
-          <span className="text-[12px] text-xyne-fg-primary">{allUsers ? "On" : "Off"}</span>
-        </label>
+      <div className="flex items-center justify-between gap-3">
+        <RunDateRangeFilter
+          preset={preset}
+          customFrom={customFrom}
+          customTo={customTo}
+          onChange={(next) => {
+            setOffset(0);
+            setPreset(next.preset);
+            setCustomFrom(next.customFrom);
+            setCustomTo(next.customTo);
+          }}
+        />
+        {canViewAllRuns && (
+          <div className="flex items-center justify-end gap-2">
+            <span className="text-[12px] text-xyne-fg-tertiary">All Runs</span>
+            <label
+              className="flex items-center gap-2 select-none"
+              title="Show every user's runs of this agent. Runs that used a user's private token are hidden."
+            >
+              <input
+                type="checkbox"
+                checked={allUsers}
+                onChange={(e) => {
+                  setOffset(0);
+                  setAllUsers(e.target.checked);
+                  if (!e.target.checked) {
+                    setUserFilter("");
+                    setQuery("");
+                    setUserOptions([]);
+                  }
+                }}
+                className="h-4 w-4 cursor-pointer accent-xyne-accent"
+                aria-label="Show all users' runs"
+              />
+              <span className="text-[12px] text-xyne-fg-primary">{allUsers ? "On" : "Off"}</span>
+            </label>
+          </div>
+        )}
       </div>
       {allUsers && (
-        <div className="flex items-center gap-2">
-          {/* User filter — the primary "find runs by who ran them" control. */}
-          <select
-            value={userFilter}
-            onChange={(e) => setUserFilter(e.target.value)}
-            className="h-8 min-w-[160px] max-w-[220px] rounded-md border border-xyne-border-subtle bg-xyne-surface px-2 text-[12px] text-xyne-fg-primary focus:border-xyne-border focus:outline-none"
-            aria-label="Filter by user"
-          >
-            <option value="">All users ({userOptions.length})</option>
-            {userOptions.map((u) => (
-              <option key={u.id} value={u.id}>
-                {u.label}
-              </option>
-            ))}
-          </select>
-          {/* Free-text — task or owner, so you can also "find anything". */}
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search task or user…"
-            className="h-8 flex-1 rounded-md border border-xyne-border-subtle bg-xyne-surface px-2.5 text-[12px] text-xyne-fg-primary placeholder:text-xyne-fg-muted focus:border-xyne-border focus:outline-none"
-            aria-label="Search runs"
-          />
-          {(userFilter || query) && (
-            <span className="shrink-0 text-[11px] text-xyne-fg-tertiary">
-              {visibleRuns.length} / {runs.length}
-            </span>
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2">
+            {/* User filter — the primary "find runs by who ran them" control,
+                backed by server facets so the options are every user with runs
+                in the window, not just those on the current page. */}
+            <SelectField
+              className="w-[220px] shrink-0"
+              value={userFilter}
+              options={userSelectOptions}
+              placeholder="All users"
+              // SelectField emits null when the field is cleared, and "" is a
+              // real selectable option here — coalescing keeps both paths on
+              // the same "every user" value instead of sending userId=null.
+              onValueChange={(v: string | null) => {
+                setOffset(0);
+                setUserFilter(v ?? "");
+              }}
+            />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter this page (session id, task, user)…"
+              className="h-9 flex-1 rounded-md border border-xyne-border-subtle bg-xyne-surface px-2.5 text-[12px] text-xyne-fg-primary placeholder:text-xyne-fg-muted focus:border-xyne-border focus:outline-none"
+              aria-label="Filter runs on this page"
+            />
+            {(userFilter || query) && (
+              <span className="shrink-0 text-[11px] text-xyne-fg-tertiary">
+                {visibleRuns.length} / {page.rows.length} on this page
+              </span>
+            )}
+          </div>
+          {query && (
+            <p className="text-[11px] text-xyne-fg-muted">
+              Filters the {page.rows.length} runs on this page only — narrow the date range or
+              user filter to search further.
+            </p>
           )}
         </div>
       )}
     </div>
-  ) : null;
+  );
 
   let body: ReactNode;
-  if (loading) {
+  if (error) {
+    // Ahead of the two `page.total === 0` branches on purpose: EMPTY_RUN_PAGE is
+    // also what the catch installs, so an error checked second would be painted
+    // over by "No runs in this range". Same banner as RunsPageV3.
+    body = (
+      <div className="p-6">
+        <div className="rounded-xl bg-red-500/10 text-red-500 p-4 text-[13px]">{error}</div>
+      </div>
+    );
+  } else if (loading) {
     // Skeleton mirrors the real RunRow layout so the transition doesn't jitter.
     body = (
       <div className="flex flex-col gap-2 p-6">
@@ -253,7 +251,31 @@ export function RunHistoryTab({ agentSlug, userId, canViewAllRuns }: Props) {
         ))}
       </div>
     );
-  } else if (runs.length === 0) {
+  } else if (page.total === 0 && preset !== "365d") {
+    // Empty *because of the window*, which is the new default failure mode now
+    // that the tab shows 30 days instead of "the last 50 runs, any age" — say
+    // so and offer the widest preset rather than claiming the agent never ran.
+    body = (
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 pt-10 pb-28 text-center">
+        <ClockIcon size={32} className="text-xyne-fg-muted" />
+        <p className="text-[14px] font-medium text-xyne-fg-secondary">No runs in this range</p>
+        <p className="max-w-[280px] text-[13px] text-xyne-fg-tertiary">
+          Nothing matched the selected dates{allUsers && userFilter ? " and user" : ""}. Try a wider
+          window.
+        </p>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => {
+            setOffset(0);
+            setPreset("365d");
+          }}
+        >
+          Widen to 1 year
+        </Button>
+      </div>
+    );
+  } else if (page.total === 0) {
     body = (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 pt-10 pb-28 text-center">
         <ClockIcon size={32} className="text-xyne-fg-muted" />
@@ -266,13 +288,14 @@ export function RunHistoryTab({ agentSlug, userId, canViewAllRuns }: Props) {
       </div>
     );
   } else if (visibleRuns.length === 0) {
-    // Have runs, but the active user/text filter excluded them all.
+    // Have runs on this page, but the free-text filter excluded them all.
     body = (
       <div className="flex flex-1 flex-col items-center justify-center gap-3 pt-10 pb-28 text-center">
         <ClockIcon size={32} className="text-xyne-fg-muted" />
         <p className="text-[14px] font-medium text-xyne-fg-secondary">No matching runs</p>
         <p className="max-w-[280px] text-[13px] text-xyne-fg-tertiary">
-          No runs match the current filter. Clear the user or search filter to see all runs.
+          No runs on this page match the current filter. Clear the search box, or change the user or
+          date filter to look further.
         </p>
       </div>
     );
@@ -309,8 +332,19 @@ export function RunHistoryTab({ agentSlug, userId, canViewAllRuns }: Props) {
 
   return (
     <div className="flex h-full flex-col">
-      {allRunsToggle}
-      {body}
+      {controls}
+      {/* The list scrolls, the footer stays pinned — otherwise the only way to
+          reach Next on a full page is to scroll past 25 rows. */}
+      <div className="min-h-0 flex-1 overflow-y-auto">{body}</div>
+      <div className="border-t border-xyne-border-subtle px-6 py-3">
+        <RunListFooter
+          total={page.total}
+          limit={PAGE_SIZE}
+          offset={offset}
+          loading={loading || refreshing}
+          onOffsetChange={setOffset}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/xyne-claw-auth/frontend/src/v3/components/runs/RunDateRangeFilter.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/runs/RunDateRangeFilter.tsx
@@ -1,0 +1,93 @@
+import {
+  RUN_RANGE_PRESETS,
+  RUN_CUSTOM_RANGE_MAX_DAYS,
+  dateInputValue,
+  shiftDateInputValue,
+  type RunRangePreset,
+} from "../../lib/runFormat";
+
+interface Props {
+  preset: RunRangePreset;
+  customFrom: string;
+  customTo: string;
+  onChange: (next: { preset: RunRangePreset; customFrom: string; customTo: string }) => void;
+}
+
+/**
+ * Date-window control for the run listings: the same pill group the metrics
+ * page uses, plus a "Custom" pill that reveals two native date inputs.
+ *
+ * Native `<input type="date">` rather than a component: there is no date picker
+ * in v3's ui/ kit, and the two other v3 pages with a custom window
+ * (DigitalTwinReplyActivity, DigitalTwinMemories) already use the native input.
+ * Adding a picker here would make this the only page that looks different.
+ */
+export function RunDateRangeFilter({ preset, customFrom, customTo, onChange }: Props) {
+  // Span bounds, not just the cross-bounds below: `to - from` over the server's
+  // window cap is rejected on every keystroke-triggered refetch, and on the
+  // Activity tab that 400 is the only feedback the user gets. Bounding the
+  // inputs means the pair the control can produce is always one the endpoint
+  // accepts. Both sides go through dateInputValue so they stay in the viewer's
+  // local calendar, matching what the inputs themselves display.
+  const today = dateInputValue(new Date());
+  const fromMin = customTo ? shiftDateInputValue(customTo, -RUN_CUSTOM_RANGE_MAX_DAYS) : null;
+  const fromSpanCap = customFrom ? shiftDateInputValue(customFrom, RUN_CUSTOM_RANGE_MAX_DAYS) : null;
+  // A future `to` is never useful here — runs can't have started after now.
+  const toMax = fromSpanCap && fromSpanCap < today ? fromSpanCap : today;
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1 rounded-full bg-xyne-bg-secondary p-1">
+        {RUN_RANGE_PRESETS.map((opt) => (
+          <button
+            key={opt.id}
+            onClick={() => onChange({ preset: opt.id, customFrom, customTo })}
+            className={
+              "px-3 py-1 rounded-full text-[12px] font-medium transition-colors " +
+              (preset === opt.id
+                ? "bg-xyne-fg-primary text-xyne-fg-inverse"
+                : "text-xyne-fg-muted hover:text-xyne-fg-primary")
+            }
+          >
+            {opt.label}
+          </button>
+        ))}
+        <button
+          onClick={() => onChange({ preset: "custom", customFrom, customTo })}
+          className={
+            "px-3 py-1 rounded-full text-[12px] font-medium transition-colors " +
+            (preset === "custom"
+              ? "bg-xyne-fg-primary text-xyne-fg-inverse"
+              : "text-xyne-fg-muted hover:text-xyne-fg-primary")
+          }
+        >
+          Custom
+        </button>
+      </div>
+
+      {preset === "custom" && (
+        <div className="flex items-center gap-2">
+          {/* Cross-bounded so the two inputs can't be dragged into an inverted
+              range the server would 400 on (`to <= from`), and span-bounded so
+              they can't be dragged into an over-long one either. */}
+          <input
+            type="date"
+            value={customFrom}
+            min={fromMin || undefined}
+            max={customTo || today}
+            onChange={(e) => onChange({ preset, customFrom: e.target.value, customTo })}
+            className="rounded-md border border-xyne-border bg-xyne-surface px-[6px] py-[3px] text-[12px] text-xyne-fg-primary"
+          />
+          <span className="text-[12px] text-xyne-fg-muted">→</span>
+          <input
+            type="date"
+            value={customTo}
+            min={customFrom || undefined}
+            max={toMax}
+            onChange={(e) => onChange({ preset, customFrom, customTo: e.target.value })}
+            className="rounded-md border border-xyne-border bg-xyne-surface px-[6px] py-[3px] text-[12px] text-xyne-fg-primary"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/runs/RunListFooter.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/runs/RunListFooter.tsx
@@ -1,0 +1,49 @@
+import { Button } from "../ui/Button";
+
+interface Props {
+  total: number;
+  limit: number;
+  offset: number;
+  loading: boolean;
+  onOffsetChange: (next: number) => void;
+}
+
+/**
+ * The server's hard ceiling on `offset` — GET /runs/paged throws
+ * badRequest("offset may not exceed 10000") past it, because deep OFFSET over
+ * an index-ordered scan stops being cheap. Mirrored here so Next is disabled at
+ * the boundary instead of walking the user into a guaranteed 400.
+ */
+export const MAX_RUN_LIST_OFFSET = 10000;
+
+/**
+ * Range readout + Prev/Next for the run listings, matching the admin
+ * Digital-Twin user-controls footer word for word and class for class so
+ * pagination reads the same everywhere in v3.
+ *
+ * The denominator is the point: `total` is an exact count over the same where
+ * clause as the rows, which is why this is offset paging and not a cursor.
+ */
+export function RunListFooter({ total, limit, offset, loading, onOffsetChange }: Props) {
+  // The page count is clamped to what the offset ceiling actually reaches: a
+  // 30k-run window would otherwise advertise "Page 1 of 1200" when every page
+  // past 401 is a 400 from the server. The run count either side of it stays
+  // the true `total` — the list is that big, it just isn't all pageable.
+  const totalPages = Math.min(
+    Math.max(1, Math.ceil(total / limit)),
+    Math.floor(MAX_RUN_LIST_OFFSET / limit) + 1,
+  );
+  const currentPage = Math.floor(offset / limit) + 1;
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 text-[11px] text-xyne-fg-muted">
+      <div>
+        {total === 0 ? "0 runs" : `${offset + 1}–${Math.min(offset + limit, total)} of ${total} runs`}
+        <span className="ml-2">· Page {currentPage} of {totalPages}</span>
+      </div>
+      <div className="flex gap-2">
+        <Button size="sm" variant="secondary" disabled={offset === 0 || loading} onClick={() => onOffsetChange(Math.max(0, offset - limit))}>Previous</Button>
+        <Button size="sm" variant="secondary" disabled={offset + limit >= total || offset + limit > MAX_RUN_LIST_OFFSET || loading} onClick={() => onOffsetChange(offset + limit)}>Next</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/xyne-claw-auth/frontend/src/v3/components/runs/RunRow.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/runs/RunRow.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import {
+  CircleDashedIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  MinusCircleIcon,
+  CaretRightIcon,
+  CopyIcon,
+  CheckIcon,
+} from "@phosphor-icons/react";
+import type { AgentRunListItem } from "../../../lib/api";
+import { runOwnerLabel, triggerLabel, shortSessionId } from "../../lib/runFormat";
+import { formatTimeAgo, formatDuration, truncate } from "../home/homeUtils";
+
+// Status icon size bumped from 16 → 22 and switched to filled weight so it
+// reads as a real status anchor (replaces the old text "completed" badge).
+export function StatusIcon({ status }: { status: AgentRunListItem["status"] }) {
+  switch (status) {
+    case "running":
+      return <CircleDashedIcon size={22} className="animate-spin text-xyne-info" />;
+    case "completed":
+      return <CheckCircleIcon size={22} weight="fill" className="text-xyne-success" />;
+    case "failed":
+      return <XCircleIcon size={22} weight="fill" className="text-xyne-error" />;
+    case "cancelled":
+      return <MinusCircleIcon size={22} weight="fill" className="text-xyne-fg-muted" />;
+    // The union is exhaustive today, but the DB column is a plain string and
+    // the backend can add a status before the frontend union catches up. With
+    // no default the component returns undefined for such a row, which is not
+    // a valid element — render the muted glyph instead of breaking the list.
+    default:
+      return <MinusCircleIcon size={22} weight="fill" className="text-xyne-fg-muted" />;
+  }
+}
+
+/**
+ * The run's session id, shortened, with copy-to-clipboard.
+ *
+ * Copying the SHORT form is deliberate: the paged listing matches a sessionId
+ * prefix of 4+ chars, so the 8 chars on screen paste straight back into the
+ * search box and resolve. Clicks are stopped from bubbling — the whole row is
+ * a button that navigates, and copying an id must not also open the run.
+ */
+function SessionIdChip({ sessionId }: { sessionId: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      title={`${sessionId} — click to copy`}
+      onClick={(e) => {
+        e.stopPropagation();
+        void navigator.clipboard?.writeText(sessionId).then(
+          () => {
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1200);
+          },
+          () => {},
+        );
+      }}
+      className="inline-flex items-center gap-1 rounded font-mono text-[11px] text-xyne-fg-tertiary transition-colors hover:text-xyne-fg-primary"
+    >
+      {shortSessionId(sessionId)}
+      {copied ? (
+        <CheckIcon size={11} className="text-xyne-success" />
+      ) : (
+        <CopyIcon size={11} className="opacity-0 transition-opacity group-hover:opacity-60" />
+      )}
+    </button>
+  );
+}
+
+/**
+ * One run in a list. Shared verbatim between the agent Activity tab and the
+ * admin Runs page so a run looks identical wherever it is listed — the class
+ * names here are load-bearing for that, do not tweak them per-surface.
+ *
+ * `run` is typed to the light `AgentRunListItem`, which is a structural subset
+ * of `AgentRun`, so callers holding a full row can pass it straight through.
+ */
+export function RunRow({
+  run,
+  showOwner,
+  agentLabel,
+  onOpen,
+}: {
+  run: AgentRunListItem;
+  showOwner?: boolean;
+  /** Display name of the agent. Pass it on CROSS-AGENT listings only — on the
+   *  agent Activity tab every row is the same agent and the chip is noise. */
+  agentLabel?: string;
+  onOpen?: () => void;
+}) {
+  const duration =
+    run.completedAt
+      ? formatDuration(run.startedAt, run.completedAt)
+      : run.status === "running"
+        ? "Running…"
+        : null;
+
+  const tokens =
+    run.tokensIn != null || run.tokensOut != null
+      ? `${run.tokensIn ?? 0} → ${run.tokensOut ?? 0} tok`
+      : null;
+
+  // Collected meta facts rendered on the second line with `·` separators
+  // — e.g. "Chat · 1d ago · 7s · 27994 → 336 tok".
+  const metaParts = [
+    // In admin "All Runs" mode, lead with the owning user so runs are
+    // attributable — real name/email when the scope=all listing hydrated it,
+    // falling back to a short id.
+    showOwner ? runOwnerLabel(run) : null,
+    triggerLabel(run.triggerSource),
+    formatTimeAgo(run.startedAt),
+    duration,
+    tokens,
+  ].filter((p): p is string => !!p);
+
+  const clickable = !!onOpen;
+  return (
+    <div
+      onClick={onOpen}
+      role={clickable ? "button" : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onKeyDown={
+        clickable
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onOpen?.();
+              }
+            }
+          : undefined
+      }
+      className={`group flex items-center gap-3 rounded-lg border border-xyne-border-subtle px-4 py-3 transition-colors hover:bg-xyne-surface-subtle hover:border-xyne-border ${
+        clickable ? "cursor-pointer" : ""
+      }`}
+    >
+      <StatusIcon status={run.status} />
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex min-w-0 items-center gap-2">
+          {/* The agent reads as a label ON the run, not as a separate column
+              beside it — a fixed-width badge outside the card left long names
+              truncated against a hard edge and detached the name from the row
+              it described. `shrink-0` up to a cap so a long agent name yields
+              to the task text rather than squeezing it out. */}
+          {agentLabel && (
+            <span
+              title={run.agentSlug}
+              className="max-w-[9rem] shrink-0 truncate rounded bg-xyne-surface-subtle px-1.5 py-0.5 text-[11px] font-medium text-xyne-fg-secondary"
+            >
+              {agentLabel}
+            </span>
+          )}
+          <span className="truncate text-[13px] font-medium text-xyne-fg-primary">
+            {truncate(run.task, 80)}
+          </span>
+        </div>
+        <div className="flex items-center flex-wrap gap-x-1.5 text-[11px] text-xyne-fg-tertiary">
+          <SessionIdChip sessionId={run.sessionId} />
+          {metaParts.map((part, i) => (
+            <span key={i} className="inline-flex items-center gap-1.5">
+              <span className="text-xyne-fg-muted">·</span>
+              {part}
+            </span>
+          ))}
+        </div>
+      </div>
+      {clickable && (
+        <CaretRightIcon
+          size={16}
+          className="shrink-0 text-xyne-fg-muted opacity-0 transition-opacity group-hover:opacity-100"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/xyne-claw-auth/frontend/src/v3/lib/runFormat.ts
+++ b/apps/xyne-claw-auth/frontend/src/v3/lib/runFormat.ts
@@ -1,0 +1,142 @@
+/**
+ * Formatting helpers shared by every surface that lists agent runs.
+ *
+ * These started life module-private inside RunHistoryTab. They live here now
+ * because two surfaces (the agent Activity tab and the admin Runs page) render
+ * the same rows: if each kept its own copy, a user or a trigger would slowly
+ * start reading differently depending on which page you opened it from.
+ */
+
+/**
+ * Human label for a run's owner — real name/email when the elevated
+ * (scope=all) listing hydrated it, else a short id.
+ *
+ * The parameter is structural rather than a named row type so it accepts both
+ * `AgentRunListItem` (paged listing) and `AgentRun` (full row) without either
+ * module importing the other's shape.
+ */
+export function runOwnerLabel(run: { userId: string; userName?: string | null; userEmail?: string | null }): string {
+  return run.userName || run.userEmail || `user ${run.userId.slice(0, 8)}`;
+}
+
+/**
+ * `source` is typed `string`, not the frontend's triggerSource union, on
+ * purpose: the Prisma schema documents values the union omits (e.g. "slack"),
+ * and narrowing here would make a real row fail to compile. The chain already
+ * falls through to "API" for anything unrecognised.
+ */
+export function triggerLabel(source: string): string {
+  return source === "spaces"
+    ? "Spaces"
+    : source === "scheduled"
+      ? "Scheduled"
+      : source === "chat"
+        ? "Chat"
+        : source === "automation"
+          ? "Automation"
+          : "API";
+}
+
+/**
+ * Display form of a session id: the first segment of the UUID.
+ *
+ * Short enough to sit in a row without crowding the task text, and long enough
+ * to be unambiguous in practice (8 hex chars). The paged listing accepts a
+ * sessionId PREFIX of 4+ chars, so whatever the user copies off the row is
+ * directly pasteable into the search box and will resolve.
+ */
+export function shortSessionId(sessionId: string): string {
+  const head = sessionId.split("-")[0] ?? sessionId;
+  return head.slice(0, 8);
+}
+
+/**
+ * Does this query read as someone hunting a session id rather than words?
+ *
+ * Used to decide whether the search box asks the SERVER (an id names one run,
+ * which may be on any page or outside the date window) or filters the loaded
+ * rows client-side. Hex-and-dashes only, 4+ chars — "refund" and "8 failed
+ * runs" stay on the client path, "479eb839" and a full UUID go to the server.
+ */
+export function looksLikeSessionId(query: string): boolean {
+  const q = query.trim();
+  return q.length >= 4 && /^[0-9a-fA-F-]+$/.test(q) && /[0-9a-fA-F]/.test(q);
+}
+
+export type RunRangePreset = "7d" | "30d" | "90d" | "365d" | "custom";
+
+export const RUN_RANGE_PRESETS: Array<{ id: RunRangePreset; label: string; days: number }> = [
+  { id: "7d", label: "7d", days: 7 },
+  { id: "30d", label: "30d", days: 30 },
+  { id: "90d", label: "90d", days: 90 },
+  { id: "365d", label: "1y", days: 365 },
+];
+
+/** Format a Date as the YYYY-MM-DD an `<input type="date">` expects, in the
+ *  viewer's LOCAL calendar — `toISOString().slice(0,10)` would show yesterday
+ *  for anyone west of UTC in the evening. */
+export function dateInputValue(d: Date): string {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Widest custom window the two date inputs may span, in whole calendar days.
+ *
+ * 365 and not 366, even though the server's cap is 366 days: `dateInputToIso`
+ * snaps the `to` side to 23:59:59.999, so two dates N days apart become a span
+ * of N days PLUS almost a full day. At N=366 that is over the cap and every
+ * refetch 400s; at N=365 it lands just under it.
+ */
+export const RUN_CUSTOM_RANGE_MAX_DAYS = 365;
+
+/**
+ * Shift a `<input type="date">` value by `days` and return it in the same
+ * format, staying in the viewer's LOCAL calendar — day arithmetic via the
+ * Date constructor, not `+ n * 86400000`, so a DST transition inside the range
+ * doesn't slide the result onto the neighbouring day.
+ */
+export function shiftDateInputValue(v: string, days: number): string | null {
+  if (!v) return null;
+  const [y, m, d] = v.split("-").map(Number);
+  if (!y || !m || !d) return null;
+  const dt = new Date(y, m - 1, d + days);
+  return Number.isNaN(dt.getTime()) ? null : dateInputValue(dt);
+}
+
+/**
+ * Parse an `<input type="date">` value (YYYY-MM-DD) as LOCAL time and return an
+ * ISO string for the API. `end=true` snaps to the last millisecond of the day
+ * so picking a single date is inclusive of that whole day.
+ *
+ * The local-time construction matters: `new Date("2026-09-03")` is parsed as
+ * UTC midnight, which shifts the window by up to a day for anyone east or west
+ * of UTC — the user picks "the 3rd" and gets the 2nd's runs.
+ */
+export function dateInputToIso(v: string, end = false): string | null {
+  if (!v) return null;
+  const [y, m, d] = v.split("-").map(Number);
+  if (!y || !m || !d) return null;
+  const dt = end ? new Date(y, m - 1, d, 23, 59, 59, 999) : new Date(y, m - 1, d, 0, 0, 0, 0);
+  const t = dt.getTime();
+  return Number.isNaN(t) ? null : dt.toISOString();
+}
+
+/**
+ * Resolve a preset (or a custom pair) to the `{ from, to }` ISO window the
+ * /runs/paged endpoint takes. A custom side that is blank or unparseable falls
+ * back to the 30-day default rather than sending garbage the server would 400
+ * — the date inputs are partially filled for as long as the user is typing.
+ */
+export function rangeToIso(preset: RunRangePreset, customFrom: string, customTo: string): { from: string; to: string } {
+  const now = new Date();
+  if (preset === "custom") {
+    const from = dateInputToIso(customFrom) ?? new Date(now.getTime() - 30 * 86_400_000).toISOString();
+    const to = dateInputToIso(customTo, true) ?? now.toISOString();
+    return { from, to };
+  }
+  const days = RUN_RANGE_PRESETS.find((p) => p.id === preset)?.days ?? 30;
+  return { from: new Date(now.getTime() - days * 86_400_000).toISOString(), to: now.toISOString() };
+}

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -9,6 +9,7 @@
 
 import type { TwinDelivery, TwinReplyDestination } from "../types/twin-delivery.js";
 import type { UserQuestion } from "../tools/types.js";
+import { normalizeUnifiedPatch } from "./unified-patch.js";
 
 // ── Inlined FlowUI types (mirrors @xyne/shared) ──────────────────────────────
 
@@ -1024,20 +1025,18 @@ export function buildCodeFlow(code: string, language?: string): FlowDefinition {
 }
 
 export function buildDiffFlow(path: string, patch: string): FlowDefinition {
-  const firstMeaningfulLine = patch.split('\n').find((line) => line.trim() !== '') ?? '';
-  const headed =
-    firstMeaningfulLine.startsWith('diff --git ') || firstMeaningfulLine.startsWith('--- ');
-  const headedPatch = headed ? patch : `--- a/${path}\n+++ b/${path}\n${patch}`;
-  const lines = patch.split('\n');
-  const added = lines.filter((line) => line.startsWith('+') && !line.startsWith('+++')).length;
-  const removed = lines.filter((line) => line.startsWith('-') && !line.startsWith('---')).length;
+  // Never pass the model's patch through verbatim: bare `@@` headers, missing
+  // file headers and guessed line counts all make @pierre/diffs emit zero hunks
+  // WITHOUT throwing, which shows up as a blank diff card. See unified-patch.ts.
+  const normalized = normalizeUnifiedPatch(path, patch);
+  const { added, removed } = normalized;
   return new FlowBuilder(`diff-${crypto.randomUUID()}`)
     .addComponent({
       id: 'diff',
       type: 'diff',
       props: {
         path,
-        patch: clipArtifact(headedPatch, ' … diff truncated'),
+        patch: clipArtifact(normalized.patch ?? patch, ' … diff truncated'),
       },
     })
     .setData({ kind: 'diff', fallbackText: `${path} · +${added}/−${removed}` })

--- a/packages/xyne-claw-shared/src/flow/code-artifact-flow.test.ts
+++ b/packages/xyne-claw-shared/src/flow/code-artifact-flow.test.ts
@@ -31,6 +31,9 @@ describe("buildCodeFlow", () => {
 });
 
 describe("buildDiffFlow", () => {
+  // Note the declared counts (2 and 3) do not match the body — models get these
+  // wrong constantly, so normalizeUnifiedPatch recomputes them. Header-repair
+  // itself is covered in depth by unified-patch.test.ts.
   const hunk = "@@ -41,2 +41,3 @@\n-messaging.onTokenRefresh(noop);\n+messaging.onTokenRefresh((t) => registerDevice(t));\n";
 
   it("adds file headers to a bare hunk list so the patch parses", () => {
@@ -40,9 +43,19 @@ describe("buildDiffFlow", () => {
     expect(flow.components[0]).toMatchObject({ id: "diff", type: "diff" });
     const props = flow.components[0]?.props as { path: string; patch: string };
     expect(props.path).toBe("src/push/token.ts");
-    expect(props.patch).toBe(`--- a/src/push/token.ts\n+++ b/src/push/token.ts\n${hunk}`);
+    expect(props.patch).toBe(
+      "--- a/src/push/token.ts\n+++ b/src/push/token.ts\n@@ -41,1 +41,1 @@\n" +
+        "-messaging.onTokenRefresh(noop);\n+messaging.onTokenRefresh((t) => registerDevice(t));\n",
+    );
     // Preview line only — no action surface on a display-only card.
     expect(flow.data).toEqual({ kind: "diff", fallbackText: "src/push/token.ts · +1/−1" });
+  });
+
+  it("renders a bare @@ header, which the diff parser silently drops otherwise", () => {
+    const flow = buildDiffFlow("src/a.ts", "@@\n-const a = 1;\n+const a = 2;\n");
+    const { patch } = flow.components[0]?.props as { patch: string };
+    expect(patch).toContain("@@ -1,1 +1,1 @@");
+    expect(flow.data).toMatchObject({ fallbackText: "src/a.ts · +1/−1" });
   });
 
   it("still adds headers when a hunk body line looks like a file header", () => {
@@ -52,10 +65,17 @@ describe("buildDiffFlow", () => {
     expect(patch.startsWith("--- a/db/migrations/002.sql\n+++ b/db/migrations/002.sql\n")).toBe(true);
   });
 
-  it("leaves an already-headed patch untouched", () => {
+  it("keeps the git header block of an already-headed patch", () => {
     const full = `diff --git a/x.ts b/x.ts\n--- a/x.ts\n+++ b/x.ts\n${hunk}`;
-    const flow = buildDiffFlow("x.ts", full);
-    expect((flow.components[0]?.props as { patch: string }).patch).toBe(full);
+    const { patch } = buildDiffFlow("x.ts", full).components[0]?.props as { patch: string };
+    expect(patch.startsWith("diff --git a/x.ts b/x.ts\n--- a/x.ts\n+++ b/x.ts\n")).toBe(true);
+  });
+
+  it("falls back to the raw patch when there is nothing to normalize", () => {
+    // Nothing renderable, but the card is still posted rather than swallowed —
+    // post-diff is what refuses this input, upstream of the builder.
+    const { patch } = buildDiffFlow("x.ts", "no diff here").components[0]?.props as { patch: string };
+    expect(patch).toBe("no diff here");
   });
 
   it("truncates a runaway patch with a visible marker", () => {

--- a/packages/xyne-claw-shared/src/flow/unified-patch.ts
+++ b/packages/xyne-claw-shared/src/flow/unified-patch.ts
@@ -1,0 +1,217 @@
+/**
+ * Repairs the loosely-formed "unified diffs" that models actually emit into
+ * something the diff card can draw.
+ *
+ * The `diff` FlowUI component is rendered by @pierre/diffs (`PatchDiff`), whose
+ * parser is strict in two ways that matter here:
+ *
+ *   1. A hunk boundary is the literal prefix `@@ `, and the header must read
+ *      `@@ -<start>[,<count>] +<start>[,<count>] @@`. A bare `@@` — by far the
+ *      most common thing an agent writes — is not a boundary at all, so the
+ *      whole patch collapses into the file-header block and ZERO hunks come out.
+ *   2. A non-git patch must START with a `--- ` line immediately followed by a
+ *      `+++ ` line. Anything else (no headers, or a sentence above them) makes
+ *      the parser treat the entire text as patch metadata and emit no files.
+ *
+ * Both failures are silent — the parser logs and returns empty rather than
+ * throwing — so the card's error boundary never fires and the user just gets a
+ * blank body. Hence: normalize before we hand a patch to the renderer.
+ *
+ * A third, subtler failure this also fixes: the parser stops consuming a hunk
+ * once it has read `additionCount` additions and `deletionCount` deletions. A
+ * header whose counts are too low (models guess these) silently truncates the
+ * hunk mid-render. So the counts are always RECOMPUTED from the body and never
+ * trusted.
+ */
+
+/** One hunk, already split into its (repaired) body lines. */
+interface ParsedHunk {
+  /** Declared `-start` from the original header, when it had a valid range. */
+  deletionStart?: number | undefined;
+  /** Declared `+start` from the original header, when it had a valid range. */
+  additionStart?: number | undefined;
+  /** Trailing context text after the closing `@@`, e.g. a function signature. */
+  context: string;
+  /** Body lines, each already prefixed with one of ` `, `+`, `-`, `\`. */
+  body: string[];
+  additions: number;
+  deletions: number;
+  /** Context lines — they count toward BOTH the old and new side. */
+  common: number;
+}
+
+export interface NormalizedPatch {
+  /**
+   * A patch @pierre/diffs can parse into at least one hunk, or `null` when the
+   * input carried no diff body at all (nothing to draw — callers should refuse
+   * rather than post an empty card).
+   */
+  patch: string | null;
+  added: number;
+  removed: number;
+  hunks: number;
+}
+
+/** Body lines are the only thing a hunk may contain. `\` is the
+ *  "\ No newline at end of file" marker, which the parser accepts. */
+function bodyPrefix(line: string): ' ' | '+' | '-' | '\\' | null {
+  const first = line[0];
+  if (first === ' ' || first === '+' || first === '-' || first === '\\') return first;
+  // A context line whose content is empty is supposed to be a single space, but
+  // models routinely emit a truly empty line. Read it as empty context.
+  if (line === '' || line === '\r') return ' ';
+  return null;
+}
+
+/** Models like to wrap the patch in a ```diff fence. Unwrap it. */
+function stripCodeFence(patch: string): string {
+  const lines = patch.split('\n');
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start]!.trim() === '') start += 1;
+  while (end > start && lines[end - 1]!.trim() === '') end -= 1;
+  if (start < end && /^```/.test(lines[start]!.trim()) && lines[end - 1]!.trim() === '```') {
+    return lines.slice(start + 1, end - 1).join('\n');
+  }
+  return patch;
+}
+
+/**
+ * Reads whatever range a hunk header carries. Tolerates every shape seen in the
+ * wild: `@@`, `@@ @@`, `@@ ... @@`, `@@ -12 +12 @@`, `@@ -12,3 +12,5 @@ ctx`.
+ * Returns the declared starts only when the range is actually parseable.
+ */
+function readHunkHeader(line: string): {
+  deletionStart?: number | undefined;
+  additionStart?: number | undefined;
+  context: string;
+} {
+  const closing = line.indexOf('@@', 2);
+  const spec = closing === -1 ? line.slice(2) : line.slice(2, closing);
+  const context = closing === -1 ? '' : line.slice(closing + 2).trim();
+  const range = /^\s*-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s*$/.exec(spec);
+  if (!range) return { context };
+  return { deletionStart: Number(range[1]), additionStart: Number(range[2]), context };
+}
+
+function pushBodyLine(hunk: ParsedHunk, line: string): void {
+  const prefix = bodyPrefix(line);
+  if (prefix === '\\') {
+    hunk.body.push(line);
+    return;
+  }
+  const content = prefix === ' ' && (line === '' || line === '\r') ? ' ' : line;
+  hunk.body.push(content);
+  if (prefix === '+') hunk.additions += 1;
+  else if (prefix === '-') hunk.deletions += 1;
+  else hunk.common += 1;
+}
+
+/**
+ * Rewrites `patch` so @pierre/diffs can render it, using `path` for the file
+ * headers when the patch does not supply its own.
+ *
+ * Git patches (`diff --git`) keep their own header block verbatim — it carries
+ * rename/mode/index metadata the card would otherwise lose — but their hunk
+ * headers are rewritten just the same.
+ */
+export function normalizeUnifiedPatch(path: string, patch: string): NormalizedPatch {
+  const lines = stripCodeFence(patch).split('\n');
+  // The patch's own terminating newline yields a final empty element. Reading it
+  // as an empty context line would append a phantom line to the last hunk — and
+  // grow the patch by one line on every re-normalization.
+  if (lines.length > 0 && (lines[lines.length - 1] === '' || lines[lines.length - 1] === '\r')) lines.pop();
+
+  const preamble: string[] = [];
+  const hunks: ParsedHunk[] = [];
+  let current: ParsedHunk | undefined;
+  let sawGitHeader = false;
+
+  for (const raw of lines) {
+    const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw;
+
+    if (line.startsWith('@@')) {
+      const { deletionStart, additionStart, context } = readHunkHeader(line);
+      current = { deletionStart, additionStart, context, body: [], additions: 0, deletions: 0, common: 0 };
+      hunks.push(current);
+      continue;
+    }
+
+    if (current) {
+      if (bodyPrefix(line) !== null) {
+        pushBodyLine(current, line);
+        continue;
+      }
+      // Prose after a hunk (a model explaining itself) ends the hunk. Drop it
+      // rather than feeding the parser a line it will reject.
+      current = undefined;
+      continue;
+    }
+
+    if (line.startsWith('diff --git ')) sawGitHeader = true;
+    preamble.push(line);
+  }
+
+  // No `@@` anywhere, but there is a +/- body: treat the whole thing as one
+  // hunk instead of dropping it. Only the preamble was collected, so re-read it.
+  if (hunks.length === 0) {
+    const synthetic: ParsedHunk = { context: '', body: [], additions: 0, deletions: 0, common: 0 };
+    for (const line of preamble) {
+      if (line.startsWith('--- ') || line.startsWith('+++ ') || line.startsWith('diff --git ')) continue;
+      if (bodyPrefix(line) === null) continue;
+      pushBodyLine(synthetic, line);
+    }
+    if (synthetic.additions + synthetic.deletions === 0) return { patch: null, added: 0, removed: 0, hunks: 0 };
+    hunks.push(synthetic);
+    preamble.length = 0;
+    sawGitHeader = false;
+  }
+
+  const drawable = hunks.filter((hunk) => hunk.additions + hunk.deletions + hunk.common > 0);
+  if (drawable.length === 0) return { patch: null, added: 0, removed: 0, hunks: 0 };
+
+  const out: string[] = [];
+  if (sawGitHeader) {
+    out.push(...preamble);
+  } else {
+    // Rebuild the header pair rather than reusing the preamble as-is: the
+    // parser only recognises a unified file when `--- ` is the very FIRST line
+    // and `+++ ` the second, so any stray prose above them loses the file.
+    const declaredOld = preamble.find((line) => line.startsWith('--- '))?.slice(4).trim();
+    const declaredNew = preamble.find((line) => line.startsWith('+++ '))?.slice(4).trim();
+    out.push(`--- ${declaredOld || `a/${path}`}`);
+    out.push(`+++ ${declaredNew || `b/${path}`}`);
+  }
+
+  // Line numbers: honour whatever the patch declared, and for unanchored hunks
+  // walk forward from the previous one leaving a one-line gap, so the renderer
+  // draws its "collapsed" separator between them instead of running two
+  // unrelated hunks together as one block.
+  let nextDeletionStart = 1;
+  let nextAdditionStart = 1;
+  let added = 0;
+  let removed = 0;
+
+  for (const hunk of drawable) {
+    const deletionCount = hunk.deletions + hunk.common;
+    const additionCount = hunk.additions + hunk.common;
+    const deletionStart = hunk.deletionStart ?? nextDeletionStart;
+    const additionStart = hunk.additionStart ?? nextAdditionStart;
+    // A zero-length side is legal only at position 0 (pure insert/delete at the
+    // start of a file); everything else must be 1-based.
+    const safeDeletionStart = deletionCount === 0 ? Math.max(deletionStart - 1, 0) : Math.max(deletionStart, 1);
+    const safeAdditionStart = additionCount === 0 ? Math.max(additionStart - 1, 0) : Math.max(additionStart, 1);
+
+    out.push(
+      `@@ -${safeDeletionStart},${deletionCount} +${safeAdditionStart},${additionCount} @@${hunk.context ? ` ${hunk.context}` : ''}`,
+    );
+    out.push(...hunk.body);
+
+    nextDeletionStart = safeDeletionStart + deletionCount + 1;
+    nextAdditionStart = safeAdditionStart + additionCount + 1;
+    added += hunk.additions;
+    removed += hunk.deletions;
+  }
+
+  return { patch: `${out.join('\n')}\n`, added, removed, hunks: drawable.length };
+}

--- a/packages/xyne-claw-shared/src/tools/code-artifacts/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/code-artifacts/tools.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import type { ToolDefinition, ToolExecutionContext, UiWidget } from "../types.js";
 import { publishUiWidget } from "../ui-widget.js";
+import { normalizeUnifiedPatch } from "../../flow/unified-patch.js";
 
 function widgetId(context: ToolExecutionContext | undefined, type: UiWidget["type"]): string {
   return `${type}:${context?.toolCallId ?? crypto.randomUUID()}`;
@@ -61,7 +62,9 @@ export const postDiff: ToolDefinition = {
     "changed lines rendered in place with an expand-to-full-patch control. Use this whenever " +
     "you are showing a change to an existing file, instead of pasting before/after blocks. " +
     "`patch` is unified-diff text: `@@` hunk headers with ` `/`+`/`-` line prefixes. Bare " +
-    "hunks are fine — the file headers are added for you from `path`. " +
+    "`@@` headers are fine — the file headers, line ranges and line counts are all filled " +
+    "in for you from `path` and from the hunk bodies. What you MUST get right is the line " +
+    "prefixes: every line inside a hunk starts with a space (context), `+` or `-`. " +
     "This card only DISPLAYS the change: it applies nothing and asks the user for nothing, so " +
     "if you need the edit made, still say what you intend to do next.",
   source: "custom:code-artifacts",
@@ -78,18 +81,27 @@ export const postDiff: ToolDefinition = {
     const patch = typeof params["patch"] === "string" ? params["patch"] : "";
     if (!path) return "Error: path is required.";
     if (!patch.trim()) return "Error: patch is required.";
-    if (!/^@@|^diff --git |^--- /m.test(patch)) {
-      return "Error: patch must be unified-diff text (at least one @@ hunk header).";
+
+    // Repair the patch HERE rather than trusting the shape check that used to
+    // live in its place: the renderer drops an unparseable patch silently, so a
+    // patch that merely *contains* an @@ could still post a blank card.
+    const normalized = normalizeUnifiedPatch(path, patch);
+    if (!normalized.patch) {
+      return (
+        "Error: no diff lines found in patch. Every line inside a hunk must start with " +
+        "a space (unchanged), '+' (added) or '-' (removed) — e.g.\n" +
+        "@@\n-const a = 1;\n+const a = 2;"
+      );
     }
 
     const error = await postWidget(context, {
       id: widgetId(context, "diff"),
       type: "diff",
       operation: "create",
-      payload: { path, patch },
+      payload: { path, patch: normalized.patch },
     });
     if (error) return error;
-    return `Posted a diff card for ${path} to the thread. Do not repeat the patch in your reply — the user can already see it.`;
+    return `Posted a diff card for ${path} (+${normalized.added}/−${normalized.removed}) to the thread. Do not repeat the patch in your reply — the user can already see it.`;
   },
 };
 


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
