### PR TITLE
fix: XYNE-56391 domain conflict for native and electron

### DIFF
--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -932,6 +932,34 @@ export class AuthV2Controller {
       logger.info(`${tag()} User has ${workspaces.length} workspace(s) before invitation check`);
       const userExistsButRemoved = await this.userService.userExistsButNoActiveWorkspaces(googleUserData.email);
 
+      // Domain-conflict detection, mirroring handleCallback. Without it the Electron renderer
+      // receives workspaces: [] for a user whose email domain already maps to an enterprise org
+      // and offers "create an organization" instead of the request-to-join UI.
+      let domainConflict = null;
+      let domainConflictError = null;
+      let publicEmailError = null;
+
+      if (workspaces.length === 0 && !userExistsButRemoved) {
+        if (stateData.enterpriseLogin) {
+          try {
+            await organizationDomainService.assertCanCreateOrgForEmail(googleUserData.email);
+          } catch (error) {
+            if (error instanceof PublicEmailDomainError) {
+              publicEmailError = error;
+            } else if (error instanceof OrganizationDomainConflictError) {
+              domainConflictError = error;
+            }
+          }
+        }
+
+        if (!domainConflictError && !publicEmailError) {
+          domainConflict = await organizationDomainService.findEnterpriseWorkspaceByEmailDomain(googleUserData.email);
+          domainConflictError = domainConflict
+            ? new OrganizationDomainConflictError(domainConflict.domain, domainConflict)
+            : null;
+        }
+      }
+
       const isProduction = process.env.NODE_ENV === 'production';
 
       // If an invitation is pending: set google_access_token so the Electron renderer can later
@@ -1059,6 +1087,10 @@ export class AuthV2Controller {
         picture: googleUserData.picture,
         workspaces,
         userExistsButRemoved,
+        ...(domainConflictError ? { domainConflictError: domainConflictError.message } : {}),
+        ...(domainConflict ? { enterpriseJoinOrgName: domainConflict.name } : {}),
+        ...(domainConflict ? { enterpriseJoinWorkspaces: JSON.stringify(domainConflict.workspaces) } : {}),
+        ...(publicEmailError ? { publicEmailDomainError: publicEmailError.message } : {}),
       });
     } catch (error) {
       logger.error(`${tag()} Google OAuth login failed (platform=electron):`, error);
@@ -1144,6 +1176,9 @@ export class AuthV2Controller {
 
       // Native does PKCE inside the Google SDK, so only the web branch verifies it server-side.
       let codeVerifier: string | undefined;
+      // Only the web branch carries OAuth state, so enterpriseLogin is captured there and stays
+      // undefined for native (same effect as an absent flag on the web callback).
+      let enterpriseLogin: boolean | undefined;
       if (!isMobileNative) {
         const state = (req.query.state || req.body?.state) as string | undefined;
         if (!state) {
@@ -1159,6 +1194,7 @@ export class AuthV2Controller {
         }
         // Web-mobile carries state — adopt the flowId minted in initiateLogin for the trace.
         flowId = stateData.flowId ?? 'mobile-login';
+        enterpriseLogin = stateData.enterpriseLogin;
         logger.info(`${tag()} Google OAuth state validated (platform=${stateData.platform})`);
         await oauthStateServiceV2.deleteState(state);
         codeVerifier = (await pkceServiceV2.getAndDeleteVerifier(state)) ?? undefined;
@@ -1243,6 +1279,34 @@ export class AuthV2Controller {
       const workspaces = await this.userService.getWorkspacesByEmail(googleUserData.email);
       logger.info(`${tag()} User has ${workspaces.length} workspace(s) before invitation check`);
       const userExistsButRemoved = await this.userService.userExistsButNoActiveWorkspaces(googleUserData.email);
+
+      // Domain-conflict detection, mirroring handleCallback. Without it the mobile client
+      // receives workspaces: [] for a user whose email domain already maps to an enterprise org
+      // and offers "create an organization" instead of the request-to-join UI.
+      let domainConflict = null;
+      let domainConflictError = null;
+      let publicEmailError = null;
+
+      if (workspaces.length === 0 && !userExistsButRemoved) {
+        if (enterpriseLogin) {
+          try {
+            await organizationDomainService.assertCanCreateOrgForEmail(googleUserData.email);
+          } catch (error) {
+            if (error instanceof PublicEmailDomainError) {
+              publicEmailError = error;
+            } else if (error instanceof OrganizationDomainConflictError) {
+              domainConflictError = error;
+            }
+          }
+        }
+
+        if (!domainConflictError && !publicEmailError) {
+          domainConflict = await organizationDomainService.findEnterpriseWorkspaceByEmailDomain(googleUserData.email);
+          domainConflictError = domainConflict
+            ? new OrganizationDomainConflictError(domainConflict.domain, domainConflict)
+            : null;
+        }
+      }
 
       const isProduction = process.env.NODE_ENV === 'production';
       const cookieOptions = {
@@ -1341,6 +1405,10 @@ export class AuthV2Controller {
           picture: googleUserData.picture,
           workspaces,
           userExistsButRemoved,
+          ...(domainConflictError ? { domainConflictError: domainConflictError.message } : {}),
+          ...(domainConflict ? { enterpriseJoinOrgName: domainConflict.name } : {}),
+          ...(domainConflict ? { enterpriseJoinWorkspaces: JSON.stringify(domainConflict.workspaces) } : {}),
+          ...(publicEmailError ? { publicEmailDomainError: publicEmailError.message } : {}),
         });
         return;
       }
@@ -1355,6 +1423,14 @@ export class AuthV2Controller {
         picture: googleUserData.picture || '',
         workspaces: JSON.stringify(workspaces),
       });
+      if (domainConflictError && domainConflict) {
+        params.set('domainConflictError', domainConflictError.message);
+        params.set('enterpriseJoinOrgName', domainConflict.name);
+        params.set('enterpriseJoinWorkspaces', JSON.stringify(domainConflict.workspaces));
+      }
+      if (publicEmailError) {
+        params.set('publicEmailDomainError', publicEmailError.message);
+      }
 
       res.redirect(`${frontendUrl}?${params.toString()}`);
       return;

--- a/apps/backend/src/controllers/authV2Controller.ts
+++ b/apps/backend/src/controllers/authV2Controller.ts
@@ -1276,7 +1276,10 @@ export class AuthV2Controller {
         return;
       }
 
-      const workspaces = await this.userService.getWorkspacesByEmail(googleUserData.email);
+      const workspaces = this.getEnterpriseAwareWorkspaces(
+        await this.userService.getWorkspacesByEmail(googleUserData.email),
+        enterpriseLogin,
+      );
       logger.info(`${tag()} User has ${workspaces.length} workspace(s) before invitation check`);
       const userExistsButRemoved = await this.userService.userExistsButNoActiveWorkspaces(googleUserData.email);
 

--- a/apps/backend/src/controllers/microsoftAuthController.ts
+++ b/apps/backend/src/controllers/microsoftAuthController.ts
@@ -934,6 +934,33 @@ export class MicrosoftAuthController {
       // This mirrors Google's exchangeElectronCode which always sets google_access_token (line 842).
       if (workspaces.length === 0 && !userExistsButRemoved && !stateData.invitationId && !bodyInvitationId) {
         logger.info(`${tag()} Microsoft OAuth login succeeded (platform=electron, outcome=no_workspace, count=0) — no workspaces/invitation, returning no-access`);
+
+      // Domain-conflict detection, mirroring handleCallback. Without it the client receives
+      // workspaces: [] for a user whose email domain already maps to an enterprise org and
+      // offers "create an organization" instead of the request-to-join UI.
+      let domainConflict = null;
+      let domainConflictError = null;
+      let publicEmailError = null;
+
+        if (stateData.enterpriseLogin) {
+          try {
+            await organizationDomainService.assertCanCreateOrgForEmail(email);
+          } catch (error) {
+            if (error instanceof PublicEmailDomainError) {
+              publicEmailError = error;
+            } else if (error instanceof OrganizationDomainConflictError) {
+              domainConflictError = error;
+            }
+          }
+        }
+
+        if (!domainConflictError && !publicEmailError) {
+          domainConflict = await organizationDomainService.findEnterpriseWorkspaceByEmailDomain(email);
+          domainConflictError = domainConflict
+            ? new OrganizationDomainConflictError(domainConflict.domain, domainConflict)
+            : null;
+        }
+
         const tokenKey = await this.storePendingOAuthTokens(
           token.refresh_token as string | undefined,
           accessToken,
@@ -961,6 +988,10 @@ export class MicrosoftAuthController {
           email,
           name: profile.displayName,
           picture: undefined,
+          ...(domainConflictError ? { domainConflictError: domainConflictError.message } : {}),
+          ...(domainConflict ? { enterpriseJoinOrgName: domainConflict.name } : {}),
+          ...(domainConflict ? { enterpriseJoinWorkspaces: JSON.stringify(domainConflict.workspaces) } : {}),
+          ...(publicEmailError ? { publicEmailDomainError: publicEmailError.message } : {}),
         });
         return;
       }
@@ -1452,6 +1483,23 @@ export class MicrosoftAuthController {
       // workspaces list WITHOUT a userId or session so the shared mobile resolver shows the picker
       // (multi) or the create-org flow (0). loginWorkspace mints the real cookies after the pick.
       const userExistsButRemoved = await this.userService.userExistsButNoActiveWorkspaces(email);
+
+      // Domain-conflict detection, mirroring handleCallback. Without it the client receives
+      // workspaces: [] for a user whose email domain already maps to an enterprise org and
+      // offers "create an organization" instead of the request-to-join UI.
+      let domainConflict = null;
+      let domainConflictError = null;
+
+      // Native mobile carries no OAuth state, so there is no enterpriseLogin flag to gate the
+      // create-org assertion on; only the enterprise-workspace lookup applies here (and with no
+      // assertion there is no PublicEmailDomainError to report).
+      if (workspaces.length === 0 && !userExistsButRemoved) {
+        domainConflict = await organizationDomainService.findEnterpriseWorkspaceByEmailDomain(email);
+        domainConflictError = domainConflict
+          ? new OrganizationDomainConflictError(domainConflict.domain, domainConflict)
+          : null;
+      }
+
       logger.info(`${tag()} Microsoft OAuth login succeeded (platform=mobile, outcome=${workspaceOutcome(workspaces.length)}, count=${workspaces.length})`);
       res.json({
         success: true,
@@ -1459,6 +1507,9 @@ export class MicrosoftAuthController {
         name: profile.displayName,
         workspaces,
         userExistsButRemoved,
+        ...(domainConflictError ? { domainConflictError: domainConflictError.message } : {}),
+        ...(domainConflict ? { enterpriseJoinOrgName: domainConflict.name } : {}),
+        ...(domainConflict ? { enterpriseJoinWorkspaces: JSON.stringify(domainConflict.workspaces) } : {}),
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/apps/dashboard/src/machines/authMachine.ts
+++ b/apps/dashboard/src/machines/authMachine.ts
@@ -189,6 +189,27 @@ const getWorkspaces = (output?: OAuthCallbackOutput): Workspace[] => {
   return output?.workspaces || [];
 };
 
+// Domain-conflict fields arrive as URL params on the web callback (processingOAuthCallback) and
+// on the OAUTH_CALLBACK_COMPLETE event from the Electron IPC / React Native bridge. Both paths
+// end in a creatingOrg transition, so both must translate them into the request-to-join context.
+const getEnterpriseJoinContext = (
+  output?: OAuthCallbackOutput,
+): { error: string | null; enterpriseJoinTarget: EnterpriseJoinTarget | null } => {
+  return {
+    error: output?.domainConflictError ?? output?.publicEmailDomainError ?? null,
+    enterpriseJoinTarget:
+      output?.enterpriseJoinOrgName && output.enterpriseJoinWorkspaces
+        ? {
+            orgName: output.enterpriseJoinOrgName,
+            workspaces: JSON.parse(output.enterpriseJoinWorkspaces) as Array<{
+              id: string;
+              name: string;
+            }>,
+          }
+        : null,
+  };
+};
+
 export const authMachine = createMachine(
   {
     /** @xstate-layout N4IgpgJg5mDOIC5QEMCuAXAFgWWQY0wEsA7MAOgLDwGsSoBlOWQge2IGIBtABgF1FQABxbN0rYgJAAPRACYAjAE4yANgAsADjXaArIsUaA7AGZ1AGhABPRJuUbjew9xUbZa7muOGAvt4tosXAISckoaOkZYZjYueX4kEGFRcUkZBAVldS1dfSNTNQtrBHUVMmN5WR1TDRVueyrffwwcfCJSCkwqWmIGJnEuWXihEUIxNlS5JVVNbTU9AxNzK0QNeTIdbk35eTmVY25FY1lGkACW4PbBACcWPD6egHkAQWaAYWQAGw+AI3xqdggbHIJAAbixqOQzkE2uRrrd7lBnm9Pj8-ghQbdkGNiDxeLjJElRikEmlDAoyGodnVjHMFCpZCpCjYNNwynp3HolIYdOoTlDWiEyHC7lE6EisO8vr8aOwwFcblchR8sQAzFhXAC2ZH5F1hNxFzEeLwlKOl1HRxDBeCx4lx+IShOxEwQZLWlPc9lp8npjOWCGMNTIimcskMuxqbkUfOa0MFIM+hAgNp6ABVwWAOID2hiIdqYwL2vGPonk1A0xDiBarTa2Ha+ASRk6SYgyaywyp5M5uDo1Io5homf7uGtKjoeWGdLI6jUVNHAgXyEWS2JU+mOHKFUrVeqtTqYWQl0mV2W11XMdi60NEo3iaBSeT3dSvT7B1PWZstvIZ6YlGo5+d9zODMxGtdBIHYAAZB4AHEHgAVRTe1hmScZmwQbZTApbINh0bljEOAc-Q7VkFAOQwtA0CiaX-WN2lQYggOIECsXA2CYIggBRAB9egAEloIAOV4gSkOvFCJDQipyLIbhZAcOoPEUQxDAqQdJzUIMtADRx6gMGiFzIejGOYsCIHYV5OKeAAlLiOKsqyHis0THVvaREAqRQ1iqScFBMXydEIoo1FkDR1nKSoVD7KcaWMXw-BAYgWAgOBJD3EIG3E50AFpfSKLKdCDfQlI0HRvQULRPP03UOi6CI+lQ5CiQatyEGCwc1HUdYSsUDsOrDDQ9PitLLn1BFxUwSVURoDKmoku8bA2GT5B5H95AcBwx3azqAr0SKAoDDteSG-NqsPUtywzGam3m-1DFKBxvQCkKKlqQxXzDdYVHI5a9iMCpjmO+dquMwhQMgK7XLSAw21Wcp5CcYN+sHPZjFUIwx20b76R8QGAMFIzmmA0GWIgCHmrSCpA25cjai8Gk7uRhkKS8UqNh2Fwxzi7wgA */
@@ -859,7 +880,7 @@ export const authMachine = createMachine(
                   workspaces: [],
                   pendingUserData: output?.pendingUserData || null,
                   userExistsButRemoved: output?.userExistsButRemoved || false,
-                  error: null,
+                  ...getEnterpriseJoinContext(output),
                 };
               }),
             },
@@ -962,7 +983,7 @@ export const authMachine = createMachine(
                   workspaces: [],
                   pendingUserData: output?.pendingUserData || null,
                   userExistsButRemoved: output?.userExistsButRemoved || false,
-                  error: null,
+                  ...getEnterpriseJoinContext(output),
                 };
               }),
             },
@@ -1046,7 +1067,7 @@ export const authMachine = createMachine(
                   workspaces: [],
                   pendingUserData: output?.pendingUserData || null,
                   userExistsButRemoved: output?.userExistsButRemoved || false,
-                  error: null,
+                  ...getEnterpriseJoinContext(output),
                 };
               }),
             },

--- a/apps/dashboard/src/providers/AuthProvider.tsx
+++ b/apps/dashboard/src/providers/AuthProvider.tsx
@@ -117,17 +117,35 @@ const handleNativeSignInResult = (
     return;
   }
 
-  if (payload.workspaces && payload.workspaces.length > 0 && payload.email) {
+  // Zero workspaces still goes to the machine when the backend reported a domain conflict, so
+  // the enterprise request-to-join UI renders instead of falling through to the session bootstrap.
+  const nativeHasDomainConflict = !!(payload.domainConflictError || payload.publicEmailDomainError);
+  if (
+    payload.email &&
+    ((payload.workspaces && payload.workspaces.length > 0) || nativeHasDomainConflict)
+  ) {
     authActor.send({
       type: 'OAUTH_CALLBACK_COMPLETE',
       output: {
-        workspaces: payload.workspaces as Workspace[],
+        workspaces: (payload.workspaces ?? []) as Workspace[],
         pendingUserData: {
           email: payload.email,
           name: payload.name ?? '',
           ...(payload.picture ? { picture: payload.picture } : {}),
         },
         userExistsButRemoved: payload.userExistsButRemoved || false,
+        ...(payload.domainConflictError
+          ? { domainConflictError: payload.domainConflictError }
+          : {}),
+        ...(payload.publicEmailDomainError
+          ? { publicEmailDomainError: payload.publicEmailDomainError }
+          : {}),
+        ...(payload.enterpriseJoinOrgName
+          ? { enterpriseJoinOrgName: payload.enterpriseJoinOrgName }
+          : {}),
+        ...(payload.enterpriseJoinWorkspaces
+          ? { enterpriseJoinWorkspaces: payload.enterpriseJoinWorkspaces }
+          : {}),
       },
     });
     return;
@@ -278,6 +296,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 ...(data.picture ? { picture: data.picture } : {}),
               },
               userExistsButRemoved: data.userExistsButRemoved || false,
+              ...(data.domainConflictError
+                ? { domainConflictError: data.domainConflictError }
+                : {}),
+              ...(data.publicEmailDomainError
+                ? { publicEmailDomainError: data.publicEmailDomainError }
+                : {}),
+              ...(data.enterpriseJoinOrgName
+                ? { enterpriseJoinOrgName: data.enterpriseJoinOrgName }
+                : {}),
+              ...(data.enterpriseJoinWorkspaces
+                ? { enterpriseJoinWorkspaces: data.enterpriseJoinWorkspaces }
+                : {}),
             },
           });
         } else {

--- a/apps/dashboard/src/utils/electronAuth.ts
+++ b/apps/dashboard/src/utils/electronAuth.ts
@@ -4,6 +4,10 @@ export interface ElectronAuthData {
   name: string;
   picture?: string;
   userExistsButRemoved: boolean;
+  domainConflictError?: string;
+  publicEmailDomainError?: string;
+  enterpriseJoinOrgName?: string;
+  enterpriseJoinWorkspaces?: string;
 }
 
 export const isElectron = (): boolean => {

--- a/apps/dashboard/src/utils/reactNativeBridge.ts
+++ b/apps/dashboard/src/utils/reactNativeBridge.ts
@@ -200,6 +200,10 @@ export interface NativeGoogleSignInResultPayload {
   name?: string;
   picture?: string;
   userExistsButRemoved?: boolean;
+  domainConflictError?: string;
+  publicEmailDomainError?: string;
+  enterpriseJoinOrgName?: string;
+  enterpriseJoinWorkspaces?: string;
 }
 
 export interface NativeMicrosoftSignInResultPayload {
@@ -210,6 +214,10 @@ export interface NativeMicrosoftSignInResultPayload {
   name?: string;
   error?: string;
   errorMessage?: string;
+  domainConflictError?: string;
+  publicEmailDomainError?: string;
+  enterpriseJoinOrgName?: string;
+  enterpriseJoinWorkspaces?: string;
   workspaces?: { id: string; name: string; role: string }[];
   picture?: string;
   userExistsButRemoved?: boolean;

--- a/apps/electron/src/services/deep-links.ts
+++ b/apps/electron/src/services/deep-links.ts
@@ -457,6 +457,12 @@ function exchangeAuthCode(code: string, state: string, invitationId: string | nu
                 name: responseBody.name,
                 picture: responseBody.picture,
                 userExistsButRemoved: responseBody.userExistsButRemoved || false,
+                // Present when the user's email domain already maps to an enterprise org;
+                // the renderer needs these to show request-to-join instead of create-org.
+                domainConflictError: responseBody.domainConflictError,
+                publicEmailDomainError: responseBody.publicEmailDomainError,
+                enterpriseJoinOrgName: responseBody.enterpriseJoinOrgName,
+                enterpriseJoinWorkspaces: responseBody.enterpriseJoinWorkspaces,
               });
               forwardAuthEventToClawOverlay('auth:success');
               mainWindow?.show();


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
