### PR TITLE
fix: XYNE-61540 claw connector suggestions, agent OAuth keys and MCP OAuth return

### DIFF
--- a/apps/xyne-claw-auth/backend/src/http/routes.ts
+++ b/apps/xyne-claw-auth/backend/src/http/routes.ts
@@ -37,6 +37,7 @@ import { sessionsArchiveRouter } from "../routes/sessions-archive.js";
 import { experimentsInternalRouter } from "../routes/experiments-internal.js";
 import { artifactAppsInternalRouter } from "../routes/artifact-apps-internal.js";
 import { errorPipelineIngestRouter, errorPipelineInternalRouter } from "../routes/error-pipeline.js";
+import { connectorsInternalRouter } from "../routes/connectors-internal.js";
 import { googleOAuthRouter, googleCallbackRouter } from "../routes/google-oauth.js";
 import { microsoftOAuthRouter, microsoftCallbackRouter } from "../routes/microsoft-oauth.js";
 import { calendlyOAuthRouter, calendlyCallbackRouter } from "../routes/calendly-oauth.js";
@@ -171,6 +172,7 @@ function mountCoreApi(app: Express): void {
   app.use(`${BASE}/error-pipeline`, errorPipelineIngestRouter); // Grafana webhook ingest (JWT-authed inside)
   app.use(`${BASE}/internal/error-pipeline`, requireStrictS2S, errorPipelineInternalRouter); // run-result callback from xyne-claw (S2S only)
   app.use(`${BASE}/internal/tts`, requireStrictS2S, ttsRouter);
+  app.use(`${BASE}/internal/connectors`, requireStrictS2S, connectorsInternalRouter); // connector availability lookup for xyne-claw (S2S only)
 }
 
 function mountOAuthProviders(app: Express): void {

--- a/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
@@ -5,6 +5,7 @@ import { CONFIG } from "../config.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "./oauth-state.js";
 import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
+import { oauthLimiter } from "../middleware/rate-limiters.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -125,7 +126,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
   const router = Router();
   router.use("/:userId", pinUserIdParam);
 
-  router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req: Request<{ userId: string }>, res: Response) => {
+  router.post(`/:userId/oauth/${type}/authorize`, oauthLimiter, asyncHandler(async (req: Request<{ userId: string }>, res: Response) => {
     const { userId } = req.params;
     const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 

--- a/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/classic-oauth-provider.ts
@@ -4,6 +4,7 @@ import { encrypt } from "../crypto.js";
 import { CONFIG } from "../config.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "./oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -126,7 +127,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
 
   router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req: Request<{ userId: string }>, res: Response) => {
     const { userId } = req.params;
-    const { redirectUri } = req.body as { redirectUri?: string };
+    const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 
     const callbackUri = redirectUri ?? `${process.env["AUTH_SERVICE_URL"] ?? "http://localhost:3003"}/claw/api/v1/${type}/callback`;
 
@@ -138,7 +139,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
     url.searchParams.set("response_type", "code");
     url.searchParams.set("scope", config.scope);
     for (const [k, v] of Object.entries(config.extraAuthParams ?? {})) url.searchParams.set(k, v);
-    url.searchParams.set("state", signOAuthState(userId));
+    url.searchParams.set("state", signOAuthState(userId, { returnTo: resolveOAuthReturn(returnTo) }));
 
     ok(res, { authUrl: url.toString() });
   }));
@@ -161,29 +162,34 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
   const callbackRouter = Router();
 
   callbackRouter.get(`/${type}/callback`, async (req: Request, res: Response) => {
-    const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+    // Stays the default until the state is verified below: an unverified state
+    // must never steer the redirect.
+    let frontendUrl = defaultOAuthReturn();
 
     try {
       const { code, state, error: oauthError } = req.query as { code?: string; state?: string; error?: string };
 
       if (oauthError) {
         log.error(`[${type}-oauth] OAuth error: ${oauthError}`);
-        res.redirect(`${frontendUrl}?${type}_error=${encodeURIComponent(oauthError)}`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, oauthError));
         return;
       }
 
       if (!code || !state) {
-        res.redirect(`${frontendUrl}?${type}_error=missing_code_or_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "missing_code_or_state"));
         return;
       }
 
       let userId: string;
       try {
-        userId = verifyOAuthState(state).userId;
+        const verified = verifyOAuthState(state);
+        userId = verified.userId;
+        // Signed, so this is the origin that actually started the flow.
+        frontendUrl = resolveOAuthReturn(verified.extra?.["returnTo"]);
       } catch (err) {
         const reason = err instanceof OAuthStateError ? err.reason : "malformed";
         log.error(`[${type}-oauth] state ${reason}`);
-        res.redirect(`${frontendUrl}?${type}_error=invalid_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "invalid_state"));
         return;
       }
 
@@ -193,7 +199,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
       try {
         creds = await exchangeCode(code, redirectUri);
       } catch {
-        res.redirect(`${frontendUrl}?${type}_error=token_exchange_failed`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "token_exchange_failed"));
         return;
       }
 
@@ -203,7 +209,7 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
         const user = await prisma.user.findUnique({ where: { id: userId } });
         if (!user) {
           log.error(`[${type}-oauth] User not found: ${userId}`);
-          res.redirect(`${frontendUrl}?${type}_error=user_not_found`);
+          res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "user_not_found"));
           return;
         }
       }
@@ -211,10 +217,10 @@ export function createClassicOAuthProvider(config: ClassicOAuthConfig): ClassicO
       await storeTokens(userId, creds);
 
       log.info(`[${type}-oauth] Stored ${label} credentials for user ${userId} via browser callback`);
