### PR TITLE
feat: XYNE-62847 upgraded search performance calls

### DIFF
--- a/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
+++ b/apps/dashboard/src/components/Call/InstantCallModal/InstantCallModal.tsx
@@ -1,23 +1,25 @@
-import { ChannelScopeType, ChannelVisibility } from '@xyne/shared';
-import { Hash, Lock, Users, X } from 'lucide-react';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { ChannelScopeType } from '@xyne/shared';
+import type { VisibleChannel } from '@xyne/shared/hooks';
+import { X } from 'lucide-react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAllVisibleChannels } from '../../../hooks/useChannels';
-import { useUserGroupSearch } from '@xyne/shared/hooks';
-import { useSelf, useActiveUsers, useUsers } from '../../../hooks/useUsers';
+import { useSelf, useActiveUsers, useUsersById } from '../../../hooks/useUsers';
+import { useParticipantCandidates } from '../../../hooks/useParticipantCandidates';
 import { useZero } from '../../../hooks/useZero';
 import { queries } from '../../../zero/queries';
 import { SearchParticipants } from '../../../routes/CallHistoryScreen/SearchParticipants';
-import { getUserDisplayName, isUserDeactivated } from '../../../utils/userDisplayName';
 import {
   parseParticipants,
   matchParticipants,
   looksLikeBulkEntry,
 } from '../../../utils/participantUtils';
-import { rankParticipantOptions } from '../../../utils/participantSearch';
-import Avatar from '../../ui/Avatar/Avatar';
 import Button from '../../ui/Button';
 import Dialog from '../../ui/Dialog';
-import { ParticipantOptionContent } from '../ParticipantOptionContent';
+import {
+  buildChannelParticipantOption,
+  buildUserGroupParticipantOption,
+  buildUserParticipantOption,
+} from '../participantOptions';
 
 interface InstantCallModalProps {
   isOpen: boolean;
@@ -37,8 +39,11 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
   const [notFoundUsers, setNotFoundUsers] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // Full roster — used ONLY by the bulk-paste matcher below, which runs on Enter
+  // rather than per keystroke. Reading the array is free; nothing maps over it.
   const activeUsers = useActiveUsers();
-  const allUsers = useUsers();
+  const usersById = useUsersById();
+  const allVisibleChannels = useAllVisibleChannels();
 
   // Focus on Search Participant Input when modal opens
   useEffect(() => {
@@ -49,86 +54,51 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
     }
   }, [isOpen]);
 
-  const allVisibleChannels = useAllVisibleChannels();
-  const userGroups = useUserGroupSearch(searchQuery, 10);
-
-  // Filter for DEFAULT public channels only (not DMs)
-  const channels = useMemo(() => {
-    return allVisibleChannels.filter(channel => channel.scopeType === ChannelScopeType.DEFAULT);
-  }, [allVisibleChannels]);
-
-  const inviteUserOrChannelOptions = useMemo(() => {
-    const userOptions =
-      activeUsers
-        .filter(u => u.id !== user?.id)
-        .map(user => ({
-          ...user,
-          label: user.name ?? user.email,
-          value: `user:${user.id}`,
-          icon: (
-            <Avatar
-              userId={user.id}
-              size={'sm'}
-              showActiveStatus={false}
-              className='rounded-md size-[18px] flex items-center justify-center bg-background'
-            />
-          ),
-          children: (
-            <ParticipantOptionContent
-              icon={
-                <Avatar
-                  userId={user.id}
-                  size='sm'
-                  showActiveStatus={false}
-                  className='rounded-md size-[18px] flex items-center justify-center bg-background'
-                />
-              }
-              label={getUserDisplayName(user)}
-              subtitle={user.email}
-              isDeactivated={isUserDeactivated(user)}
-            />
-          ),
-          type: 'user' as const,
-        })) || [];
-
-    const channelOptions = channels.map(channel => ({
-      ...channel,
-      label: channel.name,
-      value: `channel:${channel.id}`,
-      icon:
-        channel.visibility === ChannelVisibility.PRIVATE ? (
-          <Lock className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />
-        ) : (
-          <Hash className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />
-        ),
-      type: 'channel' as const,
-    }));
-
-    const userGroupOptions = userGroups.map(group => ({
-      ...group,
-      label: group.name,
-      value: `user_group:${group.id}`,
-      icon: <Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />,
-      subtitle: group.alias || group.description,
-      children: (
-        <ParticipantOptionContent
-          icon={<Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />}
-          label={group.name}
-          subtitle={group.alias || group.description}
-        />
-      ),
-      type: 'user_group' as const,
-    }));
-
-    return [...userOptions, ...channelOptions, ...userGroupOptions].sort((a, b) =>
-      a.label.localeCompare(b.label),
-    );
-  }, [activeUsers, channels, userGroups, allUsers, user?.id]);
-
-  const rankedParticipantOptions = useMemo(
-    () => rankParticipantOptions(inviteUserOrChannelOptions, searchQuery),
-    [inviteUserOrChannelOptions, searchQuery],
+  const excludedUserIds = useMemo(
+    () => (user?.id ? new Set([user.id]) : new Set<string>()),
+    [user?.id],
   );
+
+  // DEFAULT-scope channels only (no DMs, no group DMs).
+  const channelFilter = useCallback(
+    (channel: VisibleChannel) => channel.scopeType === ChannelScopeType.DEFAULT,
+    [],
+  );
+
+  // Bounded + ranked candidates. Only these get turned into rows, so a keystroke
+  // decorates ~40 entities instead of the whole workspace.
+  const { users, userGroups, channels } = useParticipantCandidates({
+    query: searchQuery,
+    excludeUserIds: excludedUserIds,
+    channelFilter,
+  });
+
+  const participantOptions = useMemo(
+    () => [
+      ...users.map(buildUserParticipantOption),
+      ...channels.map(buildChannelParticipantOption),
+      ...userGroups.map(buildUserGroupParticipantOption),
+    ],
+    [users, channels, userGroups],
+  );
+
+  // Pills for the current selection. Bulk paste can add people the ranked slice
+  // never contained, and a picked channel drops out of the list as soon as the
+  // query changes — both would leave a selected value with no renderable pill.
+  const selectedOptions = useMemo(() => {
+    const channelsById = new Map(allVisibleChannels.map(c => [c.id, c]));
+    return selectedParticipants.flatMap(value => {
+      if (value.startsWith('user:')) {
+        const found = usersById.get(value.slice('user:'.length));
+        return found ? [buildUserParticipantOption(found)] : [];
+      }
+      if (value.startsWith('channel:')) {
+        const found = channelsById.get(value.slice('channel:'.length));
+        return found ? [buildChannelParticipantOption(found)] : [];
+      }
+      return [];
+    });
+  }, [selectedParticipants, usersById, allVisibleChannels]);
 
   const handleSubmit = () => {
     onSubmit(selectedParticipants);
@@ -248,7 +218,8 @@ export const InstantCallModal: React.FC<InstantCallModalProps> = ({
             <div className='space-y-2'>
               <p className='text-muted-foreground text-[13px] leading-5'>{participantLabel}</p>
               <SearchParticipants
-                options={rankedParticipantOptions}
+                options={participantOptions}
+                prefilledOptions={selectedOptions}
                 selectedValues={selectedParticipants}
                 onMultiSelect={handleMultiSelect}
                 searchQuery={searchQuery}

--- a/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
+++ b/apps/dashboard/src/components/Call/ScheduleCallModal/ScheduleCallModal.tsx
@@ -1,14 +1,14 @@
 import React, { useMemo, useCallback, useState, useRef } from 'react';
 import { Button } from '../../ui/Button';
 import Input from '../../ui/Input';
-import { ChannelScopeType, ChannelVisibility, isDeskChannelType } from '@xyne/shared';
+import { ChannelScopeType, isDeskChannelType } from '@xyne/shared';
 import { useQuery } from '@tanstack/react-query';
 import { channelService } from '../../../services/Chat/channelService';
-import { useSelf, useActiveUsers, useUsers } from '../../../hooks/useUsers';
+import { useSelf, useActiveUsers, useUsersById } from '../../../hooks/useUsers';
 import { useZero } from '../../../hooks/useZero';
-import { isUserDeactivated } from '../../../utils/userDisplayName';
 import { useAllVisibleChannels, useChannel } from '../../../hooks/useChannels';
-import { useUserGroupSearch } from '@xyne/shared/hooks';
+import type { VisibleChannel } from '@xyne/shared/hooks';
+import { useParticipantCandidates } from '../../../hooks/useParticipantCandidates';
 import {
   ApiError,
   callService,
@@ -25,14 +25,16 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '../../ui/dropdown-menu';
-import { ChevronDown, ChevronUp, Hash, Info, Lock, Users, X } from 'lucide-react';
+import { ChevronDown, ChevronUp, Info, X } from 'lucide-react';
 import { DatePicker } from '../../ui/DatePicker/DatePicker';
 import { TimePicker } from '../../ui/TimePicker/TimePicker';
 import { RadioGroup, Radio } from '../../ui/RadioGroup/RadioGroup';
 import { SearchParticipants } from '../../../routes/CallHistoryScreen/SearchParticipants';
-import { rankParticipantOptions } from '../../../utils/participantSearch';
-import Avatar from '../../ui/Avatar/Avatar';
-import { ParticipantOptionContent } from '../ParticipantOptionContent';
+import {
+  buildChannelParticipantOption,
+  buildUserGroupParticipantOption,
+  buildUserParticipantOption,
+} from '../participantOptions';
 import { Controller, useForm } from 'react-hook-form';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 import {
@@ -92,8 +94,10 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
 }) => {
   const user = useSelf();
   const zero = useZero();
+  // Full roster — read only by the bulk-paste matcher (`handleBulkUserEntry`), which
+  // runs on Enter, not per keystroke. Nothing maps over it.
   const allUsers = useActiveUsers();
-  const fullUserList = useUsers();
+  const usersById = useUsersById();
   const allVisibleChannels = useAllVisibleChannels();
 
   // When opened from a thread, fetch channel participants to restrict the picker
@@ -245,7 +249,6 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
 
   // Search query state (not in form)
   const [searchQuery, setSearchQuery] = React.useState('');
-  const userGroups = useUserGroupSearch(searchQuery, 10);
   const [notFoundUsers, setNotFoundUsers] = React.useState<string[]>([]);
 
   const {
@@ -336,45 +339,14 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
     validateTimes,
   });
 
-  const buildUserOption = (
-    u: Pick<(typeof allUsers)[number], 'id' | 'name'> &
-      Partial<Pick<(typeof allUsers)[number], 'email' | 'displayName' | 'status'>>,
-  ) => ({
-    ...u,
-    label: getUserDisplayName(u),
-    subtitle: u.name,
-    value: `user:${u.id}`,
-    icon: (
-      <Avatar
-        userId={u.id}
-        size={'sm'}
-        showActiveStatus={false}
-        className='rounded-md size-[18px] flex items-center justify-center bg-background'
-      />
-    ),
-    children: (
-      <ParticipantOptionContent
-        icon={
-          <Avatar
-            userId={u.id}
-            size='sm'
-            showActiveStatus={false}
-            className='rounded-md size-[18px] flex items-center justify-center bg-background'
-          />
-        }
-        label={getUserDisplayName(u)}
-        subtitle={u.email}
-        isDeactivated={isUserDeactivated(u)}
-      />
-    ),
-    type: 'user' as const,
-  });
-
   // Build ParticipantOptions for the unfurled channel-member checkbox list.
   // Members come from the API as { id, name }, so no allUsers cross-reference is needed.
+  // Bounded by the channel's own membership, not the workspace.
   const channelMembersOptions = useMemo(() => {
     if (!selectedChannelId || !selectedChannelParticipants) return null;
-    return selectedChannelParticipants.filter(m => m.id !== user?.id).map(buildUserOption);
+    return selectedChannelParticipants
+      .filter(m => m.id !== user?.id)
+      .map(buildUserParticipantOption);
   }, [selectedChannelId, selectedChannelParticipants, user?.id]);
 
   const {
@@ -391,137 +363,80 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
     selectiveExclusionsInitializedRef,
   });
 
-  // Build participant options
-  const inviteUserOrChannelOptions = useMemo(() => {
-    // When opened from a thread, only show channel members (no channels)
-    if (channelParticipantUserIds) {
-      const channelUserOptions = allUsers
-        .filter(u => u.id !== user?.id && channelParticipantUserIds.has(u.id))
-        .map(buildUserOption);
-
-      // In edit mode, inject pre-filled participants from the call in case they're missing
-      if (isEditMode && initialCall?.participants) {
-        initialCall.participants
-          .filter(p => !p.isExternal && p.userId !== user?.id)
-          .forEach(p => {
-            const alreadyIncluded = channelUserOptions.some(u => u.value === `user:${p.userId}`);
-            if (!alreadyIncluded) {
-              const fullUser = allUsers.find(u => u.id === p.userId);
-              if (fullUser) channelUserOptions.push(buildUserOption(fullUser));
-            }
-          });
-      }
-
-      return channelUserOptions.sort((a, b) => a.label.localeCompare(b.label));
-    }
-
-    const userOptions = allUsers.filter(u => u.id !== user?.id).map(buildUserOption);
-
-    const channelOptions = channels.map(channel => ({
-      ...channel,
-      label: channel.name,
-      value: `channel:${channel.id}`,
-      icon:
-        channel.visibility === ChannelVisibility.PRIVATE ? (
-          <Lock className='size-3.5 text-gray-600 mx-0.5' strokeWidth={2.3} />
-        ) : (
-          <Hash className='size-3.5 text-gray-600 mx-0.5' strokeWidth={2.3} />
-        ),
-      type: 'channel' as const,
-    }));
-
-    const userGroupOptions = userGroups.map(group => ({
-      ...group,
-      label: group.name,
-      value: `user_group:${group.id}`,
-      icon: <Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />,
-      subtitle: group.alias || group.description,
-      children: (
-        <ParticipantOptionContent
-          icon={<Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />}
-          label={group.name}
-          subtitle={group.alias || group.description}
-        />
-      ),
-      type: 'user_group' as const,
-    }));
-
-    // In edit mode, the call's existing channel may be filtered out of `channels`
-    // (e.g. a Desk channel). Inject it into options so it remains searchable/selectable.
-    // DM/GROUP_DM-backed calls are excluded: they prefill individual participants from
-    // call_participants rather than a channel pill (see useScheduleCallInitialization),
-    // and their `name` is raw user IDs, so injecting one puts a UUID in the picker.
-    if (isEditMode && initialCall?.channelId) {
-      const alreadyIncluded = channelOptions.some(
-        c => c.value === `channel:${initialCall.channelId}`,
-      );
-      if (!alreadyIncluded) {
-        const existingChannel = allVisibleChannels.find(c => c.id === initialCall.channelId);
-        if (
-          existingChannel &&
-          existingChannel.scopeType !== ChannelScopeType.DM &&
-          existingChannel.scopeType !== ChannelScopeType.GROUP_DM
-        ) {
-          channelOptions.push({
-            ...existingChannel,
-            label: existingChannel.name,
-            value: `channel:${existingChannel.id}`,
-            icon:
-              existingChannel.visibility === ChannelVisibility.PRIVATE ? (
-                <Lock className='size-3.5 text-gray-600 mx-0.5' strokeWidth={2.3} />
-              ) : (
-                <Hash className='size-3.5 text-gray-600 mx-0.5' strokeWidth={2.3} />
-              ),
-            type: 'channel' as const,
-          });
-        }
-      }
-    }
-
-    // Pre-filled participants may not appear in the current search results
-    // (useUserSearch is limited). Inject them so their pills always render.
-    if (isEditMode && initialCall?.participants) {
-      initialCall.participants
-        .filter(p => !p.isExternal && p.userId !== user?.id)
-        .forEach(p => {
-          const alreadyIncluded = userOptions.some(u => u.value === `user:${p.userId}`);
-          if (!alreadyIncluded) {
-            const fullUser = allUsers.find(u => u.id === p.userId);
-            if (fullUser) userOptions.push(buildUserOption(fullUser));
-          }
-        });
-    }
-
-    // Inject initialParticipants (create mode pre-fill from "Meet With" panel)
-    if (!isEditMode && initialParticipants) {
-      initialParticipants.forEach(id => {
-        const alreadyIncluded = userOptions.some(u => u.value === `user:${id}`);
-        if (!alreadyIncluded) {
-          const fullUser = allUsers.find(u => u.id === id);
-          if (fullUser) userOptions.push(buildUserOption(fullUser));
-        }
-      });
-    }
-
-    return [...userOptions, ...channelOptions, ...userGroupOptions].sort((a, b) =>
-      a.label.localeCompare(b.label),
+  // Groups whose every expanded member is already selected — they add nothing, so
+  // drop them from the list. Re-reading the ref is safe: expansion always writes it
+  // before updating `participants`, which re-runs this memo. Removing any one member
+  // puts the group back.
+  const fullyRepresentedGroupIds = useMemo(() => {
+    const selectedUserIds = new Set(
+      participants.filter(v => v.startsWith('user:')).map(v => v.replace('user:', '')),
     );
-  }, [
-    allUsers,
-    channels,
-    user?.id,
-    isEditMode,
-    initialCall,
-    initialParticipants,
-    allVisibleChannels,
-    channelParticipantUserIds,
-    userGroups,
-    fullUserList,
-  ]);
+    const represented = new Set<string>();
+    for (const [groupId, memberIds] of expandedGroupMembersRef.current) {
+      if (memberIds.length > 0 && memberIds.every(id => selectedUserIds.has(id))) {
+        represented.add(groupId);
+      }
+    }
+    return represented;
+  }, [participants]);
 
-  // Drop groups whose every member is already picked. Re-reading the ref is safe here:
-  // expansion always writes it before updating `participants`, which re-runs this memo.
-  // Removing any one member drops the group back into the list.
+  const excludedUserIds = useMemo(
+    () => (user?.id ? new Set([user.id]) : new Set<string>()),
+    [user?.id],
+  );
+
+  // DEFAULT-scope, non-Desk channels only.
+  const channelFilter = useCallback(
+    (channel: VisibleChannel) =>
+      channel.scopeType === ChannelScopeType.DEFAULT && !isDeskChannelType(channel.type),
+    [],
+  );
+
+  // Bounded + ranked candidates. Only these get decorated into rows, so a keystroke
+  // builds ~40 options instead of one per workspace user. Opened from a thread the
+  // picker is people-only, restricted to that channel's members.
+  const {
+    users: candidateUsers,
+    userGroups: candidateUserGroups,
+    channels: candidateChannels,
+  } = useParticipantCandidates({
+    query: searchQuery,
+    excludeUserIds: excludedUserIds,
+    restrictToUserIds: channelParticipantUserIds,
+    excludeUserGroupIds: fullyRepresentedGroupIds,
+    includeChannels: !channelParticipantUserIds,
+    includeUserGroups: !channelParticipantUserIds,
+    channelFilter,
+  });
+
+  const rankedParticipantOptions = useMemo(
+    () => [
+      ...candidateUsers.map(buildUserParticipantOption),
+      ...candidateChannels.map(buildChannelParticipantOption),
+      ...candidateUserGroups.map(buildUserGroupParticipantOption),
+    ],
+    [candidateUsers, candidateChannels, candidateUserGroups],
+  );
+
+  // Pills for the current selection. `rankedParticipantOptions` is a query-ranked
+  // slice, so a prefilled participant (edit mode, "Meet With", bulk paste) is usually
+  // absent from it — without a resolvable option here their pill would vanish while
+  // they stayed selected. Bounded by the selection, not the workspace.
+  const selectedParticipantOptions = useMemo(() => {
+    const channelsById = new Map(allVisibleChannels.map(c => [c.id, c]));
+    return participants.flatMap(value => {
+      if (value.startsWith('user:')) {
+        const found = usersById.get(value.replace('user:', ''));
+        return found ? [buildUserParticipantOption(found)] : [];
+      }
+      if (value.startsWith('channel:')) {
+        const found = channelsById.get(value.replace('channel:', ''));
+        return found ? [buildChannelParticipantOption(found)] : [];
+      }
+      return [];
+    });
+  }, [participants, usersById, allVisibleChannels]);
+
   // A non-organizer participant may only add/remove people (and only on a DM/GROUP_DM
   // call, which is what gates the entry point). Mirrors the backend rule in
   // scheduleCallController.updateScheduledCall, which rejects any other field from them.
@@ -550,19 +465,6 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
         : undefined,
     [participantsOnly, initialCall, user?.id],
   );
-
-  const rankedParticipantOptions = useMemo(() => {
-    const selectedUserIds = new Set(
-      participants.filter(v => v.startsWith('user:')).map(v => v.replace('user:', '')),
-    );
-    const remaining = inviteUserOrChannelOptions.filter(option => {
-      if (!option.value.startsWith('user_group:')) return true;
-      const members = expandedGroupMembersRef.current.get(option.value.replace('user_group:', ''));
-      if (!members?.length) return true;
-      return !members.every(id => selectedUserIds.has(id));
-    });
-    return rankParticipantOptions(remaining, searchQuery);
-  }, [inviteUserOrChannelOptions, searchQuery, participants]);
 
   const handleStartTimeChange = useCallback(
     (timeString: string): void => {
@@ -1964,6 +1866,7 @@ export const ScheduleCallModal: React.FC<ScheduleCallModalProps> = ({
                   render={({ field }) => (
                     <SearchParticipants
                       options={rankedParticipantOptions}
+                      prefilledOptions={selectedParticipantOptions}
                       disableClientFiltering
                       selectedValues={field.value}
                       onMultiSelect={async (values: string[]) => {

--- a/apps/dashboard/src/components/Call/participantOptions.tsx
+++ b/apps/dashboard/src/components/Call/participantOptions.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react';
+import { Hash, Lock, Users } from 'lucide-react';
+import { ChannelVisibility } from '@xyne/shared';
+import type { UserGroupLike, VisibleChannel } from '@xyne/shared/hooks';
+import type { User } from '../../machines/stateMachine';
+import { getUserDisplayName, isUserDeactivated } from '../../utils/userDisplayName';
+import Avatar from '../ui/Avatar/Avatar';
+import { ParticipantOptionContent } from './ParticipantOptionContent';
+
+/**
+ * Row builders shared by the call participant pickers (Instant / Schedule).
+ *
+ * These allocate React elements, so they must only ever be mapped over a BOUNDED
+ * list — the ranked slice from `useParticipantCandidates`, or the current
+ * selection. Mapping them over the full workspace roster is what made the call
+ * modals slow in the first place.
+ */
+
+export interface ParticipantOption {
+  value: string;
+  label: string;
+  subtitle?: string | null;
+  icon: ReactNode;
+  children?: ReactNode;
+  isDeactivated?: boolean;
+  type: 'user' | 'channel' | 'user_group';
+}
+
+/** Minimal shape the user row needs — channel-member payloads omit most fields. */
+export type UserLikeForOption = Pick<User, 'id' | 'name'> &
+  Partial<Pick<User, 'email' | 'displayName' | 'status'>>;
+
+const userAvatar = (userId: string): ReactNode => (
+  <Avatar
+    userId={userId}
+    size='sm'
+    showActiveStatus={false}
+    className='rounded-md size-[18px] flex items-center justify-center bg-background'
+  />
+);
+
+export function buildUserParticipantOption(user: UserLikeForOption): ParticipantOption {
+  const label = getUserDisplayName(user);
+  return {
+    ...user,
+    value: `user:${user.id}`,
+    label,
+    // The dropdown row comes from `children`, so this only surfaces in the
+    // channel-member checklist — whose payload is `{ id, name }` with no email.
+    // Falling back to `name` keeps that list rendering exactly as it did.
+    subtitle: user.email ?? user.name,
+    icon: userAvatar(user.id),
+    children: (
+      <ParticipantOptionContent
+        icon={userAvatar(user.id)}
+        label={label}
+        subtitle={user.email}
+        isDeactivated={isUserDeactivated(user)}
+      />
+    ),
+    type: 'user',
+  };
+}
+
+export function buildChannelParticipantOption(
+  channel: Pick<VisibleChannel, 'id' | 'name' | 'visibility'>,
+): ParticipantOption {
+  return {
+    ...channel,
+    value: `channel:${channel.id}`,
+    label: channel.name,
+    icon:
+      channel.visibility === ChannelVisibility.PRIVATE ? (
+        <Lock className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />
+      ) : (
+        <Hash className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />
+      ),
+    type: 'channel',
+  };
+}
+
+export function buildUserGroupParticipantOption(group: UserGroupLike): ParticipantOption {
+  const icon = <Users className='size-3.5 text-muted-foreground mx-0.5' strokeWidth={2.3} />;
+  const subtitle = group.alias || group.description;
+  return {
+    ...group,
+    value: `user_group:${group.id}`,
+    label: group.name,
+    subtitle,
+    icon,
+    children: <ParticipantOptionContent icon={icon} label={group.name} subtitle={subtitle} />,
+    type: 'user_group',
+  };
+}

--- a/apps/dashboard/src/hooks/useParticipantCandidates.ts
+++ b/apps/dashboard/src/hooks/useParticipantCandidates.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { UserGroupLike, VisibleChannel } from '@xyne/shared/hooks';
 import { useUserGroupSearch } from '@xyne/shared/hooks';
 import { searchChannels } from '@xyne/shared/utils';
+import { rankChannelsByAffinity } from '../utils/rankingUtils';
 import type { User } from '../machines/stateMachine';
 import { searchUsers, useActiveUsers } from './useUsers';
 import { useAllVisibleChannels } from './useChannels';
@@ -83,7 +84,11 @@ function useVisibleChannelCandidates(
 
   return useMemo(() => {
     if (pool.length === 0) return [];
-    // searchChannels slices to `limit` for both the query and the browse case.
+    // Browse (no query): `searchChannels` would just `slice(0, limit)` in whatever
+    // order the visible-channel list happens to be in — arbitrary once a workspace
+    // has hundreds of channels. Rank by affinity + recency instead, the same
+    // most-used-first ordering Cmd+K and the slash pickers use for their browse state.
+    if (!query) return rankChannelsByAffinity(pool).slice(0, limit);
     return searchChannels(pool, query, limit);
   }, [pool, query, limit]);
 }

--- a/apps/dashboard/src/hooks/useParticipantCandidates.ts
+++ b/apps/dashboard/src/hooks/useParticipantCandidates.ts
@@ -1,0 +1,154 @@
+import { useMemo } from 'react';
+import type { UserGroupLike, VisibleChannel } from '@xyne/shared/hooks';
+import { useUserGroupSearch } from '@xyne/shared/hooks';
+import { searchChannels } from '@xyne/shared/utils';
+import type { User } from '../machines/stateMachine';
+import { searchUsers, useActiveUsers } from './useUsers';
+import { useAllVisibleChannels } from './useChannels';
+import { useRankedActivePeople } from './useRankedPeopleSearch';
+
+/**
+ * Bounded candidate source for the participant pickers.
+ *
+ * Returns at most `userLimit` / `userGroupLimit` / `channelLimit` **raw** entities,
+ * already ranked for `query`. Callers decorate only what comes back.
+ *
+ * That ordering is the entire point. The call modals used to map the complete
+ * workspace user list into option objects — each carrying two `<Avatar>` elements
+ * and a `<ParticipantOptionContent>` — then `localeCompare`-sort it, then re-spread
+ * all of it through a fresh Fuse index, on every keystroke. At 2k users that is
+ * ~6k React elements and ~22k ICU comparisons per character typed. Applying the
+ * limit *before* decoration is the same fix `UnifiedParticipantSearch` made for the
+ * recording share modals (XYNE-59221); this hook is that fix in a form the call
+ * modals can use, since they need picker features (`lockedValues`, the channel-member
+ * unfurl, bulk paste) that `UnifiedParticipantSearch` does not expose.
+ *
+ * Ranking matches the rest of the app: `useRankedActivePeople` (token match → MFU
+ * affinity → DM recency), the shared `searchChannels` matcher, and `useUserGroupSearch`.
+ */
+export interface ParticipantCandidateOptions {
+  /** Current search text. Empty string = browse mode (still capped). */
+  query: string;
+  /** Hard cap on returned users. */
+  userLimit?: number;
+  /** Hard cap on returned user groups. */
+  userGroupLimit?: number;
+  /** Hard cap on returned channels. Ignored when `includeChannels` is false. */
+  channelLimit?: number;
+  /** Never offered — typically the current user plus anyone already committed. */
+  excludeUserIds?: ReadonlySet<string>;
+  /**
+   * Restrict candidates to this set (thread-scoped pickers, where only members of
+   * the originating channel may be invited). Ranking then runs over that pool
+   * instead of the workspace, so a small allowlist still returns full results.
+   * `null`/omitted = the whole workspace.
+   */
+  restrictToUserIds?: ReadonlySet<string> | null;
+  /** Groups already fully represented by the current selection. */
+  excludeUserGroupIds?: ReadonlySet<string>;
+  /** Set false for pickers that only offer people (thread-scoped calls). */
+  includeChannels?: boolean;
+  /** Set false for pickers that only offer people (thread-scoped calls). */
+  includeUserGroups?: boolean;
+  /** Extra per-channel predicate, e.g. dropping Desk channels. Must be memoized. */
+  channelFilter?: (channel: VisibleChannel) => boolean;
+}
+
+export interface ParticipantCandidates {
+  users: User[];
+  userGroups: UserGroupLike[];
+  channels: VisibleChannel[];
+}
+
+const EMPTY_IDS: ReadonlySet<string> = new Set();
+
+/**
+ * Visible-channel search. Deliberately NOT `useChannelSearch`, which searches
+ * `useAllChannels()` — that includes channels the user cannot open. The call
+ * pickers must only ever offer channels from `useAllVisibleChannels()`.
+ */
+function useVisibleChannelCandidates(
+  query: string,
+  limit: number,
+  enabled: boolean,
+  channelFilter: ((channel: VisibleChannel) => boolean) | undefined,
+): VisibleChannel[] {
+  const visibleChannels = useAllVisibleChannels();
+
+  // Filter before ranking: the predicate is cheap and shrinks the Fuse corpus.
+  const pool = useMemo(() => {
+    if (!enabled) return [];
+    return channelFilter ? visibleChannels.filter(channelFilter) : visibleChannels;
+  }, [enabled, visibleChannels, channelFilter]);
+
+  return useMemo(() => {
+    if (pool.length === 0) return [];
+    // searchChannels slices to `limit` for both the query and the browse case.
+    return searchChannels(pool, query, limit);
+  }, [pool, query, limit]);
+}
+
+export function useParticipantCandidates({
+  query,
+  userLimit = 20,
+  userGroupLimit = 10,
+  channelLimit = 10,
+  excludeUserIds = EMPTY_IDS,
+  restrictToUserIds = null,
+  excludeUserGroupIds = EMPTY_IDS,
+  includeChannels = true,
+  includeUserGroups = true,
+  channelFilter,
+}: ParticipantCandidateOptions): ParticipantCandidates {
+  const trimmedQuery = query.trim();
+  const activeUsers = useActiveUsers();
+
+  // Over-fetch by the exclusion count so filtering afterwards can still fill the cap.
+  const userFetchLimit = userLimit + excludeUserIds.size;
+
+  // Workspace-wide ranking. Always called (rules of hooks); its result is discarded
+  // when `restrictToUserIds` is set. Both paths are memoized, so an unused pass costs
+  // one Fuse index build over a list that is already indexed elsewhere in the app.
+  const workspaceRanked = useRankedActivePeople(trimmedQuery, userFetchLimit);
+
+  // Allowlist pool, rebuilt only when the roster changes — NOT per keystroke.
+  const restrictedPool = useMemo(() => {
+    if (!restrictToUserIds) return null;
+    return activeUsers.filter(u => restrictToUserIds.has(u.id));
+  }, [activeUsers, restrictToUserIds]);
+
+  const restrictedRanked = useMemo(() => {
+    if (!restrictedPool) return null;
+    return searchUsers(restrictedPool, trimmedQuery, userFetchLimit);
+  }, [restrictedPool, trimmedQuery, userFetchLimit]);
+
+  const users = useMemo(() => {
+    const ranked = restrictedRanked ?? workspaceRanked;
+    const out: User[] = [];
+    for (const user of ranked) {
+      if (excludeUserIds.has(user.id)) continue;
+      out.push(user);
+      if (out.length >= userLimit) break;
+    }
+    return out;
+  }, [restrictedRanked, workspaceRanked, excludeUserIds, userLimit]);
+
+  const rawUserGroups = useUserGroupSearch(
+    query,
+    includeUserGroups ? userGroupLimit + excludeUserGroupIds.size : 0,
+  );
+  const userGroups = useMemo(() => {
+    if (!includeUserGroups) return [];
+    if (excludeUserGroupIds.size === 0) return rawUserGroups.slice(0, userGroupLimit);
+    return rawUserGroups.filter(g => !excludeUserGroupIds.has(g.id)).slice(0, userGroupLimit);
+  }, [rawUserGroups, excludeUserGroupIds, userGroupLimit, includeUserGroups]);
+
+  const channels = useVisibleChannelCandidates(
+    trimmedQuery,
+    channelLimit,
+    includeChannels,
+    channelFilter,
+  );
+
+  return useMemo(() => ({ users, userGroups, channels }), [users, userGroups, channels]);
+}

--- a/apps/dashboard/src/routes/CallHistoryScreen/SearchParticipants.tsx
+++ b/apps/dashboard/src/routes/CallHistoryScreen/SearchParticipants.tsx
@@ -37,6 +37,17 @@ interface SearchParticipantsProps {
    * still applies.
    */
   disableClientFiltering?: boolean;
+  /**
+   * Options used ONLY to render the pills for already-selected values — never
+   * offered in the dropdown.
+   *
+   * `options` is now a bounded, query-ranked slice (see `useParticipantCandidates`),
+   * so a selected participant who does not match the current query is simply absent
+   * from it. Without a resolvable option their pill silently disappears while they
+   * stay selected. Callers that prefill a selection (edit-mode calls, thread-scoped
+   * invites) pass the resolved options for their selected values here.
+   */
+  prefilledOptions?: ParticipantOptions[];
 }
 
 export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
@@ -55,6 +66,7 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
   exclusiveSelection = true,
   lockedValues,
   disableClientFiltering = false,
+  prefilledOptions,
 }) => {
   const [selectedOptionsMap, setSelectedOptionsMap] = useState<Map<string, ParticipantOptions>>(
     new Map(),
@@ -72,19 +84,43 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
     return selectedValues.some(v => v.startsWith('user:'));
   }, [selectedValues]);
 
-  // Cache selected options so they remain visible even when filtered out of options
+  // value -> option, so resolving a selection is O(1) instead of a linear scan of
+  // `options` per selected value. `options` wins over `prefilledOptions` on conflict:
+  // a live ranked row is fresher than a prefilled one.
+  const optionByValue = useMemo(() => {
+    const map = new Map<string, ParticipantOptions>();
+    for (const option of prefilledOptions ?? []) map.set(option.value, option);
+    for (const option of options) map.set(option.value, option);
+    return map;
+  }, [options, prefilledOptions]);
+
+  const prefilledValues = useMemo(
+    () => new Set((prefilledOptions ?? []).map(opt => opt.value)),
+    [prefilledOptions],
+  );
+
+  // Fallback cache so a selected option still renders a pill after it drops out of
+  // the (bounded, query-ranked) `options` slice.
+  //
+  // Values the caller resolves via `prefilledOptions` are skipped: they are already
+  // reachable through `optionByValue`, so caching them would be pure churn. That
+  // matters because the builders mint fresh objects on every keystroke — an
+  // identity check alone can never bail out, and returning a new Map each time
+  // forced a second render per character typed.
   useEffect(() => {
+    const uncached = selectedValues.filter(
+      value => !prefilledValues.has(value) && optionByValue.has(value),
+    );
+    if (uncached.length === 0) return;
     setSelectedOptionsMap(prev => {
       const next = new Map(prev);
-      selectedValues.forEach(value => {
-        const option = options.find(opt => opt.value === value);
-        if (option) {
-          next.set(value, option);
-        }
-      });
+      for (const value of uncached) {
+        const option = optionByValue.get(value);
+        if (option) next.set(value, option);
+      }
       return next;
     });
-  }, [selectedValues, options]);
+  }, [selectedValues, optionByValue, prefilledValues]);
 
   const hasGroupSelected = useMemo(() => {
     return exclusiveSelection && selectedValues.some(v => v.startsWith('user_group:'));
@@ -120,15 +156,9 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
 
   const selectedOptions = useMemo(() => {
     return selectedValues
-      .map(value => {
-        const currentOption = options.find(opt => opt.value === value);
-        if (currentOption) return currentOption;
-
-        // Fallback to cached option
-        return selectedOptionsMap.get(value);
-      })
+      .map(value => optionByValue.get(value) ?? selectedOptionsMap.get(value))
       .filter((opt): opt is ParticipantOptions => opt !== undefined);
-  }, [options, selectedValues, selectedOptionsMap]);
+  }, [optionByValue, selectedValues, selectedOptionsMap]);
 
   const hasChannelSelected = useMemo(() => {
     return exclusiveSelection && selectedValues.some(v => v.startsWith('channel:'));
@@ -187,7 +217,7 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
     }
 
     if (exclusiveSelection && isChannel && !selectedValues.includes(value)) {
-      const option = options.find(opt => opt.value === value);
+      const option = optionByValue.get(value);
       if (option) {
         setSelectedOptionsMap(prev => new Map(prev).set(value, option));
       }
@@ -200,7 +230,7 @@ export const SearchParticipants: React.FC<SearchParticipantsProps> = ({
     if (selectedValues.includes(value)) {
       void onMultiSelect(selectedValues.filter(v => v !== value));
     } else {
-      const option = options.find(opt => opt.value === value);
+      const option = optionByValue.get(value);
       if (option) {
         setSelectedOptionsMap(prev => new Map(prev).set(value, option));
       }


### PR DESCRIPTION
https://drive.google.com/file/d/1yQ-NsFKo6VGMoDrF5eTEp13s55HctW95/view?usp=sharing

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
