### PR TITLE
feat: EULER-80631 gate app webhook events per installed app + Bitbot snake_case aliases

### DIFF
--- a/apps/backend/src/apps/core/appWebhookEventConfigs.test.ts
+++ b/apps/backend/src/apps/core/appWebhookEventConfigs.test.ts
@@ -1,0 +1,105 @@
+import { AppEventType } from '@/apps/types';
+import {
+    findAppWebhookEventConfig,
+    resolveAppEventDelivery,
+    withSnakeCaseAliases,
+} from './appWebhookEventConfigs';
+import { config } from '@/config/env';
+
+jest.mock('@/config/env', () => ({
+    config: {
+        apps: {
+            snakeCaseAliasesEnabled: true,
+        },
+    },
+}));
+
+describe('appWebhookEventConfigs', () => {
+    describe('findAppWebhookEventConfig', () => {
+        it('matches the bot email case-insensitively', () => {
+            const appConfig = findAppWebhookEventConfig('VARYS@APP.XYNE.AI');
+            expect(appConfig).toBeDefined();
+            expect(appConfig?.botEmail).toBe('varys@app.xyne.ai');
+            expect(appConfig?.snakeCaseAliasEvents).toContain(AppEventType.APP_MENTION);
+        });
+
+        it('returns undefined for unknown or missing emails', () => {
+            expect(findAppWebhookEventConfig('nobody@example.com')).toBeUndefined();
+            expect(findAppWebhookEventConfig(null)).toBeUndefined();
+            expect(findAppWebhookEventConfig(undefined)).toBeUndefined();
+            expect(findAppWebhookEventConfig('')).toBeUndefined();
+        });
+    });
+
+    describe('resolveAppEventDelivery', () => {
+        it('delivers alias-listed events when the flag is on', () => {
+            expect(resolveAppEventDelivery('varys@app.xyne.ai', AppEventType.APP_MENTION)).toBe('alias');
+        });
+
+        it('skips events the app is not subscribed to', () => {
+            expect(resolveAppEventDelivery('varys@app.xyne.ai', AppEventType.USER_MENTIONED)).toBe('skip');
+            expect(resolveAppEventDelivery('varys@app.xyne.ai', AppEventType.DM)).toBe('skip');
+        });
+
+        it('skips alias events when the kill-switch flag is off', () => {
+            const original = config.apps.snakeCaseAliasesEnabled;
+            try {
+                config.apps.snakeCaseAliasesEnabled = false;
+                expect(resolveAppEventDelivery('varys@app.xyne.ai', AppEventType.APP_MENTION)).toBe('skip');
+            } finally {
+                config.apps.snakeCaseAliasesEnabled = original;
+            }
+        });
+
+        it('delivers every event for unconfigured apps', () => {
+            expect(resolveAppEventDelivery('unknown@app.xyne.ai', AppEventType.APP_MENTION)).toBe('direct');
+            expect(resolveAppEventDelivery(null, AppEventType.USER_MENTIONED)).toBe('direct');
+        });
+    });
+
+    describe('withSnakeCaseAliases', () => {
+        const event = {
+            eventType: AppEventType.APP_MENTION,
+            payload: {
+                conversationId: 'conv-1',
+                channelId: 'chan-1',
+                messageId: 'msg-1',
+                workspaceId: 'ws-1',
+                userId: 'user-1',
+                content: 'hello',
+                cleanContent: 'hello',
+                createdAt: new Date('2026-09-02T10:29:10.000Z'),
+                senderName: 'Sender',
+                channelName: 'chan',
+            },
+            timestamp: '2026-09-02T10:29:10.000Z',
+        } as unknown as import('@/apps/types').BaseAppEvent;
+
+        it('adds snake_case aliases alongside camelCase fields', () => {
+            const aliased = withSnakeCaseAliases(event);
+            const payload = aliased.payload as unknown as Record<string, unknown>;
+            expect(payload.conversationId).toBe('conv-1');
+            expect(payload.conversation_id).toBe('conv-1');
+            expect(payload.channel_id).toBe('chan-1');
+            expect(payload.message_id).toBe('msg-1');
+            expect(payload.workspace_id).toBe('ws-1');
+            expect(payload.user_id).toBe('user-1');
+        });
+
+        it('never mutates the original event', () => {
+            withSnakeCaseAliases(event);
+            expect('conversation_id' in event.payload).toBe(false);
+            expect(event.payload.conversationId).toBe('conv-1');
+        });
+
+        it('keeps pre-existing snake_case fields untouched', () => {
+            const aliased = withSnakeCaseAliases({
+                ...event,
+                payload: { ...event.payload, conversation_id: 'existing' },
+            } as unknown as import('@/apps/types').BaseAppEvent);
+            const payload = aliased.payload as unknown as Record<string, unknown>;
+            expect(payload.conversation_id).toBe('existing');
+            expect(payload.conversationId).toBe('conv-1');
+        });
+    });
+});

