### PR TITLE
fix: XYNE-62950 stop MESSAGE_RECEIVED firing twice on server-side message paths

### DIFF
--- a/apps/backend/src/apps/core/conversationUtils.ts
+++ b/apps/backend/src/apps/core/conversationUtils.ts
@@ -80,6 +80,7 @@ export async function findOrCreateConversation(
         isMarkdown: isMarkdown,
         messageMetadata: metadata,
         uploadedFiles: uploadedFiles,
+        emitsMessageReceivedViaSideEffects: true,
       });
 
       // Trigger side effects for notifications, activities, and unread counts

--- a/apps/backend/src/automations/steps/send-message.step.ts
+++ b/apps/backend/src/automations/steps/send-message.step.ts
@@ -153,6 +153,7 @@ export class SendMessageStep extends BaseActionStep<
           isBot,
           isMarkdown: true,
           uploadedFiles: deliveryFiles,
+          emitsMessageReceivedViaSideEffects: true,
         });
       } catch (error) {
         await removeUnclaimedAutomationDeliveryFiles(deliveryFiles);

--- a/apps/backend/src/services/conversationService.ts
+++ b/apps/backend/src/services/conversationService.ts
@@ -87,6 +87,8 @@ export interface CreateConversationWithMessageParams {
   pinned?: boolean;
   /** Migration import: skip live-only side effects (MESSAGE_RECEIVED automations, meet-link extraction) so bulk-imported history never fires workflows. */
   suppressAutomations?: boolean;
+  /** Caller replays MessagesSideEffectHandler.onInsert itself, which already emits MESSAGE_RECEIVED for the initial message — don't emit it twice. */
+  emitsMessageReceivedViaSideEffects?: boolean;
 }
 
 export interface AddMessageToConversationParams {
@@ -340,6 +342,7 @@ export class ConversationService {
       isAddingParticipant = true,
       pinned,
       suppressAutomations = false,
+      emitsMessageReceivedViaSideEffects = false,
     } = params;
 
     // Check if channel exists
@@ -541,7 +544,7 @@ export class ConversationService {
     // new channel conversation. Which message kinds fire is a user-configured
     // trigger condition; loops are prevented by the run chain. Fire-and-forget.
     // Migration import suppresses this so bulk-imported history never fires workflows.
-    if (!suppressAutomations) {
+    if (!suppressAutomations && !emitsMessageReceivedViaSideEffects) {
       void emitMessageReceived({
         messageId: message.messageId,
         conversationId: conversation.conversationId,

--- a/apps/backend/src/services/messageDeliveryService.ts
+++ b/apps/backend/src/services/messageDeliveryService.ts
@@ -221,6 +221,7 @@ export async function deliverServerMessage(
       isBot,
       createdAt: new Date(timestamp),
       uploadedFiles,
+      emitsMessageReceivedViaSideEffects: true,
     });
 
     resolvedConversationId = result.conversation.conversationId;

--- a/apps/backend/src/workers/scheduledMessageWorker.ts
+++ b/apps/backend/src/workers/scheduledMessageWorker.ts
@@ -119,6 +119,7 @@ class ScheduledMessageWorker {
       content: formattedMessage,
       msgType: MessageType.BOT,
       isBot: true,
+      emitsMessageReceivedViaSideEffects: true,
     });
 
     try {


### PR DESCRIPTION
## Problem

A message created through a server-side path fans out the automation `MESSAGE_RECEIVED` event **twice**, so every matching automation runs twice on one message.

Both emit sites fire for the first message of a new conversation:

- `conversationService.createConversationWithMessage` → `emitMessageReceived` (`conversationService.ts:548`)
- `MessagesSideEffectHandler.onInsert` → `emitMessageReceived`, gated on `conversation.initialMessageId === message.messageId` (`messages-handler.ts:403`)

Side effects are dispatched **only** from the Zero mutation endpoint (`zero/server.ts:360`) — there is no DB CDC — so a server-side (Prisma) write gets no notifications, unread counts, activity or Vespa indexing unless the caller replays the handler by hand. Four callers do exactly that, and therefore hit both emit sites. The handler's gate is always true on those paths because the service sets `initialMessageId` moments earlier.

Neither `emitMessageReceived` nor `eventRouter.emit` dedupes on `(eventType, messageId, workflowId)`, so nothing downstream absorbs it.

## Impact

Harmless-looking for most step types (a duplicate `SEND_MESSAGE`, ticket or webhook just reads as noise), but `RUN_AGENT` is different: its twins race on claw's `(conversationId, agentSlug)` lock and the loser is rejected with `HTTP 409 duplicate automation run for this conversation and agent already in progress`. That throws through `run-agent.step.ts:97` into `attempts: 1`, so the run is marked FAILED with no retry.

Measured on the `Alerts RCA` automation for 2026-09-08:

- one alert message (`cmtscnyoa0n11vq1xlvp1gzyk`) produced two executions 24 ms apart — matching two `[EVENT-ROUTER] event=MESSAGE_RECEIVED` lines under a single requestId
- 2103 messages produced 2 executions that day; 1712 produced 1
- **61 of 65 failed runs were this 409**

## Fix

Add `emitsMessageReceivedViaSideEffects` to `CreateConversationWithMessageParams`. A caller that replays the side-effect handler sets it, and the service skips its emit — leaving the handler as the single emitter on that path, identical to how a message typed in the app behaves.

Set on the four callers that replay the handler:

| file | |
|---|---|
| `apps/core/conversationUtils.ts` | Slack / bot ingest — the reported path |
| `services/messageDeliveryService.ts` | replays via `runSideEffects()` |
| `workers/scheduledMessageWorker.ts` | |
| `automations/steps/send-message.step.ts` | |

Reusing the existing `suppressAutomations` was not viable: it also gates `processMeetLinksFromChatMessage` (`conversationService.ts:492`), so it would have silently disabled meet-link extraction for every ingested message. The new flag suppresses only the event.

## Safety

The flag defaults to `false`, so every other caller is unchanged. Callers that do **not** replay the handler — `integrations/core` (inbound email), `gcsPollingService`, `approval-notifications`, `networkDocumentWorkflow`, `whatsappMigrationService` and the migration scripts — keep the service-side emit as their only one.

Cross-checked all 12 `createConversationWithMessage` callers: every caller that replays the handler has the flag, every caller that doesn't, doesn't. No path goes from 1 emit to 0.

`send-message.step.ts` and the flagged branches of `conversationUtils` / `messageDeliveryService` always create a new conversation, so the handler's `initialMessageId` gate is always true there and the flag can never suppress a lone emit. The reply branches (`addMessageToConversation`) are untouched — they emit `TICKET_COMMENTED`, not `MESSAGE_RECEIVED`.

## Checks run

`gitleaks` (no leaks) · tenant-key guard · backend `typecheck` (clean) · backend `build` (clean) · `change-analysis` · schema-migration validation · enum guard. Zero↔Prisma parity and dashboard/framework/automation checks skipped — no such files changed.

## Not covered

- Claw still hard-fails a *genuine* concurrent duplicate with 409 + `attempts: 1`. Making its conversation guard reply `200 {deduplicated:true}` like the step guard (`webhook.ts:4121`) is a separate change in another service.
- The five callers that skip the handler also miss notifications, unread counts and Vespa indexing. Giving them the handler and then deleting `conversationService.ts:548` outright is the right end state, but it changes visible behaviour on those paths and belongs in its own PR.

## Origin

Both emit sites were added in the same commit — `a6ab66f37` (2026-06-02, `XYNE-13245`). The ingest path had already been replaying the handler since `55ec87e267` (2026-04-22), so the overlap has been live since June.
