### PR TITLE
fix: XYNE-62296 sync stage icons on ticket surfaces with the board definition

### DIFF
--- a/apps/dashboard/src/components/Board/BoardStageConfigScreen/BoardStageConfigScreen.types.tsx
+++ b/apps/dashboard/src/components/Board/BoardStageConfigScreen/BoardStageConfigScreen.types.tsx
@@ -1,5 +1,5 @@
-import { CircleDashed, CircleDot, Signature, CircleX, CircleCheck } from 'lucide-react';
 import { TicketStatusV2 } from '@xyne/shared';
+import { StageStatusIcon } from '../../../utils/board/stageStatusIcon';
 import type { ApproverEntry } from '../ApproverSelector/ApproverSelector.types';
 
 /**
@@ -46,27 +46,27 @@ export const STATUS_OPTIONS = [
   {
     status: TicketStatusV2.TODO,
     label: 'To Do',
-    icon: <CircleDashed strokeWidth={2.5} className='w-3.5 h-3.5 text-orange-500' />,
+    icon: <StageStatusIcon status={TicketStatusV2.TODO} />,
   },
   {
     status: TicketStatusV2.STARTED,
     label: 'Started',
-    icon: <CircleDot strokeWidth={2.5} className='w-3.5 h-3.5 text-blue-500' />,
+    icon: <StageStatusIcon status={TicketStatusV2.STARTED} />,
   },
   {
     status: TicketStatusV2.PAUSED,
     label: 'Paused',
-    icon: <Signature strokeWidth={2.5} className='w-3.5 h-3.5 text-teal-500' />,
+    icon: <StageStatusIcon status={TicketStatusV2.PAUSED} />,
   },
   {
     status: TicketStatusV2.COMPLETED,
     label: 'Completed',
-    icon: <CircleCheck strokeWidth={2.5} className='w-3.5 h-3.5 text-green-500' />,
+    icon: <StageStatusIcon status={TicketStatusV2.COMPLETED} />,
   },
   {
     status: TicketStatusV2.CANCELLED,
     label: 'Cancelled',
-    icon: <CircleX strokeWidth={2.5} className='w-3.5 h-3.5 text-red-500' />,
+    icon: <StageStatusIcon status={TicketStatusV2.CANCELLED} />,
   },
 ];
 

--- a/apps/dashboard/src/components/Board/StatusIndicator/StatusIndicator.tsx
+++ b/apps/dashboard/src/components/Board/StatusIndicator/StatusIndicator.tsx
@@ -8,21 +8,20 @@ export const StatusIndicator = ({
   stageIndex,
   totalNonCancelledStages,
 }: StatusIndicatorProps): ReactElement => {
-  // Define color and ring color based on status
   const getStatusConfig = (s: TicketStatusV2): { color: string; ringColor: string } => {
     switch (s) {
       case TicketStatusV2.TODO:
-        return { color: '#9CA3AF', ringColor: '#9CA3AF' }; // Gray
+        return { color: 'var(--status-new)', ringColor: 'var(--status-new)' };
       case TicketStatusV2.STARTED:
-        return { color: '#3B82F6', ringColor: '#3B82F6' }; // Blue
+        return { color: 'var(--status-scheduled)', ringColor: 'var(--status-scheduled)' };
       case TicketStatusV2.PAUSED:
-        return { color: '#EAB308', ringColor: '#EAB308' }; // Yellow
+        return { color: 'var(--status-paused)', ringColor: 'var(--status-paused)' };
       case TicketStatusV2.COMPLETED:
-        return { color: '#22C55E', ringColor: '#22C55E' }; // Green
+        return { color: 'var(--status-success)', ringColor: 'var(--status-success)' };
       case TicketStatusV2.CANCELLED:
-        return { color: '#EF4444', ringColor: '#EF4444' }; // Red
+        return { color: 'var(--status-failure)', ringColor: 'var(--status-failure)' };
       default:
-        return { color: '#9CA3AF', ringColor: '#9CA3AF' };
+        return { color: 'var(--status-new)', ringColor: 'var(--status-new)' };
     }
   };
 

--- a/apps/dashboard/src/components/Release/ReleaseStagePicker.tsx
+++ b/apps/dashboard/src/components/Release/ReleaseStagePicker.tsx
@@ -19,6 +19,7 @@ export interface ReleaseStageOption {
 interface ReleaseStagePickerProps {
   ticketId: string;
   stageName: string | null | undefined;
+  statusV2?: string | null | undefined;
   // Stages sourced from the ticket's board (queries.stagesByBoards). Pass
   // an empty array if the board has no stages configured yet.
   stages: readonly ReleaseStageOption[];
@@ -43,6 +44,7 @@ interface ReleaseStagePickerProps {
 export function ReleaseStagePicker({
   ticketId,
   stageName,
+  statusV2,
   stages,
   boardId,
   onAfterChange,
@@ -59,6 +61,7 @@ export function ReleaseStagePicker({
         ticketId={ticketId}
         stageName={stageName}
         stageLabel={stageName ?? '—'}
+        statusV2={statusV2}
         boardId={boardId}
         onAfterStageChange={onAfterChange}
       />

--- a/apps/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
+++ b/apps/dashboard/src/components/Tickets/MergeTicketsDialog/MergeTicketsDialog.tsx
@@ -21,6 +21,7 @@ interface MergeTicket {
   title?: string | null | undefined;
   xyneId?: string | null | undefined;
   stageName?: string | null | undefined;
+  statusV2?: string | null | undefined;
   priority?: TicketPriority | string | null | undefined;
   assignedTo?: string | null | undefined;
   userGroupId?: string | null | undefined;
@@ -258,6 +259,7 @@ export const MergeTicketsDialog: React.FC<MergeTicketsDialogProps> = ({
                       {ticket.stageName !== undefined && (
                         <TicketStatusWithStages
                           currentStageName={ticket.stageName}
+                          statusV2={ticket.statusV2}
                           showLeadingDot={false}
                           labelClassName='max-w-[120px] truncate'
                         />

--- a/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketCard/TicketCard.tsx
@@ -605,6 +605,7 @@ export const TicketCard: React.FC<TicketCardProps> = ({
           <div className='flex items-center gap-2.5 shrink-0'>
             <TicketStatusWithStages
               currentStageName={ticket.stageName}
+              statusV2={ticket.statusV2}
               showLeadingDot={false}
               labelClassName='max-w-[120px] truncate'
             />
@@ -653,12 +654,18 @@ export const TicketCard: React.FC<TicketCardProps> = ({
                 <span className='text-xs font-medium text-muted-foreground font-mono'>
                   {ticket.xyneId}
                 </span>
-                {!isCompact && <TicketStatusWithStages currentStageName={ticket.stageName} />}
+                {!isCompact && (
+                  <TicketStatusWithStages
+                    currentStageName={ticket.stageName}
+                    statusV2={ticket.statusV2}
+                  />
+                )}
                 {isCompact && (
                   <StagePicker
                     ticketId={ticket.id}
                     stageName={ticket.stageName}
                     stageLabel={ticket.stageName || 'To Do'}
+                    statusV2={ticket.statusV2}
                     boardId={ticket.boardId}
                   />
                 )}
@@ -945,6 +952,7 @@ export const TicketCard: React.FC<TicketCardProps> = ({
                     <div className='flex items-center gap-2'>
                       <TicketStatusWithStages
                         currentStageName={ticket.stageName}
+                        statusV2={ticket.statusV2}
                         showLeadingDot={false}
                         iconOnly
                       />

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -82,8 +82,8 @@ import { useChannel, useAllChannels } from '../../../hooks/useChannels';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import UserAvatar, { AvatarShape, AvatarSize } from '../../UserAvatar/UserAvatar';
 import { Selector } from './Selector';
-import { TicketPriorityIcon, TicketStatusIcon } from '../../../assets/icons';
-import { getTicketStatusColor } from '../../Tickets/CalendarView/CompactTicketBadge/utils';
+import { TicketPriorityIcon } from '../../../assets/icons';
+import { StageIndicator } from '../../../utils/board/stageStatusIcon';
 import { mutators } from '../../../zero/mutators';
 import { apiInstance } from '../../../services/clients/apiClient';
 import { getReachableStageIds, findMatchingTransition } from '../../../utils/stageTransitionUtils';
@@ -104,7 +104,6 @@ import {
   formatReferenceLabel,
   useTicketReferences,
 } from '../../../hooks/useTicketReferences';
-import { TicketStatusIcon as TicketStageIcon } from '../TicketStatus/TicketStatusIcon';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
 import { calculateETADeadline, calculateWorkingDurationMs } from '../../../utils/etaCalculation';
 import { formatETADisplay, getLocalISOString, getStatusBadgeConfig } from '../utils';
@@ -170,18 +169,6 @@ interface StageInfo {
   formId?: string | null;
   eta: number | null;
 }
-
-const getStageProgress = (
-  currentStageName: string | null | undefined,
-  stages: StageInfo[] | undefined,
-): number => {
-  if (!stages || stages.length === 0 || !currentStageName) return 0;
-
-  const currentStage = stages.find(stage => stage.name === currentStageName);
-  if (!currentStage) return 0;
-
-  return Math.round((currentStage.sequenceNumber / stages.length) * 100);
-};
 
 const PRIORITY_OPTIONS: TicketPriority[] = [
   TicketPriority.LOW,
@@ -2965,8 +2952,6 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     const boardStages = relatedTicket?.boardId
       ? stagesByBoardId.get(relatedTicket.boardId)
       : undefined;
-    const stageProgress = getStageProgress(relatedTicket?.stageName, boardStages);
-    const displayProgress = stageProgress === 0 ? 1 : stageProgress;
     const assigneeId = relatedTicket?.assignedTo?.replace(/^(user:|group:)/, '') || '';
     const priorityIcon = relatedTicket?.priority ? getPriorityIcon(relatedTicket.priority) : null;
 
@@ -3009,7 +2994,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
 
         <div className='relative group flex items-center justify-between gap-4 rounded-lg border border-border bg-muted px-3 py-2.5 shadow-sm'>
           <div className='flex items-center gap-3 min-w-0'>
-            <TicketStageIcon progressPercentage={displayProgress} size={18} />
+            <StageIndicator stages={boardStages} stageName={relatedTicket?.stageName} size={18} />
             <div className='flex items-center gap-4 min-w-0'>
               <span className='text-sm font-medium text-muted-foreground font-mono shrink-0'>
                 {relatedTicket?.xyneId || relatedTicket?.id || '—'}
@@ -3123,8 +3108,6 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     const boardStages = mappedTicket?.boardId
       ? stagesByBoardId.get(mappedTicket.boardId)
       : undefined;
-    const stageProgress = getStageProgress(mappedTicket?.stageName, boardStages);
-    const displayProgress = stageProgress === 0 ? 1 : stageProgress;
     const priority = mappedTicket?.priority;
     const assignedTo = mappedTicket?.assignedTo;
     const priorityIcon = priority ? getPriorityIcon(priority) : null;
@@ -3268,7 +3251,11 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
             )}
             {boardStages && boardStages.length > 0 && (
               <div className='flex items-center gap-1.5'>
-                <TicketStageIcon progressPercentage={displayProgress} size={18} />
+                <StageIndicator
+                  stages={boardStages}
+                  stageName={mappedTicket?.stageName}
+                  size={18}
+                />
                 <span className='text-xs font-medium text-foreground whitespace-nowrap'>
                   {boardStages.findIndex(stage => stage.name === mappedTicket?.stageName) + 1}/
                   {boardStages.length}
@@ -3882,7 +3869,12 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                 >
                   {stageReadOnly ? (
                     <span className='inline-flex items-center gap-2 rounded-md bg-muted px-2 py-1 text-sm'>
-                      <TicketStatusIcon size={14} color={getTicketStatusColor(ticket.statusV2)} />
+                      <StageIndicator
+                        stages={stages}
+                        stageName={ticket.stageName}
+                        fallbackStatus={ticket.statusV2}
+                        isNonLinearBoard={isNonLinearBoard}
+                      />
                       {ticket.stageName || 'Not set'}
                     </span>
                   ) : (
@@ -3892,20 +3884,20 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                       onValueChange={handleStageChange}
                       placeholder='Set Status'
                       icon={
-                        <TicketStatusIcon size={14} color={getTicketStatusColor(ticket.statusV2)} />
+                        <StageIndicator
+                          stages={stages}
+                          stageName={ticket.stageName}
+                          fallbackStatus={ticket.statusV2}
+                          isNonLinearBoard={isNonLinearBoard}
+                        />
                       }
-                      getItemIcon={item =>
-                        (() => {
-                          const stage = selectorStages.find(s => s.name === item.name);
-                          const itemStatusV2 = stage?.defaultTicketStatusV2 ?? ticket.statusV2;
-                          return (
-                            <TicketStatusIcon
-                              size={14}
-                              color={getTicketStatusColor(itemStatusV2)}
-                            />
-                          );
-                        })()
-                      }
+                      getItemIcon={item => (
+                        <StageIndicator
+                          stages={stages}
+                          stageName={item.name}
+                          isNonLinearBoard={isNonLinearBoard}
+                        />
+                      )}
                       noBorder={true}
                       isItemDisabled={item => item.name === ticket.stageName}
                     />
@@ -4918,8 +4910,6 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                   : undefined;
                 const stageIndex =
                   boardStages?.findIndex(stage => stage.name === parentTicket.stageName) ?? -1;
-                const stageProgress = getStageProgress(parentTicket.stageName, boardStages);
-                const displayProgress = stageProgress === 0 ? 1 : stageProgress;
                 const assigneeId = parentTicket.assignedTo?.replace(/^(user:|group:)/, '') || '';
                 const navigateToParentTicket = (): void => {
                   const channelType = channelTypeMap.get(parentTicket.channelId);
@@ -4994,7 +4984,11 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
                       </Tooltip>
                       {boardStages && boardStages.length > 0 && (
                         <div className='flex items-center gap-1.5'>
-                          <TicketStageIcon progressPercentage={displayProgress} size={18} />
+                          <StageIndicator
+                            stages={boardStages}
+                            stageName={parentTicket.stageName}
+                            size={18}
+                          />
                           <span className='whitespace-nowrap text-xs font-medium text-foreground'>
                             {stageIndex + 1}/{boardStages.length}
                           </span>

--- a/apps/dashboard/src/components/Tickets/TicketListView/StagePicker.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/StagePicker.tsx
@@ -8,6 +8,7 @@ import { mutators } from '../../../zero/mutators';
 import { queries } from '../../../zero/queries';
 import { useCachedQuery } from '../../../hooks/useCachedQuery';
 import { getStageColor } from '../../../routes/KanbanBoardScreen/KanbanBoardScreen.utils';
+import { StageIndicator } from '../../../utils/board/stageStatusIcon';
 import { cn } from '../../../utils/classNames';
 import { surfaceMutationError } from '../../../utils/zeroMutationToast';
 import { useAuth } from '../../../hooks/useAuth';
@@ -23,6 +24,7 @@ interface StagePickerProps {
   ticketId: string;
   stageName: string | null | undefined;
   stageLabel: string;
+  statusV2?: string | null | undefined;
   boardId?: string | null;
   /**
    * When provided, called instead of mutating Zero / opening StageFormModal.
@@ -167,6 +169,7 @@ export function StagePicker({
   ticketId,
   stageName,
   stageLabel,
+  statusV2,
   boardId,
   onStageChange,
   onAfterStageChange,
@@ -625,8 +628,6 @@ export function StagePicker({
     setOpen(false);
   };
 
-  const dotColor = getStageColor(currentStage);
-
   const trigger = (
     <button
       type='button'
@@ -640,9 +641,12 @@ export function StagePicker({
       data-track-category='Tickets'
       data-track-name='ToggleRowStage'
     >
-      <span
-        className='inline-block w-1.5 h-1.5 rounded-full'
-        style={{ backgroundColor: dotColor }}
+      <StageIndicator
+        stages={stages}
+        stageName={currentStage}
+        fallbackStatus={statusV2}
+        isNonLinearBoard={isNonLinear}
+        size={12}
       />
       <span>{stageLabel}</span>
       <ChevronDown className='w-3 h-3 opacity-60' />
@@ -677,9 +681,11 @@ export function StagePicker({
               data-track-category='Tickets'
               data-track-name='SelectRowStage'
             >
-              <span
-                className='inline-block w-1.5 h-1.5 rounded-full'
-                style={{ backgroundColor: getStageColor(stage) }}
+              <StageIndicator
+                stages={stages}
+                stageName={stage}
+                isNonLinearBoard={isNonLinear}
+                size={12}
               />
               <span className='text-foreground'>{stage}</span>
             </button>

--- a/apps/dashboard/src/components/Tickets/TicketListView/TicketListView.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/TicketListView.tsx
@@ -144,6 +144,7 @@ export interface SelectableRow {
   channelId: string;
   conversationId: string;
   stageName?: string | null;
+  statusV2?: string | null;
   priority?: TicketListItem['priority'];
   assignedTo?: string | null;
   userGroupId?: string | null;
@@ -786,6 +787,7 @@ export const TicketListView = function TicketListView({
                       channelId: row.channelId ?? '',
                       conversationId: row.conversationId ?? '',
                       stageName: row.stageName,
+                      statusV2: row.statusV2,
                       priority: row.priority,
                       assignedTo: row.assignedTo,
                       userGroupId: row.userGroupId,
@@ -818,6 +820,7 @@ export const TicketListView = function TicketListView({
       channelId: t.channelId ?? '',
       conversationId: t.conversationId ?? '',
       stageName: t.stageName,
+      statusV2: t.statusV2,
       priority: t.priority,
       assignedTo: t.assignedTo,
       userGroupId: t.userGroupId,

--- a/apps/dashboard/src/components/Tickets/TicketStatus/TicketStatusIcon.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketStatus/TicketStatusIcon.tsx
@@ -1,95 +1,43 @@
 import React from 'react';
+import { TicketStatusV2 } from '@xyne/shared';
 import { cn } from '../../../utils/classNames';
+import { getStageStatusMeta } from '../../../utils/board/stageStatusIcon';
+import { StatusIndicator } from '../../Board/StatusIndicator';
 
-interface TicketStatusIconProps {
-  progressPercentage: number;
-  size?: number;
-}
-
-const getStatusColor = (progressPercentage: number, zeroColor: string): string => {
-  if (progressPercentage === 100) return 'var(--status-success)';
-  if (progressPercentage > 0) return 'var(--status-scheduled)';
-  return zeroColor;
-};
-
-export const TicketStatusIcon: React.FC<TicketStatusIconProps> = ({
-  progressPercentage,
-  size = 16,
-}) => {
-  const center = size / 2;
-  const radius = size / 2 - 1;
-
-  const polarToCartesian = (cx: number, cy: number, r: number, angle: number) => {
-    const rad = (angle - 90) * (Math.PI / 180);
-    return {
-      x: cx + r * Math.cos(rad),
-      y: cy + r * Math.sin(rad),
-    };
-  };
-
-  const describeArc = (cx: number, cy: number, r: number, percent: number) => {
-    if (percent <= 0) return '';
-
-    const endAngle = (percent / 100) * 360;
-    const start = polarToCartesian(cx, cy, r, 0);
-    const end = polarToCartesian(cx, cy, r, endAngle);
-
-    const largeArcFlag = endAngle > 180 ? 1 : 0;
-
-    return `
-      M ${cx} ${cy}
-      L ${start.x} ${start.y}
-      A ${r} ${r} 0 ${largeArcFlag} 1 ${end.x} ${end.y}
-      Z
-    `;
-  };
-
-  const color = getStatusColor(progressPercentage, 'transparent');
-  const innerRadius = radius - 2;
-
-  return (
-    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
-      {/* Outer border */}
-      <circle cx={center} cy={center} r={radius} fill='none' stroke={color} strokeWidth='2' />
-
-      {/* Progress sector */}
-      {progressPercentage > 0 && (
-        <path d={describeArc(center, center, innerRadius, progressPercentage)} fill={color} />
-      )}
-    </svg>
-  );
-};
-
-// calculate progress based on stages
-// handles progress calculation
 interface TicketStatusWithStagesProps {
   currentStageName: string | null;
+  /**
+   * The ticket's status snapshot. Cards render outside any board-stage query, so
+   * the indicator falls back to a status-only fill here instead of the board
+   * definition's position-based one — see StageIndicator for the exact form.
+   */
+  statusV2?: string | null | undefined;
   showLeadingDot?: boolean;
   iconOnly?: boolean;
   className?: string;
-  iconClassName?: string;
   labelClassName?: string;
 }
 
