### PR TITLE
fix: XYNE-62857 Modifying ci.yaml with flag to enable our own runners

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -23,8 +23,6 @@ concurrency:
 
 jobs:
   ci:
-    # TEMPORARY: pinned to fix/flag-for-runners to test the USE_SELF_HOSTED_CI
-    # toggle in ci.yml — revert to @main before merging.
-    uses: juspay/xyne-spaces/.github/workflows/ci.yml@fix/flag-for-runners
+    uses: juspay/xyne-spaces/.github/workflows/ci.yml@main
     permissions:
       contents: read

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -23,6 +23,8 @@ concurrency:
 
 jobs:
   ci:
-    uses: juspay/xyne-spaces/.github/workflows/ci.yml@main
+    # TEMPORARY: pinned to fix/flag-for-runners to test the USE_SELF_HOSTED_CI
+    # toggle in ci.yml — revert to @main before merging.
+    uses: juspay/xyne-spaces/.github/workflows/ci.yml@fix/flag-for-runners
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   # ---------------------------------------------------------------------------
   backend:
     name: Backend typecheck + build
-    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners-mini' || 'ubuntu-latest' }}
     # tsc over backend's type surface (incl. generated Prisma/Zero schemas)
     # exceeds Node's ~2GB default heap on the runner.
     env:
@@ -64,7 +64,7 @@ jobs:
   # ---------------------------------------------------------------------------
   dashboard:
     name: Dashboard ${{ matrix.task }}
-    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI != 'true' && 'ubuntu-latest' || matrix.task == 'build' && 'ci-cluster-github-runners-mini-max' || 'ci-cluster-github-runners-mini' }}
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
   # Framework lint — self-contained (no workspace deps).
   framework-lint:
     name: Framework lint
-    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
   # ---------------------------------------------------------------------------
   gitleaks:
     name: Secret scan (gitleaks)
-    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     env:
       GITLEAKS_VERSION: "8.30.1"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,25 @@ env:
   PNPM_FLAGS: "--frozen-lockfile --prod=false"
 
 jobs:
+  # TEMPORARY: DNS debugging on ci-pool. Just echoes hello + tests DNS
+  # resolution of an external hostname from a real ARC self-hosted runner
+  # pod. Remove once the ci-pool DNS issue is root-caused and fixed.
+  hello:
+    name: Hello (DNS debug)
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
+    steps:
+      - name: Say hello and test DNS
+        run: |
+          echo "hello"
+          getent hosts broker.actions.githubusercontent.com || echo "DNS resolution FAILED"
+
   # ---------------------------------------------------------------------------
   # Backend: depends on @xyne/shared and agentic-framework, which are workspace
   # packages consumed from their built dist/ — so they are compiled first.
   # ---------------------------------------------------------------------------
   backend:
     name: Backend typecheck + build
+    if: false # TEMPORARY: disabled during ci-pool DNS debugging
     runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     # tsc over backend's type surface (incl. generated Prisma/Zero schemas)
     # exceeds Node's ~2GB default heap on the runner.
@@ -64,6 +77,7 @@ jobs:
   # ---------------------------------------------------------------------------
   dashboard:
     name: Dashboard ${{ matrix.task }}
+    if: false # TEMPORARY: disabled during ci-pool DNS debugging
     runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
@@ -118,6 +132,7 @@ jobs:
   # Framework lint — self-contained (no workspace deps).
   framework-lint:
     name: Framework lint
+    if: false # TEMPORARY: disabled during ci-pool DNS debugging
     runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,12 @@ jobs:
   # Dashboard: depends on @xyne/shared and @xyne/icons, consumed from dist/.
   # ---------------------------------------------------------------------------
   dashboard:
-    name: Dashboard build
+    name: Dashboard ${{ matrix.task }}
     runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        task: [lint, typecheck, build]
     env:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
@@ -83,17 +87,19 @@ jobs:
       - name: Build workspace libraries
         run: pnpm --filter @xyne/shared --filter @xyne/icons run build
 
-      # Lint, format check, typecheck, then build — merged into one job (was a
-      # 3-way matrix of separate pods) to avoid paying for checkout/setup-node/
-      # install/workspace-lib-build three times over. Trades the previous
-      # parallel-pod wall-clock time for less duplicated setup cost.
+      # --- lint leg ---------------------------------------------------------
+      # errors-only (warnings ignored).
       - name: Lint (errors only)
+        if: matrix.task == 'lint'
         run: pnpm --filter xyne-spaces-dashboard run lint:errors-only
 
+      # --- typecheck leg ----------------------------------------------------
       - name: Format check
+        if: matrix.task == 'typecheck'
         run: pnpm --filter xyne-spaces-dashboard run format:check
 
       - name: Restore tsc incremental state
+        if: matrix.task == 'typecheck'
         uses: actions/cache@v4
         with:
           path: apps/dashboard/node_modules/.tmp/tsconfig.app.tsbuildinfo
@@ -102,9 +108,11 @@ jobs:
             dashboard-tsbuildinfo-${{ runner.os }}-
 
       - name: Typecheck
+        if: matrix.task == 'typecheck'
         run: pnpm --filter xyne-spaces-dashboard run typecheck
 
       - name: Build
+        if: matrix.task == 'build'
         run: pnpm --filter xyne-spaces-dashboard run build
 
   # Framework lint — self-contained (no workspace deps).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   # ---------------------------------------------------------------------------
   backend:
     name: Backend typecheck + build
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     # tsc over backend's type surface (incl. generated Prisma/Zero schemas)
     # exceeds Node's ~2GB default heap on the runner.
     env:
@@ -64,7 +64,7 @@ jobs:
   # ---------------------------------------------------------------------------
   dashboard:
     name: Dashboard ${{ matrix.task }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +118,7 @@ jobs:
   # Framework lint — self-contained (no workspace deps).
   framework-lint:
     name: Framework lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -142,7 +142,7 @@ jobs:
   # ---------------------------------------------------------------------------
   xyne-claw:
     name: xyne-claw typecheck
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -170,7 +170,7 @@ jobs:
   # ---------------------------------------------------------------------------
   gitleaks:
     name: Secret scan (gitleaks)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     env:
       GITLEAKS_VERSION: "8.30.1"
     steps:
@@ -214,7 +214,7 @@ jobs:
   # ---------------------------------------------------------------------------
   trivy:
     name: Vulnerability scan (Trivy)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     env:
       TRIVY_VERSION: "0.72.0"
       # secrets handled by gitleaks; scan deps (vuln) + IaC (misconfig) only.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,10 @@ jobs:
   # Framework lint — self-contained (no workspace deps).
   framework-lint:
     name: Framework lint
-    runs-on: ubuntu-latest
+    # TEMPORARY: routed to mini-max for one final end-to-end test of all
+    # three self-hosted scale sets together. Move back to ubuntu-latest
+    # after this confirms clean.
+    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,7 @@ jobs:
   # Framework lint — self-contained (no workspace deps).
   framework-lint:
     name: Framework lint
-    # TEMPORARY: routed to mini-max for one final end-to-end test of all
-    # three self-hosted scale sets together. Move back to ubuntu-latest
-    # after this confirms clean.
-    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,8 @@ jobs:
   # Dashboard: depends on @xyne/shared and @xyne/icons, consumed from dist/.
   # ---------------------------------------------------------------------------
   dashboard:
-    name: Dashboard ${{ matrix.task }}
+    name: Dashboard build
     runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        task: [lint, typecheck, build]
     env:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
@@ -87,19 +83,17 @@ jobs:
       - name: Build workspace libraries
         run: pnpm --filter @xyne/shared --filter @xyne/icons run build
 
-      # --- lint leg ---------------------------------------------------------
-      # errors-only (warnings ignored).
+      # Lint, format check, typecheck, then build — merged into one job (was a
+      # 3-way matrix of separate pods) to avoid paying for checkout/setup-node/
+      # install/workspace-lib-build three times over. Trades the previous
+      # parallel-pod wall-clock time for less duplicated setup cost.
       - name: Lint (errors only)
-        if: matrix.task == 'lint'
         run: pnpm --filter xyne-spaces-dashboard run lint:errors-only
 
-      # --- typecheck leg ----------------------------------------------------
       - name: Format check
-        if: matrix.task == 'typecheck'
         run: pnpm --filter xyne-spaces-dashboard run format:check
 
       - name: Restore tsc incremental state
-        if: matrix.task == 'typecheck'
         uses: actions/cache@v4
         with:
           path: apps/dashboard/node_modules/.tmp/tsconfig.app.tsbuildinfo
@@ -108,11 +102,9 @@ jobs:
             dashboard-tsbuildinfo-${{ runner.os }}-
 
       - name: Typecheck
-        if: matrix.task == 'typecheck'
         run: pnpm --filter xyne-spaces-dashboard run typecheck
 
       - name: Build
-        if: matrix.task == 'build'
         run: pnpm --filter xyne-spaces-dashboard run build
 
   # Framework lint — self-contained (no workspace deps).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,25 +18,12 @@ env:
   PNPM_FLAGS: "--frozen-lockfile --prod=false"
 
 jobs:
-  # TEMPORARY: DNS debugging on ci-pool. Just echoes hello + tests DNS
-  # resolution of an external hostname from a real ARC self-hosted runner
-  # pod. Remove once the ci-pool DNS issue is root-caused and fixed.
-  hello:
-    name: Hello (DNS debug)
-    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
-    steps:
-      - name: Say hello and test DNS
-        run: |
-          echo "hello"
-          getent hosts broker.actions.githubusercontent.com || echo "DNS resolution FAILED"
-
   # ---------------------------------------------------------------------------
   # Backend: depends on @xyne/shared and agentic-framework, which are workspace
   # packages consumed from their built dist/ — so they are compiled first.
   # ---------------------------------------------------------------------------
   backend:
     name: Backend typecheck + build
-    if: false # TEMPORARY: disabled during ci-pool DNS debugging
     runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     # tsc over backend's type surface (incl. generated Prisma/Zero schemas)
     # exceeds Node's ~2GB default heap on the runner.
@@ -77,7 +64,6 @@ jobs:
   # ---------------------------------------------------------------------------
   dashboard:
     name: Dashboard ${{ matrix.task }}
-    if: false # TEMPORARY: disabled during ci-pool DNS debugging
     runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
@@ -132,7 +118,6 @@ jobs:
   # Framework lint — self-contained (no workspace deps).
   framework-lint:
     name: Framework lint
-    if: false # TEMPORARY: disabled during ci-pool DNS debugging
     runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
   # ---------------------------------------------------------------------------
   xyne-claw:
     name: xyne-claw typecheck
-    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
@@ -214,7 +214,7 @@ jobs:
   # ---------------------------------------------------------------------------
   trivy:
     name: Vulnerability scan (Trivy)
-    runs-on: ${{ vars.USE_SELF_HOSTED_CI == 'true' && 'ci-cluster-github-runners' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     env:
       TRIVY_VERSION: "0.72.0"
       # secrets handled by gitleaks; scan deps (vuln) + IaC (misconfig) only.


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