-      res.redirect(`${frontendUrl}?${type}_connected=true`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_connected`, "true"));
     } catch (err) {
       log.error(`[${type}-oauth] browser callback error:`, err);
-      res.redirect(`${frontendUrl}?${type}_error=internal_error`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "internal_error"));
     }
   });
 

--- a/apps/xyne-claw-auth/backend/src/lib/connector-availability.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-availability.ts
@@ -28,6 +28,34 @@ export async function availableServerIds(
   return new Set([...personal.map((c) => c.mcpServerId), ...shared.map((s) => s.id)]);
 }
 
+export interface ConnectorAvailability {
+  personal: Set<string>;
+  org: Set<string>;
+}
+
+export async function availabilityForServerIds(
+  userId: string,
+  serverIds: string[],
+): Promise<ConnectorAvailability> {
+  if (serverIds.length === 0) return { personal: new Set(), org: new Set() };
+
+  const [personal, shared] = await Promise.all([
+    prisma.userMcpConnection.findMany({
+      where: { userId, mcpServerId: { in: serverIds } },
+      select: { mcpServerId: true },
+    }),
+    prisma.mcpServer.findMany({
+      where: { id: { in: serverIds }, ...GLOBAL_FALLBACK_WHERE },
+      select: { id: true },
+    }),
+  ]);
+
+  return {
+    personal: new Set(personal.map((c) => c.mcpServerId)),
+    org: new Set(shared.map((s) => s.id)),
+  };
+}
+
 export async function availableServerTypes(
   userId: string,
   serverTypes: string[],

--- a/apps/xyne-claw-auth/backend/src/lib/connector-hints.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-hints.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from "vitest";
+import {
+  connectorTypesFromText,
+  connectorTypesUserAskedFor,
+  wantsConnectorRoster,
+} from "./connector-hints.js";
+
+test("wantsConnectorRoster catches browse phrasings the model used to own", () => {
+  expect(wantsConnectorRoster("list down all the connectors")).toBe(true);
+  expect(wantsConnectorRoster("what connectors are available")).toBe(true);
+  expect(wantsConnectorRoster("show me all mcps")).toBe(true);
+  expect(wantsConnectorRoster("which integrations do you support")).toBe(true);
+});
+
+test("wantsConnectorRoster stays false when a specific connector is named", () => {
+  expect(wantsConnectorRoster("show me the google connector")).toBe(false);
+  expect(wantsConnectorRoster("connect the notion integration")).toBe(false);
+});
+
+test("wantsConnectorRoster stays false for ordinary tasks", () => {
+  expect(wantsConnectorRoster("summarize this doc for me")).toBe(false);
+  expect(wantsConnectorRoster("")).toBe(false);
+});
+
+test("connectors added to the hint table are inferrable by name and domain", () => {
+  expect(connectorTypesFromText("read this article from reddit", { includeKeywords: true })).toContain("reddit");
+  expect(connectorTypesFromText("https://www.reddit.com/r/programming/comments/x", {})).toContain("reddit");
+  expect(connectorTypesFromText("check this sentry issue", { includeKeywords: true })).toContain("sentry");
+  expect(connectorTypesFromText("is jenkins failing", { includeKeywords: true })).toContain("jenkins");
+});
+
+test("naming a connector still reads as an explicit ask, not a roster", () => {
+  expect(connectorTypesUserAskedFor("connect google")).toContain("google");
+  expect(connectorTypesUserAskedFor("show me the google connector")).toContain("google");
+  expect(connectorTypesUserAskedFor("summarize this google doc")).toEqual([]);
+});

--- a/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
@@ -65,6 +65,26 @@ export const CONNECTOR_HINTS: readonly ConnectorHint[] = [
   { serverType: "mixpanel", domains: ["mixpanel.com"], keywords: ["mixpanel"] },
   { serverType: "bigquery", keywords: ["bigquery"] },
   { serverType: "databricks", domains: ["databricks.com"], keywords: ["databricks"] },
+  { serverType: "reddit", domains: ["reddit.com"], keywords: ["reddit"] },
+  { serverType: "sentry", domains: ["sentry.io"], keywords: ["sentry"] },
+  { serverType: "twitter", domains: ["twitter.com", "x.com"], keywords: ["twitter", "tweet"] },
+  { serverType: "mongodb", domains: ["mongodb.com"], keywords: ["mongodb", "mongo"] },
+  { serverType: "clickhouse", domains: ["clickhouse.com"], keywords: ["clickhouse"] },
+  { serverType: "miro", domains: ["miro.com"], keywords: ["miro"] },
+  { serverType: "calendly", domains: ["calendly.com"], keywords: ["calendly"] },
+  { serverType: "docusign", domains: ["docusign.com", "docusign.net"], keywords: ["docusign"] },
+  { serverType: "egnyte", domains: ["egnyte.com"], keywords: ["egnyte"] },
+  { serverType: "excalidraw", domains: ["excalidraw.com"], keywords: ["excalidraw"] },
+  { serverType: "honeycomb", domains: ["honeycomb.io"], keywords: ["honeycomb"] },
+  { serverType: "customerio", domains: ["customer.io"], keywords: ["customer.io", "customerio"] },
+  { serverType: "attio", domains: ["attio.com"], keywords: ["attio"] },
+  { serverType: "mailerlite", domains: ["mailerlite.com"], keywords: ["mailerlite"] },
+  { serverType: "jotform", domains: ["jotform.com"], keywords: ["jotform"] },
+  { serverType: "webflow", domains: ["webflow.com"], keywords: ["webflow"] },
+  { serverType: "wix", domains: ["wix.com"], keywords: ["wix"] },
+  { serverType: "jenkins", keywords: ["jenkins"] },
+  { serverType: "kibana", keywords: ["kibana"] },
+  { serverType: "rapidapi-linkedin", domains: ["linkedin.com"], keywords: ["linkedin"] },
 ];
 
 /** Finds http(s) URLs; the host itself is then parsed, never regex-matched. */
@@ -182,6 +202,18 @@ const SHOW_CONNECTOR_INTENT =
  * report this: it has an incentive to claim explicit intent so its card is
  * shown, and has been observed doing so for plain task requests.
  */
+const ROSTER_INTENT =
+  /\b(show|see|view|open|display|list|find|browse|bring up|pull up|what|which|any)\b[^.?!\n]{0,60}\b(connector|connectors|mcp|mcps|integration|integrations)\b/i;
+
+export function wantsConnectorRoster(text: string): boolean {
+  if (!text.trim()) return false;
+  if (!ROSTER_INTENT.test(text)) return false;
+  return connectorTypesFromText(text, {
+    includeKeywords: true,
+    includeConnectKeywords: true,
+  }).length === 0;
+}
+
 export function connectorTypesUserAskedFor(text: string): string[] {
   if (!text.trim()) return [];
   if (!CONNECT_INTENT.test(text) && !SHOW_CONNECTOR_INTENT.test(text)) return [];

--- a/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/connector-hints.ts
@@ -32,6 +32,7 @@ export interface ConnectorHint {
   domains?: readonly string[];
   /** Whole-word prose signals, lowercase. */
   keywords?: readonly string[];
+  connectKeywords?: readonly string[];
 }
 
 export const CONNECTOR_HINTS: readonly ConnectorHint[] = [
@@ -41,11 +42,13 @@ export const CONNECTOR_HINTS: readonly ConnectorHint[] = [
     serverType: "google",
     domains: ["docs.google.com", "drive.google.com", "sheets.google.com", "mail.google.com"],
     keywords: ["gmail", "google doc", "google docs", "google drive", "google sheet", "google sheets", "google calendar", "google meet"],
+    connectKeywords: ["google", "google workspace"],
   },
   {
     serverType: "microsoft",
     domains: ["outlook.com", "outlook.office.com", "sharepoint.com"],
     keywords: ["onedrive", "outlook", "teams", "sharepoint"],
+    connectKeywords: ["microsoft", "microsoft 365", "office 365"],
   },
   { serverType: "slack", domains: ["slack.com"], keywords: ["slack"] },
   { serverType: "notion", domains: ["notion.so"], keywords: ["notion"] },
@@ -121,6 +124,7 @@ function keywordIndex(text: string, keyword: string): number {
 /** Connector types the text implies, in the order they first appear. */
 export interface ConnectorMatchOptions {
   includeKeywords?: boolean;
+  includeConnectKeywords?: boolean;
 }
 
 export function connectorTypesFromText(
@@ -144,11 +148,13 @@ export function connectorTypesFromText(
       }
     }
 
-    if (options.includeKeywords) {
-      for (const keyword of hint.keywords ?? []) {
-        const at = keywordIndex(prose, keyword);
-        if (at >= 0 && (earliest === -1 || at < earliest)) earliest = at;
-      }
+    const prosePatterns = [
+      ...(options.includeKeywords ? (hint.keywords ?? []) : []),
+      ...(options.includeConnectKeywords ? (hint.connectKeywords ?? []) : []),
+    ];
+    for (const keyword of prosePatterns) {
+      const at = keywordIndex(prose, keyword);
+      if (at >= 0 && (earliest === -1 || at < earliest)) earliest = at;
     }
 
     if (earliest >= 0) hits.push({ serverType: hint.serverType, at: earliest });
@@ -167,13 +173,17 @@ export function connectorTypesFromText(
 const CONNECT_INTENT =
   /\b(re)?connect(ed|ing|ion|ions)?\b|\bauthori[sz]e\b|\bintegrate\b|\bset ?up\b|\bsign in\b|\blog in\b|\bhook up\b/i;
 
+const SHOW_CONNECTOR_INTENT =
+  /\b(show|see|view|open|display|list|find|bring up|pull up)\b[^.?!\n]{0,60}\b(connector|connectors|mcp|mcps|integration|integrations)\b/i;
+
 /**
- * Connector types the HUMAN explicitly asked to connect, read from their own
- * message. The model cannot be trusted to report this: it has an incentive to
- * claim explicit intent so its card is shown, and has been observed doing so
- * for plain task requests.
+ * Connector types the HUMAN explicitly asked for, read from their own message —
+ * either to connect one or to be shown one. The model cannot be trusted to
+ * report this: it has an incentive to claim explicit intent so its card is
+ * shown, and has been observed doing so for plain task requests.
  */
-export function connectorTypesUserAskedToConnect(text: string): string[] {
-  if (!text.trim() || !CONNECT_INTENT.test(text)) return [];
-  return connectorTypesFromText(text, { includeKeywords: true });
+export function connectorTypesUserAskedFor(text: string): string[] {
+  if (!text.trim()) return [];
+  if (!CONNECT_INTENT.test(text) && !SHOW_CONNECTOR_INTENT.test(text)) return [];
+  return connectorTypesFromText(text, { includeKeywords: true, includeConnectKeywords: true });
 }

--- a/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
@@ -7,6 +7,7 @@ import { syncToolsForServer } from "../tool-sync.js";
 import { evictSession } from "../mcp/runner.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState } from "./oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -52,6 +53,8 @@ interface StatePayload {
   clientSecret?: string | undefined;
   codeVerifier: string;
   redirectUri: string;
+  /** Where the UI that started this flow wants the browser sent back to. */
+  returnTo?: string;
 }
 
 export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider {
@@ -199,7 +202,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
 
   router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req, res) => {
     const { userId } = req.params as { userId: string };
-    const { redirectUri, scope } = req.body as { redirectUri?: string; scope?: string };
+    const { redirectUri, scope, returnTo } = req.body as { redirectUri?: string; scope?: string; returnTo?: string };
 
     const callbackUri =
       redirectUri ??
@@ -210,7 +213,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = deriveCodeChallenge(codeVerifier);
 
-    const state = encodeState({ userId, clientId, ...(confidential ? { clientSecret } : {}), codeVerifier, redirectUri: callbackUri });
+    const state = encodeState({ userId, clientId, ...(confidential ? { clientSecret } : {}), codeVerifier, redirectUri: callbackUri, returnTo: resolveOAuthReturn(returnTo) });
 
     const url = new URL(authUrl);
     url.searchParams.set("client_id", clientId);
@@ -268,19 +271,21 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
   const callbackRouter = Router();
 
   callbackRouter.get(`/${type}/callback`, async (req: Request, res: Response) => {
-    const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+    // Default until the state verifies below — an unverified state must never
+    // steer the redirect.
+    let frontendUrl = defaultOAuthReturn();
 
     try {
       const { code, state, error: oauthError } = req.query as { code?: string; state?: string; error?: string };
 
       if (oauthError) {
         log.error(`[${type}-oauth] OAuth error: ${oauthError}`);
-        res.redirect(`${frontendUrl}?${type}_error=${encodeURIComponent(oauthError)}`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, oauthError));
         return;
       }
 
       if (!code || !state) {
-        res.redirect(`${frontendUrl}?${type}_error=missing_code_or_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "missing_code_or_state"));
         return;
       }
 
@@ -288,11 +293,12 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
       try {
         statePayload = decodeState(state);
       } catch {
-        res.redirect(`${frontendUrl}?${type}_error=invalid_state`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "invalid_state"));
         return;
       }
 
       const { userId, clientId, clientSecret, codeVerifier, redirectUri } = statePayload;
+      frontendUrl = resolveOAuthReturn(statePayload.returnTo);
 
       const tokenRes = await fetch(tokenUrl, {
         method: "POST",
@@ -303,7 +309,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
       if (!tokenRes.ok) {
         const text = await tokenRes.text();
         log.error(`[${type}-oauth] Browser callback token exchange failed: ${tokenRes.status} ${text}`);
-        res.redirect(`${frontendUrl}?${type}_error=token_exchange_failed`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "token_exchange_failed"));
         return;
       }
 
@@ -312,17 +318,17 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
       const user = await prisma.user.findUnique({ where: { id: userId } });
       if (!user) {
         log.error(`[${type}-oauth] User not found: ${userId}`);
-        res.redirect(`${frontendUrl}?${type}_error=user_not_found`);
+        res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "user_not_found"));
         return;
       }
 
       await storeTokens(userId, clientId, clientSecret, tokens.access_token, tokens.refresh_token, tokens.expires_in);
 
       log.info(`[${type}-oauth] Stored ${label} credentials for user ${userId} via browser callback`);
