### PR TITLE
fix: XYNE-62423 link replacement permission fix

### DIFF
--- a/apps/backend/src/services/calendarSyncConfig.ts
+++ b/apps/backend/src/services/calendarSyncConfig.ts
@@ -19,6 +19,8 @@ const EMPTY_ELIGIBILITY_CONFIG: TeamEligibilityConfig = { domains: [], teams: []
  * Single Superposition (CAC) key gating Xyne Call auto-injection eligibility
  * (see Xyne Call Link Auto-Injection PRD, FR-2). Value shape:
  *   { "domains": ["juspay.in"], "teams": ["Xyne"] }
+ * Both lists must be populated for the feature to act on anyone — an
+ * organizer must match an entry in each (see isTeamEligible).
  * Sourced from Superposition instead of a plain env var so it can be
  * toggled/rolled out without a redeploy. Missing, empty, malformed, or
  * unreachable config is treated as "feature disabled" — never throws.
@@ -49,21 +51,23 @@ export async function getTeamEligibilityConfig(): Promise<TeamEligibilityConfig>
 
 /**
  * Whether the given organizer is eligible for Xyne Call auto-injection:
- * eligible when either their email domain OR their UserProfile team
- * (case-insensitive) is present in the CAC-configured allowlist.
+ * eligible only when BOTH their email domain AND their UserProfile team
+ * (case-insensitive) are present in the CAC-configured allowlist. Fails
+ * closed — an organizer with no team, a domain outside the list, or either
+ * list left empty is not eligible.
  */
 export async function isTeamEligible(params: {
   email?: string | null;
   team?: string | null;
 }): Promise<boolean> {
   const { domains, teams } = await getTeamEligibilityConfig();
-  if (domains.length === 0 && teams.length === 0) return false;
+  if (domains.length === 0 || teams.length === 0) return false;
 
   const emailDomain = params.email?.trim().toLowerCase().split('@')[1];
-  if (emailDomain && domains.includes(emailDomain)) return true;
+  if (!emailDomain || !domains.includes(emailDomain)) return false;
 
   const team = params.team?.trim().toLowerCase();
-  if (team && teams.includes(team)) return true;
+  if (!team || !teams.includes(team)) return false;
 
-  return false;
+  return true;
 }

--- a/apps/backend/src/services/xyneCallLinkInjector.ts
+++ b/apps/backend/src/services/xyneCallLinkInjector.ts
@@ -3,7 +3,7 @@
  *
  * For every eligible event organized by a connected, allowlisted user:
  * creates/recovers a hosted Xyne Call, clears the existing (non-Xyne)
- * conference entry when every participant is internal (@juspay.in), and
+ * conference entry when every participant shares the organizer's domain, and
  * always upserts the managed description link. Ineligible/ambiguous events
  * pass through untouched. One event failing must never abort the batch
  * (PRD §9).
@@ -20,10 +20,12 @@
  *  2. The event's organizer email must equal the connected user's email —
  *     never patch an event where the user is only an attendee (FR-3).
  *  3. The organizer must be eligible per the Superposition-backed CAC config —
- *     either their email domain OR their UserProfile team is allowlisted (FR-2).
- * Internal-only vs external-participant classification (FR-4) is a
- * separate, hardcoded check against @juspay.in — distinct from the
- * allowlist above, which only gates whether Xyne acts on the event at all.
+ *     BOTH their email domain AND their UserProfile team must be allowlisted
+ *     (FR-2).
+ * Internal-only vs external-participant classification (FR-4) is a separate
+ * check — every attendee must share the organizer's own email domain —
+ * distinct from the allowlist above, which only gates whether Xyne acts on
+ * the event at all.
  */
 
 import { type GCalEvent } from '@/services/googleCalendarCallStore';
@@ -40,7 +42,6 @@ import { logger } from '@/utils/logger';
 
 const TAG = '[CALENDAR_SYNC][GOOGLE][XYNE_CALL_INJECTOR]';
 
-const INTERNAL_PARTICIPANT_DOMAIN = 'juspay.in';
 const SKIPPED_EVENT_TYPES = new Set(['outOfOffice', 'focusTime', 'workingLocation', 'fromGmail']);
 
 type SkipReason =
@@ -76,10 +77,17 @@ function isEligibleShape(event: GCalEvent): SkipReason | null {
   return null;
 }
 
-/** Every organizer + attendee email must resolve to the internal domain. */
+/**
+ * Every attendee must share the organizer's own email domain. The organizer
+ * defines what "internal" means for their event, so a Xyne-eligible organizer
+ * at any domain gets the same treatment without a hardcoded company domain.
+ * An organizer whose email has no resolvable domain is treated as not
+ * internal-only, so their existing conference entry is left untouched.
+ */
 export function isInternalOnly(event: GCalEvent): boolean {
-  const emails = [event.organizer?.email, ...(event.attendees ?? []).map((a) => a.email)];
-  return emails.every((email) => emailDomain(email) === INTERNAL_PARTICIPANT_DOMAIN);
+  const organizerDomain = emailDomain(event.organizer?.email);
+  if (!organizerDomain) return false;
+  return (event.attendees ?? []).every((a) => emailDomain(a.email) === organizerDomain);
 }
 
 /** FR-7: is this event already correctly reconciled, so no patch is needed? */


### PR DESCRIPTION
https://github.com/juspay/xyne-spaces/pull/1524

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
