### PR TITLE
fix: XYNE-55539 align DM sidebar item preview styling

### DIFF
--- a/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
@@ -273,8 +273,8 @@ export const DmListItem = ({
       className={cn(
         'group flex w-full font-normal items-center gap-3 px-3 py-2 text-left cursor-pointer transition-colors duration-150 h-auto rounded-[14px] border border-transparent',
         isUnread ? 'bg-activity-sidebar-primary' : 'bg-transparent',
-        'hover:bg-sidebar-accent',
-        isSelected && 'bg-sidebar-accent border-sidebar-border',
+        'hover:!bg-sidebar-accent',
+        isSelected && '!bg-sidebar-accent border-sidebar-border',
       )}
       role='button'
       tabIndex={0}
@@ -340,8 +340,10 @@ export const DmListItem = ({
             data-track-category='DM_LIST'
             data-track-name='PREVIEW_LINK_CONTAINER'
             className={cn(
-              'w-full text-sm line-clamp-1 truncate break-normal whitespace-normal',
-              isUnread ? 'text-foreground' : 'text-muted-foreground',
+              'w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm break-normal',
+              isUnread
+                ? 'text-foreground [&_.message-html-root]:!text-foreground'
+                : 'text-muted-foreground [&_.message-html-root]:!text-muted-foreground',
               // Make RenderMessageWithHTML output inline and preserve link styles
               '[&_.message-html-root]:inline',
               '[&_.message-html-root_*]:inline',


### PR DESCRIPTION
## Summary

1. **Problem Description:**
   DM sidebar list item previews did not fully match Activity sidebar read/unread styling. The preview wrapper could be muted while the nested rendered message HTML kept foreground color, and long rendered previews could wrap below the sender prefix such as `You:`.

2. **If this is a bug fix or an enhancement, how did you identify the issue?:**
   Reported from the DM sidebar UI. The rendered DOM showed `text-muted-foreground` on the preview container, but the nested `.message-html-root.jp-message-html` still inherited the global message foreground styling.

3. **Explain the solution implemented in the PR:**
   Scoped the DM preview color override to `.message-html-root` for read/unread states, changed the preview container to a single-line nowrap/ellipsis layout, and aligned DM item hover/selected background strength with Activity sidebar item styles.

4. **Documentation (link to docs created/updated for this change):**
   N/A

5. **DB Alter Details (if any):**
   N/A

6. **Data fix Details (if any):**
   N/A

7. **Environment variable Changes (if any):**
   N/A

8. **Testing (how it was tested; screenshots/links):**
   - `git diff --check`
   - `pnpm --dir apps/dashboard exec prettier --check src/components/Chat/DirectMessages/DmListItem.tsx`
   - `pnpm --dir apps/dashboard exec eslint src/components/Chat/DirectMessages/DmListItem.tsx --quiet`
   - `pnpm --dir apps/dashboard run typecheck`

9. **Services to which this change is to be deployed:**
   Dashboard

10. **Main PR link (if this PR is raised against a release branch):**
    N/A