-      res.redirect(`${frontendUrl}?${type}_connected=true`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_connected`, "true"));
     } catch (err) {
       log.error(`[${type}-oauth] browser callback error:`, err);
-      res.redirect(`${frontendUrl}?${type}_error=internal_error`);
+      res.redirect(withOAuthResult(frontendUrl, `${type}_error`, "internal_error"));
     }
   });
 

--- a/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/mcp-oauth-provider.ts
@@ -8,6 +8,7 @@ import { evictSession } from "../mcp/runner.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "./oauth-token-endpoint.js";
 import { signOAuthState, verifyOAuthState } from "./oauth-state.js";
 import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "./oauth-return.js";
+import { oauthLimiter } from "../middleware/rate-limiters.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "./http.js";
 import { createLogger } from "../logger.js";
@@ -200,7 +201,7 @@ export function createMcpOAuthProvider(config: McpOAuthConfig): McpOAuthProvider
   const router = Router();
   router.use("/:userId", pinUserIdParam);
 
-  router.post(`/:userId/oauth/${type}/authorize`, asyncHandler(async (req, res) => {
+  router.post(`/:userId/oauth/${type}/authorize`, oauthLimiter, asyncHandler(async (req, res) => {
     const { userId } = req.params as { userId: string };
     const { redirectUri, scope, returnTo } = req.body as { redirectUri?: string; scope?: string; returnTo?: string };
 

--- a/apps/xyne-claw-auth/backend/src/lib/oauth-return.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/oauth-return.ts
@@ -1,0 +1,100 @@
+/**
+ * Post-OAuth return targets.
+ *
+ * Every OAuth callback used to redirect to a single global FRONTEND_URL (the
+ * claw SPA), so a flow started from Spaces finished on claw's home page and the
+ * user lost their place. The starting UI can now pass `returnTo`; the callback
+ * sends the browser back there instead.
+ *
+ * The value is a HINT, never trusted: it arrives from the browser and is acted
+ * on immediately after a credential is minted, so an unvalidated one is an open
+ * redirect handing an attacker the "connected" landing. Anything that isn't an
+ * allowed origin silently falls back to the old FRONTEND_URL behaviour.
+ */
+
+import { CONFIG } from "../config.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("oauth-return");
+
+function originOf(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Origins a post-OAuth redirect may target. */
+function allowedOrigins(): Set<string> {
+  const configured = (process.env["OAUTH_RETURN_ORIGINS"] ?? "")
+    .split(",")
+    .map((entry) => originOf(entry.trim()))
+    .filter((entry): entry is string => !!entry);
+
+  return new Set(
+    [
+      originOf(CONFIG.frontendUrl),
+      originOf(CONFIG.spacesAppUrl),
+      ...configured,
+    ].filter((entry): entry is string => !!entry),
+  );
+}
+
+/**
+ * Dev convenience: the local dashboard (:5173) is not any configured origin —
+ * SPACES_APP_URL points at the API (:3001) — so a localhost return would fall
+ * back to claw and the flow would look broken on every developer's machine.
+ * Production stays strictly on the allowlist.
+ */
+function isDevLoopback(origin: string): boolean {
+  if (process.env["NODE_ENV"] === "production") return false;
+  return /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
+}
+
+/** The default target — exactly what every callback did before `returnTo`. */
+export function defaultOAuthReturn(): string {
+  return process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+}
+
+/**
+ * Validate a client-supplied `returnTo`. Returns the default whenever it is
+ * absent, unparseable, or points somewhere we don't serve.
+ */
+export function resolveOAuthReturn(candidate: unknown): string {
+  if (typeof candidate !== "string" || candidate.trim().length === 0) {
+    return defaultOAuthReturn();
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate.trim());
+  } catch {
+    log.warn("[oauth-return] ignoring unparseable returnTo");
+    return defaultOAuthReturn();
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    log.warn(`[oauth-return] ignoring returnTo with protocol ${parsed.protocol}`);
+    return defaultOAuthReturn();
+  }
+  if (!allowedOrigins().has(parsed.origin) && !isDevLoopback(parsed.origin)) {
+    log.warn(`[oauth-return] ignoring returnTo outside the allowlist: ${parsed.origin}`);
+    return defaultOAuthReturn();
+  }
+  return parsed.toString();
+}
+
+/**
+ * Append the connected/error marker the UIs poll for. Uses URL rather than
+ * string concatenation because a returnTo legitimately carries its own query
+ * (e.g. /ai/library?tab=agents) and `?x=y` would corrupt it.
+ */
+export function withOAuthResult(base: string, key: string, value: string): string {
+  try {
+    const url = new URL(base);
+    url.searchParams.set(key, value);
+    return url.toString();
+  } catch {
+    return `${base}?${key}=${encodeURIComponent(value)}`;
+  }
+}

--- a/apps/xyne-claw-auth/backend/src/routes/agents.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agents.ts
@@ -3915,6 +3915,129 @@ router.post(
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Agent-level GitHub Copilot device-code login. Mirrors the user-level flow in
+// settings.ts, but stores the token as an AGENT credential so every run of this
+// agent uses it, rather than binding it to the person who signed in.
+//
+// Note this spends the signing-in user's Copilot seat on behalf of everyone who
+// runs the agent — unlike Claude/ChatGPT team accounts, Copilot is licensed per
+// user. Owner-or-admin only, and the acting user is recorded on the credential.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const AGENT_COPILOT_DEVICE_PREFIX = "gh-device-agent:";
+
+router.post(
+  "/:slug/provider-credentials/copilot/github-login",
+  requireAgentOwnerOrAdmin,
+  async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const agent = req.agentContext!.agent;
+      const ghRes = await fetch(GITHUB_DEVICE_CODE_URL, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: new URLSearchParams({ client_id: GITHUB_CLIENT_ID, scope: "read:user" }),
+      });
+      if (!ghRes.ok) {
+        const text = await ghRes.text().catch(() => "");
+        res.status(502).json({ success: false, error: `GitHub error: ${text.slice(0, 200)}` });
+        return;
+      }
+      const data = (await ghRes.json()) as {
+        device_code: string;
+        user_code: string;
+        verification_uri: string;
+        expires_in: number;
+        interval: number;
+      };
+      const redis = redisService.getConnection();
+      await redis.set(
+        `${AGENT_COPILOT_DEVICE_PREFIX}${agent.id}`,
+        JSON.stringify({ device_code: data.device_code, interval: data.interval }),
+        "EX",
+        DEVICE_CODE_TTL,
+      );
+      res.json({
+        success: true,
+        data: {
+          userCode: data.user_code,
+          verificationUri: data.verification_uri,
+          expiresIn: data.expires_in,
+          interval: data.interval,
+        },
+      });
+    } catch (err) {
+      log.error("[agents] copilot/github-login error:", err);
+      res.status(500).json({ success: false, error: "Failed to initiate GitHub login" });
+    }
+  },
+);
+
+router.post(
+  "/:slug/provider-credentials/copilot/github-poll",
+  requireAgentOwnerOrAdmin,
+  async (req: Request<{ slug: string }>, res: Response) => {
+    try {
+      const agent = req.agentContext!.agent;
+      const requesterId = getRequesterId(req);
+      const key = `${AGENT_COPILOT_DEVICE_PREFIX}${agent.id}`;
+      const redis = redisService.getConnection();
+      const raw = await redis.get(key);
+      if (!raw) {
+        res.status(400).json({ success: false, error: "No pending login — start again" });
+        return;
+      }
+      const { device_code } = JSON.parse(raw) as { device_code: string };
+
+      const ghRes = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: new URLSearchParams({
+          client_id: GITHUB_CLIENT_ID,
+          device_code,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      });
+      const data = (await ghRes.json()) as {
+        access_token?: string;
+        error?: string;
+        error_description?: string;
+      };
+
+      if (data.access_token) {
+        const encrypted = encrypt(data.access_token, CONFIG.encryptionKey);
+        await agentProviderCredentialsRepository.upsert(agent.id, "copilot", {
+          encryptedKey: encrypted.ciphertext,
+          iv: encrypted.iv,
+          authTag: encrypted.authTag,
+          authType: "oauth_token",
+          baseUrl: "https://api.githubcopilot.com",
+          ...(requesterId ? { createdByUserId: requesterId } : {}),
+        });
+        await redis.del(key);
+        res.json({ success: true, data: { status: "approved" } });
+        return;
+      }
+      if (data.error === "authorization_pending") {
+        res.json({ success: true, data: { status: "pending" } });
+        return;
+      }
+      if (data.error === "slow_down") {
+        res.json({ success: true, data: { status: "slow_down" } });
+        return;
+      }
+      await redis.del(key);
+      res.status(400).json({
+        success: false,
+        error: data.error_description ?? data.error ?? "Authorization failed",
+      });
+    } catch (err) {
+      log.error("[agents] copilot/github-poll error:", err);
+      res.status(500).json({ success: false, error: "GitHub login failed" });
+    }
+  },
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Agent-level Codex model list — mirror of `/settings/codex/models` but reads
 // the agent-scoped credential. ChatGPT OAuth tokens cannot hit OpenAI's
 // `/v1/models` (missing `api.model.read` scope, returns 403); Codex CLI works

--- a/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from "express";
 import { availableServerTypesSafe } from "../lib/connector-availability.js";
+import { prisma } from "../db.js";
 import { createLogger } from "../logger.js";
 
 const log = createLogger("connectors-internal");
@@ -34,5 +35,26 @@ connectorsInternalRouter.post("/available", async (req: Request, res: Response) 
     return;
   }
 
-  res.json({ success: true, connected: serverTypes.filter((t) => available.has(t)), known: true });
+  let existing: string[] = [];
+  try {
+    const rows = await prisma.mcpServer.findMany({
+      where: { type: { in: serverTypes }, enabled: true },
+      select: { type: true },
+    });
+    existing = rows.map((r) => r.type);
+  } catch (err) {
+    log.warn(
+      `[connectors-internal] catalog lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    res.json({ success: true, connected: serverTypes.filter((t) => available.has(t)), known: true });
+    return;
+  }
+
+  res.json({
+    success: true,
+    connected: serverTypes.filter((t) => available.has(t)),
+    existing: serverTypes.filter((t) => existing.includes(t)),
+    catalogKnown: true,
+    known: true,
+  });
 });

