### PR TITLE
feat: XYNE-57690 persist radar filter selection in localStorage

### DIFF
--- a/apps/dashboard/src/components/RadarPanel/RadarPanel.tsx
+++ b/apps/dashboard/src/components/RadarPanel/RadarPanel.tsx
@@ -43,6 +43,7 @@ import {
 import { ChannelScopeType } from '@xyne/shared';
 import { useAuth } from '../../hooks/useAuth';
 import { useRadarEnabled } from '../../hooks/radarCacConfig';
+import { usePersistedRadarFilters } from '../../hooks/usePersistedRadarFilters';
 import { useUsersById } from '../../hooks/useUsers';
 import { useAllChannels } from '../../hooks/useChannels';
 import { cn } from '../../utils/classNames';
@@ -110,21 +111,33 @@ const RadarPanel = (): ReactElement => {
     notFound?: boolean;
   } | null>(null);
   const [debugLookup, setDebugLookup] = useState('');
-  const [filterChannels, setFilterChannels] = useState<Set<string>>(new Set());
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [filterCategory, setFilterCategory] = useState<'pending' | 'channels' | 'time'>('pending');
   // "Pending on" replaces the old tabs: me maps to the pending feed, others to
-  // the waiting feed, both to all.
-  const [pendingMe, setPendingMe] = useState(true);
-  const [pendingOthers, setPendingOthers] = useState(true);
-  const [pendingUsers, setPendingUsers] = useState<Set<string>>(new Set());
-  const [requestedByUsers, setRequestedByUsers] = useState<Set<string>>(new Set());
+  // the waiting feed, both to all. The selection is kept per user across
+  // reloads, so returning to Radar does not mean picking the filters again.
+  const {
+    pendingMe,
+    setPendingMe,
+    pendingOthers,
+    setPendingOthers,
+    pendingUsers,
+    setPendingUsers,
+    requestedByUsers,
+    setRequestedByUsers,
+    filterChannels,
+    setFilterChannels,
+    timeRange,
+    setTimeRange,
+    customFrom,
+    setCustomFrom,
+    customTo,
+    setCustomTo,
+    clearAllFilters,
+  } = usePersistedRadarFilters(user?.id);
   const [requesterSearch, setRequesterSearch] = useState('');
   const [holderSearch, setHolderSearch] = useState('');
   const [channelSearch, setChannelSearch] = useState('');
-  const [timeRange, setTimeRange] = useState<'any' | 'today' | '7d' | '30d' | 'custom'>('any');
-  const [customFrom, setCustomFrom] = useState('');
-  const [customTo, setCustomTo] = useState('');
   const [calMonth, setCalMonth] = useState(() => {
     const d = new Date();
     return new Date(d.getFullYear(), d.getMonth(), 1);
@@ -935,17 +948,6 @@ const RadarPanel = (): ReactElement => {
         ]
       : []),
   ];
-
-  const clearAllFilters = () => {
-    setPendingMe(false);
-    setPendingOthers(false);
-    setPendingUsers(new Set());
-    setRequestedByUsers(new Set());
-    setFilterChannels(new Set());
-    setTimeRange('any');
-    setCustomFrom('');
-    setCustomTo('');
-  };
 
   // DMs belong here — they are channels, and most Radar threads live in one.
   // What is dropped is the unnamed fallback: a DM whose participants cannot be

--- a/apps/dashboard/src/hooks/usePersistedRadarFilters.ts
+++ b/apps/dashboard/src/hooks/usePersistedRadarFilters.ts
@@ -1,0 +1,170 @@
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export type RadarTimeRange = 'any' | 'today' | '7d' | '30d' | 'custom';
+
+const TIME_RANGES: RadarTimeRange[] = ['any', 'today', '7d', '30d', 'custom'];
+
+/** What survives a reload. The transient bits of the panel — which rail tab is
+ *  open, the picker search boxes, the calendar's visible month — are not here:
+ *  they describe the popover, not the feed the user chose to look at. */
+export interface RadarFilters {
+  pendingMe: boolean;
+  pendingOthers: boolean;
+  pendingUsers: Set<string>;
+  requestedByUsers: Set<string>;
+  filterChannels: Set<string>;
+  timeRange: RadarTimeRange;
+  customFrom: string;
+  customTo: string;
+}
+
+const DEFAULT_FILTERS: RadarFilters = {
+  pendingMe: true,
+  pendingOthers: true,
+  pendingUsers: new Set(),
+  requestedByUsers: new Set(),
+  filterChannels: new Set(),
+  timeRange: 'any',
+  customFrom: '',
+  customTo: '',
+};
+
+const STORAGE_PREFIX = 'xyne:radar-filters';
+
+const storageKeyFor = (userId: string): string => `${STORAGE_PREFIX}:${userId}`;
+
+const isStringArray = (v: unknown): v is string[] =>
+  Array.isArray(v) && v.every(x => typeof x === 'string');
+
+const toSet = (v: unknown): Set<string> => (isStringArray(v) ? new Set(v) : new Set());
+
+const readStorage = (key: string): RadarFilters => {
+  if (typeof window === 'undefined') return DEFAULT_FILTERS;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return DEFAULT_FILTERS;
+    const p = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      pendingMe: typeof p['pendingMe'] === 'boolean' ? p['pendingMe'] : DEFAULT_FILTERS.pendingMe,
+      pendingOthers:
+        typeof p['pendingOthers'] === 'boolean'
+          ? p['pendingOthers']
+          : DEFAULT_FILTERS.pendingOthers,
+      pendingUsers: toSet(p['pendingUsers']),
+      requestedByUsers: toSet(p['requestedByUsers']),
+      filterChannels: toSet(p['filterChannels']),
+      timeRange: TIME_RANGES.includes(p['timeRange'] as RadarTimeRange)
+        ? (p['timeRange'] as RadarTimeRange)
+        : DEFAULT_FILTERS.timeRange,
+      customFrom: typeof p['customFrom'] === 'string' ? p['customFrom'] : '',
+      customTo: typeof p['customTo'] === 'string' ? p['customTo'] : '',
+    };
+  } catch {
+    return DEFAULT_FILTERS;
+  }
+};
+
+const writeStorage = (key: string, filters: RadarFilters): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        pendingMe: filters.pendingMe,
+        pendingOthers: filters.pendingOthers,
+        pendingUsers: [...filters.pendingUsers],
+        requestedByUsers: [...filters.requestedByUsers],
+        filterChannels: [...filters.filterChannels],
+        timeRange: filters.timeRange,
+        customFrom: filters.customFrom,
+        customTo: filters.customTo,
+      }),
+    );
+  } catch {
+    // Quota or private mode — the filters still hold for this session.
+  }
+};
+
+export interface PersistedRadarFilters extends RadarFilters {
+  setPendingMe: Dispatch<SetStateAction<boolean>>;
+  setPendingOthers: Dispatch<SetStateAction<boolean>>;
+  setPendingUsers: Dispatch<SetStateAction<Set<string>>>;
+  setRequestedByUsers: Dispatch<SetStateAction<Set<string>>>;
+  setFilterChannels: Dispatch<SetStateAction<Set<string>>>;
+  setTimeRange: Dispatch<SetStateAction<RadarTimeRange>>;
+  setCustomFrom: Dispatch<SetStateAction<string>>;
+  setCustomTo: Dispatch<SetStateAction<string>>;
+  clearAllFilters: () => void;
+}
+
+/**
+ * Radar's filter selection, mirrored to localStorage per user so the feed comes
+ * back the way it was left instead of resetting to everything on every visit.
+ */
+export const usePersistedRadarFilters = (userId: string | undefined): PersistedRadarFilters => {
+  const storageKey = userId ? storageKeyFor(userId) : null;
+
+  const [filters, setFilters] = useState<RadarFilters>(() =>
+    storageKey ? readStorage(storageKey) : DEFAULT_FILTERS,
+  );
+
+  // The panel mounts before auth necessarily has a user, and the key is the
+  // user id — so a key arriving late still gets its stored selection, unless
+  // the user has already picked something in the meantime.
+  const hydratedKeyRef = useRef<string | null>(storageKey);
+  const touchedRef = useRef(false);
+
+  useEffect(() => {
+    if (!storageKey || hydratedKeyRef.current === storageKey) return;
+    hydratedKeyRef.current = storageKey;
+    if (touchedRef.current) return;
+    setFilters(readStorage(storageKey));
+  }, [storageKey]);
+
+  const setField = useCallback(
+    <K extends keyof RadarFilters>(key: K, value: SetStateAction<RadarFilters[K]>): void => {
+      touchedRef.current = true;
+      setFilters(prev => {
+        const nextValue =
+          typeof value === 'function'
+            ? (value as (p: RadarFilters[K]) => RadarFilters[K])(prev[key])
+            : value;
+        if (nextValue === prev[key]) return prev;
+        const next: RadarFilters = { ...prev, [key]: nextValue };
+        if (storageKey) writeStorage(storageKey, next);
+        return next;
+      });
+    },
+    [storageKey],
+  );
+
+  const clearAllFilters = useCallback(() => {
+    touchedRef.current = true;
+    const next: RadarFilters = {
+      ...DEFAULT_FILTERS,
+      pendingMe: false,
+      pendingOthers: false,
+      pendingUsers: new Set(),
+      requestedByUsers: new Set(),
+      filterChannels: new Set(),
+    };
+    if (storageKey) writeStorage(storageKey, next);
+    setFilters(next);
+  }, [storageKey]);
+
+  const setters = useMemo(
+    () => ({
+      setPendingMe: (v: SetStateAction<boolean>) => setField('pendingMe', v),
+      setPendingOthers: (v: SetStateAction<boolean>) => setField('pendingOthers', v),
+      setPendingUsers: (v: SetStateAction<Set<string>>) => setField('pendingUsers', v),
+      setRequestedByUsers: (v: SetStateAction<Set<string>>) => setField('requestedByUsers', v),
+      setFilterChannels: (v: SetStateAction<Set<string>>) => setField('filterChannels', v),
+      setTimeRange: (v: SetStateAction<RadarTimeRange>) => setField('timeRange', v),
+      setCustomFrom: (v: SetStateAction<string>) => setField('customFrom', v),
+      setCustomTo: (v: SetStateAction<string>) => setField('customTo', v),
+    }),
+    [setField],
+  );
+
+  return { ...filters, ...setters, clearAllFilters };
+};


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
Radar's filters reset to "everything" on every visit, so the selection had to be
re-picked each time the panel was opened. XYNE-57690.

