### PR TITLE
fix: XYNE-62503 Fix detailed summary generation retry button

### DIFF
--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -237,6 +237,28 @@ export class CallRepository {
     });
   }
 
+  /**
+   * HEADLESS recordings whose detailed summary has sat in 'pending' since
+   * before `staleBefore` with no row activity. Summary generation runs
+   * in-process in the API, so a backend restart mid-run leaves the row
+   * 'pending' forever — this is the query the validation worker sweeps.
+   * updatedAt is part of the predicate so a fresh manual regenerate on an old
+   * recording (which re-publishes 'pending' and bumps updatedAt) is not swept
+   * on the next cycle.
+   */
+  async findStalePendingSummaryCalls(take: number, staleBefore: Date): Promise<Call[]> {
+    return DatabaseClient.getInstance().call.findMany({
+      where: {
+        callType: CallType.HEADLESS,
+        endedAt: { lt: staleBefore },
+        updatedAt: { lt: staleBefore },
+        metadata: { path: ['detailedSummaryStatus'], equals: 'pending' },
+      },
+      orderBy: { endedAt: 'asc' },
+      take,
+    });
+  }
+
   async update(id: string, data: UpdateCallInput): Promise<Call> {
     const client = DatabaseClient.getInstance();
     const result = await client.call.update({

--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -561,8 +561,9 @@ class NoteTakerTranscriptService {
   }
 
   /**
-   * Merge just the detailed-summary status onto Call.metadata. Used by the
-   * queue worker to publish 'pending'/'failed' transitions without touching
+   * Merge just the detailed-summary status onto Call.metadata. Used by
+   * regenerateSummary and by the CallValidationWorker stale-'pending' sweep to
+   * publish 'pending'/'failed' transitions without touching
    * detailedSummaryCanvasId or detailedSummaryReady — those are owned by the
    * success paths in processFinalTranscript and regenerateSummary and must
    * remain the source of truth for readers on older recordings.

--- a/apps/backend/src/workers/callValidationWorker.ts
+++ b/apps/backend/src/workers/callValidationWorker.ts
@@ -7,17 +7,32 @@ import { repositories } from '@/database/repositories';
 import { updateCallSystemMessageIfNeeded } from '@/zero/utils/systemMessagesUtils';
 import { recurringCallService } from '@/services/recurringCallService';
 import { callSideEffectService } from '@/services/callSideEffectService';
+import { noteTakerTranscriptService } from '@/services/noteTakerTranscriptService';
+import { logDetailedSummaryFailed } from '@/services/detailedSummaryFailureLog';
 
 const POLL_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 
+// A recording whose detailed summary has been 'pending' this long with no row
+// activity is treated as stranded (the API process that owned the in-flight
+// generation is gone). Must stay above the worst-case honest run — roughly
+// 55 min with callLlmRetry's 5 attempts × 5 min timeout plus 2/4/8/16 min
+// backoff — so a slow-but-alive run is not swept prematurely. If one is, it
+// simply overwrites 'failed' with 'ready' when it finishes.
+const SUMMARY_PENDING_STALE_MS = 60 * 60 * 1000; // 1 hour
+const SUMMARY_SWEEP_BATCH_SIZE = 50;
+
 /**
  * Call Validation Worker
- * 
+ *
  * Runs periodically to validate active calls against LiveKit room state.
  * Automatically ends calls that:
  * - Have no corresponding LiveKit room
  * - Have zero active participants in LiveKit
- * 
+ *
+ * Also sweeps HEADLESS recordings whose detailed summary has been stuck in
+ * 'pending' for over an hour, marking them 'failed' so the recording screen
+ * offers "Try again" instead of shimmering forever.
+ *
  * This replaces the frontend-triggered validateRooms endpoint to avoid
  * unnecessary API calls triggered by participant updates.
  */
@@ -74,10 +89,11 @@ export class CallValidationWorker {
     try {
       logger.info('[CallValidationWorker] Starting validation cycle');
 
-      // Run both checks in parallel
+      // Run all checks in parallel
       await Promise.all([
         this.validateLiveActiveCalls(),
         this.cleanupStaleScheduledCalls(),
+        this.failStalePendingSummaries(),
       ]);
 
       logger.info('[CallValidationWorker] Validation cycle completed');
@@ -190,6 +206,55 @@ export class CallValidationWorker {
       }
     } catch (error) {
       logger.error(`[CallValidationWorker] Failed to clean up stale scheduled call ${externalId}:`, error);
+    }
+  }
+
+  /**
+   * Defense mechanism for stranded summary generation: summary work runs
+   * in-process in the API (awaited in the transcript-ready webhook, or
+   * fire-and-forget from the regenerate endpoint), so a backend restart
+   * mid-run leaves Call.metadata.detailedSummaryStatus at 'pending' with
+   * nothing to ever flip it. Marking such rows 'failed' lets the recording
+   * screen (which trusts the backend status) surface "Try again" — the
+   * status change reaches open screens through Zero sync.
+   */
+  private async failStalePendingSummaries(): Promise<void> {
+    try {
+      const staleBefore = new Date(Date.now() - SUMMARY_PENDING_STALE_MS);
+      const staleCalls = await repositories.calls.findStalePendingSummaryCalls(
+        SUMMARY_SWEEP_BATCH_SIZE,
+        staleBefore,
+      );
+
+      if (staleCalls.length === 0) {
+        logger.debug('[CallValidationWorker] No stale pending summaries found');
+        return;
+      }
+
+      logger.info(
+        `[CallValidationWorker] Found ${staleCalls.length} recording(s) with a summary stuck in 'pending'`,
+      );
+
+      for (const call of staleCalls) {
+        await this.failStalePendingSummary(call);
+      }
+    } catch (error) {
+      logger.error('[CallValidationWorker] Error sweeping stale pending summaries:', error);
+    }
+  }
+
+  private async failStalePendingSummary(call: Call): Promise<void> {
+    const { externalId, endedAt, updatedAt } = call;
+
+    try {
+      await noteTakerTranscriptService.markDetailedSummaryStatus(call, 'failed');
+      logDetailedSummaryFailed(externalId, 'stale_pending_swept');
+      logger.info(
+        `[CallValidationWorker] [${externalId}] detailed_summary_status_updated | from=pending, to=failed, reason=stale_pending_swept`,
+        { endedAt, updatedAt },
+      );
+    } catch (error) {
+      logger.error(`[CallValidationWorker] Failed to sweep stale pending summary ${externalId}:`, error);
     }
   }
 


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
