### PR TITLE
feat: XYNE-57690: resolve radar items from completion reactions

### DIFF
--- a/apps/backend/src/services/radar/radarApplier.ts
+++ b/apps/backend/src/services/radar/radarApplier.ts
@@ -17,9 +17,13 @@ export interface ApplyParams {
   channelId: string;
   /** Validator-approved operations only — the applier trusts its input. */
   operations: ParserOperation[];
-  /** The window's last message: items + audit + watermark commit atomically. */
-  watermark: { createdAt: Date; messageId: string };
-  actorType: 'llm' | 'manual';
+  /**
+   * The window's last message: items + audit + watermark commit atomically.
+   * Omitted by callers that settle ONE item without consuming a window — a
+   * reaction resolve must not swallow messages nobody has parsed yet.
+   */
+  watermark?: { createdAt: Date; messageId: string };
+  actorType: 'llm' | 'manual' | 'reaction';
   actorId?: string;
 }
 
@@ -133,6 +137,8 @@ class RadarApplier {
         if (auditRows.length > 0) {
           await tx.executionItemMutation.createMany({ data: auditRows });
         }
+
+        if (!watermark) return;
 
         await tx.executionThreadState.upsert({
           where: { conversationId },

--- a/apps/backend/src/services/radar/radarParser.ts
+++ b/apps/backend/src/services/radar/radarParser.ts
@@ -32,6 +32,11 @@ export interface ParserOpenItem {
   context: string | null;
   requested_by: string[];
   pending_on: string[];
+  /** The message that raised this item. Sent on a reaction pass so the model
+   *  can tell "the tick is ON the ask" from "the tick is on an answer" — it
+   *  cannot infer that link, and without it a tick on the ask reads as a
+   *  message that settles nothing. */
+  source_message_id?: string;
 }
 
 export interface ParserOperation {
@@ -85,6 +90,16 @@ const TRANSITIONS_SCHEMA: Record<string, unknown> = {
   },
 };
 
+/**
+ * What "resolve" means, in one place. The window parser and the reaction
+ * matcher must agree on this or the same conversation settles differently
+ * depending on whether someone typed "done" or clicked a tick.
+ */
+const RESOLVE_MEANING =
+  'an open item is FULFILLED: the thing asked for was actually delivered (the ' +
+  'information given, the work verifiably done), the requester confirmed or ' +
+  'accepted the outcome, or the ask was explicitly withdrawn/cancelled';
+
 const SYSTEM_PROMPT = `You are the state-transition parser of Radar, an execution-tracking engine for workplace chat.
 
 Radar tracks "execution items": concrete asks or commitments inside a thread. Each item has requested_by (who is waiting on it) and pending_on (who must act next — who "holds the ball"). An item is a ball being passed, not a task board entry.
@@ -94,12 +109,13 @@ You receive one thread's current state:
 - new_messages: messages that arrived since the last parse, in chronological order. Each lists its author and the users it explicitly @mentions.
 - context_messages: the last few ALREADY-PROCESSED messages from just before new_messages, oldest first. Read them to understand what the thread is about, but they were handled in earlier passes: never cite one as a sourceMessageId, and never create an item for an ask that appears only there.
 - known_users: id -> name for everyone involved so far (authors, mentions, item participants). Use it to match a name in prose to an id.
+- reaction: present ONLY on a reaction pass (see below). Absent on an ordinary window parse.
 
 Decide which state transitions the new messages imply. Operations:
 
 1. "create" — a new concrete ask or commitment that no open item already covers. title: short imperative summary of what must happen. contextSummary: one sentence of context. requestedBy: who is asking/waiting (usually the author). pendingOn: who must act.
    An ask includes a DIRECT QUESTION aimed at a specific person: asking someone for a status, an answer, a review, an update or a decision puts the ball with them until they respond. "@dev-bot what's the status of PR 25?" IS a trackable item (pendingOn: dev-bot, title: "Share the status of PR 25").
-2. "resolve" — an open item is FULFILLED: the thing asked for was actually delivered (the information given, the work verifiably done), the requester confirmed or accepted the outcome, or the ask was explicitly withdrawn/cancelled. itemId: the open item's id.
+2. "resolve" — ${RESOLVE_MEANING}. itemId: the open item's id.
 3. "reassign" — the ball moved on an open item: it was explicitly handed to someone, someone claimed it, or the ball bounced back to the asker: a clarifying question, a dispute ("works for me", "cannot reproduce", "I don't think that's a bug"), or any reply the requester must now verify, confirm or answer before the item can close. itemId + new pendingOn (a bounce-back goes to requested_by).
 
 A reply is not fulfillment. When the assignee responds without delivering what was asked — they push back, can't reproduce, disagree, answer partially, or hand back a question — the item stays OPEN and the ball moves to whoever must act next (usually the requester, via reassign). Only the requester's confirmation, an objectively delivered result, or an explicit withdrawal closes an item.
@@ -110,6 +126,13 @@ Assignment rules:
 - An actionable ask with no inferable assignee is still tracked: create it with pendingOn: [].
 - Every operation cites sourceMessageId: the message in this window that caused it.
 - Every operation includes reason: ONE short sentence explaining why this operation follows from the messages (e.g. why this person holds the ball, or what confirmed completion).
+
+REACTION PASS. When "reaction" is present, someone put a reaction on the single message in new_messages, and open_items has already been narrowed to items that person is party to. A reaction carries no text: the emoji's NAME is the only signal of intent, and the emoji and the message decide together.
+
+The only legal operation on a reaction pass is "resolve", and an empty operations array is the normal answer. Emit one only when BOTH hold:
+  - the emoji asserts COMPLETION — a tick, a check mark, "done", "shipped", "fixed". An emoji meaning seen, received or in progress ("eyes", "on-it", "checking", "reviewing", a thumbs-up) is NOT completion; nor is a celebration, a joke or a heart. Beware negations: "not-done" is not a completion. When an emoji could plausibly mean either, treat it as acknowledgement and emit nothing.
+  - the reacted message settles ONE specific open item, per the resolve rule above. An item whose source_message_id equals the reacted message's id was RAISED BY that message: a completion emoji there is not a comment on a delivery, it is the reactor asserting that item is now finished — resolve it.
+Topical overlap is not settlement: a tick on a lunch plan settles nothing, even when the reactor holds open work in the thread. If two items fit equally well, emit nothing — a wrong close costs more than a missed one.
 
 Be conservative about chatter: greetings, acknowledgements, thanks, FYIs and status updates someone volunteers produce NO operations — an empty operations array is the normal answer for such windows. A bare @mention with no request text is a HANDOFF, not noise: tagging someone under shared content (a report, a table, a log, an error) or into a thread puts that content in front of them — create an item pending on the mentioned user, titled from what the content or thread is about (e.g. "Review the tagging coverage report"). The ONLY exception is an explicit cc: when the message itself marks the mention as informational — "cc @x", "fyi @x", "looping in @x for visibility" — it is not an ask, create nothing. But do not confuse conservatism with dropping real asks: a request or question directed at a mentioned user is never chatter. Do not create an item for something an open item already covers; do not resolve on a vague "ok" unless it clearly confirms completion.
 
@@ -196,6 +219,23 @@ function tryParseJson(raw: string): { ok: true; value: unknown } | { ok: false; 
 
 class RadarParser {
   /**
+   * Same resolution as entity extraction (entityLlmClient.ts): radar's own key
+   * when one is minted, otherwise the shared gateway key. A dedicated key keeps
+   * radar's rate limit and spend off the quota other features use.
+   */
+  private resolveAuth(): { apiKey: string; baseUrl: string; keyName: string } {
+    const apiKey = config.radar.litellmApiKey || config.litellm.apiKey;
+    const baseUrl = config.litellm.baseUrl;
+    const keyName = config.radar.litellmApiKey
+      ? 'RADAR_EXECUTION_LITELLM_API_KEY'
+      : 'LITELLM_API_KEY';
+    if (!apiKey || !baseUrl) {
+      throw new Error('LiteLLM is not configured: set LITELLM_BASE_URL and an API key');
+    }
+    return { apiKey, baseUrl, keyName };
+  }
+
+  /**
    * One parse call per drained window. Returns the model's proposed
    * transitions after schema validation with repair retries; throws when the
    * model can't produce schema-valid output (the caller treats a parser
@@ -206,18 +246,9 @@ class RadarParser {
     newMessages: ParserWindowMessage[],
     knownUsers: Record<string, string> = {},
     contextMessages: ParserWindowMessage[] = [],
+    reaction?: { by: string; emoji: string },
   ): Promise<ParsedTransitions> {
-    // Same resolution as entity extraction (entityLlmClient.ts): radar's own
-    // key when one is minted, otherwise the shared gateway key. A dedicated key
-    // keeps radar's rate limit and spend off the quota other features use.
-    const apiKey = config.radar.litellmApiKey || config.litellm.apiKey;
-    const baseUrl = config.litellm.baseUrl;
-    const keyName = config.radar.litellmApiKey
-      ? 'RADAR_EXECUTION_LITELLM_API_KEY'
-      : 'LITELLM_API_KEY';
-    if (!apiKey || !baseUrl) {
-      throw new Error('LiteLLM is not configured: set LITELLM_BASE_URL and an API key');
-    }
+    const { apiKey, baseUrl, keyName } = this.resolveAuth();
 
     const model = config.radar.parserModel;
     if (!model) {
@@ -235,6 +266,7 @@ class RadarParser {
         text: m.text.slice(0, MAX_MESSAGE_TEXT_CHARS),
       })),
       known_users: knownUsers,
+      ...(reaction ? { reaction } : {}),
     };
 
     const messages = [

--- a/apps/backend/src/services/radar/radarReactionResolver.ts
+++ b/apps/backend/src/services/radar/radarReactionResolver.ts
@@ -1,0 +1,244 @@
+import { config } from '@/config/env';
+import { DatabaseClient } from '@/database/client';
+import { logger } from '@/utils/logger';
+import { extractUserMentions } from '@/utils/mentionParser';
+import { radarParser, type ParserOperation } from '@/services/radar/radarParser';
+import { radarApplier } from '@/services/radar/radarApplier';
+
+const prisma = DatabaseClient.getInstance();
+const TAG = '[RADAR-REACTION]';
+
+/**
+ * Reaction-driven resolution.
+ *
+ * A tick carries no text, so it never enters a parse window, and the message it
+ * points at is usually already below the watermark — the window parser cannot
+ * see it. But it is the cleanest signal Radar gets: the parser's hardest job is
+ * guessing which message settles which item, and a reaction names the message
+ * outright.
+ *
+ * The shape is deliberately flat. SQL answers the only question it can answer
+ * cheaply — does this person hold anything here — and that discards almost
+ * every reaction in a workspace. What survives goes to the parser as a normal
+ * pass with a "reaction" field, judged by the same prompt and the same resolve
+ * rule as typed messages, so a tick and the word "done" cannot settle a
+ * conversation differently.
+ */
+class RadarReactionResolver {
+  async onReaction(reactionId: string): Promise<void> {
+    if (!config.radar.enabled) return;
+
+    const reaction = await prisma.reaction.findUnique({
+      where: { reactionId },
+      select: { messageId: true, userId: true, emojiName: true, workspaceId: true },
+    });
+    if (!reaction) return;
+
+    const message = await prisma.message.findUnique({
+      where: { messageId: reaction.messageId },
+      select: {
+        messageId: true,
+        content: true,
+        conversationId: true,
+        createdAt: true,
+        isDeleted: true,
+      },
+    });
+    if (!message || message.isDeleted) return;
+
+    const conversation = await prisma.conversation.findUnique({
+      where: { conversationId: message.conversationId },
+      select: { channelId: true },
+    });
+    if (!conversation?.channelId) return;
+
+    // The candidate set IS the authorization boundary: only items the reactor
+    // already holds or already asked for. requestedBy counts as much as
+    // pendingOn — the asker ticking the answer is the strongest confirmation
+    // there is, and the more common half of the pattern.
+    //
+    // Asked first because it is indexed SQL and it eliminates nearly
+    // everything: most reactions are from people who hold nothing in that
+    // thread, and none of those should cost a token. Nothing is logged for
+    // them either — a run row per thumbs-up would bury the ones worth reading.
+    const candidates = await prisma.executionItem.findMany({
+      where: {
+        workspaceId: reaction.workspaceId,
+        conversationId: message.conversationId,
+        status: 'OPEN',
+        OR: [{ pendingOn: { has: reaction.userId } }, { requestedBy: { has: reaction.userId } }],
+      },
+      // Unbounded on purpose: the predicates above already bound it to one
+      // thread AND to items this person is party to, which is a handful.
+      // Ordered newest-first only so the prompt is deterministic.
+      orderBy: { updatedAt: 'desc' },
+      select: {
+        id: true,
+        title: true,
+        contextSummary: true,
+        requestedBy: true,
+        pendingOn: true,
+        sourceMessageId: true,
+      },
+    });
+    // Every reaction that gets this far is logged, including the ones that do
+    // nothing. "I reacted and nothing happened" has to be answerable from the
+    // debug panel, and "no row at all" is the one answer it cannot give.
+    // Reuses the parser's run log — a reaction is a degenerate window, so
+    // every column already means something.
+    const startedAt = Date.now();
+    const run = {
+      workspaceId: reaction.workspaceId,
+      conversationId: message.conversationId,
+      gatePassed: false,
+      gateReason: 'reaction-no-candidates',
+      parserRan: false,
+      proposedOps: undefined as unknown,
+      validOps: undefined as unknown,
+      droppedOps: undefined as unknown,
+      applied: undefined as unknown,
+      assessment: undefined as string | undefined,
+      error: undefined as string | undefined,
+    };
+
+    try {
+      if (candidates.length === 0) {
+        run.assessment = `${reaction.emojiName}: reactor holds no open item in this thread.`;
+        return;
+      }
+
+      // An item cannot be settled by a message posted before it was asked for.
+      // Compared against the SOURCE MESSAGE, not the item row: the parser
+      // writes items on a debounce, so item.createdAt trails the ask by up to
+      // a window and would reject legitimate answers sent in between.
+      const askedAt = new Map(
+        (
+          await prisma.message.findMany({
+            where: { messageId: { in: candidates.map(c => c.sourceMessageId) } },
+            select: { messageId: true, createdAt: true },
+          })
+        ).map(m => [m.messageId, m.createdAt]),
+      );
+      const eligible = candidates.filter(c => {
+        const at = askedAt.get(c.sourceMessageId);
+        return at ? at <= message.createdAt : true;
+      });
+
+      if (eligible.length === 0) {
+        run.gateReason = 'reaction-predates-ask';
+        run.assessment = `Reacted message predates all ${candidates.length} candidate item(s).`;
+        return;
+      }
+
+      run.gatePassed = true;
+      run.gateReason = 'reaction';
+
+      const nameById = await this.namesFor([
+        reaction.userId,
+        ...eligible.flatMap(c => [...c.requestedBy, ...c.pendingOn]),
+      ]);
+      const reactorName = nameById.get(reaction.userId) ?? reaction.userId;
+
+      run.parserRan = true;
+      const transitions = await radarParser.parseWindow(
+        eligible.map(c => ({
+          id: c.id,
+          title: c.title,
+          context: c.contextSummary,
+          requested_by: c.requestedBy,
+          pending_on: c.pendingOn,
+          source_message_id: c.sourceMessageId,
+        })),
+        [
+          {
+            id: message.messageId,
+            author: { id: reaction.userId, name: reactorName },
+            text: message.content,
+            mentions: extractUserMentions(message.content).map(id => ({
+              id,
+              name: nameById.get(id) ?? id,
+            })),
+            timestamp_iso: message.createdAt.toISOString(),
+          },
+        ],
+        Object.fromEntries(nameById),
+        [],
+        { by: reactorName, emoji: reaction.emojiName },
+      );
+
+      run.proposedOps = transitions.operations;
+      run.assessment = transitions.assessment;
+
+      // The model chose from a closed list; re-checking that it stayed inside
+      // it, and that it only resolved, is what keeps a hallucinated id or a
+      // stray create out of the applier.
+      const openById = new Set(eligible.map(c => c.id));
+      const valid = transitions.operations.filter(
+        op => op.op === 'resolve' && op.itemId && openById.has(op.itemId),
+      );
+      const dropped = transitions.operations.filter(op => !valid.includes(op));
+      if (dropped.length > 0) run.droppedOps = dropped;
+      if (valid.length === 0) return;
+
+      const operations: ParserOperation[] = valid.map(op => ({
+        ...op,
+        sourceMessageId: message.messageId,
+      }));
+      run.validOps = operations;
+
+      run.applied = await radarApplier.apply({
+        workspaceId: reaction.workspaceId,
+        conversationId: message.conversationId,
+        channelId: conversation.channelId,
+        operations,
+        // No watermark: this settles one item and consumes no window.
+        // Advancing it would silently swallow every unparsed message here.
+        actorType: 'reaction',
+        actorId: reaction.userId,
+      });
+
+      logger.info(`${TAG} resolved by reaction`, {
+        itemIds: operations.map(o => o.itemId),
+        emoji: reaction.emojiName,
+        conversationId: message.conversationId,
+      });
+    } catch (error) {
+      // A reaction is an optimisation, never the only route to a resolve — a
+      // parser outage must not surface to the person who clicked an emoji.
+      run.error = error instanceof Error ? error.message : String(error);
+      logger.warn(`${TAG} reaction pass failed`, { error: run.error });
+    } finally {
+      await prisma.executionRunLog
+        .create({
+          data: {
+            workspaceId: run.workspaceId,
+            conversationId: run.conversationId,
+            gatePassed: run.gatePassed,
+            gateReason: run.gateReason,
+            windowSize: 1,
+            parserRan: run.parserRan,
+            proposedOps: run.proposedOps as object | undefined,
+            validOps: run.validOps as object | undefined,
+            droppedOps: run.droppedOps as object | undefined,
+            applied: run.applied as object | undefined,
+            assessment: run.assessment,
+            error: run.error,
+            durationMs: Date.now() - startedAt,
+          },
+        })
+        .catch(error => logger.warn(`${TAG} run log write failed`, { error }));
+    }
+  }
+
+  private async namesFor(ids: string[]): Promise<Map<string, string>> {
+    const unique = [...new Set(ids)];
+    if (unique.length === 0) return new Map();
+    const users = await prisma.user.findMany({
+      where: { id: { in: unique } },
+      select: { id: true, name: true },
+    });
+    return new Map(users.map(u => [u.id, u.name]));
+  }
+}
+
+export const radarReactionResolver = new RadarReactionResolver();

--- a/apps/backend/src/zero/side-effects/tables/reactions-handler.ts
+++ b/apps/backend/src/zero/side-effects/tables/reactions-handler.ts
@@ -1,7 +1,9 @@
 import { BaseSideEffectHandler } from '../base-handler';
 import type { SideEffectJobConfig } from '../types';
 import { db } from '@/database/client';
+import { logger } from '@/utils/logger';
 import { activityService } from '@/services/activity/activityService';
+import { radarReactionResolver } from '@/services/radar/radarReactionResolver';
 
 export class ReactionsSideEffectHandler extends BaseSideEffectHandler {
   private async getReactionContext(reactionId: string) {
@@ -52,6 +54,17 @@ export class ReactionsSideEffectHandler extends BaseSideEffectHandler {
 
   async onInsert(job: SideEffectJobConfig): Promise<void> {
     const { entityId: reactionId } = job;
+
+    // Runs on its own context, not the activity one below: that path drops
+    // self-reactions and never reads the emoji, and Radar needs both. Failures
+    // are swallowed — execution tracking must not cost someone their
+    // notification.
+    try {
+      await radarReactionResolver.onReaction(reactionId);
+    } catch (error) {
+      logger.error('[REACTIONS] Radar reaction resolve failed', { reactionId, error });
+    }
+
     const context = await this.getReactionContext(reactionId);
 
     if (!context) {

--- a/apps/dashboard/src/components/AppSidebar/ChatQuickMenu.tsx
+++ b/apps/dashboard/src/components/AppSidebar/ChatQuickMenu.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from 'react';
+import { createElement, useMemo, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import {
   ChatPlus,
@@ -8,8 +8,18 @@ import {
   SendPlaneSlant,
   ListAiGenerated,
 } from '@xyne/icons';
+import { Radar as RadarIcon } from 'lucide-react';
+import { type PikaIconProps } from '@xyne/icons';
 import { type PikaIcon } from './navigationConfig';
+import { useAuth } from '../../hooks/useAuth';
+import { useRadarEnabled } from '../../hooks/radarCacConfig';
 import { QUICK_NAV_ROW_CLASS, QuickNavList } from './RailQuickNav';
+
+// @xyne/icons has no radar glyph, so this borrows lucide's the way
+// AudioWaveIcon does in navigationConfig — `variant` is dropped rather than
+// passed through to the <svg>.
+const RadarNavIcon = ({ variant: _variant, ...props }: PikaIconProps): ReactElement =>
+  createElement(RadarIcon, props);
 
 const CHAT_NAV_ITEMS: {
   key: string;
@@ -30,7 +40,21 @@ const CHAT_NAV_ITEMS: {
   { key: 'bookmarks', label: 'Bookmarks', to: '/chat/bookmarks', icon: BookmarkDefault },
   { key: 'drafts-sent', label: 'Drafts & Sent', to: '/chat/drafts-sent', icon: SendPlaneSlant },
   { key: 'recap', label: 'Recap', to: '/chat/dir/recap', icon: ListAiGenerated },
+  { key: 'radar', label: 'Radar', to: '/chat/dir/radar', icon: RadarNavIcon },
 ];
+
+/**
+ * The rows this user may actually open. Radar's route is registered
+ * unconditionally (the rollout gate lives inside RadarPanel), so the CAC check
+ * has to drop the row here or people outside the rollout get a dead link.
+ */
+const useChatNavItems = (): typeof CHAT_NAV_ITEMS => {
+  const radarEnabled = useRadarEnabled(useAuth().user?.email);
+  return useMemo(
+    () => CHAT_NAV_ITEMS.filter(item => item.key !== 'radar' || radarEnabled),
+    [radarEnabled],
+  );
+};
 
 export const ChatQuickMenu = ({
   prefixWs,
@@ -42,7 +66,7 @@ export const ChatQuickMenu = ({
   onDismiss?: () => void;
 }): ReactElement => (
   <QuickNavList heading='Chat'>
-    {CHAT_NAV_ITEMS.map(item => {
+    {useChatNavItems().map(item => {
       const Icon = item.icon;
       return (
         <Link


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

Resolves Radar execution items from completion reactions (XYNE-57690).

A tick carries no text, so it never enters a parse window, and the message it points at is usually already below the watermark — the window parser structurally cannot see it. But it is the cleanest signal Radar gets: the parser's hardest job is guessing which message settles which item, and a reaction names the message outright.

The flow is deliberately flat. Indexed SQL answers the one question it can answer cheaply — does this person hold an open item in this thread — and that discards almost every reaction in a workspace before a token is spent. What survives goes to the parser as an ordinary pass carrying a `reaction` field, judged by the **same prompt and the same resolve rule** as typed messages, so a tick and the word "done" cannot settle a conversation differently.

Notable choices:

- **One model call, one prompt.** The reaction rules live inside `SYSTEM_PROMPT` rather than a prompt of their own. Two paraphrases of one resolve rule is how the same conversation ends up settling differently depending on how someone said it.
- **`open_items` carry `source_message_id` on a reaction pass.** Without it the model cannot tell "the tick is ON the ask" from "the tick is on a message that settles nothing", and it reads the former as the latter. With it, a tick on a message that raised several items closes all of them — which is what the person ticking it means.
- **The candidate query is the authorization boundary.** Only items the reactor holds or asked for, and the model's answer is re-checked against that list, so a hallucinated id or a stray `create` cannot reach the applier.
- **`requestedBy` counts as much as `pendingOn`.** The asker ticking the answer is the strongest confirmation there is, and the more common half of the pattern.
- **No watermark advance.** This settles one item and consumes no window; advancing would silently swallow every unparsed message in the thread.
- **Every reaction that reaches a live message writes a run-log row**, including the ones that resolve nothing. "I reacted and nothing happened" has to be answerable from the debug panel, and "no row at all" is the one answer it cannot give. It reuses the parser's run log — a reaction is a degenerate window, so every column already means something.

Also adds Radar to the sidebar Chat quick menu, behind the same CAC gate as the ChatDirectory entry — the route is always registered, so an ungated link would hand people outside the rollout a dead screen.

## Areas Touched

- [x] `apps/backend` (API / worker)
- [x] `apps/dashboard`

---

## Zero (Sync) Changes

- [x] No Zero changes — **skip this section**

`reactions-handler.ts` is a Zero side-effect handler, but only gains a call at the top of the existing `onInsert`. No mutator, schema, query or ACL touched.

## Schema & Data Changes

- [x] No schema changes — **skip this section**

`actorType='reaction'` and the `reaction*` `gateReason` values are new values in existing plain-`String` columns. No migration, no new Postgres enum.

## Config, Environment & URLs

- [x] No config changes — **skip this section**

Runs under the existing `ENABLE_RADAR_EXECUTION`. No new env keys.

## API Contract

- [x] No API changes

---

## How did you test it?

19 end-to-end scenarios against the real DB and the real model, each seeding its own thread in `#engineering`: tick on the ask, tick on the answer, unrelated-message rejection (a tick on a lunch plan), ack vs resolve emoji, bystander rejection, cross-thread isolation, messages predating the ask, deleted messages, split source messages, already-resolved items, and 2- and 3-candidate disambiguation. **19/19.**

Wiring verified by driving `processSideEffectJobs` exactly as the Zero push endpoint does — item flipped `OPEN → RESOLVED` with an audit row of `actorType='reaction'`. Separately confirmed `execution_thread_states` gained **0** rows (no watermark advance), and that run-log rows appear for every outcome including the no-ops (`reaction`, `reaction-no-candidates`, `reaction-predates-ask`).

Quick menu verified in the browser: `New Message · Threads · Unreads · Bookmarks · Drafts & Sent · Recap · Radar`, icon rendering.

### Automated

- [x] Not covered by tests — the behaviour under test is a model judgement plus DB state; the scenarios need a live LiteLLM and a seeded DB, so they do not belong in the unit suite.
- [ ] Backend unit tests — not run
- [ ] End-to-end suite — not run

### Manual

**Users**
- [x] Single user
- [ ] Two users at once — not run
- [ ] Different roles or permission levels — not run
- [ ] Different workspaces / spaces — not run

**Login**
- [x] Dev auth (`ENABLE_DEV_AUTH`)

**Run mode**
- [x] Local dev

**Surface & data**
- [x] Web browser
- [x] Error paths — model failure abstains, out-of-list itemId is dropped, gateway 429/502 observed and handled
- [ ] Electron desktop — not run
- [ ] Narrow viewport, dark + light theme — not run
- [ ] Emoji-picker click in a real browser — **not run**

---

## Checklist

- [x] Reviewed my own diff; scoped to one thing
- [x] Backend `typecheck` — 0 errors in touched files
- [x] Dashboard `lint:errors-only` — clean on the changed file
- [x] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `feature/*`
- [x] No debug logging or commented-out code left behind
- [x] No new deps
- [ ] `pnpm run build:shared` — fails before compiling anything: corepack pins pnpm 10.15.0, local is 11.21.0. Pre-existing environment issue, unrelated to this change.
- [ ] Dashboard `typecheck` — fails on 4 pre-existing errors in `CallShareModal.tsx` (`callById`, `shares`), not in this diff. `build` not run.
- [ ] Formatting — not run

---

## Reviewer notes

Two things worth a look rather than taking on trust:

1. **Run-log volume.** Every reaction reaching a live message writes a row, and `execution_run_logs` is described in the schema as the fastest-growing table here. Most rows will be `reaction-no-candidates`. Retention sweeps it, but the rate goes up materially — one condition reverts it if that trade is wrong.
2. **The emoji-picker click is the one untested link.** Everything from the side-effect job inward is verified end to end; the click that creates the reaction row is not.