### PR TITLE
feat: XYNE-62911 Gmail like Search in Desk

### DIFF
--- a/apps/backend/src/services/emailClassificationService.ts
+++ b/apps/backend/src/services/emailClassificationService.ts
@@ -8,6 +8,8 @@ import { logger } from '../utils/logger.js';
 import { resolveFormFieldDefinitionsForForm } from '../utils/fieldDefinition.js';
 import { EmailClassificationRepository } from '../database/repositories/emailClassificationRepository.js';
 import { DatabaseClient } from '../database/client.js';
+import { vespaQueue } from '../queues/vespaQueue.js';
+import { ticketSchema } from '@/vespa/src/types';
 import { LLMClient, createUserMessage } from 'agentic-framework';
 import { AgentsConfig } from '../agents/config.js';
 import { logLLMCallStart, logLLMSuccess, logLLMError } from '../agents/agentLogger.js';
@@ -50,6 +52,22 @@ Respond with this exact JSON structure:
   "confidence": number between 0.0 and 1.0,
   "reasoning": "Brief explanation of why this priority was chosen"
 }`;
+
+/**
+ * Re-index after classification writes `aiCategory` / `aiPriority` / `userGroupId` through
+ * Prisma. The classifier runs after the ticket was first fed, so without this the index
+ * keeps the pre-classification values and a search filtered on them omits the ticket.
+ */
+const queueTicketReindex = async (ticketId: string): Promise<void> => {
+  try {
+    await vespaQueue.addJob({ schema: ticketSchema, jobType: 'feed', docId: ticketId });
+  } catch (error) {
+    logger.error('[Classification] Failed to queue Vespa feed after classification', {
+      ticketId,
+      error,
+    });
+  }
+};
 
 export class EmailClassificationService {
   private repo = new EmailClassificationRepository();
@@ -296,6 +314,7 @@ export class EmailClassificationService {
         error: err instanceof Error ? err.message : err,
       });
     });
+    await queueTicketReindex(ticketId);
   }
 
   /**
@@ -341,6 +360,8 @@ export class EmailClassificationService {
         where: { id: ticketId },
         data: { userGroupId: newResolvedGroupId },
       });
+      // Inside the guard: classifyTicket already queued a feed for its own columns.
+      await queueTicketReindex(ticketId);
     }
 
     return newResolvedGroupId;

--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -84,6 +84,9 @@ function parseVespaResults(children: any[]): { grouped: boolean; groups?: any[];
 
 const MAX_FILTER_VALUES = 50;
 const MAX_VESPA_HITS = 400;
+// Every hit costs a Postgres lookup in transformVespaResults, so this bounds hydration
+// cost rather than index work.
+const MAX_HYDRATED_HITS = 200;
 
 /**
  * Keep every non-mail hit, but only the highest-ranked mail hit for each Desk
@@ -228,6 +231,17 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       callEndsAt,      // Call visible range end timestamp
       stage,       // Ticket stage
       assignee,    // Assigned user name
+      userGroups,  // User group id(s) - comma-separated
+      aiCategory,  // AI-assigned category(ies) - comma-separated
+      isArchived,  // 'true'|'false' — restrict to archived / non-archived tickets
+      lastEmailAtStart, // Epoch-ms lower bound on the conversation's newest email
+      lastEmailAtEnd,   // Epoch-ms upper bound on the conversation's newest email
+      createdAtStart,   // Epoch-ms lower bound on ticket creation (inclusive)
+      createdAtEnd,     // Epoch-ms upper bound on ticket creation (inclusive)
+      ccEmail,     // Desk: cc address(es) for the mail `cc:` filter
+      bccEmail,    // Desk: bcc address(es) for the mail `bcc:` filter
+      filename,    // Desk: attachment file name token(s) for the `filename:` filter
+      generatedTags,    // Tag-framework tag(s), "category:value" - comma-separated
       filterOnly,  // Flag for filter-only search (no query text)
       collectionId, // KB collection id(s) - comma-separated; restricts file results to those clIds
       fileId,      // KB file id(s) - comma-separated; restricts file results to those Vespa docIds (collectionItem.fileId)
@@ -609,7 +623,8 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       const { results, total } = await vespaService.searchService.searchApps(String(q ?? ''), workspaceId, {
         view: appsView,
         orgId: callerOrgId,
-        limit: limit ? Number(limit) : 50,
+        // Clamped here because this branch returns before `effectiveLimit` is computed.
+        limit: Math.min(limit ? Number(limit) : 50, MAX_HYDRATED_HITS),
         offset: offset ? Number(offset) : 0,
       });
       res.json({ success: true, results, total });
@@ -619,8 +634,9 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
     const isFilterOnlyDynamicFieldSearch =
       filterOnly === 'true' &&
       (dynamicFieldValues !== undefined || dynamicFieldDateRanges !== undefined);
-    const effectiveLimit =
+    const requestedLimit =
       limit !== undefined ? Number(limit) : isFilterOnlyDynamicFieldSearch ? 200 : 20;
+    const effectiveLimit = Math.min(requestedLimit, MAX_HYDRATED_HITS);
 
     // Build options object
     const options: any = {
@@ -754,6 +770,18 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       options.mail.to = toFilterValues(toEmail, 'toEmail');
     }
 
+    if (ccEmail) {
+      options.mail.cc = toFilterValues(ccEmail, 'ccEmail');
+    }
+
+    if (bccEmail) {
+      options.mail.bcc = toFilterValues(bccEmail, 'bccEmail');
+    }
+
+    if (filename) {
+      options.mail.attachmentFilenames = toFilterValues(filename, 'filename');
+    }
+
     if (withUser) {
       const participantIds = toFilterValues(withUser, 'withUser');
       options.slack.participants = participantIds;
@@ -880,6 +908,46 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       options.ticket.assignedTo = toFilterValues(assignee, 'assignee');
     }
 
+    if (userGroups) {
+      options.ticket.userGroupId = toFilterValues(userGroups, 'userGroups');
+    }
+
+    if (aiCategory) {
+      options.ticket.aiCategory = toFilterValues(aiCategory, 'aiCategory');
+    }
+
+    if (isArchived !== undefined) {
+      options.ticket.isArchived = isArchived === 'true';
+    }
+
+    // On mail this bounds the individual email timestamp, which is looser than the
+    // conversation bound and so cannot drop a conversation the caller's range would keep.
+    if (lastEmailAtStart !== undefined) {
+      options.ticket.lastEmailAtStart = Number(lastEmailAtStart);
+      options.mail.timestampStart = Number(lastEmailAtStart);
+    }
+
+    if (lastEmailAtEnd !== undefined) {
+      options.ticket.lastEmailAtEnd = Number(lastEmailAtEnd);
+      options.mail.timestampEnd = Number(lastEmailAtEnd);
+    }
+
+    if (createdAtStart !== undefined) {
+      options.ticket.createdAtStart = Number(createdAtStart);
+    }
+
+    if (createdAtEnd !== undefined) {
+      options.ticket.createdAtEnd = Number(createdAtEnd);
+    }
+
+    // mapTicket copies the latest email's tags onto the ticket, so the same values match
+    // either schema.
+    if (generatedTags) {
+      const tagValues = toFilterValues(generatedTags, 'generatedTags');
+      options.ticket.generatedTags = tagValues;
+      options.mail.generatedTags = tagValues;
+    }
+
     if (subApp) {
       options.file.subApp = toFilterValues(subApp, 'subApp');
     }
@@ -918,18 +986,21 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       options.groupBy = '';
     }
 
-    const isMailOnlySearch =
-      searchApps.length === 1 && searchApps[0].trim().toLowerCase() === 'mail';
-    const mailGroupOffset = isMailOnlySearch
+    // Mirrors YqlBuilder's isConversationScoped, including the `mail` requirement — see the
+    // comment there for why a ticket-only search must not be grouped.
+    const normalisedSearchApps = searchApps.map((app) => app.trim().toLowerCase());
+    const isConversationSearch =
+      normalisedSearchApps.includes('mail') &&
+      normalisedSearchApps.every((app) => ['mail', 'ticket'].includes(app));
+    // Grouped results are one row per conversation, so `offset` has to skip GROUPS; Vespa's
+    // own offset paginates hits, so the group prefix is fetched and sliced here instead.
+    const groupOffset = isConversationSearch
       ? Math.max(Number(offset) || 0, 0)
       : 0;
 
-    // Vespa's top-level offset paginates hits, not grouping buckets. Desk mail
-    // results are grouped by threadId, so fetch the ranked group prefix and
-    // slice the requested page after parsing the grouping response.
-    if (isMailOnlySearch && mailGroupOffset > 0) {
+    if (isConversationSearch && groupOffset > 0) {
       options.offset = 0;
-      options.limit = Math.min(MAX_VESPA_HITS, mailGroupOffset + effectiveLimit);
+      options.limit = Math.min(MAX_VESPA_HITS, groupOffset + effectiveLimit);
     }
 
     // Call vespa search
@@ -956,8 +1027,8 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       // Grouped result don't have matchFeatures
       // Need to be added explicitly
       // Return grouped results
-      const pageGroups = isMailOnlySearch
-        ? parsedResults.groups.slice(mailGroupOffset, mailGroupOffset + effectiveLimit)
+      const pageGroups = isConversationSearch
+        ? parsedResults.groups.slice(groupOffset, groupOffset + effectiveLimit)
         : parsedResults.groups;
 
       const groupedResults = await Promise.all(

--- a/apps/backend/src/validators/vespaSearchValidator.ts
+++ b/apps/backend/src/validators/vespaSearchValidator.ts
@@ -275,6 +275,82 @@ export const vespaSearchQuerySchema = Joi.object({
     'string.base': 'Assignee must be a string'
   }),
 
+  userGroups: Joi.string().optional().messages({
+    'string.base': 'UserGroups must be a string'
+  }),
+
+  aiCategory: Joi.string().optional().messages({
+    'string.base': 'aiCategory must be a string'
+  }),
+
+  isArchived: Joi.string().valid('true', 'false').optional().messages({
+    'any.only': 'isArchived must be "true" or "false"'
+  }),
+
+  lastEmailAtStart: Joi.number().integer().min(0).optional().messages({
+    'number.base': 'lastEmailAtStart must be a timestamp',
+    'number.integer': 'lastEmailAtStart must be an integer timestamp',
+    'number.min': 'lastEmailAtStart cannot be negative'
+  }),
+
+  lastEmailAtEnd: Joi.number().integer().min(0).optional().messages({
+    'number.base': 'lastEmailAtEnd must be a timestamp',
+    'number.integer': 'lastEmailAtEnd must be an integer timestamp',
+    'number.min': 'lastEmailAtEnd cannot be negative'
+  }),
+
+  createdAtStart: Joi.number().integer().min(0).optional().messages({
+    'number.base': 'createdAtStart must be a timestamp',
+    'number.integer': 'createdAtStart must be an integer timestamp',
+    'number.min': 'createdAtStart cannot be negative'
+  }),
+
+  createdAtEnd: Joi.number().integer().min(0).optional().messages({
+    'number.base': 'createdAtEnd must be a timestamp',
+    'number.integer': 'createdAtEnd must be an integer timestamp',
+    'number.min': 'createdAtEnd cannot be negative'
+  }),
+
+  ccEmail: Joi.alternatives()
+    .try(
+      Joi.array().items(Joi.string()),
+      Joi.string().custom((value) => {
+        return value.split(',').map((v: string) => v.trim()).filter(Boolean);
+      })
+    )
+    .optional()
+    .messages({
+      'alternatives.types': 'ccEmail must be a string or array'
+    }),
+
+  bccEmail: Joi.alternatives()
+    .try(
+      Joi.array().items(Joi.string()),
+      Joi.string().custom((value) => {
+        return value.split(',').map((v: string) => v.trim()).filter(Boolean);
+      })
+    )
+    .optional()
+    .messages({
+      'alternatives.types': 'bccEmail must be a string or array'
+    }),
+
+  filename: Joi.alternatives()
+    .try(
+      Joi.array().items(Joi.string()),
+      Joi.string().custom((value) => {
+        return value.split(',').map((v: string) => v.trim()).filter(Boolean);
+      })
+    )
+    .optional()
+    .messages({
+      'alternatives.types': 'filename must be a string or array'
+    }),
+
+  generatedTags: Joi.string().optional().messages({
+    'string.base': 'generatedTags must be a string'
+  }),
+
   subApp: Joi.string().valid('canvas', 'transcript', 'recording', 'rca', 'collections').optional().messages({
     'string.base': 'SubApp must be a string',
     'any.only': 'SubApp must be one of: canvas, transcript, recording, rca, collections'

--- a/apps/backend/src/vespa/src/types.ts
+++ b/apps/backend/src/vespa/src/types.ts
@@ -281,6 +281,9 @@ export interface VespaTicketDocument extends Omit<VespaDocument, 'orgId' | 'work
   ticketType: string;
   priority: TicketPriority;
   stage: string;
+  isArchived: boolean;
+  lastEmailAt: number;
+  aiCategory: string;
   createdAtTimestamp: number;
   createdAt: string;
   updatedAt: string;

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -80,6 +80,7 @@ export interface TicketFilters {
   // New filters
   boardId?: string[]; // Filter by board ID - comma-separated
   tags?: string[]; // Filter by tags
+  generatedTags?: string[]; // "category:value" tags; present on both ticket.sd and mail.sd
   dynamicFieldValues?: string[]; // Filter by dynamic form field tokens (fieldId::value)
   dynamicFieldDateRanges?: Record<string, { start?: number; end?: number }>;
   createdBefore?: string; // Created before date (multiple formats)
@@ -88,6 +89,16 @@ export interface TicketFilters {
   createdRange?: string; // Time keyword (today, yesterday, this week, etc.)
   stage?: string[]; // Filter by ticket stage - comma-separated
   assignedTo?: string[]; // Filter by assigned user ID - comma-separated
+  userGroupId?: string[]; // Filter by user group ID - comma-separated
+  aiCategory?: string[]; // Filter by AI-assigned category - comma-separated
+  isArchived?: boolean; // Restrict to archived / non-archived tickets
+  // Epoch-ms bounds on the conversation's newest email.
+  lastEmailAtStart?: number;
+  lastEmailAtEnd?: number;
+  // Epoch-ms bounds on ticket creation. Inclusive and exact, unlike createdBefore/After
+  // above, which snap to day boundaries and so are narrower than the caller's range.
+  createdAtStart?: number;
+  createdAtEnd?: number;
 }
 
 export interface FileFilters {
@@ -122,6 +133,15 @@ export interface MailFilters {
   channelId?: string[];
   from?: string[];
   to?: string[];
+  cc?: string[];
+  bcc?: string[];
+  attachmentFilenames?: string[];
+  generatedTags?: string[];
+  // Epoch-ms bounds on the individual email's timestamp. Only the END bound is fed from the
+  // caller's per-CONVERSATION lastEmailAt range — see vespaSearch/index.ts for why the start
+  // bound is not safe to translate that way.
+  timestampStart?: number;
+  timestampEnd?: number;
   createdBefore?: string;
   createdAfter?: string;
   createdOn?: string;
@@ -412,11 +432,19 @@ export class YqlBuilder {
       }
     }
 
-    const isMailOnly = apps.length === 1 && apps[0].toLowerCase() === 'mail';
+    // Must agree with the handler's isConversationSearch gate: if it pages groups and this
+    // emits no grouping clause, the search returns zero ids with no error.
+    const normalisedApps = apps.map((app) => app.trim().toLowerCase());
+    // mail and ticket both carry `threadId` = conversationId, which is what lets one query
+    // span both instead of a per-schema query unioned by the caller. `mail` must be present:
+    // a ticket created outside Desk has no conversationId, so grouping a ticket-only search
+    // would collapse every such ticket into one result.
+    const isConversationScoped =
+      normalisedApps.includes('mail') &&
+      normalisedApps.every((app) => ['mail', 'ticket'].includes(app));
 
-    if (isMailOnly) {
-      // Deduplicate mail results by conversation: one result per threadId,
-      // keeping the highest-relevance hit within each thread.
+    if (isConversationScoped) {
+      // Collapsing here rather than after paging keeps a long thread from consuming a page.
       yql += ` | all(group(threadId) max(${safeLimit}) order(-max(relevance())) each(max(1) each(output(summary(default)))))`;
     } else if (groupBy && this.shouldGroup(groupBy, schemas, apps)) {
       const groupClause = this.buildGroupingClause(groupBy, Math.min(safeLimit, 50));
@@ -874,6 +902,16 @@ export class YqlBuilder {
    * Build YQL condition for Ticket app
    * Applies to ticket schema only
    */
+  /** OR of `field contains <bound value>`; null when there is nothing to match. */
+  private buildContainsClause(
+    field: string,
+    values: string[] | undefined,
+    params: VespaQueryParams,
+  ): string | null {
+    if (!values || values.length === 0) return null;
+    return values.map((value) => `${field} contains ${params.bind(field, value.trim())}`).join(' or ');
+  }
+
   private buildTicketConditions(filters: TicketFilters, userId: string, params: VespaQueryParams): string {
     const conditions: string[] = [];
 
@@ -943,6 +981,11 @@ export class YqlBuilder {
         .map((tag) => `tags contains ${params.bind('tags', tag.trim())}`)
         .join(' or ');
       conditions.push(`(${tagConditions})`);
+    }
+
+    const generatedTags = this.buildContainsClause('generatedTags', filters.generatedTags, params);
+    if (generatedTags) {
+      conditions.push(`(${generatedTags})`);
     }
 
     // Dynamic field filter (fieldId::value tokens)
@@ -1034,6 +1077,45 @@ export class YqlBuilder {
         .map((assignedTo) => `assignedTo contains ${params.bind('assignedTo', assignedTo.trim())}`)
         .join(' or ');
       conditions.push(`(${assignees})`);
+    }
+
+    // userGroupId is attribute-only (no index), so `contains` is an exact id match.
+    if (filters.userGroupId && filters.userGroupId.length > 0) {
+      const userGroups = filters.userGroupId
+        .map((userGroupId) => `userGroupId contains ${params.bind('userGroupId', userGroupId.trim())}`)
+        .join(' or ');
+      conditions.push(`(${userGroups})`);
+    }
+
+    if (filters.aiCategory && filters.aiCategory.length > 0) {
+      const aiCategories = filters.aiCategory
+        .map((aiCategory) => `aiCategory contains ${params.bind('aiCategory', aiCategory.trim())}`)
+        .join(' or ');
+      conditions.push(`(${aiCategories})`);
+    }
+
+    // Opt-in so only the caller that wants it pays for the clause. Safe against a document
+    // fed before ticket.sd gained the field: `bool` is not nullable, so an unset value reads
+    // as false and the document is treated as not-archived rather than dropped.
+    if (filters.isArchived !== undefined) {
+      conditions.push(`isArchived contains "${filters.isArchived}"`);
+    }
+
+    // Interpolated raw (bind() is for strings), so coerce — a non-finite value would inject YQL.
+    if (Number.isFinite(filters.lastEmailAtStart)) {
+      conditions.push(`lastEmailAt >= ${Number(filters.lastEmailAtStart)}`);
+    }
+
+    if (Number.isFinite(filters.lastEmailAtEnd)) {
+      conditions.push(`lastEmailAt <= ${Number(filters.lastEmailAtEnd)}`);
+    }
+
+    if (Number.isFinite(filters.createdAtStart)) {
+      conditions.push(`createdAtTimestamp >= ${Number(filters.createdAtStart)}`);
+    }
+
+    if (Number.isFinite(filters.createdAtEnd)) {
+      conditions.push(`createdAtTimestamp <= ${Number(filters.createdAtEnd)}`);
     }
 
     // Date filters (ISO or dd/mm/yy or dd mon yy - no time keywords)
@@ -1322,7 +1404,7 @@ export class YqlBuilder {
       conditions.push(`(${channels})`);
     }
 
-    const buildPeopleClause = (field: 'from' | 'to', emails: string[]): string =>
+    const buildPeopleClause = (field: 'from' | 'to' | 'cc' | 'bcc', emails: string[]): string =>
       emails
         .map(
           (email) =>
@@ -1336,6 +1418,36 @@ export class YqlBuilder {
 
     if (filters.to && filters.to.length > 0) {
       conditions.push(`(${buildPeopleClause('to', filters.to)})`);
+    }
+
+    if (filters.cc && filters.cc.length > 0) {
+      conditions.push(`(${buildPeopleClause('cc', filters.cc)})`);
+    }
+
+    if (filters.bcc && filters.bcc.length > 0) {
+      conditions.push(`(${buildPeopleClause('bcc', filters.bcc)})`);
+    }
+
+    // Indexed, so `contains` matches on tokens: "report" finds "Q3 report.pdf".
+    if (filters.attachmentFilenames && filters.attachmentFilenames.length > 0) {
+      const names = filters.attachmentFilenames
+        .map((name) => `attachmentFilenames contains ${params.bind('attachmentFilenames', name.trim())}`)
+        .join(' or ');
+      conditions.push(`(${names})`);
+    }
+
+    const generatedTags = this.buildContainsClause('generatedTags', filters.generatedTags, params);
+    if (generatedTags) {
+      conditions.push(`(${generatedTags})`);
+    }
+
+    // Interpolated raw (bind() is for strings), so coerce — a non-finite value would inject YQL.
+    if (Number.isFinite(filters.timestampStart)) {
+      conditions.push(`timestamp >= ${Number(filters.timestampStart)}`);
+    }
+
+    if (Number.isFinite(filters.timestampEnd)) {
+      conditions.push(`timestamp <= ${Number(filters.timestampEnd)}`);
     }
 
     if (filters.createdBefore) {

--- a/apps/backend/src/zero/queries.ts
+++ b/apps/backend/src/zero/queries.ts
@@ -1355,6 +1355,7 @@ export const queries: AnyQueryRegistry = defineQueries({
       priority: z.array(z.nativeEnum(TicketPriority)).optional(),
       stageName: z.array(z.string()).optional(),
       aiCategory: z.array(z.string()).optional(),
+      conversationIds: z.array(z.string()).optional(),
       hasAiDraft: z.boolean().optional(),
       hasSubTickets: z.boolean().optional(),
       userGroups: z.array(z.string()).optional(),
@@ -1369,7 +1370,7 @@ export const queries: AnyQueryRegistry = defineQueries({
       args => args.createdAtStart === undefined || args.createdAtEnd === undefined || args.createdAtStart <= args.createdAtEnd,
       'createdAtStart must be less than or equal to createdAtEnd',
     ),
-    ({ ctx, args: { channelId, merchantMid, assignedTo, createdBy, priority, stageName, aiCategory, hasAiDraft, hasSubTickets, userGroups, lastEmailAtStart, lastEmailAtEnd, createdAtStart, createdAtEnd, conversationLabelId, dynamicFieldFilters, formEntityValueFieldIds } }) => {
+    ({ ctx, args: { channelId, merchantMid, assignedTo, createdBy, priority, stageName, aiCategory, conversationIds, hasAiDraft, hasSubTickets, userGroups, lastEmailAtStart, lastEmailAtEnd, createdAtStart, createdAtEnd, conversationLabelId, dynamicFieldFilters, formEntityValueFieldIds } }) => {
       let query = zql.tickets.where('channelId', channelId);
 
       if (merchantMid) {
@@ -1394,6 +1395,10 @@ export const queries: AnyQueryRegistry = defineQueries({
 
       if (aiCategory && aiCategory.length > 0) {
         query = query.where(({ or, cmp }) => or(...aiCategory.map((c) => cmp('aiCategory', c))));
+      }
+
+      if (conversationIds !== undefined) {
+        query = query.where('conversationId', 'IN', conversationIds.length > 0 ? conversationIds : ['']);
       }
 
       if (hasAiDraft) {
@@ -1751,6 +1756,7 @@ export const queries: AnyQueryRegistry = defineQueries({
       priority: z.array(z.nativeEnum(TicketPriority)).optional(),
       stageName: z.array(z.string()).optional(),
       aiCategory: z.array(z.string()).optional(),
+      conversationIds: z.array(z.string()).optional(),
       hasAiDraft: z.boolean().optional(),
       hasSubTickets: z.boolean().optional(),
       mailboxFolder: z.enum(['inbox', 'all', 'starred', 'spam', 'sent', 'drafts']).optional(),
@@ -1768,7 +1774,7 @@ export const queries: AnyQueryRegistry = defineQueries({
       args => args.createdAtStart === undefined || args.createdAtEnd === undefined || args.createdAtStart <= args.createdAtEnd,
       'createdAtStart must be less than or equal to createdAtEnd',
     ),
-    ({ ctx, args: { channelId, assignedTo, createdBy, priority, stageName, aiCategory, hasAiDraft, hasSubTickets, mailboxFolder, userGroups, lastEmailAtStart, lastEmailAtEnd, createdAtStart, createdAtEnd, conversationLabelId, dynamicFieldFilters, limit, start, dir } }) => {
+    ({ ctx, args: { channelId, assignedTo, createdBy, priority, stageName, aiCategory, conversationIds, hasAiDraft, hasSubTickets, mailboxFolder, userGroups, lastEmailAtStart, lastEmailAtEnd, createdAtStart, createdAtEnd, conversationLabelId, dynamicFieldFilters, limit, start, dir } }) => {
       let query = zql.tickets.where('channelId', channelId);
       query = query.where('isArchived', false);
 
@@ -1790,6 +1796,10 @@ export const queries: AnyQueryRegistry = defineQueries({
 
       if (aiCategory && aiCategory.length > 0) {
         query = query.where(({ or, cmp }) => or(...aiCategory.map((c) => cmp('aiCategory', c))));
+      }
+
+      if (conversationIds !== undefined) {
+        query = query.where('conversationId', 'IN', conversationIds.length > 0 ? conversationIds : ['']);
       }
 
       if (hasAiDraft) {

--- a/apps/backend/src/zero/vespa-injection/core/mapper.ts
+++ b/apps/backend/src/zero/vespa-injection/core/mapper.ts
@@ -706,6 +706,11 @@ export const mapTicket = async (args: InsertValue<TicketsSchema>): Promise<Vespa
     ticketType: "", // later we should populate ticket type
     priority: args.priority,
     stage: args.stageName,
+    isArchived: args.isArchived ?? false,
+    // Epoch ms: the Zero row carries an ISO string, but ticket.sd declares `long`, and
+    // Vespa rejects the whole document on a type mismatch rather than skipping the field.
+    lastEmailAt: toTimestamp(args.lastEmailAt),
+    aiCategory: args.aiCategory || "",
     createdAtTimestamp: toTimestamp(args.createdAt),
     createdAt: toDateString(args.createdAt),
     updatedAt: toDateString(args.updatedAt),

--- a/apps/dashboard/src/components/Tickets/TicketListView/TicketListRow.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/TicketListRow.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../../utils/classNames';
 import { findEmailAddress, parseFirstEmailAddress } from '../../../utils/emailAddress';
 import { Tooltip } from '../../ui/Tooltip/Tooltip';
 import { TruncatedTooltip } from '../../ui/Tooltip/TruncatedTooltip';
+import { HighlightedText } from '../../ui/HighlightedText/HighlightedText';
 import { Checkbox } from '../../ui/Checkbox/Checkbox';
 import { useAuthContextValues } from '../../../hooks/useAuth';
 import type { TicketListItem } from './TicketListView.types';
@@ -15,6 +16,8 @@ import { getTicketListColumnAlignClass } from './ticketListColumns';
 
 interface TicketListRowProps {
   ticket: TicketListItem;
+  /** Words from the active search, marked inside the title. */
+  highlightTerms?: readonly string[] | undefined;
   onClick: () => void;
   isActive?: boolean;
   showExtraFields?: boolean;
@@ -90,6 +93,7 @@ const parseSender = (
 
 export const TicketListRow = ({
   ticket,
+  highlightTerms,
   onClick,
   isActive = false,
   showExtraFields = false,
@@ -221,7 +225,7 @@ export const TicketListRow = ({
             hasUnread ? 'text-foreground font-semibold' : 'text-muted-foreground font-medium',
           )}
         >
-          {ticketIdValue}
+          <HighlightedText text={ticketIdValue} terms={highlightTerms} />
         </span>
         <TruncatedTooltip content={ticket.title}>
           <span
@@ -230,7 +234,7 @@ export const TicketListRow = ({
               hasUnread ? 'font-semibold' : 'font-normal',
             )}
           >
-            {ticket.title}
+            <HighlightedText text={ticket.title} terms={highlightTerms} />
           </span>
         </TruncatedTooltip>
         {ticket.aiCategory && (

--- a/apps/dashboard/src/components/Tickets/TicketListView/TicketListView.tsx
+++ b/apps/dashboard/src/components/Tickets/TicketListView/TicketListView.tsx
@@ -125,6 +125,19 @@ interface TicketListViewProps {
   showExtraFields?: boolean;
   skeletonRowCount?: number;
   emptyState?: React.ReactNode;
+  /**
+   * Conversation ids in search-relevance order. When set the list abandons keyset paging and
+   * pages in memory; filters must apply before slicing or pages come back ragged.
+   */
+  rankOrder?: readonly string[] | undefined;
+  /** Search hit the index ceiling: lower-ranked matches exist but were never fetched. */
+  searchTruncated?: boolean;
+  /** A search request is in flight, so `rankOrder` is empty or about to grow. */
+  searchPending?: boolean;
+  /** Widen the ranked window, once Zero has filtered the fetched ids below a full page. */
+  onRequestMoreRankedIds?: (() => void) | undefined;
+  /** Words from the active search, marked inside each row's title. */
+  highlightTerms?: readonly string[] | undefined;
   className?: string;
   selectedIds?: ReadonlySet<string>;
   onToggleSelect?: (row: SelectableRow) => void;
@@ -162,6 +175,11 @@ export const TicketListView = function TicketListView({
   showExtraFields = false,
   skeletonRowCount = 8,
   emptyState,
+  rankOrder,
+  searchTruncated = false,
+  searchPending = false,
+  onRequestMoreRankedIds,
+  highlightTerms,
   className,
   selectedIds,
   onToggleSelect,
@@ -405,7 +423,22 @@ export const TicketListView = function TicketListView({
     [columnWidths, getAvailableColumnsWidth, resizeColumnPair, totalColumnUnits],
   );
 
-  const pageStart = pageCursors[pageIndex] ?? null;
+  // Ranked (search) mode: relevance order replaces the lastEmailAt keyset, so instead of a
+  // cursor Zero gets a growing PREFIX of the rank list, extended until the page fills. A
+  // prefix is sound because Zero's filters drop rows without reordering them, so growing it
+  // can only append lower-ranked rows; earlier pages never move.
+  const isRanked = !!rankOrder && rankOrder.length > 0;
+  const rankByConversationId = useMemo(() => {
+    const order = new Map<string, number>();
+    rankOrder?.forEach((conversationId, index) => order.set(conversationId, index));
+    return order;
+  }, [rankOrder]);
+  const rankedConversationIds = useMemo(
+    () => (isRanked ? rankOrder.slice(0, fetchLimit) : conversationIdWhitelist),
+    [isRanked, rankOrder, fetchLimit, conversationIdWhitelist],
+  );
+
+  const pageStart = isRanked ? null : (pageCursors[pageIndex] ?? null);
   const [firstPage, firstPageDetails] = useCachedQuery(
     queries.supportTicketsPageV3({
       channelId,
@@ -415,9 +448,7 @@ export const TicketListView = function TicketListView({
       priority,
       stageName,
       aiCategory,
-      ...(conversationIdWhitelist !== undefined
-        ? { conversationIds: conversationIdWhitelist }
-        : {}),
+      ...(rankedConversationIds !== undefined ? { conversationIds: rankedConversationIds } : {}),
       hasAiDraft,
       hasSubTickets,
       lastEmailAtStart,
@@ -439,6 +470,23 @@ export const TicketListView = function TicketListView({
 
   const loadStartTimeRef = useRef<number | null>(Date.now());
 
+  // A widening appends to the rank list without reordering it, so it must not reset paging
+  // or the fetch window: the reset and the doubling below would then collide in one commit
+  // and can cancel out, leaving `needMoreRows` true with no effect left to fire. Only a list
+  // that does not extend the previous one is a new search.
+  const rankEpochRef = useRef({ epoch: 0, ids: [] as readonly string[] });
+  const rankEpoch = useMemo(() => {
+    const prev = rankEpochRef.current;
+    const ids = rankOrder ?? [];
+    const extendsPrev =
+      prev.ids.length > 0 &&
+      ids.length >= prev.ids.length &&
+      prev.ids.every((id, index) => ids[index] === id);
+    if (!extendsPrev) prev.epoch += 1;
+    prev.ids = ids;
+    return prev.epoch;
+  }, [rankOrder]);
+
   // Filter key — reset accumulator + pagination when filter changes (new view = new data).
   const filterKey = useMemo(
     () =>
@@ -449,7 +497,7 @@ export const TicketListView = function TicketListView({
         p: priority ?? null,
         s: stageName ?? null,
         ac: aiCategory ?? null,
-        ci: conversationIdWhitelist ?? null,
+        ci: isRanked ? rankEpoch : (conversationIdWhitelist ?? null),
         ad: hasAiDraft ?? null,
         hst: hasSubTickets ?? null,
         mf: mailboxFolder ?? null,
@@ -468,6 +516,8 @@ export const TicketListView = function TicketListView({
       priority,
       stageName,
       aiCategory,
+      isRanked,
+      rankEpoch,
       conversationIdWhitelist,
       hasAiDraft,
       hasSubTickets,
@@ -578,10 +628,28 @@ export const TicketListView = function TicketListView({
     return rows;
   }, [allRows, mailboxFolder, dynamicFieldEntries]);
 
+  // Ranked mode sorts the filtered set by search relevance; Zero's `IN` returns table order,
+  // so without this the ranking Vespa computed is lost.
+  const orderedAll = useMemo<SupportTicketRow[]>(() => {
+    if (!isRanked) return filteredAll;
+    const rankOf = (row: SupportTicketRow): number =>
+      rankByConversationId.get(row.conversationId) ?? Number.MAX_SAFE_INTEGER;
+    return [...filteredAll].sort((left, right) => rankOf(left) - rankOf(right));
+  }, [filteredAll, isRanked, rankByConversationId]);
+
   // Paginate over the FILTERED rows: render one PAGE_SIZE window; a (PAGE_SIZE+1)th filtered
   // row is the "next page exists" sentinel (mirrors the server keyset paging, on filtered rows).
-  const filteredTickets = useMemo(() => filteredAll.slice(0, PAGE_SIZE), [filteredAll]);
-  const hasNextPage = filteredAll.length > PAGE_SIZE;
+  // Ranked mode holds the whole set, so it slices by page index instead.
+  const filteredTickets = useMemo(
+    () =>
+      isRanked
+        ? orderedAll.slice(pageIndex * PAGE_SIZE, (pageIndex + 1) * PAGE_SIZE)
+        : orderedAll.slice(0, PAGE_SIZE),
+    [orderedAll, isRanked, pageIndex],
+  );
+  const hasNextPage = isRanked
+    ? orderedAll.length > (pageIndex + 1) * PAGE_SIZE
+    : orderedAll.length > PAGE_SIZE;
 
   useEffect(() => {
     onTicketsLoaded?.(filteredTickets);
@@ -589,23 +657,44 @@ export const TicketListView = function TicketListView({
 
   const complete = firstPageDetails.type === 'complete';
   // Server returned fewer rows than requested → the channel/folder is genuinely exhausted;
-  // no amount of extra fetching can surface additional rows.
-  const serverExhausted = allRows.length < fetchLimit;
+  // no amount of extra fetching can surface additional rows. Ranked mode is exhausted once
+  // the window covers the whole rank list.
+  const serverExhausted = isRanked ? fetchLimit >= rankOrder.length : allRows.length < fetchLimit;
   // A client-filtered folder (Inbox / All Mail) can filter a full server page down below a
   // page's worth. Keep growing the fetch window (effect below) until we have a full page
   // (+1 sentinel) of MATCHING rows OR the source is genuinely exhausted — there is no fixed
   // cap, so matching tickets sitting behind a long run of archived/spam are never missed.
+  // Ranked mode pages in memory, so it needs enough to cover the CURRENT page, not the first.
   // `converged` = the page is definitive (safe to show its empty state).
-  const needMoreRows = complete && !serverExhausted && filteredAll.length < PAGE_SIZE + 1;
-  const converged = complete && !needMoreRows;
+  const targetRowCount = isRanked ? (pageIndex + 1) * PAGE_SIZE + 1 : PAGE_SIZE + 1;
+  const needMoreRows = complete && !serverExhausted && filteredAll.length < targetRowCount;
+  // Once the window covers every fetched id and the page is still short, only a deeper Vespa
+  // slice can make up the shortfall. Guarded on `searchTruncated` so an exhausted search stops.
+  const needMoreRankedIds =
+    isRanked &&
+    complete &&
+    serverExhausted &&
+    searchTruncated &&
+    filteredAll.length < targetRowCount;
+
+  const converged = complete && !needMoreRows && !needMoreRankedIds && !searchPending;
 
   const rowsEmpty = converged && filteredTickets.length === 0;
-  const showInitialSkeletons = (!complete && allRows.length === 0) || needMoreRows;
+  // A search refills through several Vespa and Zero rounds; holding one skeleton until the
+  // page is definitive avoids flashing partial rows between them.
+  const showInitialSkeletons =
+    isRanked || searchPending ? !converged : (!complete && allRows.length === 0) || needMoreRows;
 
   const isLastPage = !hasNextPage;
 
   const goToNextPage = useCallback(() => {
     if (isLastPage) return;
+    // Ranked mode pages an in-memory list; there is no cursor to advance.
+    if (isRanked) {
+      setPageIndex(pageIndex + 1);
+      onPageChange?.(pageIndex + 1);
+      return;
+    }
     // Continue from the last RENDERED (filtered) row: filtered rows are a subsequence of the
     // keyset-ordered buffer, so their (lastEmailAt, id) is a valid cursor and the next page
     // picks up the next matching rows without skipping or duplicating.
@@ -619,7 +708,7 @@ export const TicketListView = function TicketListView({
     });
     setPageIndex(pageIndex + 1);
     onPageChange?.(pageIndex + 1);
-  }, [isLastPage, filteredTickets, pageIndex, onPageChange]);
+  }, [isLastPage, isRanked, filteredTickets, pageIndex, onPageChange]);
 
   const goToPrevPage = useCallback(() => {
     if (pageIndex === 0) return;
@@ -630,6 +719,11 @@ export const TicketListView = function TicketListView({
   useEffect(() => {
     virtuosoRef.current?.scrollToIndex({ index: 0 });
   }, [pageIndex]);
+
+  useEffect(() => {
+    if (!needMoreRankedIds) return;
+    onRequestMoreRankedIds?.();
+  }, [needMoreRankedIds, onRequestMoreRankedIds]);
 
   // Grow the fetch window until the client-filtered page holds a full PAGE_SIZE (+1 sentinel)
   // of matching rows, or the source is genuinely exhausted — so Inbox / All Mail never miss
@@ -767,6 +861,7 @@ export const TicketListView = function TicketListView({
         return (
           <TicketListRow
             ticket={row as TicketListItem}
+            highlightTerms={highlightTerms}
             isActive={isActive}
             showExtraFields={showExtraFields}
             gridTemplate={ticketListGridTemplate}
@@ -806,7 +901,14 @@ export const TicketListView = function TicketListView({
 
   const fromIndex = pageIndex * PAGE_SIZE + 1;
   const toIndex = pageIndex * PAGE_SIZE + filteredTickets.length;
-  const rangeLabel = `${fromIndex}–${toIndex}`;
+  // On a truncated search the total is unknowable — the ranked window deliberately stops
+  // before the whole matched set — so flag that rather than invent a denominator. No count
+  // is cited: `searchTruncated` describes the index-side cut, while rankOrder may since have
+  // been narrowed further (the AI-tag filter intersects into the same list), so any number
+  // here would describe a different set from the one that was truncated.
+  const rangeLabel = searchTruncated
+    ? `${fromIndex}–${toIndex} of top matches`
+    : `${fromIndex}–${toIndex}`;
 
   const toSelectable = (t: SupportTicketRow): SelectableRow => {
     const entry: SelectableRow = {

--- a/apps/dashboard/src/components/ui/HighlightedText/HighlightedText.tsx
+++ b/apps/dashboard/src/components/ui/HighlightedText/HighlightedText.tsx
@@ -1,0 +1,36 @@
+import { Fragment, useMemo, type JSX } from 'react';
+import { normalizeHighlightTerms, splitOnHighlightTerms } from '../../../utils/highlightTerms';
+
+interface HighlightedTextProps {
+  text: string;
+  /** Words from the active search. Empty or absent renders `text` unchanged. */
+  terms?: readonly string[] | undefined;
+}
+
+/** Marks search terms in plain display text, for fields rendered from Zero rather than
+ * from the search hit, which already carries Vespa's <hi> tags. */
+export const HighlightedText = ({ text, terms }: HighlightedTextProps): JSX.Element => {
+  const segments = useMemo(
+    () => (terms?.length ? splitOnHighlightTerms(text, normalizeHighlightTerms(terms)) : []),
+    [text, terms],
+  );
+
+  if (segments.length === 0) return <>{text}</>;
+
+  return (
+    <>
+      {segments.map((segment, index) =>
+        segment.matched ? (
+          <mark
+            key={index}
+            className='bg-yellow-200 font-medium text-foreground dark:bg-yellow-500/30'
+          >
+            {segment.text}
+          </mark>
+        ) : (
+          <Fragment key={index}>{segment.text}</Fragment>
+        ),
+      )}
+    </>
+  );
+};

--- a/apps/dashboard/src/components/xyne-desk/EmailBody/EmailBodyRenderer.tsx
+++ b/apps/dashboard/src/components/xyne-desk/EmailBody/EmailBodyRenderer.tsx
@@ -9,6 +9,7 @@ import {
 import { preprocessEmailHtml } from './preprocessEmailHtml';
 import { collapseQuotedHistory } from './collapseQuotedHistory';
 import { useCidImageResolver } from './useCidImageResolver';
+import { normalizeHighlightTerms, splitOnHighlightTerms } from '../../../utils/highlightTerms';
 
 interface EmailBodyRendererProps {
   body: string;
@@ -19,6 +20,11 @@ interface EmailBodyRendererProps {
   onMailtoClick?: ((email: string) => void) | undefined;
   /** Scroll the parent container to the bottom after the iframe loads. Only true for the latest email. */
   autoScroll?: boolean;
+  /**
+   * Search terms to mark in the body. The body renders inside a sandboxed iframe, so this
+   * is applied to the parsed document before it becomes the srcdoc rather than by React.
+   */
+  highlightTerms?: string[];
   attachments?: ReadonlyArray<{
     id: string;
     metadata?: unknown;
@@ -93,6 +99,7 @@ const blockRemoteImages = (root: HTMLElement): number => {
 };
 
 const IFRAME_STYLES = `
