### PR TITLE
feat: XYNE-17198 add entity filter to chat and ticket search

### DIFF
--- a/apps/backend/src/services/vespaSearch/index.ts
+++ b/apps/backend/src/services/vespaSearch/index.ts
@@ -216,6 +216,7 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       board,       // Board name/ID
       tags,        // Comma-separated tags (ticket Tag framework — NOT thread types)
       threadType,  // Thread classification type(s) - comma-separated; matches thread roots
+      entity,      // Entity name(s) - comma-separated; AND-ed across slack + ticket results
       messageActs, // Thread type(s) a message was cited as evidence for - comma-separated
       dynamicFieldValues, // Dynamic field filters
       dynamicFieldDateRanges, // JSON string of fieldId -> { start, end }
@@ -838,6 +839,14 @@ export const searchHandler = async (req: Request, res: Response): Promise<void> 
       const tagValues = toFilterValues(tags, 'tags');
       options.ticket.tags = tagValues;
       options.slack.messageActs = tagValues;
+    }
+
+    // Entity filter — same values for both schemas; AND-ed inside YqlBuilder so a doc must
+    // mention every requested entity.
+    if (entity) {
+      const entityNames = toFilterValues(entity, 'entity');
+      options.slack.entityNames = entityNames;
+      options.ticket.entityNames = entityNames;
     }
 
     if (dynamicFieldValues) {

--- a/apps/backend/src/validators/vespaSearchValidator.ts
+++ b/apps/backend/src/validators/vespaSearchValidator.ts
@@ -219,6 +219,19 @@ export const vespaSearchQuerySchema = Joi.object({
     'string.base': 'messageActs must be a comma-separated string'
   }),
 
+  // Entity filter: entity name(s) annotated on chat messages / tickets (`entityNames`).
+  entity: Joi.alternatives()
+    .try(
+      Joi.array().items(Joi.string()),
+      Joi.string().custom((value) => {
+        return value.split(',').map((name: string) => name.trim()).filter(Boolean);
+      })
+    )
+    .optional()
+    .messages({
+      'alternatives.types': 'entity must be a string or array of entity names'
+    }),
+
   dynamicFieldValues: Joi.alternatives()
     .try(
       Joi.array().items(Joi.string()),

--- a/apps/backend/src/vespa/src/utils/YqlBuilder.ts
+++ b/apps/backend/src/vespa/src/utils/YqlBuilder.ts
@@ -57,6 +57,9 @@ export interface SlackFilters {
   // messages that justified a tag. Different questions; both exact attribute filters.
   threadType?: string[];
   messageActs?: string[];
+  // Entity filter: docs annotated with these entity names (chat_message/ticket `entityNames`).
+  // AND-ed, not OR-ed — multiple entities narrow to docs mentioning every one of them.
+  entityNames?: string[];
   // Date filters
   createdBefore?: string; // Created before date (multiple formats)
   createdAfter?: string; // Created after date (multiple formats)
@@ -88,6 +91,9 @@ export interface TicketFilters {
   createdRange?: string; // Time keyword (today, yesterday, this week, etc.)
   stage?: string[]; // Filter by ticket stage - comma-separated
   assignedTo?: string[]; // Filter by assigned user ID - comma-separated
+  // Entity filter: docs annotated with these entity names (chat_message/ticket `entityNames`).
+  // AND-ed, not OR-ed — multiple entities narrow to docs mentioning every one of them.
+  entityNames?: string[];
 }
 
 export interface FileFilters {
@@ -466,6 +472,7 @@ export class YqlBuilder {
       createdByUserId: boolean;
       isPrivate: boolean;
       messageType: boolean;
+      entityNames: boolean;
     }
   > = {
     [messageSchema]: {
@@ -475,6 +482,7 @@ export class YqlBuilder {
       createdByUserId: false,
       isPrivate: true,
       messageType: true,
+      entityNames: true,
     },
     [channelSchema]: {
       ownerId: true,
@@ -483,6 +491,7 @@ export class YqlBuilder {
       createdByUserId: false,
       isPrivate: true,
       messageType: false,
+      entityNames: false,
     },
     [attachmentSchema]: {
       ownerId: false,
@@ -491,6 +500,7 @@ export class YqlBuilder {
       createdByUserId: false,
       isPrivate: false,
       messageType: false,
+      entityNames: false,
     },
     [ticketSchema]: {
       ownerId: false,
@@ -499,6 +509,7 @@ export class YqlBuilder {
       createdByUserId: false,
       isPrivate: false,
       messageType: false,
+      entityNames: true,
     },
     [fileSchema]: {
       ownerId: true,
@@ -507,6 +518,7 @@ export class YqlBuilder {
       createdByUserId: false,
       isPrivate: true,
       messageType: false,
+      entityNames: false,
     },
     [mailSchema]: {
       ownerId: false,
@@ -515,6 +527,7 @@ export class YqlBuilder {
       createdByUserId: false,
       isPrivate: false,
       messageType: false,
+      entityNames: false,
     },
     [callSchema]: {
       ownerId: false,
@@ -523,6 +536,7 @@ export class YqlBuilder {
       createdByUserId: true,
       isPrivate: false,
       messageType: false,
+      entityNames: false,
     },
   };
 
@@ -827,6 +841,20 @@ export class YqlBuilder {
       conditions.push(`(${acts})`);
     }
 
+    // Entity filter — AND-ed so multiple entities narrow to messages mentioning every one
+    // of them. entityNames exists only on chat_message, so skip it when the query is pruned
+    // to chat_channel/chat_attachment only (else Vespa rejects the field reference).
+    if (
+      filters.entityNames &&
+      filters.entityNames.length > 0 &&
+      this.schemasHaveField(selectedSchemas, (f) => f.entityNames)
+    ) {
+      const entities = filters.entityNames
+        .map((entityName) => `entityNames contains ${params.bind('entityNames', entityName.trim())}`)
+        .join(' and ');
+      conditions.push(`(${entities})`);
+    }
+
     if (filters.createdBefore) {
       const timestamp = parseDateToTimestamp(filters.createdBefore, 'start');
       if (timestamp) conditions.push(`createdAtTimestamp < ${timestamp}`);
@@ -952,6 +980,14 @@ export class YqlBuilder {
         .map((tag) => `tags contains ${params.bind('tags', tag.trim())}`)
         .join(' or ');
       conditions.push(`(${tagConditions})`);
+    }
+
+    // Entity filter — AND-ed so multiple entities narrow to tickets mentioning every one of them.
+    if (filters.entityNames && filters.entityNames.length > 0) {
+      const entities = filters.entityNames
+        .map((entityName) => `entityNames contains ${params.bind('entityNames', entityName.trim())}`)
+        .join(' and ');
+      conditions.push(`(${entities})`);
     }
 
     // Dynamic field filter (fieldId::value tokens)

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.tsx
@@ -272,6 +272,7 @@ const TEXT_FILTER_HINTS: Record<string, string> = {
   range: 'last 7 days',
   board: 'board name',
   tags: 'tag1, tag2',
+  entity: 'Big Basket, Swiggy',
   // Board stages are per-board, so there's no workspace-wide candidate list to offer —
   // both of these stay typed-only, hinted rather than picked.
   stage: 'stage name',
@@ -279,7 +280,8 @@ const TEXT_FILTER_HINTS: Record<string, string> = {
   // `type:` with no value - hint the value set; `typeAutocomplete` completes it once you type.
   type: 'messages, files, tickets…',
 };
-const TEXT_FILTER_HINT_REGEX = /\b(before|after|on|range|board|tags|stage|status|type):\s*$/i;
+const TEXT_FILTER_HINT_REGEX =
+  /\b(before|after|on|range|board|tags|entity|stage|status|type):\s*$/i;
 
 /**
  * The `mentions:` result sections, in the same order `availableMentionTargets` concatenates
@@ -743,6 +745,7 @@ const ChannelCommandMenu = ({
     ((item: { id: string; name: string; email?: string; type?: ChipType }) => void) | null
   >(null);
 
+  const commitEntityRef = useRef<(() => boolean) | null>(null);
   const insertTextRef = useRef<((text: string) => void) | null>(null);
   const toggleQuotesRef = useRef<(() => void) | null>(null);
 
@@ -1399,6 +1402,10 @@ const ChannelCommandMenu = ({
   );
 
   // Store the insertMention function when it's ready
+  const handleCommitEntityReady = useCallback((commitEntity: () => boolean) => {
+    commitEntityRef.current = commitEntity;
+  }, []);
+
   const handleInsertMentionReady = useCallback(
     (
       insertMention: (item: { id: string; name: string; email?: string; type?: ChipType }) => void,
@@ -3686,6 +3693,15 @@ const ChannelCommandMenu = ({
       }
     }
 
+    // An uncommitted `entity:<value>` becomes its chip instead of running the search.
+    // This handler is on an ancestor's onKeyDownCapture, so it sees Enter before Lexical
+    // does — the editor can't claim this key itself (see EntityChipPlugin).
+    if (commitEntityRef.current?.()) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+
     // If mention search is active, let the mention selection handle Enter
     if (mentionSearchType !== null) {
       e.preventDefault();
@@ -3876,6 +3892,7 @@ const ChannelCommandMenu = ({
             setSelectedMentionIndex={setSelectedMentionIndex}
             onNavigate={markNavigated}
             hasNavigated={hasNavigated}
+            onCommitEntityReady={handleCommitEntityReady}
             onInsertMentionReady={handleInsertMentionReady}
             onReplaceTriggerChipsReady={fn => {
               replaceTriggerChipsRef.current = fn;

--- a/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.types.ts
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/ChannelCommandMenu.types.ts
@@ -170,6 +170,9 @@ export const ChipType = {
   // Value filter: a board. `id` is the boardId the backend matches on, `name` the label —
   // typing a board's name would match nothing, so it has to be picked.
   BOARD: 'board',
+  // Value filter: an entity name ("Big Basket"). Unlike BOARD there is no candidate list —
+  // the backend matches the name itself, so `id` and `name` are both the typed text.
+  ENTITY: 'entity',
 } as const;
 
 export type ChipType = (typeof ChipType)[keyof typeof ChipType];
@@ -292,6 +295,7 @@ export type FilterKind =
   | 'stage'
   | 'board'
   | 'tags'
+  | 'entity'
   | 'date'
   | 'mention' // bare @user
   | 'channelMention'; // bare #channel
@@ -326,6 +330,8 @@ export const FILTER_RELEVANCE: Record<FilterKind, TabType[]> = {
   stage: [TabType.TICKETS],
   board: [TabType.TICKETS],
   tags: [TabType.TICKETS],
+  // Entity annotations are ingested onto chat messages and tickets alike.
+  entity: [TabType.MESSAGES, TabType.TICKETS],
   // Desk omitted: the Cmd+K path never populates mail date params (backend wires date to
   // slack/ticket/file only). Add DESK once options.mail.createdBefore/After/On/Range is set.
   date: [
@@ -404,6 +410,7 @@ const PREFIX_TO_KIND: Record<ChipPrefix, FilterKind> = {
   'assignee:': 'assignee',
   'priority:': 'priority',
   'board:': 'board',
+  'entity:': 'entity',
   'on:': 'date',
   'after:': 'date',
   'before:': 'date',

--- a/apps/dashboard/src/components/Chat/ChatDirectory/EntityChipPlugin.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/EntityChipPlugin.tsx
@@ -5,8 +5,9 @@
  * boards, priorities, dates), so `MentionPlugin` drives them all through one
  * trigger → typeahead → insert path. Entity names have no such list — the backend matches
  * the name itself — so the value can only come from what the user typed, and the chip is
- * committed by a keystroke instead of a selection. That is a different mechanism, hence a
- * separate plugin rather than another branch in MentionPlugin.
+ * committed by a keystroke instead of a selection. Only that *trigger* differs: the splice
+ * itself is `$spliceFilterChip` from FilterChipNode, the same one MentionPlugin uses,
+ * so this file holds nothing but the entity-specific scan and the two commit keys.
  *
  * The chip needs no callback: `LexicalSearchInput`'s change handler walks the tree and
  * reports every FilterChipNode, so inserting the node is what puts it in the palette's
@@ -23,7 +24,6 @@
 import { useEffect } from 'react';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import {
-  $createTextNode,
   $getSelection,
   $isRangeSelection,
   COMMAND_PRIORITY_HIGH,
@@ -31,7 +31,7 @@ import {
   TextNode,
 } from 'lexical';
 
-import { $createFilterChip } from './FilterChipNode';
+import { $spliceFilterChip } from './FilterChipNode';
 import { ChipType, type ChipData } from './ChannelCommandMenu.types';
 
 export interface EntityChipPluginProps {
@@ -58,8 +58,6 @@ export function EntityChipPlugin({
       if (!pending) return false;
 
       const { node, start, caret, value } = pending;
-      const text = node.getTextContent();
-      const textAfter = text.slice(caret);
 
       const chipData: ChipData = {
         id: value,
@@ -68,14 +66,11 @@ export function EntityChipPlugin({
         prefix: ENTITY_PREFIX,
       };
 
-      node.setTextContent(text.slice(0, start));
-      const chip = $createFilterChip(chipData, currentUserID);
       // Re-arming leaves the next trigger already typed, so the caret can keep going.
-      const trailing = $createTextNode(reArm ? ` ${ENTITY_PREFIX}` : ' ');
-      node.insertAfter(chip);
-      chip.insertAfter(trailing);
-      if (textAfter) trailing.insertAfter($createTextNode(textAfter));
-      trailing.selectEnd();
+      $spliceFilterChip(node, start, caret, [chipData], {
+        currentUserId: currentUserID,
+        trailingText: reArm ? ` ${ENTITY_PREFIX}` : ' ',
+      });
 
       return true;
     };

--- a/apps/dashboard/src/components/Chat/ChatDirectory/EntityChipPlugin.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/EntityChipPlugin.tsx
@@ -1,0 +1,144 @@
+/**
+ * Turns typed `entity:<name>` text into an entity filter chip.
+ *
+ * Every other chip in the palette is picked from a candidate list (people, channels,
+ * boards, priorities, dates), so `MentionPlugin` drives them all through one
+ * trigger → typeahead → insert path. Entity names have no such list — the backend matches
+ * the name itself — so the value can only come from what the user typed, and the chip is
+ * committed by a keystroke instead of a selection. That is a different mechanism, hence a
+ * separate plugin rather than another branch in MentionPlugin.
+ *
+ * The chip needs no callback: `LexicalSearchInput`'s change handler walks the tree and
+ * reports every FilterChipNode, so inserting the node is what puts it in the palette's
+ * selected filters.
+ *
+ * Commit keys:
+ *   `,`      handled here, via Lexical's KEY_DOWN_COMMAND.
+ *   `Enter`  NOT handled here. The palette owns Enter on an ancestor `onKeyDownCapture`,
+ *            which runs before the event reaches Lexical at all, so a command listener
+ *            would never see it. Instead `onCommitEntityReady` hands the commit function
+ *            up to the palette, which calls it from its own handler — the same shape
+ *            MentionPlugin uses for `onInsertMentionReady`.
+ */
+import { useEffect } from 'react';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import {
+  $createTextNode,
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_HIGH,
+  KEY_DOWN_COMMAND,
+  TextNode,
+} from 'lexical';
+
+import { $createFilterChip } from './FilterChipNode';
+import { ChipType, type ChipData } from './ChannelCommandMenu.types';
+
+export interface EntityChipPluginProps {
+  /**
+   * Receives the commit function, for callers that own a key the editor never sees.
+   * Returns true when a pending `entity:<value>` was turned into a chip.
+   */
+  onCommitEntityReady?: (commitEntity: () => boolean) => void;
+  currentUserID?: string;
+}
+
+export function EntityChipPlugin({
+  onCommitEntityReady,
+  currentUserID,
+}: EntityChipPluginProps): null {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    // Command listeners already run inside an editor.update(), so `$`-functions read the
+    // in-flight state directly. Reading via editor.getEditorState() here would see the
+    // PREVIOUS state and miss the value the user just finished typing.
+    const commitPendingEntity = (reArm: boolean): boolean => {
+      const pending = findPendingEntity();
+      if (!pending) return false;
+
+      const { node, start, caret, value } = pending;
+      const text = node.getTextContent();
+      const textAfter = text.slice(caret);
+
+      const chipData: ChipData = {
+        id: value,
+        name: value,
+        type: ChipType.ENTITY,
+        prefix: ENTITY_PREFIX,
+      };
+
+      node.setTextContent(text.slice(0, start));
+      const chip = $createFilterChip(chipData, currentUserID);
+      // Re-arming leaves the next trigger already typed, so the caret can keep going.
+      const trailing = $createTextNode(reArm ? ` ${ENTITY_PREFIX}` : ' ');
+      node.insertAfter(chip);
+      chip.insertAfter(trailing);
+      if (textAfter) trailing.insertAfter($createTextNode(textAfter));
+      trailing.selectEnd();
+
+      return true;
+    };
+
+    const removeKeyDownCommand = editor.registerCommand(
+      KEY_DOWN_COMMAND,
+      event => {
+        if (event.key !== ',' || event.metaKey || event.ctrlKey || event.altKey) return false;
+        if (!commitPendingEntity(true)) return false;
+        event.preventDefault();
+        event.stopPropagation();
+        return true;
+      },
+      COMMAND_PRIORITY_HIGH,
+    );
+
+    // Called from the palette's capture handler, i.e. outside any editor context — so
+    // unlike the command listeners above this has to open its own update.
+    onCommitEntityReady?.((): boolean => {
+      let committed = false;
+      editor.update(() => {
+        committed = commitPendingEntity(false);
+      });
+      return committed;
+    });
+
+    return (): void => {
+      removeKeyDownCommand();
+    };
+  }, [editor, currentUserID, onCommitEntityReady]);
+
+  return null;
+}
+
+const ENTITY_PREFIX = 'entity:';
+
+interface PendingEntity {
+  node: TextNode;
+  start: number;
+  caret: number;
+  value: string;
+}
+
+/**
+ * The uncommitted `entity:<value>` run the caret sits in, or null. Reads only the text
+ * BEFORE the caret so a caret parked mid-word doesn't swallow the rest of the line.
+ */
+function findPendingEntity(): PendingEntity | null {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null;
+
+  const node = selection.anchor.getNode();
+  if (!(node instanceof TextNode)) return null;
+
+  const caret = selection.anchor.offset;
+  const beforeCaret = node.getTextContent().slice(0, caret);
+  const start = beforeCaret.toLowerCase().lastIndexOf(ENTITY_PREFIX);
+  if (start === -1) return null;
+  // Must start a word, or `identity:foo` would arm on the `entity:` inside it.
+  if (start > 0 && /[A-Za-z0-9_]/.test(beforeCaret[start - 1] ?? '')) return null;
+
+  const value = beforeCaret.slice(start + ENTITY_PREFIX.length).trim();
+  if (!value) return null;
+
+  return { node, start, caret, value };
+}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/FilterChipNode.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/FilterChipNode.tsx
@@ -31,7 +31,7 @@ import {
   type SerializedTextNode,
   type Spread,
 } from 'lexical';
-import { CalendarDays, LayoutGrid, SignalHigh } from 'lucide-react';
+import { Building2, CalendarDays, LayoutGrid, SignalHigh } from 'lucide-react';
 import { Hashtag, UserTwo, Lock02Close } from '@xyne/icons';
 import { ChannelScopeType, ChannelVisibility, TicketPriority } from '@xyne/shared';
 import { useChannel } from '../../../hooks/useChannels';
@@ -98,6 +98,10 @@ export function chipLabelText(mentionData: ChipData): string {
   // Date chips read as the bare date; the prefix already says which edge it is.
   if (mentionData.type === ChipType.DATE) {
     return mentionData.id;
+  }
+  // Entity chips read as the bare name ("Big Basket") — the `entity:` prefix carries the rest.
+  if (mentionData.type === ChipType.ENTITY) {
+    return mentionData.name;
   }
   // A mention filter reads the way a mention is written — `mentions: @alice` — because the
   // `@` is the thing being searched for, not a type marker. The avatar beside it doesn't
@@ -267,6 +271,11 @@ export function ChipIcon({ mentionData }: { mentionData: ChipData }): React.JSX.
   // call useChannel with a board id.
   if (mentionData.type === ChipType.BOARD) {
     return <LayoutGrid className={ICON_CLASS} />;
+  }
+  // Entity — a value filter like board, glyph rather than an avatar. Also checked before
+  // the channel branch, which would otherwise call useChannel with an entity name.
+  if (mentionData.type === ChipType.ENTITY) {
+    return <Building2 className={ICON_CLASS} />;
   }
   // User filters show the picked person's photo (the design's 16px avatar, rounded-sm = 4px);
   // `Avatar` resolves the user from the id and falls back to initials, so ChipData stays

--- a/apps/dashboard/src/components/Chat/ChatDirectory/FilterChipNode.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/FilterChipNode.tsx
@@ -11,13 +11,17 @@
  * (`from: [avatar] Alice`), per the design. It still reports its text through
  * `getTextContent()`, so the pill's combined text is unchanged (`from: Alice`).
  *
- * `$createFilterChip(mentionData)` builds the whole pill; `FilterChipPlugin`
- * demotes it to plain text on the first edit so the filter stays parseable
- * downstream.
+ * `$createFilterChip(mentionData)` builds the whole pill and
+ * `$spliceFilterChip()` puts it into the editor in place of the text that summoned it —
+ * the one splice shared by every chip source, whether the value was picked from a
+ * typeahead (`MentionPlugin`) or typed and committed by a keystroke (`EntityChipPlugin`).
+ * `FilterChipPlugin` demotes a chip back to plain text on the first edit so the filter
+ * stays parseable downstream.
  */
 
 import React from 'react';
 import {
+  $createTextNode,
   $getRoot,
   $isElementNode,
   DecoratorNode,
@@ -539,6 +543,58 @@ export function $createFilterChip(
     );
   }
   return container;
+}
+
+export interface ChipSpliceOptions {
+  // `| undefined` explicitly: under exactOptionalPropertyTypes a caller whose own
+  // `currentUserID` prop is optional could not otherwise forward it as a property.
+  currentUserId?: string | undefined;
+  /**
+   * Text node left after the LAST chip, and where the caret lands. Defaults to a plain
+   * space; a caller that re-arms its own trigger passes e.g. `' entity:'` so the user can
+   * keep typing the next value.
+   */
+  trailingText?: string;
+}
+
+/**
+ * Replaces `node`'s `[start, end)` with `chips` — the one splice every chip source needs,
+ * however the value was obtained (picked from a typeahead, or typed and committed by a
+ * keystroke). Each chip is followed by a space so the pills read as separate filters;
+ * whatever followed `end` is preserved after the trailing text, and the caret is placed
+ * at the end of that trailing node.
+ *
+ * Must run inside an `editor.update()`. Returns the trailing text node the caret ends up
+ * in, or null when there is nothing to insert.
+ */
+export function $spliceFilterChip(
+  node: TextNode,
+  start: number,
+  end: number,
+  chips: ChipData[],
+  { currentUserId, trailingText = ' ' }: ChipSpliceOptions = {},
+): TextNode | null {
+  if (chips.length === 0) return null;
+
+  const text = node.getTextContent();
+  const textAfter = text.slice(end);
+  node.setTextContent(text.slice(0, start));
+
+  let cursor: LexicalNode = node;
+  let trailing: TextNode | null = null;
+  for (const [index, chipData] of chips.entries()) {
+    const chip = $createFilterChip(chipData, currentUserId);
+    cursor.insertAfter(chip);
+    // Only the last separator is the caller's to choose — the caret ends up there.
+    trailing = $createTextNode(index === chips.length - 1 ? trailingText : ' ');
+    chip.insertAfter(trailing);
+    cursor = trailing;
+  }
+  if (!trailing) return null;
+
+  if (textAfter) trailing.insertAfter($createTextNode(textAfter));
+  trailing.selectEnd();
+  return trailing;
 }
 
 // ---- Priority chip helpers ----

--- a/apps/dashboard/src/components/Chat/ChatDirectory/LexicalSearchInput.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/LexicalSearchInput.tsx
@@ -38,6 +38,7 @@ import {
   BoardTriggerType,
   MentionsTriggerType,
 } from './MentionPlugin';
+import { EntityChipPlugin } from './EntityChipPlugin';
 import { PastePlugin } from './PastePlugin';
 import { cn } from '../../../utils/classNames';
 import { ChipType, type ChipData } from './ChannelCommandMenu.types';
@@ -71,6 +72,7 @@ interface LexicalSearchInputProps {
   onNavigate?: () => void;
   hasNavigated?: boolean;
   onReplaceTriggerChipsReady?: (replaceChips: (chips: ChipData[]) => void) => void;
+  onCommitEntityReady?: (commitEntity: () => boolean) => void;
   onInsertMentionReady?: (
     insertMention: (item: { id: string; name: string; email?: string }) => void,
   ) => void;
@@ -661,6 +663,7 @@ export function LexicalSearchInput({
   setSelectedMentionIndex,
   onNavigate,
   hasNavigated,
+  onCommitEntityReady,
   onInsertMentionReady,
   onReplaceTriggerChipsReady,
   onMentionInserted,
@@ -766,6 +769,10 @@ export function LexicalSearchInput({
           <SingleLinePastePlugin />
           <FilterChipPlugin />
           <ChipOrderPlugin />
+          <EntityChipPlugin
+            {...(onCommitEntityReady ? { onCommitEntityReady } : {})}
+            {...(currentUserID ? { currentUserID } : {})}
+          />
           <MentionPlugin
             {...(onUserSearch ? { onUserSearch } : {})}
             {...(onChannelSearch ? { onChannelSearch } : {})}

--- a/apps/dashboard/src/components/Chat/ChatDirectory/MentionPlugin.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/MentionPlugin.tsx
@@ -9,15 +9,13 @@ import {
   KEY_ESCAPE_COMMAND,
   KEY_TAB_COMMAND,
   TextNode,
-  type LexicalNode,
   $getSelection,
   $isRangeSelection,
-  $createTextNode,
   $getRoot,
 } from 'lexical';
 import { TicketPriority } from '@xyne/shared';
 import { isChipPrefix, type ChipPrefix } from '../../../search/filterModel';
-import { $createFilterChip, $removeExistingPriorityChips } from './FilterChipNode';
+import { $removeExistingPriorityChips, $spliceFilterChip } from './FilterChipNode';
 import { ChipType, type ChipData } from './ChannelCommandMenu.types';
 
 export type ChannelTriggerType = '#' | 'in:' | 'in:#' | 'in:@';
@@ -229,21 +227,10 @@ export function MentionPlugin({
         // Bail if the trigger moved out from under us (same guard insertMention uses).
         if (textContent.substring(mentionStart, mentionStart + trigger.length) !== trigger) return;
 
-        const textBefore = textContent.substring(0, mentionStart);
-        const textAfter = textContent.substring(cursorOffset);
-        anchorNode.setTextContent(textBefore);
-
         // Chips in order, each followed by a space, so they read as separate pills.
-        let cursor: LexicalNode = anchorNode;
-        for (const chip of chips) {
-          const chipNode = $createFilterChip(chip, currentUserID);
-          cursor.insertAfter(chipNode);
-          const spaceNode = $createTextNode(' ');
-          chipNode.insertAfter(spaceNode);
-          cursor = spaceNode;
-        }
-        if (textAfter) cursor.insertAfter($createTextNode(textAfter));
-        cursor.selectEnd();
+        $spliceFilterChip(anchorNode, mentionStart, cursorOffset, chips, {
+          currentUserId: currentUserID,
+        });
 
         for (const chip of chips) onMentionSelect?.(chip);
       });
@@ -311,32 +298,15 @@ export function MentionPlugin({
               return;
             }
 
-            // Get text parts
-            const textBefore = textContent.substring(0, mentionStart);
-            const textAfter = textContent.substring(cursorOffset);
-
-            // Set the node text to only the text before trigger
-            anchorNode.setTextContent(textBefore);
-
             const mentionData = buildMentionData(item, type, trigger);
             // Priority is the exclusive filter — drop any existing priority chip first.
             if (type === ChipType.PRIORITY) {
               $removeExistingPriorityChips();
             }
-            // Insert the chip pill (icon + editable label) then a trailing space.
-            const chip = $createFilterChip(mentionData, currentUserID);
-            const spaceNode = $createTextNode(' ');
-            anchorNode.insertAfter(chip);
-            chip.insertAfter(spaceNode);
-
-            // If there's text after, add it
-            if (textAfter) {
-              const afterNode = $createTextNode(textAfter);
-              spaceNode.insertAfter(afterNode);
-            }
-
-            // Move cursor after the space
-            spaceNode.selectEnd();
+            // Swap the typed trigger for the chip pill; the caret lands after its trailing space.
+            $spliceFilterChip(anchorNode, mentionStart, cursorOffset, [mentionData], {
+              currentUserId: currentUserID,
+            });
 
             onMentionSelect?.(mentionData);
           } else {
@@ -357,32 +327,15 @@ export function MentionPlugin({
         const triggerAtStart = textContent.substring(mentionStart, mentionStart + trigger.length);
         if (triggerAtStart !== trigger) return;
 
-        // Get text parts
-        const textBefore = textContent.substring(0, mentionStart);
-        const textAfter = textContent.substring(cursorOffset);
-
-        // Set the node text to only the text before trigger
-        anchorNode.setTextContent(textBefore);
-
         const mentionData = buildMentionData(item, type, trigger);
         // Priority is the exclusive filter — drop any existing priority chip first.
         if (type === ChipType.PRIORITY) {
           $removeExistingPriorityChips();
         }
-        // Insert the chip pill (icon + editable label) then a trailing space.
-        const chip = $createFilterChip(mentionData, currentUserID);
-        const spaceNode = $createTextNode(' ');
-        anchorNode.insertAfter(chip);
-        chip.insertAfter(spaceNode);
-
-        // If there's text after, add it
-        if (textAfter) {
-          const afterNode = $createTextNode(textAfter);
-          spaceNode.insertAfter(afterNode);
-        }
-
-        // Move cursor after the space
-        spaceNode.selectEnd();
+        // Swap the typed trigger for the chip pill; the caret lands after its trailing space.
+        $spliceFilterChip(anchorNode, mentionStart, cursorOffset, [mentionData], {
+          currentUserId: currentUserID,
+        });
 
         onMentionSelect?.(mentionData);
       });

--- a/apps/dashboard/src/components/Chat/SearchResults/SearchQueryInput.tsx
+++ b/apps/dashboard/src/components/Chat/SearchResults/SearchQueryInput.tsx
@@ -9,6 +9,7 @@ import {
   type KeyboardEvent,
 } from 'react';
 import {
+  Building2,
   CalendarDays,
   LayoutGrid,
   Loader2,
@@ -86,6 +87,13 @@ interface SearchQueryInputProps {
 /** Ties the wrapping <label> to the text input so a click anywhere focuses it. */
 const QUERY_INPUT_ID = 'search-query-input';
 
+/** Glyph-only token kinds. The rest (user/channel/priority) render their own component. */
+const GLYPH_BY_ICON_KIND: Partial<Record<TokenIcon['kind'], typeof CalendarDays>> = {
+  date: CalendarDays,
+  board: LayoutGrid,
+  entity: Building2,
+};
+
 function TokenGlyph({ icon }: { icon?: TokenIcon | undefined }): ReactElement | null {
   if (!icon) return null;
   if (icon.kind === 'user') {
@@ -105,8 +113,7 @@ function TokenGlyph({ icon }: { icon?: TokenIcon | undefined }): ReactElement | 
       <SignalHigh size={16} className={cn('shrink-0', PRIORITY_ICON_COLOR[icon.value] ?? '')} />
     );
   }
-  const Icon =
-    icon.kind === 'date' ? CalendarDays : icon.kind === 'board' ? LayoutGrid : SlidersHorizontal;
+  const Icon = GLYPH_BY_ICON_KIND[icon.kind] ?? SlidersHorizontal;
   // No colour: the glyph inherits `--chip-fg` from the pill, matching the palette's chip.
   return <Icon size={16} className='shrink-0' />;
 }

--- a/apps/dashboard/src/hooks/useSearchMetrics.ts
+++ b/apps/dashboard/src/hooks/useSearchMetrics.ts
@@ -124,15 +124,21 @@ export const CMDK_USER_LIMIT = 25;
  * (`status:todo`, `board:…`) keeps working; an explicit pick from the results page's
  * Filters popover wins for that field.
  */
+type ResolvedTextFilters = ReturnType<typeof parseSearchFilters> & {
+  /** Chip-only — never parsed from the query. See parseSearchFilters. */
+  entity: string | undefined;
+};
+
 function resolveTextFilters(
   query: string,
   overrides: StructuredSearchFilters,
-): ReturnType<typeof parseSearchFilters> {
+): ResolvedTextFilters {
   const parsed = parseSearchFilters(query);
   return {
     ...parsed,
     board: overrides.board || parsed.board,
     tags: overrides.tags || parsed.tags,
+    entity: overrides.entity,
     status: overrides.status || parsed.status,
     before: overrides.before || parsed.before,
     after: overrides.after || parsed.after,
@@ -149,6 +155,12 @@ function resolveTextFilters(
 function boardFilterFromChips(mentions: SelectedMention[]): StructuredSearchFilters {
   const boards = mentions.filter(m => m.type === ChipType.BOARD).map(m => m.id);
   return boards.length > 0 ? { board: boards.join(',') } : {};
+}
+
+/** Entity chips carry the name the backend matches, so they travel as-is. */
+function entityFilterFromChips(mentions: SelectedMention[]): StructuredSearchFilters {
+  const entities = mentions.filter(m => m.type === ChipType.ENTITY).map(m => m.id);
+  return entities.length > 0 ? { entity: entities.join(',') } : {};
 }
 
 function dateFiltersFromChips(mentions: SelectedMention[]): StructuredSearchFilters {
@@ -531,6 +543,9 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       if (selectedMentions.some(m => m.type === ChipType.PRIORITY)) {
         sessionFiltersRef.current.add('priority');
       }
+      if (selectedMentions.some(m => m.type === ChipType.ENTITY)) {
+        sessionFiltersRef.current.add('entity');
+      }
       if (parsedFiltersForImpression.board) sessionFiltersRef.current.add('board');
       if (parsedFiltersForImpression.tags) sessionFiltersRef.current.add('tags');
       if (parsedFiltersForImpression.before) sessionFiltersRef.current.add('before');
@@ -806,6 +821,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
         searchText,
         board: boardFilter,
         tags: tagsFilter,
+        entity: entityFilter,
         before: beforeFilter,
         after: afterFilter,
         on: onFilter,
@@ -817,6 +833,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
         ...structuredFilters,
         ...dateFiltersFromChips(selectedMentions),
         ...boardFilterFromChips(selectedMentions),
+        ...entityFilterFromChips(selectedMentions),
       });
 
       // Priority is chip-only: value comes solely from the chip; raw `priority:` text
@@ -841,6 +858,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
         priorityFilter ||
         boardFilter ||
         tagsFilter ||
+        entityFilter ||
         beforeFilter ||
         afterFilter ||
         onFilter ||
@@ -947,6 +965,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
               ...(priorityFilter && { priority: priorityFilter }),
               ...(boardFilter && { board: boardFilter }),
               ...(tagsFilter && { tags: tagsFilter }),
+              ...(entityFilter && { entity: entityFilter }),
               ...(beforeFilter && { before: beforeFilter }),
               ...(afterFilter && { after: afterFilter }),
               ...(onFilter && { on: onFilter }),
@@ -1394,6 +1413,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       searchText,
       board: boardFilter,
       tags: tagsFilter,
+      entity: entityFilter,
       before: beforeFilter,
       after: afterFilter,
       on: onFilter,
@@ -1405,6 +1425,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       ...structuredFilters,
       ...dateFiltersFromChips(selectedMentions),
       ...boardFilterFromChips(selectedMentions),
+      ...entityFilterFromChips(selectedMentions),
     });
 
     // Mirror performSearch: priority is chip-only (value from the chip, not text).
@@ -1414,6 +1435,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
       priorityFilter ||
       boardFilter ||
       tagsFilter ||
+      entityFilter ||
       beforeFilter ||
       afterFilter ||
       onFilter ||
@@ -1463,6 +1485,7 @@ export function useSearchMetrics(options: UseSearchMetricsOptions = {}) {
           ...(priorityFilter && { priority: priorityFilter }),
           ...(boardFilter && { board: boardFilter }),
           ...(tagsFilter && { tags: tagsFilter }),
+          ...(entityFilter && { entity: entityFilter }),
           ...(beforeFilter && { before: beforeFilter }),
           ...(afterFilter && { after: afterFilter }),
           ...(onFilter && { on: onFilter }),

--- a/apps/dashboard/src/search/filterModel.ts
+++ b/apps/dashboard/src/search/filterModel.ts
@@ -22,6 +22,7 @@ export const CHIP_PREFIXES = [
   'assignee:',
   'priority:',
   'board:',
+  'entity:',
   // Date chips are value filters like priority — a window, not an entity.
   'on:',
   'after:',
@@ -53,6 +54,8 @@ export interface SearchResultsFilters {
   statuses: string[];
   boardIds: string[];
   tags: string[];
+  /** Entity names annotated on messages/tickets. AND-ed by the backend, not OR-ed. */
+  entities: string[];
   // Date range: either a keyword (`range:last 7 days`) or explicit bounds (YYYY-MM-DD).
   dateRange: string;
   after: string;
@@ -79,6 +82,7 @@ export const DEFAULT_SEARCH_FILTERS: SearchResultsFilters = {
   statuses: [],
   boardIds: [],
   tags: [],
+  entities: [],
   dateRange: '',
   after: '',
   before: '',
@@ -202,6 +206,7 @@ export interface StructuredSearchFilters {
   status?: string;
   board?: string;
   tags?: string;
+  entity?: string;
   before?: string;
   after?: string;
   range?: string;

--- a/apps/dashboard/src/search/filterRegistry.ts
+++ b/apps/dashboard/src/search/filterRegistry.ts
@@ -52,6 +52,7 @@ export type TokenIcon =
   | { kind: 'priority'; value: string }
   | { kind: 'date' }
   | { kind: 'board' }
+  | { kind: 'entity' }
   | { kind: 'value' };
 
 /** One removable thing in the search box / bar. */
@@ -150,7 +151,7 @@ export interface TypedFilters {
 }
 
 /** The backend query-param names a text-list filter can set. */
-type SearchFilterKey = 'status' | 'board' | 'tags';
+type SearchFilterKey = 'status' | 'board' | 'tags' | 'entity';
 
 /** Filter values travel as plain strings (URL params, typed syntax), so options are too. */
 export type FilterOption = { value: string; label: string };
@@ -316,9 +317,10 @@ function textListEntry(opts: {
   id: string;
   label: string;
   param: string;
-  field: 'statuses' | 'boardIds' | 'tags';
+  field: 'statuses' | 'boardIds' | 'tags' | 'entities';
   syntax: string;
-  typedKey: 'status' | 'board' | 'tags';
+  /** Omitted for chip-only filters, whose value can only come from a chip or the param. */
+  typedKey?: 'status' | 'board' | 'tags';
   searchKey: SearchFilterKey;
   tokenIcon?: TokenIcon;
   appliesTo?: (docType: DocType) => boolean;
@@ -345,7 +347,7 @@ function textListEntry(opts: {
     read: (params, typed) => ({
       [opts.field]: params.get(opts.param)
         ? csv(params.get(opts.param))
-        : csv(typed[opts.typedKey]),
+        : csv(opts.typedKey ? typed[opts.typedKey] : undefined),
     }),
     write: (f, params) => setOrDelete(params, opts.param, f[opts.field].join(',')),
     queryText: f => (f[opts.field].length > 0 ? `${opts.syntax}${f[opts.field].join(',')}` : ''),
@@ -858,6 +860,28 @@ export const FILTER_REGISTRY: FilterEntry[] = [
     // and a message's `messageActs`, so this is one filter over both.
     appliesTo: isTicketOrMessageType,
     control: { kind: 'text', placeholder: 'e.g. billing, urgent' },
+  }),
+  textListEntry({
+    id: 'entity',
+    label: 'Entity',
+    param: 'entity',
+    field: 'entities',
+    syntax: 'entity:',
+    searchKey: 'entity',
+    // Same glyph the palette chip uses (ChipIcon in FilterChipNode), so a filter looks
+    // identical in cmd+K and on the results page.
+    tokenIcon: { kind: 'entity' },
+    // Entity annotations live on both a message's and a ticket's `entityNames`, and the
+    // backend AND-s the values — two entities means docs mentioning both, not either.
+    appliesTo: isTicketOrMessageType,
+    control: { kind: 'text', placeholder: 'e.g. Big Basket, Swiggy' },
+    // The chip's value IS what the backend matches (an entity name, not an id), so unlike
+    // `board:` the label needs no resolver — it reads back exactly what was typed.
+    chip: {
+      type: ChipType.ENTITY,
+      prefix: 'entity:',
+      label: value => value,
+    },
   }),
 ];
 

--- a/apps/dashboard/src/services/searchService.ts
+++ b/apps/dashboard/src/services/searchService.ts
@@ -216,6 +216,10 @@ export class SearchService {
       params['tags'] = filters.tags;
     }
 
+    if (filters.entity) {
+      params['entity'] = filters.entity;
+    }
+
     if (filters.before) {
       params['before'] = filters.before;
     }

--- a/apps/dashboard/src/types/search.ts
+++ b/apps/dashboard/src/types/search.ts
@@ -129,6 +129,7 @@ export interface VespaSearchFilters {
   priority?: string; // HIGH, MEDIUM, LOW, CRITICAL
   board?: string; // Board name/ID
   tags?: string; // Comma-separated tags — ticket labels and message tags alike
+  entity?: string; // Comma-separated entity names — AND-ed across messages and tickets
   before?: string; // Created before date (multiple formats)
   after?: string; // Created after date (multiple formats)
   on?: string; // Created on specific date (multiple formats)

--- a/apps/dashboard/src/utils/searchFilterParser.ts
+++ b/apps/dashboard/src/utils/searchFilterParser.ts
@@ -22,8 +22,10 @@ export function parseSearchFilters(text: string) {
   let assignee: string | undefined;
   let type: string | undefined;
 
-  // `priority:` is intentionally NOT parsed: it's a chip-only filter (via
-  // selectedMentions), so raw `priority:` text is left intact for full-text search.
+  // `priority:` and `entity:` are intentionally NOT parsed: they're chip-only filters
+  // (via selectedMentions), so raw text is left intact for full-text search. Parsing an
+  // uncommitted `entity:Big Bask` would filter on a half-typed value on every keystroke —
+  // the value only becomes a filter once EntityChipPlugin commits it to a chip.
 
   // Parse board:value
   const boardMatch = searchText.match(/\bboard:\s*(\S+)/i);


### PR DESCRIPTION
POT:https://drive.google.com/file/d/1U89S4UkB_p3Rbesnod4X_PZUBWiT41TR/view?usp=sharing

Added entity filter for chat and ticket search
   filters on Vespa `entityNames`, multiple entities are AND-ed — a doc must mention every one

Added entity chip support
   on pressing enter or `,` it become chips

Chip only filter, like `priority:`
   raw text is never parsed, so a half typed `entity:Big Bask` does not filter on an incomplete value

Backend
   `entity` query param fans out to both slack and ticket filters, values bound as params
   chat clause is skipped when the query prunes to schemas without the field

Frontend
   one registry entry drives the cmd+K chip, results page token, Filters modal row and URL param







Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
