### PR TITLE
feat: show summary preview and generating loader in recordings list

### DIFF
--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx
@@ -9,6 +9,7 @@ import {
   MicOn,
   MusicQuaverNote,
   Share01,
+  Spinner,
   ThreeDotsMenuHorizontal,
 } from '@xyne/icons';
 import { AudioLines } from 'lucide-react';
@@ -44,7 +45,12 @@ import {
 import { cn } from '../../../utils/classNames';
 import { TextShimmer } from '../../../components/ui/ShimmerText';
 import { useRecordingTitleState } from '../../../hooks/useRecordingTitleState';
-import { formatRecordingTimestamp, toRecordingTitleInput } from '../utils/RecordingsV2.utils';
+import {
+  formatRecordingTimestamp,
+  isRecordingSummaryGenerating,
+  toRecordingSummaryPreview,
+  toRecordingTitleInput,
+} from '../utils/RecordingsV2.utils';
 import {
   LabelChip,
   SuggestedLabelChip,
@@ -176,6 +182,8 @@ const RecordingsV2Pill = ({
   const durationMs = recording.endedAt
     ? Math.max(0, recording.endedAt - recording.startedAt)
     : null;
+  const summaryPreview = toRecordingSummaryPreview(recording.aiSummary);
+  const isSummaryGenerating = isRecordingSummaryGenerating(recording);
   const isOwner = currentUserId !== undefined && currentUserId === recording.createdByUserId;
   const visibleTags = normalizeRecordingTags(tags);
   const visibleSuggestedTags = isOwner ? normalizeRecordingTags(suggestedTags) : [];
@@ -432,6 +440,23 @@ const RecordingsV2Pill = ({
             </DropdownMenu>
           </span>
         </span>
+
+        {isSummaryGenerating ? (
+          <span className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+            <Spinner size={12} className='shrink-0 animate-spin' />
+            <TextShimmer
+              as='span'
+              glassEffect={false}
+              className='shimmer-text-themed text-xs'
+            >
+              Generating summary…
+            </TextShimmer>
+          </span>
+        ) : summaryPreview ? (
+          <span className='line-clamp-2 text-xs leading-5 text-muted-foreground'>
+            {summaryPreview}
+          </span>
+        ) : null}
 
         {visibleTags.length > 0 || visibleSuggestedTags.length > 0 ? (
           <span className='flex flex-wrap items-center gap-1.5'>

--- a/apps/dashboard/src/routes/RecordingsV2Screen/utils/RecordingsV2.utils.ts
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/utils/RecordingsV2.utils.ts
@@ -320,3 +320,41 @@ export function formatRecordingTimestamp(startedAt: number): string {
   }
   return format(startedDate, 'EEE, MMM d');
 }
+
+/**
+ * A recording's quick `aiSummary` is generated asynchronously by the AI pipeline
+ * after the call ends (see `call.trigger.ts`: "aiSummary and transcript are
+ * generated asynchronously after the call ends"). While it is in flight the row
+ * shows a small loader instead of blank space.
+ *
+ * The window is bounded so recordings that predate summaries — or whose
+ * generation silently failed — don't strand the loader forever: past the window
+ * with no summary, the row simply shows nothing.
+ */
+export const SUMMARY_GENERATING_WINDOW_MS = 15 * 60 * 1000;
+
+export function isRecordingSummaryGenerating(
+  recording: Pick<OatsRecordingEntry, 'status' | 'endedAt' | 'aiSummary'>,
+): boolean {
+  if (recording.aiSummary?.trim()) return false;
+  if (recording.status !== CallStatus.ENDED) return false;
+  if (!recording.endedAt) return false;
+  return Date.now() - recording.endedAt < SUMMARY_GENERATING_WINDOW_MS;
+}
+
+/**
+ * Flattens the stored `aiSummary` (markdown or HTML) into a single plain-text
+ * line for the list preview. The row clamps it to two lines with CSS, so this
+ * only needs to strip markup and collapse whitespace, not truncate.
+ */
+export function toRecordingSummaryPreview(summary: string | null | undefined): string {
+  if (!summary) return '';
+  return summary
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // md images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // md links -> link text
+    .replace(/<[^>]+>/g, ' ') // html tags
+    .replace(/[#>*_`~]+/g, ' ') // md emphasis / heading / quote markers
+    .replace(/^\s*[-+]\s+/gm, ' ') // list bullets
+    .replace(/\s+/g, ' ')
+    .trim();
+}


### PR DESCRIPTION
## What
The recordings list (Xyne Scribe, V2 list view) now surfaces each recording's AI summary state directly in the row:
- When a quick `aiSummary` exists, the row shows it as a two-line plain-text preview (markdown/HTML stripped, CSS `line-clamp-2`).
- When the summary is still being generated (call `ENDED`, no `aiSummary` yet, and `endedAt` is within a bounded 15-minute window), the row shows a small spinner + shimmer "Generating summary…" instead of blank space.
- Outside that window with no summary (legacy recordings, or generation that silently failed), the row shows nothing — so the loader never strands forever.

## Why
Summaries are generated asynchronously after a call ends. Previously the list gave no indication that a summary was on its way, so a freshly-ended recording looked identical to one with no summary. This adds a clear, self-terminating "generating" signal and a useful at-a-glance preview.

## Changes
- `apps/dashboard/src/routes/RecordingsV2Screen/utils/RecordingsV2.utils.ts`: new helpers `SUMMARY_GENERATING_WINDOW_MS`, `isRecordingSummaryGenerating(recording)`, `toRecordingSummaryPreview(summary)`.
- `apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingsV2Pill.tsx`: renders the preview / generating loader between the title row and tags, reusing the existing `TextShimmer` and `Spinner` from `@xyne/icons`.

## Validation
- `tsc --noEmit` passes.
- Verified live in a seeded sandbox: a recording with a summary shows the two-line preview; a recording ended <15 min ago with no summary shows the spinner + "Generating summary…" shimmer. Proof-of-test video attached in the thread.

## Scope / notes
- Frontend-only, additive. No schema, API, or data-model changes.
- Reuses the existing `aiSummary` field already synced to the recordings list; no new queries.