### PR TITLE
feat: XYNE-62912 inside participant picker filter

### DIFF
--- a/apps/dashboard/src/hooks/useRecordingParticipants.ts
+++ b/apps/dashboard/src/hooks/useRecordingParticipants.ts
@@ -1,11 +1,15 @@
 import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { toast } from 'sonner';
 import type { User } from '@xyne/shared/machines';
-import { useActiveUsers, useUsersById, useSelf, searchUsers } from './useUsers';
+import { useUsersById, useSelf } from './useUsers';
+import { useRankedActivePeople } from './useRankedPeopleSearch';
 import { recordingService } from '../services/Recording/recordingService';
 import type { RecordingParticipantShare } from '../services/Recording/recordingService';
 import { getRecordingParticipantIds, logRecordingError } from '../utils/recordingUtils';
 import { getApiErrorMessage } from '../utils/apiError';
+
+/** Suggestions offered per keystroke. Everything above this is never decorated. */
+const RESULT_LIMIT = 6;
 
 interface UseRecordingParticipantsArgs {
   recordingExternalId: string;
@@ -50,7 +54,6 @@ export function useRecordingParticipants({
   const [pending, setPending] = useState<ReadonlyMap<string, 'add' | 'remove'>>(new Map());
   const searchRef = useRef<HTMLInputElement>(null);
 
-  const users = useActiveUsers();
   const usersById = useUsersById();
   const self = useSelf();
 
@@ -100,15 +103,35 @@ export function useRecordingParticipants({
   );
 
   const trimmedQuery = query.trim();
+
+  // Ranked with the shared people recipe (token match -> MFU affinity -> DM recency),
+  // the same one the recording share modal and the call pickers use. It replaces a
+  // `users.filter(...)` that copied the entire active roster on every keystroke just
+  // to drop the handful of people already added, and it gives this search two things
+  // the raw `searchUsers` call never had: affinity ordering, and the substring
+  // fallback that makes a single typed character match at all (Fuse's
+  // `minMatchCharLength: 2` silently returns nothing for one-character queries).
+  //
+  // Over-fetch by the current participant count so removing them below can still
+  // fill `RESULT_LIMIT`.
+  //
+  // `seedDmContactsAtRest` is off because the results list is hidden until something
+  // is typed — the browse state would be built over the whole roster and thrown away.
+  const rankedPeople = useRankedActivePeople(trimmedQuery, RESULT_LIMIT + participantIds.length, {
+    seedDmContactsAtRest: false,
+  });
+
   const results = useMemo(() => {
     if (!trimmedQuery) return [];
     const already = new Set(participantIds);
-    return searchUsers(
-      users.filter(user => !already.has(user.id)),
-      trimmedQuery,
-      6,
-    );
-  }, [trimmedQuery, users, participantIds]);
+    const matches: User[] = [];
+    for (const user of rankedPeople) {
+      if (already.has(user.id)) continue;
+      matches.push(user);
+      if (matches.length >= RESULT_LIMIT) break;
+    }
+    return matches;
+  }, [trimmedQuery, rankedPeople, participantIds]);
 
   useEffect(() => setHighlighted(0), [trimmedQuery]);
   const activeIndex = highlighted < results.length ? highlighted : 0;

--- a/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/RecordingsV2Screen.tsx
@@ -449,7 +449,6 @@ const RecordingsV2Screen = (): ReactElement => {
                 <RecordingDateFilter value={selectedDatePreset} onChange={setSelectedDatePreset} />
 
                 <RecordingPeopleFilter
-                  creators={users}
                   currentUserId={currentUser?.id}
                   selectedUserId={selectedCreatorId}
                   onUserChange={handleCreatorChange}

--- a/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingPeopleFilter.tsx
+++ b/apps/dashboard/src/routes/RecordingsV2Screen/components/RecordingPeopleFilter.tsx
@@ -5,75 +5,82 @@ import Avatar from '../../../components/ui/Avatar/Avatar';
 import { Button } from '../../../components/ui/Button/Button';
 import { EntitySelector } from '../../../components/ui/EntitySelector/EntitySelector';
 import type { SelectorOption } from '../../../components/ui/EntitySelector/EntitySelector.types';
+import { useRankedActivePeople } from '../../../hooks/useRankedPeopleSearch';
+import { useActiveUsers, useUser } from '../../../hooks/useUsers';
 import { cn } from '../../../utils/classNames';
-import { getUserDisplayName, matchesUserQuery } from '../../../utils/userDisplayName';
+import { getUserDisplayName } from '../../../utils/userDisplayName';
+
+/**
+ * Rows actually offered per keystroke. The filter targets a participant id that
+ * the recordings query resolves server-side, so the candidate pool is the whole
+ * workspace — but only the top-ranked slice ever becomes an option.
+ */
+const PEOPLE_LIMIT = 20;
 
 interface RecordingPeopleFilterProps {
-  creators: User[];
   currentUserId?: string | undefined;
   selectedUserId: string | null;
   onUserChange: (userId: string | null) => void;
 }
 
+/**
+ * Participant filter for the recordings list.
+ *
+ * Candidates come from `useRankedActivePeople` — the same token-match → MFU
+ * affinity → DM-recency recipe the recording share modal and the call pickers
+ * use — capped at `PEOPLE_LIMIT` *before* anything is decorated.
+ *
+ * That ordering is the fix. This filter used to be handed the complete workspace
+ * roster and, on every keystroke, substring-filter it and map every survivor into
+ * an option object carrying its own `<Avatar>` element — thousands of React
+ * elements per character typed, rendered into an unvirtualized dropdown. Ranking
+ * and slicing first means the work per keystroke is bounded by what is on screen,
+ * and the browse state now opens on frequent contacts instead of raw roster order.
+ */
 export function RecordingPeopleFilter({
-  creators,
   currentUserId,
   selectedUserId,
   onUserChange,
 }: RecordingPeopleFilterProps): ReactElement {
   const [searchValue, setSearchValue] = useState('');
 
-  const options = useMemo<SelectorOption[]>(() => {
-    const query = searchValue.trim().toLowerCase();
-    const matchedCreators = query
-      ? creators.filter(creator => matchesUserQuery(creator, searchValue))
-      : creators;
+  const rankedPeople = useRankedActivePeople(searchValue.trim(), PEOPLE_LIMIT);
+  // Resolved from the full roster (not the ranked slice): the trigger label and
+  // the checkmark must survive a query the selected person does not match, and a
+  // participant may since have been deactivated.
+  const selectedUser = useUser(selectedUserId ?? '');
+  const hasPeople = useActiveUsers().length > 0;
 
-    const creatorOptions = matchedCreators.map(creator => ({
-      value: creator.id,
-      label: `${getUserDisplayName(creator)}${creator.id === currentUserId ? ' (you)' : ''}`,
+  const options = useMemo<SelectorOption[]>(() => {
+    const toOption = (user: User): SelectorOption => ({
+      value: user.id,
+      label: `${getUserDisplayName(user)}${user.id === currentUserId ? ' (you)' : ''}`,
       icon: (
         <Avatar
-          userId={creator.id}
+          userId={user.id}
           size='sm'
           showActiveStatus={false}
           className='size-4 rounded-md flex items-center justify-center'
         />
       ),
-      subtitle: creator.email ?? null,
-    }));
+      subtitle: user.email ?? null,
+    });
 
-    const selectedCreator = creators.find(creator => creator.id === selectedUserId);
-    if (selectedCreator && !creatorOptions.some(option => option.value === selectedCreator.id)) {
-      return [
-        {
-          value: selectedCreator.id,
-          label: `${getUserDisplayName(selectedCreator)}${selectedCreator.id === currentUserId ? ' (you)' : ''}`,
-          icon: (
-            <Avatar
-              userId={selectedCreator.id}
-              size='sm'
-              showActiveStatus={false}
-              className='size-4 rounded-md flex items-center justify-center'
-            />
-          ),
-          subtitle: selectedCreator.email ?? null,
-        },
-        ...creatorOptions,
-      ];
+    const rows = rankedPeople.map(toOption);
+    if (selectedUser && !rankedPeople.some(person => person.id === selectedUser.id)) {
+      rows.unshift(toOption(selectedUser));
     }
+    return rows;
+  }, [rankedPeople, selectedUser, currentUserId]);
 
-    return creatorOptions;
-  }, [creators, currentUserId, searchValue, selectedUserId]);
-
-  if (creators.length === 0) {
+  if (!hasPeople) {
     return (
       <Button
         type='button'
         variant='outline'
         disabled
         className='h-9 gap-1 rounded-xl border-border px-3 font-medium shadow-none'
-        aria-label='People filter unavailable because there are no recordings'
+        aria-label='People filter unavailable because there are no people to filter by'
       >
         People
         <ChevronDown className='size-4' aria-hidden='true' />


### PR DESCRIPTION
https://drive.google.com/file/d/1qi8EA-posDNH5pAC3Io4CJJuw7Y4sgRw/view?usp=sharing

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
