### PR TITLE
feat: XYNE-62891 make URLs inert in the activity sidebar

### DIFF
--- a/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
+++ b/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
@@ -46,11 +46,21 @@ export const DirectMessageActivity = ({
       className='flex items-start'
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} disableLinks={true} />
+        <MessageBubble
+          message={message}
+          showAvatar={false}
+          variant='default'
+          contentOnly={true}
+          disableLinks={true}
+        />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} disableLinks />
+            <RenderMessageWithHTML
+              message={message.content}
+              showEdited={message.edited}
+              disableLinks
+            />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
+++ b/apps/dashboard/src/components/Activity/DirectMessageActivity.tsx
@@ -46,11 +46,11 @@ export const DirectMessageActivity = ({
       className='flex items-start'
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
+        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} disableLinks={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+            <RenderMessageWithHTML message={message.content} showEdited={message.edited} disableLinks />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
+++ b/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
@@ -49,11 +49,21 @@ export const KeywordMatchActivity = ({
       className='flex items-start'
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} disableLinks={true} />
+        <MessageBubble
+          message={message}
+          showAvatar={false}
+          variant='default'
+          contentOnly={true}
+          disableLinks={true}
+        />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} disableLinks />
+            <RenderMessageWithHTML
+              message={message.content}
+              showEdited={message.edited}
+              disableLinks
+            />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
+++ b/apps/dashboard/src/components/Activity/KeywordMatchActivity.tsx
@@ -49,11 +49,11 @@ export const KeywordMatchActivity = ({
       className='flex items-start'
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
+        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} disableLinks={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+            <RenderMessageWithHTML message={message.content} showEdited={message.edited} disableLinks />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
@@ -50,11 +50,11 @@ export const MessageMentionActivity = ({
       className='flex items-start'
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
+        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} disableLinks={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+            <RenderMessageWithHTML message={message.content} showEdited={message.edited} disableLinks />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageMentionActivity.tsx
@@ -50,11 +50,21 @@ export const MessageMentionActivity = ({
       className='flex items-start'
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} disableLinks={true} />
+        <MessageBubble
+          message={message}
+          showAvatar={false}
+          variant='default'
+          contentOnly={true}
+          disableLinks={true}
+        />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} disableLinks />
+            <RenderMessageWithHTML
+              message={message.content}
+              showEdited={message.edited}
+              disableLinks
+            />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
@@ -44,11 +44,21 @@ export const MessageRepliedActivity = ({
       isExpanded={isExpanded}
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} disableLinks={true} />
+        <MessageBubble
+          message={message}
+          showAvatar={false}
+          variant='default'
+          contentOnly={true}
+          disableLinks={true}
+        />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} disableLinks />
+            <RenderMessageWithHTML
+              message={message.content}
+              showEdited={message.edited}
+              disableLinks
+            />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivity.tsx
@@ -44,11 +44,11 @@ export const MessageRepliedActivity = ({
       isExpanded={isExpanded}
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} />
+        <MessageBubble message={message} showAvatar={false} variant='default' contentOnly={true} disableLinks={true} />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(message.content) ?? (
-            <RenderMessageWithHTML message={message.content} showEdited={message.edited} />
+            <RenderMessageWithHTML message={message.content} showEdited={message.edited} disableLinks />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
@@ -100,14 +100,17 @@ export const MessageRepliedActivityV2 = ({
           message={latestReplyMessage}
           showAvatar={false}
           variant='default'
-          contentOnly={true} disableLinks={true}
+          contentOnly={true}
+          disableLinks={true}
         />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(latestReplyMessage.content) ?? (
             <RenderMessageWithHTML
               message={latestReplyMessage.content}
-              showEdited={latestReplyMessage.edited} disableLinks />
+              showEdited={latestReplyMessage.edited}
+              disableLinks
+            />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/MessageRepliedActivityV2.tsx
@@ -100,15 +100,14 @@ export const MessageRepliedActivityV2 = ({
           message={latestReplyMessage}
           showAvatar={false}
           variant='default'
-          contentOnly={true}
+          contentOnly={true} disableLinks={true}
         />
       ) : (
         <div className='text-foreground text-sm line-clamp-1 truncate whitespace-normal break-all'>
           {getFlowJsonPreviewText(latestReplyMessage.content) ?? (
             <RenderMessageWithHTML
               message={latestReplyMessage.content}
-              showEdited={latestReplyMessage.edited}
-            />
+              showEdited={latestReplyMessage.edited} disableLinks />
           )}
         </div>
       )}

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
@@ -50,10 +50,20 @@ export const ReactionAddedActivity = ({
       isExpanded={isExpanded}
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} contentOnly={true} disableLinks={true} variant='default' />
+        <MessageBubble
+          message={message}
+          showAvatar={false}
+          contentOnly={true}
+          disableLinks={true}
+          variant='default'
+        />
       ) : (
         (getFlowJsonPreviewText(reactionPreview) ?? (
-          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} disableLinks />
+          <RenderMessageWithHTML
+            message={reactionPreview}
+            showEdited={message.edited}
+            disableLinks
+          />
         ))
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivity.tsx
@@ -50,10 +50,10 @@ export const ReactionAddedActivity = ({
       isExpanded={isExpanded}
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} contentOnly={true} variant='default' />
+        <MessageBubble message={message} showAvatar={false} contentOnly={true} disableLinks={true} variant='default' />
       ) : (
         (getFlowJsonPreviewText(reactionPreview) ?? (
-          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} />
+          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} disableLinks />
         ))
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
@@ -82,10 +82,10 @@ export const ReactionAddedActivityV2 = ({
       isExpanded={isExpanded}
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} contentOnly={true} variant='default' />
+        <MessageBubble message={message} showAvatar={false} contentOnly={true} disableLinks={true} variant='default' />
       ) : (
         (getFlowJsonPreviewText(reactionPreview) ?? (
-          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} />
+          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} disableLinks />
         ))
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
+++ b/apps/dashboard/src/components/Activity/ReactionAddedActivityV2.tsx
@@ -82,10 +82,20 @@ export const ReactionAddedActivityV2 = ({
       isExpanded={isExpanded}
     >
       {isExpanded ? (
-        <MessageBubble message={message} showAvatar={false} contentOnly={true} disableLinks={true} variant='default' />
+        <MessageBubble
+          message={message}
+          showAvatar={false}
+          contentOnly={true}
+          disableLinks={true}
+          variant='default'
+        />
       ) : (
         (getFlowJsonPreviewText(reactionPreview) ?? (
-          <RenderMessageWithHTML message={reactionPreview} showEdited={message.edited} disableLinks />
+          <RenderMessageWithHTML
+            message={reactionPreview}
+            showEdited={message.edited}
+            disableLinks
+          />
         ))
       )}
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -57,6 +57,8 @@ interface RenderMessageWithHTMLProps {
   showEdited?: boolean;
   isSystemMessage?: boolean;
   breakLongLinks?: boolean;
+  /** Render URLs/links as inert plain text (activity sidebar: a click opens the activity, not the link). */
+  disableLinks?: boolean;
   /** Needed to render embedded FlowScreenManager widgets */
   messageId?: string;
   conversationId?: string;
@@ -865,6 +867,7 @@ const parseNode = (
   conversationId?: string,
   preserveThreadRoute = false,
   slashCommandArtifactContext?: RenderMessageWithHTMLProps['slashCommandArtifactContext'],
+  disableLinks = false,
 ): React.ReactNode | null => {
   if (node.nodeType === Node.TEXT_NODE) {
     const text = node.textContent || '';
@@ -888,7 +891,16 @@ const parseNode = (
         addTokenizedNodes(parts, textBeforeUrl, skipEmojiWrapping, `emoji-url-${offset}`);
       }
 
-      if (parseInternalXyneLink(url)) {
+      if (disableLinks) {
+        parts.push(
+          <span
+            key={`${keyPrefix}-url-${offset}`}
+            className={cn('text-primary', breakLongLinks && 'break-all')}
+          >
+            {url}
+          </span>,
+        );
+      } else if (parseInternalXyneLink(url)) {
         const external = isExternalUrl(url);
         const linkProps = getAnchorTargetProps(url);
 
@@ -1118,6 +1130,7 @@ const parseNode = (
       conversationId,
       preserveThreadRoute,
       slashCommandArtifactContext,
+      disableLinks,
     );
     if (parsed !== null) children.push(parsed);
   });
@@ -1252,6 +1265,14 @@ const parseNode = (
     }
   }
 
+  if (tag === 'a' && disableLinks) {
+    return (
+      <span key={`${keyPrefix}-nolink-${idx}`} className='text-primary'>
+        {children}
+      </span>
+    );
+  }
+
   if (tag === 'a') {
     let href = el.getAttribute('href');
     if (href && isValidURL(href)) {
@@ -1356,6 +1377,7 @@ export const RenderMessageWithHTML: React.FC<RenderMessageWithHTMLProps> = ({
   showEdited = false,
   isSystemMessage = false,
   breakLongLinks = false,
+  disableLinks = false,
   messageId,
   conversationId,
   preserveThreadRoute = false,
@@ -1405,6 +1427,7 @@ export const RenderMessageWithHTML: React.FC<RenderMessageWithHTMLProps> = ({
           conversationId,
           preserveThreadRoute,
           slashCommandArtifactContext,
+          disableLinks,
         );
         if (parsed !== null) nodes.push(parsed);
       });
@@ -1418,6 +1441,7 @@ export const RenderMessageWithHTML: React.FC<RenderMessageWithHTMLProps> = ({
     keyPrefix,
     navigate,
     breakLongLinks,
+    disableLinks,
     messageId,
     conversationId,
     preserveThreadRoute,

--- a/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
+++ b/apps/dashboard/src/components/Chat/RenderMessageWithHTML/RenderMessageWithHTML.tsx
@@ -895,7 +895,7 @@ const parseNode = (
         parts.push(
           <span
             key={`${keyPrefix}-url-${offset}`}
-            className={cn('text-primary', breakLongLinks && 'break-all')}
+            className={cn('text-primary hover:underline', breakLongLinks && 'break-all')}
           >
             {url}
           </span>,
@@ -1267,7 +1267,7 @@ const parseNode = (
 
   if (tag === 'a' && disableLinks) {
     return (
-      <span key={`${keyPrefix}-nolink-${idx}`} className='text-primary'>
+      <span key={`${keyPrefix}-nolink-${idx}`} className='text-primary hover:underline'>
         {children}
       </span>
     );

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.tsx
@@ -494,6 +494,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
   channelId,
   conversation,
   contentOnly = false,
+  disableLinks = false,
   onClick,
   threadInfo,
   channelScopeType,
@@ -1267,6 +1268,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                       className={`jp-message-html whitespace-pre-wrap break-all-words inline-block ${getEmojiFontSizeClass(noteHtml)}`}
                     >
                       <RenderMessageWithHTML
+                        disableLinks={disableLinks}
                         message={noteHtml}
                         showEdited={message.edited}
                         messageId={message.messageId}
@@ -1350,6 +1352,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                       ) : (
                         <div className='jp-message-html inline-block'>
                           <RenderMessageWithHTML
+                            disableLinks={disableLinks}
                             message={DOMPurify.sanitize(forwardedMessageData.optionalText)}
                             showEdited={message.edited}
                             preserveThreadRoute={context === 'thread'}
@@ -1412,6 +1415,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                               />
                             ) : (
                               <RenderMessageWithHTML
+                                disableLinks={disableLinks}
                                 message={noteHtml}
                                 showEdited={false}
                                 preserveThreadRoute={context === 'thread'}
@@ -1452,6 +1456,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                           ) : (
                             <div className='jp-message-html inline-block'>
                               <RenderMessageWithHTML
+                                disableLinks={disableLinks}
                                 message={resolvedForwardedContent}
                                 showEdited={false}
                                 preserveThreadRoute={context === 'thread'}
@@ -1511,6 +1516,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({
                       ) : (
                         <div className='jp-message-html inline-block'>
                           <RenderMessageWithHTML
+                            disableLinks={disableLinks}
                             message={isWorkflowMessage ? 'Workflow created' : message.content}
                             showEdited={message.edited}
                             isSystemMessage={isSystemMessage}

--- a/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.types.ts
+++ b/apps/dashboard/src/components/ui/MessageBubble/MessageBubble.types.ts
@@ -69,6 +69,8 @@ export interface MessageBubbleProps {
   conversation?: ConversationWithTicket;
   context?: 'channel' | 'thread';
   contentOnly?: boolean;
+  /** Render URLs/links as inert plain text (activity sidebar previews). */
+  disableLinks?: boolean;
   onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
   threadInfo?: ThreadInfo;
   channelScopeType?: ChannelScopeType | undefined;


### PR DESCRIPTION
## What
URLs in the activity sidebar are now rendered as inert plain text instead of clickable links. Clicking an activity row (even on a URL) opens the activity/thread in the main panel, where the URL is clickable as normal. Thread and DM views are unchanged — URLs there stay directly clickable.

## Why
In the activity sidebar a directly-clickable URL let users jump straight to an external link and skip the context of the activity itself. The sidebar's job is to route you into the thread; the URL should be actioned from there.

## How
- Added an opt-in `disableLinks?: boolean` prop to `RenderMessageWithHTML`. When set, both the URL-regex text branch and the HTML `<a>` element branch render a `<span>` instead of an `<a>`, so there is no anchor to navigate on. Threaded positionally through `parseNode`, following the existing `breakLongLinks` pattern (no new context).
- Forwarded the flag through `MessageBubble` (types + all render call sites).
- Opted in from the 7 activity-sidebar components (mention, replied v1/v2, keyword match, reaction v1/v2, DM), in both collapsed and expanded branches.
- `ActivityItemCard.handleClick` is unchanged: with no anchor present, the click falls through to the card handler that opens the thread. Mark-as-read still fires.

## Scope / risk
Frontend-only, render-time change. No schema, migration, or backend change. Does not touch DM sidebar, main chat thread, or the click handler.

## Testing (POT)
Verified against the real `RenderMessageWithHTML` component:
- Thread (`disableLinks=false`): `<a href="https://example.com/pricing" target="_blank">` — clickable.
- Activity sidebar (`disableLinks=true`): `<span class="text-primary">https://example.com/pricing</span>` — inert text, no anchor; a click does not navigate away.
Typecheck passes on all changed files. A screen recording is attached in the originating thread.