### PR TITLE
feat: XYNE-62761 shift all calls to google stt

### DIFF
--- a/apps/backend/src/automations/steps/make-call.step.ts
+++ b/apps/backend/src/automations/steps/make-call.step.ts
@@ -243,7 +243,7 @@ export class MakeCallStep extends BaseActionStep<typeof MakeCallConfigSchema, Ma
       channelId,
       callOrigin: CallOrigin.CHANNEL,
       callType,
-      sttModel: 'azure',
+      sttModel: 'google',
       createdBy: initiatorUserId,
       ...(allInvitedUserIds.length > 0 && { invitedUserIds: allInvitedUserIds }),
     });

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -511,7 +511,7 @@ export class CallController {
         const roomLink = buildCallInviteUrl(callExternalId);
         const roomMetadata = JSON.stringify({
           callType: CallType.HEADLESS,
-          sttModel: sttModel || 'azure',
+          sttModel: sttModel || 'google',
           createdBy: userId,
           workspaceId: req.user!.workspaceId,
           notesCanvasId,
@@ -767,7 +767,7 @@ export class CallController {
         channelId: channel.id,
         callOrigin: conversationId ? CallOrigin.CONVERSATION : CallOrigin.CHANNEL,
         callType,
-        sttModel: sttModel || 'azure',
+        sttModel: sttModel || 'google',
         createdBy: userId,
         ...(conversationId && { conversationId }),
         ...(linkedArtifactMessageId && { artifactMessageId: linkedArtifactMessageId }),


### PR DESCRIPTION
## Summary
Shift all call transcription to Google Cloud STT instead of Azure OpenAI Whisper.

Calls previously fell back to the `'azure'` default because the regular call flow never sends an `sttModel`. Azure Whisper auto-detects language, which is what produced multi-lingual transcripts. Google STT is pinned to a fixed language (`en-US`) with domain hot-words, so it stays in English.

## Changes
- `apps/backend/src/controllers/callController.ts` — `initiateCall`: default `sttModel` to `'google'` for both the headless/recording room metadata and the regular channel/conversation room metadata (was `'azure'`).
- `apps/backend/src/automations/steps/make-call.step.ts` — automation-initiated calls now stamp `sttModel: 'google'` (was `'azure'`).

Clients may still pass an explicit `sttModel`; this only changes the default. The Python transcription agent (`multi_user_transcriber._create_stt`) uses Google when `sttModel === 'google'` and `GOOGLE_APPLICATION_CREDENTIALS` is set, and safely falls back to Azure Whisper if the credentials are missing.

## PR checklist
1. Problem Description: Call transcripts came back multi-lingual because calls defaulted to Azure Whisper (auto language detection). Team decision: move all calls to Google STT.
2. If this is a bug fix or an enhancement, how did you identify the issue?: Traced call STT selection — regular calls never send `sttModel`, so the backend `|| 'azure'` default was used, routing calls to Azure Whisper.
3. Explain the solution implemented in the PR: Change the call-side `sttModel` defaults to `'google'` in the two `callController.initiateCall` room-metadata blocks and the automation `make-call.step`.
4. Documentation: N/A
5. DB Alter Details (if any): N/A
6. Data fix Details (if any): N/A
7. Environment variable Changes (if any): No new variables, but Google STT only engages when `GOOGLE_APPLICATION_CREDENTIALS` is set on the transcription-agent deployment. If it is unset in an environment, calls will silently continue on Azure Whisper. Confirm it is set in prod.
8. Testing: Verified selection logic in `apps/backend/python-agent/modules/multi_user_transcriber.py` (`_create_stt` / `_create_google_stt_instance`) and metadata plumbing in `main.py` (`set_stt_model_override`). Needs a live call verification post-deploy.
9. Services to which this change is to be deployed: backend (calls API + automation worker); transcription-agent must have Google credentials configured.
10. Main PR link (if this PR is raised against a release branch): N/A