### PR TITLE
fix: XYNE-62492 activity-code-block-for-detailed-and-condensed-view

### DIFF
--- a/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
@@ -417,7 +417,7 @@ export const ActivityItemCard = ({
               : 'text-foreground',
             isExpanded
               ? 'whitespace-normal break-normal'
-              : 'line-clamp-1 break-normal whitespace-normal',
+              : 'line-clamp-2 break-normal whitespace-normal rounded-md border border-border bg-muted/50 px-2.5 py-1.5',
           )}
         >
           {children}

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -12,6 +12,13 @@ import { queries } from '../../../zero/queries';
 import { useZero } from '../../../hooks/useZero';
 import { ActivityItem } from '../ActivityItem';
 import { NofocusRefProvider } from '../ActivityItemCard';
+import { CodeBlockRenderContext } from '../../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+
+const ACTIVITY_CODE_BLOCK_OPTIONS = {
+  collapseThreshold: 10,
+  previewLines: 10,
+  showExpandToggle: true,
+};
 import { GroupedTicketActivity } from '../GroupedTicketActivity';
 import * as Tabs from '@radix-ui/react-tabs';
 import * as Switch from '@radix-ui/react-switch';
@@ -852,13 +859,17 @@ const ActivityListView = (): ReactElement => {
                 // px wraps each row (not the scroller) and pb creates the 8px
                 // row gap — padding is used instead of margin so Virtuoso's
                 // item measurement includes it.
+                const row =
+                  item.type === 'single' ? (
+                    <ActivityItem activity={item.activity} isExpanded={isExpanded} />
+                  ) : (
+                    <GroupedTicketActivity activities={item.activities} isExpanded={isExpanded} />
+                  );
                 return (
                   <div className='px-3 pb-3'>
-                    {item.type === 'single' ? (
-                      <ActivityItem activity={item.activity} isExpanded={isExpanded} />
-                    ) : (
-                      <GroupedTicketActivity activities={item.activities} isExpanded={isExpanded} />
-                    )}
+                    <CodeBlockRenderContext.Provider value={ACTIVITY_CODE_BLOCK_OPTIONS}>
+                      {row}
+                    </CodeBlockRenderContext.Provider>
                   </div>
                 );
               }}

--- a/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
+++ b/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { htmlToPlainText } from '../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -48,10 +48,8 @@ export const DirectMessageActivity = ({
       {isExpanded ? (
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
-          )}
+        <div className='text-foreground text-sm line-clamp-2 whitespace-normal break-words'>
+          {getFlowJsonPreviewText(message.content) ?? htmlToPlainText(message.content)}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
+++ b/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { htmlToPlainText } from '../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -51,10 +51,8 @@ export const KeywordMatchActivity = ({
       {isExpanded ? (
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
-          )}
+        <div className='text-foreground text-sm line-clamp-2 whitespace-normal break-words'>
+          {getFlowJsonPreviewText(message.content) ?? htmlToPlainText(message.content)}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
@@ -3,7 +3,7 @@ import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { AtMark } from '@xyne/icons';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { htmlToPlainText } from '../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -52,10 +52,8 @@ export const MessageMentionActivity = ({
       {isExpanded ? (
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
-          )}
+        <div className='text-foreground text-sm line-clamp-2 whitespace-normal break-words'>
+          {getFlowJsonPreviewText(message.content) ?? htmlToPlainText(message.content)}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { htmlToPlainText } from '../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { useRouteContext } from '../../hooks/useRouteContext';
@@ -46,10 +46,8 @@ export const MessageRepliedActivity = ({
       {isExpanded ? (
         <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
       ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
-          )}
+        <div className='text-foreground text-sm line-clamp-2 whitespace-normal break-words'>
+          {getFlowJsonPreviewText(message.content) ?? htmlToPlainText(message.content)}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { htmlToPlainText } from '../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -103,13 +103,9 @@ export const MessageRepliedActivityV2 = ({
           contentOnly={true}
         />
       ) : (
-        <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
-          {getFlowJsonPreviewText(latestReplyMessage.content) ?? (
-            <RenderMessageWithHTML
-              message={latestReplyMessage.content}
-              showEdited={latestReplyMessage.edited}
-            />
-          )}
+        <div className='text-foreground text-sm line-clamp-2 whitespace-normal break-words'>
+          {getFlowJsonPreviewText(latestReplyMessage.content) ??
+            htmlToPlainText(latestReplyMessage.content)}
         </div>
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { htmlToPlainText } from '../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -52,9 +52,9 @@ export const ReactionAddedActivity = ({
       {isExpanded ? (
         <MessageBubble message={message} showAvatar={false} contentOnly={true} variant='default' />
       ) : (
-        (getFlowJsonPreviewText(reactionPreview) ?? (
-          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} />
-        ))
+        <div className='text-foreground text-sm line-clamp-2 whitespace-normal break-words'>
+          {getFlowJsonPreviewText(reactionPreview) ?? htmlToPlainText(reactionPreview)}
+        </div>
       )}
     </ActivityItemCard>
   );

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 import type { ActivityWithRelated } from '../../types/activity';
 import { MessageBubble } from '../ui/MessageBubble/MessageBubble';
 import { ActivityItemCard } from './ActivityItemCard';