The filter selection now lives in `usePersistedRadarFilters` and is mirrored to
localStorage under `xyne:radar-filters:<userId>` — the same per-user key shape
`xyne:user-threads-sort` and `xyne-sos-alerts` already use, and the same
read/validate/write structure as `usePersistedDeskMetricsFilters`.

Stored: pendingMe, pendingOthers, pendingUsers, requestedByUsers, filterChannels,
timeRange, customFrom, customTo (Sets serialized as arrays). Not stored: the
popover's own state — open rail tab, the three search boxes, calendar month.

Every field is validated independently on read and falls back to its default, so a
stale or hand-edited entry can't break the panel; writes are try/caught for quota
and private mode. An all-off selection is stored as all-off rather than collapsing
to the defaults, so "Clear all" survives a reload.

Setters keep `Dispatch<SetStateAction<T>>` signatures, so the existing functional
updaters in RadarPanel are unchanged — the panel diff is the useState block
becoming one destructure, plus `clearAllFilters` moving into the hook.

## Areas Touched
- [x] `apps/dashboard`

---

## Zero (Sync) Changes
- [x] No Zero changes — **skip this section**

## Schema & Data Changes
- [x] No schema changes — **skip this section**

## Config, Environment & URLs
- [x] No config changes — **skip this section**

