### PR TITLE
fix: XYNE-54851 align channel info header action buttons

### DIFF
--- a/apps/dashboard/src/components/Chat/Info/Info.tsx
+++ b/apps/dashboard/src/components/Chat/Info/Info.tsx
@@ -344,6 +344,7 @@ const Info = ({
       <div className='flex justify-between px-4 mb-4 gap-x-3 overflow-x-auto no-scrollbar'>
         <Button
           variant='ghost'
+          size='inline'
           onClick={handleStarToggle}
           className={[
             headerLinkContainerStyle,
@@ -421,6 +422,7 @@ const Info = ({
         {isParticipant && !isDM && !isGroupDM && (
           <Button
             variant='ghost'
+            size='inline'
             onClick={handleLeaveChannel}
             className={headerLinkContainerStyle}
             data-track-category='CHAT_INFO'


### PR DESCRIPTION
The breaking code is present in sbx.
## Problem

In the channel Info popover, the **Starred** and **Leave** tiles render shorter than **Add People** / **Call** and top-align in the row, so the action strip looks broken.

## Cause

Starred and Leave use the shared `<Button>`; the other two are plain `<button>`s. `Button`'s default `size='default'` injects a fixed `h-9`, so those two stay 36px tall while the plain buttons stretch to the row height set by `p-[12px]` + icon + label. Introduced in the PostHog tracking PR (#1213) when the two plain buttons were swapped to `<Button>` without a size.

## Fix

Add `size='inline'` (`h-auto justify-start`, the variant that exists for exactly this — buttons carrying their own height/padding via `className`) to both. Height comes from `headerLinkContainerStyle` again and all four tiles match. PostHog `trackId` / `data-track-*` attributes are untouched.

## Testing

- `tsc --noEmit -p tsconfig.app.json` clean
- Pre-commit dashboard lint + build passed
- Not yet checked in a running app — please eyeball the Info popover (starred and unstarred, and a channel where Leave shows) before merge
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/656da70a-bccd-4279-8d7f-20b5ddf0f859" />

