### PR TITLE
fix: XYNE-62896 debug panel refactoring

### DIFF
--- a/apps/xyne-claw-auth/backend/src/lib/debug-trace-html.test.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/debug-trace-html.test.ts
@@ -144,4 +144,133 @@ describe("renderDebugTraceHtml", () => {
     const html = renderDebugTraceHtml({});
     expect(html).toContain("No tool calls recorded.");
   });
+
+  it("renders llm_request with its params, effective system prompt, tools and skills", () => {
+    const html = renderDebugTraceHtml({
+      startedAt: START,
+      events: [
+        {
+          seq: 1,
+          at: at(1),
+          kind: "llm_request",
+          llmCall: 2,
+          data: {
+            provider: "claude",
+            model: "claude-opus-5",
+            temperature: 0.2,
+            maxTokens: 8000,
+            thinkingLevel: "high",
+            fastMode: true,
+            toolCount: 1,
+            systemPrompt: "You are Doctor. <available_skills>pdf-tools</available_skills>",
+            tools: [{ name: "spaces", description: "search spaces", parameters: { type: "object", properties: { question: { type: "string" } } } }],
+            toolNames: ["spaces"],
+            availableSkills: [{ name: "pdf-tools", description: "read pdfs" }],
+            paletteAdded: ["spaces"],
+            paletteRemoved: [],
+          },
+        },
+      ],
+    });
+    expect(html).toContain("LLM request #2 — claude/claude-opus-5");
+    expect(html).toContain("thinking high");
+    expect(html).toContain("maxTokens 8000");
+    expect(html).toContain("fast mode");
+    expect(html).toContain("palette +1/−0");
+    expect(html).toContain("system prompt (62 chars)");
+    expect(html).toContain("You are Doctor.");
+    expect(html).toContain("tools (1)");
+    expect(html).toContain("properties");
+    expect(html).toContain("skills — pdf-tools");
+  });
+
+  it("renders folded request fields on the session_prompt row", () => {
+    const html = renderDebugTraceHtml({
+      startedAt: START,
+      events: [
+        {
+          seq: 1,
+          at: at(1),
+          kind: "session_prompt",
+          llmCall: 1,
+          data: { kind: "fresh", messageCount: 2, toolCount: 3, thinkingLevel: "low", systemPrompt: "FOLDEDSYSTEMPROMPT" },
+        },
+      ],
+    });
+    expect(html).toContain("LLM call #1 sent");
+    expect(html).toContain("3 tools");
+    expect(html).toContain("FOLDEDSYSTEMPROMPT");
+  });
+
+  it("renders blob refs as preview plus a size note, never [object Object]", () => {
+    const html = renderDebugTraceHtml({
+      startedAt: START,
+      events: [
+        {
+          seq: 1,
+          at: at(1),
+          kind: "llm_request",
+          llmCall: 1,
+          data: {
+            toolCount: 2,
+            systemPrompt: { hash: "deadbeef", bytes: 200, originalBytes: 20481, truncated: true, preview: "PREVIEWOFPROMPT" },
+            toolsRef: { hash: "cafebabe", bytes: 4096, preview: "[{\"name\":\"spaces\"}]" },
+          },
+        },
+      ],
+    });
+    expect(html).not.toContain("[object Object]");
+    expect(html).toContain("PREVIEWOFPROMPT");
+    expect(html).toContain("truncated — 20481 bytes");
+    expect(html).toContain("truncated — 4096 bytes");
+  });
+
+  it("renders llm_response stop reason, cache usage and ttft", () => {
+    const html = renderDebugTraceHtml({
+      startedAt: START,
+      events: [
+        {
+          seq: 1,
+          at: at(2),
+          kind: "llm_response",
+          llmCall: 1,
+          data: {
+            stopReason: "end_turn",
+            ttftMs: 640,
+            totalMs: 9000,
+            usage: { input_tokens: 100, output_tokens: 20, cache_read_input_tokens: 900, cache_creation_input_tokens: 50 },
+          },
+        },
+      ],
+    });
+    expect(html).toContain("LLM response #1 — stop end_turn");
+    expect(html).toContain("ttft 640 ms");
+    expect(html).toContain("in 100");
+    expect(html).toContain("cacheR 900");
+    expect(html).toContain("cacheW 50");
+  });
+
+  it("renders the compact rows for palette, skill, subagent, fallback and delegation events", () => {
+    const html = renderDebugTraceHtml({
+      startedAt: START,
+      events: [
+        { seq: 1, at: at(1), kind: "tool_palette_change", data: { source: "load-tools", added: ["pdf"], removed: ["code"], activeCount: 7 } },
+        { seq: 2, at: at(2), kind: "skill_loaded", data: { slug: "pdf-tools", path: "/skills/pdf-tools/SKILL.md" } },
+        { seq: 3, at: at(3), kind: "subagent_start", data: { subagentName: "researcher", provider: "claude", model: "claude-opus-5", questionChars: 120, childRunId: "run-9" } },
+        { seq: 4, at: at(4), kind: "subagent_end", data: { subagentName: "researcher", status: "completed", durationMs: 4000, textLength: 900, toolsUsed: ["spaces"] } },
+        { seq: 5, at: at(5), kind: "provider_fallback", data: { fromProvider: "claude", toProvider: "bedrock", attempt: 2, reason: "overloaded" } },
+        { seq: 6, at: at(6), kind: "delegation", data: { kind: "subagent", caller: "doctor", callee: "researcher", depth: 1, reason: "deep_research" } },
+        { seq: 7, at: at(7), kind: "message_append", data: { from: 0, to: 2, count: 2, messages: ["APPENDEDMESSAGEBODY"] } },
+      ],
+    });
+    expect(html).toContain("Tool palette load-tools — +1 / −1");
+    expect(html).toContain("added pdf");
+    expect(html).toContain("Skill loaded — pdf-tools");
+    expect(html).toContain("Subagent start — researcher");
+    expect(html).toContain("Subagent end — researcher (completed)");
+    expect(html).toContain("Provider fallback claude → bedrock");
+    expect(html).toContain("Delegation subagent — doctor → researcher");
+    expect(html).not.toContain("message_append");
+    expect(html).not.toContain("APPENDEDMESSAGEBODY");
+  });
 });

--- a/apps/xyne-claw-auth/backend/src/lib/debug-trace-html.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/debug-trace-html.ts
@@ -32,6 +32,8 @@ export const DEBUG_TRACE_MAX_BYTES = 2_000_000;
 
 const SECRET_RE = /(bearer\s+\S+|sk-[A-Za-z0-9]{8,}|token"?\s*[:=]\s*"?\S+)/gi;
 const THINKING_MAX = 600;
+const SYSTEM_PROMPT_MAX = 4000;
+const TOOLS_MAX = 4000;
 const ARG_SUMMARY_MAX = 80;
 
 const TOOL_LABELS = new Map<string, string>(
@@ -124,10 +126,193 @@ function toolLabel(toolName: string): string {
   return TOOL_LABELS.get(toolName) ?? "";
 }
 
+/**
+ * A payload the recorder interned into the blob log instead of inlining it.
+ * The hash and byte count outlive the content (a `metadata` capture keeps the
+ * ref and drops the bytes), so a row can still say what existed and how big it
+ * was — which is the whole reason these must not render as `[object Object]`.
+ */
+interface BlobRefLike {
+  hash: string;
+  bytes: number;
+  originalBytes?: number;
+  truncated?: true;
+  preview?: string;
+}
+
+function isBlobRefLike(value: unknown): value is BlobRefLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { hash?: unknown }).hash === "string" &&
+    typeof (value as { bytes?: unknown }).bytes === "number"
+  );
+}
+
+interface Payload {
+  value: unknown;
+  ref: BlobRefLike | null;
+}
+
+/**
+ * Read a field that may be inline, a BlobRef standing in for the value, or a
+ * sibling `<field>Ref` — the form materialization leaves behind when the blob
+ * content could not be resolved.
+ */
+function payload(data: Record<string, unknown>, field: string): Payload {
+  const inline = data[field];
+  if (isBlobRefLike(inline)) return { value: undefined, ref: inline };
+  const sibling = data[`${field}Ref`];
+  return { value: inline, ref: isBlobRefLike(sibling) ? sibling : null };
+}
+
+function refNote(ref: BlobRefLike): string {
+  const bytes = ref.originalBytes ?? ref.bytes;
+  return `[${ref.truncated || ref.preview ? "truncated" : "not captured"} — ${bytes} bytes]`;
+}
+
+function jsonText(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2) ?? "";
+  } catch {
+    return String(value);
+  }
+}
+
+function payloadBlock(p: Payload, max: number): string {
+  if (p.value !== undefined && p.value !== null) {
+    const body = cleanBlock(jsonText(p.value), max);
+    return p.ref ? `${body}\n${escapeHtml(refNote(p.ref))}` : body;
+  }
+  if (!p.ref) return "";
+  const preview = p.ref.preview ? cleanBlock(p.ref.preview, max) : "";
+  return preview ? `${preview}\n${escapeHtml(refNote(p.ref))}` : escapeHtml(refNote(p.ref));
+}
+
+function payloadSize(p: Payload): number | null {
+  if (typeof p.value === "string") return p.value.length;
+  if (p.ref) return p.ref.originalBytes ?? p.ref.bytes;
+  return null;
+}
+
+function payloadCount(p: Payload): number | null {
+  return Array.isArray(p.value) ? p.value.length : null;
+}
+
+/** Names out of a list of strings, of `{ name }` objects, or of a bare ref. */
+function nameList(p: Payload, max: number): string {
+  if (Array.isArray(p.value)) {
+    const names = p.value
+      .map((item) => (typeof item === "string" ? item : str(rec(item)["name"]) ?? ""))
+      .filter((n) => n.length > 0);
+    return names.length > 0 ? clean(names.join(", "), max) : "";
+  }
+  return p.ref?.preview ? clean(p.ref.preview, max) : "";
+}
+
+function collapsed(label: string, body: string): string {
+  return body ? `<details><summary>${escapeHtml(label)}</summary><pre>${body}</pre></details>` : "";
+}
+
+/**
+ * Providers disagree on usage key names (`input` / `inputTokens` /
+ * `cache_read_input_tokens`), and `llm_response` carries the provider's raw
+ * object, so read whichever spelling arrived.
+ */
+function usageParts(usage: Record<string, unknown>): string {
+  const pick = (...keys: string[]): number | null => {
+    for (const key of keys) {
+      const value = num(usage[key]);
+      if (value !== null) return value;
+    }
+    return null;
+  };
+  return [
+    ["in", pick("input", "inputTokens", "input_tokens", "promptTokens", "prompt_tokens")],
+    ["out", pick("output", "outputTokens", "output_tokens", "completionTokens", "completion_tokens")],
+    ["cacheR", pick("cacheRead", "cacheReadTokens", "cachedInputTokens", "cache_read_input_tokens")],
+    ["cacheW", pick("cacheWrite", "cacheWriteTokens", "cache_creation_input_tokens")],
+  ]
+    .filter(([, value]) => value !== null)
+    .map(([label, value]) => `${String(label)} ${String(value)}`)
+    .join(" · ");
+}
+
+/** Request params, shared by `llm_request` and the `session_prompt` row that
+ *  materialization folds a request into. */
+function requestMeta(data: Record<string, unknown>): string[] {
+  const toolCount = num(data["toolCount"]) ?? payloadCount(payload(data, "tools"));
+  const added = payloadCount(payload(data, "paletteAdded")) ?? 0;
+  const removed = payloadCount(payload(data, "paletteRemoved")) ?? 0;
+  return [
+    toolCount !== null ? `${toolCount} tools` : "",
+    data["thinkingLevel"] ? `thinking ${clean(data["thinkingLevel"], 20)}` : "",
+    num(data["temperature"]) !== null ? `temp ${num(data["temperature"])}` : "",
+    num(data["maxTokens"]) !== null ? `maxTokens ${num(data["maxTokens"])}` : "",
+    data["fastMode"] === true ? "fast mode" : "",
+    added > 0 || removed > 0 ? `palette +${added}/−${removed}` : "",
+  ].filter(Boolean);
+}
+
+/**
+ * The effective system prompt (the one pi actually sent, `<available_skills>`
+ * included), the tool definitions with their schemas, and the skill list — all
+ * collapsed, because each is kilobytes and none of it is what a reader scans a
+ * timeline for.
+ */
+function requestBody(data: Record<string, unknown>): string {
+  const system = payload(data, "systemPrompt");
+  const tools = payload(data, "tools");
+  const skills = payload(data, "availableSkills");
+  const systemSize = payloadSize(system);
+  const toolCount = num(data["toolCount"]) ?? payloadCount(tools);
+  const skillNames = nameList(skills, 300);
+  return (
+    collapsed(
+      `system prompt${systemSize !== null ? ` (${systemSize} chars)` : ""}`,
+      payloadBlock(system, SYSTEM_PROMPT_MAX),
+    ) +
+    collapsed(`tools${toolCount !== null ? ` (${toolCount})` : ""}`, payloadBlock(tools, TOOLS_MAX)) +
+    (skillNames ? `<div class="meta">skills — ${skillNames}</div>` : "")
+  );
+}
+
+/** Emitted once per run and back-referenced thereafter — see the materializer's
+ *  `dedupeRepeatedPayloads`. An exported trace must still show them on every
+ *  call, so resolve the references before rendering. */
+const DEDUPED_FOLD_FIELDS = ["systemPrompt", "tools", "toolNames", "availableSkills"] as const;
+
+function rehydrateRepeatedPayloads(list: DebugTraceEvent[]): DebugTraceEvent[] {
+  const bySeq = new Map<number, Record<string, unknown>>();
+  for (const event of list) {
+    const seq = num(event.seq);
+    const data = event.data;
+    if (seq !== null && seq !== undefined && data && typeof data === "object") {
+      bySeq.set(seq, data as Record<string, unknown>);
+    }
+  }
+  return list.map((event) => {
+    if (!event.data || typeof event.data !== "object") return event;
+    const data = event.data as Record<string, unknown>;
+    let next: Record<string, unknown> | null = null;
+    for (const field of DEDUPED_FOLD_FIELDS) {
+      const from = data[`${field}UnchangedFromSeq`];
+      if (typeof from !== "number") continue;
+      const source = bySeq.get(from)?.[field];
+      if (source === undefined) continue;
+      next ??= { ...data };
+      next[field] = source;
+    }
+    return next ? { ...event, data: next } : event;
+  });
+}
+
 function events(run: DebugTraceRun): DebugTraceEvent[] {
   if (!Array.isArray(run.events)) return [];
   const list = run.events.filter((e): e is DebugTraceEvent => Boolean(e) && typeof e === "object");
-  return [...list].sort((a, b) => (num(a.seq) ?? 0) - (num(b.seq) ?? 0));
+  const sorted = [...list].sort((a, b) => (num(a.seq) ?? 0) - (num(b.seq) ?? 0));
+  return rehydrateRepeatedPayloads(sorted);
 }
 
 interface ToolStat {
@@ -194,7 +379,9 @@ export function renderDebugTraceHtml(run: DebugTraceRun): string {
 
   for (const event of all) {
     const kind = event.kind ?? "";
-    if (kind === "tool_execution_end") continue;
+    // tool_execution_end is folded into its start row; message_append is
+    // transcript bookkeeping and would add one empty row per turn.
+    if (kind === "tool_execution_end" || kind === "message_append") continue;
     const at = str(event.at);
     const off = offset(at, startBase);
     const data = rec(event.data);
@@ -231,6 +418,8 @@ export function renderDebugTraceHtml(run: DebugTraceRun): string {
         meta: clean(data["reason"], 60),
       });
     } else if (kind === "session_prompt") {
+      // Materialization folds the turn's llm_request into this row, so the
+      // request params and prompt/tool payloads may live here.
       rendered = row({
         offset: off,
         badge: "llm",
@@ -240,6 +429,113 @@ export function renderDebugTraceHtml(run: DebugTraceRun): string {
           data["kind"] ? clean(data["kind"], 20) : "",
           `${num(data["messageCount"]) ?? 0} messages`,
           num(data["imagesCount"]) ? `${num(data["imagesCount"])} images` : "",
+          ...requestMeta(data),
+        ].filter(Boolean).join(" · "),
+        body: requestBody(data),
+      });
+    } else if (kind === "llm_request") {
+      rendered = row({
+        offset: off,
+        badge: "request",
+        kindClass: "k-prompt",
+        title:
+          `LLM request #${num(event.llmCall) ?? 0} — ` +
+          `${clean(data["provider"], 30) || clean(run.provider, 30) || "?"}/` +
+          `${clean(data["model"], 60) || clean(run.model, 60) || "?"}`,
+        meta: requestMeta(data).join(" · "),
+        body: requestBody(data),
+      });
+    } else if (kind === "llm_response") {
+      rendered = row({
+        offset: off,
+        badge: "response",
+        kindClass: "k-llm",
+        title: `LLM response #${num(event.llmCall) ?? 0}${data["stopReason"] ? ` — stop ${clean(data["stopReason"], 40)}` : ""}`,
+        meta: [
+          num(data["ttftMs"]) !== null ? `ttft ${ms(data["ttftMs"])}` : "",
+          num(data["totalMs"]) !== null ? `total ${ms(data["totalMs"])}` : "",
+          usageParts(rec(data["usage"])),
+          data["errorMessage"] ? `error ${clean(data["errorMessage"], 120)}` : "",
+        ].filter(Boolean).join(" · "),
+      });
+    } else if (kind === "tool_palette_change") {
+      const added = payload(data, "added");
+      const removed = payload(data, "removed");
+      const addedNames = nameList(added, 160);
+      const removedNames = nameList(removed, 160);
+      rendered = row({
+        offset: off,
+        badge: "tools",
+        kindClass: "k-session",
+        title: `Tool palette ${clean(data["source"], 24) || "change"} — +${payloadCount(added) ?? 0} / −${payloadCount(removed) ?? 0}`,
+        meta: [
+          addedNames ? `added ${addedNames}` : "",
+          removedNames ? `removed ${removedNames}` : "",
+          num(data["activeCount"]) !== null ? `${num(data["activeCount"])} active` : "",
+        ].filter(Boolean).join(" · "),
+      });
+    } else if (kind === "skill_loaded") {
+      rendered = row({
+        offset: off,
+        badge: "skill",
+        kindClass: "k-sub",
+        title: `Skill loaded — ${clean(data["slug"], 60) || "(unnamed)"}`,
+        meta: [
+          clean(data["path"], 140),
+          data["viaToolCallId"] ? `via ${clean(data["viaToolCallId"], 40)}` : "",
+        ].filter(Boolean).join(" · "),
+      });
+    } else if (kind === "subagent_start") {
+      rendered = row({
+        offset: off,
+        badge: "subagent",
+        kindClass: "k-sub",
+        title: `Subagent start — ${clean(data["subagentName"] ?? event.subagentName, 40) || "(unnamed)"}`,
+        meta: [
+          `${clean(data["provider"], 30) || "?"}/${clean(data["model"], 60) || "?"}`,
+          num(data["questionChars"]) !== null ? `question ${num(data["questionChars"])} chars` : "",
+          payloadCount(payload(data, "toolNames")) !== null
+            ? `${payloadCount(payload(data, "toolNames"))} tools`
+            : "",
+          data["childRunId"] ? `run ${clean(data["childRunId"], 40)}` : "",
+        ].filter(Boolean).join(" · "),
+      });
+    } else if (kind === "subagent_end") {
+      rendered = row({
+        offset: off,
+        badge: "subagent",
+        kindClass: data["status"] === "error" ? "k-retry" : "k-sub",
+        title: `Subagent end — ${clean(data["subagentName"] ?? event.subagentName, 40) || "(unnamed)"}${data["status"] ? ` (${clean(data["status"], 20)})` : ""}`,
+        meta: [
+          num(data["durationMs"]) !== null ? ms(data["durationMs"]) : "",
+          num(data["textLength"]) !== null ? `${num(data["textLength"])} chars` : "",
+          nameList(payload(data, "toolsUsed"), 160) ? `tools ${nameList(payload(data, "toolsUsed"), 160)}` : "",
+          data["providerError"] ? `error ${clean(data["providerError"], 120)}` : "",
+        ].filter(Boolean).join(" · "),
+      });
+    } else if (kind === "provider_fallback") {
+      rendered = row({
+        offset: off,
+        badge: "fallback",
+        kindClass: "k-retry",
+        title: `Provider fallback ${clean(data["fromProvider"], 30) || "?"} → ${clean(data["toProvider"], 30) || "?"}`,
+        meta: [
+          num(data["attempt"]) !== null ? `attempt ${num(data["attempt"])}` : "",
+          data["reason"] ? `reason ${clean(data["reason"], 120)}` : "",
+        ].filter(Boolean).join(" · "),
+      });
+    } else if (kind === "delegation") {
+      const detail = payload(data, "detail");
+      const detailText = typeof detail.value === "string" ? detail.value : detail.ref?.preview ?? "";
+      rendered = row({
+        offset: off,
+        badge: "delegation",
+        kindClass: "k-sub",
+        title: `Delegation ${clean(data["kind"], 24) || ""} — ${clean(data["caller"], 40) || "?"} → ${clean(data["callee"], 40) || "?"}`,
+        meta: [
+          num(data["depth"]) !== null ? `depth ${num(data["depth"])}` : "",
+          data["reason"] ? `reason ${clean(data["reason"], 80)}` : "",
+          clean(detailText, 120),
         ].filter(Boolean).join(" · "),
       });
     } else if (kind === "thinking") {
@@ -260,12 +556,7 @@ export function renderDebugTraceHtml(run: DebugTraceRun): string {
         promptAt && at && !Number.isNaN(Date.parse(promptAt)) && !Number.isNaN(Date.parse(at))
           ? Date.parse(at) - Date.parse(promptAt)
           : null;
-      const tokenParts = [
-        num(usage["input"]) !== null ? `in ${num(usage["input"])}` : "",
-        num(usage["output"]) !== null ? `out ${num(usage["output"])}` : "",
-        num(usage["cacheRead"]) !== null ? `cacheR ${num(usage["cacheRead"])}` : "",
-        num(usage["cacheWrite"]) !== null ? `cacheW ${num(usage["cacheWrite"])}` : "",
-      ].filter(Boolean).join(" · ");
+      const tokenParts = usageParts(usage);
       rendered = row({
         offset: off,
         badge: "llm",

--- a/apps/xyne-claw-auth/backend/src/lib/webhook-commands/debug.ts
+++ b/apps/xyne-claw-auth/backend/src/lib/webhook-commands/debug.ts
@@ -1,5 +1,6 @@
 import { agentRunRepository } from "../../repositories/agentRunRepository.js";
 import { gcsService } from "../../services/storageService.js";
+import { CONFIG } from "../../config.js";
 import { getSlotOwner } from "../message-queue.js";
 import { postGeneratedMarkdownFile } from "../spaces-generated-file.js";
 import { renderDebugTraceHtml, type DebugTraceRun } from "../debug-trace-html.js";
@@ -7,6 +8,12 @@ import type { WebhookCommandCtx } from "./context.js";
 
 const REPLY_LABEL = "Failed to post /debug reply";
 const DEBUG_RUN_PREFIX = "claw-debug-runs";
+/** Discovery markers, written at run START: `_index/<convId>/<runId>~<storeKey>.json`. */
+const DEBUG_INDEX_PREFIX = `${DEBUG_RUN_PREFIX}/_index`;
+/** A conversation with many runs still only needs the newest handful. */
+const MAX_INDEX_DOWNLOADS = 5;
+/** Claw inlines each run's transcript; we render exactly one, newest-first. */
+const CLAW_RUN_LIMIT = 10;
 const NO_TRACE =
   "🧵 **Debug** — no execution trace has been checkpointed for this run yet — try again in a minute or after it finishes.";
 
@@ -15,6 +22,7 @@ interface ResolvedRun {
   status: string;
   agentSlug: string;
   conversationId: string;
+  userId?: string;
 }
 
 function errMsg(err: unknown): string {
@@ -40,6 +48,10 @@ async function resolveRun(ctx: WebhookCommandCtx): Promise<ResolvedRun | null> {
     status: row.status,
     agentSlug: row.agentSlug ?? ctx.agent.slug,
     conversationId,
+    // The userId hint lets claw (and the archive restore behind it) reach the
+    // key shapes that fold a user id in — agent-chat's `<userId>_<conv>_<slug>`
+    // and the Digital-Twin `<conv>-<userId>_<slug>`.
+    ...(row.userId ? { userId: row.userId } : {}),
   };
 }
 
@@ -48,24 +60,157 @@ function epochOf(name: string): number {
   return match ? Number(match[1]) : 0;
 }
 
-interface PickedFile {
+function safeToken(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+interface PickedRun {
   name: string;
+  snapshot: DebugTraceRun;
   matchedSession: boolean;
 }
 
-async function pickNewestSnapshot(storeKey: string, sessionId: string): Promise<PickedFile | null> {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Pick the snapshot for THIS session, falling back to the thread's newest.
+ *
+ * A run's own `sessionId` is authoritative; the file name only carries a
+ * sanitized token of it, so it is the second-best match.
+ */
+function pickSnapshot(
+  candidates: Array<{ name: string; snapshot: DebugTraceRun }>,
+  sessionId: string,
+): PickedRun | null {
+  if (candidates.length === 0) return null;
+  const byEpoch = (a: { name: string }, b: { name: string }): number =>
+    epochOf(b.name) - epochOf(a.name) || b.name.localeCompare(a.name);
+  const sorted = [...candidates].sort(byEpoch);
+  const token = safeToken(sessionId);
+  const exact = sorted.find((c) => c.snapshot.sessionId === sessionId);
+  const byName = exact ?? sorted.find((c) => c.name.includes(token));
+  if (byName) return { ...byName, matchedSession: true };
+  const newest = sorted[0];
+  return newest ? { ...newest, matchedSession: false } : null;
+}
+
+/**
+ * Ask xyne-claw for the conversation's debug bundle.
+ *
+ * Preferred over reading GCS here: claw resolves runs from the run index (and
+ * its own PVC), so branch keys, Digital-Twin per-user keys and userId-prefixed
+ * agent-chat keys all resolve without this command re-guessing the shape — the
+ * guess is exactly what used to make `/debug` say "no trace" for those threads.
+ */
+async function fetchFromClaw(ctx: WebhookCommandCtx, run: ResolvedRun): Promise<PickedRun | null> {
+  const url =
+    `${CONFIG.xyneClawUrl.replace(/\/+$/, "")}/internal/sessions/${encodeURIComponent(run.conversationId)}/debug` +
+    `?agentSlug=${encodeURIComponent(run.agentSlug)}&limit=${CLAW_RUN_LIMIT}` +
+    `${run.userId ? `&userId=${encodeURIComponent(run.userId)}` : ""}`;
+  const res = await fetch(url, {
+    headers: { ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}) },
+    signal: AbortSignal.timeout(Number(process.env["DEBUG_PROXY_TIMEOUT_MS"] ?? 30_000)),
+  });
+  if (!res.ok) {
+    if (res.status !== 404) {
+      ctx.log.warn("/debug claw lookup failed", { status: res.status, conversationId: run.conversationId });
+    }
+    return null;
+  }
+  const body = (await res.json()) as { data?: { runs?: unknown } };
+  const rows = Array.isArray(body?.data?.runs) ? body.data.runs : [];
+  const candidates = rows.flatMap((row) => {
+    if (!isRecord(row) || typeof row["fileName"] !== "string" || !isRecord(row["data"])) return [];
+    return [{ name: row["fileName"], snapshot: row["data"] as DebugTraceRun }];
+  });
+  return pickSnapshot(candidates, run.sessionId);
+}
+
+interface IndexEntry {
+  runId: string;
+  storeKey: string;
+  startedAtMs: number;
+}
+
+/** `_index/<convId>/<runId>~<storeKey>.json` — `~` can appear in neither half. */
+function parseIndexMarker(objectName: string): IndexEntry | null {
+  const leaf = objectName.slice(objectName.lastIndexOf("/") + 1);
+  if (!leaf.endsWith(".json")) return null;
+  const body = leaf.slice(0, -".json".length);
+  const sep = body.indexOf("~");
+  if (sep <= 0) return null;
+  const runId = body.slice(0, sep);
+  const storeKey = body.slice(sep + 1);
+  if (!runId || !storeKey) return null;
+  const dash = runId.indexOf("-");
+  const startedAtMs = dash > 0 ? Number(runId.slice(0, dash)) : Number.NaN;
+  return { runId, storeKey, startedAtMs: Number.isFinite(startedAtMs) ? startedAtMs : 0 };
+}
+
+async function downloadSnapshot(storeKey: string, name: string): Promise<DebugTraceRun | null> {
+  const buffer = await gcsService.getFileBuffer(`${DEBUG_RUN_PREFIX}/${storeKey}/${name}`);
+  const parsed: unknown = JSON.parse(buffer.toString("utf8"));
+  return isRecord(parsed) ? (parsed as DebugTraceRun) : null;
+}
+
+/**
+ * Index-driven discovery, for when claw is unreachable.
+ *
+ * The marker NAME carries the storeKey the run was actually written under, so
+ * this stays a lookup rather than a fourth guess at the key shape.
+ */
+async function fetchFromIndex(ctx: WebhookCommandCtx, run: ResolvedRun): Promise<PickedRun | null> {
+  const prefix = `${DEBUG_INDEX_PREFIX}/${run.conversationId}/`;
+  const entries = (await gcsService.listFiles(prefix))
+    .map(parseIndexMarker)
+    .filter((e): e is IndexEntry => e !== null)
+    .sort((a, b) => b.startedAtMs - a.startedAtMs || (a.runId < b.runId ? 1 : -1));
+  if (entries.length === 0) return null;
+
+  const token = `-${safeToken(run.sessionId)}`;
+  const mine = entries.filter((e) => e.runId.endsWith(token));
+  // This session's runs first; otherwise the newest few, so one missing object
+  // (a marker whose snapshot upload lost the race) doesn't end the search.
+  const ordered = [...mine, ...entries.filter((e) => !mine.includes(e))].slice(0, MAX_INDEX_DOWNLOADS);
+  for (const entry of ordered) {
+    const name = `debug-run-${entry.runId}.json`;
+    try {
+      const snapshot = await downloadSnapshot(entry.storeKey, name);
+      if (snapshot) return { name, snapshot, matchedSession: entry.runId.endsWith(token) };
+    } catch (err) {
+      ctx.log.warn("/debug indexed snapshot download failed", {
+        error: errMsg(err),
+        storeKey: entry.storeKey,
+        runId: entry.runId,
+      });
+    }
+  }
+  return null;
+}
+
+/**
+ * Pre-index runs only. They predate the discovery markers, so the shared-thread
+ * storeKey is the sole way to reach them — and the only shape they ever used.
+ */
+async function fetchLegacyStoreKey(ctx: WebhookCommandCtx, run: ResolvedRun): Promise<PickedRun | null> {
+  const storeKey = `${run.conversationId}_${run.agentSlug}`;
   const prefix = `${DEBUG_RUN_PREFIX}/${storeKey}/`;
-  const paths = await gcsService.listFiles(prefix);
-  const names = paths
+  const names = (await gcsService.listFiles(prefix))
     .map((p) => (p.startsWith(prefix) ? p.slice(prefix.length) : p))
-    .filter((n) => n.startsWith("debug-run-") && n.endsWith(".json"));
-  if (names.length === 0) return null;
-  const byEpoch = (a: string, b: string): number => epochOf(b) - epochOf(a) || b.localeCompare(a);
-  const safeSessionId = sessionId.replace(/[^a-zA-Z0-9_-]/g, "-");
-  const matching = names.filter((n) => n.includes(safeSessionId)).sort(byEpoch);
-  if (matching[0]) return { name: matching[0], matchedSession: true };
-  const newest = [...names].sort(byEpoch)[0];
-  return newest ? { name: newest, matchedSession: false } : null;
+    .filter((n) => n.startsWith("debug-run-") && n.endsWith(".json"))
+    .sort((a, b) => epochOf(b) - epochOf(a) || b.localeCompare(a));
+  const token = safeToken(run.sessionId);
+  const name = names.find((n) => n.includes(token)) ?? names[0];
+  if (!name) return null;
+  try {
+    const snapshot = await downloadSnapshot(storeKey, name);
+    return snapshot ? { name, snapshot, matchedSession: name.includes(token) } : null;
+  } catch (err) {
+    ctx.log.warn("/debug legacy snapshot download failed", { error: errMsg(err), storeKey, name });
+    return null;
+  }
 }
 
 export async function handleDebug(ctx: WebhookCommandCtx): Promise<void> {
@@ -80,30 +225,25 @@ export async function handleDebug(ctx: WebhookCommandCtx): Promise<void> {
     return;
   }
 
-  const storeKey = `${run.conversationId}_${run.agentSlug}`;
-  let picked: PickedFile | null = null;
-  try {
-    picked = await pickNewestSnapshot(storeKey, run.sessionId);
-  } catch (err) {
-    ctx.log.warn("/debug snapshot listing failed", { error: errMsg(err), storeKey });
+  const resolved = run;
+  let picked: PickedRun | null = null;
+  for (const lookup of [fetchFromClaw, fetchFromIndex, fetchLegacyStoreKey]) {
+    try {
+      picked = await lookup(ctx, resolved);
+    } catch (err) {
+      ctx.log.warn("/debug snapshot lookup failed", { error: errMsg(err), via: lookup.name });
+      picked = null;
+    }
+    if (picked) break;
   }
   if (!picked) {
     await ctx.reply(NO_TRACE, REPLY_LABEL);
     return;
   }
 
-  let snapshot: DebugTraceRun;
-  try {
-    const buffer = await gcsService.getFileBuffer(`${DEBUG_RUN_PREFIX}/${storeKey}/${picked.name}`);
-    snapshot = JSON.parse(buffer.toString("utf8")) as DebugTraceRun;
-  } catch (err) {
-    ctx.log.warn("/debug snapshot download failed", { error: errMsg(err), file: picked.name });
-    await ctx.reply(NO_TRACE, REPLY_LABEL);
-    return;
-  }
-
+  const snapshot = picked.snapshot;
   const html = renderDebugTraceHtml(snapshot);
-  const shortId = run.sessionId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 8);
+  const shortId = safeToken(run.sessionId).slice(0, 8);
   const filename = `debug-${run.agentSlug}-${shortId}.html`;
 
   const eventList = Array.isArray(snapshot.events) ? (snapshot.events as Array<Record<string, unknown>>) : [];

--- a/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
+++ b/apps/xyne-claw-auth/backend/src/routes/agent-chat.ts
@@ -158,37 +158,74 @@ function shouldRedactRun(crossUser: boolean, runUserId: string | null | undefine
   return !isAgentOwnedRun(triggerSource);
 }
 
+/** Payload keys whose VALUE is withheld from a viewer who doesn't own the run. */
+const REDACTED_KEYS = new Set(["result"]);
+
+/**
+ * A v2 trace carries a large payload either inline (`result`) or interned into
+ * the blob log and referenced by the SIBLING key `resultRef`, whose `preview`
+ * holds the first ~200 chars of that SAME content. Redacting only the inline
+ * spelling would hand a viewer a preview of the body we just withheld, so a
+ * redacted key's `<key>Ref` sibling is redacted too. Deriving this from one set
+ * keeps the two spellings from drifting if the list ever grows.
+ */
+function isRedactedKey(key: string): boolean {
+  return REDACTED_KEYS.has(key) || (key.endsWith("Ref") && REDACTED_KEYS.has(key.slice(0, -"Ref".length)));
+}
+
 /**
  * Strip RESULT bodies from a run's tool invocations while preserving every
  * other field (name, args, isError, status, subagent nesting). Used when an
  * admin inspects a run they don't own.
  */
 function redactToolResults(invocations: unknown[]): unknown[] {
-  return invocations.map((inv) =>
-    inv && typeof inv === "object" && "result" in inv
-      ? { ...(inv as Record<string, unknown>), result: REDACTED_TOOL_RESULT }
-      : inv,
-  );
+  return invocations.map((inv) => {
+    if (!inv || typeof inv !== "object") return inv;
+    const record = inv as Record<string, unknown>;
+    const hits = Object.keys(record).filter(isRedactedKey);
+    if (hits.length === 0) return inv;
+    const out = { ...record };
+    for (const key of hits) out[key] = REDACTED_TOOL_RESULT;
+    return out;
+  });
 }
 
 /**
- * Deeply replace every `result` field's value with the placeholder, anywhere in
- * a debug-artifact tree, preserving all other keys (toolName, args, input,
- * userId, sessionId, timing). Shape-agnostic on purpose — xyne-claw's snapshot
- * structure isn't typed here, so we redact by key rather than by known path,
- * which fails safe if the shape changes. Used for the deep "Debug" drawer when
- * an admin inspects another user's (non-private) run.
+ * Deeply replace every redacted field's value (and its blob-ref sibling) with
+ * the placeholder, anywhere in a debug-artifact tree, preserving all other keys
+ * (toolName, args, input, userId, sessionId, timing). Shape-agnostic on purpose
+ * — xyne-claw's snapshot structure isn't typed here, so we redact by key rather
+ * than by known path, which fails safe if the shape changes. Used for the deep
+ * "Debug" drawer when an admin inspects another user's (non-private) run.
  */
 function redactResultKeysDeep(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(redactResultKeysDeep);
   if (value && typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = k === "result" ? REDACTED_TOOL_RESULT : redactResultKeysDeep(v);
+      out[k] = isRedactedKey(k) ? REDACTED_TOOL_RESULT : redactResultKeysDeep(v);
     }
     return out;
   }
   return value;
+}
+
+/**
+ * Re-state claw's page counters after the per-user ACL dropped runs from the
+ * page. claw counts every run in the conversation; a viewer must not be told
+ * about runs the ACL just hid, so those come off the total — but the runs we
+ * never fetched (older pages) stay counted, since "there is more history" is
+ * exactly what the drawer's "showing N of M" line has to say.
+ */
+function paginationAfterAcl(
+  fetchedRuns: number,
+  visibleRuns: number,
+  totalRuns: number | undefined,
+  truncated: boolean | undefined,
+): { totalRuns: number; truncated: boolean } {
+  const total = totalRuns ?? fetchedRuns;
+  const notFetched = Math.max(0, total - fetchedRuns);
+  return { totalRuns: visibleRuns + notFetched, truncated: truncated === true };
 }
 
 // Debug artifacts are no longer read off the local filesystem — they live on
@@ -2680,15 +2717,27 @@ router.get("/:slug/chat/:convId/debug", async (req: Request<{ slug: string; conv
     // xyne-claw's S2S debug endpoint, which reads its own PVC and lazily
     // restores from the GCS archive if the session was evicted. Authz was
     // already enforced above.
+    // claw caps the run list (default 25) and pages it with `before` (a runId
+    // cursor). Forward both: without them a long thread's older runs were
+    // unreachable — the drawer could not even ask for them.
+    const rawLimit = req.query["limit"];
+    const limitParam = typeof rawLimit === "string" && /^\d+$/.test(rawLimit) ? rawLimit : "";
+    const rawBefore = req.query["before"];
+    const beforeParam = typeof rawBefore === "string" && rawBefore !== "" ? rawBefore : "";
     const upstreamUrl =
       `${CONFIG.xyneClawUrl}/internal/sessions/${encodeURIComponent(req.params.convId)}/debug` +
       `?agentSlug=${encodeURIComponent(req.params.slug)}` +
-      `${ownerId ? `&userId=${encodeURIComponent(ownerId)}` : ""}`;
+      `${ownerId ? `&userId=${encodeURIComponent(ownerId)}` : ""}` +
+      `${limitParam ? `&limit=${limitParam}` : ""}` +
+      `${beforeParam ? `&before=${encodeURIComponent(beforeParam)}` : ""}`;
     let upstream: globalThis.Response;
     try {
       upstream = await fetch(upstreamUrl, {
         headers: { ...(CONFIG.xyneClawS2sKey ? { "x-s2s-key": CONFIG.xyneClawS2sKey } : {}) },
-        signal: AbortSignal.timeout(15_000),
+        // A long thread's bundle can take several seconds to assemble on claw's
+        // side once GCS runs are merged in. A 15s ceiling turned a slow-but-fine
+        // read into a 502 that looked to the user like "no debug data exists".
+        signal: AbortSignal.timeout(Number(process.env["DEBUG_PROXY_TIMEOUT_MS"] ?? 45_000)),
       });
     } catch (err) {
       log.error("[agent-chat] debug proxy fetch failed:", err instanceof Error ? err.message : err);
@@ -2705,6 +2754,10 @@ router.get("/:slug/chat/:convId/debug", async (req: Request<{ slug: string; conv
         debugEvents?: unknown[] | null;
         runs?: Array<{ fileName: string; data: { userId?: string; sessionId?: string; [k: string]: unknown } }>;
         subagents?: Array<{ fileName: string; data: { parentSessionId?: string } }>;
+        /** Runs in the whole conversation vs. runs on this page — claw caps the
+         *  page, so the drawer needs both to say "showing N of M". */
+        totalRuns?: number;
+        truncated?: boolean;
         followUpDiagnostics?: Array<{
           sessionId: string;
           startedAt: string;
@@ -2770,10 +2823,22 @@ router.get("/:slug/chat/:convId/debug", async (req: Request<{ slug: string; conv
             },
           })),
           subagents: [],
+          // The synth bundle IS every run we can see, so nothing is paged out.
+          totalRuns: active.length,
+          truncated: false,
         },
       };
     } else if (!upstream.ok) {
-      res.status(502).json({ success: false, error: `Debug service error (${upstream.status})` });
+      // Forward claw's own reason instead of flattening every failure to a bare
+      // 502 — a rejected id and an unconfigured S2S key are different problems
+      // and the drawer can only say which if the code survives the hop.
+      const upstreamBody = (await upstream.json().catch(() => null)) as { error?: string; code?: string } | null;
+      res.status(502).json({
+        success: false,
+        error: upstreamBody?.error ?? `Debug service error (${upstream.status})`,
+        ...(upstreamBody?.code ? { code: upstreamBody.code } : {}),
+        upstreamStatus: upstream.status,
+      });
       return;
     } else {
       body = (await upstream.json()) as typeof body;
@@ -2796,6 +2861,7 @@ router.get("/:slug/chat/:convId/debug", async (req: Request<{ slug: string; conv
         debugEvents: ownSession ? d.debugEvents ?? [] : [],
         runs: ownRuns,
         subagents: (d.subagents ?? []).filter((s) => ownSessionIds.has(s.data?.parentSessionId ?? "")),
+        ...paginationAfterAcl((d.runs ?? []).length, ownRuns.length, d.totalRuns, d.truncated),
       };
     } else if (hasElevatedDebugAccess && body?.data) {
       // Elevated viewers see everything EXCEPT other users' runs that executed under a
@@ -2833,6 +2899,13 @@ router.get("/:slug/chat/:convId/debug", async (req: Request<{ slug: string; conv
       const d = body.data;
       const hideDebugSession = d.debugSession?.sessionId ? hiddenSessionIds.has(d.debugSession.sessionId) : false;
       const debugSessionOwned = readable(d.debugSession?.sessionId, d.debugSession?.userId);
+      const visibleRuns = (d.runs ?? [])
+        .filter((r) => !hiddenSessionIds.has(r.data?.sessionId ?? ""))
+        .map((r) =>
+          readable(r.data?.sessionId, r.data?.userId)
+            ? r
+            : { ...r, data: redactResultKeysDeep(r.data) as typeof r.data },
+        );
       body.data = {
         ...d,
         debugSession: hideDebugSession
@@ -2845,18 +2918,13 @@ router.get("/:slug/chat/:convId/debug", async (req: Request<{ slug: string; conv
           : !d.debugSession || debugSessionOwned
             ? d.debugEvents ?? null
             : (redactResultKeysDeep(d.debugEvents ?? []) as unknown[]),
-        runs: (d.runs ?? [])
-          .filter((r) => !hiddenSessionIds.has(r.data?.sessionId ?? ""))
-          .map((r) =>
-            readable(r.data?.sessionId, r.data?.userId)
-              ? r
-              : { ...r, data: redactResultKeysDeep(r.data) as typeof r.data },
-          ),
+        runs: visibleRuns,
         subagents: (d.subagents ?? [])
           .filter((s) => !hiddenSessionIds.has(s.data?.parentSessionId ?? ""))
           .map((s) =>
             ownsSession(s.data?.parentSessionId) ? s : { ...s, data: redactResultKeysDeep(s.data) as typeof s.data },
           ),
+        ...paginationAfterAcl((d.runs ?? []).length, visibleRuns.length, d.totalRuns, d.truncated),
       };
     }
     if (body.data) {

--- a/apps/xyne-claw-auth/frontend/src/components/DebugDrawer.tsx
+++ b/apps/xyne-claw-auth/frontend/src/components/DebugDrawer.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import {
   Activity,
   AlertCircle,
+  AlertTriangle,
   Bot,
   Braces,
   BrainCircuit,
@@ -22,6 +23,7 @@ import {
   Quote,
   RefreshCw,
   RotateCcw,
+  Sparkles,
   User,
   Workflow,
   Wrench,
@@ -60,6 +62,90 @@ function asString(value: unknown): string {
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   return "";
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+/**
+ * Palette diffs arrive under two spellings: a `tool_palette_change` event names
+ * them `added`/`removed`, while `paletteAdded`/`paletteRemoved` is what the
+ * materializer folds off an `llm_request` onto its `session_prompt`. Read both
+ * so a palette row renders its chips on either shape.
+ */
+function paletteList(data: Record<string, unknown>, folded: "paletteAdded" | "paletteRemoved", own: "added" | "removed"): string[] {
+  const foldedList = stringList(data[folded]);
+  return foldedList.length > 0 ? foldedList : stringList(data[own]);
+}
+
+/** A payload the v2 writer interned into the blob log instead of inlining. */
+type BlobRefLike = { hash: string; bytes?: number; originalBytes?: number; truncated?: boolean; preview?: string };
+
+function asBlobRef(value: unknown): BlobRefLike | null {
+  if (!isRecord(value) || typeof value.hash !== "string") return null;
+  return value as BlobRefLike;
+}
+
+type ResolvedField = {
+  text: string;
+  /** Bytes for a ref (what the writer stored), chars for an inline string. */
+  size: number;
+  truncated: boolean;
+  isRef: boolean;
+};
+
+/**
+ * Reads a payload field that may arrive inline OR as a blob ref — either in the
+ * field itself or in its `<field>Ref` sibling, which is what survives when the
+ * blob content could not be resolved. A ref renders its preview rather than an
+ * empty panel, so "captured but not inlined" never looks like "nothing here".
+ */
+function resolveFieldText(data: Record<string, unknown>, key: string): ResolvedField | null {
+  const inline = data[key];
+  if (typeof inline === "string") {
+    return inline ? { text: inline, size: inline.length, truncated: false, isRef: false } : null;
+  }
+  const ref = asBlobRef(inline) ?? asBlobRef(data[`${key}Ref`]);
+  if (!ref) return null;
+  const preview = typeof ref.preview === "string" ? ref.preview : "";
+  return {
+    text: preview,
+    size: typeof ref.bytes === "number" ? ref.bytes : preview.length,
+    truncated: ref.truncated === true || ref.originalBytes !== undefined || !preview,
+    isRef: true,
+  };
+}
+
+function fieldSizeLabel(field: ResolvedField): string {
+  return `${field.size} ${field.isRef ? "bytes" : "chars"}${field.truncated ? " · truncated" : ""}`;
+}
+
+/**
+ * What a ref-backed field is actually showing. On the LIVE channel a ref is
+ * always just its ~200-char preview — the payload stays in claw's blob log
+ * until the run finishes and the trace is materialized, and we deliberately
+ * don't push a 20 KB system prompt over the wire every turn. Say that, instead
+ * of letting a preview pass for the whole value.
+ */
+function refNote(field: ResolvedField, live = false): string {
+  const head = field.text ? "preview" : "not inlined";
+  const tail = live ? " · full content available when the run completes" : "";
+  return `${head} · ${field.size} bytes${field.truncated ? " · truncated" : ""}${tail}`;
+}
+
+/** Body for a resolved payload: the text plus, for refs, what is missing. */
+function FieldText({ field, className = "", live = false }: { field: ResolvedField; className?: string; live?: boolean }) {
+  return (
+    <>
+      <pre className={`max-h-72 overflow-auto whitespace-pre-wrap text-[12px] leading-relaxed text-xyne-fg-secondary ${className}`}>
+        {field.text || "(payload not captured)"}
+      </pre>
+      {field.isRef && (
+        <p className="mt-1 text-[11px] text-amber-700 dark:text-amber-300">{refNote(field, live)}</p>
+      )}
+    </>
+  );
 }
 
 function formatTime(iso: string): string {
@@ -258,7 +344,19 @@ function JsonViewerModal({ value, title, onClose }: { value: unknown; title: str
   return createPortal(modal, document.body);
 }
 
-function JsonViewer({ value, title = "JSON", defaultExpandedDepth = 999 }: { value: unknown; title?: string; defaultExpandedDepth?: number }) {
+function JsonViewer({
+  value,
+  title = "JSON",
+  defaultExpandedDepth = 999,
+  scroll = true,
+}: {
+  value: unknown;
+  title?: string;
+  defaultExpandedDepth?: number;
+  /** Set false when an ancestor already scrolls: nesting a second scroller
+   *  swallows the wheel as soon as the pointer crosses this box. */
+  scroll?: boolean;
+}) {
   const [expanded, setExpanded] = useState(false);
   const parsedValue = useMemo(() => parseJsonLike(value), [value]);
   return (
@@ -271,7 +369,7 @@ function JsonViewer({ value, title = "JSON", defaultExpandedDepth = 999 }: { val
           <CopyJsonButton value={parsedValue} />
           <button type="button" onClick={() => setExpanded(true)} className="rounded p-1 text-xyne-fg-muted hover:bg-black/5 dark:hover:bg-white/10 hover:text-xyne-fg-primary" title="Open expanded JSON viewer"><Maximize2 size={12} /></button>
         </div>
-        <div className="max-h-64 overflow-auto p-2">
+        <div className={`p-2 ${scroll ? "max-h-64 overflow-auto" : ""}`}>
           <JsonNode value={parsedValue} depth={0} defaultExpandedDepth={defaultExpandedDepth} />
         </div>
       </div>
@@ -473,17 +571,176 @@ function messageLabel(role: string): string {
 
 type TimelineEvent = Record<string, unknown> & { startedAt?: string };
 
-function compactTimeline(events: unknown[]): TimelineEvent[] {
+/**
+ * Kinds that never earn a timeline row: stream bookkeeping and transcript
+ * deltas (`message_append`). `llm_request`/`llm_response` are not listed —
+ * compactTimeline folds them onto their turn's `session_prompt` row instead.
+ */
+const HIDDEN_TIMELINE_KINDS = new Set(["message_update", "stream_rate", "message_append"]);
+
+/** Request fields the materializer lifts onto the turn's `session_prompt`;
+ *  mirrored here (with their blob-ref spellings) for the live fold below. */
+const FOLD_REQUEST_FIELDS = [
+  "systemPrompt",
+  "tools",
+  "toolNames",
+  "availableSkills",
+  "temperature",
+  "maxTokens",
+  "thinkingLevel",
+  "fastMode",
+  "model",
+  "provider",
+  "paletteAdded",
+  "paletteRemoved",
+] as const;
+
+/** `llm_response` fields the materializer renames onto the prompt row — what
+ *  RequestParamsStrip reads for stop reason, cache hit/miss and TTFT. */
+const FOLD_RESPONSE_FIELDS: ReadonlyArray<readonly [string, string]> = [
+  ["usage", "responseUsage"],
+  ["stopReason", "responseStopReason"],
+  ["ttftMs", "ttftMs"],
+];
+
+/**
+ * Merge one `llm_request` / `llm_response` onto its turn's prompt row, the way
+ * materialization does for a completed run. Ref spellings ride along: live
+ * events carry `systemPromptRef` where a materialized one carries the inlined
+ * `systemPrompt`, and the row renderer reads either.
+ */
+function foldLlmEvent(row: TimelineEvent, event: TimelineEvent): TimelineEvent {
+  const eventData = isRecord(event.data) ? event.data : {};
+  const merged: Record<string, unknown> = { ...(isRecord(row.data) ? row.data : {}) };
+  if (asString(event.kind) === "llm_request") {
+    for (const field of FOLD_REQUEST_FIELDS) {
+      const refKey = `${field}Ref`;
+      // The request's value REPLACES the prompt row's in EITHER spelling:
+      // session_prompt carries only the persona prompt, which must not shadow
+      // the true effective one just because it arrived inline and this didn't.
+      if (eventData[field] !== undefined) {
+        merged[field] = eventData[field];
+        delete merged[refKey];
+      } else if (eventData[refKey] !== undefined) {
+        merged[refKey] = eventData[refKey];
+        delete merged[field];
+      }
+    }
+  } else {
+    for (const [from, to] of FOLD_RESPONSE_FIELDS) {
+      if (eventData[from] !== undefined) merged[to] = eventData[from];
+    }
+  }
+  return { ...row, data: merged };
+}
+
+/**
+ * Fields the materializer emits once per run and back-references thereafter
+ * (`<field>UnchangedFromSeq`), because a 48-tool catalog and a 28 KB system
+ * prompt are identical on every call and re-sending them per turn doubled the
+ * bundle. Rehydrate here so every downstream renderer still sees a plain value.
+ */
+const DEDUPED_FOLD_FIELDS = ["systemPrompt", "tools", "toolNames", "availableSkills"] as const;
+
+function rehydrateRepeatedPayloads(events: unknown[]): unknown[] {
+  const bySeq = new Map<number, Record<string, unknown>>();
+  for (const value of events) {
+    if (!isRecord(value) || typeof value.seq !== "number") continue;
+    if (isRecord(value.data)) bySeq.set(value.seq, value.data);
+  }
+  let touched = false;
+  const out = events.map((value) => {
+    if (!isRecord(value) || !isRecord(value.data)) return value;
+    let data: Record<string, unknown> | null = null;
+    for (const field of DEDUPED_FOLD_FIELDS) {
+      const from = value.data[`${field}UnchangedFromSeq`];
+      if (typeof from !== "number") continue;
+      const source = bySeq.get(from)?.[field];
+      if (source === undefined) continue;
+      data ??= { ...value.data };
+      data[field] = source;
+    }
+    if (!data) return value;
+    touched = true;
+    return { ...value, data };
+  });
+  return touched ? out : events;
+}
+
+function compactTimeline(rawEvents: unknown[]): TimelineEvent[] {
+  const events = rehydrateRepeatedPayloads(rawEvents);
   const compacted: TimelineEvent[] = [];
   const pendingTools = new Map<string, number>();
+  // Prompt row per LLM call, so this turn's `llm_request` / `llm_response` fold
+  // onto it. Materialization does the same fold for a completed run; doing it
+  // here too keeps the LIVE timeline from showing a duplicate LLM row every
+  // turn, and gives the live prompt row the request's params.
+  const promptRows = new Map<number, number>();
+  // A call's prompt row and its request/response are produced by different
+  // hooks, so the request can arrive first. Knowing up front which calls DO get
+  // a prompt row lets us hold the fold instead of emitting a duplicate LLM row.
+  const promptCalls = new Set<number>();
+  for (const value of events) {
+    if (isRecord(value) && asString(value.kind) === "session_prompt" && typeof value.llmCall === "number") {
+      promptCalls.add(value.llmCall);
+    }
+  }
+  const deferredFolds = new Map<number, TimelineEvent[]>();
+  // Tool rows stay addressable after their end event lands, so a late
+  // `tool_invocation_update` (background task finishing) folds into the same
+  // row instead of appearing as an orphan event.
+  const toolRows = new Map<string, number>();
 
   for (const value of events) {
-    if (!isRecord(value) || ["message_update", "stream_rate"].includes(asString(value.kind))) continue;
+    if (!isRecord(value) || HIDDEN_TIMELINE_KINDS.has(asString(value.kind))) continue;
     const event = value as TimelineEvent;
     const kind = asString(event.kind);
+    const llmCall = typeof event.llmCall === "number" ? event.llmCall : undefined;
+    if (kind === "session_prompt") {
+      const rowIndex = compacted.length;
+      compacted.push(event);
+      if (llmCall === undefined) continue;
+      if (promptRows.has(llmCall)) continue;
+      promptRows.set(llmCall, rowIndex);
+      for (const held of deferredFolds.get(llmCall) ?? []) {
+        compacted[rowIndex] = foldLlmEvent(compacted[rowIndex]!, held);
+      }
+      deferredFolds.delete(llmCall);
+      continue;
+    }
+    if (kind === "llm_request" || kind === "llm_response") {
+      const rowIndex = llmCall !== undefined ? promptRows.get(llmCall) : undefined;
+      if (rowIndex !== undefined) {
+        compacted[rowIndex] = foldLlmEvent(compacted[rowIndex]!, event);
+        continue;
+      }
+      if (llmCall !== undefined && promptCalls.has(llmCall)) {
+        deferredFolds.set(llmCall, [...(deferredFolds.get(llmCall) ?? []), event]);
+        continue;
+      }
+      // No prompt row for this call (a compaction or follow-up call has none),
+      // so the request stands on its own — same fallback as materialization.
+      if (kind === "llm_request") compacted.push(event);
+      continue;
+    }
     const toolCallId = asString(event.toolCallId);
+    if (kind === "tool_invocation_update") {
+      const updateId = toolCallId || (isRecord(event.data) ? asString(event.data.toolCallId) : "");
+      const rowIndex = toolRows.get(updateId);
+      if (rowIndex === undefined) continue;
+      const row = compacted[rowIndex]!;
+      compacted[rowIndex] = {
+        ...row,
+        data: {
+          ...(isRecord(row.data) ? row.data : {}),
+          ...(isRecord(event.data) ? event.data : {}),
+        },
+      };
+      continue;
+    }
     if (kind === "tool_execution_start" && toolCallId) {
       pendingTools.set(toolCallId, compacted.length);
+      toolRows.set(toolCallId, compacted.length);
       compacted.push(event);
       continue;
     }
@@ -512,7 +769,13 @@ function eventTitle(kind: string, data: Record<string, unknown>): string {
     const name = asString(data.toolName);
     return name ? `Tool · ${name}` : "Tool call";
   }
-  if (kind === "session_prompt") return "LLM request";
+  if (kind === "session_prompt" || kind === "llm_request") return "LLM request";
+  if (kind === "tool_palette_change") return "Tool palette changed";
+  if (kind === "skill_loaded") return "Skill loaded";
+  if (kind === "subagent_start") return "Subagent started";
+  if (kind === "subagent_end") return "Subagent finished";
+  if (kind === "provider_fallback") return "Provider fallback";
+  if (kind === "delegation") return "Agent delegation";
   if (kind === "thinking") return "Thinking";
   if (kind === "assistant_turn_end") return "Assistant response";
   if (kind === "session_start") return "Session started";
@@ -554,7 +817,14 @@ function eventVisual(kind: string, isError: boolean): EventVisual {
   if (kind.startsWith("tool_execution")) return { Icon: Wrench, label: "TOOL", rail: "border-amber-500", chip: "bg-amber-500/10 text-amber-700 dark:text-amber-300" };
   switch (kind) {
     case "session_start": return { Icon: CirclePlay, label: "SESSION", rail: "border-sky-500", chip: "bg-sky-500/10 text-sky-700 dark:text-sky-300" };
-    case "session_prompt": return { Icon: BrainCircuit, label: "LLM", rail: "border-xyne-border-strong", chip: "text-xyne-fg-muted", quiet: true };
+    case "session_prompt":
+    case "llm_request": return { Icon: BrainCircuit, label: "LLM", rail: "border-xyne-border-strong", chip: "text-xyne-fg-muted", quiet: true };
+    case "tool_palette_change": return { Icon: Wrench, label: "PALETTE", rail: "border-amber-400", chip: "bg-amber-400/10 text-amber-700 dark:text-amber-300" };
+    case "skill_loaded": return { Icon: Sparkles, label: "SKILL", rail: "border-indigo-500", chip: "bg-indigo-500/10 text-indigo-700 dark:text-indigo-300" };
+    case "subagent_start":
+    case "subagent_end": return { Icon: Workflow, label: "SUB", rail: "border-cyan-500", chip: "bg-cyan-500/10 text-cyan-700 dark:text-cyan-300" };
+    case "delegation": return { Icon: Workflow, label: "A2A", rail: "border-blue-500", chip: "bg-blue-500/10 text-blue-700 dark:text-blue-300" };
+    case "provider_fallback": return { Icon: RotateCcw, label: "FALLBACK", rail: "border-orange-500", chip: "bg-orange-500/10 text-orange-700 dark:text-orange-300" };
     case "thinking": return { Icon: Lightbulb, label: "THINK", rail: "border-violet-500", chip: "bg-violet-500/10 text-violet-700 dark:text-violet-300" };
     case "assistant_turn_end": return { Icon: MessageSquareText, label: "ASST", rail: "border-emerald-500", chip: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300" };
     case "compaction_start":
@@ -583,6 +853,7 @@ function DebugTimelineSection({
   selectedEventKey,
   onSelectEvent,
   timeMode = "delta",
+  live = false,
 }: {
   title: string;
   data: Record<string, unknown> | null;
@@ -591,6 +862,8 @@ function DebugTimelineSection({
   selectedEventKey?: string | null;
   onSelectEvent?: (key: string) => void;
   timeMode?: "delta" | "abs";
+  /** These events are streaming in, not read back off a completed trace. */
+  live?: boolean;
 }) {
   const events = useMemo(() => {
     const raw = data?.events;
@@ -598,6 +871,11 @@ function DebugTimelineSection({
   }, [data]);
 
   const visibleEvents = useMemo(() => compactTimeline(events), [events]);
+
+  // The full transcript, carried ONCE on the snapshot. Each turn's panel is a
+  // prefix of it (`data.messagesTo`), so rows slice rather than each shipping
+  // its own copy — that copy was O(turns^2) on the wire.
+  const transcript = useMemo(() => (Array.isArray(data?.messages) ? data.messages : undefined), [data]);
 
   // Expand/collapse all timeline cards. The cards are native <details> elements
   // (no React state to lift), so we flip their `open` attribute through a ref.
@@ -610,16 +888,23 @@ function DebugTimelineSection({
     });
   };
 
-  // Earliest event time = the origin for Δ timestamps in this run/turn.
+  // Per-row timestamps. Δ is the GAP FROM THE PREVIOUS ROW — that is what
+  // answers "what was slow?", which is the whole reason to look at a timeline.
+  // Time-from-run-start is still useful for orientation, so it moves to the
+  // hover title rather than being the headline number.
+  const eventTimesMs = useMemo(
+    () =>
+      visibleEvents.map((e) => {
+        if (!isRecord(e)) return undefined;
+        const t = Date.parse(asString(e.at) || asString(e.startedAt));
+        return Number.isFinite(t) ? t : undefined;
+      }),
+    [visibleEvents],
+  );
   const originMs = useMemo(() => {
-    let min = Number.POSITIVE_INFINITY;
-    for (const e of visibleEvents) {
-      if (!isRecord(e)) continue;
-      const t = Date.parse(asString(e.at) || asString(e.startedAt));
-      if (Number.isFinite(t)) min = Math.min(min, t);
-    }
-    return Number.isFinite(min) ? min : undefined;
-  }, [visibleEvents]);
+    const known = eventTimesMs.filter((t): t is number => t !== undefined);
+    return known.length > 0 ? Math.min(...known) : undefined;
+  }, [eventTimesMs]);
 
   // Sub-steps (thinking / assistant / tool) indent under the spine; the LAST
   // assistant turn is the conclusion and stays flush.
@@ -649,7 +934,8 @@ function DebugTimelineSection({
   const thinkingConfig = isRecord(data?.thinking) ? data.thinking as Record<string, unknown> : null;
   const thinkingLevel = thinkingConfig ? asString(thinkingConfig.effectiveLevel) : "";
 
-  const headerMeta = [asString(data?.provider), asString(data?.model), thinkingLevel ? `thinking ${thinkingLevel}` : "", toolsUsed.length ? `${toolsUsed.length} tools` : "", `${visibleEvents.length} events`].filter(Boolean).join(" · ");
+  const runWarnings = stringList(data?.warnings);
+  const headerMeta = [asString(data?.provider), asString(data?.model), thinkingLevel ? `thinking ${thinkingLevel}` : "", toolsUsed.length ? `${toolsUsed.length} tools` : "", `${visibleEvents.length} events`, runWarnings.length ? "partial trace" : ""].filter(Boolean).join(" · ");
   const TurnIcon = data?.subagentName ? Workflow : MessageSquareText;
   const turnIconColor = data?.subagentName ? "text-cyan-600 dark:text-cyan-400" : "text-xyne-fg-tertiary";
   return (
@@ -666,6 +952,14 @@ function DebugTimelineSection({
       </summary>
 
       <div className="ml-1.5 border-l border-xyne-border-subtle pl-4 pb-3 pt-1 space-y-2">
+        {runWarnings.length > 0 && (
+          <div className="space-y-0.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1.5 text-[11px] leading-relaxed text-amber-800 dark:text-amber-200">
+            {runWarnings.map((warning, index) => (
+              <p key={`${index}-${warning}`} className="break-words">{warning}</p>
+            ))}
+          </div>
+        )}
+
         {Boolean(data?.task || data?.question || data?.providerError) && (
           <p className={`text-[12px] leading-relaxed ${data?.providerError ? "text-red-600 dark:text-red-400" : "text-xyne-fg-secondary"}`}>
             {asString(data?.providerError) || asString(data?.question) || asString(data?.task)}
@@ -762,9 +1056,12 @@ function DebugTimelineSection({
                     selected={selectedEventKey === `${String(event.seq ?? idx)}`}
                     onSelect={onSelectEvent}
                     subagentTracesByParentToolCallId={subagentTracesByParentToolCallId}
+                    transcript={transcript}
                     originMs={originMs}
+                    prevMs={idx > 0 ? eventTimesMs[idx - 1] : undefined}
                     timeMode={timeMode}
                     indented={indented}
+                    live={live}
                   />
                 );
               })}
@@ -821,15 +1118,210 @@ function MessageSnapshot({ message }: { message: unknown }) {
   );
 }
 
+/**
+ * The system prompt with its `<available_skills>` block tinted. The block is the
+ * answer to "which skills could the model even see", and it is unfindable by eye
+ * inside a 20 KB prompt. Rendered as real nodes — never innerHTML — so prompt
+ * text that contains markup stays inert.
+ */
+function SystemPromptText({ text }: { text: string }) {
+  const parts = useMemo(() => {
+    const closed = /<available_skills>[\s\S]*?<\/available_skills>/.exec(text);
+    // A truncated prompt loses the closing tag; highlight to the end instead of
+    // silently giving up on the one region worth finding.
+    const start = closed ? closed.index : text.indexOf("<available_skills>");
+    if (start < 0) return null;
+    const end = closed ? closed.index + closed[0].length : text.length;
+    return { before: text.slice(0, start), block: text.slice(start, end), after: text.slice(end) };
+  }, [text]);
+
+  if (!parts) return <>{text}</>;
+  return (
+    <>
+      {parts.before}
+      <span className="rounded-sm bg-amber-400/20 text-xyne-fg-primary ring-1 ring-inset ring-amber-500/30">{parts.block}</span>
+      {parts.after}
+    </>
+  );
+}
+
+type SkillEntry = { name: string; description: string; location: string };
+
+function skillEntries(value: unknown): SkillEntry[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const name = asString(item.name);
+    return name ? [{ name, description: asString(item.description), location: asString(item.location) }] : [];
+  });
+}
+
+function AvailableSkillsPanel({ skills }: { skills: SkillEntry[] }) {
+  if (skills.length === 0) return null;
+  return (
+    <details className="group/sk rounded-md bg-xyne-surface">
+      <summary className="flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5">
+        <ChevronDown size={11} className="shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/sk:rotate-0" />
+        <Sparkles size={11} className="shrink-0 self-center text-xyne-fg-tertiary" />
+        <span className="text-[12px] font-semibold text-xyne-fg-secondary">Available skills</span>
+        <span className="ml-auto text-[11px] text-xyne-fg-muted">{skills.length} skill{skills.length === 1 ? "" : "s"}</span>
+      </summary>
+      <div className="max-h-72 overflow-y-auto overscroll-contain px-2 pb-2 pt-1">
+        {skills.map((skill) => (
+          <div key={skill.name} className="border-b border-xyne-border-subtle/40 py-1 last:border-b-0">
+            <p className="font-mono text-[11.5px] text-xyne-fg-primary">{skill.name}</p>
+            {skill.description && <p className="text-[11.5px] leading-relaxed text-xyne-fg-muted">{skill.description}</p>}
+            {skill.location && <p className="truncate font-mono text-[10px] text-xyne-fg-tertiary">{skill.location}</p>}
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+type ToolEntry = { name: string; description: string; parameters: unknown };
+
+/** Full definitions when the trace has them, name-only rows when it only kept
+ *  `toolNames` — a shorter list is still the truth about what was offered. */
+function toolEntries(data: Record<string, unknown>): ToolEntry[] {
+  if (Array.isArray(data.tools)) {
+    return data.tools.flatMap((item) => {
+      if (!isRecord(item)) return [];
+      const name = asString(item.name);
+      return name ? [{ name, description: asString(item.description), parameters: item.parameters }] : [];
+    });
+  }
+  return stringList(data.toolNames).map((name) => ({ name, description: "", parameters: undefined }));
+}
+
+function ToolDefinitionsPanel({ tools }: { tools: ToolEntry[] }) {
+  if (tools.length === 0) return null;
+  return (
+    <details className="group/tools rounded-md bg-xyne-surface">
+      <summary className="flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5">
+        <ChevronDown size={11} className="shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/tools:rotate-0" />
+        <Wrench size={11} className="shrink-0 self-center text-xyne-fg-tertiary" />
+        <span className="text-[12px] font-semibold text-xyne-fg-secondary">Tools offered</span>
+        <span className="ml-auto text-[11px] text-xyne-fg-muted">{tools.length} tool{tools.length === 1 ? "" : "s"}</span>
+      </summary>
+      <div className="max-h-96 overflow-y-auto overscroll-contain px-2 pb-2 pt-1">
+        {tools.map((tool) => (
+          <details key={tool.name} className="group/tool border-b border-xyne-border-subtle/40 last:border-b-0">
+            <summary className="flex cursor-pointer list-none items-baseline gap-2 py-1">
+              <ChevronDown size={10} className="shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/tool:rotate-0" />
+              <span className="shrink-0 font-mono text-[11.5px] text-xyne-fg-primary">{tool.name}</span>
+              {tool.description && <span className="min-w-0 truncate text-[11.5px] text-xyne-fg-muted">{tool.description}</span>}
+            </summary>
+            <div className="ml-1.5 border-l border-xyne-border-subtle pb-1 pl-3 pt-1 space-y-1">
+              {tool.description && <p className="text-[11.5px] leading-relaxed text-xyne-fg-secondary">{tool.description}</p>}
+              {tool.parameters !== undefined
+                ? <JsonViewer value={tool.parameters} title={`${tool.name} parameters`} defaultExpandedDepth={2} scroll={false} />
+                : <p className="text-[11px] text-xyne-fg-muted">No parameter schema captured for this tool.</p>}
+            </div>
+          </details>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+/** The mid-run palette diff (load-tools / fast-mode), which otherwise only ever
+ *  showed up as a silent change in what the model could call. */
+function PaletteChips({ added, removed }: { added: string[]; removed: string[] }) {
+  if (added.length === 0 && removed.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1 rounded-md bg-xyne-surface px-2 py-1.5">
+      <span className="mr-1 text-[11px] text-xyne-fg-muted">Tool palette</span>
+      {added.map((name) => (
+        <span key={`add-${name}`} className="rounded bg-emerald-500/10 px-1 font-mono text-[10.5px] text-emerald-700 dark:text-emerald-300">+{name}</span>
+      ))}
+      {removed.map((name) => (
+        <span key={`rm-${name}`} className="rounded bg-red-500/10 px-1 font-mono text-[10.5px] text-red-700 dark:text-red-300">−{name}</span>
+      ))}
+    </div>
+  );
+}
+
+function RequestParamsStrip({ data }: { data: Record<string, unknown> }) {
+  const items: Array<[string, string]> = [];
+  const push = (label: string, value: string) => { if (value) items.push([label, value]); };
+  push("Model", asString(data.model));
+  push("Provider", asString(data.provider));
+  if (typeof data.temperature === "number") push("Temp", String(data.temperature));
+  if (typeof data.maxTokens === "number") push("Max tokens", String(data.maxTokens));
+  push("Thinking", asString(data.thinkingLevel));
+  if (typeof data.fastMode === "boolean") push("Fast mode", data.fastMode ? "on" : "off");
+  push("Stop", asString(data.responseStopReason));
+
+  const usage = isRecord(data.responseUsage) ? data.responseUsage : null;
+  const cacheRead = typeof usage?.cacheRead === "number" ? usage.cacheRead : null;
+  const cacheWrite = typeof usage?.cacheWrite === "number" ? usage.cacheWrite : null;
+  if (cacheRead != null || cacheWrite != null) {
+    // Read tokens are the cache HIT: zero reads on a repeat turn is the tell for
+    // a prompt-cache miss, which is why the raw numbers stay visible.
+    push("Cache", `${cacheRead ?? 0} read / ${cacheWrite ?? 0} write · ${(cacheRead ?? 0) > 0 ? "hit" : "miss"}`);
+  }
+  if (typeof data.ttftMs === "number") push("TTFT", `${data.ttftMs}ms`);
+
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1 rounded-md bg-xyne-surface px-2 py-1.5 text-[11px] text-xyne-fg-secondary">
+      {items.map(([label, value]) => (
+        <span key={label}><span className="text-xyne-fg-muted">{label}:</span> {value}</span>
+      ))}
+    </div>
+  );
+}
+
+/** Non-fatal read problems for the run(s) on screen. Without this a partial
+ *  artifact read is indistinguishable from an agent that simply did nothing. */
+function WarningsNotice({ warnings }: { warnings: string[] }) {
+  const [expanded, setExpanded] = useState(false);
+  if (warnings.length === 0) return null;
+  const shown = expanded ? warnings : warnings.slice(0, 3);
+  return (
+    <div className="flex shrink-0 gap-2 border-b border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-[11px] text-amber-800 dark:text-amber-200">
+      <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <p className="font-semibold">Partial trace · {warnings.length} warning{warnings.length === 1 ? "" : "s"}</p>
+        {shown.map((warning, index) => (
+          <p key={`${index}-${warning}`} className="break-words leading-relaxed">{warning}</p>
+        ))}
+        {warnings.length > 3 && (
+          <button type="button" onClick={() => setExpanded((current) => !current)} className="underline underline-offset-2 hover:no-underline">
+            {expanded ? "Show less" : `Show ${warnings.length - 3} more`}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function collectWarnings(bundle: DebugArtifactBundle | null): string[] {
+  if (!bundle) return [];
+  const sources: unknown[] = [
+    bundle.warnings,
+    bundle.debugSession?.warnings,
+    ...(bundle.runs ?? []).map((run) => run.data.warnings),
+    ...(bundle.subagents ?? []).map((sub) => sub.data.warnings),
+  ];
+  // Runs share most warnings (same blob log, same GCS miss) — dedupe or the
+  // strip turns into a wall of the same line.
+  return [...new Set(sources.flatMap((source) => stringList(source)))];
+}
+
 function DebugEventItem({
   event,
   eventKey,
   selected = false,
   onSelect,
   subagentTracesByParentToolCallId,
+  transcript,
   originMs,
+  prevMs,
   timeMode = "delta",
   indented = false,
+  live = false,
 }: {
   event: unknown;
   eventKey: string;
@@ -837,12 +1329,21 @@ function DebugEventItem({
   selected?: boolean;
   onSelect?: (key: string) => void;
   subagentTracesByParentToolCallId?: Map<string, SubagentTraceGroup[]>;
-  /** Run start (ms) used to compute Δ timestamps. */
+  /** The run's full transcript. A turn's panel is the prefix ending at this
+   *  event's `messagesTo`; absent on the live stream, where there is no
+   *  snapshot yet. */
+  transcript?: unknown[];
+  /** Earliest event in the run — used for the "into run" figure on hover. */
   originMs?: number;
+  /** Timestamp of the row above this one; Δ is measured against it. */
+  prevMs?: number;
   /** "delta" → +Xs from run start (default); "abs" → wall-clock time. */
   timeMode?: "delta" | "abs";
   /** Sub-steps of a turn (thinking / assistant / tool) indent under the spine. */
   indented?: boolean;
+  /** This row came off the LIVE stream, where every big payload is still just a
+   *  blob-ref preview. Changes what the ref affordances promise. */
+  live?: boolean;
 }) {
   if (!isRecord(event)) {
     return <JsonViewer value={event} title="Event" />;
@@ -862,10 +1363,41 @@ function DebugEventItem({
     ? subagentTracesByParentToolCallId.get(asString(data.toolCallId) || asString(event.toolCallId)) ?? []
     : [];
 
+  // session_prompt carries the folded llm_request: the TRUE system prompt (with
+  // its <available_skills> block), the tool schemas the model was handed, and
+  // the request params. Payloads may be inline strings or blob refs.
+  const isPromptEvent = kind === "session_prompt" || kind === "llm_request";
+  const systemPromptField = resolveFieldText(data, "systemPrompt");
+  const userPromptField = resolveFieldText(data, "prompt");
+  const availableSkills = isPromptEvent ? skillEntries(data.availableSkills) : [];
+  const offeredTools = isPromptEvent ? toolEntries(data) : [];
+  const paletteAdded = paletteList(data, "paletteAdded", "added");
+  const paletteRemoved = paletteList(data, "paletteRemoved", "removed");
+  // Only consulted when the lists came back empty — a palette diff big enough
+  // to be interned arrives as `addedRef`/`removedRef` with a preview.
+  const paletteAddedField = resolveFieldText(data, "added");
+  const paletteRemovedField = resolveFieldText(data, "removed");
+  const thinkingField = resolveFieldText(data, "text");
+  const assistantField = resolveFieldText(data, "assistantText");
+  const errorField = resolveFieldText(data, "error");
+  // A ref can sit in the field itself, so "present" is not the same as "inline".
+  const hasInlineResult = "result" in data && !asBlobRef(data.result);
+  const hasInlineArgs = "args" in data && !asBlobRef(data.args);
+  const resultField = hasInlineResult ? null : resolveFieldText(data, "result");
+  const argsField = hasInlineArgs ? null : resolveFieldText(data, "args");
+  // Older traces embedded the prefix per event; newer ones carry only the
+  // cursor. Accept both so a trace written before this change still renders.
+  const panelMessages = Array.isArray(data.messages)
+    ? data.messages
+    : transcript && typeof data.messagesTo === "number"
+      ? transcript.slice(0, Math.max(0, Math.min(data.messagesTo, transcript.length)))
+      : undefined;
+  const messagesField = panelMessages ? null : resolveFieldText(data, "messages");
+
   const summary = eventSummary(kind, data);
   // LLM request is low-signal: its msg count rides on the title, so suppress the
   // redundant "Sending N messages" preview.
-  const showSummary = Boolean(summary) && kind !== "session_prompt";
+  const showSummary = Boolean(summary) && !isPromptEvent;
   const timestamp = isTool ? (at || startedAt) : at;
   const visual = eventVisual(kind, isError);
   const VisualIcon = visual.Icon;
@@ -876,7 +1408,7 @@ function DebugEventItem({
   const isFinalAssistant = kind === "assistant_turn_end" && !indented;
   const titleText = isTool
     ? (asString(data.toolName) || "tool")
-    : kind === "session_prompt"
+    : isPromptEvent
       ? `LLM request${msgCount != null ? ` · ${msgCount} msgs` : ""}`
       : isFinalAssistant
         ? "Assistant response · final"
@@ -889,13 +1421,25 @@ function DebugEventItem({
         ? "font-mono font-medium text-xyne-fg-primary"
         : "font-semibold text-xyne-fg-primary";
 
-  // Time column: Δ-from-start by default (de-noises repeated wall-clock times),
-  // absolute on the abs toggle and always on hover.
+  // Time column: the gap since the previous row by default, absolute on the abs
+  // toggle. A run-start-relative column looks like a stopwatch and hides the one
+  // thing a timeline is read for — which step took the time.
   const eventMs = timestamp ? Date.parse(timestamp) : NaN;
   const absTime = timestamp ? formatTime(timestamp) : "";
-  const timeText = timeMode === "abs" || originMs == null || !Number.isFinite(eventMs)
+  const gapMs = prevMs != null && Number.isFinite(eventMs) ? eventMs - prevMs : undefined;
+  const timeText = timeMode === "abs" || !Number.isFinite(eventMs)
     ? absTime
-    : formatDelta(eventMs - originMs);
+    : gapMs === undefined
+      ? "+0.0s" // first row: nothing precedes it
+      : formatDelta(gapMs);
+  // Everything the column no longer shows, on hover.
+  const timeTitle = [
+    absTime,
+    originMs != null && Number.isFinite(eventMs) ? `${formatDelta(eventMs - originMs).replace(/^\+/, "")} into run` : "",
+    gapMs !== undefined ? `${formatDelta(gapMs).replace(/^\+/, "")} since previous` : "",
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   return (
     <details className={`group/event border-l-2 ${visual.rail} ${indented ? "ml-4" : ""} ${selected ? "bg-xyne-surface-subtle/60" : "hover:bg-black/[0.015] dark:hover:bg-white/[0.025]"}`}>
@@ -916,7 +1460,7 @@ function DebugEventItem({
             <span className="shrink-0 text-[10px] text-cyan-600 dark:text-cyan-400">+{subagentTraces.length} sub</span>
           )}
           <span className="ml-auto flex shrink-0 items-center font-mono text-[10.5px] tabular-nums">
-            <span className="w-[50px] text-right text-xyne-fg-secondary" title={absTime}>{timeText}</span>
+            <span className="w-[50px] text-right text-xyne-fg-secondary" title={timeTitle}>{timeText}</span>
             <span className="w-[50px] text-right text-xyne-fg-muted">{isTool && duration ? `${duration}ms` : ""}</span>
             <span className="w-[58px] text-right">
               {isTool && (data.isError
@@ -935,46 +1479,68 @@ function DebugEventItem({
         )}
       </summary>
       <div className={`pl-[16px] pr-2 pb-3 pt-1 space-y-1.5 ${selected ? "bg-xyne-surface-subtle/60" : ""}`}>
-        {kind === "session_prompt" && (
+        {isPromptEvent && (
           <div className="space-y-1.5">
-            {typeof data.systemPrompt === "string" && data.systemPrompt && (
+            <RequestParamsStrip data={data} />
+            {systemPromptField && (
               <details className="group/sp rounded-md bg-xyne-surface">
                 <summary className="flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5">
                   <ChevronDown size={11} className="shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/sp:rotate-0" />
                   <FileText size={11} className="shrink-0 self-center text-xyne-fg-tertiary" />
                   <span className="text-[12px] font-semibold text-xyne-fg-secondary">System prompt</span>
-                  <span className="ml-auto text-[11px] text-xyne-fg-muted">{data.systemPrompt.length} chars</span>
+                  <span className="ml-auto text-[11px] text-xyne-fg-muted">{fieldSizeLabel(systemPromptField)}</span>
                 </summary>
                 <div className="px-2 pb-2 pt-1">
-                  <pre className="max-h-72 overflow-auto whitespace-pre-wrap text-[12px] leading-relaxed text-xyne-fg-secondary">{data.systemPrompt}</pre>
+                  <pre className="max-h-72 overflow-auto whitespace-pre-wrap text-[12px] leading-relaxed text-xyne-fg-secondary">
+                    {systemPromptField.text ? <SystemPromptText text={systemPromptField.text} /> : "(payload not captured)"}
+                  </pre>
+                  {systemPromptField.isRef && (
+                    <p className="mt-1 text-[11px] text-amber-700 dark:text-amber-300">{refNote(systemPromptField, live)}</p>
+                  )}
                 </div>
               </details>
             )}
-            {Array.isArray(data.messages) && data.messages.length > 0 && (
+            <AvailableSkillsPanel skills={availableSkills} />
+            <ToolDefinitionsPanel tools={offeredTools} />
+            <PaletteChips added={paletteAdded} removed={paletteRemoved} />
+            {panelMessages && panelMessages.length > 0 && (
               <details className="group/im rounded-md bg-xyne-surface">
                 <summary className="flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5">
                   <ChevronDown size={11} className="shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/im:rotate-0" />
                   <MessagesSquare size={11} className="shrink-0 self-center text-xyne-fg-tertiary" />
                   <span className="text-[12px] font-semibold text-xyne-fg-secondary">Input messages</span>
-                  <span className="ml-auto text-[11px] text-xyne-fg-muted">{data.messages.length} message{data.messages.length === 1 ? "" : "s"}</span>
+                  <span className="ml-auto text-[11px] text-xyne-fg-muted">{panelMessages.length} message{panelMessages.length === 1 ? "" : "s"}</span>
                 </summary>
                 <div className="px-2 pb-2 pt-1">
-                  {data.messages.map((msg, idx) => (
+                  {panelMessages.map((msg, idx) => (
                     <MessageSnapshot key={`${seq}-msg-${idx}`} message={msg} />
                   ))}
                 </div>
               </details>
             )}
-            {typeof data.prompt === "string" && data.prompt && (
+            {messagesField && (
+              <details className="group/imr rounded-md bg-xyne-surface">
+                <summary className="flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5">
+                  <ChevronDown size={11} className="shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/imr:rotate-0" />
+                  <MessagesSquare size={11} className="shrink-0 self-center text-xyne-fg-tertiary" />
+                  <span className="text-[12px] font-semibold text-xyne-fg-secondary">Input messages</span>
+                  <span className="ml-auto text-[11px] text-xyne-fg-muted">{fieldSizeLabel(messagesField)}</span>
+                </summary>
+                <div className="px-2 pb-2 pt-1">
+                  <FieldText field={messagesField} live={live} />
+                </div>
+              </details>
+            )}
+            {userPromptField && (
               <details className="group/up rounded-md bg-xyne-surface">
                 <summary className="flex cursor-pointer list-none items-baseline gap-2 px-2 py-1.5">
                   <ChevronDown size={11} className="shrink-0 self-center text-xyne-fg-tertiary transition-transform -rotate-90 group-open/up:rotate-0" />
                   <User size={11} className="shrink-0 self-center text-xyne-fg-tertiary" />
                   <span className="text-[12px] font-semibold text-xyne-fg-secondary">User prompt</span>
-                  <span className="ml-auto text-[11px] text-xyne-fg-muted">{data.prompt.length} chars</span>
+                  <span className="ml-auto text-[11px] text-xyne-fg-muted">{fieldSizeLabel(userPromptField)}</span>
                 </summary>
                 <div className="px-2 pb-2 pt-1">
-                  <pre className="max-h-64 overflow-auto whitespace-pre-wrap text-[12px] leading-relaxed text-xyne-fg-secondary">{data.prompt}</pre>
+                  <FieldText field={userPromptField} className="max-h-64" live={live} />
                 </div>
               </details>
             )}
@@ -987,19 +1553,31 @@ function DebugEventItem({
 
         {kind === "tool_execution_start" && (
           <div className="space-y-1.5">
-            {"args" in data && (
+            {hasInlineArgs && (
               <div className="space-y-1 rounded-md bg-xyne-surface px-2 py-1.5">
                 <p className="text-[12px] font-semibold text-xyne-fg-secondary">Arguments</p>
                 <JsonViewer value={data.args} title="Arguments" defaultExpandedDepth={999} />
               </div>
             )}
-            <SubagentTraceInline traces={subagentTraces} />
+            {argsField && (
+              <div className="space-y-1 rounded-md bg-xyne-surface px-2 py-1.5">
+                <p className="text-[12px] font-semibold text-xyne-fg-secondary">Arguments</p>
+                <FieldText field={argsField} live={live} />
+              </div>
+            )}
+            <SubagentTraceInline traces={subagentTraces} live={live} />
           </div>
         )}
 
         {kind === "tool_execution_end" && (
           <div className="space-y-1.5">
-            {"args" in data && (
+            {argsField && (
+              <div className="space-y-1 rounded-md bg-xyne-surface px-2 py-1.5">
+                <p className="text-[12px] font-semibold text-xyne-fg-secondary">Arguments</p>
+                <FieldText field={argsField} live={live} />
+              </div>
+            )}
+            {hasInlineArgs && (
               <div className="space-y-1 rounded-md bg-xyne-surface px-2 py-1.5">
                 <p className="text-[12px] font-semibold text-xyne-fg-secondary">Arguments</p>
                 <JsonViewer value={data.args} title="Arguments" defaultExpandedDepth={999} />
@@ -1030,29 +1608,41 @@ function DebugEventItem({
                 ))}
               </div>
             )}
-            {"result" in data && (
+            {hasInlineResult && (
               <div className="space-y-1 rounded-md bg-xyne-surface px-2 py-1.5">
                 <p className="text-[12px] font-semibold text-xyne-fg-secondary">Result</p>
                 <ToolResultView value={data.result} />
               </div>
             )}
-            <SubagentTraceInline traces={subagentTraces} />
+            {resultField && (
+              <div className="space-y-1 rounded-md bg-xyne-surface px-2 py-1.5">
+                <p className="text-[12px] font-semibold text-xyne-fg-secondary">Result</p>
+                <FieldText field={resultField} live={live} />
+              </div>
+            )}
+            <SubagentTraceInline traces={subagentTraces} live={live} />
           </div>
         )}
 
-        {kind === "thinking" && typeof data.text === "string" && (
+        {kind === "thinking" && thinkingField && (
           // Match the collapsed preview exactly (italic sans, secondary, aligned
           // under the title) so expanding just reveals the FULL text in place,
           // not a heavier card with a different font.
-          <p className="whitespace-pre-wrap pl-[58px] pr-6 text-[12px] italic leading-relaxed text-xyne-fg-secondary">{data.text}</p>
+          <p className="whitespace-pre-wrap pl-[58px] pr-6 text-[12px] italic leading-relaxed text-xyne-fg-secondary">
+            {thinkingField.text || "(payload not captured)"}
+            {thinkingField.isRef && <span className="not-italic text-amber-700 dark:text-amber-300"> · {refNote(thinkingField, live)}</span>}
+          </p>
         )}
 
         {kind === "assistant_turn_end" && (
           <div className="space-y-1.5">
-            {typeof data.assistantText === "string" && (
+            {assistantField && (
               // Same casual-expand treatment as thinking (non-italic, matches the
               // assistant preview). Usage stats stay below as a metadata row.
-              <p className="whitespace-pre-wrap pl-[58px] pr-6 text-[12px] leading-relaxed text-xyne-fg-secondary">{data.assistantText}</p>
+              <p className="whitespace-pre-wrap pl-[58px] pr-6 text-[12px] leading-relaxed text-xyne-fg-secondary">
+                {assistantField.text || "(payload not captured)"}
+                {assistantField.isRef && <span className="text-amber-700 dark:text-amber-300"> · {refNote(assistantField, live)}</span>}
+              </p>
             )}
             {(isRecord(data.usage) || typeof data.streamChars === "number" || typeof data.streamCharsPerSec === "number") && (
               <div className="flex flex-wrap gap-x-4 gap-y-1 rounded-md bg-xyne-surface px-2 py-1.5 text-[11px] text-xyne-fg-secondary">
@@ -1068,8 +1658,34 @@ function DebugEventItem({
           </div>
         )}
 
-        {kind === "session_error" && typeof data.error === "string" && (
-          <pre className="whitespace-pre-wrap rounded-md bg-xyne-surface p-2 text-[12px] leading-relaxed text-red-700 dark:text-red-300">{data.error}</pre>
+        {kind === "session_error" && errorField && (
+          <pre className="whitespace-pre-wrap rounded-md bg-xyne-surface p-2 text-[12px] leading-relaxed text-red-700 dark:text-red-300">
+            {errorField.text || "(payload not captured)"}
+            {errorField.isRef ? ` · ${refNote(errorField, live)}` : ""}
+          </pre>
+        )}
+
+        {kind === "tool_palette_change" && (
+          paletteAdded.length > 0 || paletteRemoved.length > 0 ? (
+            <PaletteChips added={paletteAdded} removed={paletteRemoved} />
+          ) : (
+            // The `initial` palette event lists EVERY tool, which is big enough
+            // to get interned — show the ref's preview instead of an empty row.
+            <>
+              {paletteAddedField && (
+                <div className="space-y-1 rounded-md bg-xyne-surface px-2 py-1.5">
+                  <p className="text-[12px] font-semibold text-xyne-fg-secondary">Added</p>
+                  <FieldText field={paletteAddedField} live={live} />
+                </div>
+              )}
+              {paletteRemovedField && (
+                <div className="space-y-1 rounded-md bg-xyne-surface px-2 py-1.5">
+                  <p className="text-[12px] font-semibold text-xyne-fg-secondary">Removed</p>
+                  <FieldText field={paletteRemovedField} live={live} />
+                </div>
+              )}
+            </>
+          )
         )}
 
         {kind === "session_end" && (
@@ -1082,7 +1698,7 @@ function DebugEventItem({
           </div>
         )}
 
-        {!["session_prompt", "tool_execution_start", "tool_execution_end", "assistant_turn_end", "session_error", "session_end"].includes(kind) && (
+        {!["session_prompt", "llm_request", "tool_execution_start", "tool_execution_end", "assistant_turn_end", "session_error", "session_end"].includes(kind) && (
           <details className="rounded-md bg-xyne-surface">
             <summary className="cursor-pointer list-none px-2 py-1.5 text-[11px] text-xyne-fg-muted hover:text-xyne-fg-secondary">Show raw event data</summary>
             <div className="px-2 pb-2 pt-1"><JsonViewer value={data} title="Event data" /></div>
@@ -1136,16 +1752,22 @@ function LiveDebugTrace({
     <div>
       {rootEvents.length > 0 && (
         <div>
-          {rootEvents.map((event, idx) => (
-            <DebugEventItem
-              key={`live-root-${event.seq}-${idx}`}
-              event={event}
-              eventKey={`live-root-${event.seq}-${idx}`}
-              selected={selectedEventKey === `live-root-${event.seq}-${idx}`}
-              onSelect={onSelectEvent}
-              subagentTracesByParentToolCallId={subagentTraceGroups}
-            />
-          ))}
+          {rootEvents.map((event, idx) => {
+            const prev = idx > 0 ? rootEvents[idx - 1] : undefined;
+            const prevAt = prev ? Date.parse(asString(prev.at) || asString(prev.startedAt)) : NaN;
+            return (
+              <DebugEventItem
+                key={`live-root-${event.seq}-${idx}`}
+                event={event}
+                eventKey={`live-root-${event.seq}-${idx}`}
+                selected={selectedEventKey === `live-root-${event.seq}-${idx}`}
+                onSelect={onSelectEvent}
+                subagentTracesByParentToolCallId={subagentTraceGroups}
+                {...(Number.isFinite(prevAt) ? { prevMs: prevAt } : {})}
+                live
+              />
+            );
+          })}
         </div>
       )}
     </div>
@@ -1156,7 +1778,8 @@ function eventSummary(kind: string, data: Record<string, unknown>): string {
   switch (kind) {
     case "session_start":
       return asString(data.task);
-    case "session_prompt": {
+    case "session_prompt":
+    case "llm_request": {
       const count = typeof data.messageCount === "number" ? data.messageCount : 0;
       return count ? `Sending ${count} message${count === 1 ? "" : "s"} to the model` : "";
     }
@@ -1164,9 +1787,24 @@ function eventSummary(kind: string, data: Record<string, unknown>): string {
     case "tool_execution_end":
       return "";
     case "thinking":
-      return typeof data.text === "string" ? truncate(data.text, 240) : "";
+      return truncate(resolveFieldText(data, "text")?.text ?? "", 240);
     case "assistant_turn_end":
-      return typeof data.assistantText === "string" ? truncate(data.assistantText, 240) : "";
+      return truncate(resolveFieldText(data, "assistantText")?.text ?? "", 240);
+    case "tool_palette_change": {
+      const added = paletteList(data, "paletteAdded", "added").length;
+      const removed = paletteList(data, "paletteRemoved", "removed").length;
+      const parts = [added ? `+${added}` : "", removed ? `−${removed}` : ""].filter(Boolean).join(" ");
+      return parts ? `Tool palette ${parts}` : "";
+    }
+    case "skill_loaded":
+      return asString(data.name) || asString(data.skill) || asString(data.location);
+    case "subagent_start":
+    case "subagent_end":
+      return asString(data.subagentName) || asString(data.task) || asString(data.question);
+    case "delegation":
+      return asString(data.targetAgent) || asString(data.task) || asString(data.question);
+    case "provider_fallback":
+      return asString(data.reason) || [asString(data.from), asString(data.to)].filter(Boolean).join(" → ");
     case "compaction_start":
       return "Conversation history is being condensed";
     case "compaction_end": {
@@ -1180,7 +1818,7 @@ function eventSummary(kind: string, data: Record<string, unknown>): string {
     case "auto_retry_start":
       return "Retrying after a transient error";
     case "session_error":
-      return asString(data.error);
+      return truncate(resolveFieldText(data, "error")?.text ?? "", 240);
     case "session_end":
       return "";
     case "citation_reflection": {
@@ -1220,7 +1858,7 @@ function groupSubagentTraces(traces: DebugArtifactBundle["subagents"]): Subagent
     .filter((item) => item.parentToolCallId);
 }
 
-function SubagentTraceInline({ traces }: { traces: SubagentTraceGroup[] }) {
+function SubagentTraceInline({ traces, live = false }: { traces: SubagentTraceGroup[]; live?: boolean }) {
   if (traces.length === 0) return null;
   return (
     <div className="mt-1 space-y-1.5">
@@ -1234,6 +1872,7 @@ function SubagentTraceInline({ traces }: { traces: SubagentTraceGroup[] }) {
             <DebugTimelineSection
               title={`${sub.subagentName}: ${truncate(asString(sub.trace.question) || "Subagent task", 80)}`}
               data={sub.trace}
+              live={live}
             />
           </div>
         ))}
@@ -1331,10 +1970,16 @@ function DebugSessionBody({
   bundle,
   selectedTurnIndex,
   selectedSessionId,
+  onLoadOlderRuns,
+  loadingOlderRuns = false,
 }: {
   bundle: DebugArtifactBundle;
   selectedTurnIndex?: number | null;
   selectedSessionId?: string | null;
+  /** Absent once the server-side page cap is reached — the older runs are then
+   *  only reachable by cursor, which this drawer doesn't drive. */
+  onLoadOlderRuns?: () => void;
+  loadingOlderRuns?: boolean;
 }) {
   const [selectedEventKey, setSelectedEventKey] = useState<string | null>(null);
   const [timeMode, setTimeMode] = useState<"delta" | "abs">("delta");
@@ -1383,6 +2028,29 @@ function DebugSessionBody({
           </p>
         </div>
       </div>
+
+      {/* The run list is a capped PAGE. Without this line a long thread just
+          stops at its 25th-newest run and looks like that is all there ever
+          was — the older runs exist, they were simply not fetched. */}
+      {bundle.truncated && (
+        <div className="flex flex-wrap items-center gap-2 rounded-md border border-xyne-border-subtle bg-xyne-surface-subtle px-2 py-1.5 text-[11px] text-xyne-fg-muted">
+          <span>
+            Showing {persistedRuns.length} of {bundle.totalRuns ?? persistedRuns.length} runs · older runs not loaded
+          </span>
+          {onLoadOlderRuns ? (
+            <button
+              type="button"
+              onClick={onLoadOlderRuns}
+              disabled={loadingOlderRuns}
+              className="rounded border border-xyne-border-subtle bg-xyne-surface px-1.5 py-0.5 font-medium text-xyne-fg-secondary transition hover:border-xyne-border hover:text-xyne-fg-primary disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loadingOlderRuns ? "Loading…" : "Load older runs"}
+            </button>
+          ) : (
+            <span>page limit reached</span>
+          )}
+        </div>
+      )}
 
       {legacyPairs.map((pair, index) => {
         // Hide legacy pairs entirely when a sessionId selector is active —
@@ -1470,16 +2138,28 @@ function DebugSessionBody({
   );
 }
 
+/** claw's own defaults for the run page (`DEFAULT_RUN_LIMIT` / `MAX_RUN_LIMIT`
+ *  in its debug route). Raising `limit` IS the paging UI here: one more click
+ *  fetches an older slab, up to the server's ceiling. */
+const RUN_PAGE_DEFAULT = 25;
+const RUN_PAGE_MAX = 100;
+
 export function DebugDrawer({ open, agentSlug, conversationId, onClose, inline = false, width = 460, liveEvents = [], running = false, artifactsReadyVersion = 0, selectedTurnIndex = null, selectedTurnLive = false, selectedSessionId = null }: DebugDrawerProps) {
   const [bundle, setBundle] = useState<DebugArtifactBundle | null>(null);
   const [bundleHasCurrentRun, setBundleHasCurrentRun] = useState(true);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [refreshVersion, setRefreshVersion] = useState(0);
+  const [runLimit, setRunLimit] = useState(RUN_PAGE_DEFAULT);
+  // A wider page refetches in the background (the current bundle stays on
+  // screen), so the button needs its own pending flag — `loading` only covers
+  // the first, bundle-less fetch.
+  const [olderRunsPending, setOlderRunsPending] = useState(false);
   const [showLiveTrace, setShowLiveTrace] = useState(false);
   const expectedRunRef = useRef<{ sessionId?: string; startedAt: number } | null>(null);
   const previousRunningRef = useRef(false);
   const previousArtifactsReadyVersionRef = useRef(artifactsReadyVersion);
+  const warnings = useMemo(() => collectWarnings(bundle), [bundle]);
   const currentLiveStream = useMemo(() => liveStreamStatus(liveEvents), [liveEvents]);
   const savedStream = useMemo(() => persistedStreamStatus(bundle), [bundle]);
   const streamStatus = running && currentLiveStream ? currentLiveStream : savedStream ?? currentLiveStream;
@@ -1522,6 +2202,8 @@ export function DebugDrawer({ open, agentSlug, conversationId, onClose, inline =
     setBundle(null);
     setBundleHasCurrentRun(true);
     setError(null);
+    setRunLimit(RUN_PAGE_DEFAULT);
+    setOlderRunsPending(false);
     previousArtifactsReadyVersionRef.current = artifactsReadyVersion;
   }, [agentSlug, conversationId]);
 
@@ -1536,7 +2218,7 @@ export function DebugDrawer({ open, agentSlug, conversationId, onClose, inline =
       if (inFlight) return false;
       inFlight = true;
       try {
-        const data = await fetchConversationDebugArtifacts(agentSlug, conversationId);
+        const data = await fetchConversationDebugArtifacts(agentSlug, conversationId, { limit: runLimit });
         if (cancelled) return false;
         setBundle(data);
         setError(null);
@@ -1580,7 +2262,11 @@ export function DebugDrawer({ open, agentSlug, conversationId, onClose, inline =
     return () => {
       cancelled = true;
     };
-  }, [open, agentSlug, conversationId, artifactsReadyVersion, refreshVersion]);
+  }, [open, agentSlug, conversationId, artifactsReadyVersion, refreshVersion, runLimit]);
+
+  // Any bundle landing (wider page, refresh, or in-progress poll) answers the
+  // pending "load older" click.
+  useEffect(() => { setOlderRunsPending(false); }, [bundle]);
 
   // A VIEWER / reloaded tab has no driving stream (`running` is false), so the
   // fetch runs once. When the fetched bundle is a PARTIAL in-progress run
@@ -1603,7 +2289,7 @@ export function DebugDrawer({ open, agentSlug, conversationId, onClose, inline =
     if (!open || running || !agentSlug || !conversationId || !bundleInProgress || livePollStopped) return;
     let cancelled = false;
     const id = window.setInterval(() => {
-      fetchConversationDebugArtifacts(agentSlug, conversationId)
+      fetchConversationDebugArtifacts(agentSlug, conversationId, { limit: runLimit })
         .then((data) => { if (!cancelled) setBundle(data); }) // a completed bundle flips bundleInProgress → effect tears down
         .catch(() => { if (!cancelled) setLivePollStopped(true); });
     }, 4000);
@@ -1611,7 +2297,7 @@ export function DebugDrawer({ open, agentSlug, conversationId, onClose, inline =
       cancelled = true;
       window.clearInterval(id);
     };
-  }, [open, running, agentSlug, conversationId, bundleInProgress, livePollStopped]);
+  }, [open, running, agentSlug, conversationId, bundleInProgress, livePollStopped, runLimit]);
 
   if (!open) return null;
 
@@ -1652,6 +2338,7 @@ export function DebugDrawer({ open, agentSlug, conversationId, onClose, inline =
           <X size={16} />
         </button>
       </div>
+      <WarningsNotice warnings={warnings} />
       {streamStatus && <StreamRateStatus rate={streamStatus.rate} collected={streamStatus.collected} live={running && streamStatus.live} />}
 
       <div className="min-h-0 flex-1 overflow-y-auto p-2.5">
@@ -1708,7 +2395,20 @@ export function DebugDrawer({ open, agentSlug, conversationId, onClose, inline =
             })()}
             <div className={`transition-all duration-300 ease-out ${bundle ? "opacity-100 translate-y-0" : "opacity-0 translate-y-1 pointer-events-none"}`}>
               {bundle ? (
-                <DebugSessionBody bundle={bundle} selectedTurnIndex={selectedTurnIndex} selectedSessionId={selectedSessionId} />
+                <DebugSessionBody
+                  bundle={bundle}
+                  selectedTurnIndex={selectedTurnIndex}
+                  selectedSessionId={selectedSessionId}
+                  loadingOlderRuns={olderRunsPending}
+                  {...(runLimit < RUN_PAGE_MAX
+                    ? {
+                        onLoadOlderRuns: () => {
+                          setOlderRunsPending(true);
+                          setRunLimit((limit) => Math.min(RUN_PAGE_MAX, limit + RUN_PAGE_DEFAULT));
+                        },
+                      }
+                    : {})}
+                />
               ) : (
                 <p className="py-6 text-[13px] text-xyne-fg-muted">
                   No debugger artifacts found for this conversation.

--- a/apps/xyne-claw-auth/frontend/src/lib/api.ts
+++ b/apps/xyne-claw-auth/frontend/src/lib/api.ts
@@ -2910,6 +2910,61 @@ export interface PlanTodo {
   status: PlanTodoStatus;
 }
 
+/** A payload interned into the v2 blob log and referenced by hash. Large fields
+ *  (system prompt, tool result, transcript) arrive as one of these instead of a
+ *  string whenever the blob content could not be inlined — capture level
+ *  `metadata`, or a blob log that lost its tail. `preview` is the first ~200
+ *  chars so a reader always has something to show. */
+export interface DebugBlobRef {
+  hash: string;
+  bytes: number;
+  originalBytes?: number;
+  truncated?: true;
+  preview?: string;
+}
+
+export interface DebugSkillRef {
+  name: string;
+  description?: string;
+  location?: string;
+}
+
+export interface DebugToolDefinition {
+  name: string;
+  description?: string;
+  /** JSON Schema the model was given for this tool's arguments. */
+  parameters?: unknown;
+}
+
+/**
+ * Event payload. Every field is optional and must be guarded at the read site:
+ * older runs predate them, capture level can drop them, and the big ones may
+ * come through as a `DebugBlobRef`. The index signature stays because readers
+ * (the debug drawer, the trace exporter) treat data as an open bag.
+ */
+export interface DebugEventData {
+  [key: string]: unknown;
+  /** On `session_prompt`, the TRUE prompt pi sent — persona plus the
+   *  `<available_skills>` block — not just the persona prompt. */
+  systemPrompt?: string | DebugBlobRef;
+  availableSkills?: DebugSkillRef[];
+  tools?: DebugToolDefinition[];
+  toolNames?: string[];
+  /** Mid-run tool-palette diff (load-tools / fast-mode). */
+  paletteAdded?: string[];
+  paletteRemoved?: string[];
+  temperature?: number;
+  maxTokens?: number;
+  thinkingLevel?: string;
+  fastMode?: boolean;
+  model?: string;
+  provider?: string;
+  /** `cacheRead`/`cacheWrite` are the prompt-cache hit/miss signal. */
+  responseUsage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+  responseStopReason?: string;
+  ttftMs?: number;
+}
+
 export interface DebugEventRecord {
   seq: number;
   at: string;
@@ -2919,7 +2974,9 @@ export interface DebugEventRecord {
   toolCallId?: string;
   parentToolCallId?: string;
   subagentName?: string;
-  data: Record<string, unknown>;
+  /** Run id of the child trace a `subagent_start` / `delegation` event spawned. */
+  childRunId?: string;
+  data: DebugEventData;
 }
 
 export interface StreamCallbacks {
@@ -3444,13 +3501,31 @@ export interface DebugArtifactBundle {
   debugEvents: Record<string, unknown>[] | null;
   runs: Array<{ fileName: string; data: Record<string, unknown> }>;
   subagents: Array<{ fileName: string; data: Record<string, unknown> }>;
+  /** Non-fatal problems hit while reading these artifacts (dropped torn line,
+   *  unreadable blob log, GCS miss). Surfaced in the drawer so a partial trace
+   *  never reads as "no data". Individual runs carry their own `data.warnings`. */
+  warnings?: string[];
+  /** Runs this viewer may see in the whole conversation. `runs` is one capped
+   *  page of them; without these a long thread silently loses its older runs. */
+  totalRuns?: number;
+  /** True when runs older than this page exist — ask again with a bigger
+   *  `limit`, or with `before` set to the oldest runId on this page. */
+  truncated?: boolean;
 }
 
-export async function fetchConversationDebugArtifacts(slug: string, conversationId: string): Promise<DebugArtifactBundle> {
+export async function fetchConversationDebugArtifacts(
+  slug: string,
+  conversationId: string,
+  opts?: { limit?: number; before?: string },
+): Promise<DebugArtifactBundle> {
+  const params = new URLSearchParams();
+  if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+  if (opts?.before !== undefined) params.set("before", opts.before);
+  const query = params.toString();
   const data = await request<{
     success: boolean;
     data: DebugArtifactBundle;
-  }>(`${AUTH_API_URL}/api/v1/agent-chat/${slug}/chat/${conversationId}/debug`);
+  }>(`${AUTH_API_URL}/api/v1/agent-chat/${slug}/chat/${conversationId}/debug${query ? `?${query}` : ""}`);
   return data.data;
 }
 

--- a/apps/xyne-claw/src/agent.ts
+++ b/apps/xyne-claw/src/agent.ts
@@ -46,7 +46,36 @@ import {
 } from "./session-store.js";
 import { acquireSessionLock, refreshSessionLock, releaseSessionLock, startSessionLockHeartbeat, SessionLockedError } from "./session-lock.js";
 import { kickOffPrReviewRoom, registerLivePrRunContext, unregisterLivePrRunContext } from "./pr-review-room.js";
-import { gcsUploadDebugRun } from "./storage.js";
+import { gcsUploadDebugRunWithRetries, gcsUploadDebugObject, gcsPutDebugIndex } from "./storage.js";
+import {
+  BlobIndex,
+  BlobWriter,
+  Recorder,
+  RunStore,
+  startCapture,
+  installStreamCapture,
+  resolveCaptureLevel,
+  runIdFor,
+  runFileNameFor,
+  startingRunObjectName,
+  indexObjectName,
+  packedRunObjectName,
+  packRun,
+  readRun,
+  toV1Snapshot,
+  emptyLatency,
+  emptyTokenUsage,
+  type CaptureHandles,
+  type RunHeader,
+  type RunStatus,
+  type DebugEventKind,
+  type DebugEventRecord,
+  type DebugSessionSnapshot,
+  type DebugThinkingConfiguration,
+  type DebugSpeedConfiguration,
+  type StreamRateSample,
+} from "./debug/index.js";
+import { isSafeId } from "./safe-id.js";
 import { createCommandGuard } from "./command-guard.js";
 import { writeSessionSkills, deleteSessionSkills } from "./session-skills.js";
 import { installLlmCallMetrics } from "./llm-call-metrics.js";
@@ -278,105 +307,17 @@ export class QuotaExhaustedError extends Error {
   }
 }
 
-type DebugEventKind =
-  | "session_start"
-  | "session_tools"
-  | "mode_switch"
-  | "session_prompt"
-  | "stream_rate"
-  | "thinking"
-  | "assistant_turn_end"
-  | "tool_execution_start"
-  | "tool_execution_end"
-  | "compaction_start"
-  | "compaction_end"
-  | "auto_retry_start"
-  | "auto_retry_end"
-  | "citation_reflection"
-  | "twin_deliver_reflection"
-  | "follow_up_generation_start"
-  | "follow_up_generation_end"
-  | "background_subagents_delivered"
-  | "session_end"
-  | "session_cancelled"
-  | "session_error";
-
-export interface DebugEventRecord {
-  seq: number;
-  at: string;
-  kind: DebugEventKind;
-  turn?: number;
-  llmCall?: number;
-  toolCallId?: string;
-  parentToolCallId?: string;
-  subagentName?: string;
-  data: Record<string, unknown>;
-}
-
-interface StreamRateSample {
-  offsetMs: number;
-  streamsPerSec: number;
-  streamsCollected: number;
-}
-
-interface DebugThinkingConfiguration {
-  /** Value selected by agent model settings / provider config / default policy. */
-  requestedLevel: string;
-  /** Pi's final value after capability clamping for the resolved model. */
-  effectiveLevel: string;
-  /** Where the requested setting came from, so precedence is inspectable. */
-  source: "agent_model_settings" | "provider_credential" | "codex_default" | "server_default" | "temperature_override";
-  /** Whether the resolved Pi model was registered as reasoning-capable. */
-  modelSupportsReasoning: boolean;
-  /** The provider request shape that disables/enables thinking for this model. */
-  wireMode: string;
-}
-
-/** Provider fast mode (modelSettings.speed) as it was resolved for this run —
- *  so a "why wasn't it faster?" report can be answered from the trace. */
-interface DebugSpeedConfiguration {
-  requested: ModelSpeed;
-  applied: boolean;
-  reason: string;
-}
-
-interface DebugSessionSnapshot {
-  schemaVersion: 1;
-  conversationId?: string;
-  sessionId?: string;
-  agentSlug?: string;
-  userId?: string;
-  userName?: string;
-  userEmail?: string;
-  provider?: string;
-  /** The model resolved for this particular run (not merely the agent default). */
-  model?: string;
-  /** Requested/effective thinking selection and its provider wire representation. */
-  thinking?: DebugThinkingConfiguration;
-  /** Requested/applied provider fast mode and the eligibility verdict. */
-  speed?: DebugSpeedConfiguration;
-  startedAt: string;
-  finishedAt: string;
-  task: string;
-  context?: string;
-  systemPromptOverride?: boolean;
-  /** True when the snapshot was captured via the fallback writer in runTask's
-   *  finally because the agent loop threw (cancel / transient provider error)
-   *  before the success-path write could run. Tools list + messages are
-   *  whatever state existed at throw time. UI can branch on this to mark the
-   *  debugger view as "partial". */
-  cancelled?: boolean;
-  /** True for the incremental snapshot written at each turn boundary while the
-   *  run is still in flight (so the debugger can show a PARTIAL trace instead of
-   *  404ing until completion). Overwritten by the final snapshot on completion. */
-  inProgress?: boolean;
-  messages: unknown[];
-  toolInvocations: ToolInvocation[];
-  tokenUsage: TokenUsage;
-  latency: LatencyMetrics;
-  lastAssistantText: string;
-  events: DebugEventRecord[];
-}
+// Debug trace types live in ./debug — one definition shared by the recorder,
+// the materializer and the retrieval route. Re-exported here because
+// routes/run.ts and subagent-tools.ts have always imported them from agent.js.
+export type {
+  DebugEventKind,
+  DebugEventRecord,
+  DebugSessionSnapshot,
+  DebugThinkingConfiguration,
+  DebugSpeedConfiguration,
+  StreamRateSample,
+} from "./debug/index.js";
 
 function cloneForDebug<T>(value: T): T {
   try {
@@ -1866,6 +1807,11 @@ export interface RunTaskOptions {
    *  runTask drains it, injecting each completed subagent result back into the
    *  session so the model can incorporate it before finishing. */
   backgroundRegistry?: import("./subagent-tools.js").BackgroundSubagentRegistry | undefined;
+  /** Slot the run fills in with its own trace handles, shared with the subagent
+   *  tools via SubagentProgressCtx. The tools are built before this run opens
+   *  its trace, so a child can only learn where to write itself — and which
+   *  recorder to announce itself on — through this object. */
+  parentDebug?: import("./subagent-tools.js").ParentDebugHandle | undefined;
   fastMode?: boolean | undefined;
   fastToolCatalogNames?: string[] | undefined;
   fastToolController?: FastToolRuntimeController | undefined;
@@ -1984,6 +1930,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     autoToolCitations,
     isRegenerate,
     backgroundRegistry,
+    parentDebug,
     fastMode,
     fastToolCatalogNames,
     fastToolController,
@@ -2575,14 +2522,12 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
   // instead of advancing to the configured fallback. See ProviderTerminalError.
   let lastTurnErrorDetail: string | null = null;
   let compactedThisRun = false;
-  const debugEvents: DebugEventRecord[] = [];
-  let debugSeq = 0;
-  // Set once the success-path debug write (near the end of the agent loop) has
-  // run. The inner finally below uses this as a guard so it only fires the
-  // fallback partial-state debug write when the success path didn't get there
-  // — i.e. the loop threw (RunCancelledError, ProviderStallError, etc.). The
-  // success path keeps producing the full snapshot exactly as it did before.
-  let debugWritten = false;
+  // The trace recorder owns event capture and persistence for this run. It is
+  // created a few lines below, once the store key and header are known; every
+  // pushDebugEvent call site funnels through it.
+  let recorder: Recorder | null = null;
+  let capture: CaptureHandles | null = null;
+  let debugRunStore: RunStore | null = null;
   let llmCallSeq = 0;
   let currentPromptText = "";
   let currentPromptKind: "fresh" | "resume" = "fresh";
@@ -2654,120 +2599,99 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     try { return JSON.stringify(result); } catch { return String(result); }
   };
 
+  // Every debug emission in this file goes through here. The recorder applies
+  // the per-field size policy from the event registry, interns large payloads
+  // into the run's blob log, appends to the on-disk event log and pushes the
+  // event live — and it can never throw, because this runs inside pi's event
+  // subscription where a throw would take the run down with it.
   const pushDebugEvent = (kind: DebugEventKind, data: Record<string, unknown> = {}, extras?: Partial<DebugEventRecord>): void => {
-    const event: DebugEventRecord = {
-      seq: ++debugSeq,
-      at: extras?.at ?? new Date().toISOString(),
-      kind,
-      ...(extras?.turn != null ? { turn: extras.turn } : {}),
-      ...(extras?.llmCall != null ? { llmCall: extras.llmCall } : {}),
-      ...(extras?.toolCallId ? { toolCallId: extras.toolCallId } : {}),
-      ...(extras?.parentToolCallId ? { parentToolCallId: extras.parentToolCallId } : {}),
-      ...(extras?.subagentName ? { subagentName: extras.subagentName } : {}),
-      data,
-    };
-    debugEvents.push(event);
-    pushDebugProgress(progressUrl, sessionId ?? conversationId ?? "unknown", event);
+    recorder?.record(kind, data, extras);
   };
 
-  // Incremental debug snapshot — written at assistant turn boundaries and tool
-  // lifecycle boundaries (NOT per token), so the debugger can serve a PARTIAL
-  // bundle mid-run and does not leave a completed tool displayed as running.
-  // Writes only debug-session.json + debug-events.json
-  // (never the immutable debug-run-*.json). `messages` is intentionally omitted
-  // (kept only in the final snapshot) to avoid O(turns) PVC growth — the drawer
-  // renders off `events`/`toolInvocations`. Skipped once the completion write
-  // has run (debugWritten). Best-effort: never throws into the run loop.
-  let partialDebugFlushing = false;
-  // Tracks the in-flight partial write so the completion/finally writers can
-  // await it before writing their FULL snapshot — otherwise the two race on the
-  // same debug-session.json path and can leave a torn/partial final trace.
-  let partialFlushPromise: Promise<void> | null = null;
-  const flushDebugPartial = async (): Promise<void> => {
-    if (!conversationId || debugWritten || partialDebugFlushing) return;
-    partialDebugFlushing = true;
+  /**
+   * The single terminal path for a run's trace. Idempotent — the success path
+   * and the fallback in `finally` both call it and only the first one lands.
+   *
+   * Order matters, and each stage is independently guarded: the append-only log
+   * is already durable, the header/materialize step makes it readable, and the
+   * GCS upload puts a copy somewhere the PVC eviction sweep can't reach. A pod
+   * that is out of disk still gets a complete off-pod artifact, which is the
+   * exact case that used to lose traces entirely.
+   */
+  const finishDebugCapture = async (status: RunStatus, finalText: string): Promise<void> => {
+    if (!capture || capture.finished) return;
+    const finalLatency: LatencyMetrics = {
+      totalMs: Date.now() - runStartedAt,
+      llmDecodeMs: latency.llmDecodeMs,
+      llmWaitMs: latency.llmWaitMs,
+      llmTotalMs: latency.llmWaitMs + latency.llmDecodeMs,
+      llmTurns: latency.llmTurns,
+      llmRetries: latency.llmRetries,
+      ...(latency.lastRetryReason ? { lastRetryReason: latency.lastRetryReason } : {}),
+      ...(latency.firstTurnTtftMs != null ? { firstTurnTtftMs: latency.firstTurnTtftMs } : {}),
+      ...(latency.llmDecodeMs > 0 && tokenUsage.output > 0
+        ? { tokensPerSec: Math.round(tokenUsage.output / (latency.llmDecodeMs / 1000)) }
+        : {}),
+      ...(latency.streamCharsPerSec != null ? { streamCharsPerSec: latency.streamCharsPerSec } : {}),
+      ...(latency.streamChars ? { streamChars: latency.streamChars } : {}),
+      ...(latency.streamThinkingChars ? { streamThinkingChars: latency.streamThinkingChars } : {}),
+      ...(latency.streamTextChars ? { streamTextChars: latency.streamTextChars } : {}),
+      toolMs: toolInvocations.reduce((sum, inv) => sum + (inv.durationMs ?? 0), 0),
+    };
     try {
-      const debugDir = await ensureSessionDebugDir(conversationId);
-      if (debugWritten) return; // completion writer won the race while we awaited
-      const { writeFile } = await import("node:fs/promises");
-      if (debugWritten) return;
-      // Strip the per-event full-transcript `messages` embeds (session_prompt /
-      // assistant_turn_end each carry a deep clone of the WHOLE session for that
-      // turn) — keeping them would make each partial file O(turns) and the
-      // rewrite-every-turn cadence O(turns²) bytes to the PVC. The drawer renders
-      // off event metadata + toolInvocations, not these mid-run message embeds.
-      const leanEvents = debugEvents.map((e) =>
-        e.data && (e.data as Record<string, unknown>)["messages"] !== undefined
-          ? { ...e, data: { ...(e.data as Record<string, unknown>), messages: undefined } }
-          : e,
-      );
-      const snapshot: DebugSessionSnapshot = {
-        schemaVersion: 1,
-        conversationId,
-        ...(sessionId ? { sessionId } : {}),
-        ...(progressMeta?.agentSlug ? { agentSlug: progressMeta.agentSlug } : {}),
-        userId,
-        ...(userName ? { userName } : {}),
-        ...(userEmail ? { userEmail } : {}),
-        ...(provider ? { provider } : {}),
-        model: model.id,
-        thinking: debugThinking,
-        ...(debugSpeed ? { speed: debugSpeed } : {}),
-        inProgress: true,
-        startedAt: debugStartedIso,
-        finishedAt: new Date().toISOString(),
-        task,
-        ...(context ? { context } : {}),
-        ...(systemPromptOverride ? { systemPromptOverride: true } : {}),
-        messages: [],
-        toolInvocations: cloneForDebug(toolInvocations),
-        tokenUsage: { ...tokenUsage },
-        latency: {
-          totalMs: Date.now() - runStartedAt,
-          llmDecodeMs: latency.llmDecodeMs,
-          llmWaitMs: latency.llmWaitMs,
-          llmTotalMs: latency.llmWaitMs + latency.llmDecodeMs,
-          llmTurns: latency.llmTurns,
-          llmRetries: latency.llmRetries,
-          toolMs: toolInvocations.reduce((sum, inv) => sum + (inv.durationMs ?? 0), 0),
-        },
-        lastAssistantText: streamedText,
-        events: leanEvents,
-      };
-      await writeFile(`${debugDir}/debug-session.json`, JSON.stringify(snapshot), "utf8");
-      await writeFile(`${debugDir}/debug-events.json`, JSON.stringify(leanEvents), "utf8");
+      await capture.finish(status, { text: finalText, tokenUsage: { ...tokenUsage }, latency: finalLatency });
     } catch (err) {
-      log.warn(`[agent] partial debug flush failed: ${err instanceof Error ? err.message : String(err)}`);
-    } finally {
-      partialDebugFlushing = false;
+      log.warn(`[agent] debug finish failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    if (!debugRunStore || !debugStoreKey) return;
+    // Upload off-pod. The v1 snapshot keeps every existing reader working; the
+    // packed v2 run carries the full fidelity (blobs included) for the newer
+    // retrieval path. Both best-effort, neither on the run's critical path.
+    try {
+      const run = await readRun(debugRunStore.runDir);
+      if (run) {
+        const v1 = Buffer.from(JSON.stringify(toV1Snapshot(run)), "utf8");
+        const uploaded = await gcsUploadDebugRunWithRetries(debugStoreKey, runFileNameFor(debugRunId), v1);
+        const packed = await packRun(debugRunStore.runDir);
+        if (packed) {
+          await gcsUploadDebugObject(`${debugStoreKey}/${packedRunObjectName(debugRunId)}`, packed);
+        }
+        if (uploaded) {
+          await debugRunStore.markUploaded();
+        } else {
+          // GCS unreachable: keep the v1 snapshot on the PVC so the trace is
+          // still servable from this pod until the session is archived.
+          const debugDir = await ensureSessionDebugDir(debugStoreKey);
+          const { writeFile } = await import("node:fs/promises");
+          await writeFile(`${debugDir}/${runFileNameFor(debugRunId)}`, v1);
+        }
+      }
+    } catch (err) {
+      log.warn(`[agent] debug run upload failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   };
 
-  // Serialize partial snapshots. A plain `void flushDebugPartial()` can lose a
-  // tool-end update when a turn-boundary write is already in flight because
-  // flushDebugPartial deliberately skips concurrent writes. Chaining preserves
-  // every requested boundary and gives the final writer one promise to await.
+  // Mid-run durability is no longer a rewrite-the-whole-file affair: the
+  // recorder appends each event as it happens, so a partial trace is simply
+  // "whatever is on disk right now". flushHint() only asks the store to get its
+  // queued appends onto the fd sooner; it copies nothing and never blocks the
+  // run loop. (The old flushDebugPartial rewrote debug-session.json at every
+  // turn and tool boundary, which is what made a long run cost O(turns^2)
+  // bytes to the PVC.)
   const queueDebugPartialFlush = (): void => {
-    const previous = partialFlushPromise ?? Promise.resolve();
-    const next = previous
-      .catch(() => {})
-      .then(() => flushDebugPartial());
-    partialFlushPromise = next;
-    void next.finally(() => {
-      if (partialFlushPromise === next) partialFlushPromise = null;
-    });
+    recorder?.flushHint();
   };
 
+
+  // Stream rate is a live-only heartbeat (once per second while decoding). It
+  // is deliberately not persisted, and recordLive consumes no sequence number —
+  // burning one per tick used to leave holes in the persisted event log that
+  // looked like dropped events.
   const pushLiveStreamRate = (streamsPerSec: number, active: boolean): void => {
-    const event: DebugEventRecord = {
-      seq: ++debugSeq,
-      at: new Date().toISOString(),
-      kind: "stream_rate",
+    recorder?.recordLive("stream_rate", { streamsPerSec, streamsCollected: turnStreamCount, active }, {
       turn: latency.llmTurns + 1,
       ...(llmCallSeq ? { llmCall: llmCallSeq } : {}),
-      data: { streamsPerSec, streamsCollected: turnStreamCount, active },
-    };
-    pushDebugProgress(progressUrl, sessionId ?? conversationId ?? "unknown", event);
+    });
   };
 
   const flushStreamRate = (active: boolean): void => {
@@ -2793,11 +2717,6 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     streamRateTimer = null;
     flushStreamRate(false);
     streamWindowStartedAt = null;
-  };
-
-  const snapshotMessages = (): unknown[] => {
-    const messages = (session as unknown as { messages?: unknown[] }).messages ?? [];
-    return cloneForDebug(messages);
   };
 
   const repairDanglingToolUses = (reason: string): number => {
@@ -2842,6 +2761,120 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     currentPromptKind = kind;
     currentPromptImagesCount = imagesCount;
   };
+
+  // ── Debug capture ──────────────────────────────────────────────────────
+  // Opened BEFORE the model is ever called, and the header is written with
+  // status "running" immediately: any run that gets this far is discoverable
+  // on the PVC and (fire-and-forget) in GCS within about a second, so a pod
+  // killed mid-run still leaves a readable, correctly-labelled trace instead
+  // of nothing at all.
+  //
+  // The store key falls back to the sessionId when there is no conversationId —
+  // runs without one used to produce no artifact whatsoever.
+  const debugStoreKey = conversationId ?? (sessionId && isSafeId(sessionId) ? sessionId : undefined);
+  const debugRunId = runIdFor(runStartedAt, sessionId);
+  const debugCaptureLevel = resolveCaptureLevel();
+  if (debugStoreKey) {
+    debugRunStore = await RunStore.open({
+      storeKey: debugStoreKey,
+      runId: debugRunId,
+      captureLevel: debugCaptureLevel,
+    }).catch((err: unknown) => {
+      log.warn(`[agent] debug store open failed: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    });
+  }
+  const debugBlobs = new BlobWriter({
+    appendLine: (line) => debugRunStore?.appendBlobLine(line),
+    captureLevel: debugCaptureLevel,
+  });
+  recorder = new Recorder({
+    store: debugRunStore,
+    blobs: debugBlobs,
+    captureLevel: debugCaptureLevel,
+    ...(progressUrl
+      ? {
+          live: {
+            push: (event: DebugEventRecord) =>
+              pushDebugProgress(progressUrl, sessionId ?? conversationId ?? "unknown", event),
+          },
+        }
+      : {}),
+  });
+  const debugHeader: RunHeader = {
+    schemaVersion: 2,
+    runId: debugRunId,
+    storeKey: debugStoreKey ?? "unknown",
+    ...(conversationId ? { conversationId } : {}),
+    ...(progressMeta?.conversationId ? { rawConversationId: progressMeta.conversationId } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(progressMeta?.agentSlug ? { agentSlug: progressMeta.agentSlug } : {}),
+    ...(userId ? { userId } : {}),
+    ...(userName ? { userName } : {}),
+    ...(userEmail ? { userEmail } : {}),
+    ...(provider ? { provider } : {}),
+    model: model.id,
+    thinking: debugThinking,
+    ...(debugSpeed ? { speed: debugSpeed } : {}),
+    captureLevel: debugCaptureLevel,
+    startedAt: debugStartedIso,
+    finishedAt: debugStartedIso,
+    status: "running",
+    task,
+    ...(context ? { context } : {}),
+    ...(systemPromptOverride ? { systemPromptOverride: true } : {}),
+    mode: mode ?? "auto",
+    counts: { events: 0, blobs: 0, messages: 0, toolCalls: 0 },
+    tokenUsage: emptyTokenUsage(),
+    latency: emptyLatency(),
+  };
+  capture = startCapture({
+    store: debugRunStore,
+    recorder,
+    header: debugHeader,
+    // Off-pod discovery marker. Written at START, not at finish, and it carries
+    // the run's REAL store key in its own object name — which is what lets the
+    // retrieval path stop guessing key shapes (branch keys, per-user twin keys
+    // and userId-prefixed keys each used to defeat a different guesser).
+    onStart: (h) => {
+      if (!debugStoreKey) return;
+      // Index under every id a caller might ask by. The debugger asks with the
+      // RAW conversation id, while `conversationId` here is the session key —
+      // indexing only the latter made the whole discovery layer unreachable.
+      for (const id of new Set([h.rawConversationId, h.conversationId].filter((v): v is string => !!v))) {
+        void gcsPutDebugIndex(indexObjectName(id, h.runId, debugStoreKey));
+      }
+      // Deliberately NOT written under the final snapshot's object name: a
+      // header-only stub parked there would permanently shadow the complete
+      // trace if the finish-time upload later failed.
+      void gcsUploadDebugObject(
+        `${debugStoreKey}/${startingRunObjectName(h.runId)}`,
+        Buffer.from(JSON.stringify(toV1Snapshot({ header: h, events: [], blobs: BlobIndex.empty(), warnings: [] })), "utf8"),
+        "application/json",
+      );
+    },
+  });
+  // Subagent tools were constructed before this point; hand them the run they
+  // are children of, so their traces land in this run's store and their
+  // start/end shows up on this run's timeline.
+  if (parentDebug) {
+    parentDebug.recorder = recorder;
+    parentDebug.runId = debugRunId;
+    parentDebug.captureLevel = debugCaptureLevel;
+    if (debugStoreKey) parentDebug.storeKey = debugStoreKey;
+  }
+
+  // The one hook that sees what the model is ACTUALLY sent: pi's assembled
+  // system prompt (with its <available_skills> block), the resolved tool
+  // definitions including their JSON schemas, and the real transcript. Installed
+  // after installLlmCallMetrics so this wrapper sits outermost, and before
+  // session.subscribe below so the first turn is captured.
+  installStreamCapture({
+    agent: session.agent as unknown as { streamFn: (model: unknown, context: unknown, options?: unknown) => unknown },
+    recorder,
+    fastMode: fastMode === true,
+    ...(provider ? { provider } : {}),
+  });
 
   pushDebugEvent("session_start", {
     conversationId,
@@ -2903,8 +2936,7 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
         kind: currentPromptKind,
         prompt: currentPromptText,
         imagesCount: currentPromptImagesCount,
-        messageCount: snapshotMessages().length,
-        messages: snapshotMessages(),
+        messageCount: recorder?.messageCount ?? 0,
         ...(personaSystemPrompt ? { systemPrompt: personaSystemPrompt } : {}),
         turnIndex: (event as { turnIndex?: number }).turnIndex,
         timestamp: (event as { timestamp?: string }).timestamp,
@@ -3165,7 +3197,6 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
           });
         }
         pushDebugEvent("assistant_turn_end", {
-          message: cloneForDebug(msg),
           assistantText: session.getLastAssistantText() ?? "",
           usage: cloneForDebug(msg.usage),
           stopReason,
@@ -3176,7 +3207,6 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
           streamCharsPerSec: latency.streamCharsPerSec,
           streamsCollected: turnStreamCount,
           streamRateSamples: turnStreamRateSamples,
-          messages: snapshotMessages(),
         }, {
           turn: latency.llmTurns,
           ...(llmCallSeq ? { llmCall: llmCallSeq } : {}),
@@ -3835,73 +3865,11 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
     },
   });
 
-  if (conversationId) {
-    try {
-      // Let any in-flight incremental partial write finish before the full
-      // completion snapshot overwrites the same debug-session.json (no torn write).
-      await (partialFlushPromise ?? Promise.resolve()).catch(() => {});
-      const debugDir = await ensureSessionDebugDir(conversationId);
-      const { writeFile } = await import("node:fs/promises");
-      const debugSnapshot: DebugSessionSnapshot = {
-        schemaVersion: 1,
-        conversationId,
-        ...(sessionId ? { sessionId } : {}),
-        ...(progressMeta?.agentSlug ? { agentSlug: progressMeta.agentSlug } : {}),
-        userId,
-        ...(userName ? { userName } : {}),
-        ...(userEmail ? { userEmail } : {}),
-        ...(provider ? { provider } : {}),
-        model: model.id,
-        thinking: debugThinking,
-        ...(debugSpeed ? { speed: debugSpeed } : {}),
-        startedAt: debugStartedIso,
-        finishedAt: new Date().toISOString(),
-        task,
-        ...(context ? { context } : {}),
-        ...(systemPromptOverride ? { systemPromptOverride: true } : {}),
-        messages: cloneForDebug(sessionMessages ?? []),
-        toolInvocations: cloneForDebug(toolInvocations),
-        tokenUsage: { ...tokenUsage },
-        latency: {
-          totalMs: Date.now() - runStartedAt,
-          llmDecodeMs: latency.llmDecodeMs,
-          llmWaitMs: latency.llmWaitMs,
-          llmTotalMs: latency.llmWaitMs + latency.llmDecodeMs,
-          llmTurns: latency.llmTurns,
-          llmRetries: latency.llmRetries,
-          ...(latency.lastRetryReason ? { lastRetryReason: latency.lastRetryReason } : {}),
-          ...(latency.firstTurnTtftMs != null ? { firstTurnTtftMs: latency.firstTurnTtftMs } : {}),
-          ...(latency.llmDecodeMs > 0 && tokenUsage.output > 0 ? { tokensPerSec: Math.round(tokenUsage.output / (latency.llmDecodeMs / 1000)) } : {}),
-          ...(latency.streamCharsPerSec != null ? { streamCharsPerSec: latency.streamCharsPerSec } : {}),
-          ...(latency.streamChars ? { streamChars: latency.streamChars } : {}),
-          ...(latency.streamThinkingChars ? { streamThinkingChars: latency.streamThinkingChars } : {}),
-          ...(latency.streamTextChars ? { streamTextChars: latency.streamTextChars } : {}),
-          toolMs: toolInvocations.reduce((sum, inv) => sum + (inv.durationMs ?? 0), 0),
-        },
-        lastAssistantText: text,
-        events: cloneForDebug(debugEvents),
-      };
-      await writeFile(`${debugDir}/debug-session.json`, JSON.stringify(debugSnapshot, null, 2), "utf8");
-      await writeFile(`${debugDir}/debug-events.json`, JSON.stringify(debugEvents, null, 2), "utf8");
-      // Per-run snapshots go straight to GCS, NOT the PVC: each one embeds the
-      // full conversation so far, so keeping them on disk grows O(turns²) per
-      // conversation and the TTL sweep never reclaims an active thread (prod
-      // ENOSPC, 2026-06-12). The debug route reads them back from GCS. Local
-      // write only as a fallback (local dev / GCS down) so debugging still works.
-      const safeSessionId = (sessionId ?? "local").replace(/[^a-zA-Z0-9_-]/g, "-");
-      const runFile = `debug-run-${runStartedAt}-${safeSessionId}.json`;
-      const runSnapshot = Buffer.from(JSON.stringify(debugSnapshot), "utf8");
-      if (await gcsUploadDebugRun(conversationId, runFile, runSnapshot)) {
-        log.info(`[agent] Debug artifacts written: ${debugDir}/debug-session.json, gcs:${runFile}`);
-      } else {
-        await writeFile(`${debugDir}/${runFile}`, runSnapshot);
-        log.info(`[agent] Debug artifacts written: ${debugDir}/debug-session.json, ${debugDir}/${runFile} (GCS unavailable)`);
-      }
-      debugWritten = true;
-    } catch (err) {
-      log.warn(`[agent] Failed to write debug artifacts: ${err instanceof Error ? err.message : String(err)}`);
-    }
-  }
+  // Finish the trace: durable append-only data is already on disk, so this only
+  // stamps the final header and materializes the v1 compat artifacts every
+  // existing reader (drawer, webhook /debug, HTML export) still consumes.
+  await finishDebugCapture("completed", streamedText);
+
 
   // Log context usage for monitoring
   const contextUsage = session.getContextUsage?.();
@@ -3999,80 +3967,15 @@ export async function runTask(opts: RunTaskOptions): Promise<RunResult> {
       agent: progressMeta?.agentSlug ?? "unknown",
     });
 
-    // Fallback debug write — fires when the success-path block didn't run
-    // because the agent loop threw (cancel / transient provider error / any
-    // other error). Without this the debugger UI shows nothing for the run
-    // after a Stop click, even though we already have all session events,
-    // tool invocations, and partial assistant text in memory. The success
-    // path sets debugWritten=true above so we don't double-write.
-    if (!debugWritten && conversationId) {
-      try {
-        // Let any in-flight incremental partial write finish before the fallback
-        // snapshot overwrites the same debug-session.json (no torn write).
-        await (partialFlushPromise ?? Promise.resolve()).catch(() => {});
-        const debugDir = await ensureSessionDebugDir(conversationId);
-        const { writeFile } = await import("node:fs/promises");
-        let partialSessionMessages: Array<Record<string, unknown>> = [];
-        try {
-          partialSessionMessages = (session as unknown as { messages: Array<Record<string, unknown>> }).messages ?? [];
-        } catch { /* session may not be initialised yet */ }
-        const partialText = streamedText || (() => {
-          try { return session.getLastAssistantText() ?? ""; } catch { return ""; }
-        })();
-        const debugSnapshot: DebugSessionSnapshot = {
-          schemaVersion: 1,
-          conversationId,
-          ...(sessionId ? { sessionId } : {}),
-          ...(progressMeta?.agentSlug ? { agentSlug: progressMeta.agentSlug } : {}),
-          userId,
-          ...(userName ? { userName } : {}),
-          ...(userEmail ? { userEmail } : {}),
-          ...(provider ? { provider } : {}),
-          model: model.id,
-          thinking: debugThinking,
-          ...(debugSpeed ? { speed: debugSpeed } : {}),
-          cancelled: true,
-          startedAt: debugStartedIso,
-          finishedAt: new Date().toISOString(),
-          task,
-          ...(context ? { context } : {}),
-          ...(systemPromptOverride ? { systemPromptOverride: true } : {}),
-          messages: cloneForDebug(partialSessionMessages),
-          toolInvocations: cloneForDebug(toolInvocations),
-          tokenUsage: { ...tokenUsage },
-          latency: {
-            totalMs: Date.now() - runStartedAt,
-            llmDecodeMs: latency.llmDecodeMs,
-            llmWaitMs: latency.llmWaitMs,
-            llmTotalMs: latency.llmWaitMs + latency.llmDecodeMs,
-            llmTurns: latency.llmTurns,
-            llmRetries: latency.llmRetries,
-            ...(latency.lastRetryReason ? { lastRetryReason: latency.lastRetryReason } : {}),
-            ...(latency.firstTurnTtftMs != null ? { firstTurnTtftMs: latency.firstTurnTtftMs } : {}),
-            ...(latency.streamCharsPerSec != null ? { streamCharsPerSec: latency.streamCharsPerSec } : {}),
-            ...(latency.streamChars ? { streamChars: latency.streamChars } : {}),
-            ...(latency.streamThinkingChars ? { streamThinkingChars: latency.streamThinkingChars } : {}),
-            ...(latency.streamTextChars ? { streamTextChars: latency.streamTextChars } : {}),
-            toolMs: toolInvocations.reduce((sum, inv) => sum + (inv.durationMs ?? 0), 0),
-          },
-          lastAssistantText: partialText,
-          events: cloneForDebug(debugEvents),
-        };
-        await writeFile(`${debugDir}/debug-session.json`, JSON.stringify(debugSnapshot, null, 2), "utf8");
-        await writeFile(`${debugDir}/debug-events.json`, JSON.stringify(debugEvents, null, 2), "utf8");
-        const safeSessionId = (sessionId ?? "local").replace(/[^a-zA-Z0-9_-]/g, "-");
-        const runFile = `debug-run-${runStartedAt}-${safeSessionId}.json`;
-        const runSnapshot = Buffer.from(JSON.stringify(debugSnapshot), "utf8");
-        if (await gcsUploadDebugRun(conversationId, runFile, runSnapshot)) {
-          log.info(`[agent] Debug artifacts written (cancelled): ${debugDir}/debug-session.json, gcs:${runFile}`);
-        } else {
-          await writeFile(`${debugDir}/${runFile}`, runSnapshot);
-          log.info(`[agent] Debug artifacts written (cancelled): ${debugDir}/debug-session.json, ${debugDir}/${runFile} (GCS unavailable)`);
-        }
-        debugWritten = true;
-      } catch (err) {
-        log.warn(`[agent] Failed to write partial debug artifacts: ${err instanceof Error ? err.message : String(err)}`);
-      }
+    // Fallback finish — fires when the success path didn't run because the loop
+    // threw (Stop, provider error, stall). The events are already durable on
+    // disk; this stamps the terminal status so the drawer shows the run as
+    // cancelled rather than leaving it looking like it is still in flight.
+    if (capture && !capture.finished) {
+      const partialText = streamedText || (() => {
+        try { return session.getLastAssistantText() ?? ""; } catch { return ""; }
+      })();
+      await finishDebugCapture("cancelled", partialText);
     }
   }
   } finally {

--- a/apps/xyne-claw/src/debug/blobs.ts
+++ b/apps/xyne-claw/src/debug/blobs.ts
@@ -1,0 +1,329 @@
+/**
+ * Content-addressed blob log for debug traces.
+ *
+ * The v1 writer embedded every large payload inline in every event, so a 20 KB
+ * system prompt sent on 12 turns cost 240 KB on disk and the transcript re-embed
+ * made whole files grow O(turns^2). Here a payload is hashed once and written
+ * once; events carry a 16-hex `BlobRef` instead. Twelve turns of an identical
+ * prompt cost 20 KB total.
+ *
+ * The log is `blobs.jsonl`, one `BlobLine` per line, append-only. It is written
+ * through an injected `appendLine` rather than a file handle so the recorder can
+ * stay synchronous and the store can own all the I/O sequencing.
+ *
+ * Two invariants everything else depends on:
+ *   - A ref is NEVER silently lossy. Oversized content is cut at
+ *     `BLOB_MAX_BYTES` with `truncated: true` and the real `originalBytes`.
+ *   - `serializeForBlob` never throws. A cyclic tool result or a BigInt in a
+ *     provider response must not be able to kill a run for the sake of a trace.
+ */
+
+import { createHash } from "node:crypto";
+import { gunzipSync, gzipSync } from "node:zlib";
+
+import { metric } from "../metrics.js";
+import type { BlobRef, CaptureLevel } from "./types.js";
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/** Hard cap on stored blob bytes. Beyond this we truncate and say so. */
+export const BLOB_MAX_BYTES = envInt("DEBUG_BLOB_MAX_BYTES", 2_000_000);
+
+/** Above this, try gzip+base64 — below it the base64 overhead usually wins. */
+export const BLOB_GZIP_OVER = envInt("DEBUG_BLOB_GZIP_OVER", 4_096);
+
+/** Gzip is synchronous and runs on the agent loop; big payloads take the fast
+ *  level, where the ratio loss is small and the CPU saving is not. */
+const GZIP_FAST_OVER = 256 * 1024;
+
+const PREVIEW_CHARS = 200;
+
+export interface BlobLine {
+  /** sha256 of the *serialized source value*, first 16 hex chars. */
+  hash: string;
+  /** Byte length of the decoded content (post-truncation), not of `content`. */
+  bytes: number;
+  enc: "utf8" | "gzip+base64";
+  truncated?: true;
+  originalBytes?: number;
+  /** utf8 text, or base64 of its gzip, per `enc`. */
+  content: string;
+}
+
+export function hashContent(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex").slice(0, 16);
+}
+
+/**
+ * Cycle- and BigInt-tolerant fallback. The WeakSet marks any *repeated* object
+ * as circular, not only true ancestors — a shared (non-cyclic) reference is
+ * therefore reported as `[Circular]`. That over-report is the price of a
+ * single-pass stringify that cannot recurse forever, and this path only runs
+ * after plain `JSON.stringify` has already failed.
+ */
+function safeStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  return (
+    JSON.stringify(value, (_k, v: unknown) => {
+      if (typeof v === "bigint") return v.toString();
+      if (typeof v === "object" && v !== null) {
+        if (seen.has(v)) return "[Circular]";
+        seen.add(v);
+      }
+      if (typeof v === "function" || typeof v === "symbol") return String(v);
+      return v;
+    }) ?? String(value)
+  );
+}
+
+/** Never throws, always returns a string. */
+export function serializeForBlob(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    const s = JSON.stringify(value);
+    // undefined/function/symbol stringify to `undefined`, not to a string.
+    if (typeof s === "string") return s;
+  } catch {
+    // Cycles and BigInt land here.
+  }
+  try {
+    return safeStringify(value);
+  } catch {
+    try {
+      return String(value);
+    } catch {
+      return "[unserializable]";
+    }
+  }
+}
+
+/**
+ * Cut a utf8 buffer at `max` bytes on a character boundary.
+ *
+ * Slicing mid-sequence and calling `toString` would splice a U+FFFD into the
+ * content, which is exactly the kind of silent corruption that makes a 2 MB MCP
+ * envelope unparseable for the reader.
+ */
+function truncateUtf8(buf: Buffer, max: number): string {
+  let end = Math.min(max, buf.length);
+  // Back off while the first EXCLUDED byte is a utf8 continuation byte (10xxxxxx);
+  // once it is a lead or ascii byte, [0, end) is a complete sequence.
+  while (end > 0) {
+    const b = buf[end];
+    if (b === undefined || (b & 0xc0) !== 0x80) break;
+    end--;
+  }
+  let s = buf.subarray(0, end).toString("utf8");
+  // Defensive: a lone high surrogate can only survive if the source string had
+  // one, but a half-pair here would break JSON.stringify of the blob line.
+  const last = s.charCodeAt(s.length - 1);
+  if (s.length > 0 && last >= 0xd800 && last <= 0xdbff) s = s.slice(0, -1);
+  return s;
+}
+
+function previewOf(content: string): string {
+  return content.slice(0, PREVIEW_CHARS).replace(/[\r\n]+/g, " ");
+}
+
+function encode(content: string, byteLen: number): { enc: BlobLine["enc"]; body: string } {
+  if (byteLen <= BLOB_GZIP_OVER) return { enc: "utf8", body: content };
+  try {
+    const level = byteLen > GZIP_FAST_OVER ? 1 : 6;
+    const packed = gzipSync(Buffer.from(content, "utf8"), { level }).toString("base64");
+    // base64 inflates by 4/3; only worth it when the compression still wins.
+    if (packed.length < content.length) return { enc: "gzip+base64", body: packed };
+  } catch {
+    // Fall through to plain utf8 — a trace is worth more than a compressed one.
+  }
+  return { enc: "utf8", body: content };
+}
+
+export class BlobWriter {
+  private readonly appendLine: (line: string) => void;
+  private readonly captureLevel: CaptureLevel;
+  private readonly seen = new Set<string>();
+
+  constructor(opts: { appendLine: (line: string) => void; captureLevel: CaptureLevel }) {
+    this.appendLine = opts.appendLine;
+    this.captureLevel = opts.captureLevel;
+  }
+
+  /** Distinct blobs interned so far. */
+  get size(): number {
+    return this.seen.size;
+  }
+
+  has(hash: string): boolean {
+    return this.seen.has(hash);
+  }
+
+  /**
+   * Intern a value and return its ref. Returns undefined only when capture is
+   * off. At `metadata` the hash/size/truncation are still computed and returned
+   * — the timeline stays complete, only the payload is withheld.
+   */
+  intern(value: unknown): BlobRef | undefined {
+    if (this.captureLevel === "off") return undefined;
+
+    const serialized = serializeForBlob(value);
+    const buf = Buffer.from(serialized, "utf8");
+    const originalBytes = buf.length;
+    const truncated = originalBytes > BLOB_MAX_BYTES;
+    const content = truncated ? truncateUtf8(buf, BLOB_MAX_BYTES) : serialized;
+    const bytes = truncated ? Buffer.byteLength(content, "utf8") : originalBytes;
+
+    // Key on the FULL serialized value, not the stored prefix: two different
+    // oversized payloads that share a 2 MB head must not alias to one blob.
+    const hash = hashContent(serialized);
+
+    const ref: BlobRef = {
+      hash,
+      bytes,
+      ...(truncated ? { truncated: true as const, originalBytes } : {}),
+      ...(this.captureLevel === "full" ? { preview: previewOf(content) } : {}),
+    };
+
+    if (this.seen.has(hash)) return ref;
+
+    /** The dedupe set is a promise that the content is IN the log: once a hash
+     *  is in it, every later intern of the same value returns a ref and writes
+     *  nothing. Marking it before the line is accepted turns one failed write
+     *  into a run-long trail of refs pointing at content that was never
+     *  written. */
+    const markSeen = (): void => {
+      this.seen.add(hash);
+      if (truncated) {
+        metric.count("debug_blob_truncated");
+        metric.observe("debug_blob_dropped_bytes", originalBytes - bytes);
+      }
+    };
+
+    // At `metadata` there is no line to accept: the ref is the whole record.
+    if (this.captureLevel !== "full") {
+      markSeen();
+      return ref;
+    }
+
+    const { enc, body } = encode(content, bytes);
+    const line: BlobLine = {
+      hash,
+      bytes,
+      enc,
+      ...(truncated ? { truncated: true as const, originalBytes } : {}),
+      content: body,
+    };
+    try {
+      this.appendLine(JSON.stringify(line));
+      markSeen();
+    } catch {
+      // Not marked seen: the next intern of this value tries the write again,
+      // and until one succeeds the reader reports the miss as a warning rather
+      // than the run failing over a trace line.
+    }
+    return ref;
+  }
+
+  /**
+   * Registry `ref(n)` policy: keep the value inline while it is small, otherwise
+   * intern it. `inlineUnder: 0` means "always intern".
+   */
+  maybeIntern(
+    value: unknown,
+    inlineUnder: number,
+  ): { inline: unknown } | { ref: BlobRef } | { omitted: true } {
+    if (this.captureLevel === "off") return { omitted: true };
+    if (inlineUnder > 0) {
+      const bytes = Buffer.byteLength(serializeForBlob(value), "utf8");
+      if (bytes <= inlineUnder) return { inline: value };
+    }
+    const ref = this.intern(value);
+    return ref ? { ref } : { omitted: true };
+  }
+}
+
+function parseLine(raw: string): BlobLine | null {
+  const line = raw.trim();
+  if (!line) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null; // Torn tail from a crashed pod, or a partially flushed line.
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const o = parsed as Partial<BlobLine>;
+  if (typeof o.hash !== "string" || typeof o.content !== "string") return null;
+  if (o.enc !== "utf8" && o.enc !== "gzip+base64") return null;
+  return {
+    hash: o.hash,
+    bytes: typeof o.bytes === "number" ? o.bytes : Buffer.byteLength(o.content, "utf8"),
+    enc: o.enc,
+    ...(o.truncated === true ? { truncated: true as const } : {}),
+    ...(typeof o.originalBytes === "number" ? { originalBytes: o.originalBytes } : {}),
+    content: o.content,
+  };
+}
+
+/** Read side of `blobs.jsonl`. Decoding is lazy and memoized. */
+export class BlobIndex {
+  private readonly lines = new Map<string, BlobLine>();
+  private readonly decoded = new Map<string, string>();
+
+  private constructor(lines: readonly BlobLine[]) {
+    // First write wins: the writer only emits one line per hash, and a duplicate
+    // can only come from a concatenated/re-appended log.
+    for (const l of lines) if (!this.lines.has(l.hash)) this.lines.set(l.hash, l);
+  }
+
+  static fromLines(lines: string[]): BlobIndex {
+    const parsed: BlobLine[] = [];
+    for (const raw of lines) {
+      const l = parseLine(raw);
+      if (l) parsed.push(l);
+    }
+    return new BlobIndex(parsed);
+  }
+
+  static empty(): BlobIndex {
+    return new BlobIndex([]);
+  }
+
+  get size(): number {
+    return this.lines.size;
+  }
+
+  get hashes(): string[] {
+    return [...this.lines.keys()];
+  }
+
+  meta(hash: string): Omit<BlobLine, "content"> | undefined {
+    const l = this.lines.get(hash);
+    if (!l) return undefined;
+    const { content: _content, ...rest } = l;
+    return rest;
+  }
+
+  get(hash: string): string | undefined {
+    const cached = this.decoded.get(hash);
+    if (cached !== undefined) return cached;
+    const l = this.lines.get(hash);
+    if (!l) return undefined;
+    let out: string;
+    if (l.enc === "gzip+base64") {
+      try {
+        out = gunzipSync(Buffer.from(l.content, "base64")).toString("utf8");
+      } catch {
+        return undefined; // Corrupt payload reads as a miss, not a throw.
+      }
+    } else {
+      out = l.content;
+    }
+    this.decoded.set(hash, out);
+    return out;
+  }
+}

--- a/apps/xyne-claw/src/debug/capture.ts
+++ b/apps/xyne-claw/src/debug/capture.ts
@@ -1,0 +1,468 @@
+/**
+ * Run lifecycle capture: the guaranteed-write header dance, and the stream hook.
+ *
+ * Two responsibilities that share one theme — *never lose the evidence*:
+ *
+ * 1. `startCapture` writes a `status: "running"` header the instant a run
+ *    begins, so a pod killed mid-turn still leaves a discoverable artifact.
+ *    `finish` then does header → v1 materialization → close, each step in its
+ *    own try/catch, because a failure in one must not cost us the others.
+ * 2. `installStreamCapture` wraps `agent.streamFn`, which is the ONLY place the
+ *    prompt the model actually receives is visible. Everything upstream sees
+ *    the persona prompt; pi assembles the real one (`<available_skills>` and
+ *    all) on its way to the provider. Capturing it here is the whole point of
+ *    the v2 rewrite.
+ *
+ * GCS upload deliberately lives outside this module: importing storage.ts would
+ * drag HTTP into every unit test. The caller injects `onStart`/`onFinish`.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { createLogger } from "../logger.js";
+import { metric } from "../metrics.js";
+import { hashContent } from "./blobs.js";
+import { toV1Events, toV1Snapshot } from "./materialize.js";
+import type { Recorder } from "./recorder.js";
+import { readRun, type RunStore } from "./store.js";
+import {
+  isCaptureLevel,
+  type CaptureLevel,
+  type LatencyMetrics,
+  type RunHeader,
+  type RunStatus,
+  type TokenUsage,
+} from "./types.js";
+
+const log = createLogger("debug");
+
+export interface StartCaptureOpts {
+  store: RunStore | null;
+  recorder: Recorder;
+  header: RunHeader;
+  /** Extra conversation ids to index this run under (review-room runs index under the parent thread too). */
+  alsoIndexUnder?: string[];
+  /**
+   * Write the session-level v1 compat artifacts (`debug-session.json` +
+   * `debug-events.json`) at finish. Defaults to true.
+   *
+   * A subagent run shares its parent's debug dir, and those two files are named
+   * per SESSION, not per run — so a child finishing mid-parent-run would
+   * overwrite the parent's snapshot with its own. Child runs pass false: their
+   * own append-only trio is still written, and the parent still materializes
+   * the session when it finishes.
+   */
+  materializeV1?: boolean;
+  /**
+   * Fire-and-forget side effects (GCS index marker at start, upload at finish).
+   * They receive the header only; a caller that also needs `alsoIndexUnder`
+   * closes over the same opts object it built.
+   */
+  onStart?: (h: RunHeader) => void;
+  onFinish?: (h: RunHeader) => void;
+}
+
+export interface CaptureHandles {
+  readonly recorder: Recorder;
+  readonly finished: boolean;
+  finish(status: RunStatus, final: { text: string; tokenUsage: TokenUsage; latency: LatencyMetrics }): Promise<void>;
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Hooks are caller-supplied; a throw in one must not derail the lifecycle. */
+function fire(hook: ((h: RunHeader) => void) | undefined, header: RunHeader): void {
+  if (!hook) return;
+  try {
+    hook(header);
+  } catch (err) {
+    log.warn("debug: capture hook threw", { error: errText(err), runId: header.runId });
+  }
+}
+
+/** Atomic enough for a file a reader may be polling: write beside, then rename. */
+async function writeJsonAtomic(file: string, value: unknown): Promise<void> {
+  const tmp = `${file}.tmp-${process.pid}-${Date.now()}`;
+  // No pretty-printing: indenting a 20 MB trace burns CPU and bytes for a file
+  // only ever read by a parser.
+  await fs.writeFile(tmp, JSON.stringify(value), "utf8");
+  await fs.rename(tmp, file);
+}
+
+export function startCapture(o: StartCaptureOpts): CaptureHandles {
+  const { store, recorder } = o;
+
+  // The guarantee: an in-flight run is already discoverable. finishedAt tracks
+  // startedAt until the real finish lands, so readers can spot a crashed run by
+  // `status === "running"` alone.
+  const running: RunHeader = { ...o.header, status: "running", finishedAt: o.header.startedAt };
+  try {
+    store?.writeHeader(running);
+    metric.count("debug_artifact_write", { result: "ok", stage: "start" });
+  } catch (err) {
+    metric.count("debug_artifact_write", { result: "fail", stage: "start" });
+    log.warn("debug: start header write failed", { error: errText(err), runId: running.runId });
+  }
+  fire(o.onStart, running);
+
+  let finished = false;
+
+  return {
+    recorder,
+    get finished(): boolean {
+      return finished;
+    },
+    async finish(status, final): Promise<void> {
+      if (finished) return;
+      finished = true;
+
+      let header = running;
+
+      // 1. Durable, append-only data first. Everything else is derived from it,
+      //    so a crash after this point still leaves a complete v2 run.
+      try {
+        const textRef = recorder.internText(final.text);
+        header = {
+          ...running,
+          status,
+          finishedAt: new Date().toISOString(),
+          counts: {
+            events: recorder.eventCount,
+            blobs: recorder.blobCount,
+            messages: recorder.messageCount,
+            toolCalls: recorder.toolCallCount,
+          },
+          tokenUsage: final.tokenUsage,
+          latency: final.latency,
+          ...(textRef !== undefined ? { lastAssistantTextRef: textRef } : {}),
+        };
+        store?.writeHeader(header);
+        await store?.flush();
+        metric.count("debug_artifact_write", { result: "ok", stage: "header" });
+      } catch (err) {
+        metric.count("debug_artifact_write", { result: "fail", stage: "header" });
+        log.warn("debug: final header write failed", { error: errText(err), runId: header.runId });
+      }
+
+      // 2. v1 compat artifacts, read back from what step 1 just persisted so the
+      //    snapshot resolves blob refs exactly the way a remote reader would.
+      //    Skipped for a child run: those files belong to the session, and this
+      //    run only owns part of it.
+      try {
+        if (store && o.materializeV1 !== false) {
+          const run = await readRun(store.runDir);
+          if (run) {
+            await writeJsonAtomic(path.join(store.debugDir, "debug-session.json"), toV1Snapshot(run));
+            await writeJsonAtomic(path.join(store.debugDir, "debug-events.json"), toV1Events(run));
+            metric.count("debug_artifact_write", { result: "ok", stage: "materialize" });
+          } else {
+            metric.count("debug_artifact_write", { result: "fail", stage: "materialize" });
+            log.warn("debug: run unreadable, v1 artifacts skipped", { runId: header.runId });
+          }
+        }
+      } catch (err) {
+        metric.count("debug_artifact_write", { result: "fail", stage: "materialize" });
+        log.warn("debug: v1 materialization failed", { error: errText(err), runId: header.runId });
+      }
+
+      try {
+        await store?.close();
+        metric.count("debug_artifact_write", { result: "ok", stage: "close" });
+      } catch (err) {
+        metric.count("debug_artifact_write", { result: "fail", stage: "close" });
+        log.warn("debug: store close failed", { error: errText(err), runId: header.runId });
+      }
+
+      fire(o.onFinish, header);
+    },
+  };
+}
+
+// ── Stream hook ─────────────────────────────────────────────────────────────
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function num(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function isThenable(v: unknown): v is Promise<unknown> {
+  return isRecord(v) && typeof (v as { then?: unknown }).then === "function";
+}
+
+/** Providers disagree on where the model id lives; take the first plausible one. */
+function modelIdOf(model: unknown): string | undefined {
+  if (typeof model === "string") return model;
+  if (!isRecord(model)) return undefined;
+  return str(model["id"]) ?? str(model["modelId"]) ?? str(model["model"]) ?? str(model["name"]);
+}
+
+export interface AvailableSkill {
+  name: string;
+  description?: string;
+  location?: string;
+}
+
+const SKILLS_BLOCK_RE = /<available_skills>([\s\S]*?)<\/available_skills>/i;
+const SKILL_RE = /<skill>([\s\S]*?)<\/skill>/gi;
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;|&apos;/g, "'")
+    // &amp; last, so `&amp;lt;` decodes to the literal `&lt;` rather than `<`.
+    .replace(/&amp;/g, "&");
+}
+
+function innerTag(body: string, tag: string): string | undefined {
+  const m = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, "i").exec(body);
+  const raw = m?.[1];
+  if (raw === undefined) return undefined;
+  const value = decodeEntities(raw).trim();
+  return value.length > 0 ? value : undefined;
+}
+
+/**
+ * Pull the skill catalog back out of the assembled system prompt.
+ *
+ * This is the only record of what the model could see: the catalog is built by
+ * pi at prompt-assembly time and never passes through our own config objects.
+ */
+export function parseAvailableSkills(systemPrompt: string): AvailableSkill[] {
+  if (typeof systemPrompt !== "string") return [];
+  const block = SKILLS_BLOCK_RE.exec(systemPrompt)?.[1];
+  if (!block) return [];
+  const out: AvailableSkill[] = [];
+  SKILL_RE.lastIndex = 0;
+  for (let m = SKILL_RE.exec(block); m !== null; m = SKILL_RE.exec(block)) {
+    const body = m[1] ?? "";
+    const name = innerTag(body, "name");
+    if (!name) continue;
+    const description = innerTag(body, "description");
+    const location = innerTag(body, "location");
+    out.push({
+      name,
+      ...(description !== undefined ? { description } : {}),
+      ...(location !== undefined ? { location } : {}),
+    });
+  }
+  return out;
+}
+
+export function paletteDiff(
+  prev: readonly string[],
+  next: readonly string[],
+): { added: string[]; removed: string[] } {
+  const before = new Set(prev);
+  const after = new Set(next);
+  return {
+    added: next.filter((n) => !before.has(n)),
+    removed: prev.filter((p) => !after.has(p)),
+  };
+}
+
+export function resolveCaptureLevel(): CaptureLevel {
+  const raw = process.env["DEBUG_CAPTURE"]?.trim().toLowerCase();
+  return isCaptureLevel(raw) ? raw : "full";
+}
+
+interface StreamCaptureOpts {
+  agent: { streamFn: (model: unknown, context: unknown, options?: unknown) => unknown };
+  recorder: Recorder;
+  fastMode?: boolean;
+  provider?: string;
+}
+
+/** Bounded so a run that rewrites its prompt every turn can't grow the cache. */
+const SKILL_CACHE_LIMIT = 16;
+
+const WRAPPED = Symbol.for("xyne.debug.streamCapture");
+
+export function installStreamCapture(o: StreamCaptureOpts): void {
+  const { agent, recorder } = o;
+  const base = agent.streamFn;
+  if (typeof base !== "function") return;
+  // Re-installing (provider fallback rebuilds the session) must not double-record.
+  if ((base as unknown as Record<symbol, unknown>)[WRAPPED] === true) return;
+
+  let prevToolNames: string[] = [];
+  let llmCall = 0;
+  const skillCache = new Map<string, AvailableSkill[]>();
+
+  const skillsFor = (systemPrompt: string): AvailableSkill[] => {
+    // A ~20 KB regex parse per turn is pure waste when the prompt rarely moves.
+    const key = hashContent(systemPrompt);
+    const hit = skillCache.get(key);
+    if (hit) return hit;
+    const parsed = parseAvailableSkills(systemPrompt);
+    if (skillCache.size >= SKILL_CACHE_LIMIT) {
+      const oldest = skillCache.keys().next();
+      if (!oldest.done) skillCache.delete(oldest.value);
+    }
+    skillCache.set(key, parsed);
+    return parsed;
+  };
+
+  const recordRequest = (model: unknown, context: unknown, options: unknown, call: number): void => {
+    const ctx = isRecord(context) ? context : {};
+    const opt = isRecord(options) ? options : {};
+
+    const rawMessages = ctx["messages"];
+    const messages = Array.isArray(rawMessages) ? (rawMessages as unknown[]) : [];
+    // `from` is where this request's *new* messages start; the request itself
+    // covers [0, to). Both are indices into the run's transcript log.
+    const messagesFrom = recorder.messageCount;
+    recorder.recordTranscript(messages);
+    const messagesTo = recorder.messageCount;
+
+    const systemPrompt = typeof ctx["systemPrompt"] === "string" ? (ctx["systemPrompt"] as string) : "";
+    const rawTools = ctx["tools"];
+    const tools = (Array.isArray(rawTools) ? (rawTools as unknown[]) : []).filter(isRecord).map((t) => {
+      const name = str(t["name"]) ?? "";
+      const description = str(t["description"]) ?? str(t["label"]);
+      return {
+        name,
+        ...(description !== undefined ? { description } : {}),
+        ...(t["parameters"] !== undefined ? { parameters: t["parameters"] } : {}),
+      };
+    });
+    const toolNames = tools.map((t) => t.name).filter((n) => n.length > 0);
+
+    const first = call === 1;
+    const { added, removed } = paletteDiff(prevToolNames, toolNames);
+    prevToolNames = toolNames;
+
+    const modelId = modelIdOf(model);
+    const provider = o.provider ?? (isRecord(model) ? str(model["provider"]) : undefined);
+    const thinkingLevel =
+      str(opt["thinkingLevel"]) ??
+      (isRecord(opt["thinking"]) ? str((opt["thinking"] as Record<string, unknown>)["level"]) : undefined) ??
+      str(opt["thinking"]);
+    const maxTokens = num(opt["maxTokens"]) ?? num(opt["max_tokens"]) ?? num(opt["maxOutputTokens"]);
+    const temperature = num(opt["temperature"]);
+
+    recorder.record(
+      "llm_request",
+      {
+        ...(modelId !== undefined ? { model: modelId } : {}),
+        ...(provider !== undefined ? { provider } : {}),
+        ...(temperature !== undefined ? { temperature } : {}),
+        ...(maxTokens !== undefined ? { maxTokens } : {}),
+        ...(thinkingLevel !== undefined ? { thinkingLevel } : {}),
+        fastMode: o.fastMode === true,
+        toolCount: tools.length,
+        systemPrompt,
+        tools,
+        toolNames,
+        availableSkills: skillsFor(systemPrompt),
+        // The first call has nothing to differ against — its palette is the
+        // baseline, reported by the `initial` tool_palette_change below.
+        paletteAdded: first ? [] : added,
+        paletteRemoved: first ? [] : removed,
+        messagesFrom,
+        messagesTo,
+      },
+      { llmCall: call },
+    );
+
+    if (added.length > 0 || removed.length > 0) {
+      recorder.record(
+        "tool_palette_change",
+        {
+          // The first call establishes the palette; a later change is pi having
+          // materialized lazily-loaded tools mid-run.
+          source: first ? "initial" : "load-tools",
+          added,
+          removed,
+          activeCount: toolNames.length,
+        },
+        { llmCall: call },
+      );
+    }
+  };
+
+  const recordResponse = (call: number, startedAt: number, value: unknown, err?: unknown): void => {
+    const v = isRecord(value) ? value : {};
+    const usage = isRecord(v["usage"]) ? v["usage"] : undefined;
+    // TTFT is measured by installLlmCallMetrics, which owns the iterator; we
+    // surface it only if the provider result carries it.
+    const ttftMs = num(v["ttftMs"]) ?? num(v["timeToFirstTokenMs"]);
+    recorder.record(
+      "llm_response",
+      {
+        ...(err !== undefined ? { errorMessage: errText(err) } : {}),
+        ...(str(v["stopReason"]) !== undefined ? { stopReason: str(v["stopReason"]) } : {}),
+        ...(ttftMs !== undefined ? { ttftMs } : {}),
+        ...(usage !== undefined ? { usage } : {}),
+        totalMs: Date.now() - startedAt,
+      },
+      { llmCall: call },
+    );
+  };
+
+  /**
+   * Observe the terminal outcome without touching the token stream —
+   * installLlmCallMetrics already wraps the iterator, and a second wrapper
+   * doubles per-token overhead for no new signal.
+   */
+  const observe = (result: unknown, call: number, startedAt: number): void => {
+    if (isThenable(result)) {
+      result.then(
+        (resolved) => observe(resolved, call, startedAt),
+        (err: unknown) => recordResponse(call, startedAt, undefined, err),
+      );
+      return;
+    }
+    if (!isRecord(result)) return;
+    const holder = result["result"];
+    const promise = typeof holder === "function" ? (holder as () => unknown).call(result) : holder;
+    if (!isThenable(promise)) return;
+    promise.then(
+      (value) => recordResponse(call, startedAt, value),
+      (err: unknown) => recordResponse(call, startedAt, undefined, err),
+    );
+  };
+
+  const wrapped = function (this: unknown, ...args: unknown[]): unknown {
+    const call = ++llmCall;
+    const startedAt = Date.now();
+    // A debug failure must never break an LLM call; every field access above is
+    // guarded, and this is the backstop for the shapes we didn't anticipate.
+    try {
+      recordRequest(args[0], args[1], args[2], call);
+    } catch (err) {
+      metric.count("debug_stream_capture_error", { stage: "request" });
+      log.warn("debug: llm_request capture failed", { error: errText(err) });
+    }
+
+    let result: unknown;
+    try {
+      result = (base as (...a: unknown[]) => unknown).apply(this, args);
+    } catch (err) {
+      recordResponse(call, startedAt, undefined, err);
+      throw err;
+    }
+
+    try {
+      observe(result, call, startedAt);
+    } catch (err) {
+      metric.count("debug_stream_capture_error", { stage: "response" });
+      log.warn("debug: llm_response capture failed", { error: errText(err) });
+    }
+    return result;
+  };
+
+  (wrapped as unknown as Record<symbol, unknown>)[WRAPPED] = true;
+  agent.streamFn = wrapped as StreamCaptureOpts["agent"]["streamFn"];
+}

--- a/apps/xyne-claw/src/debug/index.ts
+++ b/apps/xyne-claw/src/debug/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Debug tracing — public surface.
+ *
+ * Callers (agent.ts, subagent-tools.ts, routes/debug.ts) import from here and
+ * never reach into the individual modules, so the internal split can change
+ * without touching the run loop.
+ *
+ * The shape of the whole thing:
+ *
+ *   record()  →  Recorder  →  RunStore   (events.jsonl, append-only)
+ *                    ↓
+ *               BlobWriter →  RunStore   (blobs.jsonl, content-addressed)
+ *
+ *   readRun() →  materialize →  the v1 snapshot every existing reader expects
+ */
+
+export * from "./types.js";
+export {
+  EVENTS,
+  LEGACY_EVENT_KINDS,
+  isKnownKind,
+  specFor,
+  policyFor,
+  plain,
+  ref,
+  range,
+  drop,
+  type DebugEventKind,
+  type EventSpec,
+  type FieldPolicy,
+} from "./registry.js";
+export * from "./keys.js";
+export {
+  BlobWriter,
+  BlobIndex,
+  hashContent,
+  serializeForBlob,
+  BLOB_MAX_BYTES,
+  BLOB_GZIP_OVER,
+  type BlobLine,
+} from "./blobs.js";
+export {
+  RunStore,
+  readRun,
+  listRunDirs,
+  packRun,
+  unpackRun,
+  debugDirFor,
+  type ReadRun,
+  type RunStoreOpts,
+} from "./store.js";
+export { Recorder, type RecorderOpts } from "./recorder.js";
+export {
+  toV1Snapshot,
+  toV1Events,
+  toV2Run,
+  deriveToolInvocations,
+  replayMessages,
+} from "./materialize.js";
+export {
+  startCapture,
+  installStreamCapture,
+  parseAvailableSkills,
+  paletteDiff,
+  resolveCaptureLevel,
+  type StartCaptureOpts,
+  type CaptureHandles,
+  type AvailableSkill,
+} from "./capture.js";

--- a/apps/xyne-claw/src/debug/keys.ts
+++ b/apps/xyne-claw/src/debug/keys.ts
@@ -1,0 +1,210 @@
+/**
+ * Naming and key resolution for debug artifacts.
+ *
+ * Every "debug files not found" bug this codebase has had came from the same
+ * root cause: three different places each GUESSED the storeKey a run had been
+ * written under (`routes/debug.ts`, `webhook-commands/debug.ts`, and the GCS
+ * archive path), and each guessed a slightly different set of shapes. Branch
+ * keys, Digital-Twin per-user keys and userId-prefixed keys each broke a
+ * different guesser.
+ *
+ * The fix has two halves, and both live here:
+ *
+ * 1. `candidateStoreKeys` — ONE list of shapes, used by every caller.
+ * 2. The GCS run index — at run start we write a marker whose NAME contains the
+ *    actual storeKey. Discovery then stops being a guess: list the markers for
+ *    a conversation and you have the exact keys, including shapes nobody
+ *    enumerated.
+ *
+ * Guessing remains as a fallback for runs written before the index existed.
+ */
+
+/** Mirrors `safeUserKeySegment` in xyne-claw-shared/tools/sandbox/tools.ts. */
+function safeUserKeySegment(userId: string): string {
+  const cleaned = userId.replace(/[^A-Za-z0-9]/g, "");
+  return cleaned.length <= 40 ? cleaned : cleaned.slice(0, 40);
+}
+
+/** Filesystem/GCS-safe token: the charset `isSafeId` already enforces. */
+export function safeRunToken(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, "-");
+}
+
+/**
+ * Session-dir names that are NOT sessions — the eviction/restore machinery
+ * parks temporary copies alongside real ones. Matching these produced traces
+ * attributed to the wrong run, or a 404 when the real dir sorted after them.
+ */
+const TEMP_DIR_MARKERS = [".stale-", ".restore-", ".pvc-", ".tmp-"];
+
+export function isTempSessionDirName(name: string): boolean {
+  return TEMP_DIR_MARKERS.some((m) => name.includes(m));
+}
+
+/**
+ * Every storeKey shape a conversation can legitimately have been written under.
+ *
+ * Ordered most-specific first so a caller that stops at the first hit gets the
+ * narrowest match. Callers should still try them all — a conversation can have
+ * runs under several shapes when an agent slug changed mid-thread.
+ */
+export function candidateStoreKeys(
+  convId: string,
+  agentSlug?: string,
+  userId?: string,
+): string[] {
+  const keys: string[] = [];
+  const push = (k: string | undefined): void => {
+    if (k && !keys.includes(k)) keys.push(k);
+  };
+
+  const slug = agentSlug?.trim();
+  const uid = userId?.trim();
+
+  if (slug) {
+    // Digital-Twin per-user fold: `<convId>-<safeUserId>_<slug>`.
+    if (uid) push(`${convId}-${safeUserKeySegment(uid)}_${slug}`);
+    // Standard shared-thread key.
+    push(`${convId}_${slug}`);
+    // Agent-chat threads prefix the owner's userId.
+    if (uid) push(`${uid}_${convId}_${slug}`);
+  }
+  // Bare conversation id (no agent slug in play).
+  push(convId);
+  if (uid) push(`${uid}_${convId}`);
+  return keys;
+}
+
+/**
+ * Does an on-disk session dir belong to `convId`?
+ *
+ * Deliberately stricter than a bare `startsWith(convId)`: the remainder after
+ * the conversation id must look like a key segment, otherwise `conv-123` also
+ * matches `conv-1234`, and one conversation's drawer shows another's runs.
+ */
+export function sessionDirMatchesConversation(dirName: string, convId: string): boolean {
+  if (isTempSessionDirName(dirName)) return false;
+  if (dirName === convId) return true;
+  if (dirName.startsWith(`${convId}_`)) return true;
+  // Digital-Twin fold `<convId>-<safeUserId>_<slug>`: the hyphenated remainder
+  // must be an alphanumeric user segment followed by `_<slug>`.
+  if (dirName.startsWith(`${convId}-`)) {
+    return /^[A-Za-z0-9]{1,40}_[A-Za-z0-9_-]+$/.test(dirName.slice(convId.length + 1));
+  }
+  // userId-prefixed agent-chat threads: `<userId>_<convId>_<slug>`.
+  if (dirName.includes(`_${convId}_`)) return true;
+  if (dirName.endsWith(`_${convId}`)) return true;
+  return false;
+}
+
+// ── Run identity ────────────────────────────────────────────────────────────
+
+/** `<startedAtMs>-<safeSessionId>` — also the run directory name. */
+export function runIdFor(startedAtMs: number, sessionId: string | undefined): string {
+  return `${startedAtMs}-${safeRunToken(sessionId ?? "local")}`;
+}
+
+/**
+ * Legacy v1 artifact name. Preserved EXACTLY — `routes/debug.ts`, the webhook
+ * `/debug` command, the claw-auth proxy and the loop-watchdog tests all parse
+ * this pattern.
+ */
+export function runFileNameFor(runId: string): string {
+  return `debug-run-${runId}.json`;
+}
+
+const RUN_FILE_RE = /^debug-run-(\d{13,})-([A-Za-z0-9_-]+)\.json$/;
+
+export function parseRunFileName(
+  fileName: string,
+): { runId: string; startedAtMs: number; sessionToken: string } | null {
+  const m = RUN_FILE_RE.exec(fileName);
+  if (!m) return null;
+  const startedAtMs = Number(m[1]);
+  if (!Number.isFinite(startedAtMs)) return null;
+  return { runId: `${m[1]}-${m[2]}`, startedAtMs, sessionToken: m[2] as string };
+}
+
+/**
+ * Start-of-run placeholder object.
+ *
+ * Deliberately NOT `runFileNameFor(runId)`: a header-only stub written to the
+ * final snapshot's name would survive a failed finish-time upload and shadow
+ * the complete trace forever. This name is only ever consulted when no richer
+ * copy of the run exists anywhere.
+ */
+export function startingRunObjectName(runId: string): string {
+  return `debug-run-${runId}.starting.json`;
+}
+
+export function isStartingRunObjectName(name: string): boolean {
+  const base = name.slice(name.lastIndexOf("/") + 1);
+  return base.startsWith("debug-run-") && base.endsWith(".starting.json");
+}
+
+/** Packed v2 run (gzipped ndjson of header + events + blobs). */
+export function packedRunObjectName(runId: string): string {
+  return `v2/${runId}.ndjson.gz`;
+}
+
+export function parsePackedRunObjectName(name: string): { runId: string } | null {
+  const base = name.slice(name.lastIndexOf("/") + 1);
+  if (!base.endsWith(".ndjson.gz")) return null;
+  const runId = base.slice(0, -".ndjson.gz".length);
+  return runId ? { runId } : null;
+}
+
+// ── GCS discovery index ─────────────────────────────────────────────────────
+
+export const DEBUG_INDEX_PREFIX = "_index";
+
+/**
+ * Discovery marker: `_index/<convId>/<runId>~<storeKey>.json`.
+ *
+ * `~` is the separator because `isSafeId`'s charset (`[A-Za-z0-9_-]`) excludes
+ * it, so neither a runId nor a storeKey can contain one — the split is
+ * unambiguous no matter what a caller passes.
+ */
+export function indexObjectName(convId: string, runId: string, storeKey: string): string {
+  return `${DEBUG_INDEX_PREFIX}/${convId}/${runId}~${storeKey}.json`;
+}
+
+export function indexPrefixFor(convId: string): string {
+  return `${DEBUG_INDEX_PREFIX}/${convId}/`;
+}
+
+export function parseIndexObjectName(
+  name: string,
+): { convId: string; runId: string; storeKey: string; startedAtMs: number } | null {
+  const parts = name.split("/");
+  if (parts.length < 3) return null;
+  const idx = parts.indexOf(DEBUG_INDEX_PREFIX);
+  if (idx < 0 || parts.length < idx + 3) return null;
+  const convId = parts[idx + 1];
+  const leaf = parts[idx + 2];
+  if (!convId || !leaf || !leaf.endsWith(".json")) return null;
+  const body = leaf.slice(0, -".json".length);
+  const sep = body.indexOf("~");
+  if (sep <= 0) return null;
+  const runId = body.slice(0, sep);
+  const storeKey = body.slice(sep + 1);
+  if (!runId || !storeKey) return null;
+  const dash = runId.indexOf("-");
+  const startedAtMs = dash > 0 ? Number(runId.slice(0, dash)) : Number.NaN;
+  return {
+    convId,
+    runId,
+    storeKey,
+    startedAtMs: Number.isFinite(startedAtMs) ? startedAtMs : 0,
+  };
+}
+
+/** Sort newest-first by the epoch embedded in the runId, never by string. */
+export function compareRunIdsNewestFirst(a: string, b: string): number {
+  const at = Number(a.slice(0, a.indexOf("-")));
+  const bt = Number(b.slice(0, b.indexOf("-")));
+  const av = Number.isFinite(at) ? at : 0;
+  const bv = Number.isFinite(bt) ? bt : 0;
+  if (av !== bv) return bv - av;
+  return a < b ? 1 : a > b ? -1 : 0;
+}

--- a/apps/xyne-claw/src/debug/materialize.ts
+++ b/apps/xyne-claw/src/debug/materialize.ts
@@ -1,0 +1,752 @@
+/**
+ * v2 → v1 materialization.
+ *
+ * The write path is append-only and de-duplicated (blob refs, transcript
+ * deltas, one `llm_request` per model call). Every existing reader — DebugDrawer,
+ * the dashboard trace panel, the debug HTML exporter, the webhook `/debug`
+ * command — still expects the old fully-inlined `DebugSessionSnapshot`. This
+ * module rebuilds that shape on read so the rewrite is invisible to all of them.
+ *
+ * Three things here are compatibility, not design:
+ *
+ * - `llm_request` is FOLDED into the turn's `session_prompt`. The drawer has one
+ *   "prompt" row per turn and no concept of a separate request event; folding is
+ *   what makes the true effective system prompt (the one with `<available_skills>`
+ *   appended by pi) appear where the UI already looks for it. The pairing is by
+ *   SEQ ADJACENCY, not by `llmCall` — see `foldModelCalls`.
+ * - Per-event `messages` are RE-INLINED from the replayed transcript, because the
+ *   drawer renders a transcript panel per event. The v2 writer stores an index
+ *   range instead of a copy — that is the fix for the O(turns²) traces — so the
+ *   copy has to come back here, sliced to the range (or, failing that, to the
+ *   transcript as it stood at that event's seq) so a turn shows ITS transcript.
+ * - Re-inlining is budgeted. A 400-turn run would otherwise materialize into
+ *   hundreds of megabytes of duplicated transcript; over budget we blank the
+ *   OLDEST embeds first and say so in `warnings`, so a huge trace degrades
+ *   instead of taking the process down.
+ *
+ * Everything this module cannot reconstruct faithfully becomes a `warning` on
+ * the snapshot rather than a silent repair: a transcript with a visible hole is
+ * recoverable, one that was quietly spliced is not.
+ */
+
+import type { Citation } from "xyne-claw-shared";
+import type { BlobIndex, BlobLine } from "./blobs.js";
+import type { ReadRun } from "./store.js";
+import type {
+  BlobRef,
+  DebugEventRecord,
+  DebugEventV2,
+  DebugSessionSnapshot,
+  RunHeader,
+  ToolInvocation,
+} from "./types.js";
+import { isBlobRef } from "./types.js";
+
+/** Total bytes of re-inlined per-event transcript we are willing to produce. */
+const DEFAULT_MAX_INLINE_BYTES = 8_000_000;
+
+/** Collects non-fatal read problems; deduped because one bad blob is referenced
+ *  by every event that carries its hash. */
+type Warn = (message: string) => void;
+
+function warningSink(): { warn: Warn; warnings: string[] } {
+  const warnings: string[] = [];
+  const seen = new Set<string>();
+  return {
+    warnings,
+    warn: (message) => {
+      if (seen.has(message)) return;
+      seen.add(message);
+      warnings.push(message);
+    },
+  };
+}
+
+/**
+ * Blob fields whose content is the value itself, not a JSON encoding of it.
+ *
+ * `serializeForBlob` passes strings through unchanged, so a stored `result` of
+ * `{"content":[...]}` is an MCP envelope STRING, not an object. Parsing it back
+ * would silently change the type the UI (and the exporter's `JSON.parse` guards)
+ * has always seen. Anything not listed here was structured on the way in and is
+ * parsed back to structure.
+ */
+const STRING_BLOB_FIELDS = new Set([
+  "assistantText",
+  "context",
+  "detail",
+  "error",
+  "errorMessage",
+  "lastAssistantText",
+  "message",
+  "prompt",
+  "question",
+  "result",
+  "summary",
+  "systemPrompt",
+  "task",
+  "text",
+]);
+
+/**
+ * Fields lifted from `llm_request` onto the turn's `session_prompt`.
+ *
+ * `messagesFrom`/`messagesTo` are in here because the request is the ONLY event
+ * that carries the transcript range for its model call; without them the prompt
+ * row has no range and its panel falls back to the whole transcript.
+ */
+const FOLD_REQUEST_FIELDS = [
+  "systemPrompt",
+  "tools",
+  "toolNames",
+  "availableSkills",
+  "model",
+  "provider",
+  "temperature",
+  "maxTokens",
+  "thinkingLevel",
+  "fastMode",
+  "paletteAdded",
+  "paletteRemoved",
+  "messagesFrom",
+  "messagesTo",
+] as const;
+
+/**
+ * Folded fields that are usually IDENTICAL on every call of a run: the system
+ * prompt, the tool catalog, the parsed skill list.
+ *
+ * On disk they cost one copy each (content addressing). Re-inlining them into
+ * every `session_prompt` would hand that duplication straight back on the wire —
+ * a 4-turn run measured 49% redundant bytes, and it scales with turn count. So
+ * the first occurrence carries the payload and later identical ones carry
+ * `<field>UnchangedFromSeq` instead. Consumers rehydrate by walking back to that
+ * seq (DebugDrawer does it in `compactTimeline`, the HTML exporter in its own
+ * pre-pass), so nothing is lost — a turn that genuinely CHANGES one of these
+ * (mid-run `load-tools`, a provider fallback with a different prompt) still
+ * carries the new value in full, which is exactly when you need to see it.
+ */
+const DEDUPED_FOLD_FIELDS = ["systemPrompt", "tools", "toolNames", "availableSkills"] as const;
+
+export const UNCHANGED_FROM_SUFFIX = "UnchangedFromSeq";
+
+function dedupeRepeatedPayloads(events: readonly DebugEventRecord[]): void {
+  // Serialized value of each field as last EMITTED, with the seq that carries it.
+  const last = new Map<string, { seq: number; json: string }>();
+  for (const record of events) {
+    for (const field of DEDUPED_FOLD_FIELDS) {
+      const value = record.data[field];
+      if (value === undefined) continue;
+      const json = JSON.stringify(value);
+      if (json === undefined) continue;
+      const prev = last.get(field);
+      if (prev && prev.json === json) {
+        delete record.data[field];
+        record.data[`${field}${UNCHANGED_FROM_SUFFIX}`] = prev.seq;
+      } else {
+        last.set(field, { seq: record.seq, json });
+      }
+    }
+  }
+}
+
+/** Events whose `data.messages` the drawer renders as a transcript panel. */
+const TRANSCRIPT_EMBED_KINDS = new Set(["session_prompt", "assistant_turn_end"]);
+
+// ── primitives ──────────────────────────────────────────────────────────────
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function asNumber(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function asStatus(v: unknown): "running" | "completed" | undefined {
+  return v === "running" || v === "completed" ? v : undefined;
+}
+
+function asBackgroundState(v: unknown): "running" | "completed" | "error" | undefined {
+  return v === "running" || v === "completed" || v === "error" ? v : undefined;
+}
+
+function bySeq(a: DebugEventV2, b: DebugEventV2): number {
+  return a.seq - b.seq;
+}
+
+function byteLength(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value) ?? "", "utf8");
+  } catch {
+    return 0;
+  }
+}
+
+function decodeBlobField(field: string, raw: string, ref: BlobRef, warn?: Warn): unknown {
+  if (STRING_BLOB_FIELDS.has(field)) return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // Content that isn't JSON was a string all along (an unregistered field), or
+    // the blob was cut mid-value. The raw text is still the best we have, but a
+    // structured field arriving as a string changes what the UI renders, so say
+    // so rather than letting the panel look merely odd.
+    warn?.(
+      ref.truncated === true
+        ? `field "${field}" (blob ${ref.hash}) was truncated at ${ref.bytes} of ${ref.originalBytes ?? ref.bytes} bytes and no longer parses as JSON; the raw text is shown instead`
+        : `field "${field}" (blob ${ref.hash}) could not be parsed back to JSON; the raw text is shown instead`,
+    );
+    return raw;
+  }
+}
+
+/**
+ * Replace every `<field>Ref` with the resolved `<field>`.
+ *
+ * A ref whose content is absent (capture level `metadata`, or a blob log that
+ * lost its tail) is LEFT IN PLACE rather than dropped: the hash and byte count
+ * still tell the reader something existed and how big it was.
+ *
+ * A ref that was TRUNCATED on the way in leaves `<field>Truncated` and
+ * `<field>OriginalBytes` behind it. Without them the UI shows a cut payload as
+ * if it were the whole thing, which is the one way a trace can actively mislead.
+ */
+function resolveData(
+  data: Record<string, unknown>,
+  blobs: BlobIndex,
+  warn?: Warn,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const refs: Array<[string, BlobRef]> = [];
+  for (const [k, v] of Object.entries(data)) {
+    if (k.endsWith("Ref") && isBlobRef(v)) {
+      refs.push([k, v]);
+      continue;
+    }
+    out[k] = v;
+  }
+  for (const [k, refValue] of refs) {
+    const field = k.slice(0, -"Ref".length);
+    const raw = blobs.get(refValue.hash);
+    if (raw === undefined) {
+      out[k] = refValue;
+      continue;
+    }
+    out[field] = decodeBlobField(field, raw, refValue, warn);
+    if (refValue.truncated === true) {
+      out[`${field}Truncated`] = true;
+      if (refValue.originalBytes !== undefined) {
+        out[`${field}OriginalBytes`] = refValue.originalBytes;
+      }
+    }
+  }
+  return out;
+}
+
+// ── transcript replay ───────────────────────────────────────────────────────
+
+function readDelta(data: Record<string, unknown>, blobs: BlobIndex): unknown[] | undefined {
+  const inline = data.messages;
+  if (Array.isArray(inline)) return inline;
+  const ref = data.messagesRef;
+  if (!isBlobRef(ref)) return undefined;
+  const raw = blobs.get(ref.hash);
+  if (raw === undefined) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+interface Transcript {
+  messages: unknown[];
+  /** Transcript length after each `message_append`, in seq order. Lets an event
+   *  that carries no range be sliced to the transcript as it stood back then. */
+  checkpoints: Array<{ seq: number; length: number }>;
+  warnings: string[];
+}
+
+/** `12..18` for a delta we could not apply; `12..?` when the writer's own
+ *  bookkeeping is missing too. */
+function missingRange(from: number, to: number | undefined): string {
+  return `${from}..${to ?? "?"}`;
+}
+
+/**
+ * Rebuild the full transcript from the `message_append` deltas.
+ *
+ * `reset: true` means compaction rewrote the list rather than extending it, so
+ * the delta REPLACES what came before. A delta whose `from` lands inside the
+ * accumulator truncates to that point first — mid-turn rewrites are otherwise
+ * appended twice.
+ *
+ * Deltas are concatenated, so anything we cannot apply — an unreadable blob, a
+ * `from` past the end of what we have — leaves a HOLE at a position the reader
+ * cannot see. Every such gap is reported; a spliced transcript that claims to be
+ * complete is worse than a short one that admits it.
+ */
+function replayTranscript(run: ReadRun): Transcript {
+  const acc: unknown[] = [];
+  const checkpoints: Array<{ seq: number; length: number }> = [];
+  const { warn, warnings } = warningSink();
+  const appends = run.events.filter((e) => e.kind === "message_append").sort(bySeq);
+
+  for (const e of appends) {
+    const data = e.data ?? {};
+    const delta = readDelta(data, run.blobs);
+    const declaredFrom = asNumber(data.from);
+    const declaredTo = asNumber(data.to);
+    if (!delta) {
+      warn(
+        `transcript incomplete: dropped delta at seq ${e.seq} (messages ${missingRange(declaredFrom ?? acc.length, declaredTo)} missing)`,
+      );
+      checkpoints.push({ seq: e.seq, length: acc.length });
+      continue;
+    }
+    if (data.reset === true) {
+      acc.length = 0;
+      acc.push(...delta);
+      checkpoints.push({ seq: e.seq, length: acc.length });
+      continue;
+    }
+    if (declaredFrom !== undefined && declaredFrom >= 0 && declaredFrom < acc.length) {
+      acc.length = declaredFrom;
+    } else if (declaredFrom !== undefined && declaredFrom > acc.length) {
+      // An earlier delta went missing: appending here silently renumbers every
+      // message after the gap, so name the range that is absent.
+      warn(
+        `transcript incomplete: delta at seq ${e.seq} starts at message ${declaredFrom} but only ${acc.length} are known (messages ${missingRange(acc.length, declaredFrom)} missing)`,
+      );
+    }
+    acc.push(...delta);
+    checkpoints.push({ seq: e.seq, length: acc.length });
+  }
+
+  return { messages: acc, checkpoints, warnings };
+}
+
+export function replayMessages(run: ReadRun): unknown[] {
+  return replayTranscript(run).messages;
+}
+
+/**
+ * Transcript length as of a given seq. Returns a cursor rather than a lookup
+ * because it walks the checkpoints once: callers MUST query in ascending seq
+ * order (the materializer iterates a seq-sorted list).
+ */
+function lengthAsOfCursor(t: Transcript): (seq: number) => number {
+  let i = 0;
+  let length = 0;
+  return (seq: number): number => {
+    while (i < t.checkpoints.length) {
+      const c = t.checkpoints[i];
+      if (c === undefined || c.seq > seq) break;
+      length = c.length;
+      i += 1;
+    }
+    return length;
+  };
+}
+
+// ── tool invocations ────────────────────────────────────────────────────────
+
+function resultToString(v: unknown): string | undefined {
+  if (v === undefined) return undefined;
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v) ?? "";
+  } catch {
+    return String(v);
+  }
+}
+
+/**
+ * Rebuild `ToolInvocation[]` from the start/end/update event trio.
+ *
+ * The three kinds are a state machine per `toolCallId`: start writes a `running`
+ * row so an in-flight trace shows the call, end replaces it with the completed
+ * one, and update patches it afterwards — that last one is how a background
+ * subagent flips from `running` to `completed` long after its tool call
+ * returned.
+ */
+export function deriveToolInvocations(run: ReadRun): ToolInvocation[] {
+  const rows = new Map<string, ToolInvocation>();
+  const ordered = [...run.events].sort(bySeq);
+
+  /** End events predate stable ids in old traces; fall back to the newest
+   *  still-running row for the same tool name. */
+  const runningKeyFor = (toolName: string | undefined): string | undefined => {
+    if (!toolName) return undefined;
+    let found: string | undefined;
+    for (const [key, row] of rows) {
+      if (row.toolName === toolName && row.status === "running") found = key;
+    }
+    return found;
+  };
+
+  for (const e of ordered) {
+    if (e.kind === "tool_execution_start") {
+      const d = resolveData(e.data ?? {}, run.blobs);
+      const key = e.toolCallId ?? `seq:${e.seq}`;
+      rows.set(key, {
+        toolName: asString(d.toolName) ?? "unknown",
+        args: d.args,
+        result: "",
+        isError: false,
+        startedAt: e.at,
+        durationMs: 0,
+        status: "running",
+        ...(e.toolCallId !== undefined ? { toolCallId: e.toolCallId } : {}),
+        ...(e.parentToolCallId !== undefined ? { parentToolCallId: e.parentToolCallId } : {}),
+        ...(e.subagentName !== undefined ? { subagentName: e.subagentName } : {}),
+      });
+      continue;
+    }
+
+    if (e.kind === "tool_execution_end") {
+      const d = resolveData(e.data ?? {}, run.blobs);
+      const toolName = asString(d.toolName);
+      const key = e.toolCallId ?? runningKeyFor(toolName) ?? `seq:${e.seq}`;
+      const prev = rows.get(key);
+      const citations = Array.isArray(d.citations) ? (d.citations as Citation[]) : undefined;
+      const debug =
+        typeof d.debug === "object" && d.debug !== null && !Array.isArray(d.debug)
+          ? (d.debug as Record<string, unknown>)
+          : undefined;
+      const toolCallId = e.toolCallId ?? prev?.toolCallId;
+      const parentToolCallId = e.parentToolCallId ?? prev?.parentToolCallId;
+      const subagentName = e.subagentName ?? prev?.subagentName;
+      const backgroundState = asBackgroundState(d.backgroundState);
+      const backgroundTaskId = asString(d.backgroundTaskId);
+
+      rows.set(key, {
+        toolName: toolName ?? prev?.toolName ?? "unknown",
+        args: d.args !== undefined ? d.args : prev?.args,
+        result: resultToString(d.result) ?? "",
+        isError: d.isError === true,
+        startedAt: prev?.startedAt ?? e.at,
+        durationMs: asNumber(d.durationMs) ?? prev?.durationMs ?? 0,
+        status: asStatus(d.status) ?? "completed",
+        ...(toolCallId !== undefined ? { toolCallId } : {}),
+        ...(parentToolCallId !== undefined ? { parentToolCallId } : {}),
+        ...(subagentName !== undefined ? { subagentName } : {}),
+        ...(citations !== undefined ? { citations } : {}),
+        ...(debug !== undefined ? { debug } : {}),
+        ...(typeof d.background === "boolean" ? { background: d.background } : {}),
+        ...(backgroundState !== undefined ? { backgroundState } : {}),
+        ...(backgroundTaskId !== undefined ? { backgroundTaskId } : {}),
+      });
+      continue;
+    }
+
+    if (e.kind === "tool_invocation_update") {
+      const d = resolveData(e.data ?? {}, run.blobs);
+      const key = asString(d.toolCallId) ?? e.toolCallId;
+      const row = key ? rows.get(key) : undefined;
+      // A patch for a call we never saw start has nothing to attach to; the
+      // start/end pair is the record of the call, so dropping it loses nothing.
+      if (!row) continue;
+      const status = asStatus(d.status);
+      if (status !== undefined) row.status = status;
+      if (typeof d.background === "boolean") row.background = d.background;
+      const backgroundState = asBackgroundState(d.backgroundState);
+      if (backgroundState !== undefined) row.backgroundState = backgroundState;
+      const backgroundTaskId = asString(d.backgroundTaskId);
+      if (backgroundTaskId !== undefined) row.backgroundTaskId = backgroundTaskId;
+      const durationMs = asNumber(d.durationMs);
+      if (durationMs !== undefined) row.durationMs = durationMs;
+      const result = resultToString(d.result);
+      if (result !== undefined) row.result = result;
+    }
+  }
+
+  return [...rows.values()];
+}
+
+// ── events ──────────────────────────────────────────────────────────────────
+
+function baseRecord(e: DebugEventV2, blobs: BlobIndex, warn: Warn): DebugEventRecord {
+  return {
+    seq: e.seq,
+    at: e.at,
+    kind: e.kind,
+    ...(e.turn !== undefined ? { turn: e.turn } : {}),
+    ...(e.llmCall !== undefined ? { llmCall: e.llmCall } : {}),
+    ...(e.toolCallId !== undefined ? { toolCallId: e.toolCallId } : {}),
+    ...(e.parentToolCallId !== undefined ? { parentToolCallId: e.parentToolCallId } : {}),
+    ...(e.subagentName !== undefined ? { subagentName: e.subagentName } : {}),
+    ...(e.childRunId !== undefined ? { childRunId: e.childRunId } : {}),
+    data: resolveData(e.data ?? {}, blobs, warn),
+  };
+}
+
+function foldRequest(target: DebugEventRecord, request: DebugEventRecord): void {
+  for (const field of FOLD_REQUEST_FIELDS) {
+    const v = request.data[field];
+    if (v !== undefined) target.data[field] = v;
+  }
+}
+
+function foldResponse(target: DebugEventRecord, response: DebugEventRecord): void {
+  if (response.data.usage !== undefined) target.data.responseUsage = response.data.usage;
+  if (response.data.stopReason !== undefined) {
+    target.data.responseStopReason = response.data.stopReason;
+  }
+  if (response.data.ttftMs !== undefined) target.data.ttftMs = response.data.ttftMs;
+}
+
+/**
+ * Attach each model call's request/response to the prompt row it belongs to.
+ *
+ * The pairing key is SEQ, not `llmCall`. There are two independent counters:
+ * agent.ts bumps its own on pi's `turn_start`, the stream hook bumps its own on
+ * every `streamFn` invocation. Any call without a matching turn_start — a
+ * retry, a compaction call, a provider fallback — drifts them apart, and from
+ * then on an `llmCall`-keyed fold staples one turn's system prompt and tool list
+ * onto a different turn's panel. Seq is the single ordering both writers share,
+ * and adjacency in it is what "same model call" actually means.
+ *
+ * Both emission orders are tolerated. Pi emits `turn_start` before calling
+ * `streamFn`, so the prompt row normally comes first; a request that arrives
+ * first (a hook that runs ahead, a re-ordered log) is held and claimed by the
+ * prompt that follows it, unless its own response lands in between — that
+ * request's call is over and cannot belong to a turn that has not started.
+ *
+ * `llmCall` equality is only the fallback, for a request the seq pass could not
+ * place at all.
+ *
+ * Returns the request records that were folded away (the caller drops them from
+ * the timeline; their content now lives on the prompt row).
+ */
+function foldModelCalls(records: DebugEventRecord[]): Set<DebugEventRecord> {
+  const foldedRequests = new Set<DebugEventRecord>();
+  const promptsWithRequest = new Set<DebugEventRecord>();
+  const foldedResponses = new Set<DebugEventRecord>();
+  /** Where each model call's request landed — `undefined` when that request had
+   *  no prompt row to fold into. Request and response DO share one counter (the
+   *  stream hook stamps both), so this pairing cannot drift. */
+  const requestTargets = new Map<number, DebugEventRecord | undefined>();
+
+  let openPrompt: DebugEventRecord | undefined;
+  let unclaimedRequest: DebugEventRecord | undefined;
+
+  for (const r of records) {
+    if (r.kind === "session_prompt") {
+      if (unclaimedRequest) {
+        foldRequest(r, unclaimedRequest);
+        foldedRequests.add(unclaimedRequest);
+        promptsWithRequest.add(r);
+        if (unclaimedRequest.llmCall !== undefined) requestTargets.set(unclaimedRequest.llmCall, r);
+        unclaimedRequest = undefined;
+      }
+      openPrompt = r;
+      continue;
+    }
+    if (r.kind === "llm_request") {
+      if (openPrompt && !promptsWithRequest.has(openPrompt)) {
+        foldRequest(openPrompt, r);
+        foldedRequests.add(r);
+        promptsWithRequest.add(openPrompt);
+        if (r.llmCall !== undefined) requestTargets.set(r.llmCall, openPrompt);
+      } else {
+        // A second call within one turn (retry, compaction). It has no prompt
+        // row of its own yet; the next one may still claim it.
+        unclaimedRequest = r;
+        if (r.llmCall !== undefined) requestTargets.set(r.llmCall, undefined);
+      }
+      continue;
+    }
+    if (r.kind === "llm_response") {
+      const call = r.llmCall;
+      if (call !== undefined && requestTargets.has(call)) {
+        // Follow the request: a response to a call that never had a prompt row
+        // must not be pinned onto the prompt that happens to be open.
+        const target = requestTargets.get(call);
+        if (target) {
+          foldResponse(target, r);
+          foldedResponses.add(r);
+        }
+      } else if (openPrompt) {
+        foldResponse(openPrompt, r);
+        foldedResponses.add(r);
+      }
+      // The call this response closes is over, so a request still waiting for a
+      // home cannot belong to a turn that has not started yet.
+      unclaimedRequest = undefined;
+      continue;
+    }
+  }
+
+  // Fallback: a request/response the seq pass never placed still carries its
+  // writer-stamped llmCall, which is right whenever the counters happen not to
+  // have drifted.
+  const freePromptByCall = new Map<number, DebugEventRecord>();
+  for (const r of records) {
+    if (r.kind !== "session_prompt" || r.llmCall === undefined) continue;
+    if (promptsWithRequest.has(r)) continue;
+    if (!freePromptByCall.has(r.llmCall)) freePromptByCall.set(r.llmCall, r);
+  }
+  for (const r of records) {
+    if (r.llmCall === undefined) continue;
+    const target = freePromptByCall.get(r.llmCall);
+    if (!target) continue;
+    if (r.kind === "llm_request" && !foldedRequests.has(r)) {
+      foldRequest(target, r);
+      foldedRequests.add(r);
+      promptsWithRequest.add(target);
+      freePromptByCall.delete(r.llmCall);
+    } else if (r.kind === "llm_response" && !foldedResponses.has(r)) {
+      foldResponse(target, r);
+      foldedResponses.add(r);
+    }
+  }
+
+  return foldedRequests;
+}
+
+interface BuiltEvents {
+  events: DebugEventRecord[];
+  warnings: string[];
+  transcript: Transcript;
+}
+
+function buildV1Events(run: ReadRun): BuiltEvents {
+  const { warn, warnings } = warningSink();
+
+  const records = [...run.events]
+    .sort(bySeq)
+    // Bookkeeping for the transcript log, not a timeline row — the drawer would
+    // render one grey "message_append" line per turn for no information.
+    .filter((e) => e.kind !== "message_append")
+    .map((e) => baseRecord(e, run.blobs, warn));
+
+  const foldedRequests = foldModelCalls(records);
+  const events = records.filter((r) => !foldedRequests.has(r));
+  dedupeRepeatedPayloads(events);
+
+  // ── re-inline the per-event transcript panels ────────────────────────────
+  const transcript = replayTranscript(run);
+  for (const w of transcript.warnings) warn(w);
+  const lengthAsOf = lengthAsOfCursor(transcript);
+
+  // Each turn's transcript panel is a PREFIX of `snapshot.messages`, so stamping
+  // the cursor is enough — the reader slices. Inlining the prefix instead put
+  // the whole transcript-so-far on the wire twice per turn, which is O(turns^2)
+  // and was 42% of a 4-turn bundle. `messagesTo` is what the panel needs and it
+  // costs 12 bytes.
+  for (const r of events) {
+    if (!TRANSCRIPT_EMBED_KINDS.has(r.kind)) continue;
+    // The event's own range wins. Without one (an `assistant_turn_end`, or a
+    // prompt row whose request never made it), the transcript AS OF THIS EVENT
+    // is the honest answer — showing turn 1 the messages of turn 40 is a lie.
+    const to = asNumber(r.data.messagesTo) ?? lengthAsOf(r.seq);
+    r.data.messagesTo = Math.max(0, Math.min(to, transcript.messages.length));
+  }
+
+  return { events, warnings, transcript };
+}
+
+export function toV1Events(run: ReadRun): DebugEventRecord[] {
+  return buildV1Events(run).events;
+}
+
+// ── snapshot ────────────────────────────────────────────────────────────────
+
+/**
+ * The drawer reads the stream counters off the snapshot root, not off
+ * `latency`. Mirrored rather than moved — both readers exist.
+ */
+interface SnapshotWithStreamMirror extends DebugSessionSnapshot {
+  streamChars?: number;
+  streamCharsPerSec?: number;
+  streamTextChars?: number;
+  streamThinkingChars?: number;
+}
+
+function copyHeaderIdentity(h: RunHeader): Partial<DebugSessionSnapshot> {
+  return {
+    ...(h.conversationId !== undefined ? { conversationId: h.conversationId } : {}),
+    ...(h.sessionId !== undefined ? { sessionId: h.sessionId } : {}),
+    ...(h.agentSlug !== undefined ? { agentSlug: h.agentSlug } : {}),
+    ...(h.userId !== undefined ? { userId: h.userId } : {}),
+    ...(h.userName !== undefined ? { userName: h.userName } : {}),
+    ...(h.userEmail !== undefined ? { userEmail: h.userEmail } : {}),
+    ...(h.provider !== undefined ? { provider: h.provider } : {}),
+    ...(h.model !== undefined ? { model: h.model } : {}),
+    ...(h.thinking !== undefined ? { thinking: h.thinking } : {}),
+    ...(h.speed !== undefined ? { speed: h.speed } : {}),
+    ...(h.context !== undefined ? { context: h.context } : {}),
+    ...(h.systemPromptOverride !== undefined
+      ? { systemPromptOverride: h.systemPromptOverride }
+      : {}),
+  };
+}
+
+export function toV1Snapshot(run: ReadRun): DebugSessionSnapshot {
+  const h = run.header;
+  // One build, one replay: the events and the snapshot's `messages` must be the
+  // same transcript, and its warnings must reach the reader exactly once.
+  const built = buildV1Events(run);
+  const latency = h.latency;
+  const warnings = [...run.warnings, ...built.warnings];
+
+  const lastAssistantText =
+    h.lastAssistantTextRef !== undefined
+      ? (run.blobs.get(h.lastAssistantTextRef.hash) ?? "")
+      : "";
+
+  const snapshot: SnapshotWithStreamMirror = {
+    schemaVersion: 1,
+    ...copyHeaderIdentity(h),
+    startedAt: h.startedAt,
+    finishedAt: h.finishedAt,
+    task: h.task,
+    ...(h.status === "running" ? { inProgress: true } : {}),
+    ...(h.status === "cancelled" || h.status === "error" || h.status === "crashed"
+      ? { cancelled: true }
+      : {}),
+    messages: built.transcript.messages,
+    toolInvocations: deriveToolInvocations(run),
+    tokenUsage: h.tokenUsage,
+    latency,
+    lastAssistantText,
+    events: built.events,
+    ...(latency.streamChars !== undefined ? { streamChars: latency.streamChars } : {}),
+    ...(latency.streamCharsPerSec !== undefined
+      ? { streamCharsPerSec: latency.streamCharsPerSec }
+      : {}),
+    ...(latency.streamTextChars !== undefined
+      ? { streamTextChars: latency.streamTextChars }
+      : {}),
+    ...(latency.streamThinkingChars !== undefined
+      ? { streamThinkingChars: latency.streamThinkingChars }
+      : {}),
+    ...(warnings.length > 0 ? { warnings } : {}),
+  };
+
+  return snapshot;
+}
+
+// ── raw v2 passthrough ──────────────────────────────────────────────────────
+
+/**
+ * The un-materialized run, for readers that want the append-only form: header
+ * and events verbatim plus a CONTENT-FREE blob index, so a caller can size a
+ * payload (or decide to fetch it) without paying for it.
+ */
+export function toV2Run(run: ReadRun): {
+  runId: string;
+  header: RunHeader;
+  events: DebugEventV2[];
+  blobIndex: Array<Omit<BlobLine, "content">>;
+} {
+  const blobIndex: Array<Omit<BlobLine, "content">> = [];
+  for (const hash of run.blobs.hashes) {
+    const meta = run.blobs.meta(hash);
+    if (meta) blobIndex.push(meta);
+  }
+  return { runId: run.header.runId, header: run.header, events: run.events, blobIndex };
+}

--- a/apps/xyne-claw/src/debug/recorder.ts
+++ b/apps/xyne-claw/src/debug/recorder.ts
@@ -1,0 +1,281 @@
+/**
+ * Recorder — the one door every debug event goes through.
+ *
+ * It exists so that "emit an event" is a single call with a single failure
+ * mode. The old code emitted from a dozen sites, each deciding for itself what
+ * to trim; the two bugs that produced were (a) transcripts embedded per turn,
+ * making trace files grow O(turns^2), and (b) a throw from inside pi's event
+ * queue taking the whole run down. Both are structurally impossible here:
+ * trimming is the registry's job, and `record()` cannot throw.
+ */
+
+import { createLogger } from "../logger.js";
+import { metric } from "../metrics.js";
+import type { BlobWriter } from "./blobs.js";
+import { policyFor, specFor, type EventSpec } from "./registry.js";
+import type { RunStore } from "./store.js";
+import type { BlobRef, CaptureLevel, DebugEventRecord, DebugEventV2 } from "./types.js";
+
+const log = createLogger("debug");
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * A caller may date an event to when it really happened rather than to when it
+ * reached the recorder — agent.ts stamps `session_start` with the run's true
+ * start, which is earlier than the first `record()` by however long setup took.
+ * Anything unparseable falls back to our own clock: a wrong timestamp reorders
+ * the whole timeline.
+ */
+function isoAt(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const ms = Date.parse(v);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : undefined;
+}
+
+/**
+ * In-memory retention for `snapshotEvents()`. A long-running agent can emit
+ * tens of thousands of events; the on-disk log stays complete, this window is
+ * only what an in-process reader (live drawer, crash reporter) can still see.
+ */
+const MAX_RETAINED_EVENTS = 5_000;
+
+/** Long enough to coalesce a burst of tool events, short enough that a reader
+ *  arriving mid-run sees a near-current file. */
+const FLUSH_DEBOUNCE_MS = 250;
+
+/** Envelope fields copied onto every event of a child/subagent run. */
+const ENVELOPE_KEYS = ["parentToolCallId", "subagentName", "childRunId"] as const;
+
+/** Meta fields a caller may stamp per event. `seq`, `kind` and `data` are owned
+ *  by the recorder and ignored if passed; `at` is honoured when it parses (see
+ *  `isoAt`) but is not copied through `#stamp`. */
+const META_KEYS = [
+  "turn",
+  "llmCall",
+  "toolCallId",
+  "parentToolCallId",
+  "subagentName",
+  "childRunId",
+] as const;
+
+/** At `off` we still stream live, but only the run's bookends reach disk. */
+const OFF_LEVEL_PERSISTED_KINDS = new Set(["session_start", "session_end"]);
+
+export interface RecorderOpts {
+  store: RunStore | null;
+  blobs: BlobWriter;
+  captureLevel: CaptureLevel;
+  live?: { push: (event: DebugEventRecord) => void };
+  envelope?: { parentToolCallId?: string; subagentName?: string; childRunId?: string };
+}
+
+export class Recorder {
+  readonly #store: RunStore | null;
+  readonly #blobs: BlobWriter;
+  readonly #captureLevel: CaptureLevel;
+  readonly #live: { push: (event: DebugEventRecord) => void } | undefined;
+  readonly #envelope: RecorderOpts["envelope"];
+
+  #seq = 0;
+  #eventCount = 0;
+  #messageCount = 0;
+  #toolCallCount = 0;
+  #events: DebugEventV2[] = [];
+  #flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(o: RecorderOpts) {
+    this.#store = o.store;
+    this.#blobs = o.blobs;
+    this.#captureLevel = o.captureLevel;
+    this.#live = o.live;
+    this.#envelope = o.envelope;
+  }
+
+  get seq(): number {
+    return this.#seq;
+  }
+  get eventCount(): number {
+    return this.#eventCount;
+  }
+  get messageCount(): number {
+    return this.#messageCount;
+  }
+  get toolCallCount(): number {
+    return this.#toolCallCount;
+  }
+  get blobCount(): number {
+    return this.#blobs.size;
+  }
+
+  /**
+   * Record an event. Never throws — it runs inside pi's event queue, where an
+   * exception aborts the run rather than losing a trace line.
+   */
+  record(kind: string, data?: Record<string, unknown>, meta?: Partial<DebugEventV2>): void {
+    try {
+      const spec = specFor(kind);
+      const event: DebugEventV2 = {
+        seq: ++this.#seq,
+        at: isoAt(meta?.at) ?? new Date().toISOString(),
+        kind,
+        data: this.#applyPolicy(spec, data),
+      };
+      this.#stamp(event, meta);
+      this.#eventCount += 1;
+      if (kind === "tool_execution_end") this.#toolCallCount += 1;
+
+      this.#retain(event);
+      if (!spec.liveOnly && this.#shouldPersist(kind)) this.#store?.appendEvent(event);
+      // Bulk bookkeeping (message_append) would drown an SSE reader in exactly
+      // the payload the ref policy just moved out of the event file.
+      if (!spec.persistOnly) this.#live?.push(event);
+    } catch (err) {
+      metric.count("debug_record_error", { kind });
+      log.debug(`[debug] dropped event kind=${kind}: ${errText(err)}`);
+    }
+  }
+
+  /**
+   * Live-channel-only emission: no seq is consumed and nothing is written, so
+   * high-frequency telemetry (stream_rate ticks) cannot punch holes in the
+   * persisted sequence the way it used to.
+   */
+  recordLive(kind: string, data: Record<string, unknown>, meta?: Partial<DebugEventV2>): void {
+    try {
+      if (!this.#live) return;
+      const event: DebugEventRecord = {
+        seq: this.#seq,
+        at: new Date().toISOString(),
+        kind,
+        data: { ...data },
+      };
+      this.#stamp(event, meta);
+      this.#live.push(event);
+    } catch (err) {
+      metric.count("debug_record_error", { kind });
+      log.debug(`[debug] dropped live event kind=${kind}: ${errText(err)}`);
+    }
+  }
+
+  /**
+   * Append-only transcript capture: emits ONLY the messages added since the
+   * last call. Recording the whole array per turn is what made traces
+   * quadratic. A shorter incoming array means the list was replaced
+   * (compaction), so we restate it in full and flag the discontinuity.
+   */
+  recordTranscript(messages: readonly unknown[]): void {
+    try {
+      const total = messages.length;
+      if (total === this.#messageCount) return;
+      if (total < this.#messageCount) {
+        this.#messageCount = 0;
+        this.record("message_append", {
+          from: 0,
+          to: total,
+          count: total,
+          reset: true,
+          messages: messages.slice(),
+        });
+        this.#messageCount = total;
+        return;
+      }
+      const from = this.#messageCount;
+      const delta = messages.slice(from);
+      this.record("message_append", { from, to: total, count: delta.length, messages: delta });
+      this.#messageCount = total;
+    } catch (err) {
+      metric.count("debug_record_error", { kind: "message_append" });
+      log.debug(`[debug] dropped transcript delta: ${errText(err)}`);
+    }
+  }
+
+  /** Intern a value into the blob log without recording an event (header
+   *  fields such as `lastAssistantTextRef`). */
+  internText(value: unknown): BlobRef | undefined {
+    try {
+      return this.#blobs.intern(value);
+    } catch (err) {
+      log.debug(`[debug] failed to intern a blob: ${errText(err)}`);
+      return undefined;
+    }
+  }
+
+  /** Shallow copy: callers get the tail without a handle on recorder state. */
+  snapshotEvents(): DebugEventV2[] {
+    return this.#events.slice();
+  }
+
+  /** Debounced, fire-and-forget durability nudge. Never awaited, never throws. */
+  flushHint(): void {
+    try {
+      if (!this.#store || this.#flushTimer) return;
+      const timer = setTimeout(() => {
+        this.#flushTimer = null;
+        void this.#store?.flush().catch(() => {});
+      }, FLUSH_DEBOUNCE_MS);
+      // A pending hint must not keep the process alive at shutdown.
+      timer.unref?.();
+      this.#flushTimer = timer;
+    } catch {
+      this.#flushTimer = null;
+    }
+  }
+
+  /** Envelope first, then per-event meta: a call site can always override the
+   *  run-wide envelope (a parent run recording one child's tool call). */
+  #stamp(event: DebugEventV2 | DebugEventRecord, meta: Partial<DebugEventV2> | undefined): void {
+    const target = event as unknown as Record<string, unknown>;
+    const envelope = this.#envelope;
+    if (envelope) {
+      for (const k of ENVELOPE_KEYS) {
+        const v = envelope[k];
+        if (v !== undefined) target[k] = v;
+      }
+    }
+    if (meta) {
+      for (const k of META_KEYS) {
+        const v = meta[k];
+        if (v !== undefined) target[k] = v;
+      }
+    }
+  }
+
+  #shouldPersist(kind: string): boolean {
+    return this.#captureLevel !== "off" || OFF_LEVEL_PERSISTED_KINDS.has(kind);
+  }
+
+  #retain(event: DebugEventV2): void {
+    this.#events.push(event);
+    if (this.#events.length > MAX_RETAINED_EVENTS) {
+      this.#events = this.#events.slice(this.#events.length - MAX_RETAINED_EVENTS);
+    }
+  }
+
+  /**
+   * Apply the registry policy field by field. A `ref` field that spills becomes
+   * a sibling `<field>Ref` and the original is not carried, so a reader never
+   * has to guess whether it is holding content or a pointer.
+   */
+  #applyPolicy(spec: EventSpec, data: Record<string, unknown> | undefined): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    if (!data) return out;
+    for (const [field, value] of Object.entries(data)) {
+      // An absent field is absent; `"x": null` reads as "we measured null".
+      if (value === undefined || value === null) continue;
+      const policy = policyFor(spec, field);
+      if (policy.t === "drop") continue;
+      if (policy.t === "plain" || policy.t === "range") {
+        out[field] = value;
+        continue;
+      }
+      const held = this.#blobs.maybeIntern(value, policy.inlineUnder);
+      if ("inline" in held) out[field] = held.inline;
+      else if ("ref" in held) out[`${field}Ref`] = held.ref;
+      // `omitted` (capture level off / metadata drop): neither field is written.
+    }
+    return out;
+  }
+}

--- a/apps/xyne-claw/src/debug/registry.ts
+++ b/apps/xyne-claw/src/debug/registry.ts
@@ -1,0 +1,365 @@
+/**
+ * Event registry — the single place that says what a debug event carries and
+ * how big each field is allowed to get on disk.
+ *
+ * Adding an event is one entry here plus one `recorder.record()` call. The size
+ * policy travels with the field declaration, so there is no second list to
+ * remember (the old code had exactly that bug: a `leanEvents` strip in the
+ * partial writer that the final writer didn't apply, which is how per-event
+ * transcript embeds grew the file quadratically).
+ *
+ * Policies:
+ *   plain()   — persisted as-is. Small scalars, counters, enums.
+ *   ref(n)    — inline while the serialized value is ≤ n bytes, otherwise
+ *               interned into blobs.jsonl and replaced by `<field>Ref`.
+ *   ref()     — always interned.
+ *   range()   — an index span into the transcript log, not a copy of it.
+ *   drop()    — never persisted (re-derivable, or superseded).
+ */
+
+export type FieldPolicy =
+  | { t: "plain" }
+  | { t: "ref"; inlineUnder: number }
+  | { t: "range" }
+  | { t: "drop" };
+
+export const plain = (): FieldPolicy => ({ t: "plain" });
+export const ref = (inlineUnder = 0): FieldPolicy => ({ t: "ref", inlineUnder });
+export const range = (): FieldPolicy => ({ t: "range" });
+export const drop = (): FieldPolicy => ({ t: "drop" });
+
+export interface EventSpec {
+  fields: Record<string, FieldPolicy>;
+  /** Policy for fields not named in `fields`. Defaults to `ref(4_000)`. */
+  rest?: FieldPolicy;
+  /** Never persisted — live channel only (high-frequency telemetry). */
+  liveOnly?: true;
+  /** Never pushed to the live channel — persisted only (bulk bookkeeping). */
+  persistOnly?: true;
+}
+
+/** Identity helper; exists so the object literal keeps its literal key types. */
+export function defineEvents<T extends Record<string, EventSpec>>(events: T): T {
+  return events;
+}
+
+/**
+ * Every kind the system emits.
+ *
+ * The 21 legacy kinds are preserved exactly — the dashboard, the debug HTML
+ * exporter and DebugDrawer all switch on these strings, so removing one drops
+ * rows silently rather than failing loudly.
+ */
+export const EVENTS = defineEvents({
+  // ── Session lifecycle ────────────────────────────────────────────────────
+  session_start: {
+    fields: {
+      conversationId: plain(),
+      sessionId: plain(),
+      agentSlug: plain(),
+      userId: plain(),
+      provider: plain(),
+      model: plain(),
+      thinking: plain(),
+      speed: plain(),
+      mode: plain(),
+      systemPromptOverride: plain(),
+      captureLevel: plain(),
+      task: ref(4_000),
+      context: ref(4_000),
+    },
+  },
+  session_tools: {
+    fields: { mode: plain(), toolCount: plain(), tools: ref(2_000) },
+  },
+  mode_switch: {
+    fields: { from: plain(), to: plain(), reason: plain() },
+  },
+  session_end: {
+    fields: {
+      textLength: plain(),
+      toolCount: plain(),
+      tokenUsage: plain(),
+      latency: plain(),
+      durationMs: plain(),
+      streamChars: plain(),
+      streamCharsPerSec: plain(),
+    },
+  },
+  session_cancelled: {
+    fields: {
+      reason: plain(),
+      partialTextLength: plain(),
+      toolCount: plain(),
+      tokenUsage: plain(),
+      atMs: plain(),
+    },
+  },
+  session_error: {
+    fields: { errorClass: plain(), atMs: plain(), error: ref(2_000) },
+  },
+
+  // ── Turn lifecycle ───────────────────────────────────────────────────────
+  session_prompt: {
+    fields: {
+      kind: plain(),
+      imagesCount: plain(),
+      messageCount: plain(),
+      turnIndex: plain(),
+      timestamp: plain(),
+      prompt: ref(2_000),
+      // The persona prompt we hand to pi. The prompt actually sent to the model
+      // — pi's assembled one, with <available_skills> appended — is captured by
+      // llm_request instead, which is the whole point of the stream hook.
+      systemPrompt: drop(),
+      // Re-derivable from the transcript log; embedding it per turn is what made
+      // the old traces O(turns^2).
+      messages: drop(),
+      messagesFrom: range(),
+      messagesTo: range(),
+    },
+  },
+  assistant_turn_end: {
+    fields: {
+      stopReason: plain(),
+      errorMessage: plain(),
+      streamChars: plain(),
+      streamThinkingChars: plain(),
+      streamTextChars: plain(),
+      streamCharsPerSec: plain(),
+      streamsCollected: plain(),
+      usage: plain(),
+      assistantText: ref(2_000),
+      streamRateSamples: ref(1_000),
+      message: drop(),
+      messages: drop(),
+      messagesFrom: range(),
+      messagesTo: range(),
+    },
+  },
+  thinking: {
+    fields: { chars: plain(), text: ref(2_000) },
+  },
+  stream_rate: {
+    fields: { streamsPerSec: plain(), streamsCollected: plain(), active: plain() },
+    liveOnly: true,
+  },
+
+  // ── Tools ────────────────────────────────────────────────────────────────
+  tool_execution_start: {
+    fields: { toolName: plain(), args: ref(2_000) },
+  },
+  tool_execution_end: {
+    fields: {
+      toolName: plain(),
+      isError: plain(),
+      durationMs: plain(),
+      status: plain(),
+      background: plain(),
+      backgroundState: plain(),
+      backgroundTaskId: plain(),
+      args: ref(2_000),
+      // Cap is the 2 MB blob limit, NOT a second content cap: the string here is
+      // exactly what the model saw, and re-truncating it would break MCP
+      // `{"content":[...]}` envelopes that downstream parsers still read.
+      result: ref(4_000),
+      debug: ref(4_000),
+      citations: ref(2_000),
+    },
+  },
+  tool_invocation_update: {
+    fields: {
+      toolCallId: plain(),
+      status: plain(),
+      background: plain(),
+      backgroundState: plain(),
+      backgroundTaskId: plain(),
+      durationMs: plain(),
+      result: ref(4_000),
+    },
+  },
+  tool_palette_change: {
+    fields: {
+      source: plain(),
+      added: ref(2_000),
+      removed: ref(2_000),
+      activeCount: plain(),
+      budget: plain(),
+    },
+  },
+
+  // ── Model requests (new — the fix for the invisible system prompt) ───────
+  llm_request: {
+    fields: {
+      model: plain(),
+      provider: plain(),
+      temperature: plain(),
+      maxTokens: plain(),
+      thinkingLevel: plain(),
+      fastMode: plain(),
+      toolCount: plain(),
+      /** The TRUE effective system prompt, `<available_skills>` included. */
+      systemPrompt: ref(),
+      /** Full tool definitions: name, description, JSON schema. */
+      tools: ref(),
+      toolNames: ref(2_000),
+      availableSkills: ref(2_000),
+      paletteAdded: plain(),
+      paletteRemoved: plain(),
+      messagesFrom: range(),
+      messagesTo: range(),
+    },
+  },
+  llm_response: {
+    fields: {
+      stopReason: plain(),
+      ttftMs: plain(),
+      totalMs: plain(),
+      errorMessage: plain(),
+      usage: plain(),
+    },
+  },
+  message_append: {
+    fields: { from: plain(), to: plain(), count: plain(), messages: ref() },
+    persistOnly: true,
+  },
+
+  // ── Recovery / control flow ─────────────────────────────────────────────
+  compaction_start: {
+    fields: { reason: plain(), tokensBefore: plain(), messageCount: plain() },
+  },
+  compaction_end: {
+    fields: {
+      reason: plain(),
+      aborted: plain(),
+      willRetry: plain(),
+      errorMessage: plain(),
+      tokensBefore: plain(),
+      tokensAfter: plain(),
+      messageCount: plain(),
+      droppedMessageCount: plain(),
+      summary: ref(2_000),
+    },
+  },
+  auto_retry_start: {
+    fields: { attempt: plain(), maxAttempts: plain(), errorMessage: plain(), reason: plain() },
+  },
+  auto_retry_end: {
+    fields: { attempt: plain(), recovered: plain(), errorMessage: plain() },
+  },
+  provider_fallback: {
+    fields: { fromProvider: plain(), toProvider: plain(), attempt: plain(), reason: plain() },
+  },
+
+  // ── Delegation ──────────────────────────────────────────────────────────
+  subagent_start: {
+    fields: {
+      subagentName: plain(),
+      childRunId: plain(),
+      questionChars: plain(),
+      provider: plain(),
+      model: plain(),
+      question: ref(2_000),
+      toolNames: ref(2_000),
+    },
+  },
+  subagent_end: {
+    fields: {
+      subagentName: plain(),
+      childRunId: plain(),
+      status: plain(),
+      durationMs: plain(),
+      textLength: plain(),
+      providerError: plain(),
+      toolsUsed: ref(2_000),
+    },
+  },
+  background_subagents_delivered: {
+    fields: { round: plain(), count: plain(), tasks: ref(2_000) },
+  },
+  delegation: {
+    fields: {
+      kind: plain(),
+      caller: plain(),
+      callee: plain(),
+      depth: plain(),
+      reason: plain(),
+      detail: ref(2_000),
+    },
+  },
+
+  // ── Skills ──────────────────────────────────────────────────────────────
+  skill_loaded: {
+    fields: { slug: plain(), path: plain(), viaToolCallId: plain() },
+  },
+
+  // ── Answer-quality reflections ──────────────────────────────────────────
+  citation_reflection: {
+    fields: {
+      phase: plain(),
+      round: plain(),
+      maxRounds: plain(),
+      outcome: plain(),
+      initialCited: plain(),
+      sourcesWereCiteable: plain(),
+      finalCited: plain(),
+    },
+  },
+  twin_deliver_reflection: {
+    fields: { phase: plain(), round: plain(), delivered: plain(), action: plain() },
+  },
+  follow_up_generation_start: {
+    fields: { model: plain(), sourceToolCallId: plain() },
+  },
+  follow_up_generation_end: {
+    fields: {
+      outcome: plain(),
+      suggestionCount: plain(),
+      durationMs: plain(),
+      suggestions: ref(2_000),
+    },
+  },
+});
+
+export type DebugEventKind = keyof typeof EVENTS & string;
+
+/** Kinds that existed before the v2 rewrite. Pinned by test — a rename here is
+ *  a silent data loss for every consumer that switches on the string. */
+export const LEGACY_EVENT_KINDS = [
+  "session_start",
+  "session_tools",
+  "mode_switch",
+  "session_prompt",
+  "stream_rate",
+  "thinking",
+  "assistant_turn_end",
+  "tool_execution_start",
+  "tool_execution_end",
+  "compaction_start",
+  "compaction_end",
+  "auto_retry_start",
+  "auto_retry_end",
+  "citation_reflection",
+  "twin_deliver_reflection",
+  "follow_up_generation_start",
+  "follow_up_generation_end",
+  "background_subagents_delivered",
+  "session_end",
+  "session_cancelled",
+  "session_error",
+] as const;
+
+/** Permissive fallback so an unregistered kind can never crash the recorder. */
+const DEFAULT_SPEC: EventSpec = { fields: {}, rest: ref(4_000) };
+
+export function isKnownKind(kind: string): kind is DebugEventKind {
+  return Object.prototype.hasOwnProperty.call(EVENTS, kind);
+}
+
+export function specFor(kind: string): EventSpec {
+  return isKnownKind(kind) ? EVENTS[kind] : DEFAULT_SPEC;
+}
+
+export function policyFor(spec: EventSpec, field: string): FieldPolicy {
+  return spec.fields[field] ?? spec.rest ?? ref(4_000);
+}

--- a/apps/xyne-claw/src/debug/store.ts
+++ b/apps/xyne-claw/src/debug/store.ts
@@ -1,0 +1,460 @@
+/**
+ * Per-run on-disk store: `session.json` + `events.jsonl` + `blobs.jsonl`.
+ *
+ * Everything here is built around one assumption: the pod can die at any
+ * instant, including mid-write. That drives three choices.
+ *
+ * 1. **Append-only, one `appendFile` per drain.** Writes never seek, never
+ *    rewrite, never hold a mutable in-memory document that has to be re-emitted.
+ *    A process killed between two appends leaves every earlier line intact.
+ * 2. **A single serialized queue.** `appendEvent`/`appendBlobLine` are called
+ *    from inside pi's synchronous event subscription, so they return `void` and
+ *    push onto a promise chain instead of awaiting. Two concurrent
+ *    `appendFile`s to one path can interleave partial buffers; the chain makes
+ *    that impossible without keeping a handle open across the whole run.
+ * 3. **`session.json` is written tmp+rename.** It is the guaranteed artifact —
+ *    written once at start with `status: "running"` and once at finish — so it
+ *    must never be observable half-written. A reader that finds it garbage gets
+ *    "no run" rather than a run with invented fields.
+ *
+ * The read side is deliberately forgiving: a torn final line is the *expected*
+ * shape of a crashed run, not a corruption to reject. `readRun` drops it,
+ * reports it in `warnings`, and infers `status: "crashed"` for a run whose
+ * header still says "running" but whose files stopped changing long ago.
+ */
+
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { gunzipSync, gzipSync } from "node:zlib";
+
+import { PATHS } from "../config.js";
+import { createLogger } from "../logger.js";
+import { metric } from "../metrics.js";
+import { BlobIndex, type BlobLine } from "./blobs.js";
+import { compareRunIdsNewestFirst } from "./keys.js";
+import type { CaptureLevel, DebugEventV2, RunHeader } from "./types.js";
+
+const log = createLogger("debug");
+
+const SESSION_FILE = "session.json";
+const SESSION_TMP = "session.json.tmp";
+const EVENTS_FILE = "events.jsonl";
+const BLOBS_FILE = "blobs.jsonl";
+const UPLOADED_MARKER = ".uploaded";
+
+/**
+ * How long a "running" run may sit untouched before a reader calls it crashed.
+ * Read per call rather than at import so a test (or a redeploy that tightens
+ * the window) does not need a fresh module instance.
+ */
+function crashGraceMs(): number {
+  const raw = Number(process.env["DEBUG_CRASH_GRACE_MS"]);
+  return Number.isFinite(raw) && raw > 0 ? raw : 120_000;
+}
+
+export function debugDirFor(storeKey: string, dataDir?: string): string {
+  // Absolute on purpose: PATHS.dataDir defaults to a relative "./data", and
+  // every downstream consumer (archiver, GCS uploader, route handlers) resolves
+  // paths from a different cwd than the one the run was written from.
+  return path.resolve(dataDir ?? PATHS.dataDir, "sessions", storeKey, "debug");
+}
+
+export interface RunStoreOpts {
+  storeKey: string;
+  runId: string;
+  captureLevel: CaptureLevel;
+  dataDir?: string;
+}
+
+export class RunStore {
+  readonly runDir: string;
+  readonly debugDir: string;
+  readonly runId: string;
+  readonly storeKey: string;
+  readonly captureLevel: CaptureLevel;
+
+  /** Serializes every write; a rejection is swallowed so the chain survives. */
+  private chain: Promise<void> = Promise.resolve();
+  /** Lines waiting for their file's next drain, coalesced into one append. */
+  private readonly buffers = new Map<string, string[]>();
+  private readonly scheduled = new Set<string>();
+  private failures = 0;
+
+  private constructor(opts: RunStoreOpts, debugDir: string) {
+    this.debugDir = debugDir;
+    this.runDir = path.join(debugDir, "runs", opts.runId);
+    this.runId = opts.runId;
+    this.storeKey = opts.storeKey;
+    this.captureLevel = opts.captureLevel;
+  }
+
+  static async open(opts: RunStoreOpts): Promise<RunStore> {
+    const debugDir = debugDirFor(opts.storeKey, opts.dataDir);
+    const store = new RunStore(opts, debugDir);
+    await fs.mkdir(store.runDir, { recursive: true });
+    return store;
+  }
+
+  private get eventsPath(): string {
+    return path.join(this.runDir, EVENTS_FILE);
+  }
+
+  private get blobsPath(): string {
+    return path.join(this.runDir, BLOBS_FILE);
+  }
+
+  private get headerPath(): string {
+    return path.join(this.runDir, SESSION_FILE);
+  }
+
+  appendEvent(e: DebugEventV2): void {
+    let line: string;
+    try {
+      line = JSON.stringify(e);
+    } catch (err) {
+      // A non-serializable payload is a recorder bug, but it must not take the
+      // run down — drop the one event and keep the trace.
+      this.onFailure("serialize_event", err);
+      return;
+    }
+    this.enqueueLine(this.eventsPath, line);
+  }
+
+  appendBlobLine(line: string): void {
+    this.enqueueLine(this.blobsPath, line);
+  }
+
+  writeHeader(h: RunHeader): void {
+    let body: string;
+    try {
+      body = JSON.stringify(h);
+    } catch (err) {
+      this.onFailure("serialize_header", err);
+      return;
+    }
+    const tmp = path.join(this.runDir, SESSION_TMP);
+    this.enqueue(async () => {
+      await fs.writeFile(tmp, body, "utf8");
+      await fs.rename(tmp, this.headerPath);
+    }, "write_header");
+  }
+
+  /** Resolves once every write queued *before* this call has hit disk. */
+  async flush(): Promise<void> {
+    // A queued drain can itself schedule nothing new, but a caller may append
+    // while we await, so settle repeatedly until the buffers are empty.
+    for (let i = 0; i < 8; i++) {
+      await this.chain;
+      if (!this.hasPending()) return;
+    }
+    await this.chain;
+  }
+
+  async close(): Promise<void> {
+    await this.flush();
+  }
+
+  async markUploaded(): Promise<void> {
+    try {
+      await fs.writeFile(path.join(this.runDir, UPLOADED_MARKER), "", "utf8");
+    } catch (err) {
+      this.onFailure("mark_uploaded", err);
+    }
+  }
+
+  async isUploaded(): Promise<boolean> {
+    try {
+      await fs.stat(path.join(this.runDir, UPLOADED_MARKER));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private hasPending(): boolean {
+    for (const buf of this.buffers.values()) if (buf.length > 0) return true;
+    return false;
+  }
+
+  private enqueueLine(file: string, line: string): void {
+    const buf = this.buffers.get(file);
+    if (buf) buf.push(line);
+    else this.buffers.set(file, [line]);
+    if (this.scheduled.has(file)) return;
+    this.scheduled.add(file);
+    this.enqueue(async () => {
+      // No await between claiming the buffer and swapping it, so a concurrent
+      // append either lands in this batch or schedules the next one.
+      this.scheduled.delete(file);
+      const pending = this.buffers.get(file);
+      if (!pending || pending.length === 0) return;
+      this.buffers.set(file, []);
+      await fs.appendFile(file, `${pending.join("\n")}\n`, { encoding: "utf8", flag: "a" });
+    }, "append");
+  }
+
+  private enqueue(task: () => Promise<void>, op: string): void {
+    this.chain = this.chain.then(task).catch((err: unknown) => {
+      this.onFailure(op, err);
+    });
+  }
+
+  private onFailure(op: string, err: unknown): void {
+    this.failures += 1;
+    metric.count("debug_store_write_error", { op });
+    // One log line per run is enough to find the pod; a per-event log during a
+    // full disk turns a degraded run into an unreadable one.
+    if (this.failures <= 3) {
+      log.warn(`debug store ${op} failed`, {
+        runId: this.runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+// ── Read path ───────────────────────────────────────────────────────────────
+
+export interface ReadRun {
+  header: RunHeader;
+  events: DebugEventV2[];
+  blobs: BlobIndex;
+  warnings: string[];
+}
+
+interface RawRun {
+  header: RunHeader;
+  events: DebugEventV2[];
+  blobLines: BlobLine[];
+  warnings: string[];
+}
+
+interface ParsedLines<T> {
+  values: T[];
+  warnings: string[];
+  /** Newest mtime seen, or 0 when the file is absent. */
+  mtimeMs: number;
+}
+
+async function readJsonLines<T>(
+  file: string,
+  fileName: string,
+  keep: (v: unknown) => v is T,
+): Promise<ParsedLines<T>> {
+  let raw: string;
+  let mtimeMs = 0;
+  try {
+    const [text, st] = await Promise.all([fs.readFile(file, "utf8"), fs.stat(file)]);
+    raw = text;
+    mtimeMs = st.mtimeMs;
+  } catch {
+    // A run that produced no blobs (or died before its first event) is normal.
+    return { values: [], warnings: [`${fileName} missing`], mtimeMs: 0 };
+  }
+
+  const lines = raw.split("\n");
+  const values: T[] = [];
+  const warnings: string[] = [];
+  let torn = 0;
+  let bad = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined || line.trim() === "") continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // Only the final line can legitimately be half-written; anything earlier
+      // means real corruption and is reported separately.
+      if (isLastNonEmpty(lines, i)) torn += 1;
+      else bad += 1;
+      continue;
+    }
+    if (keep(parsed)) values.push(parsed);
+    else bad += 1;
+  }
+
+  if (torn > 0) warnings.push(`dropped ${torn} torn line at end of ${fileName}`);
+  if (bad > 0) warnings.push(`dropped ${bad} unreadable line${bad === 1 ? "" : "s"} in ${fileName}`);
+  return { values, warnings, mtimeMs };
+}
+
+function isLastNonEmpty(lines: string[], index: number): boolean {
+  for (let j = index + 1; j < lines.length; j++) {
+    const rest = lines[j];
+    if (rest !== undefined && rest.trim() !== "") return false;
+  }
+  return true;
+}
+
+function isEventV2(v: unknown): v is DebugEventV2 {
+  if (typeof v !== "object" || v === null) return false;
+  const e = v as Partial<DebugEventV2>;
+  return typeof e.seq === "number" && typeof e.kind === "string";
+}
+
+function isBlobLine(v: unknown): v is BlobLine {
+  if (typeof v !== "object" || v === null) return false;
+  const b = v as Partial<BlobLine>;
+  return typeof b.hash === "string" && typeof b.content === "string";
+}
+
+function isHeader(v: unknown): v is RunHeader {
+  if (typeof v !== "object" || v === null) return false;
+  const h = v as Partial<RunHeader>;
+  return typeof h.runId === "string" && typeof h.startedAt === "string";
+}
+
+async function readHeader(runDir: string): Promise<{ header: RunHeader; mtimeMs: number } | null> {
+  try {
+    const file = path.join(runDir, SESSION_FILE);
+    const [text, st] = await Promise.all([fs.readFile(file, "utf8"), fs.stat(file)]);
+    const parsed: unknown = JSON.parse(text);
+    if (!isHeader(parsed)) return null;
+    return { header: parsed, mtimeMs: st.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A run whose header still says "running" but whose files stopped changing is a
+ * pod that was killed: relabel it in the RETURNED header only. Rewriting it on
+ * disk would race a run that is merely slow (a 20-minute tool call is not a
+ * crash), and the on-disk header stays the writer's to own.
+ */
+function inferCrash(header: RunHeader, newestMtimeMs: number, now: number): RunHeader {
+  if (header.status !== "running") return header;
+  if (header.finishedAt !== header.startedAt) return header;
+  if (newestMtimeMs <= 0) return header;
+  if (now - newestMtimeMs <= crashGraceMs()) return header;
+  return { ...header, status: "crashed", finishedAt: new Date(newestMtimeMs).toISOString() };
+}
+
+async function readRunRaw(runDir: string): Promise<RawRun | null> {
+  const head = await readHeader(runDir);
+  if (!head) return null;
+
+  const [events, blobs] = await Promise.all([
+    readJsonLines(path.join(runDir, EVENTS_FILE), EVENTS_FILE, isEventV2),
+    readJsonLines(path.join(runDir, BLOBS_FILE), BLOBS_FILE, isBlobLine),
+  ]);
+
+  const newest = Math.max(head.mtimeMs, events.mtimeMs, blobs.mtimeMs);
+  const header = inferCrash(head.header, newest, Date.now());
+  const warnings = [...events.warnings, ...blobs.warnings];
+  if (header.status === "crashed" && head.header.status === "running") {
+    warnings.push("run had no finish record; status inferred as crashed");
+  }
+
+  return { header, events: events.values, blobLines: blobs.values, warnings };
+}
+
+function indexBlobs(lines: BlobLine[], warnings: string[]): BlobIndex {
+  try {
+    return BlobIndex.fromLines(lines.map((l) => JSON.stringify(l)));
+  } catch (err) {
+    // The blob log is an optimization; losing it costs payloads, not the trace.
+    warnings.push("blob log unreadable; payloads omitted");
+    log.warn("debug blob index failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return BlobIndex.empty();
+  }
+}
+
+export async function readRun(runDir: string): Promise<ReadRun | null> {
+  const raw = await readRunRaw(runDir);
+  if (!raw) return null;
+  const warnings = [...raw.warnings];
+  return {
+    header: raw.header,
+    events: raw.events,
+    blobs: indexBlobs(raw.blobLines, warnings),
+    warnings,
+  };
+}
+
+/** Absolute run dirs under `<debugDir>/runs`, newest first. */
+export async function listRunDirs(debugDir: string): Promise<string[]> {
+  const runsDir = path.join(debugDir, "runs");
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(runsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort(compareRunIdsNewestFirst)
+    .map((name) => path.join(runsDir, name));
+}
+
+// ── Packing (archive / transport format) ────────────────────────────────────
+
+type PackedLine =
+  | { t: "h"; v: RunHeader }
+  | { t: "e"; v: DebugEventV2 }
+  | { t: "b"; v: BlobLine };
+
+/**
+ * Gzipped ndjson: one header line, then events, then blob lines. Blob lines are
+ * carried verbatim rather than re-encoded from a `BlobIndex`, so a gzip+base64
+ * blob survives the round trip byte-for-byte.
+ */
+export async function packRun(runDir: string): Promise<Buffer | null> {
+  const raw = await readRunRaw(runDir);
+  if (!raw) return null;
+  const lines: PackedLine[] = [
+    { t: "h", v: raw.header },
+    ...raw.events.map((v): PackedLine => ({ t: "e", v })),
+    ...raw.blobLines.map((v): PackedLine => ({ t: "b", v })),
+  ];
+  const ndjson = lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+  try {
+    return gzipSync(Buffer.from(ndjson, "utf8"));
+  } catch (err) {
+    log.warn("debug packRun gzip failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+export function unpackRun(buf: Buffer): ReadRun | null {
+  let text: string;
+  try {
+    text = gunzipSync(buf).toString("utf8");
+  } catch {
+    return null;
+  }
+
+  let header: RunHeader | null = null;
+  const events: DebugEventV2[] = [];
+  const blobLines: BlobLine[] = [];
+  const warnings: string[] = [];
+  const lines = text.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined || line.trim() === "") continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      if (isLastNonEmpty(lines, i)) warnings.push("dropped 1 torn line at end of packed run");
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null) continue;
+    const rec = parsed as { t?: unknown; v?: unknown };
+    if (rec.t === "h" && isHeader(rec.v)) header = rec.v;
+    else if (rec.t === "e" && isEventV2(rec.v)) events.push(rec.v);
+    else if (rec.t === "b" && isBlobLine(rec.v)) blobLines.push(rec.v);
+  }
+
+  if (!header) return null;
+  return { header, events, blobs: indexBlobs(blobLines, warnings), warnings };
+}

--- a/apps/xyne-claw/src/debug/types.ts
+++ b/apps/xyne-claw/src/debug/types.ts
@@ -1,0 +1,284 @@
+/**
+ * Debug trace types — the contract every other module in `debug/` builds against.
+ *
+ * Two formats live here on purpose:
+ *
+ * - **v2** (`RunHeader` + `DebugEventV2` + blob refs) is the WRITE path: an
+ *   append-only trio of files per run. Payloads over a threshold are interned
+ *   into a content-addressed blob log and referenced by hash, so the same 20 KB
+ *   system prompt costs 20 KB once per run instead of once per turn.
+ * - **v1** (`DebugSessionSnapshot`) is the READ path, produced on demand by
+ *   `materialize.ts`. It is byte-compatible with what the debugger UI has always
+ *   consumed, so the write-path rewrite is invisible to every existing reader.
+ *
+ * The v1 interfaces moved here verbatim from agent.ts. Do not "clean them up" —
+ * DebugDrawer, the dashboard trace panel, the debug HTML exporter and the
+ * webhook `/debug` command all read these field names.
+ */
+
+import type { Citation } from "xyne-claw-shared";
+
+// ── Shared value types (moved verbatim from agent.ts) ───────────────────────
+
+export type ModelSpeed = "standard" | "fast";
+
+export interface TokenUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+export interface ToolInvocation {
+  toolName: string;
+  args: unknown;
+  result: string;
+  isError: boolean;
+  startedAt: string;
+  durationMs: number;
+  status?: "running" | "completed";
+  parentToolCallId?: string;
+  subagentName?: string;
+  toolCallId?: string;
+  citations?: Citation[];
+  debug?: Record<string, unknown>;
+  background?: boolean;
+  backgroundState?: "running" | "completed" | "error";
+  backgroundTaskId?: string;
+}
+
+export interface LatencyMetrics {
+  totalMs: number;
+  llmDecodeMs: number;
+  llmWaitMs: number;
+  llmTotalMs: number;
+  llmTurns: number;
+  llmRetries: number;
+  lastRetryReason?: string;
+  firstTurnTtftMs?: number;
+  tokensPerSec?: number;
+  streamCharsPerSec?: number;
+  streamChars?: number;
+  streamThinkingChars?: number;
+  streamTextChars?: number;
+  toolMs: number;
+}
+
+export interface StreamRateSample {
+  offsetMs: number;
+  streamsPerSec: number;
+  streamsCollected: number;
+}
+
+export interface DebugThinkingConfiguration {
+  /** Value selected by agent model settings / provider config / default policy. */
+  requestedLevel: string;
+  /** Pi's final value after capability clamping for the resolved model. */
+  effectiveLevel: string;
+  /** Where the requested setting came from, so precedence is inspectable. */
+  source:
+    | "agent_model_settings"
+    | "provider_credential"
+    | "codex_default"
+    | "server_default"
+    | "temperature_override";
+  /** Whether the resolved Pi model was registered as reasoning-capable. */
+  modelSupportsReasoning: boolean;
+  /** The provider request shape that disables/enables thinking for this model. */
+  wireMode: string;
+}
+
+/** Provider fast mode (modelSettings.speed) as it was resolved for this run. */
+export interface DebugSpeedConfiguration {
+  requested: ModelSpeed;
+  applied: boolean;
+  reason: string;
+}
+
+// ── Capture policy ──────────────────────────────────────────────────────────
+
+/**
+ * How much of a run is persisted.
+ *
+ * - `full`     — everything, payloads included (dev default).
+ * - `metadata` — every event, every measurement, every blob *hash and size*,
+ *                but no blob content. The timeline renders; the payloads don't.
+ * - `off`      — header plus session_start/session_end only.
+ *
+ * Mirrors the OpenTelemetry GenAI stance that prompt/tool content capture is a
+ * separate, switchable layer rather than something baked into the span.
+ */
+export type CaptureLevel = "off" | "metadata" | "full";
+
+export function isCaptureLevel(v: unknown): v is CaptureLevel {
+  return v === "off" || v === "metadata" || v === "full";
+}
+
+// ── v2 write format ─────────────────────────────────────────────────────────
+
+/**
+ * A pointer into `blobs.jsonl`.
+ *
+ * Refs live in a SIBLING field (`<field>Ref`), never in the field itself, so a
+ * reader never has to guess whether a string is content or a pointer.
+ */
+export interface BlobRef {
+  /** sha256 of the serialized content, first 16 hex chars. */
+  hash: string;
+  /** Stored bytes (post-truncation). */
+  bytes: number;
+  /** Present only when the value exceeded the blob cap. */
+  originalBytes?: number;
+  /** Present only when truncated — never truncate silently. */
+  truncated?: true;
+  /** First ~200 chars, so a collapsed UI row renders without a fetch. */
+  preview?: string;
+}
+
+export function isBlobRef(v: unknown): v is BlobRef {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    typeof (v as { hash?: unknown }).hash === "string" &&
+    typeof (v as { bytes?: unknown }).bytes === "number"
+  );
+}
+
+export interface DebugEventV2 {
+  seq: number;
+  at: string;
+  kind: string;
+  turn?: number;
+  llmCall?: number;
+  toolCallId?: string;
+  parentToolCallId?: string;
+  subagentName?: string;
+  /** Correlates a subagent/child run back to the tool call that spawned it. */
+  childRunId?: string;
+  data: Record<string, unknown>;
+}
+
+export type RunStatus = "running" | "completed" | "cancelled" | "error" | "crashed";
+
+export interface RunCounts {
+  events: number;
+  blobs: number;
+  messages: number;
+  toolCalls: number;
+}
+
+/**
+ * `session.json` — written twice: once at run start with `status: "running"`
+ * (this is the guaranteed artifact that makes "no debug file" impossible for a
+ * run that started), once at finish with the real status and metrics.
+ */
+export interface RunHeader {
+  schemaVersion: 2;
+  /** `${startedAtMs}-${safeSessionId}` — also the run directory name. */
+  runId: string;
+  /** The SESSION KEY this run ran under. Confusingly this is what `runTask`
+   *  receives as `conversationId`; it already encodes the agent slug and, for
+   *  branches/twins, more besides. */
+  conversationId?: string;
+  /** The RAW Spaces conversation id — what a debugger caller actually asks for.
+   *  Kept separate because discovery is keyed on it and the two differ for every
+   *  real run (`conv9` vs `conv9_ask-ai`). */
+  rawConversationId?: string;
+  /** The session-dir / GCS path segment this run was written under. */
+  storeKey: string;
+  sessionId?: string;
+  agentSlug?: string;
+  userId?: string;
+  userName?: string;
+  userEmail?: string;
+  provider?: string;
+  model?: string;
+  thinking?: DebugThinkingConfiguration;
+  speed?: DebugSpeedConfiguration;
+  captureLevel: CaptureLevel;
+  startedAt: string;
+  /** Equals `startedAt` while the run is in flight. */
+  finishedAt: string;
+  status: RunStatus;
+  task: string;
+  context?: string;
+  systemPromptOverride?: boolean;
+  mode?: string;
+  /** Set on subagent / delegated child runs. */
+  parentRunId?: string;
+  parentToolCallId?: string;
+  subagentName?: string;
+  /** Child-run question, for subagent traces. */
+  question?: string;
+  counts: RunCounts;
+  tokenUsage: TokenUsage;
+  latency: LatencyMetrics;
+  lastAssistantTextRef?: BlobRef;
+}
+
+export function emptyTokenUsage(): TokenUsage {
+  return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+}
+
+export function emptyLatency(): LatencyMetrics {
+  return {
+    totalMs: 0,
+    llmDecodeMs: 0,
+    llmWaitMs: 0,
+    llmTotalMs: 0,
+    llmTurns: 0,
+    llmRetries: 0,
+    toolMs: 0,
+  };
+}
+
+// ── v1 read format (unchanged contract for every existing consumer) ─────────
+
+export interface DebugEventRecord {
+  seq: number;
+  at: string;
+  kind: string;
+  turn?: number;
+  llmCall?: number;
+  toolCallId?: string;
+  parentToolCallId?: string;
+  subagentName?: string;
+  childRunId?: string;
+  data: Record<string, unknown>;
+}
+
+export interface DebugSessionSnapshot {
+  schemaVersion: 1;
+  conversationId?: string;
+  sessionId?: string;
+  agentSlug?: string;
+  userId?: string;
+  userName?: string;
+  userEmail?: string;
+  provider?: string;
+  /** The model resolved for this particular run (not merely the agent default). */
+  model?: string;
+  /** Requested/effective thinking selection and its provider wire representation. */
+  thinking?: DebugThinkingConfiguration;
+  /** Requested/applied provider fast mode and the eligibility verdict. */
+  speed?: DebugSpeedConfiguration;
+  startedAt: string;
+  finishedAt: string;
+  task: string;
+  context?: string;
+  systemPromptOverride?: boolean;
+  /** Run ended without a clean completion (stop, error, or a crashed pod). */
+  cancelled?: boolean;
+  /** Run is still in flight; the trace is a partial view. */
+  inProgress?: boolean;
+  messages: unknown[];
+  toolInvocations: ToolInvocation[];
+  tokenUsage: TokenUsage;
+  latency: LatencyMetrics;
+  lastAssistantText: string;
+  events: DebugEventRecord[];
+  /** Additive: non-fatal problems hit while reading this run (dropped torn
+   *  line, unreadable blob log, GCS miss). Surfaced in the UI so a partial
+   *  trace never masquerades as a complete one. */
+  warnings?: string[];
+}

--- a/apps/xyne-claw/src/routes/debug.ts
+++ b/apps/xyne-claw/src/routes/debug.ts
@@ -1,25 +1,72 @@
 /**
  * S2S debug-artifact server.
  *
- * Debug artifacts (debug-session.json, debug-events.json, debug-run-*.json,
- * subagents-*.json) are written to THIS pod's PVC under
+ * Debug artifacts are written to THIS pod's PVC under
  * {dataDir}/sessions/<storeKey>/debug. claw-auth runs in a separate pod and
- * cannot see this PVC, so its debugger view must fetch the artifacts from here
- * over S2S instead of reading its own filesystem. If the session was archived
- * to GCS and evicted from the PVC, we lazily restore it first.
+ * cannot see this PVC, so its debugger view must fetch them over S2S instead of
+ * reading its own filesystem.
+ *
+ * The retrieval rule this file exists to enforce: **a run that exists anywhere
+ * must never come back as "not found"**. Every previous 404 came from one lookup
+ * being treated as authoritative — a storeKey guess that missed a branch/twin
+ * key, a session dir that existed but had no `debug/`, a run that had been
+ * uploaded to GCS and evicted from the PVC. So the lookup is LAYERED, and each
+ * layer only ADDS runs:
+ *
+ *   1. PVC          — new-format run dirs + legacy `debug-run-*.json`
+ *   2. GCS index    — `_index/<convId>/<runId>~<storeKey>.json` markers, written
+ *                     at run START; the storeKey is in the name, so this layer
+ *                     is authoritative rather than a guess
+ *   3. GCS runs     — per storeKey (index ∪ guessed ∪ on-disk), v1 snapshots and
+ *                     packed v2 objects
+ *   4. Archive      — only when 1–3 found nothing: restore from the session
+ *                     archive and redo layer 1
+ *
+ * 404 therefore means "genuinely nothing anywhere", and everything swallowed on
+ * the way there is reported in `warnings` — silent degradation is how a partial
+ * trace passes for a complete one.
  */
 
 import { Router, type Request, type Response } from "express";
-import { readFile, readdir } from "node:fs/promises";
-import { createReadStream, existsSync, readdirSync, statSync } from "node:fs";
+import type { Dirent } from "node:fs";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { createReadStream, existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { PATHS } from "../config.js";
 import { validateS2SKey } from "../middleware/auth.js";
 import { restoreSessionFromArchive } from "../session-store.js";
-import { gcsListDebugRuns, gcsDownloadDebugRun } from "../storage.js";
+import {
+  gcsDirectConfigured,
+  gcsDownloadDebugObject,
+  gcsDownloadDebugRun,
+  gcsListDebugIndex,
+  gcsListDebugRuns,
+} from "../storage.js";
 import { isSafeId } from "../safe-id.js";
 import { metric } from "../metrics.js";
 import { isCaptureFileName, watchdogDir } from "../loop-watchdog.js";
+import {
+  candidateStoreKeys,
+  compareRunIdsNewestFirst,
+  debugDirFor,
+  isStartingRunObjectName,
+  listRunDirs,
+  packedRunObjectName,
+  parseIndexObjectName,
+  parsePackedRunObjectName,
+  parseRunFileName,
+  readRun,
+  runFileNameFor,
+  safeRunToken,
+  sessionDirMatchesConversation,
+  startingRunObjectName,
+  toV1Snapshot,
+  toV2Run,
+  unpackRun,
+  type BlobLine,
+  type ReadRun,
+  type RunHeader,
+} from "../debug/index.js";
 
 import { createLogger } from "../logger.js";
 const log = createLogger("debug");
@@ -30,6 +77,27 @@ function sessionsRoot(): string {
   return path.join(PATHS.dataDir, "sessions");
 }
 
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isEnoent(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException | null)?.code === "ENOENT";
+}
+
+/**
+ * Warnings are a diagnostic channel, not a log: they ride back on the response
+ * so the debugger can say "this trace is partial and here is why". Deduped and
+ * capped so one GCS outage across a dozen storeKeys doesn't produce a dozen
+ * identical lines (or an unbounded payload).
+ */
+const MAX_WARNINGS = 60;
+
+function pushWarning(warnings: string[], message: string): void {
+  if (warnings.length >= MAX_WARNINGS || warnings.includes(message)) return;
+  warnings.push(message);
+}
+
 async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
   try {
     return JSON.parse(await readFile(filePath, "utf8")) as T;
@@ -38,68 +106,573 @@ async function readJsonIfExists<T>(filePath: string): Promise<T | null> {
   }
 }
 
-/**
- * Resolve all on-disk session dirs for a RAW conversationId. The dir name is
- * the storeKey, which depending on the caller is `<convId>`,
- * `<convId>_<agentSlug>`, `<userId>_<convId>_<agentSlug>` (agent-chat
- * threads prefix the owner's userId), or the per-user Digital Twin form
- * `<convId>-<userId>_<agentSlug>` (buildSandboxStoreKey hyphen-folds the
- * userId into the conv segment). Match the convId as an exact name, a
- * prefix segment, or an embedded `_`-delimited segment — prefix-only matching
- * 404'd every userId-prefixed thread (prod, 2026-06-12).
- *
- * Branching produces MULTIPLE matching dirs for one conversation: the root
- * `<convId>_<slug>` plus each branch `<convId>__branch__<assistantId>_<slug>`.
- * Both shapes start with `<convId>_`, so the old single-result lookup picked
- * a random one and the debugger lost every run that lived on the others.
- * We return all matches so the caller can merge their debug artifacts.
- *
- * The returned root dir (`<convId>_<slug>` without `__branch__`) is FIRST in
- * the list — callers that need a single "primary" dir for storeKey-style
- * uses (e.g. GCS listing) pick the head, and it's stable across calls.
- */
-function resolveSessionDirs(convId: string): string[] {
-  const root = sessionsRoot();
-  const matches = new Set<string>();
-  const exact = path.join(root, convId);
-  if (existsSync(exact)) matches.add(exact);
+async function pathExists(p: string): Promise<boolean> {
   try {
-    for (const e of readdirSync(root, { withFileTypes: true })) {
-      if (!e.isDirectory()) continue;
-      const name = e.name;
-      if (
-        name === convId ||
-        name.startsWith(`${convId}_`) ||
-        // Per-user Digital Twin fold: buildSandboxStoreKey joins the userId to
-        // the conv segment with a HYPHEN (`<convId>-<userId>_<slug>`), so the
-        // char after convId is `-` not `_` and none of the other patterns hit.
-        // Without this clause every twin session 404'd here even though the
-        // dir sat on the PVC (the GCS-restore fallback below already knew the
-        // form, but it re-resolves through this matcher and inherited the miss).
-        name.startsWith(`${convId}-`) ||
-        name.includes(`_${convId}_`) ||
-        name.endsWith(`_${convId}`)
-      ) {
-        matches.add(path.join(root, name));
-      }
-    }
+    await stat(p);
+    return true;
   } catch {
-    // sessions root may not exist yet
+    return false;
   }
-  // Stable ordering: root (non-branch) dirs first, then branches. Callers
-  // that need one "primary" dir (e.g. for GCS storeKey heuristics) get the
-  // root deterministically.
-  return [...matches].sort((a, b) => {
-    const aBranch = path.basename(a).includes("__branch__");
-    const bBranch = path.basename(b).includes("__branch__");
-    if (aBranch !== bBranch) return aBranch ? 1 : -1;
-    return a.localeCompare(b);
-  });
 }
 
-async function readSubagentArtifacts(
-  debugDirs: string[],
-): Promise<Array<{ fileName: string; data: Record<string, unknown> }>> {
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values.filter((v) => v.length > 0))];
+}
+
+// ── Run discovery ───────────────────────────────────────────────────────────
+
+/**
+ * Where a run was found. Ranked: a local new-format run beats a GCS copy, and
+ * the start-of-run placeholder is dead last — it is a header with zero events,
+ * written so a run that never finished is still *discoverable*, never so it can
+ * stand in for a copy that has a trace in it.
+ */
+type RunSource = "pvc" | "pvc-legacy" | "gcs" | "gcs-starting";
+
+const SOURCE_RANK: Record<RunSource, number> = {
+  pvc: 0,
+  "pvc-legacy": 1,
+  gcs: 2,
+  "gcs-starting": 3,
+};
+
+export interface RunLocation {
+  runId: string;
+  /** Legacy v1 artifact name — the identity every existing reader keys on. */
+  fileName: string;
+  storeKey: string;
+  source: RunSource;
+  /** New-format run dir on the PVC (`…/debug/runs/<runId>`). */
+  runDir?: string;
+  /** Legacy v1 snapshot file on the PVC. */
+  filePath?: string;
+  /** This sighting came from a GCS discovery marker rather than a real listing. */
+  viaIndex?: boolean;
+  /** EVERY sighting was a marker — nothing anywhere claims the bytes exist. */
+  indexOnly?: boolean;
+  /**
+   * Subagent/delegated child run, per its header. `undefined` = the header has
+   * not been read yet (a GCS-only run), which the caller treats as a parent
+   * until hydration proves otherwise.
+   */
+  isChild?: boolean;
+  /** Parent run this child belongs to, when its header named one. */
+  parentRunId?: string;
+}
+
+/**
+ * Dedupe by runId — the same run legitimately appears on the PVC, in the GCS
+ * index and in the GCS run listing — keeping the richest copy, then order
+ * newest-first by the epoch inside the runId (never by filename string: a
+ * 13-digit epoch and a 14-digit one sort backwards lexically).
+ */
+export function mergeRunLocations(locations: readonly RunLocation[]): RunLocation[] {
+  const best = new Map<string, RunLocation>();
+  // Parentage and index-only-ness are properties of the RUN, not of whichever
+  // sighting happened to win the rank comparison: only the PVC sighting has a
+  // header to read, and only the marker sighting knows it came from a marker.
+  const classified = new Map<string, { isChild: boolean; parentRunId?: string }>();
+  const corroborated = new Set<string>();
+
+  for (const loc of locations) {
+    if (loc.viaIndex !== true) corroborated.add(loc.runId);
+    if (loc.isChild !== undefined && !classified.has(loc.runId)) {
+      classified.set(loc.runId, {
+        isChild: loc.isChild,
+        ...(loc.parentRunId !== undefined ? { parentRunId: loc.parentRunId } : {}),
+      });
+    }
+    const prev = best.get(loc.runId);
+    if (!prev || SOURCE_RANK[loc.source] < SOURCE_RANK[prev.source]) best.set(loc.runId, loc);
+  }
+
+  return [...best.values()]
+    .map((loc) => ({
+      ...loc,
+      ...(classified.get(loc.runId) ?? {}),
+      ...(corroborated.has(loc.runId) ? {} : { indexOnly: true }),
+    }))
+    .sort((a, b) => compareRunIdsNewestFirst(a.runId, b.runId));
+}
+
+/**
+ * Split discovered runs into turns and subagent children.
+ *
+ * A child run is a run — it has its own header, events and blobs — but it is
+ * NOT a turn. Left in `runs[]` it renders as a phantom "Turn N" in the drawer,
+ * and worse, it eats the page budget and evicts the real turn it was spawned
+ * from. An unclassified run counts as a parent: we cannot prove otherwise
+ * without its header, and hydration re-checks.
+ */
+export function partitionRunLocations(locations: readonly RunLocation[]): {
+  parents: RunLocation[];
+  children: RunLocation[];
+} {
+  const parents: RunLocation[] = [];
+  const children: RunLocation[] = [];
+  for (const loc of locations) (loc.isChild === true ? children : parents).push(loc);
+  return { parents, children };
+}
+
+/**
+ * Ceiling on child runs hydrated alongside one page. A single turn can spawn
+ * dozens of subagents; without a cap, "page of 25 turns" is an unbounded
+ * download by another name.
+ */
+export const MAX_CHILD_RUNS_PER_PAGE = 100;
+
+/**
+ * The children belonging to the turns on this page.
+ *
+ * Matched by `parentRunId`. A child whose header never recorded one is kept
+ * regardless: the drawer keys those off `parentSessionId`, and dropping them
+ * would lose the trace entirely — but they are matched last so a real parent's
+ * children never lose their slot to one.
+ */
+export function childrenForPage(
+  children: readonly RunLocation[],
+  page: readonly RunLocation[],
+  cap: number = MAX_CHILD_RUNS_PER_PAGE,
+): { hydrate: RunLocation[]; withheld: number } {
+  const pageIds = new Set(page.map((p) => p.runId));
+  const matched = children.filter((c) => c.parentRunId !== undefined && pageIds.has(c.parentRunId));
+  const unattached = children.filter((c) => c.parentRunId === undefined);
+  const ordered = [...matched, ...unattached];
+  return { hydrate: ordered.slice(0, cap), withheld: Math.max(0, ordered.length - cap) };
+}
+
+/**
+ * Session dirs belonging to `convId`, root dirs before branch dirs.
+ *
+ * One conversation legitimately owns several dirs: the root `<convId>_<slug>`
+ * plus each branch `<convId>__branch__<assistantId>_<slug>`. Callers that need
+ * a single "primary" dir take the head, which is stable across calls.
+ */
+export function orderSessionDirNames(names: readonly string[], convId: string): string[] {
+  return names
+    .filter((n) => sessionDirMatchesConversation(n, convId))
+    .sort((a, b) => {
+      const aBranch = a.includes("__branch__");
+      const bBranch = b.includes("__branch__");
+      if (aBranch !== bBranch) return aBranch ? 1 : -1;
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+}
+
+async function listSessionDirNames(warnings: string[]): Promise<string[]> {
+  try {
+    const entries = await readdir(sessionsRoot(), { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch (err) {
+    // A pod that has never run anything has no sessions root — that is not a
+    // degradation. Anything else is.
+    if (!isEnoent(err)) pushWarning(warnings, `sessions root unreadable: ${errText(err)}`);
+    return [];
+  }
+}
+
+/** Mirrors `SESSION_FILE` in debug/store.ts — the per-run header. */
+const RUN_HEADER_FILE = "session.json";
+
+/**
+ * Read ONLY the header of an on-disk run, to learn whether it is a turn or a
+ * subagent child.
+ *
+ * This has to happen during discovery, before pagination, and that is the
+ * awkward part: you cannot know a run is a child until something reads its
+ * header, but reading whole runs before paginating is exactly the cost
+ * pagination exists to avoid. The header is the cheap half — one small
+ * `session.json`, versus `events.jsonl` + `blobs.jsonl` that routinely run to
+ * megabytes — so classification pays a per-run stat-and-parse and hydration
+ * still only touches the page.
+ */
+async function classifyRunDir(runDir: string): Promise<Pick<RunLocation, "isChild" | "parentRunId">> {
+  const header = await readJsonIfExists<Partial<RunHeader>>(path.join(runDir, RUN_HEADER_FILE));
+  // An unreadable header leaves the run unclassified rather than guessing:
+  // hydration will read it properly and can still demote it.
+  if (!header) return {};
+  const parentRunId = typeof header.parentRunId === "string" ? header.parentRunId : undefined;
+  const isChild = parentRunId !== undefined || typeof header.parentToolCallId === "string";
+  return { isChild, ...(parentRunId !== undefined ? { parentRunId } : {}) };
+}
+
+async function collectPvcLocations(storeKey: string, warnings: string[]): Promise<RunLocation[]> {
+  const debugDir = debugDirFor(storeKey);
+  const out: RunLocation[] = [];
+
+  const runDirs = await listRunDirs(debugDir);
+  const classes = await Promise.all(runDirs.map((d) => classifyRunDir(d)));
+  for (const [i, runDir] of runDirs.entries()) {
+    const runId = path.basename(runDir);
+    out.push({
+      runId,
+      fileName: runFileNameFor(runId),
+      storeKey,
+      source: "pvc",
+      runDir,
+      ...(classes[i] ?? {}),
+    });
+  }
+
+  const entries = await readdir(debugDir, { withFileTypes: true }).catch((err: unknown) => {
+    if (!isEnoent(err)) pushWarning(warnings, `debug dir ${storeKey} unreadable: ${errText(err)}`);
+    return [] as Dirent[];
+  });
+  for (const e of entries) {
+    if (!e.isFile() || !e.name.startsWith("debug-run-") || !e.name.endsWith(".json")) continue;
+    // A legacy name that doesn't parse still identifies a run: fall back to the
+    // raw token rather than dropping an artifact that is sitting right there.
+    const runId = parseRunFileName(e.name)?.runId ?? e.name.slice("debug-run-".length, -".json".length);
+    if (!runId) continue;
+    out.push({
+      runId,
+      fileName: e.name,
+      storeKey,
+      source: "pvc-legacy",
+      filePath: path.join(debugDir, e.name),
+    });
+  }
+  return out;
+}
+
+/**
+ * Layer 2: the discovery markers. Their names carry the run's REAL storeKey, so
+ * branch keys, per-user twin keys and userId-prefixed keys need no guessing.
+ */
+async function collectIndexLocations(
+  convId: string,
+  warnings: string[],
+): Promise<{ locations: RunLocation[]; storeKeys: string[] }> {
+  const names = await gcsListDebugIndex(convId);
+  if (names === null) {
+    // A pod with no object store is a supported deployment, not a degraded one:
+    // warning here painted every healthy local-dev run as a partial trace.
+    if (gcsDirectConfigured()) {
+      pushWarning(warnings, "GCS discovery index unavailable; falling back to storeKey guessing");
+    }
+    return { locations: [], storeKeys: [] };
+  }
+  const locations: RunLocation[] = [];
+  const storeKeys: string[] = [];
+  for (const name of names) {
+    const parsed = parseIndexObjectName(name);
+    if (!parsed) {
+      pushWarning(warnings, `unparsable discovery marker ${name}`);
+      continue;
+    }
+    storeKeys.push(parsed.storeKey);
+    locations.push({
+      runId: parsed.runId,
+      fileName: runFileNameFor(parsed.runId),
+      storeKey: parsed.storeKey,
+      source: "gcs",
+      viaIndex: true,
+    });
+  }
+  return { locations, storeKeys: unique(storeKeys) };
+}
+
+/**
+ * Object names under one storeKey → locations. Pure, because the one thing that
+ * must not regress here is how a start-of-run placeholder ranks against a real
+ * artifact.
+ */
+export function gcsLocationsFromNames(storeKey: string, names: readonly string[]): RunLocation[] {
+  const out: RunLocation[] = [];
+  for (const name of names) {
+    // Checked BEFORE the generic `debug-run-*.json` branch: a placeholder also
+    // ends in `.json`, and the generic parse would mint the phantom runId
+    // `<runId>.starting` — a second, empty row for a run that already exists.
+    if (isStartingRunObjectName(name)) {
+      const base = name.slice(name.lastIndexOf("/") + 1);
+      const runId = base.slice("debug-run-".length, -".starting.json".length);
+      if (runId) out.push({ runId, fileName: runFileNameFor(runId), storeKey, source: "gcs-starting" });
+      continue;
+    }
+    if (name.startsWith("debug-run-") && name.endsWith(".json")) {
+      const runId = parseRunFileName(name)?.runId ?? name.slice("debug-run-".length, -".json".length);
+      if (runId) out.push({ runId, fileName: name, storeKey, source: "gcs" });
+      continue;
+    }
+    // A run whose v1 upload failed but whose packed v2 object landed is still a
+    // run; hydration knows how to read it.
+    const packed = parsePackedRunObjectName(name);
+    if (packed) {
+      out.push({ runId: packed.runId, fileName: runFileNameFor(packed.runId), storeKey, source: "gcs" });
+    }
+  }
+  return out;
+}
+
+async function collectGcsLocations(storeKey: string, warnings: string[]): Promise<RunLocation[]> {
+  const names = await gcsListDebugRuns(storeKey);
+  if (names === null) {
+    // Same reasoning as the index listing: "not configured" is not a failure.
+    if (gcsDirectConfigured()) pushWarning(warnings, `GCS run listing unavailable for ${storeKey}`);
+    return [];
+  }
+  return gcsLocationsFromNames(storeKey, names);
+}
+
+// ── Pagination ──────────────────────────────────────────────────────────────
+
+export const DEFAULT_RUN_LIMIT = 25;
+export const MAX_RUN_LIMIT = 100;
+
+export function parseRunLimit(raw: unknown): number {
+  const n = typeof raw === "string" ? Number(raw) : typeof raw === "number" ? raw : Number.NaN;
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_RUN_LIMIT;
+  return Math.min(Math.floor(n), MAX_RUN_LIMIT);
+}
+
+export interface RunPage<T> {
+  page: T[];
+  totalRuns: number;
+  truncated: boolean;
+  /** Runs OLDER than this page — what a `before` cursor would fetch next. */
+  remaining: number;
+}
+
+/**
+ * Cursor pagination over the newest-first list. `before` is a runId: the page
+ * starts at the run immediately OLDER than it, so a caller can walk a long
+ * thread instead of hitting a silent cap. A cursor that no longer resolves to a
+ * known run still positions correctly — we fall back to the epoch comparison.
+ */
+export function paginateRuns<T extends { runId: string }>(
+  sorted: readonly T[],
+  limit: number,
+  before?: string,
+): RunPage<T> {
+  let start = 0;
+  if (before !== undefined) {
+    const exact = sorted.findIndex((r) => r.runId === before);
+    if (exact >= 0) {
+      start = exact + 1;
+    } else {
+      // Cursor no longer in the list (run aged out, or a client-held id): take
+      // the first run that sorts strictly older than it.
+      const older = sorted.findIndex((r) => compareRunIdsNewestFirst(before, r.runId) < 0);
+      start = older >= 0 ? older : sorted.length;
+    }
+  }
+  const page = sorted.slice(start, start + limit);
+  const remaining = sorted.length - (start + page.length);
+  return { page, totalRuns: sorted.length, truncated: remaining > 0, remaining };
+}
+
+// ── Hydration ───────────────────────────────────────────────────────────────
+
+/**
+ * Total bytes of re-inlined transcript we are willing to materialize for ONE
+ * response. materialize.ts budgets per run; a page of 25 runs each taking the
+ * default 8 MB would be 200 MB of JSON, so the budget is split across the page.
+ */
+
+interface HydratedRun {
+  loc: RunLocation;
+  /** Present when the full v2 run was readable (PVC dir or packed GCS object). */
+  run?: ReadRun;
+  snapshot: Record<string, unknown>;
+}
+
+async function readRunFromDisk(loc: RunLocation, warnings: string[]): Promise<ReadRun | null> {
+  if (!loc.runDir) return null;
+  try {
+    const run = await readRun(loc.runDir);
+    if (!run) {
+      pushWarning(warnings, `run ${loc.runId}: header missing or unreadable on disk`);
+      return null;
+    }
+    for (const w of run.warnings) pushWarning(warnings, `run ${loc.runId}: ${w}`);
+    return run;
+  } catch (err) {
+    pushWarning(warnings, `run ${loc.runId}: unreadable on disk (${errText(err)})`);
+    return null;
+  }
+}
+
+async function readPackedFromGcs(loc: RunLocation, warnings: string[]): Promise<ReadRun | null> {
+  const buf = await gcsDownloadDebugObject(`${loc.storeKey}/${packedRunObjectName(loc.runId)}`);
+  if (!buf) return null;
+  const run = unpackRun(buf);
+  if (!run) {
+    pushWarning(warnings, `run ${loc.runId}: packed GCS object unreadable`);
+    return null;
+  }
+  for (const w of run.warnings) pushWarning(warnings, `run ${loc.runId}: ${w}`);
+  return run;
+}
+
+async function parseV1(
+  buf: Buffer | null,
+  loc: RunLocation,
+  warnings: string[],
+): Promise<Record<string, unknown> | null> {
+  if (!buf) return null;
+  try {
+    return JSON.parse(buf.toString("utf8")) as Record<string, unknown>;
+  } catch (err) {
+    pushWarning(warnings, `run ${loc.runId}: GCS snapshot is not valid JSON (${errText(err)})`);
+    return null;
+  }
+}
+
+async function readV1FromGcs(loc: RunLocation, warnings: string[]): Promise<Record<string, unknown> | null> {
+  return parseV1(await gcsDownloadDebugRun(loc.storeKey, loc.fileName), loc, warnings);
+}
+
+async function readStartingFromGcs(loc: RunLocation, warnings: string[]): Promise<Record<string, unknown> | null> {
+  return parseV1(
+    await gcsDownloadDebugObject(`${loc.storeKey}/${startingRunObjectName(loc.runId)}`),
+    loc,
+    warnings,
+  );
+}
+
+/**
+ * The artifact sources hydration walks, most-complete first. Injected rather
+ * than called directly because the ORDER is the correctness property — a
+ * header-only copy winning over one with events is the exact bug this shape
+ * exists to keep tested.
+ */
+export interface RunArtifactSources {
+  localRun(loc: RunLocation, warnings: string[]): Promise<ReadRun | null>;
+  localV1(loc: RunLocation, warnings: string[]): Promise<Record<string, unknown> | null>;
+  packedRun(loc: RunLocation, warnings: string[]): Promise<ReadRun | null>;
+  remoteV1(loc: RunLocation, warnings: string[]): Promise<Record<string, unknown> | null>;
+  startingV1(loc: RunLocation, warnings: string[]): Promise<Record<string, unknown> | null>;
+}
+
+export const defaultRunArtifactSources: RunArtifactSources = {
+  localRun: readRunFromDisk,
+  localV1: async (loc, warnings) => {
+    if (!loc.filePath) return null;
+    const data = await readJsonIfExists<Record<string, unknown>>(loc.filePath);
+    if (!data) pushWarning(warnings, `run ${loc.runId}: local snapshot ${loc.fileName} unreadable`);
+    return data;
+  },
+  packedRun: readPackedFromGcs,
+  remoteV1: readV1FromGcs,
+  startingV1: readStartingFromGcs,
+};
+
+/**
+ * Everything that discovered this run turned out to be a marker, and the bytes
+ * are gone — the shape `/clear` leaves behind. Distinguished from a genuine
+ * read failure because the caller drops these from the response entirely
+ * instead of reporting a run it cannot show.
+ */
+function pushMissingWarning(loc: RunLocation, warnings: string[]): void {
+  if (loc.indexOnly === true) {
+    pushWarning(warnings, `run ${loc.runId}: discovery marker with no surviving artifact (session cleared?); dropped`);
+  } else {
+    pushWarning(warnings, `run ${loc.runId}: discovered but no readable artifact on PVC or GCS`);
+  }
+}
+
+/** Every source in richest-first order; the run is only "missing" if all miss. */
+export async function hydrateV1(
+  loc: RunLocation,
+  warnings: string[],
+  src: RunArtifactSources = defaultRunArtifactSources,
+): Promise<HydratedRun | null> {
+  const local = await src.localRun(loc, warnings);
+  if (local) {
+    return { loc, run: local, snapshot: toV1Snapshot(local) as unknown as Record<string, unknown> };
+  }
+  const localV1 = await src.localV1(loc, warnings);
+  if (localV1) return { loc, snapshot: localV1 };
+  // Packed v2 BEFORE the remote v1 snapshot. Both legitimately exist for one
+  // run, and the v1 object may be a truncated upload — or, before it moved to
+  // its own name, the header-only start placeholder — so preferring it served
+  // an empty trace for a run whose events were sitting right there.
+  const packed = await src.packedRun(loc, warnings);
+  if (packed) {
+    return { loc, run: packed, snapshot: toV1Snapshot(packed) as unknown as Record<string, unknown> };
+  }
+  const remote = await src.remoteV1(loc, warnings);
+  if (remote) return { loc, snapshot: remote };
+  // Last resort: the placeholder. Zero events by construction — its whole job
+  // is keeping a run that died before finishing visible at all.
+  const starting = await src.startingV1(loc, warnings);
+  if (starting) {
+    pushWarning(warnings, `run ${loc.runId}: only the start-of-run placeholder survives; the run never finished uploading`);
+    return { loc, snapshot: starting };
+  }
+  pushMissingWarning(loc, warnings);
+  return null;
+}
+
+interface V2RunPayload {
+  runId: string;
+  header: RunHeader | Record<string, unknown>;
+  events: unknown[];
+  blobIndex: Array<Omit<BlobLine, "content">>;
+  /** The v2 form was gone; this is the v1 snapshot reshaped, not a real trace. */
+  derivedFromV1?: true;
+}
+
+async function hydrateV2(
+  loc: RunLocation,
+  warnings: string[],
+  src: RunArtifactSources = defaultRunArtifactSources,
+): Promise<V2RunPayload | null> {
+  const run = (await src.localRun(loc, warnings)) ?? (await src.packedRun(loc, warnings));
+  if (run) return toV2Run(run);
+  // Older runs exist only as v1 snapshots. Reshaping one loses blob refs but
+  // keeps the run visible, which beats dropping it from the list. The
+  // placeholder is tried last for the same reason it ranks last everywhere:
+  // header only, no events.
+  const local =
+    (await src.localV1(loc, warnings)) ??
+    (await src.remoteV1(loc, warnings)) ??
+    (await src.startingV1(loc, warnings));
+  if (!local) {
+    pushMissingWarning(loc, warnings);
+    return null;
+  }
+  pushWarning(warnings, `run ${loc.runId}: no v2 form available; derived from the v1 snapshot`);
+  return {
+    runId: loc.runId,
+    header: local,
+    events: Array.isArray(local["events"]) ? (local["events"] as unknown[]) : [],
+    blobIndex: [],
+    derivedFromV1: true,
+  };
+}
+
+/**
+ * How many of this page's locations turned out not to be turns: a dropped
+ * discovery marker, or a run whose header (unreadable before hydration, because
+ * it lived only in GCS) names a parent. Subtracted from `totalRuns` so the count
+ * the drawer paginates against matches what it can actually render.
+ */
+function countUnservedParents(
+  page: readonly RunLocation[],
+  hydrated: ReadonlyArray<V2RunPayload | null>,
+): number {
+  let n = 0;
+  for (const [i, loc] of page.entries()) {
+    const r = hydrated[i];
+    if (!r) {
+      if (loc.indexOnly === true) n += 1;
+      continue;
+    }
+    const h = r.header as Record<string, unknown>;
+    if (typeof h["parentRunId"] === "string" || typeof h["parentToolCallId"] === "string") n += 1;
+  }
+  return n;
+}
+
+// ── Subagent artifacts ──────────────────────────────────────────────────────
+
+interface SubagentArtifact {
+  fileName: string;
+  data: Record<string, unknown>;
+}
+
+async function readLegacySubagentArtifacts(debugDirs: string[]): Promise<SubagentArtifact[]> {
   const artifacts = await Promise.all(
     debugDirs.map(async (debugDir) => {
       try {
@@ -117,18 +690,53 @@ async function readSubagentArtifacts(
       }
     }),
   );
-  const seen = new Set<string>();
-  return artifacts.flat().filter((item): item is { fileName: string; data: Record<string, unknown> } => {
-    if (!item) return false;
-    const key = `${String(item.data["parentSessionId"] ?? "")}:${String(item.data["parentToolCallId"] ?? "")}:${String(item.data["subagentName"] ?? "")}`;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
+  return artifacts.flat().filter((item): item is SubagentArtifact => item !== null);
 }
 
-// GET /internal/sessions/:convId/debug?agentSlug=<slug>
-// Serves the debugger artifacts for a conversation from this pod's PVC.
+/**
+ * A child run recorded in the new format is a first-class run with a
+ * `parentRunId`/`parentToolCallId` header. The drawer only knows the legacy
+ * `subagents-*.json` shape, so project it into that shape rather than teaching
+ * the UI a second one. `sessionId` on a child header is the PARENT's session
+ * (subagent-tools reuses it), which is exactly what `parentSessionId` means here.
+ */
+function subagentFromChildRun(h: RunHeader, snapshot: Record<string, unknown>): SubagentArtifact | null {
+  if (h.parentRunId === undefined && h.parentToolCallId === undefined) return null;
+  const name = h.subagentName ?? "subagent";
+  const token = safeRunToken(`${name}-${h.parentToolCallId ?? h.runId}`);
+  return {
+    fileName: `subagents-${token}.json`,
+    data: {
+      ...snapshot,
+      schemaVersion: 1,
+      parentSessionId: h.sessionId ?? h.parentRunId ?? "",
+      ...(h.parentToolCallId !== undefined ? { parentToolCallId: h.parentToolCallId } : {}),
+      subagentName: name,
+      ...(h.question !== undefined ? { question: h.question } : {}),
+    },
+  };
+}
+
+/** Legacy files win over derived ones — they carry the child's own transcript. */
+function dedupeSubagents(items: readonly SubagentArtifact[]): SubagentArtifact[] {
+  const seen = new Set<string>();
+  const out: SubagentArtifact[] = [];
+  for (const item of items) {
+    const key = `${String(item.data["parentSessionId"] ?? "")}:${String(item.data["parentToolCallId"] ?? "")}:${String(item.data["subagentName"] ?? "")}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+// ── GET /internal/sessions/:convId/debug ────────────────────────────────────
+
+function fail(res: Response, status: number, error: string, code: "invalid_id" | "not_found" | "internal", extra?: Record<string, unknown>): void {
+  metric.count("debug_bundle", { result: code });
+  res.status(status).json({ success: false, error, code, ...(extra ?? {}) });
+}
+
 router.get("/internal/sessions/:convId/debug", validateS2SKey, async (req: Request<{ convId: string }>, res: Response) => {
   try {
     const { convId } = req.params;
@@ -137,133 +745,265 @@ router.get("/internal/sessions/:convId/debug", validateS2SKey, async (req: Reque
     // All three ids end up in filesystem paths under the sessions root —
     // reject anything outside the safe charset before touching the disk.
     if (!isSafeId(convId) || (agentSlug !== undefined && !isSafeId(agentSlug)) || (userId !== undefined && !isSafeId(userId))) {
-      res.status(400).json({ success: false, error: "Invalid conversation id, agent slug, or user id" });
+      fail(res, 400, "Invalid conversation id, agent slug, or user id", "invalid_id");
       return;
     }
 
-    let sessionDirPaths = resolveSessionDirs(convId);
-    if (sessionDirPaths.length === 0) {
-      // Not on the PVC — try restoring from the GCS archive under every
-      // storeKey form claw uses on disk: `<convId>`, `<convId>_<agentSlug>`,
-      // the agent-chat form `<userId>_<convId>_<agentSlug>`, and the per-user
-      // Digital Twin form `<convId>-<userId>_<agentSlug>` (buildSandboxStoreKey
-      // folds userId into the conv segment for agentSlug==="digital-twin").
-      const keys = [
-        convId,
-        ...(agentSlug ? [`${convId}_${agentSlug}`] : []),
-        ...(userId ? [`${userId}_${convId}`] : []),
-        ...(userId && agentSlug ? [`${userId}_${convId}_${agentSlug}`] : []),
-        ...(userId && agentSlug ? [`${convId}-${userId}_${agentSlug}`] : []),
-      ];
-      for (const k of keys) {
-        if (await restoreSessionFromArchive(k).catch(() => false)) break;
-      }
-      sessionDirPaths = resolveSessionDirs(convId);
+    const warnings: string[] = [];
+    const format = req.query["format"] === "v2" ? "v2" : "v1";
+    const limit = parseRunLimit(req.query["limit"]);
+    const rawBefore = req.query["before"];
+    let before: string | undefined;
+    if (typeof rawBefore === "string" && rawBefore !== "") {
+      if (isSafeId(rawBefore)) before = rawBefore;
+      else pushWarning(warnings, `ignoring malformed 'before' cursor ${rawBefore}`);
     }
 
-    if (sessionDirPaths.length === 0) {
-      res.status(404).json({ success: false, error: "Debug artifacts not found" });
-      return;
-    }
+    // 1. PVC.
+    let dirNames = orderSessionDirNames(await listSessionDirNames(warnings), convId);
+    let pvcLocations = (await Promise.all(dirNames.map((n) => collectPvcLocations(n, warnings)))).flat();
 
-    // Branching: one conversation can have many session dirs — the root
-    // `<convId>_<slug>` plus each branch `<convId>__branch__<assistantId>_<slug>`.
-    // The debugger needs runs from ALL of them merged into one bundle so it
-    // can pin by AgentRun.sessionId across branches.
-    const debugDirs = sessionDirPaths
-      .map((p) => path.join(p, "debug"))
-      .filter((d) => existsSync(d));
-    if (debugDirs.length === 0) {
-      res.status(404).json({ success: false, error: "Debug artifacts not found" });
-      return;
-    }
+    // 2. Discovery index — authoritative storeKeys, no guessing.
+    const index = await collectIndexLocations(convId, warnings);
 
-    const primaryDebugDir = debugDirs[0]!;
-    // debug-session.json + debug-events.json are per-session-dir and represent
-    // the LATEST live trace recorded in that dir. The frontend treats these as
-    // "live" info; for branched conversations the most useful one is the root.
-    // Pick the primary (root preferred by resolveSessionDirs ordering).
-    const debugSession = await readJsonIfExists<Record<string, unknown>>(path.join(primaryDebugDir, "debug-session.json"));
-    const debugEvents = await readJsonIfExists<Record<string, unknown>[]>(path.join(primaryDebugDir, "debug-events.json"));
+    // 3. GCS runs for every key anyone knows about.
+    const guessedKeys = candidateStoreKeys(convId, agentSlug, userId);
+    const gcsKeys = unique([...index.storeKeys, ...guessedKeys, ...dirNames]);
+    const gcsLocations = (await Promise.all(gcsKeys.map((k) => collectGcsLocations(k, warnings)))).flat();
 
-    // Aggregate debug-run-*.json files across every matching dir. The same
-    // run file name only ever exists in one dir (it's session-id scoped), so
-    // a plain Map by fileName is enough to dedupe.
-    const runsByName = new Map<string, { fileName: string; data: Record<string, unknown> }>();
-    for (const dir of debugDirs) {
-      const dirEntries = await readdir(dir, { withFileTypes: true }).catch(() => []);
-      for (const entry of dirEntries) {
-        if (!entry.isFile() || !entry.name.startsWith("debug-run-") || !entry.name.endsWith(".json")) continue;
-        const data = await readJsonIfExists<Record<string, unknown>>(path.join(dir, entry.name));
-        if (data && !runsByName.has(entry.name)) {
-          runsByName.set(entry.name, { fileName: entry.name, data });
+    let locations = mergeRunLocations([...pvcLocations, ...index.locations, ...gcsLocations]);
+
+    // 4. Archive restore. Last resort only: it pulls a whole session onto the
+    // PVC. Keyed on the dir NAME, not just "no dir exists" — a dir that exists
+    // but lost its `debug/` (eviction mid-write) used to skip restore entirely.
+    if (locations.length === 0) {
+      let restored = false;
+      for (const key of unique([...index.storeKeys, ...guessedKeys, ...dirNames])) {
+        try {
+          if (await restoreSessionFromArchive(key)) restored = true;
+        } catch (err) {
+          pushWarning(warnings, `archive restore failed for ${key}: ${errText(err)}`);
         }
       }
-    }
-    const runs = [...runsByName.values()];
-
-    // Per-run snapshots now live in GCS (claw-debug-runs/<storeKey>/) instead
-    // of the PVC — see agent.ts. Merge them in per storeKey (one per session
-    // dir), newest first, capped TOTAL so a long-running thread doesn't turn
-    // this endpoint into a bulk download.
-    const MAX_GCS_RUNS = 50;
-    const localNames = new Set(runs.map((r) => r.fileName));
-    const gcsCandidates: Array<{ storeKey: string; name: string }> = [];
-    for (const dir of debugDirs) {
-      const storeKey = path.basename(path.dirname(dir));
-      const gcsNames = (await gcsListDebugRuns(storeKey)) ?? [];
-      for (const name of gcsNames) {
-        if (!name.startsWith("debug-run-") || !name.endsWith(".json")) continue;
-        if (localNames.has(name)) continue;
-        gcsCandidates.push({ storeKey, name });
+      if (restored) {
+        dirNames = orderSessionDirNames(await listSessionDirNames(warnings), convId);
+        pvcLocations = (await Promise.all(dirNames.map((n) => collectPvcLocations(n, warnings)))).flat();
+        locations = mergeRunLocations([...pvcLocations, ...index.locations, ...gcsLocations]);
       }
     }
-    // Filename starts with a millisecond timestamp; sort descending is
-    // newest-first, even across mixed storeKeys.
-    gcsCandidates.sort((a, b) => b.name.localeCompare(a.name));
-    if (gcsCandidates.length > MAX_GCS_RUNS) {
-      log.info(`[debug] ${convId}: serving newest ${MAX_GCS_RUNS} of ${gcsCandidates.length} GCS debug runs across ${debugDirs.length} dir(s)`);
+
+    const debugDirs: string[] = [];
+    for (const name of dirNames) {
+      const dir = debugDirFor(name);
+      if (await pathExists(dir)) debugDirs.push(dir);
     }
-    const newest = gcsCandidates.slice(0, MAX_GCS_RUNS);
-    const gcsRuns = (
-      await Promise.all(
-        newest.map(async ({ storeKey, name }) => {
-          const buf = await gcsDownloadDebugRun(storeKey, name);
-          if (!buf) return null;
-          try {
-            return { fileName: name, data: JSON.parse(buf.toString("utf8")) as Record<string, unknown> };
-          } catch {
-            return null;
-          }
-        }),
-      )
-    ).filter((x): x is { fileName: string; data: Record<string, unknown> } => x !== null);
-    runs.push(...gcsRuns);
+    const primaryDebugDir = debugDirs[0] ?? null;
+
+    // Turns and subagent children are paginated separately: the page budget
+    // belongs to turns, and children ride along with the turn that spawned them.
+    const { parents, children } = partitionRunLocations(locations);
+    const { page, totalRuns, truncated, remaining } = paginateRuns(parents, limit, before);
+    const childPage = childrenForPage(children, page);
+    if (childPage.withheld > 0) {
+      pushWarning(warnings, `${childPage.withheld} subagent run(s) withheld from this page (cap ${MAX_CHILD_RUNS_PER_PAGE})`);
+    }
+    if (truncated) {
+      // The cap stays — a 400-turn thread must not be a bulk download — but a
+      // caller that never passed `limit` has to be TOLD it got a slice, or 25
+      // runs read as "that's the whole conversation".
+      pushWarning(
+        warnings,
+        `showing ${page.length} of ${totalRuns} runs; ${remaining} older run(s) withheld — page with ?before=${page[page.length - 1]?.runId ?? ""} or raise ?limit= (max ${MAX_RUN_LIMIT})`,
+      );
+    }
+
+    if (format === "v2") {
+      if (totalRuns === 0 && childPage.hydrate.length === 0) {
+        fail(res, 404, "Debug artifacts not found", "not_found", { warnings });
+        return;
+      }
+      const pageV2 = await Promise.all(page.map((loc) => hydrateV2(loc, warnings)));
+      const childV2 = await Promise.all(childPage.hydrate.map((loc) => hydrateV2(loc, warnings)));
+      // v2 consumers nest by `header.parentRunId` themselves, so children stay
+      // in the list — but they never counted toward `totalRuns`, which is a
+      // count of TURNS.
+      const v2Runs = [...pageV2, ...childV2].filter((r): r is V2RunPayload => r !== null);
+      const adjustedTotal = Math.max(0, totalRuns - countUnservedParents(page, pageV2));
+      if (adjustedTotal === 0 && v2Runs.length === 0) {
+        fail(res, 404, "Debug artifacts not found", "not_found", { warnings });
+        return;
+      }
+      metric.count("debug_bundle", { result: "ok", format: "v2" });
+      res.json({
+        success: true,
+        data: { format: "v2", conversationId: convId, runs: v2Runs, totalRuns: adjustedTotal, truncated, warnings },
+      });
+      return;
+    }
+
+    const toHydrate = [...page, ...childPage.hydrate];
+    const results = await Promise.all(toHydrate.map((loc) => hydrateV1(loc, warnings)));
+
+    const hydrated: HydratedRun[] = [];
+    const childHydrated: HydratedRun[] = [];
+    let notTurns = 0;
+    for (const [i, loc] of page.entries()) {
+      const r = results[i];
+      if (!r) {
+        // Nothing anywhere. An index-only location was never a run to begin
+        // with (see pushMissingWarning); stop counting it as one.
+        if (loc.indexOnly === true) notTurns += 1;
+        continue;
+      }
+      // A GCS-only run could not be classified before pagination — no header
+      // without a download. Now that hydration produced one, demote it instead
+      // of rendering a phantom turn.
+      if (r.run && (r.run.header.parentRunId !== undefined || r.run.header.parentToolCallId !== undefined)) {
+        childHydrated.push(r);
+        notTurns += 1;
+        continue;
+      }
+      hydrated.push(r);
+    }
+    for (const r of results.slice(page.length)) if (r) childHydrated.push(r);
+
+    // `totalRuns` counted every discovered parent-or-unclassified location;
+    // subtract what this page proved was not a turn. Locations on OTHER pages
+    // stay counted — reading them to find out is the cost pagination avoids.
+    const adjustedTotal = Math.max(hydrated.length, totalRuns - notTurns);
+    const runs = hydrated.map((h) => ({ fileName: h.loc.fileName, data: h.snapshot }));
+
+    // debug-session.json / debug-events.json are the per-dir "latest live trace"
+    // the frontend renders as session-level info. They are only materialized at
+    // finish, so fall back to the newest run rather than showing nothing while a
+    // run is in flight.
+    let debugSession = primaryDebugDir
+      ? await readJsonIfExists<Record<string, unknown>>(path.join(primaryDebugDir, "debug-session.json"))
+      : null;
+    let debugEvents = primaryDebugDir
+      ? await readJsonIfExists<Record<string, unknown>[]>(path.join(primaryDebugDir, "debug-events.json"))
+      : null;
+    const newest = hydrated[0];
+    if (!debugSession && newest) debugSession = newest.snapshot;
+    if (!debugEvents && newest && Array.isArray(newest.snapshot["events"])) {
+      debugEvents = newest.snapshot["events"] as Record<string, unknown>[];
+    }
 
     // Subagent artifacts can live under the parent session's debug dir AND under
     // each referenced parent sessionId's dir (mirrors claw-auth's old logic).
     const parentSessionIds = new Set<string>();
     const collect = (d: Record<string, unknown> | null): void => {
       const id = d && typeof d["sessionId"] === "string" ? d["sessionId"] : "";
-      // sessionIds come from artifact file contents, not the request — still
-      // joined into paths below, so apply the same charset guard.
+      // sessionIds come from artifact contents, not the request — still joined
+      // into paths below, so apply the same charset guard.
       if (id && isSafeId(id)) parentSessionIds.add(id);
     };
     collect(debugSession);
     for (const r of runs) collect(r.data);
     const root = sessionsRoot();
-    const subagentDebugDirs = [...debugDirs, ...[...parentSessionIds].map((id) => path.join(root, id, "debug"))];
-    const subagents = await readSubagentArtifacts(subagentDebugDirs);
+    const subagentDirs = [...debugDirs, ...[...parentSessionIds].map((id) => path.join(root, id, "debug"))];
+    // Children go here and ONLY here — the drawer renders `subagents` nested
+    // under their turn, so a child that also appeared in `runs` was a duplicate
+    // rendered as a phantom turn. A child with no v2 header (v1 snapshot only)
+    // cannot be projected into the legacy shape and is simply omitted.
+    const derived = childHydrated
+      .map((h) => (h.run ? subagentFromChildRun(h.run.header, h.snapshot) : null))
+      .filter((s): s is SubagentArtifact => s !== null);
+    const subagents = dedupeSubagents([...(await readLegacySubagentArtifacts(subagentDirs)), ...derived]);
 
+    if (adjustedTotal === 0 && !debugSession && subagents.length === 0) {
+      fail(res, 404, "Debug artifacts not found", "not_found", { warnings });
+      return;
+    }
+
+    if (truncated) {
+      log.info(`[debug] ${convId}: serving ${runs.length} of ${adjustedTotal} runs (limit ${limit})`);
+    }
+    metric.count("debug_bundle", { result: "ok", format: "v1" });
     res.json({
       success: true,
-      data: { conversationId: convId, debugDir: primaryDebugDir, debugSession, debugEvents, runs, subagents },
+      data: {
+        conversationId: convId,
+        debugDir: primaryDebugDir,
+        debugSession,
+        debugEvents,
+        runs,
+        subagents,
+        totalRuns: adjustedTotal,
+        truncated,
+        warnings,
+      },
     });
   } catch (err) {
     log.error("[debug] artifacts error:", err);
-    res.status(500).json({ success: false, error: "Internal server error" });
+    fail(res, 500, "Internal server error", "internal");
   }
 });
+
+// ── GET /internal/sessions/:convId/debug/blob/:hash ─────────────────────────
+
+/** Blob hashes are the first 16 hex chars of a sha256; accept any hex prefix length. */
+const BLOB_HASH_RE = /^[a-f0-9]{8,64}$/;
+
+router.get(
+  "/internal/sessions/:convId/debug/blob/:hash",
+  validateS2SKey,
+  async (req: Request<{ convId: string; hash: string }>, res: Response) => {
+    try {
+      const { convId, hash } = req.params;
+      const runId = typeof req.query["runId"] === "string" ? req.query["runId"] : undefined;
+      const storeKey = typeof req.query["storeKey"] === "string" ? req.query["storeKey"] : undefined;
+      if (
+        !isSafeId(convId) ||
+        !BLOB_HASH_RE.test(hash) ||
+        runId === undefined ||
+        !isSafeId(runId) ||
+        (storeKey !== undefined && !isSafeId(storeKey))
+      ) {
+        metric.count("debug_blob", { result: "invalid_id" });
+        res.status(400).json({ success: false, error: "Invalid conversation id, hash, run id, or store key", code: "invalid_id" });
+        return;
+      }
+
+      const warnings: string[] = [];
+      const keys = storeKey
+        ? [storeKey]
+        : unique([...orderSessionDirNames(await listSessionDirNames(warnings), convId), ...candidateStoreKeys(convId)]);
+
+      let run: ReadRun | null = null;
+      for (const key of keys) {
+        const runDir = path.join(debugDirFor(key), "runs", runId);
+        if (!(await pathExists(runDir))) continue;
+        run = await readRunFromDisk({ runId, fileName: runFileNameFor(runId), storeKey: key, source: "pvc", runDir }, warnings);
+        if (run) break;
+      }
+      if (!run) {
+        for (const key of keys) {
+          run = await readPackedFromGcs({ runId, fileName: runFileNameFor(runId), storeKey: key, source: "gcs" }, warnings);
+          if (run) break;
+        }
+      }
+
+      const content = run?.blobs.get(hash);
+      if (content === undefined) {
+        metric.count("debug_blob", { result: "not_found" });
+        res.status(404).json({ success: false, error: "Blob not found", code: "not_found" });
+        return;
+      }
+
+      // Content-addressed: the bytes behind a hash can never change, so this is
+      // safe to cache forever. Private — a trace can contain user content.
+      res.setHeader("Cache-Control", "private, max-age=31536000, immutable");
+      res.type("text/plain; charset=utf-8");
+      metric.count("debug_blob", { result: "ok" });
+      res.send(content);
+    } catch (err) {
+      log.error("[debug] blob error:", err);
+      metric.count("debug_blob", { result: "internal" });
+      res.status(500).json({ success: false, error: "Internal server error", code: "internal" });
+    }
+  },
+);
 
 router.get("/debug/loop-watchdog", validateS2SKey, async (req: Request, res: Response) => {
   try {

--- a/apps/xyne-claw/src/routes/run.ts
+++ b/apps/xyne-claw/src/routes/run.ts
@@ -2239,6 +2239,9 @@ export async function processTask(
     // runTask (opts), so a detached spawn registered inside a tool's execute()
     // is drained by runTask after the model loop settles. See agent.ts.
     const backgroundSubagentRegistry: import("../subagent-tools.js").BackgroundSubagentRegistry = new Map();
+    // Filled in by runTask once this run's trace is open; the subagent tools
+    // below only close over the object.
+    const parentDebugHandle: import("../subagent-tools.js").ParentDebugHandle = {};
 
     const fastModeEnabled = effectiveFastMode(fastMode, agentConfig);
     const fastToolController: FastToolRuntimeController = {};
@@ -2294,6 +2297,7 @@ export async function processTask(
             // the result back to a parent that's already thrown RunCancelledError.
             ...(abortSignal ? { abortSignal } : {}),
             backgroundRegistry: backgroundSubagentRegistry,
+            parentDebug: parentDebugHandle,
           },
           undefined, // bonusToolsBySubagent — removed with the sandbox subagent
           customSubagents,
@@ -2469,6 +2473,7 @@ export async function processTask(
             : "spaces";
         const calleeDirectPickSuffixes = calleeToolsConfig?.direct ?? [];
         const calleeInnerTools: string[] = [];
+        const calleeDebugHandle: import("../subagent-tools.js").ParentDebugHandle = {};
         const calleeSubagents = buildSubagentTools(
           calleeGroups,
           calleeCustom.tools,
@@ -2496,6 +2501,7 @@ export async function processTask(
               userId,
             },
             ...(signal ? { abortSignal: signal } : {}),
+            parentDebug: calleeDebugHandle,
           },
           undefined,
           spec.customSubagents as import("../subagent-tools.js").CustomSubagentSpec[] | undefined,
@@ -2542,6 +2548,7 @@ export async function processTask(
           sessionId: `${sessionId}-a2a-${spec.slug}`,
           skills: spec.skills,
           abortSignal: signal,
+          parentDebug: calleeDebugHandle,
           progressMeta: {
             ...(conversationId ? { conversationId } : {}),
             agentSlug: spec.slug,
@@ -3926,6 +3933,7 @@ export async function processTask(
         finalAnswerMaxTurns: channelId ? 2 : undefined,
         ...(isRegenerate ? { isRegenerate: true } : {}),
         backgroundRegistry: backgroundSubagentRegistry,
+        parentDebug: parentDebugHandle,
         fastMode: fastModeEnabled,
         ...(catalogActive ? { fastToolCatalogNames: fastCatalogNames } : {}),
         ...(catalogActive ? { fastToolController } : {}),

--- a/apps/xyne-claw/src/session-store.ts
+++ b/apps/xyne-claw/src/session-store.ts
@@ -20,7 +20,8 @@ import { existsSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { PATHS, SERVER } from "./config.js";
-import { gcsRestoreSessionToDisk, gcsUploadSessionFromDisk, gcsDeleteSession, gcsSessionUpdatedAt, type SessionDiskFile } from "./storage.js";
+import { gcsRestoreSessionToDisk, gcsUploadSessionFromDisk, gcsDeleteSession, gcsDeleteDebugRuns, gcsDeleteDebugIndex, gcsSessionUpdatedAt, gcsUploadDebugObject, gcsUploadDebugRunWithRetries, gcsPutDebugIndex, type SessionDiskFile } from "./storage.js";
+import { indexObjectName, listRunDirs, packRun, packedRunObjectName, readRun, runFileNameFor, toV1Snapshot, type RunHeader } from "./debug/index.js";
 import { metric } from "./metrics.js";
 
 import { createLogger } from "./logger.js";
@@ -94,6 +95,97 @@ export async function ensureSessionDebugDir(conversationId: string): Promise<str
   return dir;
 }
 
+/** Mirrors the marker `RunStore.markUploaded` writes (debug/store.ts). */
+const DEBUG_UPLOADED_MARKER = ".uploaded";
+
+/** `<storeKey>.stale-<ts>` and friends are parked copies of a real session dir. */
+function storeKeyForSessionDirName(name: string): string {
+  const m = /\.(?:stale|restore|pvc|tmp)-\d+$/.exec(name);
+  return m ? name.slice(0, m.index) : name;
+}
+
+/**
+ * Conversation ids a run is discoverable by: the RAW Spaces conversation id
+ * (what the debugger asks with) and the session key (`conversationId` on the
+ * header). Deduped and order-stable — raw first, because that is the lookup
+ * that matters if only one marker write survives.
+ */
+function indexConvIdsForHeader(header: RunHeader): string[] {
+  const ids = [header.rawConversationId, header.conversationId].filter((v): v is string => !!v);
+  return [...new Set(ids)];
+}
+
+/**
+ * Lift this pod's un-uploaded debug runs off a session dir that is about to be
+ * destroyed. Returns how many made it to GCS.
+ *
+ * Eviction, the stale-local rollback and snapshot overwrites all delete a
+ * session dir outright — taking `debug/runs/**` with it. A run whose own finish
+ * path could not reach GCS (no `.uploaded` marker) existed ONLY there, so those
+ * deletes were silently the end of the trace. This re-attempts the same two
+ * uploads the finish path does plus the discovery marker, which also indexes a
+ * run that was never indexed because GCS was down at run start.
+ *
+ * Best-effort by construction: a destructive caller must not be blocked by a
+ * storage outage, so nothing here throws.
+ */
+export async function salvageDebugRuns(sessionDirPath: string): Promise<number> {
+  let runDirs: string[];
+  try {
+    runDirs = await listRunDirs(path.join(sessionDirPath, "debug"));
+  } catch {
+    return 0;
+  }
+
+  let salvaged = 0;
+  for (const runDir of runDirs) {
+    try {
+      if (existsSync(path.join(runDir, DEBUG_UPLOADED_MARKER))) continue;
+      const run = await readRun(runDir);
+      if (!run) {
+        metric.count("debug_salvage", { result: "unreadable" });
+        continue;
+      }
+      // The header owns the storeKey it was written under; the dir name is only
+      // a fallback for a header torn before that field landed.
+      const runId = run.header.runId || path.basename(runDir);
+      const storeKey = run.header.storeKey || storeKeyForSessionDirName(path.basename(sessionDirPath));
+      const v1 = Buffer.from(JSON.stringify(toV1Snapshot(run)), "utf8");
+      const uploadedV1 = await gcsUploadDebugRunWithRetries(storeKey, runFileNameFor(runId), v1);
+      const packed = await packRun(runDir);
+      const uploadedPacked = packed
+        ? await gcsUploadDebugObject(`${storeKey}/${packedRunObjectName(runId)}`, packed)
+        : false;
+      if (!uploadedV1 && !uploadedPacked) {
+        metric.count("debug_salvage", { result: "upload_failed" });
+        log.warn(`[session-store] debug salvage could not upload run ${runId} (${storeKey})`);
+        continue;
+      }
+      // Index only once something is there to point at: a marker for an object
+      // that never landed turns "no trace" into a broken row in the drawer.
+      // Both ids, exactly as the start-of-run marker does (agent.ts): the
+      // debugger asks by the RAW conversation id, while `conversationId` is the
+      // session key, and indexing only one leaves the run unfindable by the
+      // other.
+      for (const convId of indexConvIdsForHeader(run.header)) {
+        await gcsPutDebugIndex(indexObjectName(convId, runId, storeKey));
+      }
+      // The dir usually dies right after this, but the stale-local rollback can
+      // put it back — the marker stops the next salvage re-uploading it.
+      await writeFile(path.join(runDir, DEBUG_UPLOADED_MARKER), "").catch(() => {});
+      salvaged++;
+      metric.count("debug_salvage", { result: "uploaded" });
+    } catch (err) {
+      metric.count("debug_salvage", { result: "error" });
+      log.warn(`[session-store] debug salvage failed for ${runDir}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  if (salvaged > 0) {
+    log.info(`[session-store] Salvaged ${salvaged} debug run(s) from ${path.basename(sessionDirPath)}`);
+  }
+  return salvaged;
+}
+
 /** Delete a specific session — BOTH the local dir AND the GCS archive.
  *  Deleting only local disk left the GCS snapshot behind, so the next message
  *  resumed the archived session from storage — making `/clear` unable to rescue
@@ -115,7 +207,71 @@ export async function deleteSession(conversationId: string): Promise<void> {
   } catch (err) {
     log.warn(`[session-store] GCS archive delete failed for ${conversationId}:`, err instanceof Error ? err.message : String(err));
   }
+  // Debug runs live under their OWN GCS prefix, not inside the session archive,
+  // so clearing a session used to leave its traces behind indefinitely.
+  try {
+    const removed = await gcsDeleteDebugRuns(conversationId);
+    if (removed > 0) log.info(`[session-store] Deleted ${removed} GCS debug object(s) for ${conversationId}`);
+  } catch (err) {
+    log.warn(`[session-store] GCS debug delete failed for ${conversationId}:`, err instanceof Error ? err.message : String(err));
+  }
+  // ...and the discovery markers that point AT those objects. Deleting only the
+  // objects left the `_index/<convId>/` markers behind, so discovery kept
+  // listing runs whose payload was gone — phantom rows that 404 on open.
+  try {
+    let removed = 0;
+    for (const convId of candidateIndexConvIds(conversationId)) {
+      removed += await gcsDeleteDebugIndex(convId, conversationId);
+    }
+    if (removed > 0) log.info(`[session-store] Deleted ${removed} GCS debug marker(s) for ${conversationId}`);
+  } catch (err) {
+    log.warn(`[session-store] GCS debug index delete failed for ${conversationId}:`, err instanceof Error ? err.message : String(err));
+  }
 }
+
+/**
+ * Conversation ids whose `_index/` folder can hold markers for this storeKey.
+ *
+ * A marker is written under both the raw conversation id and the session key,
+ * and only the session key (= this storeKey) reaches `deleteSession` — the raw
+ * id has to be recovered from it. So we derive every id shape the key can have
+ * been built from and list each. Over-guessing is free: deletion matches on the
+ * `~<storeKey>.json` suffix, so a candidate that was never a real conversation
+ * id simply lists nothing, and one that belongs to a DIFFERENT store key of the
+ * same conversation keeps its markers.
+ */
+function candidateIndexConvIds(storeKey: string): string[] {
+  const ids = new Set<string>([storeKey]);
+  // `<convId>_<slug>` — the slug is always the LAST segment (buildSandboxStoreKey).
+  const bare = bareConversationIdForStoreKey(storeKey);
+  for (const id of bare ? [storeKey, bare] : [storeKey]) {
+    ids.add(id);
+    // Digital-Twin per-user fold: `<convId>-<safeUserId>`.
+    const twin = /^(.+)-[A-Za-z0-9]{1,40}$/.exec(id);
+    if (twin?.[1]) ids.add(twin[1]);
+    // Branch sessions: `<convId>__branch__<assistantId>`.
+    const branch = id.indexOf("__branch__");
+    if (branch > 0) ids.add(id.slice(0, branch));
+  }
+  return [...ids];
+}
+
+/**
+ * Per-run trace dirs, relative to the session dir. Excluded from the session
+ * archive: `debug/runs/**` is append-only and grows for the life of the thread,
+ * so archiving it makes every ~30s checkpoint re-upload every PRIOR run's
+ * events.jsonl and blobs.jsonl — unbounded duplicated work, and the same cost
+ * profile that filled a pod's disk (prod ENOSPC 2026-06-12).
+ *
+ * Nothing is lost: each run has its OWN durable home under
+ * `claw-debug-runs/<storeKey>/` (written at finish, and by `salvageDebugRuns`
+ * before any path that destroys a session dir), and the read path resolves runs
+ * from there when the PVC copy is gone. The small v1 artifacts that sit
+ * alongside it — `debug/debug-session.json`, `debug/debug-events.json`,
+ * `debug/subagents-*.json` — are rewritten in place, not accumulated, and stay
+ * in the archive.
+ */
+const ARCHIVE_EXCLUDED_DIR = "debug/runs";
 
 /**
  * Walk a session dir and list every regular file (path + size, NO contents).
@@ -130,6 +286,7 @@ async function listSessionFiles(dir: string): Promise<SessionDiskFile[]> {
       const abs = path.join(current, e.name);
       const rel = prefix ? `${prefix}/${e.name}` : e.name;
       if (e.isDirectory()) {
+        if (rel === ARCHIVE_EXCLUDED_DIR) continue;
         await walk(abs, rel);
       } else if (e.isFile()) {
         const s = await stat(abs);
@@ -370,6 +527,7 @@ async function restoreFromPvcFallback(conversationId: string): Promise<boolean> 
   try {
     await rm(tmp, { recursive: true, force: true }).catch(() => {});
     await cp(source, tmp, { recursive: true, force: false, errorOnExist: false });
+    await salvageDebugRuns(local);
     await rm(local, { recursive: true, force: true }).catch(() => {});
     await rename(tmp, local);
     metric.count("session_pvc_fallback_hit", { conversationId });
@@ -528,8 +686,15 @@ async function writeRestoredFiles(conversationId: string, files: { path: string;
 /** Clock-skew + write-latency margin for the local-vs-GCS comparison. */
 const FRESHNESS_SKEW_MS = Number(process.env["SESSION_FRESHNESS_SKEW_MS"] ?? 2_000);
 
-/** Newest mtime across every regular file in the session dir (0 if none). */
-async function localSessionUpdatedAt(conversationId: string): Promise<number> {
+/**
+ * Newest mtime across every regular file in the session dir: 0 when the dir is
+ * genuinely empty, `null` when the walk FAILED.
+ *
+ * The two used to be one value, so "unknown" read as "empty" — and an EACCES/EIO
+ * on a perfectly good session sent it down the delete-then-restore path on the
+ * strength of a number we never measured. Callers must refuse to delete on null.
+ */
+async function localSessionUpdatedAt(conversationId: string): Promise<number | null> {
   let newest = 0;
   async function walk(current: string): Promise<void> {
     const entries = await readdir(current, { withFileTypes: true });
@@ -545,7 +710,7 @@ async function localSessionUpdatedAt(conversationId: string): Promise<number> {
   try {
     await walk(sessionDir(conversationId));
   } catch {
-    return 0;
+    return null;
   }
   return newest;
 }
@@ -589,7 +754,13 @@ export async function ensureFreshSession(conversationId: string): Promise<Sessio
 
   let decision: SessionFreshness;
   let gcsAt: number | null = null;
-  if (localAt === 0) {
+  if (localAt === null) {
+    // The dir is there but unreadable. Every branch below either deletes or
+    // moves it aside on the strength of that mtime, so with no mtime the only
+    // safe move is to leave it alone and run against what is on disk.
+    decision = "local-unverified";
+    log.error(`session_restore_unverified conversationId=${conversationId} reason=local_walk_failed`);
+  } else if (localAt === 0) {
     // An EMPTY local dir would short-circuit restoreSessionFromArchive
     // ("already local") — remove it so the restore actually runs.
     if (hasSession(conversationId)) {
@@ -628,8 +799,11 @@ export async function ensureFreshSession(conversationId: string): Promise<Sessio
       const restore = await restoreSessionFromArchiveDetailed(conversationId).catch((): SessionRestoreOutcome => "failed");
       if (restore === "restored") {
         const restoredAt = await localSessionUpdatedAt(conversationId);
-        if (restoredAt + FRESHNESS_SKEW_MS < gcsAt) {
+        // An unreadable restore is "unknown", not "too old" — rolling back on it
+        // would delete the copy we just fetched without ever having read it.
+        if (restoredAt !== null && restoredAt + FRESHNESS_SKEW_MS < gcsAt) {
           decision = "restore-failed";
+          await salvageDebugRuns(sessionDir(conversationId));
           await rm(sessionDir(conversationId), { recursive: true, force: true }).catch(() => {});
           await rename(backup, dir).catch(() => {});
           metric.count("session_freshness", { decision });
@@ -639,6 +813,9 @@ export async function ensureFreshSession(conversationId: string): Promise<Sessio
           throw new SessionRestoreStaleError(conversationId, localAt, gcsAt);
         }
         decision = "restored-stale";
+        // The backup is this pod's own local copy; its debug runs are nowhere
+        // else if their finish-time upload failed.
+        await salvageDebugRuns(backup);
         await rm(backup, { recursive: true, force: true }).catch(() => {});
       } else {
         decision = "restore-failed";
@@ -653,7 +830,7 @@ export async function ensureFreshSession(conversationId: string): Promise<Sessio
   }
 
   log.info(
-    `[session-store] freshness ${conversationId}: local=${localAt ? new Date(localAt).toISOString() : "none"} gcs=${gcsAt !== null ? (gcsAt ? new Date(gcsAt).toISOString() : "none") : "unknown"} → ${decision}`,
+    `[session-store] freshness ${conversationId}: local=${localAt === null ? "unknown" : localAt ? new Date(localAt).toISOString() : "none"} gcs=${gcsAt !== null ? (gcsAt ? new Date(gcsAt).toISOString() : "none") : "unknown"} → ${decision}`,
   );
   metric.count("session_freshness", { decision });
   return decision;
@@ -877,6 +1054,7 @@ export async function snapshotLiveSessionHandle(
       return { ok: false, reason: "target_exists" };
     }
     try {
+      await salvageDebugRuns(targetDir);
       await rm(targetDir, { recursive: true, force: true });
     } catch (err) {
       log.warn(
@@ -1087,10 +1265,17 @@ async function disposeSessionDir(name: string): Promise<DisposeOutcome> {
   if (isActiveSessionOrBareSpillDir(name)) return "skipped-active";
   const dir = path.join(sessionsRoot(), name);
   if (name.includes(".stale-")) {
+    // Rollback debris is deleted, never archived, so its debug runs get no
+    // second chance from the archive path — lift them out first.
+    await salvageDebugRuns(dir);
     await rm(dir, { recursive: true, force: true }).catch(() => {});
     return "removed-stale";
   }
   if (await archiveSessionToGcsWithRetries(name)) {
+    // The archive deliberately does NOT carry `debug/runs/**` (see
+    // ARCHIVE_EXCLUDED_DIR), so a successful archive is not a second chance for
+    // a run whose finish-time upload failed — lift those out before the delete.
+    await salvageDebugRuns(dir);
     await rm(dir, { recursive: true, force: true }).catch(() => {});
     return "archived";
   }

--- a/apps/xyne-claw/src/storage.ts
+++ b/apps/xyne-claw/src/storage.ts
@@ -33,6 +33,7 @@ import {
   type StorageService,
 } from "@xyne/storage";
 import { GCS, STORAGE } from "./config.js";
+import { indexPrefixFor } from "./debug/keys.js";
 import { createLogger } from "./logger.js";
 
 const log = createLogger("gcs");
@@ -75,13 +76,28 @@ export interface SessionArchiveObject {
   updatedMs: number;
 }
 
-// Sticky: once we learn there are no usable credentials (local dev without
-// ADC), stop trying — mirrors the old metadata-server probe behavior.
+// Once we learn there are no usable credentials (local dev without ADC), stop
+// trying — mirrors the old metadata-server probe behavior. NOT permanently
+// sticky: a transient ADC hiccup during pod startup used to disable direct
+// storage for the whole process lifetime, which silently cost every later run
+// its GCS debug artifact. Re-probe after a cooldown instead.
 let credentialsUnavailable = false;
+let credentialsDisabledAt = 0;
+const CREDS_RETRY_MS = Number(process.env["STORAGE_CREDS_RETRY_MS"] ?? 300_000);
 let storage: StorageService | null = null;
 
 export function gcsDirectConfigured(): boolean {
+  if (credentialsUnavailable && Date.now() - credentialsDisabledAt >= CREDS_RETRY_MS) {
+    credentialsUnavailable = false;
+    log.info("[gcs] credential cooldown elapsed — re-enabling direct storage probe");
+  }
   return BUCKET.length > 0 && !credentialsUnavailable;
+}
+
+/** Test seam + explicit recovery hook: forget a past credential failure. */
+export function resetStorageCredentialProbe(): void {
+  credentialsUnavailable = false;
+  credentialsDisabledAt = 0;
 }
 
 function getStorage(): StorageService | null {
@@ -121,7 +137,8 @@ function noteIfCredsError(err: unknown): void {
   const msg = err instanceof Error ? err.message : String(err);
   if (/could not load the default credentials|unable to detect.*project|metadata|Could not load credentials/i.test(msg)) {
     credentialsUnavailable = true;
-    log.warn("[gcs] no application default credentials — direct storage disabled (using claw-auth fallback)");
+    credentialsDisabledAt = Date.now();
+    log.warn(`[gcs] no application default credentials — direct storage disabled for ${CREDS_RETRY_MS}ms (using claw-auth fallback)`);
   }
 }
 
@@ -216,12 +233,182 @@ export async function gcsUploadDebugRun(storeKey: string, fileName: string, data
 }
 
 /**
- * List per-run debug snapshot file names for a session (bare names, no
- * prefix). Returns null on error/disabled — caller falls back to local files.
+ * Upload a debug run with bounded retries.
+ *
+ * A single-attempt upload meant one transient 5xx cost the run its only
+ * off-pod artifact — and the PVC copy is exactly what gets evicted later, so
+ * the trace disappeared entirely. Three attempts with backoff turns a blip
+ * into a non-event; a real outage still degrades to PVC-only, which the
+ * retrieval path handles.
+ */
+export async function gcsUploadDebugRunWithRetries(
+  storeKey: string,
+  fileName: string,
+  data: Buffer,
+  attempts = 3,
+): Promise<boolean> {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (await gcsUploadDebugRun(storeKey, fileName, data)) {
+      if (attempt > 1) log.info(`[gcs] debug-run upload for ${storeKey}/${fileName} succeeded on attempt ${attempt}`);
+      return true;
+    }
+    // A credential failure is not retryable within this window — bail early
+    // rather than burning the backoff on a guaranteed miss.
+    if (!gcsDirectConfigured()) return false;
+    if (attempt < attempts) await new Promise((r) => setTimeout(r, 500 * 2 ** (attempt - 1)));
+  }
+  return false;
+}
+
+/**
+ * Write a run-discovery marker.
+ *
+ * The storeKey a run was written under is not derivable from the conversation
+ * id — branch keys, per-user twin keys and userId-prefixed agent-chat keys all
+ * exist, and every reader that GUESSED the shape eventually 404'd a run that
+ * was sitting right there. The marker encodes the real storeKey in its own
+ * object name, so discovery becomes a list instead of a guess.
+ */
+export async function gcsPutDebugIndex(indexRelPath: string): Promise<boolean> {
+  const client = getStorage();
+  if (!client) return false;
+  try {
+    await client.uploadFileV2(Buffer.alloc(0), {
+      path: `${DEBUG_RUN_PREFIX}/${indexRelPath}`,
+      contentType: "application/json",
+      timeoutMs: STORAGE_TIMEOUT_MS,
+    });
+    return true;
+  } catch (err) {
+    noteIfCredsError(err);
+    log.warn(`[gcs] debug index write failed for ${indexRelPath}:`, err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/**
+ * List discovery markers for a conversation. Returns relative names under the
+ * debug-run prefix (i.e. `_index/<convId>/<runId>~<storeKey>.json`).
+ *
+ * null means "the listing FAILED" — the caller falls back to key guessing and
+ * tells the user the read was degraded. Storage being switched off is not a
+ * failure: a dev box with no bucket has no markers to find, and reporting that
+ * as degraded made every local debug read look broken, so it returns [].
+ */
+export async function gcsListDebugIndex(convId: string): Promise<string[] | null> {
+  const client = getStorage();
+  if (!client) return [];
+  const prefix = `${DEBUG_RUN_PREFIX}/${indexPrefixFor(convId)}`;
+  try {
+    const files = await client.listFiles(prefix);
+    return files.map((f) => f.name.slice(`${DEBUG_RUN_PREFIX}/`.length)).filter(Boolean);
+  } catch (err) {
+    noteIfCredsError(err);
+    log.warn(`[gcs] debug index list failed for ${convId}:`, err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+/**
+ * Delete one storeKey's discovery markers for a conversation.
+ *
+ * `/clear` used to drop `claw-debug-runs/<storeKey>/*` and stop there, leaving
+ * the markers pointing at objects that no longer exist — discovery then listed
+ * phantom runs that 404'd on open. Markers are written under BOTH the raw
+ * conversation id and the session key, so the caller passes each id it might
+ * have been indexed under; the storeKey suffix in the marker NAME is what makes
+ * the match exact, so a conversation's OTHER store keys are never touched.
+ * Returns how many markers were removed.
+ */
+export async function gcsDeleteDebugIndex(convId: string, storeKey: string): Promise<number> {
+  const client = getStorage();
+  if (!client) return 0;
+  const prefix = `${DEBUG_RUN_PREFIX}/${indexPrefixFor(convId)}`;
+  const suffix = `~${storeKey}.json`;
+  try {
+    const files = await client.listFiles(prefix);
+    let deleted = 0;
+    for (const f of files) {
+      if (!f.name.endsWith(suffix)) continue;
+      try {
+        await client.deleteFile(f.name);
+        deleted++;
+      } catch {
+        // Best-effort: a stranded marker resolves to a missing run, which the
+        // read path already tolerates.
+      }
+    }
+    return deleted;
+  } catch (err) {
+    noteIfCredsError(err);
+    log.warn(`[gcs] debug index delete failed for ${convId}/${storeKey}:`, err instanceof Error ? err.message : String(err));
+    return 0;
+  }
+}
+
+/** Delete every debug object for a storeKey. Used when a session is cleared. */
+export async function gcsDeleteDebugRuns(storeKey: string): Promise<number> {
+  const client = getStorage();
+  if (!client) return 0;
+  const prefix = `${DEBUG_RUN_PREFIX}/${storeKey}/`;
+  try {
+    const files = await client.listFiles(prefix);
+    let deleted = 0;
+    for (const f of files) {
+      try {
+        await client.deleteFile(f.name);
+        deleted++;
+      } catch {
+        // Best-effort: a leftover object costs storage, not correctness.
+      }
+    }
+    return deleted;
+  } catch (err) {
+    noteIfCredsError(err);
+    log.warn(`[gcs] debug-run delete failed for ${storeKey}:`, err instanceof Error ? err.message : String(err));
+    return 0;
+  }
+}
+
+/** Download an arbitrary object under the debug-run prefix (index markers, packed runs). */
+export async function gcsDownloadDebugObject(relPath: string): Promise<Buffer | null> {
+  const client = getStorage();
+  if (!client) return null;
+  try {
+    return await client.getFileBuffer(`${DEBUG_RUN_PREFIX}/${relPath}`);
+  } catch {
+    return null;
+  }
+}
+
+/** Upload an arbitrary object under the debug-run prefix (packed v2 runs). */
+export async function gcsUploadDebugObject(relPath: string, data: Buffer, contentType = "application/gzip"): Promise<boolean> {
+  const client = getStorage();
+  if (!client) return false;
+  try {
+    await client.uploadFileV2(data, {
+      path: `${DEBUG_RUN_PREFIX}/${relPath}`,
+      contentType,
+      timeoutMs: STORAGE_TIMEOUT_MS,
+    });
+    return true;
+  } catch (err) {
+    noteIfCredsError(err);
+    log.warn(`[gcs] debug object upload failed for ${relPath}:`, err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/**
+ * List per-run debug snapshot file names for a session (bare names, no prefix).
+ *
+ * Same null-vs-[] contract as gcsListDebugIndex: null is a real listing
+ * failure (caller falls back to local files and reports a degraded read),
+ * [] is "storage is not configured, so there is nothing off-pod to find".
  */
 export async function gcsListDebugRuns(storeKey: string): Promise<string[] | null> {
   const client = getStorage();
-  if (!client) return null;
+  if (!client) return [];
   const prefix = `${DEBUG_RUN_PREFIX}/${storeKey}/`;
   try {
     const files = await client.listFiles(prefix);

--- a/apps/xyne-claw/src/subagent-tools.ts
+++ b/apps/xyne-claw/src/subagent-tools.ts
@@ -26,6 +26,24 @@ import { SUBAGENT_DEFINITIONS, findSubagentDefinitionForServer, isPresentationTo
 import { acquireFollowUpLock, isValidFollowUpHandle } from "./subagent-followup.js";
 import type { McpToolGroup } from "./mcp.js";
 import { resolveModel, applyCopilotProxyIfNeeded, capCustomToolOutput, pushDebugProgress, pushInvocation, type CopilotConfig, type ClaudeConfig, type CodexConfig, type DebugEventRecord, type ProgressDest, type ToolInvocation } from "./agent.js";
+import {
+  BlobWriter,
+  Recorder,
+  RunStore,
+  emptyLatency,
+  emptyTokenUsage,
+  installStreamCapture,
+  readRun,
+  resolveCaptureLevel,
+  safeRunToken,
+  startCapture,
+  toV1Snapshot,
+  type CaptureLevel,
+  type LatencyMetrics,
+  type RunHeader,
+  type RunStatus,
+  type TokenUsage,
+} from "./debug/index.js";
 import { compactionExtension } from "./compaction-extension.js";
 import { installMidTurnCompaction } from "./mid-turn-compaction.js";
 import { createScopedToolMap } from "./scoped-tools.js";
@@ -133,13 +151,6 @@ const MCP_REQUEST_TIMEOUT_MS = 600_000;
 type SubagentExecResult = { content: Array<{ type: "text"; text: string }>; details: Record<string, unknown> };
 type CachedEntry = { promise: Promise<SubagentExecResult>; insertedAt: number };
 const subagentResultCache = new Map<string, Map<string, CachedEntry>>();
-type SubagentDebugEvent = {
-  seq: number;
-  at: string;
-  kind: string;
-  toolCallId?: string;
-  data: Record<string, unknown>;
-};
 
 function normalizeQuestion(q: string): string {
   return q.trim().toLowerCase().replace(/\s+/g, " ");
@@ -428,6 +439,29 @@ export interface SubagentProgressCtx {
    *  loop settles. Absent (e.g. nested contexts) ⇒ `run_in_background` is not
    *  exposed and every call runs blocking, as before. */
   backgroundRegistry?: BackgroundSubagentRegistry;
+  /** The parent run's trace handles. Subagent tools are built (routes/run.ts)
+   *  before the parent opens its trace (agent.ts), so this is a slot the parent
+   *  fills in once its recorder exists — the same shared-object trick
+   *  backgroundRegistry uses. Absent (nested/A2A contexts) ⇒ the child still
+   *  records, it just can't be filed under the parent's run. */
+  parentDebug?: ParentDebugHandle;
+}
+
+/** Late-bound view of the parent run's trace, so a child can be written into
+ *  the same store and announce itself on the parent's timeline. */
+export interface ParentDebugHandle {
+  recorder?: Recorder;
+  /** The storeKey the parent's own run was written under. */
+  storeKey?: string;
+  runId?: string;
+  captureLevel?: CaptureLevel;
+  /** Whether the parent's capture has already been finished and uploaded.
+   *  Filled by agent.ts alongside `recorder`. A detached background subagent
+   *  can outlive the parent's finish, and anything appended to the parent's
+   *  run after that point is never re-uploaded — see recordSubagentEnd. Absent
+   *  (nested/A2A contexts, or a parent that never wired it) reads as
+   *  "still open", which is the pre-existing behaviour. */
+  isFinished?: () => boolean;
 }
 
 // ── Shared MCP loader helper ──────────────────────────────────────────────
@@ -728,37 +762,225 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
         streamsCollected?: number;
         streamRateSamples?: Array<{ offsetMs: number; streamsPerSec: number; streamsCollected: number }>;
       } | null = null;
-      const debugEvents: SubagentDebugEvent[] = [];
-      let debugSeq = 0;
       let providerError: string | null = null;
+
+      // ── Debug capture ────────────────────────────────────────────────────
+      // The child gets a real run of its own, in the same append-only format
+      // the parent uses and inside the PARENT's debug tree — whoever can read
+      // the parent's trace already has its children. Opened before the child
+      // session exists, so a pod killed mid-subagent still leaves a "running"
+      // header instead of nothing at all.
+      // `debugCtx` is a const alias so the narrowing survives into the closures
+      // below; `progressCtx` is a parameter and re-widens inside them.
+      const debugCtx = progressCtx;
+      const parentDebug = debugCtx?.parentDebug;
+      const childRunId = `${execStartedAt}-${safeRunToken(def.name)}-${safeRunToken(_toolCallId)}`;
+      // Prefer the key the parent's own run was written under. Without the
+      // handle (nested / A2A contexts) fall back to the key the legacy child
+      // artifact has always used, so both land in one directory either way.
+      const childStoreKey =
+        parentDebug?.storeKey ?? debugCtx?.parentDebugSessionId ?? debugCtx?.parentSessionId;
+      const childCaptureLevel: CaptureLevel = parentDebug?.captureLevel ?? resolveCaptureLevel();
+      const childStore = childStoreKey
+        ? await RunStore.open({
+            storeKey: childStoreKey,
+            runId: childRunId,
+            captureLevel: childCaptureLevel,
+          }).catch((err: unknown) => {
+            log.warn(`[${def.name}] child debug store open failed: ${err instanceof Error ? err.message : String(err)}`);
+            return null;
+          })
+        : null;
+      const childBlobs = new BlobWriter({
+        appendLine: (line) => childStore?.appendBlobLine(line),
+        captureLevel: childCaptureLevel,
+      });
+      const recorder = new Recorder({
+        store: childStore,
+        blobs: childBlobs,
+        captureLevel: childCaptureLevel,
+        ...(debugCtx
+          ? {
+              live: {
+                push: (event: DebugEventRecord) =>
+                  pushDebugProgress(debugCtx.progressUrl, debugCtx.parentSessionId, event),
+              },
+            }
+          : {}),
+        // Stamped on every event, so no emission site repeats the parentage.
+        envelope: { parentToolCallId: _toolCallId, subagentName: def.name, childRunId },
+      });
+      const childStartedIso = new Date(execStartedAt).toISOString();
+      const childProvider = resolvedProvider?.provider ?? "litellm";
+      const childModelId = resolvedProvider?.config.model ?? "shared";
+      const childTokenUsage: TokenUsage = emptyTokenUsage();
+      let childTurns = 0;
+      let childToolMs = 0;
+      // parentRunId + parentToolCallId + subagentName are what let the
+      // retrieval route nest this run under its parent — no child-only format.
+      const childHeader: RunHeader = {
+        schemaVersion: 2,
+        runId: childRunId,
+        storeKey: childStoreKey ?? "unknown",
+        ...(debugCtx?.parentMeta?.conversationId ? { conversationId: debugCtx.parentMeta.conversationId } : {}),
+        ...(debugCtx?.parentSessionId ? { sessionId: debugCtx.parentSessionId } : {}),
+        ...(debugCtx?.parentMeta?.agentSlug ? { agentSlug: debugCtx.parentMeta.agentSlug } : {}),
+        ...(debugCtx?.parentMeta?.userId ? { userId: debugCtx.parentMeta.userId } : {}),
+        provider: childProvider,
+        model: childModelId,
+        captureLevel: childCaptureLevel,
+        startedAt: childStartedIso,
+        finishedAt: childStartedIso,
+        status: "running",
+        task: question,
+        ...(parentDebug?.runId ? { parentRunId: parentDebug.runId } : {}),
+        parentToolCallId: _toolCallId,
+        subagentName: def.name,
+        question,
+        counts: { events: 0, blobs: 0, messages: 0, toolCalls: 0 },
+        tokenUsage: emptyTokenUsage(),
+        latency: emptyLatency(),
+      };
+      // `materializeV1: false`: the child shares the PARENT's debug dir, and the
+      // v1 files (`debug-session.json` / `debug-events.json`) live at that dir's
+      // root — one per directory, not one per run. Letting a child write them
+      // overwrites the parent's own trace with the subagent's.
+      const childCapture = startCapture({
+        store: childStore,
+        recorder,
+        header: childHeader,
+        materializeV1: false,
+      });
+      // Delegation is first-class in the PARENT timeline: the parent's own
+      // trace says what it spawned and where that run landed, so a reader never
+      // has to correlate two files by tool call id to find the child.
+      parentDebug?.recorder?.record(
+        "subagent_start",
+        {
+          subagentName: def.name,
+          childRunId,
+          question,
+          questionChars: question.length,
+          provider: childProvider,
+          model: childModelId,
+          toolNames: (tools ?? []).map((t) => t.name),
+        },
+        { toolCallId: _toolCallId },
+      );
       const pushDebugEvent = (kind: string, data: Record<string, unknown> = {}, toolCallId?: string): void => {
-        const event = {
-          seq: ++debugSeq,
-          at: new Date().toISOString(),
-          kind,
-          ...(toolCallId ? { toolCallId } : {}),
-          data,
-        };
-        debugEvents.push(event);
-        if (progressCtx) {
-          pushDebugProgress(progressCtx.progressUrl, progressCtx.parentSessionId, {
-            ...event,
-            kind: kind as DebugEventRecord["kind"],
-            parentToolCallId: _toolCallId,
-            subagentName: def.name,
-          });
-        }
+        recorder.record(kind, data, toolCallId !== undefined ? { toolCallId } : undefined);
       };
       const pushLiveStreamRate = (streamsPerSec: number, active: boolean): void => {
-        if (!progressCtx) return;
-        pushDebugProgress(progressCtx.progressUrl, progressCtx.parentSessionId, {
-          seq: ++debugSeq,
-          at: new Date().toISOString(),
-          kind: "stream_rate",
-          parentToolCallId: _toolCallId,
-          subagentName: def.name,
-          data: { streamsPerSec, streamsCollected: turnStreamCount, active },
-        });
+        // Live-only: a once-per-second heartbeat must not consume sequence
+        // numbers, which is what used to punch holes in the persisted log.
+        recorder.recordLive("stream_rate", { streamsPerSec, streamsCollected: turnStreamCount, active });
+      };
+      /** What the child can actually vouch for: wall clock, turns, tool time.
+       *  The decode/wait split is owned by installLlmCallMetrics, which reports
+       *  to metrics rather than back into this scope. */
+      const childLatencyAt = (totalMs: number): LatencyMetrics => {
+        const stream = lastAssistantStreamSummary;
+        return {
+          ...emptyLatency(),
+          totalMs,
+          llmTurns: childTurns,
+          toolMs: childToolMs,
+          ...(stream?.streamChars !== undefined ? { streamChars: stream.streamChars } : {}),
+          ...(stream?.streamThinkingChars !== undefined ? { streamThinkingChars: stream.streamThinkingChars } : {}),
+          ...(stream?.streamTextChars !== undefined ? { streamTextChars: stream.streamTextChars } : {}),
+          ...(stream?.streamCharsPerSec !== undefined ? { streamCharsPerSec: stream.streamCharsPerSec } : {}),
+        };
+      };
+      const finishChildCapture = async (status: RunStatus, text: string, durationMs: number): Promise<void> => {
+        try {
+          await childCapture.finish(status, {
+            text,
+            tokenUsage: { ...childTokenUsage },
+            latency: childLatencyAt(durationMs),
+          });
+        } catch (err) {
+          // Never let a trace failure change what the subagent returns.
+          metric.count("debug_artifact_write", { result: "fail", stage: "subagent_finish" });
+          log.warn(`[${def.name}] child debug finish failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      };
+      /**
+       * Close the delegation out on BOTH timelines, child first.
+       *
+       * The child's own trace is the authoritative copy: it is still open here,
+       * whereas the parent's capture may already be done. A detached
+       * `run_in_background` subagent routinely finishes after the parent has
+       * uploaded — appending there writes into a run nobody will re-upload, so
+       * the event exists on the PVC only, which is exactly the copy eviction
+       * takes. We therefore record into the child unconditionally and mirror
+       * onto the parent's timeline only while that timeline is still being
+       * written. MUST be called before finishChildCapture, which closes the
+       * child's store.
+       */
+      const recordSubagentEnd = (data: Record<string, unknown>): void => {
+        const payload = { subagentName: def.name, childRunId, ...data };
+        pushDebugEvent("subagent_end", payload, _toolCallId);
+        if (parentDebug?.isFinished?.() === true) {
+          log.info(`[${def.name}] parent trace already finished — subagent_end kept in child run ${childRunId} only`);
+          return;
+        }
+        parentDebug?.recorder?.record("subagent_end", payload, { toolCallId: _toolCallId });
+      };
+      /** Legacy per-child artifact, kept for one release: a rolling deploy has
+       *  old pods still reading `subagents-<name>-<toolCallId>.json`. `def.name`
+       *  is operator-authored — unsanitized, a `/` in it wrote outside the
+       *  debug dir entirely. */
+      const writeLegacyChildSnapshot = async (
+        stage: "subagent_end" | "subagent_error",
+        body: Record<string, unknown>,
+      ): Promise<void> => {
+        const sessionKey = debugCtx?.parentDebugSessionId ?? debugCtx?.parentSessionId;
+        if (!sessionKey) return;
+        try {
+          const debugDir = await ensureSessionDebugDir(sessionKey);
+          const { writeFile } = await import("node:fs/promises");
+          const safeName = `${safeRunToken(def.name)}-${safeRunToken(_toolCallId)}`;
+          // Materialize the child's OWN run instead of dumping the recorder's
+          // in-memory window. Post-v2 those raw events carry `<field>Ref`
+          // pointers rather than content and no transcript at all — and
+          // routes/debug.ts PREFERS this file over the richer derived
+          // projection, so a raw dump makes the drawer strictly worse than it
+          // was before the refactor. Reading back is safe here: this runs after
+          // finishChildCapture, which has already written the final header and
+          // flushed events + blobs (close() only drains; it removes nothing).
+          const materialized = childStore ? await readRun(childStore.runDir) : null;
+          if (childStore && !materialized) {
+            log.warn(`[${def.name}] child run unreadable — legacy artifact falls back to raw events`);
+          }
+          const snapshot = {
+            // Spread first so the identity fields below always win: the reader
+            // keys subagent rows off parentSessionId/parentToolCallId/subagentName.
+            ...(materialized ? toV1Snapshot(materialized) : { events: recorder.snapshotEvents() }),
+            schemaVersion: 1,
+            runId: childRunId,
+            parentSessionId: debugCtx?.parentSessionId,
+            parentToolCallId: _toolCallId,
+            subagentName: def.name,
+            question,
+            provider: childProvider,
+            model: childModelId,
+            startedAt: childStartedIso,
+            finishedAt: new Date().toISOString(),
+            toolsUsed,
+            providerError,
+            ...body,
+          };
+          // Not pretty-printed: this now carries the child's full transcript and
+          // resolved tool results, and indenting a multi-MB trace burns CPU and PVC
+          // bytes for a file only ever read by a parser.
+          await writeFile(`${debugDir}/subagents-${safeName}.json`, JSON.stringify(snapshot), "utf8");
+          metric.count("debug_artifact_write", { result: "ok", stage });
+        } catch (err) {
+          // A silently lost artifact is indistinguishable from a run that never
+          // happened — the ambiguity that made child traces untrustworthy.
+          metric.count("debug_artifact_write", { result: "fail", stage });
+          log.warn(`[${def.name}] child debug artifact write failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
       };
       const flushStreamRate = (active: boolean): void => {
         if (streamWindowStartedAt == null || firstDeltaAt == null) return;
@@ -782,14 +1004,6 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
         streamRateTimer = null;
         flushStreamRate(false);
         streamWindowStartedAt = null;
-      };
-      const snapshotMessages = (): unknown[] => {
-        const messages = (sessionRef as { messages?: unknown[] } | null)?.messages ?? [];
-        try {
-          return JSON.parse(JSON.stringify(messages)) as unknown[];
-        } catch {
-          return messages;
-        }
       };
       const stickyTimer = progressCtx?.progressUrl
         ? setInterval(() => {
@@ -965,10 +1179,23 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
         // with "Cannot continue from message role: assistant". See mid-turn-compaction.ts.
         installMidTurnCompaction(session);
 
+        // The one hook that sees what the child model is ACTUALLY sent: pi's
+        // assembled system prompt, the resolved tool schemas, and the real
+        // transcript. That last part is why no emission below embeds messages
+        // any more — the transcript flows through here as append-only deltas.
+        installStreamCapture({
+          agent: session.agent as unknown as {
+            streamFn: (model: unknown, context: unknown, options?: unknown) => unknown;
+          },
+          recorder,
+          ...(resolvedProvider?.provider ? { provider: resolvedProvider.provider } : {}),
+        });
+
         pushDebugEvent("session_start", {
-          parentSessionId,
-          parentToolCallId: _toolCallId,
-          subagentName: def.name,
+          sessionId: parentSessionId,
+          provider: childProvider,
+          model: childModelId,
+          captureLevel: childCaptureLevel,
           question,
           questionChars: question.length,
         });
@@ -1103,6 +1330,8 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
               }
             }
             const started = childInflight.get(event.toolCallId);
+            const childToolDurationMs = started ? Date.now() - started.startedAt : undefined;
+            if (childToolDurationMs !== undefined) childToolMs += childToolDurationMs;
             turnStartedAt = Date.now();
             firstDeltaAt = null;
             pushDebugEvent("tool_execution_end", {
@@ -1119,7 +1348,7 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
                 }
               })(),
               isError: event.isError,
-              durationMs: started ? Date.now() - started.startedAt : undefined,
+              durationMs: childToolDurationMs,
             }, event.toolCallId);
             childInflight.delete(event.toolCallId);
           }
@@ -1145,18 +1374,30 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
             }
           }
           if (event.type === "message_end") {
-            const msg = (event as { message?: { role?: string; usage?: unknown; stopReason?: string; errorMessage?: string } }).message;
+            const msg = (event as {
+              message?: {
+                role?: string;
+                usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+                stopReason?: string;
+                errorMessage?: string;
+              };
+            }).message;
             if (msg?.role === "assistant") {
               stopStreamRateTimer();
+              // The child's own header needs a real cost, not a zero — nothing
+              // else in this scope sees per-turn usage.
+              childTurns += 1;
+              if (msg.usage) {
+                childTokenUsage.input += msg.usage.input ?? 0;
+                childTokenUsage.output += msg.usage.output ?? 0;
+                childTokenUsage.cacheRead += msg.usage.cacheRead ?? 0;
+                childTokenUsage.cacheWrite += msg.usage.cacheWrite ?? 0;
+              }
               if (firstDeltaAt != null && turnStreamChars > 0) {
                 const elapsed = Math.max(0.001, (Date.now() - firstDeltaAt) / 1000);
                 lastStreamCharsPerSec = Math.round(turnStreamChars / elapsed);
               }
               pushDebugEvent("assistant_turn_end", {
-                message: (() => {
-                  try { return JSON.parse(JSON.stringify(msg)); }
-                  catch { return msg ?? {}; }
-                })(),
                 usage: (() => {
                   try { return JSON.parse(JSON.stringify(msg.usage ?? {})); }
                   catch { return msg?.usage ?? {}; }
@@ -1170,7 +1411,6 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
                 ...(lastStreamCharsPerSec != null ? { streamCharsPerSec: lastStreamCharsPerSec } : {}),
                 streamsCollected: turnStreamCount,
                 streamRateSamples: turnStreamRateSamples,
-                messages: snapshotMessages(),
               });
               lastAssistantStreamSummary = {
                 streamChars: turnStreamChars,
@@ -1231,8 +1471,9 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
         // bloat context and re-anchor the model. Send ONLY the new question.
         const promptText = followUpResumed ? `## Follow-up\n${question}` : childPrompt;
         pushDebugEvent("session_prompt", {
+          kind: followUpResumed ? "resume" : "fresh",
           prompt: promptText,
-          messages: snapshotMessages(),
+          messageCount: recorder.messageCount,
         });
         turnStartedAt = Date.now();
         firstDeltaAt = null;
@@ -1348,38 +1589,25 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
         pushDebugEvent("session_end", {
           durationMs: execDurationMs,
           textLength: text.length,
+          toolCount: toolsUsed.length,
           toolsUsed,
           providerError,
+          tokenUsage: { ...childTokenUsage },
           ...(lastAssistantStreamSummary ?? {}),
         });
-        if (parentSessionId) {
-          try {
-            const debugDir = await ensureSessionDebugDir(progressCtx?.parentDebugSessionId ?? parentSessionId);
-            const { writeFile } = await import("node:fs/promises");
-            const safeToolCallId = _toolCallId.replace(/[^a-zA-Z0-9_-]/g, "-");
-            const safeName = `${def.name}-${safeToolCallId}`;
-            const childSnapshot = {
-              schemaVersion: 1,
-              parentSessionId,
-              parentToolCallId: _toolCallId,
-              subagentName: def.name,
-              question,
-              provider: resolvedProvider?.provider ?? "litellm",
-              model: resolvedProvider?.config.model ?? "shared",
-              startedAt: new Date(execStartedAt).toISOString(),
-              finishedAt: new Date().toISOString(),
-              text,
-              toolsUsed,
-              providerError,
-              messages: snapshotMessages(),
-              events: debugEvents,
-              ...(lastAssistantStreamSummary ?? {}),
-            };
-            await writeFile(`${debugDir}/subagents-${safeName}.json`, JSON.stringify(childSnapshot, null, 2), "utf8");
-          } catch (err) {
-            log.warn(`[${def.name}] Failed to write child debug artifact: ${err instanceof Error ? err.message : String(err)}`);
-          }
-        }
+        recordSubagentEnd({
+          status: "completed",
+          durationMs: execDurationMs,
+          textLength: text.length,
+          providerError,
+          toolsUsed,
+        });
+        await finishChildCapture("completed", text, execDurationMs);
+        await writeLegacyChildSnapshot("subagent_end", {
+          status: "completed",
+          text,
+          ...(lastAssistantStreamSummary ?? {}),
+        });
         if (followUpEnabled && followUpHandle) {
           text += `\n\n---\n_Follow-up:_ to ask THIS \`${def.name}\` subagent another question WITH the full context of this run, call \`${def.name}\` again passing \`session_id: "${followUpHandle}"\`. Omit it to start fresh.`;
         }
@@ -1394,34 +1622,20 @@ function makeSubagentTool(def: SubagentDefinition, tools: ToolDefinition[], skil
         stopStreamRateTimer();
         const msg = err instanceof Error ? err.message : String(err);
         log.error(`[${def.name}] Failed:`, msg);
-        pushDebugEvent("session_error", { error: msg });
-        if (progressCtx?.parentSessionId) {
-          try {
-            const debugDir = await ensureSessionDebugDir(progressCtx.parentDebugSessionId ?? progressCtx.parentSessionId);
-            const { writeFile } = await import("node:fs/promises");
-            const safeToolCallId = _toolCallId.replace(/[^a-zA-Z0-9_-]/g, "-");
-            const safeName = `${def.name}-${safeToolCallId}`;
-            const childSnapshot = {
-              schemaVersion: 1,
-              parentSessionId: progressCtx.parentSessionId,
-              parentToolCallId: _toolCallId,
-              subagentName: def.name,
-              question,
-              provider: resolvedProvider?.provider ?? "litellm",
-              model: resolvedProvider?.config.model ?? "shared",
-              startedAt: new Date(execStartedAt).toISOString(),
-              finishedAt: new Date().toISOString(),
-              error: msg,
-              toolsUsed,
-              providerError,
-              messages: snapshotMessages(),
-              events: debugEvents,
-            };
-            await writeFile(`${debugDir}/subagents-${safeName}.json`, JSON.stringify(childSnapshot, null, 2), "utf8");
-          } catch {
-            // ignore
-          }
-        }
+        const failedDurationMs = Date.now() - execStartedAt;
+        // A parent-cancelled child is not a failure — it stopped on purpose,
+        // and a trace that calls it an error sends readers hunting a bug.
+        const failedStatus: RunStatus = debugCtx?.abortSignal?.aborted ? "cancelled" : "error";
+        pushDebugEvent("session_error", { error: msg, atMs: failedDurationMs });
+        recordSubagentEnd({
+          status: failedStatus,
+          durationMs: failedDurationMs,
+          providerError,
+          toolsUsed,
+          errorMessage: msg,
+        });
+        await finishChildCapture(failedStatus, msg, failedDurationMs);
+        await writeLegacyChildSnapshot("subagent_error", { status: failedStatus, error: msg });
         return { content: [{ type: "text" as const, text: `${def.name} subagent failed: ${msg}` }], details: {} };
       } finally {
         // Dispose the child session even on the error path — the success path


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