--- a/apps/backend/src/apps/core/appWebhookEventConfigs.ts
+++ b/apps/backend/src/apps/core/appWebhookEventConfigs.ts
@@ -1,0 +1,119 @@
+import { AppEventType, BaseAppEvent } from '@/apps/types';
+import { config } from '@/config/env';
+
+/**
+ * Per-app webhook delivery configuration.
+ *
+ * Some installed apps (e.g. Bitbot/Varys) do not consume the generic
+ * camelCase app-event envelope for every event type — their webhook
+ * contract only accepts specific events, or expects snake_case field
+ * aliases. This module keys those contracts by the app bot user's email
+ * (stable across environments, unlike per-environment user ids) so
+ * `eventSubscriptionUtils` can gate delivery per event type.
+ */
+export interface AppWebhookEventConfig {
+    /** Bot user email (lowercase) this config applies to. */
+    botEmail: string;
+    /**
+     * Event types the app's webhook consumes in the generic camelCase
+     * envelope. Empty list means the app receives no generic events.
+     */
+    subscribedEvents: AppEventType[];
+    /**
+     * Events that must be delivered with snake_case field aliases added
+     * alongside the camelCase fields (legacy contract compatibility).
+     */
+    snakeCaseAliasEvents?: AppEventType[];
+    /**
+     * Bot-posted reply shown when the app is @mentioned but the event
+     * is gated (or delivery failed), telling the user how to invoke it.
+     */
+    mentionGuidanceMessage?: string;
+}
+
+export const APP_WEBHOOK_EVENT_CONFIGS: AppWebhookEventConfig[] = [
+    {
+        // Varys (Bitbot) — its webhook only accepts the snake_case PR-check
+        // contract. Generic events 400 with "Missing required field:
+        // conversation_id". Only APP_MENTION is delivered, with aliases.
+        botEmail: 'varys@app.xyne.ai',
+        subscribedEvents: [],
+        snakeCaseAliasEvents: [AppEventType.APP_MENTION],
+        mentionGuidanceMessage:
+            "👋 I'm Varys. I watch Bitbucket pull requests — I don't respond to plain mentions in chat.\n\n" +
+            'To run a PR check, either:\n' +
+            '• Use the **Run PR Check** button on a PR-linked ticket, or\n' +
+            '• Post the full Bitbucket PR URL as a **new top-level message** in this channel (e.g. `https://bitbucket.org/<workspace>/<repo>/pull-requests/<id>`)',
+    },
+];
+
+/** How a given (app, event) pair should be delivered. */
+export type AppEventDeliveryMode = 'direct' | 'alias' | 'skip';
+
+/**
+ * Find the webhook event config for an installed app by its bot user email.
+ * Case-insensitive; returns undefined for unknown/unset emails (default
+ * behaviour: deliver every event unchanged).
+ */
+export function findAppWebhookEventConfig(
+    botEmail: string | null | undefined,
+): AppWebhookEventConfig | undefined {
+    if (!botEmail) return undefined;
+    const normalized = botEmail.trim().toLowerCase();
+    return APP_WEBHOOK_EVENT_CONFIGS.find(
+        (appConfig) => appConfig.botEmail.toLowerCase() === normalized,
+    );
+}
+
+/**
+ * Resolve the delivery mode for an (app, event) pair:
+ * - 'direct': app is configured and subscribed → send the event as-is
+ * - 'alias':  app expects this event with snake_case aliases → send the
+ *             aliased copy (only while the flag is enabled; otherwise 'skip')
+ * - 'skip':   app does not consume this event → do not call the webhook
+ */
+export function resolveAppEventDelivery(
+    botEmail: string | null | undefined,
+    eventType: AppEventType,
+): AppEventDeliveryMode {
+    const appConfig = findAppWebhookEventConfig(botEmail);
+    if (!appConfig) return 'direct';
+
+    if (appConfig.subscribedEvents.includes(eventType)) return 'direct';
+
+    const aliasEvents = appConfig.snakeCaseAliasEvents ?? [];
+    if (aliasEvents.includes(eventType)) {
+        return config.apps.snakeCaseAliasesEnabled ? 'alias' : 'skip';
+    }
+    return 'skip';
+}
+
+/** camelCase payload field → snake_case alias to add. */
+const SNAKE_CASE_ALIASES: Record<string, string> = {
+    workspaceId: 'workspace_id',
+    orgId: 'org_id',
+    orgMemberId: 'org_member_id',
+    conversationId: 'conversation_id',
+    messageId: 'message_id',
+    channelId: 'channel_id',
+    userId: 'user_id',
+};
+
+/**
+ * Return a shallow copy of `event` whose payload carries snake_case aliases
+ * alongside the original camelCase fields. Never mutates the input; a
+ * pre-existing snake_case field is left untouched.
+ */
+export function withSnakeCaseAliases(event: BaseAppEvent): BaseAppEvent {
+    const payload = { ...(event.payload as unknown as Record<string, unknown>) };
+    for (const [camelKey, snakeKey] of Object.entries(SNAKE_CASE_ALIASES)) {
+        if (
+            camelKey in payload &&
+            payload[camelKey] !== undefined &&
+            !(snakeKey in payload)
+        ) {
+            payload[snakeKey] = payload[camelKey];
+        }
+    }
+    return { ...event, payload: payload as unknown as BaseAppEvent['payload'] };
+}

