### PR TITLE
fix: eliminate hover-driven style recalc storm in thread list

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -1162,7 +1162,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
       data-hover-key={hoverToolbarKey}
       className={cn(
         isMobile && 'no-select-mobile',
-        'group/bubble relative transition-all duration-200 ease-in-out',
+        'group/bubble relative transition-colors duration-200 ease-in-out',
         // Row highlight driven by the shared MessageHoverToolbar, which stamps
         // `data-hovered` on the [data-message-id] root. Applied at the root so
         // every sub-layout (message, link/canvas previews, reply layout) is

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/MessageHoverToolbar.tsx
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/MessageHoverToolbar.tsx
@@ -90,6 +90,16 @@ export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ contai
     const container = containerRef.current;
     if (!container) return;
 
+    // The container's viewport rect only shifts on scroll/resize/layout, not
+    // per hovered row. Reading it on every pointerover forced a second
+    // synchronous layout flush per event; cache it and recompute lazily after
+    // a scroll/resize instead.
+    let containerTop = 0;
+    let containerTopDirty = true;
+    const markContainerDirty = (): void => {
+      containerTopDirty = true;
+    };
+
     const handlePointerOver = (event: MouseEvent): void => {
       // While a picker/dropdown is pinned open, freeze the toolbar in place.
       if (pinnedOpenRef.current) return;
@@ -117,6 +127,15 @@ export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ contai
       const hoverKey = row.getAttribute('data-hover-key');
       if (!messageId || !hoverKey) return;
 
+      // Read layout geometry BEFORE stamping data-hovered so this
+      // getBoundingClientRect read does not flush the style invalidation we are
+      // about to create. The container rect is cached across rows.
+      if (containerTopDirty) {
+        containerTop = container.getBoundingClientRect().top;
+        containerTopDirty = false;
+      }
+      const top = Math.round(row.getBoundingClientRect().top - containerTop);
+
       setHighlightedRow(row);
       const actions = getMessageHoverActions(hoverKey);
       hoveredMessage.current = {
@@ -124,9 +143,6 @@ export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ contai
         ...(actions?.conversationId !== undefined && { conversationId: actions.conversationId }),
       };
 
-      const top = Math.round(
-        row.getBoundingClientRect().top - container.getBoundingClientRect().top,
-      );
       const prev = activeRowRef.current;
       if (prev && prev.hoverKey === hoverKey && prev.top === top) return;
       setActiveRow({ hoverKey, messageId, top });
@@ -138,6 +154,7 @@ export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ contai
     };
 
     const handleScroll = (): void => {
+      markContainerDirty();
       if (pinnedOpenRef.current) return;
       hide();
     };
@@ -148,6 +165,7 @@ export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ contai
     container.addEventListener('mouseleave', handlePointerLeave);
     // The (Virtuoso) scroller lives inside the container — capture catches it.
     container.addEventListener('scroll', handleScroll, { capture: true, passive: true });
+    window.addEventListener('resize', markContainerDirty);
     return (): void => {
       cancelPendingClear();
       container.removeEventListener('pointerover', handlePointerOver);
@@ -155,6 +173,7 @@ export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ contai
       container.removeEventListener('mouseover', handlePointerOver);
       container.removeEventListener('mouseleave', handlePointerLeave);
       container.removeEventListener('scroll', handleScroll, { capture: true });
+      window.removeEventListener('resize', markContainerDirty);
     };
   }, [cancelPendingClear, containerRef, hide, setHighlightedRow]);
 

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/MessageHoverToolbar.tsx
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/MessageHoverToolbar.tsx
@@ -159,10 +159,11 @@ export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ contai
       hide();
     };
 
+    // Pointer events already cover mouse, touch and pen, so one
+    // pointerover/pointerleave pair is enough. The old mouseover/mouseleave
+    // duplicates fired handlePointerOver twice per mouse move.
     container.addEventListener('pointerover', handlePointerOver);
     container.addEventListener('pointerleave', handlePointerLeave);
-    container.addEventListener('mouseover', handlePointerOver);
-    container.addEventListener('mouseleave', handlePointerLeave);
     // The (Virtuoso) scroller lives inside the container — capture catches it.
     container.addEventListener('scroll', handleScroll, { capture: true, passive: true });
     window.addEventListener('resize', markContainerDirty);
