### PR TITLE
feat: XYNE-62826 downtime prevention (cherry-pick #1442 into releases-20260904)

### DIFF
--- a/apps/backend/python-agent/config/env.py
+++ b/apps/backend/python-agent/config/env.py
@@ -98,7 +98,11 @@ class Config:
     # Backend API Configuration
     backend_url: str
     transcription_agent_api_key: str
-    
+    # LiveKit explicit-dispatch identity for this pod — which agentName the backend can
+    # target with createDispatch. Which role this build serves is decided outside this
+    # process entirely now (a human-edited Superposition config), not self-reported.
+    transcription_agent_name: str
+
     # Redis Configuration (matching TypeScript backend)
     redis_host: str
     redis_port: int
@@ -226,7 +230,8 @@ class Config:
             # Backend API
             backend_url=os.getenv("BACKEND_URL", "http://localhost:3001"),
             transcription_agent_api_key=os.getenv("TRANSCRIPTION_AGENT_API_KEY"),
-            
+            transcription_agent_name=os.getenv("LIVEKIT_TRANSCRIPTION_AGENT_NAME", "xyne-automatic"),
+
             # Redis (matching TypeScript: REDIS_HOST, REDIS_PORT, REDIS_PASSWORD, REDIS_TLS)
             redis_host=os.getenv("REDIS_HOST", "localhost"),
             redis_port=int(os.getenv("REDIS_PORT", "6379")),

--- a/apps/backend/python-agent/main.py
+++ b/apps/backend/python-agent/main.py
@@ -620,8 +620,15 @@ if __name__ == "__main__":
     start_health_server_background()
 
     # Run the LiveKit agent (blocks until shutdown)
+    # agent_name switches this worker from automatic dispatch (joins every room) to
+    # explicit dispatch — the backend must now request it by name via
+    # AgentDispatchClient.createDispatch. This is what makes zero-downtime, canary-tested
+    # agent rollouts possible: a new pod runs under a new agent_name and is invisible to
+    # real traffic until the backend (via this pod's own self-report, or a human fallback)
+    # rolls it into the 'stable' or 'test' slot.
     cli.run_app(WorkerOptions(
         entrypoint_fnc=entrypoint,
+        agent_name=config.transcription_agent_name,
         shutdown_process_timeout=60.0,
         job_memory_warn_mb=4096,
     ))

--- a/apps/backend/src/controllers/callController.ts
+++ b/apps/backend/src/controllers/callController.ts
@@ -508,6 +508,9 @@ export class CallController {
           }
         }
 
+        stage = 'transcription_agent_resolution';
+        const headlessAgentName = await livekitService.resolveAgentNameForUser(userId);
+
         const roomLink = buildCallInviteUrl(callExternalId);
         const roomMetadata = JSON.stringify({
           callType: CallType.HEADLESS,
@@ -517,6 +520,7 @@ export class CallController {
           notesCanvasId,
           detailedSummaryCanvasId,
           ...(channelId && conversationId ? { channelId, conversationId } : {}),
+          ...(headlessAgentName && { agentName: headlessAgentName }),
         });
 
         stage = 'livekit_room_creation';
@@ -527,6 +531,13 @@ export class CallController {
           metadata: roomMetadata,
         });
         logger.info(`[${callExternalId}] livekit_room_created | user_id=${userId}, path=note_taker`);
+
+        stage = 'transcription_agent_dispatch';
+        if (headlessAgentName) {
+          await livekitService.dispatchTranscriptionAgentForCall(callExternalId, headlessAgentName);
+        } else {
+          logger.error(`[${callExternalId}] transcription_agent_dispatch_skipped | reason=no_active_agent_name_configured`);
+        }
 
         stage = 'initiator_user_lookup';
         const initiator = await db.user.findUnique({ where: { id: userId }, select: { picture: true } });
@@ -761,6 +772,9 @@ export class CallController {
         }
       }
 
