### PR TITLE
fix: XYNE-61392 persist My Tickets column selection across remounts

### DIFF
--- a/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/KanbanBoardScreen.tsx
@@ -198,7 +198,13 @@ import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
 import { useBoardsSlaPolicies } from '../../hooks/useChannelSlaPolicy';
 import { useKanbanCounts } from './useKanbanCounts';
 import { valuesToFilters } from '../../utils/savedViewSerialization';
-import { readViewDraft, writeViewDraft, clearViewDraft } from './viewDraft';
+import {
+  readViewDraft,
+  writeViewDraft,
+  clearViewDraft,
+  readViewColumns,
+  writeViewColumns,
+} from './viewDraft';
 import { useConfirmDialog } from '../../hooks/useConfirmDialog';
 import { getApiErrorMessage } from '../../utils/apiError';
 import {
@@ -522,8 +528,20 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
       viewModeProp === 'workspace-view' && !hasSharedSeed ? readViewDraft(viewDraftKey) : null,
     [viewModeProp, viewDraftKey, hasSharedSeed],
   );
+  const persistedColumnsKey =
+    viewModeProp === 'my-tickets' ||
+    viewModeProp === 'user-tickets' ||
+    viewModeProp === 'group-tickets'
+      ? viewModeProp
+      : null;
   const [visibleColumns, setVisibleColumns] = useState<Set<string>>(
-    () => new Set(initialDraft?.columns ?? initialColumns ?? DEFAULT_VISIBLE_COLUMNS),
+    () =>
+      new Set(
+        initialDraft?.columns ??
+          (persistedColumnsKey ? readViewColumns(persistedColumnsKey) : null) ??
+          initialColumns ??
+          DEFAULT_VISIBLE_COLUMNS,
+      ),
   );
   // The tickets table always surfaces the Stage column (parity with the Support
   // desk table, which renders TicketTable with its stage-inclusive defaults).
@@ -1112,6 +1130,11 @@ const KanbanBoardScreen: React.FC<BoardKanbanScreenProps> = ({
         .sort(),
     [visibleColumns],
   );
+
+  useEffect(() => {
+    if (!persistedColumnsKey) return;
+    writeViewColumns(persistedColumnsKey, savableColumns);
+  }, [persistedColumnsKey, savableColumns]);
 
   const savedViewSignature = useMemo(
     () =>

--- a/apps/dashboard/src/routes/KanbanBoardScreen/viewDraft.ts
+++ b/apps/dashboard/src/routes/KanbanBoardScreen/viewDraft.ts
@@ -48,3 +48,25 @@ export const clearViewDraft = (viewKey: string): void => {
     /* storage unavailable */
   }
 };
+
+const columnsKey = (viewKey: string): string => `view-columns-${viewKey}`;
+
+export const readViewColumns = (viewKey: string): string[] | null => {
+  try {
+    const raw = sessionStorage.getItem(columnsKey(viewKey));
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter((key): key is string => typeof key === 'string');
+  } catch {
+    return null;
+  }
+};
+
+export const writeViewColumns = (viewKey: string, columns: string[]): void => {
+  try {
+    sessionStorage.setItem(columnsKey(viewKey), JSON.stringify(columns));
+  } catch {
+    /* storage unavailable */
+  }
+};


### PR DESCRIPTION
POT - https://drive.google.com/file/d/1fkpVX3AzNpe3OKDbq3pElGDT1GcIITMs/view?usp=sharing

## What

Column selections made in the Customize panel on **My Tickets** (and the `?assignee=` / `?group=` variants of the same screen) now survive opening a ticket and coming back, and a refresh within the tab.

Follow-up to #1296, which fixed the same symptom for saved views only.

## Why

#1296 keys its sessionStorage draft off `viewId` and is gated on `viewMode === 'workspace-view'`, so My Tickets never enters that path.

On My Tickets, filters, groupBy and sub-status are already persisted by `ticketFiltersMachine`, but `visibleColumns` was plain component state. Opening a ticket unmounts `KanbanBoardScreen`; the next mount fell back to `DEFAULT_VISIBLE_COLUMNS`, so any column the user had added was gone. The active saved-config chip made this look worse: `selectedViewId` is restored from sessionStorage, but only the id, never that config's columns.

## How

- **`viewDraft.ts`** — `readViewColumns` / `writeViewColumns`, a columns-only store under `view-columns-<viewMode>`, with the same `try/catch` degradation and array-of-strings validation as the existing draft helpers.
- **`KanbanBoardScreen.tsx`** — `persistedColumnsKey` is the view mode for `my-tickets` / `user-tickets` / `group-tickets`, else `null`. Column state seeds with precedence **draft > stored columns > `initialColumns` > defaults**, and an effect writes `savableColumns` back on every change.

Derived columns (`stage`, `board`) are excluded from what is stored, so the existing sub-status sync effect keeps owning them on remount.

Keyed by view mode rather than only the literal `my-tickets` because the assignee and group variants render the same screen with the same Customize panel, and the filter machine already keys their storage the same way.

## Scope

`apps/dashboard` only, 2 files. No schema, no backend, no migration.

## Testing

- prettier, eslint (0 errors, no warnings on the new lines), `tsc --noEmit --project tsconfig.app.json` exit 0.
- Manual: My Tickets → Customize → tick Created At / Created By → open a ticket → back. Before: columns reset to defaults. After: selection intact.
