### PR TITLE
fix: XYNE-62761 remove transcript translation LLM call

### DIFF
--- a/apps/backend/src/services/noteTakerTranscriptService.ts
+++ b/apps/backend/src/services/noteTakerTranscriptService.ts
@@ -603,11 +603,6 @@ class NoteTakerTranscriptService {
 
     await repositories.calls.update(call.id, { transcript: storagePath });
     logger.info(`[${callId}] call_record_updated`, { fields_updated: 'transcript', path: 'note_taker' });
-
-    // Fire-and-forget: translate transcript asynchronously in the background.
-    transcriptService.translateTranscriptAsync(callId, storagePath).catch((err) => {
-      logger.error(`[${callId}] background_translation_failed`, { error: err, path: 'note_taker' });
-    });
   }
 
   /**

--- a/apps/backend/src/services/transcriptService.ts
+++ b/apps/backend/src/services/transcriptService.ts
@@ -17,7 +17,7 @@ import { vespaQueue } from '@/queues/vespaQueue';
 import { fileSchema, SubApp } from '@/vespa/src/types';
 import { CacConfigService } from '@/services/cacConfigService';
 import { getCallTicketSuggestionsTotal } from '@/services/otel/suggestionMetrics';
-import { executeCallLlmWithRetry, executeStreamingLlmRequest, type SummaryModelType } from './callLlmRetry';
+import { executeCallLlmWithRetry, type SummaryModelType } from './callLlmRetry';
 import { callRecordingService } from '@/services/callRecordingService';
 import { callLabelService } from '@/services/callLabelService';
 import { TagMethod } from '@xyne/shared';
@@ -525,13 +525,7 @@ export class TranscriptService {
 
       logger.info(`[${callId}] transcript_processing_completed`, { message_id: messageId });
 
-      // 13. Fire-and-forget: Translate transcript asynchronously in background
-      // This updates the same GCS file without blocking the response
-      this.translateTranscriptAsync(callId, txtStoragePath).catch((err) => {
-        logger.error(`[${callId}] background_translation_failed`, { error: err });
-      });
-
-      // 14. Attach identified transcript (real-name labelled) as a second attachment when available.
+      // 13. Attach identified transcript (real-name labelled) as a second attachment when available.
       // Written by the Python agent's RealtimeIdentifier during the call into
       // transcriptions/{callId}_identified.jsonl — may not exist if no voiceprints were enrolled.
       void this.attachIdentifiedTranscriptIfExists(callId, messageId, call.createdByUserId, callMessage.conversationId, channel.workspaceId);
@@ -767,11 +761,6 @@ export class TranscriptService {
         });
         logger.info(`[${callId}] identified_transcript_attachment_created`, { attachment_id: attachment.id });
       }
-
-      // Apply the same background translation as the plain transcript
-      this.translateIdentifiedTranscriptAsync(callId, formattedPath).catch((err) => {
-        logger.error(`[${callId}] identified_background_translation_failed`, { error: err });
-      });
     } catch (err) {
       logger.error(`[${callId}] identified_transcript_attach_failed`, { error: err });
     }
@@ -879,203 +868,6 @@ export class TranscriptService {
         `[${callId}] formatted_transcript_download_failed | path=${storagePath}, error=${error}`
       );
       return null;
-    }
-  }
-
-  /**
-   * Translate transcript asynchronously in background (fire-and-forget)
-   * Downloads raw transcript from GCS, translates it, and overwrites the same file
-   * @param callId - The external call ID
-   * @param gcsPath - The GCS path to the transcript file
-   */
-  async translateTranscriptAsync(callId: string, storagePath: string): Promise<void> {
-    try {
-      logger.info(`Starting background translation for call: ${callId}`);
-
-      // 1. Download raw transcript
-      const buffer = await this.transcriptStorage.getFileBuffer(storagePath);
-      const rawTranscript = buffer.toString('utf-8');
-
-      // 2. Translate the transcript
-      const translatedTranscript = await this.postProcessTranscript(rawTranscript, callId);
-
-      // 3. Re-upload translated version (overwrites the same file)
-      await this.transcriptStorage.uploadFileV2(Buffer.from(translatedTranscript, 'utf-8'), {
-        path: storagePath,
-        contentType: 'text/plain',
-        metadata: { callId, type: 'transcript', translated: 'true' },
-      });
-
-      // 4. Update database attachment metadata to mark as translated
-      const attachments = await repositories.messageAttachments.findByCallId(callId);
-
-      if (attachments.length > 0) {
-        const transcriptAttachment = attachments[0];
-        const current = await repositories.messageAttachments.findById(transcriptAttachment.id);
-        const currentMetadata = (current?.metadata as Record<string, any>) || {}; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-        await repositories.messageAttachments.updateVersion(transcriptAttachment.id, {
-          ...currentMetadata,
-        });
-        logger.info(`Updated database attachment metadata for call: ${callId}`);
-      } else {
-        logger.warn(`No attachment found in database for call: ${callId}`);
-      }
-
-      logger.info(`Successfully completed background translation for call: ${callId}`);
-    } catch (error) {
-      logger.error(`Failed to translate transcript in background for call ${callId}:`, error);
-    }
-  }
-
-  /**
-   * Same as translateTranscriptAsync but for the identified transcript GCS file.
-   * Overwrites the identified formatted .txt with the translated version.
-   */
-  private async translateIdentifiedTranscriptAsync(callId: string, gcsPath: string): Promise<void> {
-    try {
-      logger.info(`[${callId}] identified_translation_started`);
-
-      const buffer = await this.transcriptStorage.getFileBuffer(gcsPath);
-      const rawTranscript = buffer.toString('utf-8');
-
-      const translatedTranscript = await this.postProcessTranscript(rawTranscript, callId);
-
-      await this.transcriptStorage.uploadFileV2(Buffer.from(translatedTranscript, 'utf-8'), {
-        path: gcsPath,
-        contentType: 'text/plain',
-        metadata: { callId, type: 'identified_transcript', translated: 'true' },
-      });
-
-      logger.info(`[${callId}] identified_translation_completed`);
-    } catch (error) {
-      logger.error(`[${callId}] identified_translation_failed`, { error: error });
-    }
-  }
-
-  /**
-   * Post-process transcript: translate to English
-   * Handles long transcripts by chunking them into smaller pieces
-   * @param transcript - The formatted transcript text
-   * @returns Post-processed transcript or original if processing fails
-   */
-  async postProcessTranscript(transcript: string, callId?: string): Promise<string> {
-    const systemInstructions = `You are processing a call transcript. Your task is to translate any non-English text to English, and to fix one specific brand name spelling.
-
-IMPORTANT:
-- Keep ALL timestamps exactly as they are: [MM:SS] format
-- Keep ALL speaker names exactly as they are
-- Only translate the spoken text to English
-- Do not modify, fix, or improve the text beyond translation
-- Do not add new lines or remove existing ones
-- Do not add commentary or explanations
-- Do not use placeholders like "[...]" or "[content continues]"
-- Preserve the exact line-by-line structure: [MM:SS] Speaker Name: text
-- Translate EVERY line completely, do not skip or truncate any content
-
-BRAND NAME CORRECTION:
-- The word "Xyne" (a product/brand name, pronounced like "zine") is often misspelled by speech-to-text as "Zain", "Zine", "Xine", "Zyane", or "Zyne"
-- When any of word that phonetically sounds like XYNE appear as a standalone word or as part of a compound like "Zain Spaces", "Zine Calls", etc., replace it with "Xyne"
-- Only apply this correction when the word is clearly a reference to the brand (e.g. "Xyne Spaces", "Xyne Calls"), not when it is part of an unrelated proper noun or personal name
-
-Output ONLY the processed transcript, nothing else.`;
-
-    try {
-      const lines = transcript.split('\n').filter((l) => l.trim());
-      const MAX_LINES_PER_CHUNK = 100;
-
-      if (lines.length <= MAX_LINES_PER_CHUNK) {
-        const translated = await executeStreamingLlmRequest({
-          userPrompt: transcript,
-          systemPrompt: systemInstructions,
-          operation: 'transcript_translation',
-          callId,
-        });
-
-        if (!translated.ok) {
-          logger.warn(`post_process_transcript_failed | reason=${translated.reason} | using_original=true`);
-          return transcript;
-        }
-
-        logger.info('Successfully post-processed transcript (streaming translation)');
-        return translated.content;
-      }
-
-      // For long transcripts, process in chunks with LIMITED CONCURRENCY.
-      // Each chunk is a separate streaming request; a bounded worker pool keeps
-      // the number of concurrent streams in check (the previous unbounded
-      // Promise.all overwhelmed the LiteLLM deployment).
-      const CHUNK_CONCURRENCY = 3;
-      const totalChunks = Math.ceil(lines.length / MAX_LINES_PER_CHUNK);
-
-      logger.info(
-        `Transcript has ${lines.length} lines, processing in ${totalChunks} chunks of ${MAX_LINES_PER_CHUNK} (concurrency ${CHUNK_CONCURRENCY})`
-      );
-
-      // Build chunk metadata up front so results can be reassembled in order.
-      const chunks: Array<{ chunkText: string; chunkIndex: number; startLine: number; endLine: number }> = [];
-      for (let i = 0; i < lines.length; i += MAX_LINES_PER_CHUNK) {
-        const chunkLines = lines.slice(i, i + MAX_LINES_PER_CHUNK);
-        chunks.push({
-          chunkText: chunkLines.join('\n'),
-          chunkIndex: Math.floor(i / MAX_LINES_PER_CHUNK) + 1,
-          startLine: i + 1,
-          endLine: i + chunkLines.length,
-        });
-      }
-
-      const results: string[] = new Array(chunks.length);
-      let nextIndex = 0;
-
-      const processChunk = async (chunk: typeof chunks[0], index: number): Promise<void> => {
-        logger.info(
-          `Processing chunk ${chunk.chunkIndex}/${totalChunks} (lines ${chunk.startLine}-${chunk.endLine})`
-        );
-
-        try {
-          const translated = await executeStreamingLlmRequest({
-            userPrompt: chunk.chunkText,
-            systemPrompt: systemInstructions,
-            operation: 'transcript_translation',
-            callId,
-          });
-
-          if (!translated.ok) {
-            logger.warn(`post_process_chunk_failed | chunk=${chunk.chunkIndex}/${totalChunks} | reason=${translated.reason} | using_original=true`);
-            results[index] = chunk.chunkText;
-            return;
-          }
-
-          logger.info(`Chunk ${chunk.chunkIndex}/${totalChunks} completed`);
-          results[index] = translated.content;
-        } catch (error) {
-          logger.error(`Error processing chunk ${chunk.chunkIndex}:`, error);
-          results[index] = chunk.chunkText;
-        }
-      };
-
-      // Worker-pool: run up to CHUNK_CONCURRENCY chunks at a time.
-      const workers = Array.from(
-        { length: Math.min(CHUNK_CONCURRENCY, chunks.length) },
-        async () => {
-          while (nextIndex < chunks.length) {
-            const currentIndex = nextIndex;
-            nextIndex += 1;
-            await processChunk(chunks[currentIndex], currentIndex);
-          }
-        }
-      );
-
-      await Promise.all(workers);
-
-      const processedTranscript = results.join('\n');
-      logger.info(
-        `Successfully post-processed transcript in ${results.length} chunks (streaming translation)`
-      );
-      return processedTranscript;
-    } catch (error) {
-      logger.error('Error during transcript post-processing:', error);
-      return transcript; // Fallback to original if processing fails
     }
   }
 


### PR DESCRIPTION
## Summary
Remove the background LLM translation that ran on every generated call transcript.

Now that all calls use Google STT pinned to `en-US` (PR #1573), transcripts already come back in English, so the fire-and-forget `postProcessTranscript` translation pass is redundant — it added an LLM round-trip (and LiteLLM load) per transcript, plus a GCS re-upload, for no benefit.

## Changes
- `apps/backend/src/services/transcriptService.ts`
  - Remove the fire-and-forget `translateTranscriptAsync(...)` call from the main transcript-processing flow.
  - Remove the fire-and-forget `translateIdentifiedTranscriptAsync(...)` call from the identified-transcript flow.
  - Delete the now-unused methods `translateTranscriptAsync`, `translateIdentifiedTranscriptAsync`, and `postProcessTranscript` (the LLM translation routine).
  - Drop the now-unused `executeStreamingLlmRequest` import (still used by other services; unchanged there).
- `apps/backend/src/services/noteTakerTranscriptService.ts`
  - Remove the fire-and-forget `translateTranscriptAsync(...)` call from the note-taker attach flow.

The transcript is still formatted, uploaded to GCS, attached, and saved on the Call record exactly as before. Only the post-upload translation/overwrite step is removed. Summary generation, identified-transcript attachment, and Vespa indexing are untouched.

## PR checklist
1. Problem Description: Every generated transcript triggered a background LLM call to translate non-English text to English and re-upload the file. With calls moved to Google STT pinned to en-US, transcripts are already English, so this pass is wasted LLM cost/latency.
2. If this is a bug fix or an enhancement, how did you identify the issue?: Traced transcript post-processing — `translateTranscriptAsync` / `translateIdentifiedTranscriptAsync` call `postProcessTranscript`, which fans out streaming LLM requests per 100-line chunk on every transcript.
3. Explain the solution implemented in the PR: Remove the two fire-and-forget translation call sites (plus the note-taker one) and delete the unused translation methods and import.
4. Documentation: N/A
5. DB Alter Details (if any): N/A
6. Data fix Details (if any): N/A. Existing transcripts already stored are unaffected.
7. Environment variable Changes (if any): None.
8. Testing: Backend `tsc --noEmit` passes with no errors on the edited files; grep confirms no remaining references to the removed methods. Needs a live call to confirm transcript still attaches and reads correctly post-deploy.
9. Services to which this change is to be deployed: backend (calls transcript processing + note-taker worker).
10. Main PR link (if this PR is raised against a release branch): N/A. Related: #1573 (shift calls to Google STT).