### PR TITLE
fix: XYNE-61540 claw connector suggestions + agent copilot oauth

### DIFF
--- a/apps/xyne-claw-auth/backend/src/http/routes.ts
+++ b/apps/xyne-claw-auth/backend/src/http/routes.ts
@@ -37,6 +37,7 @@ import { sessionsArchiveRouter } from "../routes/sessions-archive.js";
 import { experimentsInternalRouter } from "../routes/experiments-internal.js";
 import { artifactAppsInternalRouter } from "../routes/artifact-apps-internal.js";
 import { errorPipelineIngestRouter, errorPipelineInternalRouter } from "../routes/error-pipeline.js";
+import { connectorsInternalRouter } from "../routes/connectors-internal.js";
 import { googleOAuthRouter, googleCallbackRouter } from "../routes/google-oauth.js";
 import { microsoftOAuthRouter, microsoftCallbackRouter } from "../routes/microsoft-oauth.js";
 import { calendlyOAuthRouter, calendlyCallbackRouter } from "../routes/calendly-oauth.js";
@@ -171,6 +172,7 @@ function mountCoreApi(app: Express): void {
   app.use(`${BASE}/error-pipeline`, errorPipelineIngestRouter); // Grafana webhook ingest (JWT-authed inside)
   app.use(`${BASE}/internal/error-pipeline`, requireStrictS2S, errorPipelineInternalRouter); // run-result callback from xyne-claw (S2S only)
   app.use(`${BASE}/internal/tts`, requireStrictS2S, ttsRouter);
+  app.use(`${BASE}/internal/connectors`, requireStrictS2S, connectorsInternalRouter); // connector availability lookup for xyne-claw (S2S only)
 }
 
 function mountOAuthProviders(app: Express): void {

--- a/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
@@ -4,6 +4,7 @@ import { encrypt } from "../crypto.js";
 import { CONFIG } from "../config.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "./oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -126,7 +127,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
 
   router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req: Request<{ userId: string }>, res: Response) => {
     const { userId } = req.params;
-    const { redirectUri } = req.body as { redirectUri?: string };
+    const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 
     const callbackUri = redirectUri ?? `${process.env["AUTH_SERVICE_URL"] ?? "http://localhost:3003"}/claw/api/v1/${type}/callback`;
 
@@ -138,7 +139,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
     url.searchParams.set("response_type", "code");
     url.searchParams.set("scope", config.scope);
     for (const [k, v] of Object.entries(config.extraAuthParams ?? {})) url.searchParams.set(k, v);
-    url.searchParams.set("state", signOAuthState(userId));
+    url.searchParams.set("state", signOAuthState(userId, { returnTo: resolveOAuthReturn(returnTo) }));
 
     ok(res, { authUrl: url.toString() });
   }));
@@ -161,29 +162,34 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
   const callbackRouter = Router();
 
   callbackRouter.get(`/${type}/callback`, async (req: Request, res: Response) => {
-    const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+    // Stays the default until the state is verified below: an unverified state
+    // must never steer the redirect.
+    let frontendUrl = defaultOAuthReturn();
 
     try {
       const { code, state, error: oauthError } = req.query as { code?: string; state?: string; error?: string };
 
       if (oauthError) {
         log.error(`[${type}-oauth] OAuth error: ${oauthError}`);
-        res.redirect(`${frontendUrl}?${type}_error=${encodeURIComponent(oauthError)}`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, oauthError));
         return;
       }
 
       if (!code || !state) {
-        res.redirect(`${frontendUrl}?${type}_error=missing_code_or_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "missing_code_or_state"));
         return;
       }
 
       let userId: string;
       try {
-        userId = verifyOAuthState(state).userId;
+        const verified = verifyOAuthState(state);
+        userId = verified.userId;
+        // Signed, so this is the origin that actually started the flow.
+        frontendUrl = resolveOAuthReturn(verified.extra?.["returnTo"]);
       } catch (err) {
         const reason = err instanceof OAuthStateError ? err.reason : "malformed";
         log.error(`[${type}-oauth] state ${reason}`);
-        res.redirect(`${frontendUrl}?${type}_error=invalid_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "invalid_state"));
         return;
       }
 
@@ -193,7 +199,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
       try {
         creds = await exchangeCode(code, redirectUri);
       } catch {
-        res.redirect(`${frontendUrl}?${type}_error=token_exchange_failed`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "token_exchange_failed"));
         return;
       }
 
@@ -203,7 +209,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
         const user = await prisma.user.findUnique({ where: { id: userId } });
         if (!user) {
           log.error(`[${type}-oauth] User not found: ${userId}`);
-          res.redirect(`${frontendUrl}?${type}_error=user_not_found`);
+          res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "user_not_found"));
           return;
         }
       }
@@ -211,10 +217,10 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
       await storeTokens(userId, creds);
 
       log.info(`[${type}-oauth] Stored ${label} credentials for user ${userId} via browser callback`);
