### PR TITLE
feat: XYNE-62466 activity feed with date separators and channel chips

### DIFF
--- a/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityItemCard.tsx
@@ -19,14 +19,14 @@ import { useRouteContext } from '../../hooks/useRouteContext';
 import { usePlatform } from '../../hooks/usePlatform';
 import UserAvatar from '../UserAvatar/UserAvatar';
 import { AvatarSize } from '../UserAvatar/UserAvatar';
-import { formatDistanceToNow, isToday } from 'date-fns';
+import { differenceInCalendarDays, format, isToday, isYesterday } from 'date-fns';
 import { formatTimeAmPm } from '../../utils/dateUtils';
 import { UserHoverWrapper } from '../ui/UserMentionPopover/UserMentionPopover';
 import { cn } from '../../utils/classNames';
 import { Button } from '../ui/Button';
-import { GenericMentionHoverPopover } from '../ui/GenericMentionPopover/GenericMentionPopover';
 import { SquareCheck, SquareDot } from 'lucide-react';
 import { Tooltip } from '../ui/Tooltip';
+import { ChannelChipGlyph } from '../Chat/ChatDirectory/FilterChipNode';
 
 interface ActivityItemCardProps {
   activity: Activity;
@@ -81,6 +81,7 @@ export const ActivityItemCard = ({
   const channel = useChannel(channelId || '');
   const { displayName: channelDisplayName } = useChannelDisplayName(channel, context.userID);
   const displayedChannelName = channel ? channelDisplayName : unresolvedChannelLabel;
+  const isDeskChannel = isDeskChannelType(channel?.type) || channel?.type === ChannelType.SUPPORT;
 
   // Appends ?selectedActivity=id to path, preserving existing hash
   const appendSelectedActivity = (path: string): string => {
@@ -113,7 +114,6 @@ export const ActivityItemCard = ({
       return;
     }
 
-    const isDeskChannel = isDeskChannelType(channel?.type);
     // In the Activity panel, open desk/Support tickets inside the panel's own
     // outlet (so the activity list stays mounted) instead of redirecting to the
     // full /support inbox. The embedded ticket route only exists under
@@ -227,10 +227,62 @@ export const ActivityItemCard = ({
     if (isToday(dateObj)) {
       return formatTimeAmPm(dateObj);
     }
-    return formatDistanceToNow(dateObj, { addSuffix: true });
+    if (isYesterday(dateObj)) {
+      return 'Yesterday';
+    }
+    const daysAgo = differenceInCalendarDays(new Date(), dateObj);
+    if (daysAgo > 0 && daysAgo < 7) {
+      return format(dateObj, 'EEEE');
+    }
+    return dateObj.getFullYear() === new Date().getFullYear()
+      ? format(dateObj, 'MMM d')
+      : format(dateObj, 'MMM d, yyyy');
   };
 
   const activityTimestamp = activity.updatedAt ?? activity.createdAt;
+
+  const openChannel = () => {
+    if (!channelId) return;
+    void navigate(
+      resolveSdlcActivityTarget({
+        activity: { channelId },
+        channelType: channel?.type,
+        fallbackPath: isDeskChannel ? `/support/${channelId}` : `${baseRoute}/${channelId}`,
+      }),
+    );
+  };
+
+  const handleChannelClick = (e: React.MouseEvent<HTMLSpanElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
+    openChannel();
+  };
+
+  const handleChannelKeyDown = (e: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.stopPropagation();
+      e.preventDefault();
+      openChannel();
+    }
+  };
+
+  const showChannelChip =
+    actorAction !== 'paused_from_assignment' &&
+    actorAction !== 'resumed_from_assignment' &&
+    actorAction !== 'workflow_question' &&
+    Boolean(channelId);
+
+  const channelChipInner = (
+    <>
+      <span className='flex shrink-0 opacity-70'>
+        <ChannelChipGlyph channel={channel} size={12} />
+      </span>
+      <span className='truncate'>{displayedChannelName}</span>
+    </>
+  );
+
+  const channelChipClass =
+    'inline-flex min-w-0 max-w-[55%] flex-shrink-0 items-center gap-1 rounded-[6px] bg-activity-chip px-1.5 py-[1px] text-xs font-medium leading-[18px] text-foreground/90 transition-colors';
 
   return (
     <Button
@@ -238,7 +290,7 @@ export const ActivityItemCard = ({
       role='button'
       onClick={handleClick}
       className={cn(
-        'group flex w-full font-normal items-start gap-3 px-3 pt-2.5 pb-2 text-left transition-colors duration-150 h-auto rounded-[14px] border border-transparent',
+        'group flex w-full font-normal items-start gap-3 px-3 py-2.5 text-left transition-colors duration-150 h-auto rounded-[14px] border border-transparent',
         activity.isRead ? 'bg-transparent' : 'bg-activity-sidebar-primary',
         'hover:!bg-sidebar-accent',
         'data-[selected]:!bg-sidebar-accent data-[selected]:border-sidebar-border',
@@ -253,7 +305,7 @@ export const ActivityItemCard = ({
         isRead: activity.isRead,
       })}
     >
-      <div className='relative flex-shrink-0'>
+      <div className='relative flex-shrink-0 pt-px'>
         <UserHoverWrapper userId={actorId}>
           <button
             onClick={e => e.stopPropagation()}
@@ -278,23 +330,25 @@ export const ActivityItemCard = ({
       </div>
 
       <div className='flex flex-1 flex-col min-w-0 overflow-hidden'>
-        <div className='flex w-full items-start justify-between gap-2 flex-wrap'>
-          <div
-            className={cn(
-              'text-sm leading-snug min-w-0 flex-1 truncate',
-              // Sets the color the truncation ellipsis is drawn in (text-overflow
-              // paints the "…" from THIS element's color, not the clipped child's),
-              // so the ellipsis matches the muted/foreground title state.
-              activity.isRead ? 'text-muted-foreground' : 'text-foreground',
-            )}
-          >
-            {titlePrefix && <span className='mr-1.5 inline-flex align-middle'>{titlePrefix}</span>}
+        <div className='flex w-full items-center gap-2'>
+          <div className='flex min-w-0 flex-1 items-center gap-1.5 [&>span]:min-w-0'>
+            {titlePrefix && <span className='inline-flex flex-shrink-0'>{titlePrefix}</span>}
             {isMobile ? (
-              <span className='font-semibold'>{actorName}</span>
+              <span
+                className={cn(
+                  'truncate text-[15px] font-semibold leading-5',
+                  activity.isRead ? 'text-muted-foreground' : 'text-foreground',
+                )}
+              >
+                {actorName}
+              </span>
             ) : (
               <UserHoverWrapper userId={actorId}>
                 <button
-                  className='hover:underline flex-shrink-0 font-semibold'
+                  className={cn(
+                    'block max-w-full truncate text-[15px] font-semibold leading-5 hover:underline',
+                    activity.isRead ? 'text-muted-foreground' : 'text-foreground',
+                  )}
                   onClick={e => e.stopPropagation()}
                   data-track-category='ACTIVITY'
                   data-track-name='VIEW_USER_PROFILE'
@@ -304,63 +358,12 @@ export const ActivityItemCard = ({
                 </button>
               </UserHoverWrapper>
             )}
-
-            {/* Description children (the `description` prop) set their own
-                text-muted-foreground; on unread we override them to foreground via
-                the child selector. Read + the container's color handle the rest. */}
-            <span className={cn('ml-1.5', activity.isRead ? '' : '*:text-foreground')}>
-              {description}
-            </span>
-
-            {actorAction !== 'paused_from_assignment' &&
-              actorAction !== 'resumed_from_assignment' &&
-              actorAction !== 'workflow_question' &&
-              channelId &&
-              (isMobile ? (
-                <span className='ml-1.5 font-semibold'>{`#${displayedChannelName}`}</span>
-              ) : (
-                <GenericMentionHoverPopover
-                  data={{
-                    icon: '#',
-                    title: displayedChannelName,
-                    subtitle: channel?.description || 'Channel',
-                  }}
-                >
-                  {/* Rendered as a <span role="button">, not a <button>: the title
-                      line truncates via the container's text-overflow ellipsis, which
-                      can only cut through inline text. A <button> is an atomic
-                      inline-level box whose text is isolated from the parent's inline
-                      formatting context, so it can't be ellipsized — it gets clipped
-                      whole and leaves empty space. A span is real inline text. */}
-                  <span
-                    role='button'
-                    tabIndex={0}
-                    className='hover:underline cursor-pointer text-left ml-1.5 font-semibold'
-                    onClick={e => e.stopPropagation()}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.stopPropagation();
-                      }
-                    }}
-                    data-track-category='ACTIVITY'
-                    data-track-name='VIEW_CHANNEL'
-                    data-track-metadata={JSON.stringify({
-                      activityId: activity.id,
-                      channelId: activity.channelId,
-                      channelName: displayedChannelName,
-                    })}
-                  >
-                    {`#${displayedChannelName}`}
-                  </span>
-                </GenericMentionHoverPopover>
-              ))}
           </div>
 
-          <span className='flex-shrink-0 flex items-center gap-1.5 whitespace-nowrap text-xs text-muted-foreground ml-auto sm:ml-2'>
+          <span className='flex-shrink-0 flex items-center gap-1.5 whitespace-nowrap text-xs tabular-nums text-muted-foreground'>
             {!isMobile &&
               !['reacted', 'removed'].includes(activity.actorAction) &&
-              !isDeskChannelType(channel?.type) &&
-              channel?.type !== ChannelType.SUPPORT &&
+              !isDeskChannel &&
               (activity.isRead ? (
                 <Tooltip content='Mark as unread' delayDuration={0} side='top'>
                   <div
@@ -368,7 +371,7 @@ export const ActivityItemCard = ({
                     tabIndex={0}
                     onClick={handleMarkAsUnread}
                     onKeyDown={handleMarkAsUnreadKeyDown}
-                    className='opacity-0 group-hover:opacity-100 transition-opacity rounded hover:bg-accent/50 cursor-pointer'
+                    className='-m-1 p-1 opacity-0 group-hover:opacity-100 transition-opacity rounded-md hover:bg-accent/50 cursor-pointer'
                     aria-label='Mark as unread'
                     data-track-category='ACTIVITY'
                     data-track-name='MARK_AS_UNREAD'
@@ -387,7 +390,7 @@ export const ActivityItemCard = ({
                     tabIndex={0}
                     onClick={handleMarkAsRead}
                     onKeyDown={handleMarkAsReadKeyDown}
-                    className='opacity-0 group-hover:opacity-100 transition-opacity rounded hover:bg-accent/50 cursor-pointer'
+                    className='-m-1 p-1 opacity-0 group-hover:opacity-100 transition-opacity rounded-md hover:bg-accent/50 cursor-pointer'
                     aria-label='Mark as read'
                     data-track-category='ACTIVITY'
                     data-track-name='MARK_AS_READ'
@@ -401,16 +404,54 @@ export const ActivityItemCard = ({
                 </Tooltip>
               ))}
             {showUnreadDot && !activity.isRead && (
-              <span className='h-2.5 w-2.5 rounded-full bg-primary flex-shrink-0' />
+              <span className='h-2 w-2 rounded-full bg-primary flex-shrink-0' />
             )}
             {getTimestampDisplay(activityTimestamp)}
           </span>
         </div>
 
-        {/* Content Body */}
         <div
           className={cn(
-            'mt-px w-full',
+            'mt-0.5 flex w-full min-w-0 items-center gap-1.5',
+            activity.isRead ? 'text-muted-foreground' : 'text-foreground',
+          )}
+        >
+          <span
+            className={cn(
+              'min-w-0 truncate [&_span]:text-[13px] [&_span]:leading-[18px]',
+              activity.isRead ? '' : '[&_span]:text-foreground',
+            )}
+          >
+            {description}
+          </span>
+          {showChannelChip &&
+            (isMobile ? (
+              <span className={channelChipClass}>{channelChipInner}</span>
+            ) : (
+              <Tooltip content={displayedChannelName} delayDuration={400} side='top'>
+                <span
+                  role='button'
+                  tabIndex={0}
+                  className={cn(channelChipClass, 'cursor-pointer hover:bg-activity-chip-hover')}
+                  onClick={handleChannelClick}
+                  onKeyDown={handleChannelKeyDown}
+                  data-track-category='ACTIVITY'
+                  data-track-name='VIEW_CHANNEL'
+                  data-track-metadata={JSON.stringify({
+                    activityId: activity.id,
+                    channelId: activity.channelId,
+                    channelName: displayedChannelName,
+                  })}
+                >
+                  {channelChipInner}
+                </span>
+              </Tooltip>
+            ))}
+        </div>
+
+        <div
+          className={cn(
+            'mt-1 w-full',
             activity.isRead
               ? 'text-muted-foreground [&_.jp-message-html]:text-muted-foreground'
               : 'text-foreground',

--- a/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
+++ b/apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx
@@ -20,9 +20,10 @@ import { cn } from '../../../utils/classNames';
 import type { ActivityWithRelated } from '../../../types/activity';
 import { ActivityClassification, UserType } from '@xyne/shared';
 import { Bot, UserUser02 } from '@xyne/icons';
-import { groupActivities, type ActivityFeedItem } from '../activityGrouping';
+import { groupActivities, insertDateSeparators, type ActivityFeedItem } from '../activityGrouping';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { Skeleton } from '../../ui/Skeleton';
+import { DatePill } from '../../Chat/DatePill';
 import { useShortcut } from '../../../shortcuts';
 import { extractUserMentions } from '../../../utils/mentionParser';
 import {
@@ -557,7 +558,7 @@ const ActivityListView = (): ReactElement => {
   }, [activities, activeTab, visibleTabs]);
 
   const groupedActivities = useMemo(() => {
-    return groupActivities(filteredActivities);
+    return insertDateSeparators(groupActivities(filteredActivities));
   }, [filteredActivities]);
 
   const selectedActivityIdRef = useRef<string | null>(
@@ -602,11 +603,10 @@ const ActivityListView = (): ReactElement => {
     if (!container) return;
     const handler = (e: Event) => {
       const target = e.target as HTMLElement;
-      // Skip selection stamping if the click is on "Mark as read" or "Mark as unread"
-      // buttons — those should not highlight the row as "open".
       if (
         target.closest('[data-track-name="MARK_AS_READ"]') ||
-        target.closest('[data-track-name="MARK_AS_UNREAD"]')
+        target.closest('[data-track-name="MARK_AS_UNREAD"]') ||
+        target.closest('[data-track-name="VIEW_CHANNEL"]')
       ) {
         return;
       }
@@ -841,19 +841,33 @@ const ActivityListView = (): ReactElement => {
                   setFetchCursor(null);
                 }
               }}
-              computeItemKey={(_, item) =>
-                item.type === 'single' ? item.activity.id : `group:${item.activities[0]!.id}`
-              }
+              computeItemKey={(_, item) => {
+                if (item.type === 'date') return `date:${item.key}`;
+                return item.type === 'single'
+                  ? item.activity.id
+                  : `group:${item.activities[0]!.id}`;
+              }}
               increaseViewportBy={1000}
               minOverscanItemCount={{ top: 5, bottom: 10 }}
               components={{ Footer: () => <div className='h-16' aria-hidden='true' /> }}
               itemsRendered={restoreSelectedRow}
               itemContent={(_, item) => {
+                if (item.type === 'date') {
+                  return (
+                    <div className='px-3 pb-0.5 pt-1.5'>
+                      <DatePill
+                        dateText={item.dateText}
+                        staticRule
+                        className='border-transparent bg-muted text-[11px] font-medium text-muted-foreground'
+                      />
+                    </div>
+                  );
+                }
                 // px wraps each row (not the scroller) and pb creates the 8px
                 // row gap — padding is used instead of margin so Virtuoso's
                 // item measurement includes it.
                 return (
-                  <div className='px-3 pb-3'>
+                  <div className='px-3 pb-1.5'>
                     {item.type === 'single' ? (
                       <ActivityItem activity={item.activity} isExpanded={isExpanded} />
                     ) : (

--- a/apps/dashboard/src/components/Activity/SlashCommandArtifactActivity.tsx
+++ b/apps/dashboard/src/components/Activity/SlashCommandArtifactActivity.tsx
@@ -64,7 +64,7 @@ export const SlashCommandArtifactActivity = ({
       className='flex items-start'
       actorAction={activity.actorAction}
     >
-      <div className={isExpanded ? 'text-sm text-foreground' : 'truncate text-sm text-foreground'}>
+      <div className='text-sm text-foreground'>
         <TextNode node={bodyNode} />
       </div>
     </ActivityItemCard>

--- a/apps/dashboard/src/components/Activity/activityGrouping.ts
+++ b/apps/dashboard/src/components/Activity/activityGrouping.ts
@@ -1,11 +1,21 @@
 import type { ActivityWithRelated } from '../../types/activity';
+import { isToday } from 'date-fns';
+import { formatDatePill } from '../../utils/dateUtils';
 
 export interface ActivityGroup {
   type: 'group';
   activities: ActivityWithRelated[];
 }
 
-export type ActivityFeedItem = { type: 'single'; activity: ActivityWithRelated } | ActivityGroup;
+export interface ActivityDateSeparator {
+  type: 'date';
+  key: string;
+  dateText: string;
+}
+
+export type ActivityRowItem = { type: 'single'; activity: ActivityWithRelated } | ActivityGroup;
+
+export type ActivityFeedItem = ActivityRowItem | ActivityDateSeparator;
 
 const TICKET_ACTIVITY_PREFIX = 'ticket_';
 const GROUP_WINDOW_MS = 30 * 1000; // 30 seconds
@@ -20,10 +30,10 @@ const GROUP_WINDOW_MS = 30 * 1000; // 30 seconds
  * - Time gap between consecutive activities must be ≤ 30s
  * - Any non-ticket activity or different actor/ticket breaks the group
  */
-export function groupActivities(activities: ActivityWithRelated[]): ActivityFeedItem[] {
+export function groupActivities(activities: ActivityWithRelated[]): ActivityRowItem[] {
   if (activities.length === 0) return [];
 
-  const result: ActivityFeedItem[] = [];
+  const result: ActivityRowItem[] = [];
   let currentGroup: ActivityWithRelated[] = [];
 
   function flushGroup(): void {
@@ -70,5 +80,30 @@ export function groupActivities(activities: ActivityWithRelated[]): ActivityFeed
   }
 
   flushGroup();
+  return result;
+}
+
+export function insertDateSeparators(items: ActivityRowItem[]): ActivityFeedItem[] {
+  const result: ActivityFeedItem[] = [];
+  let lastKey: string | null = null;
+
+  for (const item of items) {
+    const activity = item.type === 'single' ? item.activity : item.activities[0];
+    const timestamp = activity?.updatedAt ?? activity?.createdAt;
+
+    if (timestamp) {
+      const date = new Date(timestamp);
+      const key = date.toDateString();
+      if (key !== lastKey) {
+        if (!isToday(date)) {
+          result.push({ type: 'date', key, dateText: formatDatePill(date) });
+        }
+        lastKey = key;
+      }
+    }
+
+    result.push(item);
+  }
+
   return result;
 }

--- a/apps/dashboard/src/components/Chat/ChatDirectory/FilterChipNode.tsx
+++ b/apps/dashboard/src/components/Chat/ChatDirectory/FilterChipNode.tsx
@@ -33,7 +33,7 @@ import {
 } from 'lexical';
 import { CalendarDays, LayoutGrid, SignalHigh } from 'lucide-react';
 import { Hashtag, UserTwo, Lock02Close } from '@xyne/icons';
-import { ChannelScopeType, ChannelVisibility, TicketPriority } from '@xyne/shared';
+import { type Channel, ChannelScopeType, ChannelVisibility, TicketPriority } from '@xyne/shared';
 import { useChannel } from '../../../hooks/useChannels';
 import Avatar from '../../ui/Avatar/Avatar';
 import { ChipType, type ChipData } from './ChannelCommandMenu.types';
@@ -233,6 +233,16 @@ export function ChannelChipIcon({
   size?: number;
 }): React.JSX.Element {
   const channel = useChannel(id);
+  return <ChannelChipGlyph channel={channel} size={size} />;
+}
+
+export function ChannelChipGlyph({
+  channel,
+  size = ICON_SIZE,
+}: {
+  channel: Channel | null | undefined;
+  size?: number;
+}): React.JSX.Element {
   if (!channel) {
     return <Hashtag size={size} />;
   }

--- a/apps/dashboard/src/components/Chat/DatePill/DatePill.tsx
+++ b/apps/dashboard/src/components/Chat/DatePill/DatePill.tsx
@@ -1,13 +1,20 @@
 import { ReactElement, useEffect, useRef, useState } from 'react';
 import Badge from '../../ui/Badge';
+import { cn } from '../../../utils/classNames';
 
 export interface DatePillProps {
   dateText: string;
+  className?: string;
+  staticRule?: boolean;
 }
 
-export const DatePill = ({ dateText }: DatePillProps): ReactElement => {
+export const DatePill = ({
+  dateText,
+  className,
+  staticRule = false,
+}: DatePillProps): ReactElement => {
   // Default false for rendering grey horizontal rule
-  const [showLines, setShowLines] = useState(false);
+  const [showLines, setShowLines] = useState(staticRule);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
 
@@ -16,6 +23,7 @@ export const DatePill = ({ dateText }: DatePillProps): ReactElement => {
 
   // This workaround is particularly to introduce grey horizontal rule for DatePills at the start of a day in a conversation
   useEffect(() => {
+    if (staticRule) return;
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
 
@@ -55,7 +63,7 @@ export const DatePill = ({ dateText }: DatePillProps): ReactElement => {
         cancelAnimationFrame(rafRef.current);
       }
     };
-  }, []);
+  }, [staticRule]);
 
   return (
     <div
@@ -70,7 +78,7 @@ export const DatePill = ({ dateText }: DatePillProps): ReactElement => {
       />
 
       <div className='relative'>
-        <Badge variant='outline' className='bg-background'>
+        <Badge variant='outline' className={cn('bg-background', className)}>
           {dateText}
         </Badge>
       </div>

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -150,6 +150,8 @@
     --claw-ai-solid-hover: #6d28d9;
 
     --activity-sidebar-primary: hsl(0 0% 100% / 0.5);
+    --activity-chip: rgba(35, 34, 41, 0.07);
+    --activity-chip-hover: rgba(35, 34, 41, 0.13);
 
     --chat-composer-border: rgba(35, 34, 41, 0.06);
     --chat-composer-border-active: rgba(35, 34, 41, 0.2);
@@ -291,6 +293,8 @@
     --claw-ai-solid-hover: #6d28d9;
 
     --activity-sidebar-primary: hsl(0 0% 100% / 0.5);
+    --activity-chip: rgba(35, 34, 41, 0.07);
+    --activity-chip-hover: rgba(35, 34, 41, 0.13);
 
     --chat-composer-border: rgba(35, 34, 41, 0.06);
     --chat-composer-border-active: rgba(35, 34, 41, 0.2);
@@ -447,6 +451,8 @@
     --claw-ai-solid-hover: #8b5cf6;
 
     --activity-sidebar-primary: rgba(45, 46, 52, 0.5);
+    --activity-chip: rgba(255, 255, 255, 0.09);
+    --activity-chip-hover: rgba(255, 255, 255, 0.16);
 
     --chat-composer-border: rgba(255, 255, 255, 0.06);
     --chat-composer-border-active: rgba(255, 255, 255, 0.2);

--- a/apps/dashboard/tailwind.config.js
+++ b/apps/dashboard/tailwind.config.js
@@ -102,6 +102,8 @@ export default {
         },
         activity: {
           'sidebar-primary': 'var(--activity-sidebar-primary)',
+          chip: 'var(--activity-chip)',
+          'chip-hover': 'var(--activity-chip-hover)',
         },
         desk: {
           helper: 'var(--desk-helper-foreground)',


### PR DESCRIPTION
POT - 

https://github.com/user-attachments/assets/50894d24-8fd6-426e-bcfb-1007b7d9caa8



## What

Activity rows crammed actor, action and channel onto one truncating line, so the channel name was the first thing to get cut (`#xyne-troub…`, `#Samit Barai, Piyush Kes…`), and the feed had no day boundaries. This reshapes the row into a Slack-style hierarchy and adds date separators.

**Before → After**

| | Before | After |
|---|---|---|
| Row | `Samit Barai updated ticket in #xyne-troub…` on one truncating line | Line 1 actor + timestamp · Line 2 action + channel chip · Line 3 content |
| Channel | inline `#name`, eaten by the actor line's ellipsis | its own chip, truncates against its own cap |
| Channel hover | 300px hover card overlapping the rows above | tooltip with the full name |
| Channel click | swallowed, went nowhere | opens the channel |
| Days | none | `Yesterday`, `Friday, September 4`, … (no pill for today) |
| Timestamp | `3 days ago` | `1:42 PM` / `Yesterday` / `Friday` / `Mar 4, 2024` |

## Changes

**`ActivityItemCard`** — three-line layout. The channel chip's glyph comes from `ChannelChipGlyph`, extracted out of `ChannelChipIcon` so the two can't drift (DMs and group DMs get the person icon; one lock glyph instead of a third variant). Clicking the chip routes through `resolveSdlcActivityTarget`, the same resolver the card body uses, so SDLC channels don't land on a chat route the app hides. It deliberately leaves the activity unread, so `VIEW_CHANNEL` is excluded from the selection stamper. `isDeskChannel` is now computed once — it was spelled three ways in this file and the copies disagreed about whether `SUPPORT` counts.

**`activityGrouping`** — `insertDateSeparators` wraps `groupActivities`, keyed on `updatedAt ?? createdAt`, which is also the feed's sort key, so separators stay monotonic. Renders the existing `DatePill`; no new separator component.

**Tokens** — `--activity-chip` / `--activity-chip-hover`, translucent on purpose so the chip reads the same over the row's read, unread, hover and selected states, in all three themes.

**`SlashCommandArtifactActivity`** — dropped `truncate` from the body. `TextNode` renders a block `<p>`, which `text-overflow` can't ellipsize, so the SEV2 body clipped mid-word against the card edge. The card's own `line-clamp-1` already handles it.

**`DatePill`** — optional `className` and `staticRule`. The stuck-to-top detection only means anything inside `GroupedVirtuoso`; as a plain flow item it attached a scroll listener per pill on every virtualization mount. Chat callers are untouched.

## Testing

Driven against the local stack as `admin@xyne.ai`:

Against a locally seeded feed of 77 activities covering every type the panel renders, spread over 8 days:

- **Coverage** — scrolled the whole list, collected every rendered `data-activity-id`, diffed against the DB: **75 of 77 render**. The two absentees are rows 2 and 3 of a same-ticket burst, which correctly collapse into one `GroupedTicketActivity`.
- **Name truncation** — 44-char actor name: `display:block`, `clientWidth 268 < scrollWidth 356`, ellipsized.
- **Chip click** — row stays `data-selected` free and keeps its unread background; URL lands on the channel.
- Both light and dark themes.
- `tsc --noEmit` clean; eslint 0 errors (pre-existing warnings only); prettier clean on all dashboard files.


## Proof of testing

<!-- POT: drag XYNE-62466-POT.mp4 onto this line -->

Both halves are real captures of the local stack — same build, same account (`admin@xyne.ai`), same 77-activity local fixture, same script, same 1440×900 viewport. Only the six source files below were toggled between the two runs.

Recorded with `.claude/skills/xyne-pot`:

```
node scripts/record.mjs activity-feed-slack-layout after
node scripts/record.mjs activity-feed-slack-layout before --base HEAD~1 \
  --revert apps/dashboard/src/components/Activity/ActivityItemCard.tsx \
  --revert apps/dashboard/src/components/Activity/ActivityListView/ActivityListView.tsx \
  --revert apps/dashboard/src/components/Activity/activityGrouping.ts \
  --revert apps/dashboard/src/components/Activity/SlashCommandArtifactActivity.tsx \
  --revert apps/dashboard/src/components/Chat/DatePill/DatePill.tsx \
  --revert apps/dashboard/src/components/Chat/ChatDirectory/FilterChipNode.tsx
```

The list was left at its real default width (452px) rather than dragged to the 640px max — widening it would have hidden the truncation this PR fixes.

### Assertions, run identically on both sides

| assertion | before | after |
|---|---|---|
| date separator rendered between days | ✗ absent | ✓ present |
| `Yesterday` appears in the feed | ✗ absent | ✓ present |
| no `days ago` timestamps | ✗ present | ✓ absent |
| no `Unknown Channel` | ✓ absent | ✓ absent |

### What the footage shows

- **0–4s** — top of the feed. Before: `a mentioned you in #xyne-troubles…`, `declared a SEV2 in…`, `and 2 others replied on your …` — actor, action and channel sharing one truncating line, and the channel is what gets cut. After: three lines, chip intact.
- **4–8s** — hovering the channel. Before: a 300px hover card covering the header and the row underneath. After: a tooltip with the full name, row still readable.
- **9–19s** — scrolling back. Before: four consecutive rows stamped `2 days ago` with nothing dividing them. After: a `Sunday, September 6` separator, `Yesterday` above it, `Sunday` below.

