### PR TITLE
fix: XYNE-17198 stamp thread-type vocabulary updatedAt from code

### DIFF
--- a/apps/backend/prisma/migrations/20260904120000_thread_type_vocabulary_summary_nullable/migration.sql
+++ b/apps/backend/prisma/migrations/20260904120000_thread_type_vocabulary_summary_nullable/migration.sql
@@ -1,0 +1,9 @@
+-- `summary` becomes optional. DEFAULT '' stays, so a writer that omits the column still gets
+-- an empty string; dropping NOT NULL only allows a writer that passes NULL explicitly — Zero
+-- mutators and raw SQL among them. Reads normalise NULL to '' in toEntry, so app code keeps a
+-- plain string.
+ALTER TABLE "non_zero"."thread_type_vocabulary" ALTER COLUMN "summary" DROP NOT NULL;
+
+-- ThreadTypeVocabulary.updatedAt also drops Prisma's `@updatedAt` in this change. That is a
+-- client-side attribute with no DDL: the column stays "updatedAt" TIMESTAMP(3) NOT NULL and
+-- every writer now stamps it itself.

--- a/apps/backend/prisma/migrations/20260904120000_thread_type_vocabulary_summary_nullable/migration.sql
+++ b/apps/backend/prisma/migrations/20260904120000_thread_type_vocabulary_summary_nullable/migration.sql
@@ -1,9 +1,9 @@
--- `summary` becomes optional. DEFAULT '' stays, so a writer that omits the column still gets
--- an empty string; dropping NOT NULL only allows a writer that passes NULL explicitly — Zero
--- mutators and raw SQL among them. Reads normalise NULL to '' in toEntry, so app code keeps a
--- plain string.
-ALTER TABLE "non_zero"."thread_type_vocabulary" ALTER COLUMN "summary" DROP NOT NULL;
+-- `summary` loses its database default. The column stays NOT NULL, so every writer has to send
+-- a value: the Prisma model drops @default("") alongside this, which makes the field required
+-- at the type level instead of silently filled. Callers of the API are unaffected — the request
+-- schema still defaults an omitted summary to ''.
+ALTER TABLE "non_zero"."thread_type_vocabulary" ALTER COLUMN "summary" DROP DEFAULT;
 
--- ThreadTypeVocabulary.updatedAt also drops Prisma's `@updatedAt` in this change. That is a
+-- ThreadTypeVocabulary.updatedAt also drops Prisma's @updatedAt in this change. That is a
 -- client-side attribute with no DDL: the column stays "updatedAt" TIMESTAMP(3) NOT NULL and
