### PR TITLE
fix: skip ticket_md rebuild when no card-relevant field changed on ticket.update

### DIFF
--- a/packages/shared/src/zero/mutators.ts
+++ b/packages/shared/src/zero/mutators.ts
@@ -4335,7 +4335,27 @@ export const mutators = defineMutators({
           ...updateData,
         });
 
-        await updateTicketMdFromZero(tx, zql, id);
+        // Only rebuild the serialized ticket card (ticket_md) — and walk the
+        // sub-ticket/parent graph via updateTicketMdFromZero — when a field that
+        // actually appears in that card changed. Fields like kanbanPosition,
+        // boardId, userGroupId, metadata and isArchived never affect ticket_md,
+        // so for those edits (e.g. drag-to-reorder on the kanban) the rebuild +
+        // conversation write + relatives sync is pure write-amplification.
+        // When no md-relevant field changed the serialized md is byte-identical
+        // to what is stored, so skipping the call is behavior-preserving:
+        // updateTicketMdFromZero would early-return after the same reads anyway.
+        const ticketMdFieldChanged =
+          title !== undefined ||
+          description !== undefined ||
+          statusV2 !== undefined ||
+          priority !== undefined ||
+          stageName !== undefined ||
+          assignedTo !== undefined ||
+          ticketType !== undefined ||
+          eta !== undefined;
+        if (ticketMdFieldChanged) {
+          await updateTicketMdFromZero(tx, zql, id);
+        }
       },
     ),
     archiveDeskTicket: defineMutator(


### PR DESCRIPTION
## Problem
Setting a ticket's assignee/PM (and other field edits, plus kanban drag-reorder) shows significant lag. Every `ticket.update` Zero mutator unconditionally calls `updateTicketMdFromZero()` → `syncTicketRelativesFromZero()`, which re-serializes the ticket card (`ticket_md`) onto the ticket's conversation row and walks the sub-ticket/parent graph with sequential per-row reads. This runs on BOTH the client (blocking the optimistic apply) and the server.

Runtime (last 24h): `ticket.update` mutator p99 ~2.8s, spiking to ~11.7s.

Edits that do NOT change any field shown on the card — kanbanPosition (drag-to-reorder), boardId, userGroupId, metadata, isArchived — still paid the full rebuild + conversation write + relatives-sync cost for what ends up being a no-op md write.

## Fix
Gate the `updateTicketMdFromZero` call in the `ticket.update` mutator on whether a field that actually appears in `ticket_md` changed: title, description, statusV2, priority, stageName, assignedTo, ticketType, eta. When none changed, the serialized md is byte-identical to what is stored, so the existing `conversation.ticket_md === ticketMd` early-return would fire anyway — skipping the call is behavior-preserving and just avoids the redundant reads/write and poke fan-out.

## Scope / risk
- One file: `packages/shared/src/zero/mutators.ts`.
- Behavior-preserving (only skips a provably no-op path). `assignedTo` remains in the gate list, so assignee/PM changes still rebuild the card correctly.
- `npx tsc --noEmit` passes for `@xyne/shared`.

## Follow-ups (not in this PR)
- Move `syncTicketRelativesFromZero` fan-out off the synchronous client mutator into a server-side after-commit worker so the optimistic apply is O(1).
- Re-evaluate the `await …).server` in `TicketDetails.applyTicketUpdate` once the cascade is cheap.
- Profile the separate slow create path `POST /api/tickets/` (p99 ~3.8s) and its `suggest-board`/`duplicates`/`kanban/counts` siblings (~9–10s).