### PR TITLE
refactor(dpip): suffix v2 tables with _v2 in the shared dpip schema

### DIFF
--- a/dpip-ingestion-v2/README.md
+++ b/dpip-ingestion-v2/README.md
@@ -4,10 +4,11 @@ TypeScript HTTP ingestion function for the DPIP daily registry datasets,
 v2 payload contract.
 
 Deployed as its own Cloud Run service, separate from `dpip-ingestion/`.
-Both services share one Cloud SQL instance, but this one owns its own
-database (`dpip_v2`, set via `DB_NAME`); table names are therefore identical
-to v1's. The two are triggered by different email subjects and must not
-share a `DPIP_BEARER_SECRET`.
+Both services use the same Cloud SQL instance, the same database, and the
+same `dpip` schema; v2's tables carry a `_v2` suffix so they sit alongside
+v1's without colliding. Set `DB_NAME` to the same value the v1 service uses.
+The two are triggered by different email subjects and must not share a
+`DPIP_BEARER_SECRET`.
 
 Differences from v1:
 

--- a/dpip-ingestion-v2/console-source/index.js
+++ b/dpip-ingestion-v2/console-source/index.js
@@ -200,7 +200,7 @@ async function writeReports(client, rows) {
     const values = valuesClause(batch, fields);
     const result = await client.query(
       `
-        INSERT INTO dpip.reports (
+        INSERT INTO dpip.reports_v2 (
           identifier_type,
           reported_date,
           party_id,
@@ -243,7 +243,7 @@ async function writeScreenings(client, rows) {
     const values = valuesClause(batch, fields);
     const result = await client.query(
       `
-        INSERT INTO dpip.screenings (
+        INSERT INTO dpip.screenings_v2 (
           screening_date,
           party_id,
           event_type,
@@ -280,7 +280,7 @@ async function writeHistoryTable(client, table, rows) {
     const values = valuesClause(batch, fields);
     const result = await client.query(
       `
-        INSERT INTO dpip.${table} (${fields.join(", ")})
+        INSERT INTO dpip.${table}_v2 (${fields.join(", ")})
         VALUES ${values.sql}
         ON CONFLICT DO NOTHING
         RETURNING 1
@@ -353,7 +353,7 @@ async function readAllDpipTables(logContext) {
         const result = await client.query(
           `
             SELECT ${textFields.join(", ")}
-            FROM dpip.${table}
+            FROM dpip.${table}_v2
             ORDER BY ${spec.key.join(", ")}
           `
         );

--- a/dpip-ingestion-v2/migrations.md
+++ b/dpip-ingestion-v2/migrations.md
@@ -2,29 +2,17 @@
 
 Branch: `feature/dpip-daily-injestion`
 
-These tables live in their **own database** (`dpip_v2`) on the **same Cloud
-SQL instance** as v1. A Postgres database is a fully isolated namespace, so
-the table, constraint, and trigger names are identical to v1's — nothing
-collides, and no suffix is needed.
-
-Because this is a fresh database, nothing from v1's migrations exists here:
-schema `dpip` and the function `dpip.set_updated_at()` are both created
-below.
+These tables live in the same database and the same `dpip` schema as v1,
+on the same Cloud SQL instance. Every v2 table name carries a `_v2` suffix, so
+nothing collides with v1's tables, constraints, or triggers.
 
 ## Prerequisites
 
-Run once, as an admin user, connected to any database on the instance:
+No new database is created. Connect to the same database v1 uses — the
+value of `DB_NAME` on the v1 Cloud Run service — and run Migration 1 there.
 
-```sql
-CREATE DATABASE dpip_v2;
-```
-
-Then connect **to `dpip_v2`** and run Migration 1. Everything below assumes
-that connection; running it against the v1 database would fail on
-`CREATE SCHEMA` conflicts.
-
-The Cloud Run v2 service is pointed here purely by its `DB_NAME=dpip_v2`
-environment variable. Its `DB_USER` needs `CREATE` on this database.
+The v2 Cloud Run service must be given that same `DB_NAME`. Its `DB_USER` needs
+`CREATE` on schema `dpip`.
 
 ## Migration 1
 
@@ -33,7 +21,7 @@ BEGIN;
 
 CREATE SCHEMA IF NOT EXISTS dpip;
 
-CREATE TABLE dpip.reports (
+CREATE TABLE dpip.reports_v2 (
   identifier_type TEXT NOT NULL
     CHECK (btrim(identifier_type) <> ''),
   reported_date DATE NOT NULL,
@@ -58,7 +46,7 @@ CREATE TABLE dpip.reports (
     CHECK (metrics_value >= 0),
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  CONSTRAINT reports_unique_key UNIQUE (
+  CONSTRAINT reports_v2_unique_key UNIQUE (
     identifier_type,
     reported_date,
     party_id,
@@ -69,7 +57,7 @@ CREATE TABLE dpip.reports (
   )
 );
 
-CREATE TABLE dpip.screenings (
+CREATE TABLE dpip.screenings_v2 (
   screening_date DATE NOT NULL,
   party_id TEXT NOT NULL
     CHECK (btrim(party_id) <> ''),
@@ -81,7 +69,7 @@ CREATE TABLE dpip.screenings (
     CHECK (count >= 0),
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  CONSTRAINT screenings_unique_key UNIQUE (
+  CONSTRAINT screenings_v2_unique_key UNIQUE (
     screening_date,
     party_id,
     event_type,
@@ -89,19 +77,19 @@ CREATE TABLE dpip.screenings (
   )
 );
 
-CREATE TABLE dpip.cluster_external_entities (
+CREATE TABLE dpip.cluster_external_entities_v2 (
   cluster_count BIGINT NOT NULL
     CHECK (cluster_count >= 0),
   num_external_entities BIGINT NOT NULL
     CHECK (num_external_entities >= 0),
   last_updated_date DATE NOT NULL,
-  CONSTRAINT cluster_external_entities_unique_key UNIQUE (
+  CONSTRAINT cluster_external_entities_v2_unique_key UNIQUE (
     num_external_entities,
     last_updated_date
   )
 );
 
-CREATE TABLE dpip.external_entity_identifiers (
+CREATE TABLE dpip.external_entity_identifiers_v2 (
   party_id TEXT NOT NULL
     CHECK (btrim(party_id) <> ''),
   external_entity_count BIGINT NOT NULL
@@ -109,52 +97,52 @@ CREATE TABLE dpip.external_entity_identifiers (
   num_identifiers BIGINT NOT NULL
     CHECK (num_identifiers >= 0),
   last_updated_date DATE NOT NULL,
-  CONSTRAINT external_entity_identifiers_unique_key UNIQUE (
+  CONSTRAINT external_entity_identifiers_v2_unique_key UNIQUE (
     party_id,
     num_identifiers,
     last_updated_date
   )
 );
 
-CREATE TABLE dpip.cluster_identifiers (
+CREATE TABLE dpip.cluster_identifiers_v2 (
   cluster_count BIGINT NOT NULL
     CHECK (cluster_count >= 0),
   num_identifiers BIGINT NOT NULL
     CHECK (num_identifiers >= 0),
   last_updated_date DATE NOT NULL,
-  CONSTRAINT cluster_identifiers_unique_key UNIQUE (
+  CONSTRAINT cluster_identifiers_v2_unique_key UNIQUE (
     num_identifiers,
     last_updated_date
   )
 );
 
-CREATE TABLE dpip.party_identifiers (
+CREATE TABLE dpip.party_identifiers_v2 (
   party_ids TEXT NOT NULL
     CHECK (btrim(party_ids) <> ''),
   num_identifiers BIGINT NOT NULL
     CHECK (num_identifiers >= 0),
   last_updated_date DATE NOT NULL,
-  CONSTRAINT party_identifiers_unique_key UNIQUE (
+  CONSTRAINT party_identifiers_v2_unique_key UNIQUE (
     party_ids,
     last_updated_date
   )
 );
 
-CREATE TABLE dpip.entities_by_customer (
+CREATE TABLE dpip.entities_by_customer_v2 (
   party_id TEXT NOT NULL,
   customer_type TEXT NOT NULL
     CHECK (customer_type IN ('INDIVIDUAL', 'MERCHANT', 'ALL')),
   entity_count BIGINT NOT NULL
     CHECK (entity_count >= 0),
   last_updated_date DATE NOT NULL,
-  CONSTRAINT entities_by_customer_unique_key UNIQUE (
+  CONSTRAINT entities_by_customer_v2_unique_key UNIQUE (
     party_id,
     customer_type,
     last_updated_date
   )
 );
 
-CREATE FUNCTION dpip.set_updated_at()
+CREATE OR REPLACE FUNCTION dpip.set_updated_at()
 RETURNS TRIGGER
 LANGUAGE plpgsql
 AS $$
@@ -164,38 +152,38 @@ BEGIN
 END;
 $$;
 
-CREATE TRIGGER reports_set_updated_at
-BEFORE UPDATE ON dpip.reports
+CREATE TRIGGER reports_v2_set_updated_at
+BEFORE UPDATE ON dpip.reports_v2
 FOR EACH ROW
 EXECUTE FUNCTION dpip.set_updated_at();
 
-CREATE TRIGGER screenings_set_updated_at
-BEFORE UPDATE ON dpip.screenings
+CREATE TRIGGER screenings_v2_set_updated_at
+BEFORE UPDATE ON dpip.screenings_v2
 FOR EACH ROW
 EXECUTE FUNCTION dpip.set_updated_at();
 
-COMMENT ON COLUMN dpip.reports.identifier_type IS
+COMMENT ON COLUMN dpip.reports_v2.identifier_type IS
   'Identifier type from the source, including the literal value ALL.';
 
-COMMENT ON COLUMN dpip.reports.customer_type IS
+COMMENT ON COLUMN dpip.reports_v2.customer_type IS
   'Reporter-asserted customer segment: INDIVIDUAL, MERCHANT, or the ALL rollup.';
 
-COMMENT ON COLUMN dpip.reports.metrics_type IS
+COMMENT ON COLUMN dpip.reports_v2.metrics_type IS
   'One scalar metric type per report row.';
 
-COMMENT ON COLUMN dpip.reports.metrics_value IS
+COMMENT ON COLUMN dpip.reports_v2.metrics_value IS
   'The non-negative value for the row metric type.';
 
-COMMENT ON COLUMN dpip.screenings.event_type IS
+COMMENT ON COLUMN dpip.screenings_v2.event_type IS
   'Screening event type from the source, including the literal value ALL.';
 
-COMMENT ON COLUMN dpip.external_entity_identifiers.party_id IS
+COMMENT ON COLUMN dpip.external_entity_identifiers_v2.party_id IS
   'Lowercase party ID, or the literal text value ''null'' when unavailable.';
 
-COMMENT ON TABLE dpip.entities_by_customer IS
+COMMENT ON TABLE dpip.entities_by_customer_v2 IS
   'Distinct flagged external entities split by owning party and by the customer segment they were reported under. INDIVIDUAL + MERCHANT can exceed ALL: an entity reported under both counts once in each.';
 
-COMMENT ON COLUMN dpip.entities_by_customer.party_id IS
+COMMENT ON COLUMN dpip.entities_by_customer_v2.party_id IS
   'Lowercase party ID of the entity owner, or the literal text value ''all'' for the registry-wide row.';
 
 COMMIT;
@@ -203,34 +191,42 @@ COMMIT;
 
 ## Verification
 
-Connected to `dpip_v2`:
+Connected to the v1 database:
 
 ```sql
-SELECT current_database();
-
 SELECT table_name
 FROM information_schema.tables
 WHERE table_schema = 'dpip'
+  AND table_name LIKE '%\_v2'
 ORDER BY table_name;
 ```
 
-Expect `dpip_v2` and exactly seven tables:
+Expect exactly seven tables:
 
 ```
-cluster_external_entities
-cluster_identifiers
-entities_by_customer
-external_entity_identifiers
-party_identifiers
-reports
-screenings
+cluster_external_entities_v2
+cluster_identifiers_v2
+entities_by_customer_v2
+external_entity_identifiers_v2
+party_identifiers_v2
+reports_v2
+screenings_v2
 ```
+
+v1's seven table names are unchanged and must still be present alongside them.
 
 ## Rollback
 
-Because v2 owns the whole database, teardown is one statement — run it from
-a connection to a *different* database on the instance:
+Only the v2 tables are dropped. The schema and `dpip.set_updated_at()` stay,
+because v1 still uses both.
 
 ```sql
-DROP DATABASE dpip_v2;
+DROP TABLE
+  dpip.reports_v2,
+  dpip.screenings_v2,
+  dpip.cluster_external_entities_v2,
+  dpip.external_entity_identifiers_v2,
+  dpip.cluster_identifiers_v2,
+  dpip.party_identifiers_v2,
+  dpip.entities_by_customer_v2;
 ```

--- a/dpip-ingestion-v2/sql/clear-all-data.sql
+++ b/dpip-ingestion-v2/sql/clear-all-data.sql
@@ -1,12 +1,12 @@
 BEGIN;
 
 TRUNCATE TABLE
-  dpip.reports,
-  dpip.screenings,
-  dpip.cluster_external_entities,
-  dpip.external_entity_identifiers,
-  dpip.cluster_identifiers,
-  dpip.party_identifiers,
-  dpip.entities_by_customer;
+  dpip.reports_v2,
+  dpip.screenings_v2,
+  dpip.cluster_external_entities_v2,
+  dpip.external_entity_identifiers_v2,
+  dpip.cluster_identifiers_v2,
+  dpip.party_identifiers_v2,
+  dpip.entities_by_customer_v2;
 
 COMMIT;

--- a/dpip-ingestion-v2/src/database.ts
+++ b/dpip-ingestion-v2/src/database.ts
@@ -96,7 +96,7 @@ async function writeReports(
     const values = valuesClause(batch, fields);
     const result = await client.query<{ inserted: boolean }>(
       `
-        INSERT INTO dpip.reports (
+        INSERT INTO dpip.reports_v2 (
           identifier_type,
           reported_date,
           party_id,
@@ -146,7 +146,7 @@ async function writeScreenings(
     const values = valuesClause(batch, fields);
     const result = await client.query<{ inserted: boolean }>(
       `
-        INSERT INTO dpip.screenings (
+        INSERT INTO dpip.screenings_v2 (
           screening_date,
           party_id,
           event_type,
@@ -191,7 +191,7 @@ async function writeHistoryTable(
     const values = valuesClause(batch, fields);
     const result: QueryResult = await client.query(
       `
-        INSERT INTO dpip.${table} (${fields.join(', ')})
+        INSERT INTO dpip.${table}_v2 (${fields.join(', ')})
         VALUES ${values.sql}
         ON CONFLICT DO NOTHING
         RETURNING 1
@@ -278,7 +278,7 @@ export async function readAllDpipTables(
         const result = await client.query<DpipRow>(
           `
             SELECT ${textFields.join(', ')}
-            FROM dpip.${table}
+            FROM dpip.${table}_v2
             ORDER BY ${spec.key.join(', ')}
           `,
         );


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