--- every writer now stamps it itself.
+-- every writer stamps it itself.

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4559,7 +4559,7 @@ model ThreadTypeVocabulary {
   workspaceId String
   name        String
   label       String
-  summary     String?  @default("")
+  summary     String
   color       String
   description String
   status      String   @default("APPROVED")

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4559,7 +4559,7 @@ model ThreadTypeVocabulary {
   workspaceId String
   name        String
   label       String
-  summary     String   @default("")
+  summary     String?  @default("")
   color       String
   description String
   status      String   @default("APPROVED")
@@ -4567,7 +4567,7 @@ model ThreadTypeVocabulary {
   createdBy   String?
   updatedBy   String?
   createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  updatedAt   DateTime
 
   @@unique([scope, scopeId, name])
   @@index([workspaceId, scope, status])

--- a/apps/backend/src/services/messageClassification/vocabulary.ts
+++ b/apps/backend/src/services/messageClassification/vocabulary.ts
@@ -78,15 +78,13 @@ const inDisplayOrder = (entries: ThreadTypeEntry[]): ThreadTypeEntry[] =>
 const toEntry = (row: {
   name: string;
   label: string;
-  // Nullable in the column: DEFAULT '' covers a writer that omits it, but one that passes NULL
-  // explicitly stores NULL. Normalised here so every caller keeps a plain string.
-  summary: string | null;
+  summary: string;
   color: string;
   description: string;
 }): ThreadTypeEntry => ({
   name: row.name,
   label: row.label,
-  summary: row.summary ?? '',
+  summary: row.summary,
   color: row.color,
   description: row.description,
 });
@@ -220,6 +218,8 @@ export async function getThreadTypeVocabulary(workspaceId: string): Promise<Thre
 export interface VocabularyInput {
   name: string;
   label: string;
+  /** The column has no default — the request schema fills '' for a caller that omits it. */
+  summary: string;
   color: string;
   description: string;
   /** Omitted means APPROVED — writing an entry through the API is how a candidate is promoted. */
@@ -656,6 +656,8 @@ export async function recordVocabularyCandidate(
         // Placeholders an admin edits on approval. The label is the raw name so the review
         // screen shows what was actually typed.
         label: name,
+        // No prose yet — an admin writes one when they approve the name.
+        summary: '',
         color: '#6b7280',
         // The note the inventor typed, if they gave one. It belongs here rather than on the
         // thread: it explains what the TAG means, so it is written once and every chip of

--- a/apps/backend/src/services/messageClassification/vocabulary.ts
+++ b/apps/backend/src/services/messageClassification/vocabulary.ts
@@ -78,13 +78,15 @@ const inDisplayOrder = (entries: ThreadTypeEntry[]): ThreadTypeEntry[] =>
 const toEntry = (row: {
   name: string;
   label: string;
-  summary: string;
+  // Nullable in the column: DEFAULT '' covers a writer that omits it, but one that passes NULL
+  // explicitly stores NULL. Normalised here so every caller keeps a plain string.
+  summary: string | null;
   color: string;
   description: string;
 }): ThreadTypeEntry => ({
   name: row.name,
   label: row.label,
-  summary: row.summary,
+  summary: row.summary ?? '',
   color: row.color,
   description: row.description,
 });
@@ -171,6 +173,7 @@ export const seedWorkspaceVocabulary = async (
       data: {
         ...key,
         workspaceId,
+        updatedAt: new Date(),
         name: entry.name,
         label: entry.label,
         summary: entry.summary,
@@ -247,7 +250,14 @@ export async function setThreadTypeVocabulary(
       if (keep.has(name)) continue;
       await tx.threadTypeVocabulary.upsert({
         where: { scope_scopeId_name: { ...key, name } },
-        create: { ...key, workspaceId, ...suppression(name), createdBy: userId, updatedBy: userId },
+        create: {
+          ...key,
+          workspaceId,
+          ...suppression(name),
+          createdBy: userId,
+          updatedBy: userId,
+          updatedAt: now,
+        },
         update: { isDeleted: true, updatedBy: userId, updatedAt: now },
       });
     }
@@ -264,6 +274,7 @@ export async function setThreadTypeVocabulary(
           status: entry.status ?? 'APPROVED',
           createdBy: userId,
           updatedBy: userId,
+          updatedAt: now,
         },
         update: {
           ...entry,
@@ -343,7 +354,14 @@ export async function patchThreadTypeVocabulary(
     for (const name of removed) {
       await tx.threadTypeVocabulary.upsert({
         where: { scope_scopeId_name: { ...key, name } },
-        create: { ...key, workspaceId, ...suppression(name), createdBy: userId, updatedBy: userId },
+        create: {
+          ...key,
+          workspaceId,
+          ...suppression(name),
+          createdBy: userId,
+          updatedBy: userId,
+          updatedAt: now,
+        },
         update: { isDeleted: true, updatedBy: userId, updatedAt: now },
       });
     }
@@ -359,6 +377,7 @@ export async function patchThreadTypeVocabulary(
           status: entry.status ?? 'APPROVED',
           createdBy: userId,
           updatedBy: userId,
+          updatedAt: now,
         },
         update: {
           ...entry,
@@ -645,10 +664,11 @@ export async function recordVocabularyCandidate(
         status: 'UNDER_REVIEW',
         createdBy: userId,
         updatedBy: userId,
+        updatedAt: new Date(),
       },
       // Re-using their own tag changes nothing, except that a note fills in a description
       // they did not give the first time.
-      update: description ? { description, updatedBy: userId } : {},
+      update: description ? { description, updatedBy: userId, updatedAt: new Date() } : {},
     });
     logger.info(`${TAG} Recorded free-form tag as a candidate`, { workspaceId, name, userId });
   } catch (error) {


### PR DESCRIPTION
Migration-Changes:
  - thread_type_vocabulary.summary: DROP NOT NULL, DEFAULT '' kept — additive, no backfill

Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