-      res.redirect(`${frontendUrl}?${type}_connected=true`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_connected`, "true"));
     } catch (err) {
       log.error(`[${type}-oauth] browser callback error:`, err);
-      res.redirect(`${frontendUrl}?${type}_error=internal_error`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "internal_error"));
     }
   });
 

--- a/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
@@ -32,6 +32,7 @@ export interface ConnectorHint {
   domains?: readonly string[];
   /** Whole-word prose signals, lowercase. */
   keywords?: readonly string[];
+  connectKeywords?: readonly string[];
 }
 
 export const CONNECTOR_HINTS: readonly ConnectorHint[] = [
@@ -41,11 +42,13 @@ export const CONNECTOR_HINTS: readonly ConnectorHint[] = [
     serverType: "google",
     domains: ["docs.google.com", "drive.google.com", "sheets.google.com", "mail.google.com"],
     keywords: ["gmail", "google doc", "google docs", "google drive", "google sheet", "google sheets", "google calendar", "google meet"],
+    connectKeywords: ["google", "google workspace"],
   },
   {
     serverType: "microsoft",
     domains: ["outlook.com", "outlook.office.com", "sharepoint.com"],
     keywords: ["onedrive", "outlook", "teams", "sharepoint"],
+    connectKeywords: ["microsoft", "microsoft 365", "office 365"],
   },
   { serverType: "slack", domains: ["slack.com"], keywords: ["slack"] },
   { serverType: "notion", domains: ["notion.so"], keywords: ["notion"] },
@@ -121,6 +124,7 @@ function keywordIndex(text: string, keyword: string): number {
 /** Connector types the text implies, in the order they first appear. */
 export interface ConnectorMatchOptions {
   includeKeywords?: boolean;
+  includeConnectKeywords?: boolean;
 }
 
 export function connectorTypesFromText(
@@ -144,11 +148,13 @@ export function connectorTypesFromText(
       }
     }
 
-    if (options.includeKeywords) {
-      for (const keyword of hint.keywords ?? []) {
-        const at = keywordIndex(prose, keyword);
-        if (at >= 0 && (earliest === -1 || at < earliest)) earliest = at;
-      }
+    const prosePatterns = [
+      ...(options.includeKeywords ? (hint.keywords ?? []) : []),
+      ...(options.includeConnectKeywords ? (hint.connectKeywords ?? []) : []),
+    ];
+    for (const keyword of prosePatterns) {
+      const at = keywordIndex(prose, keyword);
+      if (at >= 0 && (earliest === -1 || at < earliest)) earliest = at;
     }
 
     if (earliest >= 0) hits.push({ serverType: hint.serverType, at: earliest });
@@ -167,13 +173,17 @@ export function connectorTypesFromText(
 const CONNECT_INTENT =
   /\b(re)?connect(ed|ing|ion|ions)?\b|\bauthori[sz]e\b|\bintegrate\b|\bset ?up\b|\bsign in\b|\blog in\b|\bhook up\b/i;
 
+const SHOW_CONNECTOR_INTENT =
+  /\b(show|see|view|open|display|list|find|bring up|pull up)\b[^.?!\n]{0,60}\b(connector|connectors|mcp|mcps|integration|integrations)\b/i;
+
 /**
- * Connector types the HUMAN explicitly asked to connect, read from their own
- * message. The model cannot be trusted to report this: it has an incentive to
- * claim explicit intent so its card is shown, and has been observed doing so
- * for plain task requests.
+ * Connector types the HUMAN explicitly asked for, read from their own message —
+ * either to connect one or to be shown one. The model cannot be trusted to
+ * report this: it has an incentive to claim explicit intent so its card is
+ * shown, and has been observed doing so for plain task requests.
  */
-export function connectorTypesUserAskedToConnect(text: string): string[] {
-  if (!text.trim() || !CONNECT_INTENT.test(text)) return [];
-  return connectorTypesFromText(text, { includeKeywords: true });
+export function connectorTypesUserAskedFor(text: string): string[] {
+  if (!text.trim()) return [];
+  if (!CONNECT_INTENT.test(text) && !SHOW_CONNECTOR_INTENT.test(text)) return [];
+  return connectorTypesFromText(text, { includeKeywords: true, includeConnectKeywords: true });
 }

--- a/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
@@ -7,6 +7,7 @@ import { syncToolsForServer } from "../tool-sync.js";
 import { evictSession } from "../mcp/runner.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState } from "./oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -52,6 +53,8 @@ interface StatePayload {
   clientSecret?: string | undefined;
   codeVerifier: string;
   redirectUri: string;
+  /** Where the UI that started this flow wants the browser sent back to. */
+  returnTo?: string;
 }
 
 export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider {
@@ -199,7 +202,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
 
   router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req, res) => {
     const { userId } = req.params as { userId: string };
-    const { redirectUri, scope } = req.body as { redirectUri?: string; scope?: string };
+    const { redirectUri, scope, returnTo } = req.body as { redirectUri?: string; scope?: string; returnTo?: string };
 
     const callbackUri =
       redirectUri ??
@@ -210,7 +213,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = deriveCodeChallenge(codeVerifier);
 
-    const state = encodeState({ userId, clientId, ...(confidential ? { clientSecret } : {}), codeVerifier, redirectUri: callbackUri });
+    const state = encodeState({ userId, clientId, ...(confidential ? { clientSecret } : {}), codeVerifier, redirectUri: callbackUri, returnTo: resolveOAuthReturn(returnTo) });
 
     const url = new URL(authUrl);
     url.searchParams.set("client_id", clientId);
@@ -268,19 +271,21 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
   const callbackRouter = Router();
 
   callbackRouter.get(`/${type}/callback`, async (req: Request, res: Response) => {
-    const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+    // Default until the state verifies below — an unverified state must never
+    // steer the redirect.
+    let frontendUrl = defaultOAuthReturn();
 
     try {
       const { code, state, error: oauthError } = req.query as { code?: string; state?: string; error?: string };
 
       if (oauthError) {
         log.error(`[${type}-oauth] OAuth error: ${oauthError}`);
-        res.redirect(`${frontendUrl}?${type}_error=${encodeURIComponent(oauthError)}`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, oauthError));
         return;
       }
 
       if (!code || !state) {
-        res.redirect(`${frontendUrl}?${type}_error=missing_code_or_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "missing_code_or_state"));
         return;
       }
 
@@ -288,11 +293,12 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
       try {
         statePayload = decodeState(state);
       } catch {
-        res.redirect(`${frontendUrl}?${type}_error=invalid_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "invalid_state"));
         return;
       }
 
       const { userId, clientId, clientSecret, codeVerifier, redirectUri } = statePayload;
+      frontendUrl = resolveOAuthReturn(statePayload.returnTo);
 
       const tokenRes = await fetch(tokenUrl, {
         method: "POST",
@@ -303,7 +309,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
       if (!tokenRes.ok) {
         const text = await tokenRes.text();
         log.error(`[${type}-oauth] Browser callback token exchange failed: ${tokenRes.status} ${text}`);
-        res.redirect(`${frontendUrl}?${type}_error=token_exchange_failed`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "token_exchange_failed"));
         return;
       }
 
@@ -312,17 +318,17 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
       const user = await prisma.user.findUnique({ where: { id: userId } });
       if (!user) {
         log.error(`[${type}-oauth] User not found: ${userId}`);
-        res.redirect(`${frontendUrl}?${type}_error=user_not_found`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "user_not_found"));
         return;
       }
 
       await storeTokens(userId, clientId, clientSecret, tokens.access_token, tokens.refresh_token, tokens.expires_in);
 
       log.info(`[${type}-oauth] Stored ${label} credentials for user ${userId} via browser callback`);
-      res.redirect(`${frontendUrl}?${type}_connected=true`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_connected`, "true"));
     } catch (err) {
       log.error(`[${type}-oauth] browser callback error:`, err);
-      res.redirect(`${frontendUrl}?${type}_error=internal_error`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "internal_error"));
     }
   });
 

