### PR TITLE
fix: XYNE-62896 debug panel optimizations

### DIFF
--- a/apps/backend/src/controllers/xyneAIControllerV2.ts
+++ b/apps/backend/src/controllers/xyneAIControllerV2.ts
@@ -1094,11 +1094,28 @@ export class XyneAIControllerV2 {
       res.status(400).json({ success: false, error: 'convId is required' });
       return;
     }
+    // Run-page cursor. claw caps the page (default 25) and pages it with a
+    // `before` runId; validated here rather than forwarded raw because both
+    // values end up in a downstream URL. Anything malformed is dropped, which
+    // just means "first page" — claw also warns about a cursor it ignored.
+    const rawLimit = req.query.limit;
+    const rawBefore = req.query.before;
+    const paging = {
+      ...(typeof rawLimit === 'string' && /^\d+$/.test(rawLimit) ? { limit: rawLimit } : {}),
+      ...(typeof rawBefore === 'string' && /^[A-Za-z0-9_.-]{1,128}$/.test(rawBefore)
+        ? { before: rawBefore }
+        : {}),
+    };
     try {
+      // `result` is forwarded untouched. The bundle carries `warnings`,
+      // `totalRuns`, `truncated` and per-event trace payloads whose shape is
+      // owned by xyne-claw's materializer; whitelisting fields here would blank
+      // debugger panels the next time that format grows one.
       const result = await getClawDebugArtifacts(
         { headers: req.headers, userId },
         convId,
-        (req.query.agentSlug as string) || 'ask-ai'
+        (req.query.agentSlug as string) || 'ask-ai',
+        paging
       );
       res.json(result);
     } catch (error) {

--- a/apps/backend/src/services/clawAgentService.ts
+++ b/apps/backend/src/services/clawAgentService.ts
@@ -204,6 +204,15 @@ export interface ClawDebugArtifactBundle {
   runs: Array<{ fileName: string; data: Record<string, unknown> }>;
   subagents: Array<{ fileName: string; data: Record<string, unknown> }>;
   followUpDiagnostics?: FollowUpDiagnostic[];
+  /** Runs in the whole conversation vs. the runs on this page — xyne-claw caps
+   *  the page (default 25) and claw-auth restates both after its per-user ACL,
+   *  so the debugger can say "showing N of M" and page with `before`. */
+  totalRuns?: number;
+  truncated?: boolean;
+  /** Non-fatal read problems (evicted PVC dir, unreadable GCS object, ignored
+   *  cursor). Surfaced so a partial trace never reads as "the agent did
+   *  nothing". Passed through verbatim — never summarised or dropped here. */
+  warnings?: string[];
 }
 
 export interface FollowUpDiagnostic {
@@ -1285,20 +1294,54 @@ export async function deleteClawConversation(
   return (await response.json()) as { success: boolean; data: { deleted: number } };
 }
 
+/**
+ * Ceiling for the debug-bundle proxy hop. claw-auth already bounds its own hop
+ * to xyne-claw at 45s, so anything slower than this is a stalled connection,
+ * not a slow read — and without a signal here a stall pinned the request (and
+ * the dashboard's spinner) forever, since the browser client sets no timeout.
+ */
+const DEBUG_BUNDLE_TIMEOUT_MS = (() => {
+  const override = Number(process.env['CLAW_DEBUG_PROXY_TIMEOUT_MS']);
+  // A non-numeric override would make AbortSignal.timeout throw on every call,
+  // so an unusable value falls back rather than breaking the endpoint.
+  return Number.isFinite(override) && override > 0 ? override : 60_000;
+})();
+
 export async function getClawDebugArtifacts(
   req: { headers?: { cookie?: string }; userId: string },
   convId: string,
-  agentSlug?: string
+  agentSlug?: string,
+  // xyne-claw caps the run page and pages it with a `before` runId cursor;
+  // claw-auth forwards both. Forward them here too, otherwise `truncated`
+  // reaches the debugger with no way to ask for the withheld runs.
+  paging?: { limit?: string; before?: string }
 ): Promise<{ success: boolean; data: ClawDebugArtifactBundle }> {
   const slug = agentSlug || 'ask-ai';
-  const url = `${getClawBaseUrl()}/claw/api/v1/agent-chat/${encodeURIComponent(slug)}/chat/${encodeURIComponent(convId)}/debug`;
-  const response = await fetch(url, {
-    headers: {
-      ...getS2SHeaders(),
-      ...extractUserIdHeader(req.userId),
-      ...extractCookieHeader(req),
-    },
-  });
+  const query = new URLSearchParams();
+  if (paging?.limit) query.set('limit', paging.limit);
+  if (paging?.before) query.set('before', paging.before);
+  const queryString = query.toString();
+  const suffix = queryString ? `?${queryString}` : '';
+  const url = `${getClawBaseUrl()}/claw/api/v1/agent-chat/${encodeURIComponent(slug)}/chat/${encodeURIComponent(convId)}/debug${suffix}`;
+  // Qualified: bare `Response` resolves to express's in this module.
+  let response: globalThis.Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        ...getS2SHeaders(),
+        ...extractUserIdHeader(req.userId),
+        ...extractCookieHeader(req),
+      },
+      signal: AbortSignal.timeout(DEBUG_BUNDLE_TIMEOUT_MS),
+    });
+  } catch (error) {
+    // An abort surfaces as a DOMException whose message ("The operation was
+    // aborted due to timeout") tells the debugger nothing about which hop died.
+    logger.error(
+      `[ClawAgentService] getDebugArtifacts fetch failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+    throw new Error('Failed to fetch debug artifacts');
+  }
 
   if (!response.ok) {
     const errorText = await response.text();
@@ -1308,6 +1351,11 @@ export async function getClawDebugArtifacts(
     );
   }
 
+  // Deliberately an unfiltered pass-through: the bundle's event payloads carry
+  // fields this service has no schema for (blob refs, `<field>UnchangedFromSeq`
+  // back-references, folded llm_request/llm_response params). Re-mapping keys
+  // here would silently blank panels in the debugger every time claw's trace
+  // format grows a field.
   return (await response.json()) as { success: boolean; data: ClawDebugArtifactBundle };
 }
 

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/AskAIDebugPanel.tsx
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/AskAIDebugPanel.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import {
   Activity,
   AlertCircle,
+  AlertTriangle,
   Bot,
   Braces,
   BrainCircuit,
@@ -22,6 +23,7 @@ import {
   Quote,
   RefreshCw,
   RotateCcw,
+  Sparkles,
   User,
   Workflow,
   Wrench,
@@ -32,7 +34,23 @@ import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { fetchV2DebugArtifacts } from '../../../../services/XyneAI/XyneAISessionsV2Service';
 import { debugArtifactFailureState } from './debugArtifactPollingPolicy';
-import { mergeLiveDebugTimeline } from './unifiedDebugTimeline';
+import {
+  asBlobRef,
+  collectDebugWarnings,
+  compactTimeline,
+  fieldSizeLabel,
+  mergeLiveDebugTimeline,
+  paletteList,
+  refNote,
+  resolveFieldText,
+  resolvePanelMessages,
+  skillEntries,
+  stringList,
+  toolEntries,
+  type ResolvedField,
+  type SkillEntry,
+  type ToolEntry,
+} from './unifiedDebugTimeline';
 import type {
   DebugArtifactBundle,
   DebugEventRecord,
@@ -424,10 +442,14 @@ function JsonViewer({
   value,
   title = 'JSON',
   defaultExpandedDepth = 999,
+  scroll = true,
 }: {
   value: unknown;
   title?: string;
   defaultExpandedDepth?: number;
+  /** Set false when an ancestor already scrolls: nesting a second scroller
+   *  swallows the wheel as soon as the pointer crosses this box. */
+  scroll?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   const parsedValue = useMemo(() => parseJsonLike(value), [value]);
@@ -452,7 +474,7 @@ function JsonViewer({
             <Maximize2 size={12} />
           </button>
         </div>
-        <div className='max-h-64 overflow-auto p-2'>
+        <div className={`p-2 ${scroll ? 'max-h-64 overflow-auto' : ''}`}>
           <JsonNode value={parsedValue} depth={0} defaultExpandedDepth={defaultExpandedDepth} />
         </div>
       </div>
@@ -723,49 +745,18 @@ function messageLabel(role: string): string {
   return role || 'Message';
 }
 
-type TimelineEvent = Record<string, unknown> & { startedAt?: string };
-
-function compactTimeline(events: unknown[]): TimelineEvent[] {
-  const compacted: TimelineEvent[] = [];
-  const pendingTools = new Map<string, number>();
-
-  for (const value of events) {
-    if (!isRecord(value) || ['message_update', 'stream_rate'].includes(asString(value['kind'])))
-      continue;
-    const event = value as TimelineEvent;
-    const kind = asString(event['kind']);
-    const toolCallId = asString(event['toolCallId']);
-    if (kind === 'tool_execution_start' && toolCallId) {
-      pendingTools.set(toolCallId, compacted.length);
-      compacted.push(event);
-      continue;
-    }
-    if (kind === 'tool_execution_end' && toolCallId && pendingTools.has(toolCallId)) {
-      const index = pendingTools.get(toolCallId)!;
-      const start = compacted[index]!;
-      compacted[index] = {
-        ...event,
-        startedAt: asString(start['at']),
-        data: {
-          ...(isRecord(start['data']) ? start['data'] : {}),
-          ...(isRecord(event['data']) ? event['data'] : {}),
-        },
-      };
-      pendingTools.delete(toolCallId);
-      continue;
-    }
-    compacted.push(event);
-  }
-
-  return compacted;
-}
-
 function eventTitle(kind: string, data: Record<string, unknown>): string {
   if (kind === 'tool_execution_start' || kind === 'tool_execution_end') {
     const name = asString(data['toolName']);
     return name ? `Tool · ${name}` : 'Tool call';
   }
-  if (kind === 'session_prompt') return 'LLM request';
+  if (kind === 'session_prompt' || kind === 'llm_request') return 'LLM request';
+  if (kind === 'tool_palette_change') return 'Tool palette changed';
+  if (kind === 'skill_loaded') return 'Skill loaded';
+  if (kind === 'subagent_start') return 'Subagent started';
+  if (kind === 'subagent_end') return 'Subagent finished';
+  if (kind === 'provider_fallback') return 'Provider fallback';
+  if (kind === 'delegation') return 'Agent delegation';
   if (kind === 'thinking') return 'Thinking';
   if (kind === 'assistant_turn_end') return 'Assistant response';
   if (kind === 'session_start') return 'Session started';
@@ -815,12 +806,49 @@ function eventVisual(kind: string, isError: boolean): EventVisual {
         chip: 'bg-sky-500/10 text-sky-700 dark:text-sky-300',
       };
     case 'session_prompt':
+    case 'llm_request':
       return {
         Icon: BrainCircuit,
         label: 'LLM',
         rail: 'border-xyne-border-strong',
         chip: 'text-xyne-fg-muted',
         quiet: true,
+      };
+    case 'tool_palette_change':
+      return {
+        Icon: Wrench,
+        label: 'PALETTE',
+        rail: 'border-amber-400',
+        chip: 'bg-amber-400/10 text-amber-700 dark:text-amber-300',
+      };
+    case 'skill_loaded':
+      return {
+        Icon: Sparkles,
+        label: 'SKILL',
+        rail: 'border-indigo-500',
+        chip: 'bg-indigo-500/10 text-indigo-700 dark:text-indigo-300',
+      };
+    case 'subagent_start':
+    case 'subagent_end':
+      return {
+        Icon: Workflow,
+        label: 'SUB',
+        rail: 'border-cyan-500',
+        chip: 'bg-cyan-500/10 text-cyan-700 dark:text-cyan-300',
+      };
+    case 'delegation':
+      return {
+        Icon: Workflow,
+        label: 'A2A',
+        rail: 'border-blue-500',
+        chip: 'bg-blue-500/10 text-blue-700 dark:text-blue-300',
+      };
+    case 'provider_fallback':
+      return {
+        Icon: RotateCcw,
+        label: 'FALLBACK',
+        rail: 'border-orange-500',
+        chip: 'bg-orange-500/10 text-orange-700 dark:text-orange-300',
       };
     case 'thinking':
       return {
@@ -924,6 +952,7 @@ function DebugTimelineSection({
   onSelectEvent,
   timeMode = 'delta',
   followUpDiagnostic,
+  live = false,
 }: {
   title: string;
   data: Record<string, unknown> | null;
@@ -933,6 +962,8 @@ function DebugTimelineSection({
   onSelectEvent?: (key: string) => void;
   timeMode?: 'delta' | 'abs';
   followUpDiagnostic?: FollowUpDiagnostic | null;
+  /** This run is still streaming, so its big payloads are blob-ref previews. */
+  live?: boolean;
 }) {
   const [expanded, setExpanded] = useState(defaultOpen);
   const events = useMemo<unknown[]>(() => {
@@ -951,6 +982,14 @@ function DebugTimelineSection({
     });
   }, [events, followUpDiagnostic]);
 
+  // The full transcript, carried ONCE on the run snapshot. Each turn's panel is
+  // a prefix of it (`data.messagesTo`), so rows slice rather than each shipping
+  // its own copy — that copy was O(turns²) on the wire.
+  const transcript = useMemo<unknown[] | undefined>(() => {
+    const raw = data?.['messages'];
+    return Array.isArray(raw) ? (raw as unknown[]) : undefined;
+  }, [data]);
+
   // Expand/collapse all timeline cards. The cards are native <details> elements
   // (no React state to lift), so we flip their `open` attribute through a ref.
   // Scoped to the timeline's direct-child cards — opens each tool/event card
@@ -962,16 +1001,23 @@ function DebugTimelineSection({
     });
   };
 
-  // Earliest event time = the origin for Δ timestamps in this run/turn.
+  // Per-row timestamps. Δ is the GAP FROM THE PREVIOUS ROW — that is what
+  // answers "what was slow?", which is the whole reason to read a timeline.
+  // Time-from-run-start still has value for orientation, so it moves to the
+  // hover title instead of being the headline number.
+  const eventTimesMs = useMemo(
+    () =>
+      visibleEvents.map(e => {
+        if (!isRecord(e)) return undefined;
+        const t = Date.parse(asString(e['at']) || asString(e['startedAt']));
+        return Number.isFinite(t) ? t : undefined;
+      }),
+    [visibleEvents],
+  );
   const originMs = useMemo(() => {
-    let min = Number.POSITIVE_INFINITY;
-    for (const e of visibleEvents) {
-      if (!isRecord(e)) continue;
-      const t = Date.parse(asString(e['at']) || asString(e['startedAt']));
-      if (Number.isFinite(t)) min = Math.min(min, t);
-    }
-    return Number.isFinite(min) ? min : undefined;
-  }, [visibleEvents]);
+    const known = eventTimesMs.filter((t): t is number => t !== undefined);
+    return known.length > 0 ? Math.min(...known) : undefined;
+  }, [eventTimesMs]);
 
   // Sub-steps (thinking / assistant / tool) indent under the spine; the LAST
   // assistant turn is the conclusion and stays flush.
@@ -1015,11 +1061,13 @@ function DebugTimelineSection({
   const streamCharsPerSec =
     typeof data?.['streamCharsPerSec'] === 'number' ? data['streamCharsPerSec'] : undefined;
 
+  const runWarnings = stringList(data?.['warnings']);
   const headerMeta = [
     asString(data?.['provider']),
     asString(data?.['model']),
     toolsUsed.length ? `${toolsUsed.length} tools` : '',
     `${visibleEvents.length} events`,
+    runWarnings.length ? 'partial trace' : '',
   ]
     .filter(Boolean)
     .join(' · ');
@@ -1049,6 +1097,16 @@ function DebugTimelineSection({
 
       {expanded && (
         <div className='ml-1.5 border-l border-xyne-border-subtle pl-4 pb-3 pt-1 space-y-2'>
+          {runWarnings.length > 0 && (
+            <div className='space-y-0.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-[11px] leading-relaxed text-amber-800 dark:text-amber-200'>
+              {runWarnings.map((warning, index) => (
+                <p key={`${index}-${warning}`} className='break-words'>
+                  {warning}
+                </p>
+              ))}
+            </div>
+          )}
+
           {Boolean(data?.['task'] || data?.['question'] || data?.['providerError']) && (
             <p
               className={`text-[12px] leading-relaxed ${data?.['providerError'] ? 'text-red-600 dark:text-red-400' : 'text-xyne-fg-secondary'}`}
@@ -1181,9 +1239,12 @@ function DebugTimelineSection({
                       selected={selectedEventKey === ek}
                       onSelect={onSelectEvent}
                       subagentTracesByParentToolCallId={subagentTracesByParentToolCallId}
+                      transcript={transcript}
                       originMs={originMs}
+                      prevMs={idx > 0 ? eventTimesMs[idx - 1] : undefined}
                       timeMode={timeMode}
                       indented={indented}
+                      live={live}
                     />
                   );
                 })}
@@ -1262,15 +1323,277 @@ function MessageSnapshot({ message }: { message: unknown }) {
   );
 }
 
+/** Body for a resolved payload: the text plus, for refs, what is missing. */
+function FieldText({
+  field,
+  className = '',
+  live = false,
+}: {
+  field: ResolvedField;
+  className?: string;
+  live?: boolean;
+}) {
+  return (
+    <>
+      <pre
+        className={`max-h-72 overflow-y-auto overscroll-contain whitespace-pre-wrap text-[12px] leading-relaxed text-xyne-fg-secondary ${className}`}
+      >
+        {field.text || '(payload not captured)'}
+      </pre>
+      {field.isRef && (
+        <p className='mt-1 text-[11px] text-amber-700 dark:text-amber-300'>
+          {refNote(field, live)}
+        </p>
+      )}
+    </>
+  );
+}
+
+/** Highlights the `<available_skills>` region so it is findable in a 28 KB
+ *  prompt. Split into text nodes rather than injected HTML — the prompt is
+ *  model-authored content and must never be parsed as markup. */
+function SystemPromptText({ text }: { text: string }) {
+  const parts = useMemo(() => {
+    const closed = /<available_skills>[\s\S]*?<\/available_skills>/.exec(text);
+    // A truncated prompt (or a ref preview) loses the closing tag; highlight to
+    // the end instead of silently giving up on the one region worth finding.
+    const start = closed ? closed.index : text.indexOf('<available_skills>');
+    if (start < 0) return null;
+    const end = closed ? closed.index + closed[0].length : text.length;
+    return { before: text.slice(0, start), block: text.slice(start, end), after: text.slice(end) };
+  }, [text]);
+
+  if (!parts) return <>{text}</>;
+  return (
+    <>
+      {parts.before}
+      <span className='rounded-sm bg-amber-400/20 text-xyne-fg-primary ring-1 ring-inset ring-amber-500/30'>
+        {parts.block}
+      </span>
+      {parts.after}
+    </>
+  );
+}
+
+/** Which skills the model could even see this turn — the question the persona-
+ *  only system prompt could never answer. */
+function AvailableSkillsPanel({ skills }: { skills: SkillEntry[] }) {
+  if (skills.length === 0) return null;
+  return (
+    <details className='group/sk rounded-md bg-xyne-surface'>
+      <summary className='flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5'>
+        <ChevronDown
+          size={11}
+          className='shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/sk:rotate-0'
+        />
+        <Sparkles size={11} className='shrink-0 self-center text-xyne-fg-tertiary' />
+        <span className='text-[12px] font-semibold text-xyne-fg-secondary'>Available skills</span>
+        <span className='ml-auto text-[11px] text-xyne-fg-muted'>
+          {skills.length} skill{skills.length === 1 ? '' : 's'}
+        </span>
+      </summary>
+      <div className='max-h-72 overflow-y-auto overscroll-contain px-2 pb-2 pt-1'>
+        {skills.map(skill => (
+          <div
+            key={skill.name}
+            className='border-b border-xyne-border-subtle/40 py-1 last:border-b-0'
+          >
+            <p className='font-mono text-[11.5px] text-xyne-fg-primary'>{skill.name}</p>
+            {skill.description && (
+              <p className='text-[11.5px] leading-relaxed text-xyne-fg-muted'>
+                {skill.description}
+              </p>
+            )}
+            {skill.location && (
+              <p className='truncate font-mono text-[10px] text-xyne-fg-tertiary'>
+                {skill.location}
+              </p>
+            )}
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+/** The tool catalog handed to the model, with each schema — the "why did it
+ *  call the wrong tool" panel. The parameter viewer deliberately does NOT
+ *  scroll: this list already does, and stacked scrollers swallow the wheel
+ *  wherever the pointer happens to sit across ~48 tools. */
+function ToolDefinitionsPanel({ tools }: { tools: ToolEntry[] }) {
+  if (tools.length === 0) return null;
+  return (
+    <details className='group/tools rounded-md bg-xyne-surface'>
+      <summary className='flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5'>
+        <ChevronDown
+          size={11}
+          className='shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/tools:rotate-0'
+        />
+        <Wrench size={11} className='shrink-0 self-center text-xyne-fg-tertiary' />
+        <span className='text-[12px] font-semibold text-xyne-fg-secondary'>Tools offered</span>
+        <span className='ml-auto text-[11px] text-xyne-fg-muted'>
+          {tools.length} tool{tools.length === 1 ? '' : 's'}
+        </span>
+      </summary>
+      <div className='max-h-96 overflow-y-auto overscroll-contain px-2 pb-2 pt-1'>
+        {tools.map(tool => (
+          <details
+            key={tool.name}
+            className='group/tool border-b border-xyne-border-subtle/40 last:border-b-0'
+          >
+            <summary className='flex cursor-pointer list-none items-baseline gap-2 py-1'>
+              <ChevronDown
+                size={10}
+                className='shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/tool:rotate-0'
+              />
+              <span className='shrink-0 font-mono text-[11.5px] text-xyne-fg-primary'>
+                {tool.name}
+              </span>
+              {tool.description && (
+                <span className='min-w-0 truncate text-[11.5px] text-xyne-fg-muted'>
+                  {tool.description}
+                </span>
+              )}
+            </summary>
+            <div className='ml-1.5 border-l border-xyne-border-subtle pb-1 pl-3 pt-1 space-y-1'>
+              {tool.description && (
+                <p className='text-[11.5px] leading-relaxed text-xyne-fg-secondary'>
+                  {tool.description}
+                </p>
+              )}
+              {tool.parameters !== undefined ? (
+                <JsonViewer
+                  value={tool.parameters}
+                  title={`${tool.name} parameters`}
+                  defaultExpandedDepth={2}
+                  scroll={false}
+                />
+              ) : (
+                <p className='text-[11px] text-xyne-fg-muted'>
+                  No parameter schema captured for this tool.
+                </p>
+              )}
+            </div>
+          </details>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+/** The mid-run palette diff (load-tools / fast-mode), which otherwise only ever
+ *  showed up as a silent change in what the model could call. */
+function PaletteChips({ added, removed }: { added: string[]; removed: string[] }) {
+  if (added.length === 0 && removed.length === 0) return null;
+  return (
+    <div className='flex flex-wrap items-center gap-1 rounded-md bg-xyne-surface px-2 py-1.5'>
+      <span className='mr-1 text-[11px] text-xyne-fg-muted'>Tool palette</span>
+      {added.map(name => (
+        <span
+          key={`add-${name}`}
+          className='rounded bg-emerald-500/10 px-1 font-mono text-[10.5px] text-emerald-700 dark:text-emerald-300'
+        >
+          +{name}
+        </span>
+      ))}
+      {removed.map(name => (
+        <span
+          key={`rm-${name}`}
+          className='rounded bg-red-500/10 px-1 font-mono text-[10.5px] text-red-700 dark:text-red-300'
+        >
+          −{name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** What the model was actually asked for, on one line: sampling params plus the
+ *  response's stop reason, prompt-cache hit/miss and TTFT. */
+function RequestParamsStrip({ data }: { data: Record<string, unknown> }) {
+  const items: Array<[string, string]> = [];
+  const push = (label: string, value: string) => {
+    if (value) items.push([label, value]);
+  };
+  push('Model', asString(data['model']));
+  push('Provider', asString(data['provider']));
+  if (typeof data['temperature'] === 'number') push('Temp', String(data['temperature']));
+  if (typeof data['maxTokens'] === 'number') push('Max tokens', String(data['maxTokens']));
+  push('Thinking', asString(data['thinkingLevel']));
+  if (typeof data['fastMode'] === 'boolean') push('Fast mode', data['fastMode'] ? 'on' : 'off');
+  push('Stop', asString(data['responseStopReason']));
+
+  const usage = isRecord(data['responseUsage']) ? data['responseUsage'] : null;
+  const cacheRead = typeof usage?.['cacheRead'] === 'number' ? usage['cacheRead'] : null;
+  const cacheWrite = typeof usage?.['cacheWrite'] === 'number' ? usage['cacheWrite'] : null;
+  if (cacheRead !== null || cacheWrite !== null) {
+    // Read tokens are the cache HIT: zero reads on a repeat turn is the tell for
+    // a prompt-cache miss, which is why the raw numbers stay visible.
+    push(
+      'Cache',
+      `${cacheRead ?? 0} read / ${cacheWrite ?? 0} write · ${(cacheRead ?? 0) > 0 ? 'hit' : 'miss'}`,
+    );
+  }
+  if (typeof data['ttftMs'] === 'number') push('TTFT', `${data['ttftMs']}ms`);
+
+  if (items.length === 0) return null;
+  return (
+    <div className='flex flex-wrap gap-x-4 gap-y-1 rounded-md bg-xyne-surface px-2 py-1.5 text-[11px] text-xyne-fg-secondary'>
+      {items.map(([label, value]) => (
+        <span key={label}>
+          <span className='text-xyne-fg-muted'>{label}:</span> {value}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** Non-fatal read problems for the run(s) on screen. Without this a partial
+ *  artifact read is indistinguishable from an agent that simply did nothing. */
+function WarningsNotice({ warnings }: { warnings: string[] }) {
+  const [expanded, setExpanded] = useState(false);
+  if (warnings.length === 0) return null;
+  const shown = expanded ? warnings : warnings.slice(0, 3);
+  return (
+    <div className='flex shrink-0 gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-[11px] text-amber-800 dark:text-amber-200'>
+      <AlertTriangle size={12} className='mt-0.5 shrink-0' />
+      <div className='min-w-0 flex-1 space-y-0.5'>
+        <p className='font-semibold'>
+          Partial trace · {warnings.length} warning{warnings.length === 1 ? '' : 's'}
+        </p>
+        {shown.map((warning, index) => (
+          <p key={`${index}-${warning}`} className='break-words leading-relaxed'>
+            {warning}
+          </p>
+        ))}
+        {warnings.length > 3 && (
+          <button
+            type='button'
+            data-track-category='XyneAI'
+            data-track-name='DEBUG_WARNINGS_TOGGLE'
+            onClick={() => setExpanded(current => !current)}
+            className='underline underline-offset-2 hover:no-underline'
+          >
+            {expanded ? 'Show less' : `Show ${warnings.length - 3} more`}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function DebugEventItem({
   event,
   eventKey,
   selected = false,
   onSelect,
   subagentTracesByParentToolCallId,
+  transcript,
   originMs,
+  prevMs,
   timeMode = 'delta',
   indented = false,
+  live = false,
 }: {
   event: unknown;
   eventKey: string;
@@ -1278,12 +1601,21 @@ function DebugEventItem({
   selected?: boolean;
   onSelect?: ((key: string) => void) | undefined;
   subagentTracesByParentToolCallId?: Map<string, SubagentTraceGroup[]> | undefined;
+  /** The run's full transcript. A turn's panel is the prefix ending at this
+   *  event's `messagesTo`; absent on a live-only run, where there is no
+   *  snapshot yet. */
+  transcript?: unknown[] | undefined;
   /** Run start (ms) used to compute Δ timestamps. */
   originMs?: number | undefined;
+  /** Timestamp of the row above this one; Δ is measured against it. */
+  prevMs?: number | undefined;
   /** "delta" → +Xs from run start (default); "abs" → wall-clock time. */
   timeMode?: 'delta' | 'abs';
   /** Sub-steps of a turn (thinking / assistant / tool) indent under the spine. */
   indented?: boolean;
+  /** This row is still streaming, where every big payload is only a blob-ref
+   *  preview. Changes what the ref affordances promise. */
+  live?: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
   if (!isRecord(event)) {
@@ -1307,10 +1639,35 @@ function DebugEventItem({
         ) ?? [])
       : [];
 
+  // session_prompt carries the folded llm_request: the TRUE system prompt (with
+  // its <available_skills> block), the tool schemas the model was handed, and
+  // the request params. Payloads may be inline strings or blob refs.
+  const isPromptEvent = kind === 'session_prompt' || kind === 'llm_request';
+  const systemPromptField = resolveFieldText(data, 'systemPrompt');
+  const userPromptField = resolveFieldText(data, 'prompt');
+  const availableSkills = isPromptEvent ? skillEntries(data['availableSkills']) : [];
+  const offeredTools = isPromptEvent ? toolEntries(data) : [];
+  const paletteAdded = paletteList(data, 'paletteAdded', 'added');
+  const paletteRemoved = paletteList(data, 'paletteRemoved', 'removed');
+  // Only consulted when the lists came back empty — a palette diff big enough
+  // to be interned arrives as `addedRef`/`removedRef` with a preview.
+  const paletteAddedField = resolveFieldText(data, 'added');
+  const paletteRemovedField = resolveFieldText(data, 'removed');
+  const thinkingField = resolveFieldText(data, 'text');
+  const assistantField = resolveFieldText(data, 'assistantText');
+  const errorField = resolveFieldText(data, 'error');
+  // A ref can sit in the field itself, so "present" is not the same as "inline".
+  const hasInlineResult = 'result' in data && !asBlobRef(data['result']);
+  const hasInlineArgs = 'args' in data && !asBlobRef(data['args']);
+  const resultField = hasInlineResult ? null : resolveFieldText(data, 'result');
+  const argsField = hasInlineArgs ? null : resolveFieldText(data, 'args');
+  const panelMessages = resolvePanelMessages(data, transcript);
+  const messagesField = panelMessages ? null : resolveFieldText(data, 'messages');
+
   const summary = eventSummary(kind, data);
   // LLM request is low-signal: its msg count rides on the title, so suppress the
   // redundant "Sending N messages" preview.
-  const showSummary = Boolean(summary) && kind !== 'session_prompt';
+  const showSummary = Boolean(summary) && !isPromptEvent;
   const timestamp = isTool ? at || startedAt : at;
   const visual = eventVisual(kind, isError);
   const VisualIcon = visual.Icon;
@@ -1321,7 +1678,7 @@ function DebugEventItem({
   const isFinalAssistant = kind === 'assistant_turn_end' && !indented;
   const titleText = isTool
     ? asString(data['toolName']) || 'tool'
-    : kind === 'session_prompt'
+    : isPromptEvent
       ? `LLM request${msgCount !== null ? ` · ${msgCount} msgs` : ''}`
       : isFinalAssistant
         ? 'Assistant response · final'
@@ -1334,14 +1691,28 @@ function DebugEventItem({
         ? 'font-mono font-medium text-xyne-fg-primary'
         : 'font-semibold text-xyne-fg-primary';
 
-  // Time column: Δ-from-start by default (de-noises repeated wall-clock times),
-  // absolute on the abs toggle and always on hover.
+  // Time column: the gap since the previous row by default, absolute on the abs
+  // toggle. A run-start-relative column reads like a stopwatch and hides the one
+  // thing a timeline is opened for — which step took the time.
   const eventMs = timestamp ? Date.parse(timestamp) : NaN;
   const absTime = timestamp ? formatTime(timestamp) : '';
+  const gapMs = prevMs !== undefined && Number.isFinite(eventMs) ? eventMs - prevMs : undefined;
   const timeText =
-    timeMode === 'abs' || originMs === undefined || !Number.isFinite(eventMs)
+    timeMode === 'abs' || !Number.isFinite(eventMs)
       ? absTime
-      : formatDelta(eventMs - originMs);
+      : gapMs === undefined
+        ? '+0.0s' // first row: nothing precedes it
+        : formatDelta(gapMs);
+  // Everything the column no longer shows, on hover.
+  const timeTitle = [
+    absTime,
+    originMs !== undefined && Number.isFinite(eventMs)
+      ? `${formatDelta(eventMs - originMs).replace(/^\+/, '')} into run`
+      : '',
+    gapMs !== undefined ? `${formatDelta(gapMs).replace(/^\+/, '')} since previous` : '',
+  ]
+    .filter(Boolean)
+    .join(' · ');
 
   return (
     <details
@@ -1375,7 +1746,7 @@ function DebugEventItem({
             </span>
           )}
           <span className='ml-auto flex shrink-0 items-center font-mono text-[10.5px] tabular-nums'>
-            <span className='w-[50px] text-right text-xyne-fg-secondary' title={absTime}>
+            <span className='w-[50px] text-right text-xyne-fg-secondary' title={timeTitle}>
               {timeText}
             </span>
             <span className='w-[50px] text-right text-xyne-fg-muted'>
@@ -1415,9 +1786,10 @@ function DebugEventItem({
             (kind === 'follow_up_generation_end' && typeof data['outcome'] === 'string')) && (
             <FollowUpDiagnosticsSection diagnostic={data as unknown as FollowUpDiagnostic} />
           )}
-          {kind === 'session_prompt' && (
+          {isPromptEvent && (
             <div className='space-y-1.5'>
-              {typeof data['systemPrompt'] === 'string' && data['systemPrompt'] && (
+              <RequestParamsStrip data={data} />
+              {systemPromptField && (
                 <details className='group/sp rounded-md bg-xyne-surface'>
                   <summary className='flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5'>
                     <ChevronDown
@@ -1429,17 +1801,29 @@ function DebugEventItem({
                       System prompt
                     </span>
                     <span className='ml-auto text-[11px] text-xyne-fg-muted'>
-                      {data['systemPrompt'].length} chars
+                      {fieldSizeLabel(systemPromptField)}
                     </span>
                   </summary>
                   <div className='px-2 pb-2 pt-1'>
-                    <pre className='max-h-72 overflow-auto whitespace-pre-wrap text-[12px] leading-relaxed text-xyne-fg-secondary'>
-                      {data['systemPrompt']}
+                    <pre className='max-h-72 overflow-y-auto overscroll-contain whitespace-pre-wrap text-[12px] leading-relaxed text-xyne-fg-secondary'>
+                      {systemPromptField.text ? (
+                        <SystemPromptText text={systemPromptField.text} />
+                      ) : (
+                        '(payload not captured)'
+                      )}
                     </pre>
+                    {systemPromptField.isRef && (
+                      <p className='mt-1 text-[11px] text-amber-700 dark:text-amber-300'>
+                        {refNote(systemPromptField, live)}
+                      </p>
+                    )}
                   </div>
                 </details>
               )}
-              {Array.isArray(data['messages']) && data['messages'].length > 0 && (
+              <AvailableSkillsPanel skills={availableSkills} />
+              <ToolDefinitionsPanel tools={offeredTools} />
+              <PaletteChips added={paletteAdded} removed={paletteRemoved} />
+              {panelMessages && panelMessages.length > 0 && (
                 <details className='group/im rounded-md bg-xyne-surface'>
                   <summary className='flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5'>
                     <ChevronDown
@@ -1454,17 +1838,42 @@ function DebugEventItem({
                       Input messages
                     </span>
                     <span className='ml-auto text-[11px] text-xyne-fg-muted'>
-                      {data['messages'].length} message{data['messages'].length === 1 ? '' : 's'}
+                      {panelMessages.length} message{panelMessages.length === 1 ? '' : 's'}
                     </span>
                   </summary>
+                  {/* No scroll cap here: each MessageSnapshot already owns a
+                      scrolling <pre>, and stacking scrollers swallows the wheel. */}
                   <div className='px-2 pb-2 pt-1'>
-                    {(data['messages'] as unknown[]).map((msg, idx) => (
+                    {panelMessages.map((msg, idx) => (
                       <MessageSnapshot key={`${seq}-msg-${idx}`} message={msg} />
                     ))}
                   </div>
                 </details>
               )}
-              {typeof data['prompt'] === 'string' && data['prompt'] && (
+              {messagesField && (
+                <details className='group/imr rounded-md bg-xyne-surface'>
+                  <summary className='flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5'>
+                    <ChevronDown
+                      size={11}
+                      className='shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/imr:rotate-0'
+                    />
+                    <MessagesSquare
+                      size={11}
+                      className='shrink-0 self-center text-xyne-fg-tertiary'
+                    />
+                    <span className='text-[12px] font-semibold text-xyne-fg-secondary'>
+                      Input messages
+                    </span>
+                    <span className='ml-auto text-[11px] text-xyne-fg-muted'>
+                      {fieldSizeLabel(messagesField)}
+                    </span>
+                  </summary>
+                  <div className='px-2 pb-2 pt-1'>
+                    <FieldText field={messagesField} live={live} />
+                  </div>
+                </details>
+              )}
+              {userPromptField && (
                 <details className='group/up rounded-md bg-xyne-surface'>
                   <summary className='flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5'>
                     <ChevronDown
@@ -1476,13 +1885,11 @@ function DebugEventItem({
                       User prompt
                     </span>
                     <span className='ml-auto text-[11px] text-xyne-fg-muted'>
-                      {data['prompt'].length} chars
+                      {fieldSizeLabel(userPromptField)}
                     </span>
                   </summary>
                   <div className='px-2 pb-2 pt-1'>
-                    <pre className='max-h-64 overflow-auto whitespace-pre-wrap text-[12px] leading-relaxed text-xyne-fg-secondary'>
-                      {data['prompt']}
-                    </pre>
+                    <FieldText field={userPromptField} className='max-h-64' live={live} />
                   </div>
                 </details>
               )}
@@ -1499,22 +1906,34 @@ function DebugEventItem({
 
           {kind === 'tool_execution_start' && (
             <div className='space-y-1.5'>
-              {'args' in data && (
+              {hasInlineArgs && (
                 <div className='space-y-1 rounded-md bg-xyne-surface px-2 py-1.5'>
                   <p className='text-[12px] font-semibold text-xyne-fg-secondary'>Arguments</p>
                   <JsonViewer value={data['args']} title='Arguments' defaultExpandedDepth={999} />
                 </div>
               )}
-              <SubagentTraceInline traces={subagentTraces} />
+              {argsField && (
+                <div className='space-y-1 rounded-md bg-xyne-surface px-2 py-1.5'>
+                  <p className='text-[12px] font-semibold text-xyne-fg-secondary'>Arguments</p>
+                  <FieldText field={argsField} live={live} />
+                </div>
+              )}
+              <SubagentTraceInline traces={subagentTraces} live={live} />
             </div>
           )}
 
           {kind === 'tool_execution_end' && (
             <div className='space-y-1.5'>
-              {'args' in data && (
+              {hasInlineArgs && (
                 <div className='space-y-1 rounded-md bg-xyne-surface px-2 py-1.5'>
                   <p className='text-[12px] font-semibold text-xyne-fg-secondary'>Arguments</p>
                   <JsonViewer value={data['args']} title='Arguments' defaultExpandedDepth={999} />
+                </div>
+              )}
+              {argsField && (
+                <div className='space-y-1 rounded-md bg-xyne-surface px-2 py-1.5'>
+                  <p className='text-[12px] font-semibold text-xyne-fg-secondary'>Arguments</p>
+                  <FieldText field={argsField} live={live} />
                 </div>
               )}
               {/* Vespa query — emitted by kb-search and spaces-search. Lives
@@ -1550,32 +1969,50 @@ function DebugEventItem({
                   )}
                 </div>
               )}
-              {'result' in data && (
+              {hasInlineResult && (
                 <div className='space-y-1 rounded-md bg-xyne-surface px-2 py-1.5'>
                   <p className='text-[12px] font-semibold text-xyne-fg-secondary'>Result</p>
                   <ToolResultView value={data['result']} />
                 </div>
               )}
-              <SubagentTraceInline traces={subagentTraces} />
+              {resultField && (
+                <div className='space-y-1 rounded-md bg-xyne-surface px-2 py-1.5'>
+                  <p className='text-[12px] font-semibold text-xyne-fg-secondary'>Result</p>
+                  <FieldText field={resultField} live={live} />
+                </div>
+              )}
+              <SubagentTraceInline traces={subagentTraces} live={live} />
             </div>
           )}
 
-          {kind === 'thinking' && typeof data['text'] === 'string' && (
+          {kind === 'thinking' && thinkingField && (
             // Match the collapsed preview exactly (italic sans, secondary, aligned
             // under the title) so expanding just reveals the FULL text in place,
             // not a heavier card with a different font.
             <p className='whitespace-pre-wrap pl-[58px] pr-6 text-[12px] italic leading-relaxed text-xyne-fg-secondary'>
-              {data['text']}
+              {thinkingField.text || '(payload not captured)'}
+              {thinkingField.isRef && (
+                <span className='not-italic text-amber-700 dark:text-amber-300'>
+                  {' '}
+                  · {refNote(thinkingField, live)}
+                </span>
+              )}
             </p>
           )}
 
           {kind === 'assistant_turn_end' && (
             <div className='space-y-1.5'>
-              {typeof data['assistantText'] === 'string' && (
+              {assistantField && (
                 // Same casual-expand treatment as thinking (non-italic, matches the
                 // assistant preview). Usage stats stay below as a metadata row.
                 <p className='whitespace-pre-wrap pl-[58px] pr-6 text-[12px] leading-relaxed text-xyne-fg-secondary'>
-                  {data['assistantText']}
+                  {assistantField.text || '(payload not captured)'}
+                  {assistantField.isRef && (
+                    <span className='text-amber-700 dark:text-amber-300'>
+                      {' '}
+                      · {refNote(assistantField, live)}
+                    </span>
+                  )}
                 </p>
               )}
               {(isRecord(data['usage']) ||
@@ -1622,11 +2059,34 @@ function DebugEventItem({
             </div>
           )}
 
-          {kind === 'session_error' && typeof data['error'] === 'string' && (
+          {kind === 'session_error' && errorField && (
             <pre className='whitespace-pre-wrap rounded-md bg-xyne-surface p-2 text-[12px] leading-relaxed text-red-700 dark:text-red-300'>
-              {data['error']}
+              {errorField.text || '(payload not captured)'}
+              {errorField.isRef ? ` · ${refNote(errorField, live)}` : ''}
             </pre>
           )}
+
+          {kind === 'tool_palette_change' &&
+            (paletteAdded.length > 0 || paletteRemoved.length > 0 ? (
+              <PaletteChips added={paletteAdded} removed={paletteRemoved} />
+            ) : (
+              // The `initial` palette event lists EVERY tool, which is big enough
+              // to get interned — show the ref's preview instead of an empty row.
+              <>
+                {paletteAddedField && (
+                  <div className='space-y-1 rounded-md bg-xyne-surface px-2 py-1.5'>
+                    <p className='text-[12px] font-semibold text-xyne-fg-secondary'>Added</p>
+                    <FieldText field={paletteAddedField} live={live} />
+                  </div>
+                )}
+                {paletteRemovedField && (
+                  <div className='space-y-1 rounded-md bg-xyne-surface px-2 py-1.5'>
+                    <p className='text-[12px] font-semibold text-xyne-fg-secondary'>Removed</p>
+                    <FieldText field={paletteRemovedField} live={live} />
+                  </div>
+                )}
+              </>
+            ))}
 
           {kind === 'session_end' && (
             <div className='flex flex-wrap gap-x-4 gap-y-1 rounded-md bg-xyne-surface px-2 py-1.5 text-[11px] text-xyne-fg-secondary'>
@@ -1663,6 +2123,7 @@ function DebugEventItem({
 
           {![
             'session_prompt',
+            'llm_request',
             'tool_execution_start',
             'tool_execution_end',
             'assistant_turn_end',
@@ -1688,7 +2149,8 @@ function eventSummary(kind: string, data: Record<string, unknown>): string {
   switch (kind) {
     case 'session_start':
       return asString(data['task']);
-    case 'session_prompt': {
+    case 'session_prompt':
+    case 'llm_request': {
       const count = typeof data['messageCount'] === 'number' ? data['messageCount'] : 0;
       return count ? `Sending ${count} message${count === 1 ? '' : 's'} to the model` : '';
     }
@@ -1696,9 +2158,29 @@ function eventSummary(kind: string, data: Record<string, unknown>): string {
     case 'tool_execution_end':
       return '';
     case 'thinking':
-      return typeof data['text'] === 'string' ? truncate(data['text'], 240) : '';
+      return truncate(resolveFieldText(data, 'text')?.text ?? '', 240);
     case 'assistant_turn_end':
-      return typeof data['assistantText'] === 'string' ? truncate(data['assistantText'], 240) : '';
+      return truncate(resolveFieldText(data, 'assistantText')?.text ?? '', 240);
+    case 'tool_palette_change': {
+      const added = paletteList(data, 'paletteAdded', 'added').length;
+      const removed = paletteList(data, 'paletteRemoved', 'removed').length;
+      const parts = [added ? `+${added}` : '', removed ? `−${removed}` : '']
+        .filter(Boolean)
+        .join(' ');
+      return parts ? `Tool palette ${parts}` : '';
+    }
+    case 'skill_loaded':
+      return asString(data['name']) || asString(data['skill']) || asString(data['location']);
+    case 'subagent_start':
+    case 'subagent_end':
+      return asString(data['subagentName']) || asString(data['task']) || asString(data['question']);
+    case 'delegation':
+      return asString(data['targetAgent']) || asString(data['task']) || asString(data['question']);
+    case 'provider_fallback':
+      return (
+        asString(data['reason']) ||
+        [asString(data['from']), asString(data['to'])].filter(Boolean).join(' → ')
+      );
     case 'compaction_start':
       return 'Conversation history is being condensed';
     case 'compaction_end': {
@@ -1713,7 +2195,7 @@ function eventSummary(kind: string, data: Record<string, unknown>): string {
     case 'auto_retry_start':
       return 'Retrying after a transient error';
     case 'session_error':
-      return asString(data['error']);
+      return truncate(resolveFieldText(data, 'error')?.text ?? '', 240);
     case 'session_end':
       return '';
     case 'citation_reflection': {
@@ -1777,7 +2259,13 @@ function groupSubagentTraces(traces: DebugArtifactBundle['subagents']): Subagent
     .filter(item => item.parentToolCallId);
 }
 
-function SubagentTraceInline({ traces }: { traces: SubagentTraceGroup[] }) {
+function SubagentTraceInline({
+  traces,
+  live = false,
+}: {
+  traces: SubagentTraceGroup[];
+  live?: boolean;
+}) {
   if (traces.length === 0) return null;
   return (
     <div className='mt-1 space-y-1.5'>
@@ -1791,6 +2279,7 @@ function SubagentTraceInline({ traces }: { traces: SubagentTraceGroup[] }) {
             key={`${sub.parentToolCallId}:${sub.subagentName}`}
             title={`${sub.subagentName}: ${truncate(asString(sub.trace['question']) || 'Subagent task', 80)}`}
             data={sub.trace}
+            live={live}
           />
         ))}
       </div>
@@ -2036,10 +2525,14 @@ function DebugSessionBody({
   bundle,
   selectedTurnIndex,
   selectedSessionId,
+  running = false,
 }: {
   bundle: DebugArtifactBundle;
   selectedTurnIndex?: number | null;
   selectedSessionId?: string | null;
+  /** A request is in flight, so the newest run's payloads are still blob-ref
+   *  previews merged off the live stream rather than materialized values. */
+  running?: boolean;
 }) {
   const [selectedEventKey, setSelectedEventKey] = useState<string | null>(null);
   const [timeMode, setTimeMode] = useState<'delta' | 'abs'>('delta');
@@ -2146,6 +2639,7 @@ function DebugSessionBody({
             selectedEventKey={selectedEventKey}
             onSelectEvent={setSelectedEventKey}
             timeMode={timeMode}
+            live={running && useRootTimeline}
           />
         );
       })}
@@ -2174,6 +2668,9 @@ function DebugSessionBody({
           const followUpDiagnostic = (bundle.followUpDiagnostics ?? []).find(
             diagnostic => diagnostic.sessionId === runSessionId,
           );
+          // Only the newest run can be the one in flight; older turns are fully
+          // materialized even while a new request streams.
+          const runIsLive = running && index === persistedRuns.length - 1;
           return (
             <DebugTimelineSection
               key={run.fileName}
@@ -2184,6 +2681,7 @@ function DebugSessionBody({
               selectedEventKey={selectedEventKey}
               onSelectEvent={setSelectedEventKey}
               timeMode={timeMode}
+              live={runIsLive}
               {...(followUpDiagnostic ? { followUpDiagnostic } : {})}
             />
           );
@@ -2208,6 +2706,7 @@ function DebugSessionBody({
           selectedEventKey={selectedEventKey}
           onSelectEvent={setSelectedEventKey}
           timeMode={timeMode}
+          live={running}
           {...(() => {
             const diagnostic = (bundle.followUpDiagnostics ?? []).find(
               item => item.sessionId === asString(root?.['sessionId']),
@@ -2268,6 +2767,9 @@ export function AskAIDebugPanel({
     () => mergeLiveDebugTimeline(bundle, liveEvents, conversationId ?? ''),
     [bundle, conversationId, liveEvents],
   );
+  // A partial artifact read must be visible: without this, a trace whose blobs
+  // could not be resolved looks exactly like an agent that did nothing.
+  const bundleWarnings = useMemo(() => collectDebugWarnings(unifiedBundle), [unifiedBundle]);
 
   useEffect(() => {
     if (running && !previousRunningRef.current) {
@@ -2475,6 +2977,7 @@ export function AskAIDebugPanel({
           live={running && streamStatus.live}
         />
       )}
+      <WarningsNotice warnings={bundleWarnings} />
 
       <div ref={bodyRef} className='min-h-0 flex-1 overflow-y-auto p-2.5'>
         {!conversationId ? (
@@ -2514,6 +3017,7 @@ export function AskAIDebugPanel({
                   bundle={unifiedBundle}
                   selectedTurnIndex={selectedTurnIndex}
                   selectedSessionId={selectedSessionId}
+                  running={running}
                 />
               ) : (
                 <p className='py-6 text-[13px] text-xyne-fg-muted'>

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/components/unifiedDebugTimeline.ts
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/components/unifiedDebugTimeline.ts
@@ -141,3 +141,378 @@ export function mergeLiveDebugTimeline(
 
   return base;
 }
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * Trace resolution layer
+ *
+ * claw's v2 writer no longer ships every payload inline on every event. Three
+ * encodings sit between a raw event and something renderable, and each one
+ * renders BLANK if the panel reads the field naively:
+ *   1. blob refs        — the value moved to the run's blob log; a sibling
+ *                         `<field>Ref` carries `{ hash, bytes, preview }`.
+ *   2. back-references  — a value identical to an earlier event's carries
+ *                         `<field>UnchangedFromSeq: <seq>` and nothing else.
+ *   3. transcript cursor — turns carry `messagesTo` (a count) instead of a
+ *                         copy of the messages, which was O(turns²) on the wire.
+ * Everything the panel renders goes through the helpers below, so a payload
+ * that was captured but not inlined always shows SOMETHING (its preview plus
+ * what is missing) rather than an empty panel.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/** A payload the v2 writer interned into the blob log instead of inlining. */
+export type BlobRefLike = {
+  hash: string;
+  bytes?: number;
+  originalBytes?: number;
+  truncated?: boolean;
+  preview?: string;
+};
+
+export function asBlobRef(value: unknown): BlobRefLike | null {
+  if (!isRecord(value) || typeof value['hash'] !== 'string') return null;
+  return value as BlobRefLike;
+}
+
+export type ResolvedField = {
+  text: string;
+  /** Bytes for a ref (what the writer stored), chars for an inline string. */
+  size: number;
+  truncated: boolean;
+  isRef: boolean;
+};
+
+/**
+ * Reads a payload field that may arrive inline OR as a blob ref — either in the
+ * field itself or in its `<field>Ref` sibling, which is what survives when the
+ * blob content could not be resolved. A ref renders its preview rather than an
+ * empty panel, so "captured but not inlined" never looks like "nothing here".
+ */
+export function resolveFieldText(data: Record<string, unknown>, key: string): ResolvedField | null {
+  const inline = data[key];
+  if (typeof inline === 'string') {
+    return inline ? { text: inline, size: inline.length, truncated: false, isRef: false } : null;
+  }
+  const ref = asBlobRef(inline) ?? asBlobRef(data[`${key}Ref`]);
+  if (!ref) return null;
+  const preview = typeof ref.preview === 'string' ? ref.preview : '';
+  return {
+    text: preview,
+    size: typeof ref.bytes === 'number' ? ref.bytes : preview.length,
+    truncated: ref.truncated === true || ref.originalBytes !== undefined || !preview,
+    isRef: true,
+  };
+}
+
+export function fieldSizeLabel(field: ResolvedField): string {
+  return `${field.size} ${field.isRef ? 'bytes' : 'chars'}${field.truncated ? ' · truncated' : ''}`;
+}
+
+/**
+ * What a ref-backed field is actually showing. On the LIVE channel a ref is
+ * always just its ~200-char preview — the payload stays in claw's blob log
+ * until the run finishes and the trace is materialized, and we deliberately
+ * don't push a 28 KB system prompt over the wire every turn. Say that, instead
+ * of letting a preview pass for the whole value.
+ */
+export function refNote(field: ResolvedField, live = false): string {
+  const head = field.text ? 'preview' : 'not inlined';
+  const tail = live ? ' · full content available when the run completes' : '';
+  return `${head} · ${field.size} bytes${field.truncated ? ' · truncated' : ''}${tail}`;
+}
+
+export function stringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+/**
+ * Palette diffs arrive under two spellings: a `tool_palette_change` event names
+ * them `added`/`removed`, while `paletteAdded`/`paletteRemoved` is what the
+ * materializer folds off an `llm_request` onto its `session_prompt`. Read both
+ * so a palette row renders its chips on either shape.
+ */
+export function paletteList(
+  data: Record<string, unknown>,
+  folded: 'paletteAdded' | 'paletteRemoved',
+  own: 'added' | 'removed',
+): string[] {
+  const foldedList = stringList(data[folded]);
+  return foldedList.length > 0 ? foldedList : stringList(data[own]);
+}
+
+export type SkillEntry = { name: string; description: string; location: string };
+
+export function skillEntries(value: unknown): SkillEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item: unknown) => {
+    if (!isRecord(item)) return [];
+    const name = asString(item['name']);
+    return name
+      ? [{ name, description: asString(item['description']), location: asString(item['location']) }]
+      : [];
+  });
+}
+
+export type ToolEntry = { name: string; description: string; parameters: unknown };
+
+/** Full definitions when the trace has them, name-only rows when it only kept
+ *  `toolNames` — a shorter list is still the truth about what was offered. */
+export function toolEntries(data: Record<string, unknown>): ToolEntry[] {
+  const tools = data['tools'];
+  if (Array.isArray(tools)) {
+    return tools.flatMap((item: unknown) => {
+      if (!isRecord(item)) return [];
+      const name = asString(item['name']);
+      return name
+        ? [{ name, description: asString(item['description']), parameters: item['parameters'] }]
+        : [];
+    });
+  }
+  return stringList(data['toolNames']).map(name => ({
+    name,
+    description: '',
+    parameters: undefined,
+  }));
+}
+
+/**
+ * The messages a turn's panel should show. Newer traces carry only the cursor
+ * (`messagesTo`) and expect the reader to slice the RUN's transcript; older ones
+ * embedded the prefix per event. Accept both so a trace written before the
+ * cursor change still renders.
+ */
+export function resolvePanelMessages(
+  data: Record<string, unknown>,
+  transcript: unknown[] | undefined,
+): unknown[] | undefined {
+  const embedded = data['messages'];
+  if (Array.isArray(embedded)) return embedded as unknown[];
+  const cursor = data['messagesTo'];
+  if (!transcript || typeof cursor !== 'number') return undefined;
+  return transcript.slice(0, Math.max(0, Math.min(cursor, transcript.length)));
+}
+
+export type TimelineEvent = Record<string, unknown> & { startedAt?: string };
+
+/**
+ * Kinds that never earn a timeline row: stream bookkeeping and transcript
+ * deltas (`message_append`). `llm_request`/`llm_response` are not listed —
+ * compactTimeline folds them onto their turn's `session_prompt` row instead.
+ */
+const HIDDEN_TIMELINE_KINDS = new Set(['message_update', 'stream_rate', 'message_append']);
+
+/** Request fields the materializer lifts onto the turn's `session_prompt`;
+ *  mirrored here (with their blob-ref spellings) for the live fold below. */
+const FOLD_REQUEST_FIELDS = [
+  'systemPrompt',
+  'tools',
+  'toolNames',
+  'availableSkills',
+  'temperature',
+  'maxTokens',
+  'thinkingLevel',
+  'fastMode',
+  'model',
+  'provider',
+  'paletteAdded',
+  'paletteRemoved',
+  'messagesFrom',
+  'messagesTo',
+] as const;
+
+/** `llm_response` fields the materializer renames onto the prompt row — what
+ *  the request-params strip reads for stop reason, cache hit/miss and TTFT. */
+const FOLD_RESPONSE_FIELDS: ReadonlyArray<readonly [string, string]> = [
+  ['usage', 'responseUsage'],
+  ['stopReason', 'responseStopReason'],
+  ['ttftMs', 'ttftMs'],
+];
+
+/**
+ * Merge one `llm_request` / `llm_response` onto its turn's prompt row, the way
+ * materialization does for a completed run. Ref spellings ride along: live
+ * events carry `systemPromptRef` where a materialized one carries the inlined
+ * `systemPrompt`, and the row renderer reads either.
+ */
+function foldLlmEvent(row: TimelineEvent, event: TimelineEvent): TimelineEvent {
+  const eventData = isRecord(event['data']) ? event['data'] : {};
+  const merged: Record<string, unknown> = { ...(isRecord(row['data']) ? row['data'] : {}) };
+  if (asString(event['kind']) === 'llm_request') {
+    for (const field of FOLD_REQUEST_FIELDS) {
+      const refKey = `${field}Ref`;
+      // The request's value REPLACES the prompt row's in EITHER spelling:
+      // session_prompt carries only the persona prompt, which must not shadow
+      // the true effective one just because it arrived inline and this didn't.
+      if (eventData[field] !== undefined) {
+        merged[field] = eventData[field];
+        delete merged[refKey];
+      } else if (eventData[refKey] !== undefined) {
+        merged[refKey] = eventData[refKey];
+        delete merged[field];
+      }
+    }
+  } else {
+    for (const [from, to] of FOLD_RESPONSE_FIELDS) {
+      if (eventData[from] !== undefined) merged[to] = eventData[from];
+    }
+  }
+  return { ...row, data: merged };
+}
+
+/**
+ * Fields the materializer emits once per run and back-references thereafter
+ * (`<field>UnchangedFromSeq`), because a 48-tool catalog and a 28 KB system
+ * prompt are identical on every call and re-sending them per turn doubled the
+ * bundle. Rehydrate here so every downstream renderer still sees a plain value.
+ */
+const DEDUPED_FOLD_FIELDS = ['systemPrompt', 'tools', 'toolNames', 'availableSkills'] as const;
+
+function rehydrateRepeatedPayloads(events: unknown[]): unknown[] {
+  const bySeq = new Map<number, Record<string, unknown>>();
+  for (const value of events) {
+    if (!isRecord(value) || typeof value['seq'] !== 'number') continue;
+    if (isRecord(value['data'])) bySeq.set(value['seq'], value['data']);
+  }
+  let touched = false;
+  const out = events.map(value => {
+    if (!isRecord(value) || !isRecord(value['data'])) return value;
+    const eventData = value['data'];
+    let data: Record<string, unknown> | null = null;
+    for (const field of DEDUPED_FOLD_FIELDS) {
+      const from = eventData[`${field}UnchangedFromSeq`];
+      if (typeof from !== 'number') continue;
+      const source = bySeq.get(from)?.[field];
+      if (source === undefined) continue;
+      data ??= { ...eventData };
+      data[field] = source;
+    }
+    if (!data) return value;
+    touched = true;
+    return { ...value, data };
+  });
+  return touched ? out : events;
+}
+
+/**
+ * Collapse the raw event stream into the rows the timeline shows: back-refs
+ * rehydrated, bookkeeping hidden, each turn's `llm_request`/`llm_response`
+ * folded onto its `session_prompt`, and each tool's start/end/update folded
+ * into one row.
+ */
+export function compactTimeline(rawEvents: unknown[]): TimelineEvent[] {
+  const events = rehydrateRepeatedPayloads(rawEvents);
+  const compacted: TimelineEvent[] = [];
+  const pendingTools = new Map<string, number>();
+  // Prompt row per LLM call, so this turn's `llm_request` / `llm_response` fold
+  // onto it. Materialization does the same fold for a completed run; doing it
+  // here too keeps the LIVE timeline from showing a duplicate LLM row every
+  // turn, and gives the live prompt row the request's params.
+  const promptRows = new Map<number, number>();
+  // A call's prompt row and its request/response are produced by different
+  // hooks, so the request can arrive first. Knowing up front which calls DO get
+  // a prompt row lets us hold the fold instead of emitting a duplicate LLM row.
+  const promptCalls = new Set<number>();
+  for (const value of events) {
+    if (
+      isRecord(value) &&
+      asString(value['kind']) === 'session_prompt' &&
+      typeof value['llmCall'] === 'number'
+    ) {
+      promptCalls.add(value['llmCall']);
+    }
+  }
+  const deferredFolds = new Map<number, TimelineEvent[]>();
+  // Tool rows stay addressable after their end event lands, so a late
+  // `tool_invocation_update` (background task finishing) folds into the same
+  // row instead of appearing as an orphan event.
+  const toolRows = new Map<string, number>();
+
+  for (const value of events) {
+    if (!isRecord(value) || HIDDEN_TIMELINE_KINDS.has(asString(value['kind']))) continue;
+    const event = value as TimelineEvent;
+    const kind = asString(event['kind']);
+    const llmCall = typeof event['llmCall'] === 'number' ? event['llmCall'] : undefined;
+    if (kind === 'session_prompt') {
+      const rowIndex = compacted.length;
+      compacted.push(event);
+      if (llmCall === undefined || promptRows.has(llmCall)) continue;
+      promptRows.set(llmCall, rowIndex);
+      for (const held of deferredFolds.get(llmCall) ?? []) {
+        compacted[rowIndex] = foldLlmEvent(compacted[rowIndex]!, held);
+      }
+      deferredFolds.delete(llmCall);
+      continue;
+    }
+    if (kind === 'llm_request' || kind === 'llm_response') {
+      const rowIndex = llmCall !== undefined ? promptRows.get(llmCall) : undefined;
+      if (rowIndex !== undefined) {
+        compacted[rowIndex] = foldLlmEvent(compacted[rowIndex]!, event);
+        continue;
+      }
+      if (llmCall !== undefined && promptCalls.has(llmCall)) {
+        deferredFolds.set(llmCall, [...(deferredFolds.get(llmCall) ?? []), event]);
+        continue;
+      }
+      // No prompt row for this call (a compaction or follow-up call has none),
+      // so the request stands on its own — same fallback as materialization.
+      if (kind === 'llm_request') compacted.push(event);
+      continue;
+    }
+    const toolCallId = asString(event['toolCallId']);
+    if (kind === 'tool_invocation_update') {
+      const updateId =
+        toolCallId || (isRecord(event['data']) ? asString(event['data']['toolCallId']) : '');
+      const rowIndex = toolRows.get(updateId);
+      if (rowIndex === undefined) continue;
+      const row = compacted[rowIndex]!;
+      compacted[rowIndex] = {
+        ...row,
+        data: {
+          ...(isRecord(row['data']) ? row['data'] : {}),
+          ...(isRecord(event['data']) ? event['data'] : {}),
+        },
+      };
+      continue;
+    }
+    if (kind === 'tool_execution_start' && toolCallId) {
+      pendingTools.set(toolCallId, compacted.length);
+      toolRows.set(toolCallId, compacted.length);
+      compacted.push(event);
+      continue;
+    }
+    if (kind === 'tool_execution_end' && toolCallId && pendingTools.has(toolCallId)) {
+      const index = pendingTools.get(toolCallId)!;
+      const start = compacted[index]!;
+      compacted[index] = {
+        ...event,
+        startedAt: asString(start['at']),
+        data: {
+          ...(isRecord(start['data']) ? start['data'] : {}),
+          ...(isRecord(event['data']) ? event['data'] : {}),
+        },
+      };
+      pendingTools.delete(toolCallId);
+      continue;
+    }
+    compacted.push(event);
+  }
+
+  return compacted;
+}
+
+/**
+ * Non-fatal read problems for every run on screen. Runs share most warnings
+ * (same blob log, same GCS miss), so dedupe — otherwise the notice turns into a
+ * wall of the same line.
+ */
+export function collectDebugWarnings(bundle: DebugArtifactBundle | null): string[] {
+  if (!bundle) return [];
+  const sources: unknown[] = [
+    bundle.warnings,
+    bundle.debugSession?.['warnings'],
+    ...(bundle.runs ?? []).map(run => run.data['warnings']),
+    ...(bundle.subagents ?? []).map(sub => sub.data['warnings']),
+  ];
+  return [...new Set(sources.flatMap(source => stringList(source)))];
+}

--- a/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAITypes.ts
+++ b/apps/dashboard/src/components/Chat/XyneAISidebar/utils/XyneAITypes.ts
@@ -241,6 +241,10 @@ export interface DebugArtifactBundle {
   runs: Array<{ fileName: string; data: Record<string, unknown> }>;
   subagents: Array<{ fileName: string; data: Record<string, unknown> }>;
   followUpDiagnostics?: FollowUpDiagnostic[];
+  /** Non-fatal problems hit while reading the trace (an unresolvable blob, a
+   *  truncated payload). Surfaced as a notice so a PARTIAL read is visible
+   *  rather than looking like an agent that did nothing. */
+  warnings?: string[];
 }
 
 export interface FollowUpDiagnostic {

--- a/apps/dashboard/src/services/XyneAI/XyneAISessionsV2Service.ts
+++ b/apps/dashboard/src/services/XyneAI/XyneAISessionsV2Service.ts
@@ -10,6 +10,7 @@ import type {
   PendingAction,
   ToolInvocation,
   DebugArtifactBundle,
+  DebugEventRecord,
   ReactArtifactManifest,
 } from '../../components/Chat/XyneAISidebar/utils/XyneAITypes';
 import type { AttachedContextItem } from '../../components/Chat/XyneAISidebar/components/ContextPickerPanel';
@@ -337,12 +338,183 @@ export async function rateV2Message(
   });
 }
 
+// ============================================================================
+// Debug trace payload types (xyne-claw v1 event stream, post-materialization)
+//
+// The shapes below mirror xyne-claw's `debug/materialize.ts` (`toV1Events`).
+// Nothing between claw and here filters keys, so these are descriptive, not
+// enforcing: every payload also keeps its index signature so an unmodelled
+// field still survives to the renderer instead of being a type error.
+// ============================================================================
+
+/**
+ * A payload the trace writer interned into the run's blob log instead of
+ * inlining. Arrives either in the field itself or in a SIBLING `<field>Ref` —
+ * on the live stream, and at capture level "metadata", the ref is all there is.
+ * `preview` (~200 chars) exists so a collapsed row renders without a fetch;
+ * a consumer that only accepts `typeof value === 'string'` renders a blank
+ * panel for every ref, which is the bug this type exists to prevent.
+ */
+export interface DebugBlobRef {
+  /** sha256 of the serialized content, first 16 hex chars. */
+  hash: string;
+  /** Stored bytes (post-truncation). */
+  bytes: number;
+  /** Present only when the value exceeded the blob cap. */
+  originalBytes?: number;
+  /** Present only when truncated — the writer never truncates silently. */
+  truncated?: true;
+  /** First ~200 chars of the payload. */
+  preview?: string;
+}
+
+export function isDebugBlobRef(value: unknown): value is DebugBlobRef {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { hash?: unknown }).hash === 'string' &&
+    typeof (value as { bytes?: unknown }).bytes === 'number'
+  );
+}
+
+/** A value that may arrive inline or interned. */
+export type MaybeBlobRef<T> = T | DebugBlobRef;
+
+/** One entry of the `<available_skills>` block the agent actually saw. */
+export interface DebugAvailableSkill {
+  name: string;
+  description?: string;
+  location?: string;
+}
+
+/** A tool as offered to the model, with its full JSON schema. */
+export interface DebugToolDefinition {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+}
+
+/** `cacheRead` is the prompt-cache HIT count: zero reads on a repeat turn is
+ *  the tell for a cache miss, so the raw numbers are kept, not a boolean. */
+export interface DebugResponseUsage {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * The `data` payload of a trace event. Modelled around `session_prompt`, onto
+ * which the materializer folds its turn's `llm_request`/`llm_response`.
+ *
+ * Three encodings live here and every consumer has to handle all three:
+ *  1. blob refs — `<field>` may instead be a `<field>Ref` sibling;
+ *  2. back-references — the system prompt and tool catalog are identical on
+ *     every call, so they ship ONCE and later events carry
+ *     `<field>UnchangedFromSeq: <seq>`, resolved against that seq's event in
+ *     the same run. Without this, turn 2+ shows nothing where turn 1 shows it;
+ *  3. transcript cursor — `messagesTo` is a count into the RUN's
+ *     `snapshot.messages`, not an embedded copy (older traces still embed
+ *     `messages`; accept both).
+ */
+export interface DebugEventData {
+  /** The TRUE prompt pi sent, including the `<available_skills>` XML block —
+   *  not the persona prompt, which is what this field used to carry. */
+  systemPrompt?: MaybeBlobRef<string>;
+  systemPromptRef?: DebugBlobRef;
+  systemPromptUnchangedFromSeq?: number;
+
+  tools?: MaybeBlobRef<DebugToolDefinition[]>;
+  toolsRef?: DebugBlobRef;
+  toolsUnchangedFromSeq?: number;
+
+  toolNames?: MaybeBlobRef<string[]>;
+  toolNamesRef?: DebugBlobRef;
+  toolNamesUnchangedFromSeq?: number;
+
+  availableSkills?: MaybeBlobRef<DebugAvailableSkill[]>;
+  availableSkillsRef?: DebugBlobRef;
+  availableSkillsUnchangedFromSeq?: number;
+
+  /** Mid-run tool-palette diff. A `tool_palette_change` event spells the same
+   *  diff `added`/`removed`; a folded `session_prompt` uses these. Read both. */
+  paletteAdded?: string[];
+  paletteRemoved?: string[];
+  added?: string[];
+  removed?: string[];
+
+  /** Transcript range for this model call — slice `snapshot.messages`. */
+  messagesFrom?: number;
+  messagesTo?: number;
+  /** Older traces embedded the prefix instead of a cursor. */
+  messages?: MaybeBlobRef<unknown[]>;
+  messagesRef?: DebugBlobRef;
+
+  model?: string;
+  provider?: string;
+  temperature?: number;
+  maxTokens?: number;
+  thinkingLevel?: string;
+  fastMode?: boolean;
+
+  responseUsage?: DebugResponseUsage;
+  responseStopReason?: string;
+  ttftMs?: number;
+
+  /** Tool rows. `result` may be interned, in which case `resultRef.preview`
+   *  carries the same content — anything that filters one must filter both. */
+  result?: MaybeBlobRef<unknown>;
+  resultRef?: DebugBlobRef;
+  args?: MaybeBlobRef<unknown>;
+  argsRef?: DebugBlobRef;
+
+  /** Unmodelled fields reach the renderer untouched — the trace format grows
+   *  faster than this file does. */
+  [key: string]: unknown;
+}
+
+/** A trace event with its payload typed. Structurally a `DebugEventRecord`,
+ *  so it stays assignable wherever the looser shape is expected. */
+export interface DebugTraceEvent extends Omit<DebugEventRecord, 'data'> {
+  /** Kinds now include `llm_request`, `llm_response`, `message_append`
+   *  (bookkeeping — hide), `tool_palette_change`, `skill_loaded`,
+   *  `subagent_start`/`subagent_end`, `provider_fallback`, `delegation` and
+   *  `tool_invocation_update` (patches an existing tool row by toolCallId). */
+  data: DebugEventData;
+}
+
+/**
+ * The bundle as it actually arrives, with the fields the base type predates.
+ * Extends rather than edits `DebugArtifactBundle` so existing consumers keep
+ * working while new ones can read the pagination and warning surface.
+ */
+export interface DebugTraceBundle extends DebugArtifactBundle {
+  /** Runs in the whole conversation vs. this page — claw caps the page and
+   *  claw-auth restates both after its per-user ACL ("showing N of M").
+   *  `warnings` comes from the base type. */
+  totalRuns?: number;
+  truncated?: boolean;
+}
+
+/**
+ * Fetch the debug trace for a conversation.
+ *
+ * `before`/`limit` page the run list: claw caps a page (default 25) and reports
+ * `totalRuns`/`truncated`, so a long thread's older runs are reachable only by
+ * passing the last run's id back as `before`.
+ */
 export async function fetchV2DebugArtifacts(
   conversationId: string,
   agentSlug?: string | null,
-): Promise<DebugArtifactBundle> {
-  const query = agentSlug ? `?agentSlug=${encodeURIComponent(agentSlug)}` : '';
-  const response = await apiInstance.get<{ success: boolean; data: DebugArtifactBundle }>(
+  paging?: { limit?: number; before?: string },
+): Promise<DebugTraceBundle> {
+  const params = new URLSearchParams();
+  if (agentSlug) params.set('agentSlug', agentSlug);
+  if (paging?.limit !== undefined) params.set('limit', String(paging.limit));
+  if (paging?.before) params.set('before', paging.before);
+  const query = params.toString() ? `?${params.toString()}` : '';
+  const response = await apiInstance.get<{ success: boolean; data: DebugTraceBundle }>(
     `/xyne-ai/v2/conversations/${encodeURIComponent(conversationId)}/debug${query}`,
   );
   if (!response.data.success) throw new Error('Failed to fetch debug artifacts');


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
