### PR TITLE
fix: XYNE-62960 Fix msg_length check for slack adapters

### DIFF
--- a/apps/backend/src/apps/platform-adapters/slack/controller.ts
+++ b/apps/backend/src/apps/platform-adapters/slack/controller.ts
@@ -320,16 +320,16 @@ export class SlackController {
 			return;
 		}
 
+		if (JSON.stringify(req.body).length > XYNE_MESSAGE_CONTENT_MAX_LENGTH) {
+			res.status(200).json({ ok: false, error: "msg_too_long" });
+			return;
+		}
 		const context = getSlackAuthContext(req);
 		const channelId = getResolvedChannelId(req);
 		const args = await transformPostMessage(
 			{ ...parsed.data, channel: channelId },
 			context,
 		);
-		if (args.content.length > XYNE_MESSAGE_CONTENT_MAX_LENGTH) {
-			res.status(200).json({ ok: false, error: "msg_too_long" });
-			return;
-		}
 
 		const threadResolution = await resolveSlackThreadConversationId(
 			args.conversationId,
@@ -416,12 +416,12 @@ export class SlackController {
 			return;
 		}
 
-		const context = getSlackAuthContext(req);
-		const args = await transformUpdate(parsed.data, context);
-		if (args.content.length > XYNE_MESSAGE_CONTENT_MAX_LENGTH) {
+		if (JSON.stringify(req.body).length > XYNE_MESSAGE_CONTENT_MAX_LENGTH) {
 			res.status(200).json({ ok: false, error: "msg_too_long" });
 			return;
 		}
+		const context = getSlackAuthContext(req);
+		const args = await transformUpdate(parsed.data, context);
 		const channelId = getResolvedChannelId(req);
 
 		const existingMessage = await repositories.messages.findById(args.messageId);

--- a/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackBlockKitToFlowJSON.ts
+++ b/apps/backend/src/integrations/adapters/slack-webhook-tickets/utils/slackBlockKitToFlowJSON.ts
@@ -715,7 +715,7 @@ export function slackBlockElementToFlowComponent(element: SlackBlockElement): Fl
       return {
         id: crypto.randomUUID(),
         type: 'button',
-        props: { label: btn.text.text, variant },
+        props: { label: btn.text.text, variant, ...(btn.url && { url: btn.url }) },
       };
     }
     case 'image': {

--- a/apps/dashboard/src/components/flowUI/nodes/ButtonNode.tsx
+++ b/apps/dashboard/src/components/flowUI/nodes/ButtonNode.tsx
@@ -16,13 +16,21 @@ export const ButtonNode: React.FC<ButtonNodeProps> = ({ node }) => {
         variant?: 'primary' | 'secondary' | 'destructive' | 'ghost' | 'outline';
         size?: 'sm' | 'md' | 'lg';
         icon?: string;
+        url?: string;
         action?: { id: string };
       }
     | undefined;
 
   const { executeAction, validateAllFields, isSubmitting, state, compact } = useFlow();
 
+  const url = props?.url;
+  const isLinkButton = !!url && /^https?:\/\//i.test(url);
+
   const handleClick = () => {
+    if (isLinkButton) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+      return;
+    }
     void (async () => {
       const action = (node.props as { action?: Parameters<typeof executeAction>[0] }).action;
       if (!action) return;

--- a/apps/dashboard/src/global.css
+++ b/apps/dashboard/src/global.css
@@ -2046,6 +2046,19 @@ mark.chat-text-highlight,
   @apply my-1;
 }
 
+/* Block Kit flows render inside .jp-message-html, so the generic list rules
+   above apply to them too — and at (0,1,1) they outrank any utility class set
+   on the element itself, which makes per-item spacing unfixable from the
+   component. Slack renders a bullet run as plain lines with no per-item gap, so
+   drop both the block and item margins for flows; a blank line still reads as
+   a break through the layout gap between components, without a bullet run
+   costing a margin on every line. */
+:is(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary)
+  :is(.flow-ui-container, .flow-ui-compact)
+  :is(ul, ol, li) {
+  @apply my-0;
+}
+
 /* Inline the first <p> inside an <li> so the marker shares a line with the text
    instead of sitting alone above it. */
 :is(.jp-message-html, .bot-markdown-content, .bot-markdown-content-call-summary)

--- a/packages/shared/src/validation/flowSchema.ts
+++ b/packages/shared/src/validation/flowSchema.ts
@@ -205,6 +205,7 @@ export const buttonComponentSchema = baseComponentSchema.extend({
     variant: z.enum(['primary', 'secondary', 'destructive', 'ghost', 'outline']).optional(),
     size: z.enum(['sm', 'md', 'lg']).optional(),
     icon: z.string().optional(),
+    url: z.string().optional(),
     action: flowActionSchema.optional(),
   }).strict(),
 });


### PR DESCRIPTION
Services-Requiring-Redeployment:
  - backend
  - dashboard

## Type of Change

- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- What changed, and why. Link the ticket (XYNE-xxxx) or issue. -->


## Areas Touched

- [ ] `apps/backend` (API / worker)
- [ ] `apps/dashboard`
- [ ] `apps/electron`
- [ ] `apps/xyne-claw` / `apps/xyne-claw-auth`
- [ ] `packages/shared` or another shared package
- [ ] Infra (docker, scripts, nix, CI)

---

## Zero (Sync) Changes

- [ ] No Zero changes — **skip this section**
- [ ] Adds/modifies a **mutator**
- [ ] Adds/modifies the **schema** (tables, columns, relationships)
- [ ] Adds/modifies a **query or ACL**

If any of the above:

- [ ] Server (`apps/backend/src/zero/mutators.ts`) and client (`apps/dashboard/src/zero/mutators.ts`) mutators mirror each other — same namespace, name, and args schema
- [ ] No `Date.now()` / `uuid()` generated inside a mutator
- [ ] Optimistic client result matches the server result (no state flash on rebase)
- [ ] New tables exported in `createSchema()` and given a Query ACL registered in `query-acl-factory.ts`
- [ ] Matching Prisma model + migration, client regenerated

## Schema & Data Changes

- [ ] No schema changes — **skip this section**
- [ ] Prisma schema modified (`apps/backend/prisma` and/or `prisma-common`)
- [ ] Migration added
- [ ] Backfill / data migration included

If any of the above:

- [ ] Clients regenerated (`db:generate`, `db:common:generate`)
- [ ] No new Postgres enum or enum value — enums are frozen (`pnpm run test:enum`)
- [ ] Backward compatible with deployed code, or rollout order noted below
- [ ] Backfill is idempotent

<!-- Rollout / rollback notes: -->

## Config, Environment & URLs

- [ ] No config changes — **skip this section**
- [ ] Env variable added / renamed / removed
- [ ] **Base URL, host, port, or origin changed** (API, Zero, Vespa, Claw, LiveKit, LiteLLM, …)
- [ ] CORS / allowed origins / OAuth redirect URIs changed
- [ ] Feature flag or runtime config changed

If any of the above:

- [ ] Key added to **all** relevant env files, not just the one you run — `apps/backend/.env.{example,local,test}`, `apps/dashboard/.env.{example,local,test}`, plus the app you touched
- [ ] Env setup / secret scripts and docker compose updated
- [ ] Verified in every consumer with its own base URL — dashboard (`VITE_API_BASE_URL`, `VITE_ZERO_SERVER`), Electron (`VITE_ELECTRON_*`), shareable links (`VITE_SHAREABLE_ORIGIN`), server-to-server (`BACKEND_URL`, `XYNE_CLAW_URL`, `XYNE_CLAW_AUTH_URL`)
- [ ] Google / Microsoft OAuth redirect URIs still resolve
- [ ] Nothing hardcoded, no secrets committed

<!-- Keys added/changed: -->

## API Contract

- [ ] No API changes
- [ ] New endpoint
- [ ] Existing contract modified (shape, status codes, auth)
- [ ] Breaking for dashboard / electron / external / bots — migration noted above

---

## How did you test it?
<!-- What you actually ran. Screenshots or a recording for UI changes. -->


### Automated

- [ ] Backend unit tests — `pnpm --filter xyne-spaces-backend run test`
- [ ] Claw tests — `pnpm --filter xyne-claw run test`
- [ ] End-to-end suite — `pnpm run test`
- [ ] Added / updated tests for this change
- [ ] Not covered by tests <!-- why? -->

### Manual

**Users**
- [ ] Single user
- [ ] Two users at once (two accounts / two browsers) — sync lands on both, no cross-user leakage
- [ ] Different roles or permission levels (member vs admin, ACL boundaries)
- [ ] Different workspaces / spaces — data stays scoped

**Login**
- [ ] Google
- [ ] Microsoft
- [ ] Dev auth (`ENABLE_DEV_AUTH`)
- [ ] Fresh signup / first-time user
- [ ] Session expiry, re-login, logout

**Run mode**
- [ ] Local dev (`pnpm run dev:all`)
- [ ] Test mode (`dev:test`)
- [ ] Sandbox / claw test (`claw:test`)
- [ ] Prod-like local (`dev:prod`)
- [ ] Docker compose
- [ ] Electron desktop

**Sync & resilience** — for anything touching Zero
- [ ] Multiple tabs stay consistent
- [ ] Reload / hard refresh — no duplicate or lost rows
- [ ] Offline then reconnect — pending mutations replay cleanly
- [ ] Concurrent edits on the same entity by two users

**Surface & data**
- [ ] Web browser
- [ ] Electron desktop
- [ ] Narrow viewport, dark + light theme
- [ ] Empty state
- [ ] Large / realistic data volume
- [ ] Error paths (network failure, denied permission, invalid input)

---

## Checklist

- [ ] Reviewed my own diff; scoped to one thing
- [ ] `pnpm run build:shared` passes
- [ ] Backend `typecheck` + `build` pass
- [ ] Dashboard `lint:errors-only` + `typecheck` + `build` pass
- [ ] Formatting clean in the packages I touched
- [ ] New deps added with `pnpm --filter <pkg> add <dep>`; version pins in root `pnpm.overrides`
- [ ] Commits follow `<type>: <TICKET-ID> <subject>`; branch is `fix/*` or `feature/*`
- [ ] Docs / guidelines updated where behaviour changed
- [ ] No debug logging or commented-out code left behind
