### PR TITLE
fix: XYNE-62937 attachment shortcut targets thread instead of main channel

### DIFF
--- a/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
+++ b/apps/dashboard/src/components/ui/InputBox/InputBox.tsx
@@ -64,6 +64,7 @@ import { formatTypingMessage, resolveCommandTextFromHtml } from './InputBox.util
 import type { InputBoxHandle } from '../../../hooks/useDragAndDropAreaRef';
 import { sanitizeHtmlContent } from '../../Chat/ChatInput/ChatInput.utils';
 import { getEmojiFontSizeClass } from '../../../utils/emojiUtils';
+import { isEventFromInput } from '../../../utils/chatUtils';
 import { useDraftAttachments } from '../../../hooks/useDraft';
 import { MediaViewer } from '../files';
 import { usePlatform } from '../../../hooks/usePlatform';
@@ -409,6 +410,11 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
 
     useScope('composer', isFocused && !disabled && !isSending);
 
+    const isEventFromThisComposer = useCallback(
+      (event: KeyboardEvent): boolean => isEventFromInput(event, id),
+      [id],
+    );
+
     useShortcutById(
       'composer.attach',
       () => {
@@ -417,6 +423,7 @@ export const InputBox = forwardRef<InputBoxHandle, InputBoxProps>(
       },
       {
         enabled: Boolean(features.fileAttachments) && !disabled && !isSending,
+        when: isEventFromThisComposer,
       },
     );
 


### PR DESCRIPTION
[POT](https://drive.google.com/file/d/1dJrXt73SwUR6wdiSBfZOiMjMrLGZQR1O/view?usp=sharing)
## Type of Change

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description

With a thread open, pressing the attach shortcut (`mod+o`) while the **channel** composer is focused put the file into the **thread** composer instead.

`composer.attach` is registered once per mounted `InputBox` (`InputBox.tsx:413`), and unlike the `useScope('composer', …)` call directly above it, the registration was not tied to focus and carried no `when` predicate. Both composers are mounted at the same time whenever a thread panel is open, so both were equal candidates. `resolveShortcut` ranks by scope, then priority, then falls through to `shortcutsRegistry.ts:266`:

```ts
return b.entry.order - a.entry.order;   // most recently registered wins
```

Scope rank is identical for both (`composer`), and `composer.attach` has no priority, so the tiebreak decided it — and the thread composer mounts last, so the thread always won regardless of where the caret was.

Paste and drag-drop were unaffected because they resolve by DOM: `handlePaste` fires on the ProseMirror instance that received the event, and drop listeners are bound per panel via `useDragAndDropAreaRef`.

**Fix:** give the registration a `when` predicate so `resolveShortcut` filters out every `InputBox` except the one the keystroke came from, using the same `isEventFromInput` / `data-input-id` mechanism already used by `composer.editLastMessage` in `ChatListV4.tsx:1169` and `ThreadList.tsx:146`. The order tiebreak is never reached with more than one candidate now.

Applied inside `InputBox` rather than at each call site, so `ComposeDmPanel` and `QuickDmComposer` get it too. `GlobalCommandMenu.tsx:209` documents the same hazard for `mod+f`.

**Why it's safe:** `isFocused` is driven by TipTap's `onFocus`/`onBlur`, and the `composer` scope is only pushed while focused. Whenever the shortcut is eligible at all, DOM focus is inside that instance's ProseMirror, which sits under the `data-input-id` wrapper — so the predicate returns true for exactly the composer that already owned the scope. When no composer is focused the scope rank was already `-1` and nothing fired; unchanged.

## Areas Touched

- [ ] `apps/backend` (API / worker)
- [x] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

## Schema & Data Changes

- [x] No schema changes — **skip this section**

## Config, Environment & URLs

- [x] No config changes — **skip this section**

## API Contract

- [x] No API changes

---

## How did you test it?

Static verification only — no dev-server run, so this needs a manual pass before merge.

- `pnpm --filter xyne-spaces-dashboard run typecheck` — clean
- `npx eslint src/components/ui/InputBox/InputBox.tsx` — 0 errors (15 warnings, all pre-existing and elsewhere in the file)
- `npx prettier --check src/components/ui/InputBox/InputBox.tsx` — clean

**Suggested manual pass:**

1. Open a channel, open any message's thread in the side panel.
2. Focus the **main channel** composer, press `mod+o`, pick a file → should land in the channel tray (previously landed in the thread).
3. Focus the **thread** composer, press `mod+o` → should land in the thread tray.
4. Close the thread, press `mod+o` → channel tray, unchanged.
5. Confirm the dev-only `[Shortcuts] Ambiguous shortcut resolution for "mod+o"` warning (`shortcutsRegistry.ts:240`) no longer fires. It is `tieWarnings`-deduped, so hard-reload first.
6. Regression check: `mod+o` in the DM compose panel and the quick-DM composer still opens their own pickers.

Desktop only — `ShortcutsProvider` returns children unwrapped on mobile, so the shortcut never registers there.

### Automated

- [ ] Backend unit tests
- [ ] Claw tests
- [ ] End-to-end suite
- [ ] Added / updated tests for this change
- [x] Not covered by tests <!-- `apps/dashboard` has no test runner configured (no vitest/playwright, no test files) -->

### Manual

**Run mode**
- [ ] Not yet run — see suggested manual pass above

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes <!-- not run; no shared-package changes -->
- [ ] Backend `typecheck` + `build` pass <!-- not run; no backend changes -->
- [x] Dashboard `typecheck` passes; `eslint` clean on the touched file <!-- full `lint:errors-only` and `build` not run -->
- [x] Formatting clean in the packages I touched
- [x] No new deps
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*`
- [x] No docs/guidelines change needed — behaviour now matches what the shortcut already claimed to do
- [x] No debug logging or commented-out code left behind