@@ -170,8 +171,6 @@ export const MessageHoverToolbar: React.FC<MessageHoverToolbarProps> = ({ contai
       cancelPendingClear();
       container.removeEventListener('pointerover', handlePointerOver);
       container.removeEventListener('pointerleave', handlePointerLeave);
-      container.removeEventListener('mouseover', handlePointerOver);
-      container.removeEventListener('mouseleave', handlePointerLeave);
       container.removeEventListener('scroll', handleScroll, { capture: true });
       window.removeEventListener('resize', markContainerDirty);
     };

--- a/apps/dashboard/src/components/Chat/MessageAttachment/MessageAttachment.tsx
+++ b/apps/dashboard/src/components/Chat/MessageAttachment/MessageAttachment.tsx
@@ -1371,7 +1371,7 @@ export const MessageAttachment: React.FC<MessageAttachmentProps> = ({
     <>
       <div
         className={cn(
-          'message-attachment group/attachment relative flex flex-col bg-card border border-border rounded-lg overflow-hidden hover:shadow-md transition-all duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+          'message-attachment group/attachment relative flex flex-col bg-card border border-border rounded-lg overflow-hidden hover:shadow-md transition-shadow duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
           compact
             ? 'w-16 h-16 '
             : isInGrid
@@ -1432,7 +1432,7 @@ export const MessageAttachment: React.FC<MessageAttachmentProps> = ({
         </div>
 
         {/* Hover overlay for better UX feedback */}
-        <div className='absolute inset-0 bg-black bg-opacity-0 group-hover/attachment:bg-opacity-5 transition-all duration-200 pointer-events-none' />
+        <div className='absolute inset-0 bg-black bg-opacity-0 group-hover/attachment:bg-opacity-5 transition-colors duration-200 pointer-events-none' />
       </div>
     </>
   );

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -1158,7 +1158,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                           }
                         }
                   }
-                  className={`${isMobile ? 'text-[12px]' : 'text-xs'} text-muted-foreground cursor-pointer hover:underline transition-all duration-150 visual-regression-hide ${searchItemView ? 'ml-auto shrink-0' : ''}`}
+                  className={`${isMobile ? 'text-[12px]' : 'text-xs'} text-muted-foreground cursor-pointer hover:underline transition-colors duration-150 visual-regression-hide ${searchItemView ? 'ml-auto shrink-0' : ''}`}
                 >
                   {searchItemView || context === 'thread'
                     ? formatThreadTimestamp(message.createdAt)
@@ -1801,7 +1801,7 @@ export const ReactionView = ({
               <button
                 type='button'
                 data-testid='message-reaction-chip'
-                className={`inline-flex items-center gap-1 h-6 px-2 rounded-full text-sm cursor-pointer transition-all duration-150 ${
+                className={`inline-flex items-center gap-1 h-6 px-2 rounded-full text-sm cursor-pointer transition-colors duration-150 ${
                   reaction.userHasReacted
                     ? 'bg-accent border border-action-primary hover:bg-accent/80'
                     : 'bg-muted hover:bg-accent'
@@ -1874,7 +1874,7 @@ export const ReactionView = ({
             <Popover.Trigger asChild>
               <button
                 type='button'
-                className='inline-flex items-center justify-center w-6 h-6 rounded-full text-muted-foreground bg-muted hover:bg-accent cursor-pointer transition-all duration-150'
+                className='inline-flex items-center justify-center w-6 h-6 rounded-full text-muted-foreground bg-muted hover:bg-accent cursor-pointer transition-colors duration-150'
                 onClick={e => e.stopPropagation()}
                 data-track-category='MESSAGE'
                 data-track-name='OPEN_EMOJI_PICKER'


### PR DESCRIPTION
## What
Fixes the main-thread CPU pin (~91%) when hovering messages in a long thread. Applies fixes #1 and #2 from the performance profile; toolbar-remount (#3) and thread virtualization are intentionally left for a follow-up.

## Root cause
Each `pointerover` forced a synchronous style recalc that re-evaluated **every** animatable property on every `transition-all` element, starting thousands of `scrollbar-color` transitions (99% of the storm) — a pure `transition-all` artifact. The hover toolbar compounded it by reading `getBoundingClientRect()` twice per event, flushing layout synchronously.

## Changes
**#1 — Scope animations to what actually changes**
- `ChatBubble` bubble root: `transition-all` → `transition-colors` (only `data-[hovered]:bg-muted/50` animates). This is the amplifier — one instance per rendered message.
- `MessageAttachment` card: `transition-all` → `transition-shadow` (preserves the intended `hover:shadow-md`).
- `MessageAttachment` hover overlay: `transition-all` → `transition-colors`.

**#2 — Remove the forced synchronous reflow per hover** (`MessageHoverToolbar`)
- Cache the container's viewport rect; recompute lazily only after scroll/resize instead of reading `getBoundingClientRect()` twice per `pointerover`.
- Read row geometry **before** stamping `data-hovered`, so the layout read no longer flushes the style invalidation it just created.

## Intentionally not touched
- `ExpandableMessage` / `RenderMessageWithHTML` keep `transition-all` — they animate `max-height`/spacing for expand-collapse, not color.
- `MessageHoverToolbar` `key={hoverKey}` remount (#3) and `ThreadList` virtualization are separate follow-ups (this will likely be merged with the thread-virtualization work).

## Validation
- `pnpm --filter dashboard typecheck` passes clean.
- Manual re-profile of thread hover still pending (please re-profile after merge/preview).

## Notes
No XYNE ticket key was provided for the branch/title — happy to rename if there's a ticket to attach.
