### PR TITLE
feat: XYNE-62812 google calendar event push

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -164,6 +164,7 @@ import { modelSyncQueue } from '@/queues/modelSyncQueue';
 import { presenceCleanupQueue } from '@/queues/presenceCleanupQueue';
 import { microsoftCalendarSyncQueue } from '@/queues/microsoftCalendarSyncQueue';
 import { googleCalendarSyncQueue } from '@/queues/googleCalendarSyncQueue';
+import { callCalendarPushQueue } from '@/queues/callCalendarPushQueue';
 import { warmUserRegistryQueue } from '@/queues/warmUserRegistryQueue';
 import { watchRenewalQueue } from '@/pubsub';
 import { etaDeadlineQueue } from '@/queues/etaDeadlineQueue';
@@ -984,6 +985,11 @@ export class App {
     logger.info('Initializing Google Calendar sync queue (producer)...');
     await googleCalendarSyncQueue.initialize();
 
+    // Outbound side of the same story: scheduling a call here enqueues a push
+    // onto the organizer's calendar, drained by the worker.
+    logger.info('Initializing call calendar push queue (producer)...');
+    await callCalendarPushQueue.initialize();
+
     // Initialize unified watch renewal queue (replaces Gmail + Calendar renewal queues)
     logger.info('Initializing unified watch renewal queue...');
     await watchRenewalQueue.initialize();
@@ -1114,6 +1120,7 @@ export class App {
       // Close calendar sync queues
       await microsoftCalendarSyncQueue.close();
       await googleCalendarSyncQueue.close();
+      await callCalendarPushQueue.close();
       await watchRenewalQueue.close();
 
       // Close warm user registry queue

--- a/apps/backend/src/controllers/scheduleCallController.ts
+++ b/apps/backend/src/controllers/scheduleCallController.ts
@@ -18,6 +18,7 @@ import {
   sendCallInvitationReply,
 } from '@/services/callInvitationEmailService';
 import { CallVespaFeedSource, queueCallVespaFeed } from '@/services/callVespaQueue';
+import { queueCallCalendarPush, queueCallCalendarPushMany } from '@/queues/callCalendarPushQueue';
 import { buildCallInviteUrl } from '@/utils/urlUtils';
 
 // Number of milliseconds to buffer recurring call instances ahead of time (60 days)
@@ -441,6 +442,10 @@ export class ScheduleCallController {
 
       queueCallVespaFeed(callId, { source: CallVespaFeedSource.ScheduleCallControllerCreateScheduledCall });
 
+      // Put the call on the organizer's Google Calendar (and, as attendees, on
+      // every participant's) so it is visible to people who never open Xyne.
+      queueCallCalendarPush(callId, 'scheduleCall');
+
       // Send immediate notifications + create activities for all participants (excluding organizer)
       try {
         await scheduledCallNotificationService.sendScheduledCallNotifications({
@@ -670,6 +675,8 @@ export class ScheduleCallController {
       });
 
       logger.info(`[updateScheduledCall] repo update complete | callId=${call.id} resolvedChannelId=${resolvedChannelId}`);
+
+      queueCallCalendarPush(call.id, 'updateScheduledCall');
 
       if (newlyAddedExternalInvitees.length > 0) {
         const inviteStartsAt = updatedCall.startsAt ?? call.startsAt;
@@ -1107,6 +1114,14 @@ export class ScheduleCallController {
             });
           }
         }
+
+        // Title / time / participant edits cascaded above; mirror them out.
+        // (The regeneration branch is covered by recurringCallService, which
+        // pushes the new instances and withdraws the superseded ones.)
+        queueCallCalendarPushMany(
+          allScheduledInstances.map((instance) => instance.id),
+          'updateRecurringSeries',
+        );
       }
 
       if (newlyAddedExternalInvitees.length > 0) {
@@ -1222,6 +1237,9 @@ export class ScheduleCallController {
 
       // Mark the instance as CANCELLED (preserve record)
       await repositories.scheduledCalls.cancelCall(call.id);
+
+      // Withdraw the mirrored calendar event so attendees' calendars clear too.
+      queueCallCalendarPush(call.id, 'cancelScheduledCall');
 
       logger.info(`Call ${externalId} cancelled by organizer ${userId}`);
 

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -32,6 +32,28 @@ function parseRecordingParticipantIds(stored: string | null): string[] {
 }
 
 /**
+ * The outbound mirror of a Call on the organizer's Google Calendar, recorded
+ * under `calls.metadata.googleCalendarPush`. Absent until the call has been
+ * pushed; removed again when the remote event is deleted.
+ */
+export type GoogleCalendarPushState = {
+  /** Google's event id on the organizer's primary calendar. */
+  eventId: string;
+  /** ExternalSource the event was written through, so a reconnect is detectable. */
+  sourceId: string;
+  /** Organizer whose calendar owns the event — the only account allowed to edit it. */
+  organizerUserId: string;
+  /**
+   * Digest of the event body last written. A reconcile whose payload hashes to
+   * this skips the PATCH entirely — Google emails every attendee on an event
+   * update, so a no-op write is not free.
+   */
+  contentHash: string;
+  htmlLink?: string;
+  syncedAt: string;
+};
+
+/**
  * Shape of `calls.metadata` as written by this repository.
  * `artifactMessageId` is set only for calls started from a slash-command
  * artifact card, and links the call back to the message that owns it.
@@ -40,6 +62,7 @@ export interface CallMetadata {
   systemMessageId?: string;
   conversationId?: string;
   artifactMessageId?: string;
+  googleCalendarPush?: GoogleCalendarPushState;
 }
 
 const getArtifactMessageId = (metadata: Prisma.JsonValue | null): string | undefined =>
@@ -767,6 +790,88 @@ export class CallRepository {
     return participants
       .map(p => p.email)
       .filter((email): email is string => Boolean(email));
+  }
+
+  /**
+   * Everything the outbound Google Calendar push needs to mirror a call, in a
+   * single query. Not `findByExternalId`: the push job runs outside any tenant
+   * scope and knows only a call id, so it reads the row's own `workspaceId`
+   * here and opens a scope with it before doing anything else.
+   */
+  async findForCalendarPush(callId: string): Promise<{
+    id: string;
+    externalId: string;
+    workspaceId: string;
+    title: string | null;
+    description: string | null;
+    status: string;
+    callOrigin: string;
+    createdByUserId: string;
+    roomLink: string | null;
+    startsAt: Date | null;
+    endsAt: Date | null;
+    timezone: string;
+    metadata: Prisma.JsonValue | null;
+    updatedAt: Date;
+  } | null> {
+    return await DatabaseClient.getInstance().call.findUnique({
+      where: { id: callId },
+      select: {
+        id: true,
+        externalId: true,
+        workspaceId: true,
+        title: true,
+        description: true,
+        status: true,
+        callOrigin: true,
+        createdByUserId: true,
+        roomLink: true,
+        startsAt: true,
+        endsAt: true,
+        timezone: true,
+        metadata: true,
+        updatedAt: true,
+      },
+    });
+  }
+
+  /** `updatedAt` alone, to detect a call edited while a push job was running. */
+  async findCalendarPushRevision(callId: string): Promise<Date | null> {
+    const row = await DatabaseClient.getInstance().call.findUnique({
+      where: { id: callId },
+      select: { updatedAt: true },
+    });
+    return row?.updatedAt ?? null;
+  }
+
+  /**
+   * Record (or clear) the Google Calendar event this call is mirrored to.
+   *
+   * Written as a jsonb merge rather than a read-modify-write of the whole
+   * column: `calls.metadata` also carries `systemMessageId` / `conversationId`
+   * written by unrelated flows, and a push job that round-tripped the object
+   * would silently drop whichever of those landed in between.
+   */
+  async setGoogleCalendarPushState(
+    callId: string,
+    state: GoogleCalendarPushState | null,
+  ): Promise<void> {
+    const db = DatabaseClient.getInstance();
+
+    if (state === null) {
+      await db.$executeRaw`
+        UPDATE "calls"
+        SET "metadata" = COALESCE("metadata", '{}'::jsonb) - 'googleCalendarPush'
+        WHERE "id" = ${callId}
+      `;
+      return;
+    }
+
+    await db.$executeRaw`
+      UPDATE "calls"
+      SET "metadata" = COALESCE("metadata", '{}'::jsonb) || ${JSON.stringify({ googleCalendarPush: state })}::jsonb
+      WHERE "id" = ${callId}
+    `;
   }
 
   /**

--- a/apps/backend/src/database/repositories/users.ts
+++ b/apps/backend/src/database/repositories/users.ts
@@ -454,4 +454,19 @@ export class UserRepository extends BaseRepository<User, CreateUserInput, Update
       select: { id: true, name: true, displayName: true },
     });
   }
+
+  /**
+   * Emails for a set of user ids, in one query. Used when a fan-out needs to
+   * address people outside Xyne — e.g. building the attendee list for a
+   * Google Calendar invite. Only ACTIVE members who have not left are
+   * returned, so a departed teammate is never re-invited.
+   */
+  async getEmailsByIds(userIds: string[]): Promise<Array<{ id: string; email: string }>> {
+    if (userIds.length === 0) return [];
+
+    return await this.db.user.findMany({
+      where: { id: { in: userIds }, status: UserStatus.ACTIVE, leftAt: null },
+      select: { id: true, email: true },
+    });
+  }
 }

--- a/apps/backend/src/queues/callCalendarPushQueue.ts
+++ b/apps/backend/src/queues/callCalendarPushQueue.ts
@@ -1,0 +1,172 @@
+/**
+ * Call → Google Calendar Push Queue
+ *
+ * Keeps the outbound push off the request path. Scheduling, editing or
+ * cancelling a call enqueues one job; the job reconciles the organizer's
+ * Google Calendar with the call's current state (see callCalendarPushService).
+ *
+ * Because the job is a reconciler rather than a command, the jobId is
+ * deterministic per call: a burst of edits collapses into one run that reads
+ * the final state, and — more importantly — two workers can never both decide
+ * a call has no event yet and create two. The cost of that serialisation is a
+ * narrow window where an edit landing mid-run is dropped, so the processor
+ * re-reads the call's revision afterwards and re-enqueues if it moved.
+ *
+ * Drains in the worker process only (ENABLE_CALENDAR_SYNC_WORKER, the same
+ * flag as the inbound calendar sync); the API is a pure producer.
+ */
+
+import Bull from 'bull';
+import { redisService } from '@/services/redisService';
+import { logger } from '@/utils/logger';
+import { repositories } from '@/database/repositories';
+import { runAsSystem } from '@/database/tenant/context';
+import { syncCallToGoogleCalendar } from '@/services/callCalendarPushService';
+
+const TAG = '[CALENDAR_PUSH][QUEUE]';
+
+/** Lets a burst of edits to one call coalesce into a single reconcile. */
+const PUSH_COALESCE_DELAY_MS = 1_500;
+
+type CallCalendarPushJobData = {
+  callId: string;
+  /** Set on the follow-up job scheduled when a call was edited mid-run. */
+  isFollowUp?: boolean;
+};
+
+function pushJobId(callId: string, suffix?: string): string {
+  return suffix ? `call-calendar-push-${callId}-${suffix}` : `call-calendar-push-${callId}`;
+}
+
+/**
+ * Bull refuses to create a job whose id matches one sitting in a terminal
+ * state that has not been removed. Our ids are deterministic per call, so a
+ * single exhausted-retries failure would otherwise block that call from ever
+ * pushing again. Clear the dead job before re-adding.
+ */
+async function clearDeadJobForReenqueue(queue: Bull.Queue, jobId: string): Promise<void> {
+  try {
+    const existing = await queue.getJob(jobId);
+    if (!existing) return;
+    if ((await existing.isFailed()) || (await existing.isCompleted())) {
+      await existing.remove();
+      logger.warn(`${TAG} Cleared stale job before re-enqueue`, { jobId });
+    }
+  } catch (err) {
+    logger.warn(`${TAG} Failed to check/clear stale job before re-enqueue`, {
+      jobId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+class CallCalendarPushQueue {
+  private queue: Bull.Queue | null = null;
+  private processorRegistered = false;
+
+  private async ensureQueue(): Promise<Bull.Queue> {
+    if (this.queue) return this.queue;
+
+    this.queue = new Bull('call-calendar-push', {
+      redis: {
+        ...redisService.getRedisConfig(),
+        lazyConnect: false,
+      },
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 5_000 },
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    });
+
+    return this.queue;
+  }
+
+  /** Producer-side setup, called in both the API and the worker. */
+  async initialize(): Promise<void> {
+    await this.ensureQueue();
+    logger.info(`${TAG} Push queue initialized (producer)`);
+  }
+
+  /** Register the processor. Worker process only; call after initialize(). */
+  async startProcessing(): Promise<void> {
+    const queue = await this.ensureQueue();
+    if (this.processorRegistered) return;
+
+    // Concurrency 1: deterministic job ids already serialise per call, and a
+    // single Google account is the bottleneck for every call it organizes.
+    queue.process('sync-call', async (job) => {
+      const { callId, isFollowUp } = job.data as CallCalendarPushJobData;
+      const reconciledAt = await syncCallToGoogleCalendar(callId);
+      if (!reconciledAt) return;
+
+      // A follow-up already covers one missed edit; chaining further would
+      // let a steadily-edited call re-enqueue itself indefinitely.
+      if (isFollowUp) return;
+
+      const current = await runAsSystem(() =>
+        repositories.calls.findCalendarPushRevision(callId),
+      );
+      if (!current || current.getTime() === reconciledAt.getTime()) return;
+
+      logger.info(`${TAG} Call changed while pushing; scheduling follow-up`, { callId });
+      const followUpId = pushJobId(callId, 'followup');
+      await clearDeadJobForReenqueue(queue, followUpId);
+      await queue.add(
+        'sync-call',
+        { callId, isFollowUp: true },
+        { jobId: followUpId, delay: PUSH_COALESCE_DELAY_MS },
+      );
+    });
+
+    queue.on('failed', (job, err) => {
+      logger.error(`${TAG} Push job failed`, {
+        jobId: job.id,
+        callId: job.data?.callId,
+        error: err.message,
+      });
+    });
+
+    this.processorRegistered = true;
+    logger.info(`${TAG} Push queue processor registered`);
+  }
+
+  async enqueueSync(callId: string): Promise<void> {
+    const queue = await this.ensureQueue();
+    const jobId = pushJobId(callId);
+    await clearDeadJobForReenqueue(queue, jobId);
+    await queue.add('sync-call', { callId }, { jobId, delay: PUSH_COALESCE_DELAY_MS });
+  }
+
+  async close(): Promise<void> {
+    if (this.queue) {
+      await this.queue.close();
+      this.queue = null;
+      this.processorRegistered = false;
+    }
+  }
+}
+
+export const callCalendarPushQueue = new CallCalendarPushQueue();
+
+/**
+ * Mirror a call onto the organizer's Google Calendar, in the background.
+ *
+ * Fire-and-forget by design: the calendar copy is a projection of the call,
+ * so a Redis hiccup must never fail the scheduling request that produced it.
+ */
+export function queueCallCalendarPush(callId: string, context: string): void {
+  void callCalendarPushQueue.enqueueSync(callId).catch((err) => {
+    logger.error(`${TAG} Failed to enqueue push`, {
+      callId,
+      context,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+}
+
+/** Enqueue a push for several calls — a recurring series' materialized instances. */
+export function queueCallCalendarPushMany(callIds: string[], context: string): void {
+  for (const callId of callIds) queueCallCalendarPush(callId, context);
+}

--- a/apps/backend/src/services/calendarConferencePatcher.ts
+++ b/apps/backend/src/services/calendarConferencePatcher.ts
@@ -23,21 +23,13 @@ import {
   patchGoogleEvent,
   GoogleCalendarPatchConflictError,
 } from '@/services/googleCalendarApi';
+import { escapeHtmlAttribute } from '@/services/calendarEventPayload';
 import { logger } from '@/utils/logger';
 
 const TAG = '[CALENDAR_SYNC][GOOGLE][CONFERENCE_PATCHER]';
 
 const MANAGED_DESCRIPTION_START = '<!-- xyne-call:start -->';
 const MANAGED_DESCRIPTION_END = '<!-- xyne-call:end -->';
-
-/** Escapes a URL for safe use inside an HTML attribute in the event description. */
-export function escapeHtmlAttribute(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
 
 function buildManagedBlock(roomLink: string): string {
   // Google Calendar's description field renders a small safe subset of HTML

--- a/apps/backend/src/services/calendarEventPayload.ts
+++ b/apps/backend/src/services/calendarEventPayload.ts
@@ -1,0 +1,99 @@
+/**
+ * Calendar Event Payload (pure)
+ *
+ * The shared, I/O-free vocabulary for the two directions of calendar
+ * integration: how Xyne marks an event as its own, how a join link is rendered
+ * into a description, and what body is written when a Xyne-scheduled call is
+ * pushed out to Google.
+ *
+ * Deliberately free of database, network and config imports so both the
+ * inbound sync and the outbound push can depend on it without either dragging
+ * in the other.
+ */
+
+import { createHash } from 'crypto';
+
+/**
+ * Value of `extendedProperties.private.xyneOrigin` on a Calendar event that
+ * Xyne created by pushing an internally scheduled call outward
+ * (see callCalendarPushService).
+ *
+ * It is the loop-breaker for the two inbound passes. Both the sync (which
+ * would mint a second, calendar-origin Call for an event Xyne already has a
+ * Call for) and the link injector (which would treat it as a foreign event
+ * needing a Xyne link grafted on) must leave these events alone. Xyne is the
+ * source of truth for them; the calendar copy is the mirror, not the original.
+ */
+export const XYNE_CALENDAR_ORIGIN_VALUE = 'xyne';
+
+/** True when this event is Xyne's own outbound mirror of a scheduled call. */
+export function isXyneOriginatedEvent(
+  privateProperties: Record<string, string> | undefined
+): boolean {
+  return privateProperties?.xyneOrigin === XYNE_CALENDAR_ORIGIN_VALUE;
+}
+
+/** Escapes a URL for safe use inside an HTML attribute in the event description. */
+export function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export interface GoogleEventBodyParams {
+  title: string;
+  /** Organizer-authored agenda, if any. Rendered above the join block. */
+  description?: string | null;
+  roomLink: string;
+  startsAt: Date;
+  endsAt: Date;
+  timezone: string;
+  attendeeEmails: string[];
+  callId: string;
+  callExternalId: string;
+}
+
+/**
+ * Google Calendar renders a small safe subset of HTML in the description on
+ * both web and mobile, so the join link shows as a clickable "Join Xyne Call"
+ * rather than a pasted URL — matching what the inbound link injector writes.
+ */
+function buildEventDescription(description: string | null | undefined, roomLink: string): string {
+  const joinBlock = `<b>𝓧  <a href="${escapeHtmlAttribute(roomLink)}">Join Xyne Call</a></b>`;
+  const agenda = description?.trim();
+  return agenda ? `${agenda}\n\n${joinBlock}` : joinBlock;
+}
+
+/**
+ * The Google event body for a Xyne-scheduled call.
+ *
+ * `extendedProperties.private.xyneOrigin` is what keeps the push from feeding
+ * itself: the inbound sync and the link injector both skip events carrying it,
+ * so the event this creates never comes back around as a second Call.
+ */
+export function buildGoogleEventBody(params: GoogleEventBodyParams): Record<string, unknown> {
+  return {
+    summary: params.title,
+    description: buildEventDescription(params.description, params.roomLink),
+    start: { dateTime: params.startsAt.toISOString(), timeZone: params.timezone },
+    end: { dateTime: params.endsAt.toISOString(), timeZone: params.timezone },
+    attendees: params.attendeeEmails.map((email) => ({ email })),
+    extendedProperties: {
+      private: {
+        xyneOrigin: XYNE_CALENDAR_ORIGIN_VALUE,
+        xyneManaged: 'true',
+        xyneCallId: params.callId,
+        xyneCallExternalId: params.callExternalId,
+        xyneRoomLink: params.roomLink,
+      },
+    },
+    reminders: { useDefault: true },
+  };
+}
+
+/** Digest of the exact payload written to Google, used to skip no-op updates. */
+export function hashEventBody(body: Record<string, unknown>): string {
+  return createHash('sha1').update(JSON.stringify(body)).digest('hex');
+}

--- a/apps/backend/src/services/callCalendarPushService.ts
+++ b/apps/backend/src/services/callCalendarPushService.ts
@@ -1,0 +1,271 @@
+/**
+ * Outbound Google Calendar Push (Xyne → Calendar)
+ *
+ * The mirror image of the inbound calendar sync. A call scheduled inside Xyne
+ * exists only in Xyne, so it never appears on anyone's calendar — people don't
+ * join a pre-scheduled call they were never blocked out for. This service
+ * writes such a call onto the ORGANIZER's primary Google Calendar with every
+ * participant as an attendee, so Google fans the invite out to internal
+ * members and external invitees alike, including people who never connected
+ * Xyne.
+ *
+ * Reconciliation, not commands: `syncCallToGoogleCalendar(callId)` reads the
+ * call's current state and makes Google match it, so the same job is safe to
+ * run on create, on edit, on cancel, and on retry.
+ *   SCHEDULED   → create the event, or patch the one already pushed
+ *   CANCELLED   → delete the event and forget its id
+ *   ACTIVE/ENDED→ leave Google alone; the meeting is happening or happened,
+ *                 and yanking it off calendars mid-call helps nobody
+ *
+ * Gating (PRD "whoever has an active source"): the organizer must have an
+ * ACTIVE Google calendar ExternalSource. No source means no push and no error
+ * — the call still lives in Xyne exactly as it does today.
+ *
+ * Only Xyne-native calls are pushed. A call whose origin is already a calendar
+ * (GOOGLE_CALENDAR / MICROSOFT_CALENDAR) came FROM that calendar; pushing it
+ * back would duplicate the event it was derived from.
+ */
+
+import { AuthProvider, CallOrigin, CallStatus } from '@xyne/shared';
+import { repositories } from '@/database/repositories';
+import type {
+  CallMetadata,
+  GoogleCalendarPushState,
+} from '@/database/repositories/callRepository';
+import { getCalendarCredentialsBySourceId } from '@/services/calendarTokenRefresh';
+import {
+  deleteGoogleEvent,
+  insertGoogleEvent,
+  patchGoogleEvent,
+  GoogleCalendarEventGoneError,
+} from '@/services/googleCalendarApi';
+import { buildGoogleEventBody, hashEventBody } from '@/services/calendarEventPayload';
+import { normalizeCalendarOwnerEmail } from '@/services/calendarCallStore.utils';
+import { runAsServiceActor, runAsSystem } from '@/database/tenant/context';
+import { buildCallInviteUrl } from '@/utils/urlUtils';
+import { logger } from '@/utils/logger';
+
+const TAG = '[CALENDAR_PUSH][GOOGLE]';
+
+/** Origins that Xyne owns end-to-end, and may therefore mirror outward. */
+const PUSHABLE_ORIGINS = new Set<string>([CallOrigin.CHANNEL, CallOrigin.CONVERSATION]);
+
+/**
+ * Attendees for the invite: every internal participant plus every external
+ * invitee, minus the organizer (Google puts them on the event as its owner).
+ * Deduped case-insensitively so a member invited both by channel membership
+ * and by email address is not listed twice.
+ */
+async function resolveAttendeeEmails(callId: string, organizerEmail: string): Promise<string[]> {
+  const [participants, externalEmails] = await Promise.all([
+    repositories.calls.findParticipants(callId),
+    repositories.calls.findExternalInviteeEmails(callId),
+  ]);
+
+  const internalUsers = await repositories.users.getEmailsByIds(
+    participants.map((p) => p.userId),
+  );
+
+  const organizer = normalizeCalendarOwnerEmail(organizerEmail);
+  const seen = new Set<string>([organizer]);
+  const attendees: string[] = [];
+
+  for (const email of [...internalUsers.map((u) => u.email), ...externalEmails]) {
+    const normalized = normalizeCalendarOwnerEmail(email);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    attendees.push(normalized);
+  }
+
+  // Sorted so an unchanged guest list always produces the same event body,
+  // and therefore the same content hash, whatever order the rows came back in.
+  return attendees.sort();
+}
+
+/**
+ * The organizer's ACTIVE Google calendar connection, with a fresh access
+ * token. Null when they never connected, disconnected, or the source was
+ * deactivated by a permanent auth failure — all of which mean "don't push".
+ */
+async function resolveOrganizerCredentials(organizerUserId: string) {
+  const source = await repositories.externalSources.findCalendarSourceByOwner(
+    organizerUserId,
+    'GOOGLE',
+  );
+
+  if (!source) return null;
+  if (!source.isActive) {
+    logger.info(`${TAG} Organizer's Google calendar source is inactive; skipping push`, {
+      organizerUserId,
+      sourceId: source.id,
+    });
+    return null;
+  }
+
+  const credentials = await getCalendarCredentialsBySourceId(source.id, AuthProvider.GOOGLE);
+  if (!credentials) {
+    logger.warn(`${TAG} No usable Google credentials for organizer; skipping push`, {
+      organizerUserId,
+      sourceId: source.id,
+    });
+    return null;
+  }
+
+  return { sourceId: source.id, credentials };
+}
+
+/** Remove the mirrored event, then forget it so a later re-push starts clean. */
+async function removePushedEvent(
+  callId: string,
+  pushState: GoogleCalendarPushState,
+  organizerUserId: string,
+): Promise<void> {
+  const resolved = await resolveOrganizerCredentials(organizerUserId);
+
+  if (!resolved) {
+    // Without a live connection the event cannot be withdrawn from Google.
+    // Keep the stored id: if the organizer reconnects, the next sync for this
+    // call still knows which event to delete.
+    logger.warn(`${TAG} Cannot delete pushed event — organizer has no active source`, {
+      callId,
+      eventId: pushState.eventId,
+    });
+    return;
+  }
+
+  await deleteGoogleEvent(resolved.credentials.accessToken, pushState.eventId, {
+    sendUpdates: 'all',
+  });
+  await repositories.calls.setGoogleCalendarPushState(callId, null);
+
+  logger.info(`${TAG} Deleted pushed event`, { callId, eventId: pushState.eventId });
+}
+
+/**
+ * Make the organizer's Google Calendar match this call's current state.
+ * Safe to call repeatedly; safe to call for calls that will never push.
+ *
+ * Returns the `updatedAt` of the row it reconciled against, so a caller can
+ * tell whether the call was edited again while this ran, or null when there
+ * was no such row.
+ */
+export async function syncCallToGoogleCalendar(callId: string): Promise<Date | null> {
+  // The job carries only a call id, so the row's own workspaceId is read
+  // cross-workspace first and every later query runs inside that scope.
+  const call = await runAsSystem(() => repositories.calls.findForCalendarPush(callId));
+
+  if (!call) {
+    logger.warn(`${TAG} Call not found; nothing to sync`, { callId });
+    return null;
+  }
+
+  if (!PUSHABLE_ORIGINS.has(call.callOrigin)) return call.updatedAt;
+
+  await runAsServiceActor(call.createdByUserId, call.workspaceId, async () => {
+    const pushState = (call.metadata as CallMetadata | null)?.googleCalendarPush ?? null;
+
+    if (call.status === CallStatus.CANCELLED) {
+      if (pushState) await removePushedEvent(call.id, pushState, call.createdByUserId);
+      return;
+    }
+
+    // Only a still-scheduled call is written or rewritten. Once it is live or
+    // over, the calendar entry stays exactly as the attendees last saw it.
+    if (call.status !== CallStatus.SCHEDULED) return;
+
+    if (!call.startsAt || !call.endsAt) {
+      logger.info(`${TAG} Call has no start/end; nothing to put on a calendar`, { callId });
+      return;
+    }
+
+    const organizer = await repositories.users.findById(call.createdByUserId);
+    if (!organizer?.email) {
+      logger.warn(`${TAG} Organizer has no email; skipping push`, {
+        callId,
+        organizerUserId: call.createdByUserId,
+      });
+      return;
+    }
+
+    const resolved = await resolveOrganizerCredentials(call.createdByUserId);
+    if (!resolved) return;
+
+    const attendeeEmails = await resolveAttendeeEmails(call.id, organizer.email);
+    const body = buildGoogleEventBody({
+      title: call.title ?? 'Xyne Call',
+      description: call.description,
+      // Every scheduled call is created with a roomLink; derive it from the
+      // public id rather than emit a dead "Join" link if one is ever missing.
+      roomLink: call.roomLink ?? buildCallInviteUrl(call.externalId),
+      startsAt: call.startsAt,
+      endsAt: call.endsAt,
+      timezone: call.timezone,
+      attendeeEmails,
+      callId: call.id,
+      callExternalId: call.externalId,
+    });
+
+    const contentHash = hashEventBody(body);
+
+    // Nothing about the event changed since the last push. Returning here is
+    // not just an optimisation: `sendUpdates: 'all'` makes Google email every
+    // attendee on an update, and reconciles run for reasons that have nothing
+    // to do with the calendar (a series cascade, a buffer replenishment, a
+    // retry). Those must not surface as "this meeting changed".
+    if (pushState?.eventId && pushState.contentHash === contentHash) {
+      logger.info(`${TAG} Event already matches call; skipping update`, {
+        callId,
+        eventId: pushState.eventId,
+      });
+      return;
+    }
+
+    // sendUpdates:'all' on every write — unlike the inbound reconciler these
+    // ARE the organizer's own changes, so invitees should be told about them.
+    let event;
+    if (pushState?.eventId) {
+      try {
+        event = await patchGoogleEvent(resolved.credentials.accessToken, pushState.eventId, body, {
+          sendUpdates: 'all',
+        });
+      } catch (err) {
+        if (!(err instanceof GoogleCalendarEventGoneError)) throw err;
+        // Someone deleted the event straight from Google. Re-create it rather
+        // than leaving the call permanently invisible on their calendar.
+        logger.warn(`${TAG} Pushed event vanished; re-creating`, {
+          callId,
+          eventId: pushState.eventId,
+        });
+        event = await insertGoogleEvent(resolved.credentials.accessToken, body, {
+          sendUpdates: 'all',
+        });
+      }
+    } else {
+      event = await insertGoogleEvent(resolved.credentials.accessToken, body, {
+        sendUpdates: 'all',
+      });
+    }
+
+    if (!event.id) {
+      throw new Error(`Google returned an event without an id for call ${callId}`);
+    }
+
+    await repositories.calls.setGoogleCalendarPushState(call.id, {
+      eventId: event.id,
+      sourceId: resolved.sourceId,
+      organizerUserId: call.createdByUserId,
+      contentHash,
+      ...(event.htmlLink ? { htmlLink: event.htmlLink } : {}),
+      syncedAt: new Date().toISOString(),
+    });
+
+    logger.info(`${TAG} Pushed call to organizer's calendar`, {
+      callId,
+      eventId: event.id,
+      attendees: attendeeEmails.length,
+      created: !pushState?.eventId,
+    });
+  });
+
+  return call.updatedAt;
+}

--- a/apps/backend/src/services/googleCalendarApi.ts
+++ b/apps/backend/src/services/googleCalendarApi.ts
@@ -18,6 +18,22 @@ export class GoogleCalendarPatchConflictError extends Error {
   }
 }
 
+/**
+ * Thrown when the event no longer exists on Google (404) or was already
+ * deleted (410). Callers that mirror a Xyne row onto Calendar treat this as
+ * "the remote copy is gone" and either re-create it or drop their stored
+ * event id, rather than failing the job forever.
+ */
+export class GoogleCalendarEventGoneError extends Error {
+  constructor(eventId: string) {
+    super(`Google Calendar event ${eventId} no longer exists`);
+    this.name = 'GoogleCalendarEventGoneError';
+  }
+}
+
+/** Who Google emails when a write changes an event. */
+export type GoogleSendUpdates = 'all' | 'externalOnly' | 'none';
+
 export async function getGoogleEventById(accessToken: string, eventId: string): Promise<GCalEvent> {
   const res = await fetch(
     `https://www.googleapis.com/calendar/v3/calendars/primary/events/${encodeURIComponent(eventId)}`,
@@ -38,20 +54,24 @@ export async function getGoogleEventById(accessToken: string, eventId: string): 
 /**
  * PATCH a single Google Calendar event owned by the connected (organizer)
  * user. Used by the Xyne Call Link Auto-Injection reconciler to replace/inject
- * the conference entry and description block. Callers own retry-on-conflict
+ * the conference entry and description block, and by the outbound push to
+ * update an event Xyne itself created. Callers own retry-on-conflict
  * decisions; this function only performs the network call and surfaces a
  * typed error for 412 so callers can distinguish "stale etag, re-evaluate
  * once" from other failures.
+ *
+ * `sendUpdates` defaults to 'none': the reconciler is a background pass, not
+ * an organizer-authored change, so it must not email attendees. The outbound
+ * push passes 'all' because there the edit *is* the organizer's own.
  */
 export async function patchGoogleEvent(
   accessToken: string,
   eventId: string,
   body: Record<string, unknown>,
-  options?: { conferenceDataVersion?: boolean; etag?: string }
+  options?: { conferenceDataVersion?: boolean; etag?: string; sendUpdates?: GoogleSendUpdates }
 ): Promise<GCalEvent> {
-  // This is a background reconciliation, not an organizer-authored update.
-  // Suppress attendee emails; webhook delivery is unaffected by sendUpdates.
-  const params = new URLSearchParams({ sendUpdates: 'none' });
+  // Webhook delivery is unaffected by sendUpdates.
+  const params = new URLSearchParams({ sendUpdates: options?.sendUpdates ?? 'none' });
   if (options?.conferenceDataVersion) {
     params.set('conferenceDataVersion', '1');
   }
@@ -78,12 +98,77 @@ export async function patchGoogleEvent(
     throw new GoogleCalendarPatchConflictError(eventId);
   }
 
+  if (res.status === 404 || res.status === 410) {
+    throw new GoogleCalendarEventGoneError(eventId);
+  }
+
   if (!res.ok) {
     const text = await res.text();
     throw new Error(`Google Calendar API ${res.status}: ${text}`);
   }
 
   return (await res.json()) as GCalEvent;
+}
+
+/**
+ * Create a Google Calendar event on the connected user's primary calendar.
+ * Used by the outbound push so a call scheduled inside Xyne shows up on the
+ * organizer's calendar — and, via `attendees` + `sendUpdates: 'all'`, on every
+ * invitee's calendar, including people who never connected Xyne.
+ */
+export async function insertGoogleEvent(
+  accessToken: string,
+  body: Record<string, unknown>,
+  options?: { sendUpdates?: GoogleSendUpdates }
+): Promise<GCalEvent> {
+  const params = new URLSearchParams({ sendUpdates: options?.sendUpdates ?? 'all' });
+
+  const res = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/primary/events?${params.toString()}`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(30_000),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Google Calendar API ${res.status}: ${text}`);
+  }
+
+  return (await res.json()) as GCalEvent;
+}
+
+/**
+ * Delete an event from the connected user's primary calendar. A 404/410 means
+ * someone already removed it, which is the state the caller wanted, so it
+ * resolves instead of throwing.
+ */
+export async function deleteGoogleEvent(
+  accessToken: string,
+  eventId: string,
+  options?: { sendUpdates?: GoogleSendUpdates }
+): Promise<void> {
+  const params = new URLSearchParams({ sendUpdates: options?.sendUpdates ?? 'all' });
+
+  const res = await fetch(
+    `https://www.googleapis.com/calendar/v3/calendars/primary/events/${encodeURIComponent(eventId)}?${params.toString()}`,
+    {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      signal: AbortSignal.timeout(30_000),
+    }
+  );
+
+  if (res.ok || res.status === 404 || res.status === 410) return;
+
+  const text = await res.text();
+  throw new Error(`Google Calendar API ${res.status}: ${text}`);
 }
 
 interface CalendarFetchResult<TEvent> {

--- a/apps/backend/src/services/googleCalendarCallStore.ts
+++ b/apps/backend/src/services/googleCalendarCallStore.ts
@@ -11,6 +11,7 @@ import { logger } from '@/utils/logger';
 import { type Prisma } from '@prisma/client';
 import { CallOrigin, CallStatus, CallType } from '@xyne/shared';
 import { MAX_CALENDAR_EVENTS_PER_SYNC } from '@/services/calendarSyncConfig';
+import { isXyneOriginatedEvent } from '@/services/calendarEventPayload';
 import {
   buildCalendarExternalId,
   buildCalendarExternalIdPrefix,
@@ -105,6 +106,11 @@ export async function storeGCalEventAsCall(
   userEmail: string
 ): Promise<void> {
   if (!event.id) return;
+
+  // Xyne's own outbound mirror of a call scheduled inside Xyne. The Call row
+  // already exists and Xyne owns it; storing this event too would produce a
+  // second, calendar-origin duplicate of the same meeting.
+  if (isXyneOriginatedEvent(event.extendedProperties?.private)) return;
 
   const now = new Date();
   const calendarOwnerEmail = normalizeCalendarOwnerEmail(userEmail);

--- a/apps/backend/src/services/recurringCallService.ts
+++ b/apps/backend/src/services/recurringCallService.ts
@@ -9,6 +9,7 @@ import { scheduledCallNotificationService } from '@/services/scheduledCallNotifi
 import { addHHMMDuration } from '@/utils/dateUtils';
 import { DatabaseClient } from '@/database/client';
 import { CallVespaFeedSource, queueCallVespaFeed } from '@/services/callVespaQueue';
+import { queueCallCalendarPush, queueCallCalendarPushMany } from '@/queues/callCalendarPushQueue';
 import { runWithContext } from '@/database/tenant/context';
 import { buildCallInviteUrl } from '@/utils/urlUtils';
 
@@ -118,6 +119,10 @@ class RecurringCallService {
       }, tx);
 
       queueCallVespaFeed(callId, { source: CallVespaFeedSource.RecurringCallServiceCreateInstance });
+      // Every materialized instance — first creation, buffer replenishment,
+      // regeneration, the auto-end chain — passes through here, so this one
+      // hook puts the whole series on the organizer's calendar.
+      queueCallCalendarPush(callId, 'recurringCallService.createInstance');
 
       // Send immediate CALL_SCHEDULED notifications + activities for the first instance only
       if (notifyParticipants) {
@@ -422,6 +427,12 @@ class RecurringCallService {
     scheduledInstanceIds.forEach((callId) => queueCallVespaFeed(callId, {
       source: CallVespaFeedSource.RecurringCallServiceRegenerateFutureInstancesCancelledInstance,
     }));
+    // The replacements were pushed by createInstance; these are the instances
+    // the new rule superseded, so withdraw their calendar events.
+    queueCallCalendarPushMany(
+      scheduledInstanceIds,
+      'recurringCallService.regenerateFutureInstances',
+    );
 
     return callIds;
   }
@@ -522,6 +533,8 @@ class RecurringCallService {
       repositories.scheduledCalls.cancelSeries({ seriesId, now, tx }),
     );
 
+    queueCallCalendarPushMany(futureInstanceIds, 'recurringCallService.cancelSeries');
+
     return result;
   }
 
@@ -547,9 +560,13 @@ class RecurringCallService {
       }
     }
 
-    return db.$transaction(async (tx) =>
+    const result = await db.$transaction(async (tx) =>
       repositories.scheduledCalls.deleteSeries({ seriesId, tx }),
     );
+
+    queueCallCalendarPushMany(instanceIds, 'recurringCallService.deleteSeries');
+
+    return result;
   }
 }
 

--- a/apps/backend/src/services/xyneCallLinkInjector.ts
+++ b/apps/backend/src/services/xyneCallLinkInjector.ts
@@ -32,11 +32,12 @@ import { type GCalEvent } from '@/services/googleCalendarCallStore';
 import { type CalendarCredentials } from '@/services/calendarTokenRefresh';
 import { isTeamEligible } from '@/services/calendarSyncConfig';
 import { resolveXyneCallForEvent, resolveXyneChannelForUser } from '@/services/xyneCallService';
-import {
-  reconcileEventConference,
-  escapeHtmlAttribute,
-} from '@/services/calendarConferencePatcher';
+import { reconcileEventConference } from '@/services/calendarConferencePatcher';
 import { buildCalendarExternalId } from '@/services/calendarCallStore.utils';
+import {
+  escapeHtmlAttribute,
+  isXyneOriginatedEvent,
+} from '@/services/calendarEventPayload';
 import { DatabaseClient } from '@/database/client';
 import { logger } from '@/utils/logger';
 
@@ -48,6 +49,7 @@ type SkipReason =
   | 'missing_id_or_organizer'
   | 'cancelled'
   | 'unsupported_event_type'
+  | 'xyne_originated'
   | 'not_organizer'
   | 'not_eligible';
 
@@ -74,6 +76,10 @@ function isEligibleShape(event: GCalEvent): SkipReason | null {
   if (!event.id || !event.organizer?.email) return 'missing_id_or_organizer';
   if (event.status === 'cancelled') return 'cancelled';
   if (event.eventType && SKIPPED_EVENT_TYPES.has(event.eventType)) return 'unsupported_event_type';
+  // Xyne pushed this event out from a call it already owns (callCalendarPushService).
+  // It carries its own Xyne link; resolving a *second* hosted Call for it would
+  // fork the meeting in two.
+  if (isXyneOriginatedEvent(event.extendedProperties?.private)) return 'xyne_originated';
   return null;
 }
 

--- a/apps/backend/src/worker.ts
+++ b/apps/backend/src/worker.ts
@@ -40,6 +40,7 @@ import { etaDeadlineWorker } from '@/workers/etaDeadlineWorker';
 import { emailFetchWorker } from '@/workers/emailFetchWorker';
 import { googleCalendarSyncQueue } from '@/queues/googleCalendarSyncQueue';
 import { microsoftCalendarSyncQueue } from '@/queues/microsoftCalendarSyncQueue';
+import { callCalendarPushQueue } from '@/queues/callCalendarPushQueue';
 import { teamIntelligenceWorker } from '@/workers/teamIntelligenceWorker';
 import { emailClassificationWorker } from '@/workers/emailClassificationWorker';
 import { emailClassificationQueue } from '@/queues/emailClassificationQueue';
@@ -302,6 +303,9 @@ class WorkerService {
 
         logger.info('Starting Microsoft Calendar sync worker...');
         await microsoftCalendarSyncQueue.startProcessing();
+
+        logger.info('Starting call calendar push worker...');
+        await callCalendarPushQueue.startProcessing();
       } else {
         logger.info('Calendar sync worker is disabled (ENABLE_CALENDAR_SYNC_WORKER=false)');
       }
@@ -530,6 +534,7 @@ class WorkerService {
       if (appConfig.enableCalendarSyncWorker) {
         await googleCalendarSyncQueue.close();
         await microsoftCalendarSyncQueue.close();
+        await callCalendarPushQueue.close();
       }
 
       if (appConfig.enableTeamIntelligenceWorker) {


### PR DESCRIPTION

<img width="524" height="484" alt="Screenshot 2026-09-07 at 3 18 26 PM" src="https://github.com/user-attachments/assets/d66b3402-e8cd-412f-be55-35757ff1c61d" />



Services-Requiring-Redeployment:
  - backend

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
