### PR TITLE
feat: XYNE-62467 subscribe/unsubscribe from any message in a thread

### DIFF
--- a/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
+++ b/apps/dashboard/src/components/Chat/ChatBubble/ChatBubble.tsx
@@ -926,6 +926,11 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
     channel?.type !== ChannelType.SUPPORT &&
     (context === 'channel' || context === 'thread');
 
+  const showSubscription =
+    (!isSystemMessage || isTicketCreationMessage || isCallMessage) &&
+    (!isMessageDeleted || context === 'channel') &&
+    (context === 'thread' || (!!replies?.onOpenThread && !isShowInChannel));
+
   const shouldEnableMobileThreadOpen =
     isMobile &&
     (!isSystemMessage || isTicketCreationMessage || isCallMessage) &&
@@ -1069,6 +1074,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
         (!isMessageDeleted || context === 'channel') && {
           onReplyInThread: replies.onOpenThread,
         }),
+      showSubscription,
       ...(!isSystemMessage &&
         !isMessageDeleted && {
           onInitiateCall: handleInitiateCall,
@@ -1403,6 +1409,7 @@ export const ChatBubble: React.FC<ChatBubbleProps> = ({
                     replies?.onOpenThread?.(e);
                   },
                 })}
+              showSubscription={showSubscription}
               {...(!isSystemMessage &&
                 !isMessageDeleted && {
                   onInitiateCall: handleInitiateCall,

--- a/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
+++ b/apps/dashboard/src/components/Chat/HoverActionsToolbar/HoverActionsToolbar.tsx
@@ -67,6 +67,7 @@ export interface HoverActionsToolbarProps {
   showEditAction?: boolean;
   reactionsMd?: string | null;
   onReplyInThread?: (e?: React.MouseEvent) => void;
+  showSubscription?: boolean;
   onCreateTicket?: () => void;
   onCreateSubTicket?: () => void;
   onEditMessage?: () => void;
@@ -125,6 +126,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
   showEditAction = false,
   reactionsMd,
   onReplyInThread,
+  showSubscription,
   onCreateTicket,
   onCreateSubTicket,
   onEditMessage,
@@ -187,7 +189,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
     onRemindMeOption ||
     onForwardMessage ||
     (messageShortcuts && messageShortcuts.length > 0) ||
-    (onReplyInThread && conversationId);
+    (showSubscription && conversationId);
 
   // Keep toolbar visible if dropdown is open, even if parent says to hide
   if (!isVisible && !isDropdownOpen) return null;
@@ -384,7 +386,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
             {(() => {
               const hasEditSection = (showEditAction && onEditMessage) || onSendToChannel;
               const hasSubscriptionSection =
-                (onReplyInThread && conversationId) ||
+                (showSubscription && conversationId) ||
                 onMarkAsUnread ||
                 onBookmark ||
                 onRemindMeOption ||
@@ -430,7 +432,7 @@ export const HoverActionsToolbar: React.FC<HoverActionsToolbarProps> = ({
                   {hasEditSection && hasSubscriptionSection && <DropdownMenuSeparator />}
 
                   {/* Conversation Subscription */}
-                  {isDropdownOpen && onReplyInThread && conversationId && (
+                  {isDropdownOpen && showSubscription && conversationId && (
                     <DropdownMenuItem asChild>
                       <ConversationSubscription
                         conversationId={conversationId}

--- a/apps/dashboard/src/components/Chat/MessageActionsDrawer/MessageActionsDrawer.tsx
+++ b/apps/dashboard/src/components/Chat/MessageActionsDrawer/MessageActionsDrawer.tsx
@@ -43,6 +43,7 @@ export interface MessageActionsDrawerProps {
   showEditAction?: boolean;
   reactionsMd?: string | null;
   onReplyInThread?: (e?: React.MouseEvent) => void;
+  showSubscription?: boolean;
   onCreateTicket?: () => void;
   onEditMessage?: () => void;
   onDeleteMessage?: () => void;
@@ -77,6 +78,7 @@ export const MessageActionsDrawer: React.FC<MessageActionsDrawerProps> = ({
   showEditAction = false,
   reactionsMd,
   onReplyInThread,
+  showSubscription,
   onCreateTicket,
   onEditMessage,
   onDeleteMessage,
@@ -338,7 +340,7 @@ export const MessageActionsDrawer: React.FC<MessageActionsDrawerProps> = ({
                   )}
 
                   {/* Conversation Subscription */}
-                  {open && onReplyInThread && conversationId && (
+                  {open && showSubscription && conversationId && (
                     <ConversationSubscription
                       conversationId={conversationId}
                       {...(conversation && { conversation })}


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-62467 — Users should be able to subscribe/unsubscribe from any message within a thread, not just the first message.

The "Subscribe / Unsubscribe from notifications" entry in the message hover dropdown (`HoverActionsToolbar`) and the mobile long-press drawer (`MessageActionsDrawer`) was gated on the message also having a "Reply in thread" action. Thread replies never get that action, and the thread panel does not pass `replies` to any bubble, so no message inside a thread (root included) showed the toggle.

`ChatBubble` now computes a dedicated `showSubscription` flag and both surfaces gate on it:
- **Thread context:** true for every non-system, non-deleted message (root and replies).
- **Channel context:** term-for-term identical to the previous condition, so channel behaviour is unchanged.

No backend changes. `subscribeToConversation` / `unsubscribeFromConversation` are already conversation-scoped, every reply carries the thread's `conversationId`, and the thread header bell reads the same live query, so toggling from any reply updates the header bell reactively.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

- Dashboard `typecheck`, `lint:errors-only`, `format:check`, and full `vite build` pass. ESLint warnings on the touched files are pre-existing baseline (diffed against a stashed run).
- Static trace of all six `ChatBubble` render sites: channel list, pins, and search results behave exactly as before; both `ThreadList` bubbles (root and replies) now receive the flag.
- Verified the reply's `conversationId` resolves to the thread's own conversation (never a nested child), so the mutator hits the same `conversation_participants` row as the header bell.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- UI gating change; no existing spec asserts the subscription item in threads -->

### Manual

**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev (`pnpm run dev:all`)

**Surface & data**
- [x] Web browser

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XapnA5SMYkGLbXhFkj6r4m
