### PR TITLE
fix: XYNE-62304 show attachment label when DM preview content is empty markup

### DIFF
--- a/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
+++ b/apps/dashboard/src/components/Chat/DirectMessages/DmListItem.tsx
@@ -20,7 +20,7 @@ import { useUser } from '../../../hooks/useUsers';
 import { StatusIndicator } from '../../ui/StatusIndicator';
 import { getInitialMessageFromConversation } from '../../../utils/conversationMessageHelpers';
 import { RenderMessageWithHTML } from '../../Chat/RenderMessageWithHTML/RenderMessageWithHTML';
-import { sanitizeHtmlString } from '../../../utils/sanitizer';
+import { sanitizeHtmlString, htmlToPlainText } from '../../../utils/sanitizer';
 import { getFlowJsonPreviewText } from '../../../utils/flowPreview';
 import { getUserDisplayName } from '../../../utils/userDisplayName';
 import { getSlashCommandArtifactPreviewText } from '@xyne/shared';
@@ -83,8 +83,15 @@ export const DmListItem = ({
       }
     }
 
-    const rawContent =
-      lastMessage.content || (lastMessage.hasAttachment ? 'Sent an attachment' : 'Message');
+    // Attachment-only messages arrive as empty rich-text markup (e.g. '<p></p>'),
+    // which is truthy but renders blank. Fall back to a label whenever the message
+    // has no visible text, so an attachment preview is not shown as an empty line.
+    const hasVisibleText = htmlToPlainText(lastMessage.content).length > 0;
+    const rawContent = hasVisibleText
+      ? lastMessage.content
+      : lastMessage.hasAttachment
+        ? 'Sent an attachment'
+        : lastMessage.content || 'Message';
 
     return sanitizeHtmlString(rawContent);
   }, [lastMessage]);


### PR DESCRIPTION
## Summary
Follow-up to PR #1495. That fix only handled the case where an attachment message's `content` was an empty string. In reality, attachment-only messages store empty rich-text markup (e.g. `<p></p>`) — the composer (tiptap) serialises an empty editor as `<p></p>`, `sanitizeHtmlContent` preserves it, and the `conversations.send` mutator's guard is `content === ''`, which `<p></p>` passes. So `lastMessage.content` is truthy and the previous `content || (hasAttachment ? 'Sent an attachment' : 'Message')` short-circuits to the empty markup, rendering a blank DM list preview.

## Fix
In `DmListItem.tsx`, detect visually-empty content via `htmlToPlainText(...)` and fall back to `Sent an attachment` (or `Message`) only when the message has no visible text. Real text and emoji/image-only messages continue to render as-is.

## Testing
- `pnpm --filter xyne-spaces-dashboard run typecheck` → pass (exit 0)
- `prettier --check` on the file → clean
