### PR TITLE
feat: XYNE-62482 add Sub-tickets tab to Desk thread view

### DIFF
--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -29,6 +29,7 @@ import {
   FolderDefault,
   ClipboardCheck as ClipboardCheckIcon,
   ThreeDotsMenuVertical,
+  GitBranch,
 } from '@xyne/icons';
 import { useChannelDisplayName } from '../../hooks/useChannelDisplayName';
 import {
@@ -64,6 +65,7 @@ import {
   ChannelScopeType,
   ChannelType,
   BaseTicketType,
+  isDeskChannelType,
   parseTicketMd,
 } from '@xyne/shared';
 import { RCAPanelView } from '../Tickets/RCAPanelView';
@@ -105,7 +107,7 @@ import { sendRecordingEvent, useRecordingStore } from '../../hooks/useRecordingS
 import { getRecordingDefaultLayout } from '../../hooks/useRecordingDefaultLayout';
 import { ConversationTabContext } from './ConversationTabContext';
 
-type TabType = 'thread' | 'details' | 'files' | 'rca';
+type TabType = 'thread' | 'details' | 'files' | 'rca' | 'subtickets';
 type UnderTicketTabType = 'replies' | 'rca';
 
 interface ThreadMessagesProps {
@@ -794,6 +796,10 @@ export const ThreadMessages = ({
     setUnderTicketActiveTab('replies');
   }, [underTicketView, selectedTab, isFixTicket, hideTabBar]);
 
+  const showSubTicketsTab = isDeskChannelType(channel?.type);
+  // The panel is reused across threads, so this tab can vanish while still selected.
+  const currentTab = !showSubTicketsTab && activeTab === 'subtickets' ? 'thread' : activeTab;
+
   const tabs = useMemo(() => {
     const allTabs = [
       { value: 'thread' as const, label: 'Messages', icon: <ChatDefault size={14} /> },
@@ -804,6 +810,9 @@ export const ThreadMessages = ({
         count: files.length,
         icon: <FolderDefault size={14} />,
       },
+      ...(showSubTicketsTab
+        ? [{ value: 'subtickets' as const, label: 'Sub-tickets', icon: <GitBranch size={14} /> }]
+        : []),
       ...(isFixTicket
         ? [{ value: 'rca' as const, label: 'RCA', icon: <ClipboardCheckIcon size={14} /> }]
         : []),
@@ -811,7 +820,7 @@ export const ThreadMessages = ({
 
     // Filter out Details tab when ticketId doesn't exist
     return !derivedTicketId ? allTabs.filter(tab => tab.value !== 'details') : allTabs;
-  }, [files.length, ticketId, derivedTicketId, isFixTicket]);
+  }, [files.length, ticketId, derivedTicketId, isFixTicket, showSubTicketsTab]);
 
   const handleCreateTicket = (): void => {
     setIsCreateTicketModalOpen(true);
@@ -1578,7 +1587,7 @@ export const ThreadMessages = ({
         {!simpleView && derivedTicketId ? (
           /* Ticket Thread: Header with Tabs */
           <Tabs.Root
-            value={activeTab}
+            value={currentTab}
             onValueChange={value => {
               setActiveTab(value as TabType);
               // Mirror it back, or re-opening the same tab from outside is a no-op.
@@ -1603,7 +1612,7 @@ export const ThreadMessages = ({
                         <button
                           className={cn(
                             'flex items-center justify-center gap-2 px-2.5 py-1.5 rounded-lg whitespace-nowrap transition-colors duration-100 cursor-pointer',
-                            activeTab === tab.value
+                            currentTab === tab.value
                               ? 'bg-muted text-foreground'
                               : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
                           )}
@@ -1720,6 +1729,16 @@ export const ThreadMessages = ({
             >
               <TicketDetails ticketId={derivedTicketId} onFillRCA={() => setActiveTab('rca')} />
             </Tabs.Content>
+
+            {/* Sub-tickets Tab Content */}
+            {showSubTicketsTab && (
+              <Tabs.Content
+                value='subtickets'
+                className='flex-1 min-h-0 bg-background overflow-hidden data-[state=inactive]:hidden'
+              >
+                <TicketDetails ticketId={derivedTicketId} subTicketsOnly />
+              </Tabs.Content>
+            )}
 
             {/* RCA Tab Content */}
             {isFixTicket && (

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -465,6 +465,8 @@ interface TicketDetailsProps {
   onFillRCA?: () => void;
   /** Display the current stage without exposing manual lifecycle transitions. */
   stageReadOnly?: boolean;
+  /** Show only the Sub-Tickets section, for hosts that give it its own tab. */
+  subTicketsOnly?: boolean;
 }
 
 const TicketKeyValuePair = ({
@@ -579,6 +581,7 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
   expandedView = false,
   onFillRCA,
   stageReadOnly = false,
+  subTicketsOnly = false,
 }) => {
   const zero = useZero();
   const navigate = useNavigate();
@@ -3429,17 +3432,24 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
         </div>
       )}
 
-      <div className='relative'>
+      <div
+        className={cn(
+          'relative',
+          // Hide the sibling sections instead of re-parenting the sub-tickets one.
+          subTicketsOnly &&
+            '[&>*:not([data-testid=sub-tickets-section]):not(.archived-guard)]:hidden',
+        )}
+      >
         {/* Archived overlay - blocks all interactions on content */}
         {ticket?.isArchived && (
           <div
-            className='absolute inset-0 z-50 cursor-not-allowed'
+            className='archived-guard absolute inset-0 z-50 cursor-not-allowed'
             style={{ backgroundColor: 'transparent' }}
           />
         )}
 
         {ticket?.isArchived && (
-          <div className='mb-4 p-3 bg-muted border border-border rounded-lg flex items-center gap-3'>
+          <div className='archived-guard mb-4 p-3 bg-muted border border-border rounded-lg flex items-center gap-3'>
             <Archive className='w-5 h-5 text-muted-foreground shrink-0' />
             <div className='flex-1'>
               <p className='text-sm font-medium text-foreground'>


### PR DESCRIPTION
Desk agents can't see or manage a ticket's sub-tickets from the thread view — they're buried in the Details tab among metadata, forms and Related Tickets.

The Sub-Tickets section (tree, create, link existing) needs its own tab beside Messages/Details/Files, in Desk channels only.


-----

<img width="1574" height="810" alt="Screenshot 2026-09-04 at 3 16 51 PM" src="https://github.com/user-attachments/assets/a75172b6-688a-44de-b6f2-dbead2f60a49" />
