### PR TITLE
fix: XYNE-62886 render blank lines in text file preview as real non-breaking space

### DIFF
--- a/apps/dashboard/src/components/FileViewer/TxtViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/TxtViewer.tsx
@@ -255,7 +255,7 @@ const TxtViewer: React.FC<BaseViewerProps> = memo(({ source, searchable }) => {
                 </span>
                 <span className='flex-1 whitespace-pre-wrap break-words'>
                   {/* Non-breaking space keeps empty lines from collapsing */}
-                  <HighlightedText text={line} ranges={matchesByRow.get(index)} fallback='\u00A0' />
+                  <HighlightedText text={line} ranges={matchesByRow.get(index)} fallback={'\u00A0'} />
                 </span>
               </div>
             ))}

--- a/apps/dashboard/src/components/FileViewer/TxtViewer.tsx
+++ b/apps/dashboard/src/components/FileViewer/TxtViewer.tsx
@@ -255,7 +255,11 @@ const TxtViewer: React.FC<BaseViewerProps> = memo(({ source, searchable }) => {
                 </span>
                 <span className='flex-1 whitespace-pre-wrap break-words'>
                   {/* Non-breaking space keeps empty lines from collapsing */}
-                  <HighlightedText text={line} ranges={matchesByRow.get(index)} fallback={'\u00A0'} />
+                  <HighlightedText
+                    text={line}
+                    ranges={matchesByRow.get(index)}
+                    fallback={'\u00A0'}
+                  />
                 </span>
               </div>
             ))}


### PR DESCRIPTION
## Ticket
XYNE-62886

1. Problem Description:
Blank/empty lines in the `.txt` file preview render the literal text `\u00A0` instead of an empty line.

2. If this is a bug fix or an enhancement, how did you identify the issue?:
Reported in a Spaces thread — a pasted text file showed `\u00A0` on an empty line. Traced to the text viewer's empty-line fallback.

3. Explain the solution implemented in the PR:
`TxtViewer` passed the empty-line fallback as a quoted JSX attribute (`fallback='\u00A0'`). JSX does not process backslash escape sequences inside quoted attribute strings, so the value was the literal 6 characters `\u00A0`. Wrapping it in an expression container (`fallback={'\u00A0'}`) makes it a JS string literal, where `\u00A0` resolves to the actual U+00A0 non-breaking space. One-line change in `apps/dashboard/src/components/FileViewer/TxtViewer.tsx`. (CodeViewer's equivalent fallback is already inside a JS expression, so it was unaffected.)

4. Documentation (link to docs created/updated for this change):
N/A

5. DB Alter Details (if any):
N/A

6. Data fix Details (if any):
N/A — render-path only; stored files are unaffected.

7. Environment variable Changes (if any):
N/A

8. Testing (how it was tested; screenshots/links):
Rendered the real `HighlightedText` component both ways with the project's own esbuild toolchain. Before: blank line shows literal `\u00A0`. After: blank line renders as a real non-breaking space (visually empty, keeps its height). Before/after POT screenshots shared in the originating Spaces thread.

9. Services to which this change is to be deployed:
dashboard (frontend)

10. Main PR link (if this PR is raised against a release branch):
N/A — raised against main.