### PR TITLE
fix: channel info modal leaves large empty whitespace on About tab

### DIFF
--- a/apps/dashboard/src/components/Chat/Info/Info.tsx
+++ b/apps/dashboard/src/components/Chat/Info/Info.tsx
@@ -293,7 +293,13 @@ const Info = ({
   return (
     <div
       ref={popoverContainerRef}
-      className='overflow-clip h-[720px] bg-background flex flex-col'
+      className={cn(
+        'overflow-clip bg-background flex flex-col',
+        // The About tab is short; a fixed height leaves a large empty gap.
+        // Size to content there, and keep the fixed height on tabs that host
+        // a scroll viewport (Members' virtualized list needs a definite height).
+        activeTab === 'about' ? 'max-h-[720px]' : 'h-[720px]',
+      )}
       style={{ position: 'relative' }}
     >
       <div className='w-full flex items-start justify-between gap-2 p-4 pb-6'>


### PR DESCRIPTION
1. Problem Description:
The channel info modal (About tab) renders with a large block of empty whitespace between the "Created By …" line and the pinned "Channel ID" footer. The modal is forced to a fixed 720px height regardless of content, so the short About tab looks broken/empty.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in-app (screenshot of the xyne-spaces channel info modal). Traced to `apps/dashboard/src/components/Chat/Info/Info.tsx` — the modal root div hardcodes `h-[720px]`. The Dialog wrapper in `SupportScreen.tsx` sets only `max-w-[620px]` and no height, so the whole modal height comes from that class. On the short About tab this leaves a big gap (the footer is pinned via `mt-auto`).

3. Explain the solution implemented in the PR:
Make the modal height content-driven on the About tab (`max-h-[720px]`) while keeping the fixed `h-[720px]` on the tabs that host a scroll viewport. This is important because the Members tab uses a `Virtuoso` virtualized list with `height: 100%`, which requires a definite parent height — a blanket `max-h` would collapse that list to zero. Change is a one-line className -> cn() conditional keyed off `activeTab`.

4. Documentation (link to docs created/updated for this change): N/A

5. DB Alter Details (if any): N/A

6. Data fix Details (if any): N/A

7. Environment variable Changes (if any): N/A

8. Testing (how it was tested; screenshots/links): Verified the About tab now sizes to its content (no empty gap) and that Members/Notifications/Settings/AI Preference tabs retain the 720px height so their scroll viewports (incl. the Virtuoso members list) still work.

9. Services to which this change is to be deployed: dashboard (frontend only)

10. Main PR link (if this PR is raised against a release branch): N/A (raised against main)