### PR TITLE
fix: XYNE-63241 add supportTicketsFilteredV4 with IN filters and repoint V3 callers

### DIFF
--- a/apps/backend/src/api/sdk/v1/mapper.ts
+++ b/apps/backend/src/api/sdk/v1/mapper.ts
@@ -427,7 +427,7 @@ export const V1_MAPPER: Readonly<Record<string, V1Target>> = {
 
   // ----- supportTickets -----
   'supportTickets.list': { kind: 'query', name: 'supportTicketsPageV4' },
-  'supportTickets.listFiltered': { kind: 'query', name: 'supportTicketsFilteredV3' },
+  'supportTickets.listFiltered': { kind: 'query', name: 'supportTicketsFilteredV4' },
   'supportTickets.get': { kind: 'query', name: 'supportTicketRowV3' },
   'supportTickets.getByKey': { kind: 'query', name: 'supportTicketByXyneIdV4' },
   'supportTickets.getDetail': { kind: 'query', name: 'supportTicketDetailV2' },

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -1446,6 +1446,107 @@ export const queries: AnyQueryRegistry = defineQueries({
     }
   ),
 
+  supportTicketsFilteredV4: defineQuery(
+    z.object({
+      channelId: z.string(),
+      isMember: z.boolean(),
+      merchantMid: z.string().optional(),
+      assignedTo: z.array(z.string()).optional(),
+      createdBy: z.array(z.string()).optional(),
+      priority: z.array(z.nativeEnum(TicketPriority)).optional(),
+      stageName: z.array(z.string()).optional(),
+      aiCategory: z.array(z.string()).optional(),
+      hasAiDraft: z.boolean().optional(),
+      hasSubTickets: z.boolean().optional(),
+      userGroups: z.array(z.string()).optional(),
+      lastEmailAtStart: z.number().optional(),
+      lastEmailAtEnd: z.number().optional(),
+      createdAtStart: z.number().optional(),
+      createdAtEnd: z.number().optional(),
+      conversationLabelId: z.string().optional(),
+      dynamicFieldFilters: supportDynamicFieldFiltersSchema,
+      formEntityValueFieldIds: z.array(z.string()).optional(),
+    }).refine(
+      args => args.createdAtStart === undefined || args.createdAtEnd === undefined || args.createdAtStart <= args.createdAtEnd,
+      'createdAtStart must be less than or equal to createdAtEnd',
+    ),
+    ({ ctx, args: { channelId, merchantMid, assignedTo, createdBy, priority, stageName, aiCategory, hasAiDraft, hasSubTickets, userGroups, lastEmailAtStart, lastEmailAtEnd, createdAtStart, createdAtEnd, conversationLabelId, dynamicFieldFilters, formEntityValueFieldIds } }) => {
+      let query = zql.tickets.where('channelId', channelId);
+
+      if (merchantMid) {
+        query = query.where('merchantId', merchantMid);
+      }
+
+      if (assignedTo && assignedTo.length > 0) {
+        query = query.where('assignedTo', 'IN', assignedTo);
+      }
+
+      if (createdBy && createdBy.length > 0) {
+        query = query.where('createdBy', 'IN', createdBy);
+      }
+
+      if (priority && priority.length > 0) {
+        query = query.where('priority', 'IN', priority);
+      }
+
+      if (stageName && stageName.length > 0) {
+        query = query.where('stageName', 'IN', stageName);
+      }
+
+      if (aiCategory && aiCategory.length > 0) {
+        query = query.where('aiCategory', 'IN', aiCategory);
+      }
+
+      if (hasAiDraft) {
+        query = query.where(({ exists }) =>
+          exists('emailDrafts', (draft) => draft.where('userId', 'IS', null)),
+        );
+      }
+
+      if (hasSubTickets) {
+        query = query.where(({ exists }) => exists('subTicketMappings'));
+      }
+
+      if (userGroups && userGroups.length > 0) {
+        query = query.where('userGroupId', 'IN', userGroups);
+      }
+      if (conversationLabelId) {
+        query = query.where(({ exists }) =>
+          exists('conversationLabelMappings', (m) => m.where('labelId', conversationLabelId)),
+        );
+      }
+
+      if (lastEmailAtStart !== undefined) {
+        query = query.where('lastEmailAt', '>=', lastEmailAtStart);
+      }
+
+      if (lastEmailAtEnd !== undefined) {
+        query = query.where('lastEmailAt', '<=', lastEmailAtEnd);
+      }
+
+      if (createdAtStart !== undefined) {
+        query = query.where('createdAt', '>=', createdAtStart);
+      }
+
+      if (createdAtEnd !== undefined) {
+        query = query.where('createdAt', '<=', createdAtEnd);
+      }
+
+      query = applySupportDynamicFieldFilters(query, dynamicFieldFilters);
+
+      return query
+        .orderBy('createdAt', 'desc')
+        .related('project')
+        .related('tagMappings')
+        .related('entity')
+        .related('conversation', (c) => c.related('channel'))
+        .related('emailReads', (q) => q.where('userId', ctx.userID))
+        .related('formEntityValues', (fev) =>
+          relateSupportDynamicFieldValues(fev, dynamicFieldFilters, formEntityValueFieldIds),
+        );
+    }
+  ),
+
   // Topics Explorer: one desk's tickets in a created-at window, rolled up client-side.
   // Not supportTicketsPageV3 — that pulls emailDrafts, emailReads, userMailbox and
   // formEntityValues per row, where this reads scalar columns and no relation at all.

--- a/apps/dashboard/src/routes/SupportScreen/SupportKanbanBoard.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportKanbanBoard.tsx
@@ -120,7 +120,7 @@ export const SupportKanbanBoard = ({
   // first row below.
   const { conversationIdWhitelist, ...restTicketFilter } = ticketFilter;
   const [supportTickets, supportTicketsDetails] = useCachedQuery(
-    queries.supportTicketsFilteredV3({
+    queries.supportTicketsFilteredV4({
       channelId,
       isMember,
       ...restTicketFilter,

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -238,7 +238,7 @@ import { WorkspaceDeskEmailCard } from '../../components/xyne-desk/WorkspaceDesk
 import { WorkspaceOzonetelCard } from '../../components/xyne-desk/WorkspaceOzonetelCard/WorkspaceOzonetelCard';
 
 // Unified type for tickets from the supportTicketsFiltered query
-type SupportTicket = QueryResultType<typeof queries.supportTicketsFilteredV3>[number];
+type SupportTicket = QueryResultType<typeof queries.supportTicketsFilteredV4>[number];
 
 const ChannelInfoModal = ({
   channelId,

--- a/apps/dashboard/src/routes/SupportScreen/SupportTicketTable.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportTicketTable.tsx
@@ -80,7 +80,7 @@ export const SupportTicketTable = ({
 
   const { conversationIdWhitelist, ...restTicketFilter } = ticketFilter;
   const [supportTickets, supportTicketsDetails] = useCachedQuery(
-    queries.supportTicketsFilteredV3({
+    queries.supportTicketsFilteredV4({
       channelId,
       isMember,
       ...restTicketFilter,
@@ -176,7 +176,7 @@ export const SupportTicketTable = ({
     if (dynamicallyFilteredTickets) onTicketsLoaded?.(dynamicallyFilteredTickets as Ticket[]);
   }, [dynamicallyFilteredTickets, onTicketsLoaded]);
 
-  // supportTicketsFilteredV3 already relates tagMappings on every row, so unlike
+  // supportTicketsFilteredV4 already relates tagMappings on every row, so unlike
   // Board's ticketsQueryV2 there's no fallback path needed here.
   const tagsByTicketId = useMemo(() => {
     const map = new Map<string, TicketTag[]>();

--- a/packages/shared/src/zero/queries.ts
+++ b/packages/shared/src/zero/queries.ts
@@ -1276,6 +1276,113 @@ export const queries = defineQueries({
         );
     },
   ),
+
+  supportTicketsFilteredV4: defineQuery(
+    z.object({
+      channelId: z.string(),
+      isMember: z.boolean(),
+      merchantMid: z.string().optional(),
+      assignedTo: z.array(z.string()).optional(),
+      createdBy: z.array(z.string()).optional(),
+      priority: z.array(z.nativeEnum(TicketPriority)).optional(),
+      stageName: z.array(z.string()).optional(),
+      aiCategory: z.array(z.string()).optional(),
+      conversationIds: z.array(z.string()).optional(),
+      hasAiDraft: z.boolean().optional(),
+      hasSubTickets: z.boolean().optional(),
+      userGroups: z.array(z.string()).optional(),
+      lastEmailAtStart: z.number().optional(),
+      lastEmailAtEnd: z.number().optional(),
+      createdAtStart: z.number().optional(),
+      createdAtEnd: z.number().optional(),
+      conversationLabelId: z.string().optional(),
+      dynamicFieldFilters: supportDynamicFieldFiltersSchema,
+      formEntityValueFieldIds: z.array(z.string()).optional(),
+    }).refine(
+      args => args.createdAtStart === undefined || args.createdAtEnd === undefined || args.createdAtStart <= args.createdAtEnd,
+      'createdAtStart must be less than or equal to createdAtEnd',
+    ),
+    ({ ctx, args: { channelId, merchantMid, assignedTo, createdBy, priority, stageName, aiCategory, conversationIds, hasAiDraft, hasSubTickets, userGroups, lastEmailAtStart, lastEmailAtEnd, createdAtStart, createdAtEnd, conversationLabelId, dynamicFieldFilters, formEntityValueFieldIds } }) => {
+      let query = zql.tickets.where('channelId', channelId);
+      query = query.where('isArchived', false);
+
+      if (merchantMid) {
+        query = query.where('merchantId', merchantMid);
+      }
+
+      if (assignedTo && assignedTo.length > 0) {
+        query = query.where('assignedTo', 'IN', assignedTo);
+      }
+
+      if (createdBy && createdBy.length > 0) {
+        query = query.where('createdBy', 'IN', createdBy);
+      }
+
+      if (priority && priority.length > 0) {
+        query = query.where('priority', 'IN', priority);
+      }
+
+      if (stageName && stageName.length > 0) {
+        query = query.where('stageName', 'IN', stageName);
+      }
+
+      if (aiCategory && aiCategory.length > 0) {
+        query = query.where('aiCategory', 'IN', aiCategory);
+      }
+
+      if (conversationIds !== undefined) {
+        query = query.where('conversationId', 'IN', conversationIds.length > 0 ? conversationIds : ['']);
+      }
+
+      if (hasAiDraft) {
+        query = query.where(({ exists }) =>
+          exists('emailDrafts', (draft) => draft.where('userId', 'IS', null)),
+        );
+      }
+
+      if (hasSubTickets) {
+        query = query.where(({ exists }) => exists('subTicketMappings'));
+      }
+
+      if (userGroups && userGroups.length > 0) {
+        query = query.where('userGroupId', 'IN', userGroups);
+      }
+      if (conversationLabelId) {
+        query = query.where(({ exists }) =>
+          exists('conversationLabelMappings', (m) => m.where('labelId', conversationLabelId)),
+        );
+      }
+
+      if (lastEmailAtStart !== undefined) {
+        query = query.where('lastEmailAt', '>=', lastEmailAtStart);
+      }
+
+      if (lastEmailAtEnd !== undefined) {
+        query = query.where('lastEmailAt', '<=', lastEmailAtEnd);
+      }
+
+      if (createdAtStart !== undefined) {
+        query = query.where('createdAt', '>=', createdAtStart);
+      }
+
+      if (createdAtEnd !== undefined) {
+        query = query.where('createdAt', '<=', createdAtEnd);
+      }
+
+      query = applySupportDynamicFieldFilters(query, dynamicFieldFilters);
+
+      return query
+        .orderBy('createdAt', 'desc')
+        .related('project')
+        .related('tagMappings')
+        .related('entity')
+        .related('conversation', c => c.related('channel'))
+        .related('emailReads', q => q.where('userId', ctx.userID))
+        .related('formEntityValues', fev =>
+          relateSupportDynamicFieldValues(fev, dynamicFieldFilters, formEntityValueFieldIds),
+        );
+    },
+  ),
   // Topics Explorer: one desk's tickets in a created-at window, rolled up client-side.
   // Not supportTicketsPageV3 — that pulls emailDrafts, emailReads, userMailbox and
   // formEntityValues per row, where this reads scalar columns and no relation at all.


### PR DESCRIPTION
## Problem
The `supportTicketsFilteredV3` Zero query builds its multi-select filters as OR-of-equality chains — `query.where(({ or, cmp }) => or(...arr.map((v) => cmp(field, v))))` — for `assignedTo`, `priority`, `stageName`, and `aiCategory`. When a user selects many values, these expand into a deep nested boolean expression tree and trip SQLite's `expression tree is too large` error, so the support ticket list fails to load.

## Fix (version bump)
Rather than mutate V3 in place, this adds a new **`supportTicketsFilteredV4`** that is identical to V3 except the four filters above use `IN` — `query.where(field, 'IN', arr)` — which is semantically identical (an OR of equalities) but compiles to a flat set-membership check instead of a deep boolean tree. This mirrors the `IN` usage already present in the same query for `createdBy` and `userGroups`.

V3 is left **untouched** so already-synced clients keep working, per the versioning convention in `mapper.ts`.

### Added
- `supportTicketsFilteredV4` in `apps/backend/src/zero/queries.ts`
- `supportTicketsFilteredV4` in `packages/shared/src/zero/queries.ts`

Each V4 is a verbatim copy of that file's own current V3 body (fields preserved) with only the OR→IN substitution.

### Repointed all V3 callers to V4
- `apps/backend/src/api/sdk/v1/mapper.ts` — `supportTickets.listFiltered` → `supportTicketsFilteredV4`
- `apps/dashboard/src/routes/SupportScreen/SupportTicketTable.tsx`
- `apps/dashboard/src/routes/SupportScreen/SupportKanbanBoard.tsx`
- `apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx`

## Correctness / Validation
- `IN [a,b,c]` == `= a OR = b OR = c`; no behavior change.
- V4 schema and shape are identical to V3, so all caller args remain valid.
- Typecheck of `packages/shared` and `apps/dashboard` passes with no new errors. The remaining `apps/backend` type errors are pre-existing (`@xyne/shared` ETA-management / SDLC dist staleness) and unrelated to these files.

## Notes
The sibling queries `supportTicketsFilteredV2`, `supportTicketsPageV2/V3` still use the same OR-chain pattern and carry the same latent risk; left out to keep this PR scoped.
