### PR TITLE
fix: keep ThreadList mounted across thread query re-subscription (preserve unread divider & scroll position)

### DIFF
--- a/apps/dashboard/src/components/Chat/ThreadPannel.tsx
+++ b/apps/dashboard/src/components/Chat/ThreadPannel.tsx
@@ -307,6 +307,29 @@ export const ThreadMessages = ({
   const messagesDetails = propThreadMessages ? { type: 'complete' as const } : queryDetails;
   const isMessagesLoaded = messagesDetails.type === 'complete' || messagesDetails.type === 'error';
 
+  // The enriched thread query is re-subscribed whenever its inputs change — most
+  // notably when channel membership (isMember) resolves and recreates the query
+  // object. During that re-subscription `conversation` reads null for a frame or
+  // two while `isMessagesLoaded` stays true. That transient used to flip the render
+  // below from <ThreadList> to the "No thread messages" placeholder and back,
+  // remounting ThreadList mid-open. The remount re-ran ThreadList's mark-as-read
+  // effect, which overwrote the stored lastReadAt with `now`, so the unread divider
+  // and first-unread scroll position were lost and the panel fell back to the
+  // bottom. Hold the last resolved conversation for the current thread so the
+  // placeholder only shows for a genuinely empty/absent thread and ThreadList stays
+  // stably mounted across the re-subscription. Reset synchronously when the thread
+  // id changes so a switched-to thread never reads the previous one's value.
+  const lastResolvedConversationRef = useRef(conversation);
+  const lastResolvedConversationIdRef = useRef(derivedConversationId);
+  if (lastResolvedConversationIdRef.current !== derivedConversationId) {
+    lastResolvedConversationIdRef.current = derivedConversationId;
+    lastResolvedConversationRef.current = undefined;
+  }
+  if (conversation) {
+    lastResolvedConversationRef.current = conversation;
+  }
+  const stableConversation = conversation ?? lastResolvedConversationRef.current;
+
   const threadParticipantIds = useMemo(() => {
     const set = new Set<string>();
     for (const m of messages) {
@@ -1636,7 +1659,7 @@ export const ThreadMessages = ({
               value='thread'
               className='flex-1 flex flex-col h-full overflow-hidden data-[state=inactive]:hidden'
             >
-              {isMessagesLoaded && !conversation && !!derivedConversationId ? (
+              {isMessagesLoaded && !stableConversation && !!derivedConversationId ? (
                 <div className='flex flex-col items-center justify-center flex-1 text-muted-foreground'>
                   <ChatDefault size={48} className='mb-2 opacity-40' />
                   <p className='text-sm'>No thread messages</p>
@@ -1792,7 +1815,7 @@ export const ThreadMessages = ({
             {headerActionsContainer
               ? createPortal(simpleViewHeaderActions, headerActionsContainer)
               : null}
-            {isMessagesLoaded && !conversation && !!derivedConversationId ? (
+            {isMessagesLoaded && !stableConversation && !!derivedConversationId ? (
               <div className='flex flex-col items-center justify-center flex-1 text-muted-foreground'>
                 <ChatDefault size={48} className='mb-2 opacity-40' />
                 <p className='text-sm'>No thread messages</p>


### PR DESCRIPTION
## What
Fixes a regression on `feature/virtualise-thread-panel` where opening a thread panel loses the unread divider and the restored/first-unread scroll position, and the panel falls back to the bottom.

## Root cause
`ThreadMessages` (`apps/dashboard/src/components/Chat/ThreadPannel.tsx`) derives both `conversation` and `isMessagesLoaded` from the same enriched `threadConversationV2` query. That query is re-subscribed whenever its inputs change — most notably when channel membership (`isMember`) resolves and recreates the query object. During the re-subscription window, `conversation` reads `null` for a frame or two while `isMessagesLoaded` stays `true`. The render then flips from `<ThreadList>` to the `"No thread messages"` placeholder and back, **remounting `ThreadList` mid-open** (~250–300ms after first mount).

The remount re-runs `ThreadList`'s mark-as-read effect (`useThreadReadTracking`), which unconditionally writes `lastReadAt = Date.now()`. The second mount then reads that fresh value, computes `firstUnreadIndex = null`, and `deriveThreadScrollIntent` falls through to `bottom` — so the unread divider disappears and the saved / first-unread scroll position is not restored.

## Fix
Hold the last resolved `conversation` for the current thread (`stableConversation`) so the `"No thread messages"` placeholder only shows for a genuinely empty/absent thread. This keeps `ThreadList` stably mounted across the query re-subscription — no remount, so the mark-as-read effect runs once and the divider / scroll intent are preserved. The sticky value is reset synchronously when the thread id changes so a switched-to thread never reads the previous one's conversation. `ThreadList` still receives the real `conversation` prop; only the empty-state condition uses `stableConversation`.

## Scope
- One file: `apps/dashboard/src/components/Chat/ThreadPannel.tsx` (+25 / −2).
- Both thread-panel render sites (ticket-thread tab and the normal/simple view) updated.
- The `underTicketView` replies list already renders `ThreadList` unconditionally and was unaffected.

## Validation
- `pnpm --filter dashboard typecheck` (tsc `tsconfig.app.json`) passes.
- Existing behavior retained: bottom-fallback for a fully-read thread with nothing saved is unchanged; unread and saved-position cases now keep `ThreadList` mounted so the divider and stored scrollTop survive.

## Notes
No ticket key was available for this change; the parent `feature/virtualise-thread-panel` branch is likewise descriptive-only. Happy to re-title with an `XYNE-` key if one should be attached.