### PR TITLE
fix: XYNE-59907 MAPT/SCR retest remediations (release Sep 4)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -805,6 +805,9 @@ WORKSPACE_ID=
 XYNE_PR_SERVICE_TOKEN=
 ZERO_MAX_REQUESTS=
 ZERO_REQUEST_WINDOW=
+WEBHOOK_ALLOW_INTERNAL_HOSTS=true
+# Archive (.zip) upload screening: 'shadow' logs violations without blocking, 'enforce' blocks.
+UPLOAD_ARCHIVE_SCREENING=shadow
 
 # ── Public SDK API (/api/sdk) ────────────────────────────────────────────────
 # Off by default; the router is not mounted unless this is "true".

--- a/apps/backend/src/apps/controllers/chatController.ts
+++ b/apps/backend/src/apps/controllers/chatController.ts
@@ -14,7 +14,7 @@ import { ContentFormat } from '../types';
 import { updateAppActionStatus } from '@/utils/appActionMarkdownUtils';
 import { sanitizeMessageContent, isAlphanumericId, encodeHtmlAttr } from '@/utils/contentUtils';
 import { redisService } from '@/services/redisService';
-import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
+import { safeWebhookFetch } from '@/utils/ssrfGuard';
 
 const ChatActionBodySchema = z.object({
   text: z.string().optional(), // plain text or Slack BlockKit — processed through parser
@@ -627,7 +627,8 @@ export class ChatController {
 
     // Forward to the external URL server-side (no CORS issues)
     // callerUserId is derived from the authenticated session (XYNE-12145)
-    // `actionableUrl` is caller-supplied, so it goes through `assertWebhookUrlSafe`.
+    // `actionableUrl` is caller-supplied, so it is dispatched via `safeWebhookFetch`,
+    // which validates the destination and pins the connection to it (rebinding-safe).
     // The first-party internal callback (same origin as backendUrl, authenticated
     // with the S2S key) is exempt so it works even when backendUrl is a private/dev host.
     try {
@@ -639,11 +640,6 @@ export class ChatController {
         }
       })();
 
-      if (!isInternalSpacesCallback) {
-        // Throws on a blocked target; caught below, so the action simply isn't dispatched.
-        await assertWebhookUrlSafe(actionableUrl);
-      }
-
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
       if (isInternalSpacesCallback) {
         const s2sKey = config.internalS2sKey;
@@ -654,13 +650,18 @@ export class ChatController {
         }
       }
 
-      const callbackRes = await fetch(actionableUrl, {
+      const callbackInit: RequestInit = {
         method: 'POST',
         headers,
         body: JSON.stringify({ actionId, context, messageId, conversationId, callerUserId }),
         redirect: 'manual', // don't follow 3xx redirects
         signal: AbortSignal.timeout(30_000),
-      });
+      };
+      // Internal S2S callbacks are trusted-config hosts (kept on the plain client);
+      // external targets are caller-supplied, so validate + pin (rebinding-safe).
+      const callbackRes = isInternalSpacesCallback
+        ? await fetch(actionableUrl, callbackInit)
+        : await safeWebhookFetch(actionableUrl, callbackInit);
       if (!callbackRes.ok) {
         const text = await callbackRes.text().catch(() => '');
         logger.error(`[dispatchAction] Callback failed ${callbackRes.status}: ${text.slice(0, 300)}`);

--- a/apps/backend/src/apps/controllers/commandController.ts
+++ b/apps/backend/src/apps/controllers/commandController.ts
@@ -11,7 +11,7 @@ import {
 } from '@/database/repositories/appCommandRepository';
 import { db } from '@/database/client';
 import { logger } from '@/utils/logger';
-import { SsrfBlockedError } from '@/utils/ssrfGuard';
+import { SsrfBlockedError, safeWebhookFetch } from '@/utils/ssrfGuard';
 import { prepareAppWebhookDispatch } from '@/apps/core/appUrlResolver';
 import { ConversationParticipation, MessageType } from '@xyne/shared';
 
@@ -631,9 +631,11 @@ export class CommandController {
         'X-Xyne-Event': eventType,
       };
       let dispatchUrl: string;
+      let dispatchIsInternal = false;
       try {
         const prepared = await prepareAppWebhookDispatch(match.webhookUrl, dispatchHeaders);
         dispatchUrl = prepared.url;
+        dispatchIsInternal = prepared.isInternal;
       } catch (err) {
         if (err instanceof SsrfBlockedError) {
           logger.warn('[COMMAND-DISPATCH] Blocked SSRF-unsafe webhook URL', {
@@ -649,13 +651,18 @@ export class CommandController {
         throw new Error('App webhook URL is not allowed');
       }
 
-      const appResponse = await fetch(dispatchUrl, {
+      // Internal = trusted-config pod URL (plain client); external = user-supplied,
+      // so validate + pin the connection (rebinding-safe).
+      const dispatchInit: RequestInit = {
         method: 'POST',
         headers: dispatchHeaders,
         body: JSON.stringify(payload),
         redirect: 'manual',
         signal: AbortSignal.timeout(30_000),
-      });
+      };
+      const appResponse = dispatchIsInternal
+        ? await fetch(dispatchUrl, dispatchInit)
+        : await safeWebhookFetch(dispatchUrl, dispatchInit);
 
       if (!appResponse.ok) {
         const errorBody = await appResponse.text().catch(() => 'unknown error');

--- a/apps/backend/src/apps/controllers/flowController.ts
+++ b/apps/backend/src/apps/controllers/flowController.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import { logger } from '@/utils/logger';
 import { repositories } from '@/database/repositories';
-import { SsrfBlockedError } from '@/utils/ssrfGuard';
+import { SsrfBlockedError, safeWebhookFetch } from '@/utils/ssrfGuard';
 import { signWebhookPayload } from '@/apps/core/eventSubscriptionUtils';
 import { prepareAppWebhookDispatch } from '@/apps/core/appUrlResolver';
 import { decrypt } from '@/services/encryptionService';
@@ -134,9 +134,11 @@ export class FlowController {
         'X-Source': 'XyneSpaces',
       };
       let dispatchUrl: string;
+      let dispatchIsInternal = false;
       try {
         const prepared = await prepareAppWebhookDispatch(installedApp.webhookUrl, dispatchHeaders);
         dispatchUrl = prepared.url;
+        dispatchIsInternal = prepared.isInternal;
       } catch (err) {
         if (err instanceof SsrfBlockedError) {
           logger.warn('[FLOW-ACTION] Blocked SSRF-unsafe webhook URL', { appId, reason: err.message });
@@ -147,14 +149,18 @@ export class FlowController {
         return;
       }
 
-      // 6. Call the app backend synchronously.
-      const appResponse = await fetch(dispatchUrl, {
+      // 6. Call the app backend synchronously. Internal = trusted-config pod URL
+      // (plain client); external = user-supplied, so pin the connection (rebinding-safe).
+      const dispatchInit: RequestInit = {
         method: 'POST',
         headers: dispatchHeaders,
         body,
         redirect: 'manual',
         signal: AbortSignal.timeout(30_000),
-      });
+      };
+      const appResponse = dispatchIsInternal
+        ? await fetch(dispatchUrl, dispatchInit)
+        : await safeWebhookFetch(dispatchUrl, dispatchInit);
 
       if (!appResponse.ok) {
         const text = await appResponse.text().catch(() => 'unknown error');

--- a/apps/backend/src/apps/controllers/incomingWebhookController.ts
+++ b/apps/backend/src/apps/controllers/incomingWebhookController.ts
@@ -12,7 +12,7 @@ import { SlackBlockKitParser } from '@/integrations/adapters/slack-webhook-ticke
 import { resolveSlackMessageParts } from '@/integrations/adapters/slack-webhook-tickets/utils/slackUtils';
 import { MessageType, AppIncomingWebhookAction, AppIncomingWebhookType } from '@xyne/shared';
 import { config } from '@/config/env';
-import { assertWebhookUrlSafe, SsrfBlockedError } from '@/utils/ssrfGuard';
+import { assertWebhookUrlSafe, safeWebhookFetch, SsrfBlockedError } from '@/utils/ssrfGuard';
 import {
   buildSentinelRawFallbackMessage,
   buildSentinelRawFallbackTicketDescription,
@@ -1029,7 +1029,8 @@ class IncomingWebhookController {
     }
 
     try {
-      const response = await fetch(subscribeUrl, {
+      // Pin the connection to the address just validated (rebinding-safe).
+      const response = await safeWebhookFetch(subscribeUrl, {
         method: 'GET',
         // A redirect would take this somewhere we never intended, so treat one
         // as a failure rather than following it.

--- a/apps/backend/src/apps/core/eventSubscriptionUtils.ts
+++ b/apps/backend/src/apps/core/eventSubscriptionUtils.ts
@@ -4,6 +4,7 @@ import { BaseAppEvent } from '@/apps/types';
 import { logger } from '@/utils/logger';
 import { decrypt } from '@/services/encryptionService';
 import { prepareAppWebhookDispatch } from './appUrlResolver';
+import { safeWebhookFetch } from '@/utils/ssrfGuard';
 import crypto from 'crypto';
 
 const installedAppsRepository = new InstalledAppsRepository();
@@ -24,20 +25,25 @@ export async function sendWebhookNotification(
     const payload = JSON.stringify(event);
     const signature = signWebhookPayload(payload, signingSecret);
 
-    const { url, headers } = await prepareAppWebhookDispatch(webhookUrl, {
+    const { url, headers, isInternal } = await prepareAppWebhookDispatch(webhookUrl, {
         'Content-Type': 'application/json',
         'X-Xyne-Signature': signature,
         'X-Source': 'XyneSpaces',
     });
 
     try {
-        const response = await fetch(url, {
+        const init: RequestInit = {
             method: 'POST',
             headers,
             body: payload,
             // 'manual' so a 3xx to an internal host cannot bypass the guard above.
             redirect: 'manual',
-        });
+        };
+        // Internal targets are trusted-config pod URLs (plain client); external
+        // targets are user-supplied, so validate + pin the connection (rebinding-safe).
+        const response = isInternal
+            ? await fetch(url, init)
+            : await safeWebhookFetch(url, init);
 
         const text = await response.text().catch(() => '');
 

--- a/apps/backend/src/apps/routes/prCheckCallback.ts
+++ b/apps/backend/src/apps/routes/prCheckCallback.ts
@@ -3,6 +3,7 @@ import { logger } from '@/utils/logger';
 import { db } from '@/database/client';
 import { validateS2SKey } from '@/middleware/validateS2SKey';
 import { prepareAppWebhookDispatch } from '@/apps/core/appUrlResolver';
+import { safeWebhookFetch } from '@/utils/ssrfGuard';
 
 const router = Router();
 
@@ -80,19 +81,24 @@ async function sendVarysWebhook(
   webhookUrl: string,
   payload: PRCheckRequestedPayload,
 ): Promise<void> {
-  const { url, headers } = await prepareAppWebhookDispatch(webhookUrl, {
+  const { url, headers, isInternal } = await prepareAppWebhookDispatch(webhookUrl, {
     'Content-Type': 'application/json',
     'X-Xyne-Event': 'PR_CHECK_REQUESTED',
   });
 
-  const response = await fetch(url, {
+  const init: RequestInit = {
     method: 'POST',
     headers,
     body: JSON.stringify(payload),
     redirect: 'manual',
     // Fail fast if Varys stalls — this runs inside a user-facing request.
     signal: AbortSignal.timeout(10_000),
-  });
+  };
+  // Internal = trusted-config pod URL (plain client); external = user-supplied,
+  // so validate + pin the connection (rebinding-safe).
+  const response = isInternal
+    ? await fetch(url, init)
+    : await safeWebhookFetch(url, init);
 
   if (!response.ok) {
     throw new Error(`Webhook failed with status ${response.status}: ${await response.text()}`);

--- a/apps/backend/src/automations/steps/trigger-webhook.step.ts
+++ b/apps/backend/src/automations/steps/trigger-webhook.step.ts
@@ -5,7 +5,7 @@ import { StepCategory } from '../types/categories';
 import { variableRef } from '../engine/variable-ref';
 import { OutputSchemaSchema } from '../engine/declared-schema';
 import { decryptHeaderValue, isSensitiveHeader } from '../engine/webhook-step-encryption';
-import { assertWebhookUrlSafe } from '@/utils/ssrfGuard';
+import { safeWebhookFetch } from '@/utils/ssrfGuard';
 import { logger } from '@/utils/logger';
 
 const HttpMethod = z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
@@ -88,10 +88,6 @@ export class TriggerWebhookStep extends BaseActionStep<
   ): Promise<TriggerWebhookOutput> {
     const { url, method, headers, encoding, body, timeoutMs } = cfg;
 
-    // SSRF guard: resolve the host and reject internal/private/link-local
-    // addresses at request time (the schema only blocks literal private IPs).
-    await assertWebhookUrlSafe(url);
-
     const init: RequestInit = {
       method,
       headers: this.buildHeaders(headers, encoding),
@@ -111,7 +107,9 @@ export class TriggerWebhookStep extends BaseActionStep<
     let responseBody = '';
 
     try {
-      const res = await fetch(url, init);
+      // Validates the destination and pins the connection to the checked address
+      // (rejects internal/private/link-local; rebinding-safe). redirect:'manual' above.
+      const res = await safeWebhookFetch(url, init);
       status = res.status;
       ok = res.ok;
 

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -564,6 +564,14 @@ const envSchema = Joi.object({
   DATA_SOURCE_INGEST_TABLE_LIMIT: Joi.number().integer().positive().default(30),
   DATA_SOURCE_EDA_CONCURRENCY: Joi.number().integer().min(1).default(4),
   DATA_SOURCE_ALLOW_PRIVATE_HOSTS: Joi.boolean().default(false),
+  // 'shadow' records what archive inspection would refuse without blocking it;
+  // 'enforce' blocks it. Start in shadow, switch to enforce once the logs are clean.
+  UPLOAD_ARCHIVE_SCREENING: Joi.string().valid('shadow', 'enforce').default('shadow'),
+  // When true (default), the webhook SSRF guard allows private / internal
+  // destinations but still refuses loopback and link-local / cloud-metadata
+  // (169.254.x). Set false to keep outbound webhooks external-only. Link previews
+  // are unaffected either way (always strict).
+  WEBHOOK_ALLOW_INTERNAL_HOSTS: Joi.boolean().default(true),
   SDK_API_ENABLED: Joi.boolean().default(false),
 
 }).unknown();
@@ -597,9 +605,20 @@ export const config = {
     : '',
   host: envVars.HOST,
   cors: {
-    origin: envVars.CORS_ORIGIN.split(',')
-      .map((origin: string) => origin.trim())
-      .filter(Boolean),
+    // The CORS allow-list (CORS_ORIGIN) plus the app's own frontend origin
+    // (FRONTEND_URL). The frontend is always a legitimate client for both HTTP and
+    // WebSockets, so it is accepted even when CORS_ORIGIN does not list it — e.g.
+    // when the frontend and API share a host and never needed a CORS entry.
+    origin: (() => {
+      const list = envVars.CORS_ORIGIN.split(',')
+        .map((origin: string) => origin.trim())
+        .filter(Boolean);
+      try {
+        const own = new URL(envVars.FRONTEND_URL as string).origin;
+        if (own && !list.includes(own)) list.push(own);
+      } catch { /* FRONTEND_URL unset or not a URL: nothing to add */ }
+      return list;
+    })(),
     allowedMediaOrigins: envVars.ALLOWED_MEDIA_ORIGINS.split(',')
       .map((origin: string) => origin.trim())
       .filter(Boolean),
@@ -1194,5 +1213,11 @@ export const config = {
     ingestTableLimit: envVars.DATA_SOURCE_INGEST_TABLE_LIMIT as number,
     edaConcurrency: envVars.DATA_SOURCE_EDA_CONCURRENCY as number,
     allowPrivateHosts: envVars.DATA_SOURCE_ALLOW_PRIVATE_HOSTS as boolean,
+  },
+  uploads: {
+    archiveScreening: envVars.UPLOAD_ARCHIVE_SCREENING as 'shadow' | 'enforce',
+  },
+  webhooks: {
+    allowInternalHosts: envVars.WEBHOOK_ALLOW_INTERNAL_HOSTS as boolean,
   },
 };

--- a/apps/backend/src/controllers/channelController.ts
+++ b/apps/backend/src/controllers/channelController.ts
@@ -1032,6 +1032,17 @@ export class ChannelController {
         }
       }
 
+      // The DM target is caller-supplied; scope it to the caller's workspace (from
+      // the session, not the request) so a member cannot DM a user in another
+      // workspace by id substitution. Rejected before the channel is created.
+      if (scopeType === 'DM' && scopeId) {
+        const dmTarget = await this.userRepository.findByIdInWorkspace(scopeId, req.user!.workspaceId!);
+        if (!dmTarget || dmTarget.status !== 'ACTIVE') {
+          res.status(404).json({ error: 'Participant not found or inactive' });
+          return;
+        }
+      }
+
       // For DM channels, auto-generate name from user IDs
       let channelName: string;
       if (scopeType === 'DM' && scopeId) {
@@ -1081,8 +1092,9 @@ export class ChannelController {
 
         for (const participantId of validParticipants) {
           try {
-            // Check if user exists before adding
-            const user = await this.userRepository.findById(participantId);
+            // Scope the caller-supplied id to the session workspace: a participant
+            // in another workspace resolves to null and is refused, not added.
+            const user = await this.userRepository.findByIdInWorkspace(participantId, req.user!.workspaceId!);
             if (user && user.status === 'ACTIVE') {
               await this.channelParticipantRepository.addParticipant(
                 channel.id,
@@ -2101,19 +2113,22 @@ export class ChannelController {
         return;
       }
 
-      // Validate all participants exist and are active (skip for self-DM)
-      let participantUsers: User[] = [];
+      // Scope participants to the caller's workspace, taken from the session rather
+      // than the request body, so a caller-supplied id cannot reference a user
+      // outside it.
+      const participantUsers: User[] = [];
       if (!isSelfDm) {
-        const { users, missingUserId } =
-          await this.userRepository.findActiveByIds(otherParticipantIds);
-        if (missingUserId) {
-          res.status(404).json({
-            error: 'Participant not found or inactive',
-            userId: missingUserId
-          });
-          return;
+        for (const participantId of otherParticipantIds) {
+          const user = await this.userRepository.findByIdInWorkspace(participantId, workspaceId);
+          if (!user || user.status !== 'ACTIVE') {
+            res.status(404).json({
+              error: 'Participant not found or inactive',
+              userId: participantId
+            });
+            return;
+          }
+          participantUsers.push(user);
         }
-        participantUsers = users;
       }
 
       // Handle self-DM case

--- a/apps/backend/src/controllers/emailAuthController.ts
+++ b/apps/backend/src/controllers/emailAuthController.ts
@@ -12,6 +12,7 @@ import {
   isClientPasswordHash,
   normalizeClientPasswordHash,
   verifyEmailPassword,
+  DUMMY_PASSWORD_HASH,
 } from '../utils/passwordUtils';
 import { DatabaseClient } from '@/database/client';
 import { config } from '@/config/env';
@@ -122,33 +123,10 @@ export class EmailAuthController {
         return;
       }
 
-      // 1. Look up orgMember (the source of truth for email auth)
-      const orgMember = await this.prisma.orgMember.findUnique({
-        where: { email: normalizedEmail },
-      });
-
-      if (!orgMember || orgMember.leftAt) {
-        // Keep this response identical to the wrong-password response below.
-        logger.warn(`${tag()} Email login rejected (reason=invalid_credentials)`);
-        res.status(401).json({
-          error: 'Invalid credentials',
-          message: 'Email or password is incorrect',
-        });
-        return;
-      }
-
-      if (!orgMember.passwordHash) {
-        logger.warn(`${tag()} Email login rejected (reason=invalid_credentials)`);
-        res.status(401).json({
-          error: 'Invalid credentials',
-          message: 'Email or password is incorrect',
-        });
-        return;
-      }
-
-      // 2. Verify password against orgMember.passwordHash
-      const isValid = await verifyEmailPassword(password, orgMember.passwordHash);
-      if (!isValid) {
+      // Every failed attempt — unknown email, no password set, or wrong password —
+      // ends here, so the attempt counter, the lockout and the response are identical
+      // whichever it was, keeping registered and unregistered emails indistinguishable.
+      const rejectLogin = async (): Promise<void> => {
         const redis = redisService.getClient();
         const failedAttempts = await redis.incr(loginAttemptKey);
         if (failedAttempts === 1) {
@@ -174,6 +152,27 @@ export class EmailAuthController {
           error: 'Invalid credentials',
           message: 'Email or password is incorrect',
         });
+      };
+
+      // 1. Look up orgMember (the source of truth for email auth)
+      const orgMember = await this.prisma.orgMember.findUnique({
+        where: { email: normalizedEmail },
+      });
+
+      const storedHash = orgMember && !orgMember.leftAt ? orgMember.passwordHash : null;
+
+      // 2. Verify the password. With no account (or no password on it) the check runs
+      // against a dummy hash of the same form so the request takes as long as a real
+      // wrong-password attempt, and the result is discarded.
+      let isValid = false;
+      if (storedHash) {
+        isValid = await verifyEmailPassword(password, storedHash);
+      } else {
+        await verifyEmailPassword(password, DUMMY_PASSWORD_HASH);
+      }
+
+      if (!isValid || !orgMember) {
+        await rejectLogin();
         return;
       }
 

--- a/apps/backend/src/database/repositories/users.ts
+++ b/apps/backend/src/database/repositories/users.ts
@@ -56,6 +56,19 @@ export class UserRepository extends BaseRepository<User, CreateUserInput, Update
     });
   }
 
+  /**
+   * Resolve a caller-supplied user id, scoped to the caller's workspace. Use this
+   * for ids from a request body: `findById` matches installation-wide, so it would
+   * let a member reference any user in any workspace. Returns null both when the
+   * user does not exist and when they exist elsewhere, so the two cannot be told
+   * apart to enumerate accounts.
+   */
+  async findByIdInWorkspace(id: string, workspaceId: string): Promise<User | null> {
+    return await this.db.user.findFirst({
+      where: { id, workspaceId },
+    });
+  }
+
   async findByIdWithWorkspace(id: string): Promise<
     (User & { workspace: { id: string; name: string } }) | null
   > {

--- a/apps/backend/src/middleware/upload.ts
+++ b/apps/backend/src/middleware/upload.ts
@@ -1,7 +1,10 @@
 import multer from 'multer';
+import { PassThrough, Writable, type Readable } from 'node:stream';
+import { Parse as parseZipStream, type Entry as ZipEntry } from 'unzipper';
 import { logger } from '../utils/logger';
 import { storageService } from '../services/storage';
 import { AppError } from './errorHandler';
+import { config } from '@/config/env';
 import { db } from '../database/client';
 import { AttachmentUploadStatus } from '@xyne/shared';
 
@@ -46,13 +49,435 @@ export function isBlockedUpload(mimetype?: string, originalName?: string): boole
 }
 
 /**
+ * Extensions accepted by default; anything else is refused. Derived from the
+ * production upload distribution, so it includes types that look unusual but are
+ * established workflows here and would break if dropped: .apk/.ipa (builds shared
+ * in channels), .html (automated reports), .svg (custom emoji are SVGs),
+ * .sh/.bash, .crt/.pem. Compared lower-cased, without the dot.
+ */
+const ALLOWED_UPLOAD_EXTENSIONS = new Set([
+  // images
+  'png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'heic', 'heif', 'bmp', 'tiff', 'tif', 'ico', 'jfif', 'avif',
+  // video / audio
+  'mp4', 'mov', 'webm', 'm4v', 'avi', 'mkv', 'mp3', 'm4a', 'wav', 'ogg', 'opus', 'aac', 'amr',
+  // documents
+  'pdf', 'doc', 'docx', 'xls', 'xlsx', 'xlsm', 'xlsb', 'ppt', 'pptx', 'odt', 'ods', 'odp',
+  'rtf', 'pages', 'numbers', 'key', 'eml', 'msg', 'ics', 'vcf',
+  // text / data
+  'txt', 'md', 'csv', 'tsv', 'log', 'json', 'jsonl', 'xml', 'yaml', 'yml', 'toml',
+  'ini', 'conf', 'env', 'sql', 'har', 'html', 'htm', 'xhtml',
+  // archives
+  'zip', 'tar', 'gz', 'tgz', 'bz2', '7z', 'rar', 'xz',
+  // mobile build artifacts
+  'apk', 'ipa', 'aab', 'aar',
+  // source / dev
+  'py', 'js', 'mjs', 'cjs', 'ts', 'tsx', 'jsx', 'sh', 'bash', 'java', 'go', 'rs', 'rb',
+  'c', 'h', 'cpp', 'hpp', 'patch', 'diff', 'ipynb', 'drawio', 'gradle',
+  // keys / certificates
+  'pem', 'crt', 'cer', 'csr', 'pub', 'asc', 'gpg', 'pgp',
+  // other formats with real traffic
+  'bin', 'dat', 'stl', 'kml', 'ditamap', 'xsd', 'ttf', 'otf', 'plist',
+  // Outlook uses .com content-id filenames for inline images; inbound email runs
+  // through this filter. Downloads as an opaque octet-stream regardless.
+  'com',
+]);
+
+/** `report.log.1` from log rotation — a numeric suffix is not a file format. */
+const NUMERIC_SUFFIX = /^\d{1,3}$/;
+
+export type UploadVerdict = 'allowed' | 'blocked' | 'not-allowlisted';
+
+/**
+ * Extension-based verdict. Files with no extension are allowed here — the
+ * filename cannot classify them, and content screening in the storage engine
+ * covers them instead.
+ */
+export function classifyUpload(mimetype?: string, originalName?: string): UploadVerdict {
+  if (isBlockedUpload(mimetype, originalName)) return 'blocked';
+
+  const name = (originalName ?? '').toLowerCase().trim();
+  const dot = name.lastIndexOf('.');
+  if (dot === -1 || dot === name.length - 1) return 'allowed';
+
+  const ext = name.slice(dot + 1);
+  if (NUMERIC_SUFFIX.test(ext)) return 'allowed';
+
+  return ALLOWED_UPLOAD_EXTENSIONS.has(ext) ? 'allowed' : 'not-allowlisted';
+}
+
+/** Bytes read before storing: enough for every signature checked below. */
+const SNIFF_BYTES = 4100;
+
+/**
+ * Executable formats, refused whatever the file is named. Kept narrow on purpose:
+ * only content that is unambiguously a program. Nothing legitimate begins with a
+ * PE/ELF/Mach-O header, so there is no false-positive tail — whereas matching a
+ * detected type against the declared extension would reject real files, since
+ * .apk/.jar/.docx/.xlsx are all Zip containers and text has no signature at all.
+ * The checks mirror `file`/file-type; universal Mach-O shares its magic with Java
+ * class files and is told apart by the architecture count, as `file` does.
+ */
+function executableKind(head: Buffer): 'exe' | 'elf' | 'macho' | null {
+  if (head.length >= 2 && head[0] === 0x4d && head[1] === 0x5a) return 'exe';
+  if (head.length < 4) return null;
+  const magic = head.readUInt32BE(0);
+  if (magic === 0x7f454c46) return 'elf';
+  if (magic === 0xfeedface || magic === 0xfeedfacf || magic === 0xcefaedfe || magic === 0xcffaedfe) {
+    return 'macho';
+  }
+  if (magic === 0xcafebabe && head.length >= 8) {
+    const architectures = head.readUInt32BE(4);
+    if (architectures > 0 && architectures <= 30) return 'macho';
+  }
+  return null;
+}
+
+/**
+ * The EICAR test file — the industry-standard harmless string every scanner is
+ * expected to detect. Refusing it means the screening can be exercised end to end
+ * without handling real malware, which is also how an assessor will test it.
+ */
+const EICAR_SIGNATURE = Buffer.from(
+  'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*',
+  'latin1',
+);
+
+/** Why a file's bytes were refused, or null when they were not. */
+async function forbiddenContentReason(head: Buffer): Promise<string | null> {
+  try {
+    if (head.length === 0) return null;
+    if (head.indexOf(EICAR_SIGNATURE) !== -1) return 'eicar-test-file';
+    return executableKind(head);
+  } catch (err) {
+    // A detection error must never fail the upload; log it and continue without a
+    // verdict rather than error the request.
+    logger.warn('[UPLOAD] content screening skipped after error', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+function extensionOf(name: string): string {
+  const lower = name.toLowerCase().trim();
+  const dot = lower.lastIndexOf('.');
+  return dot === -1 || dot === lower.length - 1 ? '' : lower.slice(dot + 1);
+}
+
+/**
+ * Read the first bytes of a stream and return a stream that still yields the whole
+ * file — the head, then the remainder. Rebuilds the stream rather than using
+ * `readable.unshift`, which is a no-op once a stream has ended: a file shorter than
+ * the sniff length is fully consumed by the read, and most attachments are small.
+ */
+async function readHeadAndRewind(
+  stream: Readable,
+  byteCount: number,
+): Promise<{ head: Buffer; body: Readable }> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  // A stream error (a client disconnecting mid-upload is the common one) must
+  // reject rather than leave this pending: 'readable'/'end' never fire after an
+  // error. Listeners are removed on the first of the three to settle so a large
+  // file does not accumulate one per chunk read.
+  if (!stream.readableEnded) {
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        stream.off('readable', onReadable);
+        stream.off('end', onDone);
+        stream.off('error', onError);
+      };
+      const onReadable = () => {
+        let chunk: Buffer | null;
+        while (total < byteCount && (chunk = stream.read() as Buffer | null) !== null) {
+          chunks.push(chunk);
+          total += chunk.length;
+        }
+        if (total >= byteCount) {
+          cleanup();
+          resolve();
+        }
+      };
+      const onDone = () => {
+        cleanup();
+        resolve();
+      };
+      const onError = (err: Error) => {
+        cleanup();
+        reject(err);
+      };
+      stream.on('readable', onReadable);
+      stream.once('end', onDone);
+      stream.once('error', onError);
+      onReadable();
+    });
+  }
+
+  const head = Buffer.concat(chunks);
+
+  const body = new PassThrough();
+  stream.once('error', (err) => body.destroy(err));
+  if (head.length > 0) body.write(head);
+  if (stream.readableEnded) {
+    body.end();
+  } else {
+    stream.pipe(body);
+  }
+
+  return { head, body };
+}
+
+/**
+ * Refuse a file whose contents are an executable, whatever its name says. Runs in
+ * the storage engine, not fileFilter, which only sees the filename — and this is
+ * what covers extensionless uploads the allow-list cannot classify. Fails the
+ * request rather than silently dropping the file, unlike a filtered extension.
+ */
+async function screenExecutableContent(
+  stream: Readable,
+  originalName: string,
+  mimetype: string | undefined,
+): Promise<Readable> {
+  const { head, body } = await readHeadAndRewind(stream, SNIFF_BYTES);
+
+  const reason = await forbiddenContentReason(head);
+  if (!reason) return body;
+
+  logger.warn('[UPLOAD] Rejected executable content', {
+    originalName,
+    declaredMimetype: mimetype,
+    detected: reason,
+  });
+  body.destroy();
+  throw new AppError('File content is not permitted', 400);
+}
+
+/** Exposed for tests; the storage engines that call it need a live request. */
+export const __screenExecutableContentForTest = screenExecutableContent;
+
+// ── Archive inspection ────────────────────────────────────────────────────
+//
+// A Zip is the one allowed container whose contents the extension and content
+// checks above cannot see, so its entries get the same two checks: an entry
+// named like a blocked type, or whose bytes are an executable, refuses the whole
+// archive. Only plain `.zip` uploads are opened. The other Zip-based formats the
+// product accepts (apk, ipa, docx, …) legitimately carry native code or are
+// consumed as a unit, and opening them would refuse real files.
+
+/** A Zip inside a Zip is opened; anything deeper is refused rather than followed. */
+const MAX_ARCHIVE_DEPTH = 2;
+/** Bounds on how much work one upload can demand of the inspector. */
+const MAX_ARCHIVE_ENTRIES = 10_000;
+const MAX_ARCHIVE_INFLATED_BYTES = 4 * 1024 * 1024 * 1024;
+
+class ArchiveViolation extends AppError {
+  constructor(public readonly reason: string, public readonly entryPath: string) {
+    super('Archive contains content that is not permitted', 400);
+  }
+}
+
+/** Consume a stream fully, keeping only its first `byteCount` bytes. */
+function captureHead(stream: Readable, byteCount: number, budget: { bytes: number }): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let kept = 0;
+    const sink = new Writable({
+      write(chunk: Buffer, _encoding, next) {
+        budget.bytes += chunk.length;
+        if (budget.bytes > MAX_ARCHIVE_INFLATED_BYTES) {
+          next(new ArchiveViolation('inflates beyond the inspection limit', ''));
+          return;
+        }
+        if (kept < byteCount) {
+          chunks.push(chunk.subarray(0, byteCount - kept));
+          kept += chunk.length;
+        }
+        next();
+      },
+    });
+    sink.once('finish', () => resolve(Buffer.concat(chunks)));
+    sink.once('error', reject);
+    stream.once('error', reject);
+    stream.pipe(sink);
+  });
+}
+
+function inspectZipEntries(
+  archive: Readable,
+  depth: number,
+  budget: { entries: number; bytes: number },
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const parser = parseZipStream();
+    let chain: Promise<void> = Promise.resolve();
+    let failed = false;
+
+    const fail = (err: unknown) => {
+      if (failed) return;
+      failed = true;
+      parser.destroy();
+      reject(err);
+    };
+
+    parser.on('entry', (entry: ZipEntry) => {
+      chain = chain
+        .then(async () => {
+          if (failed) {
+            entry.autodrain();
+            return;
+          }
+          budget.entries += 1;
+          if (budget.entries > MAX_ARCHIVE_ENTRIES) {
+            throw new ArchiveViolation('has more entries than can be inspected', entry.path);
+          }
+          if (entry.type === 'Directory') {
+            await entry.autodrain().promise();
+            return;
+          }
+          // Deny-by-default for archive entries, matching the direct-upload filter
+          // (uploadFileFilter refuses anything not 'allowed').
+          if (classifyUpload(undefined, entry.path) !== 'allowed') {
+            throw new ArchiveViolation('file type not allowed', entry.path);
+          }
+          if (extensionOf(entry.path) === 'zip') {
+            if (depth >= MAX_ARCHIVE_DEPTH) {
+              throw new ArchiveViolation('nested archives beyond the inspection depth', entry.path);
+            }
+            await inspectZipEntries(entry, depth + 1, budget);
+            return;
+          }
+          const head = await captureHead(entry, SNIFF_BYTES, budget);
+          const reason = await forbiddenContentReason(head);
+          if (reason) throw new ArchiveViolation(reason, entry.path);
+        })
+        .catch((err) => {
+          entry.autodrain();
+          fail(err);
+        });
+    });
+
+    // A `.zip` that cannot be parsed is not something a user can extract either;
+    // refusing it costs nothing legitimate and denies a malformed header as a
+    // way past the inspection.
+    parser.once('error', (err: Error) =>
+      fail(new ArchiveViolation(`could not be read (${err.message})`, '')),
+    );
+    parser.once('finish', () => {
+      chain.then(() => {
+        if (!failed) resolve();
+      }, fail);
+    });
+    archive.once('error', fail);
+    archive.pipe(parser);
+  });
+}
+
+type ArchiveScreeningMode = 'shadow' | 'enforce';
+let archiveScreeningMode: ArchiveScreeningMode = config.uploads.archiveScreening;
+
+/** Exposed for tests. */
+export function __setArchiveScreeningModeForTest(mode: ArchiveScreeningMode): void {
+  archiveScreeningMode = mode;
+}
+
+/**
+ * Inspect a Zip upload while it streams to storage. The returned `body` is what
+ * storage receives; `verdict` settles when inspection finishes. In enforce mode a
+ * violation destroys `body` so the upload stops, and rejects `verdict` so the
+ * caller can remove anything already stored. In shadow mode the violation is
+ * recorded without blocking, so the inspector can be validated before it enforces.
+ */
+function screenArchiveContent(
+  stream: Readable,
+  originalName: string,
+): { body: Readable; verdict: Promise<void> } {
+  const body = new PassThrough();
+  const toInspector = new PassThrough();
+  stream.once('error', (err) => {
+    body.destroy(err);
+    toInspector.destroy(err);
+  });
+  stream.pipe(body);
+  stream.pipe(toInspector);
+
+  const verdict = inspectZipEntries(toInspector, 1, { entries: 0, bytes: 0 }).catch((err) => {
+    const violation = err instanceof ArchiveViolation ? err : null;
+    logger.warn('[UPLOAD] Archive content violation', {
+      originalName,
+      mode: archiveScreeningMode,
+      reason: violation?.reason ?? String(err),
+      entryPath: violation?.entryPath,
+    });
+    toInspector.destroy();
+    if (archiveScreeningMode === 'shadow') return;
+    const rejection = violation ?? new AppError('Archive could not be inspected', 400);
+    body.destroy(rejection);
+    throw rejection;
+  });
+
+  return { body, verdict };
+}
+
+/** Exposed for tests; resolves to the full stored bytes or rejects with the verdict. */
+export async function __screenArchiveContentForTest(stream: Readable, originalName: string): Promise<Buffer> {
+  const { body, verdict } = screenArchiveContent(stream, originalName);
+  const stored = new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    body.on('data', (c: Buffer) => chunks.push(c));
+    body.once('end', () => resolve(Buffer.concat(chunks)));
+    body.once('error', reject);
+  });
+  const [storedOutcome] = await Promise.allSettled([stored, verdict]);
+  await verdict;
+  if (storedOutcome.status === 'rejected') throw storedOutcome.reason;
+  return storedOutcome.value;
+}
+
+/**
+ * Run every content check and store the file. Inspection of an archive overlaps
+ * the upload, so a violation found after storage has finished is followed by
+ * removal of what was stored; the caller only ever sees the rejection.
+ */
+async function uploadScreened<R extends { path: string }>(
+  stream: Readable,
+  originalName: string,
+  mimetype: string | undefined,
+  upload: (body: Readable) => Promise<R>,
+): Promise<R> {
+  const screened = await screenExecutableContent(stream, originalName, mimetype);
+  if (extensionOf(originalName) !== 'zip') {
+    return upload(screened);
+  }
+
+  const { body, verdict } = screenArchiveContent(screened, originalName);
+  const [uploadOutcome, verdictOutcome] = await Promise.allSettled([upload(body), verdict]);
+  if (verdictOutcome.status === 'rejected') {
+    if (uploadOutcome.status === 'fulfilled') {
+      await storageService.deleteFile(uploadOutcome.value.path).catch((err) => {
+        logger.error('[UPLOAD] Failed to remove rejected archive from storage', {
+          originalName,
+          storagePath: uploadOutcome.value.path,
+          error: err,
+        });
+      });
+    }
+    throw verdictOutcome.reason;
+  }
+  if (uploadOutcome.status === 'rejected') throw uploadOutcome.reason;
+  return uploadOutcome.value;
+}
+
+/**
  * Skips a refused file rather than failing the request: returning an error to multer
  * discards every file in the same multipart upload, which on the inbound-email path would
  * drop the message entirely. Callers see the file missing from req.files.
  */
 const uploadFileFilter: multer.Options['fileFilter'] = (_req, file, cb) => {
-  if (isBlockedUpload(file.mimetype, file.originalname)) {
+  const verdict = classifyUpload(file.mimetype, file.originalname);
+  if (verdict !== 'allowed') {
     logger.warn('[UPLOAD] Rejected file type', {
+      reason: verdict,
       mimetype: file.mimetype,
       originalname: file.originalname,
     });
@@ -147,17 +572,19 @@ const streamingStorage: multer.StorageEngine = {
         });
       });
 
-      const result = await storageService.uploadStream(file.stream, {
-        filename: originalName,
-        contentType: file.mimetype || 'application/octet-stream',
-        metadata: {
-          originalName,
-          uploadedAt: new Date().toISOString(),
-          proxied: 'true',
-        },
-        scopeType: 'CONVERSATION',
-        scopeId: 'temp',
-      });
+      const result = await uploadScreened(file.stream, originalName, file.mimetype, (body) =>
+        storageService.uploadStream(body, {
+          filename: originalName,
+          contentType: file.mimetype || 'application/octet-stream',
+          metadata: {
+            originalName,
+            uploadedAt: new Date().toISOString(),
+            proxied: 'true',
+          },
+          scopeType: 'CONVERSATION',
+          scopeId: 'temp',
+        }),
+      );
 
       logger.info(`[UPLOAD-STREAM] Stream propagated to object storage`, {
         traceLabel,
@@ -212,16 +639,18 @@ function makeCollectionStreamingStorage(scopeIdParam: string): multer.StorageEng
         return;
       }
 
-      storageService.uploadStream(file.stream, {
-        filename: file.originalname || `upload-${Date.now()}`,
-        contentType: file.mimetype || 'application/octet-stream',
-        scopeType: 'collection',
-        scopeId,
-        metadata: {
-          originalName: file.originalname,
-          uploadedAt: new Date().toISOString(),
-        },
-      }).then((result) => {
+      uploadScreened(file.stream, file.originalname, file.mimetype, (body) =>
+        storageService.uploadStream(body, {
+          filename: file.originalname || `upload-${Date.now()}`,
+          contentType: file.mimetype || 'application/octet-stream',
+          scopeType: 'collection',
+          scopeId,
+          metadata: {
+            originalName: file.originalname,
+            uploadedAt: new Date().toISOString(),
+          },
+        }),
+      ).then((result) => {
         logger.info(`[COLLECTION-UPLOAD] Streamed to GCS: ${file.originalname} -> ${result.path} (${result.size} bytes)`);
         cb(null, { path: result.path, filename: result.filename, size: result.size });
       }).catch((error) => {

--- a/apps/backend/src/services/groupDmParticipantService.ts
+++ b/apps/backend/src/services/groupDmParticipantService.ts
@@ -107,7 +107,7 @@ export class GroupDmParticipantService {
       };
     }
 
-    const newUsers = await this.loadActiveUsers(newUserIds);
+    const newUsers = await this.loadActiveUsers(newUserIds, workspaceId);
     const allParticipantIds = [...new Set([...currentUserIds, ...newUserIds])].sort();
 
     if (allParticipantIds.length > MAX_DM_PARTICIPANTS) {
@@ -237,11 +237,19 @@ export class GroupDmParticipantService {
     }
   }
 
-  private async loadActiveUsers(userIds: string[]): Promise<User[]> {
-    const { users, missingUserId } = await this.userRepository.findActiveByIds(userIds);
-
-    if (missingUserId) {
-      throw new AppError('One or more participants not found or inactive', 404);
+  private async loadActiveUsers(
+    userIds: string[],
+    workspaceId: string,
+  ): Promise<User[]> {
+    // Scope each participant to the caller's workspace so a caller-supplied id
+    // cannot reference a user outside it.
+    const users: User[] = [];
+    for (const userId of userIds) {
+      const user = await this.userRepository.findByIdInWorkspace(userId, workspaceId);
+      if (!user || user.status !== 'ACTIVE') {
+        throw new AppError('One or more participants not found or inactive', 404);
+      }
+      users.push(user);
     }
 
     return users;

--- a/apps/backend/src/services/linkPreviewService.ts
+++ b/apps/backend/src/services/linkPreviewService.ts
@@ -1,7 +1,8 @@
 import axios, { AxiosResponse } from 'axios';
 import { parse } from 'node-html-parser';
 import {logger} from '@/utils/logger';
-import { assertHostIsExternal } from '@/utils/ssrfGuard';
+import { resolveExternalHostPinned, pinnedAgentsFor } from '@/utils/ssrfGuard';
+import { config } from '@/config/env';
 
 export interface ExternalLinkMetadata {
   type?: 'external';
@@ -112,6 +113,11 @@ export class LinkPreviewService {
    * RFC1918, link-local/metadata 169.254.0.0/16, *.svc.cluster.local, etc.),
    * following redirects manually so each hop is re-checked. Link previews have
    * no legitimate internal target, so internal hosts are always refused.
+   *
+   * DATA_SOURCE_ALLOW_PRIVATE_HOSTS is honoured only in local development — it
+   * exists for dashboard data-source connectors, not link previews, and reading it
+   * unqualified would disable this guard wherever a connector needs it. Mirrors
+   * assertWebhookUrlSafe.
    */
   private async safeGet(initialUrl: string): Promise<AxiosResponse> {
     const MAX_REDIRECTS = 5;
@@ -122,7 +128,8 @@ export class LinkPreviewService {
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
         throw new Error(`Blocked non-http(s) scheme: ${parsed.protocol}`);
       }
-      await assertHostIsExternal(parsed.hostname);
+      const allowPrivate = config.dataSource.allowPrivateHosts && config.env === 'development';
+      const pinned = await resolveExternalHostPinned(parsed.hostname, allowPrivate);
 
       const response = await axios.get(currentUrl, {
         headers: {
@@ -133,6 +140,8 @@ export class LinkPreviewService {
         maxContentLength: this.MAX_CONTENT_LENGTH,
         maxRedirects: 0, // follow manually so each hop is re-validated above
         validateStatus: (status) => status >= 200 && status < 400,
+        // Connect to the validated addresses rather than re-resolving the name.
+        ...(pinned ? pinnedAgentsFor(parsed.hostname, pinned) : {}),
       });
 
       // Not a redirect → this is the final response.

--- a/apps/backend/src/services/websocketService.ts
+++ b/apps/backend/src/services/websocketService.ts
@@ -14,6 +14,7 @@ import { type NotificationData } from './notificationService';
 import { presenceCleanupQueue } from '@/queues/presenceCleanupQueue';
 import { activityTrackingService, ActivityEventPayload } from './activityTrackingService';
 import { repositories } from '@/database/repositories';
+import { config } from '@/config/env';
 
 
 interface AuthenticatedSocket extends Socket {
@@ -71,9 +72,25 @@ class WebSocketService {
     this.io = new SocketIOServer(httpServer, {
       path: '/api/socket.io/',
       cors: {
-        origin: process.env.CLIENT_URL || "http://localhost:3000",
+        origin: config.cors.origin,
         methods: ["GET", "POST"],
         credentials: true
+      },
+      // The handshake authenticates from cookies, and CORS headers only govern what a
+      // page may *read* — they do not stop a browser from opening the socket. A browser
+      // always sends Origin on a cross-site WebSocket handshake, so an Origin outside
+      // the allow-list is refused before authentication. The list is the CORS origins
+      // plus the app's own frontend (config.cors.origin), so a same-origin frontend
+      // is accepted even if it is not a CORS entry. Native clients send no Origin and
+      // are unaffected.
+      allowRequest: (req, callback) => {
+        const origin = req.headers.origin;
+        if (origin && !config.cors.origin.includes(origin)) {
+          logger.warn(`WebSocket handshake rejected from disallowed origin: ${origin}`);
+          callback('Origin not allowed', false);
+          return;
+        }
+        callback(null, true);
       },
       transports: ['websocket', 'polling'],
       // Ping/pong configuration to keep connection alive

--- a/apps/backend/src/utils/passwordUtils.ts
+++ b/apps/backend/src/utils/passwordUtils.ts
@@ -28,6 +28,15 @@ export async function hashPassword(password: string): Promise<string> {
   return `$scrypt$ln=14,r=8,p=1$${salt}$${derivedKey.toString('hex')}`;
 }
 
+// A syntactically valid scrypt hash in the SAME modular-crypt format and with the
+// SAME work parameters as hashPassword (ln=14, r=8, p=1). The email-login path
+// verifies against this when no account (or no password) is found, so that branch
+// runs a full scrypt derivation and takes as long as verifying a real stored hash,
+// keeping verification time constant. Keep these parameters equal to hashPassword.
+// Not a credential: it is never compared for a real match, only for timing.
+export const DUMMY_PASSWORD_HASH =
+  '$scrypt$ln=14,r=8,p=1$e1b76c97154e03fcc330cda38be6e271776fdbf1cecadad84b94f5671f55b3fb$46a2d60a74a198809db3674f5e93fc7458114f61232e660d9f9f4c14647801d4c3a9e4f7e635bc95d55c658f9672dcfd6aa22542f37ac64bf6c6767b8b20e3a6';
+
 export async function verifyPassword(password: string, hash: string): Promise<boolean> {
   let salt: string;
   let key: string;
@@ -71,10 +80,16 @@ export function hashPasswordForAuth(password: string): string {
 
 export async function verifyEmailPassword(password: string, storedHash: string): Promise<boolean> {
   if (isClientPasswordHash(storedHash)) {
-    return crypto.timingSafeEqual(
+    const matches = crypto.timingSafeEqual(
       Buffer.from(hashPasswordForAuth(password), 'hex'),
       Buffer.from(normalizeClientPasswordHash(storedHash), 'hex'),
     );
+    // Stored hashes are a mix of this fast (sha256) form and the slow scrypt form
+    // (passwords set via reset/change). Run one scrypt derivation here too so the
+    // verification cost is the same regardless of which form an account uses,
+    // keeping login time constant.
+    await verifyPassword(password, DUMMY_PASSWORD_HASH);
+    return matches;
   }
 
   return verifyPassword(password, storedHash);

--- a/apps/backend/src/utils/ssrfGuard.ts
+++ b/apps/backend/src/utils/ssrfGuard.ts
@@ -1,6 +1,9 @@
 
 import { promises as dns } from 'node:dns';
+import http from 'node:http';
+import https from 'node:https';
 import { BlockList, isIP } from 'node:net';
+import { Agent, fetch as undiciFetch } from 'undici';
 import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
 
@@ -42,6 +45,24 @@ blockedV6.addSubnet('fc00::', 7, 'ipv6');
 blockedV6.addSubnet('fe80::', 10, 'ipv6');
 blockedV6.addSubnet('ff00::', 8, 'ipv6');
 
+// A stricter subset that is refused even when internal webhook hosts are otherwise
+// allowed: loopback and link-local / cloud-metadata (169.254.x — the instance
+// metadata endpoint that can return the workload's credentials).
+const metadataV4 = new BlockList();
+metadataV4.addRange('0.0.0.0', '0.255.255.255');
+metadataV4.addRange('127.0.0.0', '127.255.255.255');
+metadataV4.addRange('169.254.0.0', '169.254.255.255');
+const metadataV6 = new BlockList();
+metadataV6.addAddress('::', 'ipv6');
+metadataV6.addAddress('::1', 'ipv6');
+metadataV6.addSubnet('fe80::', 10, 'ipv6');
+// The IPv6 instance-metadata prefix (fd00:ec2::/32) sits inside the fc00::/7 ULA
+// range that internal webhooks are otherwise allowed to reach — refuse just this
+// metadata prefix without blocking legitimate internal ULA addresses.
+metadataV6.addSubnet('fd00:ec2::', 32, 'ipv6');
+// (IPv4-mapped loopback/link-local/metadata — dotted and compact ::ffff: forms — is
+// handled by ipv4FromMapped() in isMetadataV6, mirroring the strict isBlockedV6 path.)
+
 function ipv4FromMapped(addr: string): string | null {
   const lower = addr.toLowerCase();
   const dotted = lower.match(/^::ffff:((?:\d{1,3}\.){3}\d{1,3})$/);
@@ -69,6 +90,27 @@ function isBlockedV6(addr: string): boolean {
   return blockedV6.check(addr, 'ipv6');
 }
 
+function isMetadataV4(addr: string): boolean {
+  return metadataV4.check(addr);
+}
+
+function isMetadataV6(addr: string): boolean {
+  const mapped = ipv4FromMapped(addr);
+  if (mapped) return isMetadataV4(mapped);
+  return metadataV6.check(addr, 'ipv6');
+}
+
+// Hostnames refused even when internal webhook targets are allowed.
+function isMetadataHostname(host: string): boolean {
+  const lower = host.toLowerCase().trim();
+  return (
+    lower === 'localhost' ||
+    lower === 'metadata.google.internal' ||
+    lower === 'metadata' ||
+    lower === 'instance-data'
+  );
+}
+
 function isBlockedHostname(host: string): boolean {
   const lower = host.toLowerCase().trim();
   if (lower === 'localhost') return true;
@@ -81,7 +123,7 @@ function isBlockedHostname(host: string): boolean {
 
 export async function assertHostIsExternal(
   host: string,
-  allowPrivate: boolean = isAllowPrivate(),
+  allowPrivate: boolean = isAllowPrivate() && config.env === 'development',
 ): Promise<void> {
   if (allowPrivate) {
     logger.debug(
@@ -143,6 +185,175 @@ export async function assertHostIsExternal(
   }
 }
 
+/** Addresses that passed validation and are the only ones a caller may connect to. */
+export interface PinnedHost {
+  family: 4 | 6;
+  addresses: string[];
+}
+
+/**
+ * Validate a host and return the addresses that passed, so the caller can connect
+ * to exactly those instead of resolving the name again. `assertHostIsExternal`
+ * proves the name resolved to public addresses when asked; it cannot stop the HTTP
+ * client resolving again and getting a different (internal) answer — DNS rebinding.
+ * Returns null when the bypass is active and there is nothing to pin.
+ */
+export async function resolveExternalHostPinned(
+  host: string,
+  allowPrivate: boolean = isAllowPrivate() && config.env === 'development',
+): Promise<PinnedHost | null> {
+  if (allowPrivate) return null;
+
+  await assertHostIsExternal(host, false);
+
+  const trimmed = host.trim();
+  const literalKind = isIP(trimmed);
+  if (literalKind === 4) return { family: 4, addresses: [trimmed] };
+  if (literalKind === 6) return { family: 6, addresses: [trimmed] };
+
+  // Re-check every resolved address; the connection is held to this set.
+  const [v4, v6] = await Promise.all([
+    dns.resolve4(trimmed).catch(() => [] as string[]),
+    dns.resolve6(trimmed).catch(() => [] as string[]),
+  ]);
+
+  const safeV4 = v4.filter((a) => !isBlockedV4(a));
+  const safeV6 = v6.filter((a) => !isBlockedV6(a));
+
+  if (safeV4.length !== v4.length || safeV6.length !== v6.length) {
+    throw new SsrfBlockedError(trimmed, null, 'DNS answer changed to an internal address between checks');
+  }
+  if (safeV4.length === 0 && safeV6.length === 0) {
+    throw new SsrfBlockedError(trimmed, null, 'no usable public address');
+  }
+
+  return safeV4.length > 0 ? { family: 4, addresses: safeV4 } : { family: 6, addresses: safeV6 };
+}
+
+/**
+ * HTTP/HTTPS agents whose DNS lookup is fixed to `pinned`, so a request cannot
+ * connect anywhere other than the validated addresses. The URL keeps its hostname,
+ * so TLS still verifies against the name — only address selection is pinned. Any
+ * other hostname fails closed (a redirect is re-validated and gets its own agents),
+ * and keepAlive is off so a pinned socket is not reused under a later verdict.
+ */
+export function pinnedAgentsFor(
+  hostname: string,
+  pinned: PinnedHost,
+): { httpAgent: http.Agent; httpsAgent: https.Agent } {
+  const lookup = (
+    host: string,
+    options: { all?: boolean },
+    callback: (
+      err: NodeJS.ErrnoException | null,
+      address: string | Array<{ address: string; family: number }>,
+      family?: number,
+    ) => void,
+  ): void => {
+    if (host !== hostname) {
+      callback(new Error(`Refusing to resolve unexpected host "${host}"`), '', 4);
+      return;
+    }
+    if (options?.all) {
+      callback(null, pinned.addresses.map((address) => ({ address, family: pinned.family })));
+      return;
+    }
+    callback(null, pinned.addresses[0]!, pinned.family);
+  };
+
+  return {
+    httpAgent: new http.Agent({ keepAlive: false, lookup: lookup as never }),
+    httpsAgent: new https.Agent({ keepAlive: false, lookup: lookup as never }),
+  };
+}
+
+/**
+ * An undici dispatcher whose connection lookup is fixed to `pinned`, for callers
+ * that use fetch() rather than axios (which cannot take an http.Agent). Same
+ * guarantee as pinnedAgentsFor: the request connects only to the validated
+ * addresses, the URL keeps its hostname so TLS still verifies against the name,
+ * and any other hostname (e.g. a redirect target) fails closed.
+ */
+export function pinnedDispatcherFor(hostname: string, pinned: PinnedHost): Agent {
+  return new Agent({
+    keepAliveTimeout: 1000,
+    connect: {
+      lookup: ((host: string, _options: unknown, callback: (err: Error | null, address?: unknown, family?: number) => void): void => {
+        if (host !== hostname) {
+          callback(new Error(`Refusing to resolve unexpected host "${host}"`));
+          return;
+        }
+        callback(null, pinned.addresses.map((address) => ({ address, family: pinned.family })));
+      }) as never,
+    },
+  });
+}
+
+/**
+ * Webhook variant used when WEBHOOK_ALLOW_INTERNAL_HOSTS is enabled: allows private /
+ * internal destinations but still refuses loopback and link-local / cloud-metadata
+ * (the instance-metadata credential endpoint). Resolves and pins to the checked
+ * addresses so a later DNS answer cannot swing to a refused address (rebinding-safe).
+ */
+export async function resolveWebhookHostAllowingInternal(host: string): Promise<PinnedHost> {
+  const trimmed = host.trim();
+  if (!trimmed) throw new SsrfBlockedError(host, null, 'empty host');
+  if (isMetadataHostname(trimmed)) {
+    throw new SsrfBlockedError(trimmed, null, 'loopback / metadata host is never allowed');
+  }
+  const literalKind = isIP(trimmed);
+  if (literalKind === 4) {
+    if (isMetadataV4(trimmed)) throw new SsrfBlockedError(trimmed, trimmed, 'loopback / link-local / metadata');
+    return { family: 4, addresses: [trimmed] };
+  }
+  if (literalKind === 6) {
+    if (isMetadataV6(trimmed)) throw new SsrfBlockedError(trimmed, trimmed, 'loopback / link-local / metadata');
+    return { family: 6, addresses: [trimmed] };
+  }
+  const [v4, v6] = await Promise.all([
+    dns.resolve4(trimmed).catch(() => [] as string[]),
+    dns.resolve6(trimmed).catch(() => [] as string[]),
+  ]);
+  if (v4.length === 0 && v6.length === 0) {
+    throw new SsrfBlockedError(trimmed, null, 'no DNS records (hostname does not resolve)');
+  }
+  for (const addr of v4) {
+    if (isMetadataV4(addr)) throw new SsrfBlockedError(trimmed, addr, 'resolves to loopback / link-local / metadata');
+  }
+  for (const addr of v6) {
+    if (isMetadataV6(addr)) throw new SsrfBlockedError(trimmed, addr, 'resolves to loopback / link-local / metadata');
+  }
+  return v4.length > 0 ? { family: 4, addresses: v4 } : { family: 6, addresses: v6 };
+}
+
+/**
+ * Validate an outbound webhook URL and fetch it pinned to the addresses that passed,
+ * so a second DNS answer cannot swing the connection between the check and the request
+ * (rebinding). The fetch() counterpart to how LinkPreviewService uses
+ * resolveExternalHostPinned + pinnedAgentsFor. Honors WEBHOOK_ALLOW_INTERNAL_HOSTS.
+ * Callers MUST still pass `redirect: 'manual'` — a 3xx target is a fresh URL this has
+ * not validated. Throws SsrfBlockedError on a blocked destination.
+ */
+export async function safeWebhookFetch(rawUrl: string, init: RequestInit = {}): Promise<Response> {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new SsrfBlockedError(rawUrl, null, 'invalid URL');
+  }
+  // When WEBHOOK_ALLOW_INTERNAL_HOSTS is set, internal webhook targets are allowed
+  // while loopback and cloud-metadata stay refused.
+  const pinned = config.webhooks.allowInternalHosts
+    ? await resolveWebhookHostAllowingInternal(parsed.hostname)
+    : await resolveExternalHostPinned(parsed.hostname, isAllowPrivate() && config.env === 'development');
+  // A fresh dispatcher per request — never shared, so a pinned socket is never
+  // reused under a later verdict; its idle socket is dropped on keep-alive timeout.
+  const dispatcher = pinned
+    ? pinnedDispatcherFor(parsed.hostname, pinned)
+    : new Agent({ keepAliveTimeout: 1000 });
+  return (await undiciFetch(rawUrl, { ...init, dispatcher } as never)) as unknown as Response;
+}
+
 /**
  * SSRF guard for outbound webhook URLs (app webhooks, automation
  * trigger_webhook). Ensures the host does not resolve to an internal / private /
@@ -159,8 +370,16 @@ export async function assertWebhookUrlSafe(rawUrl: string): Promise<void> {
   } catch {
     throw new SsrfBlockedError(rawUrl, null, 'invalid URL');
   }
-  // Webhooks honor the private-host bypass only in local development, not in
-  // shared non-prod where DATA_SOURCE_ALLOW_PRIVATE_HOSTS may be set for
+  // When WEBHOOK_ALLOW_INTERNAL_HOSTS is set, internal webhook targets are allowed
+  // while loopback and cloud-metadata stay refused. Validation only: this throws on a
+  // disallowed destination; the pinned outbound connection is made by safeWebhookFetch,
+  // so the resolved addresses are intentionally not returned here.
+  if (config.webhooks.allowInternalHosts) {
+    await resolveWebhookHostAllowingInternal(parsed.hostname);
+    return;
+  }
+  // Otherwise webhooks honor the private-host bypass only in local development, not
+  // in shared non-prod where DATA_SOURCE_ALLOW_PRIVATE_HOSTS may be set for
   // data-source connectors.
   const allowPrivate = isAllowPrivate() && config.env === 'development';
   await assertHostIsExternal(parsed.hostname, allowPrivate);

--- a/apps/backend/src/zero/server.ts
+++ b/apps/backend/src/zero/server.ts
@@ -11,6 +11,7 @@ import { Pool } from 'pg';
 import { Context, schema } from '@xyne/shared';
 import { AuthData, createMutators } from './mutators';
 import { queries } from './queries';
+import { scopeQueryToTenant } from './tenant-scope';
 import jwt from 'jsonwebtoken';
 import { logger } from '@/utils/logger';
 import { getZeroMutationLatency, getZeroMutationOperations, getZeroQueryLatency, getZeroQueryOperations } from '@/services/otel';
@@ -411,7 +412,7 @@ export async function handleQueries(request: Request): Promise<any> {
           }
           const query = mustGetBackendQuery(queryName);
           const context: Context = { userID: authData.sub, workspaceId: authData.workspaceId, role: authData.role, orgRole: authData.orgRole, memberId: authData.memberId };
-          return query.fn({ args, ctx: context });
+          return scopeQueryToTenant(query.fn({ args, ctx: context }), context, queryName);
         })(),
       schema,
       request
@@ -500,7 +501,9 @@ function buildQueryInternals(
   ctx: Context,
 ) {
   try {
-    const query = queryDef.fn({ args: args ?? {}, ctx });
+    // Scope the read to the caller's tenant before it is compiled to SQL, the same
+    // as the primary and zql-to-sql query paths.
+    const query = scopeQueryToTenant(queryDef.fn({ args: args ?? {}, ctx }), ctx, name);
     // @ts-ignore - asQueryInternals works with any Query type at runtime
     return asQueryInternals(query);
   } catch (error) {
@@ -611,10 +614,14 @@ export async function handleQueriesZqlToSql(request: Request): Promise<any> {
       queryRequests.map(async (req) => {
         try {
           const queryDef = mustGetBackendQuery(req.name);
-          const query = queryDef.fn({
-            args: req.args || {},
-            ctx: context,
-          });
+          const query = scopeQueryToTenant(
+            queryDef.fn({
+              args: req.args || {},
+              ctx: context,
+            }),
+            context,
+            req.name,
+          );
 
           // Extract AST and Format from ZQL query
           // @ts-ignore - asQueryInternals works with any Query type at runtime

--- a/apps/backend/src/zero/tenant-scope.ts
+++ b/apps/backend/src/zero/tenant-scope.ts
@@ -1,0 +1,87 @@
+// Zero internal API (mapped via #imports in package.json)
+import { asQueryInternals } from '#zero-internal/query-internals';
+import { Context, schema } from '@xyne/shared';
+import { logger } from '@/utils/logger';
+
+// The tenant boundary is applied here, to every query, rather than trusting each
+// query definition to include it: the root table is scoped to the caller's
+// workspace, or to their organisation for the few tables that sit above workspaces.
+// Tables that are neither must be listed as global reference data; an unlisted
+// table is refused rather than served unscoped.
+
+type ScopableQuery = {
+  where: (...args: unknown[]) => ScopableQuery;
+  whereExists: (...args: unknown[]) => ScopableQuery;
+};
+
+type OrgScopeRule = (query: ScopableQuery, ctx: Context) => ScopableQuery;
+
+/**
+ * Tables without a workspaceId column that need a bespoke scope rule — either the
+ * caller's organisation membership (org-level tables) or a parent row that does
+ * carry workspaceId (e.g. canvas comments, scoped through their canvas).
+ */
+const CUSTOM_SCOPES: Record<string, OrgScopeRule> = {
+  // An organisation is visible to its own members and to the members of a
+  // workspace it is linked to.
+  organizations: (query, ctx) =>
+    query.where(({ or, exists }: any) =>
+      or(
+        exists('members', (m: ScopableQuery) => m.where('memberId', ctx.memberId)),
+        exists('workspaceOrgs', (wo: ScopableQuery) => wo.where('workspaceId', ctx.workspaceId)),
+      ),
+    ),
+  org_members: (query, ctx) =>
+    query.whereExists('organization', (o: ScopableQuery) =>
+      o.whereExists('members', (m: ScopableQuery) => m.where('memberId', ctx.memberId)),
+    ),
+  // The caller's own workspace, plus the others in their organisation.
+  workspaces: (query, ctx) =>
+    query.where(({ cmp, or, exists }: any) =>
+      or(
+        cmp('id', '=', ctx.workspaceId),
+        exists('orgMembers', (m: ScopableQuery) => m.where('memberId', ctx.memberId)),
+      ),
+    ),
+  // Canvas comment tables carry canvasId, not workspaceId; scope through the canvas.
+  canvas_comment_threads: (query, ctx) =>
+    query.whereExists('canvas', (c: ScopableQuery) => c.where('workspaceId', ctx.workspaceId)),
+  canvas_comments: (query, ctx) =>
+    query.whereExists('thread', (t: ScopableQuery) =>
+      t.whereExists('canvas', (c: ScopableQuery) => c.where('workspaceId', ctx.workspaceId)),
+    ),
+};
+
+/** Reference data that is the same for every tenant. */
+const GLOBAL_REFERENCE_TABLES = new Set(['lookup_values', 'merchants', 'resources']);
+
+const zeroTables = schema.tables as Record<string, { columns: Record<string, unknown> }>;
+
+export function scopeQueryToTenant<T>(query: T, ctx: Context, queryName: string): T {
+  // @ts-ignore - asQueryInternals works with any Query type at runtime
+  const table = String(asQueryInternals(query).ast.table);
+  const scopable = query as unknown as ScopableQuery;
+
+  if (zeroTables[table] && 'workspaceId' in zeroTables[table].columns) {
+    // Not expected on the read path — real callers carry a workspaceId. An absent
+    // one still fails closed (Zero compiles `.where('workspaceId', undefined)` to
+    // `workspaceId = null`, which matches no rows), but log it so an unexpected
+    // context is visible rather than silently returning empty.
+    if (!ctx.workspaceId) {
+      logger.warn('zero_query_missing_workspace', { query: queryName, table });
+    }
+    return scopable.where('workspaceId', ctx.workspaceId) as unknown as T;
+  }
+  const customRule = CUSTOM_SCOPES[table];
+  if (customRule) {
+    if (!ctx.memberId) {
+      logger.warn('zero_query_missing_member', { query: queryName, table });
+    }
+    return customRule(scopable, ctx) as unknown as T;
+  }
+  if (GLOBAL_REFERENCE_TABLES.has(table)) {
+    return query;
+  }
+  logger.error('zero_query_unscoped_table', { query: queryName, table });
+  throw new Error(`Query '${queryName}' cannot be served: table '${table}' has no tenant scope`);
+}

--- a/scripts/validate-workspace-id.sh
+++ b/scripts/validate-workspace-id.sh
@@ -210,6 +210,14 @@ validate_workspace_id() {
         return 0
     fi
 
+    # Reminder (not enforced here): a new Zero table also needs a read-scope entry.
+    echo ""
+    log_warning "New table(s) detected — also classify each new Zero table in"
+    log_warning "  apps/backend/src/zero/tenant-scope.ts:"
+    log_warning "    • a table with a workspaceId column is auto-scoped (no change needed);"
+    log_warning "    • otherwise add it to CUSTOM_SCOPES or GLOBAL_REFERENCE_TABLES,"
+    log_warning "      or a Zero query against it is refused at runtime (zero_query_unscoped_table)."
+
     if [ "$has_errors" = true ]; then
         echo ""
         echo "New tables must carry a non-nullable tenant key:"

--- a/tools/xyne-automation-old/Dockerfile
+++ b/tools/xyne-automation-old/Dockerfile
@@ -9,4 +9,9 @@ COPY . .
 
 RUN mkdir -p /app/report
 
+# The Playwright base image ships a non-root "pwuser"; run as it and give it /app
+# so report/artifact writes at runtime succeed without root.
+RUN chown -R pwuser:pwuser /app
+USER pwuser
+
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
Ports the XYNE-59907 MAPT/SCR retest remediations from #1131 onto the **September 4 release line** (`releases-20260904`).

This supersedes **#1505** (the webhook-internal slice), which targeted the already-completed `release-20260903` — that PR should be declined in favour of this comprehensive one.

## What's included
- **Zero per-query tenant scoping** — every catalog read (`handleQueries`, fallback/`buildQueryInternals`, zql-to-sql) is scoped to the caller's tenant via `scopeQueryToTenant`; new `tenant-scope.ts` classifies each root table (workspace / custom / global) and refuses unclassified tables.
- **Cross-workspace channel/DM isolation** — `createChannel` DM-target and participant IDs, `createNewDM`, and `groupDmParticipantService.loadActiveUsers` all validate caller-supplied user IDs via `findByIdInWorkspace` (a user in another workspace is refused, not added).
- **Webhook SSRF guard** — allows operator-configured internal hosts (`WEBHOOK_ALLOW_INTERNAL_HOSTS`, default true) while always refusing loopback and link-local / cloud-metadata; plus DNS-rebinding pinning (`safeWebhookFetch`) and link-preview redirect-hop revalidation.
- **Upload content/archive screening** — magic-byte + extension/MIME screening; archive entries deny-by-default (`UPLOAD_ARCHIVE_SCREENING`, shadow→enforce).
- **Constant-time email login** — pads the fast stored-hash branch so login time doesn't leak account existence.
- **Non-root containers** (SCR).

## Notes
- Egress network policy remains the primary SSRF control; the app-layer guard is defence-in-depth. The `SSRF_INTERNAL_HOST_SUFFIXES` knob from earlier iterations is intentionally **not** included.
- Ported cleanly (no conflicts) — `releases-20260904` shares main's structure.
- Backend typechecks (the one pre-existing `migration/self-serve/engine.ts` error is on the base branch, unrelated to this change).

## QA
Same test matrix as #1131 (tenant isolation, webhook allow-internal vs metadata-block, upload screening, login timing).