-import { RenderMessageWithHTML } from '../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
+import { htmlToPlainText } from '../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../utils/flowPreview';
 import { useUser } from '../../hooks/useUsers';
 import { getUserDisplayName } from '../../utils/userDisplayName';
@@ -84,9 +84,9 @@ export const ReactionAddedActivityV2 = ({
       {isExpanded ? (
         <MessageBubble message={message} showAvatar={false} contentOnly={true} variant='default' />
       ) : (
-        (getFlowJsonPreviewText(reactionPreview) ?? (
-          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} />
-        ))
+        <div className='text-foreground text-sm line-clamp-2 whitespace-normal break-words'>
+          {getFlowJsonPreviewText(reactionPreview) ?? htmlToPlainText(reactionPreview)}
+        </div>
       )}
     </ActivityItemCard>
   );

--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -1,4 +1,4 @@
-import React, { JSX, useEffect, useMemo, useRef, useState } from 'react';
+import React, { JSX, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { usePlatform } from '../../../hooks/usePlatform';
 import {
@@ -545,9 +545,20 @@ function CollapsibleConversationHistory({
   );
 }
 
-const CODE_BLOCK_COLLAPSE_THRESHOLD = 50;
-const CODE_BLOCK_PREVIEW_LINES = 20;
-const CODE_BLOCK_PREVIEW_MAX_HEIGHT = CODE_BLOCK_PREVIEW_LINES * 20 + 16;
+const CODE_BLOCK_LINE_HEIGHT_PX = 20;
+const CODE_BLOCK_PREVIEW_PADDING_PX = 16;
+
+export interface CodeBlockRenderOptions {
+  collapseThreshold: number;
+  previewLines: number;
+  showExpandToggle: boolean;
+}
+
+export const CodeBlockRenderContext = React.createContext<CodeBlockRenderOptions>({
+  collapseThreshold: Number.POSITIVE_INFINITY,
+  previewLines: Number.POSITIVE_INFINITY,
+  showExpandToggle: false,
+});
 
 function MessageCodeBlock({
   children,
@@ -556,6 +567,8 @@ function MessageCodeBlock({
   children: React.ReactNode;
   codeText: string;
 }): JSX.Element {
+  const { collapseThreshold, previewLines, showExpandToggle } = useContext(CodeBlockRenderContext);
+  const previewMaxHeight = previewLines * CODE_BLOCK_LINE_HEIGHT_PX + CODE_BLOCK_PREVIEW_PADDING_PX;
   const [copied, setCopied] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const resetTimerRef = useRef<number | undefined>(undefined);
@@ -583,15 +596,16 @@ function MessageCodeBlock({
   };
 
   const lines = codeText.length > 0 ? codeText.replace(/\n$/, '').split('\n').length : 0;
-  const collapsible = lines > CODE_BLOCK_COLLAPSE_THRESHOLD;
+  const collapsible = showExpandToggle && lines > collapseThreshold;
+  const silentCollapse = !showExpandToggle && lines > previewLines;
 
   return (
     <div className='xyne-code-block group/code-block relative my-3 max-w-full overflow-hidden rounded-[10px] border border-border bg-muted'>
       <div
         className='relative overflow-hidden'
         style={
-          collapsible && !isExpanded
-            ? { maxHeight: `${CODE_BLOCK_PREVIEW_MAX_HEIGHT}px` }
+          (collapsible && !isExpanded) || silentCollapse
+            ? { maxHeight: `${previewMaxHeight}px` }
             : undefined
         }
       >
@@ -614,7 +628,7 @@ function MessageCodeBlock({
             <button
               type='button'
               onClick={() => setIsExpanded(prev => !prev)}
-              className='expand-toggle-pill pointer-events-auto flex items-center gap-1 rounded-full bg-background px-2.5 py-1.5 text-[13px] leading-none text-foreground transition-colors hover:bg-muted cursor-pointer'
+              className='expand-toggle-pill pointer-events-auto flex items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5 text-[13px] font-medium leading-none text-foreground shadow-sm transition-all hover:bg-muted hover:shadow active:scale-95 cursor-pointer'
               data-track-category='MESSAGE'
               data-track-name='TOGGLE_CODE_BLOCK'
               data-track-metadata={JSON.stringify({ isExpanded, lineCount: lines })}

--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -548,6 +548,31 @@ function CollapsibleConversationHistory({
 const CODE_BLOCK_LINE_HEIGHT_PX = 20;
 const CODE_BLOCK_PREVIEW_PADDING_PX = 16;
 
+const BLOCK_LEVEL_TAGS_FOR_CODE_EXTRACTION = new Set([
+  'div',
+  'p',
+  'li',
+  'tr',
+  'section',
+  'article',
+]);
+
+const extractCodeText = (node: Node): string => {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? '';
+  if (node.nodeType !== Node.ELEMENT_NODE) return '';
+  const el = node as HTMLElement;
+  const tag = el.tagName.toLowerCase();
+  if (tag === 'br') return '\n';
+  let text = '';
+  el.childNodes.forEach(child => {
+    text += extractCodeText(child);
+  });
+  if (BLOCK_LEVEL_TAGS_FOR_CODE_EXTRACTION.has(tag) && !text.endsWith('\n')) {
+    text += '\n';
+  }
+  return text;
+};
+
 export interface CodeBlockRenderOptions {
   collapseThreshold: number;
   previewLines: number;
@@ -580,7 +605,8 @@ function MessageCodeBlock({
     [],
   );
 
-  const handleCopy = (): void => {
+  const handleCopy = (e: React.MouseEvent<HTMLButtonElement>): void => {
+    e.stopPropagation();
     void copyTextToClipboard(codeText)
       .then(() => {
         setCopied(true);
@@ -627,7 +653,10 @@ function MessageCodeBlock({
           >
             <button
               type='button'
-              onClick={() => setIsExpanded(prev => !prev)}
+              onClick={e => {
+                e.stopPropagation();
+                setIsExpanded(prev => !prev);
+              }}
               className='expand-toggle-pill pointer-events-auto flex items-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5 text-[13px] font-medium leading-none text-foreground shadow-sm transition-all hover:bg-muted hover:shadow active:scale-95 cursor-pointer'
               data-track-category='MESSAGE'
               data-track-name='TOGGLE_CODE_BLOCK'
@@ -1342,7 +1371,7 @@ const parseNode = (
   }
 
   if (tag === 'pre') {
-    const codeText = el.textContent ?? '';
+    const codeText = extractCodeText(el);
     return (
       <MessageCodeBlock key={`${keyPrefix}-code-block-${idx}`} codeText={codeText}>
         {React.createElement(tag, props, ...children)}


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
