### PR TITLE
fix: escape & first in data-flow-json attribute so Flow/agent cards render

### DIFF
--- a/apps/backend/src/apps/controllers/chatController.ts
+++ b/apps/backend/src/apps/controllers/chatController.ts
@@ -263,7 +263,7 @@ export class ChatController {
           return;
         }
 
-        const escapedJSON = JSON.stringify(flowResult.data).replace(/"/g, '&quot;');
+        const escapedJSON = encodeHtmlAttr(JSON.stringify(flowResult.data));
         // Inner text = notification/preview fallback (shown when the widget
         // isn't rendered). Prefer flow.data.fallbackText, then the flow title,
         // else a generic label — never worse than the old hardcoded "Flow JSON".
@@ -364,7 +364,7 @@ export class ChatController {
           return;
         }
         const flowId = (flowResult.data.screenId) ?? crypto.randomUUID();
-        const escapedJSON = JSON.stringify(flowResult.data).replace(/"/g, '&quot;');
+        const escapedJSON = encodeHtmlAttr(JSON.stringify(flowResult.data));
         // Inner text = notification/preview fallback (see postMessage above).
         const fbRaw = (flowResult.data.data as Record<string, unknown> | undefined)?.['fallbackText'];
         const flowFallback = encodeHtmlAttr(

--- a/apps/backend/src/apps/controllers/incomingWebhookController.ts
+++ b/apps/backend/src/apps/controllers/incomingWebhookController.ts
@@ -12,6 +12,7 @@ import { SlackBlockKitParser } from '@/integrations/adapters/slack-webhook-ticke
 import { resolveSlackMessageParts } from '@/integrations/adapters/slack-webhook-tickets/utils/slackUtils';
 import { MessageType, AppIncomingWebhookAction, AppIncomingWebhookType } from '@xyne/shared';
 import { config } from '@/config/env';
+import { encodeHtmlAttr } from '@/utils/contentUtils';
 import { assertWebhookUrlSafe, safeWebhookFetch, SsrfBlockedError } from '@/utils/ssrfGuard';
 import {
   buildSentinelRawFallbackMessage,
@@ -433,7 +434,7 @@ class IncomingWebhookController {
       return null;
     }
 
-    const escapedJSON = JSON.stringify(result.data).replace(/"/g, '&quot;');
+    const escapedJSON = encodeHtmlAttr(JSON.stringify(result.data));
     return `<div data-flow-json="${escapedJSON}">Flow JSON</div>`;
   }
 

--- a/apps/backend/src/apps/platform-adapters/slack/request-transformers/chat.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/request-transformers/chat.ts
@@ -5,6 +5,7 @@ import {
 	resolveSlackText,
 } from "@/integrations/adapters/slack-webhook-tickets/utils/slackUtils";
 import { config } from "@/config/env";
+import { encodeHtmlAttr } from "@/utils/contentUtils";
 import type { TransformContext } from "../../types";
 import type {
 	SlackChatPostMessageRequest,
@@ -49,7 +50,7 @@ async function processContent(
 		}, botToken, workspaceId);
 
 		if (flowJSON) {
-			const escapedJSON = JSON.stringify(flowJSON).replace(/"/g, "&quot;");
+			const escapedJSON = encodeHtmlAttr(JSON.stringify(flowJSON));
 			return {
 				content: `<div data-flow-json="${escapedJSON}">Flow JSON</div>`,
 				isMarkdown: false,

--- a/packages/xyne-claw-shared/src/flow/flow-text.test.ts
+++ b/packages/xyne-claw-shared/src/flow/flow-text.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { parseFlowJsonComponents, extractTextFromFlowJson } from "./flow-text.js";
+
+/**
+ * Regression coverage for the `data-flow-json` attribute round-trip.
+ *
+ * A Flow card is stored as `<div data-flow-json="...escaped JSON...">fallback</div>`.
+ * The escaping used by the backend emitters (chatController / incomingWebhookController
+ * / the Slack adapter) MUST escape `&` FIRST, otherwise any literal `&`, `<`, `>` or
+ * entity-like sequence already present in the payload (very common in an embedded
+ * agent system prompt, e.g. the string `&quot;`, `A && B`, `<file:line>`) is corrupted
+ * when the browser HTML-decodes the attribute — JSON.parse then throws and the card
+ * collapses to its bare fallback text.
+ *
+ * The canonical encoder is apps/backend `encodeHtmlAttr`. This package must not depend
+ * on apps/backend, so we replicate it here and keep it in lock-step with that helper.
+ */
+function encodeHtmlAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/** What `element.getAttribute('data-flow-json')` returns — full HTML entity decode. */
+function browserAttrDecode(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&");
+}
+
+// A payload seeded with every character class that used to break the attribute:
+// literal ampersands, an entity-looking sequence, shell `&&`, and angle brackets.
+const NASTY = 'Envelope: <div data-flow-json="{&quot;-escaped JSON}">Flow JSON</div>; run A && B; R&D <x>';
+
+const flow = {
+  version: "2.0",
+  screenId: "agent-card",
+  title: "Capability",
+  components: [{ id: "p", type: "text", props: { content: NASTY } }],
+};
+
+function wrap(escapedJSON: string): string {
+  return `<div data-flow-json="${escapedJSON}">Flow JSON</div>`;
+}
+
+describe("data-flow-json escaping round-trip", () => {
+  it("survives the browser attribute decode and JSON.parse (the frontend render path)", () => {
+    const content = wrap(encodeHtmlAttr(JSON.stringify(flow)));
+    const attr = content.match(/data-flow-json="([^"]*)"/)![1]!;
+    const decoded = browserAttrDecode(attr);
+    expect(() => JSON.parse(decoded)).not.toThrow();
+    expect(JSON.parse(decoded)).toEqual(flow);
+  });
+
+  it("the OLD quotes-only escaping corrupted such a payload (documents the bug)", () => {
+    const buggy = JSON.stringify(flow).replace(/"/g, "&quot;");
+    const decoded = browserAttrDecode(buggy.match(/[\s\S]*/)![0]);
+    // The literal `&quot;` inside the prompt is decoded back to a bare `"`,
+    // breaking the JSON structure.
+    expect(() => JSON.parse(decoded)).toThrow();
+  });
+
+  it("the shared decoder recovers the components with content intact", () => {
+    const content = wrap(encodeHtmlAttr(JSON.stringify(flow)));
+    const components = parseFlowJsonComponents(content);
+    expect(components).not.toBeNull();
+    expect(components).toHaveLength(1);
+    expect((components![0] as any).props.content).toBe(NASTY);
+  });
+
+  it("extractTextFromFlowJson returns the original text, not entity-escaped noise", () => {
+    const content = wrap(encodeHtmlAttr(JSON.stringify(flow)));
+    expect(extractTextFromFlowJson(content)).toContain("A && B");
+    expect(extractTextFromFlowJson(content)).toContain("<x>");
+    expect(extractTextFromFlowJson(content)).not.toContain("&amp;");
+  });
+});

--- a/packages/xyne-claw-shared/src/flow/flow-text.ts
+++ b/packages/xyne-claw-shared/src/flow/flow-text.ts
@@ -33,9 +33,15 @@ export function parseFlowJsonComponents(content: string): FlowComponent[] | null
   if (escaped === undefined) return null;
   try {
     const json = escaped
-      .replace(/&quot;/g, '"')
       .replace(/&#10;/g, "\n")
       .replace(/&#13;/g, "\r")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&#39;/g, "'")
+      .replace(/&quot;/g, '"')
+      // &amp; MUST be decoded LAST, after every other entity, so a
+      // literal "&amp;lt;" in the content survives as "&lt;" and not "<".
+      .replace(/&amp;/g, "&")
       // Repair stray backslashes that are NOT valid JSON escape sequences.
       // Slack mrkdwn leaves fragments like "\1" / "\6" in the content, which
       // are invalid JSON escapes; without this, JSON.parse aborts the ENTIRE


### PR DESCRIPTION
## Problem
Capability / Flow cards (e.g. the `describe-agent` card) intermittently render as the literal placeholder text `Flow JSON` instead of the actual card. The card is stored as `<div data-flow-json="…escaped JSON…">Flow JSON</div>`; the visible text is only a fallback and the real payload lives in the escaped attribute.

The four backend emitters that serialize the payload escaped **only double quotes**:
```
JSON.stringify(x).replace(/"/g, '&quot;')
```
This leaves any literal `&`, `<`, `>` or entity-like sequence already in the payload untouched. The browser HTML-decodes the entire attribute value on `getAttribute`, so a payload containing `&`, `&quot;`, `A && B`, or `<file:line>` gets corrupted, `JSON.parse` throws, and the card collapses to the bare `Flow JSON` placeholder.

This is why agents with large system prompts (which literally document the envelope and contain `&quot;`, `&&`, `<…>`) always break, while short-prompt cards render fine — making it look intermittent.

## Fix
- Switch all four emitter sites to `encodeHtmlAttr(JSON.stringify(...))`, which escapes `&` **first**, then `"` `'` `<` `>`. `encodeHtmlAttr` already existed in `apps/backend/src/utils/contentUtils.ts` and was already used for the sibling attributes on the same element.
- Align the shared decoder `parseFlowJsonComponents` in `packages/xyne-claw-shared/src/flow/flow-text.ts` to decode the full entity set (`&amp;` decoded **last**), matching the already-correct decoder in `messages-handler.ts`, so server-side preview / mention-scan text is not left with `&amp;`/`&lt;` noise.
- Add a round-trip regression test (`flow-text.test.ts`): encode → browser-style attribute decode → `JSON.parse`, plus a test asserting the old quotes-only escaping fails on a `&quot;`-containing payload.

## Sites changed
- `apps/backend/src/apps/controllers/chatController.ts` (postMessage + update paths)
- `apps/backend/src/apps/controllers/incomingWebhookController.ts`
- `apps/backend/src/apps/platform-adapters/slack/request-transformers/chat.ts`
- `packages/xyne-claw-shared/src/flow/flow-text.ts` (decoder) + new `flow-text.test.ts`

## Validation
- `vitest run src/flow/flow-text.test.ts` → 4 passed.
- Shared package `tsc` shows only pre-existing unrelated errors (`react-artifact/tools.ts`), none in the touched files.

## Notes / follow-ups
- `messages-handler.ts` keeps its own copy of the decoder (already correct). Consolidating it onto the shared `flow-text.ts` decoder is left as a follow-up to keep this change focused.