### PR TITLE
fix: XYNE-62808 derive github credential owner from the token

### DIFF
--- a/apps/backend/src/sdlc/vcs/GitHubVcsAdapter.ts
+++ b/apps/backend/src/sdlc/vcs/GitHubVcsAdapter.ts
@@ -120,7 +120,7 @@ export class GitHubVcsAdapter implements VcsProviderAdapter {
     };
   }
 
-  async validateCredential(token: string, resourceOwner: string): Promise<ValidatedCredential> {
+  async validateCredential(token: string): Promise<ValidatedCredential> {
     const identity = await this.request<{ login?: string }>('/user', token);
     if (!identity.login) {
       throw new VcsProviderError(
@@ -129,8 +129,27 @@ export class GitHubVcsAdapter implements VcsProviderAdapter {
         502
       );
     }
-    await this.request(`/users/${encodeURIComponent(resourceOwner)}`, token);
-    return { identityLogin: identity.login, resourceOwner };
+    return { identityLogin: identity.login, ...(await this.reach(token)) };
+  }
+
+  // Display only, never a gate. With per_page=1 the Link header's last page is the total.
+  private async reach(
+    token: string
+  ): Promise<{ repositoryOwner: string | null; repositoryCount: number | null }> {
+    try {
+      const { data, response } = await this.send<GitHubRepositoryResponse[]>(
+        '/user/repos?per_page=1',
+        token
+      );
+      const lastPage = /[?&]page=(\d+)>; rel="last"/.exec(response.headers.get('link') || '');
+      return {
+        repositoryOwner: data[0]?.owner?.login?.toLowerCase() ?? null,
+        repositoryCount: lastPage ? Number(lastPage[1]) : data.length,
+      };
+    } catch {
+      // Display data must not block saving a valid key.
+      return { repositoryOwner: null, repositoryCount: null };
+    }
   }
 
   async inspectRepository(input: {
@@ -487,6 +506,14 @@ export class GitHubVcsAdapter implements VcsProviderAdapter {
     token?: string,
     init: RequestInit = {}
   ): Promise<T> {
+    return (await this.send<T>(path, token, init)).data;
+  }
+
+  private async send<T = unknown>(
+    path: string,
+    token?: string,
+    init: RequestInit = {}
+  ): Promise<{ data: T; response: Response }> {
     let response: Response;
     try {
       response = await fetch(`${API_URL}${path}`, {
@@ -509,7 +536,7 @@ export class GitHubVcsAdapter implements VcsProviderAdapter {
       );
     }
     if (!response.ok) throw this.responseError(response);
-    return (await response.json()) as T;
+    return { data: (await response.json()) as T, response };
   }
 
   private responseError(response: Response): VcsProviderError {

--- a/apps/backend/src/sdlc/vcs/GitHubVcsAdapter.ts
+++ b/apps/backend/src/sdlc/vcs/GitHubVcsAdapter.ts
@@ -11,6 +11,7 @@ import type {
   ParsedRepository,
   PullRequestInspection,
   RepositoryInspection,
+  RepositoryReach,
   RepositoryVisibility,
   SourceLineRange,
   ValidatedCredential,
@@ -129,13 +130,11 @@ export class GitHubVcsAdapter implements VcsProviderAdapter {
         502
       );
     }
-    return { identityLogin: identity.login, ...(await this.reach(token)) };
+    return { identityLogin: identity.login };
   }
 
   // Display only, never a gate. With per_page=1 the Link header's last page is the total.
-  private async reach(
-    token: string
-  ): Promise<{ repositoryOwner: string | null; repositoryCount: number | null }> {
+  async repositoryReach(token: string): Promise<RepositoryReach> {
     try {
       const { data, response } = await this.send<GitHubRepositoryResponse[]>(
         '/user/repos?per_page=1',

--- a/apps/backend/src/sdlc/vcs/SdlcVcsCredentialStore.ts
+++ b/apps/backend/src/sdlc/vcs/SdlcVcsCredentialStore.ts
@@ -14,7 +14,8 @@ export interface StoredSdlcVcsCredential {
   token: string | null;
   revision: number;
   identityLogin: string | null;
-  resourceOwner: string | null;
+  repositoryOwner: string | null;
+  repositoryCount: number | null;
   fingerprint: string | null;
   validationStatus: string;
   validatedAt: string | null;

--- a/apps/backend/src/sdlc/vcs/SdlcVcsCredentialStore.ts
+++ b/apps/backend/src/sdlc/vcs/SdlcVcsCredentialStore.ts
@@ -14,9 +14,6 @@ export interface StoredSdlcVcsCredential {
   token: string | null;
   revision: number;
   identityLogin: string | null;
-  repositoryOwner: string | null;
-  repositoryCount: number | null;
-  fingerprint: string | null;
   validationStatus: string;
   validatedAt: string | null;
   validationErrorCode: string | null;

--- a/apps/backend/src/sdlc/vcs/SdlcVcsService.ts
+++ b/apps/backend/src/sdlc/vcs/SdlcVcsService.ts
@@ -5,7 +5,6 @@ import { AppError } from '@/middleware/errorHandler';
 import { logger } from '@/utils/logger';
 import type { SdlcActor } from '../types';
 import { isSafeSdlcGitRef, requireSdlcBaseBranch } from '../sdlcRepositoryContext';
-import { credentialFingerprint } from './credentialEnvelope';
 import { GitHubVcsAdapter } from './GitHubVcsAdapter';
 import { SdlcVcsCredentialStore, type StoredSdlcVcsCredential } from './SdlcVcsCredentialStore';
 import { classifyRuntimeAccessFailure } from './accessCheckPolicy';
@@ -48,24 +47,24 @@ export class SdlcVcsService implements SdlcVcs {
   async listCredentials(actor: SdlcActor): Promise<unknown[]> {
     const user = await this.requireWorkspaceUser(actor);
     const rows = await this.credentialStore.list(this.prisma, actor.workspaceId);
-    const counts = await this.repositoryCountsByProvider(actor.workspaceId);
-    return rows.map((row) => ({
-      provider: row.provider,
-      status: row.status,
-      revision: row.revision,
-      identityLogin: row.identityLogin,
-      repositoryOwner: row.repositoryOwner,
-      repositoryCount: row.repositoryCount,
-      fingerprint: row.fingerprint,
-      validationStatus: row.validationStatus,
-      validatedAt: row.validatedAt,
-      validationErrorCode: row.validationErrorCode,
-      validationErrorMessage: row.validationErrorMessage,
-      disconnectedAt: row.disconnectedAt,
-      updatedAt: row.updatedAt,
-      attachedRepositoryCount: counts.get(row.provider) ?? 0,
-      canManage: user.role === 'OWNER' || user.role === 'ADMIN',
-    }));
+    return await Promise.all(
+      rows.map(async (row) => ({
+        provider: row.provider,
+        status: row.status,
+        revision: row.revision,
+        identityLogin: row.identityLogin,
+        ...(row.status === 'CONNECTED' && row.token
+          ? await this.adapter(row.provider).repositoryReach(row.token)
+          : { repositoryOwner: null, repositoryCount: null }),
+        validationStatus: row.validationStatus,
+        validatedAt: row.validatedAt,
+        validationErrorCode: row.validationErrorCode,
+        validationErrorMessage: row.validationErrorMessage,
+        disconnectedAt: row.disconnectedAt,
+        updatedAt: row.updatedAt,
+        canManage: user.role === 'OWNER' || user.role === 'ADMIN',
+      }))
+    );
   }
 
   async configureCredential(
@@ -95,9 +94,6 @@ export class SdlcVcsService implements SdlcVcs {
         token: input.token,
         revision,
         identityLogin: validation.identityLogin,
-        repositoryOwner: validation.repositoryOwner,
-        repositoryCount: validation.repositoryCount,
-        fingerprint: credentialFingerprint(input.token),
         validationStatus: 'VALID',
         validatedAt: now,
         validationErrorCode: null,
@@ -136,8 +132,6 @@ export class SdlcVcsService implements SdlcVcs {
           validationErrorCode: null,
           validationErrorMessage: null,
           identityLogin: validation.identityLogin,
-          repositoryOwner: validation.repositoryOwner,
-          repositoryCount: validation.repositoryCount,
           updatedBy: actor.userId,
           updatedAt: now,
         });
@@ -459,16 +453,18 @@ export class SdlcVcsService implements SdlcVcs {
     }
   }
 
-  async bootstrapSandboxCredential(binding: {
-    agentSlug: typeof SDLC_AGENT_SLUG;
-    repoId: string;
-    operation: 'CLONE' | 'PUSH' | 'INTERACTIVE';
-    sandboxId: string;
-    sandboxPublicKey: string;
-  } & (
-    | { executionId: string; sessionId: string }
-    | { interactiveGrant: string; conversationId: string }
-  )): Promise<SandboxCredentialEnvelope | null> {
+  async bootstrapSandboxCredential(
+    binding: {
+      agentSlug: typeof SDLC_AGENT_SLUG;
+      repoId: string;
+      operation: 'CLONE' | 'PUSH' | 'INTERACTIVE';
+      sandboxId: string;
+      sandboxPublicKey: string;
+    } & (
+      | { executionId: string; sessionId: string }
+      | { interactiveGrant: string; conversationId: string }
+    )
+  ): Promise<SandboxCredentialEnvelope | null> {
     const repo = await this.prisma.repo.findUnique({
       where: { id: binding.repoId },
       select: { id: true, workspaceId: true },
@@ -558,17 +554,19 @@ export class SdlcVcsService implements SdlcVcs {
     );
   }
 
-  async createDraftPullRequest(input: {
-    repoId: string;
-    title: string;
-    body: string;
-    head: string;
-    base: string;
-    commitHash: string;
-  } & (
-    | { executionId: string; sessionId: string }
-    | { interactiveGrant: string; conversationId: string }
-  )) {
+  async createDraftPullRequest(
+    input: {
+      repoId: string;
+      title: string;
+      body: string;
+      head: string;
+      base: string;
+      commitHash: string;
+    } & (
+      | { executionId: string; sessionId: string }
+      | { interactiveGrant: string; conversationId: string }
+    )
+  ) {
     const repo = await this.prisma.repo.findUnique({ where: { id: input.repoId } });
     if (!repo?.workspaceId) throw new AppError('SDLC repository not found', 404);
     let actor: SdlcActor;
@@ -899,17 +897,6 @@ export class SdlcVcsService implements SdlcVcs {
       .map((repository) => repository.id);
   }
 
-  private async repositoryCountsByProvider(workspaceId: string): Promise<Map<VcsProvider, number>> {
-    const counts = new Map<VcsProvider, number>();
-    for (const provider of Object.keys(adapters) as VcsProvider[]) {
-      counts.set(
-        provider,
-        (await this.repositoryIdsForProvider(this.prisma, workspaceId, provider)).length
-      );
-    }
-    return counts;
-  }
-
   private adapter(provider: VcsProvider): VcsProviderAdapter {
     const adapter = adapters[provider];
     if (!adapter) throw new AppError(`Unsupported VCS provider: ${provider}`, 400);
@@ -979,12 +966,7 @@ export class SdlcVcsService implements SdlcVcs {
     provider: VcsProvider
   ): Promise<(StoredSdlcVcsCredential & { token: string }) | null> {
     const row = await this.credentialStore.find(this.prisma, workspaceId, provider);
-    if (
-      !row ||
-      row.status !== 'CONNECTED' ||
-      row.validationStatus !== 'VALID' ||
-      !row.token
-    ) {
+    if (!row || row.status !== 'CONNECTED' || row.validationStatus !== 'VALID' || !row.token) {
       return null;
     }
     return row as StoredSdlcVcsCredential & { token: string };

--- a/apps/backend/src/sdlc/vcs/SdlcVcsService.ts
+++ b/apps/backend/src/sdlc/vcs/SdlcVcsService.ts
@@ -54,7 +54,8 @@ export class SdlcVcsService implements SdlcVcs {
       status: row.status,
       revision: row.revision,
       identityLogin: row.identityLogin,
-      resourceOwner: row.resourceOwner,
+      repositoryOwner: row.repositoryOwner,
+      repositoryCount: row.repositoryCount,
       fingerprint: row.fingerprint,
       validationStatus: row.validationStatus,
       validatedAt: row.validatedAt,
@@ -70,13 +71,13 @@ export class SdlcVcsService implements SdlcVcs {
   async configureCredential(
     actor: SdlcActor,
     provider: VcsProvider,
-    input: { token: string; resourceOwner: string }
+    input: { token: string }
   ): Promise<unknown> {
     await this.requireWorkspaceAdmin(actor);
     const adapter = this.adapter(provider);
     let validation;
     try {
-      validation = await adapter.validateCredential(input.token, input.resourceOwner);
+      validation = await adapter.validateCredential(input.token);
     } catch (error) {
       throw this.toAppError(error);
     }
@@ -94,7 +95,8 @@ export class SdlcVcsService implements SdlcVcs {
         token: input.token,
         revision,
         identityLogin: validation.identityLogin,
-        resourceOwner: validation.resourceOwner,
+        repositoryOwner: validation.repositoryOwner,
+        repositoryCount: validation.repositoryCount,
         fingerprint: credentialFingerprint(input.token),
         validationStatus: 'VALID',
         validatedAt: now,
@@ -124,10 +126,7 @@ export class SdlcVcsService implements SdlcVcs {
     await this.requireWorkspaceAdmin(actor);
     const row = await this.requireConnectedCredential(actor.workspaceId, provider);
     try {
-      const validation = await this.adapter(provider).validateCredential(
-        row.token,
-        row.resourceOwner
-      );
+      const validation = await this.adapter(provider).validateCredential(row.token);
       const now = new Date().toISOString();
       await this.prisma.$transaction(async (tx) => {
         await this.credentialStore.save(tx, {
@@ -137,7 +136,8 @@ export class SdlcVcsService implements SdlcVcs {
           validationErrorCode: null,
           validationErrorMessage: null,
           identityLogin: validation.identityLogin,
-          resourceOwner: validation.resourceOwner,
+          repositoryOwner: validation.repositoryOwner,
+          repositoryCount: validation.repositoryCount,
           updatedBy: actor.userId,
           updatedAt: now,
         });
@@ -316,36 +316,26 @@ export class SdlcVcsService implements SdlcVcs {
       let inspection;
       let fallbackError: VcsProviderError | null = null;
       if (token) {
-        if (
-          credential?.resourceOwner &&
-          credential.resourceOwner.toLowerCase() !== parsed.owner.toLowerCase()
-        ) {
-          fallbackError = new VcsProviderError(
-            'GITHUB_RESOURCE_OWNER_MISMATCH',
-            `Workspace credential is limited to ${credential.resourceOwner}`,
-            403
-          );
-        } else {
-          try {
-            inspection = await adapter.inspectRepository({
-              repository: parsed,
-              baseBranch: this.baseBranch(repo.baseBranch),
-              token,
+        // GitHub authorises the repository; do not re-add a local owner check here.
+        try {
+          inspection = await adapter.inspectRepository({
+            repository: parsed,
+            baseBranch: this.baseBranch(repo.baseBranch),
+            token,
+          });
+        } catch (error) {
+          fallbackError = this.providerError(error);
+          if (fallbackError.retryable) throw fallbackError;
+          if (fallbackError.code === 'GITHUB_CREDENTIAL_INVALID' && credential) {
+            await this.invalidateWorkspaceCredential({
+              workspaceId: input.workspaceId,
+              userId: input.userId,
+              provider,
+              credentialId: credential.id,
+              credentialRevision: credential.revision,
+              error: fallbackError,
             });
-          } catch (error) {
-            fallbackError = this.providerError(error);
-            if (fallbackError.retryable) throw fallbackError;
-            if (fallbackError.code === 'GITHUB_CREDENTIAL_INVALID' && credential) {
-              await this.invalidateWorkspaceCredential({
-                workspaceId: input.workspaceId,
-                userId: input.userId,
-                provider,
-                credentialId: credential.id,
-                credentialRevision: credential.revision,
-                error: fallbackError,
-              });
-              credentialInvalidated = true;
-            }
+            credentialInvalidated = true;
           }
         }
         if (!inspection) {
@@ -976,7 +966,7 @@ export class SdlcVcsService implements SdlcVcs {
   private async requireConnectedCredential(
     workspaceId: string,
     provider: VcsProvider
-  ): Promise<StoredSdlcVcsCredential & { token: string; resourceOwner: string }> {
+  ): Promise<StoredSdlcVcsCredential & { token: string }> {
     const row = await this.connectedCredential(workspaceId, provider);
     if (!row) {
       throw new AppError('Workspace GitHub credential is not connected', 409);
@@ -987,18 +977,17 @@ export class SdlcVcsService implements SdlcVcs {
   private async connectedCredential(
     workspaceId: string,
     provider: VcsProvider
-  ): Promise<(StoredSdlcVcsCredential & { token: string; resourceOwner: string }) | null> {
+  ): Promise<(StoredSdlcVcsCredential & { token: string }) | null> {
     const row = await this.credentialStore.find(this.prisma, workspaceId, provider);
     if (
       !row ||
       row.status !== 'CONNECTED' ||
       row.validationStatus !== 'VALID' ||
-      !row.token ||
-      !row.resourceOwner
+      !row.token
     ) {
       return null;
     }
-    return row as StoredSdlcVcsCredential & { token: string; resourceOwner: string };
+    return row as StoredSdlcVcsCredential & { token: string };
   }
 
   private credentialState(credential: StoredSdlcVcsCredential | null): string | null {

--- a/apps/backend/src/sdlc/vcs/credentialEnvelope.ts
+++ b/apps/backend/src/sdlc/vcs/credentialEnvelope.ts
@@ -66,7 +66,3 @@ export function decryptCredentialPayload(
     decipher.final(),
   ]).toString('utf8');
 }
-
-export function credentialFingerprint(token: string): string {
-  return crypto.createHmac('sha256', encryptionKey()).update(token).digest('hex').slice(0, 12);
-}

--- a/apps/backend/src/sdlc/vcs/types.ts
+++ b/apps/backend/src/sdlc/vcs/types.ts
@@ -30,6 +30,9 @@ export interface ParsedRepository {
 
 export interface ValidatedCredential {
   identityLogin: string;
+}
+
+export interface RepositoryReach {
   repositoryOwner: string | null;
   repositoryCount: number | null;
 }
@@ -95,6 +98,7 @@ export interface VcsProviderAdapter {
   readonly provider: VcsProvider;
   parseRepositoryUrl(url: string): ParsedRepository;
   validateCredential(token: string): Promise<ValidatedCredential>;
+  repositoryReach(token: string): Promise<RepositoryReach>;
   inspectRepository(input: {
     repository: ParsedRepository;
     baseBranch?: string;

--- a/apps/backend/src/sdlc/vcs/types.ts
+++ b/apps/backend/src/sdlc/vcs/types.ts
@@ -30,7 +30,8 @@ export interface ParsedRepository {
 
 export interface ValidatedCredential {
   identityLogin: string;
-  resourceOwner: string;
+  repositoryOwner: string | null;
+  repositoryCount: number | null;
 }
 
 export interface RepositoryInspection {
@@ -93,7 +94,7 @@ export interface SourceLineRange {
 export interface VcsProviderAdapter {
   readonly provider: VcsProvider;
   parseRepositoryUrl(url: string): ParsedRepository;
-  validateCredential(token: string, resourceOwner: string): Promise<ValidatedCredential>;
+  validateCredential(token: string): Promise<ValidatedCredential>;
   inspectRepository(input: {
     repository: ParsedRepository;
     baseBranch?: string;
@@ -153,7 +154,7 @@ export interface SdlcVcs {
   configureCredential(
     actor: SdlcActor,
     provider: VcsProvider,
-    input: { token: string; resourceOwner: string }
+    input: { token: string }
   ): Promise<unknown>;
   revalidateCredential(actor: SdlcActor, provider: VcsProvider): Promise<unknown>;
   disconnectCredential(actor: SdlcActor, provider: VcsProvider): Promise<void>;

--- a/apps/dashboard/src/routes/WorkspaceManagementScreen/RepositoryCredentialsTab.tsx
+++ b/apps/dashboard/src/routes/WorkspaceManagementScreen/RepositoryCredentialsTab.tsx
@@ -12,13 +12,12 @@ interface CredentialMetadata {
   status: string;
   revision: number;
   identityLogin: string | null;
-  resourceOwner: string | null;
-  fingerprint: string | null;
+  repositoryOwner: string | null;
+  repositoryCount: number | null;
   validationStatus: string;
   validatedAt: string | null;
   validationErrorCode: string | null;
   validationErrorMessage: string | null;
-  attachedRepositoryCount: number;
   canManage: boolean;
 }
 
@@ -28,7 +27,6 @@ export function RepositoryCredentialsTab({ isActive }: { isActive: boolean }): R
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState<string | null>(null);
   const [token, setToken] = useState('');
-  const [resourceOwner, setResourceOwner] = useState('');
   const canManage = self?.role === WorkspaceRole.OWNER || self?.role === WorkspaceRole.ADMIN;
 
   const load = useCallback(async (): Promise<void> => {
@@ -50,13 +48,10 @@ export function RepositoryCredentialsTab({ isActive }: { isActive: boolean }): R
   }, [isActive, load]);
 
   const save = async (): Promise<void> => {
-    if (!token.trim() || !resourceOwner.trim()) return;
+    if (!token.trim()) return;
     setBusy('save');
     try {
-      await apiInstance.put('/sdlc/vcs/credentials/github', {
-        token: token.trim(),
-        resourceOwner: resourceOwner.trim(),
-      });
+      await apiInstance.put('/sdlc/vcs/credentials/github', { token: token.trim() });
       setToken('');
       toast.success('GitHub credential validated and saved');
       await load();
@@ -125,11 +120,13 @@ export function RepositoryCredentialsTab({ isActive }: { isActive: boolean }): R
           <p className='mt-6 text-sm text-muted-foreground'>Loading credential status…</p>
         ) : credential?.status === 'CONNECTED' ? (
           <div className='mt-6 space-y-4'>
-            <dl className='grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-4'>
-              <Metadata label='Identity' value={credential.identityLogin || 'Unknown'} />
-              <Metadata label='Resource owner' value={credential.resourceOwner || 'Unknown'} />
-              <Metadata label='Fingerprint' value={credential.fingerprint || 'Unavailable'} />
-              <Metadata label='Attached repos' value={String(credential.attachedRepositoryCount)} />
+            <dl className='grid gap-3 text-sm sm:grid-cols-2 lg:grid-cols-3'>
+              <Metadata label='GitHub account' value={credential.identityLogin || 'Unknown'} />
+              <Metadata label='Token for' value={credential.repositoryOwner || 'Unknown'} />
+              <Metadata
+                label='Repos it can access'
+                value={credential.repositoryCount?.toString() ?? 'Unknown'}
+              />
             </dl>
             <p className='text-xs text-muted-foreground'>
               {credential.validationStatus === 'VALID'
@@ -174,11 +171,9 @@ export function RepositoryCredentialsTab({ isActive }: { isActive: boolean }): R
         ) : canManage ? (
           <CredentialForm
             token={token}
-            resourceOwner={resourceOwner}
             replacing={credential?.status === 'REPLACING'}
             busy={busy === 'save'}
             onToken={setToken}
-            onOwner={setResourceOwner}
             onSubmit={() => void save()}
           />
         ) : (
@@ -193,11 +188,9 @@ export function RepositoryCredentialsTab({ isActive }: { isActive: boolean }): R
 
 function CredentialForm(props: {
   token: string;
-  resourceOwner: string;
   replacing: boolean;
   busy: boolean;
   onToken: (value: string) => void;
-  onOwner: (value: string) => void;
   onSubmit: () => void;
 }): ReactElement {
   return (
@@ -209,26 +202,13 @@ function CredentialForm(props: {
       }}
     >
       <div className='rounded-lg bg-muted p-4 text-sm text-muted-foreground'>
-        Create one fine-grained PAT for one GitHub resource owner. Grant repository{' '}
-        <strong>Contents: read/write</strong>, <strong>Pull requests: read/write</strong>, and{' '}
-        <strong>Workflows: read/write</strong>. GitHub requires Workflows permission when a task
-        changes files under <code>.github/workflows</code>. Metadata read access is added
-        automatically. Do not grant administration or branch-protection bypass.
+        Paste a fine-grained PAT. Grant repository <strong>Contents: read/write</strong>,{' '}
+        <strong>Pull requests: read/write</strong>, and <strong>Workflows: read/write</strong>.
+        GitHub requires Workflows permission when a task changes files under{' '}
+        <code>.github/workflows</code>. Metadata read access is added automatically. Do not grant
+        administration or branch-protection bypass.
       </div>
-      <div className='grid gap-4 sm:grid-cols-2'>
-        <label className='text-sm font-medium' htmlFor='sdlc-vcs-resource-owner'>
-          Resource owner
-          <Input
-            id='sdlc-vcs-resource-owner'
-            className='mt-2'
-            value={props.resourceOwner}
-            onChange={event => props.onOwner(event.target.value)}
-            placeholder='github-org-or-user'
-            data-track-category='workspace-management'
-            data-track-name='EDIT_GITHUB_RESOURCE_OWNER'
-            required
-          />
-        </label>
+      <div className='grid gap-4'>
         <label className='text-sm font-medium' htmlFor='sdlc-vcs-token'>
           Fine-grained PAT
           <Input
@@ -246,7 +226,7 @@ function CredentialForm(props: {
       <Button
         type='submit'
         loading={props.busy}
-        disabled={!props.token.trim() || !props.resourceOwner.trim()}
+        disabled={!props.token.trim()}
         data-track-category='workspace-management'
         data-track-name='SAVE_GITHUB_CREDENTIAL'
       >

--- a/packages/shared/src/sdlc.ts
+++ b/packages/shared/src/sdlc.ts
@@ -260,12 +260,6 @@ export const configureSdlcVcsCredentialSchema = z.object({
       /^github_pat_[A-Za-z0-9_]+$/,
       "Enter a GitHub fine-grained personal access token",
     ),
-  resourceOwner: z
-    .string()
-    .trim()
-    .min(1)
-    .max(100)
-    .regex(/^[A-Za-z0-9_.-]+$/),
 });
 export type ConfigureSdlcVcsCredentialInput = z.infer<
   typeof configureSdlcVcsCredentialSchema


### PR DESCRIPTION
## Problem

Repo cards under Project → Repos showed `READ REPOSITORY · proven` but `PUSH BRANCH · unavailable` and `CREATE PULL REQUEST · unavailable`, with overall status `ready` and no error message. The PAT was fine — `GET /repos/juspay/xyne-spaces` with it returns `permissions.push: true`.

`performRepositoryCheck` compared the stored `resourceOwner` against the repo owner and, on any mismatch, skipped the authenticated `inspectRepository` entirely and fell through to the anonymous one. `GitHubVcsAdapter.inspectRepository` computes `canPush = token ? repo.permissions?.push === true : false`, which is `false` without a token, so both write capabilities came back `UNAVAILABLE` while `READ_REPOSITORY` stayed `PROVEN` on a public repo.

The check was never a real fence:

- `resourceOwner` was free text typed by a workspace admin. `validateCredential` only did `GET /users/{resourceOwner}`, which proves the account exists, not that the token has any grant on it.
- Credentials are one-per-workspace-per-provider, so one typo degraded every GitHub repo in the workspace at once.
- The runtime write paths (`buildGitAuthentication`, `createDraftPullRequest`, `verifyRemoteCommit`) never compared `resourceOwner` to the repo owner. Push and PR creation were not fenced. Only the access check was.

## Change

- Deleted the `GITHUB_RESOURCE_OWNER_MISMATCH` branch. The authenticated inspect now runs whenever a token exists, and GitHub authorizes the call. A repo the token cannot see returns 404, which already flows through the existing `catch` into `fallbackError`.
- Removed `resourceOwner` from the connect payload, the shared zod schema, the credential record and the admin form. An admin now pastes a PAT and nothing else.
- The owner and the reachable repository count are derived instead of typed, and read live rather than stored: `repositoryReach(token)` on the adapter makes one `GET /user/repos?per_page=1` call at `listCredentials` time, taking the owner from the body and the count from the `Link` header's `rel="last"` page. Both are display-only and must never gate access. The credentials tab is opened rarely enough that one call per load beats keeping stored copies fresh.
- Dropped what the response no longer feeds: `fingerprint` and `attachedRepositoryCount` are gone from `listCredentials`, along with the `repositoryCountsByProvider` query that existed only to compute the latter and the now-unused `credentialFingerprint` helper. Nothing read the fingerprint, so it is no longer computed or stored either.
- Credential card now reads **GitHub account**, **Token for**, **Repos it can access**.

## Migration

None. No schema change, no backfill, no revalidation. The credential is an encrypted JSON blob inside `workflow.external_sources.credentials`, not a set of columns, and `parseStoredCredential` validates only `workspaceId`, `provider` and `revision`. Every existing blob is read as-is; its now-unused `resourceOwner` and `fingerprint` keys are ignored on read and dropped on the next save. `connectedCredential` no longer requires `resourceOwner`, so workspaces that have not revalidated keep working.

### Rollback constraint

Rolling *back* after this ships is not fully clean, in one narrow case. `configureCredential` builds its save object as a fresh literal, so a workspace that re-saves its PAT under this version gets a blob with no `resourceOwner`. The previous version's `connectedCredential` treats that as not connected.

Scope and severity:

- Only `configureCredential` drops the key. `revalidateCredential` and `invalidateWorkspaceCredential` save with `...row` / `...current`, which spread the object from `parseStoredCredential` and therefore carry `resourceOwner` forward at runtime. A workspace where nobody pastes a new PAT is unaffected, including after an unattended credential invalidation.
- Not a crash. `requireConnectedCredential` throws `AppError(..., 409)` and the error handler passes an `AppError`'s own status through, so affected calls return a 409 reading "Workspace GitHub credential is not connected". `listCredentials` does not go through that gate, so the credentials tab still loads.
- Affected paths under the old version: Start Work / `createDraftPullRequest`, `inspectPullRequest`, `revalidateCredential`.
- Self-healing: the admin re-saves the PAT under the old UI, which still has the resource-owner field.

Deliberately not dual-writing `resourceOwner` for a release. Say the word if you would rather the rollback path be clean.

## Testing

- `tsc --noEmit` clean on `apps/backend` and `apps/dashboard`.
- Pre-commit `dashboard:validate` passed (typecheck, prettier, eslint 0 errors).
- Verified against a live org-scoped PAT: card shows `Token for juspay`, `Repos it can access 622`, and the repo capabilities move from `unavailable` to `inferred`.

## Known limitation, not addressed here

The anonymous fallback swallows `fallbackError` whenever the anonymous read succeeds, so `deriveAccessStatus` reports `READY` with `errorMessage: null` and a capability downgrade on a public repo shows no reason. Pre-existing, tracked separately.

<details>
<summary>Debug</summary>

- Claude Code `session_01Q2QxUxqZacUx2SyFFxr5aj` — `8c2cc9a5e` — dropped the resourceOwner fence, derived the credential owner and reach from the token, and moved both to a live read.

</details>
