### PR TITLE
fix: gate scheduled-job channel broadcasts behind an approval card

### DIFF
--- a/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/flow-action.ts
@@ -9,6 +9,7 @@
  * Three patterns handled:
  *   1. approve-write / decline-write  — HITL write tool approval
  *   2. twin-approve / twin-decline    — Digital Twin draft approve/decline
+ *   2b. schedule-approve / schedule-decline — Scheduled-job channel-broadcast approval
  *   3. user-answer                    — Agent question answered via radio/select
  */
 
@@ -53,6 +54,7 @@ import { resolveFastMode } from "../lib/fast-mode.js";
 import { isClawAdmin } from "../middleware/agent-acl.js";
 import { applyAgentToolAction, AGENT_TOOL_SLUGS } from "../lib/agent-tools-apply.js";
 import { registerRunRecovery } from "../queue/run-recovery-worker.js";
+import { enqueueDelayedJob, enqueueCronJob, type ScheduledJobData } from "../queue/scheduled-jobs-queue.js";
 import { retryNowByToken, cancelProviderRetry } from "../queue/provider-retry-worker.js";
 
 import { createLogger } from "../logger.js";
@@ -1139,6 +1141,89 @@ router.post("/action", pinAgentSlugFromHeader, verifySpacesSignature, async (req
       } catch (err) {
         log.error("[flow-action] Twin approval error:", err);
         resp = { type: "error", message: "Failed to deliver response" };
+        res.json(resp);
+      }
+      return;
+    }
+
+    // ── 2b. Scheduled-job channel-broadcast approval ──────────────────────────
+    // A scheduled job whose result posts as a NEW message into a shared channel
+    // is created inert (`pending_approval`) by claw-auth; only the creator may
+    // arm it. Approve → enqueue in BullMQ + flip to `active`. Decline → cancel.
+    if (actionType === "schedule-approval") {
+      const scheduledJobId = data["scheduledJobId"] as string | undefined;
+      const creatorUserId = data["creatorUserId"] as string | undefined;
+      const cardAgentSlug = data["agentSlug"] as string | undefined;
+      const cardSpacesAppId = data["spacesAppId"] as string | undefined;
+
+      if (!scheduledJobId || !creatorUserId) {
+        res.status(400).json({ type: "error", message: "Missing schedule-approval fields in flowJSON.data" } satisfies AppActionResponse);
+        return;
+      }
+
+      // Only the job's creator may arm a channel broadcast. Fail closed on a
+      // missing caller identity so a stripped signature can't approve.
+      if (!callerUserId || callerUserId !== creatorUserId) {
+        log.error(`[flow-action] Unauthorized schedule-approval: caller ${callerUserId ?? "(none)"} != creator ${creatorUserId}`);
+        res.status(403).json({ type: "error", message: "Unauthorized" } satisfies AppActionResponse);
+        return;
+      }
+
+      const row = await prisma.scheduledJob.findUnique({ where: { id: scheduledJobId } });
+      if (!row) {
+        resp = { type: "close_screen", finalMessage: "This scheduled job no longer exists." };
+        res.json(resp);
+        void replaceFlowCardWithText(messageId, cardAgentSlug, "⚠️ **This scheduled job no longer exists.**", conversationId, undefined, cardSpacesAppId);
+        return;
+      }
+
+      if (actionId === "schedule-decline") {
+        if (row.status === "pending_approval") {
+          await prisma.scheduledJob.update({ where: { id: row.id }, data: { status: "cancelled" } });
+        }
+        resp = { type: "close_screen", finalMessage: "❌ Channel post declined." };
+        res.json(resp);
+        void replaceFlowCardWithText(messageId, cardAgentSlug, "❌ **Channel post declined — the job was not scheduled.**", conversationId, undefined, cardSpacesAppId);
+        return;
+      }
+
+      // actionId === "schedule-approve". Idempotent: only arm a row that is still
+      // awaiting approval (guards against a double-tap or a replayed card).
+      if (row.status !== "pending_approval") {
+        resp = { type: "close_screen", finalMessage: "This job was already handled." };
+        res.json(resp);
+        void replaceFlowCardWithText(messageId, cardAgentSlug, "✓ **Already handled.**", conversationId, undefined, cardSpacesAppId);
+        return;
+      }
+
+      const jobData: ScheduledJobData = {
+        scheduledJobId: row.id,
+        userId: row.userId,
+        agentSlug: row.agentSlug,
+        task: row.task,
+        ...(row.context ? { context: row.context } : {}),
+        ...(row.channelId ? { channelId: row.channelId } : {}),
+        ...(row.conversationId ? { conversationId: row.conversationId } : {}),
+      };
+
+      try {
+        if (row.type === "once") {
+          // Preserve the originally intended fire time; if it has already passed
+          // (approval came late), fire almost immediately.
+          const delay = row.nextRunAt ? Math.max(1000, row.nextRunAt.getTime() - Date.now()) : Number(row.delayMs ?? 0n);
+          const bullJobId = await enqueueDelayedJob(jobData, delay);
+          await prisma.scheduledJob.update({ where: { id: row.id }, data: { status: "active", bullJobId } });
+        } else {
+          const schedulerId = `cron-${row.id}`;
+          await enqueueCronJob(schedulerId, jobData, row.cronExpression!);
+          await prisma.scheduledJob.update({ where: { id: row.id }, data: { status: "active", bullSchedulerId: schedulerId } });
+        }
+        resp = { type: "close_screen", finalMessage: "✓ Scheduled." };
+        res.json(resp);
+        void replaceFlowCardWithText(messageId, cardAgentSlug, "✓ **Approved — this job is now scheduled to post to the channel.**", conversationId, undefined, cardSpacesAppId);
+      } catch (err) {
+        log.error("[flow-action] schedule-approval enqueue error:", err);
+        resp = { type: "error", message: "Failed to schedule the job" } satisfies AppActionResponse;
         res.json(resp);
       }
       return;

--- a/apps/xyne-claw-auth/backend/src/routes/scheduled-jobs.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/scheduled-jobs.ts
@@ -31,6 +31,7 @@ import {
 import { handleRunCompletion } from "../queue/run-recovery-worker.js";
 import { isDashboardTask, refreshScheduledDashboardShare } from "../services/dashboardShareRefreshService.js";
 import { designShareUrl } from "./design-shares.js";
+import { buildScheduledJobApprovalFlow } from "xyne-claw-shared";
 // cron-parser v4 is CJS (`module.exports = CronParser`). Node's native ESM
 // loader can't statically detect named exports from that pattern, so a
 // `import { parseExpression } from "cron-parser"` throws at runtime even
@@ -231,6 +232,73 @@ async function postScheduledFailureNotice(row: {
   }, appToken);
 }
 
+function withSpacesAppIdFlow<T extends { data?: Record<string, unknown> }>(flow: T, spacesAppId?: string | null): T {
+  if (!spacesAppId) return flow;
+  return { ...flow, data: { ...(flow.data ?? {}), spacesAppId } };
+}
+
+/**
+ * Post the channel-broadcast approval card for a `pending_approval` scheduled
+ * job to the thread the request came from (falling back to a DM to the creator
+ * when there is no origin thread). The job stays inert until the creator taps
+ * Approve, which the flow-action handler turns into an `active` + enqueued job.
+ * Fail-soft: any post failure leaves the pending row in place — the creator can
+ * still see/cancel it in the Scheduled Jobs UI — and is surfaced to the caller.
+ */
+async function postScheduledJobApprovalCard(opts: {
+  row: { id: string; userId: string; agentSlug: string; orgId: string; channelId: string | null; conversationId: string | null; workspaceId: string | null; label: string | null; task: string };
+  targetChannelId: string;
+  scheduleSummary: string;
+}): Promise<void> {
+  const { row, targetChannelId, scheduleSummary } = opts;
+  const agent = await prisma.agent.findFirst({ where: { slug: row.agentSlug, orgId: row.orgId } });
+  if (!agent?.spacesAppToken || !agent.spacesAppId) {
+    log.error(`[scheduled-jobs/approval] Agent ${row.agentSlug} has no Spaces app credentials — cannot post approval card for job ${row.id}`);
+    throw new Error("Agent has no Spaces app credentials to post the approval card");
+  }
+  let workspaceId = row.workspaceId;
+  if (!workspaceId) workspaceId = await getWorkspaceIdForUser(row.userId, "scheduled-job").catch(() => null);
+  if (!workspaceId) {
+    log.error(`[scheduled-jobs/approval] Job ${row.id}: missing workspaceId — cannot post approval card`);
+    throw new Error("Missing workspaceId to post the approval card");
+  }
+
+  const appToken = decryptStoredField(agent.spacesAppToken);
+  const spacesAppUserId = agent.spacesAppUserId ?? "";
+
+  const flow = withSpacesAppIdFlow(buildScheduledJobApprovalFlow({
+    scheduledJobId: row.id,
+    creatorUserId: row.userId,
+    scheduleSummary,
+    task: row.task,
+    targetChannelId,
+    ...(row.label ? { label: row.label } : {}),
+    agentSlug: row.agentSlug,
+  }), agent.spacesAppId);
+
+  // Prefer the origin thread so the creator sees the card in context; otherwise DM them.
+  if (row.channelId && row.conversationId) {
+    await spacesAppFetch("/chat/postMessage", {
+      channelId: row.channelId,
+      conversationId: row.conversationId,
+      flow,
+      userId: spacesAppUserId,
+      workspaceId,
+    }, appToken);
+    return;
+  }
+  const dmResult = (await spacesAppFetch("/channel/openDm", {
+    targetUserId: row.userId,
+    workspaceId,
+  }, appToken)) as { channelId: string };
+  await spacesAppFetch("/chat/postMessage", {
+    channelId: dmResult.channelId,
+    flow,
+    userId: spacesAppUserId,
+    workspaceId,
+  }, appToken);
+}
+
 // ── POST / — create a scheduled job ─────────────────────────────────
 
 router.post("/", asyncHandler(async (req: Request, res: Response) => {
@@ -353,6 +421,12 @@ router.post("/", asyncHandler(async (req: Request, res: Response) => {
 
   const nextRunAt = type === "once" ? new Date(Date.now() + delayMs!) : null;
 
+  // A channel-targeted result (`replyMode === "channel"`) is a broadcast into a
+  // shared channel. It must never be armed silently — gate it behind an explicit
+  // approval card. When there is no channel to post into, there is nothing to
+  // broadcast, so the normal (thread/DM) path applies.
+  const isChannelBroadcast = (replyMode === "channel") && !!channelId;
+
   // Create Prisma row
   const row = await prisma.scheduledJob.create({
     data: {
@@ -370,6 +444,9 @@ router.post("/", asyncHandler(async (req: Request, res: Response) => {
       label: label ?? null,
       workspaceId: workspaceId ?? null,
       replyMode: replyMode ?? "thread",
+      // A channel broadcast is armed only AFTER the creator approves the card
+      // posted below; until then it sits inert (the worker skips non-active rows).
+      ...(isChannelBroadcast ? { status: "pending_approval" } : {}),
       orgId: agent.orgId,
     },
   });
@@ -383,6 +460,34 @@ router.post("/", asyncHandler(async (req: Request, res: Response) => {
     channelId: channelId ?? undefined,
     conversationId: conversationId ?? undefined,
   };
+
+  // Channel broadcast: DO NOT enqueue. Persist as pending_approval and post the
+  // approval card to the origin thread. Approve → flow-action arms + enqueues it.
+  if (isChannelBroadcast) {
+    const scheduleSummary = type === "once"
+      ? (nextRunAt ? `Once — runs ${nextRunAt.toISOString()}` : "Once")
+      : `Recurring — ${normalizedCron} (Asia/Kolkata)`;
+    try {
+      await postScheduledJobApprovalCard({
+        row: { ...row, task },
+        targetChannelId: channelId!,
+        scheduleSummary,
+      });
+    } catch (err) {
+      log.error(`[scheduled-jobs] Failed to post approval card for channel job ${row.id}: ${errMsg(err)}`);
+    }
+    log.info(`[scheduled-jobs] Created ${type} channel job ${row.id} for agent ${agentSlug} as pending_approval (awaiting creator approval)`);
+    ok(res, {
+      id: row.id,
+      type: row.type,
+      status: "pending_approval",
+      requiresApproval: true,
+      nextRunAt: nextRunAt?.toISOString(),
+      cronExpression: row.cronExpression,
+      label: row.label,
+    });
+    return;
+  }
 
   // Enqueue in BullMQ
   if (type === "once") {

--- a/packages/xyne-claw-shared/src/flow/builder.ts
+++ b/packages/xyne-claw-shared/src/flow/builder.ts
@@ -561,6 +561,69 @@ export function buildTwinApprovalFlow(params: TwinApprovalFlowParams): FlowDefin
 }
 
 /**
+ * Scheduled-job channel-post approval card.
+ *
+ * A scheduled job whose result is configured to post as a TOP-LEVEL message in a
+ * channel (`replyMode === "channel"`) is a broadcast — it should never be armed
+ * silently. claw-auth creates such a job in `pending_approval` and posts THIS
+ * card to the thread the request came from. Only the creator may approve; on
+ * Approve the flow-action handler flips the row to `active` and enqueues it in
+ * BullMQ. Decline cancels the row. Nothing is scheduled until Approve.
+ */
+export interface ScheduledJobApprovalFlowParams {
+  scheduledJobId: string;
+  creatorUserId: string;
+  /** Human summary of the schedule, e.g. "Every weekday at 9:00 AM IST" or "Once, in ~2h". */
+  scheduleSummary: string;
+  /** The task/prompt the job will run. */
+  task: string;
+  /** Channel the result would post into (targetChannelId ?? channelId). */
+  targetChannelId: string;
+  /** Optional human channel name for display (falls back to the id). */
+  channelName?: string;
+  /** Optional job label. */
+  label?: string;
+  agentSlug?: string;
+}
+
+export function buildScheduledJobApprovalFlow(params: ScheduledJobApprovalFlowParams): FlowDefinition {
+  const {
+    scheduledJobId, creatorUserId, scheduleSummary, task,
+    targetChannelId, channelName, label, agentSlug,
+  } = params;
+
+  const channelLabel = channelName ? `#${channelName}` : targetChannelId;
+  const taskLine = task.length > 400 ? `${task.slice(0, 400)}…` : task;
+
+  const b = new FlowBuilder(`schedule-approval-${crypto.randomUUID()}`)
+    .setTitle('Scheduled post to a channel — approval needed')
+    .addText('intro', `This scheduled job is set to post its result as a **new message in ${channelLabel}**, visible to everyone in that channel. It will not run until you approve it.`, { variant: 'muted', size: 'sm' })
+    .addDivider('d1')
+    .addText('summary', [
+      label ? `*Job:* ${label}` : null,
+      `*Schedule:* ${scheduleSummary}`,
+      `*Posts to:* ${channelLabel}`,
+      `*Task:* ${taskLine}`,
+    ].filter(Boolean).join('\n'))
+    .addDivider('d2')
+    .addRow('actions', [
+      FlowBuilder.button('approve', '✓  Approve & schedule', { type: 'submit', actionId: 'schedule-approve', successMessage: 'Scheduled' }, { variant: 'primary' }),
+      FlowBuilder.button('decline', '✕  Decline', { type: 'submit', actionId: 'schedule-decline' }, { variant: 'destructive' }),
+    ])
+    .setData({
+      actionType: 'schedule-approval',
+      scheduledJobId,
+      creatorUserId,
+      targetChannelId,
+      ...(channelName ? { channelName } : {}),
+      ...(agentSlug ? { agentSlug } : {}),
+    });
+
+  return b.build();
+}
+
+
+/**
  * User question — radio group with the agent's options + submit button.
  */
 export function buildUserQuestionFlow(

--- a/packages/xyne-claw-shared/src/index.ts
+++ b/packages/xyne-claw-shared/src/index.ts
@@ -26,7 +26,7 @@ export {
 } from "./skill-diff/index.js";
 export type { SkillDiff, SkillForAuthz, ApproverResolution, SkillApprovalAuthz, SkillFileUpdateAuthz } from "./skill-diff/index.js";
 export { createSkillTool, updateSkillTool } from "./tools/skill-management/index.js";
-export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildCapacityRetryFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow, buildMcpConfigureFlow, buildMcpSuggestFlow, type McpSuggestConnector, buildCodeFlow, buildDiffFlow, buildTicketFlow, buildTicketProposalFlow, buildChartFlow } from "./flow/builder.js";
+export { FlowBuilder, mdToMrkdwn, buildWriteApprovalFlow, buildWriteResultFlow, buildTwinApprovalFlow, buildUserQuestionFlow, buildCapacityRetryFlow, buildGoalSuggestionFlow, buildAgentCallProposalFlow, buildCloneApprovalFlow, buildSkillUpdateApprovalFlow, buildMcpConfigureFlow, buildMcpSuggestFlow, type McpSuggestConnector, buildCodeFlow, buildDiffFlow, buildTicketFlow, buildTicketProposalFlow, buildChartFlow, buildScheduledJobApprovalFlow, type ScheduledJobApprovalFlowParams } from "./flow/builder.js";
 export type { FlowDefinition, FlowComponent, FlowAction, SelectOption, TicketArtifact, ChartArtifact } from "./flow/builder.js";
 export { buildPlanFlow, PLAN_COMPONENT_ID } from "./flow/plan-flow.js";
 export { isFlowJsonContent, parseFlowJsonComponents, extractTextFromFlowJson, extractCleanTextFromFlowJson } from "./flow/flow-text.js";

--- a/packages/xyne-claw-shared/src/tools/schedule/tools.ts
+++ b/packages/xyne-claw-shared/src/tools/schedule/tools.ts
@@ -125,7 +125,7 @@ export const scheduleTask: ToolDefinition = {
 
       const data = (await res.json()) as {
         success: boolean;
-        data?: { id: string; nextRunAt?: string; cronExpression?: string };
+        data?: { id: string; nextRunAt?: string; cronExpression?: string; status?: string; requiresApproval?: boolean };
         error?: string;
       };
 
@@ -134,6 +134,13 @@ export const scheduleTask: ToolDefinition = {
 
       const job = data.data!;
       const label = (params["label"] as string) ?? (params["task"] as string);
+
+      // A channel-broadcast job is NOT armed on creation. claw-auth persists it
+      // as pending_approval and posts an approval card to this thread; the job
+      // only starts running once the user taps Approve on that card.
+      if (job.requiresApproval || job.status === "pending_approval") {
+        return `"${label}" is set to post its result to a CHANNEL, so it needs approval before it will run. An approval card has been posted in this thread — the schedule activates only after you tap Approve (job ID: ${job.id}).`;
+      }
 
       if (type === "once" && job.nextRunAt) {
         return `Scheduled "${label}" to run at ${new Date(job.nextRunAt).toLocaleString()} (job ID: ${job.id})`;


### PR DESCRIPTION
## Problem
A scheduled job whose result posts as a **new top-level message in a channel** (`replyMode: "channel"`) was armed the instant the `schedule-task` tool created it. The model choosing `replyMode: "channel"` was sufficient to broadcast into a shared channel on every fire — no human in the loop. The only guard was prose in the tool description.

## Fix
When `replyMode === "channel"` AND a channel target exists, `claw-auth` now:
1. Persists the job as `pending_approval` (inert — the worker already skips non-`active` rows) and does **not** enqueue it in BullMQ.
2. Posts a Flow JSON approval card to the origin thread (or DMs the creator).
3. Only the **creator** may approve. Approve → row flipped to `active` + enqueued (once/cron). Decline → row `cancelled`. Handler is fail-closed on missing caller identity and idempotent (only acts on a still-`pending_approval` row).

Thread/DM jobs (`replyMode: "thread"`, the default) are unchanged.

## Changes
- `packages/xyne-claw-shared/src/flow/builder.ts` — `buildScheduledJobApprovalFlow` + exported `ScheduledJobApprovalFlowParams`.
- `packages/xyne-claw-shared/src/index.ts` — export the new builder + type.
- `apps/xyne-claw-auth/backend/src/routes/scheduled-jobs.ts` — gate `POST /` for channel broadcasts; `postScheduledJobApprovalCard` helper.
- `apps/xyne-claw-auth/backend/src/routes/flow-action.ts` — `schedule-approve` / `schedule-decline` handler.
- `packages/xyne-claw-shared/src/tools/schedule/tools.ts` — surface "pending approval" when the API returns `requiresApproval`.

## Validation
- `xyne-claw-shared` typecheck: clean.
- `xyne-claw-auth` typecheck: no new errors from these changes (remaining errors are a pre-existing `prisma generate` cascade — the CI/local sandbox couldn't download the Prisma engine).

## Notes / residual risk
- No schema migration: `ScheduledJob.status` already exists; `pending_approval` is a new value convention.
- The Scheduled Jobs UI `PATCH` path can still flip an already-active job to `replyMode: channel` / set `targetChannelId`. That is an explicit, authenticated owner action through the UI (not the silent model path this PR fixes), so it is intentionally left as a follow-up rather than gated here.
- Consider expiring unapproved `pending_approval` jobs after N days.