## API Contract
- [x] No API changes

---

## How did you test it?

Ran the local stack (backend :3001, dashboard :5173) and drove the real filter
controls in Radar as sourish.mukherjee@xyne.ai:

- Fresh user with no stored key → defaults, and nothing written until a filter is
  actually touched.
- Untick "Me", select QA Alert Bot under "Pending on", Last 30 days, #general →
  written correctly; feed narrowed 3 cards → 1.
- Hard reload → chips "Pending: Others" / "#general" / "Last 30 days" and the same
  single card returned. Inside the popover: Me unticked, Others ticked, QA Alert
  Bot still ticked, rail counts 1/1/1.
- "Clear all" then reload → stayed cleared, did not revert to Me+Others.
- Corrupt entry (`pendingMe:'yes'`, `pendingUsers:'nope'`, `filterChannels:{a:1}`,
  `timeRange:'bogus'`, unknown key) → every bad field fell back on its own while
  the one valid field was kept.
- `'{{{not json'` → clean fallback to defaults, all 3 cards, no console errors.

### Automated
- [x] Not covered by tests — no dashboard unit-test harness for hooks in this repo;
      verified end to end in the running app instead.

### Manual

**Users**
- [x] Single user

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev

**Sync & resilience** — for anything touching Zero
- [x] Reload / hard refresh — no duplicate or lost rows

**Surface & data**
- [x] Web browser
- [x] Error paths (corrupt and unparseable stored value)

---

## Checklist
- [x] Reviewed my own diff; scoped to one thing
- [x] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [x] Formatting clean in the packages I touched
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [x] No debug logging or commented-out code left behind