### PR TITLE
fix: XYNE-61822 scope SDLC reads to the hub

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -201,6 +201,7 @@ import officeConversionRoutes from '@/routes/officeConversion';
 import sdlcRoutes from '@/routes/sdlc';
 import sdlcClawRoutes from '@/routes/sdlcClaw';
 import sdlcVcsInternalRoutes from '@/routes/sdlcVcsInternal';
+import sdlcAgentInternalRoutes from '@/routes/sdlcAgentInternal';
 import { handleSdlcClawCallback } from '@/sdlc/SdlcClawCallback';
 
 
@@ -606,6 +607,7 @@ export class App {
       handleWorkflowClawCallback,
     );
     this.app.use('/api/internal/sdlc/vcs', validateS2SKey, sdlcVcsInternalRoutes);
+    this.app.use('/api/internal/sdlc/agent', validateS2SKey, sdlcAgentInternalRoutes);
     this.app.use('/api/internal/sdlc/wiki', validateS2SKey, sdlcWikiInternalRoutes);
     this.app.use(
       '/api/internal/sdlc/artifact-versions',

--- a/apps/backend/src/routes/sdlc.ts
+++ b/apps/backend/src/routes/sdlc.ts
@@ -18,7 +18,7 @@ import { sdlcVcs } from '@/sdlc/vcs';
 import { deriveAccessStatus } from '@/sdlc/vcs/accessStatus';
 import { DatabaseClient } from '@/database/client';
 import { SdlcWikiPipelineService } from '@/sdlc/wiki/SdlcWikiPipeline';
-import sdlcCleanupRoutes from '@/sdlc/cleanup/routes';
+// import sdlcCleanupRoutes from '@/sdlc/cleanup/routes';
 
 const router = Router();
 const sdlcHub = new SdlcHubService();
@@ -339,8 +339,6 @@ router.delete(
   })
 );
 
-// One-off SDLC data migrations. Delete with src/sdlc/cleanup/ once every
-// environment has run them.
-router.use('/cleanup', sdlcCleanupRoutes);
+// router.use('/cleanup', sdlcCleanupRoutes);
 
 export default router;

--- a/apps/backend/src/routes/sdlcAgentInternal.ts
+++ b/apps/backend/src/routes/sdlcAgentInternal.ts
@@ -1,0 +1,45 @@
+import { Router, type NextFunction, type Request, type Response } from 'express';
+import { resolveSdlcAgentRepositorySchema } from '@xyne/shared';
+import { DatabaseClient } from '@/database/client';
+import { AppError } from '@/middleware/errorHandler';
+import { SdlcHubService } from '@/sdlc';
+
+const router = Router();
+const prisma = DatabaseClient.getInstance();
+const sdlcHub = new SdlcHubService();
+
+function route(
+  handler: (req: Request, res: Response) => Promise<void>,
+): (req: Request, res: Response, next: NextFunction) => void {
+  return (req, res, next) => void handler(req, res).catch(next);
+}
+
+router.post(
+  '/repository-context',
+  route(async (req, res) => {
+    const input = resolveSdlcAgentRepositorySchema.parse(req.body);
+    const repo = await prisma.repo.findUnique({
+      where: { id: input.repoId },
+      select: { workspaceId: true },
+    });
+    if (!repo?.workspaceId) throw new AppError('SDLC repository not found', 404);
+
+    const actor = await prisma.user.findFirst({
+      where: { id: input.actorUserId, workspaceId: repo.workspaceId },
+      select: { id: true },
+    });
+    if (!actor) {
+      throw new AppError('Initiating user is unavailable in this workspace', 403);
+    }
+
+    const context = await sdlcHub.getRepositoryRunContext(
+      { userId: actor.id, workspaceId: repo.workspaceId },
+      input.repoId,
+      input.conversationId,
+      input.channelId
+    );
+    res.status(200).json({ success: true, context });
+  }),
+);
+
+export default router;

--- a/apps/backend/src/routes/sdlcArtifactVersionsInternal.ts
+++ b/apps/backend/src/routes/sdlcArtifactVersionsInternal.ts
@@ -1,5 +1,6 @@
 import { Router, type NextFunction, type Request, type Response } from 'express';
 import { z, ZodError } from 'zod';
+import { sdlcRepoIdsSchema } from '@xyne/shared/sdlc';
 import { AppError } from '@/middleware/errorHandler';
 import { SdlcArtifactVersionStore } from '@/sdlc/SdlcArtifactVersionStore';
 
@@ -19,9 +20,10 @@ const selectorSchema = z.discriminatedUnion('type', [
 ]);
 
 const bindingSchema = z.object({
-  repoId: z.string().trim().min(1),
+  repoIds: sdlcRepoIdsSchema,
   workspaceId: z.string().trim().min(1),
   actorUserId: z.string().trim().min(1),
+  channelId: z.string().trim().min(1).optional(),
 }).passthrough();
 
 function route(
@@ -49,10 +51,14 @@ function binding(req: Request) {
   if (!actingUserId || actingUserId !== parsed.actorUserId) {
     throw new AppError('SDLC artifact history binding mismatch', 403);
   }
+  if (!parsed.channelId && !parsed.repoIds?.length) {
+    throw new AppError('channelId is required', 400);
+  }
   return {
-    repoId: parsed.repoId,
+    ...(parsed.repoIds ? { repoIds: parsed.repoIds } : {}),
     workspaceId: parsed.workspaceId,
     userId: parsed.actorUserId,
+    ...(parsed.channelId ? { channelId: parsed.channelId } : {}),
   };
 }
 

--- a/apps/backend/src/routes/sdlcClaw.ts
+++ b/apps/backend/src/routes/sdlcClaw.ts
@@ -1,7 +1,8 @@
 import { Router, type NextFunction, type Request, type Response } from 'express';
 import {
   UserType,
-  createSdlcLinkSchema,
+  createSdlcClawLinkSchema,
+  sdlcRepoIds,
   createSdlcClawArtifactSchema,
   createSdlcTrackSchema,
   createSdlcArtifactTypeSchema,
@@ -60,30 +61,42 @@ async function actorFromRequest(req: Request): Promise<SdlcActor> {
 router.post(
   '/links',
   route(async (req, res) => {
-    const input = createSdlcLinkSchema.extend({ repoId: createSdlcLinkSchema.shape.sourceId }).parse(
-      req.body,
-    );
-    const { repoId, ...linkInput } = input;
+    const { repoId, repoIds, channelId, ...linkInput } = createSdlcClawLinkSchema.parse(req.body);
+    const namedRepoId = sdlcRepoIds({ repoId, repoIds })[0] ?? null;
+    if (!channelId && !namedRepoId) {
+      throw new AppError('channelId is required', 400);
+    }
     const link = await sdlcHub.linkContext(
       await actorFromRequest(req),
-      repoId,
+      channelId ? null : namedRepoId,
       linkInput,
-      channelIdFromBody(req)
+      channelId
     );
     res.status(201).json({ success: true, link });
   }),
 );
 
 router.post(
-  '/tracks/list',
+  '/repositories/list',
   route(async (req, res) => {
-    const repoId = typeof req.body?.repoId === 'string' ? req.body.repoId : '';
-    if (!repoId) throw new AppError('repoId is required', 400);
-    const tracks = await sdlcHub.listTracks(
+    const query = typeof req.body?.query === 'string' ? req.body.query : '';
+    const requestedLimit = Number(req.body?.limit);
+    const repositories = await sdlcHub.listRepositoryRunContexts(
       await actorFromRequest(req),
-      repoId,
+      query,
+      Number.isFinite(requestedLimit) ? requestedLimit : 20,
       channelIdFromBody(req)
     );
+    res.status(200).json({ success: true, repositories });
+  }),
+);
+
+router.post(
+  '/tracks/list',
+  route(async (req, res) => {
+    const channelId = channelIdFromBody(req);
+    if (!channelId) throw new AppError('channelId is required', 400);
+    const tracks = await sdlcHub.listTracks(await actorFromRequest(req), channelId);
     res.status(200).json({ success: true, tracks });
   }),
 );
@@ -100,13 +113,9 @@ router.post(
 router.post(
   '/artifact-types/list',
   route(async (req, res) => {
-    const repoId = typeof req.body?.repoId === 'string' ? req.body.repoId : '';
-    if (!repoId) throw new AppError('repoId is required', 400);
-    const artifactTypes = await sdlcHub.listArtifactTypes(
-      await actorFromRequest(req),
-      repoId,
-      channelIdFromBody(req)
-    );
+    const channelId = channelIdFromBody(req);
+    if (!channelId) throw new AppError('channelId is required', 400);
+    const artifactTypes = await sdlcHub.listArtifactTypes(await actorFromRequest(req), channelId);
     res.status(200).json({ success: true, artifactTypes });
   }),
 );
@@ -117,9 +126,8 @@ router.post(
     const input = createSdlcArtifactTypeSchema.parse(req.body);
     const artifactType = await sdlcHub.createArtifactType(
       await actorFromRequest(req),
-      input.repoId,
-      input.name,
-      input.channelId
+      input.channelId,
+      input.name
     );
     res.status(201).json({ success: true, artifactType });
   }),
@@ -134,7 +142,7 @@ router.patch(
     });
     const artifactType = await sdlcHub.renameArtifactType(
       await actorFromRequest(req),
-      input.repoId,
+      input.channelId,
       input.folderId,
       input.name
     );

--- a/apps/backend/src/routes/sdlcWikiInternal.ts
+++ b/apps/backend/src/routes/sdlcWikiInternal.ts
@@ -78,6 +78,7 @@ async function requireBinding(body: Record<string, unknown>) {
     repoId,
     userId: execution.createdBy,
     workspaceId: execution.workspaceId,
+    ...(context.channelId ? { channelId: context.channelId } : {}),
     context,
   };
 }

--- a/apps/backend/src/sdlc/SdlcAgentContextService.ts
+++ b/apps/backend/src/sdlc/SdlcAgentContextService.ts
@@ -1,3 +1,4 @@
+import { SDLC_AGENT_SLUG } from '@xyne/shared';
 import type { PrismaClient } from '@prisma/client';
 import { DatabaseClient } from '@/database/client';
 import { AppError } from '@/middleware/errorHandler';
@@ -20,6 +21,7 @@ export type SdlcWikiAgentRole =
 
 export interface SdlcAgentContextInput {
   operation: SdlcAgentOperation;
+  channelId?: string;
   workflowExecutionId?: string;
   sessionId?: string;
   conversationId?: string;
@@ -98,10 +100,18 @@ export class SdlcAgentContextService {
         workspaceId: actor.workspaceId,
         repoId,
         userId: actor.userId,
+        ...(input.channelId ? { channelId: input.channelId } : {}),
       }),
     ]);
     if (!repo?.projectId) throw new AppError('SDLC repository not found', 404);
