### PR TITLE
feat: XYNE-62830 add TERMINATE step to cancel automation runs from an…

### DIFF
--- a/apps/backend/src/automations/engine/automation-executor.ts
+++ b/apps/backend/src/automations/engine/automation-executor.ts
@@ -16,7 +16,7 @@ import type { StepRegistry } from '../steps/step-registry';
 import { BaseActionStep, BaseControlFlowStep, StepKind } from '../steps/base-step';
 import { VariableResolver, stripNullForOptionalKeys } from './variable-resolver';
 import { automationContextStorage } from './automation-context-storage';
-import { PauseStep, type PauseBranchSegment } from './pause-step';
+import { PauseStep, TerminateRun, type PauseBranchSegment } from './pause-step';
 import {
   isExecutableAutomationWorkflowType,
   mayDrainInFlight,
@@ -407,6 +407,18 @@ export class AutomationExecutor {
       logger.info(`AutomationExecutor: run ${runId} COMPLETED for automation ${automationId}`);
       return completed;
     } catch (err) {
+      if (TerminateRun.is(err)) {
+        const cancelled = await this.prisma.workflowExecution.update({
+          where: { id: runId },
+          data: { status: AutomationRunStatus.CANCELLED },
+        });
+        context.__meta = { error: null, chain };
+        await persistAutomationState(runId, { context: JSON.stringify(context) });
+        logger.info(
+          `AutomationExecutor: run ${runId} CANCELLED by TERMINATE for automation ${automationId} (reason=${err.reason ?? '∅'})`,
+        );
+        return cancelled;
+      }
       const errMessage = err instanceof Error ? err.message : String(err);
       await this.prisma.workflowExecution.update({
         where: { id: runId },
@@ -453,6 +465,10 @@ export class AutomationExecutor {
         const stepCtxEntry = context.steps[step.id];
         await this.markStepCompleted(runId, stepName, stepCtxEntry);
       } catch (err) {
+        if (TerminateRun.is(err)) {
+          await this.markStepCompleted(runId, stepName, context.steps[step.id]);
+          throw err;
+        }
         if (PauseStep.is(err)) {
           if (err.branchPath.length === 0) {
             await this.markStepWaiting(runId, stepName, context.steps[step.id], err.statePatch);
@@ -712,7 +728,11 @@ export class AutomationExecutor {
         `[automations] step OK    id=${step.id} type=${step.type} elapsedMs=${Date.now() - t0}`,
       );
     } catch (err) {
-      if (PauseStep.is(err)) {
+      if (TerminateRun.is(err)) {
+        logger.info(
+          `[automations] step TERMINATE id=${step.id} type=${step.type} elapsedMs=${Date.now() - t0} reason=${err.reason ?? '∅'}`,
+        );
+      } else if (PauseStep.is(err)) {
         logger.info(
           `[automations] step PAUSED id=${step.id} type=${step.type} elapsedMs=${Date.now() - t0} reason=${err.message}`,
         );

--- a/apps/backend/src/automations/engine/pause-step.ts
+++ b/apps/backend/src/automations/engine/pause-step.ts
@@ -23,3 +23,17 @@ export class PauseStep extends Error {
     return err instanceof PauseStep || (err instanceof Error && err.name === 'PauseStep');
   }
 }
+
+export class TerminateRun extends Error {
+  readonly reason: string | undefined;
+
+  constructor(reason?: string) {
+    super(reason ? `Run terminated: ${reason}` : 'Run terminated');
+    this.name = 'TerminateRun';
+    this.reason = reason;
+  }
+
+  static is(err: unknown): err is TerminateRun {
+    return err instanceof TerminateRun || (err instanceof Error && err.name === 'TerminateRun');
+  }
+}

--- a/apps/backend/src/automations/index.ts
+++ b/apps/backend/src/automations/index.ts
@@ -15,6 +15,7 @@ import { tagGeneratedTrigger } from './triggers/tag-generated.trigger';
 import { conditionalStep } from './steps/conditional.step';
 import { switchStep } from './steps/switch.step';
 import { delayStep } from './steps/delay.step';
+import { terminateStep } from './steps/terminate.step';
 
 import { sendMessageStep } from './steps/send-message.step';
 import { notifyUserStep } from './steps/notify-user.step';
@@ -62,6 +63,7 @@ export async function initializeAutomations(): Promise<void> {
   stepRegistry.register(conditionalStep);
   stepRegistry.register(switchStep);
   stepRegistry.register(delayStep);
+  stepRegistry.register(terminateStep);
 
   stepRegistry.register(sendMessageStep);
   stepRegistry.register(notifyUserStep);

--- a/apps/backend/src/automations/steps/terminate.step.ts
+++ b/apps/backend/src/automations/steps/terminate.step.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import { BaseActionStep } from './base-step';
+import { StepCategory } from '../types/categories';
+import { variableRef } from '../engine/variable-ref';
+import { TerminateRun } from '../engine/pause-step';
+
+const TerminateConfigSchema = z.object({
+  reason: variableRef(z.string().min(1)).optional().describe('Why the run was stopped'),
+});
+
+const TerminateOutputSchema = z.object({});
+
+export class TerminateStep extends BaseActionStep<typeof TerminateConfigSchema> {
+  readonly type = 'TERMINATE';
+  readonly configSchema = TerminateConfigSchema;
+  readonly outputSchema = TerminateOutputSchema;
+  readonly name = 'Terminate run';
+  readonly description =
+    'Stops the run immediately and marks it Cancelled. Works at the top level or inside a conditional / switch branch.';
+  readonly category = StepCategory.CONTROL;
+  readonly icon = 'OctagonX';
+
+  async execute(config: z.infer<typeof TerminateConfigSchema>): Promise<Record<string, unknown>> {
+    throw new TerminateRun(typeof config.reason === 'string' ? config.reason : undefined);
+  }
+}
+
+export const terminateStep = new TerminateStep();

--- a/apps/dashboard/src/components/Automation/Automation.types.ts
+++ b/apps/dashboard/src/components/Automation/Automation.types.ts
@@ -45,6 +45,9 @@ export { WorkflowEventType } from '@xyne/shared';
 export const CONDITIONAL_STEP_TYPE = 'CONDITIONAL';
 export const SWITCH_STEP_TYPE = 'SWITCH';
 
+/** Steps that pause the run — the engine only supports pausing at the top level. */
+export const PAUSING_STEP_TYPES: readonly string[] = ['DELAY', 'RUN_AGENT'];
+
 export {
   VARIABLE_REF_REGEX,
   VARIABLE_REF_DESCRIPTION_PREFIX,

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/AddStepRow/AddStepRow.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/AddStepRow/AddStepRow.tsx
@@ -3,6 +3,7 @@ import * as LucideIcons from 'lucide-react';
 import { Plus, Search, Zap, type LucideIcon } from 'lucide-react';
 import { cn } from '../../../../utils/classNames';
 import { Popover } from '../../../ui/Popover/Popover';
+import { Tooltip } from '../../../ui/Tooltip';
 import type { StepCatalogItem } from '../../Automation.types';
 import type { AddStepRowProps } from './AddStepRow.types';
 
@@ -10,6 +11,8 @@ export function AddStepRow({
   catalog,
   onPick,
   variant = 'full',
+  disabledTypes,
+  disabledHint,
 }: AddStepRowProps): React.ReactElement {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -98,40 +101,58 @@ export function AddStepRow({
                 <div className='px-3 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground'>
                   {group.category}
                 </div>
-                {group.items.map(item => (
-                  <button
-                    key={item.type}
-                    type='button'
-                    data-track-category='automation-builder'
-                    data-track-name={`add-step-pick-${item.type}`}
-                    onClick={() => {
-                      onPick(item.type);
-                      setOpen(false);
-                      setQuery('');
-                    }}
-                    className={cn(
-                      'flex w-full items-center gap-2.5 px-3 py-1.5 text-left transition-colors',
-                      'hover:bg-accent/40',
-                    )}
-                  >
-                    <span
+                {group.items.map(item => {
+                  const disabled = disabledTypes?.includes(item.type) ?? false;
+                  const row = (
+                    <button
+                      key={item.type}
+                      type='button'
+                      aria-disabled={disabled}
+                      data-track-category='automation-builder'
+                      data-track-name={`add-step-pick-${item.type}`}
+                      onClick={() => {
+                        if (disabled) return;
+                        onPick(item.type);
+                        setOpen(false);
+                        setQuery('');
+                      }}
                       className={cn(
-                        'flex size-6 flex-shrink-0 items-center justify-center rounded-md',
-                        'bg-accent/40 text-foreground',
+                        'flex w-full items-center gap-2.5 px-3 py-1.5 text-left transition-colors',
+                        disabled ? 'cursor-not-allowed opacity-45' : 'hover:bg-accent/40',
                       )}
                     >
-                      <ResolveIcon name={item.icon} className='size-3' />
-                    </span>
-                    <span className='flex flex-1 flex-col min-w-0'>
-                      <span className='truncate text-sm text-foreground'>{item.name}</span>
-                      {item.description && (
-                        <span className='line-clamp-1 text-[11px] text-muted-foreground'>
-                          {item.description}
-                        </span>
-                      )}
-                    </span>
-                  </button>
-                ))}
+                      <span
+                        className={cn(
+                          'flex size-6 flex-shrink-0 items-center justify-center rounded-md',
+                          'bg-accent/40 text-foreground',
+                        )}
+                      >
+                        <ResolveIcon name={item.icon} className='size-3' />
+                      </span>
+                      <span className='flex flex-1 flex-col min-w-0'>
+                        <span className='truncate text-sm text-foreground'>{item.name}</span>
+                        {item.description && (
+                          <span className='line-clamp-1 text-[11px] text-muted-foreground'>
+                            {item.description}
+                          </span>
+                        )}
+                      </span>
+                    </button>
+                  );
+                  return disabled && disabledHint ? (
+                    <Tooltip
+                      key={item.type}
+                      content={disabledHint}
+                      side='right'
+                      collisionPadding={8}
+                      className='max-w-[220px]'
+                    >
+                      {row}
+                    </Tooltip>
+                  ) : (
+                    row
+                  );
+                })}
               </div>
             ))
           )}

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/AddStepRow/AddStepRow.types.ts
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/AddStepRow/AddStepRow.types.ts
@@ -4,4 +4,8 @@ export interface AddStepRowProps {
   catalog: StepCatalogItem[];
   onPick: (type: string) => void;
   variant?: 'full' | 'compact';
+  /** Step types shown greyed out and not pickable. */
+  disabledTypes?: readonly string[];
+  /** Tooltip explaining why a disabled step cannot be picked here. */
+  disabledHint?: string;
 }

--- a/apps/dashboard/src/components/Automation/AutomationBuilder/BranchSteps/BranchSteps.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationBuilder/BranchSteps/BranchSteps.tsx
@@ -1,5 +1,10 @@
 import { cn } from '../../../../utils/classNames';
-import { CONDITIONAL_STEP_TYPE, SWITCH_STEP_TYPE, makeStepId } from '../../Automation.types';
+import {
+  CONDITIONAL_STEP_TYPE,
+  SWITCH_STEP_TYPE,
+  PAUSING_STEP_TYPES,
+  makeStepId,
+} from '../../Automation.types';
 import {
   buildOutputSchemaFromRunAgentConfig,
   buildOutputSchemaFromWebhookConfig,
@@ -268,7 +273,13 @@ export function BranchSteps({
             );
           })
         )}
-        <AddStepRow catalog={catalog} onPick={handleAdd} variant='compact' />
+        <AddStepRow
+          catalog={catalog}
+          onPick={handleAdd}
+          variant='compact'
+          disabledTypes={PAUSING_STEP_TYPES}
+          disabledHint='Cannot run inside a branch — add it after the conditional / switch. To stop the run early here, use Terminate run.'
+        />
       </div>
     </div>
   );

--- a/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
+++ b/apps/dashboard/src/components/Automation/AutomationRuns/RunHistory/RunHistory.tsx
@@ -232,7 +232,7 @@ function RunRow({
           <MultipleCrossCancelCircle className='size-4 text-red-600' />
         ) : run.status === 'EXTERNAL_WAIT' ? (
           <Hourglass className='size-4 text-purple-600' />
-        ) : run.status === 'SKIPPED' ? (
+        ) : run.status === 'SKIPPED' || run.status === 'CANCELLED' ? (
           <MinusCircle className='size-4 text-muted-foreground' />
         ) : run.status === 'PENDING' ? (
           <ClockDefault className='size-4 text-muted-foreground' />


### PR DESCRIPTION
Automation control-flow branches have two gaps. The rule that pausing steps (DELAY, RUN_AGENT) can't run inside a conditional/switch is enforced only at runtime and in the builder UI, so automations saved via the API, imported, or authored before the UI guard still save clean and fail on first run. Separately, when a run stops inside a branch, the enclosing conditional/switch never gets a context entry and vanishes from the run detail — the user sees the terminating step but not which branch it was in.

-----

https://github.com/user-attachments/assets/8a82a77e-b86b-4997-ab80-9e6fdaa38ea4