### PR TITLE
fix: XYNE-62816 Call invite sharing with HTML formatting

### DIFF
--- a/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
+++ b/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
@@ -37,14 +37,16 @@ import {
 import { DeviceSelector } from '../DeviceSelector/DeviceSelector';
 import { usePlatform } from '../../../hooks/usePlatform';
 import { useShortcutById, useShortcut } from '../../../shortcuts';
-import { InvitationResponse, type RecordingType } from '@xyne/shared';
+import { InvitationResponse, type Call, type RecordingType } from '@xyne/shared';
 import { RecordingButton } from './RecordingButton';
 import {
+  buildCallInviteHtml,
   getAiButtonColorClass,
   getAiButtonDisabled,
   getAiButtonTitle,
   handleAiButtonClick,
 } from '../../../utils/callControls';
+import { copyHtmlToClipboard } from '../../../utils/clipboardUtils';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -56,11 +58,20 @@ import { ShortcutHint } from '../../ui/ShortcutHint';
 
 import { XyneTelepresenceIcon } from '../../../assets/icons/XyneTelepresenceIcon';
 
-interface ActiveCallForControls {
-  externalId: string;
-  createdByUserId?: string;
+type ActiveCallForControls = Pick<
+  Call,
+  | 'externalId'
+  | 'createdByUserId'
+  | 'title'
+  | 'status'
+  | 'startsAt'
+  | 'endsAt'
+  | 'startedAt'
+  | 'endedAt'
+  | 'timezone'
+> & {
   participants?: Array<{ response?: string | null }>;
-}
+};
 
 interface CallControlsProps {
   isMicEnabled: boolean;
@@ -188,6 +199,13 @@ export function CallControls({
     return (activeCalls as ActiveCallForControls[]).find(c => c.externalId === externalId);
   }, [activeCalls, externalId]);
   const isHost = !!localParticipantId && currentCall?.createdByUserId === localParticipantId;
+  // Same room.metadata.createdBy lookup as ParticipantTile/FullCallView's hostName.
+  const hostName = useMemo(() => {
+    const hostId = currentCall?.createdByUserId;
+    if (!room || !hostId) return null;
+    if (hostId === room.localParticipant.identity) return room.localParticipant.name ?? null;
+    return room.remoteParticipants.get(hostId)?.name ?? null;
+  }, [room, currentCall?.createdByUserId]);
   // All participants in the call can admit/decline, so everyone sees the pending count.
   const requestedParticipantCount = useMemo(() => {
     return (
@@ -325,7 +343,18 @@ export function CallControls({
 
   const handleCopyInviteLink = (): void => {
     if (!roomLink) return;
-    void navigator.clipboard.writeText(roomLink).then(() => {
+    const html = buildCallInviteHtml({
+      title: currentCall?.title,
+      hostName,
+      roomLink,
+      status: currentCall?.status,
+      startsAt: currentCall?.startsAt,
+      endsAt: currentCall?.endsAt,
+      startedAt: currentCall?.startedAt,
+      endedAt: currentCall?.endedAt,
+      timezone: currentCall?.timezone,
+    });
+    void copyHtmlToClipboard(html).then(() => {
       setShowCopied(true);
       setTimeout(() => setShowCopied(false), 2000);
     });
@@ -867,11 +896,11 @@ export function CallControls({
           style={hasCustomSizing ? { padding: `${buttonPadding}px` } : undefined}
           title={
             roomLink
-              ? 'Copy invite link — works for teammates and guests'
+              ? 'Copy invite message — works for teammates and guests'
               : 'Preparing invite link…'
           }
           aria-label={
-            roomLink ? 'Copy invite link for teammates and guests' : 'Preparing invite link'
+            roomLink ? 'Copy invite message for teammates and guests' : 'Preparing invite link'
           }
           data-track-category='CALLS'
           data-track-name='SHARE_CALL_LINK'
@@ -885,7 +914,7 @@ export function CallControls({
           />
           {showCopied && (
             <span className='absolute -top-8 sm:-top-10 left-1/2 transform -translate-x-1/2 bg-green-500 text-white text-xs sm:text-sm px-2 py-1 sm:px-3 sm:py-1.5 rounded-lg shadow-lg whitespace-nowrap'>
-              Copied!
+              Invite copied!
             </span>
           )}
         </button>

--- a/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
+++ b/apps/dashboard/src/components/Call/CallControls/CallControls.tsx
@@ -40,13 +40,13 @@ import { useShortcutById, useShortcut } from '../../../shortcuts';
 import { InvitationResponse, type Call, type RecordingType } from '@xyne/shared';
 import { RecordingButton } from './RecordingButton';
 import {
-  buildCallInviteHtml,
+  buildCallInviteText,
   getAiButtonColorClass,
   getAiButtonDisabled,
   getAiButtonTitle,
   handleAiButtonClick,
 } from '../../../utils/callControls';
-import { copyHtmlToClipboard } from '../../../utils/clipboardUtils';
+import { copyTextToClipboard } from '../../../utils/clipboardUtils';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -70,7 +70,7 @@ type ActiveCallForControls = Pick<
   | 'endedAt'
   | 'timezone'
 > & {
-  participants?: Array<{ response?: string | null }>;
+  participants?: Array<{ userId: string; displayName?: string | null; response?: string | null }>;
 };
 
 interface CallControlsProps {
@@ -199,13 +199,12 @@ export function CallControls({
     return (activeCalls as ActiveCallForControls[]).find(c => c.externalId === externalId);
   }, [activeCalls, externalId]);
   const isHost = !!localParticipantId && currentCall?.createdByUserId === localParticipantId;
-  // Same room.metadata.createdBy lookup as ParticipantTile/FullCallView's hostName.
+
   const hostName = useMemo(() => {
     const hostId = currentCall?.createdByUserId;
-    if (!room || !hostId) return null;
-    if (hostId === room.localParticipant.identity) return room.localParticipant.name ?? null;
-    return room.remoteParticipants.get(hostId)?.name ?? null;
-  }, [room, currentCall?.createdByUserId]);
+    if (!hostId) return null;
+    return currentCall?.participants?.find(p => p.userId === hostId)?.displayName ?? null;
+  }, [currentCall?.createdByUserId, currentCall?.participants]);
   // All participants in the call can admit/decline, so everyone sees the pending count.
   const requestedParticipantCount = useMemo(() => {
     return (
@@ -343,7 +342,7 @@ export function CallControls({
 
   const handleCopyInviteLink = (): void => {
     if (!roomLink) return;
-    const html = buildCallInviteHtml({
+    const text = buildCallInviteText({
       title: currentCall?.title,
       hostName,
       roomLink,
@@ -354,7 +353,7 @@ export function CallControls({
       endedAt: currentCall?.endedAt,
       timezone: currentCall?.timezone,
     });
-    void copyHtmlToClipboard(html).then(() => {
+    void copyTextToClipboard(text).then(() => {
       setShowCopied(true);
       setTimeout(() => setShowCopied(false), 2000);
     });

--- a/apps/dashboard/src/components/Call/CallViews/MiniCallView.tsx
+++ b/apps/dashboard/src/components/Call/CallViews/MiniCallView.tsx
@@ -573,9 +573,10 @@ export function MiniCallView({
                     </div>
                   )}
                 </div>
-
-                {/* Controls */}
-                <div className='pb-4' onPointerDown={(e): void => e.stopPropagation()}>
+                <div
+                  className='relative z-40 pb-4'
+                  onPointerDown={(e): void => e.stopPropagation()}
+                >
                   <CallControls
                     isMicEnabled={isMicEnabled}
                     isCameraEnabled={isCameraEnabled}

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallActionsMenu.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallActionsMenu.tsx
@@ -1,6 +1,8 @@
 import { Copy, Pencil, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { copyTextToClipboard } from '../../../utils/clipboardUtils';
+import { copyHtmlToClipboard } from '../../../utils/clipboardUtils';
+import { buildCallInviteHtml } from '../../../utils/callControls';
+import { useUser } from '../../../hooks/useUsers';
 import { DropdownMenuItem } from '../../ui/dropdown-menu';
 import { type Call } from '../../../routes/CallHistoryScreen/callHistoryItem.utils';
 
@@ -29,14 +31,27 @@ export function UpcomingCallActionsMenuItems({
   onEdit,
   onCancel,
 }: UpcomingCallActionsMenuItemsProps): React.JSX.Element {
+  const hostUser = useUser(call.organizerId ?? call.createdByUserId);
+
   const handleCopyLink = (e: React.MouseEvent): void => {
     e.stopPropagation();
     if (!call.roomLink) {
       toast.error('No link available');
       return;
     }
-    copyTextToClipboard(call.roomLink)
-      .then(() => toast.success('Link copied to clipboard'))
+    const html = buildCallInviteHtml({
+      title: call.title,
+      hostName: hostUser?.name,
+      roomLink: call.roomLink,
+      status: call.status,
+      startsAt: call.startsAt,
+      endsAt: call.endsAt,
+      startedAt: call.startedAt,
+      endedAt: call.endedAt,
+      timezone: call.timezone,
+    });
+    copyHtmlToClipboard(html)
+      .then(() => toast.success('Invite copied to clipboard'))
       .catch(() => toast.error('Failed to copy link'));
   };
 

--- a/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallActionsMenu.tsx
+++ b/apps/dashboard/src/components/Call/UpcomingCallsList/UpcomingCallActionsMenu.tsx
@@ -1,7 +1,7 @@
 import { Copy, Pencil, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { copyHtmlToClipboard } from '../../../utils/clipboardUtils';
-import { buildCallInviteHtml } from '../../../utils/callControls';
+import { copyTextToClipboard } from '../../../utils/clipboardUtils';
+import { buildCallInviteText } from '../../../utils/callControls';
 import { useUser } from '../../../hooks/useUsers';
 import { DropdownMenuItem } from '../../ui/dropdown-menu';
 import { type Call } from '../../../routes/CallHistoryScreen/callHistoryItem.utils';
@@ -39,7 +39,7 @@ export function UpcomingCallActionsMenuItems({
       toast.error('No link available');
       return;
     }
-    const html = buildCallInviteHtml({
+    const text = buildCallInviteText({
       title: call.title,
       hostName: hostUser?.name,
       roomLink: call.roomLink,
@@ -50,7 +50,7 @@ export function UpcomingCallActionsMenuItems({
       endedAt: call.endedAt,
       timezone: call.timezone,
     });
-    copyHtmlToClipboard(html)
+    copyTextToClipboard(text)
       .then(() => toast.success('Invite copied to clipboard'))
       .catch(() => toast.error('Failed to copy link'));
   };

--- a/apps/dashboard/src/utils/callControls.ts
+++ b/apps/dashboard/src/utils/callControls.ts
@@ -1,3 +1,7 @@
+import { CallStatus } from '@xyne/shared';
+import { formatRelativeTime } from './dateUtils';
+import { escapeHtml } from './clipboardUtils';
+
 interface AiControllerLike {
   id: string;
   name: string;
@@ -80,6 +84,72 @@ export function getAiButtonColorClass({
     return 'bg-yellow-600 hover:bg-yellow-700 text-white shadow-yellow-500/50';
   }
   return defaultControlClass;
+}
+
+interface CallInviteInfo {
+  title?: string | null | undefined;
+  hostName?: string | null | undefined;
+  roomLink: string;
+  status?: CallStatus | null | undefined;
+  startsAt?: number | null | undefined;
+  endsAt?: number | null | undefined;
+  startedAt?: number | null | undefined;
+  endedAt?: number | null | undefined;
+  timezone?: string | null | undefined;
+}
+
+export function buildCallInviteHtml({
+  title,
+  hostName,
+  roomLink,
+  status,
+  startsAt,
+  endsAt,
+  startedAt,
+  endedAt,
+  timezone,
+}: CallInviteInfo): string {
+  const rangeStart = status === CallStatus.SCHEDULED ? startsAt : startedAt;
+  const rangeEnd = status === CallStatus.ENDED ? endedAt : endsAt;
+
+  const scheduleLines: string[] = [];
+  if (rangeStart) {
+    // 'UTC' means no real timezone was captured for this call (e.g. an instant call), so
+    // fall back to the viewer's own local zone instead of mislabeling times as UTC.
+    const timeZone = timezone && timezone.toUpperCase() !== 'UTC' ? timezone : undefined;
+    const dateLabel = new Intl.DateTimeFormat('en-US', {
+      weekday: 'short',
+      month: 'long',
+      day: 'numeric',
+      timeZone,
+    }).format(rangeStart);
+    const timeFmt = new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+      timeZone,
+    });
+    scheduleLines.push(
+      rangeEnd
+        ? `${dateLabel} · ${timeFmt.format(rangeStart)} – ${timeFmt.format(rangeEnd)}`
+        : `${dateLabel} · ${timeFmt.format(rangeStart)}`,
+    );
+    if (timeZone) scheduleLines.push(`Time zone: ${timeZone}`);
+    if (status === CallStatus.ACTIVE || status === CallStatus.IN_PROGRESS) {
+      scheduleLines.push(`This call started ${formatRelativeTime(rangeStart)}`);
+    }
+  }
+
+  const heading = title || (hostName ? `${hostName} is inviting you to join the call` : null);
+  const lines = [
+    ...(heading ? [`<b>${escapeHtml(heading)}</b>`] : []),
+    ...(title && hostName ? [`Hosted by ${escapeHtml(hostName)}`] : []),
+    ...scheduleLines.map(escapeHtml),
+    '',
+    'Xyne Call joining info',
+    `Video call link: ${escapeHtml(roomLink)}`,
+  ];
+  return lines.join('<br>');
 }
 
 export function handleAiButtonClick({

--- a/apps/dashboard/src/utils/callControls.ts
+++ b/apps/dashboard/src/utils/callControls.ts
@@ -1,6 +1,5 @@
 import { CallStatus } from '@xyne/shared';
 import { formatRelativeTime } from './dateUtils';
-import { escapeHtml } from './clipboardUtils';
 
 interface AiControllerLike {
   id: string;
@@ -98,7 +97,7 @@ interface CallInviteInfo {
   timezone?: string | null | undefined;
 }
 
-export function buildCallInviteHtml({
+export function buildCallInviteText({
   title,
   hostName,
   roomLink,
@@ -142,14 +141,14 @@ export function buildCallInviteHtml({
 
   const heading = title || (hostName ? `${hostName} is inviting you to join the call` : null);
   const lines = [
-    ...(heading ? [`<b>${escapeHtml(heading)}</b>`] : []),
-    ...(title && hostName ? [`Hosted by ${escapeHtml(hostName)}`] : []),
-    ...scheduleLines.map(escapeHtml),
+    ...(heading ? [heading] : []),
+    ...(title && hostName ? [`Hosted by ${hostName}`] : []),
+    ...scheduleLines,
     '',
     'Xyne Call joining info',
-    `Video call link: ${escapeHtml(roomLink)}`,
+    `Video call link: ${roomLink}`,
   ];
-  return lines.join('<br>');
+  return lines.join('\n');
 }
 
 export function handleAiButtonClick({

--- a/apps/dashboard/src/utils/clipboardUtils.ts
+++ b/apps/dashboard/src/utils/clipboardUtils.ts
@@ -13,6 +13,14 @@ import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
 
+export const escapeHtml = (unsafe: string): string =>
+  unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+
 const citationSanitizeSchema = {
   ...defaultSchema,
   tagNames: [...(defaultSchema.tagNames ?? []), 'cite', 'citation'],

--- a/apps/dashboard/src/utils/clipboardUtils.ts
+++ b/apps/dashboard/src/utils/clipboardUtils.ts
@@ -13,14 +13,6 @@ import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeStringify from 'rehype-stringify';
 
-export const escapeHtml = (unsafe: string): string =>
-  unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-
 const citationSanitizeSchema = {
   ...defaultSchema,
   tagNames: [...(defaultSchema.tagNames ?? []), 'cite', 'citation'],


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - dashboard

## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->
Sharing a call link (active-call share icon, and "Copy Link" on scheduled calls) copied only the bare URL. It now copies a Google Meet-style invite: bold call title (or "{host} is inviting you to join the call" for untitled/instant calls), host name, and the date/time — in the call's actual timezone via native `Intl.DateTimeFormat`, showing when it actually started once in progress rather than the originally scheduled time. XYNE-62816.

## POT:

https://github.com/user-attachments/assets/f23c96bd-6c99-4dde-afe5-3e13669f9b7f

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [x] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [x] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [x] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->
Ran the dashboard locally (`localhost:5174`), clicked the share icon on an active call and "Copy Link" on a scheduled call, and pasted the clipboard result to confirm the bold title, host, and date/time/timezone lines render correctly for instant, scheduled, in-progress, and untitled calls.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- why? -->  Pure client-side formatting/clipboard logic, no existing test harness for this component.

### Manual

**Users**
- [x] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [x] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [x] No debug logging or commented-out code left behind