-    if (!membership) throw new AppError('You are not a member of this repository', 403);
+    if (!membership) {
+      throw new AppError(
+        input.channelId
+          ? 'This repository is not part of that SDLC Hub'
+          : 'You are not a member of this repository',
+        403
+      );
+    }
     const channelId = membership.channelId;
     const baselines = await this.prisma.sdlcArtifact.findMany({
       where: { repoId: repo.id, canvas: { is: { channelId } } },
@@ -139,7 +149,7 @@ export class SdlcAgentContextService {
         input.operation === 'interactive' && input.conversationId
           ? issueSdlcInteractiveGrant(
               {
-                agentSlug: 'sdlc-agent',
+                agentSlug: SDLC_AGENT_SLUG,
                 workspaceId: actor.workspaceId,
                 repoId: repo.id,
                 actorUserId: actor.userId,

--- a/apps/backend/src/sdlc/SdlcArtifactVersionStore.ts
+++ b/apps/backend/src/sdlc/SdlcArtifactVersionStore.ts
@@ -3,6 +3,7 @@ import {
   isBaselineCanvasType,
   parseSdlcSourcePaths,
   parseSdlcSourceReferences,
+  sdlcRepoIds,
   SDLC_MEMBERSHIP_RELATION,
 } from '@xyne/shared';
 import { Prisma, type PrismaClient } from '@prisma/client';
@@ -16,6 +17,7 @@ import {
   parseWikiExecutionOutput,
   type WikiRevisionEvidence,
 } from './wiki/wikiRunState';
+import { canvasIdsForRepos } from './sdlcChannelMembership';
 
 export type SdlcArtifactVersionSelector =
   | { type: 'WIKI_PAGE'; path: string; includeArchived?: boolean }
@@ -28,6 +30,14 @@ interface RevisionRecord {
   status: RevisionStatus;
 }
 
+export interface SdlcArtifactScopeInput {
+  workspaceId: string;
+  userId: string;
+  channelId?: string;
+  repoId?: string;
+  repoIds?: string[];
+}
+
 interface ResolvedArtifact {
   canvasId: string;
   title: string;
@@ -35,6 +45,7 @@ interface ResolvedArtifact {
   artifactKind: 'WIKI' | 'BASELINE' | 'ARTIFACT';
   archived: boolean;
   content: Prisma.JsonValue | null;
+  repoId: string | null;
 }
 
 function metadataRecord(value: Prisma.JsonValue | null): Record<string, unknown> {
@@ -127,28 +138,27 @@ function versionSummary(
 export class SdlcArtifactVersionStore {
   constructor(private readonly prisma: PrismaClient = DatabaseClient.getInstance()) {}
 
-  async listArtifacts(input: {
-    repoId: string;
-    workspaceId: string;
-    userId: string;
-    kinds?: Array<'WIKI' | 'BASELINE' | 'ARTIFACT'>;
-    includeArchived?: boolean;
-  }) {
-    const repo = await this.requireRepository(input);
+  async listArtifacts(
+    input: SdlcArtifactScopeInput & {
+      kinds?: Array<'WIKI' | 'BASELINE' | 'ARTIFACT'>;
+      includeArchived?: boolean;
+    }
+  ) {
+    const scope = await this.requireScope(input);
     const canvases = await this.prisma.canvas.findMany({
       where: {
-        channelId: repo.channelId,
+        channelId: scope.channelId,
         workspaceId: input.workspaceId,
-        projectId: repo.projectId,
+        projectId: scope.projectId,
         // A hub can cover several repositories, so the artifact's repository is part of
-        // what identifies it, not just the channel it renders in.
-        sdlcArtifact: { is: { repoId: repo.id, artifactStatus: { not: 'REFRESH_CANDIDATE' } } },
+        ...(await this.canvasFilter(scope)),
+        sdlcArtifact: { is: { artifactStatus: { not: 'REFRESH_CANDIDATE' } } },
       },
       orderBy: [{ updatedAt: 'desc' }, { id: 'desc' }],
       select: {
         id: true,
         title: true,
-        sdlcArtifact: { select: { artifactType: true } },
+        sdlcArtifact: { select: { artifactType: true, repoId: true } },
         metadata: true,
         updatedAt: true,
         folder: { select: { name: true } },
@@ -166,6 +176,7 @@ export class SdlcArtifactVersionStore {
         canvasId: canvas.id,
         title: canvas.title,
         artifactKind,
+        repoId: canvas.sdlcArtifact?.repoId ?? null,
         path: artifactKind === 'WIKI' ? String(metadata.wikiRelativePath ?? '') : null,
         archived,
         updatedAt: canvas.updatedAt.toISOString(),
@@ -173,12 +184,11 @@ export class SdlcArtifactVersionStore {
     });
   }
 
-  async readArtifact(input: {
-    repoId: string;
-    workspaceId: string;
-    userId: string;
+  async readArtifact(
+    input: SdlcArtifactScopeInput & {
     selector: SdlcArtifactVersionSelector;
-  }) {
+    }
+  ) {
     const artifact = await this.resolveArtifact(input);
     const canvas = await this.prisma.canvas.findUnique({
       where: { id: artifact.canvasId },
@@ -196,14 +206,13 @@ export class SdlcArtifactVersionStore {
     };
   }
 
-  async listVersions(input: {
-    repoId: string;
-    workspaceId: string;
-    userId: string;
+  async listVersions(
+    input: SdlcArtifactScopeInput & {
     selector: SdlcArtifactVersionSelector;
     cursor?: string;
     limit: number;
-  }) {
+    }
+  ) {
     const artifact = await this.resolveArtifact(input);
     if (input.cursor) {
       const cursor = await this.prisma.canvasVersion.findFirst({
@@ -228,7 +237,7 @@ export class SdlcArtifactVersionStore {
     const hasMore = rows.length > input.limit;
     const page = hasMore ? rows.slice(0, input.limit) : rows;
     const evidence = artifact.artifactKind === 'WIKI'
-      ? await this.loadWikiEvidence(input.repoId, artifact)
+      ? await this.loadWikiEvidence(artifact.repoId, artifact)
       : new Map<string, RevisionRecord>();
     return {
       artifact: this.publicArtifact(artifact),
@@ -238,13 +247,12 @@ export class SdlcArtifactVersionStore {
     };
   }
 
-  async readVersion(input: {
-    repoId: string;
-    workspaceId: string;
-    userId: string;
+  async readVersion(
+    input: SdlcArtifactScopeInput & {
     selector: SdlcArtifactVersionSelector;
     versionId: string;
-  }) {
+    }
+  ) {
     const artifact = await this.resolveArtifact(input);
     const version = await this.prisma.canvasVersion.findFirst({
       where: { id: input.versionId, canvasId: artifact.canvasId },
@@ -259,7 +267,7 @@ export class SdlcArtifactVersionStore {
     });
     if (!version) throw new AppError('SDLC artifact version not found', 404);
     const evidence = artifact.artifactKind === 'WIKI'
-      ? await this.loadWikiEvidence(input.repoId, artifact)
+      ? await this.loadWikiEvidence(artifact.repoId, artifact)
       : new Map<string, RevisionRecord>();
     const record = evidence.get(version.id);
     const blocks = Array.isArray(version.content)
@@ -287,13 +295,10 @@ export class SdlcArtifactVersionStore {
     };
   }
 
-  private async resolveArtifact(input: {
-    repoId: string;
-    workspaceId: string;
-    userId: string;
-    selector: SdlcArtifactVersionSelector;
-  }): Promise<ResolvedArtifact> {
-    const repo = await this.requireRepository(input);
+  private async resolveArtifact(
+    input: SdlcArtifactScopeInput & { selector: SdlcArtifactVersionSelector }
+  ): Promise<ResolvedArtifact> {
+    const scope = await this.requireScope(input);
 
     let wikiPath: string | null = null;
     if (input.selector.type === 'WIKI_PAGE') {
@@ -312,38 +317,53 @@ export class SdlcArtifactVersionStore {
     const pages = wikiPath
       ? await this.prisma.canvas.findMany({
           where: {
-            channelId: repo.channelId,
+            channelId: scope.channelId,
             workspaceId: input.workspaceId,
-            projectId: repo.projectId,
-            sdlcArtifact: { is: { artifactType: 'WIKI', repoId: repo.id } },
+            projectId: scope.projectId,
+            ...(await this.canvasFilter(scope)),
+            sdlcArtifact: { is: { artifactType: 'WIKI' } },
           },
           select: {
             id: true,
             title: true,
-            sdlcArtifact: { select: { artifactType: true } },
+            sdlcArtifact: { select: { artifactType: true, repoId: true } },
             metadata: true,
             content: true,
             folder: { select: { name: true } },
           },
         })
       : [];
+    let wikiMatches: typeof pages = [];
+    if (wikiPath) {
+      wikiMatches = pages.filter(page => {
+        const metadata = metadataRecord(page.metadata);
+        return metadata.wikiRelativePath === wikiPath;
+      });
+      if (wikiMatches.length > 1) {
+        const owners = wikiMatches
+          .map(page => page.sdlcArtifact?.repoId)
+          .filter((id): id is string => Boolean(id));
+        throw new AppError(
+          `Several repositories in this hub have a Wiki page at "${wikiPath}". Name one in repoIds: ${owners.join(', ')}`,
+          409
+        );
+      }
+    }
     const canvas = wikiPath
-      ? pages.find(page => {
-          const metadata = metadataRecord(page.metadata);
-          return metadata.wikiRelativePath === wikiPath;
-        }) ?? null
+      ? wikiMatches[0] ?? null
       : await this.prisma.canvas.findFirst({
           where: {
             id: selectedCanvasId!,
-            channelId: repo.channelId,
+            channelId: scope.channelId,
             workspaceId: input.workspaceId,
-            projectId: repo.projectId,
-            sdlcArtifact: { is: { repoId: repo.id, artifactType: { not: 'DEFAULT' } } },
+            projectId: scope.projectId,
+            ...(await this.canvasFilter(scope)),
+            sdlcArtifact: { is: { artifactType: { not: 'DEFAULT' } } },
           },
           select: {
             id: true,
             title: true,
-            sdlcArtifact: { select: { artifactType: true } },
+            sdlcArtifact: { select: { artifactType: true, repoId: true } },
             metadata: true,
             content: true,
             folder: { select: { name: true } },
@@ -367,6 +387,7 @@ export class SdlcArtifactVersionStore {
         artifactKind: 'WIKI',
         archived,
         content: canvas.content,
+        repoId: canvas.sdlcArtifact?.repoId ?? null,
       };
     }
 
@@ -381,43 +402,84 @@ export class SdlcArtifactVersionStore {
       artifactKind,
       archived: false,
       content: canvas.content,
+      repoId: canvas.sdlcArtifact?.repoId ?? null,
     };
   }
 
-  private async requireRepository(input: {
-    repoId: string;
-    workspaceId: string;
-    userId: string;
-  }) {
-    const [repo, membership] = await Promise.all([
-      this.prisma.repo.findFirst({
-        where: { id: input.repoId, workspaceId: input.workspaceId, projectId: { not: null } },
+  private async requireScope(input: SdlcArtifactScopeInput): Promise<{
+    repoIds: string[] | null;
+    channelId: string;
+    projectId: string;
+  }> {
+    const named = sdlcRepoIds(input);
+    if (named.length === 0) {
+      if (!input.channelId) throw new AppError('An SDLC hub is required', 400);
+      const channel = await this.prisma.channel.findFirst({
+        where: {
+          id: input.channelId,
+          workspaceId: input.workspaceId,
+          type: 'SDLC',
+          participants: { some: { userId: input.userId } },
+        },
+        select: { id: true, projectId: true },
+      });
+      if (!channel?.projectId) throw new AppError('SDLC hub not found', 404);
+      return { repoIds: null, channelId: channel.id, projectId: channel.projectId };
+    }
+
+    const [repos, memberships] = await Promise.all([
+      this.prisma.repo.findMany({
+        where: { id: { in: named }, workspaceId: input.workspaceId, projectId: { not: null } },
         select: { id: true, projectId: true },
       }),
-      // Membership is the read check: the actor must participate in a hub this
-      // repository belongs to.
-      this.prisma.sdlcEntityLink.findFirst({
+      this.prisma.sdlcEntityLink.findMany({
         where: {
           workspaceId: input.workspaceId,
+          sourceType: 'CHANNEL',
           targetType: 'REPOSITORY',
-          targetId: input.repoId,
+          targetId: { in: named },
           relationType: SDLC_MEMBERSHIP_RELATION,
+          ...(input.channelId ? { channelId: input.channelId } : {}),
           channel: { participants: { some: { userId: input.userId } } },
         },
         orderBy: { createdAt: 'asc' },
-        select: { channelId: true },
+        select: { channelId: true, targetId: true },
       }),
     ]);
-    if (!repo?.projectId || !membership?.channelId) {
+    const reachable = new Set(memberships.map((m) => m.targetId));
+    const projectId = repos.find((repo) => repo.projectId)?.projectId;
+    const channelId = input.channelId ?? memberships[0]?.channelId;
+    if (!projectId || !channelId || named.some((id: string) => !reachable.has(id))) {
       throw new AppError('SDLC artifact not found', 404);
     }
-    return { id: repo.id, channelId: membership.channelId, projectId: repo.projectId };
+    if (!input.channelId && new Set(memberships.map((m) => m.channelId)).size > 1) {
+      throw new AppError(
+        'These repositories are reachable through more than one SDLC hub. Name the hub with channelId.',
+        409
+      );
+    }
+    return { repoIds: named, channelId, projectId };
+  }
+
+  private async canvasFilter(scope: {
+    channelId: string;
+    repoIds: string[] | null;
+  }): Promise<Prisma.CanvasWhereInput> {
+    if (!scope.repoIds) return {};
+    const canvasIds = await canvasIdsForRepos(this.prisma, scope.channelId, scope.repoIds);
+    return {
+      OR: [
+        ...(canvasIds.length > 0 ? [{ id: { in: canvasIds } }] : []),
+        { sdlcArtifact: { is: { repoId: { in: scope.repoIds } } } },
+      ],
+    };
   }
 
   private async loadWikiEvidence(
-    repoId: string,
+    repoId: string | null,
     artifact: ResolvedArtifact
   ): Promise<Map<string, RevisionRecord>> {
+    if (!repoId) return new Map();
     const links = await this.prisma.sdlcEntityLink.findMany({
       where: {
         sourceType: 'REPOSITORY',

--- a/apps/backend/src/sdlc/SdlcClawExecutionService.ts
+++ b/apps/backend/src/sdlc/SdlcClawExecutionService.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'crypto';
 import {
-  isBaselineCanvasType, PRStatus, PRStatusEvent, TicketStatusV2, type SdlcBaselineKind } from '@xyne/shared';
+  isBaselineCanvasType, PRStatus, PRStatusEvent, TicketStatusV2, type SdlcBaselineKind,
+  SDLC_AGENT_SLUG,
+} from '@xyne/shared';
 import { config } from '@/config/env';
 import { DatabaseClient } from '@/database/client';
 import { PRMetricsRepository } from '@/database/repositories/pullRequestsRepository';
@@ -34,7 +36,6 @@ import {
 } from './sdlcTicketLifecyclePrompt';
 import { sdlcVcs } from './vcs';
 
-const SDLC_AGENT_SLUG = 'sdlc-agent';
 
 interface ClawCallbackPayload {
   sessionId?: string;
@@ -132,6 +133,7 @@ export class SdlcClawExecutionService {
       repo.id,
       {
         operation: 'baseline',
+        channelId,
         workflowExecutionId: execution.id,
         sessionId,
         conversationId,
@@ -246,6 +248,7 @@ export class SdlcClawExecutionService {
     };
     const agentContext = await sdlcAgentContext.build(actor, repo.id, {
       operation: 'work',
+      channelId,
       workflowExecutionId: execution.id,
       sessionId,
       conversationId,

--- a/apps/backend/src/sdlc/SdlcHubService.ts
+++ b/apps/backend/src/sdlc/SdlcHubService.ts
@@ -1,9 +1,11 @@
 import { createHash, randomUUID } from 'crypto';
 import { Prisma, PrismaClient } from '@prisma/client';
 import {
+  SDLC_ARTIFACT_REPOSITORY_RELATION,
   SDLC_MEMBERSHIP_RELATION,
   SDLC_STRUCTURAL_RELATIONS,
   SDLC_TRACK_MEMBERSHIP_RELATION,
+  sdlcRepoIds,
   CanvasVisibility,
   ChannelAddUserPolicy,
   ChannelRole,
@@ -21,6 +23,7 @@ import {
   type CreateSdlcTrackInput,
   type UpdateSdlcBaselineDraftInput,
   type UpdateSdlcClawArtifactInput,
+  SDLC_AGENT_SLUG,
 } from '@xyne/shared';
 import { ChannelRepository } from '@/database/repositories/channelRepository';
 import { DatabaseClient } from '@/database/client';
@@ -48,7 +51,11 @@ import {
 } from './sdlcBaselineDraft';
 import { commitAndSyncCanvasArtifact } from './sdlcBaselineCanvasSync';
 import { requireSdlcProjectAccess } from './sdlcProjectAccess';
-import { isTrackInChannel, trackIdsForChannel } from './sdlcChannelMembership';
+import {
+  isRepositoryInChannel,
+  isTrackInChannel,
+  trackIdsForChannel,
+} from './sdlcChannelMembership';
 import { sdlcChannelCanvasParticipant } from './sdlcCanvasAccess';
 import { ensureLink } from './entityLinkService';
 import { BASELINE_CAPABILITIES } from './sdlcProgressiveGate';
@@ -259,10 +266,21 @@ export class SdlcHubService implements SdlcHub {
     repoId: string
   ): Promise<void> {
     await this.requireChannelRole(actor, channelId, true);
-    const artifacts = await this.prisma.sdlcArtifact.count({
-      where: { repoId, canvas: { is: { channelId } } },
-    });
-    if (artifacts > 0) {
+    const [columnArtifacts, linkedArtifacts] = await Promise.all([
+      this.prisma.sdlcArtifact.count({
+        where: { repoId, canvas: { is: { channelId } } },
+      }),
+      this.prisma.sdlcEntityLink.count({
+        where: {
+          channelId,
+          sourceType: 'CANVAS',
+          targetType: 'REPOSITORY',
+          targetId: repoId,
+          relationType: SDLC_ARTIFACT_REPOSITORY_RELATION,
+        },
+      }),
+    ]);
+    if (columnArtifacts + linkedArtifacts > 0) {
       throw new AppError(
         'This repository still has artifacts in this hub. Delete them before detaching it.',
         409
@@ -595,15 +613,18 @@ export class SdlcHubService implements SdlcHub {
   async getRepositoryRunContext(
     actor: SdlcActor,
     repoId: string,
-    conversationId: string
+    conversationId: string,
+    channelId?: string
   ): Promise<SdlcRepositoryRunContext> {
-    const repo = await this.requireRepositoryRole(actor, repoId, false);
+    const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
     const agentContext = await sdlcAgentContext.build(actor, repo.id, {
       operation: 'interactive',
       conversationId,
+      channelId: repo.channelId,
     });
     return {
       repoId: repo.id,
+      channelId: repo.channelId,
       name: repo.name,
       url: sdlcVcs.parseRepository('GITHUB', repo.canonicalUrl || repo.url).cloneUrl,
       baseBranch: requireSdlcBaseBranch(repo.baseBranch),
@@ -614,7 +635,8 @@ export class SdlcHubService implements SdlcHub {
   async listRepositoryRunContexts(
     actor: SdlcActor,
     query = '',
-    limit = 20
+    limit = 20,
+    channelId?: string
   ): Promise<SdlcRepositoryRunContext[]> {
     const safeLimit = Math.max(1, Math.min(50, Math.floor(limit)));
     const trimmedQuery = query.trim();
@@ -622,11 +644,20 @@ export class SdlcHubService implements SdlcHub {
       where: {
         workspaceId: actor.workspaceId,
         relationType: SDLC_MEMBERSHIP_RELATION,
+        ...(channelId ? { channelId } : {}),
         channel: { participants: { some: { userId: actor.userId } } },
       },
-      select: { targetId: true },
+      select: { targetId: true, channelId: true, createdAt: true },
+      orderBy: { createdAt: 'asc' },
     });
-    const repoIds = [...new Set(memberships.map((membership) => membership.targetId))];
+    const channelIdByRepoId = new Map<string, string>();
+    for (const membership of memberships) {
+      if (!membership.channelId) continue;
+      if (!channelIdByRepoId.has(membership.targetId)) {
+        channelIdByRepoId.set(membership.targetId, membership.channelId);
+      }
+    }
+    const repoIds = [...channelIdByRepoId.keys()];
     if (repoIds.length === 0) return [];
 
     const repos = await this.prisma.repo.findMany({
@@ -648,10 +679,13 @@ export class SdlcHubService implements SdlcHub {
     });
 
     return repos.flatMap((repo) => {
+      const repoChannelId = channelIdByRepoId.get(repo.id);
+      if (!repoChannelId) return [];
       try {
         return [
           {
             repoId: repo.id,
+            channelId: repoChannelId,
             name: repo.name,
             url: sdlcVcs.parseRepository('GITHUB', repo.canonicalUrl || '').cloneUrl,
             baseBranch: requireSdlcBaseBranch(repo.baseBranch),
@@ -775,7 +809,7 @@ export class SdlcHubService implements SdlcHub {
     const result = await getClawDebugArtifacts(
       { userId: execution.createdBy },
       conversationId,
-      'sdlc-agent'
+      SDLC_AGENT_SLUG
     );
     return result.data;
   }
@@ -784,28 +818,35 @@ export class SdlcHubService implements SdlcHub {
     actor: SdlcActor,
     input: CreateSdlcClawArtifactInput
   ): Promise<SdlcArtifact> {
-    const repo = await this.requireRepositoryRole(
-      actor,
-      input.repoId,
-      false,
+    const channelId =
       (input.folderId ? await this.hubOf('canvasFolder', input.folderId) : undefined) ??
-        (input.setupExecutionId ? await this.hubOfExecution(input.setupExecutionId) : undefined) ??
-        input.channelId
-    );
-    if (!repo?.channelId || !repo.projectId) {
-      throw new AppError('SDLC repository not found', 404);
+      (input.setupExecutionId ? await this.hubOfExecution(input.setupExecutionId) : undefined) ??
+      input.channelId;
+    if (!channelId) throw new AppError('An SDLC hub is required to create an artifact', 400);
+    const channel = await this.requireChannelRole(actor, channelId, false);
+    if (!channel.projectId) throw new AppError('SDLC hub not found', 404);
+    const projectId = channel.projectId;
+
+    const repoIds = sdlcRepoIds(input);
+    const repo = repoIds[0]
+      ? await this.requireRepositoryRole(actor, repoIds[0], false, channelId)
+      : null;
+    for (const extraRepoId of repoIds.slice(1)) {
+      if (!(await isRepositoryInChannel(this.prisma, extraRepoId, channelId))) {
+        throw new AppError('A named repository is not part of this hub', 404);
+      }
     }
     if (input.kind === 'BASELINE') {
-      await sdlcVcs.requireCapabilities(actor, input.repoId, [...BASELINE_CAPABILITIES]);
+      await sdlcVcs.requireCapabilities(actor, repo!.id, [...BASELINE_CAPABILITIES]);
     }
 
     const folder = input.folderId
       ? await this.prisma.canvasFolder.findFirst({
-          where: { id: input.folderId, channelId: repo.channelId },
+          where: { id: input.folderId, channelId },
           select: { id: true },
         })
       : await this.prisma.canvasFolder.findFirst({
-          where: { channelId: repo.channelId, name: 'Baseline' },
+          where: { channelId, name: 'Baseline' },
           select: { id: true },
         });
     if (!folder) throw new AppError('Artifact type folder not found', 409);
@@ -830,7 +871,7 @@ export class SdlcHubService implements SdlcHub {
         );
       }
       const executionContext = this.parseJsonRecord(execution.context);
-      if (executionContext.repoId !== repo.id) {
+      if (executionContext.repoId !== repo!.id) {
         throw new AppError('SDLC setup execution does not belong to this repository', 403);
       }
       baselineGenerationCommit =
@@ -838,7 +879,7 @@ export class SdlcHubService implements SdlcHub {
           ? executionContext.generationCommit
           : null;
       const existing = await this.findSdlcCanvas(
-        repo.channelId,
+        channelId,
         input.baselineKind!,
         input.setupExecutionId!
       );
@@ -853,8 +894,8 @@ export class SdlcHubService implements SdlcHub {
     }
 
     if (input.trackId) {
-      const inHub = await isTrackInChannel(this.prisma, input.trackId, repo.channelId);
-      if (!inHub) throw new AppError('SDLC track not found for this repository', 404);
+      const inHub = await isTrackInChannel(this.prisma, input.trackId, channelId);
+      if (!inHub) throw new AppError('SDLC track not found in this hub', 404);
     }
 
     let artifactMarkdown = input.markdown;
@@ -863,6 +904,12 @@ export class SdlcHubService implements SdlcHub {
     const citesRepository =
       (input.sourceReferences?.length ?? 0) > 0 || input.markdown.includes('[[source:');
     if (citesRepository) {
+      if (!repo) {
+        throw new AppError(
+          'Source references require a repository. Name one in repoIds, or write the artifact without [[source:]] citations.',
+          409
+        );
+      }
       const pinnedCommit =
         input.kind === 'BASELINE'
           ? baselineGenerationCommit
@@ -892,9 +939,9 @@ export class SdlcHubService implements SdlcHub {
               workspaceId: actor.workspaceId,
               title: input.title,
               content: content as unknown as Prisma.InputJsonValue,
-              channelId: repo.channelId,
+              channelId,
               folderId: folder.id,
-              projectId: repo.projectId,
+              projectId,
               createdBy: actor.userId,
               lastEditedBy: actor.userId,
               lastEditedAt: new Date(),
@@ -903,7 +950,7 @@ export class SdlcHubService implements SdlcHub {
               isCollaborative: true,
               metadata: {} as Prisma.InputJsonValue,
               participants: {
-                create: sdlcChannelCanvasParticipant(actor.workspaceId, repo.channelId),
+                create: sdlcChannelCanvasParticipant(actor.workspaceId, channelId),
               },
             },
           });
@@ -911,7 +958,7 @@ export class SdlcHubService implements SdlcHub {
             await tx.sdlcEntityLink.create({
               data: {
                 workspaceId: actor.workspaceId,
-                channelId: repo.channelId,
+                channelId,
                 sourceType: 'TRACK',
                 sourceId: input.trackId,
                 targetType: 'CANVAS',
@@ -924,7 +971,7 @@ export class SdlcHubService implements SdlcHub {
           await tx.sdlcArtifact.create({
             data: {
               workspaceId: actor.workspaceId,
-              repoId: repo.id,
+              ...(repo ? { repoId: repo.id } : {}),
               artifactId: canvas.id,
               artifactType:
                 input.kind === 'BASELINE'
@@ -940,19 +987,34 @@ export class SdlcHubService implements SdlcHub {
             },
           });
 
+          for (const artifactRepoId of repoIds) {
+            await ensureLink(
+              tx,
+              {
+                channelId,
+                sourceType: 'CANVAS',
+                sourceId: canvas.id,
+                targetType: 'REPOSITORY',
+                targetId: artifactRepoId,
+                relationType: SDLC_ARTIFACT_REPOSITORY_RELATION,
+              },
+              { workspaceId: actor.workspaceId, userId: actor.userId }
+            );
+          }
+
           const relatedIds = Array.from(
             new Set((input.relatedCanvasIds ?? []).filter(id => id !== canvas.id)),
           );
           if (relatedIds.length > 0) {
             const validRelated = await tx.canvas.findMany({
-              where: { id: { in: relatedIds }, channelId: repo.channelId },
+              where: { id: { in: relatedIds }, channelId },
               select: { id: true },
             });
             for (const related of validRelated) {
               await tx.sdlcEntityLink.create({
                 data: {
                   workspaceId: actor.workspaceId,
-                  channelId: repo.channelId,
+                  channelId,
                   sourceType: 'CANVAS',
                   sourceId: related.id,
                   targetType: 'CANVAS',
@@ -1080,7 +1142,7 @@ export class SdlcHubService implements SdlcHub {
           const candidates = await tx.canvas.findMany({
             where: {
               channelId: repo.channelId,
-              sdlcArtifact: { is: { artifactType: input.baselineKind } },
+              sdlcArtifact: { is: { artifactType: input.baselineKind, repoId: repo.id } },
             },
             select: {
               id: true,
@@ -1419,17 +1481,13 @@ export class SdlcHubService implements SdlcHub {
     actor: SdlcActor,
     input: UpdateSdlcClawArtifactInput
   ): Promise<SdlcArtifact> {
-    const repo = await this.requireRepositoryRole(
-      actor,
-      input.repoId,
-      false,
-      await this.hubOf('canvas', input.canvasId)
-    );
-    if (!repo.channelId || !repo.projectId) throw new AppError('SDLC repository not found', 404);
+    const channelId = (await this.hubOf('canvas', input.canvasId)) ?? input.channelId;
+    if (!channelId) throw new AppError('SDLC artifact not found', 404);
+    await this.requireChannelRole(actor, channelId, false);
     const existing = await this.prisma.canvas.findFirst({
       where: {
         id: input.canvasId,
-        channelId: repo.channelId,
+        channelId,
         sdlcArtifact: { isNot: null },
       },
       select: { id: true, viewAccessId: true, title: true },
@@ -1437,17 +1495,36 @@ export class SdlcHubService implements SdlcHub {
     if (!existing) throw new AppError('SDLC artifact not found', 404);
     const existingEntity = await this.prisma.sdlcArtifact.findUnique({
       where: { artifactId: existing.id },
-      select: { generationCommit: true },
+      select: { generationCommit: true, repoId: true },
     });
-    const generationCommit =
-      existingEntity?.generationCommit ?? (await sdlcVcs.resolveBaseBranchHead(repo.id));
-    const resolved = await this.resolveSourceReferences({
-      repoId: repo.id,
-      repositoryUrl: repo.canonicalUrl || repo.url,
-      generationCommit,
+    const repoId = sdlcRepoIds(input)[0] ?? existingEntity?.repoId ?? null;
+    const repo = repoId
+      ? await this.requireRepositoryRole(actor, repoId, false, channelId)
+      : null;
+    const citesRepository =
+      (input.sourceReferences?.length ?? 0) > 0 || input.markdown.includes('[[source:');
+    if (citesRepository && !repo) {
+      throw new AppError(
+        'Source references require a repository. Name one in repoIds, or write the artifact without [[source:]] citations.',
+        409
+      );
+    }
+    let generationCommit: string | null = null;
+    let resolved: { markdown: string; sourceReferences: SdlcSourceReference[] } = {
       markdown: input.markdown,
-      sourceReferences: input.sourceReferences,
-    });
+      sourceReferences: [],
+    };
+    if (repo) {
+      generationCommit =
+        existingEntity?.generationCommit ?? (await sdlcVcs.resolveBaseBranchHead(repo.id));
+      resolved = await this.resolveSourceReferences({
+        repoId: repo.id,
+        repositoryUrl: repo.canonicalUrl || repo.url,
+        generationCommit,
+        markdown: input.markdown,
+        sourceReferences: input.sourceReferences,
+      });
+    }
     const content = await convertMarkdownToBlockNote(resolved.markdown);
     return commitAndSyncCanvasArtifact(
       () =>
@@ -1466,15 +1543,15 @@ export class SdlcHubService implements SdlcHub {
             where: { artifactId: existing.id },
             create: {
               workspaceId: actor.workspaceId,
-              repoId: repo.id,
+              ...(repo ? { repoId: repo.id } : {}),
               artifactId: existing.id,
               artifactType: 'DEFAULT',
-              generationCommit,
+              ...(generationCommit ? { generationCommit } : {}),
               sourceReferences: stringifySdlcSourceReferences(resolved.sourceReferences),
               createdBy: actor.userId,
             },
             update: {
-              generationCommit,
+              ...(generationCommit ? { generationCommit } : {}),
               sourceReferences: stringifySdlcSourceReferences(resolved.sourceReferences),
             },
           });
@@ -1495,22 +1572,29 @@ export class SdlcHubService implements SdlcHub {
 
   async linkContext(
     actor: SdlcActor,
-    repoId: string,
+    repoId: string | null,
     input: CreateSdlcLinkInput,
     channelId?: string
   ): Promise<SdlcLink> {
     if (input.relationType === 'DISCUSSION') {
       throw new AppError('SDLC discussions must be created with their conversation', 400);
     }
-    const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
-    await this.requireLinkSource(repoId, repo.channelId, input.sourceType, input.sourceId);
+    let hubId = channelId;
+    if (repoId) {
+      hubId = (await this.requireRepositoryRole(actor, repoId, false, channelId)).channelId;
+    } else {
+      if (!hubId) throw new AppError('An SDLC hub is required to create a relationship', 400);
+      await this.requireChannelRole(actor, hubId, false);
+    }
+    const hubChannelId = hubId!;
+    await this.requireLinkSource(repoId, hubChannelId, input.sourceType, input.sourceId);
     await this.requireAccessibleEntity(actor, input.targetType, input.targetId);
     try {
       const link = await this.prisma.sdlcEntityLink.create({
         data: {
           ...input,
           workspaceId: actor.workspaceId,
-          channelId: repo.channelId,
+          channelId: hubChannelId,
           createdBy: actor.userId,
         },
       });
@@ -1519,7 +1603,7 @@ export class SdlcHubService implements SdlcHub {
       if (input.targetType === 'TICKET' && input.sourceType === 'CANVAS') {
         const trackLink = await this.prisma.sdlcEntityLink.findFirst({
           where: {
-            channelId: repo.channelId,
+            channelId: hubChannelId,
             sourceType: 'TRACK',
             targetType: 'CANVAS',
             targetId: input.sourceId,
@@ -1531,7 +1615,7 @@ export class SdlcHubService implements SdlcHub {
           await ensureLink(
             this.prisma,
             {
-              channelId: repo.channelId!,
+              channelId: hubChannelId,
               sourceType: 'TRACK',
               sourceId: trackLink.sourceId,
               targetType: 'TICKET',
@@ -1551,10 +1635,10 @@ export class SdlcHubService implements SdlcHub {
     }
   }
 
-  async listTracks(actor: SdlcActor, repoId: string, channelId?: string) {
-    const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
+  async listTracks(actor: SdlcActor, channelId: string) {
+    await this.requireChannelRole(actor, channelId, false);
     // Tracks carry no scope column; the CHANNEL -> TRACK edges name the hub's tracks.
-    const trackIds = repo.channelId ? await trackIdsForChannel(this.prisma, repo.channelId) : [];
+    const trackIds = await trackIdsForChannel(this.prisma, channelId);
     return this.prisma.sdlcTrack.findMany({
       where: { id: { in: trackIds } },
       orderBy: { createdAt: 'asc' },
@@ -1570,9 +1654,8 @@ export class SdlcHubService implements SdlcHub {
   }
 
   async createTrack(actor: SdlcActor, input: CreateSdlcTrackInput) {
-    const repo = await this.requireRepositoryRole(actor, input.repoId, false, input.channelId);
-    if (!repo.channelId) throw new AppError('SDLC repository not found', 404);
-    const channelId = repo.channelId;
+    await this.requireChannelRole(actor, input.channelId, false);
+    const channelId = input.channelId;
     return this.prisma.$transaction(async (tx) => {
       const track = await tx.sdlcTrack.create({
         data: {
@@ -1601,25 +1684,22 @@ export class SdlcHubService implements SdlcHub {
     });
   }
 
-  async listArtifactTypes(actor: SdlcActor, repoId: string, channelId?: string) {
-    const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
-    if (!repo?.channelId) throw new AppError('SDLC repository not found', 404);
+  async listArtifactTypes(actor: SdlcActor, channelId: string) {
+    await this.requireChannelRole(actor, channelId, false);
     return this.prisma.canvasFolder.findMany({
-      where: { channelId: repo.channelId },
+      where: { channelId },
       orderBy: { createdAt: 'asc' },
       select: { id: true, name: true, createdAt: true },
     });
   }
 
-  async createArtifactType(actor: SdlcActor, repoId: string, name: string, channelId?: string) {
-    const repo = await this.requireRepositoryRole(actor, repoId, false, channelId);
-    if (!repo?.channelId || !repo.projectId) {
-      throw new AppError('SDLC repository not found', 404);
-    }
+  async createArtifactType(actor: SdlcActor, channelId: string, name: string) {
+    const channel = await this.requireChannelRole(actor, channelId, false);
+    if (!channel.projectId) throw new AppError('SDLC hub not found', 404);
     const trimmed = name.trim();
     if (!trimmed) throw new AppError('Artifact type name is required', 400);
     const existing = await this.prisma.canvasFolder.findFirst({
-      where: { channelId: repo.channelId, name: trimmed },
+      where: { channelId, name: trimmed },
       select: { id: true },
     });
     if (existing) throw new AppError('An artifact type with this name already exists', 409);
@@ -1627,8 +1707,8 @@ export class SdlcHubService implements SdlcHub {
       data: {
         id: randomUUID(),
         workspaceId: actor.workspaceId,
-        projectId: repo.projectId,
-        channelId: repo.channelId,
+        projectId: channel.projectId,
+        channelId,
         name: trimmed,
         createdBy: actor.userId,
       },
@@ -1636,18 +1716,17 @@ export class SdlcHubService implements SdlcHub {
     });
   }
 
-  async renameArtifactType(actor: SdlcActor, repoId: string, folderId: string, name: string) {
-    const repo = await this.requireRepositoryRole(
-      actor,
-      repoId,
-      false,
-      await this.hubOf('canvasFolder', folderId)
-    );
-    if (!repo?.channelId) throw new AppError('SDLC repository not found', 404);
+  async renameArtifactType(
+    actor: SdlcActor,
+    channelId: string,
+    folderId: string,
+    name: string
+  ) {
+    await this.requireChannelRole(actor, channelId, false);
     const trimmed = name.trim();
     if (!trimmed) throw new AppError('Artifact type name is required', 400);
     const folder = await this.prisma.canvasFolder.findFirst({
-      where: { id: folderId, channelId: repo.channelId },
+      where: { id: folderId, channelId },
       select: { id: true, name: true },
     });
     if (!folder) throw new AppError('Artifact type not found', 404);
@@ -1655,7 +1734,7 @@ export class SdlcHubService implements SdlcHub {
       throw new AppError('Repo Knowledge cannot be renamed', 400);
     }
     const clash = await this.prisma.canvasFolder.findFirst({
-      where: { channelId: repo.channelId, name: trimmed, id: { not: folderId } },
+      where: { channelId, name: trimmed, id: { not: folderId } },
       select: { id: true },
     });
     if (clash) throw new AppError('An artifact type with this name already exists', 409);
@@ -1890,7 +1969,7 @@ export class SdlcHubService implements SdlcHub {
   }
 
   private async requireLinkSource(
-    repoId: string,
+    repoId: string | null,
     channelId: string,
     type: string,
     id: string
@@ -1921,7 +2000,12 @@ export class SdlcHubService implements SdlcHub {
         if (ticket) exists = { id: pullRequest.id };
       }
     }
-    if (!exists) throw new AppError(`Invalid ${type} source for repository ${repoId}`, 400);
+    if (!exists) {
+      throw new AppError(
+        `Invalid ${type} source for ${repoId ? `repository ${repoId}` : `hub ${channelId}`}`,
+        400
+      );
+    }
   }
 
   private async requireAccessibleEntity(actor: SdlcActor, type: string, id: string): Promise<void> {

--- a/apps/backend/src/sdlc/sdlcChannelMembership.ts
+++ b/apps/backend/src/sdlc/sdlcChannelMembership.ts
@@ -1,5 +1,6 @@
 import type { Prisma, PrismaClient } from '@prisma/client';
 import {
+  SDLC_ARTIFACT_REPOSITORY_RELATION,
   SDLC_MEMBERSHIP_RELATION,
   SDLC_TRACK_MEMBERSHIP_RELATION,
 } from '@xyne/shared/sdlc';
@@ -90,6 +91,20 @@ export async function findSdlcMembershipForActor(
   return membership?.channelId && role ? { channelId: membership.channelId, role } : null;
 }
 
+export async function repoIdsForChannel(db: Db, channelId: string): Promise<string[]> {
+  const edges = await db.sdlcEntityLink.findMany({
+    where: {
+      channelId,
+      sourceType: 'CHANNEL',
+      targetType: 'REPOSITORY',
+      relationType: SDLC_MEMBERSHIP_RELATION,
+    },
+    orderBy: { createdAt: 'asc' },
+    select: { targetId: true },
+  });
+  return [...new Set(edges.map((edge) => edge.targetId))];
+}
+
 /**
  * The tracks of a hub. Tracks carry no scope column; the CHANNEL -> TRACK edge is
  * what places one, so the id list comes from the link table.
@@ -139,4 +154,23 @@ export async function isCanvasInChannel(
     select: { artifactId: true },
   });
   return Boolean(artifact);
+}
+
+export async function canvasIdsForRepos(
+  db: Db,
+  channelId: string,
+  repoIds: readonly string[]
+): Promise<string[]> {
+  if (repoIds.length === 0) return [];
+  const edges = await db.sdlcEntityLink.findMany({
+    where: {
+      channelId,
+      sourceType: 'CANVAS',
+      targetType: 'REPOSITORY',
+      targetId: { in: [...repoIds] },
+      relationType: SDLC_ARTIFACT_REPOSITORY_RELATION,
+    },
+    select: { sourceId: true },
+  });
+  return [...new Set(edges.map(edge => edge.sourceId))];
 }

--- a/apps/backend/src/sdlc/types.ts
+++ b/apps/backend/src/sdlc/types.ts
@@ -32,6 +32,7 @@ export interface SdlcChannel {
 
 export interface SdlcRepositoryRunContext {
   repoId: string;
+  channelId: string;
   name: string;
   url: string;
   baseBranch: string;
@@ -68,12 +69,14 @@ export interface SdlcHub {
   listRepositoryRunContexts(
     actor: SdlcActor,
     query?: string,
-    limit?: number
+    limit?: number,
+    channelId?: string
   ): Promise<SdlcRepositoryRunContext[]>;
   getRepositoryRunContext(
     actor: SdlcActor,
     repoId: string,
-    conversationId: string
+    conversationId: string,
+    channelId?: string
   ): Promise<SdlcRepositoryRunContext>;
   createArtifactFromClaw(
     actor: SdlcActor,
@@ -83,8 +86,13 @@ export interface SdlcHub {
     actor: SdlcActor,
     input: UpdateSdlcBaselineDraftInput
   ): Promise<SdlcArtifact>;
-  listTracks(actor: SdlcActor, repoId: string, channelId?: string): Promise<unknown>;
+  listTracks(actor: SdlcActor, channelId: string): Promise<unknown>;
   createTrack(actor: SdlcActor, input: CreateSdlcTrackInput): Promise<unknown>;
-  linkContext(actor: SdlcActor, repoId: string, input: CreateSdlcLinkInput): Promise<SdlcLink>;
+  linkContext(
+    actor: SdlcActor,
+    repoId: string | null,
+    input: CreateSdlcLinkInput,
+    channelId?: string
+  ): Promise<SdlcLink>;
   unlinkContext(actor: SdlcActor, repoId: string, linkId: string): Promise<void>;
 }

--- a/apps/backend/src/sdlc/vcs/SdlcVcsService.ts
+++ b/apps/backend/src/sdlc/vcs/SdlcVcsService.ts
@@ -1,5 +1,7 @@
 import { Prisma, type PrismaClient } from '@prisma/client';
-import { ACLAuditEventType, ACLAuditTargetType } from '@xyne/shared';
+import { ACLAuditEventType, ACLAuditTargetType,
+  SDLC_AGENT_SLUG,
+} from '@xyne/shared';
 import { DatabaseClient } from '@/database/client';
 import { AppError } from '@/middleware/errorHandler';
 import { logger } from '@/utils/logger';
@@ -34,7 +36,6 @@ const adapters: Record<VcsProvider, VcsProviderAdapter> = {
 const ACCESS_REFRESH_CHUNK = 5;
 
 const activeExecutionStatuses = ['NEW', 'PENDING', 'SCHEDULED', 'RUNNING', 'EXTERNAL_WAIT'];
-const SDLC_AGENT_SLUG = 'sdlc-agent';
 
 export class SdlcVcsService implements SdlcVcs {
   private readonly credentialStore = new SdlcVcsCredentialStore();

--- a/apps/backend/src/sdlc/vcs/sandboxCredentialEnvelope.ts
+++ b/apps/backend/src/sdlc/vcs/sandboxCredentialEnvelope.ts
@@ -1,3 +1,4 @@
+import { SDLC_AGENT_SLUG } from '@xyne/shared';
 import {
   createCipheriv,
   createPublicKey,
@@ -9,7 +10,7 @@ import {
 } from 'crypto';
 
 export interface SandboxCredentialBinding {
-  agentSlug: 'sdlc-agent';
+  agentSlug: typeof SDLC_AGENT_SLUG;
   workspaceId: string;
   repoId: string;
   operation: string;

--- a/apps/backend/src/sdlc/vcs/sdlcInteractiveGrant.ts
+++ b/apps/backend/src/sdlc/vcs/sdlcInteractiveGrant.ts
@@ -1,3 +1,4 @@
+import { SDLC_AGENT_SLUG } from '@xyne/shared';
 import { createHmac, timingSafeEqual } from 'crypto';
 
 const GRANT_VERSION = 1 as const;
@@ -5,7 +6,7 @@ const GRANT_TTL_MS = 30 * 60_000;
 
 export interface SdlcInteractiveGrantClaims {
   version: typeof GRANT_VERSION;
-  agentSlug: 'sdlc-agent';
+  agentSlug: typeof SDLC_AGENT_SLUG;
   workspaceId: string;
   repoId: string;
   actorUserId: string;
@@ -59,7 +60,7 @@ export function verifySdlcInteractiveGrant(
   const value = claims as Partial<SdlcInteractiveGrantClaims>;
   if (
     value.version !== GRANT_VERSION ||
-    value.agentSlug !== 'sdlc-agent' ||
+    value.agentSlug !== SDLC_AGENT_SLUG ||
     !value.workspaceId ||
     !value.repoId ||
     !value.actorUserId ||

--- a/apps/backend/src/sdlc/wiki/SdlcWikiExecutionService.ts
+++ b/apps/backend/src/sdlc/wiki/SdlcWikiExecutionService.ts
@@ -1,3 +1,4 @@
+import { SDLC_AGENT_SLUG } from '@xyne/shared';
 import { randomUUID } from 'crypto';
 import type { PrismaClient } from '@prisma/client';
 import { config } from '@/config/env';
@@ -244,7 +245,7 @@ export class SdlcWikiExecutionService {
           : role === 'CORRECTOR'
             ? 'CORRECTING'
             : 'PROCESSING',
-      agentSlug: 'sdlc-agent',
+      agentSlug: SDLC_AGENT_SLUG,
       conversationId,
       sessionId,
       credentialSessionId: sessionId,
@@ -308,6 +309,7 @@ export class SdlcWikiExecutionService {
       repo.id,
       {
         operation: 'wiki',
+        channelId,
         workflowExecutionId: execution.id,
         sessionId,
         conversationId,
@@ -374,7 +376,7 @@ export class SdlcWikiExecutionService {
     ].join('\n\n');
     await runS2SClawAgent({
       sessionId,
-      agentSlug: 'sdlc-agent',
+      agentSlug: SDLC_AGENT_SLUG,
       task,
       userId: user.id,
       userName: user.name || user.email,

--- a/apps/backend/src/sdlc/wiki/SdlcWikiPageStore.ts
+++ b/apps/backend/src/sdlc/wiki/SdlcWikiPageStore.ts
@@ -150,6 +150,7 @@ export class SdlcWikiPageStore {
     repoId: string;
     workspaceId: string;
     userId: string;
+    channelId?: string;
     includeArchived?: boolean;
     sourcePaths?: string[];
   }): Promise<
@@ -167,7 +168,7 @@ export class SdlcWikiPageStore {
     const pages = await this.prisma.canvas.findMany({
       where: {
         channelId: repo.channelId,
-        sdlcArtifact: { is: { artifactType: 'WIKI' } },
+        sdlcArtifact: { is: { artifactType: 'WIKI', repoId: repo.id } },
       },
       select: {
         id: true,
@@ -220,6 +221,7 @@ export class SdlcWikiPageStore {
     repoId: string;
     workspaceId: string;
     userId: string;
+    channelId?: string;
     includeArchived?: boolean;
   }): Promise<WikiMapEntry[]> {
     const pages = await this.listPages(input);
@@ -235,6 +237,7 @@ export class SdlcWikiPageStore {
     repoId: string;
     workspaceId: string;
     userId: string;
+    channelId?: string;
     targetHeadSha?: string;
     changedSourcePaths?: string[];
   }): Promise<WikiAuditFinding[]> {
@@ -269,6 +272,7 @@ export class SdlcWikiPageStore {
     repoId: string;
     workspaceId: string;
     userId: string;
+    channelId?: string;
     path: string;
     includeArchived?: boolean;
   }): Promise<{
@@ -1152,15 +1156,16 @@ export class SdlcWikiPageStore {
     repoId: string;
     workspaceId: string;
     userId: string;
+    channelId?: string;
   }): Promise<{ id: string; channelId: string }> {
     // Membership is the read check: the actor must participate in a hub this
-    // repository belongs to.
     const membership = await this.prisma.sdlcEntityLink.findFirst({
       where: {
         workspaceId: input.workspaceId,
         targetType: 'REPOSITORY',
         targetId: input.repoId,
         relationType: SDLC_MEMBERSHIP_RELATION,
+        ...(input.channelId ? { channelId: input.channelId } : {}),
         channel: { participants: { some: { userId: input.userId } } },
       },
       orderBy: { createdAt: 'asc' },

--- a/apps/backend/src/sdlc/wiki/wikiRunState.ts
+++ b/apps/backend/src/sdlc/wiki/wikiRunState.ts
@@ -1,3 +1,4 @@
+import { SDLC_AGENT_SLUG } from '@xyne/shared';
 import { z } from 'zod';
 
 const gitShaSchema = z.string().regex(/^[0-9a-f]{40}$/i);
@@ -99,7 +100,7 @@ export const wikiExecutionContextSchema = z
          * and write pages into the wrong hub. Optional only for older runs.
          */
     channelId: z.string().min(1).nullish(),
-    agentSlug: z.literal('sdlc-agent').nullable(),
+    agentSlug: z.literal(SDLC_AGENT_SLUG).nullable(),
     conversationId: z.string().nullable(),
     sessionId: z.string().nullable(),
     credentialSessionId: z.string().nullable(),

--- a/packages/shared/src/sdlc.ts
+++ b/packages/shared/src/sdlc.ts
@@ -135,6 +135,8 @@ export const SDLC_MEMBERSHIP_RELATION = "REPOSITORY";
  */
 export const SDLC_TRACK_MEMBERSHIP_RELATION = "TRACK";
 
+export const SDLC_ARTIFACT_REPOSITORY_RELATION = "CONTEXT";
+
 /** Structure, not content. Every read of the content graph excludes these. */
 export const SDLC_STRUCTURAL_RELATIONS = [
   SDLC_MEMBERSHIP_RELATION,
@@ -622,9 +624,119 @@ export type CreateSdlcPullRequestInput = z.infer<
   typeof createSdlcPullRequestSchema
 >;
 
+export const SDLC_AGENT_SLUG = "sdlc-agent" as const;
+
+export const SDLC_AGENT_OPERATIONS = [
+  "interactive",
+  "baseline",
+  "artifact",
+  "work",
+  "wiki",
+] as const;
+export const sdlcAgentOperationSchema = z.enum(SDLC_AGENT_OPERATIONS);
+export type SdlcAgentOperation = z.infer<typeof sdlcAgentOperationSchema>;
+
+export const SDLC_WIKI_AGENT_ROLES = [
+  "BOOTSTRAP_SURVEY",
+  "BOOTSTRAP_PAGE",
+  "BOOTSTRAP_EDITOR",
+  "BOOTSTRAP",
+  "GENERATOR",
+  "ARCHITECTURE_VALIDATOR",
+  "CORRECTOR",
+] as const;
+export const sdlcWikiAgentRoleSchema = z.enum(SDLC_WIKI_AGENT_ROLES);
+export type SdlcWikiAgentRole = z.infer<typeof sdlcWikiAgentRoleSchema>;
+
+const nullableNonEmpty = z.string().min(1).nullable();
+
+export const sdlcAgentContextSchema = z
+  .object({
+    version: z.literal(1),
+    operation: sdlcAgentOperationSchema,
+    workspaceId: z.string().min(1),
+    projectId: z.string().min(1),
+    channelId: z.string().min(1),
+    actorUserId: z.string().min(1),
+    repository: z.object({
+      id: z.string().min(1),
+      name: z.string().min(1),
+      url: z.string().min(1),
+      baseBranch: z.string().min(1),
+    }),
+    permissions: z.object({ repositoryRole: z.enum(["ADMIN", "MEMBER"]) }),
+    gates: z.object({
+      capabilities: z.array(z.unknown()),
+      allBaselinesApproved: z.boolean(),
+    }),
+    execution: z.object({
+      workflowExecutionId: nullableNonEmpty,
+      sessionId: nullableNonEmpty,
+      conversationId: nullableNonEmpty,
+    }),
+    interactiveGrant: nullableNonEmpty.optional(),
+    artifact: z.object({
+      kind: nullableNonEmpty,
+      id: nullableNonEmpty,
+      sourceType: nullableNonEmpty,
+      sourceId: nullableNonEmpty,
+    }),
+    ticketId: nullableNonEmpty.optional(),
+    setupExecutionId: nullableNonEmpty.optional(),
+    baselineKind: sdlcBaselineKindSchema.nullable().optional(),
+    generationCommit: nullableNonEmpty.optional(),
+    wiki: z
+      .object({
+        role: sdlcWikiAgentRoleSchema.nullable(),
+        assignedCommitShas: z.array(z.string()),
+        bootstrapRef: z.string().nullable(),
+        targetHeadSha: z.string().nullable(),
+      })
+      .optional(),
+  })
+  .superRefine((context, ctx) => {
+    const fail = (message: string) =>
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message });
+    const hasExecution =
+      Boolean(context.execution.workflowExecutionId) && Boolean(context.execution.sessionId);
+
+    switch (context.operation) {
+      case "baseline":
+        if (!context.setupExecutionId) fail("setupExecutionId is required for baseline runs");
+        if (!context.baselineKind) fail("baselineKind is required for baseline runs");
+        if (!hasExecution) fail("baseline runs require a bound execution");
+        break;
+      case "artifact":
+        if (!hasExecution) fail("artifact runs require a bound execution");
+        break;
+      case "work":
+        if (!context.ticketId) fail("ticketId is required for work runs");
+        if (!hasExecution) fail("work runs require a bound execution");
+        break;
+      case "interactive":
+        if (!context.execution.conversationId) fail("interactive runs require a conversationId");
+        if (!context.interactiveGrant) fail("interactive runs require an interactiveGrant");
+        break;
+      case "wiki":
+        break;
+    }
+  });
+export type SdlcAgentContext = z.infer<typeof sdlcAgentContextSchema>;
+
+export const resolveSdlcAgentRepositorySchema = z.object({
+  agentSlug: z.literal(SDLC_AGENT_SLUG),
+  repoId: z.string().min(1),
+  actorUserId: z.string().min(1),
+  conversationId: z.string().min(1),
+  channelId: z.string().min(1).optional(),
+});
+export type ResolveSdlcAgentRepositoryInput = z.infer<
+  typeof resolveSdlcAgentRepositorySchema
+>;
+
 export const bootstrapSdlcRuntimeCredentialSchema = z
   .object({
-    agentSlug: z.literal("sdlc-agent"),
+    agentSlug: z.literal(SDLC_AGENT_SLUG),
     repoId: z.string().min(1),
     operation: z.enum(["CLONE", "PUSH", "INTERACTIVE"]),
     sandboxId: z.string().min(1).max(256),
@@ -635,9 +747,20 @@ export type BootstrapSdlcRuntimeCredentialInput = z.infer<
   typeof bootstrapSdlcRuntimeCredentialSchema
 >;
 
+export const sdlcRepoIdsSchema = z.array(z.string().min(1)).max(50).optional();
+
+export function sdlcRepoIds(input: {
+  repoId?: string | undefined;
+  repoIds?: string[] | undefined;
+}): string[] {
+  if (input.repoIds) return [...new Set(input.repoIds)];
+  return input.repoId ? [input.repoId] : [];
+}
+
 export const createSdlcClawArtifactSchema = z
   .object({
-    repoId: z.string().min(1),
+    repoId: z.string().min(1).optional(),
+    repoIds: sdlcRepoIdsSchema,
     // The hub to write into. A repository sits in several, so it cannot be inferred.
     channelId: z.string().min(1).optional(),
     kind: sdlcArtifactKindSchema.optional(),
@@ -665,6 +788,12 @@ export const createSdlcClawArtifactSchema = z
           "Baseline artifacts require baselineKind, setupExecutionId, and workflowExecutionId",
       });
     }
+    if (value.kind === "BASELINE" && sdlcRepoIds(value).length !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Baseline artifacts belong to exactly one repository",
+      });
+    }
     const isArtifact = value.kind !== "BASELINE";
     if (isArtifact) {
       if (!value.folderId) {
@@ -686,7 +815,8 @@ export type CreateSdlcClawArtifactInput = z.infer<
 >;
 
 export const updateSdlcClawArtifactSchema = z.object({
-  repoId: z.string().min(1),
+  repoId: z.string().min(1).optional(),
+  channelId: z.string().min(1).optional(),
   canvasId: z.string().min(1),
   title: z.string().trim().min(1).max(255).optional(),
   markdown: z.string().min(1).max(5_000_000),
@@ -735,23 +865,31 @@ export const createSdlcLinkSchema = z.object({
 });
 export type CreateSdlcLinkInput = z.infer<typeof createSdlcLinkSchema>;
 
-export const createSdlcTrackSchema = z.object({
-  repoId: z.string().min(1),
+export const createSdlcClawLinkSchema = createSdlcLinkSchema.extend({
   channelId: z.string().min(1).optional(),
+  repoId: z.string().min(1).optional(),
+  repoIds: sdlcRepoIdsSchema,
+});
+export type CreateSdlcClawLinkInput = z.infer<typeof createSdlcClawLinkSchema>;
+
+export const createSdlcTrackSchema = z.object({
+  repoId: z.string().min(1).optional(),
+  channelId: z.string().min(1),
   name: z.string().trim().min(1).max(120),
   description: z.string().trim().max(2000).optional(),
 });
 export type CreateSdlcTrackInput = z.infer<typeof createSdlcTrackSchema>;
 
 export const createSdlcArtifactTypeSchema = z.object({
-  repoId: z.string().min(1),
-  channelId: z.string().min(1).optional(),
+  repoId: z.string().min(1).optional(),
+  channelId: z.string().min(1),
   name: z.string().trim().min(1).max(80),
 });
 export type CreateSdlcArtifactTypeInput = z.infer<typeof createSdlcArtifactTypeSchema>;
 
 export const renameSdlcArtifactTypeSchema = z.object({
-  repoId: z.string().min(1),
+  repoId: z.string().min(1).optional(),
+  channelId: z.string().min(1),
   folderId: z.string().min(1),
   name: z.string().trim().min(1).max(80),
 });


### PR DESCRIPTION
## What

An SDLC hub is a channel covering several repositories, so the hub is the scope of a read and naming repositories only narrows it. This makes the backend and shared schemas agree with that.

- `sdlcRepoIds` normalizes the legacy scalar `repoId` and the new `repoIds` list. An explicitly empty `repoIds` means the hub itself — the only way a run with a repository pinned by trusted run context can read or write hub-scoped artifacts.
- The artifact-history internal routes (`/api/internal/sdlc/artifact-versions/*`) drop the scalar entirely. Their scope is the hub plus an optional `repoIds` narrowing.
- New `POST /api/internal/sdlc/agent/repository-context`: an agent that picks its repository mid-run resolves the same context an eagerly pinned run would have carried. Membership is re-checked server-side against the acting user.
- Artifact reads resolve repositories through `CANVAS -> REPOSITORY` edges ORed with the legacy `sdlc_artifacts.repoId` column, because wiki pages write only the column and multi-repo artifacts write only edges.

## Also

The one-off multirepo cleanup router is unmounted — every environment has run it. `src/sdlc/cleanup/` is left in place; the mount is commented so a restored or newly stood-up environment can catch up.

## Testing

- `tsc --noEmit` clean on `apps/backend` and `packages/shared` for every file this touches.
- Behaviour change to note in review: on a repo-pinned run, `list-artifacts`, `read-artifact`, `list-artifact-versions` and `read-artifact-version` now cover the whole hub instead of the pinned repository. The model narrows with `repoIds`, and an ambiguous wiki path already returns 409 naming the candidate repositories.

## Companion

Claw-side half is a separate PR against `feature/deploy-xyneclaw`.
