### PR TITLE
fix: XYNE-62706 correct user group deactivate/reactivate icons

### DIFF
--- a/apps/dashboard/src/components/UserGroup/UserGroupListItem/UserGroupListItem.tsx
+++ b/apps/dashboard/src/components/UserGroup/UserGroupListItem/UserGroupListItem.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from '../../ui/Tooltip';
 import type { UserGroup, User } from '@xyne/shared';
 import { useUsers } from '../../../hooks/useUsers';
 import { useNavigate } from 'react-router-dom';
-import { CopyCopied, CopyDefault, DeleteDustbin02, PencilEditBox, Refresh } from '@xyne/icons';
+import { CopyCopied, CopyDefault, PauseCircle, PencilEditBox, PlayCircle } from '@xyne/icons';
 import { copyTextToClipboard } from '../../../utils/clipboardUtils';
 import { toast } from 'sonner';
 import { cn } from '../../../utils/classNames';
@@ -161,7 +161,7 @@ export const UserGroupListItem = ({
               <Button
                 variant='ghost'
                 size='iconSm'
-                className='size-6 rounded-md p-1 text-muted-foreground hover:text-destructive'
+                className='size-6 rounded-md p-1 text-muted-foreground hover:text-foreground'
                 onClick={() => void onDeactivate(userGroup.id)}
                 aria-label='Deactivate user group'
                 data-track-category='UserGroups'
@@ -171,7 +171,7 @@ export const UserGroupListItem = ({
                   groupName: userGroup.name,
                 })}
               >
-                <DeleteDustbin02 size={16} />
+                <PauseCircle size={16} />
               </Button>
             </Tooltip>
           </>
@@ -187,7 +187,7 @@ export const UserGroupListItem = ({
               groupName: userGroup.name,
             })}
           >
-            <Refresh size={14} />
+            <PlayCircle size={14} />
             Reactivate
           </Button>
         )}


### PR DESCRIPTION
## What
The User Groups screen action row used a trash icon (`DeleteDustbin02`) with a red destructive hover for the **Deactivate** action, so it visually read as a hard delete even though the backend routes (added in #8625) only deactivate/pause a group.

This changes the icons to match the actual behavior:
- **Deactivate** → `PauseCircle` icon, neutral `hover:text-foreground` (no longer red/destructive)
- **Reactivate** → `PlayCircle` icon (was `Refresh`), giving a clear pause/play metaphor

No behavior change — the deactivate/reactivate mutators and wiring are unchanged. This is a purely visual fix to the messy/confusing icons reported by the team.

## Files
- `apps/dashboard/src/components/UserGroup/UserGroupListItem/UserGroupListItem.tsx` (4 insertions, 4 deletions)