+mark { background: #fde68a; color: inherit; border-radius: 2px; padding: 0 1px; }
   html, body {
     margin: 0;
     padding: 0;
@@ -335,10 +342,54 @@ interface BuiltDoc {
   hasBlockedImages: boolean;
 }
 
+/**
+ * Marks search terms on TEXT NODES of the parsed, already-sanitised document. Deliberately
+ * not a string replace on the HTML: that would match inside tag names, attributes and URLs,
+ * and could split a tag in half. Skips already-marked nodes, so re-running is idempotent.
+ */
+const EMPTY_HIGHLIGHT_TERMS: string[] = [];
+
+const HIGHLIGHT_SKIP_TAGS = new Set(['SCRIPT', 'STYLE', 'MARK', 'TEXTAREA']);
+
+const highlightTermsInDom = (root: HTMLElement, doc: Document, terms: string[]): void => {
+  const needles = normalizeHighlightTerms(terms);
+  if (needles.length === 0) return;
+
+  const walker = doc.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node: Node) =>
+      node.parentElement && HIGHLIGHT_SKIP_TAGS.has(node.parentElement.tagName)
+        ? NodeFilter.FILTER_REJECT
+        : NodeFilter.FILTER_ACCEPT,
+  });
+
+  // Collect first: replacing nodes while walking would invalidate the walker.
+  const textNodes: Text[] = [];
+  let current: Node | null;
+  while ((current = walker.nextNode())) textNodes.push(current as Text);
+
+  for (const textNode of textNodes) {
+    const segments = splitOnHighlightTerms(textNode.textContent ?? '', needles);
+    if (segments.length === 0) continue;
+
+    const fragment = doc.createDocumentFragment();
+    for (const segment of segments) {
+      if (segment.matched) {
+        const mark = doc.createElement('mark');
+        mark.textContent = segment.text;
+        fragment.appendChild(mark);
+      } else {
+        fragment.appendChild(doc.createTextNode(segment.text));
+      }
+    }
+    textNode.parentNode?.replaceChild(fragment, textNode);
+  }
+};
+
 const buildIframeSrcdoc = (
   rawBody: string,
   showRemoteImages: boolean,
   rewriteCidRefs: (html: string) => string,
+  highlightTerms: string[],
 ): BuiltDoc => {
   if (!rawBody || !rawBody.trim()) {
     return {
@@ -366,6 +417,7 @@ const buildIframeSrcdoc = (
     };
   }
 
+  highlightTermsInDom(root, doc, highlightTerms);
   collapseQuotedHistory(root, doc);
   wrapQuotesInDetails(doc);
   normalizeRecipientMentions(root, doc);
@@ -396,6 +448,7 @@ export const EmailBodyRenderer = ({
   attachments,
   onMailtoClick,
   autoScroll = false,
+  highlightTerms = EMPTY_HIGHLIGHT_TERMS,
 }: EmailBodyRendererProps): JSX.Element => {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const onMailtoClickRef = useRef(onMailtoClick);
@@ -417,8 +470,8 @@ export const EmailBodyRenderer = ({
   attachmentsRef.current = attachments;
 
   const { srcdoc, hasBlockedImages } = useMemo(
-    () => buildIframeSrcdoc(body, showRemoteImages, rewriteCidRefs),
-    [body, showRemoteImages, rewriteCidRefs],
+    () => buildIframeSrcdoc(body, showRemoteImages, rewriteCidRefs, highlightTerms),
+    [body, showRemoteImages, rewriteCidRefs, highlightTerms],
   );
 
   useEffect(() => {

--- a/apps/dashboard/src/routes/SupportScreen/DeskSearchBox.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/DeskSearchBox.tsx
@@ -1,0 +1,89 @@
+import { ReactElement, RefObject } from 'react';
+import { SearchDefault as Search, MultipleCrossCancelDefault as X } from '@xyne/icons';
+import Tooltip from '../../components/ui/Tooltip';
+import { cn } from '../../utils/classNames';
+
+const EXPANDED_WIDTH = 'w-[220px] ml-2';
+
+interface DeskSearchBoxProps {
+  value: string;
+  onChange: (value: string) => void;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  /** Omitted by the toolbar's hidden measurement twin, which only needs the width. */
+  inputRef?: RefObject<HTMLInputElement | null>;
+}
+
+/**
+ * Collapsed magnifier that expands into a text input. Rendered twice — once for real
+ * and once inside the toolbar's hidden measurement twin — so the overflow pass in
+ * useDeskToolbarOverflow budgets for whichever form is on screen.
+ */
+export function DeskSearchBox({
+  value,
+  onChange,
+  isOpen,
+  onOpenChange,
+  inputRef,
+}: DeskSearchBoxProps): ReactElement {
+  if (!isOpen && !value) {
+    return (
+      <Tooltip content='Search mail' side='bottom'>
+        <button
+          onClick={() => onOpenChange(true)}
+          aria-label='Search mail'
+          className='p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors'
+          data-track-category='Support'
+          data-track-name='OpenDeskSearch'
+        >
+          <Search size={16} />
+        </button>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <div className={cn('relative', EXPANDED_WIDTH)}>
+      <Search
+        size={16}
+        className='absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none'
+      />
+      <input
+        ref={inputRef}
+        type='text'
+        value={value}
+        onChange={event => onChange(event.target.value)}
+        onBlur={() => {
+          if (!value) onOpenChange(false);
+        }}
+        onKeyDown={event => {
+          if (event.key !== 'Escape') return;
+          onChange('');
+          onOpenChange(false);
+          event.currentTarget.blur();
+        }}
+        placeholder='Search mail'
+        aria-label='Search mail'
+        className='w-full text-sm bg-background border border-border text-foreground rounded-lg pl-8 pr-8 py-1 focus:outline-none focus:ring-1 focus:ring-blue-500'
+        data-track-category='Support'
+        data-track-name='DeskSearch'
+      />
+      {value && (
+        <button
+          onClick={() => {
+            onChange('');
+            inputRef?.current?.focus();
+          }}
+          aria-label='Clear search'
+          className='absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors'
+          data-track-category='Support'
+          data-track-name='ClearDeskSearch'
+        >
+          <X size={14} />
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default DeskSearchBox;

--- a/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
+++ b/apps/dashboard/src/routes/SupportScreen/SupportScreen.tsx
@@ -41,7 +41,6 @@ import {
   SparkleAi02 as Sparkles,
   PencilEdit as Pencil,
   UserTwo as Users,
-  SearchDefault as Search,
   UserDefault as User,
   FilterLines as ListFilter,
   BarchartDefault as BarChart4Icon,
@@ -76,6 +75,7 @@ import {
 import ChannelIcon from '../../components/Chat/ChannelIcon/ChannelIcon';
 import { logger, Event } from '../../utils/logger';
 import Tooltip, { TruncatedTooltip } from '../../components/ui/Tooltip';
+import { HighlightedText } from '../../components/ui/HighlightedText/HighlightedText';
 import { useZero } from '../../hooks/useZero';
 import { queries } from '../../zero/queries';
 import { useTicketKeysetWindow } from '../../hooks/useTicketKeysetWindow';
@@ -106,6 +106,7 @@ import {
 import {
   buildDynamicFieldFilterEntries,
   toDynamicFieldQueryFilters,
+  toVespaDynamicFieldFilters,
   type DynamicFieldQueryFilter,
 } from '../../utils/board/dynamicFieldFilters';
 import { dynamicColumnKey } from '../../components/Tickets/TicketTable/dynamicFieldColumns';
@@ -141,7 +142,7 @@ import { SupportKanbanBoard } from './SupportKanbanBoard';
 import { SupportTicketTable } from './SupportTicketTable';
 import { BoardType, FormContextType, TicketPriority, parseFieldOptionValues } from '@xyne/shared';
 import type { Ticket, FormFields, EmailChannelPreference } from '@xyne/shared';
-import { useShortcut, invokeShortcut } from '../../shortcuts';
+import { useShortcut } from '../../shortcuts';
 import { v4 as uuidv4 } from 'uuid';
 import { useUser } from '../../hooks/useUsers';
 import { BulkActionToolbar } from '../../components/Tickets/TicketTable/BulkActionToolbar';
@@ -222,6 +223,8 @@ import {
   type CollapsibleFilterId,
 } from './DeskFilterTrigger';
 import { useDeskToolbarOverflow } from './useDeskToolbarOverflow';
+import { useDeskSearch } from './useDeskSearch';
+import { DeskSearchBox } from './DeskSearchBox';
 import { clearDeskContactsCache } from '../../hooks/useDeskContacts';
 import { XyneAIStar } from '../../components/icons/xyne-ai';
 import { trackAskAIOpened } from '../../services/otel/xyneAIMetrics';
@@ -596,9 +599,22 @@ const SupportScreen = (): ReactElement => {
     [selectedChannelId],
   );
   const [kanbanTickets, setKanbanTickets] = useState<Ticket[]>([]);
+  const [deskSearchTerm, setDeskSearchTerm] = useState('');
+  const [isDeskSearchOpen, setIsDeskSearchOpen] = useState(false);
+  const deskSearchInputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     setKanbanTickets([]);
+    setDeskSearchTerm('');
+    setIsDeskSearchOpen(false);
   }, [selectedChannelId]);
+
+  const openDeskSearch = useCallback((isOpen: boolean): void => {
+    setIsDeskSearchOpen(isOpen);
+    // select() focuses too, so reopening a box that still holds a term highlights it.
+    if (isOpen) {
+      requestAnimationFrame(() => deskSearchInputRef.current?.select());
+    }
+  }, []);
 
   const [viewMode, setViewMode] = useState<ViewMode>(() => {
     const saved = localStorage.getItem('support-view-mode');
@@ -733,7 +749,63 @@ const SupportScreen = (): ReactElement => {
     };
   }, [selectedChannelId, filters.generatedTags]);
 
-  // Build the filter args once — reused by both the kanban query and the list view.
+  // Zero remains authoritative and re-applies every filter; this subset only narrows the
+  // ranked window so its budget is spent on rows that will survive.
+  // "My Tickets" toggle is the assignee fallback when the explicit assignee filter is empty.
+  const deskSearchFilters = useMemo(
+    () => ({
+      assignedTo:
+        filters.assignee && filters.assignee.length > 0
+          ? filters.assignee
+          : filters.assigned
+            ? [userID]
+            : undefined,
+      createdBy: filters.createdBy && filters.createdBy.length > 0 ? filters.createdBy : undefined,
+      priority: filters.priority && filters.priority.length > 0 ? filters.priority : undefined,
+      stageName: filters.stages && filters.stages.length > 0 ? filters.stages : undefined,
+      userGroups:
+        filters.userGroups && filters.userGroups.length > 0 ? filters.userGroups : undefined,
+      aiCategory:
+        filters.aiCategory && filters.aiCategory.length > 0 ? filters.aiCategory : undefined,
+      lastEmailAtStart: filters.lastEmailAtStart,
+      lastEmailAtEnd: filters.lastEmailAtEnd,
+      createdAtStart: filters.createdDateStart,
+      createdAtEnd: filters.createdDateEnd,
+      generatedTags:
+        filters.generatedTags && filters.generatedTags.length > 0
+          ? filters.generatedTags
+          : undefined,
+      // Only the types Zero also matches exactly.
+      ...toVespaDynamicFieldFilters(dynamicFieldEntries),
+    }),
+    [filters, userID, dynamicFieldEntries],
+  );
+
+  const {
+    conversationIds: searchConversationIds,
+    isSearching: isDeskSearching,
+    truncated: isDeskSearchTruncated,
+    fetchMore: fetchMoreDeskSearchIds,
+    terms: deskSearchTerms,
+  } = useDeskSearch({
+    searchTerm: deskSearchTerm,
+    channelId: selectedChannelId,
+    filters: deskSearchFilters,
+  });
+
+  // AI-tag filtering and desk search share one query slot, so they intersect rather than
+  // overwrite. The search side drives it — the other order would discard the ranking.
+  const conversationIdWhitelist = useMemo(() => {
+    const tagIds =
+      filters.generatedTags && filters.generatedTags.length > 0
+        ? (tagFilterConversationIds ?? [])
+        : undefined;
+    if (tagIds === undefined) return searchConversationIds ?? undefined;
+    if (searchConversationIds === null) return tagIds;
+    const tagged = new Set(tagIds);
+    return searchConversationIds.filter(id => tagged.has(id));
+  }, [filters.generatedTags, tagFilterConversationIds, searchConversationIds]);
+
   // "My Tickets" toggle is the assignee fallback when the explicit assignee filter is empty.
   const ticketFilter = useMemo(
     () => ({
@@ -746,25 +818,22 @@ const SupportScreen = (): ReactElement => {
       createdBy: filters.createdBy && filters.createdBy.length > 0 ? filters.createdBy : undefined,
       priority: filters.priority && filters.priority.length > 0 ? filters.priority : undefined,
       stageName: filters.stages && filters.stages.length > 0 ? filters.stages : undefined,
-      aiCategory:
-        filters.aiCategory && filters.aiCategory.length > 0 ? filters.aiCategory : undefined,
-      conversationIdWhitelist:
-        filters.generatedTags && filters.generatedTags.length > 0
-          ? (tagFilterConversationIds ?? [])
-          : undefined,
-      hasAiDraft: filters.hasAiDraft === true ? true : undefined,
       hasSubTickets: filters.hasSubTickets === true ? true : undefined,
       userGroups:
         filters.userGroups && filters.userGroups.length > 0 ? filters.userGroups : undefined,
+      aiCategory:
+        filters.aiCategory && filters.aiCategory.length > 0 ? filters.aiCategory : undefined,
       lastEmailAtStart: filters.lastEmailAtStart,
       lastEmailAtEnd: filters.lastEmailAtEnd,
+      conversationIdWhitelist,
+      hasAiDraft: filters.hasAiDraft === true ? true : undefined,
       createdAtStart: filters.createdDateStart,
       createdAtEnd: filters.createdDateEnd,
       dynamicFieldFilters: toDynamicFieldQueryFilters(dynamicFieldEntries),
       // Sidebar label view (selectedLabel) takes precedence over the More-Filters label pick.
       conversationLabelId: selectedLabel?.id ?? filters.conversationLabelId,
     }),
-    [filters, userID, dynamicFieldEntries, tagFilterConversationIds, selectedLabel?.id],
+    [filters, userID, dynamicFieldEntries, conversationIdWhitelist, selectedLabel?.id],
   );
 
   const availablePriorities = useMemo(() => Object.values(TicketPriority), []);
@@ -2998,9 +3067,12 @@ const SupportScreen = (): ReactElement => {
                         )}
                         <div ref={filterStaticLeftRef} className='flex items-center gap-2'>
                           {selectedChannelId && selectedChannelId !== ALL_CHANNELS_ID && (
-                            <span className='p-1.5'>
-                              <Search size={16} />
-                            </span>
+                            <DeskSearchBox
+                              value={deskSearchTerm}
+                              onChange={setDeskSearchTerm}
+                              isOpen={isDeskSearchOpen}
+                              onOpenChange={setIsDeskSearchOpen}
+                            />
                           )}
                           <Button
                             variant='outline'
@@ -3030,17 +3102,13 @@ const SupportScreen = (): ReactElement => {
                     )}
                     <div className='flex items-center gap-2 min-w-0 flex-1 overflow-hidden'>
                       {selectedChannelId && selectedChannelId !== ALL_CHANNELS_ID && (
-                        <Tooltip content='Search emails' side='bottom'>
-                          <button
-                            onClick={() => invokeShortcut('mod+f')}
-                            className='p-1.5 rounded-md hover:bg-muted text-muted-foreground hover:text-foreground transition-colors'
-                            data-track-category='Support'
-                            data-track-name='OpenDeskSearch'
-                            data-track-metadata={JSON.stringify({ channelId: selectedChannelId })}
-                          >
-                            <Search size={16} />
-                          </button>
-                        </Tooltip>
+                        <DeskSearchBox
+                          value={deskSearchTerm}
+                          onChange={setDeskSearchTerm}
+                          isOpen={isDeskSearchOpen}
+                          onOpenChange={openDeskSearch}
+                          inputRef={deskSearchInputRef}
+                        />
                       )}
                       {isSelectedChannelJoined && (
                         <>
@@ -3800,6 +3868,16 @@ const SupportScreen = (): ReactElement => {
                     ) : (
                       <TicketListView
                         isMember={isSelectedChannelJoined}
+                        {...(searchConversationIds
+                          ? {
+                              rankOrder: conversationIdWhitelist ?? [],
+                              searchTruncated: isDeskSearchTruncated,
+                              searchPending: isDeskSearching,
+                              onRequestMoreRankedIds: fetchMoreDeskSearchIds,
+                              highlightTerms: deskSearchTerms,
+                            }
+                          : {})}
+                        emptyState={deskSearchTerm ? 'No results found' : undefined}
                         mailboxFolder={
                           selectedLabel || !selectedChannelHasMailboxFolders
                             ? undefined
@@ -3862,6 +3940,7 @@ const SupportScreen = (): ReactElement => {
           <Panel id='ticket-detail' defaultSize='100%' minSize='100%'>
             <div className='h-full overflow-hidden bg-background'>
               <SupportTicketDetail
+                highlightTerms={deskSearchTerms}
                 ticketFilter={ticketFilter}
                 isMember={isSelectedChannelJoined}
                 onMailtoClick={handleMailtoClick}
@@ -4096,6 +4175,8 @@ const TicketMetaRow = ({
 };
 
 type SupportTicketDetailProps = {
+  /** Words from the active desk search, marked inside each email body. */
+  highlightTerms?: string[];
   ticketFilter: {
     assignedTo: string[] | undefined;
     createdBy: string[] | undefined;
@@ -4160,6 +4241,7 @@ export const SupportTicketDetail = ({
   navBasePath,
   onBack,
   navTickets,
+  highlightTerms,
 }: SupportTicketDetailProps): ReactElement => {
   const {
     workspaceId: routeWorkspaceId,
@@ -4834,7 +4916,7 @@ export const SupportTicketDetail = ({
                     row break its flex line instead of crushing the title to nothing. */}
                 <TruncatedTooltip content={title || 'Untitled Ticket'} side='bottom'>
                   <span className='font-medium text-foreground flex-1 min-w-[8rem] truncate'>
-                    {title || 'Untitled Ticket'}
+                    <HighlightedText text={title || 'Untitled Ticket'} terms={highlightTerms} />
                   </span>
                 </TruncatedTooltip>
 
@@ -5403,6 +5485,7 @@ export const SupportTicketDetail = ({
                       onMailtoClick={onMailtoClick}
                       mergedSourceByConversationId={mergedSourceByConversationId}
                       onUnmergeSource={handleUnmergeMergedSource}
+                      {...(highlightTerms ? { highlightTerms } : {})}
                     />
                   )}
                 </div>
@@ -5732,8 +5815,11 @@ const EmailThread = ({
   onMailtoClick,
   mergedSourceByConversationId,
   onUnmergeSource,
+  highlightTerms,
 }: {
   collapseState: EmailCollapseState;
+  /** Words from the active desk search, marked in each email body. */
+  highlightTerms?: string[];
   ticketId?: string | null | undefined;
   onReplyToEmail?: (emailId: string, mode: 'reply' | 'replyAll') => void;
   deskEmail?: string | null | undefined;
@@ -5799,6 +5885,7 @@ const EmailThread = ({
             onMailtoClick={onMailtoClick}
             {...(mergedSource && { mergedSource })}
             {...(onUnmergeSource && { onUnmergeSource })}
+            {...(highlightTerms ? { highlightTerms } : {})}
           />
         );
       })}
@@ -5818,8 +5905,10 @@ const EmailThreadItem = ({
   onMailtoClick,
   mergedSource,
   onUnmergeSource,
+  highlightTerms,
 }: {
   email: Email;
+  highlightTerms?: string[];
   isCollapsed?: boolean;
   canCollapse?: boolean;
   onToggleCollapse?: () => void;
@@ -6001,6 +6090,7 @@ const EmailThreadItem = ({
                   attachments={threadAttachments ?? email.attachments}
                   onMailtoClick={onMailtoClick}
                   autoScroll={!canCollapse}
+                  {...(highlightTerms ? { highlightTerms } : {})}
                 />
               ) : (
                 <span className='text-muted-foreground italic'>No content</span>

--- a/apps/dashboard/src/routes/SupportScreen/useDeskSearch.ts
+++ b/apps/dashboard/src/routes/SupportScreen/useDeskSearch.ts
@@ -1,0 +1,373 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { searchService } from '../../services/searchService';
+import { parseAssigneeFilter } from '../../zero/queries';
+import type { DisplaySearchResult, VespaSearchFilters } from '../../types/search';
+import { extractVespaHighlights } from '../../utils/highlightTerms';
+
+const DEBOUNCE_MS = 300;
+const PAGE_LIMIT = 101;
+
+const MAX_RANKED_CONVERSATIONS = 400;
+const CACHE_TTL_MS = 30_000;
+const CACHE_MAX_ENTRIES = 50;
+
+/**
+ * Toolbar filters pushed into the search query, so the ranked budget is spent on rows Zero
+ * will keep. A filter belongs here only if its Vespa semantics are no STRICTER than Zero's:
+ * a stricter one drops rows the list should show, and nothing downstream can recover them.
+ */
+interface DeskSearchFilters {
+  assignedTo?: string[] | undefined;
+  createdBy?: string[] | undefined;
+  priority?: string[] | undefined;
+  stageName?: string[] | undefined;
+  userGroups?: string[] | undefined;
+  aiCategory?: string[] | undefined;
+  lastEmailAtStart?: number | undefined;
+  lastEmailAtEnd?: number | undefined;
+  createdAtStart?: number | undefined;
+  createdAtEnd?: number | undefined;
+  /** "category:value". Constrains both sources, not just ticket. */
+  generatedTags?: string[] | undefined;
+  /** `fieldId::value` tokens. */
+  dynamicFieldValues?: string[] | undefined;
+  dynamicFieldDateRanges?: Record<string, { start?: number; end?: number }> | undefined;
+}
+
+/** Ticket-source filters. Dropped whenever a mail-only operator narrows the search. */
+type TicketSearchScope = Pick<
+  VespaSearchFilters,
+  | 'assignee'
+  | 'from'
+  | 'priority'
+  | 'stage'
+  | 'userGroups'
+  | 'aiCategory'
+  | 'isArchived'
+  | 'createdAtStart'
+  | 'createdAtEnd'
+  | 'dynamicFieldValues'
+  | 'dynamicFieldDateRanges'
+>;
+
+/** Filters both schemas carry, so they survive a narrowing to mail alone. */
+type SharedSearchScope = Pick<
+  VespaSearchFilters,
+  'generatedTags' | 'lastEmailAtStart' | 'lastEmailAtEnd'
+>;
+
+interface UseDeskSearchParams {
+  searchTerm: string;
+  channelId: string | null;
+  filters?: DeskSearchFilters;
+}
+
+interface UseDeskSearchResult {
+  /** null when no search is active; [] while searching, or when nothing matched. */
+  conversationIds: string[] | null;
+  isSearching: boolean;
+  /** A full page came back, so lower-ranked matches exist but were not fetched. */
+  truncated: boolean;
+  /** Widen the ranked window by one step. No-op unless `truncated`. */
+  fetchMore: () => void;
+  /**
+   * Words to highlight: the free text typed (operators excluded) plus the fragments Vespa
+   * marked in the hits, so a stemmed match is highlighted in the form the document uses.
+   */
+  terms: string[];
+}
+
+interface SearchOutcome {
+  ids: string[];
+  matchedTerms: string[];
+  truncated: boolean;
+}
+
+// Deliberately no in-flight coalescing: a promise shared across callers would inherit the
+// first caller's abort signal.
+const resultCache = new Map<string, { expiresAt: number; value: SearchOutcome }>();
+
+/** Matched conversations in Vespa's relevance order — array position is the rank. */
+const searchConversations = async (
+  filters: VespaSearchFilters,
+  offset: number,
+  signal: AbortSignal,
+): Promise<DisplaySearchResult[]> => {
+  const { results } = await searchService.vespaSearch(
+    { ...filters, limit: PAGE_LIMIT, offset },
+    signal,
+  );
+  return results;
+};
+
+interface ParsedQuery {
+  text: string;
+  fromEmail?: string;
+  toEmail?: string;
+  ccEmail?: string;
+  bccEmail?: string;
+  filename?: string;
+}
+
+/**
+ * A ticket id, `CODE-0042`. The default tokenizer splits it at the hyphen, matching every
+ * ticket in the project and scoring the right one no higher; quoting selects the backend's
+ * exact-phrase mode, where the id survives as one term and unified's id_boost ranks it first.
+ */
+const TICKET_ID_PATTERN = /^[A-Za-z][A-Za-z0-9]*-\d+$/;
+
+/** Operators that constrain `mail` only, so their presence drops the `ticket` source. */
+const MAIL_ONLY_OPERATORS = ['fromEmail', 'toEmail', 'ccEmail', 'bccEmail', 'filename'] as const;
+
+const OPERATOR_KEYS: Record<string, keyof ParsedQuery> = {
+  from: 'fromEmail',
+  to: 'toEmail',
+  cc: 'ccEmail',
+  bcc: 'bccEmail',
+  filename: 'filename',
+};
+
+const parseQuery = (raw: string): ParsedQuery => {
+  const collected: Record<string, string[]> = {};
+
+  const text = raw
+    .replace(
+      /(^|\s)(from|to|cc|bcc|filename):(\S+)/gi,
+      (_match, _lead, operator: string, value: string) => {
+        const key = OPERATOR_KEYS[operator.toLowerCase()];
+        if (key) (collected[key] ??= []).push(value);
+        return ' ';
+      },
+    )
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return {
+    text,
+    ...Object.fromEntries(
+      Object.entries(collected).map(([key, values]) => [key, values.join(',')]),
+    ),
+  };
+};
+
+const toTicketSearchFilters = (filters: DeskSearchFilters | undefined): TicketSearchScope => {
+  // Unconditional: archived tickets would otherwise fill the ranked prefix and be discarded
+  // by Zero, which filters them out in every folder.
+  const base: TicketSearchScope = { isArchived: false };
+  if (!filters) return base;
+
+  // "Unassigned" and the invert marker are Zero-side sentinels with no Vespa equivalent, so
+  // pushing them as ids would match nothing.
+  const assignee = filters.assignedTo ? parseAssigneeFilter(filters.assignedTo) : undefined;
+  const pushableAssignees =
+    assignee && !assignee.inverted && !assignee.includeUnassigned ? assignee.ids : [];
+
+  return {
+    ...base,
+    ...(pushableAssignees.length > 0 ? { assignee: pushableAssignees.join(',') } : {}),
+    ...(filters.createdBy?.length ? { from: filters.createdBy.join(',') } : {}),
+    ...(filters.priority?.length ? { priority: filters.priority.join(',') } : {}),
+    ...(filters.stageName?.length ? { stage: filters.stageName.join(',') } : {}),
+    ...(filters.userGroups?.length ? { userGroups: filters.userGroups.join(',') } : {}),
+    ...(filters.aiCategory?.length ? { aiCategory: filters.aiCategory.join(',') } : {}),
+    ...(filters.dynamicFieldValues?.length
+      ? { dynamicFieldValues: filters.dynamicFieldValues }
+      : {}),
+    ...(filters.dynamicFieldDateRanges
+      ? { dynamicFieldDateRanges: filters.dynamicFieldDateRanges }
+      : {}),
+    ...(filters.createdAtStart !== undefined ? { createdAtStart: filters.createdAtStart } : {}),
+    ...(filters.createdAtEnd !== undefined ? { createdAtEnd: filters.createdAtEnd } : {}),
+  };
+};
+
+const toSharedSearchFilters = (filters: DeskSearchFilters | undefined): SharedSearchScope => ({
+  ...(filters?.generatedTags?.length ? { generatedTags: filters.generatedTags.join(',') } : {}),
+  ...(filters?.lastEmailAtStart !== undefined
+    ? { lastEmailAtStart: filters.lastEmailAtStart }
+    : {}),
+  ...(filters?.lastEmailAtEnd !== undefined ? { lastEmailAtEnd: filters.lastEmailAtEnd } : {}),
+});
+
+const runSearch = async (
+  channelId: string,
+  parsed: ParsedQuery,
+  ticketScope: TicketSearchScope,
+  sharedScope: SharedSearchScope,
+  offset: number,
+  signal: AbortSignal,
+): Promise<SearchOutcome> => {
+  const { text, ...operators } = parsed;
+  const hasMailOnlyOperator = MAIL_ONLY_OPERATORS.some(key => !!parsed[key]);
+
+  // One query over both sources rather than one each: concatenating two ranked lists would
+  // put every mail match ahead of every ticket-only match whatever their relevance.
+  // A mail-only operator drops `ticket`, which would otherwise match on text alone and
+  // ignore the operator entirely.
+  const apps = hasMailOnlyOperator ? 'mail' : 'mail,ticket';
+  const type = hasMailOnlyOperator ? 'emails' : 'emails,tickets';
+
+  const results = await searchConversations(
+    {
+      in: channelId,
+      apps,
+      type,
+      // '*' drops the text clause server-side, leaving a pure operator filter.
+      query: text ? (TICKET_ID_PATTERN.test(text) ? `"${text}"` : text) : '*',
+      ...operators,
+      ...sharedScope,
+      ...(hasMailOnlyOperator ? {} : ticketScope),
+    },
+    offset,
+    signal,
+  );
+
+  // Grouping already collapsed each conversation to one document; dedupe defensively.
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  const matchedTerms = new Set<string>();
+  for (const result of results) {
+    const conversationId = result.searchContext?.conversationId;
+    if (!conversationId || seen.has(conversationId)) continue;
+    seen.add(conversationId);
+    ids.push(conversationId);
+    for (const field of [result.title, result.subtitle, result.context]) {
+      for (const term of extractVespaHighlights(field)) matchedTerms.add(term.toLowerCase());
+    }
+  }
+
+  return {
+    ids,
+    matchedTerms: [...matchedTerms],
+    truncated: results.length >= PAGE_LIMIT && offset + PAGE_LIMIT < MAX_RANKED_CONVERSATIONS,
+  };
+};
+
+/**
+ * Text search over a desk channel, returning the matched conversations in rank order.
+ * One query spans mail and ticket, grouped by threadId so each conversation appears once.
+ *
+ * Vespa is not authoritative: Zero re-applies every filter to the ids this returns, so the
+ * two can never disagree about what the user is allowed to see.
+ */
+export function useDeskSearch({
+  searchTerm,
+  channelId,
+  filters,
+}: UseDeskSearchParams): UseDeskSearchResult {
+  const [conversationIds, setConversationIds] = useState<string[] | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const [truncated, setTruncated] = useState(false);
+  const [matchedTerms, setMatchedTerms] = useState<string[]>([]);
+
+  // Callers rebuild `filters` every render, so key the effect on the scope's value.
+  const ticketScopeKey = JSON.stringify(toTicketSearchFilters(filters));
+  const ticketScope = useMemo<TicketSearchScope>(
+    () => JSON.parse(ticketScopeKey) as TicketSearchScope,
+    [ticketScopeKey],
+  );
+
+  const sharedScopeKey = JSON.stringify(toSharedSearchFilters(filters));
+  const sharedScope = useMemo<SharedSearchScope>(
+    () => JSON.parse(sharedScopeKey) as SharedSearchScope,
+    [sharedScopeKey],
+  );
+
+  // The offset is stored with the search it belongs to and read back as 0 under any other
+  // key, so a new query starts from page one in the same render — an effect-driven reset
+  // would let the search effect fire once with the stale offset first.
+  const searchKey = JSON.stringify([searchTerm, channelId, ticketScopeKey, sharedScopeKey]);
+  const [paging, setPaging] = useState({ key: searchKey, offset: 0 });
+  const pageOffset = paging.key === searchKey ? paging.offset : 0;
+
+  // Read through a ref so `fetchMore` keeps one identity: the list re-runs its request-more
+  // effect when the callback changes, which would widen a new search before its first page.
+  const searchKeyRef = useRef(searchKey);
+  searchKeyRef.current = searchKey;
+  const fetchMore = useCallback(() => {
+    const key = searchKeyRef.current;
+    setPaging(prev => ({ key, offset: (prev.key === key ? prev.offset : 0) + PAGE_LIMIT }));
+  }, []);
+
+  useEffect(() => {
+    const parsed = parseQuery(searchTerm);
+    // An operator with no free text is still a search ("cc:alice@x.com" on its own).
+    const hasOperator = MAIL_ONLY_OPERATORS.some(key => !!parsed[key]);
+    if ((!parsed.text && !hasOperator) || !channelId) {
+      setConversationIds(null);
+      setMatchedTerms([]);
+      setIsSearching(false);
+      setTruncated(false);
+      return;
+    }
+
+    const cacheKey = JSON.stringify([
+      channelId,
+      parsed,
+      ticketScopeKey,
+      sharedScopeKey,
+      pageOffset,
+    ]);
+    const cached = resultCache.get(cacheKey);
+    if (cached && cached.expiresAt > Date.now()) {
+      setConversationIds(cached.value.ids);
+      setMatchedTerms(cached.value.matchedTerms);
+      setTruncated(cached.value.truncated);
+      setIsSearching(false);
+      return;
+    }
+
+    // Narrow to nothing so no unfiltered row shows while the request is in flight. Skipped
+    // when only the window widened — those ids are a prefix of what is coming back.
+    if (pageOffset === 0) {
+      setConversationIds([]);
+      setTruncated(false);
+    }
+    setIsSearching(true);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      runSearch(channelId, parsed, ticketScope, sharedScope, pageOffset, controller.signal)
+        .then(outcome => {
+          // Expired entries are never evicted on read, so drop the lot at the cap.
+          if (resultCache.size >= CACHE_MAX_ENTRIES) resultCache.clear();
+          resultCache.set(cacheKey, { expiresAt: Date.now() + CACHE_TTL_MS, value: outcome });
+          if (controller.signal.aborted) return;
+          // Page 0 replaces; later pages append, preserving Vespa's rank order across pages.
+          setConversationIds(prev =>
+            pageOffset === 0 || prev === null ? outcome.ids : [...prev, ...outcome.ids],
+          );
+          setMatchedTerms(prev =>
+            pageOffset === 0
+              ? outcome.matchedTerms
+              : [...new Set([...prev, ...outcome.matchedTerms])],
+          );
+          setTruncated(outcome.truncated);
+          setIsSearching(false);
+        })
+        .catch(() => {
+          if (controller.signal.aborted) return;
+          setConversationIds([]);
+          setMatchedTerms([]);
+          setTruncated(false);
+          setIsSearching(false);
+        });
+    }, DEBOUNCE_MS);
+
+    return (): void => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchTerm, channelId, ticketScope, ticketScopeKey, sharedScope, sharedScopeKey, pageOffset]);
+
+  const terms = useMemo(() => {
+    const { text } = parseQuery(searchTerm);
+    const typed = text.split(/\s+/).filter(word => word.length > 1);
+    return [...new Set([...typed, ...matchedTerms])];
+  }, [searchTerm, matchedTerms]);
+
+  return { conversationIds, isSearching, truncated, fetchMore, terms };
+}
+
+export default useDeskSearch;

--- a/apps/dashboard/src/services/searchService.ts
+++ b/apps/dashboard/src/services/searchService.ts
@@ -136,6 +136,18 @@ export class SearchService {
       params['toEmail'] = filters.toEmail;
     }
 
+    if (filters.ccEmail) {
+      params['ccEmail'] = filters.ccEmail;
+    }
+
+    if (filters.bccEmail) {
+      params['bccEmail'] = filters.bccEmail;
+    }
+
+    if (filters.filename) {
+      params['filename'] = filters.filename;
+    }
+
     if (filters.with) {
       params['withUser'] = filters.with;
     }
@@ -227,6 +239,38 @@ export class SearchService {
 
     if (filters.assignee) {
       params['assignee'] = filters.assignee;
+    }
+
+    if (filters.userGroups) {
+      params['userGroups'] = filters.userGroups;
+    }
+
+    if (filters.aiCategory) {
+      params['aiCategory'] = filters.aiCategory;
+    }
+
+    if (filters.isArchived !== undefined) {
+      params['isArchived'] = filters.isArchived.toString();
+    }
+
+    if (filters.lastEmailAtStart !== undefined) {
+      params['lastEmailAtStart'] = filters.lastEmailAtStart.toString();
+    }
+
+    if (filters.lastEmailAtEnd !== undefined) {
+      params['lastEmailAtEnd'] = filters.lastEmailAtEnd.toString();
+    }
+
+    if (filters.createdAtStart !== undefined) {
+      params['createdAtStart'] = filters.createdAtStart.toString();
+    }
+
+    if (filters.createdAtEnd !== undefined) {
+      params['createdAtEnd'] = filters.createdAtEnd.toString();
+    }
+
+    if (filters.generatedTags) {
+      params['generatedTags'] = filters.generatedTags;
     }
 
     if (filters.dynamicFieldValues) {

--- a/apps/dashboard/src/types/search.ts
+++ b/apps/dashboard/src/types/search.ts
@@ -109,6 +109,9 @@ export interface VespaSearchFilters {
   from?: string; // User IDs
   fromEmail?: string; // Desk-only: sender email address(es) for the mail `from:` filter
   toEmail?: string; // Desk-only: recipient email address(es) for the mail `to:` filter
+  ccEmail?: string; // Desk-only: cc address(es) for the mail `cc:` filter
+  bccEmail?: string; // Desk-only: bcc address(es) for the mail `bcc:` filter
+  filename?: string; // Desk-only: attachment file name token(s) for `filename:`
   with?: string; // User ID for participant filter (matches userId, threadMentions, threadSenders)
   in?: string; // Channel IDs (scope: within channel/DM)
   mentions?: string; // User IDs the message mentions (scoped mention search; bare @user chip)
@@ -135,6 +138,14 @@ export interface VespaSearchFilters {
   range?: string; // Time keyword (today, yesterday, this week, last 7 days, etc.)
   stage?: string; // Ticket stage
   assignee?: string; // Assigned user ID
+  userGroups?: string; // Comma-separated user group IDs
+  aiCategory?: string; // Comma-separated AI-assigned categories
+  isArchived?: boolean; // Restrict to archived / non-archived tickets
+  lastEmailAtStart?: number; // Epoch-ms bounds on the conversation's newest email
+  lastEmailAtEnd?: number;
+  createdAtStart?: number; // Epoch-ms bounds on ticket creation (inclusive)
+  createdAtEnd?: number;
+  generatedTags?: string; // Comma-separated "category:value" tag-framework tags
   dynamicFieldValues?: string | string[]; // Comma-separated or array of fieldId::value tokens
   dynamicFieldDateRanges?: Record<string, { start?: number; end?: number }>;
   subApp?: string; // Comma-separated sub-apps: 'canvas', 'transcript', 'RCA'

--- a/apps/dashboard/src/utils/board/dynamicFieldFilters.ts
+++ b/apps/dashboard/src/utils/board/dynamicFieldFilters.ts
@@ -148,3 +148,53 @@ export const ticketMatchesDynamicFieldEntries = (
   }
   return true;
 };
+
+export interface VespaDynamicFieldFilters {
+  /** `fieldId::value` tokens. */
+  dynamicFieldValues?: string[];
+  dynamicFieldDateRanges?: Record<string, { start?: number; end?: number }>;
+}
+
+/**
+ * The dynamic-field filters pushed into Vespa. Vespa matches a form field with
+ * `sameElement(fieldId contains X and fieldValue contains V)` — an exact whole-value
+ * comparison — and must never be stricter than the app, or it drops rows Zero would keep.
+ *
+ * SINGLE_SELECT / BOOLEAN / NUMBER compare exactly on both sides. MULTI_SELECT / USER are
+ * equivalent too: `buildFormFields` stores one struct element per selected value, so an OR
+ * over sameElement is the any-of match `matchesDynamicFieldValue` performs.
+ *
+ * STRING is pushed as Kanban already does, but `matchesDynamicFieldValue` matches substrings
+ * client-side, so the filter is exact with a search term active and substring without one.
+ * That asymmetry is pre-existing and shared with the Kanban board, so it is left alone.
+ */
+export const toVespaDynamicFieldFilters = (
+  entries: readonly DynamicFieldFilterEntry[],
+): VespaDynamicFieldFilters => {
+  const dynamicFieldValues: string[] = [];
+  const dynamicFieldDateRanges: Record<string, { start?: number; end?: number }> = {};
+
+  for (const entry of entries) {
+    if (Array.isArray(entry.value)) {
+      if (entry.fieldType === undefined) continue;
+      for (const raw of entry.value) {
+        const value = String(raw).trim();
+        if (value) dynamicFieldValues.push(`${entry.fieldId}::${value}`);
+      }
+      continue;
+    }
+
+    const { start, end } = entry.value;
+    if (start !== undefined || end !== undefined) {
+      dynamicFieldDateRanges[entry.fieldId] = {
+        ...(start !== undefined ? { start } : {}),
+        ...(end !== undefined ? { end } : {}),
+      };
+    }
+  }
+
+  return {
+    ...(dynamicFieldValues.length > 0 ? { dynamicFieldValues } : {}),
+    ...(Object.keys(dynamicFieldDateRanges).length > 0 ? { dynamicFieldDateRanges } : {}),
+  };
+};

--- a/apps/dashboard/src/utils/highlightTerms.ts
+++ b/apps/dashboard/src/utils/highlightTerms.ts
@@ -1,0 +1,45 @@
+export interface HighlightSegment {
+  text: string;
+  matched: boolean;
+}
+
+export const normalizeHighlightTerms = (terms: readonly string[]): string[] =>
+  terms.map(term => term.trim().toLowerCase()).filter(term => term.length > 1);
+
+/** The fragments Vespa wrapped in `<hi>` — the matched form of each term, as it appears
+ * in the document, so a stemmed match ("report" for "reports") can be highlighted. */
+export const extractVespaHighlights = (html: string | undefined): string[] =>
+  html ? Array.from(html.matchAll(/<hi>(.*?)<\/hi>/gi), match => match[1] ?? '') : [];
+
+/**
+ * Splits `text` into matched / unmatched runs against already-normalized `needles`, taking
+ * the earliest occurrence each step and the longest needle on a tie. Returns an empty array
+ * when nothing matched, so callers can leave the original text untouched.
+ */
+export const splitOnHighlightTerms = (text: string, needles: string[]): HighlightSegment[] => {
+  if (!text || needles.length === 0) return [];
+
+  const lower = text.toLowerCase();
+  const segments: HighlightSegment[] = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    let at = -1;
+    let length = 0;
+    for (const needle of needles) {
+      const found = lower.indexOf(needle, cursor);
+      if (found !== -1 && (at === -1 || found < at || (found === at && needle.length > length))) {
+        at = found;
+        length = needle.length;
+      }
+    }
+    if (at === -1) break;
+    if (at > cursor) segments.push({ text: text.slice(cursor, at), matched: false });
+    segments.push({ text: text.slice(at, at + length), matched: true });
+    cursor = at + length;
+  }
+
+  if (cursor === 0) return [];
+  if (cursor < text.length) segments.push({ text: text.slice(cursor), matched: false });
+  return segments;
+};

--- a/vespa-core/vespa/common/schemas/ticket.sd
+++ b/vespa-core/vespa/common/schemas/ticket.sd
@@ -106,6 +106,22 @@ schema ticket {
       indexing: attribute | summary
       attribute: fast-search
     }
+
+    # Max email timestamp of the ticket's conversation; the Desk list's sort key.
+    field lastEmailAt type long {
+      indexing: attribute | summary
+      attribute: fast-search
+    }
+
+    field isArchived type bool {
+      indexing: attribute | summary
+      attribute: fast-search
+    }
+
+    field aiCategory type string {
+      indexing: attribute | summary
+      attribute: fast-search
+    }
     field closedBy type string {
       indexing: attribute | summary
     }


### PR DESCRIPTION
POT : 

https://github.com/user-attachments/assets/19607f72-8aea-4313-bf3e-83af8abb7d69


Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

XYNE-62911 — Gmail-style inline search in the Desk module. Typing in the desk search box
narrows the conversation list in place, ranked by relevance, with the matched text marked in
the results.

**Search operators**, matching the chips the command palette already builds:
`from:` `to:` `cc:` `bcc:` `filename:`. Each maps to a `mail.sd` attribute; `ticket.sd` has no
sender, recipient or attachment fields, so any of them narrows the search to the mail source
alone. A bare ticket id (`PLAT-0042`) is detected and sent as an exact phrase, because the
default tokenizer splits it at the hyphen and would otherwise match every ticket in the
project without ranking the right one any higher.

**One query over two sources.** `mail` covers subject and body, `ticket` covers title and
description. Both carry `threadId` = conversationId, so a single query spans them and Vespa
groups the hits onto one relevance-ordered conversation list. Running two queries and merging
here could not do that — concatenating two ranked lists puts every mail match ahead of every
ticket-only match regardless of relevance.

**Vespa ranks, Zero decides.** Vespa returns conversation ids in rank order; Zero re-applies
every filter and the per-user ACL to those ids, so the two can never disagree about what a
user is allowed to see. Filters are additionally pushed into the Vespa query only as a budget
optimisation — so the ranked window is spent on rows Zero will keep — and only where the Vespa
semantics are no stricter than Zero's.

Pushed to the ticket source: `isArchived`, assignee, creator, priority, stage, user group,
AI category, created-at range, dynamic form-field values and date ranges. Pushed to both
sources: `generatedTags` and the last-email-at range.

**Highlighting.** Matched terms are marked in the row title and ticket-id chip, in the thread
header, and inside the email body. The body renders in a sandboxed iframe, so that pass runs
over the parsed, sanitised DOM before the srcdoc is assembled — walking text nodes rather than
replacing on the HTML string, which would corrupt tags and attributes.

**Paging.** Vespa returns a page of ranked conversation ids; the list requests a wider window
when Zero filters a page below a full screen, and asks for a deeper Vespa slice only when the
local window is exhausted and the index says more exists.

### Vespa schema

`ticket.sd` gains `lastEmailAt` (long), `isArchived` (bool) and `aiCategory` (string), all
`attribute | summary`. The matching change lives in the standalone `vespa-core` repo on
`feature/adding-fields-to-ticket-schema`.

**Rollout order: that schema must be deployed before this merges.** Vespa rejects a document
carrying a field its schema does not declare, so until it is live every ticket feed fails —
not just search. A full ticket re-feed is also needed before the `lastEmailAt` and `aiCategory`
filters return complete results: those attributes read as absent on documents indexed earlier,
so a date- or category-filtered search would omit them. (`isArchived` is unaffected — `bool` is
not nullable in Vespa, so an unset value reads as `false`.)


## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [x] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind

