### PR TITLE
feat: XYNE-62767 Add playback speed control to audio player

### DIFF
--- a/apps/dashboard/src/components/ui/AudioPlayer/useAudioPlayback.ts
+++ b/apps/dashboard/src/components/ui/AudioPlayer/useAudioPlayback.ts
@@ -25,8 +25,10 @@ export interface UseAudioPlaybackReturn {
   currentTime: number;
   duration: number;
   canSeek: boolean;
+  playbackRate: number;
   toggle: () => Promise<void>;
   seek: (seconds: number) => void;
+  setPlaybackRate: (rate: number) => void;
 }
 
 export function useAudioPlayback({
@@ -37,6 +39,7 @@ export function useAudioPlayback({
   const [state, setState] = useState<AudioPlayState>('idle');
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(initialDurationSec);
+  const [playbackRate, setPlaybackRateState] = useState(1);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const blobUrlRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -89,6 +92,7 @@ export function useAudioPlayback({
       blobUrlRef.current = url;
 
       const audio = new Audio(url);
+      audio.playbackRate = playbackRate;
       audioRef.current = audio;
 
       audio.addEventListener('loadedmetadata', () => {
@@ -118,12 +122,19 @@ export function useAudioPlayback({
     setCurrentTime(seconds);
   };
 
+  const setPlaybackRate = (rate: number): void => {
+    setPlaybackRateState(rate);
+    if (audioRef.current) audioRef.current.playbackRate = rate;
+  };
+
   return {
     state,
     currentTime,
     duration,
     canSeek: state === 'playing' || state === 'paused',
+    playbackRate,
     toggle,
     seek,
+    setPlaybackRate,
   };
 }

--- a/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
+++ b/apps/dashboard/src/routes/RecordingDetailV2Screen/components/LiveRecordingControlBar.tsx
@@ -32,6 +32,13 @@ import { parseMarkedItems, type MarkedItem, type MarkedItemType } from './marked
 
 const TIMELINE_WINDOW_MS = 40 * 60 * 1000; // 40 min fixed window for the live timeline
 
+const PLAYBACK_SPEEDS = [
+  { value: 1, label: '1x' },
+  { value: 1.2, label: '1.2x' },
+  { value: 1.5, label: '1.5x' },
+  { value: 2, label: '2x' },
+] as const;
+
 interface LiveRecordingControlBarProps {
   recording: RecordingDetail;
   isLive: boolean;
@@ -554,15 +561,27 @@ const RecordedTimelineBar = ({
         />
       </div>
 
-      {/* Only worth explaining the markers once there are some to explain. */}
-      {markedTypes.size > 0 && <MarkerLegend types={markedTypes} />}
+      {/* Legend only when there's something to explain; speed only once audio can load. */}
+      {(markedTypes.size > 0 || onLoadAudio) && (
+        <div className='mt-3 flex items-center gap-4 pl-1'>
+          {markedTypes.size > 0 && <MarkerLegend types={markedTypes} />}
+          {onLoadAudio && (
+            <div className='ml-auto'>
+              <PlaybackSpeedControl
+                rate={playback.playbackRate}
+                onChange={playback.setPlaybackRate}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };
 
 /** Reads the marker vocabulary of the track above it — only the kinds actually on it. */
 const MarkerLegend = ({ types }: { types: ReadonlySet<MarkedItemType> }): ReactElement => (
-  <div className='mt-3 flex items-center gap-5 pl-1 text-xs text-muted-foreground'>
+  <div className='flex items-center gap-5 text-xs text-muted-foreground'>
     {types.has('decision') && (
       <span className='flex items-center gap-1.5'>
         <span className={cn('size-2 rounded-full', MARKER_DOT_COLOR.decision)} aria-hidden='true' />
@@ -581,6 +600,37 @@ const MarkerLegend = ({ types }: { types: ReadonlySet<MarkedItemType> }): ReactE
         Marked moments
       </span>
     )}
+  </div>
+);
+
+interface PlaybackSpeedControlProps {
+  rate: number;
+  onChange: (rate: number) => void;
+}
+
+/** Playback speed control after the audio has loaded. */
+const PlaybackSpeedControl = ({ rate, onChange }: PlaybackSpeedControlProps): ReactElement => (
+  <div className='flex shrink-0 items-center gap-2 text-xs text-muted-foreground'>
+    <span>Speed</span>
+    <div className='flex items-center gap-0.5 rounded-full bg-muted/60 p-0.5'>
+      {PLAYBACK_SPEEDS.map(speed => (
+        <button
+          key={speed.value}
+          type='button'
+          onClick={() => onChange(speed.value)}
+          className={cn(
+            'rounded-full px-2.5 py-1 font-mono text-xs transition-colors',
+            rate === speed.value
+              ? 'bg-card text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+          data-track-category='RecordingDetailV2'
+          data-track-name='set_playback_speed'
+        >
+          {speed.label}
+        </button>
+      ))}
+    </div>
   </div>
 );
 


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Adds a playback speed control (1x / 1.2x / 1.5x / 2x, hardcoded) to the ended-recording player in `RecordingDetailV2Screen`.

- `useAudioPlayback`: exposes `playbackRate` + `setPlaybackRate`, backed directly by the native `HTMLAudioElement.playbackRate` — no new library.
- `LiveRecordingControlBar.tsx`: `RecordedTimelineBar` renders a small hand-rolled pill row (`PlaybackSpeedControl`) next to the marker legend, only once audio is loadable (`onLoadAudio` present). Live (in-progress) recordings are unaffected — there's no audio element to control until the call has ended.

## POT

https://github.com/user-attachments/assets/e0f25219-8907-479e-97ee-ab928627e015



## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Manually in local dev: opened a finished recording with playable audio, switched between 1x/1.2x/1.5x/2x, confirmed audible rate change and that the selected pill persists across pause/seek/replay. Confirmed the control doesn't render when audio is unavailable, and that the live (in-progress) bar is unchanged.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests — UI-only interaction wrapper over native `<audio>` playbackRate, no branching logic to unit test

### Manual

**Users**
- [x] Single user

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser
- [x] Narrow viewport, dark + light theme
- [x] Empty state <!-- audio-unavailable recordings show no speed control -->

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [x] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
