### PR TITLE
fix: show Subscribe/Unsubscribe to notifications in thread view message menu

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -1069,6 +1069,15 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
         (!isMessageDeleted || context === 'channel') && {
           onReplyInThread: replies.onOpenThread,
         }),
+      // Conversation-level subscription. Decoupled from onReplyInThread so the
+      // toggle stays available in the per-message menu inside the thread view
+      // (thread replies carry the thread's conversationId), matching the channel.
+      ...(conversation?.conversationId &&
+        (!isSystemMessage || isTicketCreationMessage || isCallMessage) &&
+        !isShowInChannel &&
+        !isMessageDeleted && {
+          canSubscribe: true,
+        }),
       ...(!isSystemMessage &&
         !isMessageDeleted && {
           onInitiateCall: handleInitiateCall,
@@ -1403,6 +1412,10 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
                     replies?.onOpenThread?.(e);
                   },
                 })}
+              {...(conversation?.conversationId &&
+                (!isSystemMessage || isTicketCreationMessage || isCallMessage) &&
+                !isShowInChannel &&
+                !isMessageDeleted && { canSubscribe: true })}
               {...(!isSystemMessage &&
                 !isMessageDeleted && {
                   onInitiateCall: handleInitiateCall,

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
@@ -67,6 +67,13 @@ export interface HoverActionsToolbarProps {
   showEditAction?: boolean;
   reactionsMd?: string | null;
   onReplyInThread?: (e?: React.MouseEvent) => void;
+  /**
+   * Whether this message's conversation can be subscribed to for notifications.
+   * Conversation-level capability, decoupled from onReplyInThread so the toggle
+   * is available in the per-message menu both in the channel list and inside the
+   * thread view (thread replies carry the thread's conversationId).
+   */
+  canSubscribe?: boolean;
   onCreateTicket?: () => void;
   onCreateSubTicket?: () => void;
   onEditMessage?: () => void;
@@ -125,6 +132,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
   showEditAction = false,
   reactionsMd,
   onReplyInThread,
+  canSubscribe,
   onCreateTicket,
   onCreateSubTicket,
   onEditMessage,
@@ -384,7 +392,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
             {(() => {
               const hasEditSection = (showEditAction && onEditMessage) || onSendToChannel;
               const hasSubscriptionSection =
-                (onReplyInThread && conversationId) ||
+                (canSubscribe && conversationId) ||
                 onMarkAsUnread ||
                 onBookmark ||
                 onRemindMeOption ||
@@ -430,7 +438,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
                   {hasEditSection && hasSubscriptionSection && <DropdownMenuSeparator />}
 
                   {/* Conversation Subscription */}
-                  {isDropdownOpen && onReplyInThread && conversationId && (
+                  {isDropdownOpen && canSubscribe && conversationId && (
                     <DropdownMenuItem asChild>
                       <ConversationSubscription
                         conversationId={conversationId}

--- a/apps/dashboard/src/components/Chat/MessageActionsDrawer/MessageActionsDrawer.tsx
+++ b/apps/dashboard/src/components/Chat/MessageActionsDrawer/MessageActionsDrawer.tsx
@@ -43,6 +43,8 @@ export interface MessageActionsDrawerProps {
   showEditAction?: boolean;
   reactionsMd?: string | null;
   onReplyInThread?: (e?: React.MouseEvent) => void;
+  /** Conversation-level subscription capability (see HoverActionsToolbar). */
+  canSubscribe?: boolean;
   onCreateTicket?: () => void;
   onEditMessage?: () => void;
   onDeleteMessage?: () => void;
@@ -77,6 +79,7 @@ export const MessageActionsDrawer: React.FC<MessageActionsDrawerProps> = ({
   showEditAction = false,
   reactionsMd,
   onReplyInThread,
+  canSubscribe,
   onCreateTicket,
   onEditMessage,
   onDeleteMessage,
@@ -338,7 +341,7 @@ export const MessageActionsDrawer: React.FC<MessageActionsDrawerProps> = ({
                   )}
 
                   {/* Conversation Subscription */}
-                  {open && onReplyInThread && conversationId && (
+                  {open && canSubscribe && conversationId && (
                     <ConversationSubscription
                       conversationId={conversationId}
                       {...(conversation && { conversation })}


### PR DESCRIPTION
## Problem
The "Subscribe/Unsubscribe to notifications" action shows in a message's hover "…" (more-actions) menu in the channel message list, but disappears from the same menu when that message is viewed inside the Thread view. Reported by Subanesh K in #xyne-spaces-feedback.

## Related tickets / prior art
This fixes a gap already tracked internally — it is not net-new:
- **XYNE-56191** — "Add Subscribe/Unsubscribe option to the 3-dot menu on thread replies" (exact scope of this PR; MEDIUM). Should be deduplicated/closed by this PR.
- **XYNE-62467** — "Enabling subscribe/unsubscribe from any message" (CRITICAL, owner Harshpreet Singh). This PR implements it; link/close against this ticket.

Prior related work that did NOT cover the per-message menu on replies:
- PR #8521 — fixed the thread bell-icon toggle (different UI surface).
- PR #3646 — built the original web/desktop Subscribe/Unsubscribe feature.

## Root cause
The subscription menu item was gated on the presence of the `onReplyInThread` action in both `HoverActionsToolbar.tsx` and `MessageActionsDrawer.tsx`. `onReplyInThread` is only populated for messages that can open a thread (channel-list rows) — it maps to `replies.onOpenThread` in `ChatBubble.tsx`. Reply messages already inside a thread never receive `onReplyInThread`, so the conversation-level subscription toggle vanished from their menu, even though every thread reply carries the thread's `conversationId` and is fully subscribable. (The thread panel header still shows the subscription bell; only the per-message menu inside the thread was affected.)

## Fix
Decouple subscription visibility from `onReplyInThread`:
- Add an explicit `canSubscribe` capability computed in `ChatBubble.tsx`, set for subscribable messages in both channel and thread contexts (non-deleted, non-system unless ticket/call message, not show-in-channel).
- Gate the subscription item in `HoverActionsToolbar.tsx` and `MessageActionsDrawer.tsx` on `canSubscribe && conversationId` instead of `onReplyInThread && conversationId`.

This restores channel/thread parity for the notification toggle without changing any other behavior.

## Testing
- `pnpm typecheck` (dashboard) — passes.
- `eslint` on changed files — 0 errors.

## Files changed
- `apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx`
- `apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx`
- `apps/dashboard/src/components/Chat/MessageActionsDrawer/MessageActionsDrawer.tsx`