--- a/apps/xyne-claw-auth/backend/src/lib/oauth-return.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/oauth-return.ts
@@ -1,0 +1,100 @@
+/**
+ * Post-OAuth return targets.
+ *
+ * Every OAuth callback used to redirect to a single global FRONTEND_URL (the
+ * claw SPA), so a flow started from Spaces finished on claw's home page and the
+ * user lost their place. The starting UI can now pass `returnTo`; the callback
+ * sends the browser back there instead.
+ *
+ * The value is a HINT, never trusted: it arrives from the browser and is acted
+ * on immediately after a credential is minted, so an unvalidated one is an open
+ * redirect handing an attacker the "connected" landing. Anything that isn't an
+ * allowed origin silently falls back to the old FRONTEND_URL behaviour.
+ */
+
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("oauth-return");
+
+function originOf(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Origins a post-OAuth redirect may target. */
+function allowedOrigins(): Set<string> {
+  const configured = (process.env["OAUTH_RETURN_ORIGINS"] ?? "")
+    .split(",")
+    .map((entry) => originOf(entry.trim()))
+    .filter((entry): entry is string => !!entry);
+
+  return new Set(
+    [
+      originOf(CONFIG.frontendUrl),
+      originOf(CONFIG.spacesAppUrl),
+      ...configured,
+    ].filter((entry): entry is string => !!entry),
+  );
+}
+
+/**
+ * Dev convenience: the local dashboard (:5173) is not any configured origin —
+ * SPACES_APP_URL points at the API (:3001) — so a localhost return would fall
+ * back to claw and the flow would look broken on every developer's machine.
+ * Production stays strictly on the allowlist.
+ */
+function isDevLoopback(origin: string): boolean {
+  if (process.env["NODE_ENV"] === "production") return false;
+  return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+}
+
+/** The default target — exactly what every callback did before `returnTo`. */
+export function defaultOAuthReturn(): string {
+  return process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+}
+
+/**
+ * Validate a client-supplied `returnTo`. Returns the default whenever it is
+ * absent, unparseable, or points somewhere we don't serve.
+ */
+export function resolveOAuthReturn(candidate: unknown): string {
+  if (typeof candidate !== "string" || candidate.trim().length === 0) {
+    return defaultOAuthReturn();
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate.trim());
+  } catch {
+    log.warn("[oauth-return] ignoring unparseable returnTo");
+    return defaultOAuthReturn();
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    log.warn(`[oauth-return] ignoring returnTo with protocol ${parsed.protocol}`);
+    return defaultOAuthReturn();
+  }
+  if (!allowedOrigins().has(parsed.origin) && !isDevLoopback(parsed.origin)) {
+    log.warn(`[oauth-return] ignoring returnTo outside the allowlist: ${parsed.origin}`);
+    return defaultOAuthReturn();
+  }
+  return parsed.toString();
+}
+
+/**
+ * Append the connected/error marker the UIs poll for. Uses URL rather than
+ * string concatenation because a returnTo legitimately carries its own query
+ * (e.g. /ai/library?tab=agents) and `?x=y` would corrupt it.
+ */
+export function withOAuthResult(base: string, key: string, value: string): string {
+  try {
+    const url = new URL(base);
+    url.searchParams.set(key, value);
+    return url.toString();
+  } catch {
+    return `${base}?${key}=${encodeURIComponent(value)}`;
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -3915,6 +3915,129 @@ router.post(
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Agent-level GitHub Copilot device-code login. Mirrors the user-level flow in
+// settings.ts, but stores the token as an AGENT credential so every run of this
+// agent uses it, rather than binding it to the person who signed in.
+//
+// Note this spends the signing-in user's Copilot seat on behalf of everyone who
+// runs the agent — unlike Claude/ChatGPT team accounts, Copilot is licensed per
+// user. Owner-or-admin only, and the acting user is recorded on the credential.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AGENT_COPILOT_DEVICE_PREFIX = "gh-device-agent:";
+
+router.post(
+  "/:slug/provider-credentials/copilot/github-login",
+  requireAgentOwnerOrAdmin,
+  async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const agent = req.agentContext!.agent;
+      const ghRes = await fetch(GITHUB_DEVICE_CODE_URL, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: new URLSearchParams({ client_id: GITHUB_CLIENT_ID, scope: "read:user" }),
+      });
+      if (!ghRes.ok) {
+        const text = await ghRes.text().catch(() => "");
+        res.status(502).json({ success: false, error: `GitHub error: ${text.slice(0, 200)}` });
+        return;
+      }
+      const data = (await ghRes.json()) as {
+        device_code: string;
+        user_code: string;
+        verification_uri: string;
+        expires_in: number;
+        interval: number;
+      };
+      const redis = redisService.getConnection();
+      await redis.set(
+        `${AGENT_COPILOT_DEVICE_PREFIX}${agent.id}`,
+        JSON.stringify({ device_code: data.device_code, interval: data.interval }),
+        "EX",
+        DEVICE_CODE_TTL,
+      );
+      res.json({
+        success: true,
+        data: {
+          userCode: data.user_code,
+          verificationUri: data.verification_uri,
+          expiresIn: data.expires_in,
+          interval: data.interval,
+        },
+      });
+    } catch (err) {
+      log.error("[agents] copilot/github-login error:", err);
+      res.status(500).json({ success: false, error: "Failed to initiate GitHub login" });
+    }
+  },
+);
+
+router.post(
+  "/:slug/provider-credentials/copilot/github-poll",
+  requireAgentOwnerOrAdmin,
+  async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const agent = req.agentContext!.agent;
+      const requesterId = getRequesterId(req);
+      const key = `${AGENT_COPILOT_DEVICE_PREFIX}${agent.id}`;
+      const redis = redisService.getConnection();
+      const raw = await redis.get(key);
+      if (!raw) {
+        res.status(400).json({ success: false, error: "No pending login — start again" });
+        return;
+      }
+      const { device_code } = JSON.parse(raw) as { device_code: string };
+
+      const ghRes = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: new URLSearchParams({
+          client_id: GITHUB_CLIENT_ID,
+          device_code,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      });
+      const data = (await ghRes.json()) as {
+        access_token?: string;
+        error?: string;
+        error_description?: string;
+      };
+
+      if (data.access_token) {
+        const encrypted = encrypt(data.access_token, CONFIG.encryptionKey);
+        await agentProviderCredentialsRepository.upsert(agent.id, "copilot", {
+          encryptedKey: encrypted.ciphertext,
+          iv: encrypted.iv,
+          authTag: encrypted.authTag,
+          authType: "oauth_token",
+          baseUrl: "https://api.githubcopilot.com",
+          ...(requesterId ? { createdByUserId: requesterId } : {}),
+        });
+        await redis.del(key);
+        res.json({ success: true, data: { status: "approved" } });
+        return;
+      }
+      if (data.error === "authorization_pending") {
+        res.json({ success: true, data: { status: "pending" } });
+        return;
+      }
+      if (data.error === "slow_down") {
+        res.json({ success: true, data: { status: "slow_down" } });
+        return;
+      }
+      await redis.del(key);
+      res.status(400).json({
+        success: false,
+        error: data.error_description ?? data.error ?? "Authorization failed",
+      });
+    } catch (err) {
+      log.error("[agents] copilot/github-poll error:", err);
+      res.status(500).json({ success: false, error: "GitHub login failed" });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Agent-level Codex model list — mirror of `/settings/codex/models` but reads
 // the agent-scoped credential. ChatGPT OAuth tokens cannot hit OpenAI's
 // `/v1/models` (missing `api.model.read` scope, returns 403); Codex CLI works

--- a/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
@@ -1,0 +1,38 @@
+import { Router, type Request, type Response } from "express";
+import { availableServerTypesSafe } from "../lib/connector-availability.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("connectors-internal");
+
+const MAX_TYPES = 12;
+
+export const connectorsInternalRouter = Router();
+
+connectorsInternalRouter.post("/available", async (req: Request, res: Response) => {
+  const body = (req.body ?? {}) as { userId?: unknown; serverTypes?: unknown };
+  const userId = typeof body.userId === "string" ? body.userId.trim() : "";
+  const serverTypes = Array.isArray(body.serverTypes)
+    ? [
+        ...new Set(
+          body.serverTypes
+            .filter((t): t is string => typeof t === "string")
+            .map((t) => t.trim().toLowerCase())
+            .filter((t) => t.length > 0),
+        ),
+      ].slice(0, MAX_TYPES)
+    : [];
+
+  if (!userId || serverTypes.length === 0) {
+    res.json({ success: true, connected: [], known: false });
+    return;
+  }
+
+  const available = await availableServerTypesSafe(userId, serverTypes);
+  if (!available) {
+    log.warn(`[connectors-internal] availability unknown for user ${userId}`);
+    res.json({ success: true, connected: [], known: false });
+    return;
+  }
+
+  res.json({ success: true, connected: serverTypes.filter((t) => available.has(t)), known: true });
+});

--- a/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
@@ -33,6 +33,7 @@ import {
   getDocuSignClientCredentials,
 } from "../lib/docusign-config.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
 
 import { createLogger } from "../logger.js";
@@ -157,7 +158,7 @@ export const docusignOAuthProvider: OAuthTokenProvider = {
  */
 router.post("/:userId/oauth/docusign/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
-  const { redirectUri } = req.body as { redirectUri?: string };
+  const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 
   const callbackUri = redirectUri ?? defaultCallbackUri();
 
@@ -168,7 +169,7 @@ router.post("/:userId/oauth/docusign/authorize", asyncHandler(async (req: Reques
   authUrl.searchParams.set("redirect_uri", callbackUri);
   authUrl.searchParams.set("response_type", "code");
   authUrl.searchParams.set("scope", DOCUSIGN_SCOPES);
-  authUrl.searchParams.set("state", signOAuthState(userId, { redirectUri: callbackUri }));
+  authUrl.searchParams.set("state", signOAuthState(userId, { redirectUri: callbackUri, returnTo: resolveOAuthReturn(returnTo) }));
 
   ok(res, { authUrl: authUrl.toString() });
 }));
@@ -217,7 +218,9 @@ router.post("/:userId/oauth/docusign/callback", asyncHandler(async (req: Request
 export const docusignCallbackRouter = Router();
 
 docusignCallbackRouter.get("/docusign/callback", async (req: Request, res: Response) => {
-  const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+  // Default until the state verifies below — an unverified state must never
+  // steer the redirect.
+  let frontendUrl = defaultOAuthReturn();
 
   try {
     const { code, state, error: oauthError } = req.query as {
@@ -228,12 +231,12 @@ docusignCallbackRouter.get("/docusign/callback", async (req: Request, res: Respo
 
     if (oauthError) {
       log.error(`[docusign-oauth] OAuth error: ${oauthError}`);
-      res.redirect(`${frontendUrl}?docusign_error=${encodeURIComponent(oauthError)}`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", oauthError));
       return;
     }
 
     if (!code || !state) {
-      res.redirect(`${frontendUrl}?docusign_error=missing_code_or_state`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", "missing_code_or_state"));
       return;
     }
 
@@ -243,30 +246,31 @@ docusignCallbackRouter.get("/docusign/callback", async (req: Request, res: Respo
     } catch (err) {
       const reason = err instanceof OAuthStateError ? err.reason : "malformed";
       log.error(`[docusign-oauth] state ${reason}`);
-      res.redirect(`${frontendUrl}?docusign_error=invalid_state`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", "invalid_state"));
       return;
     }
 
     const userId = verified.userId;
+    frontendUrl = resolveOAuthReturn(verified.extra?.["returnTo"]);
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
       log.error(`[docusign-oauth] User not found: ${userId}`);
-      res.redirect(`${frontendUrl}?docusign_error=user_not_found`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", "user_not_found"));
       return;
     }
 
     const redirectUri = (verified.extra?.["redirectUri"] as string | undefined) ?? defaultCallbackUri();
     const result = await exchangeAndStore(userId, code, redirectUri);
     if (!result.ok) {
-      res.redirect(`${frontendUrl}?docusign_error=${encodeURIComponent(result.code)}`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", result.code));
       return;
     }
 
     log.info(`[docusign-oauth] Stored DocuSign credentials for user ${userId} (accountId: ${result.accountId})`);
-    res.redirect(`${frontendUrl}?docusign_connected=true`);
+    res.redirect(withOAuthResult(frontendUrl, "docusign_connected", "true"));
   } catch (err) {
     log.error("[docusign-oauth] browser callback error:", err);
-    res.redirect(`${frontendUrl}?docusign_error=internal_error`);
+    res.redirect(withOAuthResult(frontendUrl, "docusign_error", "internal_error"));
   }
 });
 

--- a/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
@@ -25,6 +25,7 @@ import { CONFIG } from "../config.js";
 import { syncToolsForServer } from "../tool-sync.js";
 import { evictSession } from "../mcp/runner.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "../lib/oauth-token-endpoint.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
@@ -150,7 +151,7 @@ export const egnyteOAuthProvider: OAuthTokenProvider = {
  */
 router.post("/:userId/oauth/egnyte/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
-  const { redirectUri } = req.body as { redirectUri?: string };
+  const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 
   const envDomain = process.env["EGNYTE_DOMAIN"];
   if (!envDomain || envDomain.trim().length === 0) {
@@ -167,7 +168,7 @@ router.post("/:userId/oauth/egnyte/authorize", asyncHandler(async (req: Request<
   const callbackUri = redirectUri ?? defaultCallbackUri();
 
   // Encode the domain into the signed state so the callback can use it.
-  const state = signOAuthState(userId, { domain: normalizedDomain, redirectUri: callbackUri });
+  const state = signOAuthState(userId, { domain: normalizedDomain, redirectUri: callbackUri, returnTo: resolveOAuthReturn(returnTo) });
 
   const authUrl = new URL(egnyteAuthUrl(normalizedDomain));
   authUrl.searchParams.set("client_id", clientId);
@@ -228,7 +229,9 @@ router.post("/:userId/oauth/egnyte/callback", asyncHandler(async (req: Request<{
 export const egnyteCallbackRouter = Router();
 
 egnyteCallbackRouter.get("/egnyte/callback", async (req: Request, res: Response) => {
-  const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+  // Default until the state verifies below — an unverified state must never
+  // steer the redirect.
+  let frontendUrl = defaultOAuthReturn();
 
   try {
     const { code, state, error: oauthError } = req.query as {
@@ -239,12 +242,12 @@ egnyteCallbackRouter.get("/egnyte/callback", async (req: Request, res: Response)
 
     if (oauthError) {
       log.error(`[egnyte-oauth] OAuth error: ${oauthError}`);
-      res.redirect(`${frontendUrl}?egnyte_error=${encodeURIComponent(oauthError)}`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", oauthError));
       return;
     }
 
     if (!code || !state) {
-      res.redirect(`${frontendUrl}?egnyte_error=missing_code_or_state`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "missing_code_or_state"));
       return;
     }
 
@@ -254,37 +257,38 @@ egnyteCallbackRouter.get("/egnyte/callback", async (req: Request, res: Response)
     } catch (err) {
       const reason = err instanceof OAuthStateError ? err.reason : "malformed";
       log.error(`[egnyte-oauth] state ${reason}`);
-      res.redirect(`${frontendUrl}?egnyte_error=invalid_state`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "invalid_state"));
       return;
     }
 
     const userId = verified.userId;
+    frontendUrl = resolveOAuthReturn(verified.extra?.["returnTo"]);
     const domain = verified.extra?.["domain"] as string | undefined;
     const redirectUri = (verified.extra?.["redirectUri"] as string | undefined) ?? defaultCallbackUri();
 
     if (!domain) {
-      res.redirect(`${frontendUrl}?egnyte_error=missing_domain_in_state`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "missing_domain_in_state"));
       return;
     }
 
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
       log.error(`[egnyte-oauth] User not found: ${userId}`);
-      res.redirect(`${frontendUrl}?egnyte_error=user_not_found`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "user_not_found"));
       return;
     }
 
     const result = await exchangeAndStore(userId, code, domain, redirectUri);
     if (!result.ok) {
-      res.redirect(`${frontendUrl}?egnyte_error=${encodeURIComponent(result.code)}`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", result.code));
       return;
     }
 
     log.info(`[egnyte-oauth] Stored Egnyte credentials for user ${userId} (domain: ${domain}.egnyte.com)`);
-    res.redirect(`${frontendUrl}?egnyte_connected=true`);
+    res.redirect(withOAuthResult(frontendUrl, "egnyte_connected", "true"));
   } catch (err) {
     log.error("[egnyte-oauth] browser callback error:", err);
-    res.redirect(`${frontendUrl}?egnyte_error=internal_error`);
+    res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "internal_error"));
   }
 });
 

--- a/apps/xyne-claw-auth/backend/src/routes/settings.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/settings.ts
@@ -23,7 +23,7 @@ const log = createLogger("settings");
 
 const router = Router();
 
-const VALID_PROVIDERS = new Set(["spaces", "copilot", "claude", "codex", "litellm"]);
+const VALID_PROVIDERS = new Set(["spaces", "copilot", "claude", "codex", "openrouter", "litellm"]);
 
 const GITHUB_CLIENT_ID = "Ov23li8tweQw6odWQebz";
 const GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code";

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -149,7 +149,7 @@ import { isAgentInvocableBy } from "xyne-claw-shared";
 import { isSupportedInboundAttachment } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 import { tools as xyneSpacesTools } from "../mcp/servers/xyne-spaces-tools.js";
-import { connectorTypesFromText, connectorTypesUserAskedToConnect } from "../lib/connector-hints.js";
+import { connectorTypesFromText, connectorTypesUserAskedFor } from "../lib/connector-hints.js";
 import { availableServerIds } from "../lib/connector-availability.js";
 
 const clog = createLogger("webhook");
@@ -4899,10 +4899,9 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
   let inferredTypes: string[] = [];
   if (!payload.pendingConnectorSuggestions) {
     try {
-      inferredTypes = connectorTypesFromText(ctx.rootTask ?? ctx.task ?? "").slice(
-        0,
-        MCP_SUGGEST_INFERRED_MAX,
-      );
+      inferredTypes = connectorTypesFromText(ctx.rootTask ?? ctx.task ?? "", {
+        includeKeywords: true,
+      }).slice(0, MCP_SUGGEST_INFERRED_MAX);
     } catch (err) {
       log.warn("[mcp-suggest] connector inference failed (non-fatal)", {
         error: err instanceof Error ? err.message : String(err),
@@ -4958,7 +4957,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       // request, which is exactly how an already-usable connector slipped
       // through. The server owns this fact like every other on the card.
       const askedToConnect = new Set(
-        connectorTypesUserAskedToConnect(ctx.rootTask ?? ctx.task ?? ""),
+        connectorTypesUserAskedFor(ctx.rootTask ?? ctx.task ?? ""),
       );
 
       const connectors = ordered

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -2818,7 +2818,7 @@ export async function processTask(
       allTools.push(buildDescribeAgentTool(describeAgentRef));
       // Same gate as describe-agent: a connector card is only worth posting
       // where a human is watching and can press Connect.
-      allTools.push(buildSuggestConnectorsTool(suggestConnectorsRef));
+      allTools.push(buildSuggestConnectorsTool(suggestConnectorsRef, userId));
     }
 
 

--- a/apps/xyne-claw/src/suggest-connectors.ts
+++ b/apps/xyne-claw/src/suggest-connectors.ts
@@ -23,6 +23,7 @@
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.js";
+import { SERVER } from "./config.js";
 
 const log = createLogger("suggest-connectors");
 
@@ -42,8 +43,47 @@ export interface SuggestConnectorsRef {
 }
 
 const MAX_SUGGESTIONS = 6;
+const AVAILABILITY_TIMEOUT_MS = 2000;
 
-export function buildSuggestConnectorsTool(ref: SuggestConnectorsRef): ToolDefinition {
+interface ConnectorAvailability {
+  connected: string[];
+  known: boolean;
+}
+
+const UNKNOWN_AVAILABILITY: ConnectorAvailability = { connected: [], known: false };
+
+async function fetchAvailability(
+  userId: string | undefined,
+  serverTypes: string[],
+): Promise<ConnectorAvailability> {
+  if (!userId || !SERVER.s2sKey || serverTypes.length === 0) return UNKNOWN_AVAILABILITY;
+  try {
+    const base = SERVER.authServiceUrl.replace(/\/$/, "");
+    const res = await fetch(`${base}/claw/api/v1/internal/connectors/available`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-s2s-key": SERVER.s2sKey },
+      body: JSON.stringify({ userId, serverTypes }),
+      signal: AbortSignal.timeout(AVAILABILITY_TIMEOUT_MS),
+    });
+    if (!res.ok) return UNKNOWN_AVAILABILITY;
+    const body = (await res.json()) as { connected?: unknown; known?: unknown };
+    if (body.known !== true || !Array.isArray(body.connected)) return UNKNOWN_AVAILABILITY;
+    return {
+      connected: body.connected.filter((t): t is string => typeof t === "string"),
+      known: true,
+    };
+  } catch (err) {
+    log.warn(
+      `[suggest-connectors] availability lookup failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return UNKNOWN_AVAILABILITY;
+  }
+}
+
+export function buildSuggestConnectorsTool(
+  ref: SuggestConnectorsRef,
+  userId?: string,
+): ToolDefinition {
   return {
     name: SUGGEST_CONNECTORS_TOOL_NAME,
     label: "Suggest Connectors",
@@ -148,16 +188,27 @@ export function buildSuggestConnectorsTool(ref: SuggestConnectorsRef): ToolDefin
           : `[suggest-connectors] queued ${serverTypes.length}: ${serverTypes.join(", ")}`,
       );
 
+      const availability = listAll
+        ? UNKNOWN_AVAILABILITY
+        : await fetchAvailability(userId, serverTypes);
+      const connected = availability.connected.filter((t) => serverTypes.includes(t));
+
+      const stateNote = connected.length
+        ? ` ${connected.join(", ")} ${connected.length === 1 ? "is" : "are"} ALREADY CONNECTED and the card shows it that way — do NOT tell the user to press Connect or link an account for ${connected.length === 1 ? "it" : "them"}; say what you can already do with ${connected.length === 1 ? "it" : "them"}.`
+        : availability.known
+          ? " None of them are connected yet, so each card carries a Connect button."
+          : "";
+
       return {
         content: [
           {
             type: "text" as const,
             text: listAll
               ? "A connector list with a Browse button will be shown with your reply. Do NOT list the connectors in your text — say at most one short line."
-              : `Connector cards for ${serverTypes.join(", ")} will be shown with your reply, each with a Connect button. Do NOT list or describe these connectors in your text — say at most one short line about why they help.`,
+              : `Connector cards for ${serverTypes.join(", ")} will be shown with your reply. Do NOT list or describe these connectors in your text — say at most one short line about why they help.${stateNote}`,
           },
         ],
-        details: { serverTypes, listAll },
+        details: { serverTypes, listAll, ...(availability.known ? { connected } : {}) },
       };
     },
   };

--- a/apps/xyne-claw/test/suggest-connectors-availability.test.ts
+++ b/apps/xyne-claw/test/suggest-connectors-availability.test.ts
@@ -1,0 +1,92 @@
+import { test, expect, vi, afterEach } from "vitest";
+
+vi.hoisted(() => {
+  process.env["XYNE_CLAW_S2S_KEY"] = "test-key";
+});
+
+import {
+  buildSuggestConnectorsTool,
+  type SuggestConnectorsRef,
+} from "../src/suggest-connectors.js";
+
+async function callTool(ref: SuggestConnectorsRef, params: unknown, userId?: string) {
+  const tool = buildSuggestConnectorsTool(ref, userId);
+  return (
+    tool as unknown as {
+      execute: (
+        id: string,
+        p: unknown,
+      ) => Promise<{ content: { text: string }[]; details?: Record<string, unknown> }>;
+    }
+  ).execute("tc-1", params);
+}
+
+function mockAvailability(body: unknown, ok = true): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok, json: async () => body }) as unknown as Response),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("tells the model when a connector is already connected", async () => {
+  mockAvailability({ success: true, connected: ["github"], known: true });
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["github"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["github"] });
+  expect(out.content[0]?.text).toContain("ALREADY CONNECTED");
+  expect(out.content[0]?.text).not.toContain("each card carries a Connect button");
+  expect(out.details?.["connected"]).toEqual(["github"]);
+});
+
+test("promises a Connect button only when the lookup says nothing is connected", async () => {
+  mockAvailability({ success: true, connected: [], known: true });
+
+  const out = await callTool({}, { serverTypes: ["figma"] }, "user-1");
+
+  expect(out.content[0]?.text).toContain("each card carries a Connect button");
+  expect(out.content[0]?.text).not.toContain("ALREADY CONNECTED");
+});
+
+test("stays silent about state when the lookup is unavailable", async () => {
+  mockAvailability({}, false);
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["notion"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["notion"] });
+  expect(out.content[0]?.text).not.toContain("ALREADY CONNECTED");
+  expect(out.content[0]?.text).not.toContain("Connect button");
+  expect(out.details?.["connected"]).toBeUndefined();
+});
+
+test("still queues the card when the lookup throws", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      throw new Error("connection refused");
+    }),
+  );
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["slack"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["slack"] });
+  expect(out.content[0]?.text).toContain("Connector cards for slack");
+});
+
+test("skips the lookup entirely when no userId is wired through", async () => {
+  const fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+
+  const ref: SuggestConnectorsRef = {};
+  await callTool(ref, { serverTypes: ["github"] });
+
+  expect(fetchSpy).not.toHaveBeenCalled();
+  expect(ref.value).toEqual({ serverTypes: ["github"] });
+});


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [x] New feature
- [x] Enhancement
- [x] Bugfix

## Description

The `xyne-claw` / `xyne-claw-auth` half of #1427, split out so claw deploys on its own cadence. Dashboard changes stay in #1427. XYNE-61540.

- **Connector suggestions know what's already connected.** `suggest-connectors` looks up which of the connectors it's about to offer the user already has, so the model stops suggesting something they've connected. New S2S-only endpoint backs it; capped at 12 types, 2s timeout, fails open to "unknown" so a slow lookup never blocks a suggestion.
- **The card fires on an explicit ask.** Naming a connector outright ("connect google") now triggers it, not just an inferred link or prose signal — via `connectKeywords` on the connector hints.
- **OAuth returns to the UI that started it.** Every callback redirected to one global `FRONTEND_URL` (the claw SPA), so a connector started from Spaces finished on claw's home page. The starting UI can now pass `returnTo`, carried in the existing HMAC-signed state.
- **Agent-scoped Copilot OAuth.** A GitHub device flow that stores the token on the *agent* rather than on the person signing in, so every run of the agent uses it. The existing `/user-config/:userId/github-poll` deliberately stores user-level; these routes are the agent-level counterpart, matching how Claude and Codex already work.
- **OpenRouter allowlist fix.** `settings.ts` was rejecting `openrouter` while `agents.ts` already allowed it, so the UI could offer it and then 400 on save.

## Areas Touched

- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] Feature flag or runtime config changed

Optional only: `OAUTH_RETURN_ORIGINS` (comma-separated) extends the post-OAuth redirect allowlist. Unset, the allowlist is `FRONTEND_URL` + `SPACES_APP_URL`, which is what production already has — nothing to set for this to ship. Non-production additionally accepts localhost, since `SPACES_APP_URL` points at the API port and a dev return would otherwise be rejected on every machine.

## API Contract

- [x] New endpoint

All additive:
- `POST /internal/connectors/available` — S2S only; which of the given connector types a user has connected.
- `POST /agents/:slug/provider-credentials/copilot/github-{login,poll}` — agent-scoped Copilot device flow, owner-or-admin.
- `POST /users/:userId/oauth/:type/authorize` — accepts an optional `returnTo`. Existing callers that omit it are unaffected.

No existing contract changed.

---

## Rollout notes

**This PR alone changes nothing user-visible for the OAuth redirect.** The three dashboard files that actually send `returnTo` ship in #1427. With no `returnTo` arriving, every callback falls back to the old claw URL exactly as today — safe to merge in either order, but the fix only takes effect once both are out.

The internal connectors router is mounted in `http/routes.ts`, not `main.ts` — this branch moved route mounting there after #1427 was cut.

Copilot is licensed **per user**. An agent-level Copilot token means the signing-in account's seat serves everyone who runs that agent, unlike the team Claude/ChatGPT accounts the existing agent OAuth flows capture. Deliberate, gated to owner/admin, and the acting user is recorded on the credential — but worth a second opinion before it ships.

## How did you test it?

- `apps/xyne-claw` — `vitest run test/suggest-connectors-availability.test.ts` → **5/5 pass** on this branch
- Typecheck: this branch has 18 pre-existing errors in claw-auth and 22 in claw; both counts are **unchanged** with these commits applied, and none land in the touched files
- Connector behaviour was exercised on `main` before the split: asked "connect google" and got the card; re-asked with Google connected and it was no longer offered

### Automated

- [x] Added / updated tests for this change

### Manual

**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind
- [ ] Copilot OAuth is untested end to end — needs a real GitHub account with a Copilot seat
- [ ] OAuth return is untested end to end — local Google/Microsoft are blocked by an unrelated `redirect_uri_mismatch`; a dynamically-registered connector (Notion, Miro, Attio) is the way to verify
