### PR TITLE
fix: attach shortcut sends files to the thread instead of the focused channel composer

### DIFF
--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -416,11 +416,18 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
         fileInputRef.current.click();
       },
       {
-        enabled: Boolean(features.fileAttachments) && !disabled && !isSending,
+        // Focus-gate so a mounted-but-unfocused composer (e.g. the channel
+        // composer while a thread is open) doesn't also hold this binding.
+        // Without it, both composers register composer.attach at equal scope/
+        // priority and the resolver's last tie-break (registration order) sends
+        // the file into whichever mounted later — usually the thread.
+        enabled: isFocused && Boolean(features.fileAttachments) && !disabled && !isSending,
       },
     );
 
-    useShortcutById('composer.voiceInput', () => voiceInputRef.current?.toggle());
+    useShortcutById('composer.voiceInput', () => voiceInputRef.current?.toggle(), {
+      enabled: isFocused && !disabled && !isSending,
+    });
 
     useEffect(() => {
       if (!isVoiceRecording) return;


### PR DESCRIPTION
## Problem
With a thread panel open, using the attach keyboard shortcut (`mod+O`) while the **channel** composer is focused sent the file into the **thread** composer instead. The voice-input shortcut had the same latent bug.

## Root cause
When a thread is open, two `InputBox` composers are mounted (channel + thread) and each registers the `composer.attach` (and `composer.voiceInput`) shortcut. The scope push is focus-gated — `useScope('composer', isFocused && !disabled && !isSending)` — but the shortcut *handlers* were not. So both bindings matched the single `composer` scope at equal priority, and the resolver's final tie-break in `shortcutsRegistry.ts` (`resolveShortcut`) is registration order — newest wins. The thread composer registers later, so its `fileInputRef` opened regardless of which composer was actually focused.

## Fix
Gate both shortcut handlers on `isFocused` so only the focused composer's binding is live, matching the existing scope gate. Frontend-only, 2 logical lines in `apps/dashboard/src/components/ui/InputBox/InputBox.tsx`. `tsc --noEmit` on the dashboard passes.

## Testing
- Open a channel + a thread. Focus the channel composer, press `mod+O` → picker attaches to the channel. Focus the thread composer, press `mod+O` → picker attaches to the thread.
- Confirm the dev `Ambiguous shortcut resolution for "mod+o"` warning no longer fires with a thread open.
- Repeat the focus check for the voice-input shortcut.
