### PR TITLE
fix: XYNE-62720 increase recording summary streaming LLM request timeout to 15m

### DIFF
--- a/apps/backend/src/services/callLlmRetry.ts
+++ b/apps/backend/src/services/callLlmRetry.ts
@@ -15,7 +15,7 @@ const DEFAULT_MODEL = 'glm-latest';
 // very long recordings), so the streaming client uses a generous per-request
 // timeout rather than the global default. Retries are bounded separately by
 // MAX_ATTEMPTS / backoff above.
-const STREAMING_REQUEST_TIMEOUT_MS = 600_000; // 10 minutes
+const STREAMING_REQUEST_TIMEOUT_MS = 900_000; // 15 minutes
 
 type ExtractedContent = ReturnType<typeof extractAgentContent>;
 

--- a/apps/backend/src/services/callLlmRetry.ts
+++ b/apps/backend/src/services/callLlmRetry.ts
@@ -10,11 +10,12 @@ const MAX_ATTEMPTS = 5;
 const BASE_DELAY_MS = 120_000; // 2 minutes
 const MAX_DELAY_MS = 960_000; // 16 minutes
 const DEFAULT_MODEL = 'glm-latest';
-// The non-streaming agent path for the same workload uses a 300s request
-// timeout. Long transcripts producing multi-phase markdown responses can
-// exceed the 120s LLM_REQUEST_TIMEOUT_MS default, so the streaming client
-// matches the agent path rather than the global default.
-const STREAMING_REQUEST_TIMEOUT_MS = 300_000; // 5 minutes
+// Long transcripts producing multi-phase markdown responses can exceed the
+// 120s LLM_REQUEST_TIMEOUT_MS default (and even the previous 300s ceiling for
+// very long recordings), so the streaming client uses a generous per-request
+// timeout rather than the global default. Retries are bounded separately by
+// MAX_ATTEMPTS / backoff above.
+const STREAMING_REQUEST_TIMEOUT_MS = 600_000; // 10 minutes
 
 type ExtractedContent = ReturnType<typeof extractAgentContent>;
 


### PR DESCRIPTION
## What
Increases `STREAMING_REQUEST_TIMEOUT_MS` in `apps/backend/src/services/callLlmRetry.ts` from 300s (5 min) to 600s (10 min). This is the per-request timeout for the streaming LLM client used by the recording summary / transcript post-processing path (`executeStreamingLlmRequest`).

## Why
Long recordings produce large transcripts, and multi-phase markdown summary responses can exceed the previous 300s ceiling, causing the streaming request to time out before the model finishes. Raising the per-request timeout gives long summaries room to complete.

## Notes
- Retry behavior is unchanged — attempts are still bounded by `MAX_ATTEMPTS` (5) with exponential backoff (`BASE_DELAY_MS` / `MAX_DELAY_MS`).
- Single-line constant change plus updated explanatory comment.
