### PR TITLE
feat: XYNE-62934 slack self-serve migration — Get latest messages (delta refresh…

### DIFF
--- a/apps/backend/src/migration/self-serve/engine.ts
+++ b/apps/backend/src/migration/self-serve/engine.ts
@@ -1,4 +1,5 @@
 import { PassThrough } from 'stream';
+import { randomUUID } from 'node:crypto';
 import readline from 'readline';
 import fetch from 'node-fetch';
 import { WebClient, LogLevel } from '@slack/web-api';
@@ -7,6 +8,7 @@ import { logger } from '@/utils/logger';
 import { config } from '@/config/env';
 import { decrypt } from '@/services/encryptionService';
 import { getStorageService } from '@/services/storage';
+import { createRedisClient } from '@/services/redisFactory';
 import { runAsServiceActor } from '@/database/tenant/context';
 import { UserRepository } from '@/database/repositories/users';
 import { ChannelRepository } from '@/database/repositories/channelRepository';
@@ -35,6 +37,9 @@ import { ChannelInput, MigrationJob, MigrationType } from './types';
 
 const PAGE = 1000;
 const UPLOAD_CHUNK_SIZE = 8 * 1024 * 1024;
+// Refresh scans this far back so replies on threads whose parent predates the delta are still caught (matches the
+// daily-sync "legacy thread replies" 30-day window). A reply on a thread older than this window isn't picked up.
+const REFRESH_LOOKBACK_DAYS = 30;
 const PUBLIC_CHANNELS_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -80,6 +85,9 @@ const paths = {
   manifest: (p: string) => `${p}/manifest.json`,
   users: (p: string) => `${p}/users.json`,
   conversation: (p: string, id: string) => `${p}/conversations/${id}.jsonl`,
+  conversationRefresh: (p: string, id: string, runTs: number) => `${p}/conversations/${id}.r${runTs}.jsonl`,
+  conversationsDir: (p: string) => `${p}/conversations/`,
+  cursors: (p: string) => `${p}/cursors.json`,
   pins: (p: string, id: string) => `${p}/pins/${id}.json`,
   usergroups: (p: string) => `${p}/usergroups.json`,
   channels: (p: string) => `${p}/channels.json`,
@@ -87,7 +95,7 @@ const paths = {
   publicChannelsCache: (root: string, teamId: string) => `${root}/_public-channels/${teamId}.json`,
 };
 
-export interface CollectedConversation { id: string; isMpim: boolean; members: string[]; }
+export interface CollectedConversation { id: string; isMpim: boolean; members: string[]; isEmpty?: boolean; }
 export interface ChannelMeta { id: string; name: string; isPrivate: boolean; }
 
 export interface DirUser { id: string; email?: string; real_name?: string; display_name?: string; is_bot?: boolean; deleted?: boolean; bot_id?: string; }
@@ -140,6 +148,30 @@ export class SlackMigrationEngine {
   private readonly offlineRefCache = new Map<string, { at: number; ref: SlackOfflineReference }>();
   private readonly manifestCache = new Map<string, { at: number; convs: CollectedConversation[] }>();
   private static readonly WORKER_CACHE_TTL_MS = 30 * 60 * 1000;
+  private readonly lockRedis = createRedisClient('slack-migration-ingest-lock');
+
+  // Serialize writes per target channel so two jobs ingesting the same group DM don't race past dedup. TTL avoids
+  // deadlock on a crashed holder; refreshed while held so a long ingest keeps it.
+  private async withChannelLock<T>(workspaceId: string, scope: string, fn: () => Promise<T>): Promise<T> {
+    const key = `slackmig:inglock:${workspaceId}:${scope}`;
+    const token = randomUUID();
+    const TTL_MS = 60_000, RETRY_MS = 200, MAX_WAIT_MS = 15 * 60_000;
+    const deadline = Date.now() + MAX_WAIT_MS;
+    while ((await this.lockRedis.set(key, token, 'PX', TTL_MS, 'NX')) === null) {
+      if (Date.now() > deadline) throw new Error(`ingest lock timeout: ${key}`);
+      await sleep(RETRY_MS);
+    }
+    const KEEP = "if redis.call('get',KEYS[1])==ARGV[1] then return redis.call('pexpire',KEYS[1],ARGV[2]) else return 0 end";
+    const DROP = "if redis.call('get',KEYS[1])==ARGV[1] then return redis.call('del',KEYS[1]) else return 0 end";
+    const refresh = setInterval(() => void this.lockRedis.eval(KEEP, 1, key, token, String(TTL_MS)).catch(() => undefined), TTL_MS / 2);
+    refresh.unref?.();
+    try {
+      return await fn();
+    } finally {
+      clearInterval(refresh);
+      await this.lockRedis.eval(DROP, 1, key, token).catch(() => undefined);
+    }
+  }
 
   async getOfflineReference(migrationId: string, gcsPrefix: string): Promise<SlackOfflineReference> {
     let hit = this.offlineRefCache.get(migrationId);
@@ -208,10 +240,11 @@ export class SlackMigrationEngine {
     do {
       const r = await client.conversations.list({ types: 'im,mpim', limit: 1000, cursor });
       for (const c of r.channels ?? []) {
-        const cc = c as { id: string; is_mpim?: boolean; user?: string };
+        const cc = c as { id: string; is_mpim?: boolean; user?: string; is_empty?: boolean };
         // im carries the other user in `.user`; mpim (group DM) needs members fetched, else the loader drops it.
+        // Slack's is_empty (never had a message) lets us skip the history call for dead DMs entirely.
         const members = cc.is_mpim ? await this.fetchChannelMembers(token, cc.id) : (cc.user ? [cc.user] : []);
-        out.push({ id: cc.id, isMpim: !!cc.is_mpim, members });
+        out.push({ id: cc.id, isMpim: !!cc.is_mpim, members, isEmpty: cc.is_empty });
       }
       cursor = (r.response_metadata as { next_cursor?: string })?.next_cursor || undefined;
       if (cursor && cfg.listDelayMs > 0) await sleep(cfg.listDelayMs);
@@ -240,15 +273,30 @@ export class SlackMigrationEngine {
     return members;
   }
 
-  async collectConversation(token: string, conv: CollectedConversation, gcsPrefix: string, startDate?: string, onProgress?: (p: { messages: number; newestTs: number; oldestTs: number }) => Promise<void>): Promise<{ messages: number; outcome: 'ok' | 'truncated' | 'skipped'; reason?: string }> {
+  // sinceTs > 0 ⇒ DELTA mode (refresh): still pages the full history (to see old parents' latest_reply), but only
+  // downloads/writes messages newer than sinceTs and replies added after it — everything unchanged is skipped.
+  async collectConversation(token: string, conv: CollectedConversation, gcsPrefix: string, startDate?: string, onProgress?: (p: { messages: number; newestTs: number; oldestTs: number }) => Promise<void>, destPath?: string, sinceTs = 0): Promise<{ messages: number; outcome: 'ok' | 'truncated' | 'skipped'; reason?: string; newestTs: number }> {
     const cfg = await getMigrationRuntimeConfig();
     const client = slackClient(token, cfg.requestTimeoutMs);
-    const oldest = oldestFromStartDate(startDate);
-    const pinned = await fetchPinnedMessageTimestamps(client, conv.id).catch(() => new Set<string>());
-    const stream = new PassThrough();
-    const done = this.storage.uploadStreamToPath(encryptStream(stream), {
-      path: paths.conversation(gcsPrefix, conv.id), contentType: 'application/octet-stream', chunkSize: UPLOAD_CHUNK_SIZE,
-    });
+    let oldest = oldestFromStartDate(startDate);
+    if (sinceTs > 0) {
+      // Delta: scan from the cursor, but never earlier than the 30-day lookback (so old-thread replies are caught) and
+      // never earlier than the original startDate floor.
+      const lookbackTs = Math.floor(Date.now() / 1000) - REFRESH_LOOKBACK_DAYS * 86400;
+      oldest = String(Math.max(oldest ? parseFloat(oldest) : 0, Math.min(sinceTs, lookbackTs)));
+    }
+    // Base files (destPath undefined) always exist so the union reader can open them; snapshots (destPath set, refresh) are
+    // created lazily on the first message, so a quiet DM with nothing new touches GCS zero times.
+    const outPath = destPath ?? paths.conversation(gcsPrefix, conv.id);
+    const io: { stream: PassThrough | null; done: Promise<unknown> | null } = { stream: null, done: null };
+    const sink = (): PassThrough => {
+      if (!io.stream) {
+        io.stream = new PassThrough();
+        io.done = this.storage.uploadStreamToPath(encryptStream(io.stream), { path: outPath, contentType: 'application/octet-stream', chunkSize: UPLOAD_CHUNK_SIZE });
+      }
+      return io.stream;
+    };
+    if (!destPath) sink(); // eager-create the base file even if empty
     let count = 0;
     let outcome: 'ok' | 'truncated' | 'skipped' = 'ok';
     let reason: string | undefined;
@@ -265,15 +313,25 @@ export class SlackMigrationEngine {
         page += 1;
         logger.debug('[SlackMigration] history page', { convId: conv.id, page, messages: (r.messages ?? []).length, running: count });
         for (const m of r.messages ?? []) {
-          await this.prefetchFiles(token, m, gcsPrefix);
-          if (((m as { reply_count?: number }).reply_count ?? 0) > 0 && (m as { ts?: string }).ts) {
-            const replies = await this.fetchReplies(token, conv.id, (m as { ts: string }).ts, gcsPrefix);
-            if (replies.length) (m as { _replies?: unknown[] })._replies = replies;
-          }
           const ts = parseFloat((m as { ts?: string }).ts ?? '0');
+          const replyCount = (m as { reply_count?: number }).reply_count ?? 0;
+          const latestReply = parseFloat((m as { latest_reply?: string }).latest_reply ?? '0');
+          const isNew = ts > sinceTs;                                  // full mode (sinceTs=0): everything is "new"
+          const hasNewReplies = replyCount > 0 && latestReply > sinceTs;
+          if (sinceTs > 0 && !isNew && !hasNewReplies) continue;       // delta: unchanged message → skip entirely
+          if (isNew) await this.prefetchFiles(token, m, gcsPrefix);    // only new top-level content pulls attachments
+          if (replyCount > 0 && (m as { ts?: string }).ts) {
+            const replies = await this.fetchReplies(token, conv.id, (m as { ts: string }).ts, gcsPrefix, sinceTs);
+            if (replies.length) (m as { _replies?: unknown[] })._replies = replies;
+            else if (sinceTs > 0 && !isNew) continue;                  // old thread but no NEW replies after filtering → nothing to write
+          }
           if (ts > newestTs) newestTs = ts;
+          for (const rep of (m as { _replies?: { ts?: string }[] })._replies ?? []) {
+            const rts = parseFloat(rep.ts ?? '0');
+            if (rts > newestTs) newestTs = rts;
+          }
           if (ts > 0 && ts < oldestTs) oldestTs = ts;
-          stream.write(`${JSON.stringify(m)}\n`);
+          sink().write(`${JSON.stringify(m)}\n`);
           count += 1;
         }
         if (onProgress) await onProgress({ messages: count, newestTs, oldestTs: oldestTs === Infinity ? 0 : oldestTs }); // live per-page progress
@@ -295,11 +353,16 @@ export class SlackMigrationEngine {
       }
       logger.warn('[SlackMigration] conversation not fully collected', { conversationId: conv.id, error: code, outcome });
     } finally {
-      stream.end();
+      io.stream?.end();
     }
-    await done;
-    await this.writeJson(paths.pins(gcsPrefix, conv.id), [...pinned]);
-    return { messages: count, outcome, reason };
+    if (io.done) await io.done;
+    // Fetch pins lazily — only when the conversation actually has content — so empty / no-new-activity conversations
+    // never hit the rate-limited pins.list. On refresh only overwrite pins if we got some (a failed fetch can't clobber base pins).
+    if (count > 0) {
+      const pinned = await fetchPinnedMessageTimestamps(client, conv.id).catch(() => new Set<string>());
+      if (!destPath || pinned.size > 0) await this.writeJson(paths.pins(gcsPrefix, conv.id), [...pinned]);
+    }
+    return { messages: count, outcome, reason, newestTs };
   }
 
   /** Reference dumps so ingestion resolves users/groups/channels offline (no Slack). */
@@ -396,8 +459,8 @@ export class SlackMigrationEngine {
     }
   }
 
-  /** Fetch all replies of a thread (excluding the parent) and prefetch their files. */
-  private async fetchReplies(token: string, channelId: string, ts: string, gcsPrefix: string): Promise<unknown[]> {
+  /** Fetch a thread's replies (excluding the parent) and prefetch their files. sinceTs>0 keeps only replies newer than it. */
+  private async fetchReplies(token: string, channelId: string, ts: string, gcsPrefix: string, sinceTs = 0): Promise<unknown[]> {
     const cfg = await getMigrationRuntimeConfig();
     const client = slackClient(token, cfg.requestTimeoutMs);
     const replies: unknown[] = [];
@@ -407,6 +470,7 @@ export class SlackMigrationEngine {
         client.conversations.replies({ channel: channelId, ts, limit: PAGE, cursor }));
       for (const m of r.messages ?? []) {
         if ((m as { ts?: string }).ts === ts) continue; // conversations.replies includes the parent first
+        if (sinceTs > 0 && parseFloat((m as { ts?: string }).ts ?? '0') <= sinceTs) continue; // delta: skip already-collected replies
         await this.prefetchFiles(token, m, gcsPrefix);
         replies.push(m);
       }
@@ -477,6 +541,14 @@ export class SlackMigrationEngine {
     };
   }
 
+  /** Base dump + all refresh snapshots for a conversation, oldest first. */
+  private async listConversationDataFiles(gcsPrefix: string, convId: string): Promise<string[]> {
+    const base = paths.conversation(gcsPrefix, convId);
+    const files = await this.storage.listFiles(paths.conversationsDir(gcsPrefix)).catch(() => [] as { name: string }[]);
+    const snapshots = files.map((f) => f.name).filter((n) => n.includes(`/${convId}.r`) && n.endsWith('.jsonl')).sort();
+    return [base, ...snapshots];
+  }
+
   async loadConversation(job: MigrationJob, conv: CollectedConversation, ref: SlackOfflineReference, onProgress?: () => void): Promise<{ ingested: number; failed: number }> {
     const cfg = await getMigrationRuntimeConfig();
     return runAsServiceActor('slack-migration', job.workspaceId, async () => {
@@ -523,24 +595,32 @@ export class SlackMigrationEngine {
 
       const pinnedTs = new Set(await this.readJson<string[]>(paths.pins(job.gcsPrefix, conv.id)).catch(() => []));
 
-      // Transform with the offline reference active so mentions, author lookups and usergroup import all resolve from the dumps, never Slack.
-      const stream = await this.storage.createReadStream(paths.conversation(job.gcsPrefix, conv.id));
-      const rl = readline.createInterface({ input: decryptStream(stream), crlfDelay: Infinity });
+      // Read base dump + any refresh snapshots as a union (per-message dedup downstream drops overlaps; union means a
+      // partial refresh can't lose data). Offline reference active so mentions/authors resolve from the dumps, never Slack.
+      const dataFiles = await this.listConversationDataFiles(job.gcsPrefix, conv.id);
       const messages: SlackMessage[] = await runWithSlackOfflineReference(ref, async () => {
         const out: SlackMessage[] = [];
-        for await (const line of rl) {
-          if (!line.trim()) continue;
-          let raw: unknown;
-          try { raw = JSON.parse(line); } catch { continue; }
-          // Drop Slack system messages ("X joined the channel", topic changes) and env-ignored bots,
-          // matching the existing /sync flow (isHumanMessage); real bot content is still kept.
-          if (!isHumanMessage(raw, 'channel', [], true)) continue;
-          out.push(await transformMessage(raw as never, (raw as { _replies?: never[] })._replies, cache, true, true, true, pinnedTs, job.workspaceId, ''));
+        for (const file of dataFiles) {
+          const stream = await this.storage.createReadStream(file);
+          const rl = readline.createInterface({ input: decryptStream(stream), crlfDelay: Infinity });
+          for await (const line of rl) {
+            if (!line.trim()) continue;
+            let raw: unknown;
+            try { raw = JSON.parse(line); } catch { continue; }
+            // Drop Slack system messages and env-ignored bots (matches /sync isHumanMessage); real bot content is kept.
+            if (!isHumanMessage(raw, 'channel', [], true)) continue;
+            out.push(await transformMessage(raw as never, (raw as { _replies?: never[] })._replies, cache, true, true, true, pinnedTs, job.workspaceId, ''));
+          }
         }
         return out;
       });
       if (messages.length === 0) return { ingested: 0, failed: 0 };
 
+      // Lock the write on the resolved target channel (member-set for DMs, xyneChannelId for channels); the read above is unlocked.
+      const lockScope = isChannel
+        ? `ch:${job.channelInput!.xyneChannelId}`
+        : isSelfDm ? `dm:${dmOwnerId}` : `dm:${[dmOwnerId!, ...dmOtherIds].sort().join(',')}`;
+      return await this.withChannelLock(job.workspaceId, lockScope, async () => {
       // Channel → the requester's chosen Xyne channel. DM → find/create it (only now we know it has messages, so an empty DM never pins to the top).
       const channelId = isChannel
         ? job.channelInput!.xyneChannelId
@@ -589,6 +669,7 @@ export class SlackMigrationEngine {
         : await ingestConversationSlack(ingestInput);
       await channelRepo.recalculateLastActivityFromMessages(channelId);
       return { ingested: messages.length, failed: ingestResult.errorDetails?.length ?? 0 };
+      });
     });
   }
 
@@ -623,6 +704,21 @@ export class SlackMigrationEngine {
   decryptToken(job: MigrationJob): string {
     if (!job.encryptedToken) throw new Error('migration token missing');
     return decrypt(job.encryptedToken);
+  }
+
+  /** Snapshot path a refresh writes new messages to (base file stays untouched). */
+  conversationRefreshPath(gcsPrefix: string, convId: string, runTs: number): string {
+    return paths.conversationRefresh(gcsPrefix, convId, runTs);
+  }
+
+  /** Per-conversation last-collected message ts (epoch secs) — the delta cursor for "Get latest messages". */
+  async readCursors(gcsPrefix: string): Promise<Record<string, number>> {
+    // Absent on the first collection — check first so the storage layer doesn't log a scary "file does not exist".
+    if (!(await this.storage.fileExists(paths.cursors(gcsPrefix)))) return {};
+    return this.readJson<Record<string, number>>(paths.cursors(gcsPrefix)).catch(() => ({}));
+  }
+  writeCursors(gcsPrefix: string, cursors: Record<string, number>): Promise<void> {
+    return this.writeJson(paths.cursors(gcsPrefix), cursors);
   }
 
   writeManifest(gcsPrefix: string, conversations: CollectedConversation[]): Promise<void> {

--- a/apps/backend/src/migration/self-serve/queues.ts
+++ b/apps/backend/src/migration/self-serve/queues.ts
@@ -19,7 +19,8 @@ export class MigrationQueues {
         new Bull<JobRef>(name, {
           redis: { ...getBaseRedisOptions('bullmq'), lazyConnect: false },
           defaultJobOptions: { attempts: 1, removeOnComplete: true, removeOnFail: true },
-          settings: { lockDuration: 5 * 60_000, stalledInterval: 30_000, maxStalledCount: 1 },
+          // lockDuration covers the slowest single-conversation job so an in-progress one isn't treated as stalled.
+          settings: { lockDuration: 30 * 60_000, stalledInterval: 30_000, maxStalledCount: 1 },
         }),
       );
     }

--- a/apps/backend/src/migration/self-serve/routes.ts
+++ b/apps/backend/src/migration/self-serve/routes.ts
@@ -70,6 +70,7 @@ export function buildRouter(service: SlackMigrationService): Router {
   }));
 
   router.post('/migration-jobs/:id/approve', admin, wrap(async (req, res) => { res.json(ok(await service.approve(req.params.id, actorOf(req)))); }));
+  router.post('/migration-jobs/:id/refresh', admin, wrap(async (req, res) => { res.json(ok(await service.refresh(req.params.id, actorOf(req)))); }));
   router.post('/migration-jobs/:id/stop', admin, wrap(async (req, res) => { res.json(ok(await service.stop(req.params.id, actorOf(req)))); }));
   router.post('/migration-jobs/:id/resume', admin, wrap(async (req, res) => { res.json(ok(await service.resume(req.params.id, actorOf(req)))); }));
   router.delete('/migration-jobs/:id', admin, wrap(async (req, res) => { await service.remove(req.params.id, actorOf(req)); res.json(ok({ deleted: true })); }));

--- a/apps/backend/src/migration/self-serve/service.ts
+++ b/apps/backend/src/migration/self-serve/service.ts
@@ -164,6 +164,20 @@ export class SlackMigrationService {
     return toView(updated);
   }
 
+  /** "Get latest messages": queue an incremental re-collection. Only while AWAITING_APPROVAL and with the token still held. */
+  async refresh(id: string, actor: Actor): Promise<MigrationJobView> {
+    const job = await this.mustGet(id, actor);
+    if (job.status !== MigrationStatus.AWAITING_APPROVAL) {
+      throw new HttpError(409, 'INVALID_STATE', `Only a migration awaiting approval can fetch latest messages (current: ${job.status})`);
+    }
+    if (!job.encryptedToken) {
+      throw new HttpError(409, 'TOKEN_UNAVAILABLE', 'The Slack token is no longer available for this job — re-submit to migrate newer messages.');
+    }
+    const updated = await this.store.update(id, { status: MigrationStatus.REFRESHING, refreshRequested: true, currentQueue: QueueName.COLLECTION, error: undefined });
+    await this.queues.enqueue(QueueName.COLLECTION, id, 'end');
+    return toView(updated);
+  }
+
   async stop(id: string, actor: Actor): Promise<MigrationJobView> {
     const job = await this.mustGet(id, actor);
     if (job.status === MigrationStatus.QUEUED) {

--- a/apps/backend/src/migration/self-serve/store.ts
+++ b/apps/backend/src/migration/self-serve/store.ts
@@ -38,7 +38,8 @@ function encodePatch(patch: Partial<MigrationJob>): { set: Record<string, string
         break;
       }
       case 'stopRequested':
-        set.stopRequested = v ? '1' : '0';
+      case 'refreshRequested':
+        set[k] = v ? '1' : '0';
         break;
       case 'checkpoint':
       case 'channelInput':
@@ -297,6 +298,12 @@ function decode(h: Record<string, string>): MigrationJob {
     updatedAt: numReq('updatedAt'),
     completedAt: numOpt('completedAt'),
     ingestStartedAt: numOpt('ingestStartedAt'),
+    collectedAt: numOpt('collectedAt'),
+    refreshRequested: h.refreshRequested === '1',
+    lastRefreshedAt: numOpt('lastRefreshedAt'),
+    refreshCount: numOpt('refreshCount'),
+    refreshDone: numOpt('refreshDone'),
+    refreshTotal: numOpt('refreshTotal'),
     error: opt('error'),
     issues: h.issues ? (JSON.parse(h.issues) as MigrationIssue[]) : undefined,
   };

--- a/apps/backend/src/migration/self-serve/types.ts
+++ b/apps/backend/src/migration/self-serve/types.ts
@@ -8,6 +8,7 @@ export enum MigrationStatus {
   QUEUED = 'QUEUED',
   COLLECTING = 'COLLECTING',
   AWAITING_APPROVAL = 'AWAITING_APPROVAL',
+  REFRESHING = 'REFRESHING',   // "Get latest messages": incremental re-collect of new activity before ingest
   INGESTING = 'INGESTING',
   STOPPED = 'STOPPED',
   FAILED = 'FAILED',
@@ -62,6 +63,12 @@ export interface MigrationJob {
   checkpoint: Checkpoint;
   ingestedCount?: number;       // parallel ingest: count of conversations done, tracked atomically (Redis SET) instead of the checkpoint array
   ingestStartedAt?: number;     // when ingestion first began (planner set INGESTING) — with completedAt gives the ingest duration
+  collectedAt?: number;         // when collection finished (→ AWAITING_APPROVAL) — "data current as of"
+  refreshRequested?: boolean;   // "Get latest messages" pressed → COLLECTION queue runs an incremental re-collect
+  lastRefreshedAt?: number;     // when the last incremental re-collect finished
+  refreshCount?: number;
+  refreshDone?: number;         // conversations processed so far in the current refresh
+  refreshTotal?: number;        // conversations to process in the current refresh
   stats: { conversations: number; messages: number };
   stopRequested: boolean;
   stopReason?: 'admin' | 'system';
@@ -94,6 +101,12 @@ export interface MigrationJobView {
   completedAt?: number;
   ingestStartedAt?: number;
   ingestDurationMs?: number; // completedAt − ingestStartedAt when both present — "how long ingestion took"
+  collectedAt?: number;      // when collection finished — "data current as of"
+  lastRefreshedAt?: number;
+  refreshCount?: number;
+  refreshDone?: number;
+  refreshTotal?: number;
+  canRefresh: boolean;       // awaiting approval AND token still held → "Get latest messages" available
   error?: string;
 }
 
@@ -129,6 +142,12 @@ export const toView = (j: MigrationJob): MigrationJobView => ({
   completedAt: j.completedAt,
   ingestStartedAt: j.ingestStartedAt,
   ingestDurationMs: j.ingestStartedAt && j.completedAt ? j.completedAt - j.ingestStartedAt : undefined,
+  collectedAt: j.collectedAt,
+  lastRefreshedAt: j.lastRefreshedAt,
+  refreshCount: j.refreshCount,
+  refreshDone: j.refreshDone,
+  refreshTotal: j.refreshTotal,
+  canRefresh: j.status === MigrationStatus.AWAITING_APPROVAL && !!j.encryptedToken,
   error: j.error,
   issues: j.issues,
 });

--- a/apps/backend/src/migration/self-serve/workers.ts
+++ b/apps/backend/src/migration/self-serve/workers.ts
@@ -34,7 +34,7 @@ export class MigrationWorkers {
     // the fanned-out conversation jobs for cross-process parallelism.
     const isPrimary = !process.env.NODE_APP_INSTANCE || process.env.NODE_APP_INSTANCE === '0';
     if (isPrimary) {
-      this.queues.process(QueueName.COLLECTION, (id) => this.guard(id, (j) => this.collect(j)));
+      this.queues.process(QueueName.COLLECTION, (id) => this.guard(id, (j) => j.refreshRequested ? this.refresh(j) : this.collect(j)));
       this.queues.process(QueueName.INGESTION, (id) => this.guard(id, (j) => this.ingest(j)));
       const timer = setInterval(() => void this.reconcile().catch(() => undefined), RECONCILE_EVERY_MS);
       timer.unref?.();
@@ -61,7 +61,7 @@ export class MigrationWorkers {
         }
         continue;
       }
-      const running = job.status === MigrationStatus.COLLECTING || job.status === MigrationStatus.INGESTING;
+      const running = job.status === MigrationStatus.COLLECTING || job.status === MigrationStatus.REFRESHING || job.status === MigrationStatus.INGESTING;
       if (!running) continue;
       // Status says running — but is a worker actually processing it? If Bull has it sitting in the wait/delayed
       // queue (bumped back by a restart/stall, or a resume jumped ahead), the "Collecting/Ingesting" status is
@@ -132,6 +132,7 @@ export class MigrationWorkers {
     }
 
     const done = new Set(job.checkpoint.collectedConversationIds);
+    const cursors = await this.engine.readCursors(job.gcsPrefix); // per-conversation last-collected ts → the delta cursor for refresh
     const PROGRESS_EVERY = 25;
     let collected = 0, messages = 0, skipped = 0, truncated = 0;
     // A channel is a single conversation (conversation bar meaningless) and Slack gives no message total, so report progress
@@ -154,6 +155,7 @@ export class MigrationWorkers {
         return void this.store.update(job.id, { status: MigrationStatus.STOPPED });
       }
       if (done.has(conv.id)) continue;
+      if (conv.isEmpty) { await this.store.addCollected(job.id, conv.id, 0); collected += 1; continue; } // Slack says no messages ever → skip the history call
       const result = await this.engine.collectConversation(
         token, conv, job.gcsPrefix, job.channelInput?.startDate,
         isChannel
@@ -169,6 +171,7 @@ export class MigrationWorkers {
         continue;
       }
       await this.store.addCollected(job.id, conv.id, isChannel ? 0 : result.messages); // channel count already live via setChannelProgress
+      if (result.newestTs > 0) cursors[conv.id] = result.newestTs; // remember the newest ts so refresh only fetches the delta
       collected += 1;
       messages += result.messages;
       if (result.outcome === 'truncated') {
@@ -180,11 +183,81 @@ export class MigrationWorkers {
       }
     }
 
-    // Collection done → approval gate; drop the token immediately (§5.7).
-    await this.store.update(job.id, { status: MigrationStatus.AWAITING_APPROVAL, encryptedToken: undefined });
+    await this.engine.writeCursors(job.gcsPrefix, cursors).catch(() => undefined);
+    // Collection done → approval gate. Keep the token (encrypted) through the approval window so "Get latest messages"
+    // can re-collect; it's dropped when ingestion starts (see ingest()).
+    await this.store.update(job.id, { status: MigrationStatus.AWAITING_APPROVAL, collectedAt: Date.now() });
     logger.info('[SlackMigration] collection complete → awaiting approval', {
       id: job.id, conversations: conversations.length, collected, messages, skipped, truncated,
     });
+  }
+
+  /**
+   * "Get latest messages": incremental DELTA re-collection while AWAITING_APPROVAL. Re-lists conversations (catches new
+   * DMs → full collect into base), and for each existing conversation writes only messages/replies newer than its cursor
+   * to a SNAPSHOT file (base untouched, so a partial refresh can't lose data). Old-thread replies within the 30-day
+   * lookback are caught. Ingest reads base + snapshots as a union and dedups. Returns to AWAITING_APPROVAL.
+   */
+  private async refresh(job: MigrationJob): Promise<void> {
+    if (![MigrationStatus.AWAITING_APPROVAL, MigrationStatus.REFRESHING].includes(job.status)) return;
+    let token: string;
+    try { token = this.engine.decryptToken(job); }
+    catch { await this.store.update(job.id, { status: MigrationStatus.AWAITING_APPROVAL, refreshRequested: false, error: 'Refresh needs the Slack token, which is no longer available. Re-submit to migrate newer messages.' }); return; }
+    // Keep refreshRequested set through the run so an orphaned refresh (pod died) is re-dispatched as a refresh, not a collect.
+    await this.store.update(job.id, { status: MigrationStatus.REFRESHING });
+    logger.info('[SlackMigration] refresh started', { id: job.id, type: job.type });
+
+    const existing = await this.engine.readManifest(job.gcsPrefix).catch(() => [] as CollectedConversation[]);
+    const current = await this.engine.listConversations(token, job.type, job.channelInput);
+    const knownIds = new Set(existing.map((c) => c.id));
+    const merged = [...existing, ...current.filter((c) => !knownIds.has(c.id))];
+    if (merged.length !== existing.length) await this.engine.writeManifest(job.gcsPrefix, merged);
+
+    const freshEmpty = new Map(current.map((c) => [c.id, c.isEmpty])); // FRESH is_empty from this listing — never trust the stale manifest for skipping
+    const cursors = await this.engine.readCursors(job.gcsPrefix);
+    const directory = await this.engine.readDirectory(job.gcsPrefix).catch(() => ({} as Record<string, DirUser>));
+    const isChannel = job.type === MigrationType.CHANNEL;
+    const labelFor = (conv: CollectedConversation): string => {
+      if (isChannel) return `#${job.slackChannelName ?? conv.id}`;
+      const names = conv.members.filter((m) => m !== job.ownerSlackId).map((m) => directory[m]?.real_name || directory[m]?.display_name || m);
+      return names.length ? `DM with ${names.join(', ')}` : `DM ${conv.id}`;
+    };
+    const runTs = Date.now();
+    const windowStart = job.channelInput?.startDate ? Math.floor(Date.parse(job.channelInput.startDate) / 1000) : (job.slackChannelCreated ?? 0);
+    let refreshedConvs = 0, newMessages = 0, newConvs = 0;
+    await this.store.update(job.id, { refreshTotal: merged.length, refreshDone: 0 });
+    for (const [i, conv] of merged.entries()) {
+      if (await this.store.isStopRequested(job.id)) return void this.store.update(job.id, { status: MigrationStatus.STOPPED });
+      if ((i + 1) % 10 === 0 || i + 1 === merged.length) await this.store.update(job.id, { refreshDone: i + 1 });
+      if (freshEmpty.get(conv.id) === true) continue; // Slack says still no messages ever → nothing to refresh, skip the history call
+      const isNew = !knownIds.has(conv.id);
+      // Existing conv → delta snapshot from its cursor; new conv → full collect into base (sinceTs 0).
+      const destPath = isNew ? undefined : this.engine.conversationRefreshPath(job.gcsPrefix, conv.id, runTs);
+      const sinceTs = isNew ? 0 : (cursors[conv.id] ?? 0);
+      const result = await this.engine.collectConversation(
+        token, conv, job.gcsPrefix, job.channelInput?.startDate,
+        isChannel
+          ? (p) => this.store.setChannelProgress(job.id, { messages: p.messages, start: windowStart, end: p.newestTs, through: p.oldestTs })
+          : () => this.store.markProgress(job.id),
+        destPath, sinceTs,
+      );
+      if (result.outcome === 'skipped') {
+        if (!isNew) continue; // existing conv now inaccessible: keep what we have, don't record a new issue
+        await this.store.addIssue(job.id, { conversationId: conv.id, label: labelFor(conv), kind: 'skipped', reason: result.reason ?? 'Inaccessible on Slack.' });
+        continue;
+      }
+      if (result.newestTs > 0) cursors[conv.id] = Math.max(cursors[conv.id] ?? 0, result.newestTs);
+      newMessages += result.messages;
+      if (result.messages > 0) refreshedConvs += 1;
+      if (isNew) { newConvs += 1; await this.store.addCollected(job.id, conv.id, isChannel ? 0 : result.messages); }
+    }
+
+    await this.engine.writeCursors(job.gcsPrefix, cursors).catch(() => undefined);
+    await this.store.update(job.id, {
+      status: MigrationStatus.AWAITING_APPROVAL, refreshRequested: false, lastRefreshedAt: Date.now(), refreshCount: (job.refreshCount ?? 0) + 1,
+      checkpoint: { ...job.checkpoint, totalConversations: merged.length },
+    });
+    logger.info('[SlackMigration] refresh complete → awaiting approval', { id: job.id, refreshedConvs, newConvs, newMessages });
   }
 
   /**
@@ -195,8 +268,8 @@ export class MigrationWorkers {
   private async ingest(job: MigrationJob): Promise<void> {
     // Idempotency: never re-plan a completed job (its GCS data is already deleted).
     if ([MigrationStatus.SUBMITTED, MigrationStatus.COLLECTING, MigrationStatus.COMPLETED].includes(job.status)) return;
-    // Stamp the ingest start once (kept across resume) so the completion log/UI can report how long ingestion took.
-    await this.store.update(job.id, { status: MigrationStatus.INGESTING, ...(job.ingestStartedAt ? {} : { ingestStartedAt: Date.now() }) });
+    // Stamp the ingest start once (kept across resume). Drop the token now — no collection/refresh happens after ingest begins.
+    await this.store.update(job.id, { status: MigrationStatus.INGESTING, encryptedToken: undefined, ...(job.ingestStartedAt ? {} : { ingestStartedAt: Date.now() }) });
     let conversations;
     try {
       conversations = await this.engine.readManifest(job.gcsPrefix);

--- a/apps/dashboard/src/api/slackMigrationApi.ts
+++ b/apps/dashboard/src/api/slackMigrationApi.ts
@@ -10,6 +10,7 @@ export type MigrationStatus =
   | 'QUEUED'
   | 'COLLECTING'
   | 'AWAITING_APPROVAL'
+  | 'REFRESHING'
   | 'INGESTING'
   | 'STOPPED'
   | 'FAILED'
@@ -43,6 +44,12 @@ export interface MigrationJobView {
   completedAt?: number;
   ingestStartedAt?: number;
   ingestDurationMs?: number; // how long ingestion took (completedAt − ingestStartedAt)
+  collectedAt?: number;
+  lastRefreshedAt?: number;
+  refreshCount?: number;
+  refreshDone?: number;
+  refreshTotal?: number;
+  canRefresh: boolean;
   error?: string;
   issues?: {
     conversationId: string;
@@ -84,6 +91,12 @@ export const slackMigrationApi = {
   approve: async (id: string): Promise<MigrationJobView> =>
     unwrap(
       (await apiInstance.post<Envelope<MigrationJobView>>(`${BASE}/migration-jobs/${id}/approve`))
+        .data,
+    ),
+
+  refresh: async (id: string): Promise<MigrationJobView> =>
+    unwrap(
+      (await apiInstance.post<Envelope<MigrationJobView>>(`${BASE}/migration-jobs/${id}/refresh`))
         .data,
     ),
 

--- a/apps/dashboard/src/pages/SlackMigration.tsx
+++ b/apps/dashboard/src/pages/SlackMigration.tsx
@@ -113,7 +113,8 @@ const TONE: Record<Tone, { pill: string; dot: string; bar: string; ring: string 
 };
 
 const isStalled = (j: MigrationJobView): boolean =>
-  (j.status === 'COLLECTING' || j.status === 'REFRESHING' || j.status === 'INGESTING') && Date.now() - j.heartbeatAt > STALE_MS;
+  (j.status === 'COLLECTING' || j.status === 'REFRESHING' || j.status === 'INGESTING') &&
+  Date.now() - j.heartbeatAt > STALE_MS;
 
 const ago = (ts: number): string => {
   const s = Math.max(0, Math.round((Date.now() - ts) / 1000));
@@ -162,7 +163,8 @@ const activeStage = (j: MigrationJobView): number => {
 
 // ── small pieces ─────────────────────────────────────────────────────────────
 function StatusPill({ job }: { job: MigrationJobView }): React.JSX.Element {
-  const running = job.status === 'COLLECTING' || job.status === 'REFRESHING' || job.status === 'INGESTING';
+  const running =
+    job.status === 'COLLECTING' || job.status === 'REFRESHING' || job.status === 'INGESTING';
   const stopping = running && job.stopRequested;
   const stalled = running && !stopping && isStalled(job);
   const approvedQueued = job.status === 'AWAITING_APPROVAL' && job.phase === 'ingest';
@@ -267,11 +269,16 @@ function PhaseProgress({ job }: { job: MigrationJobView }): React.JSX.Element | 
     return (
       <div>
         <div className='mb-1 flex items-center justify-between text-xs text-muted-foreground'>
-          <span>Fetching latest… {rd.toLocaleString()} / {rt.toLocaleString()} conversations</span>
+          <span>
+            Fetching latest… {rd.toLocaleString()} / {rt.toLocaleString()} conversations
+          </span>
           <span className='tabular-nums'>{pct}%</span>
         </div>
         <div className='h-1.5 overflow-hidden rounded-full bg-muted'>
-          <div className={cn('h-full rounded-full transition-[width] duration-500', TONE.blue.bar)} style={{ width: `${pct}%` }} />
+          <div
+            className={cn('h-full rounded-full transition-[width] duration-500', TONE.blue.bar)}
+            style={{ width: `${pct}%` }}
+          />
         </div>
       </div>
     );
@@ -1125,7 +1132,8 @@ function OwnerActions({
     void run(fn).finally(() => setPending(null));
   };
   const canResume = job.status === 'STOPPED' || job.status === 'FAILED';
-  const canDelete = job.status !== 'COLLECTING' && job.status !== 'REFRESHING' && job.status !== 'INGESTING';
+  const canDelete =
+    job.status !== 'COLLECTING' && job.status !== 'REFRESHING' && job.status !== 'INGESTING';
   return (
     <>
       {canResume && (

--- a/apps/dashboard/src/pages/SlackMigration.tsx
+++ b/apps/dashboard/src/pages/SlackMigration.tsx
@@ -60,6 +60,7 @@ const STATUS: Record<MigrationStatus, { label: string; tone: Tone }> = {
   QUEUED: { label: 'Queued', tone: 'muted' },
   COLLECTING: { label: 'Collecting', tone: 'blue' },
   AWAITING_APPROVAL: { label: 'Awaiting approval', tone: 'amber' },
+  REFRESHING: { label: 'Fetching latest', tone: 'blue' },
   INGESTING: { label: 'Ingesting', tone: 'violet' },
   STOPPED: { label: 'Stopped', tone: 'orange' },
   FAILED: { label: 'Failed', tone: 'red' },
@@ -112,7 +113,7 @@ const TONE: Record<Tone, { pill: string; dot: string; bar: string; ring: string 
 };
 
 const isStalled = (j: MigrationJobView): boolean =>
-  (j.status === 'COLLECTING' || j.status === 'INGESTING') && Date.now() - j.heartbeatAt > STALE_MS;
+  (j.status === 'COLLECTING' || j.status === 'REFRESHING' || j.status === 'INGESTING') && Date.now() - j.heartbeatAt > STALE_MS;
 
 const ago = (ts: number): string => {
   const s = Math.max(0, Math.round((Date.now() - ts) / 1000));
@@ -145,6 +146,7 @@ const activeStage = (j: MigrationJobView): number => {
     case 'QUEUED':
       return j.phase === 'ingest' ? 2 : 0; // queued to (re)run in its current phase
     case 'AWAITING_APPROVAL':
+    case 'REFRESHING':
       return j.phase === 'ingest' ? 2 : 1; // approved ⇒ ingest gate
     case 'INGESTING':
       return 2;
@@ -160,7 +162,7 @@ const activeStage = (j: MigrationJobView): number => {
 
 // ── small pieces ─────────────────────────────────────────────────────────────
 function StatusPill({ job }: { job: MigrationJobView }): React.JSX.Element {
-  const running = job.status === 'COLLECTING' || job.status === 'INGESTING';
+  const running = job.status === 'COLLECTING' || job.status === 'REFRESHING' || job.status === 'INGESTING';
   const stopping = running && job.stopRequested;
   const stalled = running && !stopping && isStalled(job);
   const approvedQueued = job.status === 'AWAITING_APPROVAL' && job.phase === 'ingest';
@@ -257,6 +259,24 @@ function Stepper({ job }: { job: MigrationJobView }): React.JSX.Element {
 function PhaseProgress({ job }: { job: MigrationJobView }): React.JSX.Element | null {
   const { total, collected, ingested } = job.progress;
   if (total === 0 && job.status === 'SUBMITTED') return null;
+
+  if (job.status === 'REFRESHING') {
+    const rt = job.refreshTotal ?? 0;
+    const rd = job.refreshDone ?? 0;
+    const pct = rt > 0 ? Math.min(100, Math.round((rd / rt) * 100)) : 0;
+    return (
+      <div>
+        <div className='mb-1 flex items-center justify-between text-xs text-muted-foreground'>
+          <span>Fetching latest… {rd.toLocaleString()} / {rt.toLocaleString()} conversations</span>
+          <span className='tabular-nums'>{pct}%</span>
+        </div>
+        <div className='h-1.5 overflow-hidden rounded-full bg-muted'>
+          <div className={cn('h-full rounded-full transition-[width] duration-500', TONE.blue.bar)} style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+    );
+  }
+
   const ingestPhase = job.phase === 'ingest' && job.status !== 'AWAITING_APPROVAL';
   const tone = TONE[job.status === 'COMPLETED' ? 'green' : ingestPhase ? 'violet' : 'blue'];
 
@@ -384,6 +404,12 @@ function JobCard({
               {job.submittedByName ? `${job.submittedByName} · ` : ''}submitted {ago(job.createdAt)}
               {job.channel?.startDate ? ` · from ${job.channel.startDate}` : ''}
             </div>
+            {(job.lastRefreshedAt ?? job.collectedAt) && (
+              <div className='text-xs text-muted-foreground'>
+                Data current as of {ago(job.lastRefreshedAt ?? job.collectedAt!)}
+                {job.refreshCount ? ` · synced ${job.refreshCount}×` : ''}
+              </div>
+            )}
             {job.channel?.announceInSlack && (
               <span className='mt-1.5 inline-flex items-center gap-1 rounded-full bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground'>
                 <Megaphone className='size-3' />
@@ -665,7 +691,7 @@ export default function SlackMigration(): React.JSX.Element {
   const hasActive = useMemo(
     () =>
       [...(mine ?? []), ...(all ?? [])].some(
-        j => j.status === 'COLLECTING' || j.status === 'INGESTING',
+        j => j.status === 'COLLECTING' || j.status === 'REFRESHING' || j.status === 'INGESTING',
       ),
     [mine, all],
   );
@@ -1099,7 +1125,7 @@ function OwnerActions({
     void run(fn).finally(() => setPending(null));
   };
   const canResume = job.status === 'STOPPED' || job.status === 'FAILED';
-  const canDelete = job.status !== 'COLLECTING' && job.status !== 'INGESTING';
+  const canDelete = job.status !== 'COLLECTING' && job.status !== 'REFRESHING' && job.status !== 'INGESTING';
   return (
     <>
       {canResume && (
@@ -1156,6 +1182,22 @@ function AdminActions({
   const canResume = job.status === 'STOPPED' || job.status === 'FAILED';
   return (
     <>
+      {canApprove && job.canRefresh && (
+        <Button
+          variant='outline'
+          size='sm'
+          disabled={busy}
+          loading={pending === 'refresh'}
+          trackId='slack_migration_refresh'
+          onClick={() => act('refresh', () => slackMigrationApi.refresh(job.id))}
+          data-track-category='SLACK_MIGRATION'
+          data-track-name='REFRESH_JOB'
+          title='Collect messages sent since collection before ingesting'
+        >
+          <RotateCcw className='size-3.5' />
+          Get latest messages
+        </Button>
+      )}
       {canApprove && (
         <Button
           size='sm'


### PR DESCRIPTION
## Type of Change

- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

Between **collection** and **ingestion** of a self-serve Slack migration there is a gap (often days). New DMs, messages, and thread replies posted in that window would otherwise be lost. This adds a **"Get latest messages"** delta re-collect an admin runs right before approving, plus collection-efficiency changes that make it cheap at scale and two correctness fixes for concurrent ingest.

Ticket: XYNE-62934

### "Get latest messages" (delta refresh) — DMs & channels
- New button beside **Approve**, shown only in `AWAITING_APPROVAL` and only while the Slack token is still held. New `REFRESHING` status; Approve is hidden during it.
- Per-conversation **cursor** (`cursors.json`) records the last-collected ts. Refresh re-scans from `min(cursor, now − 30 days)`:
  - new top-level messages (`ts > cursor`) collected,
  - **old-thread replies** within the 30-day window caught via `latest_reply > cursor` (mirrors the daily-sync "legacy thread replies" behaviour),
  - everything unchanged is skipped.
- New messages are written to **snapshot files** (`conversations/<id>.r<ts>.jsonl`); the base file is never overwritten, so a partial refresh cannot lose data. Ingest reads **base + snapshots as a union** and dedups per message.
- The **token** is kept (encrypted) through the approval window so refresh can run, and dropped when ingestion starts.
- New DMs created since collection are picked up via a fresh `conversations.list` diff.

### Correctness
- **Per-target-channel ingest lock** (Redis) so two people's migrations of the same **group DM** can't ingest it concurrently and race past per-message dedup (which would duplicate messages). Distinct channels never contend.
- **Bull `lockDuration` 5m → 30m** so a long single-conversation job isn't falsely flagged as stalled and re-delivered to a second worker mid-ingest (also a duplicate-message source).

### Collection efficiency (also improves initial collect)
- Skip Slack **`is_empty`** conversations entirely (never-used DMs → zero calls; uses the fresh listing, never the stale manifest).
- Fetch **`pins.list` lazily** — only when a conversation actually has content — removing the pins rate-limiting seen in prod.
- **Defer the snapshot upload** to the first new message, so a quiet DM touches GCS zero times.

### UI
- `REFRESHING` progress bar ("Fetching latest… X/Y conversations") and a **"Data current as of …"** line with a synced-count.

### Notes / trade-offs
- Rate limits are **per token**: DM refreshes use each person's own token (independent buckets); channel refreshes share the central bot token (throttle if parallelized later).
- An old-thread reply whose parent is **older than 30 days** isn't caught (`REFRESH_LOOKBACK_DAYS`, matches the daily-sync window).

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] New endpoint

`POST /migration/slack-migration/migration-jobs/:id/refresh` (admin) — queues a delta re-collect for a job in `AWAITING_APPROVAL`. Adds `REFRESHING` to the migration status enum and `canRefresh` / `refreshDone` / `refreshTotal` / `lastRefreshedAt` / `refreshCount` / `collectedAt` to the job view. No existing contract changed.

---

## How did you test it?

`tsc --noEmit` and eslint clean on both `apps/backend` and `apps/dashboard`. The refresh flow was exercised in local dev (collection → Get latest messages → delta re-collect → back to Awaiting approval), including the `is_empty` skip and lazy pins.

### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- feature is queue/Slack/GCS-side; verified via typecheck, lint, and local dev runs -->

### Manual

**Users**
- [x] Single user

**Run mode**
- [x] Local dev (`pnpm run dev:all`)