+      stage = 'transcription_agent_resolution';
+      const agentName = await livekitService.resolveAgentNameForUser(userId);
+
       // Create LiveKit room with metadata
       // The webhook will create all DB records when first participant joins
       const roomMetadata = JSON.stringify({
@@ -773,6 +787,7 @@ export class CallController {
         ...(linkedArtifactMessageId && { artifactMessageId: linkedArtifactMessageId }),
         ...(invitedUserIds && invitedUserIds.length > 0 && { invitedUserIds }),
         ...(validatedSdlcLink && { sdlcLink: validatedSdlcLink }),
+        ...(agentName && { agentName }),
       });
 
       stage = 'livekit_room_creation';
@@ -785,6 +800,16 @@ export class CallController {
 
       logger.info(`[${callExternalId}] livekit_room_created | user_id=${userId}`);
 
+      // Explicit dispatch — the worker now runs with agent_name set, so it no longer
+      // auto-joins; every call must be dispatched. Best-effort, with its own retry
+      // chain (dispatchTranscriptionAgentForCall); must not fail call creation.
+      stage = 'transcription_agent_dispatch';
+      if (agentName) {
+        await livekitService.dispatchTranscriptionAgentForCall(callExternalId, agentName);
+      } else {
+        logger.error(`[${callExternalId}] transcription_agent_dispatch_skipped | reason=no_active_agent_name_configured`);
+      }
+
       setTimeout(async () => {
         try {
           const room = await livekitService.getRoomInfo(callExternalId!);
@@ -796,6 +821,11 @@ export class CallController {
           const hasAgent = participants.some(p => p.identity.startsWith('agent-'));
           if (!hasAgent) {
             logger.error(`[${callExternalId}] agent_failed_to_join | reason=timeout_30s`);
+            // Second safety net behind dispatchTranscriptionAgentForCall's own ~9s claim
+            // check — covers e.g. a worker that claimed the job but crashed before publishing.
+            if (agentName) {
+              void livekitService.ensureTranscriptionAgent(callExternalId!, agentName, { reason: 'timeout_30s_no_agent_participant' });
+            }
           }
         } catch (error) {
           // Room might already be closed or API error, ignore as it's a best-effort diagnostic log
@@ -962,18 +992,24 @@ export class CallController {
           return;
         }
 
-        // If room exists (entered due to SCHEDULED status), delete it before creating a fresh one
+        // Resolved from the call's creator, not the joining participant — so the agent
+        // choice is deterministic regardless of which participant's join happens to
+        // trigger this block, rather than depending on join order.
+        const activeCall = call;
         if (roomInfo) {
           logger.info(`Found existing room ${callId}, deleting before creating new one`);
           await livekitService.deleteRoom(callId);
           logger.info(`Deleted existing room ${callId}`);
         }
 
+        const joinAgentName = await livekitService.resolveAgentNameForUser(activeCall.createdByUserId);
+
         // Prepare room metadata
         const roomMetadata = JSON.stringify({
           channelId: channel.id,
-          createdBy: call.createdByUserId,
-          ...(call.status === CallStatus.SCHEDULED && { scheduledCallId: call.id }),
+          createdBy: activeCall.createdByUserId,
+          ...(activeCall.status === CallStatus.SCHEDULED && { scheduledCallId: activeCall.id }),
+          ...(joinAgentName && { agentName: joinAgentName }),
         });
 
         // Create LiveKit room
@@ -984,6 +1020,19 @@ export class CallController {
           metadata: roomMetadata,
         });
 
+        if (joinAgentName) {
+          const dispatch = await livekitService.dispatchTranscriptionAgentForCall(callId, joinAgentName);
+          await repositories.calls.update(activeCall.id, {
+            metadata: {
+              ...(activeCall.metadata as Record<string, unknown> ?? {}),
+              agentName: joinAgentName,
+              ...(dispatch?.dispatchId && { dispatchId: dispatch.dispatchId }),
+              dispatchStatus: dispatch ? 'dispatched' : 'failed',
+            },
+          });
+        } else {
+          logger.error(`[${callId}] transcription_agent_dispatch_skipped | reason=no_active_agent_name_configured`);
+        }
       }
 
       // Removed users re-enter through the admit queue.

--- a/apps/backend/src/controllers/livekitWebhookController.ts
+++ b/apps/backend/src/controllers/livekitWebhookController.ts
@@ -259,6 +259,10 @@ class LiveKitWebhookController {
       numParticipants: event.room?.numParticipants,
     });
 
+    // Tear down this room's redispatch retry chain — without this it survives the call it
+    // exists for, sleeping up to 10 minutes before rediscovering the room is already gone.
+    livekitService.cancelRedispatchWatch(callId);
+
     try {
       const now = new Date();
 
@@ -351,9 +355,19 @@ class LiveKitWebhookController {
       name: participant?.name,
     });
 
-    // Skip agent participants
+    // Skip agent participants — but record that this call's dispatched agent actually
+    // joined, so dispatchStatus reflects reality (and the ~9s unclaimed-job check
+    // doesn't fire a needless redispatch for a dispatch that in fact succeeded).
     if (participant.identity.startsWith('agent-')) {
       logger.info(`[LiveKit Webhook] Skipping agent participant: ${participant.identity}`);
+      const existingCall = await repositories.calls.findByExternalId(roomName).catch(() => null);
+      if (existingCall) {
+        await repositories.calls.update(existingCall.id, {
+          metadata: { ...(existingCall.metadata as Record<string, unknown> ?? {}), dispatchStatus: 'joined' },
+        }).catch((error) => {
+          logger.warn(`[LiveKit Webhook] dispatch_status_update_failed | room=${roomName}, error=${error}`);
+        });
+      }
       return;
     }
 
@@ -393,6 +407,7 @@ class LiveKitWebhookController {
         const existingConversationId = roomMetadata.conversationId;
         const artifactMessageId = roomMetadata.artifactMessageId;
         const invitedUserIds = roomMetadata.invitedUserIds; // Selected participants for conversation calls
+        const agentName = typeof roomMetadata.agentName === 'string' ? roomMetadata.agentName : undefined;
 
         if (!channelId) {
           logger.error(`[LiveKit Webhook] Missing channelId in room metadata for ${roomName}`);
@@ -480,6 +495,8 @@ class LiveKitWebhookController {
           now,
           callOrigin,
           ...(typeof artifactMessageId === 'string' && { artifactMessageId }),
+          agentName,
+          dispatchStatus: agentName ? 'dispatched' : undefined,
         }).catch((txError) => {
           logger.error('[LiveKit Webhook] call_record_creation_failed', {
             stage: 'call_record_creation',
@@ -714,9 +731,24 @@ class LiveKitWebhookController {
       name: participant?.name,
     });
 
-    // Skip agent participants early
+    // Skip agent participants early — but trigger recovery: the agent leaving mid-call
+    // needs a redispatch to the SAME pinned agent, not a silent skip. This is what keeps
+    // a call transcribed through a worker crash once explicit dispatch has replaced the
+    // ambient automatic-dispatch pool.
     if (participant.identity.startsWith('agent-')) {
       logger.info(`[LiveKit Webhook] Skipping agent participant: ${participant.identity}`);
+      const leftCall = await repositories.calls.findByExternalId(callId).catch(() => null);
+      const pinnedAgentName = (leftCall?.metadata as { agentName?: string } | null)?.agentName;
+      if (pinnedAgentName) {
+        livekitService.ensureTranscriptionAgent(callId, pinnedAgentName, {
+          excludeIdentity: participant.identity,
+          reason: 'participant_left',
+        }).catch((error) => {
+          logger.error(`[LiveKit Webhook] ensure_transcription_agent_failed | room=${callId}, error=${error}`);
+        });
+      } else {
+        logger.warn(`[LiveKit Webhook] agent_left_no_pinned_agent_name | room=${callId}, cannot_redispatch`);
+      }
       return;
     }
 

--- a/apps/backend/src/database/repositories/callRepository.ts
+++ b/apps/backend/src/database/repositories/callRepository.ts
@@ -1419,6 +1419,9 @@ export class CallRepository {
       now: Date;
       callOrigin?: CallOrigin;
       artifactMessageId?: string;
+      /** Transcription agent this call was pinned to at creation time (from room metadata). */
+      agentName?: string;
+      dispatchStatus?: string;
     }
   ): Promise<{ call: Call; invitedParticipantIds: string[] }> {
     const {
@@ -1436,6 +1439,8 @@ export class CallRepository {
       now,
       callOrigin,
       artifactMessageId,
+      agentName,
+      dispatchStatus,
     } = params;
 
     const isHeadless = callType === CallType.HEADLESS;
@@ -1466,6 +1471,8 @@ export class CallRepository {
             systemMessageId: messageId,
             conversationId,
             ...(artifactMessageId && { artifactMessageId }),
+            ...(agentName && { agentName }),
+            ...(dispatchStatus && { dispatchStatus }),
           },
         },
       });

--- a/apps/backend/src/database/repositories/index.ts
+++ b/apps/backend/src/database/repositories/index.ts
@@ -25,7 +25,7 @@ export { UserRepository } from './users';
 export { ResourceRepository } from './resources';
 export { ResourceAccessRepository } from './resourceAccess';
 export { ACLAuditLogRepository } from './aclAuditLogs';
-export { 
+export {
   NotificationRepository, 
   NotificationPreferenceRepository, 
   BrowserNotificationSubscriptionRepository 
@@ -93,8 +93,8 @@ import { UserRepository } from './users';
 import { ResourceRepository } from './resources';
 import { ResourceAccessRepository } from './resourceAccess';
 import { ACLAuditLogRepository } from './aclAuditLogs';
-import { 
-  NotificationRepository, 
+import {
+  NotificationRepository,
   NotificationPreferenceRepository, 
   BrowserNotificationSubscriptionRepository 
 } from './notificationRepository';
@@ -270,4 +270,11 @@ export class RepositoryContainer {
   }
 }
 
-export const repositories = RepositoryContainer.getInstance();
+// Delay construction until a repository is first used. Constructing the
+// entire container during module evaluation makes any repository that imports
+// this barrel vulnerable to circular-import temporal dead zones.
+export const repositories: RepositoryContainer = new Proxy({} as RepositoryContainer, {
+  get(_target, property: keyof RepositoryContainer) {
+    return RepositoryContainer.getInstance()[property];
+  },
+});

--- a/apps/backend/src/services/liveKitService.ts
+++ b/apps/backend/src/services/liveKitService.ts
@@ -1,13 +1,95 @@
 import {
   RoomServiceClient,
   AccessToken,
+  AgentDispatchClient,
   TrackSource,
   TwirpError,
   type ParticipantInfo,
 } from 'livekit-server-sdk';
+import { ParticipantInfo_Kind } from '@livekit/protocol';
 import { config } from '@/config/env';
 import { logger } from '@/utils/logger';
+import { redisService } from '@/services/redisService';
+import { repositories } from '@/database/repositories';
+import { superpositionClient } from '@/services/superpositionClient';
 import { DEFAULT_HOST_CONTROLS, normalizeHostControls, type HostControls } from '@xyne/shared';
+
+/** Open-ended role/slot name ('default', 'test', or any future canary arm) — not a fixed enum. */
+type TranscriptionAgentRole = string;
+const DEFAULT_TRANSCRIPTION_AGENT_ROLE = 'default';
+
+/**
+ * Superposition config key holding every role's current agent build, as one JSON object —
+ * {"default": {"agentName": "...", "url": "..."}, "test": {...}} — edited directly by
+ * whoever deploys a build. A single object (not one flag per role) is what keeps roles
+ * open-ended: a new canary slot is just a new key, no code change needed here.
+ */
+const TRANSCRIPTION_AGENT_ROLES_CONFIG_KEY = 'transcription_agent_roles';
+
+/** How long to wait for an agent's own health check before treating it as unreachable. */
+const AGENT_HEALTH_CHECK_TIMEOUT_MS = 3 * 1000;
+
+interface ConfiguredTranscriptionAgent {
+  agentName: string;
+  url: string;
+}
+
+/**
+ * Superposition/CAC flag naming which agent role/slot a call creator routes to (e.g.
+ * 'default', 'test', or any future slot — open-ended, not a fixed set). Placeholder key
+ * — needs an actual flag created in Superposition's dashboard (outside this repo) before
+ * this does anything but fall through to NO_EXPLICIT_DISPATCH.
+ */
+const TRANSCRIPTION_AGENT_ROLE_FLAG = 'transcription_agent_role';
+
+/**
+ * Superposition's own stored default-config value for TRANSCRIPTION_AGENT_ROLE_FLAG —
+ * NOT a DB role name, and deliberately distinct from DEFAULT_TRANSCRIPTION_AGENT_ROLE.
+ * Every user without an explicit per-user CAC context override resolves to this value,
+ * which means it must mean "skip explicit dispatch, automatic dispatch is this user's
+ * only agent" — never "look up the DB's 'default' slot." That DB slot is reserved for
+ * CAC-listed users' own fallback (see resolveAgentName) — it must never be reachable by
+ * a user who was never explicitly routed anywhere, or every unlisted user would start
+ * getting a duplicate explicit dispatch the moment 'default' gets an active row.
+ */
+const NO_EXPLICIT_DISPATCH = 'none';
+
+/**
+ * Retry pacing for the agent-missing watch loop: 30s, 1m, 2m, 4m, 8m, then every 10m, each
+ * plus 1-10s of jitter. Unbounded on purpose — under explicit dispatch there is no ambient
+ * worker pool to fall back on, so a call that loses its agent must keep retrying for as long
+ * as the call itself runs. This same loop handles both "agent crashed mid-call" and "agent
+ * pod is temporarily at capacity" — LiveKit gives no way to tell those apart (see
+ * `checkDispatchClaimed` below), so both are just retried rather than distinguished.
+ */
+const REDISPATCH_RETRY_INITIAL_MS = 30 * 1000;
+const REDISPATCH_RETRY_MAX_MS = 10 * 60 * 1000;
+const REDISPATCH_JITTER_MIN_MS = 1000;
+const REDISPATCH_JITTER_MAX_MS = 10 * 1000;
+
+/** Serializes re-dispatches for one room against duplicate webhook deliveries/replicas. */
+const REDISPATCH_COOLDOWN_SECONDS = 15;
+const redispatchCooldownKey = (roomName: string) => `livekit:agent-redispatch:cooldown:${roomName}`;
+
+/** How long after createDispatch we check whether any worker actually claimed the job. */
+const DISPATCH_CLAIM_CHECK_DELAY_MS = 9 * 1000;
+
+function nextRedispatchDelayMs(retryIndex: number): number {
+  const backoffMs = Math.min(REDISPATCH_RETRY_INITIAL_MS * 2 ** retryIndex, REDISPATCH_RETRY_MAX_MS);
+  const jitterMs = REDISPATCH_JITTER_MIN_MS + Math.random() * (REDISPATCH_JITTER_MAX_MS - REDISPATCH_JITTER_MIN_MS);
+  return Math.round(backoffMs + jitterMs);
+}
+
+type RedispatchOutcome = 'dispatched' | 'dispatch_failed' | 'cooldown_active' | 'agent_present' | 'room_inactive' | 'no_humans' | 'error';
+const TERMINAL_REDISPATCH_OUTCOMES = new Set<RedispatchOutcome>(['agent_present', 'room_inactive', 'no_humans']);
+
+export function isAgentParticipant(participant: ParticipantInfo): boolean {
+  return participant.kind === ParticipantInfo_Kind.AGENT || participant.identity.startsWith('agent-');
+}
+
+export function isHumanParticipant(participant: ParticipantInfo): boolean {
+  return !isAgentParticipant(participant) && participant.kind !== ParticipantInfo_Kind.EGRESS;
+}
 
 export interface LiveKitRoomOptions {
   name: string;
@@ -88,6 +170,9 @@ function parseRoomMetadata(
 export class LiveKitService {
   private static instance: LiveKitService;
   private roomService: RoomServiceClient;
+  private agentDispatch: AgentDispatchClient;
+  /** Rooms being watched for a missing transcription agent — one retry chain per room. */
+  private redispatchWatchers = new Map<string, NodeJS.Timeout>();
   private apiKey: string;
   private apiSecret: string;
   private serverUrl: string;
@@ -103,6 +188,13 @@ export class LiveKitService {
 
     // Initialize room service client
     this.roomService = new RoomServiceClient(
+      this.livekitUrl,
+      this.apiKey,
+      this.apiSecret,
+    );
+
+    // Explicit agent dispatch client (routes the transcription agent into rooms)
+    this.agentDispatch = new AgentDispatchClient(
       this.livekitUrl,
       this.apiKey,
       this.apiSecret,
@@ -137,6 +229,353 @@ export class LiveKitService {
       throw error;
     }
   }
+
+  /**
+   * Resolves both the role (via the Superposition/CAC role flag, evaluated for the call
+   * creator) and the agent_name to dispatch, in one call — this is what a call creation
+   * site actually wants. The flag returns an open-ended role string (any value the DB
+   * currently has an active row for), not a fixed set — adding a new slot (a 3rd, 4th
+   * canary arm, etc.) needs zero code changes here, only a rollout call naming it and a
+   * CAC change routing some users to it. The flag key below is a placeholder pending an
+   * actual flag being created in Superposition's dashboard (outside this repo) — confirm
+   * the real key name before relying on this in anything but a test environment.
+   */
+  async resolveAgentNameForUser(userId: string): Promise<string | null> {
+    let role: string;
+    try {
+      role = await superpositionClient.getStringValue(
+        TRANSCRIPTION_AGENT_ROLE_FLAG,
+        NO_EXPLICIT_DISPATCH,
+        { userId },
+      );
+    } catch (error) {
+      // CAC/user-matching failure: treat exactly like an unlisted user rather than
+      // falling back to DEFAULT_TRANSCRIPTION_AGENT_ROLE — a Superposition outage must
+      // not suddenly hand every production user a second explicit-dispatch agent.
+      // Automatic dispatch is still there regardless, so this fails safe either way.
+      logger.error(`transcription_agent_role_resolution_failed | userId=${userId}, error=${error}, falling_back_to=no_explicit_dispatch`);
+      return null;
+    }
+
+    if (role === NO_EXPLICIT_DISPATCH) return null;
+    return this.resolveAgentName(role);
+  }
+
+  /**
+   * Every role's current {agentName, url}, read fresh from Superposition on every call —
+   * no cache, since a stale read here just means an extra ~3s health-check timeout on an
+   * already-rolled-back name, not a correctness issue. `getObjectValue` already fails
+   * closed to `{}` internally on any CAC error, so no separate try/catch is needed here.
+   */
+  private async getConfiguredAgentRoles(): Promise<Record<string, ConfiguredTranscriptionAgent>> {
+    const value = await superpositionClient.getObjectValue(TRANSCRIPTION_AGENT_ROLES_CONFIG_KEY, {});
+    return (value ?? {}) as unknown as Record<string, ConfiguredTranscriptionAgent>;
+  }
+
+  /**
+   * Fast pre-filter, not a replacement for the ~9s post-dispatch claim-check below: a
+   * bounded-timeout HTTP GET against the agent's own self-reported health. Any error,
+   * non-OK response, or timeout is treated as unhealthy — erring toward trying the
+   * fallback role quickly rather than dispatching to a name we already have reason to
+   * doubt, since the claim-check remains the real authority regardless of which way this
+   * check turns out to be wrong.
+   */
+  private async checkAgentHealthy(url: string): Promise<boolean> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), AGENT_HEALTH_CHECK_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, { signal: controller.signal });
+      return response.ok;
+    } catch (error) {
+      logger.warn(`transcription_agent_health_check_failed | url=${url}, error=${error}`);
+      return false;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * Resolves which agent_name should be dispatched for a NEW call in `role`. Any
+   * non-default role falls back to `DEFAULT_TRANSCRIPTION_AGENT_ROLE` when nothing
+   * currently holds that slot OR the holder's health check fails — this is the only
+   * fallback rule for initial resolution; a role that resolves healthy here but still
+   * isn't claimable moments later is a different situation, handled by the retry loop
+   * below, not by silently jumping to another role mid-attempt.
+   */
+  async resolveAgentName(role: TranscriptionAgentRole): Promise<string | null> {
+    const roles = await this.getConfiguredAgentRoles();
+
+    const primary = roles[role];
+    if (primary && (await this.checkAgentHealthy(primary.url))) {
+      return primary.agentName;
+    }
+
+    if (role === DEFAULT_TRANSCRIPTION_AGENT_ROLE) return null;
+
+    const fallback = roles[DEFAULT_TRANSCRIPTION_AGENT_ROLE];
+    if (fallback && (await this.checkAgentHealthy(fallback.url))) {
+      return fallback.agentName;
+    }
+    return null;
+  }
+
+  /** Bare explicit-dispatch call — best-effort, never throws. Returns null on failure. */
+  private async dispatchTranscriptionAgent(roomName: string, agentName: string) {
+    try {
+      const dispatch = await this.agentDispatch.createDispatch(roomName, agentName);
+      logger.info(`[${roomName}] transcription_agent_dispatched | dispatch_id=${dispatch.id}, agent=${agentName}`);
+      return dispatch;
+    } catch (error) {
+      logger.error(`[${roomName}] transcription_agent_dispatch_failed | agent=${agentName}, error=${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * Explicitly dispatches `agentName` into `roomName` for a real call. Fire-and-forget
+   * from the caller's perspective: on success, schedules a one-shot check ~9s later
+   * (`checkDispatchClaimed`) that arms the crash-redispatch loop if nothing claimed it.
+   * On the `createDispatch` call itself throwing, arms the same loop immediately.
+   */
+  async dispatchTranscriptionAgentForCall(roomName: string, agentName: string): Promise<{ dispatchId: string } | null> {
+    const dispatch = await this.dispatchTranscriptionAgent(roomName, agentName);
+    if (!dispatch) {
+      void this.ensureTranscriptionAgent(roomName, agentName, { reason: 'initial_dispatch_call_failed' });
+      return null;
+    }
+
+    this.scheduleClaimCheck(roomName, dispatch.id, agentName, { allowFallback: true });
+    return { dispatchId: dispatch.id };
+  }
+
+  private scheduleClaimCheck(roomName: string, dispatchId: string, agentName: string, options: { allowFallback: boolean }): void {
+    const timer = setTimeout(() => {
+      this.checkDispatchClaimed(roomName, dispatchId, agentName, options.allowFallback).catch((error) => {
+        logger.warn(`[${roomName}] dispatch_claim_check_failed | dispatch_id=${dispatchId}, error=${error}`);
+      });
+    }, DISPATCH_CLAIM_CHECK_DELAY_MS);
+    timer.unref?.();
+  }
+
+  /**
+   * Fires ~9s after a per-call dispatch. LiveKit's `createDispatch` never validates
+   * `agentName` and never errors — a typo'd name and a pod at capacity both look
+   * identical (`JS_PENDING`, empty `workerId`) forever. We deliberately don't try to
+   * tell them apart: bad name, dead pod, timeout — anything unclaimed gets the same
+   * treatment.
+   *
+   * `allowFallback` is what keeps this fail-fast substitution scoped to the INITIAL
+   * dispatch only: nobody has joined expecting continuity from a specific agent build
+   * yet at this point, so swapping straight to the default agent (one substitution,
+   * never chained further) is safe and fast — no 30s-plus wait through the unbounded
+   * crash-redispatch backoff before the call gets *any* working agent. A mid-call crash
+   * (`redispatchTranscriptionAgentIfMissing`) intentionally does NOT go through this path
+   * — it keeps retrying the SAME pinned agent, since silently swapping an agent out from
+   * under an in-progress call is a bigger, more disruptive change (would need a
+   * user-visible signal / manual control, not an automatic silent swap).
+   */
+  private async checkDispatchClaimed(roomName: string, dispatchId: string, agentName: string, allowFallback: boolean): Promise<void> {
+    const claimed = await this.isDispatchClaimed(roomName, dispatchId);
+    if (claimed) return;
+
+    if (claimed === null) {
+      // The claim check itself failed — this says nothing about whether a worker
+      // actually claimed the job (it may well have). Dispatching a second, differently-
+      // named fallback agent on this guess risks two live agents in the same room, so
+      // don't fast-fallback here: defer to the presence-checked redispatch path, which
+      // will see the original agent is already there and no-op if so.
+      logger.warn(`[${roomName}] dispatch_claim_check_indeterminate | dispatch_id=${dispatchId}, agent=${agentName}`);
+      await this.ensureTranscriptionAgent(roomName, agentName, { reason: 'dispatch_claim_check_indeterminate' });
+      return;
+    }
+
+    logger.error(`[${roomName}] transcription_agent_dispatch_unclaimed | dispatch_id=${dispatchId}, agent=${agentName}, allow_fallback=${allowFallback}`);
+
+    const fallbackAgentName = allowFallback ? await this.resolveFallbackAgentName(agentName) : null;
+    if (fallbackAgentName) {
+      logger.error(`[${roomName}] transcription_agent_fallback_to_default | from=${agentName}, to=${fallbackAgentName}, reason=dispatch_unclaimed`);
+      await this.dispatchFallbackAgent(roomName, fallbackAgentName);
+      return;
+    }
+
+    await this.ensureTranscriptionAgent(roomName, agentName, { reason: 'dispatch_unclaimed' });
+  }
+
+  /** Null when there's nothing to fall back to (default IS the agent that just failed, or isn't configured). */
+  private async resolveFallbackAgentName(failedAgentName: string): Promise<string | null> {
+    const roles = await this.getConfiguredAgentRoles();
+    const fallback = roles[DEFAULT_TRANSCRIPTION_AGENT_ROLE];
+    if (!fallback || fallback.agentName === failedAgentName) return null;
+    return fallback.agentName;
+  }
+
+  /**
+   * One-shot substitution dispatch, plus a claim-check on the fallback itself
+   * (`allowFallback: false` — if even the default agent doesn't get claimed, there's
+   * nothing left to substitute, so that path drops into the ordinary unbounded
+   * crash-redispatch loop like any other "agent missing" case).
+   */
+  private async dispatchFallbackAgent(roomName: string, fallbackAgentName: string): Promise<void> {
+    const dispatch = await this.dispatchTranscriptionAgent(roomName, fallbackAgentName);
+
+    const call = await repositories.calls.findByExternalId(roomName);
+    if (call) {
+      await repositories.calls.update(call.id, {
+        metadata: {
+          ...(call.metadata as Record<string, unknown> ?? {}),
+          agentName: fallbackAgentName,
+          ...(dispatch?.id && { dispatchId: dispatch.id }),
+          dispatchStatus: dispatch ? 'fallback_dispatched' : 'failed',
+        },
+      });
+    }
+
+    if (!dispatch) {
+      void this.ensureTranscriptionAgent(roomName, fallbackAgentName, { reason: 'fallback_dispatch_call_failed' });
+      return;
+    }
+
+    this.scheduleClaimCheck(roomName, dispatch.id, fallbackAgentName, { allowFallback: false });
+  }
+
+  /** Null means the check itself failed — genuinely unknown, not "confirmed unclaimed". */
+  private async isDispatchClaimed(roomName: string, dispatchId: string): Promise<boolean | null> {
+    try {
+      const dispatch = await this.agentDispatch.getDispatch(dispatchId, roomName);
+      const job = dispatch?.state?.jobs?.[0];
+      return Boolean(job?.state?.workerId);
+    } catch (error) {
+      logger.warn(`[${roomName}] dispatch_claim_check_call_failed | dispatch_id=${dispatchId}, error=${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * Identities in `roomName` running under `agentName`. Goes through the dispatch API
+   * because `listParticipants` has no agent_name field.
+   */
+  private async liveAgentIdentitiesForName(roomName: string, agentName: string): Promise<Set<string> | null> {
+    try {
+      const dispatches = await this.agentDispatch.listDispatch(roomName);
+      const identities = new Set<string>();
+      for (const dispatch of dispatches) {
+        if (dispatch.agentName !== agentName) continue;
+        for (const job of dispatch.state?.jobs ?? []) {
+          const identity = job.state?.participantIdentity;
+          if (identity) identities.add(identity);
+        }
+      }
+      return identities;
+    } catch (error) {
+      logger.warn(`[${roomName}] agent_dispatch_list_failed | agent=${agentName}, error=${error}`);
+      return null;
+    }
+  }
+
+  /** One re-dispatch attempt into a room that is still live but has lost its agent. Never throws. */
+  async redispatchTranscriptionAgentIfMissing(
+    roomName: string,
+    agentName: string,
+    options: { excludeIdentity?: string; reason: string; attempt?: number },
+  ): Promise<RedispatchOutcome> {
+    const { excludeIdentity, reason, attempt = 0 } = options;
+
+    try {
+      if (!(await this.acquireRedispatchCooldown(roomName))) {
+        logger.info(`[${roomName}] agent_redispatch_skipped | reason=cooldown_active, trigger=${reason}`);
+        return 'cooldown_active';
+      }
+
+      const room = await this.getRoomInfo(roomName);
+      if (!room) {
+        logger.info(`[${roomName}] agent_redispatch_stopped | reason=room_not_active, trigger=${reason}`);
+        return 'room_inactive';
+      }
+
+      const participants = await this.listParticipants(roomName);
+      const remaining = participants.filter((p) => p.identity !== excludeIdentity);
+
+      if (!remaining.some(isHumanParticipant)) {
+        logger.info(`[${roomName}] agent_redispatch_stopped | reason=no_human_participants, trigger=${reason}`);
+        return 'no_humans';
+      }
+
+      const liveAgentIdentities = await this.liveAgentIdentitiesForName(roomName, agentName);
+      const agentStillPresent = liveAgentIdentities
+        ? remaining.some((p) => liveAgentIdentities.has(p.identity))
+        : remaining.some(isAgentParticipant);
+
+      if (agentStillPresent) {
+        logger.info(`[${roomName}] agent_redispatch_stopped | reason=agent_already_present, trigger=${reason}`);
+        return 'agent_present';
+      }
+
+      logger.info(`[${roomName}] agent_redispatch_attempt | attempt=${attempt}, trigger=${reason}, agent=${agentName}, humans=${remaining.filter(isHumanParticipant).length}`);
+
+      const dispatch = await this.dispatchTranscriptionAgent(roomName, agentName);
+      return dispatch ? 'dispatched' : 'dispatch_failed';
+    } catch (error) {
+      logger.error(`[${roomName}] agent_redispatch_failed | trigger=${reason}, error=${error}`);
+      return 'error';
+    }
+  }
+
+  /** Unbounded backoff loop — keeps retrying until the agent rejoins, the call ends, or everyone leaves. */
+  private scheduleRedispatchWatch(roomName: string, agentName: string, excludeIdentity?: string, retryIndex = 0): void {
+    if (this.redispatchWatchers.has(roomName)) return;
+
+    const delayMs = nextRedispatchDelayMs(retryIndex);
+    logger.info(`[${roomName}] agent_redispatch_watch_scheduled | retry_index=${retryIndex}, next_check_in_ms=${delayMs}`);
+
+    const timer = setTimeout(async () => {
+      this.redispatchWatchers.delete(roomName);
+
+      const outcome = await this.redispatchTranscriptionAgentIfMissing(roomName, agentName, {
+        excludeIdentity,
+        reason: 'redispatch_watch',
+        attempt: retryIndex + 1,
+      });
+
+      if (!TERMINAL_REDISPATCH_OUTCOMES.has(outcome)) {
+        this.scheduleRedispatchWatch(roomName, agentName, excludeIdentity, retryIndex + 1);
+      }
+    }, delayMs);
+
+    timer.unref?.();
+    this.redispatchWatchers.set(roomName, timer);
+  }
+
+  /** Entry point for "the transcription agent is missing" — one immediate attempt, then a backoff watch. */
+  async ensureTranscriptionAgent(
+    roomName: string,
+    agentName: string,
+    options: { excludeIdentity?: string; reason: string },
+  ): Promise<void> {
+    const outcome = await this.redispatchTranscriptionAgentIfMissing(roomName, agentName, options);
+    if (!TERMINAL_REDISPATCH_OUTCOMES.has(outcome)) {
+      this.scheduleRedispatchWatch(roomName, agentName, options.excludeIdentity);
+    }
+  }
+
+  /** Tear down a room's retry chain because its call ended. */
+  cancelRedispatchWatch(roomName: string): void {
+    const timer = this.redispatchWatchers.get(roomName);
+    if (!timer) return;
+    clearTimeout(timer);
+    this.redispatchWatchers.delete(roomName);
+    logger.info(`[${roomName}] agent_redispatch_watch_cancelled | reason=call_ended`);
+  }
+
+  /** Fails OPEN: if Redis is down the feature must not silently switch off. */
+  private async acquireRedispatchCooldown(roomName: string): Promise<boolean> {
+    try {
+      return await redisService.set(redispatchCooldownKey(roomName), String(Date.now()), REDISPATCH_COOLDOWN_SECONDS, true);
+    } catch (error) {
+      logger.warn(`[${roomName}] agent_redispatch_cooldown_unavailable | proceeding_without_guard, error=${error}`);
+      return true;
+    }
+  }
+
   async muteTrack(roomName: string, identity: string, trackSid: string, muted: boolean): Promise<void> {
     try {
       await this.roomService.mutePublishedTrack(roomName, identity, trackSid, muted);


### PR DESCRIPTION
Cherry-pick of #1442 (`feat: XYNE-62826 downtime prevention`) into releases-20260904.

Squash commit bf7fd7c cherry-picked cleanly. 7 files changed, 557 insertions(+), 11 deletions(-).

Files:
- apps/backend/python-agent/config/env.py
- apps/backend/python-agent/main.py
- apps/backend/src/controllers/callController.ts
- apps/backend/src/controllers/livekitWebhookController.ts
- apps/backend/src/database/repositories/callRepository.ts
- apps/backend/src/database/repositories/index.ts
- apps/backend/src/services/liveKitService.ts