--- a/apps/backend/src/apps/core/eventSubscriptionUtils.ts
+++ b/apps/backend/src/apps/core/eventSubscriptionUtils.ts
@@ -1,11 +1,20 @@
 import { InstalledAppsRepository } from '@/database/repositories/installedAppsRepository';
 import { isValidUrl } from '@/utils/urlUtils';
-import { BaseAppEvent } from '@/apps/types';
+import { AppEventType, BaseAppEvent } from '@/apps/types';
 import { logger } from '@/utils/logger';
 import { decrypt } from '@/services/encryptionService';
 import { prepareAppWebhookDispatch } from './appUrlResolver';
 import { safeWebhookFetch } from '@/utils/ssrfGuard';
 import crypto from 'crypto';
+import { randomUUID } from 'crypto';
+import { db } from '@/database/client';
+import { MessageType } from '@xyne/shared';
+import {
+    AppWebhookEventConfig,
+    findAppWebhookEventConfig,
+    resolveAppEventDelivery,
+    withSnakeCaseAliases,
+} from './appWebhookEventConfigs';
 
 const installedAppsRepository = new InstalledAppsRepository();
 
@@ -65,6 +74,103 @@ export async function sendWebhookNotification(
     }
 }
 
+const APP_MENTION_GUIDANCE_SUBTYPE = 'app_mention_guidance';
+
+/**
+ * Post a bot-authored guidance reply in the mentioning thread when an
+ * @mentioned app's event was gated (or delivery failed), telling the user
+ * how to actually invoke the app. Mirrors the no-ticket notice pattern in
+ * prCheckApprovalService so the message renders as a normal bot reply.
+ *
+ * Deduped on (conversation, bot, subtype, mentionMessageId) so side-effect
+ * queue redelivery never double-posts.
+ */
+async function postAppMentionGuidanceMessage(params: {
+    appEventConfig: AppWebhookEventConfig;
+    botUserId: string;
+    event: BaseAppEvent;
+}): Promise<void> {
+    const { appEventConfig, botUserId, event } = params;
+    try {
+        if (!appEventConfig.mentionGuidanceMessage) return;
+        const payload = event.payload;
+        if (!('messageId' in payload)) return;
+        const { conversationId, messageId } = payload;
+
+        const existing = await db.message.findFirst({
+            where: {
+                conversationId,
+                senderId: botUserId,
+                isDeleted: false,
+                AND: [
+                    { metadata: { path: ['messageSubtype'], equals: APP_MENTION_GUIDANCE_SUBTYPE } },
+                    { metadata: { path: ['mentionMessageId'], equals: messageId } },
+                ],
+            },
+            select: { messageId: true },
+        });
+        if (existing) return;
+
+        let workspaceId = 'workspaceId' in payload ? payload.workspaceId : undefined;
+        if (!workspaceId) {
+            const conversation = await db.conversation.findUnique({
+                where: { conversationId },
+                select: { channelId: true },
+            });
+            const channel = conversation
+                ? await db.channel.findUnique({
+                      where: { id: conversation.channelId },
+                      select: { workspaceId: true },
+                  })
+                : null;
+            workspaceId = channel?.workspaceId ?? undefined;
+        }
+        if (!workspaceId) return;
+
+        const replyNow = new Date();
+        await db.$transaction([
+            db.message.create({
+                data: {
+                    messageId: randomUUID(),
+                    conversationId,
+                    workspaceId,
+                    senderId: botUserId,
+                    content: appEventConfig.mentionGuidanceMessage,
+                    msgType: MessageType.BOT,
+                    showInChannel: false,
+                    metadata: {
+                        contentFormat: 'markdown',
+                        messageSubtype: APP_MENTION_GUIDANCE_SUBTYPE,
+                        mentionMessageId: messageId,
+                    },
+                },
+            }),
+            db.conversation.update({
+                where: { conversationId },
+                data: {
+                    replyCount: { increment: 1 },
+                    lastActivityAt: replyNow,
+                },
+            }),
+            db.conversationParticipant.updateMany({
+                where: { conversationId },
+                data: { lastReplyAt: replyNow },
+            }),
+        ]);
+        logger.info('[handleEventSubscriptions] Posted app mention guidance message', {
+            conversationId,
+            botUserId,
+            mentionMessageId: messageId,
+        });
+    } catch (error) {
+        logger.error('[handleEventSubscriptions] Failed to post app mention guidance message', {
+            botUserId,
+            eventType: event.eventType,
+            error,
+        });
+    }
+}
+
 export async function handleEventSubscriptionsForUsers(
     event: BaseAppEvent,
     userIds: string[],
@@ -100,7 +206,27 @@ export async function handleEventSubscriptionsForUsers(
                 return { success: false, userId: app.userId, webhookUrl: app.webhookUrl };
             }
             const decryptedSigningSecret = decrypt(secretEnc);
-            await sendWebhookNotification(app.webhookUrl!, event, decryptedSigningSecret);
+            // Gate generic event delivery on the app's webhook contract:
+            // unconfigured apps keep receiving every event unchanged.
+            const appEventConfig = findAppWebhookEventConfig(app.user?.email ?? null);
+            const delivery = resolveAppEventDelivery(app.user?.email ?? null, event.eventType);
+            if (delivery === 'skip') {
+                logger.info('[handleEventSubscriptions] Skipping app event delivery (event not in app webhook contract)', {
+                    userId: app.userId,
+                    botEmail: app.user?.email,
+                    eventType: event.eventType,
+                });
+                if (event.eventType === AppEventType.APP_MENTION && appEventConfig?.mentionGuidanceMessage) {
+                    await postAppMentionGuidanceMessage({ appEventConfig, botUserId: app.userId, event });
+                }
+                return { success: true, skipped: true, userId: app.userId, webhookUrl: app.webhookUrl };
+            }
+
+            await sendWebhookNotification(
+                app.webhookUrl!,
+                delivery === 'alias' ? withSnakeCaseAliases(event) : event,
+                decryptedSigningSecret,
+            );
             return { success: true, userId: app.userId, webhookUrl: app.webhookUrl };
         } catch (error) {
             logger.error(`Failed to send webhook notification`, {

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -470,6 +470,9 @@ const envSchema = Joi.object({
   // Stringified JSON mapping external webhook hosts to in-cluster pod base URLs.
   // e.g. {"claw.example.com":"http://claw-auth.svc.cluster.local:3003"}
   INTERNAL_APP_HOST_MAP: Joi.string().allow('').default(''),
+  // Deliver app events with snake_case field aliases to apps whose webhook
+  // contract expects them (e.g. Bitbot/Varys). Kill-switch for the alias layer.
+  APP_EVENT_SNAKE_CASE_ALIASES_ENABLED: Joi.boolean().default(true),
   ENC_S2S_KEY: Joi.string().allow(''),
   ENCRYPTION_SERVICE_URL: Joi.string().uri().default('http://localhost:3012'),
   ENCRYPTION_REQUEST_TIMEOUT_MS: Joi.number().integer().min(1).default(5000),
@@ -1138,6 +1141,7 @@ export const config = {
   internalS2sKey: envVars.INTERNAL_S2S_KEY as string,
   apps: {
     internalHostMap: parseInternalAppHostMap(envVars.INTERNAL_APP_HOST_MAP as string),
+    snakeCaseAliasesEnabled: envVars.APP_EVENT_SNAKE_CASE_ALIASES_ENABLED as boolean,
   },
   askAI: {
     version: envVars.ASK_AI_VERSION as 'v1' | 'v2',

--- a/apps/backend/src/database/repositories/installedAppsRepository.ts
+++ b/apps/backend/src/database/repositories/installedAppsRepository.ts
@@ -64,6 +64,9 @@ export class InstalledAppsRepository extends BaseRepository<
         webhookUrl: true,
         // signingSecret is app-level now — pulled via the relation.
         app: { select: { signingSecret: true } },
+        // Bot user email — stable cross-env key for per-app webhook
+        // contract gating (see apps/core/appWebhookEventConfigs.ts).
+        user: { select: { email: true } },
       },
     });
   }


### PR DESCRIPTION
## Problem (EULER-80631 — Varys bot never responds to @Varys mentions)

Every message in a channel where the Varys (Bitbot) app was installed triggered a generic `USER_MENTIONED` app webhook to Bitbot. Bitbot's webhook contract only accepts `APP_MENTIONED` with snake_case fields — it rejected generic events with `400 {"error":"Missing required field: conversation_id"}`. Result: valid @Varys app mentions were dropped (Bitbot sees no mention), and human mentions spam-failed Bitbot's endpoint.

## Fix

1. **Per-app webhook event contracts** (`appWebhookEventConfigs.ts`, new): keyed by bot user email (stable across environments). Bitbot/Varys: only `APP_MENTION` is deliverable, with snake_case aliases.
2. **Delivery gating** (`eventSubscriptionUtils.ts`): `resolveAppEventDelivery()` returns `direct | alias | skip`. Unconfigured apps keep today's behaviour (deliver everything). Configured apps only receive their contract events — others are skipped with an info log.
3. **snake_case aliases** (`withSnakeCaseAliases`): Bitbot's legacy contract requires `conversation_id` etc. Aliases are added alongside camelCase fields, never overwriting pre-existing snake_case keys, behind kill-switch `APP_EVENT_SNAKE_CASE_ALIASES_ENABLED` (default on).
4. **Guidance message**: when an @app-mention is gated off (kill-switch) or delivery fails, the bot posts a one-time guidance reply in the thread (deduped on sender+subtype+mentionMessageId) explaining how to actually invoke it (PR-check button / full PR URL as top-level message). Users are never left without a response again.

## Files
- `apps/backend/src/apps/core/appWebhookEventConfigs.ts` (new) + `appWebhookEventConfigs.test.ts` (new, 9 tests)
- `apps/backend/src/apps/core/eventSubscriptionUtils.ts` — gate + aliased delivery + guidance
- `apps/backend/src/config/env.ts` — `APP_EVENT_SNAKE_CASE_ALIASES_ENABLED` flag
- `apps/backend/src/database/repositories/installedAppsRepository.ts` — select `user.email` for bot-email keying

## Testing
- 9 unit tests green (`appWebhookEventConfigs.test.ts`), `tsc --noEmit` clean
- Live-verified against a local mock Bitbot (host-map rewrite):
  - @Varys mention (flag ON) → aliased payload delivered, HTTP 200, HMAC-SHA256 signature verified, all 6 snake_case fields present
  - human mention (@user) with Varys installed → `USER_MENTIONED` gated, no webhook call
  - flag OFF → mention skipped + one-time guidance message posted (verified in DB)
- POT video + walkthrough evidence attached in the originating Spaces thread

## Rollout
- Default flag ON, env-var kill-switch if Bitbot rejects aliased payloads in prod
- Post-deploy: watch `handleEventSubscriptions` logs + Bitbot 400 rate for ~48h

Refs: EULER-80631 (ticket), Bitbot contract fix spec (bitbot-contract-fix-spec.html)