### PR TITLE
fix: XYNE-62493 remember last opened tab when reopening the tickets module

### DIFF
--- a/apps/dashboard/src/routes/ProjectsScreen/ProjectsScreen.tsx
+++ b/apps/dashboard/src/routes/ProjectsScreen/ProjectsScreen.tsx
@@ -1,5 +1,5 @@
-import { ReactElement } from 'react';
-import { Outlet, useLocation } from 'react-router-dom';
+import { ReactElement, useEffect, useState } from 'react';
+import { Navigate, Outlet, useLocation, useParams } from 'react-router-dom';
 import { ResizableGroup, Panel, Separator } from '../../components/ui/Resizable/Resizable';
 import {
   PROJECTS_SIDEBAR_DEFAULT_WIDTH,
@@ -16,6 +16,7 @@ import { useUserGroups } from '../../hooks/useUserGroup';
 
 const ProjectsScreen = (): ReactElement => {
   const location = useLocation();
+  const { workspaceId, ticketId } = useParams<{ workspaceId?: string; ticketId?: string }>();
   const { isMobile } = usePlatform();
   const { isWideScreen, containerRef } = useResizablePanel({ isMobile });
 
@@ -23,6 +24,25 @@ const ProjectsScreen = (): ReactElement => {
   const [projects] = useCachedQuery(queries.getAllProjects());
   const users = useUsers();
   const userGroups = useUserGroups();
+
+  const ticketsRootPath = `/${workspaceId}/projects`;
+  const lastTicketsPathKey = `lastTicketsPath_${workspaceId}`;
+  const isAtTicketsRoot = location.pathname === ticketsRootPath && !location.search;
+  const [entryRedirect, setEntryRedirect] = useState(() =>
+    isAtTicketsRoot ? localStorage.getItem(lastTicketsPathKey) : null,
+  );
+  const redirectTo =
+    isAtTicketsRoot && entryRedirect && entryRedirect !== ticketsRootPath ? entryRedirect : null;
+
+  useEffect(() => {
+    if (redirectTo) return;
+    setEntryRedirect(null);
+    if (!ticketId) {
+      localStorage.setItem(lastTicketsPathKey, `${location.pathname}${location.search}`);
+    }
+  }, [redirectTo, ticketId, lastTicketsPathKey, location.pathname, location.search]);
+
+  if (redirectTo) return <Navigate to={redirectTo} replace />;
 
   return (
     <div


### PR DESCRIPTION
POT - 

https://github.com/user-attachments/assets/5eb14cab-30cb-4aed-b3c3-01b8d229068a



## Summary
- The Tickets rail item, its keyboard shortcut, and the More menu all navigate to the bare `/projects` root, whose index route is hard-wired to My Tickets, so every re-entry reset the user to My Tickets.
- `ProjectsScreen` (the layout wrapping every tickets route) now stores the last tickets path per workspace in localStorage and, when the module is entered at the bare root, redirects once to that path.
- The stored value is consumed after the redirect, so clicking My Tickets from inside the module is not bounced back. Deep links with a query string or an explicit project/board path are left alone. Ticket detail pages are not stored, so returning lands on the board or view rather than inside a single ticket.

## Proof of testing

<!-- POT: drag XYNE-62493-POT.mp4 here -->

Both halves are real captures of the local dev stack: same build, same account, same fixture (project Platform, board Delivery), same clicks; only `ProjectsScreen.tsx` is toggled between `origin/main` and this branch.

Flow: Delivery board open → rail **DMs** → rail **Tickets**

| | before | after |
|---|---|---|
| nav trail | `/chat/dm` → `/projects` | `/chat/dm` → `/projects` → `/projects/<project>/<board>` |
| rail Tickets returns to the Delivery board | ✗ | ✓ |
| rail Tickets resets to My Tickets (`/projects`) | ✓ | ✗ |

Also verified with a separate Playwright script:
- fresh entry with nothing stored stays on My Tickets
- a full page reload at `/projects` restores the last tab
- an explicit My Tickets click inside the module is not redirected, and that choice is then remembered on re-entry
- a deep link with `?assignee=` is not redirected

Prettier, eslint, and the dashboard typecheck are clean.