--- a/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/connectors-internal.ts
@@ -1,0 +1,38 @@
+import { Router, type Request, type Response } from "express";
+import { availableServerTypesSafe } from "../lib/connector-availability.js";
+import { createLogger } from "../logger.js";
+
+const log = createLogger("connectors-internal");
+
+const MAX_TYPES = 12;
+
+export const connectorsInternalRouter = Router();
+
+connectorsInternalRouter.post("/available", async (req: Request, res: Response) => {
+  const body = (req.body ?? {}) as { userId?: unknown; serverTypes?: unknown };
+  const userId = typeof body.userId === "string" ? body.userId.trim() : "";
+  const serverTypes = Array.isArray(body.serverTypes)
+    ? [
+        ...new Set(
+          body.serverTypes
+            .filter((t): t is string => typeof t === "string")
+            .map((t) => t.trim().toLowerCase())
+            .filter((t) => t.length > 0),
+        ),
+      ].slice(0, MAX_TYPES)
+    : [];
+
+  if (!userId || serverTypes.length === 0) {
+    res.json({ success: true, connected: [], known: false });
+    return;
+  }
+
+  const available = await availableServerTypesSafe(userId, serverTypes);
+  if (!available) {
+    log.warn(`[connectors-internal] availability unknown for user ${userId}`);
+    res.json({ success: true, connected: [], known: false });
+    return;
+  }
+
+  res.json({ success: true, connected: serverTypes.filter((t) => available.has(t)), known: true });
+});

--- a/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
@@ -33,6 +33,7 @@ import {
   getDocuSignClientCredentials,
 } from "../lib/docusign-config.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
 
 import { createLogger } from "../logger.js";