-const STAGE_PROGRESS = 25;
-
 export const TicketStatusWithStages: React.FC<TicketStatusWithStagesProps> = ({
   currentStageName,
+  statusV2,
   showLeadingDot = true,
   iconOnly = false,
   className,
   labelClassName,
 }) => {
+  const status = (statusV2 as TicketStatusV2) ?? TicketStatusV2.TODO;
+
   if (iconOnly) {
-    return <TicketStatusIcon progressPercentage={STAGE_PROGRESS} size={12} />;
+    return <StatusIndicator status={status} size={12} />;
   }
   return (
     <div className={cn('flex items-center gap-1.5', className)}>
       {showLeadingDot && <div className='rounded-full h-1 w-1 bg-muted-foreground'></div>}
-      <TicketStatusIcon progressPercentage={STAGE_PROGRESS} size={12} />
+      <StatusIndicator status={status} size={12} />
       <span
         className={cn('text-xs line-clamp-1 break-all', labelClassName)}
-        style={{ color: getStatusColor(STAGE_PROGRESS, 'hsl(var(--muted-foreground))') }}
+        style={{ color: getStageStatusMeta(statusV2).cssVar }}
       >
         {currentStageName || 'Not Started'}
       </span>

--- a/apps/dashboard/src/components/Tickets/TicketTable/BulkActionToolbar.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/BulkActionToolbar.tsx
@@ -20,14 +20,14 @@ import {
   useAssigneeOptions,
   useStageOptions,
 } from './TicketTableHelper';
-import type { ActiveMenu } from './TicketTableTypes';
+import type { ActiveMenu, StageOptionSource } from './TicketTableTypes';
 import { TagSelector } from './TagSelector';
 
 interface BulkActionToolbarProps {
   selectedCount: number;
   users?: User[];
   userGroups?: UserGroup[];
-  stages?: Array<{ id: string; name: string }>;
+  stages?: StageOptionSource[];
   onAssigneeChange: (assignee: string | null) => void;
   onStatusChange: (status: TicketStatusV2) => void;
   onPriorityChange: (priority: TicketPriority | null) => void;

--- a/apps/dashboard/src/components/Tickets/TicketTable/CellEditor.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/CellEditor.tsx
@@ -111,7 +111,13 @@ export const StageCellEditor = ({
     enabled: !!boardId && !stages,
   });
   const resolvedStages = useMemo(
-    () => stages ?? (boardStages ?? []).map(stage => ({ id: stage.id, name: stage.name })),
+    () =>
+      stages ??
+      (boardStages ?? []).map(stage => ({
+        id: stage.id,
+        name: stage.name,
+        defaultTicketStatusV2: stage.defaultTicketStatusV2,
+      })),
     [stages, boardStages],
   );
   const options = useStageOptions(resolvedStages);

--- a/apps/dashboard/src/components/Tickets/TicketTable/TicketTableHelper.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TicketTableHelper.tsx
@@ -1,20 +1,16 @@
 import { TicketPriority, TicketStatusV2, UserStatus } from '@xyne/shared';
 import { getPriorityIcon } from '../TicketCard/TicketCard.utils';
-import { TicketStatusIcon } from '../../../assets/icons';
 import Avatar from '../../ui/Avatar/Avatar';
+import { Tag, UserDefault as UserIcon } from '@xyne/icons';
 import {
-  CheckTickCircle as CircleCheck,
-  CircleDashed,
-  CircleDot,
-  MultipleCrossCancelCircle as CircleX,
-  Tag,
-  UserDefault as UserIcon,
-  PauseCircle,
-} from '@xyne/icons';
+  STAGE_STATUS_META,
+  StageIndicator,
+  StageStatusIcon,
+} from '../../../utils/board/stageStatusIcon';
 import { cn } from '../../../utils/classNames';
 import { useMemo } from 'react';
 import type { User, UserGroup } from '../../../machines/stateMachine';
-import { EntityOption, StatusEntityOption } from './TicketTableTypes';
+import { EntityOption, StageOptionSource, StatusEntityOption } from './TicketTableTypes';
 import { getUserDisplayName, withYouLabel } from '../../../utils/userDisplayName';
 import { channelMembersFirst, currentUserFirst } from '../../../utils/channelMembersFirst';
 
@@ -29,43 +25,24 @@ export const TAG_COLORS = [
   'bg-indigo-500',
 ];
 
-export const StatusOptions: StatusEntityOption[] = [
-  {
-    label: 'Todo',
-    value: TicketStatusV2.TODO,
-    icon: <CircleDashed strokeWidth={2.5} className='w-3.5 h-3.5 text-orange-500' />,
-    bgColor: 'bg-orange-500/15',
-    textColor: 'text-orange-600',
-  },
-  {
-    label: 'Started',
-    value: TicketStatusV2.STARTED,
-    icon: <CircleDot strokeWidth={2.5} className='w-3.5 h-3.5 text-blue-500' />,
-    bgColor: 'bg-blue-500/15',
-    textColor: 'text-blue-600',
-  },
-  {
-    label: 'Paused',
-    value: TicketStatusV2.PAUSED,
-    icon: <PauseCircle strokeWidth={2.5} className='w-3.5 h-3.5 text-teal-500' />,
-    bgColor: 'bg-teal-500/15',
-    textColor: 'text-teal-600',
-  },
-  {
-    label: 'Cancelled',
-    value: TicketStatusV2.CANCELLED,
-    icon: <CircleX strokeWidth={2.5} className='w-3.5 h-3.5 text-red-500' />,
-    bgColor: 'bg-red-500/15',
-    textColor: 'text-red-600',
-  },
-  {
-    label: 'Completed',
-    value: TicketStatusV2.COMPLETED,
-    icon: <CircleCheck strokeWidth={2.5} className='w-3.5 h-3.5 text-green-500' />,
-    bgColor: 'bg-green-500/15',
-    textColor: 'text-green-600',
-  },
+const STATUS_OPTION_ORDER = [
+  TicketStatusV2.TODO,
+  TicketStatusV2.STARTED,
+  TicketStatusV2.PAUSED,
+  TicketStatusV2.CANCELLED,
+  TicketStatusV2.COMPLETED,
 ];
+
+export const StatusOptions: StatusEntityOption[] = STATUS_OPTION_ORDER.map(value => {
+  const meta = STAGE_STATUS_META[value];
+  return {
+    label: meta.label,
+    value,
+    icon: <StageStatusIcon status={value} />,
+    bgColor: meta.bgColor,
+    textColor: meta.textColor,
+  };
+});
 
 export const PriorityOptions: EntityOption[] = [
   { label: 'Low', value: TicketPriority.LOW, icon: getPriorityIcon(TicketPriority.LOW) },
@@ -155,13 +132,11 @@ export const UNASSIGNED_OPTION: EntityOption = {
   ),
 };
 
-export const getStageOptions = (
-  stages: Array<{ id: string; name: string }> = [],
-): EntityOption[] => {
+export const getStageOptions = (stages: StageOptionSource[] = []): EntityOption[] => {
   return stages.map(stage => ({
     value: stage.name,
     label: stage.name,
-    icon: <TicketStatusIcon size={14} />,
+    icon: <StageIndicator stages={stages} stageName={stage.name} />,
   }));
 };
 
@@ -204,6 +179,6 @@ export const useAssigneeOptions = (
   }, [users, userGroups, memberIds, selfId]);
 };
 
-export const useStageOptions = (stages: Array<{ id: string; name: string }> = []) => {
+export const useStageOptions = (stages: StageOptionSource[] = []) => {
   return useMemo(() => getStageOptions(stages), [stages]);
 };

--- a/apps/dashboard/src/components/Tickets/TicketTable/TicketTableTypes.ts
+++ b/apps/dashboard/src/components/Tickets/TicketTable/TicketTableTypes.ts
@@ -15,6 +15,12 @@ export interface StatusEntityOption extends EntityOption {
   textColor: string;
 }
 
+export interface StageOptionSource {
+  id: string;
+  name: string;
+  defaultTicketStatusV2?: string | null;
+}
+
 export interface GenericCellEditorProps {
   value: string | null;
   onValueChange: (value: string | null) => void;
@@ -48,7 +54,7 @@ export interface StageCellEditorProps {
   value: string;
   onValueChange: (value: string) => void;
   stopEditing?: () => void;
-  stages?: Array<{ id: string; name: string }>;
+  stages?: StageOptionSource[];
   data?: { boardId?: string | null } | undefined;
 }
 

--- a/apps/dashboard/src/routes/ProjectDetailScreen/ReleasesSection.tsx
+++ b/apps/dashboard/src/routes/ProjectDetailScreen/ReleasesSection.tsx
@@ -78,6 +78,7 @@ export const ReleasesSection = ({ projectId }: ReleasesSectionProps): ReactEleme
                 <ReleaseStagePicker
                   ticketId={ticket.id}
                   stageName={ticket.stageName}
+                  statusV2={ticket.statusV2}
                   boardId={ticket.boardId}
                   stages={stagesByBoard.get(ticket.boardId) ?? []}
                 />

--- a/apps/dashboard/src/routes/ReleaseDetailScreen/ReleaseDetailScreen.tsx
+++ b/apps/dashboard/src/routes/ReleaseDetailScreen/ReleaseDetailScreen.tsx
@@ -854,6 +854,7 @@ const ReleaseDetailScreen = (): ReactElement => {
                   <ReleaseStagePicker
                     ticketId={releaseTicket.id}
                     stageName={releaseTicket.stageName}
+                    statusV2={releaseTicket.statusV2}
                     boardId={releaseTicket.boardId}
                     stages={stagesByBoard.get(releaseTicket.boardId) ?? []}
                   />

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -1666,6 +1666,7 @@ const SupportScreen = (): ReactElement => {
     channelId: string;
     conversationId: string;
     stageName?: string | null | undefined;
+    statusV2?: string | null | undefined;
     priority?: string | null | undefined;
     assignedTo?: string | null | undefined;
     userGroupId?: string | null | undefined;
@@ -1695,6 +1696,7 @@ const SupportScreen = (): ReactElement => {
       channelId: string;
       conversationId: string;
       stageName?: string | null | undefined;
+      statusV2?: string | null | undefined;
       priority?: string | null | undefined;
       assignedTo?: string | null | undefined;
       userGroupId?: string | null | undefined;
@@ -1716,6 +1718,7 @@ const SupportScreen = (): ReactElement => {
             channelId: row.channelId,
             conversationId: row.conversationId,
             stageName: row.stageName,
+            statusV2: row.statusV2,
             priority: row.priority,
             assignedTo: row.assignedTo,
             userGroupId: row.userGroupId,
@@ -1757,6 +1760,7 @@ const SupportScreen = (): ReactElement => {
         channelId: string;
         conversationId: string;
         stageName?: string | null | undefined;
+        statusV2?: string | null | undefined;
         priority?: string | null | undefined;
         assignedTo?: string | null | undefined;
         userGroupId?: string | null | undefined;
@@ -1779,6 +1783,7 @@ const SupportScreen = (): ReactElement => {
               channelId: row.channelId,
               conversationId: row.conversationId,
               stageName: row.stageName,
+              statusV2: row.statusV2,
               priority: row.priority,
               assignedTo: row.assignedTo,
               userGroupId: row.userGroupId,
@@ -1815,6 +1820,7 @@ const SupportScreen = (): ReactElement => {
             channelId: ticket.channelId ?? '',
             conversationId: ticket.conversationId ?? '',
             stageName: ticket.stageName,
+            statusV2: ticket.statusV2,
             priority: ticket.priority,
             assignedTo: ticket.assignedTo,
             userGroupId: ticket.userGroupId,
@@ -1865,7 +1871,11 @@ const SupportScreen = (): ReactElement => {
     () =>
       deskBoardGatesStageMoves
         ? []
-        : availableStages.map(stage => ({ id: stage.name, name: stage.name })),
+        : availableStages.map(stage => ({
+            id: stage.name,
+            name: stage.name,
+            defaultTicketStatusV2: stage.status,
+          })),
     [availableStages, deskBoardGatesStageMoves],
   );
 

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -4919,6 +4919,7 @@ export const SupportTicketDetail = ({
                         ticketId={ticket.id}
                         stageName={ticket.stageName}
                         stageLabel={ticket.stageName || 'To Do'}
+                        statusV2={ticket.statusV2}
                         boardId={boardId}
                       />
                     </div>

--- a/apps/dashboard/src/utils/board/index.ts
+++ b/apps/dashboard/src/utils/board/index.ts
@@ -54,3 +54,11 @@ export {
   createBulkOptionInputHandlers,
   resolveBulkOptions,
 } from './formFieldOptionsUtils';
+
+export {
+  STAGE_STATUS_META,
+  getStageStatusMeta,
+  StageStatusIcon,
+  StageIndicator,
+  type StageIndicatorStage,
+} from './stageStatusIcon';

--- a/apps/dashboard/src/utils/board/stageStatusIcon.tsx
+++ b/apps/dashboard/src/utils/board/stageStatusIcon.tsx
@@ -1,0 +1,117 @@
+import type { ComponentType, ReactElement } from 'react';
+import { TicketStatusV2 } from '@xyne/shared';
+import {
+  CheckTickCircle,
+  CircleDashed,
+  CircleDot,
+  MultipleCrossCancelCircle,
+  PauseCircle,
+} from '@xyne/icons';
+import { StatusIndicator } from '../../components/Board/StatusIndicator';
+
+interface StageStatusMeta {
+  label: string;
+  Icon: ComponentType<{ strokeWidth?: number; className?: string; style?: React.CSSProperties }>;
+  cssVar: string;
+  bgColor: string;
+  textColor: string;
+}
+
+export const STAGE_STATUS_META: Record<TicketStatusV2, StageStatusMeta> = {
+  [TicketStatusV2.TODO]: {
+    label: 'Todo',
+    Icon: CircleDashed,
+    cssVar: 'var(--status-new)',
+    bgColor: 'bg-orange-500/15',
+    textColor: 'text-orange-600',
+  },
+  [TicketStatusV2.STARTED]: {
+    label: 'Started',
+    Icon: CircleDot,
+    cssVar: 'var(--status-scheduled)',
+    bgColor: 'bg-blue-500/15',
+    textColor: 'text-blue-600',
+  },
+  [TicketStatusV2.PAUSED]: {
+    label: 'Paused',
+    Icon: PauseCircle,
+    cssVar: 'var(--status-paused)',
+    bgColor: 'bg-teal-500/15',
+    textColor: 'text-teal-600',
+  },
+  [TicketStatusV2.CANCELLED]: {
+    label: 'Cancelled',
+    Icon: MultipleCrossCancelCircle,
+    cssVar: 'var(--status-failure)',
+    bgColor: 'bg-red-500/15',
+    textColor: 'text-red-600',
+  },
+  [TicketStatusV2.COMPLETED]: {
+    label: 'Completed',
+    Icon: CheckTickCircle,
+    cssVar: 'var(--status-success)',
+    bgColor: 'bg-green-500/15',
+    textColor: 'text-green-600',
+  },
+};
+
+export const getStageStatusMeta = (status: string | null | undefined): StageStatusMeta =>
+  STAGE_STATUS_META[status as TicketStatusV2] ?? STAGE_STATUS_META[TicketStatusV2.TODO];
+
+export const StageStatusIcon = ({
+  status,
+}: {
+  status: string | null | undefined;
+}): ReactElement => {
+  const { Icon, cssVar } = getStageStatusMeta(status);
+  return <Icon strokeWidth={2.5} className='w-3.5 h-3.5 shrink-0' style={{ color: cssVar }} />;
+};
+
+const resolveStageStatus = (
+  stages: readonly StageIndicatorStage[] | null | undefined,
+  stageName: string | null | undefined,
+  fallbackStatus?: string | null,
+): string | null | undefined =>
+  stages?.find(s => s.name === stageName)?.defaultTicketStatusV2 ?? fallbackStatus;
+
+export interface StageIndicatorStage {
+  name: string;
+  defaultTicketStatusV2?: string | null;
+}
+
+// Mirrors LinearStageCard in BoardStageConfigScreen: on a linear board the fill
+// comes from the stage's position among the stages that carry progress. A
+// non-linear board has no such order, and its editor shows the flat status-only
+// fill, so position is withheld there to match.
+export const StageIndicator = ({
+  stages,
+  stageName,
+  fallbackStatus,
+  isNonLinearBoard = false,
+  size = 14,
+}: {
+  stages: readonly StageIndicatorStage[] | null | undefined;
+  stageName: string | null | undefined;
+  fallbackStatus?: string | null | undefined;
+  isNonLinearBoard?: boolean;
+  size?: number;
+}): ReactElement => {
+  const activeStages = isNonLinearBoard
+    ? []
+    : (stages ?? []).filter(
+        s =>
+          s.defaultTicketStatusV2 !== TicketStatusV2.TODO &&
+          s.defaultTicketStatusV2 !== TicketStatusV2.CANCELLED,
+      );
+  const stageIndexInActive = activeStages.findIndex(s => s.name === stageName);
+  const status = resolveStageStatus(stages, stageName, fallbackStatus);
+
+  return (
+    <StatusIndicator
+      status={(status as TicketStatusV2) ?? TicketStatusV2.TODO}
+      size={size}
+      stageIndex={stageIndexInActive >= 0 ? stageIndexInActive : undefined}
+      totalNonCancelledStages={activeStages.length > 0 ? activeStages.length : undefined}
+    />
+  );
+};

--- a/apps/dashboard/src/utils/board/ticketPreviewUtils.tsx
+++ b/apps/dashboard/src/utils/board/ticketPreviewUtils.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { LayoutGrid, Folder, List } from 'lucide-react';
-import { TicketStatusIcon } from '../../components/Tickets/TicketStatus/TicketStatusIcon';
+import { TicketStatusV2 } from '@xyne/shared';
+import { StatusIndicator } from '../../components/Board/StatusIndicator';
 import type {
   PreviewField,
   CreateField,
@@ -80,7 +81,7 @@ export const renderPreviewFieldValue = (field: PreviewField): ReactNode => {
     case 'status':
       return (
         <>
-          <TicketStatusIcon size={14} progressPercentage={25} />
+          <StatusIndicator status={TicketStatusV2.STARTED} size={14} />
           <span className='text-[14px] text-muted-foreground'>User defined status</span>
         </>
       );


### PR DESCRIPTION


https://github.com/user-attachments/assets/3a009ac2-ab6b-4a3d-9396-c964f23da719



## Problem

The board designer and the ticket screen computed a stage's icon from two different variables, so they could never agree.

| | Input | Delivery board (4 stages, all configured "Started") |
|---|---|---|
| Board definition (`LinearStageCard` → `Board/StatusIndicator`) | stage **position**: `(index+1)/activeStages.length` | Triage ◔25% · In Progress ◑50% · In Review ◕75% · Done ●100% |
| Ticket screen (before) | **status category** only, from `ticket.statusV2` | one identical half-disc, four times |

`assets/icons/TicketStatusIcon` draws the same half-disc for every status — only its colour ever varied — so the shape could never match the configured icon. And it read `ticket.statusV2`, a snapshot stamped at stage-move time and independently editable as "Status Category" in the ticket table, so it also went stale whenever a stage was reconfigured.

## Fix

`StageIndicator` (`apps/dashboard/src/utils/board/stageStatusIcon.tsx`) reproduces the designer's own computation — position measured among the stages that carry progress, `TODO` and `CANCELLED` excluded — and every ticket surface renders through it:

- ticket detail Status row (trigger + read-only)
- related / mapped / parent ticket rows
- `StagePicker` trigger and menu
- table + bulk-bar stage pickers

Two correctness details:

- **Position is always computed against the board's full stage list**, never `selectorStages` / `reachableStages`. Those are filtered for reachability and would shift every index. Verified `stagesByBoard`, `getStagesByBoardIds` and `boardDetailById` all `orderBy('sequenceNumber', 'asc')`.
- **Non-linear boards withhold position.** `NonLinearTransitionEditor` passes no `stageIndex`, so its stages show a flat status-only fill; applying the linear formula there would have recreated this same bug on NON_LINEAR boards. `isNonLinearBoard` is threaded from `TicketDetails` and `StagePicker`.

## Also in this change

- `Board/StatusIndicator`: hardcoded hex (`#3B82F6`, `#EAB308`, …) → `var(--status-*)`. These icons now render on ticket cards and pickers, outside the config screens they were written for, and `--status-*` has real dark-theme variants. Side effect: PAUSED goes yellow → violet, matching `--status-paused` used everywhere else.
- Glyph, pie and label all read one `cssVar`, so a status looks the same wherever it appears.
- `statusV2` threaded through `SelectedTicket` / `SelectableRow` — the merge dialog was rendering **every** ticket as "Todo" because the selection map never captured a status.
- `StagePicker` accepts the ticket's status as a fallback for the cold-load window before the board's stages arrive.
- Board config's PAUSED glyph: lucide `Signature` → `PauseCircle` (looked like a typo).

## Testing

- `tsc --noEmit`, `eslint --quiet`, `prettier --check` clean on all 16 files.
- Before/after capture of the running local stack across three stages of the Delivery board (PLAT-23 Triage 1/4, PLAT-24 In Progress 2/4, PLAT-17 Done 4/4), same script/viewport/account/fixture with only the fix toggled. BEFORE renders the identical half-disc at all three; AFTER reproduces the board pipeline.

<!-- POT VIDEO: drag stage-icon-board-parity-POT.mp4 onto this line -->

## Known gaps (deliberately not in scope)

- `BoardStageConfigScreen`'s `LinearStageCard` still re-implements the active-stage filter locally instead of calling the shared helper — it matches stages by `tempId`, not name, so it needs an identity-based variant.
- `CreateTicketModal.tsx` keeps its own near-duplicate status option list.
- The ticket **activity feed** (`TicketActivityMessage.tsx`, `TicketActivity.tsx`) still renders the fixed half-disc for every stage transition, and collapses six activity types (including `STAGE_CHANGE_APPROVED` / `STAGE_CHANGE_REJECTED`) onto one icon. Fixing it needs the board's stages in a chat row.
- The pie divides by active stages while the adjacent "X/N" text divides by all stages; making them agree changes a displayed number and wants a product call.
- `getItemIcon` on the ticket-detail Status selector is inert — `EntitySelector.tsx:223` is `{!isStatusSelector && option.icon && …}` and `Selector` passes `isStatusSelector={true}`. Pre-existing, not a regression.
