### PR TITLE
fix: prevent duplicate ticket activities from debounced auto-save

### DIFF
--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -592,6 +592,14 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
   const [titleValue, setTitleValue] = useState('');
   const [editingDescription, setEditingDescription] = useState(false);
   const [descriptionValue, setDescriptionValue] = useState('');
+  // Remember the last value we actually dispatched a save for, per field.
+  // Each auto-save mutation bumps the ticket's updatedAt (and description saves
+  // trigger further server-side ticket writes), which changes the `ticket`
+  // object this effect depends on and re-arms the debounce. Without this guard
+  // the re-armed timer re-sends the same edit before the written value has
+  // propagated back into `ticket`, emitting one activity per cycle.
+  const lastSavedTitleRef = useRef<string | null>(null);
+  const lastSavedDescriptionRef = useRef<string | null>(null);
   const [showTagDropdown, setShowTagDropdown] = useState(false);
   const [isSubTicketModalOpen, setIsSubTicketModalOpen] = useState(false);
   const [isCreateTicketModalOpen, setIsCreateTicketModalOpen] = useState(false);
@@ -1888,8 +1896,10 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     if (!ticket || !editingTitle || isEmailDeskTicket) return;
     const trimmed = titleValue.trim();
     if (!trimmed || trimmed === ticket.title) return;
+    if (trimmed === lastSavedTitleRef.current) return;
     const ticketId = ticket.id;
     const timeoutId = setTimeout(() => {
+      lastSavedTitleRef.current = trimmed;
       void applyTicketUpdate(
         { id: ticketId, title: trimmed, updatedAt: Date.now() },
         'Failed to update title',
@@ -1904,8 +1914,10 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     if (!ticket || !editingDescription) return;
     const next = descriptionValue.trim();
     if (next === ticket.description) return;
+    if (next === lastSavedDescriptionRef.current) return;
     const ticketId = ticket.id;
     const timeoutId = setTimeout(() => {
+      lastSavedDescriptionRef.current = next;
       void applyTicketUpdate(
         { id: ticketId, description: next, updatedAt: Date.now() },
         'Failed to update description',

--- a/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx
@@ -1886,6 +1886,15 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     [zero],
   );
 
+  // Reset the per-field save guards when the viewed ticket changes. The refs
+  // track the last value dispatched for THIS ticket; without this, saving "X" on
+  // ticket A would make the auto-save skip an identical "X" typed on ticket B,
+  // since TicketDetails is not keyed by ticket id at its call sites.
+  useEffect(() => {
+    lastSavedTitleRef.current = null;
+    lastSavedDescriptionRef.current = null;
+  }, [ticket?.id]);
+
   // Debounced auto-save while editing — persist the title as the user types
   // rather than only on blur/exit. The blur/Enter handler still flushes an
   // immediate save; leaving edit mode flips `editingTitle`, whose cleanup clears
@@ -1899,11 +1908,18 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
     if (trimmed === lastSavedTitleRef.current) return;
     const ticketId = ticket.id;
     const timeoutId = setTimeout(() => {
+      // Optimistically mark this value as dispatched so the effect re-arming on
+      // the resulting `ticket.updatedAt` change doesn't re-send it. Clear the
+      // guard if the save is rejected so the exact same text can be retried.
       lastSavedTitleRef.current = trimmed;
       void applyTicketUpdate(
         { id: ticketId, title: trimmed, updatedAt: Date.now() },
         'Failed to update title',
-      );
+      ).then((saved) => {
+        if (!saved && lastSavedTitleRef.current === trimmed) {
+          lastSavedTitleRef.current = null;
+        }
+      });
     }, FIELD_AUTOSAVE_DEBOUNCE_MS);
     return (): void => clearTimeout(timeoutId);
   }, [titleValue, editingTitle, isEmailDeskTicket, ticket, applyTicketUpdate]);
@@ -1921,7 +1937,11 @@ export const TicketDetails: React.FC<TicketDetailsProps> = ({
       void applyTicketUpdate(
         { id: ticketId, description: next, updatedAt: Date.now() },
         'Failed to update description',
-      );
+      ).then((saved) => {
+        if (!saved && lastSavedDescriptionRef.current === next) {
+          lastSavedDescriptionRef.current = null;
+        }
+      });
     }, FIELD_AUTOSAVE_DEBOUNCE_MS);
     return (): void => clearTimeout(timeoutId);
   }, [descriptionValue, editingDescription, ticket, applyTicketUpdate]);


### PR DESCRIPTION
## Problem
Editing a ticket's title and/or description from the ticket Details panel could emit many duplicate activity rows (~3 for a title change, ~15+ for a description change) instead of one activity per field change. The activity feed and desk metrics were polluted with redundant TITLE/DESCRIPTION entries for a single user edit.

## Root cause
The debounced auto-save effects in `apps/dashboard/src/components/Tickets/TicketDetails/TicketDetails.tsx` depend on the whole `ticket` object. Each auto-save mutation bumps the ticket's `updatedAt` (and a description save triggers further server-side ticket writes), which changes the `ticket` object the effect depends on and re-arms the 600ms debounce. Under sync latency the written value has not yet propagated back into `ticket`, so the existing guard `trimmed === ticket.title` is still false and the re-armed timer re-sends the same edit — emitting one activity per cycle. The backend mutator is correct; this is purely a client-side re-dispatch loop.

## Fix
Track the last value we actually dispatched a save for, per field, in a ref (`lastSavedTitleRef` / `lastSavedDescriptionRef`). The ref is set immediately before dispatch, and each effect skips re-dispatching a value identical to the last one already sent. This makes the auto-save idempotent per distinct value regardless of how many times `ticket` re-renders mid-save. +12 lines, single file.

## Testing (proof)
Reproduced the ticket Details flow end-to-end against a local dev stack (dashboard + zero-cache + backend) driven by Playwright:
- Edited the title once and the description once.
- Confirmed the `ticket_activities` table contains exactly **one** TITLE row and **one** DESCRIPTION row for the edit (old→new values correct).
A screen recording of the corrected behavior is attached in the originating thread.

## Risk / rollout
Frontend-only change, no schema/migration/backfill. No behavior change other than suppressing duplicate writes. Safe to roll out with a normal dashboard deploy.