### PR TITLE
fix: XYNE-62238 show board stages as kanban columns for single or identical boards

### DIFF
--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -4264,6 +4264,17 @@ dmChannelsLatestMessagesPaginated: defineQuery(
     }
   ),
 
+  getStagesWithGatesByBoardIds: defineQuery(
+    z.object({ boardIds: z.array(z.string()) }),
+    ({ args: { boardIds } }) => {
+      const base =
+        boardIds.length === 0
+          ? zql.stages.where('id', 'nonexistent').limit(0)
+          : zql.stages.where('boardId', 'IN', boardIds).orderBy('sequenceNumber', 'asc')
+      return base.related('approvers').related('formContextMappings')
+    }
+  ),
+
   getBoardComplexityScores: defineQuery(
     z.object({ userGroupId: z.string() }),
     ({ args: { userGroupId } }) => {

--- a/apps/dashboard/src/hooks/useDragAndDrop.ts
+++ b/apps/dashboard/src/hooks/useDragAndDrop.ts
@@ -275,9 +275,11 @@ export const useDragAndDrop = ({
             // Used for linear boards without explicitly defined transitions.
             if (!isNonLinearBoard && (!transitions || transitions.length === 0)) {
               const boardHasStagesWithApproval =
-                stages.some(s => s.approvers && s.approvers.length > 0) ?? false;
+                (boardStages ?? stages).some(s => s.approvers && s.approvers.length > 0) ?? false;
               // Check if board has any stage with forms
-              const boardHasStagesWithForms = stageFormMap.size > 0;
+              const boardHasStagesWithForms = boardStages
+                ? boardStages.some(s => !!s.formId)
+                : stageFormMap.size > 0;
               // Enforce sequential movement if board has EITHER approvers OR forms
               const shouldEnforceSequentialMovement =
                 boardHasStagesWithApproval || boardHasStagesWithForms;

--- a/apps/dashboard/src/hooks/useDragAndDrop.ts
+++ b/apps/dashboard/src/hooks/useDragAndDrop.ts
@@ -28,6 +28,7 @@ interface UseDragAndDropProps {
   setLocalTickets: React.Dispatch<React.SetStateAction<Ticket[]>>;
   zero: Zero;
   stages: Stage[];
+  stagesByBoardId?: Map<string, Stage[]>;
   mode: 'stage' | 'status'; // 'stage' for board view, 'status' for project/all view
   canReorder: boolean;
   onStageFormRequired?: (data: {
@@ -54,6 +55,7 @@ export const useDragAndDrop = ({
   setLocalTickets,
   zero,
   stages,
+  stagesByBoardId,
   mode,
   canReorder,
   onStageFormRequired,
@@ -175,7 +177,12 @@ export const useDragAndDrop = ({
       if (mode === 'stage') {
         // Board view: Update stageName
         const newStageId = overTicket?.stageName || over.id;
-        const targetStage = stages.find(s => s.id === newStageId || s.name === newStageId);
+        const columnStage = stages.find(s => s.id === newStageId || s.name === newStageId);
+        const boardStages = stagesByBoardId?.get(activeTicket.boardId ?? '');
+        const targetStage =
+          boardStages && columnStage
+            ? boardStages.find(s => s.name === columnStage.name)
+            : columnStage;
 
         const newStageName = targetStage?.name;
         const newStatus = targetStage?.defaultTicketStatusV2;
@@ -186,7 +193,7 @@ export const useDragAndDrop = ({
             toast.info('Ticket stages are updated by the SDLC workflow');
             return;
           }
-          const currentStage = stages.find(s => s.name === activeTicket.stageName);
+          const currentStage = (boardStages ?? stages).find(s => s.name === activeTicket.stageName);
 
           if (currentStage && targetStage) {
             if (transitions) {
@@ -680,6 +687,7 @@ export const useDragAndDrop = ({
       setLocalTickets,
       zero,
       stages,
+      stagesByBoardId,
       mode,
       canReorder,
       computeNewPosition,

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -150,6 +150,7 @@ import type { Stage } from './KanbanBoardScreen.types';
 import {
   getStageColor,
   getStatusColumns,
+  getSharedBoardStages,
   groupTicketsByStage,
   groupTicketsByStatus,
   applyTicketFilters,
@@ -1254,6 +1255,20 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     return null;
   }, [viewMode, boardId, filters.boards]);
 
+  const [multiBoardStages, multiBoardStagesResult] = useCachedQuery(
+    queries.getStagesByBoardIds({ boardIds: filters.boards ?? [] }),
+    { enabled: shouldShowBoardWiseView },
+  );
+  const sharedBoardStagesReady =
+    !shouldShowBoardWiseView || multiBoardStagesResult.type === 'complete';
+  const sharedBoardStages = useMemo(
+    () =>
+      shouldShowBoardWiseView && sharedBoardStagesReady
+        ? getSharedBoardStages(filters.boards ?? [], multiBoardStages ?? [])
+        : null,
+    [shouldShowBoardWiseView, sharedBoardStagesReady, filters.boards, multiBoardStages],
+  );
+
   // Get all boards for the project (needed for channel stage view and create ticket modal)
   // In my-tickets/user-tickets/group-tickets, fetch ALL boards (no project filter) since tickets can span projects
   const isMyTicketsView =
@@ -1515,16 +1530,14 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       return getStatusColumns();
     }
 
-    // If multiple boards selected, use status-based columns
+    // If multiple boards selected, use their shared stages, else status-based columns
     if (shouldShowBoardWiseView) {
-      return getStatusColumns();
+      if (!sharedBoardStagesReady) return [];
+      return sharedBoardStages ?? getStatusColumns();
     }
 
     // If single board selected in filter, use its stages.
-    // Workspace-views always group by status (shouldUseStatusColumns), so never
-    // return board stage UUIDs here or columns/counts/drag mode would mismatch.
     if (
-      !isWorkspaceView &&
       filteredSingleBoardId &&
       stagesDataForFilteredBoard &&
       stagesDataForFilteredBoard.length > 0
@@ -1651,8 +1664,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     ];
   }, [
     viewMode,
-    isWorkspaceView,
     shouldShowBoardWiseView,
+    sharedBoardStagesReady,
+    sharedBoardStages,
     filteredSingleBoardId,
     stagesDataForFilteredBoard,
     channelId,
@@ -3028,9 +3042,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   }, [flowTicketNodes]);
 
   const shouldUseStatusColumns =
-    isWorkspaceView ||
-    (!filteredSingleBoardId && ['project', 'my-tickets'].includes(viewMode)) ||
-    (channelId && viewMode === 'project' && channelViewType !== 'stage');
+    !filteredSingleBoardId &&
+    !sharedBoardStages &&
+    (isWorkspaceView ||
+      ['project', 'my-tickets'].includes(viewMode) ||
+      (channelId && viewMode === 'project' && channelViewType !== 'stage'));
 
   const navBaseArgs = useMemo<KanbanTicketsPageBaseArgs>(
     () => ({
@@ -3247,13 +3263,14 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   // Use drag and drop hook
   const dragDropMode = useMemo(() => {
+    if (sharedBoardStages) return 'stage';
     // For channel tickets: use view type to determine mode
     if (channelId && viewMode === 'project') {
       return channelViewType === 'stage' ? 'stage' : 'status';
     }
     // For other views
     return viewMode === 'board' || filteredSingleBoardId ? 'stage' : 'status';
-  }, [channelId, viewMode, channelViewType, filteredSingleBoardId]);
+  }, [sharedBoardStages, channelId, viewMode, channelViewType, filteredSingleBoardId]);
 
   const canReorder = !!filteredSingleBoardId;
   const setDragLocalTickets = useCallback<React.Dispatch<React.SetStateAction<Ticket[]>>>(value => {
@@ -3410,7 +3427,8 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
 
   const hasSearchTerm = searchTerm.trim().length > 0;
   // Also require deferredFilters to have caught up before enabling queries
-  const canUseKanbanColumnPagination = isKanbanLayout && workspaceViewReady && deferredFiltersReady;
+  const canUseKanbanColumnPagination =
+    isKanbanLayout && workspaceViewReady && deferredFiltersReady && sharedBoardStagesReady;
   const shouldFetchKanbanCounts = canUseKanbanColumnPagination && !hasSearchTerm;
   const kanbanCounts = useKanbanCounts({
     ...ticketsQueryParams,

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -1257,11 +1257,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   }, [viewMode, boardId, filters.boards]);
 
   const [multiBoardStages, multiBoardStagesResult] = useCachedQuery(
-    queries.getStagesByBoardIds({ boardIds: filters.boards ?? [] }),
+    queries.getStagesWithGatesByBoardIds({ boardIds: filters.boards ?? [] }),
     { enabled: shouldShowBoardWiseView },
   );
   const sharedBoardStagesReady =
-    !shouldShowBoardWiseView || multiBoardStagesResult.type === 'complete';
+    !shouldShowBoardWiseView || multiBoardStagesResult.type !== 'unknown';
   const multiBoardStagesByBoardId = useMemo(
     () =>
       shouldShowBoardWiseView && sharedBoardStagesReady
@@ -1966,13 +1966,15 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   // NON_LINEAR boards also include transition-level forms (toStageId -> formId).
   const stageFormMap = useMemo(() => {
     const map = new Map<string, string>();
-    if (stages) {
-      stages.forEach(stage => {
-        if (stage.formId) {
-          map.set(stage.id, stage.formId);
-        }
-      });
-    }
+    const gatedStages =
+      sharedBoardStages && multiBoardStagesByBoardId
+        ? Array.from(multiBoardStagesByBoardId.values()).flat()
+        : stages;
+    gatedStages.forEach(stage => {
+      if (stage.formId) {
+        map.set(stage.id, stage.formId);
+      }
+    });
     if (isNonLinearBoard && boardStageTransitions) {
       boardStageTransitions.forEach(t => {
         if (t.formId) {
@@ -1981,7 +1983,13 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       });
     }
     return map;
-  }, [stages, isNonLinearBoard, boardStageTransitions]);
+  }, [
+    stages,
+    sharedBoardStages,
+    multiBoardStagesByBoardId,
+    isNonLinearBoard,
+    boardStageTransitions,
+  ]);
 
   const tagsByTicketId = useMemo(() => {
     const map = new Map<
@@ -3272,13 +3280,12 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   // Use drag and drop hook
   const dragDropMode = useMemo(() => {
     if (sharedBoardStages) return 'stage';
-    // For channel tickets: use view type to determine mode
     if (channelId && viewMode === 'project') {
-      return channelViewType === 'stage' ? 'stage' : 'status';
+      return shouldUseStatusColumns ? 'status' : 'stage';
     }
     // For other views
     return viewMode === 'board' || filteredSingleBoardId ? 'stage' : 'status';
-  }, [sharedBoardStages, channelId, viewMode, channelViewType, filteredSingleBoardId]);
+  }, [sharedBoardStages, channelId, viewMode, shouldUseStatusColumns, filteredSingleBoardId]);
 
   const canReorder = !!filteredSingleBoardId;
   const setDragLocalTickets = useCallback<React.Dispatch<React.SetStateAction<Ticket[]>>>(value => {
@@ -3502,7 +3509,7 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     (lastKnownKanbanGroupsRef.current?.groups.length ?? 0) > 0;
 
   const isTicketsSyncing = isKanbanLayout
-    ? !hasSearchTerm && kanbanCounts.isLoading
+    ? (!hasSearchTerm && kanbanCounts.isLoading) || !sharedBoardStagesReady
     : ticketsDetails.type !== 'complete';
 
   const kanbanTicketsForGrouping = useMemo(() => {
@@ -5300,8 +5307,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
                                   stageName?: string | undefined;
                                 }) =>
                                   openCreateForColumn({
-                                    status: col.status,
-                                    stageName: col.stageName,
+                                    ...(sharedBoardStages
+                                      ? {}
+                                      : { status: col.status, stageName: col.stageName }),
                                     assignee:
                                       group.entityType === 'user' && group.entityId
                                         ? { type: 'assigneeTo', value: group.entityId }

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -151,6 +151,7 @@ import {
   getStageColor,
   getStatusColumns,
   getSharedBoardStages,
+  groupStagesByBoard,
   groupTicketsByStage,
   groupTicketsByStatus,
   applyTicketFilters,
@@ -1261,12 +1262,19 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
   );
   const sharedBoardStagesReady =
     !shouldShowBoardWiseView || multiBoardStagesResult.type === 'complete';
-  const sharedBoardStages = useMemo(
+  const multiBoardStagesByBoardId = useMemo(
     () =>
       shouldShowBoardWiseView && sharedBoardStagesReady
-        ? getSharedBoardStages(filters.boards ?? [], multiBoardStages ?? [])
+        ? groupStagesByBoard(multiBoardStages ?? [])
         : null,
-    [shouldShowBoardWiseView, sharedBoardStagesReady, filters.boards, multiBoardStages],
+    [shouldShowBoardWiseView, sharedBoardStagesReady, multiBoardStages],
+  );
+  const sharedBoardStages = useMemo(
+    () =>
+      multiBoardStagesByBoardId
+        ? getSharedBoardStages(filters.boards ?? [], multiBoardStagesByBoardId)
+        : null,
+    [multiBoardStagesByBoardId, filters.boards],
   );
 
   // Get all boards for the project (needed for channel stage view and create ticket modal)
@@ -3292,6 +3300,9 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
     setLocalTickets: setDragLocalTickets,
     zero,
     stages,
+    ...(sharedBoardStages && multiBoardStagesByBoardId
+      ? { stagesByBoardId: multiBoardStagesByBoardId }
+      : {}),
     mode: dragDropMode,
     canReorder,
     onStageFormRequired: handleStageFormRequired,

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.utils.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.utils.ts
@@ -99,34 +99,43 @@ interface BoardStageRow {
   defaultTicketStatusV2: TicketStatusV2;
 }
 
-const normalizeStageName = (name: string): string => name.trim().toLowerCase();
-
-export const getSharedBoardStages = (
-  boardIds: string[],
+export const groupStagesByBoard = (
   stageRows: ReadonlyArray<BoardStageRow>,
-): Stage[] | null => {
-  const stagesByBoard = new Map<string, BoardStageRow[]>();
+): Map<string, Stage[]> => {
+  const stagesByBoard = new Map<string, Stage[]>();
   stageRows.forEach(row => {
     const boardStages = stagesByBoard.get(row.boardId) ?? [];
-    if (!boardStages.some(s => normalizeStageName(s.name) === normalizeStageName(row.name))) {
-      boardStages.push(row);
+    if (!boardStages.some(s => s.name === row.name)) {
+      boardStages.push({
+        id: row.id,
+        name: row.name,
+        color: getStageColor(row.name),
+        sequenceNumber: row.sequenceNumber,
+        defaultTicketStatusV2: row.defaultTicketStatusV2,
+      });
       stagesByBoard.set(row.boardId, boardStages);
     }
   });
-  const signature = (rows: BoardStageRow[]): string =>
-    rows.map(row => `${normalizeStageName(row.name)}::${row.defaultTicketStatusV2}`).join('\n');
+  return stagesByBoard;
+};
+
+export const getSharedBoardStages = (
+  boardIds: string[],
+  stagesByBoard: Map<string, Stage[]>,
+): Stage[] | null => {
+  const signature = (boardStages: Stage[]): string =>
+    boardStages
+      .map(stage => stage.name)
+      .sort()
+      .join('\n');
   const perBoard = boardIds.map(id => stagesByBoard.get(id));
   const [first] = perBoard;
   if (!first) return null;
   const firstSignature = signature(first);
-  if (perBoard.some(rows => !rows || signature(rows) !== firstSignature)) return null;
-  return first.map(stage => ({
-    id: stage.id,
-    name: stage.name,
-    color: getStageColor(stage.name),
-    sequenceNumber: stage.sequenceNumber,
-    defaultTicketStatusV2: stage.defaultTicketStatusV2,
-  }));
+  if (perBoard.some(boardStages => !boardStages || signature(boardStages) !== firstSignature)) {
+    return null;
+  }
+  return first;
 };
 
 /**

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.utils.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.utils.ts
@@ -91,6 +91,44 @@ export const getStatusColumns = (): Stage[] => {
   ];
 };
 
+interface BoardStageRow {
+  id: string;
+  boardId: string;
+  name: string;
+  sequenceNumber: number;
+  defaultTicketStatusV2: TicketStatusV2;
+}
+
+const normalizeStageName = (name: string): string => name.trim().toLowerCase();
+
+export const getSharedBoardStages = (
+  boardIds: string[],
+  stageRows: ReadonlyArray<BoardStageRow>,
+): Stage[] | null => {
+  const stagesByBoard = new Map<string, BoardStageRow[]>();
+  stageRows.forEach(row => {
+    const boardStages = stagesByBoard.get(row.boardId) ?? [];
+    if (!boardStages.some(s => normalizeStageName(s.name) === normalizeStageName(row.name))) {
+      boardStages.push(row);
+      stagesByBoard.set(row.boardId, boardStages);
+    }
+  });
+  const signature = (rows: BoardStageRow[]): string =>
+    rows.map(row => `${normalizeStageName(row.name)}::${row.defaultTicketStatusV2}`).join('\n');
+  const perBoard = boardIds.map(id => stagesByBoard.get(id));
+  const [first] = perBoard;
+  if (!first) return null;
+  const firstSignature = signature(first);
+  if (perBoard.some(rows => !rows || signature(rows) !== firstSignature)) return null;
+  return first.map(stage => ({
+    id: stage.id,
+    name: stage.name,
+    color: getStageColor(stage.name),
+    sequenceNumber: stage.sequenceNumber,
+    defaultTicketStatusV2: stage.defaultTicketStatusV2,
+  }));
+};
+
 /**
  * Filters tickets by board ID
  */

--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.utils.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.utils.ts
@@ -11,7 +11,13 @@ import { TicketStatusV2 } from '@xyne/shared';
 import { parseAssigneeFilter } from '../../zero/queries';
 import type { Stage } from './KanbanBoardScreen.types';
 import type { TicketFilters } from '../../components/Tickets/TicketFilters/types';
-import { FormFieldType, type FieldEnumOption, type FormFields } from '@xyne/shared';
+import {
+  FormContextType,
+  FormEntityType,
+  FormFieldType,
+  type FieldEnumOption,
+  type FormFields,
+} from '@xyne/shared';
 import { resolveDisplayFormFields } from '../../utils/board/resolveDisplayFormFields';
 import { matchesDynamicFieldValue } from '../../utils/board/dynamicFieldFilters';
 
@@ -97,6 +103,12 @@ interface BoardStageRow {
   name: string;
   sequenceNumber: number;
   defaultTicketStatusV2: TicketStatusV2;
+  approvers?: Stage['approvers'];
+  formContextMappings?: ReadonlyArray<{
+    contextType: FormContextType;
+    entityType: FormEntityType;
+    formId: string;
+  }>;
 }
 
 export const groupStagesByBoard = (
@@ -112,6 +124,11 @@ export const groupStagesByBoard = (
         color: getStageColor(row.name),
         sequenceNumber: row.sequenceNumber,
         defaultTicketStatusV2: row.defaultTicketStatusV2,
+        formId:
+          row.formContextMappings?.find(
+            m => m.contextType === FormContextType.STAGE && m.entityType === FormEntityType.TICKET,
+          )?.formId ?? null,
+        ...(row.approvers && { approvers: row.approvers }),
       });
       stagesByBoard.set(row.boardId, boardStages);
     }
@@ -128,7 +145,7 @@ export const getSharedBoardStages = (
       .map(stage => stage.name)
       .sort()
       .join('\n');
-  const perBoard = boardIds.map(id => stagesByBoard.get(id));
+  const perBoard = [...boardIds].sort().map(id => stagesByBoard.get(id));
   const [first] = perBoard;
   if (!first) return null;
   const firstSignature = signature(first);

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -3667,6 +3667,16 @@ export const queries = defineQueries({
       return zql.stages.where('boardId', 'IN', boardIds).orderBy('sequenceNumber', 'asc');
     },
   ),
+  getStagesWithGatesByBoardIds: defineQuery(
+    z.object({ boardIds: z.array(z.string()) }),
+    ({ args: { boardIds } }) => {
+      const base =
+        boardIds.length === 0
+          ? zql.stages.where('id', 'nonexistent').limit(0)
+          : zql.stages.where('boardId', 'IN', boardIds).orderBy('sequenceNumber', 'asc');
+      return base.related('approvers').related('formContextMappings');
+    },
+  ),
   // Query for user assignment states (on-call status) in a user group
   getUserAssignmentStates: defineQuery(
     z.object({ userGroupId: z.string() }),


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-62238 — when a single board, or several boards with identical stage definitions, are selected in a tickets view (saved views, channel tickets tab, project view, my-tickets), the kanban now shows the board's **stages** as columns instead of the five status categories.

- Single selected board: uses that board's own stages (with approvers/forms). Saved views previously forced status categories here; that short-circuit is removed.
- Multiple selected boards: fetches their stages with approvers and stage forms via a new `getStagesWithGatesByBoardIds` query and compares each board's **set of stage names** (exact names; order and status category may differ). If every board has the same names, the shared columns follow the stage order of the lowest-id board (deterministic across reloads, independent of selection or saved-view row order); otherwise it falls back to status categories exactly as before.
- Drag-and-drop in that multi-board stage mode resolves the target stage inside the dragged ticket's **own board** (`stagesByBoardId` in `useDragAndDrop`), so the category and sequence number written on drop are that board's. Approval, form, sequential-movement and backward-move gating are evaluated against the ticket's own board too, so a gated board stays gated inside a shared view.
- The channel tickets tab now derives its drag mode from the column type, so status columns always use status drops. Previously the tab was in stage-drop mode while showing status columns, which wrote the column label (for example `Todo`) into `stageName` and skipped all gating.
- Column counts and pagination are gated on the stage query settling; a query error falls back to status columns instead of an empty board, and the toolbar shows the syncing state while the stages load.
- Creating a ticket from a shared column no longer presets a stage or status from the first board, because the modal may be pointed at a different board.

No backend change beyond the additive query (present in both `packages/shared` and `apps/backend`). Stage columns are already keyed by stage name end to end (local bucketing, `useKanbanCounts`, `useKanbanTicketsPage`, `kanbanCountsService`, `KanbanColumns`, `useDragAndDrop`). Names are compared exactly because server-side column pagination and counts filter on the exact `stageName`.

Known limits: column header icons show the lowest-id board's status category; tickets whose `stageName` no longer matches any stage on their board fall into the first column, while the server counts them nowhere (pre-existing behavior of `groupTicketsByStage`, now reachable in multi-board views).

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

---

## Proof of testing

<!-- POT video: drag `XYNE-62238-stage-columns-POT.mp4` from ~/Downloads onto this line -->

Same build, same admin account, same fixture, same clicks — recorded twice against the local stack, once with the three changed files reverted to `origin/main` (before) and once with the fix (after). Scenario: `.claude/skills/xyne-pot/scenarios/saved-view-stage-columns.mjs`.

Fixture: two boards in project Platform with the same four stage names — **Payments EU** (Backlog → In Progress → Review → Done) and **Payments US** (Backlog → Review*(Paused)* → In Progress → Done), 6 tickets each; saved views "Payments EU" (one board) and "Payments EU + US" (both).

| check | before | after |
|---|---|---|
| single-board view: columns are the board stages | ✗ | ✓ |
| single-board view: status-category columns | present | absent |
| two-board view: one shared stage pipeline for both boards | ✗ | ✓ |
| two-board view: status-category columns | present | absent |
| single-board columns observed | `TODO(2) STARTED(3) COMPLETED(1)` | `BACKLOG(2) IN PROGRESS(2) REVIEW(1) DONE(1)` |
| two-board columns observed | `TODO(3) STARTED(4) PAUSED(2) COMPLETED(3)` | `BACKLOG(3) IN PROGRESS(3) REVIEW(3) DONE(3)` |
| `PAY-1` and `PAY-12` rendered | ✓ | ✓ |

Per-board gating, verified live in the two-board view after the review fixes (approver added to Payments US "Done", then removed):

| drag | board gates | result |
|---|---|---|
| `PAY-9` Backlog → Done | US has an approver on Done | blocked: "Can only move to next stage in this Board", row unchanged |
| `PAY-1` Backlog → Done | EU has no gates | moved, `stageName=Done`, `statusV2=COMPLETED` (EU's own mapping) |

(Before: Paused and Cancelled auto-collapse when empty, so they show no heading in the single-board view. In the two-board view the two US "Review" tickets landed under **Paused** — that is the category mismatch the per-board drop resolution guards against.)

Nav trail, identical on both sides:
```
/projects/views/pot62238viewmulti00000002
/projects/views/pot62238viewmulti00000002?board=pot62238boardeu…&board=pot62238boardus…&viewType=stage
/projects/views/pot62238viewmulti00000002?v=…
```