@@ -157,7 +158,7 @@ export const docusignOAuthProvider: OAuthTokenProvider = {
  */
 router.post("/:userId/oauth/docusign/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
-  const { redirectUri } = req.body as { redirectUri?: string };
+  const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 
   const callbackUri = redirectUri ?? defaultCallbackUri();
 
@@ -168,7 +169,7 @@ router.post("/:userId/oauth/docusign/authorize", asyncHandler(async (req: Reques
   authUrl.searchParams.set("redirect_uri", callbackUri);
   authUrl.searchParams.set("response_type", "code");
   authUrl.searchParams.set("scope", DOCUSIGN_SCOPES);
-  authUrl.searchParams.set("state", signOAuthState(userId, { redirectUri: callbackUri }));
+  authUrl.searchParams.set("state", signOAuthState(userId, { redirectUri: callbackUri, returnTo: resolveOAuthReturn(returnTo) }));
 
   ok(res, { authUrl: authUrl.toString() });
 }));
@@ -217,7 +218,9 @@ router.post("/:userId/oauth/docusign/callback", asyncHandler(async (req: Request
 export const docusignCallbackRouter = Router();
 
 docusignCallbackRouter.get("/docusign/callback", async (req: Request, res: Response) => {
-  const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+  // Default until the state verifies below — an unverified state must never
+  // steer the redirect.
+  let frontendUrl = defaultOAuthReturn();
 
   try {
     const { code, state, error: oauthError } = req.query as {
@@ -228,12 +231,12 @@ docusignCallbackRouter.get("/docusign/callback", async (req: Request, res: Respo
 
     if (oauthError) {
       log.error(`[docusign-oauth] OAuth error: ${oauthError}`);
-      res.redirect(`${frontendUrl}?docusign_error=${encodeURIComponent(oauthError)}`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", oauthError));
       return;
     }
 
     if (!code || !state) {
-      res.redirect(`${frontendUrl}?docusign_error=missing_code_or_state`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", "missing_code_or_state"));
       return;
     }
 
@@ -243,30 +246,31 @@ docusignCallbackRouter.get("/docusign/callback", async (req: Request, res: Respo
     } catch (err) {
       const reason = err instanceof OAuthStateError ? err.reason : "malformed";
       log.error(`[docusign-oauth] state ${reason}`);
-      res.redirect(`${frontendUrl}?docusign_error=invalid_state`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", "invalid_state"));
       return;
     }
 
     const userId = verified.userId;
+    frontendUrl = resolveOAuthReturn(verified.extra?.["returnTo"]);
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
       log.error(`[docusign-oauth] User not found: ${userId}`);
-      res.redirect(`${frontendUrl}?docusign_error=user_not_found`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", "user_not_found"));
       return;
     }
 
     const redirectUri = (verified.extra?.["redirectUri"] as string | undefined) ?? defaultCallbackUri();
     const result = await exchangeAndStore(userId, code, redirectUri);
     if (!result.ok) {
-      res.redirect(`${frontendUrl}?docusign_error=${encodeURIComponent(result.code)}`);
+      res.redirect(withOAuthResult(frontendUrl, "docusign_error", result.code));
       return;
     }
 
     log.info(`[docusign-oauth] Stored DocuSign credentials for user ${userId} (accountId: ${result.accountId})`);
-    res.redirect(`${frontendUrl}?docusign_connected=true`);
+    res.redirect(withOAuthResult(frontendUrl, "docusign_connected", "true"));
   } catch (err) {
     log.error("[docusign-oauth] browser callback error:", err);
-    res.redirect(`${frontendUrl}?docusign_error=internal_error`);
+    res.redirect(withOAuthResult(frontendUrl, "docusign_error", "internal_error"));
   }
 });
 

--- a/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/docusign-oauth.ts
@@ -34,6 +34,7 @@ import {
 } from "../lib/docusign-config.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
 import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
+import { oauthLimiter } from "../middleware/rate-limiters.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
 
 import { createLogger } from "../logger.js";
@@ -156,7 +157,7 @@ export const docusignOAuthProvider: OAuthTokenProvider = {
  * POST /:userId/oauth/docusign/authorize
  * Returns the DocuSign consent URL with an HMAC-signed `state`.
  */
-router.post("/:userId/oauth/docusign/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
+router.post("/:userId/oauth/docusign/authorize", oauthLimiter, asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
   const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 

--- a/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
@@ -25,6 +25,7 @@ import { CONFIG } from "../config.js";
 import { syncToolsForServer } from "../tool-sync.js";
 import { evictSession } from "../mcp/runner.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
+import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "../lib/oauth-token-endpoint.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
@@ -150,7 +151,7 @@ export const egnyteOAuthProvider: OAuthTokenProvider = {
  */
 router.post("/:userId/oauth/egnyte/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
-  const { redirectUri } = req.body as { redirectUri?: string };
+  const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 
   const envDomain = process.env["EGNYTE_DOMAIN"];
   if (!envDomain || envDomain.trim().length === 0) {
@@ -167,7 +168,7 @@ router.post("/:userId/oauth/egnyte/authorize", asyncHandler(async (req: Request<
   const callbackUri = redirectUri ?? defaultCallbackUri();
 
   // Encode the domain into the signed state so the callback can use it.
-  const state = signOAuthState(userId, { domain: normalizedDomain, redirectUri: callbackUri });
+  const state = signOAuthState(userId, { domain: normalizedDomain, redirectUri: callbackUri, returnTo: resolveOAuthReturn(returnTo) });
 
   const authUrl = new URL(egnyteAuthUrl(normalizedDomain));
   authUrl.searchParams.set("client_id", clientId);
@@ -228,7 +229,9 @@ router.post("/:userId/oauth/egnyte/callback", asyncHandler(async (req: Request<{
 export const egnyteCallbackRouter = Router();
 
 egnyteCallbackRouter.get("/egnyte/callback", async (req: Request, res: Response) => {
-  const frontendUrl = process.env["FRONTEND_URL"] ?? "http://localhost:5174/claw/";
+  // Default until the state verifies below — an unverified state must never
+  // steer the redirect.
+  let frontendUrl = defaultOAuthReturn();
 
   try {
     const { code, state, error: oauthError } = req.query as {
@@ -239,12 +242,12 @@ egnyteCallbackRouter.get("/egnyte/callback", async (req: Request, res: Response)
 
     if (oauthError) {
       log.error(`[egnyte-oauth] OAuth error: ${oauthError}`);
-      res.redirect(`${frontendUrl}?egnyte_error=${encodeURIComponent(oauthError)}`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", oauthError));
       return;
     }
 
     if (!code || !state) {
-      res.redirect(`${frontendUrl}?egnyte_error=missing_code_or_state`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "missing_code_or_state"));
       return;
     }
 
@@ -254,37 +257,38 @@ egnyteCallbackRouter.get("/egnyte/callback", async (req: Request, res: Response)
     } catch (err) {
       const reason = err instanceof OAuthStateError ? err.reason : "malformed";
       log.error(`[egnyte-oauth] state ${reason}`);
-      res.redirect(`${frontendUrl}?egnyte_error=invalid_state`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "invalid_state"));
       return;
     }
 
     const userId = verified.userId;
+    frontendUrl = resolveOAuthReturn(verified.extra?.["returnTo"]);
     const domain = verified.extra?.["domain"] as string | undefined;
     const redirectUri = (verified.extra?.["redirectUri"] as string | undefined) ?? defaultCallbackUri();
 
     if (!domain) {
-      res.redirect(`${frontendUrl}?egnyte_error=missing_domain_in_state`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "missing_domain_in_state"));
       return;
     }
 
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
       log.error(`[egnyte-oauth] User not found: ${userId}`);
-      res.redirect(`${frontendUrl}?egnyte_error=user_not_found`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "user_not_found"));
       return;
     }
 
     const result = await exchangeAndStore(userId, code, domain, redirectUri);
     if (!result.ok) {
-      res.redirect(`${frontendUrl}?egnyte_error=${encodeURIComponent(result.code)}`);
+      res.redirect(withOAuthResult(frontendUrl, "egnyte_error", result.code));
       return;
     }
 
     log.info(`[egnyte-oauth] Stored Egnyte credentials for user ${userId} (domain: ${domain}.egnyte.com)`);
-    res.redirect(`${frontendUrl}?egnyte_connected=true`);
+    res.redirect(withOAuthResult(frontendUrl, "egnyte_connected", "true"));
   } catch (err) {
     log.error("[egnyte-oauth] browser callback error:", err);
-    res.redirect(`${frontendUrl}?egnyte_error=internal_error`);
+    res.redirect(withOAuthResult(frontendUrl, "egnyte_error", "internal_error"));
   }
 });
 

--- a/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/egnyte-oauth.ts
@@ -26,6 +26,7 @@ import { syncToolsForServer } from "../tool-sync.js";
 import { evictSession } from "../mcp/runner.js";
 import { signOAuthState, verifyOAuthState, OAuthStateError } from "../lib/oauth-state.js";
 import { defaultOAuthReturn, resolveOAuthReturn, withOAuthResult } from "../lib/oauth-return.js";
+import { oauthLimiter } from "../middleware/rate-limiters.js";
 import { pinUserIdParam } from "../middleware/pin-user-id-param.js";
 import { type OAuthTokenProvider, TokenRefreshError } from "../lib/oauth-token-endpoint.js";
 import { asyncHandler, ok, badRequest, forbidden, HttpError } from "../lib/http.js";
@@ -149,7 +150,7 @@ export const egnyteOAuthProvider: OAuthTokenProvider = {
  * Body: { domain: string, redirectUri?: string }
  * Returns the Egnyte consent URL with an HMAC-signed `state` that includes the domain.
  */
-router.post("/:userId/oauth/egnyte/authorize", asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
+router.post("/:userId/oauth/egnyte/authorize", oauthLimiter, asyncHandler(async (req: Request<{ userId: string }>, res: Response, next?: NextFunction) => {
   const { userId } = req.params;
   const { redirectUri, returnTo } = req.body as { redirectUri?: string; returnTo?: string };
 

--- a/apps/xyne-claw-auth/backend/src/routes/servers.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/servers.ts
@@ -56,11 +56,11 @@ type ConnectorMeta = {
   mode?: string;
 };
 
-function parseConnectorMeta(value: unknown): ConnectorMeta {
+export function parseConnectorMeta(value: unknown): ConnectorMeta {
   return isRecord(value) ? (value as ConnectorMeta) : {};
 }
 
-function isVisibleToUser(meta: ConnectorMeta, requesterId?: string): boolean {
+export function isVisibleToUser(meta: ConnectorMeta, requesterId?: string): boolean {
   const scope = meta.scope ?? "global";
   if (scope === "global") return true;
   return Boolean(requesterId && meta.ownerUserId === requesterId);

--- a/apps/xyne-claw-auth/backend/src/routes/settings.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/settings.ts
@@ -23,7 +23,7 @@ const log = createLogger("settings");
 
 const router = Router();
 
-const VALID_PROVIDERS = new Set(["spaces", "copilot", "claude", "codex", "litellm"]);
+const VALID_PROVIDERS = new Set(["spaces", "copilot", "claude", "codex", "openrouter", "litellm"]);
 
 const GITHUB_CLIENT_ID = "Ov23li8tweQw6odWQebz";
 const GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code";

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -22,6 +22,7 @@ import {
   agentRequestRepository,
 } from "../repositories/index.js";
 import { buildAvailableToolsCatalog } from "./tools.js";
+import { isVisibleToUser, parseConnectorMeta } from "./servers.js";
 import {
   identityFromAgentRow,
   identityFromDraftSpec,
@@ -4929,17 +4930,20 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       // Resolve every requested type against the catalog. The model supplies
       // names only — descriptions and display names come from the row, and an
       // unknown type is dropped rather than rendered as an empty card.
-      const rows = listAll
+      const candidates = listAll
         ? await prisma.mcpServer.findMany({
             where: { enabled: true },
-            select: { id: true, type: true, name: true, description: true },
+            select: { id: true, type: true, name: true, description: true, connectorMeta: true },
             orderBy: { name: "asc" },
-            take: MCP_SUGGEST_ROSTER_SAMPLE,
           })
         : await prisma.mcpServer.findMany({
             where: { type: { in: pendingConnectorSuggestions.serverTypes }, enabled: true },
-            select: { id: true, type: true, name: true, description: true },
+            select: { id: true, type: true, name: true, description: true, connectorMeta: true },
           });
+      const visibleRows = candidates.filter((row) =>
+        isVisibleToUser(parseConnectorMeta(row.connectorMeta), ctx.senderId),
+      );
+      const rows = listAll ? visibleRows.slice(0, MCP_SUGGEST_ROSTER_SAMPLE) : visibleRows;
       const byType = new Map(rows.map((row) => [row.type, row]));
 
       const connectedIds = await availableServerIds(

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -149,7 +149,7 @@ import { isAgentInvocableBy } from "xyne-claw-shared";
 import { isSupportedInboundAttachment } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 import { tools as xyneSpacesTools } from "../mcp/servers/xyne-spaces-tools.js";
-import { connectorTypesFromText, connectorTypesUserAskedToConnect } from "../lib/connector-hints.js";
+import { connectorTypesFromText, connectorTypesUserAskedFor } from "../lib/connector-hints.js";
 import { availableServerIds } from "../lib/connector-availability.js";
 
 const clog = createLogger("webhook");
@@ -4904,10 +4904,9 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
   let inferredTypes: string[] = [];
   if (!payload.pendingConnectorSuggestions) {
     try {
-      inferredTypes = connectorTypesFromText(ctx.rootTask ?? ctx.task ?? "").slice(
-        0,
-        MCP_SUGGEST_INFERRED_MAX,
-      );
+      inferredTypes = connectorTypesFromText(ctx.rootTask ?? ctx.task ?? "", {
+        includeKeywords: true,
+      }).slice(0, MCP_SUGGEST_INFERRED_MAX);
     } catch (err) {
       log.warn("[mcp-suggest] connector inference failed (non-fatal)", {
         error: err instanceof Error ? err.message : String(err),
@@ -4963,7 +4962,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       // request, which is exactly how an already-usable connector slipped
       // through. The server owns this fact like every other on the card.
       const askedToConnect = new Set(
-        connectorTypesUserAskedToConnect(ctx.rootTask ?? ctx.task ?? ""),
+        connectorTypesUserAskedFor(ctx.rootTask ?? ctx.task ?? ""),
       );
 
       const connectors = ordered

--- a/apps/xyne-claw-auth/backend/src/routes/webhook.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/webhook.ts
@@ -150,8 +150,8 @@ import { isAgentInvocableBy } from "xyne-claw-shared";
 import { isSupportedInboundAttachment } from "xyne-claw-shared";
 import type { Todo } from "xyne-claw-shared";
 import { tools as xyneSpacesTools } from "../mcp/servers/xyne-spaces-tools.js";
-import { connectorTypesFromText, connectorTypesUserAskedFor } from "../lib/connector-hints.js";
-import { availableServerIds } from "../lib/connector-availability.js";
+import { connectorTypesFromText, connectorTypesUserAskedFor, wantsConnectorRoster } from "../lib/connector-hints.js";
+import { availabilityForServerIds } from "../lib/connector-availability.js";
 
 const clog = createLogger("webhook");
 const SDLC_AGENT_TOOL_PROFILE = buildSdlcAgentToolProfile(
@@ -3617,6 +3617,7 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     // Connector cards to post alongside the reply, so the user can connect
     // without leaving the conversation.
     pendingConnectorSuggestions?: PendingConnectorSuggestions;
+    blockedConnectors?: string[];
   };
 
   const sessionId = payload.sessionId ?? "";
@@ -4915,9 +4916,16 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
     }
   }
 
+  const rosterAsked =
+    !payload.pendingConnectorSuggestions && wantsConnectorRoster(ctx.rootTask ?? ctx.task ?? "");
+
   const pendingConnectorSuggestions: PendingConnectorSuggestions | undefined =
     payload.pendingConnectorSuggestions ??
-    (inferredTypes.length > 0 ? { serverTypes: inferredTypes, inferred: true } : undefined);
+    (rosterAsked
+      ? { serverTypes: [], listAll: true, inferred: true }
+      : inferredTypes.length > 0
+        ? { serverTypes: inferredTypes, inferred: true }
+        : undefined);
   if (pendingConnectorSuggestions && agentCardDeliverable) {
     try {
       // Roster mode: the user asked what exists, so the SERVER picks the sample
@@ -4946,10 +4954,11 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
       const rows = listAll ? visibleRows.slice(0, MCP_SUGGEST_ROSTER_SAMPLE) : visibleRows;
       const byType = new Map(rows.map((row) => [row.type, row]));
 
-      const connectedIds = await availableServerIds(
+      const availability = await availabilityForServerIds(
         ctx.senderId,
         rows.map((r) => r.id),
       );
+      const blockedTypes = new Set(payload.blockedConnectors ?? []);
 
       // Roster mode is already ordered by the query; otherwise preserve the
       // model's ordering, since it ranked them by relevance.
@@ -4975,12 +4984,17 @@ router.post("/result", requireStrictS2S, requireResultToken((req) => (req.body a
         // exceptions, both genuine user intent: roster mode ("what exists?"),
         // and the user naming a connector they want to connect, where a personal
         // connection is a legitimate want even under an org credential.
-        .filter((row) => listAll || askedToConnect.has(row.type) || !connectedIds.has(row.id))
+        .filter((row) => {
+          if (listAll || askedToConnect.has(row.type)) return true;
+          if (availability.personal.has(row.id)) return false;
+          if (availability.org.has(row.id)) return blockedTypes.has(row.type);
+          return true;
+        })
         .map((row) => ({
           serverType: row.type,
           name: row.name,
           ...(row.description ? { description: row.description } : {}),
-          connected: connectedIds.has(row.id),
+          connected: availability.personal.has(row.id) || availability.org.has(row.id),
         }));
 
       if (connectors.length === 0) {

--- a/apps/xyne-claw-auth/frontend/src/v3/components/MCPPageV3.tsx
+++ b/apps/xyne-claw-auth/frontend/src/v3/components/MCPPageV3.tsx
@@ -554,16 +554,35 @@ export function MCPPageV3({ userId }: Props) {
   // collect their credential fields via the AddConnectionDialog first. The raw
   // connect() would post empty credentials, which the backend rejects — and the
   // sidebar swallows the error, so the button appears to "do nothing".
-  const requiresCredentials = useCallback((s: McpServer) => {
-    if (s.oauth) return false;
-    if (s.type === "google" || s.type === "microsoft" || s.type === "xyne-spaces") return false;
-    const hasFormFields = (s.credentialForm?.fields?.length ?? 0) > 0;
-    const hasSchema = !!s.credentialSchema && Object.keys(s.credentialSchema).length > 0;
-    return hasFormFields || hasSchema;
-  }, []);
+  const requiresCredentials = useCallback(
+    (s: McpServer, resolvedFields?: CredentialField[]) => {
+      if (s.oauth) return false;
+      if (s.type === "google" || s.type === "microsoft" || s.type === "xyne-spaces") return false;
+      if (resolvedFields) return resolvedFields.length > 0;
+      const hasFormFields = (s.credentialForm?.fields?.length ?? 0) > 0;
+      const hasSchema = !!s.credentialSchema && Object.keys(s.credentialSchema).length > 0;
+      return hasFormFields || hasSchema;
+    },
+    [],
+  );
+
+  const resolveCredentialFields = useCallback(
+    async (type: string): Promise<CredentialField[] | undefined> => {
+      const cached = credentialFields[type];
+      if (cached) return cached;
+      try {
+        const map = await getCredentialFields();
+        setCredentialFields(map);
+        return map[type];
+      } catch {
+        return undefined;
+      }
+    },
+    [credentialFields],
+  );
 
   const handleConnect = useCallback(async (server: McpServer) => {
-    if (requiresCredentials(server)) {
+    if (requiresCredentials(server, await resolveCredentialFields(server.type))) {
       setConnectServerId(server.id);
       setShowAddDialog(true);
       return;
@@ -577,7 +596,7 @@ export function MCPPageV3({ userId }: Props) {
         description: err instanceof Error ? err.message : undefined,
       });
     }
-  }, [requiresCredentials, connect, showSnackbar]);
+  }, [requiresCredentials, resolveCredentialFields, connect, showSnackbar]);
 
   // OAuth callback params
   useEffect(() => {

--- a/apps/xyne-claw/src/mcp.ts
+++ b/apps/xyne-claw/src/mcp.ts
@@ -96,6 +96,15 @@ export function applyTrustedMcpBindings(
   return bindings ? { ...params, ...bindings } : params;
 }
 
+export class McpAuthServiceError extends Error {
+  readonly status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "McpAuthServiceError";
+    this.status = status;
+  }
+}
+
 async function authFetch<T>(path: string, sessionToken: string, init?: RequestInit): Promise<T> {
   const url = `${SERVER.authServiceUrl}${path}`;
   const res = await fetch(url, {
@@ -109,7 +118,7 @@ async function authFetch<T>(path: string, sessionToken: string, init?: RequestIn
   });
   const body = (await res.json()) as AuthResponse<T>;
   if (!body.success || body.data === undefined) {
-    throw new Error(body.error ?? `Auth service error: ${res.status}`);
+    throw new McpAuthServiceError(body.error ?? `Auth service error: ${res.status}`, res.status);
   }
   return body.data;
 }
@@ -229,6 +238,27 @@ export async function injectForwardedFiles(
   return { params: rewritten, forwarded };
 }
 
+async function callMcpWithBlockedCapture<T>(
+  path: string,
+  sessionToken: string,
+  init: RequestInit,
+  serverType: string,
+  onConnectorBlocked?: (serverType: string, status: number) => void,
+): Promise<T> {
+  try {
+    return await authFetch<T>(path, sessionToken, init);
+  } catch (err) {
+    if (err instanceof McpAuthServiceError && isCredentialRejection(err.status)) {
+      onConnectorBlocked?.(serverType, err.status);
+    }
+    throw err;
+  }
+}
+
+function isCredentialRejection(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
 export async function loadMcpToolsForUser(
   sessionId: string,
   sessionToken: string,
@@ -248,6 +278,7 @@ export async function loadMcpToolsForUser(
   // execution identity stable across context compaction and prevents a model
   // from omitting or replacing trusted run bindings.
   trustedToolBindings?: TrustedMcpToolBindings,
+  onConnectorBlocked?: (serverType: string, status: number) => void,
 ): Promise<{
   groups: McpToolGroup[];
   cleanup: () => Promise<void>;
@@ -323,7 +354,7 @@ export async function loadMcpToolsForUser(
             }
           }
           callParams = applyTrustedMcpBindings(callParams, trustedBindings);
-          const result = await authFetch<{
+          const result = await callMcpWithBlockedCapture<{
             content: string;
             citations?: import("xyne-claw-shared").Citation[];
             pendingAction?: Record<string, unknown>;
@@ -345,6 +376,8 @@ export async function loadMcpToolsForUser(
                 agentSlug,
               }),
             },
+            server.serverType,
+            onConnectorBlocked,
           );
 
           if (result.pendingAction) {

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -2879,7 +2879,7 @@ export async function processTask(
       allTools.push(buildDescribeAgentTool(describeAgentRef));
       // Same gate as describe-agent: a connector card is only worth posting
       // where a human is watching and can press Connect.
-      allTools.push(buildSuggestConnectorsTool(suggestConnectorsRef));
+      allTools.push(buildSuggestConnectorsTool(suggestConnectorsRef, userId));
     }
 
 

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -1547,6 +1547,7 @@ export async function processTask(
   const proposeAgentRef: ProposeAgentRef = {};
   const describeAgentRef: DescribeAgentRef = {};
   const suggestConnectorsRef: SuggestConnectorsRef = {};
+  const blockedConnectors = new Set<string>();
   const emitBriefRef: EmitBriefRef = {};
   let callbackProvider = provider ?? "spaces";
   // Seed from THIS run's provider — a hardcoded default made every early
@@ -1754,6 +1755,7 @@ export async function processTask(
       mcpOutputDir,
       (att) => pushAttachment(progressUrl, sessionId, att),
       trustedSdlcBindings,
+      (serverType) => blockedConnectors.add(serverType),
     );
     mcpGetAttachments = getMcpAttachments;
     // Expose the MCP-layer pendingActions getter to the catch handler so
@@ -4467,6 +4469,7 @@ export async function processTask(
       ...(suggestConnectorsRef.value
         ? { pendingConnectorSuggestions: suggestConnectorsRef.value }
         : {}),
+      ...(blockedConnectors.size > 0 ? { blockedConnectors: [...blockedConnectors] } : {}),
       ...(proposeAgentRef.value || describeAgentRef.value
         ? { pendingAgentCard: proposeAgentRef.value ?? describeAgentRef.value }
         : {}),
@@ -4662,6 +4665,7 @@ export async function processTask(
         ...(suggestConnectorsRef.value
           ? { pendingConnectorSuggestions: suggestConnectorsRef.value }
           : {}),
+        ...(blockedConnectors.size > 0 ? { blockedConnectors: [...blockedConnectors] } : {}),
         ...(pendingGoalSuggestion ? { pendingGoalSuggestion } : {}),
         ...(dedupedPendingActionsAtError.length > 0 ? { pendingActions: dedupedPendingActionsAtError } : {}),
         ...(attachmentsAtError.length > 0 ? { attachments: attachmentsAtError } : {}),

--- a/apps/xyne-claw/src/suggest-connectors.ts
+++ b/apps/xyne-claw/src/suggest-connectors.ts
@@ -18,6 +18,11 @@
  * catalog and drops anything it does not recognise. Nothing the model writes
  * reaches the card's title or description, so it cannot invent an integration
  * or misdescribe what one does.
+ *
+ * The tool checks the catalog BEFORE promising a card. It used to answer "cards
+ * will be shown" unconditionally, so a request for a connector we do not carry
+ * (prod: figma) had the model write "hit Connect on the card" over a card the
+ * server then silently dropped. Unknown types are now reported back instead.
  */
 
 import { Type } from "@sinclair/typebox";
@@ -48,9 +53,16 @@ const AVAILABILITY_TIMEOUT_MS = 2000;
 interface ConnectorAvailability {
   connected: string[];
   known: boolean;
+  existing: string[];
+  catalogKnown: boolean;
 }
 
-const UNKNOWN_AVAILABILITY: ConnectorAvailability = { connected: [], known: false };
+const UNKNOWN_AVAILABILITY: ConnectorAvailability = {
+  connected: [],
+  known: false,
+  existing: [],
+  catalogKnown: false,
+};
 
 async function fetchAvailability(
   userId: string | undefined,
@@ -66,11 +78,21 @@ async function fetchAvailability(
       signal: AbortSignal.timeout(AVAILABILITY_TIMEOUT_MS),
     });
     if (!res.ok) return UNKNOWN_AVAILABILITY;
-    const body = (await res.json()) as { connected?: unknown; known?: unknown };
+    const body = (await res.json()) as {
+      connected?: unknown;
+      known?: unknown;
+      existing?: unknown;
+      catalogKnown?: unknown;
+    };
     if (body.known !== true || !Array.isArray(body.connected)) return UNKNOWN_AVAILABILITY;
+    const catalogKnown = body.catalogKnown === true && Array.isArray(body.existing);
     return {
       connected: body.connected.filter((t): t is string => typeof t === "string"),
       known: true,
+      existing: catalogKnown
+        ? (body.existing as unknown[]).filter((t): t is string => typeof t === "string")
+        : [],
+      catalogKnown,
     };
   } catch (err) {
     log.warn(
@@ -102,20 +124,29 @@ export function buildSuggestConnectorsTool(
       "    GitHub or Bitbucket repo or PR, a Figma file, a Notion page, a Jira ticket.",
       "  • a task needs an account you have no working tools for (e.g. summarising a Google",
       "    Doc with no Google tools available),",
-      "  • the user asks to connect something by name (\"connect Figma\").",
+      "  • the user asks to connect something by name (\"connect Figma\"),",
+      "  • a tool you tried FAILED with a permission / auth error (401, 403, \"access denied\").",
+      "    That means the shared org account cannot reach THIS user\'s data, and their own",
+      "    connection is the fix. Call it even though tools for that service exist.",
       "",
       "Do NOT call it when:",
-      "  • you already have working tools for that service — an admin may have connected it",
-      "    org-wide, so tools can work without the user ever connecting anything,",
+      "  • you have working tools for that service and they are WORKING — an admin may have",
+      "    connected it org-wide, so tools can work without the user connecting anything,",
       "  • the user merely mentions a product by name, or the name appears in a task handed",
       "    to you by another agent,",
       "  • you are only explaining what a connector does.",
       "",
-      "The server resolves each type against the catalog, fills in the name, description and",
-      "connected state, and DROPS any connector that is already usable — including ones an",
-      "admin shared org-wide — unless the USER asked to connect it by name. It reads that",
-      "intent from the user\'s own message, not from you. So a card may not appear: never say",
-      "\"the card above\" or tell the user to press Connect. Say what you need and why.",
+      "The server resolves each type against the catalog and fills in the name, description",
+      "and connected state — nothing you write reaches the card. It DROPS a connector the",
+      "user has already connected themselves. One shared org-wide is dropped too, UNLESS a",
+      "tool call actually failed against it this turn, or the USER asked for it by name —",
+      "read from their own message, not from your claim.",
+      "",
+      "The tool result tells you exactly what will render. Follow it literally:",
+      "  • it names the connectors whose cards will appear → you may point at them,",
+      "  • it says a connector is NOT available → say so plainly; there is no card to press,",
+      "  • it says something is already connected → do not tell the user to connect it again.",
+      "Never refer to a card the result did not promise.",
       "",
       "This does not end your turn. Call it at most once per reply.",
     ].join("\n"),
@@ -181,17 +212,36 @@ export function buildSuggestConnectorsTool(
       }
 
       const title = typeof p["title"] === "string" ? p["title"].trim().slice(0, 120) : "";
-      ref.value = { serverTypes, ...(title ? { title } : {}), ...(listAll ? { listAll: true } : {}) };
+      const availability = listAll
+        ? UNKNOWN_AVAILABILITY
+        : await fetchAvailability(userId, serverTypes);
+
+      const renderable =
+        listAll || !availability.catalogKnown
+          ? serverTypes
+          : serverTypes.filter((t) => availability.existing.includes(t));
+
+      if (!listAll && availability.catalogKnown && renderable.length === 0) {
+        log.info(`[suggest-connectors] no catalog entry for: ${serverTypes.join(", ")}`);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `No connector is available for ${serverTypes.join(", ")}. NO card will be shown. Tell the user plainly that this connector is not available on Xyne yet — do NOT tell them to press Connect or refer to a card.`,
+            },
+          ],
+          details: { serverTypes, unavailable: serverTypes },
+        };
+      }
+
+      ref.value = { serverTypes: renderable, ...(title ? { title } : {}), ...(listAll ? { listAll: true } : {}) };
       log.info(
         listAll
           ? "[suggest-connectors] queued roster listing"
           : `[suggest-connectors] queued ${serverTypes.length}: ${serverTypes.join(", ")}`,
       );
 
-      const availability = listAll
-        ? UNKNOWN_AVAILABILITY
-        : await fetchAvailability(userId, serverTypes);
-      const connected = availability.connected.filter((t) => serverTypes.includes(t));
+      const connected = availability.connected.filter((t) => renderable.includes(t));
 
       const stateNote = connected.length
         ? ` ${connected.join(", ")} ${connected.length === 1 ? "is" : "are"} ALREADY CONNECTED and the card shows it that way — do NOT tell the user to press Connect or link an account for ${connected.length === 1 ? "it" : "them"}; say what you can already do with ${connected.length === 1 ? "it" : "them"}.`
@@ -205,10 +255,10 @@ export function buildSuggestConnectorsTool(
             type: "text" as const,
             text: listAll
               ? "A connector list with a Browse button will be shown with your reply. Do NOT list the connectors in your text — say at most one short line."
-              : `Connector cards for ${serverTypes.join(", ")} will be shown with your reply. Do NOT list or describe these connectors in your text — say at most one short line about why they help.${stateNote}`,
+              : `Connector cards for ${renderable.join(", ")} will be shown with your reply. Do NOT list or describe these connectors in your text — say at most one short line about why they help.${stateNote}`,
           },
         ],
-        details: { serverTypes, listAll, ...(availability.known ? { connected } : {}) },
+        details: { serverTypes: renderable, listAll, ...(availability.known ? { connected } : {}) },
       };
     },
   };

--- a/apps/xyne-claw/src/suggest-connectors.ts
+++ b/apps/xyne-claw/src/suggest-connectors.ts
@@ -23,6 +23,7 @@
 import { Type } from "@sinclair/typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "./logger.js";
+import { SERVER } from "./config.js";
 
 const log = createLogger("suggest-connectors");
 
@@ -42,8 +43,47 @@ export interface SuggestConnectorsRef {
 }
 
 const MAX_SUGGESTIONS = 6;
+const AVAILABILITY_TIMEOUT_MS = 2000;
 
-export function buildSuggestConnectorsTool(ref: SuggestConnectorsRef): ToolDefinition {
+interface ConnectorAvailability {
+  connected: string[];
+  known: boolean;
+}
+
+const UNKNOWN_AVAILABILITY: ConnectorAvailability = { connected: [], known: false };
+
+async function fetchAvailability(
+  userId: string | undefined,
+  serverTypes: string[],
+): Promise<ConnectorAvailability> {
+  if (!userId || !SERVER.s2sKey || serverTypes.length === 0) return UNKNOWN_AVAILABILITY;
+  try {
+    const base = SERVER.authServiceUrl.replace(/\/$/, "");
+    const res = await fetch(`${base}/claw/api/v1/internal/connectors/available`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-s2s-key": SERVER.s2sKey },
+      body: JSON.stringify({ userId, serverTypes }),
+      signal: AbortSignal.timeout(AVAILABILITY_TIMEOUT_MS),
+    });
+    if (!res.ok) return UNKNOWN_AVAILABILITY;
+    const body = (await res.json()) as { connected?: unknown; known?: unknown };
+    if (body.known !== true || !Array.isArray(body.connected)) return UNKNOWN_AVAILABILITY;
+    return {
+      connected: body.connected.filter((t): t is string => typeof t === "string"),
+      known: true,
+    };
+  } catch (err) {
+    log.warn(
+      `[suggest-connectors] availability lookup failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return UNKNOWN_AVAILABILITY;
+  }
+}
+
+export function buildSuggestConnectorsTool(
+  ref: SuggestConnectorsRef,
+  userId?: string,
+): ToolDefinition {
   return {
     name: SUGGEST_CONNECTORS_TOOL_NAME,
     label: "Suggest Connectors",
@@ -148,16 +188,27 @@ export function buildSuggestConnectorsTool(ref: SuggestConnectorsRef): ToolDefin
           : `[suggest-connectors] queued ${serverTypes.length}: ${serverTypes.join(", ")}`,
       );
 
+      const availability = listAll
+        ? UNKNOWN_AVAILABILITY
+        : await fetchAvailability(userId, serverTypes);
+      const connected = availability.connected.filter((t) => serverTypes.includes(t));
+
+      const stateNote = connected.length
+        ? ` ${connected.join(", ")} ${connected.length === 1 ? "is" : "are"} ALREADY CONNECTED and the card shows it that way — do NOT tell the user to press Connect or link an account for ${connected.length === 1 ? "it" : "them"}; say what you can already do with ${connected.length === 1 ? "it" : "them"}.`
+        : availability.known
+          ? " None of them are connected yet, so each card carries a Connect button."
+          : "";
+
       return {
         content: [
           {
             type: "text" as const,
             text: listAll
               ? "A connector list with a Browse button will be shown with your reply. Do NOT list the connectors in your text — say at most one short line."
-              : `Connector cards for ${serverTypes.join(", ")} will be shown with your reply, each with a Connect button. Do NOT list or describe these connectors in your text — say at most one short line about why they help.`,
+              : `Connector cards for ${serverTypes.join(", ")} will be shown with your reply. Do NOT list or describe these connectors in your text — say at most one short line about why they help.${stateNote}`,
           },
         ],
-        details: { serverTypes, listAll },
+        details: { serverTypes, listAll, ...(availability.known ? { connected } : {}) },
       };
     },
   };

--- a/apps/xyne-claw/test/suggest-connectors-availability.test.ts
+++ b/apps/xyne-claw/test/suggest-connectors-availability.test.ts
@@ -90,3 +90,41 @@ test("skips the lookup entirely when no userId is wired through", async () => {
   expect(fetchSpy).not.toHaveBeenCalled();
   expect(ref.value).toEqual({ serverTypes: ["github"] });
 });
+
+test("refuses to promise a card for a connector the catalog does not have", async () => {
+  mockAvailability({ success: true, connected: [], known: true, existing: [], catalogKnown: true });
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["figma"] }, "user-1");
+
+  expect(ref.value).toBeUndefined();
+  expect(out.content[0]?.text).toContain("not available on Xyne yet");
+  expect(out.content[0]?.text).toContain("NO card will be shown");
+  expect(out.details?.["unavailable"]).toEqual(["figma"]);
+});
+
+test("keeps only the connectors that exist when some of them do", async () => {
+  mockAvailability({
+    success: true,
+    connected: [],
+    known: true,
+    existing: ["github"],
+    catalogKnown: true,
+  });
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["figma", "github"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["github"] });
+  expect(out.content[0]?.text).toContain("github");
+  expect(out.content[0]?.text).not.toContain("figma");
+});
+
+test("falls open to the old behaviour when the catalog answer is missing", async () => {
+  mockAvailability({ success: true, connected: [], known: true });
+
+  const ref: SuggestConnectorsRef = {};
+  await callTool(ref, { serverTypes: ["figma"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["figma"] });
+});

--- a/apps/xyne-claw/test/suggest-connectors-availability.test.ts
+++ b/apps/xyne-claw/test/suggest-connectors-availability.test.ts
@@ -1,0 +1,92 @@
+import { test, expect, vi, afterEach } from "vitest";
+
+vi.hoisted(() => {
+  process.env["XYNE_CLAW_S2S_KEY"] = "test-key";
+});
+
+import {
+  buildSuggestConnectorsTool,
+  type SuggestConnectorsRef,
+} from "../src/suggest-connectors.js";
+
+async function callTool(ref: SuggestConnectorsRef, params: unknown, userId?: string) {
+  const tool = buildSuggestConnectorsTool(ref, userId);
+  return (
+    tool as unknown as {
+      execute: (
+        id: string,
+        p: unknown,
+      ) => Promise<{ content: { text: string }[]; details?: Record<string, unknown> }>;
+    }
+  ).execute("tc-1", params);
+}
+
+function mockAvailability(body: unknown, ok = true): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok, json: async () => body }) as unknown as Response),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("tells the model when a connector is already connected", async () => {
+  mockAvailability({ success: true, connected: ["github"], known: true });
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["github"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["github"] });
+  expect(out.content[0]?.text).toContain("ALREADY CONNECTED");
+  expect(out.content[0]?.text).not.toContain("each card carries a Connect button");
+  expect(out.details?.["connected"]).toEqual(["github"]);
+});
+
+test("promises a Connect button only when the lookup says nothing is connected", async () => {
+  mockAvailability({ success: true, connected: [], known: true });
+
+  const out = await callTool({}, { serverTypes: ["figma"] }, "user-1");
+
+  expect(out.content[0]?.text).toContain("each card carries a Connect button");
+  expect(out.content[0]?.text).not.toContain("ALREADY CONNECTED");
+});
+
+test("stays silent about state when the lookup is unavailable", async () => {
+  mockAvailability({}, false);
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["notion"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["notion"] });
+  expect(out.content[0]?.text).not.toContain("ALREADY CONNECTED");
+  expect(out.content[0]?.text).not.toContain("Connect button");
+  expect(out.details?.["connected"]).toBeUndefined();
+});
+
+test("still queues the card when the lookup throws", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      throw new Error("connection refused");
+    }),
+  );
+
+  const ref: SuggestConnectorsRef = {};
+  const out = await callTool(ref, { serverTypes: ["slack"] }, "user-1");
+
+  expect(ref.value).toEqual({ serverTypes: ["slack"] });
+  expect(out.content[0]?.text).toContain("Connector cards for slack");
+});
+
+test("skips the lookup entirely when no userId is wired through", async () => {
+  const fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+
+  const ref: SuggestConnectorsRef = {};
+  await callTool(ref, { serverTypes: ["github"] });
+
+  expect(fetchSpy).not.toHaveBeenCalled();
+  expect(ref.value).toEqual({ serverTypes: ["github"] });
+});


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend

## Type of Change

- [x] New feature
- [x] Enhancement
- [x] Bugfix

## Description

The `xyne-claw` / `xyne-claw-auth` half of #1427, split out so claw deploys on its own cadence. Dashboard changes stay in #1427. XYNE-61540.

Replaces #1527 (closed), rebuilt on the current `feature/deploy-xyneclaw` head so it includes the run-control work that landed after #1527 was cut.

- **The connector card now shows only what you can actually use.** Availability is split into your own connections vs the org's shared ones. An org credential no longer hides the card when it can't do the job — that case is driven by a real 401/403 from the MCP layer, not the model's claim. `authFetch` throws a typed error so the check reads `err.status`, not a substring match.
- **No more phantom cards.** The tool answered "cards will be shown" without checking the catalog, so asking for a connector we don't carry (figma) had the model write "hit Connect on the card" over a card the server then silently dropped. The catalog is checked before anything is promised; unknown types come back as "not available". Fails open, so the two services can deploy in any order.
- **Better recognition.** The server detects "list all the connectors" itself instead of depending on the model, and 20 connectors that had no hints (reddit, sentry, jenkins, mongodb, miro, calendly…) are inferrable from a name or link again.
- **The card fires on an explicit ask.** "connect google" triggers it, not just an inferred link. `connectorTypesUserAskedToConnect` → `connectorTypesUserAskedFor`, which also matches "show me my connectors".
- **Credentials dialog fix (v3).** `MCPPageV3` decided from `mcp_servers.credentialForm`, unset in pre-prod for Amplitude, BigQuery, Asana and Bitbucket — so the dialog was skipped and Connect posted empty credentials → 400. Now resolved from the registry at click time.
- **OAuth returns to the UI that started it.** Callbacks all went to one global `FRONTEND_URL`, so a flow started in Spaces finished on claw's home page. The starting UI can pass `returnTo`, carried in the HMAC-signed state and validated against an origin allowlist.
- **Agent-scoped Copilot OAuth.** A GitHub device flow storing the token on the *agent*, not the person signing in — the agent-level counterpart to the existing user-level route.
- **OpenRouter allowlist fix.** `settings.ts` rejected `openrouter` while `agents.ts` allowed it, so the UI could offer it and then 400 on save.
- **Rate limiting.** OAuth `authorize` routes now use the existing `oauthLimiter`, closing a CodeQL finding. `/callback` is left alone on purpose: it mounts without `requireAuth`, so the limiter would key on `req.ip`, and with no `trust proxy` every callback behind the ingress would share one bucket.

## Areas Touched

- [x] `apps/xyne-claw` / `apps/xyne-claw-auth`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] Feature flag or runtime config changed

Optional only: `OAUTH_RETURN_ORIGINS` (comma-separated) extends the post-OAuth redirect allowlist. Unset, the allowlist is `FRONTEND_URL` + `SPACES_APP_URL`, which is what production already has — nothing to set for this to ship. Non-production additionally accepts localhost, since `SPACES_APP_URL` points at the API port and a dev return would otherwise be rejected on every machine.

## API Contract

- [x] New endpoint

All additive:
- `POST /internal/connectors/available` — S2S only; which of the given connector types a user has connected.
- `POST /agents/:slug/provider-credentials/copilot/github-{login,poll}` — agent-scoped Copilot device flow, owner-or-admin.
- `POST /users/:userId/oauth/:type/authorize` — accepts an optional `returnTo`. Existing callers that omit it are unaffected.

No existing contract changed.

---

## Rollout notes

**This PR alone changes nothing user-visible for the OAuth redirect.** The three dashboard files that actually send `returnTo` ship in #1427. With no `returnTo` arriving, every callback falls back to the old claw URL exactly as today — safe to merge in either order, but the fix only takes effect once both are out.

The internal connectors router is mounted in `http/routes.ts`, not `main.ts` — this branch moved route mounting there after #1427 was cut. Same import, same `${BASE}/internal/connectors` path, same `requireStrictS2S` guard.

Copilot is licensed **per user**. An agent-level Copilot token means the signing-in account's seat serves everyone who runs that agent, unlike the team Claude/ChatGPT accounts the existing agent OAuth flows capture. Deliberate, gated to owner/admin, and the acting user is recorded on the credential — but worth a second opinion before it ships.

## Verification

Typechecked against a clean baseline of this branch's base: `xyne-claw-auth` 20 errors before / 20 after, `xyne-claw` 24 before / 24 after — **zero introduced**. (Both baselines are pre-existing local-resolution noise, not deploy-branch errors.)

Not exercised end to end: the Copilot device flow needs a Copilot seat, and the OAuth return needs a registered redirect URI, so both were verified by reading rather than by clicking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qbkst9h49jK2WvvwywM1ZR

